### PR TITLE
fix: disable metering since is problematic

### DIFF
--- a/crates/core/src/wasm_runtime/tests/contract_metering.rs
+++ b/crates/core/src/wasm_runtime/tests/contract_metering.rs
@@ -31,6 +31,7 @@ fn validate_state_metering() -> Result<(), Box<dyn std::error::Error>> {
         max_execution_seconds: 5.0,
         cpu_cycles_per_second: Some(1_000_000), // Lower limit to force gas error
         safety_margin: 0.1,
+        enable_metering: true,
     };
 
     let mut runtime =
@@ -81,6 +82,7 @@ fn test_update_state_metering() -> Result<(), Box<dyn std::error::Error>> {
         max_execution_seconds: 5.0,
         cpu_cycles_per_second: Some(2_000_000),
         safety_margin: 0.1,
+        enable_metering: true,
     };
 
     let mut runtime =
@@ -132,6 +134,7 @@ fn test_summarize_state_metering() -> Result<(), Box<dyn std::error::Error>> {
         max_execution_seconds: 5.0,
         cpu_cycles_per_second: Some(3_000_000),
         safety_margin: 0.1,
+        enable_metering: true,
     };
 
     let mut runtime =
@@ -178,6 +181,7 @@ fn test_get_state_delta_metering() -> Result<(), Box<dyn std::error::Error>> {
         max_execution_seconds: 5.0,
         cpu_cycles_per_second: Some(4_000_000),
         safety_margin: 0.1,
+        enable_metering: true,
     };
 
     let mut runtime =
@@ -229,6 +233,7 @@ fn test_timeout_metering() -> Result<(), Box<dyn std::error::Error>> {
         max_execution_seconds: 5.0,
         cpu_cycles_per_second: Some(u64::MAX),
         safety_margin: 0.1,
+        enable_metering: true,
     };
 
     let mut runtime =


### PR DESCRIPTION
This pull request introduces a new feature to enable or disable metering in the WebAssembly runtime configuration. The changes include modifications to the `RuntimeConfig` and `Runtime` structures, as well as updates to the relevant test cases to accommodate the new `enable_metering` field.

Key changes include:

### Feature Addition:
* Added a new `enable_metering` boolean field to the `RuntimeConfig` struct to allow toggling metering on or off.
* Updated the `Default` implementation for `RuntimeConfig` to set `enable_metering` to `false` by default.

### Runtime Modifications:
* Added a new `enabled_metering` boolean field to the `Runtime` struct, which is initialized based on the `RuntimeConfig`'s `enable_metering` field. [[1]](diffhunk://#diff-af139be406679681d2aa7283673b0691d8ae7ca9d126b0400e377e8dd1fccab3R139) [[2]](diffhunk://#diff-af139be406679681d2aa7283673b0691d8ae7ca9d126b0400e377e8dd1fccab3R177)
* Modified the `Runtime` initialization to conditionally add the metering middleware based on the `enabled_metering` field.
* Updated the `Runtime`'s `execute` method to check the `enabled_metering` field before calling `get_remaining_points`. [[1]](diffhunk://#diff-af139be406679681d2aa7283673b0691d8ae7ca9d126b0400e377e8dd1fccab3L354-R362) [[2]](diffhunk://#diff-af139be406679681d2aa7283673b0691d8ae7ca9d126b0400e377e8dd1fccab3R376-R378)

### Test Updates:
* Updated various test functions in `contract_metering.rs` to set `enable_metering` to `true` in the `RuntimeConfig` used for testing. [[1]](diffhunk://#diff-99e43c386f91c3c37ff611eceab96af002f986970f79d6899dd58482d06f7ef0R34) [[2]](diffhunk://#diff-99e43c386f91c3c37ff611eceab96af002f986970f79d6899dd58482d06f7ef0R85) [[3]](diffhunk://#diff-99e43c386f91c3c37ff611eceab96af002f986970f79d6899dd58482d06f7ef0R137) [[4]](diffhunk://#diff-99e43c386f91c3c37ff611eceab96af002f986970f79d6899dd58482d06f7ef0R184) [[5]](diffhunk://#diff-99e43c386f91c3c37ff611eceab96af002f986970f79d6899dd58482d06f7ef0R236)

Fixes #1464 