### PR TITLE
refactor(ops): remove deprecated UpdateMsg::Broadcasting wire variant

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -24,8 +24,7 @@ paths:
 > state-machine path**, which still serves: GC-spawned GET retries and
 > `start_targeted_op` UPDATE-triggered auto-fetch (streaming relay and
 > originator loopback also remain on legacy per #3883 port plan §7),
-> PUT GC / streaming / originator-loopback paths, the deprecated
-> UPDATE `Broadcasting` wire variant (no-op handler), CONNECT, and
+> PUT GC / streaming / originator-loopback paths, CONNECT, and
 > SUBSCRIBE's renewal / PUT-sub-op / executor / intermediate-peer
 > entry points. Phase 5 follow-up slice A (PR #3910) migrated fresh
 > inbound non-streaming relay `UpdateMsg::RequestUpdate` and
@@ -83,9 +82,9 @@ paths:
 > reuses the shared `log_broadcast_to_streaming_failure` classifier
 > and triggers `try_auto_fetch_contract` / `send_summary_back_on_rejection`
 > on the same branches as the legacy handler. The deprecated
-> `UpdateMsg::Broadcasting` wire variant remains on the legacy no-op
-> handler; Phase 6 wire cleanup will delete both the legacy streaming
-> arms in `update.rs:871-1366` and the `Broadcasting` variant.
+> `UpdateMsg::Broadcasting` wire variant has been removed; the
+> `min-compatible-version` floor was bumped to 0.2.50 to gate the
+> incompatible bincode discriminant shift.
 >
 > Task-per-tx drivers have their own invariants documented in the
 > `op_ctx_task.rs` module doc and in `OpCtx::send_and_await`'s rustdoc.

--- a/crates/core/CLAUDE.md
+++ b/crates/core/CLAUDE.md
@@ -84,8 +84,8 @@ Plus task-per-transaction drivers from #1454 Phase 2b onwards:
     (`active_relay_{get,update,put,subscribe}_txs`) and the
     `Relay*InflightGuard` RAII. PUT and UPDATE streaming relays now run
     on the task-per-tx path. The deprecated UPDATE `Broadcasting` wire
-    variant remains on the legacy no-op handler (Phase 6 wire cleanup
-    removes it). SUBSCRIBE has no streaming variants but renewals, PUT
+    variant has been removed (gated by a `min-compatible-version`
+    bump). SUBSCRIBE has no streaming variants but renewals, PUT
     sub-op subscribes, executor auto-subscribe paths, `Unsubscribe`,
     and `ForwardingAck` all stay on the legacy state machine.
 ```

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 # Minimum compatible protocol version. Peers older than this are rejected.
 # Updated by scripts/release.sh during releases. The env var
 # FREENET_MIN_COMPATIBLE_VERSION overrides this at build time.
-min-compatible-version = "0.2.48"
+min-compatible-version = "0.2.50"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/freenet-{ target }.tar.gz"

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -385,9 +385,12 @@ pub(super) fn acquire_wrapper_single_instance_lock() -> AcquireWrapperLockOutcom
             return AcquireWrapperLockOutcome::UnavailableSoProceed;
         }
     };
-    // LOCK_EX | LOCK_NB: exclusive lock, fail fast if held by another
-    // process. Released automatically when the fd closes on process
-    // exit (kernel-managed); we never need to unlock explicitly.
+    // SAFETY: `file.as_raw_fd()` returns a valid fd owned by `file`,
+    // and `libc::flock` only operates on that fd. LOCK_EX | LOCK_NB
+    // is an exclusive non-blocking lock that fails fast if held by
+    // another process. The lock is released automatically when the
+    // fd closes on process exit (kernel-managed); we never need to
+    // unlock explicitly.
     let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
     if rc != 0 {
         AcquireWrapperLockOutcome::AnotherWrapperRunning

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1328,8 +1328,6 @@ where
                 // streaming variants (RequestUpdateStreaming /
                 // BroadcastToStreaming) through task-per-tx drivers
                 // under the same source_addr + !has_update_op gates.
-                // The deprecated Broadcasting wire variant stays on
-                // the legacy path (no-op handler).
                 if let Some(sender_addr) = source_addr {
                     #[allow(clippy::wildcard_enum_match_arm)]
                     match op {
@@ -1439,11 +1437,9 @@ where
                             }
                             return Ok(None);
                         }
-                        // Deprecated `Broadcasting` variant stays legacy
-                        // (no-op handler). Pre-registered UpdateOps
-                        // (has_update_op == true) also fall through to
-                        // legacy for GC / originator-loopback paths.
-                        // Wildcard arm exists ONLY to satisfy
+                        // Pre-registered UpdateOps (has_update_op == true)
+                        // fall through to legacy for GC / originator-loopback
+                        // paths. Wildcard arm exists ONLY to satisfy
                         // non-exhaustive matches; do not expand.
                         _ => {}
                     }
@@ -3930,11 +3926,9 @@ mod tests {
         }
 
         /// Slice C (#1454 phase 5): streaming relay UPDATE variants
-        /// are now dispatched through task-per-tx drivers. The
-        /// deprecated `Broadcasting` wire variant stays on the legacy
-        /// no-op path.
+        /// are dispatched through task-per-tx drivers.
         #[test]
-        fn update_branch_dispatches_streaming_drivers_but_not_broadcasting() {
+        fn update_branch_dispatches_streaming_drivers() {
             const SOURCE: &str = include_str!("node.rs");
 
             let anchor = "NetMessageV1::Update(ref op) => {";
@@ -3954,11 +3948,6 @@ mod tests {
                 window.contains("start_relay_broadcast_to_streaming("),
                 "UPDATE branch must call start_relay_broadcast_to_streaming \
                  for streaming relay dispatch (slice C)."
-            );
-            assert!(
-                !window.contains("UpdateMsg::Broadcasting {"),
-                "UPDATE branch must not dispatch the deprecated Broadcasting \
-                 variant — it stays on the legacy no-op handler."
             );
         }
 

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -232,27 +232,19 @@ where
             } else {
                 let id = *msg.id();
                 tracing::debug!(%id, "operation in progress");
-                if let Some(target) = next_hop {
-                    tracing::debug!(%id, ?target, "sending updated op state");
-                    // IMPORTANT: Push state BEFORE sending message to avoid race condition.
-                    // If we send first, a fast response might arrive before the state is saved,
-                    // causing load_or_init to fail to find the operation.
-                    op_manager.push(id, updated_state).await?;
-                    send_with_stream(network_bridge, target, msg, stream_data).await?;
-                } else {
-                    tracing::debug!(%id, "queueing op state for local processing");
-                    debug_assert!(
-                        matches!(
-                            msg,
-                            NetMessage::V1(NetMessageV1::Update(
-                                crate::operations::update::UpdateMsg::Broadcasting { .. }
-                            ))
-                        ),
-                        "Only Update::Broadcasting messages should be re-queued locally"
-                    );
-                    op_manager.notify_op_change(msg, updated_state).await?;
-                    return Err(OpError::StatePushed);
-                }
+                let target = next_hop.ok_or_else(|| {
+                    // Only UPDATE's deprecated `Broadcasting` variant produced
+                    // SendAndContinue without a next_hop, and it has been
+                    // removed. Reaching this branch indicates a bug in an
+                    // operation's process_message implementation.
+                    OpError::UnexpectedOpState
+                })?;
+                tracing::debug!(%id, ?target, "sending updated op state");
+                // IMPORTANT: Push state BEFORE sending message to avoid race condition.
+                // If we send first, a fast response might arrive before the state is saved,
+                // causing load_or_init to fail to find the operation.
+                op_manager.push(id, updated_state).await?;
+                send_with_stream(network_bridge, target, msg, stream_data).await?;
             }
         }
 

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -847,25 +847,6 @@ impl Operation for UpdateOp {
                     new_state = None;
                     return_msg = None;
                 }
-                UpdateMsg::Broadcasting {
-                    id,
-                    broadcast_to,
-                    key,
-                    ..
-                } => {
-                    // DEPRECATED: Broadcasting messages are no longer generated.
-                    // Network peer propagation is now automatic via BroadcastStateChange event
-                    // emitted by the executor when state changes.
-                    // This handler is kept for backwards compatibility during rolling upgrades.
-                    tracing::debug!(
-                        tx = %id,
-                        %key,
-                        target_count = broadcast_to.len(),
-                        "Received deprecated Broadcasting message - ignoring (propagation is automatic)"
-                    );
-                    new_state = None;
-                    return_msg = None;
-                }
 
                 // ---- Streaming handlers ----
                 UpdateMsg::RequestUpdateStreaming {
@@ -1633,7 +1614,6 @@ fn build_op_result(
 ) -> Result<super::OperationResult, OpError> {
     // With hop-by-hop routing:
     // - forward_hop is set when forwarding RequestUpdate to the next peer
-    // - Broadcasting messages have next_hop = None (they're processed locally)
     // - BroadcastTo uses explicit addresses via conn_manager.send()
     let next_hop = forward_hop;
 
@@ -2488,7 +2468,7 @@ mod messages {
 
     use crate::{
         message::{InnerMessage, Transaction},
-        ring::{Location, PeerKeyLocation},
+        ring::Location,
         transport::peer_connection::StreamId,
     };
 
@@ -2528,14 +2508,6 @@ mod messages {
             #[serde(deserialize_with = "RelatedContracts::deser_related_contracts")]
             related_contracts: RelatedContracts<'static>,
             value: WrappedState,
-        },
-        /// Internal node instruction to track broadcasting progress.
-        Broadcasting {
-            id: Transaction,
-            broadcasted_to: usize,
-            broadcast_to: Vec<PeerKeyLocation>,
-            key: ContractKey,
-            new_value: WrappedState,
         },
         /// Broadcasting a change to a specific subscriber.
         ///
@@ -2585,7 +2557,6 @@ mod messages {
         fn id(&self) -> &Transaction {
             match self {
                 UpdateMsg::RequestUpdate { id, .. }
-                | UpdateMsg::Broadcasting { id, .. }
                 | UpdateMsg::BroadcastTo { id, .. }
                 | UpdateMsg::RequestUpdateStreaming { id, .. }
                 | UpdateMsg::BroadcastToStreaming { id, .. } => id,
@@ -2595,7 +2566,6 @@ mod messages {
         fn requested_location(&self) -> Option<crate::ring::Location> {
             match self {
                 UpdateMsg::RequestUpdate { key, .. }
-                | UpdateMsg::Broadcasting { key, .. }
                 | UpdateMsg::BroadcastTo { key, .. }
                 | UpdateMsg::RequestUpdateStreaming { key, .. }
                 | UpdateMsg::BroadcastToStreaming { key, .. } => Some(Location::from(key.id())),
@@ -2607,7 +2577,6 @@ mod messages {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             match self {
                 UpdateMsg::RequestUpdate { id, .. } => write!(f, "RequestUpdate(id: {id})"),
-                UpdateMsg::Broadcasting { id, .. } => write!(f, "Broadcasting(id: {id})"),
                 UpdateMsg::BroadcastTo { id, .. } => write!(f, "BroadcastTo(id: {id})"),
                 UpdateMsg::RequestUpdateStreaming { id, stream_id, .. } => {
                     write!(f, "RequestUpdateStreaming(id: {id}, stream: {stream_id})")

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -410,8 +410,6 @@ fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: Driv
 //      `update.rs::process_message`, lines 595–825).
 //
 // NOT migrated (stays on legacy path; see port plan §3 / §9):
-//   - `UpdateMsg::Broadcasting` (deprecated wire variant — legacy
-//      handler is a no-op).
 //   - `UpdateMsg::RequestUpdateStreaming` /
 //     `UpdateMsg::BroadcastToStreaming` (slice B follow-up — orphan
 //      stream claim + assembly).
@@ -2276,27 +2274,19 @@ mod tests {
         );
     }
 
-    /// Pin: `Broadcasting` (deprecated) must not be migrated. Legacy
-    /// handler treats it as a no-op; driver should never reference it.
+    /// Pin: the deprecated `UpdateMsg::Broadcasting` variant has been
+    /// removed. Re-introducing it would shift bincode discriminant
+    /// tags and silently break wire compatibility with peers gated by
+    /// the bumped `min-compatible-version`. If a future change needs
+    /// a new variant, append it at the end of the enum to preserve
+    /// existing tags.
     #[test]
-    fn deprecated_broadcasting_variant_stays_legacy() {
-        let src = include_str!("op_ctx_task.rs");
-        // Skip past the section header / module-level scope doc comment
-        // (which references variant names by design) by anchoring on the
-        // first relay entry-point fn.
-        let relay_start = src
-            .find("pub(crate) async fn start_relay_request_update(")
-            .expect("start_relay_request_update not found");
-        let relay_end = src
-            .find("#[cfg(test)]")
-            .expect("test module marker not found");
-        let relay_src = &src[relay_start..relay_end];
-        // Match the variant constructor (UpdateMsg::Broadcasting), not
-        // arbitrary substrings (e.g. "Broadcasting" in a doc comment).
+    fn deprecated_broadcasting_variant_must_not_return() {
+        let src = include_str!("../update.rs");
         assert!(
-            !relay_src.contains("UpdateMsg::Broadcasting"),
-            "Driver must not handle UpdateMsg::Broadcasting — deprecated wire \
-             variant; legacy no-op handler stays in place."
+            !src.contains("Broadcasting {"),
+            "UpdateMsg::Broadcasting must remain deleted; appending new variants \
+             at the end of UpdateMsg preserves bincode discriminant tags."
         );
     }
 }

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -1393,26 +1393,6 @@ impl<'a> NetEventLog<'a> {
                     timestamp: chrono::Utc::now().timestamp() as u64,
                 })
             }
-            NetMessageV1::Update(UpdateMsg::Broadcasting {
-                new_value,
-                broadcast_to,
-                broadcasted_to,
-                key,
-                id,
-            }) => {
-                let this_peer = op_manager.ring.connection_manager.own_location();
-                EventKind::Update(UpdateEvent::BroadcastEmitted {
-                    id: *id,
-                    upstream: this_peer.clone(), // We are the broadcaster
-                    broadcast_to: broadcast_to.clone(),
-                    broadcasted_to: *broadcasted_to,
-                    key: *key,
-                    value: new_value.clone(),
-                    sender: this_peer, // We are the sender
-                    timestamp: chrono::Utc::now().timestamp() as u64,
-                    state_hash: None, // Hash not available from message
-                })
-            }
             NetMessageV1::Update(UpdateMsg::BroadcastTo {
                 payload, key, id, ..
             }) => {


### PR DESCRIPTION
## Problem

`UpdateMsg::Broadcasting` is a wire variant of the UPDATE op enum that hasn't been emitted by any code path for a release cycle — peer propagation is now driven by the executor via `BroadcastStateChange` events. The receiver-side handler at `update.rs:850` was kept as a no-op for rolling-upgrade safety, leaving deprecated code in five places (variant decl, handler arm, two trait impls, telemetry arm) plus a dead local-requeue branch in `operations.rs:242-255` whose `debug_assert!` documented Broadcasting as the only producer.

## Solution

Delete the variant + all match arms + dead local-requeue branch. The variant being a `pub(crate)` core-internal enum without `#[non_exhaustive]` means removing it shifts bincode discriminant tags for every following variant (`BroadcastTo`, `RequestUpdateStreaming`, `BroadcastToStreaming`) — older peers would fail to deserialize.

To gate the wire incompatibility safely, bump `min-compatible-version` from 0.2.48 to 0.2.50. The transport layer's `version_cmp::is_compatible` check rejects older peers at handshake (`crates/core/src/transport/connection_handler.rs:1909`), so the shifted discriminants can never reach deserialization on a peer that doesn't already speak the new format.

Net diff: -97 LOC of dead code.

## Testing

- `cargo test -p freenet --lib`: **2471 passed, 16 ignored**
- `cargo test -p freenet --lib operations::update`: 50 passed
- `cargo test -p freenet --lib operations::`: 386 passed
- `cargo test -p freenet --lib node::`: 221 passed
- `cargo clippy -p freenet -- -D warnings`: clean
- `cargo fmt`: clean

Updated slice C pin tests (`update_branch_dispatches_streaming_drivers`, deletion of `deprecated_broadcasting_variant_stays_legacy`) — the pin assertions were that drivers MUST NOT reference the variant; with the variant gone these are tautological.

Drive-by: added a `SAFETY:` comment on the existing `libc::flock` unsafe block in `bin/commands/service.rs` so `cargo clippy -- -D warnings` (rust 1.93) passes the pre-commit hook on this branch. Pre-existing on `main` — not a new lint introduced by this change.

## Refs

#1454 phase 5 follow-up. The next slice in this thread is the PUT GC speculative retry / `ForwardingAck` retirement, which depends on confirming task-per-tx PUT originators never push `is_client_initiated` PutOps into the DashMap (separate PR).