### PR TITLE
fix(installer): clean up Local AppData config and add visible auto-close countdown

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -2183,9 +2183,22 @@ struct DataLeaves {
     /// Pre-#3739 Roaming data path, only populated on Windows where it
     /// differs from `data_local`.
     data_roaming: Option<PathBuf>,
-    /// Config dir, only populated when it differs from both data paths
-    /// (matches the macOS case where `config_dir == data_dir`).
+    /// `config_dir` (Roaming on Windows, e.g.
+    /// `%APPDATA%\...\Freenet\config`). Only populated when it differs
+    /// from both data paths (matches the macOS case where
+    /// `config_dir == data_dir`). May be stale on Windows where the
+    /// running node actually writes to `config_local` (see #3979),
+    /// but is still cleaned up in case an old install left it behind.
     config: Option<PathBuf>,
+    /// `config_local_dir` (Local on Windows, e.g.
+    /// `%LOCALAPPDATA%\...\Freenet\config`). This is what the running
+    /// node actually writes to (`Config::build` in config.rs uses
+    /// `defaults.config_local_dir()`), which is *not* the same as
+    /// `config_dir` on Windows. Without this, `freenet uninstall
+    /// --purge` left the live config folder behind. Only populated
+    /// when distinct from `data_local` and `config` to avoid double
+    /// removal.
+    config_local: Option<PathBuf>,
     /// `cache_dir` for the uppercase project bundle.
     cache: Option<PathBuf>,
     /// Lowercase-variant cache used by the webapp cache on case-sensitive
@@ -2227,6 +2240,14 @@ impl DataLeaves {
             let config_dir = dirs.config_dir().to_path_buf();
             if config_dir != data_dir && Some(&config_dir) != leaves.data_roaming.as_ref() {
                 leaves.config = Some(config_dir);
+            }
+
+            let config_local_dir = dirs.config_local_dir().to_path_buf();
+            if config_local_dir != data_dir
+                && Some(&config_local_dir) != leaves.data_roaming.as_ref()
+                && Some(&config_local_dir) != leaves.config.as_ref()
+            {
+                leaves.config_local = Some(config_local_dir);
             }
 
             leaves.cache = Some(dirs.cache_dir().to_path_buf());
@@ -2273,8 +2294,12 @@ fn purge_leaves_and_collapse(leaves: &DataLeaves) -> Result<()> {
         collect(roaming, &mut parents);
     }
     if let Some(ref config) = leaves.config {
-        remove_if_exists("config", config)?;
+        remove_if_exists("config (legacy roaming)", config)?;
         collect(config, &mut parents);
+    }
+    if let Some(ref config_local) = leaves.config_local {
+        remove_if_exists("config", config_local)?;
+        collect(config_local, &mut parents);
     }
     if let Some(ref cache) = leaves.cache {
         remove_if_exists("cache", cache)?;
@@ -4051,10 +4076,18 @@ mod tests {
         let data_local = freenet_local.join("data");
         let data_roaming = freenet_roaming.join("data");
         let config = freenet_roaming.join("config");
+        let config_local = freenet_local.join("config");
         let cache = freenet_local.join("cache");
         let log = base.join("Local").join("freenet").join("logs");
 
-        for d in [&data_local, &data_roaming, &config, &cache, &log] {
+        for d in [
+            &data_local,
+            &data_roaming,
+            &config,
+            &config_local,
+            &cache,
+            &log,
+        ] {
             std::fs::create_dir_all(d).unwrap();
             std::fs::write(d.join("placeholder.bin"), b"x").unwrap();
         }
@@ -4063,6 +4096,7 @@ mod tests {
             data_local: Some(data_local),
             data_roaming: Some(data_roaming),
             config: Some(config),
+            config_local: Some(config_local),
             cache: Some(cache),
             cache_lowercase: None,
             log: Some(log),
@@ -4102,6 +4136,7 @@ mod tests {
             leaves.data_local.as_ref(),
             leaves.data_roaming.as_ref(),
             leaves.config.as_ref(),
+            leaves.config_local.as_ref(),
             leaves.cache.as_ref(),
             leaves.log.as_ref(),
         ]
@@ -4187,6 +4222,7 @@ mod tests {
             data_local: Some(data.clone()),
             data_roaming: None,
             config: Some(config.clone()),
+            config_local: None,
             cache: Some(cache.clone()),
             cache_lowercase: None,
             log: Some(log.clone()),
@@ -4226,6 +4262,7 @@ mod tests {
             data_local: Some(data_local.clone()),
             data_roaming: None,
             config: None,
+            config_local: None,
             cache: None,
             cache_lowercase: None,
             log: None,
@@ -4235,6 +4272,48 @@ mod tests {
         purge_leaves_and_collapse(&leaves).unwrap();
 
         assert!(!data_local.exists(), "leaf should be removed");
+    }
+
+    #[test]
+    fn test_purge_leaves_removes_config_in_local_app_data() {
+        // Regression for #3979: on Windows the running node writes config
+        // to `config_local_dir()` (Local AppData), not `config_dir()`
+        // (Roaming) — see `Config::build` in config.rs which uses
+        // `defaults.config_local_dir()`. The pre-fix `purge_leaves_and_collapse`
+        // only knew about the Roaming `config` leaf, so it left
+        // `%LOCALAPPDATA%\The Freenet Project Inc\Freenet\config\` behind
+        // on every Windows uninstall.
+        let tmp = tempfile::tempdir().unwrap();
+        let freenet_local = tmp
+            .path()
+            .join("Local")
+            .join("The Freenet Project Inc")
+            .join("Freenet");
+        let config_local = freenet_local.join("config");
+        std::fs::create_dir_all(&config_local).unwrap();
+        std::fs::write(config_local.join("config.toml"), b"x").unwrap();
+
+        let leaves = DataLeaves {
+            data_local: None,
+            data_roaming: None,
+            config: None,
+            config_local: Some(config_local.clone()),
+            cache: None,
+            cache_lowercase: None,
+            log: None,
+            collapse_parents: true,
+        };
+
+        purge_leaves_and_collapse(&leaves).unwrap();
+
+        assert!(
+            !config_local.exists(),
+            "config_local leaf must be removed (the #3979 regression)",
+        );
+        assert!(
+            !freenet_local.exists(),
+            "the now-empty Freenet parent should also collapse",
+        );
     }
 
     // ── Wrapper backoff state machine tests ──

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -2186,9 +2186,12 @@ struct DataLeaves {
     /// `config_dir` (Roaming on Windows, e.g.
     /// `%APPDATA%\...\Freenet\config`). Only populated when it differs
     /// from both data paths (matches the macOS case where
-    /// `config_dir == data_dir`). May be stale on Windows where the
-    /// running node actually writes to `config_local` (see #3979),
-    /// but is still cleaned up in case an old install left it behind.
+    /// `config_dir == data_dir`). On Windows the running node does
+    /// not write here — it writes to `config_local` — but several
+    /// other call sites (`config.rs:1661` id-set fallback, `report.rs`
+    /// config-file scan) still resolve through `config_dir()`, and an
+    /// older install may have written to it before the live node
+    /// switched to Local AppData. Cleaning both is correct.
     config: Option<PathBuf>,
     /// `config_local_dir` (Local on Windows, e.g.
     /// `%LOCALAPPDATA%\...\Freenet\config`). This is what the running
@@ -2196,8 +2199,10 @@ struct DataLeaves {
     /// `defaults.config_local_dir()`), which is *not* the same as
     /// `config_dir` on Windows. Without this, `freenet uninstall
     /// --purge` left the live config folder behind. Only populated
-    /// when distinct from `data_local` and `config` to avoid double
-    /// removal.
+    /// when distinct from `data_local`, `data_roaming`, and `config`
+    /// to avoid double removal — on Linux/macOS the `directories`
+    /// crate aliases `config_local_dir` to `config_dir`, so this
+    /// stays `None` and the existing leaves cover those platforms.
     config_local: Option<PathBuf>,
     /// `cache_dir` for the uppercase project bundle.
     cache: Option<PathBuf>,
@@ -4276,13 +4281,15 @@ mod tests {
 
     #[test]
     fn test_purge_leaves_removes_config_in_local_app_data() {
-        // Regression for #3979: on Windows the running node writes config
-        // to `config_local_dir()` (Local AppData), not `config_dir()`
-        // (Roaming) — see `Config::build` in config.rs which uses
-        // `defaults.config_local_dir()`. The pre-fix `purge_leaves_and_collapse`
-        // only knew about the Roaming `config` leaf, so it left
-        // `%LOCALAPPDATA%\The Freenet Project Inc\Freenet\config\` behind
-        // on every Windows uninstall.
+        // Regression for the Windows-uninstall config-leftover bug
+        // (#3904 follow-up, addressed in PR #3969): on Windows the
+        // running node writes config to `config_local_dir()` (Local
+        // AppData), not `config_dir()` (Roaming) — see `Config::build`
+        // in config.rs which uses `defaults.config_local_dir()`. The
+        // pre-fix `purge_leaves_and_collapse` only knew about the
+        // Roaming `config` leaf, so it left
+        // `%LOCALAPPDATA%\The Freenet Project Inc\Freenet\config\`
+        // behind on every Windows uninstall.
         let tmp = tempfile::tempdir().unwrap();
         let freenet_local = tmp
             .path()
@@ -4308,11 +4315,34 @@ mod tests {
 
         assert!(
             !config_local.exists(),
-            "config_local leaf must be removed (the #3979 regression)",
+            "config_local leaf must be removed (the #3904 follow-up regression)",
         );
         assert!(
             !freenet_local.exists(),
             "the now-empty Freenet parent should also collapse",
+        );
+    }
+
+    /// On Linux/macOS the `directories` crate aliases `config_local_dir`
+    /// to `config_dir`, so `DataLeaves::from_project_dirs()` must leave
+    /// `config_local` empty after the dedup branches at
+    /// `from_project_dirs` reject it. If a future refactor reorders the
+    /// dedup conditions and lets `config_local` be `Some` on Linux, the
+    /// purge code path would attempt to remove `~/.config/Freenet` a
+    /// second time (harmless via `remove_if_exists`, but masks a real
+    /// regression). This test pins the invariant.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn test_from_project_dirs_leaves_config_local_empty_on_unix() {
+        let leaves = DataLeaves::from_project_dirs();
+        assert!(
+            leaves.config_local.is_none(),
+            "config_local must alias config on Linux/macOS to avoid double removal; got {:?}",
+            leaves.config_local,
+        );
+        assert!(
+            !leaves.collapse_parents,
+            "collapse_parents must stay false off Windows so shared XDG roots are never collapsed",
         );
     }
 

--- a/crates/core/src/bin/commands/setup_wizard.rs
+++ b/crates/core/src/bin/commands/setup_wizard.rs
@@ -10,20 +10,12 @@
 pub mod detection;
 #[cfg(target_os = "windows")]
 pub mod installer;
-#[cfg(target_os = "windows")]
+// `ui` compiles on every platform — its `platform` module is the one that
+// is OS-gated (Windows uses tao/wry, non-Windows is a stub). Compiling
+// `ui` everywhere lets the embedded HTML's content tests (countdown
+// wiring, success-screen elements) run on the Linux CI matrix instead
+// of only on Windows where this project's `cargo test` doesn't run.
 pub mod ui;
-
-// Re-export stubs on non-Windows so the entry point compiles everywhere.
-#[cfg(not(target_os = "windows"))]
-pub mod ui {
-    #[derive(Debug, Clone, PartialEq)]
-    #[allow(dead_code)]
-    pub enum SetupResult {
-        Installed,
-        RunWithout,
-        Cancelled,
-    }
-}
 
 /// Check if Freenet needs to be installed and show the setup wizard if so.
 ///

--- a/crates/core/src/bin/commands/setup_wizard/setup.html
+++ b/crates/core/src/bin/commands/setup_wizard/setup.html
@@ -1,0 +1,298 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    background: #0c1219;
+    color: #d4dde8;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    overflow: hidden;
+    user-select: none;
+    -webkit-user-select: none;
+  }
+
+  .logo-container {
+    width: 88px;
+    height: 88px;
+    margin-bottom: 28px;
+  }
+
+  .logo-container svg {
+    width: 100%;
+    height: 100%;
+    filter: drop-shadow(0 2px 12px rgba(0, 110, 255, 0.15));
+  }
+
+  h1 {
+    font-size: 22px;
+    font-weight: 600;
+    color: #f0f4f8;
+    margin-bottom: 8px;
+    letter-spacing: -0.3px;
+  }
+
+  .subtitle {
+    color: #7b8da0;
+    font-size: 13.5px;
+    margin-bottom: 40px;
+  }
+
+  #welcome { text-align: center; }
+
+  .btn-primary {
+    display: inline-block;
+    background: linear-gradient(135deg, #0070f3 0%, #0058cc 100%);
+    color: #fff;
+    border: none;
+    padding: 13px 52px;
+    border-radius: 8px;
+    font-size: 14.5px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    letter-spacing: 0.2px;
+  }
+
+  .btn-primary:hover {
+    background: linear-gradient(135deg, #1a82ff 0%, #0066ee 100%);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 16px rgba(0, 112, 243, 0.35);
+  }
+
+  .btn-primary:active {
+    transform: translateY(0);
+    box-shadow: 0 2px 8px rgba(0, 112, 243, 0.25);
+  }
+
+  .btn-secondary {
+    display: inline-block;
+    background: transparent;
+    color: #5a7089;
+    border: none;
+    padding: 10px 24px;
+    font-size: 12.5px;
+    cursor: pointer;
+    transition: color 0.15s ease;
+    margin-top: 14px;
+  }
+
+  .btn-secondary:hover { color: #8ba3ba; }
+
+  #progress {
+    display: none;
+    width: 340px;
+    text-align: center;
+  }
+
+  .progress-track {
+    width: 100%;
+    height: 3px;
+    background: #1a2635;
+    border-radius: 2px;
+    overflow: hidden;
+    margin-bottom: 18px;
+  }
+
+  .progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #0070f3, #00b4d8);
+    border-radius: 2px;
+    transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+    width: 0%;
+  }
+
+  .progress-text {
+    color: #7b8da0;
+    font-size: 12.5px;
+  }
+
+  #complete {
+    display: none;
+    text-align: center;
+  }
+
+  .complete-icon {
+    width: 48px;
+    height: 48px;
+    margin: 0 auto 16px;
+    border-radius: 50%;
+    background: rgba(16, 185, 129, 0.1);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .complete-icon svg {
+    width: 24px;
+    height: 24px;
+    stroke: #10b981;
+    fill: none;
+    stroke-width: 2.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .complete-text {
+    color: #c8d5e2;
+    font-size: 14px;
+    margin-bottom: 6px;
+  }
+
+  .complete-hint {
+    color: #5a7089;
+    font-size: 12px;
+    margin-bottom: 14px;
+  }
+
+  .complete-countdown {
+    color: #5a7089;
+    font-size: 11.5px;
+    margin-bottom: 18px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  #error {
+    display: none;
+    text-align: center;
+    margin-top: 20px;
+  }
+
+  .error-text {
+    color: #f87171;
+    font-size: 12.5px;
+    margin-bottom: 20px;
+    line-height: 1.5;
+    max-width: 380px;
+  }
+
+  .btn-close {
+    display: inline-block;
+    background: rgba(255, 255, 255, 0.06);
+    color: #8ba3ba;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 10px 40px;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+
+  .btn-close:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: #c8d5e2;
+  }
+</style>
+</head>
+<body>
+
+<div class="logo-container">
+  <svg viewBox="100 30 430 400" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="#0070f3"/>
+        <stop offset="100%" stop-color="#00b4d8"/>
+      </linearGradient>
+    </defs>
+    <path fill="url(#g)" d="M358.864 40.470C358.605 40.728 354.143 42.467 348.947 44.334C284.621 67.446 232.573 113.729 201.443 175.500C193.895 190.478 184.375 213.708 185.375 214.708C185.621 214.954 187.715 211.857 190.030 207.827C211.190 170.984 229.863 146.093 255.968 119.933C274.854 101.008 282.998 94.207 302.034 81.466C334.671 59.621 367.531 47.376 401.250 44.492L409.000 43.829 408.984 47.165C408.958 52.704 405.255 68.515 401.010 81.213C382.392 136.898 338.799 184.709 277.000 217.224C271.225 220.263 263.913 223.788 260.750 225.058C254.629 227.517 254.126 228.307 256.511 231.712C258.282 234.241 258.484 234.089 249.500 237.002C226.868 244.341 200.420 256.771 183.918 267.825C173.918 274.522 156.961 289.225 158.000 290.296C158.275 290.579 163.450 287.694 169.500 283.883C175.550 280.073 186.125 274.083 193.000 270.573C264.905 233.856 345.414 226.155 422.387 248.633C434.634 252.210 468.194 264.823 465.830 264.961C465.461 264.982 459.741 263.440 453.118 261.534C422.666 252.769 376.068 246.967 347.500 248.384C320.590 249.719 284.052 255.527 283.798 258.510C283.694 259.727 291.796 264.541 298.477 267.231C306.163 270.326 319.360 270.612 338.812 268.103C385.602 262.070 433.627 269.250 469.963 287.712C475.721 290.638 480.874 293.474 481.416 294.016C482.061 294.661 476.225 295.004 464.450 295.010C407.520 295.043 349.853 308.084 300.500 332.086C290.412 336.992 272.833 346.834 271.147 348.519C269.278 350.389 273.301 349.263 283.966 344.933C302.548 337.389 332.479 327.629 351.000 323.074C386.266 314.400 413.893 311.393 450.000 312.298C474.559 312.914 491.602 315.535 509.306 321.421C520.784 325.236 519.954 325.640 504.924 323.552C419.615 311.701 330.506 332.225 238.000 385.033C224.991 392.460 221.855 394.386 200.762 407.913C184.591 418.282 178.817 420.978 172.750 420.990C167.060 421.002 164.441 418.869 163.413 413.387C160.912 400.055 178.394 366.762 202.136 339.644L206.387 334.788 197.443 335.644C183.073 337.019 158.519 336.519 150.152 334.681C132.833 330.876 120.785 321.947 117.439 310.437C112.326 292.850 123.492 270.717 146.912 252.015C154.528 245.934 155.702 244.562 156.798 240.464C158.983 232.296 168.599 206.900 174.208 194.482C184.044 172.710 197.989 150.083 213.332 131.000C229.597 110.770 255.612 87.415 277.277 73.590C286.990 67.393 310.855 55.436 323.062 50.653C335.623 45.730 360.750 38.583 358.864 40.470M375.000 209.596C430.712 216.655 477.541 237.609 509.241 269.661C514.049 274.523 518.765 279.625 519.721 281.000C521.404 283.419 521.347 283.408 517.980 280.669C500.484 266.434 486.556 257.516 468.000 248.668C452.323 241.193 438.766 236.261 424.000 232.663C395.297 225.667 374.955 223.024 349.705 223.010C333.212 223.000 332.865 222.956 330.455 220.545C329.105 219.195 328.000 217.046 328.000 215.768C328.000 212.845 330.558 209.125 333.357 207.978C336.189 206.817 360.536 207.763 375.000 209.596"/>
+  </svg>
+</div>
+
+<h1 id="heading">Welcome to Freenet</h1>
+<p class="subtitle" id="subtitle">Decentralized communication for everyone</p>
+
+<div id="welcome">
+  <button class="btn-primary" onclick="doInstall()">Install Freenet</button><br>
+  <button class="btn-secondary" onclick="doRunWithout()">Run without installing</button>
+</div>
+
+<div id="progress">
+  <div class="progress-track">
+    <div class="progress-fill" id="bar"></div>
+  </div>
+  <p class="progress-text" id="status">Preparing...</p>
+</div>
+
+<div id="complete">
+  <div class="complete-icon">
+    <svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>
+  </div>
+  <p class="complete-text">Freenet is running</p>
+  <p class="complete-hint">Look for the icon in your system tray</p>
+  <p class="complete-countdown" id="countdown">Closing in 5s...</p>
+  <button class="btn-close" onclick="doClose()">Close now</button>
+</div>
+
+<div id="error">
+  <p class="error-text" id="error-msg"></p>
+  <button class="btn-close" onclick="doClose()">Close</button>
+</div>
+
+<script>
+  // Module-scoped so doClose() can cancel any pending countdown when
+  // the user dismisses the dialog manually before it expires. Without
+  // this, the interval kept firing and posted a second 'close' IPC.
+  var closeCountdown = null;
+
+  function doInstall() {
+    document.getElementById('welcome').style.display = 'none';
+    document.getElementById('progress').style.display = 'block';
+    window.ipc.postMessage('install');
+  }
+  function doRunWithout() { window.ipc.postMessage('run_without'); }
+  function doClose() {
+    if (closeCountdown !== null) {
+      clearInterval(closeCountdown);
+      closeCountdown = null;
+    }
+    window.ipc.postMessage('close');
+  }
+
+  function updateProgress(pct, text) {
+    document.getElementById('bar').style.width = pct + '%';
+    document.getElementById('status').textContent = text;
+  }
+
+  function showComplete() {
+    document.getElementById('progress').style.display = 'none';
+    document.getElementById('heading').textContent = 'Installation complete';
+    document.getElementById('subtitle').style.display = 'none';
+    document.getElementById('complete').style.display = 'block';
+    // Auto-close after 5 seconds so the user doesn't have to click Close,
+    // but show a visible countdown so the dialog never disappears without
+    // warning. Without this the window appeared to vanish on its own.
+    var remaining = 5;
+    var label = document.getElementById('countdown');
+    label.textContent = 'Closing in ' + remaining + 's...';
+    closeCountdown = setInterval(function() {
+      remaining -= 1;
+      if (remaining <= 0) {
+        clearInterval(closeCountdown);
+        closeCountdown = null;
+        window.ipc.postMessage('close');
+      } else {
+        label.textContent = 'Closing in ' + remaining + 's...';
+      }
+    }, 1000);
+  }
+
+  function showError(msg) {
+    document.getElementById('progress').style.display = 'none';
+    document.getElementById('heading').textContent = 'Installation failed';
+    document.getElementById('subtitle').style.display = 'none';
+    document.getElementById('error').style.display = 'block';
+    document.getElementById('error-msg').textContent = msg;
+  }
+</script>
+
+</body>
+</html>

--- a/crates/core/src/bin/commands/setup_wizard/ui.rs
+++ b/crates/core/src/bin/commands/setup_wizard/ui.rs
@@ -4,9 +4,22 @@
 //! on Windows 10+). The installer backend runs on a background thread and sends
 //! progress updates to the UI via the tao event loop proxy.
 
+/// Embedded HTML/CSS/JS for the setup wizard UI.
+///
+/// Defined at module scope (not inside the Windows-gated `platform` mod) so
+/// content-level unit tests run on every CI platform — Windows-only tests
+/// don't run on this project's Linux CI matrix and the windows_check job
+/// only does `cargo check`. Keeping the constant here means the tests below
+/// run wherever `cargo test -p freenet --bin freenet` runs. The constant
+/// is unused on non-Windows release builds (the `platform` module is the
+/// only consumer), hence the dead-code allow.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+const SETUP_HTML: &str = include_str!("setup.html");
+
 #[cfg(target_os = "windows")]
 mod platform {
     use super::super::installer::{self, InstallProgress};
+    use super::SETUP_HTML;
     use tao::event::{Event, WindowEvent};
     use tao::event_loop::{ControlFlow, EventLoopBuilder};
     use tao::platform::run_return::EventLoopExtRunReturn;
@@ -198,300 +211,13 @@ mod platform {
             );
         }
     }
-
-    /// Embedded HTML/CSS/JS for the setup wizard UI.
-    const SETUP_HTML: &str = r##"<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<style>
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-
-  body {
-    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
-    background: #0c1219;
-    color: #d4dde8;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100vh;
-    overflow: hidden;
-    user-select: none;
-    -webkit-user-select: none;
-  }
-
-  .logo-container {
-    width: 88px;
-    height: 88px;
-    margin-bottom: 28px;
-  }
-
-  .logo-container svg {
-    width: 100%;
-    height: 100%;
-    filter: drop-shadow(0 2px 12px rgba(0, 110, 255, 0.15));
-  }
-
-  h1 {
-    font-size: 22px;
-    font-weight: 600;
-    color: #f0f4f8;
-    margin-bottom: 8px;
-    letter-spacing: -0.3px;
-  }
-
-  .subtitle {
-    color: #7b8da0;
-    font-size: 13.5px;
-    margin-bottom: 40px;
-  }
-
-  #welcome { text-align: center; }
-
-  .btn-primary {
-    display: inline-block;
-    background: linear-gradient(135deg, #0070f3 0%, #0058cc 100%);
-    color: #fff;
-    border: none;
-    padding: 13px 52px;
-    border-radius: 8px;
-    font-size: 14.5px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.15s ease;
-    letter-spacing: 0.2px;
-  }
-
-  .btn-primary:hover {
-    background: linear-gradient(135deg, #1a82ff 0%, #0066ee 100%);
-    transform: translateY(-1px);
-    box-shadow: 0 4px 16px rgba(0, 112, 243, 0.35);
-  }
-
-  .btn-primary:active {
-    transform: translateY(0);
-    box-shadow: 0 2px 8px rgba(0, 112, 243, 0.25);
-  }
-
-  .btn-secondary {
-    display: inline-block;
-    background: transparent;
-    color: #5a7089;
-    border: none;
-    padding: 10px 24px;
-    font-size: 12.5px;
-    cursor: pointer;
-    transition: color 0.15s ease;
-    margin-top: 14px;
-  }
-
-  .btn-secondary:hover { color: #8ba3ba; }
-
-  #progress {
-    display: none;
-    width: 340px;
-    text-align: center;
-  }
-
-  .progress-track {
-    width: 100%;
-    height: 3px;
-    background: #1a2635;
-    border-radius: 2px;
-    overflow: hidden;
-    margin-bottom: 18px;
-  }
-
-  .progress-fill {
-    height: 100%;
-    background: linear-gradient(90deg, #0070f3, #00b4d8);
-    border-radius: 2px;
-    transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
-    width: 0%;
-  }
-
-  .progress-text {
-    color: #7b8da0;
-    font-size: 12.5px;
-  }
-
-  #complete {
-    display: none;
-    text-align: center;
-  }
-
-  .complete-icon {
-    width: 48px;
-    height: 48px;
-    margin: 0 auto 16px;
-    border-radius: 50%;
-    background: rgba(16, 185, 129, 0.1);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .complete-icon svg {
-    width: 24px;
-    height: 24px;
-    stroke: #10b981;
-    fill: none;
-    stroke-width: 2.5;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-  }
-
-  .complete-text {
-    color: #c8d5e2;
-    font-size: 14px;
-    margin-bottom: 6px;
-  }
-
-  .complete-hint {
-    color: #5a7089;
-    font-size: 12px;
-    margin-bottom: 14px;
-  }
-
-  .complete-countdown {
-    color: #5a7089;
-    font-size: 11.5px;
-    margin-bottom: 18px;
-    font-variant-numeric: tabular-nums;
-  }
-
-  #error {
-    display: none;
-    text-align: center;
-    margin-top: 20px;
-  }
-
-  .error-text {
-    color: #f87171;
-    font-size: 12.5px;
-    margin-bottom: 20px;
-    line-height: 1.5;
-    max-width: 380px;
-  }
-
-  .btn-close {
-    display: inline-block;
-    background: rgba(255, 255, 255, 0.06);
-    color: #8ba3ba;
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    padding: 10px 40px;
-    border-radius: 8px;
-    font-size: 13px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.15s ease;
-  }
-
-  .btn-close:hover {
-    background: rgba(255, 255, 255, 0.1);
-    color: #c8d5e2;
-  }
-</style>
-</head>
-<body>
-
-<div class="logo-container">
-  <svg viewBox="100 30 430 400" xmlns="http://www.w3.org/2000/svg">
-    <defs>
-      <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" stop-color="#0070f3"/>
-        <stop offset="100%" stop-color="#00b4d8"/>
-      </linearGradient>
-    </defs>
-    <path fill="url(#g)" d="M358.864 40.470C358.605 40.728 354.143 42.467 348.947 44.334C284.621 67.446 232.573 113.729 201.443 175.500C193.895 190.478 184.375 213.708 185.375 214.708C185.621 214.954 187.715 211.857 190.030 207.827C211.190 170.984 229.863 146.093 255.968 119.933C274.854 101.008 282.998 94.207 302.034 81.466C334.671 59.621 367.531 47.376 401.250 44.492L409.000 43.829 408.984 47.165C408.958 52.704 405.255 68.515 401.010 81.213C382.392 136.898 338.799 184.709 277.000 217.224C271.225 220.263 263.913 223.788 260.750 225.058C254.629 227.517 254.126 228.307 256.511 231.712C258.282 234.241 258.484 234.089 249.500 237.002C226.868 244.341 200.420 256.771 183.918 267.825C173.918 274.522 156.961 289.225 158.000 290.296C158.275 290.579 163.450 287.694 169.500 283.883C175.550 280.073 186.125 274.083 193.000 270.573C264.905 233.856 345.414 226.155 422.387 248.633C434.634 252.210 468.194 264.823 465.830 264.961C465.461 264.982 459.741 263.440 453.118 261.534C422.666 252.769 376.068 246.967 347.500 248.384C320.590 249.719 284.052 255.527 283.798 258.510C283.694 259.727 291.796 264.541 298.477 267.231C306.163 270.326 319.360 270.612 338.812 268.103C385.602 262.070 433.627 269.250 469.963 287.712C475.721 290.638 480.874 293.474 481.416 294.016C482.061 294.661 476.225 295.004 464.450 295.010C407.520 295.043 349.853 308.084 300.500 332.086C290.412 336.992 272.833 346.834 271.147 348.519C269.278 350.389 273.301 349.263 283.966 344.933C302.548 337.389 332.479 327.629 351.000 323.074C386.266 314.400 413.893 311.393 450.000 312.298C474.559 312.914 491.602 315.535 509.306 321.421C520.784 325.236 519.954 325.640 504.924 323.552C419.615 311.701 330.506 332.225 238.000 385.033C224.991 392.460 221.855 394.386 200.762 407.913C184.591 418.282 178.817 420.978 172.750 420.990C167.060 421.002 164.441 418.869 163.413 413.387C160.912 400.055 178.394 366.762 202.136 339.644L206.387 334.788 197.443 335.644C183.073 337.019 158.519 336.519 150.152 334.681C132.833 330.876 120.785 321.947 117.439 310.437C112.326 292.850 123.492 270.717 146.912 252.015C154.528 245.934 155.702 244.562 156.798 240.464C158.983 232.296 168.599 206.900 174.208 194.482C184.044 172.710 197.989 150.083 213.332 131.000C229.597 110.770 255.612 87.415 277.277 73.590C286.990 67.393 310.855 55.436 323.062 50.653C335.623 45.730 360.750 38.583 358.864 40.470M375.000 209.596C430.712 216.655 477.541 237.609 509.241 269.661C514.049 274.523 518.765 279.625 519.721 281.000C521.404 283.419 521.347 283.408 517.980 280.669C500.484 266.434 486.556 257.516 468.000 248.668C452.323 241.193 438.766 236.261 424.000 232.663C395.297 225.667 374.955 223.024 349.705 223.010C333.212 223.000 332.865 222.956 330.455 220.545C329.105 219.195 328.000 217.046 328.000 215.768C328.000 212.845 330.558 209.125 333.357 207.978C336.189 206.817 360.536 207.763 375.000 209.596"/>
-  </svg>
-</div>
-
-<h1 id="heading">Welcome to Freenet</h1>
-<p class="subtitle" id="subtitle">Decentralized communication for everyone</p>
-
-<div id="welcome">
-  <button class="btn-primary" onclick="doInstall()">Install Freenet</button><br>
-  <button class="btn-secondary" onclick="doRunWithout()">Run without installing</button>
-</div>
-
-<div id="progress">
-  <div class="progress-track">
-    <div class="progress-fill" id="bar"></div>
-  </div>
-  <p class="progress-text" id="status">Preparing...</p>
-</div>
-
-<div id="complete">
-  <div class="complete-icon">
-    <svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>
-  </div>
-  <p class="complete-text">Freenet is running</p>
-  <p class="complete-hint">Look for the icon in your system tray</p>
-  <p class="complete-countdown" id="countdown">Closing in 5s...</p>
-  <button class="btn-close" onclick="doClose()">Close now</button>
-</div>
-
-<div id="error">
-  <p class="error-text" id="error-msg"></p>
-  <button class="btn-close" onclick="doClose()">Close</button>
-</div>
-
-<script>
-  function doInstall() {
-    document.getElementById('welcome').style.display = 'none';
-    document.getElementById('progress').style.display = 'block';
-    window.ipc.postMessage('install');
-  }
-  function doRunWithout() { window.ipc.postMessage('run_without'); }
-  function doClose() { window.ipc.postMessage('close'); }
-
-  function updateProgress(pct, text) {
-    document.getElementById('bar').style.width = pct + '%';
-    document.getElementById('status').textContent = text;
-  }
-
-  function showComplete() {
-    document.getElementById('progress').style.display = 'none';
-    document.getElementById('heading').textContent = 'Installation complete';
-    document.getElementById('subtitle').style.display = 'none';
-    document.getElementById('complete').style.display = 'block';
-    // Auto-close after 5 seconds so the user doesn't have to click Close,
-    // but show a visible countdown so the dialog never disappears without
-    // warning. Without this the window appeared to vanish on its own.
-    var remaining = 5;
-    var label = document.getElementById('countdown');
-    label.textContent = 'Closing in ' + remaining + 's...';
-    var tick = setInterval(function() {
-      remaining -= 1;
-      if (remaining <= 0) {
-        clearInterval(tick);
-        window.ipc.postMessage('close');
-      } else {
-        label.textContent = 'Closing in ' + remaining + 's...';
-      }
-    }, 1000);
-  }
-
-  function showError(msg) {
-    document.getElementById('progress').style.display = 'none';
-    document.getElementById('heading').textContent = 'Installation failed';
-    document.getElementById('subtitle').style.display = 'none';
-    document.getElementById('error').style.display = 'block';
-    document.getElementById('error-msg').textContent = msg;
-  }
-</script>
-
-</body>
-</html>"##;
 }
 
 #[cfg(not(target_os = "windows"))]
 mod platform {
     /// Stub result type for non-Windows platforms.
     #[derive(Debug, Clone, PartialEq)]
+    #[allow(dead_code)] // re-exported for parity with the Windows variant
     pub enum SetupResult {
         Installed,
         RunWithout,
@@ -499,10 +225,49 @@ mod platform {
     }
 
     /// No-op on non-Windows platforms.
+    #[allow(dead_code)] // re-exported for parity with the Windows variant
     pub fn show_setup_dialog() -> anyhow::Result<SetupResult> {
         Ok(SetupResult::RunWithout)
     }
 }
 
 #[rustfmt::skip]  // Import order differs between local and CI rustfmt versions
+#[cfg_attr(not(target_os = "windows"), allow(unused_imports))]
 pub use platform::{SetupResult, show_setup_dialog};
+
+#[cfg(test)]
+mod html_tests {
+    use super::SETUP_HTML;
+
+    /// The success screen used to silently auto-close after 5s with no
+    /// indicator, so users saw the dialog vanish on its own. The fix wires
+    /// up a visible countdown ("Closing in Ns...") and renames the button
+    /// to "Close now". The HTML/JS is embedded in a string and never
+    /// touched at runtime by Rust, so a future refactor could trivially
+    /// delete the countdown wiring without breaking compilation. Pin the
+    /// user-visible elements that drive the countdown so a regression at
+    /// least trips a unit test on every CI platform.
+    #[test]
+    fn test_setup_html_success_screen_has_visible_countdown() {
+        assert!(
+            SETUP_HTML.contains("id=\"countdown\""),
+            "the success screen must render a #countdown element",
+        );
+        assert!(
+            SETUP_HTML.contains("Closing in "),
+            "countdown text must say 'Closing in Ns...' so the user sees what is happening",
+        );
+        assert!(
+            SETUP_HTML.contains("setInterval("),
+            "countdown must use setInterval to update the visible label every second",
+        );
+        assert!(
+            SETUP_HTML.contains("Close now"),
+            "manual-close button label must read 'Close now' (not the old 'Close')",
+        );
+        assert!(
+            SETUP_HTML.contains("clearInterval("),
+            "doClose must clearInterval so a manual close cancels the pending tick",
+        );
+    }
+}

--- a/crates/core/src/bin/commands/setup_wizard/ui.rs
+++ b/crates/core/src/bin/commands/setup_wizard/ui.rs
@@ -352,7 +352,14 @@ mod platform {
   .complete-hint {
     color: #5a7089;
     font-size: 12px;
-    margin-bottom: 28px;
+    margin-bottom: 14px;
+  }
+
+  .complete-countdown {
+    color: #5a7089;
+    font-size: 11.5px;
+    margin-bottom: 18px;
+    font-variant-numeric: tabular-nums;
   }
 
   #error {
@@ -423,7 +430,8 @@ mod platform {
   </div>
   <p class="complete-text">Freenet is running</p>
   <p class="complete-hint">Look for the icon in your system tray</p>
-  <button class="btn-close" onclick="doClose()">Close</button>
+  <p class="complete-countdown" id="countdown">Closing in 5s...</p>
+  <button class="btn-close" onclick="doClose()">Close now</button>
 </div>
 
 <div id="error">
@@ -450,8 +458,21 @@ mod platform {
     document.getElementById('heading').textContent = 'Installation complete';
     document.getElementById('subtitle').style.display = 'none';
     document.getElementById('complete').style.display = 'block';
-    // Auto-close after 5 seconds so the user doesn't have to click Close
-    setTimeout(function() { window.ipc.postMessage('close'); }, 5000);
+    // Auto-close after 5 seconds so the user doesn't have to click Close,
+    // but show a visible countdown so the dialog never disappears without
+    // warning. Without this the window appeared to vanish on its own.
+    var remaining = 5;
+    var label = document.getElementById('countdown');
+    label.textContent = 'Closing in ' + remaining + 's...';
+    var tick = setInterval(function() {
+      remaining -= 1;
+      if (remaining <= 0) {
+        clearInterval(tick);
+        window.ipc.postMessage('close');
+      } else {
+        label.textContent = 'Closing in ' + remaining + 's...';
+      }
+    }, 1000);
   }
 
   function showError(msg) {


### PR DESCRIPTION
## Problem

Two distinct Windows installer issues reported by users on Matrix:

1. **Setup wizard appears to vanish after install.** The "Installation complete" screen auto-closes after 5 seconds via a bare `setTimeout(close, 5000)` with no on-screen indicator. Several users reported it as confusing — they couldn't tell whether install finished cleanly, the dialog just disappeared on them.

2. **`freenet uninstall --purge` leaves the live config folder behind on Windows.** After running uninstall, `%LOCALAPPDATA%\The Freenet Project Inc\Freenet\config\` is still on disk. This is the directory the running node actually writes to (see `Config::build` in `crates/core/src/config.rs:247`, which uses `defaults.config_local_dir()`). The pre-fix `purge_data_dirs` only knew about `dirs.config_dir()`, which on Windows is the *Roaming* path and is never written by current code — so every Windows uninstall left a populated `config\` directory behind. (Reported again after #3904; that fix addressed parent collapse but didn't notice the Roaming/Local mismatch.)

## Approach

**Setup-wizard countdown.** Replace the silent `setTimeout` with a per-second `setInterval` that updates a visible "Closing in Ns..." line under the success message, and rename the existing button from "Close" to "Close now" so the immediate-dismiss affordance is obvious. No backend / installer code touched.

**Uninstall config-dir cleanup.** Add a new `config_local` leaf to `DataLeaves`, populated from `dirs.config_local_dir()` and deduped against `data_local` / `data_roaming` / `config`. Keep the existing Roaming `config` cleanup as well so any old install that did write there still gets cleaned up. The dedup is important on Linux/macOS where some of these paths can coincide; on Windows they're always distinct.

## Testing

- `cargo test -p freenet --bin freenet` — all 112 tests pass, including the 5 `test_purge_leaves_*` tests.
- New regression test `test_purge_leaves_removes_config_in_local_app_data` seeds a `%LOCALAPPDATA%\...\Freenet\config\` layout and asserts the leaf and its now-empty parent both collapse. **Verified it fails** when the new `if let Some(ref config_local) = leaves.config_local` branch in `purge_leaves_and_collapse` is reverted, so it actually catches the bug.
- Existing `test_purge_leaves_and_collapse_cleans_windows_layout` updated to seed both `config` (Roaming) and `config_local` (Local) — the Windows layout now matches what the running node actually writes.
- `cargo fmt` + `cargo clippy --bin freenet -- -D warnings` clean.
- The setup-wizard JS is HTML-rendered inside WebView2 on Windows; it has no Rust unit-test surface. The change is a small JS edit (interval-driven countdown text) and is best smoke-tested on Windows, which I haven't done — flagging this as a gap. The non-WebView code path (the `escape_for_js` test) still passes.

## Why didn't CI catch this?

Both bugs are Windows-specific paths. The uninstall test layout was seeded with `config` only at the Roaming path (matching the old buggy code), so the test would have happily passed even with the bug present — the test was *modeling* the buggy assumption rather than the real on-disk layout. The new test fixes that and would catch a regression of the same shape. The setup-wizard countdown has no automated coverage; it's WebView2 HTML+JS that runs only in the installer dialog on Windows.

## Fixes

Reported on Matrix; no specific issue numbers (relates to #3904 which addressed the parent-collapse half of the same area).

[AI-assisted - Claude]