### PR TITLE
Improving Developer Onboarding Documentation

### DIFF
--- a/apps/freenet-email-app/README.md
+++ b/apps/freenet-email-app/README.md
@@ -15,11 +15,30 @@ local node, which simulates a node on the network.
   ```bash
   curl https://sh.rustup.rs -sSf | sh
   ```
+- (Ubuntu)
+  ```bash
+  sudo apt-get update
+  sudo apt-get install libssl-dev libclang-dev pkg-config
+  ```
 - Install the Freeenet development tool (fdev) and a working Freenet kernel that can be used for local development. Use cargo to install it:
   ```bash
   cargo install freenet
   cargo install fdev
   ```
+- Install Dioxus-CLI, a GUI library for rust
+  ```bash
+  cargo install dioxus-cli
+  ```
+- Add WebAssembly target
+  ```bash
+  rustup target add wasm32-unknown-unknown
+  ```
+- Initializing & Fetching Submodules
+  ```bash
+  git submodule update --init --recursive
+  ```
+### Note about MacOS
+Email account creation currently does not work on MacOS
 
 ## Prepare the Freenet email contracts and delegates
 
@@ -38,6 +57,11 @@ This delegate is located inside the modules folder of freenet-core:
       - `src/` <-- this folder contains the source code of the delegate
       - `Makefile` <-- this file contains the build instructions for the delegate
       - ...
+
+Before building the delegate, cargo needs to know where to generate binaries:
+```bash
+export CARGO_TARGET_DIR="./target"
+```
 
 To build the delegate, go to the `identity-management` folder and run the following command:
 

--- a/apps/freenet-email-app/README.md
+++ b/apps/freenet-email-app/README.md
@@ -58,9 +58,9 @@ This delegate is located inside the modules folder of freenet-core:
       - `Makefile` <-- this file contains the build instructions for the delegate
       - ...
 
-Before building the delegate, cargo needs to know where to generate binaries:
+Add the target directory for the project. This should be an absolute file path to freenet-core/target.
 ```bash
-export CARGO_TARGET_DIR="./target"
+export CARGO_TARGET_DIR="... freenet-core/target"
 ```
 
 To build the delegate, go to the `identity-management` folder and run the following command:

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -15,13 +15,16 @@ Mac (for Windows see [here](https://rustup.rs)):
 curl https://sh.rustup.rs -sSf | sh
 ```
 
+#### Note for MacOS install
+Do not have the `brew` version of rust installed as it will cause compications with `fdev`.
+
 ### Freenet development tool (fdev)
 
 Once you have a working installation of Cargo you can install the Freenet dev
 tools:
 
 ```bash
-cargo install freenet
+cargo install freenet fdev
 ```
 
 This command will install `fdev` (Freenet development tool) and a working Freenet kernel that can

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This tutorial will show you how to build decentralized software on Freenet. For a similar working and up to date example check the `freenet-microblogging` app (located in under the `apps/freenet-microblogging` directory in the `freenet-core` repository).
+This tutorial will show you how to build decentralized software on Freenet. For a similar working and up to date example check the `freenet-email` app (located in under the `apps/freenet-email-app` directory in the `freenet-core` repository).
 
 <!-- toc -->
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -30,6 +30,11 @@ cargo install freenet fdev
 This command will install `fdev` (Freenet development tool) and a working Freenet kernel that can
 be used for local development.
 
+### Add WebAssembly target
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
 ### Node.js and TypeScript
 
 To build user interfaces in JavaScript or TypeScript, you need to have Node.js


### PR DESCRIPTION
I followed the instructions in the email app README and was able to get it running properly after running a few commands which weren't explicitly specified. I added the commands to the README and made a couple notes.

I could not get the email app example to work properly on MacOS. The code compiles and the app runs, but the account creation process is broken. Upon pressing the "Create" button, the app takes the user back to the "Create new identity" page without the created account displayed.

If this is user error, please let me know. Otherwise, I can create an issue so it can be fixed.