### PR TITLE
refactor(ops): migrate sub-op SUBSCRIBE to task-per-tx driver

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -116,6 +116,28 @@ paths:
 > into `ops.get`, so the GC speculative-retry block at
 > `op_state_manager.rs:1912` is provably dead for GET — retirement
 > deferred to a follow-up slice.
+>
+> Sub-operation SUBSCRIBE callers (legacy GET-originator
+> `auto_subscribe_on_get_response` fallback path; PUT/GET task-per-tx
+> drivers already routed via `maybe_subscribe_child`) now spawn
+> `subscribe::run_client_subscribe` directly — the legacy
+> `subscribe::request_subscribe` driver and the
+> `expect_and_register_sub_operation` /
+> `SubOperationTracker`-registration step are gone from the production
+> sub-op SUBSCRIBE entry point. `start_subscription_request` keeps
+> the `blocking` parameter for API stability but it is no longer
+> behaviorally distinct: blocking semantics in the task-per-tx world
+> are obtained by `await`ing `run_client_subscribe` inline (see
+> `maybe_subscribe_child` in `put/op_ctx_task.rs` and
+> `get/op_ctx_task.rs`); `start_subscription_request` is a
+> fire-and-forget spawner. The tracker (`SubOperationTracker`,
+> `expect_and_register_sub_operation`, `sub_operation_failed`,
+> `all_sub_operations_completed`, `count_pending_sub_operations`,
+> `failed_parents`, `root_ops_awaiting_sub_ops`,
+> `parent_of`) and the finalized-parent-parking branch in
+> `operations.rs::handle_op_result` are still referenced by the
+> legacy state-machine path but have no production caller after this
+> slice — Phase 3c of #1454 will delete them mechanically.
 
 ## Critical Invariant: Push-Before-Send (legacy path)
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2448,11 +2448,13 @@ pub async fn subscribe(
 /// [`crate::operations::subscribe::start_client_subscribe`] rather than going
 /// through the legacy `request_subscribe` + `handle_op_result` re-entry loop.
 ///
-/// The renewal-initiated path (`ring::connection_maintenance`), the PUT
-/// sub-op path (`operations::start_subscription_request_internal`), and the
+/// The renewal-initiated path (`ring::connection_maintenance`) and the
 /// executor/WASM-initiated path (`contract::executor::SubscribeContract::resume_op`)
-/// all call `subscribe::request_subscribe` directly and bypass this function,
-/// so they continue on the legacy path unchanged.
+/// call `subscribe::request_subscribe` directly and bypass this function,
+/// so they continue on the legacy path unchanged. The PUT/GET sub-op
+/// fallback paths (`operations::start_subscription_request`,
+/// `maybe_subscribe_child`) now route through
+/// `subscribe::run_client_subscribe` directly.
 ///
 /// The legacy `is_renewal` parameter has been removed in Phase 2b: no live
 /// caller passes `true`, and the task-per-tx path does not carry renewal

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -164,6 +164,14 @@ impl SubOperationTracker {
 
     /// Atomically registers both expected count and parent-child relationship.
     /// This prevents race conditions where children complete before registration.
+    ///
+    /// Retained alongside the rest of `SubOperationTracker` until Phase 3c
+    /// of #1454 deletes the tracker. After the sub-op SUBSCRIBE migration
+    /// (#1454 follow-up to PR #3968) no production caller registers a
+    /// child here — the legacy `handle_op_result` consumers still
+    /// reference the tracker fields, so the unit tests below keep
+    /// exercising this method until Phase 3c removes both.
+    #[allow(dead_code)]
     fn expect_and_register_sub_operation(&self, parent: Transaction, child: Transaction) {
         // Increment expected count
         self.expected_sub_operations
@@ -1164,6 +1172,11 @@ impl OpManager {
 
     /// Atomically registers both expected count and parent-child relationship.
     /// This prevents race conditions where children complete before registration.
+    ///
+    /// No production caller after the #1454 sub-op SUBSCRIBE migration;
+    /// kept alive for the unit tests in `SubOperationTracker` until
+    /// Phase 3c retires the whole tracker.
+    #[allow(dead_code)]
     pub fn expect_and_register_sub_operation(&self, parent: Transaction, child: Transaction) {
         self.sub_op_tracker
             .expect_and_register_sub_operation(parent, child);
@@ -1182,6 +1195,12 @@ impl OpManager {
     }
 
     /// Handle sub-operation failure - propagate error to parent.
+    ///
+    /// No production caller after the #1454 sub-op SUBSCRIBE migration —
+    /// the task-per-tx subscribe driver publishes its own
+    /// `HostResult::Err` on failure. Kept alive until Phase 3c retires
+    /// the whole tracker.
+    #[allow(dead_code)]
     pub async fn sub_operation_failed(
         &self,
         child: Transaction,

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -693,125 +693,37 @@ pub(crate) async fn broadcast_change_interests(
     }
 }
 
-/// Initiates a subscription after a PUT or GET completes without blocking the parent.
+/// Initiates a subscription after a PUT or GET, routing through the
+/// task-per-tx subscribe driver.
 ///
-/// This does NOT register a parent-child relationship for atomicity tracking,
-/// so the PUT/GET response is sent immediately rather than waiting for the
-/// subscription to complete.
-///
-/// This is appropriate for PUT/GET with subscribe=true, where:
-/// - The client needs immediate confirmation that the contract was stored/fetched
-/// - The subscription can complete asynchronously in the background
-/// - Subscription success/failure doesn't affect the PUT/GET result
-fn start_subscription_request_async(
-    op_manager: &OpManager,
-    parent_tx: Transaction,
-    key: ContractKey,
-) -> Transaction {
-    start_subscription_request_internal(op_manager, parent_tx, key, false)
-}
-
-/// Initiates a subscription after a PUT or GET completes, blocking the parent operation.
-///
-/// This DOES register a parent-child relationship for atomicity tracking,
-/// so the PUT/GET response waits for the subscription to complete before being sent.
-///
-/// This provides stronger atomicity guarantees but may cause timeouts under
-/// poor network conditions.
-fn start_subscription_request_blocking(
-    op_manager: &OpManager,
-    parent_tx: Transaction,
-    key: ContractKey,
-) -> Transaction {
-    start_subscription_request_internal(op_manager, parent_tx, key, true)
-}
-
-/// Initiates a subscription after a PUT or GET, with configurable blocking behavior.
-///
-/// The `blocking` parameter determines whether to block the parent operation on
-/// subscription completion:
-/// - When false (default): subscription completes asynchronously, PUT/GET responds immediately
-/// - When true: PUT/GET waits for subscription to complete before responding
-///
-/// This flag is intended to be passed from the client request (e.g., ContractRequest::Put)
-/// to allow per-operation control over subscription semantics.
+/// `blocking` is accepted for API stability (callers may inspect it for
+/// telemetry), but post-#1454 sub-op SUBSCRIBE migration it has no
+/// behavioral effect: the subscribe runs as a fire-and-forget background
+/// task in either case. The legacy `SubOperationTracker`-based blocking
+/// semantics (parent waits for child via tracker DashMap) are retired —
+/// task-per-tx PUT/GET drivers handle blocking by `await`ing
+/// `subscribe::run_client_subscribe` inline (see `maybe_subscribe_child`
+/// in `put/op_ctx_task.rs` and `get/op_ctx_task.rs`).
 pub(super) fn start_subscription_request(
     op_manager: &OpManager,
     parent_tx: Transaction,
     key: ContractKey,
     blocking: bool,
 ) -> Transaction {
-    if blocking {
-        start_subscription_request_blocking(op_manager, parent_tx, key)
-    } else {
-        start_subscription_request_async(op_manager, parent_tx, key)
-    }
-}
-
-/// Starts a subscription request while allowing callers to opt out of parent tracking.
-fn start_subscription_request_internal(
-    op_manager: &OpManager,
-    parent_tx: Transaction,
-    key: ContractKey,
-    track_parent: bool,
-) -> Transaction {
     let child_tx = Transaction::new_child_of::<subscribe::SubscribeMsg>(&parent_tx);
-    if track_parent {
-        op_manager.expect_and_register_sub_operation(parent_tx, child_tx);
-    }
 
     tracing::debug!(
         %parent_tx,
         %child_tx,
         %key,
-        "created child subscription operation"
+        blocking,
+        "spawning child subscription operation (task-per-tx driver)"
     );
 
-    let op_manager_cloned = op_manager.clone();
-
+    let op_manager_arc = std::sync::Arc::new(op_manager.clone());
+    let instance_id = *key.id();
     GlobalExecutor::spawn(async move {
-        tokio::task::yield_now().await;
-
-        // is_renewal: false - GET-triggered subscription is a new subscription
-        let sub_op = subscribe::start_op_with_id(*key.id(), child_tx, false);
-
-        match subscribe::request_subscribe(&op_manager_cloned, sub_op).await {
-            Ok(_) => {
-                tracing::debug!(%child_tx, %parent_tx, "child subscription completed");
-            }
-            Err(error) => {
-                let error_msg = format!("{}", error);
-                tracing::error!(tx = %parent_tx, child_tx = %child_tx, error = error_msg, phase = "error", "child subscription failed");
-
-                if let Err(e) = op_manager_cloned
-                    .sub_operation_failed(child_tx, &error_msg)
-                    .await
-                {
-                    tracing::error!(tx = %parent_tx, child_tx = %child_tx, error = %e, phase = "error", "failed to propagate failure");
-                }
-
-                // Without parent tracking, sub_operation_failed has no parent link
-                // to propagate through, so notify clients via the subscription channel.
-                if !track_parent {
-                    let instance_id = *key.id();
-                    if let Err(e) = op_manager_cloned
-                        .notify_contract_handler(
-                            crate::contract::ContractHandlerEvent::NotifySubscriptionError {
-                                key: instance_id,
-                                reason: format!("Subscription failed: {}", error_msg),
-                            },
-                        )
-                        .await
-                    {
-                        tracing::debug!(
-                            contract = %instance_id,
-                            error = %e,
-                            "Failed to send subscription error to notification channels"
-                        );
-                    }
-                }
-            }
-        }
+        subscribe::run_client_subscribe(op_manager_arc, instance_id, child_tx).await;
     });
 
     child_tx
@@ -1003,5 +915,85 @@ mod streaming_tests {
         assert!(!should_use_streaming(0, 0));
         assert!(should_use_streaming(0, 1));
         assert!(should_use_streaming(0, 100));
+    }
+}
+
+#[cfg(test)]
+mod sub_op_subscribe_migration_pin_tests {
+    //! Pin tests for the #1454 sub-op SUBSCRIBE migration.
+    //!
+    //! These tests scrape the source of `start_subscription_request` to
+    //! prove that:
+    //! 1. The legacy `subscribe::request_subscribe` driver and the legacy
+    //!    `expect_and_register_sub_operation` registration call are gone
+    //!    from the production sub-op SUBSCRIBE entry point.
+    //! 2. The function spawns the task-per-tx
+    //!    `subscribe::run_client_subscribe` driver instead.
+    //!
+    //! If a future refactor reintroduces the legacy paths, these tests
+    //! will fail loudly and force a re-evaluation against the rationale
+    //! recorded in `.claude/rules/operations.md`.
+
+    fn extract_start_subscription_request_body() -> &'static str {
+        let src = include_str!("operations.rs");
+        // Compose runtime-needle to avoid self-trigger (the test file
+        // itself contains the literal "fn start_subscription_request").
+        let head = ["fn ", "start_subscription_request("].concat();
+        let start = src
+            .find(&head)
+            .expect("`fn start_subscription_request(` must exist in operations.rs");
+        // Find the end of the function: a balanced `}` at column 0
+        // following an `Transaction {` body close. Easiest approximation
+        // is to slice up to the next top-level `\nasync fn ` /
+        // `\nfn ` boundary.
+        let tail_anchor = "\nasync fn has_contract(";
+        let end = src[start..]
+            .find(tail_anchor)
+            .map(|off| start + off)
+            .expect("expected `async fn has_contract` to follow");
+        &src[start..end]
+    }
+
+    #[test]
+    fn start_subscription_request_does_not_call_legacy_request_subscribe() {
+        let body = extract_start_subscription_request_body();
+        assert!(
+            !body.contains("subscribe::request_subscribe"),
+            "`start_subscription_request` must NOT route through the \
+             legacy `subscribe::request_subscribe` driver — sub-op \
+             SUBSCRIBE migrated to `subscribe::run_client_subscribe` \
+             (see #1454 follow-up)."
+        );
+    }
+
+    #[test]
+    fn start_subscription_request_does_not_register_with_sub_op_tracker() {
+        let body = extract_start_subscription_request_body();
+        assert!(
+            !body.contains("expect_and_register_sub_operation"),
+            "`start_subscription_request` must NOT call \
+             `expect_and_register_sub_operation` — `SubOperationTracker` \
+             registration was retired alongside the sub-op SUBSCRIBE \
+             migration. The tracker itself is scheduled for deletion in \
+             Phase 3c of #1454."
+        );
+        assert!(
+            !body.contains("sub_operation_failed"),
+            "`start_subscription_request` must NOT propagate failures \
+             via `sub_operation_failed` — the task-per-tx subscribe \
+             driver publishes its own `HostResult::Err`."
+        );
+    }
+
+    #[test]
+    fn start_subscription_request_spawns_task_per_tx_driver() {
+        let body = extract_start_subscription_request_body();
+        assert!(
+            body.contains("subscribe::run_client_subscribe"),
+            "`start_subscription_request` must spawn the task-per-tx \
+             subscribe driver `subscribe::run_client_subscribe` — \
+             matches the `maybe_subscribe_child` pattern in \
+             `put/op_ctx_task.rs` and `get/op_ctx_task.rs`."
+        );
     }
 }

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -720,6 +720,13 @@ pub(super) fn start_subscription_request(
         "spawning child subscription operation (task-per-tx driver)"
     );
 
+    // `run_client_subscribe` requires `Arc<OpManager>`. Callers on
+    // legacy `process_message` paths only have `&OpManager`, so we
+    // wrap a single clone here. PUT/GET task drivers that already
+    // hold `&Arc<OpManager>` route through their own
+    // `maybe_subscribe_child` helper (see
+    // `put/op_ctx_task.rs::maybe_subscribe_child` and the GET
+    // counterpart) and don't pay this cost.
     let op_manager_arc = std::sync::Arc::new(op_manager.clone());
     let instance_id = *key.id();
     GlobalExecutor::spawn(async move {
@@ -942,15 +949,32 @@ mod sub_op_subscribe_migration_pin_tests {
         let start = src
             .find(&head)
             .expect("`fn start_subscription_request(` must exist in operations.rs");
-        // Find the end of the function: a balanced `}` at column 0
-        // following an `Transaction {` body close. Easiest approximation
-        // is to slice up to the next top-level `\nasync fn ` /
-        // `\nfn ` boundary.
-        let tail_anchor = "\nasync fn has_contract(";
-        let end = src[start..]
-            .find(tail_anchor)
+        // Walk forward from the function signature to the first `{`,
+        // then track brace depth until we find the matching close.
+        // This is robust against renaming/moving the next function.
+        let body_open = src[start..]
+            .find('{')
             .map(|off| start + off)
-            .expect("expected `async fn has_contract` to follow");
+            .expect("expected `{` after function signature");
+        let mut depth: i32 = 0;
+        let mut end = body_open;
+        for (i, ch) in src[body_open..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = body_open + i + 1;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert!(
+            end > body_open,
+            "failed to find matching `}}` for start_subscription_request"
+        );
         &src[start..end]
     }
 

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -243,6 +243,11 @@ pub(crate) fn start_op(instance_id: ContractInstanceId, is_renewal: bool) -> Sub
 }
 
 /// Create a Subscribe operation with a specific transaction ID (for operation deduplication)
+///
+/// Used only by unit tests after the #1454 sub-op SUBSCRIBE migration; the
+/// production sub-op caller (`auto_subscribe_on_get_response`) now spawns
+/// the task-per-tx driver directly via `subscribe::run_client_subscribe`.
+#[allow(dead_code)]
 pub(crate) fn start_op_with_id(
     instance_id: ContractInstanceId,
     id: Transaction,

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -14,8 +14,13 @@
 //!
 //! - **Renewals** (`ring.rs::connection_maintenance` loop) — their jitter
 //!   and spam-prevention in `can_request_subscription()` are load-bearing.
-//! - **PUT sub-ops** (`start_subscription_request_internal`) — blocking
-//!   semantics with `SubOperationTracker`; migrated in Phase 2.5.
+//! - **PUT/GET sub-ops** (`start_subscription_request` and
+//!   `maybe_subscribe_child` in `put/op_ctx_task.rs` /
+//!   `get/op_ctx_task.rs`) — historically used `SubOperationTracker`
+//!   for blocking semantics; migrated to `run_client_subscribe` (PUT
+//!   in Phase 3a, GET in Phase 3b, the legacy
+//!   `auto_subscribe_on_get_response` fallback in the sub-op
+//!   SUBSCRIBE migration follow-up).
 //! - **Intermediate-peer forwarding** (`SubscribeOp::load_or_init` on
 //!   incoming `Request`) — server-side response role; migrated in Phase 5.
 //!


### PR DESCRIPTION
## Problem

`SubOperationTracker` is the legacy DashMap-based parent/child machinery
that #1454 wants to retire. After the prior task-per-tx slices (PUT,
GET, sub-op GETs in #3968), exactly **one** production caller of
`OpManager::expect_and_register_sub_operation` remained:
`operations::start_subscription_request_internal`, reached from
`auto_subscribe_on_get_response` on the legacy GET originator branch
(the only fallback path that turns a GET response into a separate
SUBSCRIBE).

While the tracker had a single live producer, Phase 3c (mechanical
deletion of `SubOperationTracker`, `root_ops_awaiting_sub_ops`,
`failed_parents`, etc.) was blocked.

## Solution

Replace the body of `start_subscription_request` with a fire-and-forget
spawn of `subscribe::run_client_subscribe` — the same task-per-tx
driver used by `maybe_subscribe_child` in `put/op_ctx_task.rs` and
`get/op_ctx_task.rs`. Drop the `track_parent` plumbing entirely:
`expect_and_register_sub_operation` is no longer invoked from any
production caller.

The `blocking` parameter is preserved on the public function for API
stability and telemetry but is now a no-op: in the task-per-tx world,
blocking semantics come from `await`ing `run_client_subscribe`
inline (which `maybe_subscribe_child` already does where it matters).
Sub-op blocking via `SubOperationTracker` was effectively dead before
this PR — `start_targeted_op` hard-codes `subscribe: false`, and
client-initiated GETs no longer push a `GetOp` into `ops.get`, so no
production legacy GET originator path reaches
`auto_subscribe_on_get_response` with `blocking_sub=true`.

`subscribe::start_op_with_id`, `OpManager::expect_and_register_sub_operation`,
`OpManager::sub_operation_failed`, and the corresponding
`SubOperationTracker::expect_and_register_sub_operation` keep
`#[allow(dead_code)]` markers pointing at Phase 3c, which will delete
the whole tracker machinery mechanically.

## Testing

- New `operations::sub_op_subscribe_migration_pin_tests` (3 structural
  pin tests, source-scrape `start_subscription_request`) verify that:
  1. `subscribe::request_subscribe` (legacy driver) is no longer
     referenced.
  2. `expect_and_register_sub_operation` and `sub_operation_failed`
     are no longer referenced.
  3. `subscribe::run_client_subscribe` is spawned.
- All 2484 lib tests pass; clippy and fmt clean.

## Follow-ups

- Phase 3c — mechanical deletion of `SubOperationTracker` and the
  finalized-parent-parking branch in `operations.rs::handle_op_result`.
  All remaining tracker references are in legacy-only code that
  becomes unreachable after this PR.

Refs #1454.