### PR TITLE
Add Claude CI analysis workflow for automated debugging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,43 @@ jobs:
 
       - name: Check code formatting
         run: cargo fmt -- --check
+
+  claude-ci-analysis:
+    name: Claude CI Analysis
+
+    runs-on: ubuntu-latest
+    needs: [test_all, clippy_check, fmt_check]
+    if: failure() && contains(github.event.pull_request.labels.*.name, 'claude-debug')
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude CI Analysis
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            The CI workflow has failed. Please analyze the failure and provide:
+            1. Root cause of the failure
+            2. Specific steps to fix the issue
+            3. Whether this appears to be a flaky test or genuine bug
+            4. Any relevant context from the codebase
+
+            Use the repository's CLAUDE.md for guidance on testing and debugging.
+
+            After your analysis, use `gh pr comment` with your Bash tool to post your findings as a comment on the PR.
+
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*),Bash(gh run view:*)"'


### PR DESCRIPTION
## Summary
- Adds a new `claude-ci-analysis` job to the CI workflow
- Runs automatically when CI fails on PRs labeled with `claude-debug`
- Provides root cause analysis and fix suggestions via PR comment

## Implementation Details

The new job:
- Depends on `test_all`, `clippy_check`, and `fmt_check` completing
- Only runs if any of those jobs fail AND the PR has the `claude-debug` label
- Uses the Claude Code Action to analyze CI logs
- Has permissions to read CI results and comment on PRs
- Posts findings directly to the PR using `gh pr comment`

## Usage

To enable Claude debugging on a PR:
1. Add the `claude-debug` label to the PR via the web UI
2. If CI fails, Claude will automatically analyze the failure
3. Claude posts its analysis as a PR comment

## Test Plan
- [x] Pre-commit checks pass
- [ ] Verify workflow syntax is valid (CI will check)
- [ ] Test with a PR that has CI failures and the `claude-debug` label

🤖 Generated with [Claude Code](https://claude.ai/code)