### PR TITLE
fix(tracing): scale event-log trim with cap to bound write amplification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,11 +205,17 @@ jobs:
           # Check ALL Rust files for test additions/removals (not just crates/core/src/)
           # TEST_ATTR_RE matches the set of attributes this repo uses to mark
           # a function as a test:
-          #   #[test]                  — plain libtest
-          #   #[tokio::test]           — async tests
-          #   #[test_log::test]        — tracing-subscriber-enabled tests
-          #   #[freenet_test(...)]     — Freenet integration-test macro
-          TEST_ATTR_RE='#\[((tokio|test_log)::)?test\]|#\[freenet_test'
+          #   #[test]                                          - plain libtest
+          #   #[tokio::test]                                   - async tests
+          #   #[tokio::test(flavor = ..., worker_threads = N)] - parameterized async tests
+          #   #[test_log::test]                                - tracing-subscriber-enabled tests
+          #   #[test_log::test(tokio::test)]                   - parameterized tracing-subscriber-enabled
+          #   #[freenet_test(...)]                             - Freenet integration-test macro
+          # The character class [(\]] after `test` matches either `]` (plain
+          # form) or `(` (parameterized form). Without that, parameterized
+          # tokio::test attributes weren't counted as new tests and fix: PRs
+          # using only such tests were incorrectly rejected.
+          TEST_ATTR_RE='#\[((tokio|test_log)::)?test(\]|\()|#\[freenet_test'
           ALL_ADDED=$(git diff "$BASE"..."$HEAD" -- '**/*.rs' \
             | grep '^+' | grep -v '^+++' || true)
           ALL_ADDED_STRIPPED=$(echo "$ALL_ADDED" | sed 's|//.*||' || true)

--- a/crates/core/src/tracing/aof.rs
+++ b/crates/core/src/tracing/aof.rs
@@ -26,20 +26,49 @@ pub(super) const MAX_LOG_RECORDS: usize = 10_000;
 // surviving record to disk, so a small REMOVE_RECS forces the entire file to
 // be copied on every ~REMOVE_RECS-record append cycle. With a flat 1005
 // against the 100_000-record cap this produced ~99x write amplification,
-// observed as ~9 MB/s of sustained disk writes from compaction churn alone
-// on a busy gateway. Scaling with MAX_LOG_RECORDS keeps the trim fraction
-// constant across cfg(test) and cfg(not(test)); the +BATCH_SIZE buffer
-// preserves the original "headroom for one fresh batch" intent.
+// observed via /proc/$pid/io as ~9 MB/s of sustained disk writes from
+// compaction churn alone on a busy gateway. Scaling with MAX_LOG_RECORDS
+// keeps the trim fraction constant across cfg(test) and cfg(not(test)); the
+// +BATCH_SIZE buffer preserves the original "headroom for one fresh batch"
+// intent.
+//
+// 25% (rather than e.g. 50%) is a tradeoff between write amplification and
+// the size of the trailing window of router-training events on disk. At 25%,
+// amortized rewrite cost is ~3x records-per-record-shed and the file
+// oscillates between ~75% and ~100% of the cap; at 50% it would be ~1.5x
+// but the on-disk window would shrink toward 50% of the cap, halving the
+// router-training history available after each compaction. 25% sits at a
+// sane point in that tradeoff without losing meaningful history.
 pub(super) const REMOVE_RECS: usize = MAX_LOG_RECORDS / 4 + EVENT_REGISTER_BATCH_SIZE;
-// Compile-time guard: each truncate_records pass rewrites every surviving
-// record to disk, so REMOVE_RECS must be a meaningful fraction of the cap
-// (>=20%) to keep amortized write amplification bounded.
+// Compile-time guards. truncate_records rewrites every surviving record on
+// each pass, so REMOVE_RECS must be a meaningful fraction of the cap
+// (lower-bound ensures bounded write amplification) but never more than half
+// the cap (upper-bound prevents a future REMOVE_RECS = MAX_LOG_RECORDS misuse
+// from clearing the entire log and leaving the steady-state band's lower
+// edge at zero or underflowed).
 const _: () = assert!(
     REMOVE_RECS * 5 >= MAX_LOG_RECORDS,
     "REMOVE_RECS must drop at least 20% of MAX_LOG_RECORDS per compaction; \
      truncate_records rewrites the entire surviving log on every pass, so a \
      smaller fraction makes every ~REMOVE_RECS appends rewrite ~MAX_LOG_RECORDS \
      bytes (the gateway-write-amplification bug fixed by this guard)"
+);
+const _: () = assert!(
+    REMOVE_RECS * 2 <= MAX_LOG_RECORDS,
+    "REMOVE_RECS must drop at most 50% of MAX_LOG_RECORDS per compaction; \
+     a larger fraction shrinks the post-compaction record window below half \
+     the cap and risks clearing the log entirely if REMOVE_RECS approaches \
+     MAX_LOG_RECORDS"
+);
+// The truncation tests assume one full BATCH_SIZE batch flush carries
+// num_recs from MAX_LOG_RECORDS to MAX_LOG_RECORDS + BATCH_SIZE; that only
+// holds when MAX_LOG_RECORDS is a multiple of BATCH_SIZE. Pin the relation
+// at compile time so changing either constant doesn't silently shift the
+// trigger point and invalidate the regression tests.
+const _: () = assert!(
+    MAX_LOG_RECORDS % EVENT_REGISTER_BATCH_SIZE == 0,
+    "MAX_LOG_RECORDS must be a multiple of EVENT_REGISTER_BATCH_SIZE so \
+     compaction triggers exactly at MAX_LOG_RECORDS + BATCH_SIZE"
 );
 // Reduced from 100 to 5 to ensure events are written more frequently,
 // especially important for integration tests which generate few events
@@ -697,6 +726,57 @@ mod tests {
              to drop a sliver",
             log.num_recs,
             MAX_LOG_RECORDS,
+        );
+        Ok(())
+    }
+
+    /// Steady-state regression: push enough records for multiple compactions
+    /// and confirm the on-disk record count stays within the
+    /// `[MAX_LOG_RECORDS - REMOVE_RECS, MAX_LOG_RECORDS + BATCH_SIZE]` band.
+    /// Without the fix the band shrinks to `[MAX - 1005, MAX + BATCH_SIZE]`,
+    /// i.e. compaction fires after every ~1005 appends and the file
+    /// oscillates between 90% and 100% full instead of 75% and 100%.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn sustained_load_keeps_log_bounded() -> anyhow::Result<()> {
+        NEW_RECORDS_TS.get_or_init(SystemTime::now);
+        let temp_dir = tempfile::tempdir()?;
+        let log_path = temp_dir.path().join("event_log");
+
+        // Push enough records to force at least three compactions so the
+        // assertion captures steady-state behaviour, not a single-pass
+        // post-trim count.
+        const TEST_LOGS: usize = 3 * MAX_LOG_RECORDS;
+
+        let mut log = LogFile::open(&log_path).await?;
+        let bytes = crate::util::test::random_bytes_2mb();
+
+        // arbitrary::Unstructured returns default values once its buffer is
+        // exhausted, so re-prime per record to keep the EventKind mix
+        // varied enough that compaction logic exercises route-event paths.
+        for i in 0..TEST_LOGS {
+            // Cycle through the buffer to keep entropy across many records.
+            let offset = (i * 31) % bytes.len();
+            let mut unstructured = arbitrary::Unstructured::new(&bytes[offset..]);
+            let tx: Transaction = unstructured.arbitrary()?;
+            let peer = PeerId::random();
+            let kind: EventKind = unstructured.arbitrary()?;
+            let event = NetEventLog {
+                tx: &tx,
+                peer_id: peer,
+                kind,
+            };
+            for msg in NetLogMessage::to_log_message(either::Either::Left(event)) {
+                log.persist_log(msg).await;
+            }
+        }
+
+        let upper_bound = MAX_LOG_RECORDS + BATCH_SIZE;
+        let lower_bound = MAX_LOG_RECORDS.saturating_sub(REMOVE_RECS);
+        assert!(
+            log.num_recs >= lower_bound && log.num_recs <= upper_bound,
+            "num_recs={} outside steady-state band [{lower_bound}, {upper_bound}] \
+             after pushing {TEST_LOGS} records",
+            log.num_recs,
         );
         Ok(())
     }

--- a/crates/core/src/tracing/aof.rs
+++ b/crates/core/src/tracing/aof.rs
@@ -22,7 +22,25 @@ const EVENT_LOG_HEADER_SIZE: usize = RECORD_LENGTH + EVENT_KIND_LENGTH; // len +
 pub(super) const MAX_LOG_RECORDS: usize = 100_000;
 #[cfg(test)]
 pub(super) const MAX_LOG_RECORDS: usize = 10_000;
-pub(super) const REMOVE_RECS: usize = 1000 + EVENT_REGISTER_BATCH_SIZE; // making space for 1000 new records
+// Drop ~25% of records on each compaction. `truncate_records` rewrites every
+// surviving record to disk, so a small REMOVE_RECS forces the entire file to
+// be copied on every ~REMOVE_RECS-record append cycle. With a flat 1005
+// against the 100_000-record cap this produced ~99x write amplification,
+// observed as ~9 MB/s of sustained disk writes from compaction churn alone
+// on a busy gateway. Scaling with MAX_LOG_RECORDS keeps the trim fraction
+// constant across cfg(test) and cfg(not(test)); the +BATCH_SIZE buffer
+// preserves the original "headroom for one fresh batch" intent.
+pub(super) const REMOVE_RECS: usize = MAX_LOG_RECORDS / 4 + EVENT_REGISTER_BATCH_SIZE;
+// Compile-time guard: each truncate_records pass rewrites every surviving
+// record to disk, so REMOVE_RECS must be a meaningful fraction of the cap
+// (>=20%) to keep amortized write amplification bounded.
+const _: () = assert!(
+    REMOVE_RECS * 5 >= MAX_LOG_RECORDS,
+    "REMOVE_RECS must drop at least 20% of MAX_LOG_RECORDS per compaction; \
+     truncate_records rewrites the entire surviving log on every pass, so a \
+     smaller fraction makes every ~REMOVE_RECS appends rewrite ~MAX_LOG_RECORDS \
+     bytes (the gateway-write-amplification bug fixed by this guard)"
+);
 // Reduced from 100 to 5 to ensure events are written more frequently,
 // especially important for integration tests which generate few events
 const EVENT_REGISTER_BATCH_SIZE: usize = 5;
@@ -623,6 +641,63 @@ mod tests {
 
         let ev = LogFile::get_router_events(TEST_LOGS, &log_path).await?;
         assert_eq!(ev.len(), total_route_events);
+        Ok(())
+    }
+
+    /// Verify the runtime behaviour matches the compile-time invariant on
+    /// REMOVE_RECS: after a compaction fires, the log must have shed enough
+    /// records that the next compaction is many appends away (not the very
+    /// next batch). Regression test for the gateway-write-amplification bug
+    /// where REMOVE_RECS=1005 against MAX_LOG_RECORDS=100_000 caused every
+    /// compaction to rewrite ~99% of the file to drop ~1% of records,
+    /// producing ~9 MB/s of sustained disk writes from compaction churn.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn truncation_leaves_meaningful_headroom() -> anyhow::Result<()> {
+        NEW_RECORDS_TS.get_or_init(SystemTime::now);
+        let temp_dir = tempfile::tempdir()?;
+        let log_path = temp_dir.path().join("event_log");
+
+        // Push exactly enough records to trigger one compaction with no
+        // straggler appends afterwards, so num_recs reflects the post-trim
+        // count rather than the steady-state fill-back.
+        // The first compaction triggers at the batch boundary just above
+        // MAX_LOG_RECORDS (i.e. at MAX_LOG_RECORDS + BATCH_SIZE records).
+        const TEST_LOGS: usize = MAX_LOG_RECORDS + BATCH_SIZE;
+
+        let mut log = LogFile::open(&log_path).await?;
+        let bytes = crate::util::test::random_bytes_2mb();
+        let mut unstructured = arbitrary::Unstructured::new(&bytes);
+        let mut transactions = Vec::with_capacity(TEST_LOGS);
+        let mut peers = Vec::with_capacity(TEST_LOGS);
+        let mut events = Vec::with_capacity(TEST_LOGS);
+
+        for _ in 0..TEST_LOGS {
+            transactions.push(unstructured.arbitrary::<Transaction>()?);
+            peers.push(PeerId::random());
+        }
+        for i in 0..TEST_LOGS {
+            let kind: EventKind = unstructured.arbitrary()?;
+            events.push(NetEventLog {
+                tx: &transactions[i],
+                peer_id: peers[i].clone(),
+                kind,
+            });
+        }
+        for msg in NetLogMessage::to_log_message(either::Either::Right(events)) {
+            log.persist_log(msg).await;
+        }
+
+        // After compaction, num_recs should sit at most 80% of MAX_LOG_RECORDS.
+        // With the original REMOVE_RECS = 1005 against MAX = 10_000 this would
+        // land at ~9000 (90%) and the assertion would fail.
+        assert!(
+            log.num_recs * 5 <= MAX_LOG_RECORDS * 4,
+            "after compaction num_recs={} is > 80% of MAX_LOG_RECORDS={}; \
+             a small REMOVE_RECS makes every compaction rewrite ~all records \
+             to drop a sliver",
+            log.num_recs,
+            MAX_LOG_RECORDS,
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## Problem

A user reported their Freenet peer doing a lot of disk write operations even at idle. Investigated this on the production gateway (nova) and a regular peer (technic):

| Peer | write_bytes | write syscalls |
|------|-------------|----------------|
| Gateway (heavy load) | ~9 MB/s sustained | ~11.6k/s |
| Technic peer | ~1.5 MB/s sustained | ~1.4k/s |

Almost all of that disk traffic comes from `_EVENT_LOG` compaction, not network packets or text logs. Watching the gateway's `_EVENT_LOG` (~89 MB) over 10 seconds showed it oscillating by tens of KB and dropping ~130 KB every ~8 s, then growing again. That cadence matches `LogFile::truncate_records` firing roughly every 8 seconds and rewriting the whole file to drop a tiny prefix.

The cause is in `crates/core/src/tracing/aof.rs`:
- `MAX_LOG_RECORDS = 100_000`
- `REMOVE_RECS = 1000 + BATCH_SIZE` (a flat ~1% of the cap)

Once `num_recs > MAX_LOG_RECORDS`, `truncate_records` skips `REMOVE_RECS` records at the head, copies every remaining record into `_EVENT_LOG.rewrite`, and renames over `_EVENT_LOG`. On a busy gateway with ~100k records of average ~890 bytes, that copies ~89 MB to drop ~1 MB. Steady-state amplification is `MAX_LOG_RECORDS / REMOVE_RECS` ≈ 99x.

## Approach

Make `REMOVE_RECS = MAX_LOG_RECORDS / 4 + BATCH_SIZE` so each compaction sheds ~25% of the cap. The on-disk size envelope is unchanged (still bounded by `MAX_LOG_RECORDS`), but compactions run ~25x less often with similar per-pass cost. Steady-state disk writes from this path drop by the same factor — projected ~9 MB/s → ~360 KB/s on a peer with comparable load.

Why constants instead of a structural rewrite (segment-based AOF):
- Segments are the right long-term design but they are a ~200 LOC refactor with new failure modes (segment open/close races, partial-segment recovery).
- The constant change captures most of the win in a tiny, reviewable diff.
- The `_EVENT_LOG` is only used for router model training and event aggregation; trimming a slightly larger fraction per compaction has no functional impact.

A `const _: () = assert!(REMOVE_RECS * 5 >= MAX_LOG_RECORDS, ...)` guard placed next to the constants makes anyone shrinking REMOVE_RECS below 20% of the cap a build error instead of a slow telemetry regression.

## Why didn't CI catch this?

CI did not have a write-amplification assertion on `_EVENT_LOG`. The existing `read_write_truncate` test self-references `REMOVE_RECS` and so passes against any value; nothing pinned the ratio. This PR closes that gap with the compile-time `const _` invariant and a new runtime test (`truncation_leaves_meaningful_headroom`) that asserts post-compaction `num_recs` sits at or below 80% of the cap. With the original `REMOVE_RECS = 1005` against the test cap of 10_000, the runtime test fails (`num_recs=9000 > 8000`); under the fix it passes. Verified locally by reverting the constant and re-running the tests.

## Testing

- `cargo fmt -p freenet`
- `cargo clippy -p freenet -- -D warnings` clean
- `cargo test -p freenet --lib tracing::` — 34 passed (3 existing aof tests + 1 new + 30 other tracing tests)
- Reverted `REMOVE_RECS` to `1000 + BATCH_SIZE` and reran: build failed at the `const _` guard, runtime test failed with the expected diagnostic. Restored the fix.

## Fixes

No GitHub issue was filed; reported informally on Matrix.

[AI-assisted - Claude]