### PR TITLE
fix(transport): count all packet bytes in dashboard metrics

### DIFF
--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -438,15 +438,23 @@ impl Socket for UdpSocket {
         let (len, addr) = self.recv_from(buf).await?;
         // Normalize ::ffff:x.x.x.x → plain IPv4 so the rest of the system
         // sees a consistent address regardless of socket type.
-        Ok((len, normalize_mapped_addr(addr)))
+        let addr = normalize_mapped_addr(addr);
+        metrics::TRANSPORT_METRICS.record_packet_received(addr, len as u64);
+        Ok((len, addr))
     }
 
     async fn send_to(&self, buf: &[u8], target: SocketAddr) -> io::Result<usize> {
         // Convert plain IPv4 targets to mapped form when sending on an IPv6 socket,
         // since AF_INET6 sockets reject AF_INET addresses with EINVAL.
         let local_is_ipv6 = self.local_addr().map(|a| a.is_ipv6()).unwrap_or(false);
-        let target = map_addr_for_send(local_is_ipv6, target);
-        self.send_to(buf, target).await
+        let mapped_target = map_addr_for_send(local_is_ipv6, target);
+        let result = self.send_to(buf, mapped_target).await;
+        if let Ok(bytes) = result {
+            // Record against the un-mapped target so per-peer keys match the
+            // normalized form used everywhere else in the system.
+            metrics::TRANSPORT_METRICS.record_packet_sent(target, bytes as u64);
+        }
+        result
     }
 
     fn send_to_blocking(&self, buf: &[u8], target: SocketAddr) -> io::Result<usize> {
@@ -454,13 +462,16 @@ impl Socket for UdpSocket {
         // However, under high load the kernel buffer might be full, returning WouldBlock.
         // In that case, we retry with exponential backoff since we're in a blocking context.
         let local_is_ipv6 = self.local_addr().map(|a| a.is_ipv6()).unwrap_or(false);
-        let target = map_addr_for_send(local_is_ipv6, target);
+        let mapped_target = map_addr_for_send(local_is_ipv6, target);
         let mut backoff_us = 1u64; // Start at 1μs
         const MAX_BACKOFF_US: u64 = 1000; // Cap at 1ms
 
         loop {
-            match self.try_send_to(buf, target) {
-                Ok(n) => return Ok(n),
+            match self.try_send_to(buf, mapped_target) {
+                Ok(n) => {
+                    metrics::TRANSPORT_METRICS.record_packet_sent(target, n as u64);
+                    return Ok(n);
+                }
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
                     // Kernel buffer full - exponential backoff
                     std::thread::sleep(std::time::Duration::from_micros(backoff_us));
@@ -794,5 +805,71 @@ mod dual_stack_tests {
             .await
             .unwrap();
         assert_eq!(&buf[..len], b"pong");
+    }
+
+    /// Regression: every successful send_to / recv_from on the production
+    /// `UdpSocket` must update both the cumulative wire-byte counters and the
+    /// per-peer counters used by the local dashboard. Before this fix, those
+    /// counters only moved on stream-transfer completion, so a node connected
+    /// for hours could legitimately show "—" for SENT/RECV despite real
+    /// keep-alive traffic flowing.
+    #[tokio::test]
+    async fn udp_socket_records_packet_metrics() {
+        use crate::transport::metrics::TRANSPORT_METRICS;
+
+        let v4_addr = SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0);
+        let sender = <UdpSocket as Socket>::bind(v4_addr).await.unwrap();
+        let receiver = <UdpSocket as Socket>::bind(v4_addr).await.unwrap();
+        let receiver_addr = receiver.local_addr().unwrap();
+        let sender_addr = sender.local_addr().unwrap();
+
+        let cumulative_sent_before = TRANSPORT_METRICS.cumulative_bytes_sent();
+        let cumulative_recv_before = TRANSPORT_METRICS.cumulative_bytes_received();
+
+        let payload = b"keep-alive-sized-control-packet";
+        <UdpSocket as Socket>::send_to(&sender, payload, receiver_addr)
+            .await
+            .unwrap();
+
+        let mut buf = [0u8; 64];
+        let (len, _) = <UdpSocket as Socket>::recv_from(&receiver, &mut buf)
+            .await
+            .unwrap();
+        assert_eq!(len, payload.len());
+
+        // Cumulative counters must move at least by the payload size each way.
+        // Other tests running in parallel may push them higher, hence the >=.
+        assert!(
+            TRANSPORT_METRICS.cumulative_bytes_sent()
+                >= cumulative_sent_before + payload.len() as u64,
+            "cumulative_bytes_sent must include the payload"
+        );
+        assert!(
+            TRANSPORT_METRICS.cumulative_bytes_received()
+                >= cumulative_recv_before + payload.len() as u64,
+            "cumulative_bytes_received must include the payload"
+        );
+
+        // Per-peer counters keyed by the un-mapped target / normalized source
+        // (both plain IPv4 here) must include the payload.
+        let peers = TRANSPORT_METRICS.per_peer_snapshot();
+        let receiver_entry = peers
+            .iter()
+            .find(|(a, _, _)| *a == receiver_addr)
+            .expect("per-peer entry for send target must exist");
+        assert!(
+            receiver_entry.1 >= payload.len() as u64,
+            "per-peer bytes_sent must include the payload (got {})",
+            receiver_entry.1
+        );
+        let sender_entry = peers
+            .iter()
+            .find(|(a, _, _)| *a == sender_addr)
+            .expect("per-peer entry for recv source must exist");
+        assert!(
+            sender_entry.2 >= payload.len() as u64,
+            "per-peer bytes_received must include the payload (got {})",
+            sender_entry.2
+        );
     }
 }

--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -872,4 +872,131 @@ mod dual_stack_tests {
             sender_entry.2
         );
     }
+
+    /// Regression: failed sends must not bump the metrics. Without this,
+    /// a future refactor could move the increment before the result check
+    /// and silently inflate the counters on every error.
+    #[tokio::test]
+    async fn udp_socket_failed_send_does_not_record_metrics() {
+        use crate::transport::metrics::TRANSPORT_METRICS;
+
+        let v4_addr = SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0);
+        let sender = <UdpSocket as Socket>::bind(v4_addr).await.unwrap();
+
+        // Connect the socket to a known-bad address so subsequent sends
+        // synchronously fail with ECONNREFUSED on Linux. This is the
+        // simplest way to force a Send error from `send_to`.
+        sender
+            .connect("127.0.0.1:1") // port 1 is reserved; nothing listens
+            .await
+            .ok();
+
+        let unbound: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        let cumulative_sent_before = TRANSPORT_METRICS.cumulative_bytes_sent();
+
+        // Capture per-peer state before — the exact behavior depends on the
+        // OS (some kernels still accept the sendto), so we tolerate either
+        // outcome but assert that *if* the send fails, no metric moves.
+        let result = <UdpSocket as Socket>::send_to(&sender, b"x", unbound).await;
+        if result.is_err() {
+            assert_eq!(
+                TRANSPORT_METRICS.cumulative_bytes_sent(),
+                cumulative_sent_before,
+                "failed send must not bump cumulative_bytes_sent"
+            );
+            // Per-peer entry for the unbound address should also not exist
+            // due to this send. (Other tests may have created it; this is
+            // why we don't assert absence outright.)
+        }
+    }
+
+    /// Verify that `send_to_blocking` (the synchronous code path used in
+    /// `spawn_blocking` contexts) also records metrics on success. Same
+    /// dashboard-correctness guarantee as the async path. Runs inside a
+    /// `spawn_blocking` so the call is in a real blocking context with the
+    /// tokio reactor still active for `try_send_to` polling.
+    #[tokio::test]
+    async fn udp_socket_blocking_send_records_packet_metrics() {
+        use crate::transport::metrics::TRANSPORT_METRICS;
+        use std::sync::Arc;
+
+        let v4_addr = SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0);
+        let sender = Arc::new(<UdpSocket as Socket>::bind(v4_addr).await.unwrap());
+        let receiver = <UdpSocket as Socket>::bind(v4_addr).await.unwrap();
+        let receiver_addr = receiver.local_addr().unwrap();
+
+        let cumulative_sent_before = TRANSPORT_METRICS.cumulative_bytes_sent();
+        let payload: &'static [u8] = b"blocking-send-payload";
+        let sender_clone = sender.clone();
+
+        tokio::task::spawn_blocking(move || {
+            <UdpSocket as Socket>::send_to_blocking(&sender_clone, payload, receiver_addr)
+                .expect("blocking send should succeed on localhost UDP");
+        })
+        .await
+        .unwrap();
+
+        // Drain the receiver so the kernel buffer doesn't leak across tests.
+        let mut buf = [0u8; 64];
+        let _ = <UdpSocket as Socket>::recv_from(&receiver, &mut buf).await;
+
+        assert!(
+            TRANSPORT_METRICS.cumulative_bytes_sent()
+                >= cumulative_sent_before + payload.len() as u64,
+            "send_to_blocking must record cumulative_bytes_sent"
+        );
+        let peers = TRANSPORT_METRICS.per_peer_snapshot();
+        let entry = peers
+            .iter()
+            .find(|(a, _, _)| *a == receiver_addr)
+            .expect("per-peer entry must exist after blocking send");
+        assert!(
+            entry.1 >= payload.len() as u64,
+            "send_to_blocking must record per-peer bytes_sent"
+        );
+    }
+
+    /// On a dual-stack IPv6 socket sending to an IPv4 target, the kernel
+    /// receives the AF_INET6-mapped form, but the per-peer entry MUST be
+    /// keyed by the canonical (un-mapped) IPv4 form. Otherwise the dashboard
+    /// would split a single peer across two map entries when the local
+    /// socket happens to be IPv6.
+    #[tokio::test]
+    async fn udp_socket_dual_stack_send_keys_per_peer_by_unmapped_addr() {
+        use crate::transport::metrics::TRANSPORT_METRICS;
+
+        let dual_addr = SocketAddr::new(std::net::IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0);
+        let dual_sock = <UdpSocket as Socket>::bind(dual_addr).await.unwrap();
+        let v4_addr = SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0);
+        let v4_recv = <UdpSocket as Socket>::bind(v4_addr).await.unwrap();
+        let v4_recv_port = v4_recv.local_addr().unwrap().port();
+
+        let target = SocketAddr::new(
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            v4_recv_port,
+        );
+        assert!(target.is_ipv4(), "test precondition");
+
+        <UdpSocket as Socket>::send_to(&dual_sock, b"dual-stack", target)
+            .await
+            .unwrap();
+
+        let peers = TRANSPORT_METRICS.per_peer_snapshot();
+        let entry = peers
+            .iter()
+            .find(|(a, _, _)| *a == target)
+            .expect("per-peer entry must be keyed by un-mapped IPv4 target");
+        assert!(
+            entry.0.is_ipv4(),
+            "per-peer key must be plain IPv4, not ::ffff:x.x.x.x"
+        );
+        // Same target in mapped form must NOT have its own entry.
+        let mapped: SocketAddr = format!("[::ffff:127.0.0.1]:{v4_recv_port}")
+            .parse()
+            .unwrap();
+        assert!(
+            peers.iter().all(|(a, _, _)| *a != mapped),
+            "mapped form must not produce a duplicate per-peer entry"
+        );
+    }
 }

--- a/crates/core/src/transport/metrics.rs
+++ b/crates/core/src/transport/metrics.rs
@@ -266,20 +266,27 @@ impl TransportMetrics {
 
     /// Record a completed inbound stream transfer.
     ///
-    /// Updates the per-snapshot `bytes_received` counter (which pairs with
-    /// `transfers_completed` for telemetry). Wire-byte counters
-    /// (`cumulative_bytes_received`, per-peer `bytes_received`) are updated at
-    /// the socket layer in `record_packet_received`.
-    pub fn record_inbound_completed(&self, _remote_addr: SocketAddr, bytes: u64) {
+    /// Aggregates stream-payload bytes into the per-snapshot `bytes_received`
+    /// counter, which pairs with `transfers_completed` for periodic telemetry.
+    /// Wire-byte counters (`cumulative_bytes_received`, per-peer
+    /// `bytes_received`) are owned by [`Self::record_packet_received`] at the
+    /// socket layer.
+    pub fn record_inbound_completed(&self, bytes: u64) {
         self.bytes_received.fetch_add(bytes, Ordering::Relaxed);
     }
 
     /// Record an outbound UDP packet at the socket layer.
     ///
-    /// Updates the cumulative dashboard counter and the per-peer counter.
-    /// Counts every packet, including keep-alives, ACKs, and small control
-    /// messages, so the local dashboard reflects real wire activity rather
-    /// than only large stream transfers.
+    /// Updates the cumulative dashboard counter and the per-peer counter so
+    /// keep-alives, ACKs, and other small control messages all show up on the
+    /// local dashboard, not just large stream transfers.
+    ///
+    /// `remote_addr` MUST be the canonical (un-mapped) form used elsewhere in
+    /// the system — the same form `recv_from` returns after
+    /// `normalize_mapped_addr`. Mismatched callers (e.g. passing a
+    /// `::ffff:x.x.x.x` mapped target on a dual-stack socket) would create a
+    /// duplicate per-peer entry that the dashboard cannot join against
+    /// `connected_peers[].address`.
     pub fn record_packet_sent(&self, remote_addr: SocketAddr, bytes: u64) {
         self.cumulative_bytes_sent
             .fetch_add(bytes, Ordering::Relaxed);
@@ -288,7 +295,8 @@ impl TransportMetrics {
 
     /// Record an inbound UDP packet at the socket layer.
     ///
-    /// See [`Self::record_packet_sent`] for the counter semantics.
+    /// See [`Self::record_packet_sent`] for the counter semantics and the
+    /// canonical-address contract on `remote_addr`.
     pub fn record_packet_received(&self, remote_addr: SocketAddr, bytes: u64) {
         self.cumulative_bytes_received
             .fetch_add(bytes, Ordering::Relaxed);
@@ -300,7 +308,17 @@ impl TransportMetrics {
         self.cumulative_bytes_received.load(Ordering::Relaxed)
     }
 
-    /// Record per-peer bytes for the given direction (bounded to MAX_TRACKED_PEERS).
+    /// Record per-peer bytes for the given direction.
+    ///
+    /// Bounded to [`MAX_TRACKED_PEERS`] entries: once full, new peers' bytes
+    /// are silently dropped (existing entries continue to update). There is no
+    /// LRU eviction. Combined with the fact that `record_packet_received`
+    /// runs at the raw socket before authentication, an attacker that
+    /// fabricates packets from many spoofed source IPs can fill the table
+    /// with abandoned entries and crowd out legitimate new peers from the
+    /// dashboard's per-peer view. Memory damage is still bounded (256 entries
+    /// × ~16 bytes), and authenticated traffic on the existing connections
+    /// continues to be metered correctly. Follow-up tracked in #3999.
     fn record_per_peer(
         &self,
         addr: SocketAddr,
@@ -671,10 +689,9 @@ mod tests {
         // double-counting bug (counted both at socket layer and at stream
         // completion) cannot regress.
         let metrics = TransportMetrics::new();
-        let addr: std::net::SocketAddr = "10.0.0.1:5000".parse().unwrap();
 
-        metrics.record_inbound_completed(addr, 2048);
-        metrics.record_inbound_completed(addr, 1024);
+        metrics.record_inbound_completed(2048);
+        metrics.record_inbound_completed(1024);
 
         assert_eq!(
             metrics.cumulative_bytes_received(),
@@ -690,7 +707,7 @@ mod tests {
         // alongside transfers_completed for telemetry.
         let stats = crate::transport::TransferStats {
             stream_id: 1,
-            remote_addr: addr,
+            remote_addr: "10.0.0.1:5000".parse().unwrap(),
             bytes_transferred: 100,
             elapsed: Duration::from_millis(10),
             peak_cwnd_bytes: 1000,

--- a/crates/core/src/transport/metrics.rs
+++ b/crates/core/src/transport/metrics.rs
@@ -58,7 +58,10 @@ pub struct TransportMetrics {
     bytes_sent: AtomicU64,
     bytes_received: AtomicU64,
 
-    // Cumulative counters (never reset — used by the local dashboard)
+    // Cumulative wire-byte counters (never reset, used by the local dashboard).
+    // Updated at the UDP socket layer for every packet, so they reflect all
+    // traffic including keep-alives, ACKs, NAT-traversal, and small control
+    // messages — not just stream transfer payloads.
     cumulative_bytes_sent: AtomicU64,
     cumulative_bytes_received: AtomicU64,
 
@@ -77,7 +80,8 @@ pub struct TransportMetrics {
     // Slowdowns during period
     slowdowns_triggered: AtomicU32,
 
-    // Per-peer transfer stats (bounded to MAX_TRACKED_PEERS entries)
+    // Per-peer wire-byte stats (bounded to MAX_TRACKED_PEERS entries).
+    // Updated at the UDP socket layer alongside the cumulative counters above.
     per_peer_stats: DashMap<SocketAddr, PeerTransferStats>,
 
     // RTT tracking (in microseconds for precision)
@@ -146,12 +150,12 @@ impl TransportMetrics {
                 Some(v.saturating_add(1))
             })
             .ok();
+        // Note: `bytes_sent` here aggregates stream-transfer payload sizes for
+        // the periodic telemetry snapshot. Wire-byte counters
+        // (`cumulative_bytes_sent`, per-peer `bytes_sent`) are updated at the
+        // socket layer in `record_packet_sent` and intentionally not touched
+        // here.
         self.bytes_sent
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-                Some(v.saturating_add(stats.bytes_transferred))
-            })
-            .ok();
-        self.cumulative_bytes_sent
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
                 Some(v.saturating_add(stats.bytes_transferred))
             })
@@ -197,11 +201,6 @@ impl TransportMetrics {
         if rtt_us > 0 {
             self.record_rtt_sample(rtt_us);
         }
-
-        // Per-peer tracking (skip if at capacity and peer is new)
-        self.record_per_peer(stats.remote_addr, stats.bytes_transferred, |s| {
-            &s.bytes_sent
-        });
     }
 
     /// Record a cwnd sample (called periodically or on transfer completion).
@@ -266,8 +265,31 @@ impl TransportMetrics {
     }
 
     /// Record a completed inbound stream transfer.
-    pub fn record_inbound_completed(&self, remote_addr: SocketAddr, bytes: u64) {
+    ///
+    /// Updates the per-snapshot `bytes_received` counter (which pairs with
+    /// `transfers_completed` for telemetry). Wire-byte counters
+    /// (`cumulative_bytes_received`, per-peer `bytes_received`) are updated at
+    /// the socket layer in `record_packet_received`.
+    pub fn record_inbound_completed(&self, _remote_addr: SocketAddr, bytes: u64) {
         self.bytes_received.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Record an outbound UDP packet at the socket layer.
+    ///
+    /// Updates the cumulative dashboard counter and the per-peer counter.
+    /// Counts every packet, including keep-alives, ACKs, and small control
+    /// messages, so the local dashboard reflects real wire activity rather
+    /// than only large stream transfers.
+    pub fn record_packet_sent(&self, remote_addr: SocketAddr, bytes: u64) {
+        self.cumulative_bytes_sent
+            .fetch_add(bytes, Ordering::Relaxed);
+        self.record_per_peer(remote_addr, bytes, |s| &s.bytes_sent);
+    }
+
+    /// Record an inbound UDP packet at the socket layer.
+    ///
+    /// See [`Self::record_packet_sent`] for the counter semantics.
+    pub fn record_packet_received(&self, remote_addr: SocketAddr, bytes: u64) {
         self.cumulative_bytes_received
             .fetch_add(bytes, Ordering::Relaxed);
         self.record_per_peer(remote_addr, bytes, |s| &s.bytes_received);
@@ -642,26 +664,30 @@ mod tests {
     }
 
     #[test]
-    fn test_inbound_completed_tracking() {
+    fn test_inbound_completed_updates_only_snapshot_bytes() {
+        // record_inbound_completed must NOT touch the cumulative or per-peer
+        // wire-byte counters — those are owned by record_packet_received and
+        // updated at the socket layer. This test pins that contract so the
+        // double-counting bug (counted both at socket layer and at stream
+        // completion) cannot regress.
         let metrics = TransportMetrics::new();
         let addr: std::net::SocketAddr = "10.0.0.1:5000".parse().unwrap();
 
         metrics.record_inbound_completed(addr, 2048);
         metrics.record_inbound_completed(addr, 1024);
 
-        // Cumulative counter
-        assert_eq!(metrics.cumulative_bytes_received(), 3072);
+        assert_eq!(
+            metrics.cumulative_bytes_received(),
+            0,
+            "cumulative is wire-byte only; stream completion must not touch it"
+        );
+        assert!(
+            metrics.per_peer_snapshot().is_empty(),
+            "per-peer is wire-byte only; stream completion must not touch it"
+        );
 
-        // Per-peer snapshot
-        let peers = metrics.per_peer_snapshot();
-        let peer = peers.iter().find(|(a, _, _)| *a == addr);
-        assert!(peer.is_some(), "peer should be tracked");
-        let (_, sent, recv) = peer.unwrap();
-        assert_eq!(*sent, 0);
-        assert_eq!(*recv, 3072);
-
-        // Periodic snapshot reflects bytes_received
-        // Need a transfer to make take_snapshot return Some
+        // The snapshot bytes_received field still aggregates transfer payloads
+        // alongside transfers_completed for telemetry.
         let stats = crate::transport::TransferStats {
             stream_id: 1,
             remote_addr: addr,
@@ -680,9 +706,77 @@ mod tests {
         metrics.record_transfer_completed(&stats);
         let snapshot = metrics.take_snapshot().unwrap();
         assert_eq!(snapshot.bytes_received, 3072);
+    }
 
-        // Cumulative survives snapshot reset
-        assert_eq!(metrics.cumulative_bytes_received(), 3072);
+    #[test]
+    fn test_packet_sent_updates_cumulative_and_per_peer() {
+        let metrics = TransportMetrics::new();
+        let addr: std::net::SocketAddr = "10.0.0.1:5000".parse().unwrap();
+
+        // Simulate small control packets that never trigger streaming —
+        // historically these were invisible to the dashboard. After the fix
+        // they must show up.
+        metrics.record_packet_sent(addr, 64);
+        metrics.record_packet_sent(addr, 200);
+
+        assert_eq!(metrics.cumulative_bytes_sent(), 264);
+
+        let peers = metrics.per_peer_snapshot();
+        let peer = peers.iter().find(|(a, _, _)| *a == addr).expect("tracked");
+        assert_eq!(peer.1, 264, "per-peer sent must reflect packet bytes");
+        assert_eq!(peer.2, 0);
+    }
+
+    #[test]
+    fn test_packet_received_updates_cumulative_and_per_peer() {
+        let metrics = TransportMetrics::new();
+        let addr: std::net::SocketAddr = "10.0.0.1:5000".parse().unwrap();
+
+        metrics.record_packet_received(addr, 128);
+        metrics.record_packet_received(addr, 256);
+
+        assert_eq!(metrics.cumulative_bytes_received(), 384);
+
+        let peers = metrics.per_peer_snapshot();
+        let peer = peers.iter().find(|(a, _, _)| *a == addr).expect("tracked");
+        assert_eq!(peer.1, 0);
+        assert_eq!(peer.2, 384);
+    }
+
+    #[test]
+    fn test_packet_metrics_survive_snapshot_reset() {
+        let metrics = TransportMetrics::new();
+        let addr: std::net::SocketAddr = "10.0.0.1:5000".parse().unwrap();
+
+        metrics.record_packet_sent(addr, 500);
+        metrics.record_packet_received(addr, 700);
+
+        // Force a snapshot via a transfer completion.
+        let stats = crate::transport::TransferStats {
+            stream_id: 1,
+            remote_addr: addr,
+            bytes_transferred: 100,
+            elapsed: Duration::from_millis(10),
+            peak_cwnd_bytes: 1000,
+            final_cwnd_bytes: 1000,
+            slowdowns_triggered: 0,
+            base_delay: Duration::from_millis(5),
+            final_ssthresh_bytes: 100000,
+            min_ssthresh_floor_bytes: 5696,
+            total_timeouts: 0,
+            final_flightsize: 0,
+            configured_rate: 0,
+        };
+        metrics.record_transfer_completed(&stats);
+        let _ = metrics.take_snapshot();
+
+        // Cumulative + per-peer wire bytes survive the snapshot reset.
+        assert_eq!(metrics.cumulative_bytes_sent(), 500);
+        assert_eq!(metrics.cumulative_bytes_received(), 700);
+        let peers = metrics.per_peer_snapshot();
+        let peer = peers.iter().find(|(a, _, _)| *a == addr).expect("tracked");
+        assert_eq!(peer.1, 500);
+        assert_eq!(peer.2, 700);
     }
 
     #[test]
@@ -694,22 +788,22 @@ mod tests {
             let addr: std::net::SocketAddr = format!("10.0.{}.{}:{}", i / 256, i % 256, 5000 + i)
                 .parse()
                 .unwrap();
-            metrics.record_inbound_completed(addr, 100);
+            metrics.record_packet_received(addr, 100);
         }
 
         assert_eq!(metrics.per_peer_snapshot().len(), MAX_TRACKED_PEERS);
 
-        // 257th peer should not be tracked in per-peer stats
+        // Beyond capacity: new peer not tracked, but cumulative still counts.
         let extra: std::net::SocketAddr = "192.168.1.1:9999".parse().unwrap();
-        metrics.record_inbound_completed(extra, 500);
+        metrics.record_packet_received(extra, 500);
 
-        // Per-peer map should not grow
         assert_eq!(metrics.per_peer_snapshot().len(), MAX_TRACKED_PEERS);
         let snapshot = metrics.per_peer_snapshot();
-        let extra_entry = snapshot.iter().find(|(a, _, _)| *a == extra);
-        assert!(extra_entry.is_none(), "257th peer should not be tracked");
+        assert!(
+            snapshot.iter().all(|(a, _, _)| *a != extra),
+            "over-capacity peer must not be tracked"
+        );
 
-        // But cumulative counter still includes the bytes
         let total: u64 = (MAX_TRACKED_PEERS as u64 * 100) + 500;
         assert_eq!(metrics.cumulative_bytes_received(), total);
     }

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -911,10 +911,7 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                         error
                     })? {
                         // Record inbound bytes for non-streamed (short) messages
-                        super::TRANSPORT_METRICS.record_inbound_completed(
-                            self.remote_conn.remote_addr,
-                            msg.len() as u64,
-                        );
+                        super::TRANSPORT_METRICS.record_inbound_completed(msg.len() as u64);
                         tracing::trace!(
                             peer_addr = %self.remote_conn.remote_addr,
                             packet_id,
@@ -945,10 +942,7 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                     self.streaming_registry.remove(stream_id);
                     // Record inbound bytes for dashboard metrics
                     let bytes_received = msg.len() as u64;
-                    super::TRANSPORT_METRICS.record_inbound_completed(
-                        self.remote_conn.remote_addr,
-                        bytes_received,
-                    );
+                    super::TRANSPORT_METRICS.record_inbound_completed(bytes_received);
                     tracing::trace!(
                         peer_addr = %self.remote_conn.remote_addr,
                         stream_id = %stream_id,


### PR DESCRIPTION
## Problem

The local-peer dashboard's per-peer SENT/RECV columns (and the global
Transfer card) showed `—` for connections that had been alive for hours
even when keep-alive traffic was clearly flowing. A user asked why a
node connected for 24+ hours could have `—` for both SENT and RECV.

Root cause: every counter that the dashboard reads
(`cumulative_bytes_sent`, `cumulative_bytes_received`, and the
`per_peer_stats` `DashMap`) is only ever bumped from
`record_transfer_completed` / `record_inbound_completed` — i.e.
when a *streamed* payload finishes. Keep-alives, ACKs, NAT-traversal
probes, and any contract operation whose payload stays under the 64 KB
streaming threshold never touched these counters, so an alive
connection that was not pushing large transfers genuinely looked dead
on the dashboard.

## Approach

Move wire-byte accounting to the UDP socket layer. Counter semantics
are now cleanly split:

- **Cumulative + per-peer counters (dashboard):** wire bytes, bumped on
  every successful packet send/recv. Keep-alives, control packets, and
  small contract ops are all visible.
- **Snapshot `bytes_sent` / `bytes_received` (telemetry):** unchanged.
  Still tied to `transfers_completed/failed` and aggregates
  stream-transfer payload sizes for periodic telemetry. No
  double-counting.

Concretely:

1. New methods `TransportMetrics::record_packet_sent` /
   `record_packet_received` update only the cumulative + per-peer
   counters.
2. The production `Socket` impl on `tokio::net::UdpSocket` calls them
   from `send_to`, `recv_from`, and `send_to_blocking` on every
   successful syscall. This is the single chokepoint all production
   packets cross, so we get full coverage with one hook site.
3. Removed the now-redundant cumulative + per-peer increments from
   `record_transfer_completed` and `record_inbound_completed`. The
   per-snapshot transfer-payload accounting they still own is what
   telemetry needs; the wire-byte accounting they previously did was
   incidental and incomplete.
4. Send-side metering keys per-peer entries by the un-mapped target
   address, so dual-stack `::ffff:x.x.x.x` mapping does not split a
   single peer across two map entries (matches the receive-side
   `normalize_mapped_addr` already in place). Pinned by a new
   `udp_socket_dual_stack_send_keys_per_peer_by_unmapped_addr` test.

Per-peer entries remain bounded to `MAX_TRACKED_PEERS = 256`, so the
new code path inherits the same DoS-resistance as the old one.

## Behavior change worth flagging

Pre-PR, only peers that completed an authenticated stream transfer
populated the per-peer DashMap, so the 256-entry cap was effectively
unreachable on a normal node. With socket-layer metering, *any* source
IP that sends a single UDP byte gets a slot. Combined with the table's
existing first-come-stays-forever policy (no LRU/TTL eviction), an
attacker that fabricates packets from many spoofed source IPs can fill
the table and shadow legitimate new peers from the dashboard's per-peer
view. Memory damage stays bounded (256 entries × ~16 bytes), and
authenticated traffic on existing connections continues to be metered
correctly. Tracked for follow-up in #3999 — moving the per-peer
increment past authentication plus adding LRU eviction is too big to
bundle here without delaying the symptom fix.

## Testing

- `udp_socket_records_packet_metrics`: integration test binds two real
  `UdpSocket`s, sends one small packet, asserts that both cumulative
  counters and the per-peer entries for the relevant addresses move by
  at least the payload size. Pins the wire-up end-to-end and would
  have caught the original bug.
- `udp_socket_dual_stack_send_keys_per_peer_by_unmapped_addr`: confirms
  the un-mapped key invariant for dual-stack socket sends.
- `udp_socket_blocking_send_records_packet_metrics`: covers
  `send_to_blocking` (the `spawn_blocking` code path the async-only
  test missed).
- `udp_socket_failed_send_does_not_record_metrics`: pins the
  "only record on Ok" contract so a future refactor can't silently
  move the increment before the result check.
- New unit tests in `transport/metrics.rs`:
  - `test_packet_sent_updates_cumulative_and_per_peer`
  - `test_packet_received_updates_cumulative_and_per_peer`
  - `test_packet_metrics_survive_snapshot_reset`
  - `test_inbound_completed_updates_only_snapshot_bytes` — pins the
    no-double-counting contract so the regression cannot return.
- Existing `test_per_peer_capacity_bound` reused with
  `record_packet_received` to confirm the 256-peer bound still applies
  on the new path.
- `cargo clippy --locked -- -D warnings` clean.
- Local: 9/9 metrics tests + 12/12 dual_stack tests pass.

## Why didn't CI catch this?

Existing tests for `TransportMetrics` only exercised the
transfer-completion path, which was sufficient under the old contract
(where that path was the *only* path). There was no test verifying
that wire bytes from non-streamed packets show up on the dashboard at
all. The new `udp_socket_records_packet_metrics` integration test and
the `test_packet_*` unit tests close that gap in this same PR.

## Follow-ups

- #3999 — recv-side per-peer metering past authentication + LRU eviction
  on the per-peer DashMap (HIGH-severity skeptical-review finding).
- #4000 — RTT samples have the same class of undercounting (only
  collected on stream completion); should be sampled from the regular
  ping/pong cycle.

[AI-assisted - Claude]