### PR TITLE
🚀 Release 0.1.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -38,7 +38,7 @@ reqwest = { version = "0.12", features = ["json"] }
 http = "1.2"
 
 # internal
-freenet = { path = "../core", version = "0.1.17" }
+freenet = { path = "../core", version = "0.1.18" }
 freenet-stdlib = { workspace = true }
 
 [features]


### PR DESCRIPTION
**Automated release PR**

- freenet: → **0.1.18**  
- fdev: → **0.2.0**

This PR will auto-merge once GitHub CI passes.
Generated by: `scripts/release.sh`

## Summary
This release reverts the async packet handler changes that were causing contract operation failures. The CI tests now pass successfully without those changes.