### PR TITLE
fix: replace deprecated GenericArray::from_slice usage

### DIFF
--- a/apps/freenet-email-app/web/src/inbox.rs
+++ b/apps/freenet-email-app/web/src/inbox.rs
@@ -4,7 +4,6 @@ use std::{
     io::{Cursor, Read},
 };
 
-use chacha20poly1305::aead::generic_array::GenericArray;
 use chacha20poly1305::{
     aead::{Aead, AeadCore, OsRng},
     XChaCha20Poly1305,
@@ -214,9 +213,9 @@ impl DecryptedMessage {
             .unwrap();
 
         use chacha20poly1305::aead::KeyInit;
-        let cipher = XChaCha20Poly1305::new(GenericArray::from_slice(&chacha_key));
+        let cipher = XChaCha20Poly1305::new((&chacha_key).into());
         let decrypted_content = cipher
-            .decrypt(GenericArray::from_slice(nonce.as_ref()), content.as_ref())
+            .decrypt(nonce.as_ref().into(), content.as_ref())
             .map_err(|e| format!("{e}"))
             .unwrap();
         let content: DecryptedMessage = serde_json::from_slice(&decrypted_content).unwrap();

--- a/crates/core/src/config/secret.rs
+++ b/crates/core/src/config/secret.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 
-#[allow(deprecated)]
-use aes_gcm::{aead::generic_array::GenericArray, KeyInit};
+use aes_gcm::KeyInit;
 use chacha20poly1305::{XChaCha20Poly1305, XNonce};
 use freenet_stdlib::client_api::DelegateRequest;
 use rsa::pkcs8::DecodePrivateKey;
@@ -148,16 +147,15 @@ impl Default for Secrets {
     }
 }
 
-#[allow(deprecated)]
 impl Secrets {
     #[inline]
     pub fn nonce(&self) -> XNonce {
-        *XNonce::from_slice(&self.nonce)
+        self.nonce.into()
     }
 
     #[inline]
     pub fn cipher(&self) -> XChaCha20Poly1305 {
-        XChaCha20Poly1305::new(GenericArray::from_slice(&self.cipher))
+        XChaCha20Poly1305::new((&self.cipher).into())
     }
 
     #[inline]

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -371,29 +371,25 @@ impl ContractExecutor for Executor<Runtime> {
                 cipher,
                 nonce,
             } => {
-                #[allow(deprecated)]
-                {
-                    use aes_gcm::aead::generic_array::GenericArray;
-                    use chacha20poly1305::{KeyInit, XChaCha20Poly1305};
-                    let key = delegate.key().clone();
-                    let arr = GenericArray::from_slice(&cipher);
-                    let cipher = XChaCha20Poly1305::new(arr);
-                    let nonce = GenericArray::from_slice(&nonce).to_owned();
-                    if let Some(contract) = attested_contract {
-                        self.delegate_attested_ids
-                            .entry(key.clone())
-                            .or_default()
-                            .push(*contract);
-                    }
-                    match self.runtime.register_delegate(delegate, cipher, nonce) {
-                        Ok(_) => Ok(DelegateResponse {
-                            key,
-                            values: Vec::new(),
-                        }),
-                        Err(err) => {
-                            tracing::warn!("failed registering delegate `{key}`: {err}");
-                            Err(ExecutorError::other(StdDelegateError::RegisterError(key)))
-                        }
+                use chacha20poly1305::{KeyInit, XChaCha20Poly1305};
+                let key = delegate.key().clone();
+                let arr = (&cipher).into();
+                let cipher = XChaCha20Poly1305::new(arr);
+                let nonce = nonce.into();
+                if let Some(contract) = attested_contract {
+                    self.delegate_attested_ids
+                        .entry(key.clone())
+                        .or_default()
+                        .push(*contract);
+                }
+                match self.runtime.register_delegate(delegate, cipher, nonce) {
+                    Ok(_) => Ok(DelegateResponse {
+                        key,
+                        values: Vec::new(),
+                    }),
+                    Err(err) => {
+                        tracing::warn!("failed registering delegate `{key}`: {err}");
+                        Err(ExecutorError::other(StdDelegateError::RegisterError(key)))
                     }
                 }
             }
@@ -661,29 +657,25 @@ impl Executor<Runtime> {
                 cipher,
                 nonce,
             } => {
-                #[allow(deprecated)]
-                {
-                    use aes_gcm::aead::generic_array::GenericArray;
-                    use chacha20poly1305::{KeyInit, XChaCha20Poly1305};
-                    let key = delegate.key().clone();
-                    let arr = GenericArray::from_slice(&cipher);
-                    let cipher = XChaCha20Poly1305::new(arr);
-                    let nonce = GenericArray::from_slice(&nonce).to_owned();
-                    if let Some(contract) = attested_contract {
-                        self.delegate_attested_ids
-                            .entry(key.clone())
-                            .or_default()
-                            .push(*contract);
-                    }
-                    match self.runtime.register_delegate(delegate, cipher, nonce) {
-                        Ok(_) => Ok(DelegateResponse {
-                            key,
-                            values: Vec::new(),
-                        }),
-                        Err(err) => {
-                            tracing::warn!("failed registering delegate `{key}`: {err}");
-                            Err(ExecutorError::other(StdDelegateError::RegisterError(key)))
-                        }
+                use chacha20poly1305::{KeyInit, XChaCha20Poly1305};
+                let key = delegate.key().clone();
+                let arr = (&cipher).into();
+                let cipher = XChaCha20Poly1305::new(arr);
+                let nonce = nonce.into();
+                if let Some(contract) = attested_contract {
+                    self.delegate_attested_ids
+                        .entry(key.clone())
+                        .or_default()
+                        .push(*contract);
+                }
+                match self.runtime.register_delegate(delegate, cipher, nonce) {
+                    Ok(_) => Ok(DelegateResponse {
+                        key,
+                        values: Vec::new(),
+                    }),
+                    Err(err) => {
+                        tracing::warn!("failed registering delegate `{key}`: {err}");
+                        Err(ExecutorError::other(StdDelegateError::RegisterError(key)))
                     }
                 }
             }

--- a/crates/core/src/transport/packet_data.rs
+++ b/crates/core/src/transport/packet_data.rs
@@ -1,10 +1,7 @@
 use std::marker::PhantomData;
 use std::{cell::RefCell, sync::Arc};
 
-use aes_gcm::{
-    aead::AeadInPlace,
-    Aes128Gcm,
-};
+use aes_gcm::{aead::AeadInPlace, Aes128Gcm};
 use rand::{prelude::SmallRng, rng, Rng, SeedableRng};
 
 use crate::transport::crypto::TransportPublicKey;

--- a/crates/core/src/transport/packet_data.rs
+++ b/crates/core/src/transport/packet_data.rs
@@ -1,9 +1,8 @@
 use std::marker::PhantomData;
 use std::{cell::RefCell, sync::Arc};
 
-#[allow(deprecated)]
 use aes_gcm::{
-    aead::{generic_array::GenericArray, AeadInPlace},
+    aead::AeadInPlace,
     Aes128Gcm,
 };
 use rand::{prelude::SmallRng, rng, Rng, SeedableRng};
@@ -74,7 +73,6 @@ impl Encryption for SymmetricAES {}
 impl Encryption for AssymetricRSA {}
 impl Encryption for UnknownEncryption {}
 
-#[allow(deprecated)]
 fn internal_sym_decryption<const N: usize>(
     data: &[u8],
     size: usize,
@@ -82,9 +80,9 @@ fn internal_sym_decryption<const N: usize>(
 ) -> Result<([u8; N], usize), aes_gcm::Error> {
     debug_assert!(data.len() >= NONCE_SIZE + TAG_SIZE);
 
-    let nonce = GenericArray::from_slice(&data[..NONCE_SIZE]);
+    let nonce = (&data[..NONCE_SIZE]).into();
     // Adjusted to extract the tag from the end of the encrypted data
-    let tag = GenericArray::from_slice(&data[size - TAG_SIZE..size]);
+    let tag = (&data[size - TAG_SIZE..size]).into();
     let encrypted_data = &data[NONCE_SIZE..size - TAG_SIZE];
     let mut buffer = [0u8; N];
     let buffer_len = encrypted_data.len();
@@ -149,7 +147,6 @@ impl<const N: usize> PacketData<Plaintext, N> {
         }
     }
 
-    #[allow(deprecated)]
     pub(crate) fn encrypt_symmetric(&self, cipher: &Aes128Gcm) -> PacketData<SymmetricAES, N> {
         _check_valid_size::<N>();
         debug_assert!(self.size <= MAX_DATA_SIZE);
@@ -172,7 +169,7 @@ impl<const N: usize> PacketData<Plaintext, N> {
 
         // Append the tag to the buffer
         buffer[NONCE_SIZE + payload_length..NONCE_SIZE + payload_length + TAG_SIZE]
-            .copy_from_slice(tag.as_slice());
+            .copy_from_slice(&tag);
 
         PacketData {
             data: buffer,
@@ -274,8 +271,7 @@ mod tests {
         rand::rng().fill(&mut key);
 
         // Create a key object for AES-GCM
-        #[allow(deprecated)]
-        let key = GenericArray::from_slice(&key);
+        let key = (&key).into();
 
         // Create a new AES-128-GCM instance
         let cipher = Aes128Gcm::new(key);
@@ -296,8 +292,7 @@ mod tests {
         rand::rng().fill(&mut key);
 
         // Create a key object for AES-GCM
-        #[allow(deprecated)]
-        let key = GenericArray::from_slice(&key);
+        let key = (&key).into();
 
         // Create a new AES-128-GCM instance
         let cipher = Aes128Gcm::new(key);


### PR DESCRIPTION
Replaced all occurrences of the deprecated GenericArray::from_slice API with modern alternatives across the codebase:

- In crates/core/src/transport/packet_data.rs: Use .into() for nonce and tag conversions, remove .as_slice() call
- In crates/core/src/contract/executor/runtime.rs: Use .into() for cipher key and nonce conversions
- In crates/core/src/config/secret.rs: Use .into() for cipher key and nonce conversions
- In apps/freenet-email-app/web/src/inbox.rs: Use .into() for chacha key and nonce conversions

Removed all #[allow(deprecated)] attributes that were suppressing these warnings. The code now compiles without deprecation warnings while maintaining the same functionality.

Fixes #2046