### PR TITLE
fix: Always merge states when initiating PUT to ensure consistency

### DIFF
--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -175,52 +175,49 @@ impl Operation for PutOp {
                         // 1. Nodes with no connections can still cache contracts
                         // 2. Nodes that are the optimal location cache locally
                         // 3. Initiators always have the data they're putting (per Nacho's requirement)
+                        // 4. States are properly merged (Freenet states are commutative monoids)
                         let is_already_seeding = op_manager.ring.is_seeding_contract(&key);
 
-                        // Always cache unless we're already seeding (to avoid duplicate work)
-                        // This ensures we always have it locally per Nacho's requirement
+                        tracing::debug!(
+                            tx = %id,
+                            %key,
+                            peer = %sender.peer,
+                            is_already_seeding,
+                            "Processing local PUT in initiating node"
+                        );
+
+                        // Always call put_contract to ensure proper state merging
+                        // Since Freenet states are commutative monoids, merging is always safe
+                        // and necessary to maintain consistency
+                        let result = put_contract(
+                            op_manager,
+                            key,
+                            value.clone(),
+                            related_contracts.clone(),
+                            contract,
+                        )
+                        .await?;
+
+                        // Mark as seeded locally if not already
                         if !is_already_seeding {
+                            op_manager.ring.seed_contract(key);
                             tracing::debug!(
                                 tx = %id,
                                 %key,
                                 peer = %sender.peer,
-                                is_already_seeding,
-                                "Caching contract locally in initiating node"
+                                "Marked contract as seeding locally"
                             );
-
-                            // Put the contract locally
-                            // IMPORTANT: Use the modified value returned from put_contract
-                            let result = put_contract(
-                                op_manager,
-                                key,
-                                value.clone(),
-                                related_contracts.clone(),
-                                contract,
-                            )
-                            .await?;
-
-                            // Mark as seeded locally if not already
-                            if !is_already_seeding {
-                                op_manager.ring.seed_contract(key);
-                            }
-
-                            tracing::debug!(
-                                tx = %id,
-                                %key,
-                                peer = %sender.peer,
-                                "Successfully cached contract locally"
-                            );
-
-                            result
-                        } else {
-                            tracing::debug!(
-                                tx = %id,
-                                %key,
-                                peer = %sender.peer,
-                                "Already seeding contract, skipping duplicate caching"
-                            );
-                            value.clone()
                         }
+
+                        tracing::debug!(
+                            tx = %id,
+                            %key,
+                            peer = %sender.peer,
+                            was_already_seeding = is_already_seeding,
+                            "Successfully processed contract locally with merge"
+                        );
+
+                        result
                     } else {
                         tracing::debug!(
                             tx = %id,


### PR DESCRIPTION
## Summary

This PR fixes an issue where we were skipping state merging when a node was already seeding a contract.

## Problem

When a node that's already seeding a contract receives a PUT for that same contract, we were skipping the call to `put_contract()` and just using the incoming value as-is. This is incorrect because:

1. Freenet states are commutative monoids - merging valid states should always yield the same result regardless of order
2. Skipping the merge could lead to inconsistent state across the network
3. The contract handler never gets a chance to properly reconcile states

## Solution

Always call `put_contract()` when initiating a PUT, regardless of whether we're already seeding. This ensures:
- Proper state merging through the contract handler
- Consistency across the network
- Correct handling of concurrent updates

## Changes

- Modified the PUT operation to always call `put_contract()` when initiating
- Updated logging to reflect the merge operation
- Added documentation explaining why merging is necessary

## Note

This PR is based on #1781 and should be merged after it.

[AI-assisted PR creation]