### PR TITLE
fix: convert remaining .send().await in transport hot paths to try_send

### DIFF
--- a/.claude/rules/channel-safety.md
+++ b/.claude/rules/channel-safety.md
@@ -22,6 +22,38 @@ stalling the entire event loop. This has caused 4+ production deadlocks:
   the event loop exceeded bridge channel capacity, deadlocking the node.
 - **Result router chain**: `result_router_tx.send().await` in the event loop
   could cascade if `SessionActor` was slow → router blocked → event loop blocked.
+- **Listener forwarding family** (#3959 → #3960 → #3961, Apr 2026):
+  the UDP listener task in `transport::connection_handler` calls
+  `try_send_*` synchronously to route every inbound packet to the right
+  per-peer channel. The original `fast_channel` wrapper used
+  `crossbeam::channel`, whose internal `Backoff::snooze` could spin in
+  `sched_yield` indefinitely on a wedged slot — taking the entire node
+  offline (#3959). #3960 replaced it with `tokio::sync::mpsc` so
+  `try_send` is guaranteed non-blocking. #3961 closed the remaining
+  `.send().await` site on the listener path (`send_nat_traversal`).
+  The recv-loop forwarding from `PeerConnection::recv` into the
+  per-stream `inbound_streams` channel was investigated and *kept* as
+  `.send().await`: the receiver there is the freenet-spawned
+  `recv_stream` reassembly task, internal and same-runtime, so the
+  cascading-backpressure pattern this rule prevents cannot form.
+
+## Exception: same-runtime internal consumers
+
+`.send().await` on a bounded channel is acceptable when **all** of the
+following hold:
+
+1. The receiver task is freenet-internal (we spawned it; it is not an
+   external client or peer).
+2. The consumer has no upstream dependency on the producer (no cycle
+   through which a stalled producer could starve its own consumer).
+3. Blocking is scoped to a single per-peer or per-connection event loop
+   (so it cannot starve other peers).
+4. Per-message consumer work is bounded and small (microseconds, not
+   "I might call into a slow external API").
+
+Document the exception inline at the call site, citing this section.
+Existing exception: `peer_connection.rs::process_inbound` legacy stream
+fragment forwarding into `inbound_streams[stream_id]`.
 
 ## Rules
 

--- a/.claude/rules/transport.md
+++ b/.claude/rules/transport.md
@@ -89,7 +89,7 @@ BEFORE changing LEDBAT++ parameters:
 
 ```
 NAT traversal:
-  1. Send multiple intro packets (up to 10 over ~3s)
+  1. Send multiple intro packets — `NAT_TRAVERSAL_MAX_ATTEMPTS` (40 in release builds, 10 under `cfg(test)`) at a 200 ms cadence, capped by a 3 s `overall_deadline` (so ~15 attempts at production settings)
   2. Use exponential backoff: 50ms → 300ms → 1s → 5s
   3. First relay observes external address (ObservedAddress msg)
   4. Rate limit: 1 intro packet/second per source IP

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -779,17 +779,26 @@ impl<S, T: TimeSource> ConnectionStateManager<S, T> {
         }
     }
 
-    /// Try to send a packet to an ongoing NAT traversal.
-    /// Returns Ok(true) if sent, Ok(false) if channel closed.
-    async fn send_nat_traversal(
+    /// Try to send a packet to an ongoing NAT traversal, without blocking.
+    ///
+    /// Returns `Ok(true)` if sent, `Ok(false)` if the channel is full or
+    /// closed. Crucially this is non-blocking: the listener task calls this
+    /// synchronously for every inbound packet, so a slow or wedged
+    /// per-handshake consumer cannot stall the listener for other peers.
+    /// Dropped intro packets are recoverable — the remote peer retries up
+    /// to 10 times over ~3 s during NAT traversal (see transport.md
+    /// "WHEN establishing connections"), so a transient channel-full event
+    /// degrades latency but does not break the handshake.
+    fn try_send_nat_traversal(
         &self,
         addr: &SocketAddr,
         packet: PacketData<UnknownEncryption>,
     ) -> Result<bool, ()> {
         if let Some(ConnectionState::NatTraversal { packet_sender, .. }) = self.states.get(addr) {
-            match packet_sender.send(packet).await {
+            match packet_sender.try_send(packet) {
                 Ok(()) => Ok(true),
-                Err(_) => Ok(false),
+                Err(mpsc::error::TrySendError::Full(_)) => Ok(false),
+                Err(mpsc::error::TrySendError::Closed(_)) => Ok(false),
             }
         } else {
             Err(())
@@ -1368,10 +1377,17 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                                             }
                                             self.connections.record_asym_attempt(remote_addr);
                                         }
-                                        if let Err(()) = self.connections.send_nat_traversal(&remote_addr, packet_data).await {
-                                            tracing::debug!(peer_addr = %remote_addr, "failed to send NAT traversal packet");
+                                        match self.connections.try_send_nat_traversal(&remote_addr, packet_data) {
+                                            Ok(true) => continue,
+                                            Ok(false) => {
+                                                tracing::debug!(peer_addr = %remote_addr, "NAT traversal channel busy/closed, dropping packet");
+                                                continue;
+                                            }
+                                            Err(()) => {
+                                                tracing::debug!(peer_addr = %remote_addr, "NAT traversal state missing");
+                                                continue;
+                                            }
                                         }
-                                        continue;
                                     }
 
                                     ConnectionState::RecentlyClosed { .. } => {
@@ -3061,6 +3077,62 @@ mod version_cmp {
         assert!(
             elapsed < BUDGET,
             "{ATTEMPTS} try_send_gateway_handshake calls took {elapsed:?} (budget {BUDGET:?})"
+        );
+        assert!(
+            full_count >= ATTEMPTS - CAPACITY,
+            "Expected at least {} Full results, got {full_count}",
+            ATTEMPTS - CAPACITY
+        );
+    }
+
+    /// Regression for #3961 — completes the trio of listener-forwarding
+    /// non-blocking tests with the NAT-traversal path. Like `try_send_established`
+    /// and `try_send_gateway_handshake`, `try_send_nat_traversal` is invoked
+    /// synchronously from `UdpPacketsListener::listen` for every inbound
+    /// packet that maps to an in-flight NAT-traversal handshake. The prior
+    /// implementation (`send_nat_traversal` with `.send().await`) could
+    /// stall the listener for every other peer if a single per-handshake
+    /// consumer was slow. This test pins the new non-blocking contract.
+    #[tokio::test]
+    async fn test_try_send_nat_traversal_never_blocks_when_full() {
+        use super::ConnectionStateManager;
+        use super::mock_transport::MockSocket;
+        use crate::simulation::VirtualTime;
+        use crate::transport::packet_data::{PacketData, UnknownEncryption};
+        use std::net::SocketAddr;
+        use std::time::{Duration, Instant};
+        use tokio::sync::{mpsc, oneshot};
+
+        const CAPACITY: usize = 4;
+        const ATTEMPTS: usize = 1_000;
+        const BUDGET: Duration = Duration::from_secs(1);
+
+        let time = VirtualTime::new();
+        let mut manager: ConnectionStateManager<MockSocket, VirtualTime> =
+            ConnectionStateManager::new(time);
+        let addr: SocketAddr = "127.0.0.1:8004".parse().unwrap();
+
+        let (tx, _rx) = mpsc::channel::<PacketData<UnknownEncryption>>(CAPACITY);
+        let (result_tx, _result_rx) = oneshot::channel();
+        let started = manager.start_nat_traversal(addr, tx, result_tx);
+        assert!(started, "Should start NAT traversal");
+
+        let make_packet = || PacketData::<UnknownEncryption>::from_buf([0u8; 32]);
+
+        let started_at = Instant::now();
+        let mut full_count = 0;
+        for _ in 0..ATTEMPTS {
+            match manager.try_send_nat_traversal(&addr, make_packet()) {
+                Ok(true) => {}
+                Ok(false) => full_count += 1,
+                Err(()) => panic!("NAT traversal state unexpectedly missing"),
+            }
+        }
+        let elapsed = started_at.elapsed();
+
+        assert!(
+            elapsed < BUDGET,
+            "{ATTEMPTS} try_send_nat_traversal calls took {elapsed:?} (budget {BUDGET:?})"
         );
         assert!(
             full_count >= ATTEMPTS - CAPACITY,

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -690,6 +690,15 @@ enum ConnectionState<S, T: TimeSource> {
     RecentlyClosed { closed_at_nanos: u64 },
 }
 
+/// Result of `ConnectionStateManager::try_send_nat_traversal` —
+/// distinguishes a slow consumer from a vanished one so the listener
+/// can log them differently.
+enum TrySendNatTraversalOutcome {
+    Sent,
+    Full,
+    Closed,
+}
+
 /// Manages connection state with atomic transitions.
 /// Single source of truth for all connection states per address.
 struct ConnectionStateManager<S, T: TimeSource> {
@@ -781,24 +790,31 @@ impl<S, T: TimeSource> ConnectionStateManager<S, T> {
 
     /// Try to send a packet to an ongoing NAT traversal, without blocking.
     ///
-    /// Returns `Ok(true)` if sent, `Ok(false)` if the channel is full or
-    /// closed. Crucially this is non-blocking: the listener task calls this
+    /// Returns the outcome distinguishing `Sent` (delivered), `Full`
+    /// (consumer not draining fast enough — usually transient), `Closed`
+    /// (handshake task already exited — state about to be removed).
+    /// Returns `Err(())` if no NAT traversal state exists for `addr`.
+    ///
+    /// Crucially this is non-blocking: the listener task calls this
     /// synchronously for every inbound packet, so a slow or wedged
     /// per-handshake consumer cannot stall the listener for other peers.
-    /// Dropped intro packets are recoverable — the remote peer retries up
-    /// to 10 times over ~3 s during NAT traversal (see transport.md
-    /// "WHEN establishing connections"), so a transient channel-full event
-    /// degrades latency but does not break the handshake.
+    /// Dropped intro packets are recoverable — `connect_outbound_inner`
+    /// retries up to `NAT_TRAVERSAL_MAX_ATTEMPTS` (40 in release builds,
+    /// 10 under `cfg(test)`) at a 200 ms cadence, capped by the 3 s
+    /// `overall_deadline`. So at production settings the remote peer
+    /// fires roughly 15 intro packets during the deadline window — a
+    /// transient channel-full event degrades latency but does not break
+    /// the handshake.
     fn try_send_nat_traversal(
         &self,
         addr: &SocketAddr,
         packet: PacketData<UnknownEncryption>,
-    ) -> Result<bool, ()> {
+    ) -> Result<TrySendNatTraversalOutcome, ()> {
         if let Some(ConnectionState::NatTraversal { packet_sender, .. }) = self.states.get(addr) {
             match packet_sender.try_send(packet) {
-                Ok(()) => Ok(true),
-                Err(mpsc::error::TrySendError::Full(_)) => Ok(false),
-                Err(mpsc::error::TrySendError::Closed(_)) => Ok(false),
+                Ok(()) => Ok(TrySendNatTraversalOutcome::Sent),
+                Err(mpsc::error::TrySendError::Full(_)) => Ok(TrySendNatTraversalOutcome::Full),
+                Err(mpsc::error::TrySendError::Closed(_)) => Ok(TrySendNatTraversalOutcome::Closed),
             }
         } else {
             Err(())
@@ -1378,9 +1394,13 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                                             self.connections.record_asym_attempt(remote_addr);
                                         }
                                         match self.connections.try_send_nat_traversal(&remote_addr, packet_data) {
-                                            Ok(true) => continue,
-                                            Ok(false) => {
-                                                tracing::debug!(peer_addr = %remote_addr, "NAT traversal channel busy/closed, dropping packet");
+                                            Ok(TrySendNatTraversalOutcome::Sent) => continue,
+                                            Ok(TrySendNatTraversalOutcome::Full) => {
+                                                tracing::debug!(peer_addr = %remote_addr, "NAT traversal channel full, dropping packet (peer will retry)");
+                                                continue;
+                                            }
+                                            Ok(TrySendNatTraversalOutcome::Closed) => {
+                                                tracing::debug!(peer_addr = %remote_addr, "NAT traversal handshake task exited; dropping packet");
                                                 continue;
                                             }
                                             Err(()) => {
@@ -3123,8 +3143,11 @@ mod version_cmp {
         let mut full_count = 0;
         for _ in 0..ATTEMPTS {
             match manager.try_send_nat_traversal(&addr, make_packet()) {
-                Ok(true) => {}
-                Ok(false) => full_count += 1,
+                Ok(super::TrySendNatTraversalOutcome::Sent) => {}
+                Ok(super::TrySendNatTraversalOutcome::Full) => full_count += 1,
+                Ok(super::TrySendNatTraversalOutcome::Closed) => {
+                    panic!("receiver still alive; should not be Closed");
+                }
                 Err(()) => panic!("NAT traversal state unexpectedly missing"),
             }
         }

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -1478,26 +1478,35 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                 }
 
                 // Legacy path: push to mpsc channel for existing recv() behavior.
-                // Use try_send (not send().await): this code runs inside
-                // PeerConnection::recv, which is the connection's only event
-                // loop. A blocking await here would stall ACKs, keepalives,
-                // and every other stream on the same connection if a single
-                // stream's consumer task gets slow. On Full or Closed we
-                // treat the stream as broken and surface it as
-                // ConnectionClosed — matching the behaviour the prior
-                // .send().await already had on Closed, just without the
-                // node-wide hang risk on Full. (See #3961 / #3959.)
+                //
+                // This is one of the rare in-tree exceptions to the
+                // `.send().await`-in-recv-loop ban from
+                // `.claude/rules/channel-safety.md`. The receiver here is
+                // the freenet-spawned `recv_stream` reassembly task in
+                // `inbound_stream_futures` — it is NOT an external client
+                // consumer, and it has no upstream dependency on this
+                // recv loop. The cascading-backpressure deadlock pattern
+                // the rule prevents (slow external consumer stalls our
+                // event loop, which feeds another channel the consumer
+                // is waiting on) cannot form here because:
+                //   - the consumer is internal and same-runtime, with
+                //     bounded per-fragment work (BTreeMap insert + Vec extend),
+                //   - blocking is scoped per-connection (each peer has
+                //     its own recv loop), so it cannot starve other peers,
+                //   - the only effect of transient backpressure is brief
+                //     ACK/keepalive delay for THIS peer until `recv_stream`
+                //     drains.
+                //
+                // Switching to `try_send` was attempted in #3961 and reverted
+                // on review (Codex P1, skeptical reviewer M2): turning
+                // transient executor pressure into `ConnectionClosed` would
+                // abort otherwise-healthy large transfers whenever more than
+                // 64 fragments back up before `recv_stream` is scheduled.
                 if let Some(sender) = self.inbound_streams.get(&stream_id) {
-                    sender.try_send((fragment_number, payload)).map_err(|err| {
-                        tracing::debug!(
-                            peer_addr = %self.remote_conn.remote_addr,
-                            stream_id = %stream_id,
-                            fragment_number,
-                            ?err,
-                            "Inbound stream consumer cannot keep up; closing connection"
-                        );
-                        TransportError::ConnectionClosed(self.remote_addr())
-                    })?;
+                    sender
+                        .send((fragment_number, payload))
+                        .await
+                        .map_err(|_| TransportError::ConnectionClosed(self.remote_addr()))?;
                     tracing::trace!(
                         peer_addr = %self.remote_conn.remote_addr,
                         stream_id = %stream_id,

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -1477,12 +1477,27 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                     return Ok(None);
                 }
 
-                // Legacy path: push to mpsc channel for existing recv() behavior
+                // Legacy path: push to mpsc channel for existing recv() behavior.
+                // Use try_send (not send().await): this code runs inside
+                // PeerConnection::recv, which is the connection's only event
+                // loop. A blocking await here would stall ACKs, keepalives,
+                // and every other stream on the same connection if a single
+                // stream's consumer task gets slow. On Full or Closed we
+                // treat the stream as broken and surface it as
+                // ConnectionClosed — matching the behaviour the prior
+                // .send().await already had on Closed, just without the
+                // node-wide hang risk on Full. (See #3961 / #3959.)
                 if let Some(sender) = self.inbound_streams.get(&stream_id) {
-                    sender
-                        .send((fragment_number, payload))
-                        .await
-                        .map_err(|_| TransportError::ConnectionClosed(self.remote_addr()))?;
+                    sender.try_send((fragment_number, payload)).map_err(|err| {
+                        tracing::debug!(
+                            peer_addr = %self.remote_conn.remote_addr,
+                            stream_id = %stream_id,
+                            fragment_number,
+                            ?err,
+                            "Inbound stream consumer cannot keep up; closing connection"
+                        );
+                        TransportError::ConnectionClosed(self.remote_addr())
+                    })?;
                     tracing::trace!(
                         peer_addr = %self.remote_conn.remote_addr,
                         stream_id = %stream_id,


### PR DESCRIPTION
## Problem

A `.send().await` call site in the UDP listener path (`send_nat_traversal` at `connection_handler.rs:790`) violated `.claude/rules/channel-safety.md`. It runs synchronously from `UdpPacketsListener::listen`, so a slow or wedged per-handshake consumer would have stalled the listener for every other peer — exactly the failure mode that caused #3959 (4-hour node hang in production) on the established-connection forwarding path.

## Solution

Convert `send_nat_traversal` to non-blocking `try_send_nat_traversal`. On `Full`, drop the packet (intro packets are retried by the remote — `NAT_TRAVERSAL_MAX_ATTEMPTS = 40` at 200 ms cadence under a 3 s `overall_deadline`, so ~15 retries in production — so a transient channel-full event degrades latency but does not break the handshake). On `Closed`, drop the packet (handshake task already exited). Promoted the return type to a dedicated `TrySendNatTraversalOutcome { Sent, Full, Closed }` enum so the listener can log the two failure cases distinguishably.

### What changed in scope after review

The original PR also converted the per-stream `inbound_streams` forwarding in `PeerConnection::process_inbound` from `.send().await` to `try_send`. Codex (P1), skeptical reviewer (M2), and testing reviewer unanimously flagged this as wrong: the receiver there is the freenet-spawned `recv_stream` reassembly task — internal, same-runtime, with no upstream dependency on the producing recv loop — so the cascading-backpressure deadlock pattern `channel-safety.md` exists to prevent cannot form. Turning `Full` into `ConnectionClosed` would have aborted otherwise-healthy large transfers under transient executor pressure (more than 64 fragments backing up before `recv_stream` is scheduled). Reverted that change, with a load-bearing comment citing the new "Exception: same-runtime internal consumers" subsection added to `channel-safety.md`.

## Testing

- New `test_try_send_nat_traversal_never_blocks_when_full` — completes the trio with `test_try_send_established_never_blocks_when_full` and `test_try_send_gateway_handshake_never_blocks_when_full` (added in #3960). Same scaffolding: fill a per-handshake channel of capacity 4 with 1000 attempts, assert the loop completes inside a 1 s budget. Updated to use the new outcome enum.
- 553 transport unit tests pass.
- `cargo clippy --all-targets -- -D warnings` clean.
- Audit: `grep -rn "\.send(.*).await" crates/core/src/transport/` returns exactly one production hit, in the documented exception (the legacy stream forwarding). Listener path is fully non-blocking.

## Documentation

- `channel-safety.md` updated to (a) record the #3959 → #3960 → #3961 listener-forwarding incident family, and (b) add an "Exception: same-runtime internal consumers" subsection with explicit conditions, since the reverted-and-kept `.send().await` would otherwise look like an unjustified rule violation.
- `transport.md:92` updated: the prior "up to 10 over ~3s" claim was the `cfg(test)` constant. Now cites the actual production retry budget.

Closes #3961

[AI-assisted - Claude]