### PR TITLE
Fix duplicate file extension in config log output

### DIFF
--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -132,7 +132,7 @@ impl ConfigArgs {
                     if filename.starts_with("config") {
                         match ext.as_str() {
                             "toml" => {
-                                tracing::info!("Found configuration file: {filename}.{ext}");
+                                tracing::info!("Found configuration file: {filename}");
                                 return Some((filename, ext));
                             }
                             "json" => {


### PR DESCRIPTION
This PR fixes a small logging issue in the config loader.
Previously, the log output showed config.toml.toml due to duplicating the file extension.
Now it correctly logs as config.toml.

This is just a cosmetic fix, no functional behavior changed.