### PR TITLE
Bump up versions and cleanup most of warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,12 +385,40 @@ checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.3.4",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 0.1.2",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.3",
  "base64 0.21.7",
  "bytes",
  "futures-util",
@@ -393,6 +443,23 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.21.0",
  "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
  "tower-layer",
  "tower-service",
 ]
@@ -451,6 +518,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,17 +540,16 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
+ "itertools",
  "lazy_static",
  "lazycell",
- "peeking_take_while",
- "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -773,11 +845,12 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
+checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
 dependencies = [
  "async-trait",
+ "convert_case",
  "json5",
  "lazy_static",
  "nom",
@@ -786,7 +859,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml 0.5.11",
+ "toml",
  "yaml-rust",
 ]
 
@@ -797,10 +870,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -1012,6 +1114,12 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -1289,9 +1397,12 @@ dependencies = [
 
 [[package]]
 name = "dlv-list"
-version = "0.3.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
 
 [[package]]
 name = "dotenvy"
@@ -1514,7 +1625,7 @@ name = "fdev"
 version = "0.0.7"
 dependencies = [
  "anyhow",
- "axum",
+ "axum 0.7.5",
  "bincode",
  "bs58",
  "chrono",
@@ -1538,7 +1649,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-tungstenite 0.21.0",
- "toml 0.8.12",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "xz2",
@@ -1573,6 +1684,16 @@ name = "flatbuffers"
 version = "23.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustc_version",
+]
+
+[[package]]
+name = "flatbuffers"
+version = "24.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8add37afff2d4ffa83bc748a70b4b1370984f6980768554182424ef71447c35f"
 dependencies = [
  "bitflags 1.3.2",
  "rustc_version",
@@ -1629,7 +1750,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "asynchronous-codec 0.7.0",
- "axum",
+ "axum 0.7.5",
  "bincode",
  "blake3",
  "bs58",
@@ -1647,7 +1768,7 @@ dependencies = [
  "delegate",
  "directories",
  "either",
- "flatbuffers",
+ "flatbuffers 24.3.25",
  "freenet-stdlib",
  "futures",
  "headers",
@@ -1658,6 +1779,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry-jaeger",
+ "opentelemetry-otlp",
  "ordered-float 4.2.0",
  "parking_lot",
  "pav_regression",
@@ -1707,7 +1829,7 @@ dependencies = [
  "bs58",
  "byteorder",
  "chrono",
- "flatbuffers",
+ "flatbuffers 23.5.26",
  "freenet-macros",
  "futures",
  "js-sys",
@@ -1981,6 +2103,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,6 +2129,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.8",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -2181,7 +2328,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2204,6 +2351,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.4",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
@@ -2212,19 +2360,35 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper 0.14.28",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper 0.14.28",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2234,6 +2398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
@@ -2241,6 +2406,9 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.6",
  "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2426,7 +2594,7 @@ dependencies = [
  "socket2 0.5.6",
  "widestring",
  "windows-sys 0.48.0",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -2964,9 +3132,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.11.0+8.1.1"
+version = "0.16.0+8.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -3609,13 +3777,12 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.2.6",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -3625,9 +3792,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f51189ce8be654f9b5f7e70e49967ed894e84a06fc35c6c042e64ac1fc5399e"
+checksum = "7690dc77bf776713848c4faa6501157469017eaf332baccd4eb1cea928743d94"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3637,9 +3804,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-jaeger"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e617c66fd588e40e0dbbd66932fdc87393095b125d4459b1a3a10feb1712f8a1"
+checksum = "fb7f5ef13427696ae8382c6f3bb7dcdadb5994223d6b983c7c50a46df7d19277"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -3655,19 +3822,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.13.0"
+name = "opentelemetry-otlp"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
+checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
 dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.12",
  "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
 ]
 
 [[package]]
-name = "opentelemetry_sdk"
-version = "0.21.2"
+name = "opentelemetry-proto"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
+checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -3720,12 +3915,12 @@ dependencies = [
 
 [[package]]
 name = "ordered-multimap"
-version = "0.4.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+checksum = "4ed8acf08e98e744e5384c8bc63ceb0364e68a6854187221c18df61c4797690e"
 dependencies = [
  "dlv-list",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -3784,12 +3979,6 @@ dependencies = [
  "ordered-float 3.9.2",
  "serde",
 ]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
@@ -3998,16 +4187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
-dependencies = [
- "proc-macro2",
- "syn 2.0.58",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4069,6 +4248,29 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f5d036824e4761737860779c906171497f6d55681139d8312388f8fe398922"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
+dependencies = [
+ "anyhow",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.58",
@@ -4362,20 +4564,22 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -4384,7 +4588,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4397,7 +4601,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -4472,9 +4676,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -4482,13 +4686,14 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
+ "base64 0.21.7",
+ "bitflags 2.5.0",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4529,9 +4734,9 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
@@ -4600,6 +4805,22 @@ checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.0",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
@@ -5075,7 +5296,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "sha2",
@@ -5491,6 +5712,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5522,6 +5752,16 @@ dependencies = [
  "socket2 0.5.6",
  "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -5596,15 +5836,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
@@ -5639,6 +5870,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.6.20",
+ "base64 0.21.7",
+ "bytes",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5646,9 +5904,13 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5747,9 +6009,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596"
+checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -5760,7 +6022,7 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
- "web-time 0.2.4",
+ "web-time",
 ]
 
 [[package]]
@@ -5918,7 +6180,7 @@ dependencies = [
  "getrandom",
  "rand",
  "serde",
- "web-time 1.1.0",
+ "web-time",
 ]
 
 [[package]]
@@ -6366,16 +6628,6 @@ dependencies = [
 
 [[package]]
 name = "web-time"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
@@ -6682,6 +6934,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,19 +10,19 @@ bs58 = "0.5"
 chacha20poly1305 = "0.10"
 chrono = { version = "0.4", default-features = true }
 clap = "4"
-crossbeam = "0.8.2"
+crossbeam = "0.8"
 ctrlc = { version = "3.4" }
 dashmap = "^5.5"
-either = "1.8"
+either = "1.11"
 futures = "0.3"
 rand = { version = "0.8" }
-semver = { version = "1.0.14",  features = ["serde"] }
+semver = { version = "1",  features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = "3"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-wasmer = "4.2.0"
+wasmer = "4.2"
 
 freenet-stdlib = { path = "./stdlib/rust/", features = ["unstable"]   }
 # freenet-stdlib = { version = "0.0.8" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/bin/freenet.rs"
 
 [dependencies]
 anyhow = "1"
-arc-swap = "1.6"
+arc-swap = "1.7"
 asynchronous-codec = "0.7"
 aes-gcm = "0.10.3"
 async-trait = "0.1"
@@ -24,11 +24,11 @@ blake3 = { workspace = true }
 bs58 = "0.5"
 byteorder = "1"
 bytes = "1"
-cache-padded = "1.1.1"
+cache-padded = "1.3"
 chacha20poly1305 = { workspace = true }
 chrono = { workspace = true }
 clap = { features = ["derive", "env"], workspace = true }
-config = { features = ["toml"], version = "0.13.0" }
+config = { features = ["toml"], version = "0.14" }
 cookie = "0.18"
 crossbeam = { workspace = true }
 ctrlc = { features = ["termination"], workspace = true }
@@ -36,26 +36,26 @@ dashmap = { workspace = true }
 delegate = "0.12"
 directories = "5"
 either = { features = ["serde"], workspace = true }
-flatbuffers = "23.5.26"
-futures = "0.3.21"
+flatbuffers = "24.3"
+futures = "0.3"
 headers = "0.4"
-itertools = "0.12.1"
+itertools = "0.12"
 libp2p = { default-features = false, features = ["autonat", "dns", "ed25519", "identify", "macros", "noise", "ping", "tcp", "tokio", "yamux"], version = "0.52.3" }
 libp2p-identity = { features = ["ed25519", "rand"], version = "0.2.7" }
 notify = "6"
 once_cell = "1"
-ordered-float = "4.1.1"
+ordered-float = "4.2"
 pav_regression = "0.4.0"
-parking_lot = "0.12.0"
+parking_lot = "0.12"
 rand = { features = ["small_rng"], workspace = true }
-rocksdb = { default-features = false, optional = true, version = "0.21.0" }
+rocksdb = { default-features = false, optional = true, version = "0.22" }
 serde = { features = ["derive", "rc"], workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 sqlx = { features = ["runtime-tokio-rustls", "sqlite"], optional = true, version = "0.7" }
 stretto = { features = ["async", "sync"], version = "0.8" }
-tar = { version = "0.4.38" }
-time = "0.3.30"
+tar = { version = "0.4" }
+time = "0.3"
 thiserror = "1"
 tokio = { features = ["fs", "macros", "rt-multi-thread", "sync", "process"], version = "1" }
 tokio-tungstenite = "0.21"
@@ -64,15 +64,16 @@ ulid = { features = ["serde"], version = "1.1" }
 unsigned-varint = { version = "0.8", features = ["codec", "asynchronous_codec"] }
 wasmer = { features = ["sys"], workspace = true }
 xz2 = { version = "0.1" }
-reqwest = { version = "0.11.23", features = ["json"] }
+reqwest = { version = "0.12", features = ["json"] }
 rsa = { version = "0.9.6", features = ["serde"] }
 
 # Tracing deps
-opentelemetry = "0.21.0"
-opentelemetry-jaeger = { features = ["collector_client", "isahc", "rt-tokio"], optional = true, version = "0.20.0" }
+opentelemetry = "0.22"
+opentelemetry-jaeger = { features = ["collector_client", "isahc", "rt-tokio"], optional = true, version = "0.21" }
 tracing = { version = "0.1" }
-tracing-opentelemetry = { optional = true, version = "0.22.0" }
+tracing-opentelemetry = { optional = true, version = "0.23.0" }
 tracing-subscriber = { optional = true, version = "0.3.16" }
+opentelemetry-otlp = { optional = true, version = "0.15" }
 
 # internal deps
 freenet-stdlib = { features = ["net"], workspace = true }
@@ -95,5 +96,5 @@ network-mode = []
 rocks_db = ["rocksdb"]
 sqlite = ["sqlx"]
 trace = ["tracing-subscriber"]
-trace-ot = ["opentelemetry-jaeger", "trace", "tracing-opentelemetry"]
+trace-ot = ["opentelemetry-jaeger", "trace", "tracing-opentelemetry", "opentelemetry-otlp"]
 websocket = ["axum/ws"]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryFrom,
     fs::{self, File},
     future::Future,
     io::Read,

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -418,6 +418,7 @@ pub(crate) trait ContractExecutor: Send + 'static {
         key: ContractKey,
         fetch_contract: bool,
     ) -> Result<(WrappedState, Option<ContractContainer>), ExecutorError>;
+
     async fn store_contract(&mut self, contract: ContractContainer) -> Result<(), ExecutorError>;
 
     async fn upsert_contract_state(

--- a/crates/core/src/contract/executor/mock_runtime.rs
+++ b/crates/core/src/contract/executor/mock_runtime.rs
@@ -119,7 +119,6 @@ impl ContractExecutor for Executor<MockRuntime> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::wasm_runtime::{ContractStore, StateStore};
 
     #[tokio::test(flavor = "multi_thread")]
     async fn local_node_handle() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/core/src/contract/storages/rocks_db.rs
+++ b/crates/core/src/contract/storages/rocks_db.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use freenet_stdlib::prelude::*;
 use rocksdb::{Options, DB};
 
-use crate::contract::ContractKey;
 use crate::wasm_runtime::StateStorage;
 
 pub struct RocksDb(DB);

--- a/crates/core/src/contract/storages/sqlite.rs
+++ b/crates/core/src/contract/storages/sqlite.rs
@@ -6,10 +6,7 @@ use sqlx::{
     ConnectOptions, Row, SqlitePool,
 };
 
-use crate::{
-    contract::ContractKey,
-    wasm_runtime::{ContractError, StateStorage, StateStoreError},
-};
+use crate::wasm_runtime::{ContractError, StateStorage, StateStoreError};
 
 async fn create_contracts_table(pool: &SqlitePool) -> Result<(), SqlDbError> {
     sqlx::query(

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -155,8 +155,6 @@ where
 }
 
 mod sealed_msg_type {
-    use crate::operations::update::UpdateMsg;
-
     use super::*;
 
     pub(crate) trait SealedTxType {

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -170,7 +170,6 @@ mod test {
     use super::*;
     use crate::{
         client_events::test::MemoryEventsGen,
-        config::GlobalExecutor,
         contract::MemoryContractHandler,
         node::{testing_impl::get_free_port, InitPeerNode},
         ring::Location,

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -1066,9 +1066,7 @@ mod messages {
     use std::fmt::Display;
 
     use super::*;
-    use crate::ring::{Location, PeerKeyLocation};
 
-    use crate::message::InnerMessage;
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Serialize, Deserialize)]

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -835,8 +835,6 @@ mod messages {
 
     use serde::{Deserialize, Serialize};
 
-    use crate::{contract::StoreResponse, message::InnerMessage};
-
     use super::*;
 
     #[derive(Debug, Serialize, Deserialize)]

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -860,7 +860,6 @@ mod messages {
 
     use super::*;
 
-    use crate::message::InnerMessage;
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Serialize, Deserialize)]

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -424,7 +424,6 @@ fn build_op_result(
 }
 
 mod messages {
-    use crate::message::InnerMessage;
     use std::fmt::Display;
 
     use super::*;

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -8,7 +8,6 @@ use std::hash::Hash;
 use std::{
     cmp::Reverse,
     collections::BTreeMap,
-    convert::TryFrom,
     fmt::Display,
     hash::Hasher,
     ops::Add,

--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -521,10 +521,6 @@ pub(crate) enum ConnectionAcquisitionStrategy {
 
 #[cfg(test)]
 mod tests {
-    use super::{Limits, TopologyManager};
-    use crate::topology::rate::Rate;
-    use crate::{message::TransactionType, ring::Location};
-
     #[test]
     fn test_topology() {
         const NUM_REQUESTS: usize = 1_000;
@@ -608,7 +604,7 @@ mod tests {
     use super::*;
     use crate::ring::Distance;
     use crate::test_utils::with_tracing;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     #[test]
     fn test_resource_manager_report() {

--- a/crates/core/src/topology/running_average.rs
+++ b/crates/core/src/topology/running_average.rs
@@ -49,8 +49,6 @@ impl RunningAverage {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, Instant};
-
     use super::*;
 
     #[test]

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -1229,16 +1229,11 @@ pub(crate) mod tracer {
 }
 
 pub(super) mod test {
+    use dashmap::DashMap;
     use std::{
         collections::HashMap,
-        sync::{
-            atomic::{AtomicUsize, Ordering::SeqCst},
-            Arc,
-        },
+        sync::atomic::{AtomicUsize, Ordering::SeqCst},
     };
-
-    use dashmap::DashMap;
-    use tokio_tungstenite::WebSocketStream;
 
     use super::*;
     use crate::{node::testing_impl::NodeLabel, ring::Distance};

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -4,7 +4,6 @@ use std::pin::Pin;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 use std::time::Duration;
-use std::vec::Vec;
 
 use crate::transport::crypto::TransportSecretKey;
 use crate::transport::packet_data::{AssymetricRSA, UnknownEncryption};
@@ -413,7 +412,7 @@ impl<S: Socket> UdpPacketsListener<S> {
         &mut self,
         remote_addr: SocketAddr,
         remote_public_key: TransportPublicKey,
-        remote_is_gateway: bool,
+        _remote_is_gateway: bool,
     ) -> (
         impl Future<Output = Result<(RemoteConnection, InboundRemoteConnection), TransportError>>
             + Send
@@ -741,7 +740,6 @@ impl InboundRemoteConnection {
 mod test {
     use std::{
         collections::HashMap,
-        net::Ipv4Addr,
         ops::Range,
         sync::{
             atomic::{AtomicU16, AtomicU64, AtomicUsize, Ordering},

--- a/crates/core/src/transport/packet_data.rs
+++ b/crates/core/src/transport/packet_data.rs
@@ -259,7 +259,7 @@ impl<DT: Encryption, const N: usize> PartialEq for PacketData<DT, N> {
 mod tests {
     use super::*;
     use aes_gcm::aead::rand_core::RngCore;
-    use aes_gcm::{Aes128Gcm, KeyInit};
+    use aes_gcm::KeyInit;
     use rand::rngs::OsRng;
 
     #[test]

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -4,7 +4,6 @@ use std::pin::Pin;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 use std::time::Duration;
-use std::vec::Vec;
 
 use crate::transport::packet_data::UnknownEncryption;
 use aes_gcm::Aes128Gcm;
@@ -390,8 +389,7 @@ async fn packet_sending(
 mod tests {
     use aes_gcm::KeyInit;
     use futures::TryFutureExt;
-    use std::net::{Ipv4Addr, SocketAddr};
-    use tokio::sync::mpsc;
+    use std::net::Ipv4Addr;
 
     use super::{
         inbound_stream::{recv_stream, InboundStream},

--- a/crates/core/src/transport/peer_connection/outbound_stream.rs
+++ b/crates/core/src/transport/peer_connection/outbound_stream.rs
@@ -90,9 +90,8 @@ pub(super) async fn send_stream(
 #[cfg(test)]
 mod tests {
     use aes_gcm::KeyInit;
-    use std::net::{Ipv4Addr, SocketAddr};
+    use std::net::Ipv4Addr;
     use tests::packet_data::MAX_PACKET_SIZE;
-    use tokio::sync::mpsc;
 
     use super::{
         symmetric_message::{SymmetricMessage, SymmetricMessagePayload},

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -159,7 +159,6 @@ impl<T> IterExt for T where T: Iterator {}
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
-    use rand::Rng;
 
     #[test]
     fn randomize_iter() {

--- a/crates/core/src/util/time_source.rs
+++ b/crates/core/src/util/time_source.rs
@@ -127,7 +127,6 @@ impl TimeSource for MockTimeSource {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use std::time::Duration;
 
     #[test]
     fn test_instant_is_updated() {

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -20,8 +20,6 @@ fn compute_ptr<T>(ptr: i64, start_ptr: i64) -> *mut T {
 }
 
 pub(crate) mod log {
-    use wasmer::Function;
-
     use super::*;
 
     pub(crate) fn prepare_export(store: &mut wasmer::Store, imports: &mut Imports) {

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -245,7 +245,7 @@ impl SecretsStore {
 #[cfg(test)]
 mod test {
     use super::*;
-    use chacha20poly1305::aead::{AeadCore, KeyInit, OsRng};
+    use chacha20poly1305::aead::{AeadCore, OsRng};
 
     #[test]
     fn store_and_load() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/core/src/wasm_runtime/store.rs
+++ b/crates/core/src/wasm_runtime/store.rs
@@ -63,8 +63,7 @@ impl<S: StoreFsManagement> SafeWriter<S> {
             }
         }
         traversed += 1 + 32; // key + type marker
-        self.file
-            .write_u32::<BigEndian>(value.as_ref().len() as u32)?;
+        self.file.write_u32::<BigEndian>(value.len() as u32)?;
         traversed += std::mem::size_of::<u32>();
         self.file.write_all(value)?;
         traversed += value.len();

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -34,8 +34,8 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 xz2 = "0.1"
 libp2p-identity = { features = ["ed25519", "rand"], version = "0.2.7" }
-reqwest = { version = "0.11.23", features = ["json"] }
-http = "1.0.0"
+reqwest = { version = "0.12", features = ["json"] }
+http = "1.1"
 
 # internal
 freenet = { path = "../core" }


### PR DESCRIPTION
Bump up the dependencies version. There is a deprecated API at `tracing.rs` line 1199, but the doc about how to update it is not clear, the new `opentelemetry-otlp` crate are missing some methods, so I just keep it.