### PR TITLE
Release v0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1444,7 +1444,7 @@ dependencies = [
  "dashmap",
  "either",
  "freenet",
- "freenet-stdlib",
+ "freenet-stdlib 0.1.5",
  "futures 0.3.31",
  "glob",
  "http 1.3.1",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1573,7 +1573,7 @@ dependencies = [
  "directories",
  "either",
  "flatbuffers",
- "freenet-stdlib",
+ "freenet-stdlib 0.1.5",
  "futures 0.3.31",
  "headers",
  "hickory-resolver",
@@ -1635,6 +1635,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "freenet-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c21b0e54ae3e7c5c9b9c845bd9eb4df94d24c94c0c5815ce5aa097492b984259"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "freenet-ping-app"
 version = "0.1.0"
 dependencies = [
@@ -1643,7 +1654,7 @@ dependencies = [
  "clap",
  "freenet",
  "freenet-ping-types",
- "freenet-stdlib",
+ "freenet-stdlib 0.1.5",
  "futures 0.3.31",
  "humantime",
  "once_cell",
@@ -1663,7 +1674,7 @@ name = "freenet-ping-contract"
 version = "0.1.0"
 dependencies = [
  "freenet-ping-types",
- "freenet-stdlib",
+ "freenet-stdlib 0.1.5",
  "serde_json",
 ]
 
@@ -1673,7 +1684,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
- "freenet-stdlib",
+ "freenet-stdlib 0.1.5",
  "humantime",
  "humantime-serde",
  "serde",
@@ -1690,7 +1701,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "flatbuffers",
- "freenet-macros",
+ "freenet-macros 0.1.1",
  "futures 0.3.31",
  "js-sys",
  "once_cell",
@@ -1708,6 +1719,38 @@ dependencies = [
  "tracing-subscriber",
  "wasm-bindgen",
  "wasmer",
+ "web-sys",
+]
+
+[[package]]
+name = "freenet-stdlib"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1637f0e80197acbabcc12cf366b6322fbbf9b695de68659af6ba01a1d3dac642"
+dependencies = [
+ "arbitrary",
+ "bincode",
+ "blake3",
+ "bs58",
+ "byteorder",
+ "chrono",
+ "flatbuffers",
+ "freenet-macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.31",
+ "js-sys",
+ "once_cell",
+ "semver",
+ "serde",
+ "serde-wasm-bindgen 0.6.5",
+ "serde_bytes",
+ "serde_json",
+ "serde_with",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite 0.26.2",
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
  "web-sys",
 ]
 
@@ -4987,7 +5030,7 @@ dependencies = [
 name = "test-contract-integration"
 version = "0.1.0"
 dependencies = [
- "freenet-stdlib",
+ "freenet-stdlib 0.1.3",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ tracing-subscriber = "0.3"
 wasmer = "5.0.4"
 wasmer-compiler-singlepass = "5.0.4"
 
-freenet-stdlib = { path = "./stdlib/rust/" }
-# freenet-stdlib = { version = "0.1.5" }
+# freenet-stdlib = { path = "./stdlib/rust/" }
+freenet-stdlib = { version = "0.1.5" }
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -39,7 +39,7 @@ http = "1.2"
 
 # internal
 freenet = { path = "../core"}
-#freenet = { version = "0.1.3"}
+#freenet = { version = "0.1.5"}
 freenet-stdlib = { workspace = true }
 
 [features]


### PR DESCRIPTION
## Summary
Bump versions for release v0.1.5:
- freenet: 0.1.4 → 0.1.5
- fdev: 0.1.2 → 0.1.3
- Switch to freenet-stdlib 0.1.5 from crates.io

## Release Process
After this PR is merged:
1. Publish freenet to crates.io
2. Update fdev to use freenet 0.1.5 from crates.io
3. Publish fdev to crates.io
4. Create GitHub release tag v0.1.5
5. Update gateways with new binaries

Note: fdev currently uses a path dependency to freenet which will need to be updated after freenet is published.

🤖 Generated with [Claude Code](https://claude.ai/code)