### PR TITLE
Rename fdev strings from 'Locutus' to 'Freenet'

### DIFF
--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -6,7 +6,7 @@ use freenet::dev_tool::OperationMode;
 use semver::Version;
 
 #[derive(clap::Parser, Clone)]
-#[clap(name = "Locutus Development Tool")]
+#[clap(name = "Freenet Development Tool")]
 #[clap(author = "The Freenet Project Inc.")]
 #[clap(version = "0.0.3")]
 pub struct Config {

--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -8,7 +8,7 @@ use semver::Version;
 #[derive(clap::Parser, Clone)]
 #[clap(name = "Freenet Development Tool")]
 #[clap(author = "The Freenet Project Inc.")]
-#[clap(version = "0.0.3")]
+#[clap(version = "0.0.6")]
 pub struct Config {
     #[clap(subcommand)]
     pub sub_command: SubCommand,

--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -18,13 +18,13 @@ pub struct Config {
 
 #[derive(clap::Parser, Clone)]
 pub struct BaseConfig {
-    /// Overrides the default data directory where Locutus contract files are stored.
+    /// Overrides the default data directory where Freenet contract files are stored.
     #[arg(long)]
     pub(crate) contract_data_dir: Option<PathBuf>,
-    /// Overrides the default data directory where Locutus delegate files are stored.
+    /// Overrides the default data directory where Freenet delegate files are stored.
     #[arg(long)]
     pub(crate) delegate_data_dir: Option<PathBuf>,
-    /// Overrides the default data directory where Locutus secret files are stored.
+    /// Overrides the default data directory where Freenet secret files are stored.
     #[arg(long)]
     pub(crate) secret_data_dir: Option<PathBuf>,
     /// Node operation mode.
@@ -154,7 +154,7 @@ fn parse_version(src: &str) -> Result<Version, String> {
     Version::parse(src).map_err(|e| e.to_string())
 }
 
-/// Create a new Locutus contract and/or app.
+/// Create a new Freenet contract and/or app.
 #[derive(clap::Parser, Clone)]
 pub struct NewPackageCliConfig {
     #[arg(id = "type", value_enum)]

--- a/crates/fdev/src/inspect.rs
+++ b/crates/fdev/src/inspect.rs
@@ -19,7 +19,7 @@ enum FileType {
     Contract,
 }
 
-/// Inspect the packaged WASM code for Locutus.
+/// Inspect the packaged WASM code for Freenet.
 #[derive(clap::Parser, Clone)]
 struct CodeInspection {}
 

--- a/crates/fdev/src/local_node.rs
+++ b/crates/fdev/src/local_node.rs
@@ -42,9 +42,9 @@ pub enum DeserializationFmt {
     MessagePack,
 }
 
-/// A CLI utility for testing out contracts against a Locutus local node.
+/// A CLI utility for testing out contracts against a Freenet local node.
 #[derive(clap::Parser, Clone)]
-#[clap(name = "Locutus Local Development Node Environment")]
+#[clap(name = "Freenet Local Development Node Environment")]
 #[clap(author = "The Freenet Project Inc.")]
 #[clap(group(
     ArgGroup::new("output")

--- a/crates/fdev/src/local_node/user_events.rs
+++ b/crates/fdev/src/local_node/user_events.rs
@@ -19,7 +19,7 @@ use crate::{util, CommandSender, DynError};
 
 use super::{state::AppState, DeserializationFmt, LocalNodeCliConfig};
 
-const HELP: &str = "Locutus Contract Development Environment
+const HELP: &str = "Freenet Contract Development Environment
 
 SUBCOMMANDS:
     help        Print this message


### PR DESCRIPTION
Currently `fdev --version` outputs
`Locutus Development Tool 0.0.3`.
This change makes the output `Freenet Development Tool 0.0.3` and brings it in line with the recent renaming decision.

edit: I went and renamed all the deprecated naming strings from the fdev tool from Locutus to Freenet as the entire tool is named fdev now and it's very confusing to still have "Locutus" name in the man pages, --help output etc.