### PR TITLE
Fix broken build

### DIFF
--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -930,7 +930,6 @@ enum PutEvent {
 
 #[cfg(feature = "trace")]
 pub(crate) mod tracer {
-    use opentelemetry_otlp::WithExportConfig;
     use tracing::level_filters::LevelFilter;
     use tracing_subscriber::{Layer, Registry};
 


### PR DESCRIPTION
This line was introduced in #1138. WithExportConfig is not used anywhere.