### PR TITLE
Fix test_put_contract flakiness by adding worker_threads specification

### DIFF
--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -126,7 +126,7 @@ async fn get_contract(
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_put_contract() -> TestResult {
     freenet::config::set_logger(Some(LevelFilter::INFO), None);
     const TEST_CONTRACT: &str = "test-contract-integration";


### PR DESCRIPTION
## Summary
- Fixed flaky `test_put_contract` test that was timing out when run concurrently with other tests
- Added `worker_threads = 4` to match all other tests in operations.rs

## Problem
The `test_put_contract` test was the only test in `operations.rs` without `worker_threads = 4` specified in its tokio test annotation. This caused resource contention when running tests concurrently, leading to timeouts after 120 seconds.

## Solution
Added `worker_threads = 4` to the test annotation to match the other 9 tests in the file. This ensures consistent thread pool sizing across all tests.

## Test Results
- Test now passes reliably when run with all other operations tests
- Previously would timeout when run concurrently but pass when run in isolation

🤖 Generated with [Claude Code](https://claude.ai/code)