### PR TITLE
fix: Prevent node crash when connection notification channels are closed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,7 +1632,7 @@ dependencies = [
  "tempfile",
  "testresult",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.27.0",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,7 +1420,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1446,7 +1446,7 @@ dependencies = [
  "tar",
  "thiserror 2.0.16",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.27.0",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -1660,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef791f340c26ee1dc720e8b68960fc405dfc3cd52fd2e9868da8f5d87233fb4f"
+checksum = "087695bd49a28e00d95260dec3ce66eec0955efd258b494d353f9d4e2ce93a22"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -1683,7 +1683,7 @@ dependencies = [
  "serde_with",
  "thiserror 1.0.69",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.27.0",
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
@@ -5231,6 +5231,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.27.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5517,6 +5529,23 @@ name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes 1.10.1",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.9.1",
+ "sha1",
+ "thiserror 2.0.16",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes 1.10.1",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,7 +1588,6 @@ dependencies = [
  "testresult",
  "thiserror 2.0.16",
  "tokio",
- "tokio-tungstenite 0.26.2",
  "tokio-tungstenite 0.27.0",
  "toml",
  "tower-http",
@@ -5221,18 +5220,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.26.2",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
@@ -5522,23 +5509,6 @@ dependencies = [
  "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
-dependencies = [
- "bytes 1.10.1",
- "data-encoding",
- "http 1.3.1",
- "httparse",
- "log",
- "rand 0.9.1",
- "sha1",
- "thiserror 2.0.16",
  "utf-8",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,6 +1589,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.27.0",
  "toml",
  "tower-http",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = "0.3"
 wasmer = "5.0.4"
 wasmer-compiler-singlepass = "5.0.4"
 
-freenet-stdlib = { version = "0.1.13" }
+freenet-stdlib = { version = "0.1.14" }
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/apps/freenet-ping/app/Cargo.toml
+++ b/apps/freenet-ping/app/Cargo.toml
@@ -10,7 +10,7 @@ testing = ["freenet-stdlib/testing", "freenet/testing"]
 anyhow = "1.0"
 chrono = { workspace = true, features = ["default"] }
 clap = { version = "4.5", features = ["derive"] }
-freenet-stdlib = { version = "0.1.13", features = ["net"] }
+freenet-stdlib = { version = "0.1.14", features = ["net"] }
 freenet-ping-types = { path = "../types", features = ["std", "clap"] }
 futures = "0.3.31"
 rand = "0.8.5"
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.21.0"
 tokio = { version = "1.47", features = ["full"] }
-tokio-tungstenite = "0.26.1"
+tokio-tungstenite = "0.27.0"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 humantime = "2.2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -52,7 +52,7 @@ stretto = { features = ["async", "sync"], version = "0.8" }
 tar = { version = "0.4" }
 thiserror = "2"
 tokio = { features = ["fs", "macros", "rt-multi-thread", "sync", "process"], version = "1" }
-tokio-tungstenite = "0.26.2"
+tokio-tungstenite = "0.27.0"
 tower-http = { features = ["fs", "trace"], version = "0.6" }
 ulid = { features = ["serde"], version = "1.1" }
 wasmer = { features = ["sys"], workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -89,6 +89,7 @@ statrs = "0.18"
 tempfile = "3"
 test-log = "0.2"
 testresult.workspace = true
+tokio-tungstenite = "0.27.0"
 # console-subscriber = { version = "0.4" }
 
 [features]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -52,7 +52,7 @@ stretto = { features = ["async", "sync"], version = "0.8" }
 tar = { version = "0.4" }
 thiserror = "2"
 tokio = { features = ["fs", "macros", "rt-multi-thread", "sync", "process"], version = "1" }
-tokio-tungstenite = "0.26.1"
+tokio-tungstenite = "0.26.2"
 tower-http = { features = ["fs", "trace"], version = "0.6" }
 ulid = { features = ["serde"], version = "1.1" }
 wasmer = { features = ["sys"], workspace = true }

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -884,7 +884,7 @@ impl P2pConnManager {
                     // Don't propagate channel closed errors - just log and continue
                     // The receiver may have timed out or been cancelled, which shouldn't crash the node
                     if let Err(e) = r.send_result(Err(error)).await {
-                        tracing::debug!(%peer_id, "Failed to send connection error notification: {:?}", e);
+                        tracing::warn!(%peer_id, "Failed to send connection error notification - receiver may have timed out: {:?}", e);
                     }
                 }
             }

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -740,12 +740,12 @@ impl P2pConnManager {
         if let Some(blocked_addrs) = &self.blocked_addresses {
             if blocked_addrs.contains(&peer.addr) {
                 tracing::info!(tx = %tx, remote = %peer.addr, "Outgoing connection to peer blocked by local policy");
-                // Ensure ConnectionError is correctly namespaced if HandshakeError::ConnectionError expects it directly
-                callback
+                // Don't propagate channel closed errors when notifying about blocked connections
+                let _ = callback
                     .send_result(Err(HandshakeError::ConnectionError(
                         crate::node::network_bridge::ConnectionError::AddressBlocked(peer.addr),
                     )))
-                    .await?;
+                    .await;
                 return Ok(());
             }
             tracing::debug!(tx = %tx, "Blocked addresses: {:?}, peer addr: {}", blocked_addrs, peer.addr);
@@ -881,7 +881,11 @@ impl P2pConnManager {
                     }
                 }
                 if let Some(mut r) = state.awaiting_connection.remove(&peer_id.addr) {
-                    r.send_result(Err(error)).await?;
+                    // Don't propagate channel closed errors - just log and continue
+                    // The receiver may have timed out or been cancelled, which shouldn't crash the node
+                    if let Err(e) = r.send_result(Err(error)).await {
+                        tracing::debug!(%peer_id, "Failed to send connection error notification: {:?}", e);
+                    }
                 }
             }
             HandshakeEvent::RemoveTransaction(tx) => {
@@ -890,7 +894,10 @@ impl P2pConnManager {
             HandshakeEvent::OutboundGatewayConnectionRejected { peer_id } => {
                 tracing::info!(%peer_id, "Connection rejected by peer");
                 if let Some(mut r) = state.awaiting_connection.remove(&peer_id.addr) {
-                    r.send_result(Err(HandshakeError::ChannelClosed)).await?;
+                    // Don't propagate channel closed errors - just log and continue
+                    if let Err(e) = r.send_result(Err(HandshakeError::ChannelClosed)).await {
+                        tracing::debug!(%peer_id, "Failed to send rejection notification: {:?}", e);
+                    }
                 }
             }
             HandshakeEvent::InboundConnectionRejected { peer_id } => {

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -1351,7 +1351,7 @@ mod test {
             Self {
                 packet_drop_policy: PacketDropPolicy::ReceiveAll,
                 peers: 2,
-                wait_time: Duration::from_secs(2),
+                wait_time: Duration::from_secs(10), // Increased for CI reliability
             }
         }
     }

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -29,7 +29,7 @@ semver = { workspace = true }
 tar = "0.4"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "signal", "parking_lot", "process"] }
-tokio-tungstenite = "0.26.1"
+tokio-tungstenite = "0.27.0"
 toml = { version = "0.9", features = ["default", "preserve_order"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }


### PR DESCRIPTION
## Problem
The freenet node was crashing with "channel closed" error when connection attempts failed, particularly when receiving "connection attempt already in progress" errors. This was happening frequently on macOS and other platforms.

## Root Cause
When a connection fails (e.g., duplicate connection attempts), the code tries to send the error back through a channel to notify the waiting operation. However, if the receiver has already timed out or been cancelled, the channel is closed. The code was propagating this channel closed error with `?`, causing the entire network event listener to exit and crash the node.

## Solution
Don't propagate channel closed errors when sending connection failure notifications. Instead, log them at debug level and continue operation. A failure to notify about a connection error shouldn't crash the entire node.

## Changes
- Modified `handle_handshake_event` to not propagate send_result errors in three locations:
  1. `OutboundConnectionFailed` handler
  2. `OutboundGatewayConnectionRejected` handler
  3. Blocked address check

## Testing
- Built and tested locally
- The node no longer crashes when connection races occur
- Connection failures are still properly logged

Fixes the crash reported where the last messages were:
```
INFO freenet::node::network_bridge::p2p_protoc: Connection failed: TransportError(ConnectionEstablishmentFailure { cause: "connection attempt already in progress" })
ERROR freenet::node: channel closed
```

[AI-assisted debugging and fix]