### PR TITLE
feat: add version command

### DIFF
--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -58,7 +58,12 @@ fn main() -> anyhow::Result<()> {
         .build()
         .unwrap();
     rt.block_on(async move {
-        let config = ConfigArgs::parse().build().await?;
+        let config = ConfigArgs::parse();
+        if config.version {
+            println!("Freenet version: {}", config.current_version());
+            return Ok(());
+        }
+        let config = config.build().await?;
         run(config).await
     })?;
     Ok(())

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -298,6 +298,7 @@ async fn websocket_interface(
                     Ok(None) => continue,
                     Err(None) => {
                         tracing::debug!("client channel closed on request");
+                        let _ = server_sink.send(Message::Close(None)).await;
                         return Ok(())
                     },
                     Err(Some(err)) => {

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -37,7 +37,11 @@ pub const DEFAULT_RANDOM_PEER_CONN_THRESHOLD: usize = 7;
 /// Default maximum number of hops to live for any operation
 /// (if it applies, e.g. connect requests).
 pub const DEFAULT_MAX_HOPS_TO_LIVE: usize = 10;
+
 pub(crate) const OPERATION_TTL: Duration = Duration::from_secs(60);
+
+/// Current version of the crate.
+pub(crate) const PCK_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // Initialize the executor once.
 static ASYNC_RT: Lazy<Option<Runtime>> = Lazy::new(GlobalExecutor::initialize_async_rt);
@@ -51,27 +55,31 @@ const FREENET_GATEWAYS_INDEX: &str = "https://freenet.org/keys/gateways.toml";
 #[derive(clap::Parser, Debug)]
 pub struct ConfigArgs {
     /// Node operation mode. Default is network mode.
-    #[clap(value_enum, env = "MODE")]
+    #[arg(value_enum, env = "MODE")]
     pub mode: Option<OperationMode>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub ws_api: WebsocketApiArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub network_api: NetworkArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub secrets: SecretArgs,
 
-    #[clap(long, env = "LOG_LEVEL")]
+    #[arg(long, env = "LOG_LEVEL")]
     pub log_level: Option<tracing::log::LevelFilter>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub config_paths: ConfigPathsArgs,
 
     /// An arbitrary identifier for the node, mostly for debugging or testing purposes.
-    #[clap(long)]
+    #[arg(long, hide = true)]
     pub id: Option<String>,
+
+    /// Show the version of the application.
+    #[arg(long, short)]
+    pub version: bool,
 }
 
 impl Default for ConfigArgs {
@@ -98,11 +106,16 @@ impl Default for ConfigArgs {
             log_level: Some(tracing::log::LevelFilter::Info),
             config_paths: Default::default(),
             id: None,
+            version: false,
         }
     }
 }
 
 impl ConfigArgs {
+    pub fn current_version(&self) -> &str {
+        PCK_VERSION
+    }
+
     fn read_config(dir: &PathBuf) -> std::io::Result<Option<Config>> {
         if !dir.exists() {
             return Ok(None);
@@ -610,21 +623,6 @@ pub struct ConfigPathsArgs {
     /// The configuration directory.
     #[arg(long, default_value = None, env = "CONFIG_DIR")]
     pub config_dir: Option<PathBuf>,
-    /// The contracts directory.
-    #[arg(long, default_value = None, env = "CONTRACTS_DIR")]
-    contracts_dir: Option<PathBuf>,
-    /// The delegates directory.
-    #[arg(long, default_value = None, env = "DELEGATES_DIR")]
-    delegates_dir: Option<PathBuf>,
-    /// The secrets directory.
-    #[arg(long, default_value = None, env = "SECRECTS_DIR")]
-    secrets_dir: Option<PathBuf>,
-    /// The database directory.
-    #[arg(long, default_value = None, env = "DB_DIR")]
-    db_dir: Option<PathBuf>,
-    /// The event log file.
-    #[arg(long, default_value = None, env = "EVENT_LOG")]
-    event_log: Option<PathBuf>,
     /// The data directory.
     #[arg(long, default_value = None, env = "DATA_DIR")]
     pub data_dir: Option<PathBuf>,
@@ -633,11 +631,6 @@ pub struct ConfigPathsArgs {
 impl ConfigPathsArgs {
     fn merge(&mut self, other: ConfigPaths) {
         self.config_dir.get_or_insert(other.config_dir);
-        self.contracts_dir.get_or_insert(other.contracts_dir);
-        self.delegates_dir.get_or_insert(other.delegates_dir);
-        self.secrets_dir.get_or_insert(other.secrets_dir);
-        self.db_dir.get_or_insert(other.db_dir);
-        self.event_log.get_or_insert(other.event_log);
         self.data_dir.get_or_insert(other.data_dir);
     }
 
@@ -669,16 +662,10 @@ impl ConfigPathsArgs {
                 };
                 Ok(defaults.data_dir().to_path_buf())
             })?;
-        let contracts_dir = self
-            .contracts_dir
-            .unwrap_or_else(|| app_data_dir.join("contracts"));
-        let delegates_dir = self
-            .delegates_dir
-            .unwrap_or_else(|| app_data_dir.join("delegates"));
-        let secrets_dir = self
-            .secrets_dir
-            .unwrap_or_else(|| app_data_dir.join("secrets"));
-        let db_dir = self.db_dir.unwrap_or_else(|| app_data_dir.join("db"));
+        let contracts_dir = app_data_dir.join("contracts");
+        let delegates_dir = app_data_dir.join("delegates");
+        let secrets_dir = app_data_dir.join("secrets");
+        let db_dir = app_data_dir.join("db");
 
         if !contracts_dir.exists() {
             fs::create_dir_all(&contracts_dir)?;
@@ -720,13 +707,13 @@ impl ConfigPathsArgs {
             })?;
 
         Ok(ConfigPaths {
+            config_dir,
+            data_dir: app_data_dir,
             contracts_dir,
             delegates_dir,
             secrets_dir,
             db_dir,
-            data_dir: app_data_dir,
             event_log,
-            config_dir,
         })
     }
 }

--- a/crates/core/src/config/secret.rs
+++ b/crates/core/src/config/secret.rs
@@ -50,11 +50,11 @@ pub struct SecretArgs {
     #[clap(long, value_parser, default_value=None, env = "TRANSPORT_KEYPAIR")]
     pub transport_keypair: Option<PathBuf>,
 
-    /// Path to the nonce file.
+    /// Path to the nonce file for encrypting data.
     #[clap(long, value_parser, default_value=None, env = "NONCE")]
     pub nonce: Option<PathBuf>,
 
-    /// Path to the cipher file.
+    /// Path to the cipher file for encrypting data.
     #[clap(long, value_parser, default_value=None, env = "CIPHER")]
     pub cipher: Option<PathBuf>,
 }

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use crate::config::PCK_VERSION;
 use crate::transport::crypto::TransportSecretKey;
 use crate::transport::packet_data::{AssymetricRSA, UnknownEncryption};
 use crate::transport::symmetric_message::OutboundConnection;
@@ -890,7 +891,7 @@ fn handle_ack_connection_error(err: Cow<'static, str>) -> TransportError {
     if let Some(expected) = err.split("expected version").nth(1) {
         TransportError::ProtocolVersionMismatch {
             expected: expected.trim().to_string(),
-            actual: version_cmp::VERSION,
+            actual: PCK_VERSION,
         }
     } else {
         TransportError::ConnectionEstablishmentFailure { cause: err }
@@ -938,9 +939,9 @@ struct InboundRemoteConnection {
 }
 
 mod version_cmp {
-    pub(super) const VERSION: &str = env!("CARGO_PKG_VERSION");
+    use crate::config::PCK_VERSION;
 
-    pub(super) const PROTOC_VERSION: [u8; 8] = parse_version_with_flags(VERSION);
+    pub(super) const PROTOC_VERSION: [u8; 8] = parse_version_with_flags(PCK_VERSION);
 
     const fn parse_version_with_flags(version: &str) -> [u8; 8] {
         let mut major = 0u8;
@@ -1086,7 +1087,7 @@ mod test {
         match handle_ack_connection_error(err_msg.into()) {
             TransportError::ProtocolVersionMismatch { expected, actual } => {
                 assert_eq!(expected, "1.2.3");
-                assert_eq!(actual, version_cmp::VERSION);
+                assert_eq!(actual, PCK_VERSION);
             }
             _ => panic!("Expected ProtocolVersionMismatch error"),
         }

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -71,10 +71,10 @@ async fn base_node_test_config(
             bandwidth_limit: None,
         },
         config_paths: {
-            let mut args = freenet::config::ConfigPathsArgs::default();
-            args.config_dir = Some(temp_dir.path().to_path_buf());
-            args.data_dir = Some(temp_dir.path().to_path_buf());
-            args
+            freenet::config::ConfigPathsArgs {
+                config_dir: Some(temp_dir.path().to_path_buf()),
+                data_dir: Some(temp_dir.path().to_path_buf()),
+            }
         },
         secrets: SecretArgs {
             transport_keypair: Some(transport_keypair),


### PR DESCRIPTION
Closes #1458 

This pull request includes several changes to the `crates/core/src/config.rs` file to improve configuration handling and versioning, as well as some adjustments to other files to align with these changes. The most important changes include the addition of a version constant, updates to the `ConfigArgs` structure, and the removal of unnecessary directory fields.

Improvements to configuration handling:

* [`crates/core/src/config.rs`](diffhunk://#diff-57cbbec45e799304c658c9dea8b670297b898fab012b543fcbb266e0b06fa42fR40-R45): Added `PCK_VERSION` constant to store the current version of the crate.
* [`crates/core/src/config.rs`](diffhunk://#diff-57cbbec45e799304c658c9dea8b670297b898fab012b543fcbb266e0b06fa42fL54-R82): Updated `ConfigArgs` structure to include a `version` flag and a method to retrieve the current version. [[1]](diffhunk://#diff-57cbbec45e799304c658c9dea8b670297b898fab012b543fcbb266e0b06fa42fL54-R82) [[2]](diffhunk://#diff-57cbbec45e799304c658c9dea8b670297b898fab012b543fcbb266e0b06fa42fR109-R118)
* [`crates/core/src/config.rs`](diffhunk://#diff-57cbbec45e799304c658c9dea8b670297b898fab012b543fcbb266e0b06fa42fL613-L627): Removed unnecessary directory fields (`contracts_dir`, `delegates_dir`, `secrets_dir`, `db_dir`, `event_log`) from `ConfigPathsArgs` and adjusted related methods. [[1]](diffhunk://#diff-57cbbec45e799304c658c9dea8b670297b898fab012b543fcbb266e0b06fa42fL613-L627) [[2]](diffhunk://#diff-57cbbec45e799304c658c9dea8b670297b898fab012b543fcbb266e0b06fa42fL636-L640) [[3]](diffhunk://#diff-57cbbec45e799304c658c9dea8b670297b898fab012b543fcbb266e0b06fa42fL672-R668) [[4]](diffhunk://#diff-57cbbec45e799304c658c9dea8b670297b898fab012b543fcbb266e0b06fa42fR710-L729)

Versioning updates:

* [`crates/core/src/transport/connection_handler.rs`](diffhunk://#diff-113b96d10b9e90853741466adcfecc53a37e53cedcc9916cdcb706581baecc4bR9): Replaced `version_cmp::VERSION` with `PCK_VERSION` for consistency in version handling. [[1]](diffhunk://#diff-113b96d10b9e90853741466adcfecc53a37e53cedcc9916cdcb706581baecc4bR9) [[2]](diffhunk://#diff-113b96d10b9e90853741466adcfecc53a37e53cedcc9916cdcb706581baecc4bL893-R894) [[3]](diffhunk://#diff-113b96d10b9e90853741466adcfecc53a37e53cedcc9916cdcb706581baecc4bL941-R944) [[4]](diffhunk://#diff-113b96d10b9e90853741466adcfecc53a37e53cedcc9916cdcb706581baecc4bL1089-R1090)

Minor improvements:

* [`crates/core/src/client_events/websocket.rs`](diffhunk://#diff-13f87fd50599c12ac039bca57bef0e57a3d3cb9da055b6a8cf2109459ade22efR301): Added a line to send a close message when the client channel is closed.
* [`crates/core/src/config/secret.rs`](diffhunk://#diff-68272b56029cac9fcc9ff40a36d2cd989cae000da755ba631e68d9c663f502a7L53-R57): Updated comments to clarify the purpose of `nonce` and `cipher` fields.
* [`crates/core/tests/operations.rs`](diffhunk://#diff-4ef05240184f26702d1f94e404a10e1b766ddcbbd1f24b49da03544382bb19aeL74-R77): Simplified initialization of `ConfigPathsArgs` in tests.