### PR TITLE
Remove `async-trait` and most of `BoxedFuture`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,7 +1693,6 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "arc-swap",
- "async-trait",
  "asynchronous-codec 0.7.0",
  "axum 0.7.5",
  "bincode",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -17,7 +17,6 @@ anyhow = "1"
 arc-swap = "1.7"
 asynchronous-codec = "0.7"
 aes-gcm = "0.10.3"
-async-trait = "0.1"
 axum = { default-features = false, features = ["http1", "matched-path", "query", "tower-log", "ws", "json"], workspace = true }
 bincode = "1.3.3"
 blake3 = { workspace = true }

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -139,6 +139,10 @@ impl<'a> OpenRequest<'a> {
     }
 }
 
+// TODO(al8n): we may cannot remove BoxFuture here, but it requires more changes,
+// as async fn in trait will make this trait not Object Safe, so in other places
+// we cannot use BoxedClient. We may need to reference the AsyncRead/AsyncWrite trait
+// to make the trait object safe.
 pub trait ClientEventsProxy {
     /// # Cancellation Safety
     /// This future must be safe to cancel.

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -139,10 +139,6 @@ impl<'a> OpenRequest<'a> {
     }
 }
 
-// TODO(al8n): we may cannot remove BoxFuture here, but it requires more changes,
-// as async fn in trait will make this trait not Object Safe, so in other places
-// we cannot use BoxedClient. We may need to reference the AsyncRead/AsyncWrite trait
-// to make the trait object safe.
 pub trait ClientEventsProxy {
     /// # Cancellation Safety
     /// This future must be safe to cancel.

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -314,7 +315,6 @@ mod sealed {
     impl ChannelHalve for Callback {}
 }
 
-#[async_trait::async_trait]
 trait ComposeNetworkMessage<Op>
 where
     Self: Sized,
@@ -322,7 +322,10 @@ where
 {
     fn initiate_op(self, op_manager: &OpManager) -> Op;
 
-    async fn resume_op(op: Op, op_manager: &OpManager) -> Result<(), OpError>;
+    fn resume_op(
+        op: Op,
+        op_manager: &OpManager,
+    ) -> impl Future<Output = Result<(), OpError>> + Send;
 }
 
 #[allow(unused)]
@@ -331,7 +334,6 @@ struct GetContract {
     fetch_contract: bool,
 }
 
-#[async_trait::async_trait]
 impl ComposeNetworkMessage<operations::get::GetOp> for GetContract {
     fn initiate_op(self, _op_manager: &OpManager) -> operations::get::GetOp {
         operations::get::start_op(self.key, self.fetch_contract)
@@ -347,7 +349,6 @@ struct SubscribeContract {
     key: ContractKey,
 }
 
-#[async_trait::async_trait]
 impl ComposeNetworkMessage<operations::subscribe::SubscribeOp> for SubscribeContract {
     fn initiate_op(self, _op_manager: &OpManager) -> operations::subscribe::SubscribeOp {
         operations::subscribe::start_op(self.key)
@@ -368,7 +369,6 @@ struct PutContract {
     related_contracts: RelatedContracts<'static>,
 }
 
-#[async_trait::async_trait]
 impl ComposeNetworkMessage<operations::put::PutOp> for PutContract {
     fn initiate_op(self, op_manager: &OpManager) -> operations::put::PutOp {
         let PutContract {
@@ -395,7 +395,6 @@ struct UpdateContract {
     new_state: WrappedState,
 }
 
-#[async_trait::async_trait]
 impl ComposeNetworkMessage<operations::update::UpdateOp> for UpdateContract {
     fn initiate_op(self, _op_manager: &OpManager) -> operations::update::UpdateOp {
         let UpdateContract { key, new_state } = self;
@@ -411,23 +410,25 @@ impl ComposeNetworkMessage<operations::update::UpdateOp> for UpdateContract {
     }
 }
 
-#[async_trait::async_trait]
 pub(crate) trait ContractExecutor: Send + 'static {
-    async fn fetch_contract(
+    fn fetch_contract(
         &mut self,
         key: ContractKey,
         fetch_contract: bool,
-    ) -> Result<(WrappedState, Option<ContractContainer>), ExecutorError>;
+    ) -> impl Future<Output = Result<(WrappedState, Option<ContractContainer>), ExecutorError>> + Send;
 
-    async fn store_contract(&mut self, contract: ContractContainer) -> Result<(), ExecutorError>;
+    fn store_contract(
+        &mut self,
+        contract: ContractContainer,
+    ) -> impl Future<Output = Result<(), ExecutorError>> + Send;
 
-    async fn upsert_contract_state(
+    fn upsert_contract_state(
         &mut self,
         key: ContractKey,
         update: Either<WrappedState, StateDelta<'static>>,
         related_contracts: RelatedContracts<'static>,
         code: Option<ContractContainer>,
-    ) -> Result<WrappedState, ExecutorError>;
+    ) -> impl Future<Output = Result<WrappedState, ExecutorError>> + Send;
 }
 
 /// A WASM executor which will run any contracts, delegates, etc. registered.

--- a/crates/core/src/contract/executor/mock_runtime.rs
+++ b/crates/core/src/contract/executor/mock_runtime.rs
@@ -40,7 +40,6 @@ impl Executor<MockRuntime> {
     }
 }
 
-#[async_trait::async_trait]
 impl ContractExecutor for Executor<MockRuntime> {
     async fn fetch_contract(
         &mut self,
@@ -99,7 +98,7 @@ impl ContractExecutor for Executor<MockRuntime> {
                     .store(key, incoming_state.clone(), contract.params().into_owned())
                     .await
                     .map_err(ExecutorError::other)?;
-                return Ok(incoming_state);
+                Ok(incoming_state)
             }
             (Either::Left(incoming_state), None) => {
                 // update case
@@ -108,7 +107,7 @@ impl ContractExecutor for Executor<MockRuntime> {
                     .update(&key, incoming_state.clone())
                     .await
                     .map_err(ExecutorError::other)?;
-                return Ok(incoming_state);
+                Ok(incoming_state)
             }
             (update, contract) => unreachable!("{update:?}, {contract:?}"),
         }

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-#[async_trait::async_trait]
 impl ContractExecutor for Executor<Runtime> {
     async fn fetch_contract(
         &mut self,

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -59,7 +59,7 @@ pub(crate) trait ContractHandler {
         contract_handler_channel: ContractHandlerChannel<ContractHandlerHalve>,
         executor_request_sender: ExecutorToEventLoopChannel<ExecutorHalve>,
         builder: Self::Builder,
-    ) -> impl Future<Output = Result<Self, DynError>>
+    ) -> impl Future<Output = Result<Self, DynError>> + Send
     where
         Self: Sized + 'static;
 
@@ -72,7 +72,7 @@ pub(crate) trait ContractHandler {
         req: ClientRequest<'a>,
         client_id: ClientId,
         updates: Option<UnboundedSender<Result<HostResponse, ClientError>>>,
-    ) -> impl Future<Output = Result<HostResponse, DynError>> + 'a;
+    ) -> impl Future<Output = Result<HostResponse, DynError>> + Send + 'a;
 
     fn executor(&mut self) -> &mut Self::ContractExecutor;
 }

--- a/crates/core/src/node/network_bridge.rs
+++ b/crates/core/src/node/network_bridge.rs
@@ -1,5 +1,6 @@
 //! Types and definitions to handle all inter-peer communication.
 
+use std::future::Future;
 use std::ops::{Deref, DerefMut};
 
 use either::Either;
@@ -22,13 +23,13 @@ pub(crate) type ConnResult<T> = std::result::Result<T, ConnectionError>;
 
 /// Allows handling of connections to the network as well as sending messages
 /// to other peers in the network with whom connection has been established.
-#[async_trait::async_trait]
 pub(crate) trait NetworkBridge: Send + Sync {
-    async fn add_connection(&mut self, peer: PeerId) -> ConnResult<()>;
+    fn add_connection(&mut self, peer: PeerId) -> impl Future<Output = ConnResult<()>> + Send;
 
-    async fn drop_connection(&mut self, peer: &PeerId) -> ConnResult<()>;
+    fn drop_connection(&mut self, peer: &PeerId) -> impl Future<Output = ConnResult<()>> + Send;
 
-    async fn send(&self, target: &PeerId, msg: NetMessage) -> ConnResult<()>;
+    fn send(&self, target: &PeerId, msg: NetMessage)
+        -> impl Future<Output = ConnResult<()>> + Send;
 }
 
 #[derive(Debug, thiserror::Error, Serialize, Deserialize)]

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -146,7 +146,6 @@ impl P2pBridge {
     }
 }
 
-#[async_trait::async_trait]
 impl NetworkBridge for P2pBridge {
     async fn add_connection(&mut self, peer: FreenetPeerId) -> super::ConnResult<()> {
         if self.active_net_connections.contains_key(&peer) {

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -9,7 +9,7 @@ use std::{
 
 use either::Either;
 use freenet_stdlib::prelude::*;
-use futures::{future::BoxFuture, Future};
+use futures::Future;
 use itertools::Itertools;
 use libp2p::{identity, PeerId as Libp2pPeerId};
 use rand::{seq::SliceRandom, Rng};
@@ -965,7 +965,7 @@ use super::op_state_manager::OpManager;
 use crate::client_events::ClientEventsProxy;
 
 pub(super) trait NetworkBridgeExt: Clone + 'static {
-    fn recv(&mut self) -> BoxFuture<Result<NetMessage, ConnectionError>>;
+    fn recv(&mut self) -> impl Future<Output = Result<NetMessage, ConnectionError>> + Send;
 }
 
 struct RunnerConfig<NB, UsrEv>

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -3,7 +3,7 @@ use std::backtrace::Backtrace as StdTrace;
 use std::{pin::Pin, time::Duration};
 
 use freenet_stdlib::prelude::ContractKey;
-use futures::{future::BoxFuture, Future};
+use futures::Future;
 use tokio::sync::mpsc::error::SendError;
 
 use crate::{
@@ -31,7 +31,7 @@ where
     fn load_or_init<'a>(
         op_manager: &'a OpManager,
         msg: &'a Self::Message,
-    ) -> BoxFuture<'a, Result<OpInitialization<Self>, OpError>>;
+    ) -> impl Future<Output = Result<OpInitialization<Self>, OpError>> + 'a;
 
     fn id(&self) -> &Transaction;
 

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -3,8 +3,6 @@ use std::{future::Future, time::Instant};
 
 use freenet_stdlib::client_api::{ErrorKind, HostResponse};
 use freenet_stdlib::prelude::*;
-use futures::future::BoxFuture;
-use futures::FutureExt;
 
 use crate::client_events::HostResult;
 use crate::{
@@ -265,41 +263,38 @@ impl Operation for GetOp {
     type Message = GetMsg;
     type Result = GetResult;
 
-    fn load_or_init<'a>(
+    async fn load_or_init<'a>(
         op_manager: &'a OpManager,
         msg: &'a Self::Message,
-    ) -> BoxFuture<'a, Result<OpInitialization<Self>, OpError>> {
-        async move {
-            let mut sender: Option<PeerId> = None;
-            if let Some(peer_key_loc) = msg.sender().cloned() {
-                sender = Some(peer_key_loc.peer);
-            };
-            let tx = *msg.id();
-            match op_manager.pop(msg.id()) {
-                Ok(Some(OpEnum::Get(get_op))) => {
-                    Ok(OpInitialization { op: get_op, sender })
-                    // was an existing operation, other peer messaged back
-                }
-                Ok(Some(op)) => {
-                    let _ = op_manager.push(tx, op).await;
-                    Err(OpError::OpNotPresent(tx))
-                }
-                Ok(None) => {
-                    // new request to get a value for a contract, initialize the machine
-                    Ok(OpInitialization {
-                        op: Self {
-                            state: Some(GetState::ReceivedRequest),
-                            id: tx,
-                            result: None,
-                            stats: None, // don't care about stats in target peers
-                        },
-                        sender,
-                    })
-                }
-                Err(err) => Err(err.into()),
+    ) -> Result<OpInitialization<Self>, OpError> {
+        let mut sender: Option<PeerId> = None;
+        if let Some(peer_key_loc) = msg.sender().cloned() {
+            sender = Some(peer_key_loc.peer);
+        };
+        let tx = *msg.id();
+        match op_manager.pop(msg.id()) {
+            Ok(Some(OpEnum::Get(get_op))) => {
+                Ok(OpInitialization { op: get_op, sender })
+                // was an existing operation, other peer messaged back
             }
+            Ok(Some(op)) => {
+                let _ = op_manager.push(tx, op).await;
+                Err(OpError::OpNotPresent(tx))
+            }
+            Ok(None) => {
+                // new request to get a value for a contract, initialize the machine
+                Ok(OpInitialization {
+                    op: Self {
+                        state: Some(GetState::ReceivedRequest),
+                        id: tx,
+                        result: None,
+                        stats: None, // don't care about stats in target peers
+                    },
+                    sender,
+                })
+            }
+            Err(err) => Err(err.into()),
         }
-        .boxed()
     }
 
     fn id(&self) -> &Transaction {

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -5,7 +5,6 @@ use freenet_stdlib::{
     client_api::{ErrorKind, HostResponse},
     prelude::*,
 };
-use futures::{future::BoxFuture, FutureExt};
 use serde::{Deserialize, Serialize};
 
 use super::{OpEnum, OpError, OpInitialization, OpOutcome, Operation, OperationResult};
@@ -140,43 +139,40 @@ impl Operation for SubscribeOp {
     type Message = SubscribeMsg;
     type Result = SubscribeResult;
 
-    fn load_or_init<'a>(
+    async fn load_or_init<'a>(
         op_manager: &'a OpManager,
         msg: &'a Self::Message,
-    ) -> BoxFuture<'a, Result<OpInitialization<Self>, OpError>> {
-        async move {
-            let mut sender: Option<PeerId> = None;
-            if let Some(peer_key_loc) = msg.sender().cloned() {
-                sender = Some(peer_key_loc.peer);
-            };
-            let id = *msg.id();
+    ) -> Result<OpInitialization<Self>, OpError> {
+        let mut sender: Option<PeerId> = None;
+        if let Some(peer_key_loc) = msg.sender().cloned() {
+            sender = Some(peer_key_loc.peer);
+        };
+        let id = *msg.id();
 
-            match op_manager.pop(msg.id()) {
-                Ok(Some(OpEnum::Subscribe(subscribe_op))) => {
-                    // was an existing operation, the other peer messaged back
-                    Ok(OpInitialization {
-                        op: subscribe_op,
-                        sender,
-                    })
-                }
-                Ok(Some(op)) => {
-                    let _ = op_manager.push(id, op).await;
-                    Err(OpError::OpNotPresent(id))
-                }
-                Ok(None) => {
-                    // new request to subcribe to a contract, initialize the machine
-                    Ok(OpInitialization {
-                        op: Self {
-                            state: Some(SubscribeState::ReceivedRequest),
-                            id,
-                        },
-                        sender,
-                    })
-                }
-                Err(err) => Err(err.into()),
+        match op_manager.pop(msg.id()) {
+            Ok(Some(OpEnum::Subscribe(subscribe_op))) => {
+                // was an existing operation, the other peer messaged back
+                Ok(OpInitialization {
+                    op: subscribe_op,
+                    sender,
+                })
             }
+            Ok(Some(op)) => {
+                let _ = op_manager.push(id, op).await;
+                Err(OpError::OpNotPresent(id))
+            }
+            Ok(None) => {
+                // new request to subcribe to a contract, initialize the machine
+                Ok(OpInitialization {
+                    op: Self {
+                        state: Some(SubscribeState::ReceivedRequest),
+                        id,
+                    },
+                    sender,
+                })
+            }
+            Err(err) => Err(err.into()),
         }
-        .boxed()
     }
 
     fn id(&self) -> &Transaction {


### PR DESCRIPTION
I remove the `async-trait` and most of `BoxedFuture`, but there is one trait `ClientEventsProxy`, I cannot change it to async fn in trait style because of currently, AFIT is not object safe, and we use Box<dyn ClientEventsProxy> in other places. In theory, we can use a definition like `AsyncWrite`/`AsyncRead` to make this trait object safe, but it requires some breaking changes.