### PR TITLE
ci(release): also upload Freenet.dmg (stable alias) on each release

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -433,7 +433,12 @@ jobs:
           cp artifacts/x86_64-windows-freenet/freenet.exe freenet.exe
 
           # macOS universal installer (signed + notarized)
+          # Upload both the versioned name (Freenet-X.Y.Z.dmg) and a
+          # stable alias (Freenet.dmg) so the quickstart page can link
+          # to /releases/latest/download/Freenet.dmg without hardcoding
+          # a version.
           cp artifacts/macos-dmg/Freenet-*.dmg .
+          cp artifacts/macos-dmg/Freenet-*.dmg Freenet.dmg
 
           # Display the created files
           ls -lh *.tar.gz *.zip *.exe *.dmg


### PR DESCRIPTION
## Problem

The macOS DMG is produced as `Freenet-X.Y.Z.dmg`, which prevents the quickstart page on freenet.org from linking to a stable URL via `/releases/latest/download/<name>`. Windows already has this working via `freenet.exe`.

I retro-uploaded a `Freenet.dmg` copy to v0.2.49 so the quickstart link works today (freenet/web#38). This PR makes it happen automatically for every future release.

## Solution

In the release-asset step of cross-compile.yml, copy the versioned DMG twice:
- `Freenet-X.Y.Z.dmg` — unchanged, versioned filename
- `Freenet.dmg` — stable alias

Both land in SHA256SUMS.txt. No extra build cost — `cp` of an already-produced artifact.

## Testing

- Diff is a one-line `cp` added to the existing asset-prep shell block. The surrounding `Freenet-*.dmg` copy already works in v0.2.49; this adds a second destination for the same source.
- No unit test applicable — exercised end-to-end by the next release build.

[AI-assisted - Claude]