### PR TITLE
fix(install): read prompt from /dev/tty when stdin is piped

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,8 +14,9 @@
 # freenet/web (served from https://freenet.org/install.sh). Keep the
 # two in sync. In particular, the service-install prompt below MUST
 # keep its $0 + /dev/tty handling so that `curl | sh` users can
-# answer the prompt - see freenet/web PR #42 for context. A previous
-# fix was already lost once via a bulk resync.
+# answer the prompt - see https://github.com/freenet/web/pull/42 and
+# its companion PR in this repo for context. A previous fix was
+# already lost once via a bulk resync.
 
 set -eu
 
@@ -428,8 +429,9 @@ main() {
     # stdin, $0 is the shell name itself (e.g. "sh", "bash"). In the
     # script-file case we read from stdin as before, so existing
     # automation patterns like `printf 'y\n' | sh install.sh` still work.
-    # The robust way to bypass the prompt in any invocation form is
-    # FREENET_NO_SERVICE=1.
+    # The shell-name allowlist covers shells likely to appear as
+    # `curl ... | <shell>`; users piping to a more exotic shell can fall
+    # back to FREENET_NO_SERVICE=1 to bypass the prompt.
     #
     # `{ true </dev/tty; } 2>/dev/null` is used instead of `[ -r /dev/tty ]`:
     # the access check can succeed even when the process has no
@@ -442,7 +444,7 @@ main() {
         echo ""
         response=""
         case "${0##*/}" in
-            sh|bash|dash|ash|busybox|-sh|-bash|-dash|-ash)
+            sh|bash|dash|ash|zsh|ksh|mksh|pdksh|yash|busybox|-sh|-bash|-dash|-ash|-zsh|-ksh|-mksh|-yash)
                 # Script source is on stdin (`curl | sh` form).
                 if { true </dev/tty; } 2>/dev/null; then
                     printf "Would you like to install Freenet as a system service? [y/N] "

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,13 @@
 #   FREENET_INSTALL_DIR  - Installation directory (default: ~/.local/bin)
 #   FREENET_NO_SERVICE   - Set to 1 to skip service installation prompt
 #   FREENET_VERSION      - Specific version to install (default: latest)
+#
+# NOTE: This file is mirrored at hugo-site/static/install.sh in
+# freenet/web (served from https://freenet.org/install.sh). Keep the
+# two in sync. In particular, the service-install prompt below MUST
+# keep its $0 + /dev/tty handling so that `curl | sh` users can
+# answer the prompt - see freenet/web PR #42 for context. A previous
+# fix was already lost once via a bulk resync.
 
 set -eu
 
@@ -409,11 +416,45 @@ main() {
         print_path_instructions "$install_dir"
     fi
 
-    # Ask about service installation (unless FREENET_NO_SERVICE is set)
+    # Ask about service installation (unless FREENET_NO_SERVICE is set).
+    #
+    # When the script is piped via `curl ... | sh`, sh reads its own script
+    # source from stdin. A plain `read` at this point would consume bytes
+    # of script source instead of capturing the user's answer, so we
+    # redirect from /dev/tty in that case.
+    #
+    # We detect "sh is reading the script from stdin" via $0: when sh runs
+    # a script file, $0 is the script path; when sh reads its source from
+    # stdin, $0 is the shell name itself (e.g. "sh", "bash"). In the
+    # script-file case we read from stdin as before, so existing
+    # automation patterns like `printf 'y\n' | sh install.sh` still work.
+    # The robust way to bypass the prompt in any invocation form is
+    # FREENET_NO_SERVICE=1.
+    #
+    # `{ true </dev/tty; } 2>/dev/null` is used instead of `[ -r /dev/tty ]`:
+    # the access check can succeed even when the process has no
+    # controlling terminal and the subsequent open(2) fails with ENXIO.
+    # Probe by actually opening /dev/tty.
+    #
+    # `read -r response || response=""` keeps EOF (e.g. Ctrl-D, closed
+    # stdin) from aborting the script under `set -eu`.
     if [ "${FREENET_NO_SERVICE:-0}" != "1" ]; then
         echo ""
-        printf "Would you like to install Freenet as a system service? [y/N] "
-        read -r response
+        response=""
+        case "${0##*/}" in
+            sh|bash|dash|ash|busybox|-sh|-bash|-dash|-ash)
+                # Script source is on stdin (`curl | sh` form).
+                if { true </dev/tty; } 2>/dev/null; then
+                    printf "Would you like to install Freenet as a system service? [y/N] "
+                    read -r response </dev/tty || response=""
+                fi
+                ;;
+            *)
+                # Script ran as a file; stdin carries the user's answer.
+                printf "Would you like to install Freenet as a system service? [y/N] "
+                read -r response || response=""
+                ;;
+        esac
         case "$response" in
             [yY]|[yY][eE][sS])
                 info "Installing service..."
@@ -427,6 +468,8 @@ main() {
                 echo ""
                 echo "You can install the service later with:"
                 echo "  freenet service install"
+                echo ""
+                echo "To skip this prompt entirely in scripted installs, set FREENET_NO_SERVICE=1."
                 ;;
         esac
     fi


### PR DESCRIPTION
## Problem

The install script published at `https://freenet.org/install.sh`
(mirrored in this file at `scripts/install.sh`) is invoked via
`curl -fsSL https://freenet.org/install.sh | sh`. When piped through
`sh`, stdin is the script source itself, not the user's terminal, so
`read -r response` at the service-install prompt silently ignores
keyboard input.

Reported by Ivvor on Matrix:
> @Ian: Freenet linux install script is broken. Streaming curl to sh
> causes it to not process keyboard input when asking if you want the
> service installed.

The user-facing copy at `freenet/web/hugo-site/static/install.sh` had
this fix applied once (commit `eff317ae`, Dec 2025) but it was lost
in `freenet/web` PRs #36 / #37 which "resynced" that file from this
canonical copy in freenet-core - which never had the fix in the first
place.

## Solution

freenet/web PR #42 (just merged) reapplies and hardens the fix in
the user-facing copy. This PR brings `scripts/install.sh` in line so
the next resync is a no-op rather than a regression.

The prompt block now:

- **Discriminates on `$0`** to tell `curl | sh` apart from
  `sh install.sh`. In the curl-pipe case, sh reads its source from
  stdin so the prompt must come from /dev/tty; in the file case,
  stdin is available for the user's answer (preserves
  `printf 'y' | sh install.sh` automation patterns).
- **Probes /dev/tty by actually opening it**
  (`{ true </dev/tty; } 2>/dev/null`) instead of `[ -r /dev/tty ]`,
  since the access check can succeed even when the subsequent
  open(2) fails with ENXIO.
- **Guards `read` against EOF** with `|| response=""` so Ctrl-D /
  closed stdin doesn't abort the script under `set -eu`.
- **Adds an env-var hint** in the skip path so users hitting the
  no-tty branch know `FREENET_NO_SERVICE=1` is the supported way to
  skip prompts in scripted installs.
- **Adds a NOTE block at the top of the file** cross-referencing
  the `freenet/web` sibling and explaining why the prompt logic
  must not be flattened back to a plain `read` (a previous fix was
  already lost once via a bulk resync).

## Testing

This is a shell-only change. Verified via a pty harness (extracts the
prompt block and exercises it with a mock `freenet` binary) across
five scenarios:

1. `curl | sh` under `script(1)` pty: reads `y` from /dev/tty,
   service installs.
2. `sh install.sh` interactive (heredoc): reads from stdin.
3. `printf 'y' | sh install.sh`: reads from piped stdin.
4. `setsid sh -c './install.sh' </dev/null`: skips prompt and prints
   the `FREENET_NO_SERVICE=1` hint.
5. `sh install.sh </dev/null`: handles EOF without aborting under
   `set -eu`.

All five scenarios pass against the modified `scripts/install.sh`.

### Why no committed regression test

freenet-core has no shell-test infrastructure today and the bug-fix
rules are wired around new `#[test]` Rust functions; adding a Rust
test that exercises a shell prompt is awkward. The testing reviewer
on the freenet/web PR recommended:

- a CI grep-guard that fails if the prompt block is flattened back
  to a plain `read`, and
- a `setsid sh -c 'cat install.sh | sh' </dev/null` smoke step,

both of which would naturally live under
`.github/workflows/install-script.yml`. That's a separate, additive
PR; this one is the focused user-facing fix.

The companion `freenet/web` PR (https://github.com/freenet/web/pull/42,
merged) covers the user-facing copy.

[AI-assisted - Claude]