### PR TITLE
Fix peer recommendation to use full skip_connections set

### DIFF
--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -192,9 +192,11 @@ impl Operation for ConnectOp {
                             skip_forwards = ?skip_forwards,
                             "Got queried for new connections from joiner",
                         );
+                        // Use the full skip_connections set to avoid recommending peers
+                        // that the joiner is already connected to (including the gateway itself)
                         if let Some(desirable_peer) = op_manager.ring.closest_to_location(
                             *ideal_location,
-                            HashSet::from([joiner.peer.clone()]),
+                            skip_connections.iter().cloned().collect(),
                         ) {
                             tracing::debug!(
                                 tx = %id,


### PR DESCRIPTION
## Problem

When handling `FindOptimalPeer` requests in small networks, the gateway was only skipping the joiner peer when recommending connections:

```rust
HashSet::from([joiner.peer.clone()])
```

This caused the gateway to repeatedly recommend itself or peers that the joiner was already connected to, preventing proper peer-to-peer mesh formation.

**Example failure scenario:**
1. Peer1 connects to Gateway (1 connection)
2. Peer1 wants more connections, sends `FindOptimalPeer` to Gateway
3. Gateway looks for peers near random location, skipping only Peer1
4. Gateway recommends itself (Gateway) back to Peer1
5. Peer1 tries to connect to Gateway again (already connected)
6. No mesh formation occurs

## Solution

Use the full `skip_connections` set that includes **all** peers the joiner is already connected to:

```rust
skip_connections.iter().cloned().collect()
```

**Location:** `crates/core/src/operations/connect.rs:199`

This ensures the gateway only recommends NEW peers that the joiner isn't already connected to.

## Background

This fix was originally implemented in commit 24a6b7c1 (branch `fix/connection-maintenance-skip-list`) but was never merged to main. This PR reapplies that critical fix.

## Testing

✅ All existing connectivity tests pass:
- `test_gateway_reconnection` 
- `test_basic_gateway_connectivity`

The fix enables proper peer discovery in multi-peer networks by ensuring gateways provide useful peer recommendations.

## Related Issues

- #1905 - Investigation revealed this regression
- #1904 - test_three_node_network_connectivity was removed  
- #1889 - Original topology manager issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-assisted debugging and comment]