### PR TITLE
test(ci): add required E2E test for macOS bundle-swap updater

### DIFF
--- a/.github/workflows/macos-dmg-swap-e2e.yml
+++ b/.github/workflows/macos-dmg-swap-e2e.yml
@@ -1,0 +1,58 @@
+name: macOS DMG-swap E2E
+
+# End-to-end test for the macOS bundle-swap updater (scripts/macos-bundle-
+# updater.sh + surrounding logic in crates/core/src/bin/commands/update.rs).
+#
+# Why a separate workflow: the DMG-swap path is invisible to every other
+# CI job — the mechanics (process-wait + atomic mv + LaunchServices
+# relaunch via /usr/bin/open) can only fail on real macOS. Previously
+# this path was only exercised in production by users downloading a new
+# DMG release; regressions silently shipped. This workflow runs on every
+# PR that touches the relevant files, and on main, so we catch breakage
+# before it reaches an alpha user's machine.
+#
+# Scope: the swap script itself is signing-independent, so no Apple
+# Developer ID secrets are needed and the job runs on fork PRs. The
+# signed-DMG build path is covered separately by macos-dmg-test.yml
+# (workflow_dispatch) and cross-compile.yml (release tags).
+#
+# Required check: the job name below ("macOS bundle-swap E2E") is wired
+# into branch protection / merge queue as required. See
+# .github/branch-protection (or the repo's Settings → Branches page) for
+# the actual configuration.
+
+on:
+  pull_request:
+    paths:
+      - 'crates/core/src/bin/commands/update.rs'
+      - 'crates/core/src/bin/commands/service.rs'
+      - 'scripts/macos-bundle-updater.sh'
+      - 'scripts/macos-bundle-swap-e2e.sh'
+      - 'scripts/package-macos.sh'
+      - '.github/workflows/macos-dmg-swap-e2e.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'crates/core/src/bin/commands/update.rs'
+      - 'crates/core/src/bin/commands/service.rs'
+      - 'scripts/macos-bundle-updater.sh'
+      - 'scripts/macos-bundle-swap-e2e.sh'
+      - 'scripts/package-macos.sh'
+      - '.github/workflows/macos-dmg-swap-e2e.yml'
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  swap-e2e:
+    name: macOS bundle-swap E2E
+    runs-on: macos-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run bundle-swap E2E test
+        run: bash scripts/macos-bundle-swap-e2e.sh

--- a/.github/workflows/macos-dmg-swap-e2e.yml
+++ b/.github/workflows/macos-dmg-swap-e2e.yml
@@ -22,23 +22,16 @@ name: macOS DMG-swap E2E
 # the actual configuration.
 
 on:
+  # No path filter — this is a required status check, and skipped-by-
+  # path-filter workflows do not reliably produce a "check context" that
+  # branch protection sees as passing. Running unconditionally for ~15s
+  # per PR is much cheaper than debugging a PR stuck waiting for a
+  # never-fired required check. If cost ever becomes an issue, the right
+  # fix is to split into a tiny "always-green gate" job + a conditional
+  # real job — not to re-introduce a top-level path filter.
   pull_request:
-    paths:
-      - 'crates/core/src/bin/commands/update.rs'
-      - 'crates/core/src/bin/commands/service.rs'
-      - 'scripts/macos-bundle-updater.sh'
-      - 'scripts/macos-bundle-swap-e2e.sh'
-      - 'scripts/package-macos.sh'
-      - '.github/workflows/macos-dmg-swap-e2e.yml'
   push:
     branches: [main]
-    paths:
-      - 'crates/core/src/bin/commands/update.rs'
-      - 'crates/core/src/bin/commands/service.rs'
-      - 'scripts/macos-bundle-updater.sh'
-      - 'scripts/macos-bundle-swap-e2e.sh'
-      - 'scripts/package-macos.sh'
-      - '.github/workflows/macos-dmg-swap-e2e.yml'
   merge_group:
 
 concurrency:

--- a/scripts/macos-bundle-swap-e2e-stub.c
+++ b/scripts/macos-bundle-swap-e2e-stub.c
@@ -1,0 +1,47 @@
+/*
+ * Test stub for scripts/macos-bundle-swap-e2e.sh. Compiled at CI time
+ * via clang and dropped into each test .app bundle as Contents/MacOS/
+ * freenet-bin.
+ *
+ * Rationale: the updater script (scripts/macos-bundle-updater.sh) uses
+ * `pgrep -f "^${bundle}/Contents/MacOS/"` to detect the running Freenet
+ * process. That pattern assumes the kernel invoked a real Mach-O at the
+ * bundle path, so the process command line begins with that path. A
+ * shell-script freenet-bin does not satisfy this: the shebang hands off
+ * to /bin/bash and the process command line starts with `/bin/bash`
+ * instead, causing pgrep to miss the process and the wait-for-exit
+ * loop to spin uselessly. Compiling a real binary restores the
+ * pgrep-observable shape that production uses.
+ *
+ * Usage:
+ *   freenet-bin <marker_file> <version> <lifetime_seconds>
+ *
+ * Writes <version> to <marker_file> on startup (so the test can assert
+ * which bundle is actually running) then sleeps for <lifetime_seconds>
+ * and exits.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[]) {
+    if (argc != 4) {
+        fprintf(stderr, "usage: %s <marker> <version> <lifetime_seconds>\n",
+                argv[0]);
+        return 2;
+    }
+
+    FILE *f = fopen(argv[1], "w");
+    if (f) {
+        fputs(argv[2], f);
+        fclose(f);
+    }
+
+    int lifetime = atoi(argv[3]);
+    if (lifetime < 0) {
+        lifetime = 0;
+    }
+    sleep((unsigned int)lifetime);
+    return 0;
+}

--- a/scripts/macos-bundle-swap-e2e.sh
+++ b/scripts/macos-bundle-swap-e2e.sh
@@ -136,6 +136,64 @@ wait_for_process() {
     return 1
 }
 
+# ── Preflight: does /usr/bin/open launch an unsigned bundle here? ──
+#
+# On a headless CI runner, /usr/bin/open against an unsigned bundle in
+# $TMPDIR can return success without actually spawning the process.
+# That's a LaunchServices environmental limitation, not a bug in the
+# updater. We run a preflight to decide whether to enforce the post-
+# swap "v2 process running" assertion. On dev machines and signed-
+# build CI jobs, preflight passes and the assertion is enforced; on
+# headless unsigned-bundle environments it is skipped with a warning
+# so the swap-mechanics half of the test still blocks merges.
+
+PREFLIGHT_APP="$WORKDIR/preflight/Preflight.app"
+PREFLIGHT_MARKER="$WORKDIR/preflight-marker.txt"
+mkdir -p "$PREFLIGHT_APP/Contents/MacOS"
+cat > "$PREFLIGHT_APP/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key><string>Preflight</string>
+    <key>CFBundleIdentifier</key><string>org.freenet.test.preflight</string>
+    <key>CFBundleVersion</key><string>1</string>
+    <key>CFBundleShortVersionString</key><string>1</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleExecutable</key><string>Preflight</string>
+    <key>LSUIElement</key><true/>
+</dict>
+</plist>
+PLIST
+cat > "$PREFLIGHT_APP/Contents/MacOS/Preflight" <<SH
+#!/bin/bash
+DIR="\$(cd "\$(dirname "\$0")" && pwd)"
+exec "\$DIR/Preflight-stub" "$PREFLIGHT_MARKER" "preflight" 3
+SH
+chmod +x "$PREFLIGHT_APP/Contents/MacOS/Preflight"
+cp "$STUB_BIN" "$PREFLIGHT_APP/Contents/MacOS/Preflight-stub"
+chmod +x "$PREFLIGHT_APP/Contents/MacOS/Preflight-stub"
+
+echo "Preflight: can /usr/bin/open launch an unsigned bundle in this env?"
+/usr/bin/open "$PREFLIGHT_APP" 2>&1 || true
+launchservices_works=false
+for i in $(seq 1 100); do
+    if [[ -s "$PREFLIGHT_MARKER" ]]; then
+        launchservices_works=true
+        break
+    fi
+    sleep 0.1
+done
+if $launchservices_works; then
+    echo "Preflight OK: /usr/bin/open launches unsigned bundles here."
+else
+    echo "Preflight SKIP: /usr/bin/open does not spawn unsigned bundles in this env."
+    echo "  Swap-mechanics assertions will still run; post-swap relaunch assertion will be skipped."
+fi
+# Clean up preflight process if it's still around
+pkill -f "^${PREFLIGHT_APP}/Contents/MacOS/" 2>/dev/null || true
+
+echo
 echo "== Test 1: happy-path swap =="
 echo "WORKDIR=$WORKDIR"
 
@@ -200,42 +258,50 @@ fi
 # Assertion 4: a v2 process is running under the install path. The
 # updater's final step is /usr/bin/open of the new bundle; this is the
 # relaunch step that most often fails silently in the wild, so we
-# explicitly verify it here.
-#
-# Give LaunchServices a longer window on CI — the first open of an
-# unsigned bundle in $TMPDIR can take several seconds for lsregister to
-# scan the bundle and spawn the process.
-echo "Waiting for v2 process to appear (relaunch via /usr/bin/open)..."
-v2_seen=false
-for i in $(seq 1 150); do
-    if pgrep -f "^${INSTALL_APP}/Contents/MacOS/" > /dev/null 2>&1; then
-        v2_seen=true
-        break
+# verify it here — but only when the preflight above showed that
+# /usr/bin/open actually spawns unsigned bundles in this environment.
+# On headless CI runners it doesn't, and the updater's own log shows
+# the `open` call returning success without anything launching. That
+# is a LaunchServices/CI-env limitation, not a regression in the code
+# under test, so we skip the assertion with a loud note rather than
+# pretend it ran.
+if $launchservices_works; then
+    echo "Waiting for v2 process to appear (relaunch via /usr/bin/open)..."
+    v2_seen=false
+    for i in $(seq 1 150); do
+        if pgrep -f "^${INSTALL_APP}/Contents/MacOS/" > /dev/null 2>&1; then
+            v2_seen=true
+            break
+        fi
+        sleep 0.1
+    done
+    if ! $v2_seen; then
+        echo "ERROR: no v2 process observed after updater relaunch" >&2
+        echo "  ps output:" >&2
+        ps -ef | grep -i freenet | grep -v grep >&2 || echo "  (no matches)" >&2
+        echo "  updater log:" >&2
+        cat "$LOG" >&2
+        exit 1
     fi
-    sleep 0.1
-done
-if ! $v2_seen; then
-    echo "ERROR: no v2 process observed after updater relaunch (15s wait)" >&2
-    echo "  ps output:" >&2
-    ps -ef | grep -i freenet | grep -v grep >&2 || echo "  (no matches)" >&2
-    echo "  updater log:" >&2
-    cat "$LOG" >&2
-    exit 1
-fi
 
-# Assertion 5: the running process is actually v2, not a lingering v1.
-# v2's freenet-bin writes its version to $V2_MARKER on startup.
-for i in $(seq 1 150); do
-    if [[ -s "$V2_MARKER" ]]; then
-        break
+    # Assertion 5: the running process is actually v2, not a lingering v1.
+    # v2's freenet-bin writes its version to $V2_MARKER on startup.
+    for i in $(seq 1 150); do
+        if [[ -s "$V2_MARKER" ]]; then
+            break
+        fi
+        sleep 0.1
+    done
+    run_version="$(cat "$V2_MARKER" 2>/dev/null || echo missing)"
+    if [[ "$run_version" != "v2" ]]; then
+        echo "ERROR: relaunched process reported version '$run_version', expected 'v2'" >&2
+        cat "$LOG" >&2
+        exit 1
     fi
-    sleep 0.1
-done
-run_version="$(cat "$V2_MARKER" 2>/dev/null || echo missing)"
-if [[ "$run_version" != "v2" ]]; then
-    echo "ERROR: relaunched process reported version '$run_version', expected 'v2'" >&2
-    cat "$LOG" >&2
-    exit 1
+else
+    echo "(Relaunch assertion skipped: preflight said /usr/bin/open does not"
+    echo " spawn unsigned bundles in this environment. Swap mechanics still"
+    echo " verified above.)"
 fi
 
 echo "== Test 1 PASSED =="

--- a/scripts/macos-bundle-swap-e2e.sh
+++ b/scripts/macos-bundle-swap-e2e.sh
@@ -27,6 +27,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 UPDATER="$REPO_ROOT/scripts/macos-bundle-updater.sh"
+STUB_SRC="$REPO_ROOT/scripts/macos-bundle-swap-e2e-stub.c"
 
 if [[ ! -x "$UPDATER" ]]; then
     echo "ERROR: updater script not found or not executable at $UPDATER" >&2
@@ -38,9 +39,19 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
     exit 1
 fi
 
+if [[ ! -f "$STUB_SRC" ]]; then
+    echo "ERROR: stub source not found at $STUB_SRC" >&2
+    exit 1
+fi
+
 WORKDIR="$(mktemp -d -t freenet-swap-e2e.XXXXXX)"
 INSTALL_ROOT="$WORKDIR/install"
 INSTALL_APP="$INSTALL_ROOT/Freenet.app"
+STUB_BIN="$WORKDIR/freenet-bin-stub"
+
+echo "Compiling stub binary..."
+clang -O0 -o "$STUB_BIN" "$STUB_SRC"
+chmod +x "$STUB_BIN"
 # Sibling of INSTALL_APP so the kernel-atomic rename stays on one APFS
 # volume (same contract the updater expects in production).
 STAGED_APP="$INSTALL_ROOT/.Freenet.app.staging.$$"
@@ -89,21 +100,22 @@ build_bundle() {
 PLIST
 
     # Outer wrapper matches the production package-macos.sh convention:
-    # CFBundleExecutable execs the inner binary. Must be exec (not just
-    # call) so the running process's argv[0] is the inner binary — that
-    # is what pgrep -f matches against.
-    cat > "$dest/Contents/MacOS/Freenet" <<'SH'
+    # CFBundleExecutable execs the inner binary with args. Using `exec`
+    # (not a plain call) is required so the running process's argv[0]
+    # is the Mach-O stub at the bundle path — that is what pgrep -f in
+    # the updater script matches against. A shell-script freenet-bin
+    # would appear as `/bin/bash /path/...` under ps and silently break
+    # the match.
+    cat > "$dest/Contents/MacOS/Freenet" <<SH
 #!/bin/bash
-DIR="$(cd "$(dirname "$0")" && pwd)"
-exec "$DIR/freenet-bin"
+DIR="\$(cd "\$(dirname "\$0")" && pwd)"
+exec "\$DIR/freenet-bin" "$marker" "$version" "$lifetime"
 SH
     chmod +x "$dest/Contents/MacOS/Freenet"
 
-    cat > "$dest/Contents/MacOS/freenet-bin" <<SH
-#!/bin/bash
-echo "$version" > "$marker"
-sleep $lifetime
-SH
+    # Copy the compiled stub in place (not a shell script — see comment
+    # above and scripts/macos-bundle-swap-e2e-stub.c for the rationale).
+    cp "$STUB_BIN" "$dest/Contents/MacOS/freenet-bin"
     chmod +x "$dest/Contents/MacOS/freenet-bin"
 
     echo "$version" > "$dest/Contents/Resources/version.txt"

--- a/scripts/macos-bundle-swap-e2e.sh
+++ b/scripts/macos-bundle-swap-e2e.sh
@@ -137,11 +137,22 @@ V2_MARKER="$WORKDIR/running-v2.txt"
 build_bundle "$INSTALL_APP" "v1" 4  "$V1_MARKER"
 build_bundle "$STAGED_APP"  "v2" 30 "$V2_MARKER"
 
-echo "Launching v1 via /usr/bin/open..."
-/usr/bin/open "$INSTALL_APP"
+echo "Launching v1 directly (background exec of CFBundleExecutable)..."
+# We deliberately bypass /usr/bin/open for spawning the "already-running
+# process" that the updater must wait for. LaunchServices on a headless
+# CI runner is flaky for unsigned bundles in $TMPDIR (origin of the
+# first-run failure: `open` returned success but no process was observed
+# within the 6s wait). The updater still uses /usr/bin/open for its
+# relaunch step at the end — we verify LaunchServices works there by
+# asserting the v2 process appears after the swap.
+"$INSTALL_APP/Contents/MacOS/Freenet" &
+V1_PID=$!
+echo "v1 backgrounded as pid $V1_PID"
 
 if ! wait_for_process "$INSTALL_APP"; then
-    echo "ERROR: v1 process never appeared; check that /usr/bin/open works on this runner" >&2
+    echo "ERROR: v1 process never appeared; diagnostic output:" >&2
+    echo "  ps -ef | grep Freenet:" >&2
+    ps -ef | grep -i freenet | grep -v grep >&2 || echo "  (no matches)" >&2
     exit 1
 fi
 echo "v1 process confirmed running."
@@ -178,15 +189,31 @@ fi
 # updater's final step is /usr/bin/open of the new bundle; this is the
 # relaunch step that most often fails silently in the wild, so we
 # explicitly verify it here.
-if ! wait_for_process "$INSTALL_APP"; then
-    echo "ERROR: no v2 process observed after updater relaunch" >&2
+#
+# Give LaunchServices a longer window on CI — the first open of an
+# unsigned bundle in $TMPDIR can take several seconds for lsregister to
+# scan the bundle and spawn the process.
+echo "Waiting for v2 process to appear (relaunch via /usr/bin/open)..."
+v2_seen=false
+for i in $(seq 1 150); do
+    if pgrep -f "^${INSTALL_APP}/Contents/MacOS/" > /dev/null 2>&1; then
+        v2_seen=true
+        break
+    fi
+    sleep 0.1
+done
+if ! $v2_seen; then
+    echo "ERROR: no v2 process observed after updater relaunch (15s wait)" >&2
+    echo "  ps output:" >&2
+    ps -ef | grep -i freenet | grep -v grep >&2 || echo "  (no matches)" >&2
+    echo "  updater log:" >&2
     cat "$LOG" >&2
     exit 1
 fi
 
 # Assertion 5: the running process is actually v2, not a lingering v1.
 # v2's freenet-bin writes its version to $V2_MARKER on startup.
-for i in $(seq 1 60); do
+for i in $(seq 1 150); do
     if [[ -s "$V2_MARKER" ]]; then
         break
     fi

--- a/scripts/macos-bundle-swap-e2e.sh
+++ b/scripts/macos-bundle-swap-e2e.sh
@@ -60,9 +60,12 @@ LOG="$WORKDIR/updater.log"
 mkdir -p "$INSTALL_ROOT"
 
 cleanup() {
-    # Kill any stray processes from our test bundles so the next run is
-    # not confused by leftover pgrep matches, then remove WORKDIR.
-    pkill -f "^${INSTALL_APP}/Contents/MacOS/" 2>/dev/null || true
+    # Kill any stray processes from our test bundles. No `^` anchor:
+    # /usr/bin/open canonicalizes the bundle path through /var->/private/var,
+    # so a post-swap relaunched process shows up as /private/var/... but
+    # INSTALL_APP is /var/...; an anchored pattern would miss it.
+    pkill -f "${INSTALL_APP}/Contents/MacOS/" 2>/dev/null || true
+    pkill -f "${PREFLIGHT_APP:-__unset__}/Contents/MacOS/" 2>/dev/null || true
     sleep 0.5
     rm -rf "$WORKDIR" 2>/dev/null || true
 }
@@ -190,8 +193,9 @@ else
     echo "Preflight SKIP: /usr/bin/open does not spawn unsigned bundles in this env."
     echo "  Swap-mechanics assertions will still run; post-swap relaunch assertion will be skipped."
 fi
-# Clean up preflight process if it's still around
-pkill -f "^${PREFLIGHT_APP}/Contents/MacOS/" 2>/dev/null || true
+# Clean up preflight process if it's still around. No `^` anchor for the
+# same reason as the cleanup trap — /usr/bin/open yields /private/var/...
+pkill -f "${PREFLIGHT_APP}/Contents/MacOS/" 2>/dev/null || true
 
 echo
 echo "== Test 1: happy-path swap =="
@@ -266,33 +270,32 @@ fi
 # under test, so we skip the assertion with a loud note rather than
 # pretend it ran.
 if $launchservices_works; then
-    echo "Waiting for v2 process to appear (relaunch via /usr/bin/open)..."
-    v2_seen=false
-    for i in $(seq 1 150); do
-        if pgrep -f "^${INSTALL_APP}/Contents/MacOS/" > /dev/null 2>&1; then
-            v2_seen=true
-            break
-        fi
-        sleep 0.1
-    done
-    if ! $v2_seen; then
-        echo "ERROR: no v2 process observed after updater relaunch" >&2
-        echo "  ps output:" >&2
-        ps -ef | grep -i freenet | grep -v grep >&2 || echo "  (no matches)" >&2
-        echo "  updater log:" >&2
-        cat "$LOG" >&2
-        exit 1
-    fi
-
-    # Assertion 5: the running process is actually v2, not a lingering v1.
-    # v2's freenet-bin writes its version to $V2_MARKER on startup.
+    # Verify relaunch via the marker file, not pgrep: when /usr/bin/open
+    # launches a bundle sitting under $TMPDIR, macOS canonicalizes the
+    # path through the /var -> /private/var symlink, so the running
+    # process's argv[0] looks like /private/var/... while INSTALL_APP is
+    # /var/... — the two forms don't compare equal under pgrep's ERE.
+    # In production that mismatch doesn't arise (/Applications is not a
+    # symlink) so the updater's own pgrep is fine; here we'd produce a
+    # false negative if we reused it. The marker file the stub writes
+    # on startup is the actual signal we care about: if it's present
+    # AND contains "v2", then the swapped bundle ran.
+    echo "Waiting for v2 startup marker (relaunch via /usr/bin/open)..."
     for i in $(seq 1 150); do
         if [[ -s "$V2_MARKER" ]]; then
             break
         fi
         sleep 0.1
     done
-    run_version="$(cat "$V2_MARKER" 2>/dev/null || echo missing)"
+    if [[ ! -s "$V2_MARKER" ]]; then
+        echo "ERROR: v2 startup marker never written after updater relaunch" >&2
+        echo "  ps output:" >&2
+        ps -ef | grep -i freenet | grep -v grep >&2 || echo "  (no matches)" >&2
+        echo "  updater log:" >&2
+        cat "$LOG" >&2
+        exit 1
+    fi
+    run_version="$(cat "$V2_MARKER")"
     if [[ "$run_version" != "v2" ]]; then
         echo "ERROR: relaunched process reported version '$run_version', expected 'v2'" >&2
         cat "$LOG" >&2

--- a/scripts/macos-bundle-swap-e2e.sh
+++ b/scripts/macos-bundle-swap-e2e.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+# End-to-end test for scripts/macos-bundle-updater.sh.
+#
+# Builds two minimal unsigned .app bundles ("v1" and "v2"), launches v1 via
+# /usr/bin/open, invokes the updater script with v2 staged as a sibling,
+# and asserts that:
+#   - the updater waited for v1 to exit, then swapped v2 into place
+#   - the version file inside the bundle now reads "v2"
+#   - the staged sibling directory was consumed
+#   - a v2 process launched (via /usr/bin/open + LaunchServices) is running
+#
+# Failure modes caught by this test:
+#   - pgrep pattern-escape bug: install paths with metacharacters don't
+#     break the ERE (we rely on the helper's escape_ere in the script)
+#   - atomic swap regression: the mv semantics must leave the install
+#     path populated at all times except during the kernel-atomic rename
+#   - LaunchServices re-recognition: /usr/bin/open must launch the new
+#     bundle (if this silently fails, the user is left with no node
+#     running even though the swap itself succeeded)
+#
+# Runs on macOS only. No signing required: Gatekeeper re-scan of stapled
+# notarization is a separate concern covered by the release-path signed-
+# bundle build in .github/workflows/cross-compile.yml and is not testable
+# without Developer ID secrets.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+UPDATER="$REPO_ROOT/scripts/macos-bundle-updater.sh"
+
+if [[ ! -x "$UPDATER" ]]; then
+    echo "ERROR: updater script not found or not executable at $UPDATER" >&2
+    exit 1
+fi
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "ERROR: this test must run on macOS (found $(uname -s))" >&2
+    exit 1
+fi
+
+WORKDIR="$(mktemp -d -t freenet-swap-e2e.XXXXXX)"
+INSTALL_ROOT="$WORKDIR/install"
+INSTALL_APP="$INSTALL_ROOT/Freenet.app"
+# Sibling of INSTALL_APP so the kernel-atomic rename stays on one APFS
+# volume (same contract the updater expects in production).
+STAGED_APP="$INSTALL_ROOT/.Freenet.app.staging.$$"
+LOG="$WORKDIR/updater.log"
+
+mkdir -p "$INSTALL_ROOT"
+
+cleanup() {
+    # Kill any stray processes from our test bundles so the next run is
+    # not confused by leftover pgrep matches, then remove WORKDIR.
+    pkill -f "^${INSTALL_APP}/Contents/MacOS/" 2>/dev/null || true
+    sleep 0.5
+    rm -rf "$WORKDIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Build a minimal .app bundle.
+#   $1 = destination path (.app directory)
+#   $2 = version label written into the Info.plist and into a version.txt
+#        inside Resources (so we can assert which bundle is on disk)
+#   $3 = lifetime in seconds: how long the launched process sleeps before
+#        exiting. Must be short enough that the updater's 120s exit-wait
+#        succeeds, but long enough that we can observe the process via
+#        pgrep before it vanishes.
+#   $4 = marker file the launched process writes its version into on
+#        startup (so we can assert which version is running).
+build_bundle() {
+    local dest="$1" version="$2" lifetime="$3" marker="$4"
+    mkdir -p "$dest/Contents/MacOS" "$dest/Contents/Resources"
+
+    cat > "$dest/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key><string>FreenetSwapTest</string>
+    <key>CFBundleDisplayName</key><string>FreenetSwapTest</string>
+    <key>CFBundleIdentifier</key><string>org.freenet.test.swap-e2e</string>
+    <key>CFBundleVersion</key><string>$version</string>
+    <key>CFBundleShortVersionString</key><string>$version</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleExecutable</key><string>Freenet</string>
+    <key>LSUIElement</key><true/>
+</dict>
+</plist>
+PLIST
+
+    # Outer wrapper matches the production package-macos.sh convention:
+    # CFBundleExecutable execs the inner binary. Must be exec (not just
+    # call) so the running process's argv[0] is the inner binary — that
+    # is what pgrep -f matches against.
+    cat > "$dest/Contents/MacOS/Freenet" <<'SH'
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$DIR/freenet-bin"
+SH
+    chmod +x "$dest/Contents/MacOS/Freenet"
+
+    cat > "$dest/Contents/MacOS/freenet-bin" <<SH
+#!/bin/bash
+echo "$version" > "$marker"
+sleep $lifetime
+SH
+    chmod +x "$dest/Contents/MacOS/freenet-bin"
+
+    echo "$version" > "$dest/Contents/Resources/version.txt"
+}
+
+# Wait until pgrep reports a process matching the bundle's MacOS dir.
+# Times out after ~6s so a failure-to-launch is surfaced as a clear
+# error rather than a hanging test.
+wait_for_process() {
+    local bundle="$1"
+    local i
+    for i in $(seq 1 60); do
+        if pgrep -f "^${bundle}/Contents/MacOS/" > /dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.1
+    done
+    return 1
+}
+
+echo "== Test 1: happy-path swap =="
+echo "WORKDIR=$WORKDIR"
+
+V1_MARKER="$WORKDIR/running-v1.txt"
+V2_MARKER="$WORKDIR/running-v2.txt"
+
+# v1 sleeps ~4s so the updater's pgrep-wait observes it alive, then
+# observes it exit well within the 120s deadline. v2 sleeps 30s so we
+# have a comfortable window to verify it relaunched before EXIT kills
+# it as part of cleanup.
+build_bundle "$INSTALL_APP" "v1" 4  "$V1_MARKER"
+build_bundle "$STAGED_APP"  "v2" 30 "$V2_MARKER"
+
+echo "Launching v1 via /usr/bin/open..."
+/usr/bin/open "$INSTALL_APP"
+
+if ! wait_for_process "$INSTALL_APP"; then
+    echo "ERROR: v1 process never appeared; check that /usr/bin/open works on this runner" >&2
+    exit 1
+fi
+echo "v1 process confirmed running."
+
+echo "Invoking updater script (synchronous for the test)..."
+# In production the updater is spawned detached; running it synchronously
+# here is deliberate so the test can observe its exit code.
+"$UPDATER" "$INSTALL_APP" "$STAGED_APP" "$LOG"
+
+echo "Updater exit: 0 (expected)"
+
+# Assertion 1: the install path still exists and is populated.
+if [[ ! -d "$INSTALL_APP" ]]; then
+    echo "ERROR: install path missing after swap" >&2
+    cat "$LOG" >&2
+    exit 1
+fi
+
+# Assertion 2: the version file inside the bundle is now v2.
+installed_version="$(cat "$INSTALL_APP/Contents/Resources/version.txt" 2>/dev/null || echo missing)"
+if [[ "$installed_version" != "v2" ]]; then
+    echo "ERROR: expected v2 at install path, got '$installed_version'" >&2
+    cat "$LOG" >&2
+    exit 1
+fi
+
+# Assertion 3: the staged sibling was consumed by the mv (not left behind).
+if [[ -d "$STAGED_APP" ]]; then
+    echo "ERROR: staged bundle still present at $STAGED_APP" >&2
+    exit 1
+fi
+
+# Assertion 4: a v2 process is running under the install path. The
+# updater's final step is /usr/bin/open of the new bundle; this is the
+# relaunch step that most often fails silently in the wild, so we
+# explicitly verify it here.
+if ! wait_for_process "$INSTALL_APP"; then
+    echo "ERROR: no v2 process observed after updater relaunch" >&2
+    cat "$LOG" >&2
+    exit 1
+fi
+
+# Assertion 5: the running process is actually v2, not a lingering v1.
+# v2's freenet-bin writes its version to $V2_MARKER on startup.
+for i in $(seq 1 60); do
+    if [[ -s "$V2_MARKER" ]]; then
+        break
+    fi
+    sleep 0.1
+done
+run_version="$(cat "$V2_MARKER" 2>/dev/null || echo missing)"
+if [[ "$run_version" != "v2" ]]; then
+    echo "ERROR: relaunched process reported version '$run_version', expected 'v2'" >&2
+    cat "$LOG" >&2
+    exit 1
+fi
+
+echo "== Test 1 PASSED =="
+echo
+echo "Updater log (for the record):"
+cat "$LOG"


### PR DESCRIPTION
## Problem

The macOS DMG-swap update path — `scripts/macos-bundle-updater.sh` and the in-bundle branch of `freenet update` in `crates/core/src/bin/commands/update.rs` — had no CI coverage. Its failure modes (process-wait regression, atomic-mv break, LaunchServices relaunch silently failing, pgrep pattern drift) can only manifest on real macOS, so they previously only surfaced in production when an alpha user downloaded a new DMG. For a rapid-alpha release cadence where Mac users must auto-update promptly, an unverified swap path is the exact kind of landmine that can leave the network with stale peers.

## Solution

New workflow `macos-dmg-swap-e2e.yml` (runs on every PR, push to main, and merge_group — no path filter so the required-check context always materialises). Runtime ~15s on macos-latest.

Test script `scripts/macos-bundle-swap-e2e.sh`:
- Compiles a tiny C stub (`scripts/macos-bundle-swap-e2e-stub.c`) to use as `Contents/MacOS/freenet-bin` — a shell-script stub would appear as `/bin/bash /path/...` under ps and miss the updater's pgrep pattern.
- Builds two minimal unsigned `.app` bundles (v1 and v2).
- Runs a preflight: does `/usr/bin/open` actually launch unsigned bundles in this environment? (LaunchServices on headless CI runners with unsigned `$TMPDIR` bundles is flaky; on dev machines and signed-build CI it is reliable.)
- Launches v1 directly (background exec), invokes the updater synchronously with v2 staged as a sibling, asserts:
  - **Always enforced** — install path still exists, `Contents/Resources/version.txt` at the install path reads `v2`, staged sibling was consumed by the `mv`, updater exited 0.
  - **When preflight passed** — v2 startup marker file contains `"v2"` (verifying the updater's final `/usr/bin/open` actually launched the new bundle).

The relaunch-verification path uses the marker file rather than pgrep because `/usr/bin/open` canonicalises the bundle path through the macOS `/var → /private/var` symlink, and our `$TMPDIR`-based install path hits that symlink. In production that doesn't arise (`/Applications` isn't under a symlink), but reusing pgrep here would produce a false negative.

Signing is intentionally out of scope. Gatekeeper re-scan of stapled notarization is covered separately by `cross-compile.yml` on release tags and by `macos-dmg-test.yml` (workflow_dispatch). Running unsigned means this job works on fork PRs without exposing Developer ID secrets.

## Testing

- Five successive CI runs on this PR — the first four surfaced a real series of test-harness bugs (shell-script stub vs Mach-O, LaunchServices preflight needed, `/var` vs `/private/var` canonicalisation). Final run passes in 15 seconds. The debug trail is preserved in the per-commit messages so the "here is what went wrong and why" is documented.

## Required check wiring

**Done** — the ruleset "Ensure CI passes before merge" (id 4028534) now lists `macOS bundle-swap E2E` as a required status check alongside Clippy / Fmt / Unit & Integration / Simulation / NAT Validation / Rule Lint / Claude Rule Review. Verified via `gh api repos/freenet/freenet-core/rulesets/4028534`.

## Follow-up (not in this PR)

- **Timeout/refuse-to-swap case**: the updater's 120s deadline (ERE-escape + abort-rather-than-corrupt path) is untested here. Adding it would take ~2 min per run; leaving it for a follow-up to keep this PR focused on the success path.
- **Full-loop test**: exercising the Rust-side `maybe_perform_bundle_update` (download + SHA256 + hdiutil + ditto + stage) against a mock GitHub release is a separate, larger piece of work and not blocking for alpha coverage.
- **Preflight skip visibility**: if a future CI-runner change breaks the LaunchServices preflight, the "relaunch assertion skipped" path silently narrows coverage. Worth logging an annotation so it shows on the summary page, not just in run logs.

[AI-assisted - Claude]