### PR TITLE
fix: Prevent race condition in non-gateway peer client operations

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -196,6 +196,14 @@ impl P2pConnManager {
         )
         .await?;
 
+        // For non-gateway peers, pass the peer_ready flag so it can be set after first handshake
+        // For gateways, pass None (they're always ready)
+        let peer_ready = if !self.is_gateway {
+            Some(self.bridge.op_manager.peer_ready.clone())
+        } else {
+            None
+        };
+
         let (mut handshake_handler, handshake_handler_msg, outbound_message) =
             HandshakeHandler::new(
                 inbound_conn_handler,
@@ -204,6 +212,7 @@ impl P2pConnManager {
                 self.bridge.op_manager.ring.router.clone(),
                 self.this_location,
                 self.is_gateway,
+                peer_ready,
             );
 
         loop {


### PR DESCRIPTION
## Summary

Fixes a race condition where non-gateway peers could receive and attempt to process client operations (PUT, GET, etc.) before completing their initial network handshake and having their `peer_id` set.

This issue was exposed by PR #1898 (removal of legacy client management), which changed the initialization order such that the SessionActor starts earlier, allowing clients to connect before the peer is fully initialized.

## Changes

### Core Implementation
- **Added `peer_ready` flag to `OpManager`**: `Arc<AtomicBool>` that tracks when a peer is ready to process client operations
  - Gateways: Set to `true` immediately (peer_id set from config)
  - Non-gateway peers: Set to `false` initially, becomes `true` after first successful handshake

- **Updated `HandshakeHandler`**: 
  - Added `peer_ready` field to track readiness state
  - Sets `peer_ready` to `true` after successfully calling `try_set_peer_key()` (handshake.rs:302-308)
  
- **Added readiness check in client operations**:
  - Before processing PUT operations, non-gateway peers check `peer_ready` flag (client_events/mod.rs:407-419)
  - Gateways bypass this check (always ready)
  - Returns clear error message if client attempts operation before peer is ready

### Key Files Modified
- `crates/core/src/node/op_state_manager.rs` - Added peer_ready and is_gateway fields
- `crates/core/src/node/network_bridge/handshake.rs` - Set peer_ready after handshake
- `crates/core/src/node/network_bridge/p2p_protoc.rs` - Pass peer_ready to HandshakeHandler
- `crates/core/src/client_events/mod.rs` - Check peer_ready before operations

## Why This Fix is Safe

1. **Gateway compatibility**: Gateways are completely unaffected
   - Always marked as ready (peer_id set from config)
   - No additional checks in their code path
   - Works seamlessly with PR #1871 (gateway bootstrap fix)

2. **Non-gateway peer behavior**: 
   - Only affects the specific race condition window
   - Clear, actionable error message if hit
   - No performance impact (single atomic load)

3. **No conflicts with PR #1898**:
   - This fix is on main branch (before #1898)
   - PR #1898 will rebase on top of this
   - Addresses the root cause, not a symptom

## Test Results

✅ **Multi-machine test passed**: Local 2-peer River integration test
- Gateway startup: 1.07s
- Peer connection: 7.05s  
- Room creation: 0.12s
- Message exchange verified between both users
- No "peer id not found" errors

Full test output available in test-results/river-test-20251002-172303/

## Related Issues

- Fixes race condition identified in #1836
- Addresses issue found in PR #1898 testing
- Compatible with PR #1871 (gateway bootstrap)

## Implementation Notes

Per @iduartgomez and @netsirius guidance:
- Implemented as separate PR to avoid conflicts with #1898
- #1898 will be rebased after this is merged
- Check only applies to non-gateways (gateway safety preserved)

[AI-assisted debugging and comment]