### PR TITLE
Add RuntimePool for concurrent contract execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -222,11 +222,10 @@ dependencies = [
  "futures-io",
  "futures-lite 2.6.0",
  "parking",
- "polling 3.8.0",
+ "polling 3.9.0",
  "rustix",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -585,9 +584,9 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "shlex",
 ]
@@ -677,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -687,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -699,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -906,9 +905,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -1107,9 +1106,9 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "delegate"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b6483c2bbed26f97861cf57651d4f2b731964a28cd2257f934a4b452480d21"
+checksum = "6178a82cf56c836a3ba61a7935cdb1c49bfaa6fa4327cd5bf554a503087de26b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1320,18 +1319,18 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a6b7c3d347de0a9f7bfd2f853be43fe32fa6fac30c70f6d6d67a1e936b87ee"
+checksum = "d6ee17054f550fd7400e1906e2f9356c7672643ed34008a9e8abe147ccd2d821"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da3ea9e1d1a3b1593e15781f930120e72aa7501610b2f82e5b6739c72e8eac5"
+checksum = "76d07902c93376f1e96c34abc4d507c0911df3816cef50b01f5a2ff3ad8c370d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1553,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.18"
+version = "0.1.17"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1911,7 +1910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "stable_deref_trait",
 ]
 
@@ -1929,9 +1928,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes 1.10.1",
@@ -1939,7 +1938,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2242,7 +2241,7 @@ dependencies = [
  "http 1.3.1",
  "hyper",
  "hyper-util",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -2280,9 +2279,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "base64 0.22.1",
  "bytes 1.10.1",
@@ -2454,9 +2453,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -2506,6 +2505,17 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "iovec"
@@ -2694,9 +2704,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -2984,12 +2994,11 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "8.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
+checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
 dependencies = [
  "bitflags 2.9.1",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -2998,7 +3007,7 @@ dependencies = [
  "mio",
  "notify-types",
  "walkdir",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3120,7 +3129,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "hashbrown 0.14.5",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "memchr",
  "ruzstd",
 ]
@@ -3557,17 +3566,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
+checksum = "8ee9b2fa7a4517d2c91ff5bc6c297a427a96749d15f98fcdbb22c05571a4d4b7"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4033,9 +4041,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes 1.10.1",
@@ -4100,7 +4108,7 @@ dependencies = [
  "bytecheck 0.8.1",
  "bytes 1.10.1",
  "hashbrown 0.15.4",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "munge",
  "ptr_meta 0.3.0",
  "rancor",
@@ -4165,15 +4173,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4190,15 +4198,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -4233,9 +4241,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4297,6 +4305,18 @@ name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -4417,9 +4437,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -4439,9 +4459,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -4460,16 +4480,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
- "schemars",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4479,9 +4500,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4666,12 +4687,12 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.4",
  "hashlink",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "log",
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "serde",
  "serde_json",
  "sha2",
@@ -4855,7 +4876,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a313e115c2cd9a88d99d60386bc88641c853d468b2c3bc454c294f385fc084"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-io",
  "atomic",
  "crossbeam-channel",
@@ -5008,9 +5029,9 @@ dependencies = [
 
 [[package]]
 name = "test-log"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f"
+checksum = "1e33b98a582ea0be1168eba097538ee8dd4bbe0f2b01b22ac92ea30054e5be7b"
 dependencies = [
  "env_logger",
  "test-log-macros",
@@ -5019,9 +5040,9 @@ dependencies = [
 
 [[package]]
 name = "test-log-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f"
+checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5163,17 +5184,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes 1.10.1",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -5227,7 +5250,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "tokio",
 ]
 
@@ -5281,42 +5304,45 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.2"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_parser",
- "toml_writer",
- "winnow",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.0.1"
+name = "toml_edit"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
+ "indexmap 2.10.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
  "winnow",
 ]
 
 [[package]]
-name = "toml_writer"
-version = "1.0.2"
+name = "toml_write"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -5674,7 +5700,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.11",
@@ -5876,7 +5902,7 @@ dependencies = [
  "bytes 1.10.1",
  "cfg-if",
  "cmake",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "js-sys",
  "more-asserts",
  "rustc-demangle",
@@ -6000,7 +6026,7 @@ dependencies = [
  "enumset",
  "getrandom 0.2.16",
  "hex",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "more-asserts",
  "rkyv",
  "sha2",
@@ -6023,7 +6049,7 @@ dependencies = [
  "dashmap",
  "enum-iterator",
  "fnv",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "libc",
  "mach2",
  "memoffset",
@@ -6044,7 +6070,7 @@ dependencies = [
  "ahash",
  "bitflags 2.9.1",
  "hashbrown 0.14.5",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "semver",
 ]
 
@@ -6055,7 +6081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags 2.9.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "semver",
 ]
 
@@ -6107,14 +6133,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6534,9 +6560,12 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"
@@ -6580,9 +6609,9 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xattr"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
  "rustix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -4459,9 +4459,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -5304,45 +5304,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.10.0",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tonic"
@@ -6563,9 +6560,6 @@ name = "winnow"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winreg"

--- a/apps/freenet-ping/Cargo.lock
+++ b/apps/freenet-ping/Cargo.lock
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.15"
+version = "0.1.17"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/apps/freenet-ping/Cargo.lock
+++ b/apps/freenet-ping/Cargo.lock
@@ -174,9 +174,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-channel"
-version = "2.5.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.5.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -199,7 +199,8 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "windows-sys 0.60.2",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -422,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytecheck"
@@ -497,9 +498,9 @@ checksum = "981520c98f422fcc584dc1a95c334e6953900b9106bc47a9839b81790009eb21"
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
@@ -588,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -598,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -610,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -802,9 +803,9 @@ checksum = "56b08621c00321efcfa3eee6a3179adc009e21ea8d24ca7adc3c326184bc3f48"
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -952,9 +953,9 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "delegate"
-version = "0.13.4"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6178a82cf56c836a3ba61a7935cdb1c49bfaa6fa4327cd5bf554a503087de26b"
+checksum = "b9b6483c2bbed26f97861cf57651d4f2b731964a28cd2257f934a4b452480d21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1132,18 +1133,18 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.7"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee17054f550fd7400e1906e2f9356c7672643ed34008a9e8abe147ccd2d821"
+checksum = "11a6b7c3d347de0a9f7bfd2f853be43fe32fa6fac30c70f6d6d67a1e936b87ee"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d07902c93376f1e96c34abc4d507c0911df3816cef50b01f5a2ff3ad8c370d"
+checksum = "6da3ea9e1d1a3b1593e15781f930120e72aa7501610b2f82e5b6739c72e8eac5"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1580,7 +1581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.10.0",
+ "indexmap 2.9.0",
  "stable_deref_trait",
 ]
 
@@ -1598,9 +1599,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1608,7 +1609,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.10.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1835,7 +1836,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.29",
+ "rustls 0.23.28",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -1860,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2034,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -2070,17 +2071,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -2225,9 +2215,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.6"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -2396,18 +2386,18 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "munge"
-version = "0.4.5"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cce144fab80fbb74ec5b89d1ca9d41ddf6b644ab7e986f7d3ed0aab31625cb1"
+checksum = "9e22e7961c873e8b305b176d2a4e1d41ce7ba31bc1c52d2a107a89568ec74c55"
 dependencies = [
  "munge_macro",
 ]
 
 [[package]]
 name = "munge_macro"
-version = "0.4.5"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574af9cd5b9971cbfdf535d6a8d533778481b241c447826d976101e0149392a1"
+checksum = "0ac7d860b767c6398e88fe93db73ce53eb496057aa6895ffa4d60cb02e1d1c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2455,11 +2445,12 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "8.1.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
+checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
 dependencies = [
  "bitflags 2.9.1",
+ "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -2468,7 +2459,7 @@ dependencies = [
  "mio",
  "notify-types",
  "walkdir",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2550,7 +2541,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "hashbrown 0.14.5",
- "indexmap 2.10.0",
+ "indexmap 2.9.0",
  "memchr",
  "ruzstd",
 ]
@@ -2766,16 +2757,17 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
-version = "3.9.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee9b2fa7a4517d2c91ff5bc6c297a427a96749d15f98fcdbb22c05571a4d4b7"
+checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "windows-sys 0.60.2",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3059,9 +3051,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.14"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3a5d9f0aba1dbcec1cc47f0ff94a4b778fe55bca98a6dfa92e4e094e57b1c4"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -3177,9 +3169,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.22"
+version = "0.12.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3244,7 +3236,7 @@ dependencies = [
  "bytecheck 0.8.1",
  "bytes",
  "hashbrown 0.15.4",
- "indexmap 2.10.0",
+ "indexmap 2.9.0",
  "munge",
  "ptr_meta 0.3.0",
  "rancor",
@@ -3309,15 +3301,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3334,15 +3326,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.4",
+ "rustls-webpki 0.103.3",
  "subtle",
  "zeroize",
 ]
@@ -3377,9 +3369,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3432,18 +3424,6 @@ name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -3564,9 +3544,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -3607,17 +3587,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.14.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
+checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
- "schemars 0.9.0",
- "schemars 1.0.4",
+ "indexmap 2.9.0",
+ "schemars",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3627,9 +3606,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.14.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4004,19 +3983,17 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -4059,7 +4036,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.29",
+ "rustls 0.23.28",
  "tokio",
 ]
 
@@ -4106,7 +4083,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4390,7 +4367,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.29",
+ "rustls 0.23.28",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.11",
@@ -4580,7 +4557,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "cmake",
- "indexmap 2.10.0",
+ "indexmap 2.9.0",
  "js-sys",
  "more-asserts",
  "rustc-demangle",
@@ -4704,7 +4681,7 @@ dependencies = [
  "enumset",
  "getrandom 0.2.16",
  "hex",
- "indexmap 2.10.0",
+ "indexmap 2.9.0",
  "more-asserts",
  "rkyv",
  "sha2",
@@ -4727,7 +4704,7 @@ dependencies = [
  "dashmap",
  "enum-iterator",
  "fnv",
- "indexmap 2.10.0",
+ "indexmap 2.9.0",
  "libc",
  "mach2",
  "memoffset",
@@ -4748,7 +4725,7 @@ dependencies = [
  "ahash",
  "bitflags 2.9.1",
  "hashbrown 0.14.5",
- "indexmap 2.10.0",
+ "indexmap 2.9.0",
  "semver",
 ]
 
@@ -4759,7 +4736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags 2.9.1",
- "indexmap 2.10.0",
+ "indexmap 2.9.0",
  "semver",
 ]
 
@@ -4811,14 +4788,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.2",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4959,9 +4936,9 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
 dependencies = [
  "windows-link",
  "windows-result",
@@ -5218,9 +5195,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 
 [[package]]
 name = "winreg"
@@ -5264,9 +5241,9 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xattr"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
  "rustix",

--- a/apps/freenet-ping/Cargo.lock
+++ b/apps/freenet-ping/Cargo.lock
@@ -174,9 +174,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -199,8 +199,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -423,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytecheck"
@@ -498,9 +497,9 @@ checksum = "981520c98f422fcc584dc1a95c334e6953900b9106bc47a9839b81790009eb21"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "shlex",
 ]
@@ -589,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -599,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -611,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -803,9 +802,9 @@ checksum = "56b08621c00321efcfa3eee6a3179adc009e21ea8d24ca7adc3c326184bc3f48"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -953,9 +952,9 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "delegate"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b6483c2bbed26f97861cf57651d4f2b731964a28cd2257f934a4b452480d21"
+checksum = "6178a82cf56c836a3ba61a7935cdb1c49bfaa6fa4327cd5bf554a503087de26b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1133,18 +1132,18 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a6b7c3d347de0a9f7bfd2f853be43fe32fa6fac30c70f6d6d67a1e936b87ee"
+checksum = "d6ee17054f550fd7400e1906e2f9356c7672643ed34008a9e8abe147ccd2d821"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da3ea9e1d1a3b1593e15781f930120e72aa7501610b2f82e5b6739c72e8eac5"
+checksum = "76d07902c93376f1e96c34abc4d507c0911df3816cef50b01f5a2ff3ad8c370d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1267,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1581,7 +1580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "stable_deref_trait",
 ]
 
@@ -1599,9 +1598,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1609,7 +1608,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1836,7 +1835,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -1861,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2035,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -2071,6 +2070,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2215,9 +2225,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -2386,18 +2396,18 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "munge"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e22e7961c873e8b305b176d2a4e1d41ce7ba31bc1c52d2a107a89568ec74c55"
+checksum = "9cce144fab80fbb74ec5b89d1ca9d41ddf6b644ab7e986f7d3ed0aab31625cb1"
 dependencies = [
  "munge_macro",
 ]
 
 [[package]]
 name = "munge_macro"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac7d860b767c6398e88fe93db73ce53eb496057aa6895ffa4d60cb02e1d1c6b"
+checksum = "574af9cd5b9971cbfdf535d6a8d533778481b241c447826d976101e0149392a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2445,12 +2455,11 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "8.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
+checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
 dependencies = [
  "bitflags 2.9.1",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -2459,7 +2468,7 @@ dependencies = [
  "mio",
  "notify-types",
  "walkdir",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2541,7 +2550,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "hashbrown 0.14.5",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "memchr",
  "ruzstd",
 ]
@@ -2757,17 +2766,16 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
+checksum = "8ee9b2fa7a4517d2c91ff5bc6c297a427a96749d15f98fcdbb22c05571a4d4b7"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3051,9 +3059,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "de3a5d9f0aba1dbcec1cc47f0ff94a4b778fe55bca98a6dfa92e4e094e57b1c4"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -3169,9 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3236,7 +3244,7 @@ dependencies = [
  "bytecheck 0.8.1",
  "bytes",
  "hashbrown 0.15.4",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "munge",
  "ptr_meta 0.3.0",
  "rancor",
@@ -3301,15 +3309,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3326,15 +3334,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -3369,9 +3377,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3424,6 +3432,18 @@ name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -3544,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -3566,9 +3586,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -3587,16 +3607,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
- "schemars",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3606,9 +3627,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3983,17 +4004,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -4036,7 +4059,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "tokio",
 ]
 
@@ -4079,44 +4102,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
 dependencies = [
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.9.0",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"
@@ -4369,7 +4390,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.11",
@@ -4559,7 +4580,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "cmake",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "js-sys",
  "more-asserts",
  "rustc-demangle",
@@ -4683,7 +4704,7 @@ dependencies = [
  "enumset",
  "getrandom 0.2.16",
  "hex",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "more-asserts",
  "rkyv",
  "sha2",
@@ -4706,7 +4727,7 @@ dependencies = [
  "dashmap",
  "enum-iterator",
  "fnv",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "libc",
  "mach2",
  "memoffset",
@@ -4727,7 +4748,7 @@ dependencies = [
  "ahash",
  "bitflags 2.9.1",
  "hashbrown 0.14.5",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "semver",
 ]
 
@@ -4738,7 +4759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags 2.9.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "semver",
 ]
 
@@ -4790,14 +4811,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4938,9 +4959,9 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link",
  "windows-result",
@@ -5197,12 +5218,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
-dependencies = [
- "memchr",
-]
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 
 [[package]]
 name = "winreg"
@@ -5246,9 +5264,9 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xattr"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
  "rustix",

--- a/apps/freenet-ping/Cargo.toml
+++ b/apps/freenet-ping/Cargo.toml
@@ -4,7 +4,7 @@ members = ["contracts/ping", "app", "types"]
 
 [workspace.dependencies]
 # freenet-stdlib = { path = "./../../stdlib/rust", features = ["contract"] }
-freenet-stdlib = { version = "0.1.11" } 
+freenet-stdlib = { version = "0.1.13" }
 freenet-ping-types = { path = "types", default-features = false }
 chrono = { version = "0.4", default-features = false }
 testresult = "0.4"

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -19,6 +19,9 @@ async fn run_local(config: Config) -> anyhow::Result<()> {
     tracing::info!("Starting freenet node in local mode");
     let socket = config.ws_api;
 
+    let _ = freenet::util::set_cleanup_on_exit(config.paths()).inspect_err(|error| {
+        tracing::error!("Failed to set cleanup on exit: {error}");
+    });
     let executor = Executor::local(Arc::new(config))
         .await
         .map_err(anyhow::Error::msg)?;

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -19,7 +19,7 @@ async fn run_local(config: Config) -> anyhow::Result<()> {
     tracing::info!("Starting freenet node in local mode");
     let socket = config.ws_api;
 
-    let executor = Executor::from_config(Arc::new(config), None)
+    let executor = Executor::local(Arc::new(config))
         .await
         .map_err(anyhow::Error::msg)?;
 

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -430,7 +430,7 @@ impl Config {
         self.secrets.transport_keypair()
     }
 
-    pub(crate) fn paths(&self) -> Arc<ConfigPaths> {
+    pub fn paths(&self) -> Arc<ConfigPaths> {
         self.config_paths.clone()
     }
 }

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -18,6 +18,7 @@ use freenet_stdlib::client_api::{
     RequestError,
 };
 use freenet_stdlib::prelude::*;
+use runtime::ExecutorWithId;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{self};
 
@@ -496,7 +497,7 @@ pub(crate) type UpsertContractR = Result<UpsertResult, ExecutorError>;
 ///
 /// Implementations must be thread-safe (Send) and have a static lifetime.
 pub(crate) trait ContractExecutor: Send + 'static {
-    type InnerExecutor: Send + 'static;
+    type InnerExecutor: ExecutorWithId;
 
     /// Fetches a contract from the store.
     fn fetch_contract(
@@ -554,6 +555,7 @@ pub(super) type OpResult = mpsc::Sender<(
 /// Consumers of the executor are required to poll for new changes in order to be notified
 /// of changes or can alternatively use the notification channel.
 pub struct Executor<R = Runtime> {
+    pub id: usize,
     mode: OperationMode,
     runtime: R,
     pub state_store: StateStore<Storage>,
@@ -577,6 +579,7 @@ impl<R> Executor<R> {
         op_manager: Option<Arc<OpManager>>,
     ) -> anyhow::Result<Self> {
         Ok(Self {
+            id: 0, // Default ID, will be set by the pool
             mode,
             runtime,
             state_store,

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -9,7 +9,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use blake3::traits::digest::generic_array::GenericArray;
 use either::Either;
 use freenet_stdlib::client_api::{
     ClientError as WsClientError, ClientRequest, ContractError as StdContractError,
@@ -537,9 +536,10 @@ pub(crate) trait ContractExecutor: Send + 'static {
 
     fn execute_delegate_request(
         &mut self,
-        req: DelegateRequest<'_>,
+        req: DelegateRequest<'static>,
         attested_contract: Option<&ContractInstanceId>,
-    ) -> Response;
+    ) -> impl Future<Output = impl Future<Output = (Self::InnerExecutor, Response)> + Send + 'static>
+           + Send;
 
     fn get_subscription_info(&self) -> Vec<crate::message::SubscriptionInfo>;
 }

--- a/crates/core/src/contract/executor/mock_runtime.rs
+++ b/crates/core/src/contract/executor/mock_runtime.rs
@@ -92,6 +92,8 @@ impl RuntimePool<String, MockRuntime> {
 
         runtimes.push(Some(executor));
 
+        let shared_storage = Storage::new(&exec_dir).await?;
+
         Ok(RuntimePool {
             runtimes,
             available: Semaphore::new(num_executors.get()),
@@ -101,6 +103,7 @@ impl RuntimePool<String, MockRuntime> {
             pending_registrations: HashMap::new(),
             next_executor_id: 1, // We start at 1 since the initial executor has ID 0
             delegate_attested_ids: HashMap::new(),
+            shared_storage,
         })
     }
 

--- a/crates/core/src/contract/executor/mock_runtime.rs
+++ b/crates/core/src/contract/executor/mock_runtime.rs
@@ -1,40 +1,13 @@
-use super::*;
-use tokio::sync::mpsc::UnboundedSender;
+use super::{runtime::RuntimePool, *};
+use std::sync::Arc;
+use tokio::sync::mpsc::{self, UnboundedSender};
+use tokio::sync::Semaphore;
 
 pub(crate) struct MockRuntime {
     pub contract_store: ContractStore,
 }
 
 impl Executor<MockRuntime> {
-    pub async fn new_mock(
-        identifier: &str,
-        event_loop_channel: ExecutorToEventLoopChannel<ExecutorHalve>,
-    ) -> anyhow::Result<Self> {
-        let data_dir = Self::test_data_dir(identifier);
-
-        let contracts_data_dir = data_dir.join("contracts");
-        std::fs::create_dir_all(&contracts_data_dir).expect("directory created");
-        let contract_store = ContractStore::new(contracts_data_dir, u16::MAX as i64)?;
-
-        // FIXME: if is sqlite it should be a dir, named <data_dir>/db
-        // let db_path = data_dir.join("db");
-        // let state_store = StateStore::new(Storage::new(&db_path).await?, u16::MAX as u32).unwrap();
-        tracing::debug!("creating state store at path: {data_dir:?}");
-        std::fs::create_dir_all(&data_dir).expect("directory created");
-        let state_store = StateStore::new(Storage::new(&data_dir).await?, u16::MAX as u32).unwrap();
-        tracing::debug!("state store created");
-
-        let executor = Executor::new(
-            state_store,
-            || Ok(()),
-            OperationMode::Local,
-            MockRuntime { contract_store },
-            Some(event_loop_channel),
-        )
-        .await?;
-        Ok(executor)
-    }
-
     pub async fn handle_request(
         &mut self,
         _id: ClientId,
@@ -43,13 +16,11 @@ impl Executor<MockRuntime> {
     ) -> Response {
         unreachable!("MockRuntime does not handle client requests directly")
     }
-}
 
-impl ContractExecutor for Executor<MockRuntime> {
-    async fn fetch_contract(
+    async fn perform_contract_get(
         &mut self,
-        key: ContractKey,
         return_contract_code: bool,
+        key: ContractKey,
     ) -> Result<(Option<WrappedState>, Option<ContractContainer>), ExecutorError> {
         let Some(parameters) = self
             .state_store
@@ -61,6 +32,7 @@ impl ContractExecutor for Executor<MockRuntime> {
                 "missing state and/or parameters for contract {key}"
             )));
         };
+
         let contract = if return_contract_code {
             self.runtime
                 .contract_store
@@ -68,12 +40,143 @@ impl ContractExecutor for Executor<MockRuntime> {
         } else {
             None
         };
-        let Ok(state) = self.state_store.get(&key).await else {
-            return Err(ExecutorError::other(anyhow::anyhow!(
+
+        match self.state_store.get(&key).await {
+            Ok(state) => Ok((Some(state), contract)),
+            Err(_) => Err(ExecutorError::other(anyhow::anyhow!(
                 "missing state for contract {key}"
-            )));
-        };
-        Ok((Some(state), contract))
+            ))),
+        }
+    }
+}
+
+impl RuntimePool<String, MockRuntime> {
+    pub async fn new_mock(
+        identifier: &str,
+        to_process_tx: mpsc::Sender<(
+            Transaction,
+            tokio::sync::oneshot::Sender<Result<OpEnum, CallbackError>>,
+        )>,
+        op_manager: Arc<OpManager>,
+        num_executors: std::num::NonZeroUsize,
+    ) -> anyhow::Result<Self> {
+        let data_dir = Executor::<MockRuntime>::test_data_dir(identifier);
+
+        let contracts_data_dir = data_dir.join("contracts");
+        std::fs::create_dir_all(&contracts_data_dir).expect("directory created");
+        let contract_store = ContractStore::new(contracts_data_dir, u16::MAX as i64)?;
+
+        tracing::debug!("creating state store at path: {data_dir:?}");
+        std::fs::create_dir_all(&data_dir).expect("directory created");
+
+        let mut runtimes = Vec::with_capacity(1);
+
+        let exec_dir = data_dir.join(format!("executor-{identifier}"));
+        std::fs::create_dir_all(&exec_dir).expect("directory created");
+
+        let state_store = StateStore::new(Storage::new(&exec_dir).await?, u16::MAX as u32).unwrap();
+
+        let executor = Executor::new(
+            state_store,
+            OperationMode::Local,
+            MockRuntime { contract_store },
+            Some(to_process_tx.clone()),
+            Some(op_manager.clone()),
+        )
+        .await?;
+
+        runtimes.push(Some(executor));
+
+        Ok(RuntimePool {
+            runtimes,
+            available: Semaphore::new(num_executors.get()),
+            op_sender: to_process_tx,
+            op_manager,
+            config: identifier.to_string(),
+        })
+    }
+
+    // Pop an executor from the pool - blocks until one is available
+    async fn pop_executor(&mut self) -> Executor<MockRuntime> {
+        // Wait for an available permit
+        let _ = self.available.acquire().await.expect("Semaphore is closed");
+
+        // Find the first available executor
+        for slot in &mut self.runtimes {
+            if let Some(executor) = slot.take() {
+                return executor;
+            }
+        }
+
+        // This should never happen because of the semaphore
+        unreachable!("No executors available despite semaphore permit")
+    }
+}
+
+impl ContractExecutor for RuntimePool<String, MockRuntime> {
+    type InnerExecutor = Executor<MockRuntime>;
+
+    fn return_executor(&mut self, executor: Self::InnerExecutor) {
+        // Find an empty slot and return the executor
+        if let Some(empty_slot) = self.runtimes.iter_mut().find(|slot| slot.is_none()) {
+            *empty_slot = Some(executor);
+            self.available.add_permits(1);
+        } else {
+            unreachable!("No empty slot found in the pool");
+        }
+    }
+
+    async fn create_new_executor(&mut self) -> Self::InnerExecutor {
+        // Create a new executor with a unique directory
+        let identifier = self.config.clone();
+        let data_dir = Executor::<MockRuntime>::test_data_dir(&identifier);
+        let exec_dir = data_dir.join(format!(
+            "executor-new-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis()
+        ));
+        std::fs::create_dir_all(&exec_dir).expect("directory created");
+
+        let contracts_data_dir = data_dir.join("contracts");
+        std::fs::create_dir_all(&contracts_data_dir).expect("directory created");
+        let contract_store = ContractStore::new(contracts_data_dir, u16::MAX as i64)
+            .expect("Failed to create contract store");
+
+        let state_store =
+            StateStore::new(Storage::new(&exec_dir).await.unwrap(), u16::MAX as u32).unwrap();
+
+        Executor::new(
+            state_store,
+            OperationMode::Local,
+            MockRuntime { contract_store },
+            Some(self.op_sender.clone()),
+            Some(self.op_manager.clone()),
+        )
+        .await
+        .expect("Failed to create new executor")
+    }
+
+    async fn fetch_contract(
+        &mut self,
+        key: ContractKey,
+        return_contract_code: bool,
+    ) -> impl Future<
+        Output = (
+            Self::InnerExecutor,
+            Result<(Option<WrappedState>, Option<ContractContainer>), ExecutorError>,
+        ),
+    > + Send
+           + 'static {
+        let mut executor = self.pop_executor().await;
+
+        async move {
+            let result = executor
+                .perform_contract_get(return_contract_code, key)
+                .await;
+            (executor, result)
+        }
     }
 
     async fn upsert_contract_state(
@@ -82,30 +185,41 @@ impl ContractExecutor for Executor<MockRuntime> {
         state: Either<WrappedState, StateDelta<'static>>,
         _related_contracts: RelatedContracts<'static>,
         code: Option<ContractContainer>,
-    ) -> Result<UpsertResult, ExecutorError> {
+    ) -> impl Future<Output = (Self::InnerExecutor, Result<UpsertResult, ExecutorError>)> + Send + 'static
+    {
+        let mut executor = self.pop_executor().await;
         // todo: instead allow to perform mutations per contract based on incoming value so we can track
         // state values over the network
-        match (state, code) {
-            (Either::Left(incoming_state), Some(contract)) => {
-                self.runtime
-                    .contract_store
-                    .store_contract(contract.clone())
-                    .map_err(ExecutorError::other)?;
-                self.state_store
-                    .store(key, incoming_state.clone(), contract.params().into_owned())
-                    .await
-                    .map_err(ExecutorError::other)?;
-                Ok(UpsertResult::Updated(incoming_state))
-            }
-            (Either::Left(incoming_state), None) => {
-                // update case
-                self.state_store
-                    .update(&key, incoming_state.clone())
-                    .await
-                    .map_err(ExecutorError::other)?;
-                Ok(UpsertResult::Updated(incoming_state))
-            }
-            (update, contract) => unreachable!("Invalid combination of state/delta and contract presence: {update:?}, {contract:?}"),
+        async move {
+            let r = async {
+                match (state, code) {
+                    (Either::Left(incoming_state), Some(contract)) => {
+                        executor
+                            .runtime
+                            .contract_store
+                            .store_contract(contract.clone())
+                            .map_err(ExecutorError::other)?;
+                        executor
+                            .state_store
+                            .store(key, incoming_state.clone(), contract.params().into_owned())
+                            .await
+                            .map_err(ExecutorError::other)?;
+                        Ok(UpsertResult::Updated(incoming_state))
+                    }
+                    (Either::Left(incoming_state), None) => {
+                        // update case
+                        executor
+                            .state_store
+                            .update(&key, incoming_state.clone())
+                            .await
+                            .map_err(ExecutorError::other)?;
+                        Ok(UpsertResult::Updated(incoming_state))
+                    }
+                    (update, contract) => unreachable!("{update:?}, {contract:?}"),
+                }
+            };
+            let r = r.await;
+            (executor, r)
         }
     }
 
@@ -116,6 +230,7 @@ impl ContractExecutor for Executor<MockRuntime> {
         _notification_ch: UnboundedSender<HostResult>,
         _summary: Option<StateSummary<'_>>,
     ) -> Result<(), Box<RequestError>> {
+        // For mock, we just acknowledge the registration without actually implementing notification
         Ok(())
     }
 
@@ -131,38 +246,5 @@ impl ContractExecutor for Executor<MockRuntime> {
 
     fn get_subscription_info(&self) -> Vec<crate::message::SubscriptionInfo> {
         vec![] // Mock implementation returns empty list
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn local_node_handle() -> Result<(), Box<dyn std::error::Error>> {
-        const MAX_SIZE: i64 = 10 * 1024 * 1024;
-        const MAX_MEM_CACHE: u32 = 10_000_000;
-        let tmp_dir = tempfile::tempdir()?;
-        let state_store_path = tmp_dir.path().join("state_store");
-        std::fs::create_dir_all(&state_store_path)?;
-        let contract_store = ContractStore::new(tmp_dir.path().join("executor-test"), MAX_SIZE)?;
-        let state_store =
-            StateStore::new(Storage::new(&state_store_path).await?, MAX_MEM_CACHE).unwrap();
-        let mut counter = 0;
-        Executor::new(
-            state_store,
-            || {
-                counter += 1;
-                Ok(())
-            },
-            OperationMode::Local,
-            MockRuntime { contract_store },
-            None,
-        )
-        .await
-        .expect("local node with handle");
-
-        assert_eq!(counter, 1);
-        Ok(())
     }
 }

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -410,6 +410,7 @@ impl Executor<Runtime> {
         let (contract_store, delegate_store, secret_store, state_store) =
             Self::get_stores(&config).await?;
         let rt = Runtime::build(contract_store, delegate_store, secret_store, false).unwrap();
+        assert!(config.mode == OperationMode::Local);
         Executor::new(state_store, OperationMode::Local, rt, None, None).await
     }
 
@@ -421,7 +422,7 @@ impl Executor<Runtime> {
         let (contract_store, delegate_store, secret_store, state_store) =
             Self::get_stores(&config).await?;
         let rt = Runtime::build(contract_store, delegate_store, secret_store, false).unwrap();
-        Executor::new(state_store, OperationMode::Local, rt, op_sender, op_manager).await
+        Executor::new(state_store, config.mode, rt, op_sender, op_manager).await
     }
 
     pub fn register_contract_notifier(

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -95,136 +95,11 @@ impl ContractExecutor for RuntimePool<Arc<Config>, Runtime> {
         code: Option<ContractContainer>,
     ) -> impl Future<Output = (Self::InnerExecutor, UpsertContractR)> + Send + 'static {
         let mut executor = self.pop_executor().await;
-
         async move {
-            match update {
-                Either::Left(state) => {
-                    // For state updates with simplified implementation
-                    let params = if let Some(code) = &code {
-                        code.params()
-                    } else {
-                        match executor.state_store.get_params(&key).await {
-                            Ok(Some(params)) => params,
-                            Ok(None) => {
-                                return (
-                                    executor,
-                                    Err(ExecutorError::request(StdContractError::Put {
-                                        key,
-                                        cause: "missing contract parameters".into(),
-                                    })),
-                                )
-                            }
-                            Err(err) => return (executor, Err(ExecutorError::other(err))),
-                        }
-                    };
-
-                    let remove_if_fail = if executor
-                        .runtime
-                        .contract_store
-                        .fetch_contract(&key, &params)
-                        .is_none()
-                    {
-                        if let Some(code) = code {
-                            if let Err(err) =
-                                executor.runtime.contract_store.store_contract(code.clone())
-                            {
-                                return (executor, Err(ExecutorError::other(err)));
-                            }
-                            true
-                        } else {
-                            return (
-                                executor,
-                                Err(ExecutorError::request(StdContractError::MissingContract {
-                                    key: key.into(),
-                                })),
-                            );
-                        }
-                    } else {
-                        false
-                    };
-
-                    // Validate the state
-                    match executor
-                        .runtime
-                        .validate_state(&key, &params, &state, &related_contracts)
-                    {
-                        Ok(validate_result) => {
-                            match validate_result {
-                                ValidateResult::Valid => {
-                                    // Store and send notifications
-                                    if let Err(err) = executor
-                                        .state_store
-                                        .store(key, state.clone(), params.clone())
-                                        .await
-                                    {
-                                        return (executor, Err(ExecutorError::other(err)));
-                                    }
-
-                                    // Attempt to send notifications
-                                    if let Err(err) = executor
-                                        .send_update_notification(&key, &params, &state)
-                                        .await
-                                    {
-                                        tracing::error!("Failed to send notifications: {}", err);
-                                    }
-
-                                    (executor, Ok(UpsertResult::Updated(state)))
-                                }
-                                ValidateResult::Invalid => (
-                                    executor,
-                                    Err(ExecutorError::request(StdContractError::invalid_put(key))),
-                                ),
-                                ValidateResult::RequestRelated(mut related) => {
-                                    if let Some(key) = related.pop() {
-                                        (
-                                            executor,
-                                            Err(ExecutorError::request(
-                                                StdContractError::MissingRelated { key },
-                                            )),
-                                        )
-                                    } else {
-                                        (executor, Err(ExecutorError::internal_error()))
-                                    }
-                                }
-                            }
-                        }
-                        Err(err) => {
-                            if remove_if_fail {
-                                let _ = executor.runtime.contract_store.remove_contract(&key);
-                            }
-                            (executor, Err(ExecutorError::execution(err, None)))
-                        }
-                    }
-                }
-                Either::Right(delta) => {
-                    // For delta updates, use the full implementation
-                    match executor.state_store.get(&key).await {
-                        Ok(current_state) => match executor.state_store.get_params(&key).await {
-                            Ok(Some(parameters)) => {
-                                let updates = vec![UpdateData::Delta(delta)];
-                                match executor
-                                    .get_updated_state(&parameters, current_state, key, updates)
-                                    .await
-                                {
-                                    Ok(new_state) => {
-                                        (executor, Ok(UpsertResult::Updated(new_state)))
-                                    }
-                                    Err(err) => (executor, Err(err)),
-                                }
-                            }
-                            Ok(None) => (
-                                executor,
-                                Err(ExecutorError::request(StdContractError::Update {
-                                    key,
-                                    cause: "missing contract parameters".into(),
-                                })),
-                            ),
-                            Err(err) => (executor, Err(ExecutorError::other(err))),
-                        },
-                        Err(err) => (executor, Err(ExecutorError::other(err))),
-                    }
-                }
-            }
+            let res =
+                upsert_contract_state_inner(&mut executor, key, update, related_contracts, code)
+                    .await;
+            (executor, res)
         }
     }
 
@@ -403,6 +278,157 @@ impl ContractExecutor for RuntimePool<Arc<Config>, Runtime> {
 
 impl Executor<Runtime> {
     // Private implementation methods
+}
+
+async fn upsert_contract_state_inner(
+    executor: &mut Executor<Runtime>,
+    key: ContractKey,
+    update: Either<WrappedState, StateDelta<'static>>,
+    related_contracts: RelatedContracts<'static>,
+    code: Option<ContractContainer>,
+) -> UpsertContractR {
+    let params = if let Some(code) = &code {
+        code.params()
+    } else {
+        executor
+            .state_store
+            .get_params(&key)
+            .await
+            .transpose()
+            .ok_or_else(|| {
+                ExecutorError::request(StdContractError::Put {
+                    key,
+                    cause: "missing contract parameters".into(),
+                })
+            })?
+            .map_err(ExecutorError::other)?
+    };
+
+    let remove_if_fail = if executor
+        .runtime
+        .contract_store
+        .fetch_contract(&key, &params)
+        .is_none()
+    {
+        let Some(code) = code else {
+            return Err(ExecutorError::request(StdContractError::MissingContract {
+                key: key.into(),
+            }));
+        };
+        executor
+            .runtime
+            .contract_store
+            .store_contract(code.clone())
+            .map_err(ExecutorError::other)?;
+        true
+    } else {
+        false
+    };
+
+    let mut updates = match update {
+        Either::Left(incoming_state) => {
+            let result = match executor.runtime.validate_state(
+                &key,
+                &params,
+                &incoming_state,
+                &related_contracts,
+            ) {
+                Ok(result) => result,
+                Err(err) => {
+                    if remove_if_fail {
+                        let _ = executor.runtime.contract_store.remove_contract(&key);
+                    }
+                    return Err(ExecutorError::execution(err, None));
+                }
+            };
+            match result {
+                ValidateResult::Valid => {
+                    executor
+                        .state_store
+                        .store(key, incoming_state.clone(), params.clone())
+                        .await
+                        .map_err(ExecutorError::other)?;
+                }
+                ValidateResult::Invalid => {
+                    return Err(ExecutorError::request(StdContractError::invalid_put(key)));
+                }
+                ValidateResult::RequestRelated(mut related) => {
+                    if let Some(key) = related.pop() {
+                        // TODO: support recursive related contracts
+                        return Err(ExecutorError::request(StdContractError::MissingRelated {
+                            key,
+                        }));
+                    } else {
+                        return Err(ExecutorError::internal_error());
+                    }
+                }
+            }
+
+            vec![UpdateData::State(incoming_state.clone().into())]
+        }
+        Either::Right(delta) => {
+            // todo: forward delta like we are doing with puts
+            tracing::warn!("Delta updates are not yet supported");
+            vec![UpdateData::Delta(delta)]
+        }
+    };
+
+    let current_state = match executor.state_store.get(&key).await {
+        Ok(s) => s,
+        Err(StateStoreError::MissingContract(_)) => {
+            tracing::warn!("Missing contract {key} for upsert");
+            return Err(ExecutorError::request(StdContractError::MissingContract {
+                key: key.into(),
+            }));
+        }
+        Err(StateStoreError::Any(err)) => return Err(ExecutorError::other(err)),
+    };
+
+    for (id, state) in related_contracts
+        .states()
+        .filter_map(|(id, c)| c.as_ref().map(|c| (id, c)))
+    {
+        updates.push(UpdateData::RelatedState {
+            related_to: *id,
+            state: state.clone(),
+        });
+    }
+
+    let updated_state = match executor
+        .attempt_state_update(&params, &current_state, &key, &updates)
+        .await?
+    {
+        Either::Left(s) => s,
+        Either::Right(mut r) => {
+            let Some(c) = r.pop() else {
+                // this branch should be unreachable since attempt_state_update should only
+                return Err(ExecutorError::internal_error());
+            };
+            return Err(ExecutorError::request(StdContractError::MissingRelated {
+                key: c.contract_instance_id,
+            }));
+        }
+    };
+    match executor
+        .runtime
+        .validate_state(&key, &params, &updated_state, &related_contracts)
+        .map_err(|e| ExecutorError::execution(e, None))?
+    {
+        ValidateResult::Valid => {
+            if updated_state.as_ref() == current_state.as_ref() {
+                Ok(UpsertResult::NoChange)
+            } else {
+                Ok(UpsertResult::Updated(updated_state))
+            }
+        }
+        ValidateResult::Invalid => Err(ExecutorError::request(
+            freenet_stdlib::client_api::ContractError::Update {
+                key,
+                cause: "invalid outcome state".into(),
+            },
+        )),
+        ValidateResult::RequestRelated(_) => todo!(),
+    }
 }
 
 impl Executor<Runtime> {

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -60,7 +60,7 @@ impl std::ops::Deref for ClientResponsesSender {
 }
 
 pub(crate) trait ContractHandler {
-    type Builder;
+    type Builder: Clone;
     type ContractExecutor: ContractExecutor;
 
     fn build(
@@ -76,15 +76,15 @@ pub(crate) trait ContractHandler {
     fn executor(&mut self) -> &mut Self::ContractExecutor;
 }
 
-pub(crate) struct NetworkContractHandler<R = Runtime> {
-    executor: RuntimePool<R>,
+pub(crate) struct NetworkContractHandler<C = Arc<Config>, R = Runtime> {
+    executor: RuntimePool<C, R>,
     channel: ContractHandlerChannel<ContractHandlerHalve>,
     op_res_handle: tokio::task::JoinHandle<()>,
 }
 
-impl ContractHandler for NetworkContractHandler<Runtime> {
+impl ContractHandler for NetworkContractHandler<Arc<Config>, Runtime> {
     type Builder = Arc<Config>;
-    type ContractExecutor = RuntimePool<Runtime>;
+    type ContractExecutor = RuntimePool<Self::Builder, Runtime>;
 
     async fn build(
         channel: ContractHandlerChannel<ContractHandlerHalve>,
@@ -120,9 +120,9 @@ impl ContractHandler for NetworkContractHandler<Runtime> {
 }
 
 #[cfg(test)]
-impl ContractHandler for NetworkContractHandler<super::MockRuntime> {
+impl ContractHandler for NetworkContractHandler<String, super::MockRuntime> {
     type Builder = String;
-    type ContractExecutor = Executor<super::MockRuntime>;
+    type ContractExecutor = RuntimePool<Self::Builder, super::MockRuntime>;
 
     async fn build(
         channel: ContractHandlerChannel<ContractHandlerHalve>,
@@ -132,8 +132,19 @@ impl ContractHandler for NetworkContractHandler<super::MockRuntime> {
     where
         Self: Sized + 'static,
     {
-        let executor = Executor::new_mock(&identifier, executor_request_sender).await?;
-        Ok(Self { executor, channel })
+        let num_executors = std::thread::available_parallelism()?;
+        let (to_process_tx, to_process) = mpsc::channel(num_executors.into());
+        let op_manager = executor_request_sender.op_manager.clone();
+        let op_res_handle =
+            tokio::spawn(executor_request_sender.handle_operation_result(to_process));
+        let executor =
+            RuntimePool::new_mock(&identifier, to_process_tx, op_manager, num_executors).await?;
+
+        Ok(Self {
+            executor,
+            channel,
+            op_res_handle,
+        })
     }
 
     fn channel(&mut self) -> &mut ContractHandlerChannel<ContractHandlerHalve> {
@@ -141,6 +152,9 @@ impl ContractHandler for NetworkContractHandler<super::MockRuntime> {
     }
 
     fn executor(&mut self) -> &mut Self::ContractExecutor {
+        if self.op_res_handle.is_finished() {
+            panic!("executor handle is finished");
+        }
         &mut self.executor
     }
 }
@@ -524,17 +538,22 @@ pub mod test {
 }
 
 pub(super) mod in_memory {
+    use tokio::sync::mpsc;
+
+    use crate::contract::executor::runtime::RuntimePool;
+
     use super::{
         super::{
             executor::{ExecutorHalve, ExecutorToEventLoopChannel},
-            Executor, MockRuntime,
+            MockRuntime,
         },
         ContractHandler, ContractHandlerChannel, ContractHandlerHalve,
     };
 
     pub(crate) struct MemoryContractHandler {
         channel: ContractHandlerChannel<ContractHandlerHalve>,
-        runtime: Executor<MockRuntime>,
+        runtime: RuntimePool<String, MockRuntime>,
+        op_res_handle: tokio::task::JoinHandle<()>,
     }
 
     impl MemoryContractHandler {
@@ -543,18 +562,27 @@ pub(super) mod in_memory {
             executor_request_sender: ExecutorToEventLoopChannel<ExecutorHalve>,
             identifier: &str,
         ) -> Self {
+            let num_executors = std::thread::available_parallelism().unwrap();
+            let (to_process_tx, to_process) = mpsc::channel(num_executors.into());
+            let op_manager = executor_request_sender.op_manager.clone();
+            let op_res_handle =
+                tokio::spawn(executor_request_sender.handle_operation_result(to_process));
+            let runtime =
+                RuntimePool::new_mock(identifier, to_process_tx, op_manager, num_executors)
+                    .await
+                    .unwrap();
+
             MemoryContractHandler {
                 channel,
-                runtime: Executor::new_mock(identifier, executor_request_sender)
-                    .await
-                    .expect("should start mock executor"),
+                runtime,
+                op_res_handle,
             }
         }
     }
 
     impl ContractHandler for MemoryContractHandler {
         type Builder = String;
-        type ContractExecutor = Executor<MockRuntime>;
+        type ContractExecutor = RuntimePool<Self::Builder, MockRuntime>;
 
         async fn build(
             channel: ContractHandlerChannel<ContractHandlerHalve>,
@@ -572,6 +600,9 @@ pub(super) mod in_memory {
         }
 
         fn executor(&mut self) -> &mut Self::ContractExecutor {
+            if self.op_res_handle.is_finished() {
+                panic!("executor handle is finished");
+            }
             &mut self.runtime
         }
     }

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -18,12 +18,10 @@ use freenet_stdlib::prelude::*;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
+use super::executor::runtime::RuntimePool;
 use super::executor::{ExecutorHalve, ExecutorToEventLoopChannel};
 use super::ExecutorError;
-use super::{
-    executor::{ContractExecutor, Executor},
-    ContractError,
-};
+use super::{executor::ContractExecutor, ContractError};
 use crate::client_events::HostResult;
 use crate::config::Config;
 use crate::message::{QueryResult, Transaction};
@@ -79,13 +77,14 @@ pub(crate) trait ContractHandler {
 }
 
 pub(crate) struct NetworkContractHandler<R = Runtime> {
-    executor: Executor<R>,
+    executor: RuntimePool<R>,
     channel: ContractHandlerChannel<ContractHandlerHalve>,
+    op_res_handle: tokio::task::JoinHandle<()>,
 }
 
 impl ContractHandler for NetworkContractHandler<Runtime> {
     type Builder = Arc<Config>;
-    type ContractExecutor = Executor<Runtime>;
+    type ContractExecutor = RuntimePool<Runtime>;
 
     async fn build(
         channel: ContractHandlerChannel<ContractHandlerHalve>,
@@ -95,8 +94,17 @@ impl ContractHandler for NetworkContractHandler<Runtime> {
     where
         Self: Sized + 'static,
     {
-        let executor = Executor::from_config(config.clone(), Some(executor_request_sender)).await?;
-        Ok(Self { executor, channel })
+        let num_executors = std::thread::available_parallelism()?;
+        let (to_process_tx, to_process) = mpsc::channel(num_executors.into());
+        let op_manager = executor_request_sender.op_manager.clone();
+        let op_res_handle =
+            tokio::spawn(executor_request_sender.handle_operation_result(to_process));
+        let executor = RuntimePool::new(config, to_process_tx, op_manager, num_executors).await?;
+        Ok(Self {
+            executor,
+            channel,
+            op_res_handle,
+        })
     }
 
     fn channel(&mut self) -> &mut ContractHandlerChannel<ContractHandlerHalve> {
@@ -104,6 +112,9 @@ impl ContractHandler for NetworkContractHandler<Runtime> {
     }
 
     fn executor(&mut self) -> &mut Self::ContractExecutor {
+        if self.op_res_handle.is_finished() {
+            panic!("executor handle is finished");
+        }
         &mut self.executor
     }
 }

--- a/crates/core/src/contract/mod.rs
+++ b/crates/core/src/contract/mod.rs
@@ -76,7 +76,10 @@ where
                 return_contract_code,
             } => {
                 // Clone needed values for the task
-                let fetch_contract = contract_handler.executor().fetch_contract(key, return_contract_code).await;
+                let fetch_contract = contract_handler
+                    .executor()
+                    .fetch_contract(key, return_contract_code)
+                    .await;
                 let id_clone = id;
 
                 pending_tasks.spawn(async move {
@@ -120,7 +123,15 @@ where
                 contract,
             } => {
                 // Clone needed values for the task
-                let put_future = contract_handler.executor().upsert_contract_state(key, Either::Left(state.clone()), related_contracts, contract).await;
+                let put_future = contract_handler
+                    .executor()
+                    .upsert_contract_state(
+                        key,
+                        Either::Left(state.clone()),
+                        related_contracts,
+                        contract,
+                    )
+                    .await;
 
                 pending_tasks.spawn(async move {
                     let span = tracing::info_span!("upsert_contract_state", %key);
@@ -161,7 +172,10 @@ where
                     freenet_stdlib::prelude::UpdateData::Delta(delta) => Either::Right(delta),
                     _ => unreachable!(),
                 };
-                let update_future = contract_handler.executor().upsert_contract_state(key, update_value, related_contracts, None).await;
+                let update_future = contract_handler
+                    .executor()
+                    .upsert_contract_state(key, update_value, related_contracts, None)
+                    .await;
 
                 pending_tasks.spawn(async move {
                     let span = tracing::info_span!("upsert_contract_state", %key);

--- a/crates/core/src/wasm_runtime/state_store.rs
+++ b/crates/core/src/wasm_runtime/state_store.rs
@@ -71,11 +71,6 @@ where
         })
     }
 
-    /// Get a reference to the underlying storage
-    pub fn storage(&self) -> &S {
-        &self.store
-    }
-
     pub async fn update(
         &mut self,
         key: &ContractKey,

--- a/crates/core/src/wasm_runtime/state_store.rs
+++ b/crates/core/src/wasm_runtime/state_store.rs
@@ -71,6 +71,11 @@ where
         })
     }
 
+    /// Get a reference to the underlying storage
+    pub fn storage(&self) -> &S {
+        &self.store
+    }
+
     pub async fn update(
         &mut self,
         key: &ContractKey,

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -189,11 +189,11 @@ async fn test_put_contract() -> TestResult {
     }
     .boxed_local();
 
-    let test = tokio::time::timeout(Duration::from_secs(120), async {
-        // Wait for nodes to start up
-        tracing::info!("Waiting for nodes to start up...");
-        tokio::time::sleep(Duration::from_secs(15)).await;
-        tracing::info!("Nodes should be ready, proceeding with test...");
+    let test = tokio::time::timeout(Duration::from_secs(180), async {
+        // Wait for nodes to start up and establish connections
+        tracing::info!("Waiting for nodes to start up and establish connections...");
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        tracing::info!("Nodes should be ready and connected, proceeding with test...");
 
         // Connect to node A's websocket API
         let uri = format!(

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -163,8 +163,8 @@ async fn test_put_contract() -> TestResult {
     .await?;
     let ws_api_port_peer_a = config_a.ws_api.ws_api_port.unwrap();
 
-    tracing::info!("Node A data dir: {:?}", preset_cfg_b.temp_dir.path());
-    tracing::info!("Node B data dir: {:?}", preset_cfg_a.temp_dir.path());
+    tracing::info!("Node A data dir: {:?}", preset_cfg_a.temp_dir.path());
+    tracing::info!("Node B data dir: {:?}", preset_cfg_b.temp_dir.path());
 
     std::mem::drop(ws_api_port_socket_a); // Free the port so it does not fail on initialization
     let node_a = async move {

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -237,6 +237,14 @@ async fn test_put_contract() -> TestResult {
             // Verify the responses
             assert_eq!(response_key, contract_key);
             assert_eq!(response_contract, contract);
+
+            // Debug the state comparison
+            tracing::info!("Original state: {:?}", wrapped_state);
+            tracing::info!("Response state: {:?}", response_state);
+            tracing::info!("Original state bytes: {:x?}", wrapped_state.as_ref());
+            tracing::info!("Response state bytes: {:x?}", response_state.as_ref());
+            tracing::info!("States equal: {}", response_state == wrapped_state);
+
             assert_eq!(response_state, wrapped_state);
         }
 

--- a/tests/test-delegate-integration/Cargo.lock
+++ b/tests/test-delegate-integration/Cargo.lock
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.6"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea1db7c5c1820d7583d21bafeead27e87f9d0d3590dcd7291f5e73e01202634"
+checksum = "ef791f340c26ee1dc720e8b68960fc405dfc3cd52fd2e9868da8f5d87233fb4f"
 dependencies = [
  "bincode",
  "blake3",


### PR DESCRIPTION
This pull request introduces several changes across multiple files, focusing on dependency updates, refactoring, and enhancements to the contract execution framework. The most significant updates include upgrading the `freenet-stdlib` dependency, improving the executor's architecture, and adding new functionality for contract lifecycle management.

### Dependency Updates:
* Updated the `freenet-stdlib` dependency from version `0.1.11` to `0.1.13` in `apps/freenet-ping/Cargo.toml` to incorporate the latest features and fixes.

### Refactoring and Code Simplification:
* Removed unused imports, such as `blake3::traits::digest::generic_array::GenericArray`, from `crates/core/src/contract/executor.rs` to clean up the codebase.
* Refactored the `CallbackError` enum to make it public while maintaining its `pub(crate)` visibility.

### Enhancements to Contract Execution:
* Introduced a new `ContractExecutor` trait with methods for contract fetching, state updates, and executor management, improving modularity and extensibility. [[1]](diffhunk://#diff-4b27ff1a8dbb6bca405e2252cf1de64c0c7645e83c43a365d9e98e08447cc50dR485-R521) [[2]](diffhunk://#diff-4b27ff1a8dbb6bca405e2252cf1de64c0c7645e83c43a365d9e98e08447cc50dR530-R558)
* Added a `handle_operation_result` method to manage asynchronous operations and handle transaction results efficiently.

### Executor Architecture Improvements:
* Replaced the `event_loop_channel` with `op_sender` and `op_manager` in the `Executor` struct, enabling better separation of concerns and facilitating executor pooling.
* Updated the `Executor`'s `new` method to initialize with the new architecture and added an `id` field for executor identification in a pool.

### Mock Runtime Adjustments:
* Removed the `new_mock` method from `MockRuntime` in `crates/core/src/contract/executor/mock_runtime.rs` and simplified the implementation to align with the new executor architecture. [[1]](diffhunk://#diff-ff3ab476b9795aab80df6281d726079767bfbd191923ac98379917db3a0fff6dL1-L37) [[2]](diffhunk://#diff-ff3ab476b9795aab80df6281d726079767bfbd191923ac98379917db3a0fff6dL46-R25)