### PR TITLE
Release v0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 rust-version = "1.80"
 publish = true


### PR DESCRIPTION
## Summary
- Bump freenet version to 0.1.10
- Bump fdev version to 0.1.8
- Includes fix for WASM execution blocking that was causing gateway connection timeouts

## Changes
- #1667: Reduced WASM execution polling from 1s to 10ms to prevent event loop blocking

🤖 Generated with [Claude Code](https://claude.ai/code)