### PR TITLE
fix: Prevent nodes from forwarding GET requests to themselves

### DIFF
--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -64,10 +64,12 @@ pub(crate) async fn request_get(
         // the initial request must provide:
         // - a location in the network where the contract resides
         // - and the key of the contract value to get
-        let candidates =
-            op_manager
-                .ring
-                .k_closest_potentially_caching(key, &skip_list, DEFAULT_MAX_BREADTH);
+        let candidates = op_manager.ring.k_closest_potentially_caching(
+            key,
+            &skip_list,
+            DEFAULT_MAX_BREADTH,
+            true, // Include self for initial request to check local cache first
+        );
         if candidates.is_empty() {
             // No peers available - check if we have the contract locally
             tracing::debug!(
@@ -662,6 +664,7 @@ impl Operation for GetOp {
                                         key,
                                         &new_skip_list,
                                         DEFAULT_MAX_BREADTH,
+                                        false, // Don't include self when forwarding after failures
                                     );
 
                                 if !new_candidates.is_empty() {
@@ -1107,6 +1110,7 @@ async fn try_forward_or_return(
             &key,
             &new_skip_list,
             DEFAULT_MAX_BREADTH,
+            false, // Don't include self when forwarding
         );
 
         if candidates.is_empty() {

--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -265,9 +265,22 @@ impl Ring {
         contract_key: &ContractKey,
         skip_list: impl Contains<PeerId> + Clone,
         k: usize,
+        include_self: bool,
     ) -> Vec<PeerKeyLocation> {
         let router = self.router.read();
         let target_location = Location::from(contract_key);
+
+        // Get own location if we should include self
+        let own_loc = if include_self {
+            let loc = self.connection_manager.own_location();
+            if !skip_list.has_element(loc.peer.clone()) {
+                Some(loc)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
 
         // Get all connected peers through the connection manager
         let connections = self.connection_manager.get_connections_by_location();
@@ -277,8 +290,15 @@ impl Ring {
             (!skip_list.has_element(conn.location.peer.clone())).then_some(&conn.location)
         });
 
+        // Chain own location if it should be included
+        let all_peers: Vec<PeerKeyLocation> = if let Some(ref own) = own_loc {
+            peers.chain(std::iter::once(own)).cloned().collect()
+        } else {
+            peers.cloned().collect()
+        };
+
         router
-            .select_k_best_peers(peers, target_location, k)
+            .select_k_best_peers(all_peers.iter(), target_location, k)
             .into_iter()
             .cloned()
             .collect()


### PR DESCRIPTION
## Summary
This PR fixes a GET operation routing bug that was causing CI test failures. It's a minimal, focused fix without unnecessary complexity.

## Problem
Nodes were incorrectly trying to forward GET requests to themselves, causing connection timeout errors in CI. This was happening because the `k_closest_potentially_caching` function always excluded the current node from the candidate list, even for initial GET requests where we should check local cache first.

## Solution
Added an `include_self` boolean parameter to `k_closest_potentially_caching` to control whether the current node should be included in the candidate list:
- **Initial GET requests**: Use `include_self=true` to check local cache first
- **Forward requests**: Use `include_self=false` after determining we don't have the contract locally

## Changes
- **ring/mod.rs**: Added `include_self` parameter to `k_closest_potentially_caching`
- **operations/get.rs**: Updated all calls to use appropriate `include_self` values

## Testing
- ✅ All tests pass locally
- ✅ `test_multiple_clients_subscription` passes
- ✅ `test_put_contract` passes
- ✅ No unnecessary changes to subscription handling

## Note
This is a cleaner version of #1785 with only the essential GET routing fix, based on feedback from @nachodg that the subscription changes were unnecessary.

[AI-assisted debugging and implementation]