### PR TITLE
refactor(ops): relay UPDATE streaming task-per-tx (slice C) — #1454 phase 5

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -24,9 +24,8 @@ paths:
 > state-machine path**, which still serves: GC-spawned GET retries and
 > `start_targeted_op` UPDATE-triggered auto-fetch (streaming relay and
 > originator loopback also remain on legacy per #3883 port plan §7),
-> PUT GC / streaming / originator-loopback paths, UPDATE relay
-> streaming variants (`RequestUpdateStreaming`, `BroadcastToStreaming`)
-> and the deprecated `Broadcasting` wire variant, CONNECT, and
+> PUT GC / streaming / originator-loopback paths, the deprecated
+> UPDATE `Broadcasting` wire variant (no-op handler), CONNECT, and
 > SUBSCRIBE's renewal / PUT-sub-op / executor / intermediate-peer
 > entry points. Phase 5 follow-up slice A (PR #3910) migrated fresh
 > inbound non-streaming relay `UpdateMsg::RequestUpdate` and
@@ -70,7 +69,23 @@ paths:
 > `announce_contract_hosted` on the relayed path (relay is not itself
 > a subscriber; prevents the #3763 subscription-storm feedback loop).
 > Slices B (streaming variants for GET/PUT/UPDATE) and C (legacy arm
-> cleanup) follow.
+> cleanup) follow. Phase 5 follow-up slice C migrated fresh inbound
+> streaming relay `UpdateMsg::RequestUpdateStreaming` and
+> `UpdateMsg::BroadcastToStreaming` to
+> `operations/update/op_ctx_task.rs::start_relay_request_update_streaming`
+> / `start_relay_broadcast_to_streaming` (same
+> `source_addr.is_some()` AND `!has_update_op(id)` gate as slice A).
+> Streaming UPDATE relays are fire-and-forget — the drivers claim the
+> inbound stream via `orphan_stream_registry().claim_or_wait`,
+> assemble the payload, apply locally via `update_contract`, and rely
+> on `BroadcastStateChange` for network propagation. No downstream
+> `pipe_stream`, no upstream reply. The `BroadcastToStreaming` driver
+> reuses the shared `log_broadcast_to_streaming_failure` classifier
+> and triggers `try_auto_fetch_contract` / `send_summary_back_on_rejection`
+> on the same branches as the legacy handler. The deprecated
+> `UpdateMsg::Broadcasting` wire variant remains on the legacy no-op
+> handler; Phase 6 wire cleanup will delete both the legacy streaming
+> arms in `update.rs:871-1366` and the `Broadcasting` variant.
 >
 > Task-per-tx drivers have their own invariants documented in the
 > `op_ctx_task.rs` module doc and in `OpCtx::send_and_await`'s rustdoc.

--- a/crates/core/CLAUDE.md
+++ b/crates/core/CLAUDE.md
@@ -73,17 +73,21 @@ Plus task-per-transaction drivers from #1454 Phase 2b onwards:
                              fire-and-forget) + fresh inbound non-streaming
                              relay UPDATE drivers (Phase 5 follow-up slice
                              A, PR #3910: `start_relay_request_update`,
-                             `start_relay_broadcast_to`)
+                             `start_relay_broadcast_to`) + fresh inbound
+                             streaming relay UPDATE drivers (Phase 5
+                             follow-up slice C:
+                             `start_relay_request_update_streaming`,
+                             `start_relay_broadcast_to_streaming` —
+                             claim inbound stream, assemble, apply
+                             locally; BroadcastStateChange propagates)
     All four relay drivers share the per-node dedup gate pattern
     (`active_relay_{get,update,put,subscribe}_txs`) and the
-    `Relay*InflightGuard` RAII. PUT streaming relays now run on the
-    task-per-tx path (slice B, `start_relay_put_streaming`).
-    Streaming UPDATE relay variants (`RequestUpdateStreaming`,
-    `BroadcastToStreaming`) and the deprecated `Broadcasting` wire
-    variant remain on legacy pending future slices. SUBSCRIBE has no
-    streaming variants but renewals, PUT sub-op subscribes, executor
-    auto-subscribe paths, `Unsubscribe`, and `ForwardingAck` all stay
-    on the legacy state machine.
+    `Relay*InflightGuard` RAII. PUT and UPDATE streaming relays now run
+    on the task-per-tx path. The deprecated UPDATE `Broadcasting` wire
+    variant remains on the legacy no-op handler (Phase 6 wire cleanup
+    removes it). SUBSCRIBE has no streaming variants but renewals, PUT
+    sub-op subscribes, executor auto-subscribe paths, `Unsubscribe`,
+    and `ForwardingAck` all stay on the legacy state machine.
 ```
 
 ## Module Map

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1324,10 +1324,12 @@ where
                 // to the legacy path. Existing UpdateOp means GC-spawned
                 // retry or pre-registered op: also fall through.
                 //
-                // Streaming variants (RequestUpdateStreaming /
-                // BroadcastToStreaming) and the deprecated Broadcasting
-                // wire variant stay on the legacy path in slice A — see
-                // port plan §3 / §9.
+                // Slice C (PR for phase 5) additionally dispatches
+                // streaming variants (RequestUpdateStreaming /
+                // BroadcastToStreaming) through task-per-tx drivers
+                // under the same source_addr + !has_update_op gates.
+                // The deprecated Broadcasting wire variant stays on
+                // the legacy path (no-op handler).
                 if let Some(sender_addr) = source_addr {
                     #[allow(clippy::wildcard_enum_match_arm)]
                     match op {
@@ -1381,13 +1383,68 @@ where
                             }
                             return Ok(None);
                         }
-                        // Streaming variants (RequestUpdateStreaming /
-                        // BroadcastToStreaming), deprecated Broadcasting,
-                        // existing UpdateOp, or guarded RequestUpdate /
-                        // BroadcastTo with has_update_op == true → legacy
-                        // path. Wildcard arm exists ONLY to satisfy
-                        // non-exhaustive matches against the slice-A
-                        // dispatch gate; do not expand.
+                        // #1454 phase 5 follow-up (slice C): streaming
+                        // relay UPDATE dispatch. Fire-and-forget:
+                        // claim stream → assemble → apply →
+                        // BroadcastStateChange fans out automatically.
+                        update::UpdateMsg::RequestUpdateStreaming {
+                            id,
+                            key,
+                            stream_id,
+                            total_size,
+                        } if !op_manager.has_update_op(id) => {
+                            if let Err(err) =
+                                update::op_ctx_task::start_relay_request_update_streaming(
+                                    op_manager.clone(),
+                                    *id,
+                                    *key,
+                                    *stream_id,
+                                    *total_size,
+                                    sender_addr,
+                                )
+                                .await
+                            {
+                                tracing::error!(
+                                    tx = %id,
+                                    %key,
+                                    error = %err,
+                                    "UPDATE relay dispatch: start_relay_request_update_streaming failed"
+                                );
+                            }
+                            return Ok(None);
+                        }
+                        update::UpdateMsg::BroadcastToStreaming {
+                            id,
+                            key,
+                            stream_id,
+                            total_size,
+                        } if !op_manager.has_update_op(id) => {
+                            if let Err(err) =
+                                update::op_ctx_task::start_relay_broadcast_to_streaming(
+                                    op_manager.clone(),
+                                    *id,
+                                    *key,
+                                    *stream_id,
+                                    *total_size,
+                                    sender_addr,
+                                )
+                                .await
+                            {
+                                tracing::error!(
+                                    tx = %id,
+                                    %key,
+                                    error = %err,
+                                    "UPDATE relay dispatch: start_relay_broadcast_to_streaming failed"
+                                );
+                            }
+                            return Ok(None);
+                        }
+                        // Deprecated `Broadcasting` variant stays legacy
+                        // (no-op handler). Pre-registered UpdateOps
+                        // (has_update_op == true) also fall through to
+                        // legacy for GC / originator-loopback paths.
+                        // Wildcard arm exists ONLY to satisfy
+                        // non-exhaustive matches; do not expand.
                         _ => {}
                     }
                 }
@@ -3872,8 +3929,12 @@ mod tests {
             );
         }
 
+        /// Slice C (#1454 phase 5): streaming relay UPDATE variants
+        /// are now dispatched through task-per-tx drivers. The
+        /// deprecated `Broadcasting` wire variant stays on the legacy
+        /// no-op path.
         #[test]
-        fn update_branch_does_not_dispatch_streaming_or_broadcasting() {
+        fn update_branch_dispatches_streaming_drivers_but_not_broadcasting() {
             const SOURCE: &str = include_str!("node.rs");
 
             let anchor = "NetMessageV1::Update(ref op) => {";
@@ -3884,24 +3945,20 @@ mod tests {
                 + branch_start;
             let window = &SOURCE[branch_start..window_end];
 
-            // Streaming + Broadcasting variants stay on legacy path in slice A.
-            // Drivers must not be invoked for them.
             assert!(
-                !window.contains("RequestUpdateStreaming {")
-                    || window.contains("// Streaming variants"),
-                "UPDATE branch appears to dispatch RequestUpdateStreaming through \
-                 the relay driver. Slice A keeps streaming on the legacy path."
+                window.contains("start_relay_request_update_streaming("),
+                "UPDATE branch must call start_relay_request_update_streaming \
+                 for streaming relay dispatch (slice C)."
             );
             assert!(
-                !window.contains("BroadcastToStreaming {")
-                    || window.contains("// Streaming variants"),
-                "UPDATE branch appears to dispatch BroadcastToStreaming through \
-                 the relay driver. Slice A keeps streaming on the legacy path."
+                window.contains("start_relay_broadcast_to_streaming("),
+                "UPDATE branch must call start_relay_broadcast_to_streaming \
+                 for streaming relay dispatch (slice C)."
             );
             assert!(
                 !window.contains("UpdateMsg::Broadcasting {"),
-                "UPDATE branch dispatches deprecated Broadcasting variant through \
-                 the relay driver. Broadcasting must stay on the legacy path."
+                "UPDATE branch must not dispatch the deprecated Broadcasting \
+                 variant — it stays on the legacy no-op handler."
             );
         }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3962,6 +3962,38 @@ mod tests {
             );
         }
 
+        /// Pin: the slice C streaming dispatch arms MUST be guarded by
+        /// `has_update_op`. Without the guard, pre-registered UpdateOps
+        /// (GC / originator-loopback) would be stolen from the legacy
+        /// state machine mid-flight, losing `load_or_init`/`push`
+        /// bookkeeping that those paths still depend on.
+        #[test]
+        fn update_streaming_arms_gate_on_has_update_op() {
+            const SOURCE: &str = include_str!("node.rs");
+
+            for arm_anchor in [
+                "update::UpdateMsg::RequestUpdateStreaming {",
+                "update::UpdateMsg::BroadcastToStreaming {",
+            ] {
+                let arm_start = SOURCE
+                    .find(arm_anchor)
+                    .unwrap_or_else(|| panic!("{arm_anchor} arm not found in UPDATE dispatch"));
+                // Scope: from arm header to its closing `return Ok(None);`
+                // — covers the match-guard clause + body.
+                let after = &SOURCE[arm_start..];
+                let arm_end = after
+                    .find("return Ok(None);")
+                    .expect("streaming arm must return Ok(None) after driver spawn");
+                let arm_src = &SOURCE[arm_start..arm_start + arm_end];
+                assert!(
+                    arm_src.contains("!op_manager.has_update_op(id)"),
+                    "streaming arm {arm_anchor} must be gated on \
+                     !op_manager.has_update_op(id); pre-registered UpdateOps \
+                     must fall through to legacy."
+                );
+            }
+        }
+
         // ── Relay PUT dispatch structural pin tests (#1454 phase 5
         // follow-up slice A). Mirror of the UPDATE tests above.
 

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1721,7 +1721,11 @@ fn log_update_contract_failure(key: &ContractKey, err: &ExecutorError) {
 /// takes `&ExecutorError` because the two call sites have different error
 /// types in scope (the streaming branch operates on the OpError already
 /// produced by `update_contract`'s `Err(err.into())`).
-fn log_broadcast_to_streaming_failure(tx: &Transaction, key: &ContractKey, err: &OpError) -> bool {
+pub(crate) fn log_broadcast_to_streaming_failure(
+    tx: &Transaction,
+    key: &ContractKey,
+    err: &OpError,
+) -> bool {
     if err.is_invalid_update_rejection() {
         tracing::info!(
             tx = %tx,

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1079,6 +1079,23 @@ async fn drive_relay_broadcast_to(
 // `claim_or_wait`; tx-level dedup is handled by `active_relay_update_txs`.
 // These are complementary — fragment metadata may arrive on a new tx
 // while tx dedup catches wire-level retries of the metadata message.
+//
+// # Why tx dedup is held across `claim_or_wait`'s timeout window
+//
+// The driver inserts into `active_relay_update_txs` BEFORE calling
+// `claim_or_wait`. Worst case (attacker sends a bogus
+// `RequestUpdateStreaming` with a fabricated `stream_id` whose
+// fragments never arrive), the tx entry is held for up to
+// `STREAM_CLAIM_TIMEOUT` (60s) before the RAII guard drops and frees
+// it. This is deliberate: releasing the tx entry before
+// `claim_or_wait` returns would let a duplicate metadata message
+// spawn a parallel driver that would also block on `claim_or_wait` —
+// amplifying work and producing duplicate telemetry on eventual
+// fragment arrival. The 60s hold is bounded, per-tx (not per-peer),
+// and the stream-level dedup inside `orphan_stream_registry` still
+// short-circuits real duplicates. Operators monitoring
+// `RELAY_UPDATE_STREAMING_INFLIGHT` will see anomalous growth if a
+// peer floods bogus stream_ids — that's the intended signal.
 
 /// Spawn a relay driver for a fresh inbound
 /// `UpdateMsg::RequestUpdateStreaming`.
@@ -2240,6 +2257,22 @@ mod tests {
             drop_body.contains("RELAY_UPDATE_STREAMING_COMPLETED_TOTAL.fetch_add"),
             "streaming guard Drop must increment \
              RELAY_UPDATE_STREAMING_COMPLETED_TOTAL"
+        );
+    }
+
+    /// Pin: `log_broadcast_to_streaming_failure` must stay `pub(crate)`
+    /// so the slice C driver can reuse the shared classifier. If Phase 6
+    /// cleanup re-privatises it, the driver's failure branch breaks
+    /// silently — this pin trips at compile-ish time (source-level scan)
+    /// instead.
+    #[test]
+    fn log_broadcast_to_streaming_failure_is_pub_crate() {
+        let src = include_str!("../update.rs");
+        assert!(
+            src.contains("pub(crate) fn log_broadcast_to_streaming_failure("),
+            "log_broadcast_to_streaming_failure must remain pub(crate) — \
+             slice C driver reuses it for failure classification; \
+             re-privatising breaks drive_relay_broadcast_to_streaming"
         );
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -36,7 +36,8 @@ use crate::operations::OpError;
 use crate::ring::{PeerKeyLocation, RingError};
 use crate::tracing::{NetEventLog, OperationFailure, state_hash_full};
 
-use super::{UpdateExecution, UpdateMsg};
+use super::{BroadcastStreamingPayload, UpdateExecution, UpdateMsg, UpdateStreamingPayload};
+use crate::transport::peer_connection::StreamId;
 
 /// Counter: number of times `start_relay_request_update` or
 /// `start_relay_broadcast_to` was invoked. Incremented under test/testing
@@ -64,6 +65,35 @@ pub static RELAY_UPDATE_COMPLETED_TOTAL: std::sync::atomic::AtomicUsize =
 /// Counter: number of duplicate inbound `RequestUpdate` /
 /// `BroadcastTo` Requests rejected by the per-node dedup gate.
 pub static RELAY_UPDATE_DEDUP_REJECTS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+// ── Slice C streaming relay UPDATE counters (#1454 phase 5) ──────────────
+//
+// Separate from slice A's `RELAY_UPDATE_*` counters so operators can
+// ramp-compare observability between non-streaming and streaming
+// relay drivers. The tx dedup set (`active_relay_update_txs`) is shared
+// across both slices since tx identity is unified; the
+// `RELAY_UPDATE_DEDUP_REJECTS` counter is also shared.
+
+/// Counter: number of times `start_relay_request_update_streaming` or
+/// `start_relay_broadcast_to_streaming` was invoked. Used by dispatch
+/// gate pin tests to prove streaming relays route through the
+/// task-per-tx driver rather than `handle_op_request`.
+#[cfg(any(test, feature = "testing"))]
+pub static RELAY_UPDATE_STREAMING_DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Counter: streaming relay UPDATE drivers currently in flight.
+pub static RELAY_UPDATE_STREAMING_INFLIGHT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Counter: total streaming relay UPDATE drivers ever spawned on this
+/// node.
+pub static RELAY_UPDATE_STREAMING_SPAWNED_TOTAL: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Counter: total streaming relay UPDATE drivers that exited.
+pub static RELAY_UPDATE_STREAMING_COMPLETED_TOTAL: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
 /// Start a client-initiated UPDATE, returning as soon as the task has been
@@ -1024,6 +1054,601 @@ async fn drive_relay_broadcast_to(
     Ok(())
 }
 
+// ── Relay UPDATE streaming drivers (#1454 phase 5 — slice C) ────────────
+//
+// Streaming UPDATE relays are qualitatively simpler than streaming PUT
+// relays:
+//   - No upstream reply to bubble (UPDATE is fire-and-forget e2e).
+//   - No downstream forward via `pipe_stream` — network propagation is
+//     automatic via `BroadcastStateChange` after local apply.
+//   - The driver's job = claim inbound stream → assemble → deserialize
+//     payload → `update_contract` → emit telemetry + (BroadcastTo only)
+//     dedup + proactive summary.
+//
+// Shared with slice A:
+//   - `active_relay_update_txs` dedup set (tx space is unified).
+//   - `RelayUpdateInflightGuard` RAII (same tx cleanup semantics).
+//   - `RELAY_UPDATE_DEDUP_REJECTS` counter for dedup observability.
+//
+// NOT shared (slice-C-specific counters):
+//   - `RELAY_UPDATE_STREAMING_INFLIGHT` / `_SPAWNED_TOTAL` /
+//     `_COMPLETED_TOTAL` / `_DRIVER_CALL_COUNT` — separate streams for
+//     ramp comparison, mirroring PUT slice B rationale.
+//
+// Fragment-level dedup is handled by `orphan_stream_registry` via
+// `claim_or_wait`; tx-level dedup is handled by `active_relay_update_txs`.
+// These are complementary — fragment metadata may arrive on a new tx
+// while tx dedup catches wire-level retries of the metadata message.
+
+/// Spawn a relay driver for a fresh inbound
+/// `UpdateMsg::RequestUpdateStreaming`.
+///
+/// Caller-side gates (in `node.rs`): `source_addr.is_some()` AND no
+/// existing `UpdateOp` in `OpManager.ops.update` for `incoming_tx`.
+pub(crate) async fn start_relay_request_update_streaming(
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    stream_id: StreamId,
+    total_size: u64,
+    sender_addr: SocketAddr,
+) -> Result<(), OpError> {
+    #[cfg(any(test, feature = "testing"))]
+    RELAY_UPDATE_STREAMING_DRIVER_CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+    if !op_manager.active_relay_update_txs.insert(incoming_tx) {
+        RELAY_UPDATE_DEDUP_REJECTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        tracing::debug!(
+            tx = %incoming_tx,
+            %key,
+            %sender_addr,
+            phase = "relay_update_streaming_dedup_reject",
+            "UPDATE relay (task-per-tx streaming): duplicate RequestUpdateStreaming for in-flight tx, dropping"
+        );
+        return Ok(());
+    }
+
+    tracing::debug!(
+        tx = %incoming_tx,
+        %key,
+        %sender_addr,
+        %stream_id,
+        total_size,
+        phase = "relay_update_streaming_request_start",
+        "UPDATE relay (task-per-tx streaming): spawning RequestUpdateStreaming driver"
+    );
+
+    // Guard pre-spawn (see `start_relay_request_update` rationale).
+    RELAY_UPDATE_STREAMING_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    RELAY_UPDATE_STREAMING_SPAWNED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let guard = RelayUpdateStreamingInflightGuard {
+        op_manager: op_manager.clone(),
+        incoming_tx,
+    };
+
+    GlobalExecutor::spawn(run_relay_request_update_streaming(
+        guard,
+        op_manager,
+        incoming_tx,
+        key,
+        stream_id,
+        total_size,
+        sender_addr,
+    ));
+    Ok(())
+}
+
+/// Spawn a relay driver for a fresh inbound
+/// `UpdateMsg::BroadcastToStreaming`.
+pub(crate) async fn start_relay_broadcast_to_streaming(
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    stream_id: StreamId,
+    total_size: u64,
+    sender_addr: SocketAddr,
+) -> Result<(), OpError> {
+    #[cfg(any(test, feature = "testing"))]
+    RELAY_UPDATE_STREAMING_DRIVER_CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+    if !op_manager.active_relay_update_txs.insert(incoming_tx) {
+        RELAY_UPDATE_DEDUP_REJECTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        tracing::debug!(
+            tx = %incoming_tx,
+            %key,
+            %sender_addr,
+            phase = "relay_update_streaming_dedup_reject",
+            "UPDATE relay (task-per-tx streaming): duplicate BroadcastToStreaming for in-flight tx, dropping"
+        );
+        return Ok(());
+    }
+
+    tracing::debug!(
+        tx = %incoming_tx,
+        %key,
+        %sender_addr,
+        %stream_id,
+        total_size,
+        phase = "relay_update_streaming_broadcast_start",
+        "UPDATE relay (task-per-tx streaming): spawning BroadcastToStreaming driver"
+    );
+
+    RELAY_UPDATE_STREAMING_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    RELAY_UPDATE_STREAMING_SPAWNED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let guard = RelayUpdateStreamingInflightGuard {
+        op_manager: op_manager.clone(),
+        incoming_tx,
+    };
+
+    GlobalExecutor::spawn(run_relay_broadcast_to_streaming(
+        guard,
+        op_manager,
+        incoming_tx,
+        key,
+        stream_id,
+        total_size,
+        sender_addr,
+    ));
+    Ok(())
+}
+
+/// RAII guard for streaming relay UPDATE drivers. Mirrors slice A's
+/// `RelayUpdateInflightGuard` but uses the streaming-specific counters.
+/// Still cleans up `active_relay_update_txs` (unified tx space).
+struct RelayUpdateStreamingInflightGuard {
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+}
+
+impl Drop for RelayUpdateStreamingInflightGuard {
+    fn drop(&mut self) {
+        self.op_manager
+            .active_relay_update_txs
+            .remove(&self.incoming_tx);
+        RELAY_UPDATE_STREAMING_INFLIGHT.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        RELAY_UPDATE_STREAMING_COMPLETED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+async fn run_relay_request_update_streaming(
+    guard: RelayUpdateStreamingInflightGuard,
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    stream_id: StreamId,
+    total_size: u64,
+    sender_addr: SocketAddr,
+) {
+    let _guard = guard;
+
+    if let Err(err) = drive_relay_request_update_streaming(
+        &op_manager,
+        incoming_tx,
+        key,
+        stream_id,
+        total_size,
+        sender_addr,
+    )
+    .await
+    {
+        tracing::warn!(
+            tx = %incoming_tx,
+            %key,
+            error = %err,
+            phase = "relay_update_streaming_request_error",
+            "UPDATE relay (task-per-tx streaming): RequestUpdateStreaming driver returned error"
+        );
+    }
+}
+
+async fn run_relay_broadcast_to_streaming(
+    guard: RelayUpdateStreamingInflightGuard,
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    stream_id: StreamId,
+    total_size: u64,
+    sender_addr: SocketAddr,
+) {
+    let _guard = guard;
+
+    if let Err(err) = drive_relay_broadcast_to_streaming(
+        &op_manager,
+        incoming_tx,
+        key,
+        stream_id,
+        total_size,
+        sender_addr,
+    )
+    .await
+    {
+        tracing::warn!(
+            tx = %incoming_tx,
+            %key,
+            error = %err,
+            phase = "relay_update_streaming_broadcast_error",
+            "UPDATE relay (task-per-tx streaming): BroadcastToStreaming driver returned error"
+        );
+    }
+}
+
+/// Inner driver for `RequestUpdateStreaming`. Mirrors the legacy
+/// handler at `update.rs:871-1071`:
+///
+/// 1. Claim inbound stream via orphan registry (atomic dedup on
+///    `stream_id`).
+/// 2. Assemble stream data.
+/// 3. Deserialize `UpdateStreamingPayload`.
+/// 4. `update_contract` (state update — related contracts preserved).
+/// 5. Emit `update_success` telemetry.
+///
+/// Network propagation is automatic via `BroadcastStateChange`.
+async fn drive_relay_request_update_streaming(
+    op_manager: &OpManager,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    stream_id: StreamId,
+    total_size: u64,
+    sender_addr: SocketAddr,
+) -> Result<(), OpError> {
+    use crate::operations::orphan_streams::{OrphanStreamError, STREAM_CLAIM_TIMEOUT};
+
+    tracing::info!(
+        tx = %incoming_tx,
+        contract = %key,
+        %stream_id,
+        total_size,
+        "UPDATE relay (task-per-tx streaming): processing RequestUpdateStreaming"
+    );
+
+    // Step 1: claim stream.
+    let stream_handle = match op_manager
+        .orphan_stream_registry()
+        .claim_or_wait(sender_addr, stream_id, STREAM_CLAIM_TIMEOUT)
+        .await
+    {
+        Ok(handle) => handle,
+        Err(OrphanStreamError::AlreadyClaimed) => {
+            tracing::debug!(
+                tx = %incoming_tx,
+                %stream_id,
+                "UPDATE relay (task-per-tx streaming): RequestUpdateStreaming skipped — stream already claimed (dedup)"
+            );
+            return Ok(());
+        }
+        Err(e) => {
+            tracing::error!(
+                tx = %incoming_tx,
+                %stream_id,
+                error = %e,
+                "UPDATE relay (task-per-tx streaming): failed to claim stream from orphan registry"
+            );
+            return Err(OpError::OrphanStreamClaimFailed);
+        }
+    };
+
+    // Step 2: assemble stream.
+    let stream_data = match stream_handle.assemble().await {
+        Ok(data) => {
+            tracing::debug!(
+                tx = %incoming_tx,
+                %stream_id,
+                assembled_size = data.len(),
+                expected_size = total_size,
+                "UPDATE relay (task-per-tx streaming): stream assembled"
+            );
+            data
+        }
+        Err(e) => {
+            tracing::error!(
+                tx = %incoming_tx,
+                %stream_id,
+                error = %e,
+                "UPDATE relay (task-per-tx streaming): failed to assemble stream"
+            );
+            return Err(OpError::StreamCancelled);
+        }
+    };
+
+    // Step 3: deserialize payload.
+    let payload: UpdateStreamingPayload = match bincode::deserialize(&stream_data) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(
+                tx = %incoming_tx,
+                error = %e,
+                "UPDATE relay (task-per-tx streaming): failed to deserialize UpdateStreamingPayload"
+            );
+            return Err(OpError::invalid_transition(incoming_tx));
+        }
+    };
+
+    let UpdateStreamingPayload {
+        related_contracts,
+        value,
+    } = payload;
+
+    // Step 4: apply update. BroadcastStateChange propagates automatically.
+    let UpdateExecution {
+        value: updated_value,
+        summary: _,
+        changed,
+        ..
+    } = super::update_contract(
+        op_manager,
+        key,
+        UpdateData::State(State::from(value.clone())),
+        related_contracts,
+    )
+    .await?;
+
+    // Step 5: telemetry.
+    let hash_after = Some(state_hash_full(&updated_value));
+    if let Some(requester_pkl) = op_manager
+        .ring
+        .connection_manager
+        .get_peer_by_addr(sender_addr)
+    {
+        if let Some(event) = NetEventLog::update_success(
+            &incoming_tx,
+            &op_manager.ring,
+            key,
+            requester_pkl,
+            None, // No before-hash for streaming (legacy match).
+            hash_after,
+            Some(updated_value.len()),
+        ) {
+            op_manager.ring.register_events(Either::Left(event)).await;
+        }
+    }
+
+    if changed {
+        tracing::debug!(
+            tx = %incoming_tx,
+            %key,
+            "UPDATE relay (task-per-tx streaming): RequestUpdateStreaming succeeded, state changed"
+        );
+    } else {
+        tracing::debug!(
+            tx = %incoming_tx,
+            %key,
+            "UPDATE relay (task-per-tx streaming): RequestUpdateStreaming yielded no state change"
+        );
+    }
+
+    Ok(())
+}
+
+/// Inner driver for `BroadcastToStreaming`. Mirrors the legacy
+/// handler at `update.rs:1073-1366`:
+///
+/// 1. Claim inbound stream.
+/// 2. Assemble stream.
+/// 3. Deserialize `BroadcastStreamingPayload`.
+/// 4. Update sender's cached summary.
+/// 5. Dedup check against broadcast_dedup_cache (BEFORE WASM merge).
+/// 6. Telemetry: `update_broadcast_received`.
+/// 7. `update_contract` (state update).
+/// 8. On success: telemetry + proactive summary notification.
+/// 9. On failure: classify via `log_broadcast_to_streaming_failure`;
+///    `try_auto_fetch_contract` on real failure,
+///    `send_summary_back_on_rejection` on benign stale-version.
+async fn drive_relay_broadcast_to_streaming(
+    op_manager: &OpManager,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    stream_id: StreamId,
+    total_size: u64,
+    sender_addr: SocketAddr,
+) -> Result<(), OpError> {
+    use crate::operations::orphan_streams::{OrphanStreamError, STREAM_CLAIM_TIMEOUT};
+
+    tracing::info!(
+        tx = %incoming_tx,
+        contract = %key,
+        %stream_id,
+        total_size,
+        sender = %sender_addr,
+        "UPDATE relay (task-per-tx streaming): processing BroadcastToStreaming"
+    );
+
+    // Step 1: claim stream.
+    let stream_handle = match op_manager
+        .orphan_stream_registry()
+        .claim_or_wait(sender_addr, stream_id, STREAM_CLAIM_TIMEOUT)
+        .await
+    {
+        Ok(handle) => handle,
+        Err(OrphanStreamError::AlreadyClaimed) => {
+            tracing::debug!(
+                tx = %incoming_tx,
+                %stream_id,
+                "UPDATE relay (task-per-tx streaming): BroadcastToStreaming skipped — stream already claimed (dedup)"
+            );
+            return Ok(());
+        }
+        Err(e) => {
+            tracing::error!(
+                tx = %incoming_tx,
+                %stream_id,
+                error = %e,
+                "UPDATE relay (task-per-tx streaming): failed to claim stream from orphan registry (broadcast)"
+            );
+            return Err(OpError::OrphanStreamClaimFailed);
+        }
+    };
+
+    // Step 2: assemble stream.
+    let stream_data = match stream_handle.assemble().await {
+        Ok(data) => {
+            tracing::debug!(
+                tx = %incoming_tx,
+                %stream_id,
+                assembled_size = data.len(),
+                expected_size = total_size,
+                "UPDATE relay (task-per-tx streaming): stream assembled (broadcast)"
+            );
+            data
+        }
+        Err(e) => {
+            tracing::error!(
+                tx = %incoming_tx,
+                %stream_id,
+                error = %e,
+                "UPDATE relay (task-per-tx streaming): failed to assemble stream (broadcast)"
+            );
+            return Err(OpError::StreamCancelled);
+        }
+    };
+
+    // Step 3: deserialize payload.
+    let payload: BroadcastStreamingPayload = match bincode::deserialize(&stream_data) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(
+                tx = %incoming_tx,
+                error = %e,
+                "UPDATE relay (task-per-tx streaming): failed to deserialize BroadcastStreamingPayload"
+            );
+            return Err(OpError::invalid_transition(incoming_tx));
+        }
+    };
+
+    let BroadcastStreamingPayload {
+        state_bytes,
+        sender_summary_bytes,
+    } = payload;
+
+    // Step 4: update sender's cached summary.
+    let sender_summary = StateSummary::from(sender_summary_bytes.clone());
+    if let Some(sender_pkl) = op_manager
+        .ring
+        .connection_manager
+        .get_peer_by_addr(sender_addr)
+    {
+        let sender_key = crate::ring::PeerKey::from(sender_pkl.pub_key().clone());
+        op_manager.interest_manager.update_peer_summary(
+            &key,
+            &sender_key,
+            Some(sender_summary.clone()),
+        );
+    }
+
+    // Step 5: dedup cache BEFORE merge (mirrors non-streaming slice A
+    // ordering — skipping WASM merge on duplicate broadcast is the key
+    // amplifier mitigation). Streaming broadcasts are always full state
+    // (`is_delta = false`).
+    if op_manager.broadcast_dedup_cache.check_and_insert(
+        &key,
+        &state_bytes,
+        false,
+        op_manager.interest_manager.now(),
+    ) {
+        tracing::debug!(
+            tx = %incoming_tx,
+            %key,
+            "UPDATE relay (task-per-tx streaming): BroadcastToStreaming skipped — duplicate payload (dedup hit)"
+        );
+        return Ok(());
+    }
+
+    let state_for_telemetry = WrappedState::from(state_bytes.clone());
+
+    // Step 6: telemetry — broadcast received.
+    if let Some(requester_pkl) = op_manager
+        .ring
+        .connection_manager
+        .get_peer_by_addr(sender_addr)
+    {
+        if let Some(event) = NetEventLog::update_broadcast_received(
+            &incoming_tx,
+            &op_manager.ring,
+            key,
+            requester_pkl,
+            state_for_telemetry.clone(),
+        ) {
+            op_manager.ring.register_events(Either::Left(event)).await;
+        }
+    }
+
+    // Step 7: WASM merge.
+    let update_result = super::update_contract(
+        op_manager,
+        key,
+        UpdateData::State(State::from(state_bytes.clone())),
+        RelatedContracts::default(),
+    )
+    .await;
+
+    let UpdateExecution {
+        value: updated_value,
+        summary: streaming_update_summary,
+        changed,
+        ..
+    } = match update_result {
+        Ok(exec) => exec,
+        Err(err) => {
+            // Classify failure: real failure → self-heal via
+            // try_auto_fetch_contract; benign stale-version rejection →
+            // send_summary_back_on_rejection. Mirrors legacy at
+            // update.rs:1336-1361.
+            if super::log_broadcast_to_streaming_failure(&incoming_tx, &key, &err) {
+                op_manager.try_auto_fetch_contract(&key, sender_addr);
+            } else if err.is_invalid_update_rejection() {
+                let op_mgr = op_manager.clone();
+                let contract_key = key;
+                let sender_summary_bytes = sender_summary_bytes.clone();
+                GlobalExecutor::spawn(async move {
+                    super::send_summary_back_on_rejection(
+                        &op_mgr,
+                        &contract_key,
+                        sender_addr,
+                        sender_summary_bytes,
+                    )
+                    .await;
+                });
+            }
+            return Err(err);
+        }
+    };
+
+    // Step 8: telemetry — broadcast applied + proactive summary.
+    if let Some(event) = NetEventLog::update_broadcast_applied(
+        &incoming_tx,
+        &op_manager.ring,
+        key,
+        &state_for_telemetry,
+        &updated_value,
+        changed,
+    ) {
+        op_manager.ring.register_events(Either::Left(event)).await;
+    }
+
+    if !changed {
+        tracing::debug!(
+            tx = %incoming_tx,
+            %key,
+            "UPDATE relay (task-per-tx streaming): BroadcastToStreaming produced no change"
+        );
+        return Ok(());
+    }
+
+    crate::node::network_status::record_update_received();
+    tracing::debug!(
+        tx = %incoming_tx,
+        %key,
+        "UPDATE relay (task-per-tx streaming): BroadcastToStreaming applied (state changed)"
+    );
+
+    let op_mgr = op_manager.clone();
+    let summary = streaming_update_summary.clone();
+    GlobalExecutor::spawn(async move {
+        super::send_proactive_summary_notification(&op_mgr, &key, sender_addr, summary).await;
+    });
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     /// Guard: `client_events.rs` must call `start_client_update` for both the
@@ -1340,8 +1965,9 @@ mod tests {
             .collect();
         assert_eq!(
             sites.len(),
-            2,
-            "expected exactly two dedup sites (RequestUpdate + BroadcastTo)"
+            4,
+            "expected four dedup sites (RequestUpdate + BroadcastTo + \
+             RequestUpdateStreaming + BroadcastToStreaming)"
         );
         for (idx, section) in sites.iter().enumerate() {
             let window = &section[..500.min(section.len())];
@@ -1376,29 +2002,244 @@ mod tests {
         );
     }
 
-    /// Pin: streaming variants MUST NOT be touched by the driver in slice A.
-    /// They stay on the legacy path until slice B. Reference the variant
-    /// names by their wire-message identifiers.
+    /// Pin: the slice A non-streaming drivers (`drive_relay_request_update`
+    /// / `drive_relay_broadcast_to`) must NOT reference the streaming
+    /// wire variants. Streaming logic lives in the slice C drivers.
     #[test]
-    fn slice_a_does_not_touch_streaming_variants() {
+    fn slice_a_drivers_do_not_touch_streaming_variants() {
         let src = include_str!("op_ctx_task.rs");
-        // Skip past the section header / module-level scope doc comment
-        // (which references variant names by design) by anchoring on the
-        // first relay entry-point fn.
-        let relay_start = src
-            .find("pub(crate) async fn start_relay_request_update(")
-            .expect("start_relay_request_update not found");
-        let relay_end = src
-            .find("#[cfg(test)]")
-            .expect("test module marker not found");
-        let relay_src = &src[relay_start..relay_end];
+        for driver_name in ["drive_relay_request_update(", "drive_relay_broadcast_to("] {
+            let start = src
+                .find(&format!("async fn {driver_name}"))
+                .unwrap_or_else(|| panic!("{driver_name} not found"));
+            // End at the fn's closing brace at column 0 — "\n}\n" — which
+            // is the cargo-fmt-canonical shape for a top-level fn body.
+            let after = &src[start..];
+            let end = after.find("\n}\n").expect("fn body end not found");
+            let driver_src = &after[..end];
+            assert!(
+                !driver_src.contains("RequestUpdateStreaming"),
+                "{driver_name} (slice A) must not reference RequestUpdateStreaming"
+            );
+            assert!(
+                !driver_src.contains("BroadcastToStreaming"),
+                "{driver_name} (slice A) must not reference BroadcastToStreaming"
+            );
+        }
+    }
+
+    // ── Slice C streaming relay driver structural pin tests ─────────────
+    // (#1454 phase 5) — pin the streaming drivers against their
+    // documented invariants.
+
+    /// Pin: slice C streaming drivers must exist and be public at the
+    /// crate level.
+    #[test]
+    fn slice_c_streaming_drivers_exist() {
+        let src = include_str!("op_ctx_task.rs");
         assert!(
-            !relay_src.contains("RequestUpdateStreaming"),
-            "slice A must not handle RequestUpdateStreaming (deferred to slice B)"
+            src.contains("pub(crate) async fn start_relay_request_update_streaming("),
+            "start_relay_request_update_streaming must exist (slice C entry point)"
         );
         assert!(
-            !relay_src.contains("BroadcastToStreaming"),
-            "slice A must not handle BroadcastToStreaming (deferred to slice B)"
+            src.contains("pub(crate) async fn start_relay_broadcast_to_streaming("),
+            "start_relay_broadcast_to_streaming must exist (slice C entry point)"
+        );
+    }
+
+    /// Pin: streaming drivers must gate on `active_relay_update_txs`
+    /// (unified tx dedup set across slices A and C).
+    #[test]
+    fn slice_c_drivers_use_tx_dedup_gate() {
+        let src = include_str!("op_ctx_task.rs");
+        for entry in [
+            "pub(crate) async fn start_relay_request_update_streaming(",
+            "pub(crate) async fn start_relay_broadcast_to_streaming(",
+        ] {
+            let start = src.find(entry).unwrap_or_else(|| panic!("{entry} missing"));
+            let body = &src[start..start + 1500];
+            assert!(
+                body.contains("active_relay_update_txs.insert"),
+                "{entry} must insert into active_relay_update_txs for per-tx dedup"
+            );
+            assert!(
+                body.contains("RELAY_UPDATE_DEDUP_REJECTS.fetch_add"),
+                "{entry} must increment RELAY_UPDATE_DEDUP_REJECTS on dedup reject"
+            );
+        }
+    }
+
+    /// Pin: streaming drivers must claim via
+    /// `orphan_stream_registry().claim_or_wait` — this is the atomic
+    /// stream-level dedup that prevents duplicate assembly runs.
+    #[test]
+    fn slice_c_drivers_claim_orphan_stream() {
+        let src = include_str!("op_ctx_task.rs");
+        for driver in [
+            "drive_relay_request_update_streaming(",
+            "drive_relay_broadcast_to_streaming(",
+        ] {
+            let start = src
+                .find(&format!("async fn {driver}"))
+                .unwrap_or_else(|| panic!("{driver} not found"));
+            let after = &src[start + 1..];
+            let end = after
+                .find("\nasync fn ")
+                .or_else(|| after.find("\n#[cfg(test)]"))
+                .unwrap_or(after.len());
+            let driver_src = &src[start..start + 1 + end];
+            assert!(
+                driver_src.contains("orphan_stream_registry()"),
+                "{driver} must claim via orphan_stream_registry() for atomic \
+                 stream dedup"
+            );
+            assert!(
+                driver_src.contains("claim_or_wait("),
+                "{driver} must use claim_or_wait on the orphan stream registry"
+            );
+        }
+    }
+
+    /// Pin: streaming drivers are fire-and-forget. They MUST NOT call
+    /// `send_and_await` (no upstream reply) and MUST NOT call
+    /// `pipe_stream` (propagation is via BroadcastStateChange, not
+    /// explicit forward).
+    #[test]
+    fn slice_c_drivers_are_fire_and_forget() {
+        let src = include_str!("op_ctx_task.rs");
+        for driver in [
+            "drive_relay_request_update_streaming(",
+            "drive_relay_broadcast_to_streaming(",
+        ] {
+            let start = src
+                .find(&format!("async fn {driver}"))
+                .unwrap_or_else(|| panic!("{driver} not found"));
+            let after = &src[start + 1..];
+            let end = after
+                .find("\nasync fn ")
+                .or_else(|| after.find("\n#[cfg(test)]"))
+                .unwrap_or(after.len());
+            let driver_src = &src[start..start + 1 + end];
+            assert!(
+                !driver_src.contains(".send_and_await("),
+                "{driver} must not call send_and_await — UPDATE streaming is \
+                 fire-and-forget"
+            );
+            assert!(
+                !driver_src.contains(".pipe_stream("),
+                "{driver} must not call pipe_stream — streaming UPDATE relay \
+                 propagation is via BroadcastStateChange after local apply, \
+                 not explicit downstream piping"
+            );
+        }
+    }
+
+    /// Pin: `BroadcastToStreaming` driver must check dedup cache BEFORE
+    /// calling `update_contract`. If the order flips, duplicate
+    /// broadcasts re-run WASM merge and amplify cost.
+    #[test]
+    fn broadcast_to_streaming_dedup_runs_before_merge() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn drive_relay_broadcast_to_streaming(")
+            .expect("drive_relay_broadcast_to_streaming not found");
+        let after = &src[start + 1..];
+        let end = after
+            .find("\nasync fn ")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .unwrap_or(after.len());
+        let driver_src = &src[start..start + 1 + end];
+
+        let dedup_pos = driver_src
+            .find("broadcast_dedup_cache.check_and_insert")
+            .expect("dedup check missing in BroadcastToStreaming driver");
+        let merge_pos = driver_src
+            .find("super::update_contract(")
+            .expect("update_contract call missing in BroadcastToStreaming driver");
+        assert!(
+            dedup_pos < merge_pos,
+            "broadcast_dedup_cache.check_and_insert MUST appear before \
+             update_contract() in drive_relay_broadcast_to_streaming"
+        );
+    }
+
+    /// Pin: `BroadcastToStreaming` driver must classify failures via
+    /// `log_broadcast_to_streaming_failure` and spawn auto-fetch or
+    /// summary-back based on the result (mirror of slice A invariant).
+    #[test]
+    fn broadcast_to_streaming_classifies_failures() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn drive_relay_broadcast_to_streaming(")
+            .expect("drive_relay_broadcast_to_streaming not found");
+        let after = &src[start + 1..];
+        let end = after
+            .find("\nasync fn ")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .unwrap_or(after.len());
+        let driver_src = &src[start..start + 1 + end];
+
+        assert!(
+            driver_src.contains("log_broadcast_to_streaming_failure"),
+            "drive_relay_broadcast_to_streaming must call \
+             log_broadcast_to_streaming_failure for failure classification"
+        );
+        assert!(
+            driver_src.contains("try_auto_fetch_contract"),
+            "drive_relay_broadcast_to_streaming must call try_auto_fetch_contract \
+             on real (non-benign) failures for self-heal"
+        );
+        assert!(
+            driver_src.contains("send_summary_back_on_rejection"),
+            "drive_relay_broadcast_to_streaming must spawn \
+             send_summary_back_on_rejection on is_invalid_update_rejection"
+        );
+    }
+
+    /// Pin: `BroadcastToStreaming` driver must spawn the proactive
+    /// summary notification on successful state change (mirrors slice
+    /// A invariant at `broadcast_to_spawns_proactive_summary`).
+    #[test]
+    fn broadcast_to_streaming_spawns_proactive_summary() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn drive_relay_broadcast_to_streaming(")
+            .expect("drive_relay_broadcast_to_streaming not found");
+        let after = &src[start + 1..];
+        let end = after
+            .find("\nasync fn ")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .unwrap_or(after.len());
+        let driver_src = &src[start..start + 1 + end];
+        assert!(
+            driver_src.contains("send_proactive_summary_notification"),
+            "drive_relay_broadcast_to_streaming must spawn \
+             send_proactive_summary_notification on successful state change"
+        );
+    }
+
+    /// Pin: the streaming RAII guard must remove from
+    /// `active_relay_update_txs` and touch the slice-C-specific
+    /// counters on drop (not the slice A counters).
+    #[test]
+    fn streaming_raii_guard_clears_dedup_and_streaming_counters() {
+        let src = include_str!("op_ctx_task.rs");
+        let drop_start = src
+            .find("impl Drop for RelayUpdateStreamingInflightGuard")
+            .expect("RelayUpdateStreamingInflightGuard Drop impl not found");
+        let drop_body = &src[drop_start..drop_start + 700];
+        assert!(
+            drop_body.contains("active_relay_update_txs"),
+            "streaming guard Drop must remove from active_relay_update_txs"
+        );
+        assert!(
+            drop_body.contains("RELAY_UPDATE_STREAMING_INFLIGHT.fetch_sub"),
+            "streaming guard Drop must decrement RELAY_UPDATE_STREAMING_INFLIGHT"
+        );
+        assert!(
+            drop_body.contains("RELAY_UPDATE_STREAMING_COMPLETED_TOTAL.fetch_add"),
+            "streaming guard Drop must increment \
+             RELAY_UPDATE_STREAMING_COMPLETED_TOTAL"
         );
     }
 


### PR DESCRIPTION
## Problem

Issue #1454 Phase 5 migrates relay operations to the task-per-transaction
driver pattern. Slice A (PR #3910) migrated non-streaming UPDATE relays
(`UpdateMsg::RequestUpdate`, `UpdateMsg::BroadcastTo`). Streaming
variants (`RequestUpdateStreaming`, `BroadcastToStreaming`) and the
deprecated `Broadcasting` wire variant were left on the legacy
state-machine path — meaning the last DashMap-resident relay UPDATE
amplifier surface (pre-registered `UpdateOp` + `load_or_init`/`push`)
remained uncovered by the slice A dedup gate.

## Solution

Add task-per-transaction drivers for both streaming variants in
`operations/update/op_ctx_task.rs`:

- `start_relay_request_update_streaming` — claims inbound stream via
  `orphan_stream_registry().claim_or_wait`, assembles, deserializes
  `UpdateStreamingPayload`, applies locally via `update_contract`,
  emits `update_success` telemetry. Fire-and-forget: propagation is
  via `BroadcastStateChange` after local apply.
- `start_relay_broadcast_to_streaming` — same stream-claim + assemble
  flow, plus pre-merge dedup cache check (amplifier mitigation), WASM
  merge, `update_broadcast_applied` telemetry, proactive summary
  spawn on success, and the legacy failure classifier
  (`log_broadcast_to_streaming_failure` + conditional
  `try_auto_fetch_contract` / `send_summary_back_on_rejection`).

Key simplification vs PUT slice B: UPDATE streaming relays are
fire-and-forget. No downstream `pipe_stream`, no upstream reply, no
request-response bookkeeping.

Dispatch gate in `node.rs` routes both variants under the same
`source_addr.is_some()` AND `!has_update_op(id)` gate as slice A.
Deprecated `UpdateMsg::Broadcasting` stays on the legacy no-op
handler; pre-registered `UpdateOp`s (GC / originator-loopback) still
fall through to legacy.

Shared counter `RELAY_UPDATE_DEDUP_REJECTS` and shared tx set
`active_relay_update_txs` ensure dedup is unified across slice A +
slice C; separate `RELAY_UPDATE_STREAMING_*` counters give operators
independent visibility during the ramp.

## Testing

- 50 UPDATE unit tests pass (including 9 new slice C structural pin
  tests + 3 updated node.rs dispatch pin tests).
- Full `cargo test -p freenet --lib` passes (2462 passed, 16
  ignored).
- `cargo clippy -p freenet --all-targets -- -D warnings` clean.
- `cargo fmt` clean.

Structural pin tests cover: driver existence, dedup-gate usage (both
drivers increment `RELAY_UPDATE_DEDUP_REJECTS`), orphan-stream claim
via `claim_or_wait`, fire-and-forget guarantee (no `send_and_await`,
no `pipe_stream`), pre-merge dedup ordering (`BroadcastToStreaming`
calls `broadcast_dedup_cache.check_and_insert` before
`update_contract`), failure classification, proactive summary spawn,
and RAII guard cleanup of streaming-specific counters
(`RELAY_UPDATE_STREAMING_INFLIGHT`,
`RELAY_UPDATE_STREAMING_COMPLETED_TOTAL`).

Linux-only multi-loopback streaming end-to-end tests remain covered
by existing `/freenet:linux-test` infrastructure.

## Fixes

Partial progress on #1454 Phase 5. After this merges, only the
deprecated `UpdateMsg::Broadcasting` wire variant + legacy streaming
arms in `update.rs:871-1366` remain — Phase 6 wire cleanup will
delete both.