### PR TITLE
ci: add conventional commits check to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,41 @@ jobs:
       - name: Check code formatting
         run: cargo fmt -- --check
 
+  conventional_commits:
+    name: Conventional Commits
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check PR title follows Conventional Commits
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+
   claude-ci-analysis:
     name: Claude CI Analysis
 


### PR DESCRIPTION
## Summary
- Add GitHub Action to validate PR titles follow Conventional Commits specification
- Uses `amannn/action-semantic-pull-request@v5` to check PR titles
- Supports standard types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
- Enforces lowercase subject pattern

## Benefits
- Ensures consistency in commit history
- Enables automated changelog generation
- Makes it easier to understand the nature of changes

## Test plan
- [ ] Create a PR with non-conventional title and verify it fails
- [ ] Create a PR with conventional title and verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)