### PR TITLE
fix: Replace local gateways with remote ones when fetched from network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "aes-gcm",
  "ahash",


### PR DESCRIPTION
## Summary

This PR fixes an issue where users would continue connecting to old/disabled gateways even after the gateway list was updated on the server. Users were getting errors like "Protocol version mismatch: expected 0.1.21, got 0.1.23" because they were still connecting to the old vega gateway.

## The Problem

1. The remote gateways.toml correctly lists only nova (running v0.1.23)
2. Users' local gateways.toml files still contained vega (running v0.1.21)
3. The code was **merging** remote and local gateways instead of replacing them
4. This meant disabled gateways would persist forever in users' configurations

## The Solution

When gateways are successfully fetched from the network:
- **Replace** the local gateways entirely with the remote ones (don't merge)
- Save the updated gateway list to the local `gateways.toml` file
- Log the replacement for visibility

When `--skip-load-from-network` is used:
- Continue using local gateways as before
- This preserves the ability to test with custom gateways

## Changes

- Modified gateway loading logic to replace instead of merge when fetching from network
- Added `save_to_file()` call to persist the updated gateways
- Added logging to indicate when gateways are being replaced
- Added TODO comment noting this behavior may change after stable release

## Testing

The fix ensures that:
1. Users will automatically switch to nova gateway (v0.1.23)
2. The old vega gateway will be removed from their local config
3. Future gateway updates will be applied automatically

This is especially important during alpha testing when we frequently update gateway versions.

[AI-assisted debugging and comment]

🤖 Generated with [Claude Code](https://claude.ai/code)