### PR TITLE
chore(ci): tier merge_group CI by release vs non-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,10 @@ jobs:
 
   test_unit:
     name: Unit & Integration
+    # Always runs on the heavy runner. Unlike test_simulation and nat_validation,
+    # this job has no runner-conditional and no skip_check: Unit & Integration is
+    # the one heavy gate kept on every merge_group entry (release or not), so the
+    # tiered model (#3973) doesn't apply here.
     runs-on: ubicloud-standard-16
     timeout-minutes: 30
     needs: fmt_check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,40 @@ jobs:
       - name: Check code formatting
         run: cargo fmt -- --check
 
+      # Locks the bash predicate that the merge_group release-gate keys off
+      # (#3973). The actual release path is only exercised on a real release
+      # merge_group entry, so a regression in the matching logic would
+      # silently skip the pre-publish gate. This self-test catches predicate
+      # quoting, anchoring, and case-sensitivity bugs on every CI run.
+      - name: Self-test merge_group release detector
+        run: |
+          set -eu
+          check() {
+            local msg="$1"
+            local expected="$2"  # "release" or "non-release"
+            local actual
+            if [[ "$msg" == build:\ release* ]]; then
+              actual="release"
+            else
+              actual="non-release"
+            fi
+            if [[ "$actual" != "$expected" ]]; then
+              echo "FAIL: '$msg' -> expected '$expected', got '$actual'"
+              return 1
+            fi
+            echo "OK:   '$msg' -> $actual"
+          }
+          # Positive cases (release-gate must fire)
+          check "build: release 0.2.49 (#3947)"                "release"
+          check "build: release 1.0.0"                         "release"
+          check "build: release 0.2.49"                        "release"
+          # Negative cases (release-gate must NOT fire)
+          check "chore: bump versions to 0.2.49"               "non-release"
+          check "refactor(ops): retire SubOperationTracker"    "non-release"
+          check "build(deps): bump rand from 0.8.5 to 0.9.2"   "non-release"
+          check "build: replace local release build"           "non-release"
+          check ""                                             "non-release"
+
       - name: Check for old-style mod.rs files
         run: |
           # New modules must use foo.rs + foo/ style, not foo/mod.rs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,18 @@ name: CI
 
 # Cost optimization strategy (Ubicloud runners ~$0.13/run):
 # 1. Skip CI entirely for docs-only changes (paths-ignore)
-# 2. Skip expensive jobs on main push - PR already validated
-# 3. Skip NAT validation for dependabot PRs - Test is sufficient for version bumps
+# 2. Skip expensive jobs on main push — PR already validated
+# 3. Skip NAT validation for dependabot PRs — Test is sufficient for version bumps
 # 4. Run fast checks (Fmt, Clippy) in parallel for quick fail-fast
 # 5. Run required checks in merge_group to satisfy branch protection
 # 6. Split unit/integration and simulation tests for parallelism
-# Estimated savings: ~25-30% reduction in CI costs
+# 7. Tiered merge_group depth (#3973):
+#    - PR runs the full suite — catches regressions in the change being made.
+#    - Non-release merge_group runs only Unit & Integration on the heavy runner;
+#      Simulation and NAT Validation are present-but-skipped to keep branch
+#      protection happy without contending for ubicloud-standard-16 slots.
+#    - Release merge_group (commit message starts with "build: release") runs
+#      the full suite as the pre-publish gate, so what ships is known-green.
 
 on:
   push:
@@ -280,12 +286,14 @@ jobs:
 
   test_unit:
     name: Unit & Integration
-    runs-on: "${{ (github.event_name == 'merge_group' && startsWith(github.event.merge_group.head_commit.message, 'build: release')) && 'ubuntu-latest' || 'ubicloud-standard-16' }}"
+    runs-on: ubicloud-standard-16
     timeout-minutes: 30
     needs: fmt_check
-    # Skip on push to main (PR already validated) and release PRs (only version bumps).
-    # For release merge_group entries: required checks can't be skipped (would block merge),
-    # so we run on a cheap runner and skip expensive steps via is_release output.
+    # Skip on push to main (PR already validated) and on release branches
+    # themselves (the release version-bump PR is gated by its merge_group entry,
+    # which runs the full suite). The release merge_group entry IS the
+    # pre-publish gate — it must run the full suite so we know what ships is
+    # green.
     if: |
       (github.event_name == 'pull_request' || github.event_name == 'merge_group') &&
       !startsWith(github.head_ref, 'release/v')
@@ -299,45 +307,27 @@ jobs:
       RUST_MIN_STACK: 268435456
 
     steps:
-      - name: Detect release merge queue
-        id: release_check
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          MERGE_COMMIT_MSG: ${{ github.event.merge_group.head_commit.message }}
-        run: |
-          if [[ "$EVENT_NAME" == "merge_group" && "$MERGE_COMMIT_MSG" == build:\ release* ]]; then
-            echo "is_release=true" >> "$GITHUB_OUTPUT"
-            echo "Skipping tests — release PRs only bump versions (main CI already validated)"
-          else
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: actions/checkout@v6
-        if: steps.release_check.outputs.is_release != 'true'
 
       - name: Install mold linker
-        if: steps.release_check.outputs.is_release != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y mold
 
       - uses: dtolnay/rust-toolchain@stable
-        if: steps.release_check.outputs.is_release != 'true'
         with:
           toolchain: 1.93.0
           targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
-        if: (success() || steps.test.conclusion == 'failure') && steps.release_check.outputs.is_release != 'true'
+        if: success() || steps.test.conclusion == 'failure'
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install nextest
-        if: steps.release_check.outputs.is_release != 'true'
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - name: Build
-        if: steps.release_check.outputs.is_release != 'true'
         env:
           # Use mold linker to avoid rust-lld crashes (see issue #2519)
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
@@ -348,14 +338,12 @@ jobs:
           make -C apps/freenet-ping -f run-ping.mk build
 
       - name: Clean test directories
-        if: steps.release_check.outputs.is_release != 'true'
         run: |
           # Remove freenet test directories from /tmp to avoid permission issues
           # when tests create directories with different user ownership
           rm -rf /tmp/freenet /tmp/freenet-* 2>/dev/null || true
 
       - name: Test
-        if: steps.release_check.outputs.is_release != 'true'
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
@@ -381,7 +369,7 @@ jobs:
             --profile ci -E 'not test(blocked_peers)'
 
       - name: Test blocked-peers (serial)
-        if: ${{ !cancelled() && steps.release_check.outputs.is_release != 'true' }}
+        if: ${{ !cancelled() }}
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
@@ -394,14 +382,19 @@ jobs:
             -E 'test(blocked_peers)' -j 1
 
       - name: Test ping-types
-        if: ${{ !cancelled() && steps.release_check.outputs.is_release != 'true' }}
+        if: ${{ !cancelled() }}
         # freenet-ping-types tests need the std feature (default).
         # Run separately since the main step uses --no-default-features.
         run: cargo nextest run -p freenet-ping-types --profile ci
 
   test_simulation:
     name: Simulation
-    runs-on: "${{ (github.event_name == 'merge_group' && startsWith(github.event.merge_group.head_commit.message, 'build: release')) && 'ubuntu-latest' || 'ubicloud-standard-16' }}"
+    # Run on the heavy runner for PRs (validates the change) and for release
+    # merge_group entries (the full-suite release gate). Skip the real steps on
+    # non-release merge_group entries to avoid contending for ubicloud-standard-16
+    # slots on every queue entry — the runner stays cheap there since every step
+    # is gated off (see skip_check below).
+    runs-on: "${{ (github.event_name == 'merge_group' && !startsWith(github.event.merge_group.head_commit.message, 'build: release')) && 'ubuntu-latest' || 'ubicloud-standard-16' }}"
     timeout-minutes: 30
     needs: fmt_check
     # Same skip conditions as test_unit (see test_unit comment for details)
@@ -414,38 +407,46 @@ jobs:
       RUST_MIN_STACK: 268435456
 
     steps:
-      - name: Detect release merge queue
-        id: release_check
+      # Skip every real step on non-release merge_group entries. PR-level CI
+      # already exercised the same code; running heavy ubicloud-standard-16
+      # simulations on every merge-queue entry contends for runner slots
+      # (issue #3973) without catching merge-time-specific regressions. The
+      # release merge_group entry (commit message starts with "build: release")
+      # still runs the full suite as the final pre-publish gate. The job
+      # remains present in the skipped case so branch-protection's required-
+      # check gate stays satisfied.
+      - name: Detect skip
+        id: skip_check
         env:
           EVENT_NAME: ${{ github.event_name }}
           MERGE_COMMIT_MSG: ${{ github.event.merge_group.head_commit.message }}
         run: |
-          if [[ "$EVENT_NAME" == "merge_group" && "$MERGE_COMMIT_MSG" == build:\ release* ]]; then
-            echo "is_release=true" >> "$GITHUB_OUTPUT"
-            echo "Skipping tests — release PRs only bump versions (main CI already validated)"
+          if [[ "$EVENT_NAME" == "merge_group" && "$MERGE_COMMIT_MSG" != build:\ release* ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping Simulation on non-release merge_group — covered by PR-level CI; full suite runs on release merge_group (#3973)"
           else
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@v6
-        if: steps.release_check.outputs.is_release != 'true'
+        if: steps.skip_check.outputs.skip != 'true'
 
       - name: Install mold linker
-        if: steps.release_check.outputs.is_release != 'true'
+        if: steps.skip_check.outputs.skip != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y mold
 
       - uses: dtolnay/rust-toolchain@stable
-        if: steps.release_check.outputs.is_release != 'true'
+        if: steps.skip_check.outputs.skip != 'true'
         with:
           toolchain: 1.93.0
 
       - uses: Swatinem/rust-cache@v2
-        if: steps.release_check.outputs.is_release != 'true'
+        if: steps.skip_check.outputs.skip != 'true'
 
       - name: Install nextest
-        if: steps.release_check.outputs.is_release != 'true'
+        if: steps.skip_check.outputs.skip != 'true'
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       # Build the simulation test binaries and fdev up-front in one cargo
@@ -453,7 +454,7 @@ jobs:
       # next two steps can run their *tests* in parallel without contending
       # for the cargo target-dir lock.
       - name: Build simulation tests and fdev
-        if: steps.release_check.outputs.is_release != 'true'
+        if: steps.skip_check.outputs.skip != 'true'
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
@@ -467,7 +468,7 @@ jobs:
           cargo build -p fdev --release --locked
 
       - name: Run simulation tests (nextest + fdev in parallel)
-        if: steps.release_check.outputs.is_release != 'true'
+        if: steps.skip_check.outputs.skip != 'true'
         env:
           RUST_LOG: info,turmoil=warn
         run: |
@@ -582,7 +583,7 @@ jobs:
           exit $FAILED
 
       - name: Upload simulation logs
-        if: always() && steps.release_check.outputs.is_release != 'true'
+        if: always() && steps.skip_check.outputs.skip != 'true'
         uses: actions/upload-artifact@v7
         with:
           name: simulation-logs
@@ -593,13 +594,17 @@ jobs:
   nat_validation:
     name: NAT Validation
     needs: fmt_check
-    runs-on: "${{ (github.event_name == 'merge_group' && startsWith(github.event.merge_group.head_commit.message, 'build: release')) && 'ubuntu-latest' || 'ubicloud-standard-16' }}"
+    # Run on the heavy runner for PRs (validates the change) and for release
+    # merge_group entries (the full-suite release gate). Skip the real steps on
+    # non-release merge_group entries to avoid contending for ubicloud-standard-16
+    # slots on every queue entry — the runner stays cheap there since every step
+    # is gated off (see skip_check below).
+    runs-on: "${{ (github.event_name == 'merge_group' && !startsWith(github.event.merge_group.head_commit.message, 'build: release')) && 'ubuntu-latest' || 'ubicloud-standard-16' }}"
     timeout-minutes: 30
     # Skip on:
     # - push to main: PR already validated code before merge
-    # - release PRs: only bump versions
+    # - release branches: covered by the release merge_group gate
     # - dependabot PRs: just version bumps, Test job is sufficient
-    # For release merge_group entries: run on cheap runner and skip expensive steps
     if: |
       (github.event_name == 'pull_request' || github.event_name == 'merge_group') &&
       !startsWith(github.head_ref, 'release/v') &&
@@ -610,47 +615,55 @@ jobs:
       RUST_MIN_STACK: 268435456
 
     steps:
-      - name: Detect release merge queue
-        id: release_check
+      # Skip every real step on non-release merge_group entries. PR-level CI
+      # already exercised the same code; running heavy ubicloud-standard-16
+      # Docker NAT validation on every merge-queue entry contends for runner
+      # slots (issue #3973) without catching merge-time-specific regressions.
+      # The release merge_group entry (commit message starts with
+      # "build: release") still runs the full suite as the final pre-publish
+      # gate. The job remains present in the skipped case so branch-
+      # protection's required-check gate stays satisfied.
+      - name: Detect skip
+        id: skip_check
         env:
           EVENT_NAME: ${{ github.event_name }}
           MERGE_COMMIT_MSG: ${{ github.event.merge_group.head_commit.message }}
         run: |
-          if [[ "$EVENT_NAME" == "merge_group" && "$MERGE_COMMIT_MSG" == build:\ release* ]]; then
-            echo "is_release=true" >> "$GITHUB_OUTPUT"
-            echo "Skipping tests — release PRs only bump versions (main CI already validated)"
+          if [[ "$EVENT_NAME" == "merge_group" && "$MERGE_COMMIT_MSG" != build:\ release* ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping NAT Validation on non-release merge_group — covered by PR-level CI; full suite runs on release merge_group (#3973)"
           else
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@v6
-        if: steps.release_check.outputs.is_release != 'true'
+        if: steps.skip_check.outputs.skip != 'true'
 
       - name: Install dependencies
-        if: steps.release_check.outputs.is_release != 'true'
+        if: steps.skip_check.outputs.skip != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y mold liblzma-dev
 
       - uses: dtolnay/rust-toolchain@stable
-        if: steps.release_check.outputs.is_release != 'true'
+        if: steps.skip_check.outputs.skip != 'true'
         with:
           toolchain: 1.93.0
           targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
-        if: steps.release_check.outputs.is_release != 'true'
+        if: steps.skip_check.outputs.skip != 'true'
 
       - name: Pull Docker images for NAT simulation
-        if: steps.release_check.outputs.is_release != 'true'
+        if: steps.skip_check.outputs.skip != 'true'
         run: docker pull alpine:latest
 
       - name: Install nextest
-        if: steps.release_check.outputs.is_release != 'true'
+        if: steps.skip_check.outputs.skip != 'true'
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - name: Build
-        if: steps.release_check.outputs.is_release != 'true'
+        if: steps.skip_check.outputs.skip != 'true'
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
@@ -660,7 +673,7 @@ jobs:
           make -C apps/freenet-ping -f run-ping.mk build
 
       - name: Run Docker NAT test
-        if: steps.release_check.outputs.is_release != 'true'
+        if: steps.skip_check.outputs.skip != 'true'
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,11 @@ jobs:
         id: create_pr
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+        # NOTE: The PR title MUST start with "build: release " — squash-merge
+        # propagates the title to the merge_group head_commit.message, where
+        # ci.yml's `skip_check` keys off it to decide whether the merge_group
+        # entry is the pre-publish gate. Renaming this prefix without
+        # updating ci.yml will silently disable the full-suite release gate.
         run: |
           PR_URL=$(gh pr create \
             --title "build: release ${{ needs.validate.outputs.version }}" \
@@ -154,7 +159,11 @@ jobs:
   wait_for_pr:
     name: Wait for PR to merge
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # 75 min covers: merge-queue scheduling + full-suite release gate (test_unit
+    # + Simulation + NAT Validation in parallel, ~10-15 min each on a busy
+    # ubicloud-standard-16) + branch-protection check propagation. Bumped from
+    # 60 min when the release merge_group started running the full suite (#3973).
+    timeout-minutes: 75
     needs: [validate, update_versions]
 
     steps:
@@ -166,7 +175,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER="${{ needs.update_versions.outputs.pr_number }}"
-          MAX_WAIT=1800  # 30 minutes
+          # 60 min budget. Was 30 min when the release merge_group skipped
+          # heavy tests; the new full-suite release gate (#3973) needs longer.
+          # Stays under the 75-min job timeout to leave headroom for shutdown.
+          MAX_WAIT=3600  # 60 minutes
           WAIT_INTERVAL=30
           ELAPSED=0
 


### PR DESCRIPTION
## Problem

The merge queue runs three `ubicloud-standard-16` jobs per entry (Unit & Integration, Simulation, NAT Validation), which exceeds Ubicloud's per-project concurrent-vCPU cap during peak hours. On 2026-04-29 some merge_group runs had jobs queued 55–101 minutes before a runner picked them up, blocking merges. Sample timings (time from run trigger to job start):

| Run (UTC) | Unit&Int | Simulation | NAT |
|---|---|---|---|
| 07:25 | +66m | +81m | +101m |
| 08:28 | +55m | +67m | +79m |
| 13:53 | +4m | +4m | +8m |

A separate gap: the release flow had no full-suite gate — `test_unit` was skipped on `build: release` merge_group entries, and Simulation/NAT only ran on PRs. Releases were relying on the version-bump PR's PR-level CI run, against an older `main` than what actually ships. (The previous "skip on release because main CI already validated" assumption was wrong: `test_unit`, `test_simulation`, and `nat_validation` are all gated to `pull_request | merge_group` only — push to main never re-validates.)

## Approach

Replace the flat "everything runs in every merge_group" model with two tiers, matching the team's intent (Nacho's framing: "be more lax in merge queue or main as long as before every release runs and requires the full suite"):

**Non-release merge_group:**
- Only Unit & Integration runs real steps on `ubicloud-standard-16`.
- Simulation and NAT Validation stay *present* (so branch-protection's required-check gate is satisfied) but skip their work on a cheap `ubuntu-latest` runner.
- Rationale: PR-level CI already exercised the same code. Simulation and NAT test ring routing, topology, and Docker NAT hole-punching — behaviors driven by the PR's own code, not by how it merges. Their merge-time unique catch rate is near zero.

**Release merge_group** (`build: release` commit message):
- The full suite runs on `ubicloud-standard-16`, including Unit & Integration whose tests were previously skipped on release entries.
- This is now the explicit pre-publish gate. What ships is known-green.

PR CI and `main` push behavior are unchanged.

## Why test_unit also changed

The previous `release_check` step in `test_unit` skipped tests on release merge_group entries with the comment "main CI already validated". This was based on a faulty assumption — `test_unit` is gated to `pull_request` and `merge_group` events only, so `main` push does NOT re-validate. The release was relying on the version-bump PR's PR-level run, which had been rebased away by queue time. Closing that gap and treating the release merge_group as the gate is the cleanest fix.

## Magic-string coupling

The release detection keys off `github.event.merge_group.head_commit.message` starting with `build: release`. This works because:

- The release PR title is hard-coded as `build: release X.Y.Z` in `release.yml`.
- The repo's merge queue uses squash-merge, so the merge_group temporary ref's head commit subject is the PR title plus `(#NNNN)`.
- Empirically verified: every past release merge_group entry (PRs #3947, #3913, #3908, #3888, #3877, #3872, #3859, #3845, #3835, #3830, #3829, #3817, #3800, #3794, …) has `head_commit.message` starting with `build: release`.

To prevent silent regression of the gate:

1. Added a `Self-test merge_group release detector` step in `fmt_check` that locks the bash predicate against 8 canned positive/negative inputs. Runs on every CI invocation.
2. Added a comment on `release.yml`'s `Create Pull Request` step warning that the title prefix is load-bearing for `ci.yml`.

## Other tweaks

- Bumped `release.yml`'s `wait_for_pr` job timeout from 60 to 75 min and `MAX_WAIT` from 30 to 60 min, since the release merge_group now runs the full suite (~20-30 min) instead of the previous skip-everything fast path.
- Updated `freenet-agent-skills/skills/release/SKILL.md` to reflect the new tiered model. The previous "skip on release" lesson was inverted by this PR; without that update, future release-skill-driven runs would still expect ~1 min merge queues and the obsolete justification.

## Testing

- YAML validates (`python3 -c "import yaml; yaml.safe_load(...)"` on both ci.yml and release.yml).
- Self-test step verified locally on all 8 canned cases.
- Empirical verification of the predicate against past merge_group runs (the matching pattern would have correctly identified every release merge_group entry in the repo's history without false positives on non-release entries).
- Branch-protection required-check names unchanged — Simulation and NAT still post a status, just with no real work on non-release merge_group.

Cannot fully prove the release merge_group path without an actual release; the next release will exercise the gate. The self-test mitigates predicate regressions; if Simulation or NAT have a latent issue that only manifests on rebased main, it surfaces at the release gate (blocking the release rather than silently shipping).

## Caveats

- Per Nacho's first observation: in unconstrained periods the three jobs run in parallel anyway, so time-savings are conditional on contention. Money savings are unconditional. Today's blockage shows the contention is real.
- There is NO push-to-main backstop for these jobs (they're gated to `pull_request | merge_group`). If a non-release merge_group skips Simulation/NAT and a routing/topology bug merges, it's only caught at the next release merge_group entry on the heavy runner. `simulation-nightly.yml` runs nightly against main and is the asynchronous safety net.
- Branch-protection green for "Simulation" / "NAT Validation" now means *either* "real green (PR or release)" *or* "skipped no-op (non-release merge_group)". Future investigators of an apparent green-CI bug should check the run details, not just the status badge.
- Ubicloud capacity is now load-bearing for releases (test_unit always heavy + Simulation + NAT on the release entry). If Ubicloud is fully out, the release blocks. Tracked separately.

## Fixes

Closes #3973

[AI-assisted - Claude]