### PR TITLE
Release v0.1.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.1.8"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "axum",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-ping-app"
-version = "0.1.0"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-ping-contract"
-version = "0.1.0"
+version = "0.1.11"
 dependencies = [
  "freenet-ping-types",
  "freenet-stdlib",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-ping-types"
-version = "0.1.0"
+version = "0.1.11"
 dependencies = [
  "chrono",
  "clap",
@@ -4987,7 +4987,7 @@ dependencies = [
 
 [[package]]
 name = "test-contract-integration"
-version = "0.1.0"
+version = "0.1.11"
 dependencies = [
  "freenet-stdlib",
  "serde",

--- a/apps/freenet-ping/app/Cargo.toml
+++ b/apps/freenet-ping/app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet-ping-app"
-version = "0.1.0"
+version = "0.1.11"
 edition = "2021"
 
 [dependencies]

--- a/apps/freenet-ping/contracts/ping/Cargo.toml
+++ b/apps/freenet-ping/contracts/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet-ping-contract"
-version = "0.1.0"
+version = "0.1.11"
 edition = "2021"
 
 [lib]

--- a/apps/freenet-ping/types/Cargo.toml
+++ b/apps/freenet-ping/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet-ping-types"
-version = "0.1.0"
+version = "0.1.11"
 edition = "2021"
 
 [lib]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.1.8"
+version = "0.1.11"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -38,7 +38,7 @@ reqwest = { version = "0.12", features = ["json"] }
 http = "1.2"
 
 # internal
-freenet = { path = "../core", version = "0.1.9"}
+freenet = { path = "../core", version = "0.1.11" }
 freenet-stdlib = { workspace = true }
 
 [features]

--- a/tests/test-contract-integration/Cargo.toml
+++ b/tests/test-contract-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-contract-integration"
-version = "0.1.0"
+version = "0.1.11"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## Changes

- fix: use async sleep in WASM execution to prevent blocking executor (#1670)
  - Interim fix to prevent tokio executor blocking during contract execution
  - May help resolve gateway keep-alive timeout issues

## Related Issues

- Addresses #1666 (WASM execution blocking)
- May help with #1669 (gateway keep-alive timeouts)