### PR TITLE
Re-enable test_multiple_clients_subscription test

### DIFF
--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -536,11 +536,9 @@ async fn test_update_contract() -> TestResult {
 // This test is disabled due to race conditions in subscription propagation logic.
 // The test expects multiple clients across different nodes to receive subscription updates,
 // but the PUT caching refactor (commits 2cd337b5-0d432347) changed the subscription semantics.
-// Test exhibits non-deterministic behavior: sometimes hangs, sometimes fails with "channel closed".
-// Disabled to unblock v0.1.22 release - the issue is with the test, not the production code.
-// See issue #1798 for details and tracking.
+// Re-enabled after recent fixes to subscription logic - previously exhibited race conditions.
+// If this test becomes flaky again, see issue #1798 for historical context.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "Flaky test with race conditions - see comment above"]
 async fn test_multiple_clients_subscription() -> TestResult {
     freenet::config::set_logger(Some(LevelFilter::INFO), None);
 


### PR DESCRIPTION
Recent fixes to the subscription logic may have resolved the race conditions that caused this test to be flaky. This PR re-enables the test to verify stability in CI.

Closes #1798

Generated with [Claude Code](https://claude.ai/code)