### PR TITLE
Rename fdev variable prefixes from "locutus" to "freenet"

### DIFF
--- a/crates/fdev/src/commands.rs
+++ b/crates/fdev/src/commands.rs
@@ -8,7 +8,7 @@ use freenet_stdlib::{
     client_api::{ClientRequest, ContractRequest, DelegateRequest},
     prelude::*,
 };
-// use locutus_runtime::{
+// use freenet_runtime::{
 //     ContractContainer, ContractInstanceId, ContractStore, DelegateContainer, DelegateStore,
 //     Parameters, SecretsStore, StateStore,
 // };

--- a/crates/fdev/src/local_node.rs
+++ b/crates/fdev/src/local_node.rs
@@ -83,6 +83,6 @@ pub struct LocalNodeCliConfig {
     #[clap(long, requires = "fmt")]
     pub(crate) terminal_output: bool,
     /// Max contract size
-    #[clap(long, env = "LOCUTUS_MAX_CONTRACT_SIZE", default_value_t = DEFAULT_MAX_CONTRACT_SIZE)]
+    #[clap(long, env = "FREENET_MAX_CONTRACT_SIZE", default_value_t = DEFAULT_MAX_CONTRACT_SIZE)]
     pub(crate) max_contract_size: i64,
 }

--- a/crates/fdev/src/new_package.rs
+++ b/crates/fdev/src/new_package.rs
@@ -25,7 +25,7 @@ pub fn create_new_package(config: NewPackageCliConfig) -> Result<(), DynError> {
 fn create_view_package(cwd: &Path) -> Result<(), DynError> {
     create_rust_crate(cwd, ContractKind::WebApp)?;
     create_web_init_files(cwd)?;
-    let locutus_file_config = BuildToolConfig {
+    let freenet_file_config = BuildToolConfig {
         contract: Contract {
             c_type: Some(ContractType::WebApp),
             lang: Some(SupportedContractLangs::Rust),
@@ -43,7 +43,7 @@ fn create_view_package(cwd: &Path) -> Result<(), DynError> {
         }),
         state: None,
     };
-    let serialized = toml::to_string(&locutus_file_config)?.into_bytes();
+    let serialized = toml::to_string(&freenet_file_config)?.into_bytes();
     let path = cwd.join("freenet").with_extension("toml");
     let mut file = File::create(path)?;
     file.write_all(&serialized)?;
@@ -52,7 +52,7 @@ fn create_view_package(cwd: &Path) -> Result<(), DynError> {
 
 fn create_regular_contract(cwd: &Path) -> Result<(), DynError> {
     create_rust_crate(cwd, ContractKind::Contract)?;
-    let locutus_file_config = BuildToolConfig {
+    let freenet_file_config = BuildToolConfig {
         contract: Contract {
             c_type: Some(ContractType::Standard),
             lang: Some(SupportedContractLangs::Rust),
@@ -61,7 +61,7 @@ fn create_regular_contract(cwd: &Path) -> Result<(), DynError> {
         webapp: None,
         state: None,
     };
-    let serialized = toml::to_string(&locutus_file_config)?.into_bytes();
+    let serialized = toml::to_string(&freenet_file_config)?.into_bytes();
     let path = cwd.join("freenet").with_extension("toml");
     let mut file = File::create(path)?;
     file.write_all(&serialized)?;


### PR DESCRIPTION
This pr concludes fdev's transition from Locutus to Freenet and ensures consistency and clarity throughout the codebase, aligning with the new project name.