### PR TITLE
Bumps freenet to "0.0.6" for freenet-token-generator

### DIFF
--- a/modules/antiflood-tokens/delegates/token-generator/Cargo.toml
+++ b/modules/antiflood-tokens/delegates/token-generator/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { workspace = true, features = ["alloc", "serde"] }
 freenet-stdlib = { workspace = true, features = ["contract"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-chrono = { workspace = true, features = ["clock", "alloc", "serde"]}
+chrono = { workspace = true, features = ["clock", "alloc", "serde"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 arbitrary = "1"
@@ -27,7 +27,7 @@ chacha20poly1305 = "0.10"
 rand = { version = "0.8", features = ["std"] }
 rand_chacha = { version = "0.3" }
 freenet-stdlib = { workspace = true, features = ["testing"] }
-freenet = { path = "../../../../crates/core", version = "0.0.5" }
+freenet = { path = "../../../../crates/core", version = "0.0.6" }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "fmt"] }
 
 [lib]


### PR DESCRIPTION
Bumps up freenet version for antiflood-tokens/delegates/token-generator from "0.0.5" to "0.0.6"