### PR TITLE
fix: make PUT auto-subscribe atomic

### DIFF
--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -950,7 +950,9 @@ impl Operation for GetOp {
                                     let mut new_skip_list = skip_list.clone();
                                     new_skip_list.insert(sender.peer.clone());
 
-                                    super::start_subscription_request(op_manager, key).await;
+                                    let _ =
+                                        super::start_subscription_request(op_manager, key, None)
+                                            .await;
                                 }
                             }
                             ContractHandlerEvent::PutResponse {

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -2757,6 +2757,9 @@ async fn test_subscription_introspection() -> TestResult {
     std::mem::drop(ws_api_port_socket_gw);
     std::mem::drop(ws_api_port_socket_node);
 
+    // Give OS time to release ports
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
     // Start nodes
     let node_gw = async {
         let config = config_gw.build().await?;


### PR DESCRIPTION
## Summary
- make `PUT` + `subscribe:true` atomic by awaiting the generated Subscribe transaction before returning the `PutResponse`
- add op-manager tracking so subscribe completions and failures resolve the waiting PUT (via result-router or timeouts)
- add a regression test that PUTs, immediately UPDATEs, and asserts notifications arrive without sleeps

## Testing
- cargo test --test operations test_put_auto_subscribe_allows_immediate_update -- --nocapture
- cargo test --test operations test_put_with_subscribe_flag -- --nocapture