### PR TITLE
docs: fix incomplete path on freenet node setup guide

### DIFF
--- a/scripts/FREENET-NODE-SETUP-GUIDE.md
+++ b/scripts/FREENET-NODE-SETUP-GUIDE.md
@@ -48,7 +48,7 @@ The `freenet-setup.sh` script supports two modes:
 ```bash
   cd freenet
   git clone https://github.com/freenet/freenet-core.git
-  cd freenet-core
+  cd freenet-core/scripts
   chmod +x freenet-node-setup.sh
 ```
 


### PR DESCRIPTION
as the next command `chmod +x freenet-node-setup.sh` on the guide is trying to use a sh file that's on `/scripts` folder.