### PR TITLE
fdev: log build steps with tracing (supersedes #1756)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "bytesize"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
+
+[[package]]
 name = "cache-padded"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1451,7 @@ dependencies = [
  "axum",
  "bincode",
  "bs58",
+ "bytesize",
  "chrono",
  "clap",
  "dashmap",

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -9,6 +9,7 @@ license-file = "LICENSE.md"
 repository = "https://github.com/freenet/freenet"
 
 [dependencies]
+bytesize = "1.3"
 anyhow = "1"
 axum = { default-features = false, features = ["http1", "matched-path", "query", "tower-log", "ws"], workspace = true }
 bincode = "1"

--- a/crates/fdev/src/build.rs
+++ b/crates/fdev/src/build.rs
@@ -9,6 +9,7 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
+use bytesize::ByteSize;
 use tar::Builder;
 
 use crate::{
@@ -102,13 +103,19 @@ fn compile_rust_wasm_lib(cli_config: &BuildToolConfig, work_dir: &Path) -> anyho
     };
 
     let package_type = cli_config.package_type;
-    println!("Compiling {package_type} with rust");
+    tracing::info!("Compiling {package_type} with rust, args: {:?}", cmd_args);
 
     // Set CARGO_TARGET_DIR if not already set to ensure consistent output location
     let mut command = Command::new("cargo");
     if env::var("CARGO_TARGET_DIR").is_err() {
         command.env("CARGO_TARGET_DIR", get_workspace_target_dir());
     }
+
+    tracing::info!(
+        command = ?"cargo",
+        args = ?cmd_args,
+        "Executing cargo command"
+    );
 
     let child = command
         .args(&cmd_args)
@@ -186,7 +193,7 @@ mod contract {
                 build_web_state(&config, embedded, cwd)?
             }
             ContractType::Standard => {
-                println!("Packaging generic contract type");
+                tracing::warn!("Packaging generic contract type");
                 build_generic_state(&mut config, cwd)?
             }
         }
@@ -425,13 +432,20 @@ mod contract {
             .map(Ok)
             .unwrap_or_else(|| get_default_ouput_dir(cwd).map(|p| p.join(DEFAULT_OUTPUT_NAME)))?;
 
-        println!("Bundling contract state");
+        tracing::info!("Bundling contract state");
         let state: PathBuf = (sources.len() == 1)
             .then(|| sources.pop().unwrap())
             .ok_or_else(|| Error::MissConfiguration(REQ_ONE_FILE_ERR.into()))?
             .into();
-        std::fs::copy(cwd.join(state), output_path)?;
-        println!("Finished bundling state");
+        let src_path = cwd.join(&state);
+        let bytes_written = std::fs::copy(&src_path, &output_path)?;
+        let human_size = bytesize::ByteSize(bytes_written).to_string();
+        tracing::info!(
+            path = ?output_path,
+            human_size = %human_size,
+            "Wrote contract state file"
+        );
+        tracing::info!("Finished bundling state");
         Ok(())
     }
 
@@ -483,8 +497,15 @@ mod contract {
                     get_default_ouput_dir(cwd)?.join(package_name)
                 };
                 let output = get_versioned_contract(&output_lib, cli_config)?;
-                let mut file = File::create(out_file)?;
+                let mut file = File::create(&out_file)?;
                 file.write_all(output.as_slice())?;
+                let size = output.len();
+                let human_size = ByteSize(size as u64).to_string();
+                tracing::info!(
+                    path = ?out_file,
+                    size = %human_size,
+                    "Wrote contract output file"
+                );
             }
             None => println!("no lang specified, skipping contract compilation"),
         }

--- a/crates/fdev/src/build.rs
+++ b/crates/fdev/src/build.rs
@@ -1,3 +1,4 @@
+use bytesize::ByteSize;
 use freenet::server::WebApp;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -9,7 +10,6 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
-use bytesize::ByteSize;
 use tar::Builder;
 
 use crate::{


### PR DESCRIPTION
This PR ports the changes from #1756 (fork by @ple1n) into a branch on this repo and addresses CI failures.\n\nSummary:\n- Switch selected println! calls in crates/fdev/src/build.rs to tracing with useful context\n- Log human-readable output sizes via bytesize\n- Update Cargo.lock and formatting to satisfy CI\n\nOriginal PR: #1756 (credits to @ple1n).\n\nOnce CI is green, please use Merge Queue.