### PR TITLE
fix(report): stringify ContractKey keys before JSON serialize

### DIFF
--- a/crates/core/src/bin/commands/report.rs
+++ b/crates/core/src/bin/commands/report.rs
@@ -11,7 +11,8 @@ use flate2::write::GzEncoder;
 use freenet::config::ConfigPaths;
 use freenet::tracing::tracer::get_log_dir;
 use freenet_stdlib::client_api::{
-    ClientRequest, HostResponse, NodeDiagnosticsConfig, NodeQuery, QueryResponse, WebApi,
+    ClientRequest, HostResponse, NodeDiagnosticsConfig, NodeDiagnosticsResponse, NodeQuery,
+    QueryResponse, WebApi,
 };
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -758,8 +759,7 @@ async fn query_node_diagnostics(host: &str, port: u16) -> Result<String> {
 
     match response {
         HostResponse::QueryResponse(QueryResponse::NodeDiagnostics(diag)) => {
-            // Serialize the diagnostics to JSON for the report
-            serde_json::to_string_pretty(&diag).context("Failed to serialize diagnostics")
+            diagnostics_to_json(&diag)
         }
         HostResponse::ContractResponse(_)
         | HostResponse::DelegateResponse { .. }
@@ -767,6 +767,54 @@ async fn query_node_diagnostics(host: &str, port: u16) -> Result<String> {
         | HostResponse::Ok
         | _ => anyhow::bail!("Unexpected response from node"),
     }
+}
+
+/// Serialize `NodeDiagnosticsResponse` to JSON for the report payload.
+///
+/// `contract_states` is keyed by `ContractKey`, whose derived `Serialize`
+/// impl emits a struct (`{instance, code}`). `serde_json` rejects non-string
+/// JSON map keys, so a direct `serde_json::to_string(&diag)` fails with
+/// "key must be a string" as soon as the node hosts at least one contract.
+/// We rebuild the field with stringified keys before serializing. The
+/// rest of the struct serializes natively. See freenet/freenet-core#3987.
+fn diagnostics_to_json(diag: &NodeDiagnosticsResponse) -> Result<String> {
+    use serde_json::{Map, Value};
+
+    let mut contract_states = Map::with_capacity(diag.contract_states.len());
+    for (key, state) in &diag.contract_states {
+        let value =
+            serde_json::to_value(state).context("Failed to serialize contract state value")?;
+        contract_states.insert(key.to_string(), value);
+    }
+
+    let mut value = Map::new();
+    value.insert(
+        "node_info".to_string(),
+        serde_json::to_value(&diag.node_info).context("Failed to serialize node_info")?,
+    );
+    value.insert(
+        "network_info".to_string(),
+        serde_json::to_value(&diag.network_info).context("Failed to serialize network_info")?,
+    );
+    value.insert(
+        "subscriptions".to_string(),
+        serde_json::to_value(&diag.subscriptions).context("Failed to serialize subscriptions")?,
+    );
+    value.insert(
+        "contract_states".to_string(),
+        Value::Object(contract_states),
+    );
+    value.insert(
+        "system_metrics".to_string(),
+        serde_json::to_value(&diag.system_metrics).context("Failed to serialize system_metrics")?,
+    );
+    value.insert(
+        "connected_peers_detailed".to_string(),
+        serde_json::to_value(&diag.connected_peers_detailed)
+            .context("Failed to serialize connected_peers_detailed")?,
+    );
+
+    serde_json::to_string_pretty(&Value::Object(value)).context("Failed to serialize diagnostics")
 }
 
 fn format_bytes(bytes: u64) -> String {
@@ -839,6 +887,135 @@ mod tests {
         let json = serde_json::to_string(&report).unwrap();
         assert!(json.contains("linux"));
         assert!(json.contains("test log"));
+    }
+
+    #[test]
+    fn test_diagnostics_to_json_with_populated_contract_states() {
+        // Regression for #3987: serde_json::to_string_pretty(&NodeDiagnosticsResponse)
+        // panicked with "key must be a string" when contract_states had any entries,
+        // because ContractKey derives Serialize as a struct (not a string) and
+        // serde_json forbids non-string JSON object keys. Every report from a node
+        // hosting at least one contract was silently uploaded with empty
+        // network_status. The fix builds JSON manually with stringified keys.
+        use freenet_stdlib::client_api::ContractState;
+        use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+        use std::collections::HashMap;
+
+        let key1 = ContractKey::from_id_and_code(
+            ContractInstanceId::new([1u8; 32]),
+            CodeHash::new([2u8; 32]),
+        );
+        let key2 = ContractKey::from_id_and_code(
+            ContractInstanceId::new([3u8; 32]),
+            CodeHash::new([4u8; 32]),
+        );
+        let mut contract_states = HashMap::new();
+        contract_states.insert(
+            key1,
+            ContractState {
+                subscribers: 2,
+                subscriber_peer_ids: vec!["peer-a".to_string(), "peer-b".to_string()],
+                size_bytes: 1234,
+            },
+        );
+        contract_states.insert(
+            key2,
+            ContractState {
+                subscribers: 0,
+                subscriber_peer_ids: vec![],
+                size_bytes: 0,
+            },
+        );
+
+        let diag = NodeDiagnosticsResponse {
+            node_info: None,
+            network_info: None,
+            subscriptions: vec![],
+            contract_states,
+            system_metrics: None,
+            connected_peers_detailed: vec![],
+        };
+
+        let json = diagnostics_to_json(&diag).expect("serialization must not fail");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("output must be valid JSON");
+
+        // Field is preserved.
+        let states = parsed["contract_states"]
+            .as_object()
+            .expect("contract_states must be a JSON object");
+        assert_eq!(states.len(), 2);
+
+        // Keys are the Base58 contract id (matches ContractKey's Display impl,
+        // which is what the report viewer expects), not the struct form
+        // {"instance":..., "code":...} that the broken derive produced.
+        assert!(states.contains_key(&key1.to_string()));
+        assert!(states.contains_key(&key2.to_string()));
+
+        // Values round-trip.
+        assert_eq!(states[&key1.to_string()]["subscribers"], 2);
+        assert_eq!(states[&key1.to_string()]["size_bytes"], 1234);
+    }
+
+    #[test]
+    fn test_native_serde_json_on_contract_states_fails_documents_root_cause() {
+        // Pin the failure mode so a stdlib-side fix that switches the key type
+        // surfaces here as a tightening, not a silent change. If this test
+        // starts passing, NodeDiagnosticsResponse.contract_states no longer
+        // requires the diagnostics_to_json workaround above and the helper can
+        // be removed in favour of a direct serde_json::to_string call.
+        use freenet_stdlib::client_api::ContractState;
+        use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+        use std::collections::HashMap;
+
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([1u8; 32]),
+            CodeHash::new([2u8; 32]),
+        );
+        let mut contract_states = HashMap::new();
+        contract_states.insert(
+            key,
+            ContractState {
+                subscribers: 0,
+                subscriber_peer_ids: vec![],
+                size_bytes: 0,
+            },
+        );
+        let diag = NodeDiagnosticsResponse {
+            node_info: None,
+            network_info: None,
+            subscriptions: vec![],
+            contract_states,
+            system_metrics: None,
+            connected_peers_detailed: vec![],
+        };
+
+        let err = serde_json::to_string(&diag)
+            .expect_err("native serde_json must reject ContractKey-keyed map");
+        assert!(
+            err.to_string().contains("key must be a string"),
+            "expected serde_json key-must-be-string error, got: {err}",
+        );
+    }
+
+    #[test]
+    fn test_diagnostics_to_json_with_empty_contract_states() {
+        // The bug only triggered when contract_states had >=1 entry, but the
+        // empty case is the path users with no hosted contracts hit. Asserting
+        // both keeps either case from regressing.
+        let diag = NodeDiagnosticsResponse {
+            node_info: None,
+            network_info: None,
+            subscriptions: vec![],
+            contract_states: std::collections::HashMap::new(),
+            system_metrics: None,
+            connected_peers_detailed: vec![],
+        };
+
+        let json = diagnostics_to_json(&diag).expect("serialization must not fail");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("output must be valid JSON");
+        assert!(parsed["contract_states"].as_object().unwrap().is_empty());
     }
 
     #[test]

--- a/crates/core/src/bin/commands/report.rs
+++ b/crates/core/src/bin/commands/report.rs
@@ -777,40 +777,50 @@ async fn query_node_diagnostics(host: &str, port: u16) -> Result<String> {
 /// "key must be a string" as soon as the node hosts at least one contract.
 /// We rebuild the field with stringified keys before serializing. The
 /// rest of the struct serializes natively. See freenet/freenet-core#3987.
+///
+/// The destructure-bind on the input forces a compile error if a field is
+/// added to `NodeDiagnosticsResponse` upstream — without it, the helper
+/// would silently drop the new field from the JSON payload.
 fn diagnostics_to_json(diag: &NodeDiagnosticsResponse) -> Result<String> {
     use serde_json::{Map, Value};
 
-    let mut contract_states = Map::with_capacity(diag.contract_states.len());
-    for (key, state) in &diag.contract_states {
+    let NodeDiagnosticsResponse {
+        node_info,
+        network_info,
+        subscriptions,
+        contract_states,
+        system_metrics,
+        connected_peers_detailed,
+    } = diag;
+
+    let mut states = Map::with_capacity(contract_states.len());
+    for (key, state) in contract_states {
         let value =
             serde_json::to_value(state).context("Failed to serialize contract state value")?;
-        contract_states.insert(key.to_string(), value);
+        states.insert(key.to_string(), value);
     }
 
     let mut value = Map::new();
     value.insert(
         "node_info".to_string(),
-        serde_json::to_value(&diag.node_info).context("Failed to serialize node_info")?,
+        serde_json::to_value(node_info).context("Failed to serialize node_info")?,
     );
     value.insert(
         "network_info".to_string(),
-        serde_json::to_value(&diag.network_info).context("Failed to serialize network_info")?,
+        serde_json::to_value(network_info).context("Failed to serialize network_info")?,
     );
     value.insert(
         "subscriptions".to_string(),
-        serde_json::to_value(&diag.subscriptions).context("Failed to serialize subscriptions")?,
+        serde_json::to_value(subscriptions).context("Failed to serialize subscriptions")?,
     );
-    value.insert(
-        "contract_states".to_string(),
-        Value::Object(contract_states),
-    );
+    value.insert("contract_states".to_string(), Value::Object(states));
     value.insert(
         "system_metrics".to_string(),
-        serde_json::to_value(&diag.system_metrics).context("Failed to serialize system_metrics")?,
+        serde_json::to_value(system_metrics).context("Failed to serialize system_metrics")?,
     );
     value.insert(
         "connected_peers_detailed".to_string(),
-        serde_json::to_value(&diag.connected_peers_detailed)
+        serde_json::to_value(connected_peers_detailed)
             .context("Failed to serialize connected_peers_detailed")?,
     );
 
@@ -1016,6 +1026,84 @@ mod tests {
         let parsed: serde_json::Value =
             serde_json::from_str(&json).expect("output must be valid JSON");
         assert!(parsed["contract_states"].as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_diagnostics_to_json_all_fields_populated_round_trip() {
+        // Guard against typos in the manual field-by-field assembly inside
+        // diagnostics_to_json: every Option must be Some, every Vec must be
+        // non-empty, and every top-level key must round-trip with a
+        // distinguishable value. If anyone accidentally inserts the same
+        // key twice, drops a field, or mis-types a key (e.g. "nodeinfo"),
+        // the missing/duplicate field surfaces here instead of in production
+        // reports. The destructure-bind already catches *new* fields at
+        // compile time; this test catches typos in the *existing* fields
+        // that the compiler cannot.
+        use freenet_stdlib::client_api::{
+            ConnectedPeerInfo, ContractState, NetworkInfo, NodeInfo, SubscriptionInfo,
+            SystemMetrics,
+        };
+        use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+        use std::collections::HashMap;
+
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([7u8; 32]),
+            CodeHash::new([8u8; 32]),
+        );
+        let mut contract_states = HashMap::new();
+        contract_states.insert(
+            key,
+            ContractState {
+                subscribers: 5,
+                subscriber_peer_ids: vec!["peer-z".to_string()],
+                size_bytes: 9999,
+            },
+        );
+
+        let diag = NodeDiagnosticsResponse {
+            node_info: Some(NodeInfo {
+                peer_id: "peer-self".to_string(),
+                is_gateway: true,
+                location: Some("0.5".to_string()),
+                listening_address: Some("0.0.0.0:31337".to_string()),
+                uptime_seconds: 3600,
+            }),
+            network_info: Some(NetworkInfo {
+                connected_peers: vec![("peer-x".to_string(), "10.0.0.1:31337".to_string())],
+                active_connections: 1,
+            }),
+            subscriptions: vec![SubscriptionInfo {
+                contract_key: ContractInstanceId::new([7u8; 32]),
+                client_id: 42,
+            }],
+            contract_states,
+            system_metrics: Some(SystemMetrics {
+                active_connections: 1,
+                hosting_contracts: 1,
+            }),
+            connected_peers_detailed: vec![ConnectedPeerInfo {
+                peer_id: "peer-x".to_string(),
+                address: "10.0.0.1:31337".to_string(),
+            }],
+        };
+
+        let json = diagnostics_to_json(&diag).expect("serialization must not fail");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("output must be valid JSON");
+
+        // All six top-level keys present and distinguishable.
+        let obj = parsed.as_object().expect("top-level must be object");
+        assert_eq!(obj.len(), 6, "expected six top-level fields, got {obj:?}");
+        assert_eq!(parsed["node_info"]["peer_id"], "peer-self");
+        assert_eq!(parsed["network_info"]["active_connections"], 1);
+        assert_eq!(parsed["subscriptions"][0]["client_id"], 42);
+        assert_eq!(parsed["system_metrics"]["hosting_contracts"], 1);
+        assert_eq!(parsed["connected_peers_detailed"][0]["peer_id"], "peer-x");
+        let states = parsed["contract_states"]
+            .as_object()
+            .expect("contract_states must be a JSON object");
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[&key.to_string()]["size_bytes"], 9999);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Every diagnostic report uploaded from a 0.2.50 node has an empty `network_status` field as soon as the node is hosting at least one contract. The `network_status_error` field added in #3897/#3898 surfaced the underlying cause:

```
"network_status": null,
"network_status_error": "127.0.0.1:7509: Failed to serialize diagnostics: key must be a string; ..."
```

This means we have been losing the most useful piece of evidence in user-submitted reports — live ring composition, per-peer state, current operations — for every report from every 0.2.50 node, not just resource-constrained ones (e.g. report `6ZPGAD`).

The offender is `NodeDiagnosticsResponse.contract_states` in `freenet-stdlib`, which is `HashMap<ContractKey, ContractState>`. `ContractKey` derives `Serialize` as a struct (`{instance, code}`), but `serde_json` forbids non-string JSON map keys. The wire path between core and clients uses bincode (which doesn't care about key types), so the bug was invisible until the report binary tried to serialize the response to JSON for upload. Bug has been latent since the field was added to stdlib in June 2025.

## Solution

Local fix in the report binary: serialize `NodeDiagnosticsResponse` field-by-field into a `serde_json::Map`, stringifying each `ContractKey` via its existing `Display` impl (Base58 contract id). Every other diagnostic field already follows the "stringify for client API" convention (`peer_id: String`, `connected_peers: Vec<(String, String)>`, `ContractHostingEntry.contract_key: String`); `contract_states` was the lone outlier.

The helper calls `key.to_string()`, which works whether the underlying type stays `HashMap<ContractKey, _>` or a future stdlib release switches it to `HashMap<String, _>` at the source — so this code does not need to change in lockstep with a stdlib bump. A separate stdlib PR will fix the type for the next stdlib release; this PR ships the user-facing fix immediately without the stdlib release round-trip.

## Testing

Three new tests in `crates/core/src/bin/commands/report.rs`:

- `test_diagnostics_to_json_with_populated_contract_states` — reproduces the exact scenario the bug broke (>=1 contract entry). Asserts the helper succeeds, the output is valid JSON, the keys are the Base58 form (matching `ContractKey::Display`), and values round-trip.
- `test_diagnostics_to_json_with_empty_contract_states` — the no-hosting-contracts path (which would not have triggered the bug). Pinned so neither branch regresses silently.
- `test_native_serde_json_on_contract_states_fails_documents_root_cause` — asserts that calling `serde_json::to_string(&NodeDiagnosticsResponse)` directly still fails with `key must be a string`. This is a tripwire: when a future stdlib release switches the key type, this test starts failing and signals that the local workaround can be removed in favour of a direct `to_string` call.

Why CI didn't catch this previously: there was no JSON round-trip test for `NodeDiagnosticsResponse` in either freenet-stdlib or freenet-core. The wire path (bincode) is the one production code uses; JSON serialization only enters the picture in the report binary, which had no unit coverage for this serialization step. The third test above closes that gap at the boundary.

All 18 report-module tests pass; `cargo clippy --bin freenet --all-targets -- -D warnings` is clean; `cargo fmt` is clean.

## Fixes

Closes #3987

[AI-assisted - Claude]