### PR TITLE
Fix invalid cfg attr & non_canonical_partial_ord

### DIFF
--- a/modules/antiflood-tokens/delegates/token-generator/src/lib.rs
+++ b/modules/antiflood-tokens/delegates/token-generator/src/lib.rs
@@ -310,7 +310,7 @@ impl TokenAssignmentInternal for TokenAllocationRecord {
             Some(currently_assigned) => {
                 let mut oldest_valid_observed = None;
                 let mut first_valid = None;
-                for (_idx, assignment) in currently_assigned.iter().enumerate() {
+                for assignment in currently_assigned.iter() {
                     // dbg!(
                     //     oldest_valid_observed.map(|a: &TokenAssignment| a.time_slot),
                     //     first_valid,

--- a/modules/antiflood-tokens/interfaces/src/lib.rs
+++ b/modules/antiflood-tokens/interfaces/src/lib.rs
@@ -728,7 +728,7 @@ impl TokenAssignment {
             TokenAssignment::signature_content(&self.time_slot, self.tier, &self.assignment_hash);
         if verifying_key.verify(&msg, &self.signature).is_err() {
             // not signed by the private key of this generator
-            #[cfg(all(target_family = "wasm", features = "contract"))]
+            #[cfg(all(target_family = "wasm", feature = "contract"))]
             {
                 freenet_stdlib::log::info(&format!(
                     "failed verification of message `{msg:?}` with signature: `{sig}`",
@@ -743,7 +743,7 @@ impl TokenAssignment {
 
 impl PartialOrd for TokenAssignment {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.time_slot.cmp(&other.time_slot))
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
In the antiflood-tokens module, one of the #[cfg]s used an incorrect attribute: features instead of feature. This inadvertently gated a few lines of code.

I also fixed two small lints. PartialOrd should only be manually implemented if Ord isn't implemented. Ord implies PartialOrd, so a PartialOrd impl should forward to Ord.

Clippy denies ignoring the index for enumerate() - it's likely that the caller intended to use it and forgot, so denying this lint is useful for finding logic bugs. In this case, it doesn't seem like the index was meant to be used anywhere.