### PR TITLE
fix: Implement local subscription handling for gateway nodes

### DIFF
--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -391,7 +391,8 @@ impl ComposeNetworkMessage<operations::subscribe::SubscribeOp> for SubscribeCont
         op: operations::subscribe::SubscribeOp,
         op_manager: &OpManager,
     ) -> Result<(), OpError> {
-        operations::subscribe::request_subscribe(op_manager, op).await
+        // No client_id for contract executor subscriptions
+        operations::subscribe::request_subscribe(op_manager, op, None).await
     }
 }
 

--- a/crates/core/src/contract/mod.rs
+++ b/crates/core/src/contract/mod.rs
@@ -277,6 +277,7 @@ where
 }
 
 #[derive(Debug, thiserror::Error)]
+#[allow(dead_code)]
 pub(crate) enum ContractError {
     #[error("handler channel dropped")]
     ChannelDropped(Box<ContractHandlerEvent>),

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -504,20 +504,30 @@ impl P2pConnManager {
                                             .as_ref()
                                             .map(|s| s.value().len())
                                             .unwrap_or(0);
-                                        let subscriber_peer_ids: Vec<String> =
-                                            if config.include_subscriber_peer_ids {
-                                                subscribers_info
-                                                    .as_ref()
-                                                    .map(|s| {
-                                                        s.value()
-                                                            .iter()
-                                                            .map(|pk| pk.peer.to_string())
-                                                            .collect()
-                                                    })
-                                                    .unwrap_or_default()
-                                            } else {
-                                                Vec::new()
-                                            };
+                                        let subscriber_peer_ids: Vec<String> = if config
+                                            .include_subscriber_peer_ids
+                                        {
+                                            subscribers_info
+                                                .as_ref()
+                                                .map(|s| {
+                                                    s.value()
+                                                        .iter()
+                                                        .filter_map(|sub| match sub {
+                                                            crate::ring::Subscriber::Remote(
+                                                                peer_loc,
+                                                            ) => Some(peer_loc.peer.to_string()),
+                                                            crate::ring::Subscriber::Local(
+                                                                client_id,
+                                                            ) => {
+                                                                Some(format!("local:{}", client_id))
+                                                            }
+                                                        })
+                                                        .collect()
+                                                })
+                                                .unwrap_or_default()
+                                        } else {
+                                            Vec::new()
+                                        };
 
                                         response.contract_states.insert(
                                             *contract_key,

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -504,30 +504,27 @@ impl P2pConnManager {
                                             .as_ref()
                                             .map(|s| s.value().len())
                                             .unwrap_or(0);
-                                        let subscriber_peer_ids: Vec<String> = if config
-                                            .include_subscriber_peer_ids
-                                        {
-                                            subscribers_info
-                                                .as_ref()
-                                                .map(|s| {
-                                                    s.value()
-                                                        .iter()
-                                                        .filter_map(|sub| match sub {
-                                                            crate::ring::Subscriber::Remote(
-                                                                peer_loc,
-                                                            ) => Some(peer_loc.peer.to_string()),
-                                                            crate::ring::Subscriber::Local(
-                                                                client_id,
-                                                            ) => {
-                                                                Some(format!("local:{}", client_id))
-                                                            }
-                                                        })
-                                                        .collect()
-                                                })
-                                                .unwrap_or_default()
-                                        } else {
-                                            Vec::new()
-                                        };
+                                        let subscriber_peer_ids: Vec<String> =
+                                            if config.include_subscriber_peer_ids {
+                                                subscribers_info
+                                                    .as_ref()
+                                                    .map(|s| {
+                                                        s.value()
+                                                            .iter()
+                                                            .map(|sub| match sub {
+                                                                crate::ring::Subscriber::Remote(
+                                                                    peer_loc,
+                                                                ) => peer_loc.peer.to_string(),
+                                                                crate::ring::Subscriber::Local(
+                                                                    client_id,
+                                                                ) => format!("local:{}", client_id),
+                                                            })
+                                                            .collect()
+                                                    })
+                                                    .unwrap_or_default()
+                                            } else {
+                                                Vec::new()
+                                            };
 
                                         response.contract_states.insert(
                                             *contract_key,

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -68,7 +68,7 @@ pub(crate) async fn request_get(
             key,
             &skip_list,
             DEFAULT_MAX_BREADTH,
-            false,
+            true, // Include self for initial request to check local cache first
         );
         if candidates.is_empty() {
             // No peers available - check if we have the contract locally

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -64,10 +64,12 @@ pub(crate) async fn request_get(
         // the initial request must provide:
         // - a location in the network where the contract resides
         // - and the key of the contract value to get
-        let candidates =
-            op_manager
-                .ring
-                .k_closest_potentially_caching(key, &skip_list, DEFAULT_MAX_BREADTH);
+        let candidates = op_manager.ring.k_closest_potentially_caching(
+            key,
+            &skip_list,
+            DEFAULT_MAX_BREADTH,
+            false,
+        );
         if candidates.is_empty() {
             // No peers available - check if we have the contract locally
             tracing::debug!(
@@ -662,6 +664,7 @@ impl Operation for GetOp {
                                         key,
                                         &new_skip_list,
                                         DEFAULT_MAX_BREADTH,
+                                        false,
                                     );
 
                                 if !new_candidates.is_empty() {
@@ -1107,6 +1110,7 @@ async fn try_forward_or_return(
             &key,
             &new_skip_list,
             DEFAULT_MAX_BREADTH,
+            false,
         );
 
         if candidates.is_empty() {

--- a/crates/core/src/operations/mod.rs
+++ b/crates/core/src/operations/mod.rs
@@ -314,7 +314,8 @@ async fn start_subscription_request(
     skip_list: HashSet<PeerId>,
 ) {
     let sub_op = subscribe::start_op(key);
-    if let Err(error) = subscribe::request_subscribe(op_manager, sub_op).await {
+    // No client_id for automatic subscription after put
+    if let Err(error) = subscribe::request_subscribe(op_manager, sub_op, None).await {
         if !try_get {
             tracing::warn!(%error, "Error subscribing to contract");
             return;

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -688,8 +688,16 @@ impl OpManager {
             .map(|subs| {
                 subs.value()
                     .iter()
-                    .filter(|pk| &pk.peer != sender)
-                    .cloned()
+                    .filter_map(|sub| match sub {
+                        crate::ring::Subscriber::Remote(peer_loc) => {
+                            if &peer_loc.peer != sender {
+                                Some(peer_loc.clone())
+                            } else {
+                                None
+                            }
+                        }
+                        crate::ring::Subscriber::Local(_) => None,
+                    })
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -79,7 +79,11 @@ pub(crate) async fn request_subscribe(
                     );
 
                     // Add local subscription
-                    if let Err(_) = op_manager.ring.add_local_subscription(&key, client_id) {
+                    if op_manager
+                        .ring
+                        .add_local_subscription(&key, client_id)
+                        .is_err()
+                    {
                         tracing::warn!("Failed to add local subscription for client {}", client_id);
                         // Continue with operation completion even if we can't add the subscription
                     }

--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -395,11 +395,6 @@ impl Ring {
         self.seeding_manager.subscribers_of(contract)
     }
 
-    /// Get only remote subscribers for a contract
-    pub fn remote_subscribers_of(&self, contract: &ContractKey) -> Vec<PeerKeyLocation> {
-        self.seeding_manager.remote_subscribers_of(contract)
-    }
-
     /// Add a local client subscription
     pub fn add_local_subscription(
         &self,

--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -62,6 +62,7 @@ pub use self::live_tx::LiveTransactionTracker;
 pub use connection::Connection;
 pub use location::{Distance, Location};
 pub use peer_key_location::PeerKeyLocation;
+pub use seeding::{ClientId, Subscriber};
 
 /// Thread safe and friendly data structure to keep track of the local knowledge
 /// of the state of the ring.
@@ -390,8 +391,23 @@ impl Ring {
     pub fn subscribers_of(
         &self,
         contract: &ContractKey,
-    ) -> Option<DmRef<'_, ContractKey, Vec<PeerKeyLocation>>> {
+    ) -> Option<DmRef<'_, ContractKey, Vec<Subscriber>>> {
         self.seeding_manager.subscribers_of(contract)
+    }
+
+    /// Get only remote subscribers for a contract
+    pub fn remote_subscribers_of(&self, contract: &ContractKey) -> Vec<PeerKeyLocation> {
+        self.seeding_manager.remote_subscribers_of(contract)
+    }
+
+    /// Add a local client subscription
+    pub fn add_local_subscription(
+        &self,
+        contract: &ContractKey,
+        client_id: ClientId,
+    ) -> Result<(), ()> {
+        self.seeding_manager
+            .add_local_subscriber(contract, client_id)
     }
 
     /// Get all network subscriptions across all contracts

--- a/crates/core/src/ring/seeding.rs
+++ b/crates/core/src/ring/seeding.rs
@@ -1,6 +1,50 @@
 use super::{Location, PeerKeyLocation, Score};
 use dashmap::{mapref::one::Ref as DmRef, DashMap};
 use freenet_stdlib::prelude::ContractKey;
+use std::fmt;
+
+/// Unique identifier for a local client connection
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ClientId(u64);
+
+impl ClientId {
+    pub fn new(id: u64) -> Self {
+        ClientId(id)
+    }
+}
+
+impl fmt::Display for ClientId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Client({})", self.0)
+    }
+}
+
+/// Represents a subscriber to a contract, either remote or local
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Subscriber {
+    /// A remote peer subscribing via network
+    Remote(PeerKeyLocation),
+    /// A local client subscribing on this node
+    Local(ClientId),
+}
+
+impl Subscriber {
+    /// Check if this is a remote subscriber with the given peer
+    pub fn is_remote_peer(&self, peer: &crate::node::PeerId) -> bool {
+        match self {
+            Subscriber::Remote(loc) => &loc.peer == peer,
+            Subscriber::Local(_) => false,
+        }
+    }
+
+    /// Get the location if this is a remote subscriber
+    pub fn location(&self) -> Option<Location> {
+        match self {
+            Subscriber::Remote(loc) => loc.location,
+            Subscriber::Local(_) => None,
+        }
+    }
+}
 
 pub(crate) struct SeedingManager {
     /// The container for subscriber is a vec instead of something like a hashset
@@ -8,7 +52,7 @@ pub(crate) struct SeedingManager {
     /// of data locality, since we are likely to end up iterating over the whole sequence
     /// of subscribers more often than inserting, and anyways is a relatively short sequence
     /// then is more optimal to just use a vector for it's compact memory layout.
-    subscribers: DashMap<ContractKey, Vec<PeerKeyLocation>>,
+    subscribers: DashMap<ContractKey, Vec<Subscriber>>,
     /// Contracts this peer is seeding.
     seeding_contract: DashMap<ContractKey, Score>,
 }
@@ -62,7 +106,7 @@ impl SeedingManager {
         own_location: Location,
     ) -> (Option<ContractKey>, Vec<PeerKeyLocation>) {
         let seed_score = self.calculate_seed_score(&key, own_location);
-        let mut old_subscribers = vec![];
+        let mut old_remote_subscribers = vec![];
         let mut contract_to_drop = None;
 
         // FIXME: reproduce this condition in tests
@@ -74,17 +118,22 @@ impl SeedingManager {
                 .map(|entry| *entry.key())
             {
                 self.seeding_contract.remove(&dropped_contract);
-                if let Some((_, mut subscribers_of_contract)) =
+                if let Some((_, subscribers_of_contract)) =
                     self.subscribers.remove(&dropped_contract)
                 {
-                    std::mem::swap(&mut subscribers_of_contract, &mut old_subscribers);
+                    // Extract only remote subscribers to return
+                    for sub in subscribers_of_contract {
+                        if let Subscriber::Remote(peer_loc) = sub {
+                            old_remote_subscribers.push(peer_loc);
+                        }
+                    }
                 }
                 contract_to_drop = Some(dropped_contract);
             }
         }
 
         self.seeding_contract.insert(key, seed_score);
-        (contract_to_drop, old_subscribers)
+        (contract_to_drop, old_remote_subscribers)
     }
 
     fn calculate_seed_score(&self, key: &ContractKey, own_location: Location) -> Score {
@@ -106,6 +155,23 @@ impl SeedingManager {
         contract: &ContractKey,
         subscriber: PeerKeyLocation,
     ) -> Result<(), ()> {
+        self.add_subscriber_internal(contract, Subscriber::Remote(subscriber))
+    }
+
+    /// Add a local client subscriber
+    pub fn add_local_subscriber(
+        &self,
+        contract: &ContractKey,
+        client_id: ClientId,
+    ) -> Result<(), ()> {
+        self.add_subscriber_internal(contract, Subscriber::Local(client_id))
+    }
+
+    fn add_subscriber_internal(
+        &self,
+        contract: &ContractKey,
+        subscriber: Subscriber,
+    ) -> Result<(), ()> {
         let mut subs = self
             .subscribers
             .entry(*contract)
@@ -113,12 +179,14 @@ impl SeedingManager {
         if subs.len() >= Self::MAX_SUBSCRIBERS {
             return Err(());
         }
-        if let Err(next_idx) = subs.value_mut().binary_search(&subscriber) {
-            let subs = subs.value_mut();
+
+        // Check if subscriber already exists
+        let exists = subs.value().iter().any(|s| s == &subscriber);
+        if !exists {
             if subs.len() == Self::MAX_SUBSCRIBERS {
                 return Err(());
             } else {
-                subs.insert(next_idx, subscriber);
+                subs.value_mut().push(subscriber);
             }
         }
         Ok(())
@@ -127,21 +195,55 @@ impl SeedingManager {
     pub fn subscribers_of(
         &self,
         contract: &ContractKey,
-    ) -> Option<DmRef<'_, ContractKey, Vec<PeerKeyLocation>>> {
+    ) -> Option<DmRef<'_, ContractKey, Vec<Subscriber>>> {
         self.subscribers.get(contract)
+    }
+
+    /// Get only remote subscribers for backward compatibility
+    pub fn remote_subscribers_of(&self, contract: &ContractKey) -> Vec<PeerKeyLocation> {
+        self.subscribers
+            .get(contract)
+            .map(|subs| {
+                subs.value()
+                    .iter()
+                    .filter_map(|s| match s {
+                        Subscriber::Remote(loc) => Some(loc.clone()),
+                        Subscriber::Local(_) => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     pub fn prune_subscriber(&self, loc: Location) {
         self.subscribers.alter_all(|_, mut subs| {
-            if let Some(pos) = subs.iter().position(|l| l.location == Some(loc)) {
+            if let Some(pos) = subs.iter().position(|s| s.location() == Some(loc)) {
                 subs.swap_remove(pos);
             }
             subs
         });
     }
 
-    /// Get all subscriptions across all contracts
+    /// Get all subscriptions across all contracts (returns only remote subscribers for compatibility)
     pub fn all_subscriptions(&self) -> Vec<(ContractKey, Vec<PeerKeyLocation>)> {
+        self.subscribers
+            .iter()
+            .map(|entry| {
+                let remote_subs: Vec<PeerKeyLocation> = entry
+                    .value()
+                    .iter()
+                    .filter_map(|s| match s {
+                        Subscriber::Remote(loc) => Some(loc.clone()),
+                        Subscriber::Local(_) => None,
+                    })
+                    .collect();
+                (*entry.key(), remote_subs)
+            })
+            .collect()
+    }
+
+    /// Get all subscribers (both local and remote) for a contract
+    pub fn all_subscribers(&self) -> Vec<(ContractKey, Vec<Subscriber>)> {
         self.subscribers
             .iter()
             .map(|entry| (*entry.key(), entry.value().clone()))

--- a/crates/core/src/ring/seeding.rs
+++ b/crates/core/src/ring/seeding.rs
@@ -29,14 +29,6 @@ pub enum Subscriber {
 }
 
 impl Subscriber {
-    /// Check if this is a remote subscriber with the given peer
-    pub fn is_remote_peer(&self, peer: &crate::node::PeerId) -> bool {
-        match self {
-            Subscriber::Remote(loc) => &loc.peer == peer,
-            Subscriber::Local(_) => false,
-        }
-    }
-
     /// Get the location if this is a remote subscriber
     pub fn location(&self) -> Option<Location> {
         match self {
@@ -199,22 +191,6 @@ impl SeedingManager {
         self.subscribers.get(contract)
     }
 
-    /// Get only remote subscribers for backward compatibility
-    pub fn remote_subscribers_of(&self, contract: &ContractKey) -> Vec<PeerKeyLocation> {
-        self.subscribers
-            .get(contract)
-            .map(|subs| {
-                subs.value()
-                    .iter()
-                    .filter_map(|s| match s {
-                        Subscriber::Remote(loc) => Some(loc.clone()),
-                        Subscriber::Local(_) => None,
-                    })
-                    .collect()
-            })
-            .unwrap_or_default()
-    }
-
     pub fn prune_subscriber(&self, loc: Location) {
         self.subscribers.alter_all(|_, mut subs| {
             if let Some(pos) = subs.iter().position(|s| s.location() == Some(loc)) {
@@ -239,14 +215,6 @@ impl SeedingManager {
                     .collect();
                 (*entry.key(), remote_subs)
             })
-            .collect()
-    }
-
-    /// Get all subscribers (both local and remote) for a contract
-    pub fn all_subscribers(&self) -> Vec<(ContractKey, Vec<Subscriber>)> {
-        self.subscribers
-            .iter()
-            .map(|entry| (*entry.key(), entry.value().clone()))
             .collect()
     }
 }


### PR DESCRIPTION
## Summary
This PR implements proper handling of local subscriptions for gateway nodes and fixes GET operation routing issues that were causing test failures.

## Problems Fixed
1. **Local Subscriptions**: When contracts are cached locally on gateway nodes, subscription requests were being forwarded to remote peers unnecessarily
2. **GET Routing Bug**: Nodes were incorrectly trying to forward GET requests to themselves, causing connection timeouts
3. **Initial GET Requests**: Initial GET requests weren't checking local cache first due to incorrect `include_self` parameter usage

## Solution
### Local Subscription Handling
- Added `Subscriber` enum to distinguish between `Remote` and `Local` subscribers
- Introduced `ClientId` type for tracking local client connections
- Modified subscription handling to check if contract is cached locally first
- Implemented dual tracking of both local and remote subscriptions
- Updated broadcast mechanisms to notify both local clients and remote peers
- Fixed client notification using `AwaitingResponse` state with synthetic `ReturnSub` messages

### GET Operation Routing Fix
- Added `include_self` parameter to `k_closest_potentially_caching` function
- Initial GET requests use `include_self=true` to check local cache first
- Forward requests after local miss use `include_self=false` to avoid self-routing
- Prevents nodes from trying to connect to themselves when forwarding requests

## Changes
1. **ring/seeding.rs**: Added Subscriber enum and local subscription tracking
2. **operations/subscribe.rs**: Added local subscription handling with proper client notification
3. **operations/update.rs**: Modified to broadcast to both local and remote subscribers
4. **ring/mod.rs**: Added `include_self` parameter to control self-inclusion in peer candidates
5. **operations/get.rs**: Fixed to use correct `include_self` values for different scenarios
6. **operations/put.rs**: Updated to use `include_self=true` for PUT operations
7. **contract/mod.rs**: Added local subscription info to debug queries

## Testing
- All tests pass locally and in CI
- The `test_multiple_clients_subscription` test validates subscription functionality
- The `test_put_contract` test validates GET/PUT operations
- Fixed intermittent CI failures that were caused by the routing issues

## Related
- Follows up on #1781 (CachingTarget implementation)
- Part of gateway optimization effort
- Fixes test failures that were blocking CI

[AI-assisted debugging and implementation]