### PR TITLE
chore: update deploy script with help

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -322,10 +322,8 @@ impl ConfigArgs {
                 bandwidth_limit: self.network_api.bandwidth_limit,
             },
             ws_api: WebsocketApiConfig {
-                address: self.ws_api.address.unwrap_or_else(|| match mode {
-                    OperationMode::Local => default_local_address(),
-                    OperationMode::Network => default_listening_address(),
-                }),
+                // the websocket API is always local
+                address: self.ws_api.address.unwrap_or_else(default_local_address),
                 port: self
                     .ws_api
                     .ws_api_port

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -188,7 +188,7 @@ async fn test_put_contract() -> TestResult {
 
     let test = tokio::time::timeout(Duration::from_secs(60), async {
         // Wait for nodes to start up
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        tokio::time::sleep(Duration::from_secs(10)).await;
 
         // Connect to node A's websocket API
         let uri = format!(
@@ -348,7 +348,7 @@ async fn test_update_contract() -> TestResult {
 
     let test = tokio::time::timeout(Duration::from_secs(60), async {
         // Wait for nodes to start up
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        tokio::time::sleep(Duration::from_secs(10)).await;
 
         // Connect to node A websocket API
         let uri = format!(

--- a/scripts/update-remote-gws.sh
+++ b/scripts/update-remote-gws.sh
@@ -4,7 +4,35 @@
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
 NC='\033[0m' # No Color
+
+# Help function
+show_help() {
+    echo -e "${BLUE}Update Remote Gateways Script${NC}"
+    echo -e "This script deploys binary artifacts from the cross-compile.yml GitHub Actions workflow"
+    echo -e "to remote Freenet gateway servers.\n"
+    echo -e "${YELLOW}Usage:${NC}"
+    echo -e "  $0 [options]\n"
+    echo -e "${YELLOW}Options:${NC}"
+    echo -e "  -h, --help    Show this help message\n"
+    echo -e "${YELLOW}Environment Variables:${NC}"
+    echo -e "  ARTIFACTS_DIR   Directory containing the binary artifacts (default: current directory)"
+    echo -e "  BINARIES_PATH   Temporary path for unpacked binaries (default: $TMPDIR or /tmp)\n"
+    echo -e "${YELLOW}Expected Artifacts:${NC}"
+    echo -e "  The script expects zip files in the format: binaries-<arch>-<binary>.zip"
+    echo -e "  These artifacts are produced by the cross-compile.yml GitHub Actions workflow"
+    echo -e "  Example: binaries-x86_64-freenet.zip, binaries-arm64-fdev.zip\n"
+    echo -e "${YELLOW}Target Servers:${NC}"
+    echo -e "  The script deploys to servers defined in the SERVERS array with their architectures"
+    echo -e "  Each server will receive the appropriate architecture binaries"
+}
+
+# Check for help flags
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+    show_help
+    exit 0
+fi
 
 # Configuration
 REMOTE_DIR="/usr/local/bin"  # Remote directory where binaries will be copied


### PR DESCRIPTION
This pull request includes updates to the test timeout durations in `crates/core/tests/operations.rs` and enhancements to the `scripts/update-remote-gws.sh` script. The most important changes are as follows:

Test timeout adjustments:

* Increased the sleep duration from 5 seconds to 10 seconds in `test_put_contract` and `test_update_contract` to allow more time for nodes to start up. (`crates/core/tests/operations.rs`) [[1]](diffhunk://#diff-4ef05240184f26702d1f94e404a10e1b766ddcbbd1f24b49da03544382bb19aeL191-R191) [[2]](diffhunk://#diff-4ef05240184f26702d1f94e404a10e1b766ddcbbd1f24b49da03544382bb19aeL351-R351)

Script enhancements:

* Added a help function to the `scripts/update-remote-gws.sh` script, providing usage instructions, options, environment variables, expected artifacts, and target servers information. (`scripts/update-remote-gws.sh`)