### PR TITLE
Update inbox.rs

### DIFF
--- a/apps/freenet-email-app/web/src/inbox.rs
+++ b/apps/freenet-email-app/web/src/inbox.rs
@@ -181,7 +181,7 @@ impl DecryptedMessage {
         }
         .try_into()
         .map_err(|e| format!("{e}"))?;
-        let inbox_key = !::from_params(INBOX_CODE_HASH, params).map_err(|e| format!("{e}"))?;
+        let inbox_key = ContractKey::from_params(INBOX_CODE_HASH, params).map_err(|e| format!("{e}"))?;
         AftRecords::pending_assignment(delegate_key, inbox_key.clone());
 
         PENDING_INBOXES_UPDATE.with(|map| {


### PR DESCRIPTION
Error: 🚫 Building project failed: error[E0425]: cannot find crate `from_params` in the list of imported crates
   --> web/src/inbox.rs:184:28
    |
184 |         let inbox_key = !::from_params(INBOX_CODE_HASH, params).map_err(|e| format!("{e}"))?;
    |                            ^^^^^^^^^^^ not found in the list of imported crates