### PR TITLE
Pass location through simple hash function

### DIFF
--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -32,10 +32,12 @@ impl Location {
                 Location(hashed as f64 / u64::MAX as f64)
             }
             std::net::IpAddr::V6(ipv6) => {
+                // Take first 8 bytes (4 segments) of IPv6 address
                 let segments = ipv6.segments();
-                let combined_segments = (u64::from(segments[0]) << 32)
-                    | (u64::from(segments[1]) << 16)
-                    | u64::from(segments[2]);
+                let combined_segments = (u64::from(segments[0]) << 48)
+                    | (u64::from(segments[1]) << 32)
+                    | (u64::from(segments[2]) << 16)
+                    | u64::from(segments[3]);
                 let hashed = distribute_hash(combined_segments);
                 Location(hashed as f64 / u64::MAX as f64)
             }

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -360,9 +360,9 @@ mod test {
 
         let locations: Vec<Location> = addresses.iter().map(Location::deterministic_loc).collect();
         let expected_locations = vec![
-            Location(0.3539831101283351),
-            Location(0.6201264112803492),
-            Location(0.1243401485619054),
+            Location(0.4539831101283351),
+            Location(0.7201264112803492),
+            Location(0.2243401485619054),
         ];
         assert_eq!(locations, expected_locations);
     }

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -237,14 +237,14 @@ impl Display for Distance {
 /// - Uses a series of bit-mixing operations (multiplication by large primes and XOR shifts).
 /// - Inspired by techniques from MurmurHash and SplitMix64, optimized for speed and distribution.
 fn distribute_hash(x: u64) -> u64 {
-    let mut h = x; // Already u64
-    h = h.wrapping_mul(0x9e3779b97f4a7c15); // Prime multiplier
-    h ^= h >> 33; // XOR and shift
-    h = h.wrapping_mul(0xc2b2ae3d27d4eb4f); // Second prime
-    h ^= h >> 29; // XOR again
-    h = h.wrapping_mul(0x85ebca6b2b2d3d1d); // Final prime
-    h ^= h >> 32; // Final XOR
-    h // Return the u64 directly
+    let mut h = x;
+    h = h.wrapping_mul(0x517cc1b727220a95);
+    h ^= h >> 32;
+    h = h.wrapping_mul(0x4cf5ad432745937f);
+    h ^= h >> 28;
+    h = h.wrapping_mul(0x2f38a814cad5c4ed);
+    h ^= h >> 31;
+    h
 }
 
 #[cfg(test)]

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -318,9 +318,9 @@ mod test {
 
         let locations: Vec<Location> = addresses.iter().map(Location::deterministic_loc).collect();
         let expected_locations = vec![
-            Location(0.9695508112571837),
-            Location(0.6870191464639596),
-            Location(0.31787443724464287),
+            Location(0.7110288569038304),
+            Location(0.6202899973091933),
+            Location(0.2587135150434003),
         ];
         assert_eq!(locations, expected_locations);
     }

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -34,10 +34,9 @@ impl Location {
             std::net::IpAddr::V6(ipv6) => {
                 // Take first 8 bytes (4 segments) of IPv6 address
                 let segments = ipv6.segments();
-                let combined_segments = (u64::from(segments[0]) << 48)
-                    | (u64::from(segments[1]) << 32)
-                    | (u64::from(segments[2]) << 16)
-                    | u64::from(segments[3]);
+                let combined_segments = (u64::from(segments[0]) << 32)
+                    | (u64::from(segments[1]) << 16)
+                    | u64::from(segments[2]);
                 let hashed = distribute_hash(combined_segments);
                 Location(hashed as f64 / u64::MAX as f64)
             }
@@ -361,9 +360,9 @@ mod test {
 
         let locations: Vec<Location> = addresses.iter().map(Location::deterministic_loc).collect();
         let expected_locations = vec![
-            Location(0.17218831909986057),
-            Location(0.6061667671923302),
-            Location(0.14432566176337014),
+            Location(0.7965489827349848),
+            Location(0.47795282110090903),
+            Location(0.07918706852076753),
         ];
         assert_eq!(locations, expected_locations);
     }

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -29,14 +29,16 @@ impl Location {
                 let combined_octets = (u32::from(octets[0]) << 16)
                     | (u32::from(octets[1]) << 8)
                     | u32::from(octets[2]);
-                Location(combined_octets as f64 / 16777215.0) // 2^24 - 1
+                let hashed = simple_hash(combined_octets);
+                Location(hashed as f64 / u32::MAX as f64)
             }
             std::net::IpAddr::V6(ipv6) => {
                 let segments = ipv6.segments();
                 let combined_segments = (u64::from(segments[0]) << 32)
                     | (u64::from(segments[1]) << 16)
                     | u64::from(segments[2]);
-                Location(combined_segments as f64 / 281474976710655.0) // 2^48 - 1
+                let hashed = simple_hash(combined_segments);
+                Location(hashed as f64 / u64::MAX as f64)
             }
         }
     }
@@ -221,6 +223,17 @@ impl Display for Distance {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
+}
+
+fn simple_hash<T: Into<u64>>(x: T) -> u64 {
+    let mut h = x.into(); // Convert input to u64 for consistency
+    h = h.wrapping_mul(0x9e3779b97f4a7c15);
+    h ^= h >> 33;
+    h = h.wrapping_mul(0xc2b2ae3d27d4eb4f);
+    h ^= h >> 29;
+    h = h.wrapping_mul(0x85ebca6b2b2d3d1d);
+    h ^= h >> 32;
+    h
 }
 
 #[cfg(test)]

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -320,9 +320,9 @@ mod test {
 
         let locations: Vec<Location> = addresses.iter().map(Location::deterministic_loc).collect();
         let expected_locations = vec![
-            Location(0.336521824390997),
-            Location(0.40492250948682484),
-            Location(0.07821476925699528),
+            Location(0.9695508112571837),
+            Location(0.6870191464639596),
+            Location(0.31787443724464287),
         ];
         assert_eq!(locations, expected_locations);
     }

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -25,11 +25,7 @@ impl Location {
     fn deterministic_loc(addr: &std::net::SocketAddr) -> Self {
         match addr.ip() {
             std::net::IpAddr::V4(ipv4) => {
-                let octets = ipv4.octets();
-                let value = u64::from(octets[0]) << 24 
-                    | u64::from(octets[1]) << 16 
-                    | u64::from(octets[2]) << 8
-                    | u64::from(octets[3]);
+                let value: u32 = ipv4.into();
                 let hashed = distribute_hash(value);
                 Location(hashed as f64 / u64::MAX as f64)
             }

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -26,7 +26,9 @@ impl Location {
         match addr.ip() {
             std::net::IpAddr::V4(ipv4) => {
                 let value: u32 = ipv4.into();
-                let hashed = distribute_hash(value as u64);
+                // Mask out the last byte
+                let masked_value = value & 0xFFFFFF00;
+                let hashed = distribute_hash(masked_value as u64);
                 Location(hashed as f64 / u64::MAX as f64)
             }
             std::net::IpAddr::V6(ipv6) => {

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -26,7 +26,7 @@ impl Location {
         match addr.ip() {
             std::net::IpAddr::V4(ipv4) => {
                 let value: u32 = ipv4.into();
-                let hashed = distribute_hash(value);
+                let hashed = distribute_hash(value as u64);
                 Location(hashed as f64 / u64::MAX as f64)
             }
             std::net::IpAddr::V6(ipv6) => {
@@ -236,8 +236,8 @@ impl Display for Distance {
 /// # Implementation
 /// - Uses a series of bit-mixing operations (multiplication by large primes and XOR shifts).
 /// - Inspired by techniques from MurmurHash and SplitMix64, optimized for speed and distribution.
-fn distribute_hash<T: Copy + Into<u64> + From<u64>>(x: T) -> T {
-    let mut h = x.into(); // Normalize input to u64
+fn distribute_hash(x: u64) -> u64 {
+    let mut h = x; // Already u64
     h = h.wrapping_mul(0x9e3779b97f4a7c15); // Prime multiplier
     h ^= h >> 33; // XOR and shift
     h = h.wrapping_mul(0xc2b2ae3d27d4eb4f); // Second prime

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -337,9 +337,9 @@ mod test {
 
         let locations: Vec<Location> = addresses.iter().map(Location::deterministic_loc).collect();
         let expected_locations = vec![
-            Location(0.0),
-            Location(0.0),
-            Location(0.0),
+            Location(0.17218831909986057),
+            Location(0.6061667671923302),
+            Location(0.14432566176337014),
         ];
         assert_eq!(locations, expected_locations);
     }

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -26,11 +26,11 @@ impl Location {
         match addr.ip() {
             std::net::IpAddr::V4(ipv4) => {
                 let octets = ipv4.octets();
-                // is necessary to convert this to u64 and shifft the bits anymore? can't we directly hash the different octets? AI!
-                let combined_octets = (u64::from(octets[0]) << 16)
-                    | (u64::from(octets[1]) << 8)
-                    | u64::from(octets[2]);
-                let hashed = distribute_hash(combined_octets);
+                let mut hash_value = distribute_hash(u64::from(octets[0]));
+                for &octet in &octets[1..3] {
+                    hash_value ^= distribute_hash(u64::from(octet));
+                }
+                let hashed = hash_value;
                 Location(hashed as f64 / u64::MAX as f64)
             }
             std::net::IpAddr::V6(ipv6) => {

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -26,11 +26,11 @@ impl Location {
         match addr.ip() {
             std::net::IpAddr::V4(ipv4) => {
                 let octets = ipv4.octets();
-                let mut hash_value = distribute_hash(u64::from(octets[0]));
-                for &octet in &octets[1..3] {
-                    hash_value ^= distribute_hash(u64::from(octet));
-                }
-                let hashed = hash_value;
+                let value = u64::from(octets[0]) << 24 
+                    | u64::from(octets[1]) << 16 
+                    | u64::from(octets[2]) << 8
+                    | u64::from(octets[3]);
+                let hashed = distribute_hash(value);
                 Location(hashed as f64 / u64::MAX as f64)
             }
             std::net::IpAddr::V6(ipv6) => {

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -26,6 +26,7 @@ impl Location {
         match addr.ip() {
             std::net::IpAddr::V4(ipv4) => {
                 let octets = ipv4.octets();
+                // is necessary to convert this to u64 and shifft the bits anymore? can't we directly hash the different octets? AI!
                 let combined_octets = (u64::from(octets[0]) << 16)
                     | (u64::from(octets[1]) << 8)
                     | u64::from(octets[2]);

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -26,9 +26,9 @@ impl Location {
         match addr.ip() {
             std::net::IpAddr::V4(ipv4) => {
                 let octets = ipv4.octets();
-                let combined_octets = (u32::from(octets[0]) << 16)
-                    | (u32::from(octets[1]) << 8)
-                    | u32::from(octets[2]);
+                let combined_octets = (u64::from(octets[0]) << 16)
+                    | (u64::from(octets[1]) << 8)
+                    | u64::from(octets[2]);
                 let hashed = distribute_hash(combined_octets);
                 Location(hashed as f64 / u64::MAX as f64)
             }
@@ -320,9 +320,9 @@ mod test {
 
         let locations: Vec<Location> = addresses.iter().map(Location::deterministic_loc).collect();
         let expected_locations = vec![
-            Location(0.9695508112571837),
-            Location(0.6870191464639596),
-            Location(0.31787443724464287),
+            Location(0.336521824390997),
+            Location(0.40492250948682484),
+            Location(0.07821476925699528),
         ];
         assert_eq!(locations, expected_locations);
     }

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -360,9 +360,9 @@ mod test {
 
         let locations: Vec<Location> = addresses.iter().map(Location::deterministic_loc).collect();
         let expected_locations = vec![
-            Location(0.7965489827349848),
-            Location(0.47795282110090903),
-            Location(0.07918706852076753),
+            Location(0.4539831101283351),
+            Location(0.7201264112803492),
+            Location(0.2243401485619054),
         ];
         assert_eq!(locations, expected_locations);
     }

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -30,7 +30,7 @@ impl Location {
                     | (u32::from(octets[1]) << 8)
                     | u32::from(octets[2]);
                 let hashed = simple_hash(combined_octets);
-                Location(hashed as f64 / u32::MAX as f64)
+                Location(hashed as f64 / u64::MAX as f64)
             }
             std::net::IpAddr::V6(ipv6) => {
                 let segments = ipv6.segments();

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -244,7 +244,7 @@ fn distribute_hash(x: u64) -> u64 {
     h ^= h >> 29; // XOR again
     h = h.wrapping_mul(0x85ebca6b2b2d3d1d); // Final prime
     h ^= h >> 32; // Final XOR
-    T::from(h) // Convert back to the original type
+    h // Return the u64 directly
 }
 
 #[cfg(test)]

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -26,13 +26,14 @@ impl Location {
         match addr.ip() {
             std::net::IpAddr::V4(ipv4) => {
                 let value: u32 = ipv4.into();
-                // Mask out the last byte
+                // Mask out the last byte for sybil mitigation
                 let masked_value = value & 0xFFFFFF00;
                 let hashed = distribute_hash(masked_value as u64);
                 Location(hashed as f64 / u64::MAX as f64)
             }
             std::net::IpAddr::V6(ipv6) => {
                 let segments = ipv6.segments();
+                // We only use the first 3 segments for sybil migation
                 let combined_segments = (u64::from(segments[0]) << 32)
                     | (u64::from(segments[1]) << 16)
                     | u64::from(segments[2]);

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -328,6 +328,23 @@ mod test {
     }
 
     #[test]
+    fn test_ipv6_address_location() {
+        let addresses = [
+            SocketAddr::new(IpAddr::V6([0x2001, 0xdb8, 0x1234, 0x5678, 0xabcd, 0xef01, 0x2345, 0x6789].into()), 12345),
+            SocketAddr::new(IpAddr::V6([0xfe80, 0x0000, 0x0000, 0x0000, 0x0202, 0xb3ff, 0xfe1e, 0x8329].into()), 12345),
+            SocketAddr::new(IpAddr::V6([0x2001, 0x4860, 0x4860, 0x0000, 0x0000, 0x0000, 0x0000, 0x8888].into()), 12345),
+        ];
+
+        let locations: Vec<Location> = addresses.iter().map(Location::deterministic_loc).collect();
+        let expected_locations = vec![
+            Location(0.0),
+            Location(0.0),
+            Location(0.0),
+        ];
+        assert_eq!(locations, expected_locations);
+    }
+
+    #[test]
     fn location_dist() {
         let l0 = Location(0.);
         let l1 = Location(0.25);

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -242,14 +242,13 @@ impl Display for Distance {
 fn distribute_hash<T: Copy + Into<u64> + From<u64>>(x: T) -> T {
     let mut h = x.into(); // Normalize input to u64
     h = h.wrapping_mul(0x9e3779b97f4a7c15); // Prime multiplier
-    h ^= h >> 33;                          // XOR and shift
+    h ^= h >> 33; // XOR and shift
     h = h.wrapping_mul(0xc2b2ae3d27d4eb4f); // Second prime
-    h ^= h >> 29;                          // XOR again
+    h ^= h >> 29; // XOR again
     h = h.wrapping_mul(0x85ebca6b2b2d3d1d); // Final prime
-    h ^= h >> 32;                          // Final XOR
+    h ^= h >> 32; // Final XOR
     T::from(h) // Convert back to the original type
 }
-
 
 #[cfg(test)]
 mod test {
@@ -330,9 +329,33 @@ mod test {
     #[test]
     fn test_ipv6_address_location() {
         let addresses = [
-            SocketAddr::new(IpAddr::V6([0x2001, 0xdb8, 0x1234, 0x5678, 0xabcd, 0xef01, 0x2345, 0x6789].into()), 12345),
-            SocketAddr::new(IpAddr::V6([0xfe80, 0x0000, 0x0000, 0x0000, 0x0202, 0xb3ff, 0xfe1e, 0x8329].into()), 12345),
-            SocketAddr::new(IpAddr::V6([0x2001, 0x4860, 0x4860, 0x0000, 0x0000, 0x0000, 0x0000, 0x8888].into()), 12345),
+            SocketAddr::new(
+                IpAddr::V6(
+                    [
+                        0x2001, 0xdb8, 0x1234, 0x5678, 0xabcd, 0xef01, 0x2345, 0x6789,
+                    ]
+                    .into(),
+                ),
+                12345,
+            ),
+            SocketAddr::new(
+                IpAddr::V6(
+                    [
+                        0xfe80, 0x0000, 0x0000, 0x0000, 0x0202, 0xb3ff, 0xfe1e, 0x8329,
+                    ]
+                    .into(),
+                ),
+                12345,
+            ),
+            SocketAddr::new(
+                IpAddr::V6(
+                    [
+                        0x2001, 0x4860, 0x4860, 0x0000, 0x0000, 0x0000, 0x0000, 0x8888,
+                    ]
+                    .into(),
+                ),
+                12345,
+            ),
         ];
 
         let locations: Vec<Location> = addresses.iter().map(Location::deterministic_loc).collect();

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -32,9 +32,8 @@ impl Location {
                 Location(hashed as f64 / u64::MAX as f64)
             }
             std::net::IpAddr::V6(ipv6) => {
-                // Take first 8 bytes (4 segments) of IPv6 address
                 let segments = ipv6.segments();
-                let combined_segments = (u64::from(segments[0]) << 32) 
+                let combined_segments = (u64::from(segments[0]) << 32)
                     | (u64::from(segments[1]) << 16)
                     | u64::from(segments[2]);
                 let hashed = distribute_hash(combined_segments);

--- a/crates/core/src/ring/location.rs
+++ b/crates/core/src/ring/location.rs
@@ -34,7 +34,7 @@ impl Location {
             std::net::IpAddr::V6(ipv6) => {
                 // Take first 8 bytes (4 segments) of IPv6 address
                 let segments = ipv6.segments();
-                let combined_segments = (u64::from(segments[0]) << 32)
+                let combined_segments = (u64::from(segments[0]) << 32) 
                     | (u64::from(segments[1]) << 16)
                     | u64::from(segments[2]);
                 let hashed = distribute_hash(combined_segments);
@@ -360,9 +360,9 @@ mod test {
 
         let locations: Vec<Location> = addresses.iter().map(Location::deterministic_loc).collect();
         let expected_locations = vec![
-            Location(0.4539831101283351),
-            Location(0.7201264112803492),
-            Location(0.2243401485619054),
+            Location(0.3539831101283351),
+            Location(0.6201264112803492),
+            Location(0.1243401485619054),
         ];
         assert_eq!(locations, expected_locations);
     }


### PR DESCRIPTION
This is to ensure even distribution of locations over the 0-1 interval, and avoid other potential issues.