### PR TITLE
fix: Remove unused dead code to resolve clippy warnings

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -472,7 +472,6 @@ impl Display for NetMessage {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -472,14 +472,6 @@ impl Display for NetMessage {
     }
 }
 
-/// The result of a connection attempt.
-#[derive(Debug, Serialize, Deserialize)]
-pub(crate) enum ConnectionResult {
-    /// The target node for connection is valid
-    Accepted,
-    /// The target node for connection is not valid
-    Connection,
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -511,7 +511,6 @@ mod test {
 
     const TEST_DELEGATE_1: &str = "test_delegate_1";
 
-
     #[derive(Debug, Serialize, Deserialize)]
     enum InboundAppMessage {
         CreateInboxRequest,

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -511,10 +511,6 @@ mod test {
 
     const TEST_DELEGATE_1: &str = "test_delegate_1";
 
-    #[derive(Debug, Serialize, Deserialize)]
-    struct SecretsContext {
-        private_key: Option<Vec<u8>>,
-    }
 
     #[derive(Debug, Serialize, Deserialize)]
     enum InboundAppMessage {

--- a/crates/core/tests/isolated_node_regression.rs
+++ b/crates/core/tests/isolated_node_regression.rs
@@ -10,7 +10,7 @@ use freenet::{
     dev_tool::TransportKeypair,
     local_node::NodeConfig,
     server::serve_gateway,
-    test_utils::{load_contract, make_get, make_put, verify_contract_exists},
+    test_utils::{load_contract, make_get, make_put},
 };
 use freenet_stdlib::{
     client_api::{ClientRequest, ContractResponse, HostResponse, WebApi},
@@ -93,7 +93,7 @@ async fn test_isolated_node_put_get_workflow() -> anyhow::Result<()> {
     // Start a single isolated node (no peers)
     let ws_port = 50700;
     let network_port = 50701;
-    let (config, temp_dir) = create_test_node_config(true, ws_port, Some(network_port)).await?;
+    let (config, _temp_dir) = create_test_node_config(true, ws_port, Some(network_port)).await?;
 
     // Load test contract and state
     const TEST_CONTRACT: &str = "test-contract-integration";


### PR DESCRIPTION
## Summary
- Remove unused `ConnectionResult` enum from message.rs
- Remove unused `SecretsContext` struct from delegate.rs

## Test plan
- [x] Verify clippy warnings are resolved with `cargo clippy --workspace --all-targets --all-features`
- [x] Ensure no functionality is affected by removing dead code

🤖 Generated with [Claude Code](https://claude.ai/code)