### PR TITLE
Release v0.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.1.11"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "axum",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.11"
+version = "0.1.13"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.11"
+version = "0.1.13"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.1.11"
+version = "0.1.13"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -38,7 +38,7 @@ reqwest = { version = "0.12", features = ["json"] }
 http = "1.2"
 
 # internal
-freenet = { path = "../core", version = "0.1.11" }
+freenet = { path = "../core", version = "0.1.13" }
 freenet-stdlib = { workspace = true }
 
 [features]


### PR DESCRIPTION
## Summary
- WebSocket max message size increased to 100MB to handle large WASM contracts
- Fixed flaky test_multiple_clients_subscription with increased timeouts  
- Improved CI reliability

This release ensures all Freenet deployments use the latest WebSocket fix that prevents silent message dropping for large contracts.

🤖 Generated with [Claude Code](https://claude.ai/code)