### PR TITLE
Fix fdev dependency conflict with tokio-tungstenite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,7 +1420,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1446,7 +1446,7 @@ dependencies = [
  "tar",
  "thiserror 2.0.16",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.27.0",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -1660,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef791f340c26ee1dc720e8b68960fc405dfc3cd52fd2e9868da8f5d87233fb4f"
+checksum = "087695bd49a28e00d95260dec3ce66eec0955efd258b494d353f9d4e2ce93a22"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -1683,7 +1683,7 @@ dependencies = [
  "serde_with",
  "thiserror 1.0.69",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.27.0",
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
@@ -5231,6 +5231,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.27.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5517,6 +5529,23 @@ name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes 1.10.1",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.9.1",
+ "sha1",
+ "thiserror 2.0.16",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes 1.10.1",
  "data-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = "0.3"
 wasmer = "5.0.4"
 wasmer-compiler-singlepass = "5.0.4"
 
-freenet-stdlib = { version = "0.1.13" }
+freenet-stdlib = { version = "0.1.14" }
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/apps/freenet-ping/app/Cargo.toml
+++ b/apps/freenet-ping/app/Cargo.toml
@@ -10,7 +10,7 @@ testing = ["freenet-stdlib/testing", "freenet/testing"]
 anyhow = "1.0"
 chrono = { workspace = true, features = ["default"] }
 clap = { version = "4.5", features = ["derive"] }
-freenet-stdlib = { version = "0.1.13", features = ["net"] }
+freenet-stdlib = { version = "0.1.14", features = ["net"] }
 freenet-ping-types = { path = "../types", features = ["std", "clap"] }
 futures = "0.3.31"
 rand = "0.8.5"
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.21.0"
 tokio = { version = "1.47", features = ["full"] }
-tokio-tungstenite = "0.26.1"
+tokio-tungstenite = "0.27.0"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 humantime = "2.2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -52,7 +52,7 @@ stretto = { features = ["async", "sync"], version = "0.8" }
 tar = { version = "0.4" }
 thiserror = "2"
 tokio = { features = ["fs", "macros", "rt-multi-thread", "sync", "process"], version = "1" }
-tokio-tungstenite = "0.26.1"
+tokio-tungstenite = "0.26.2"
 tower-http = { features = ["fs", "trace"], version = "0.6" }
 ulid = { features = ["serde"], version = "1.1" }
 wasmer = { features = ["sys"], workspace = true }

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -29,7 +29,7 @@ semver = { workspace = true }
 tar = "0.4"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "signal", "parking_lot", "process"] }
-tokio-tungstenite = "0.26.1"
+tokio-tungstenite = "0.27.0"
 toml = { version = "0.9", features = ["default", "preserve_order"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }


### PR DESCRIPTION
## Summary
- Fixed version mismatch between tokio-tungstenite used by fdev/ping app and freenet-stdlib
- Updated dependencies to resolve build error when installing fdev v0.3.1

## Changes
- Updated freenet-stdlib from 0.1.13 to 0.1.14 in workspace 
- Updated tokio-tungstenite to 0.27.0 in fdev and freenet-ping-app (to match stdlib)
- Bumped fdev version to 0.3.2
- Core remains at tokio-tungstenite 0.26.2 (doesn't directly use stdlib)

## Context
After the v0.1.22 release, users reported build errors when installing fdev v0.3.1 from crates.io. The issue was a version mismatch where fdev used tokio-tungstenite 0.26.x but freenet-stdlib 0.1.14 expected 0.27.0.

[AI-assisted debugging and comment]

🤖 Generated with [Claude Code](https://claude.ai/code)