### PR TITLE
Release v0.1.7

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.80"
 publish = true


### PR DESCRIPTION
## Summary
- Bump freenet version to 0.1.7
- Bump fdev version to 0.1.5
- Critical transport layer fixes for production issues

## Fixes
- **Fix keep-alive constants causing debug/release incompatibility** (#30)
  - Debug builds used 2s interval / 6s timeout
  - Release builds used 20s interval / 60s timeout
  - Now both use 10s interval / 30s timeout
  
- **Add graceful handling of intro packets on established connections** (#26)
  - Detects 256-byte RSA intro packets
  - Sends ACK response instead of failing with decryption error
  - Prevents connection reestablishment attempts

## Test plan
- [x] Integration tests pass
- [x] Pre-commit checks pass
- [ ] Deploy to gateways and verify connections remain stable

These fixes address the production issues where River app and other applications
were experiencing decryption errors after ~60 seconds of connection time.

🤖 Generated with [Claude Code](https://claude.ai/code)