### PR TITLE
Fix using absolute path for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "stdlib"]
 	path = stdlib
-	url = ../freenet-stdlib
+	url = https://github.com/freenet/freenet-stdlib
+


### PR DESCRIPTION
This PR is related to [this issue](https://github.com/freenet/freenet-core/issues/912)

Any developer that forks the project has to do that extra step.

This PR fixes that.