### PR TITLE
🚀 Release 0.1.18

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.16"
+version = "0.1.18"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -38,7 +38,7 @@ reqwest = { version = "0.12", features = ["json"] }
 http = "1.2"
 
 # internal
-freenet = { path = "../core", version = "0.1.14" }
+freenet = { path = "../core", version = "0.1.18" }
 freenet-stdlib = { workspace = true }
 
 [features]


### PR DESCRIPTION
**Test release for release system validation**

- freenet: 0.1.16 → **0.1.18**  
- fdev: 0.2.2 → **0.2.3**

This is a test release to validate the release system works correctly.
Generated by: manual release process