### PR TITLE
fix: align fdev/freenet binstall metadata with release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,11 @@ jobs:
           # literally (`v0.2.X`) rather than `v{ version }`. Re-point both the
           # default and the Windows override to the new release tag so that
           # `cargo binstall fdev` resolves to the actual GitHub release assets
-          # (issue #3995).
+          # (issue #3995). The `/g` flag is load-bearing — there are two
+          # pkg-url lines that both need the rewrite. Mirror in
+          # `scripts/release.sh`; tests in
+          # `crates/fdev/tests/binstall_metadata.rs::release_sed_rewrite`
+          # keep both copies of the regex in lockstep.
           sed -E "s|releases/download/v[0-9]+\.[0-9]+\.[0-9]+/fdev-|releases/download/v${VERSION}/fdev-|g" crates/fdev/Cargo.toml > crates/fdev/Cargo.toml.tmp3
           mv crates/fdev/Cargo.toml.tmp3 crates/fdev/Cargo.toml
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,15 @@ jobs:
           sed "s/freenet = { path = \"..\/core\", version = \".*\" }/freenet = { path = \"..\/core\", version = \"$VERSION\" }/" crates/fdev/Cargo.toml > crates/fdev/Cargo.toml.tmp2
           mv crates/fdev/Cargo.toml.tmp2 crates/fdev/Cargo.toml
 
+          # The fdev crate version diverged from the freenet release tag, so
+          # `[package.metadata.binstall].pkg-url` embeds the freenet version
+          # literally (`v0.2.X`) rather than `v{ version }`. Re-point both the
+          # default and the Windows override to the new release tag so that
+          # `cargo binstall fdev` resolves to the actual GitHub release assets
+          # (issue #3995).
+          sed -E "s|releases/download/v[0-9]+\.[0-9]+\.[0-9]+/fdev-|releases/download/v${VERSION}/fdev-|g" crates/fdev/Cargo.toml > crates/fdev/Cargo.toml.tmp3
+          mv crates/fdev/Cargo.toml.tmp3 crates/fdev/Cargo.toml
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,6 +20,11 @@ pkg-url = "{ repo }/releases/download/v{ version }/freenet-{ target }.tar.gz"
 pkg-fmt = "tgz"
 bin-dir = "freenet"
 
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/freenet-{ target }.zip"
+pkg-fmt = "zip"
+bin-dir = "freenet.exe"
+
 [[bin]]
 name = "freenet"
 path = "src/bin/freenet.rs"

--- a/crates/core/tests/binstall_metadata.rs
+++ b/crates/core/tests/binstall_metadata.rs
@@ -1,4 +1,4 @@
-//! Regression test for issue #3995: the freenet crate's binstall metadata
+//! Regression tests for issue #3995: the freenet crate's binstall metadata
 //! lacked a Windows override, so `cargo binstall freenet` 404'd on
 //! `x86_64-pc-windows-msvc` (the release uploads `freenet-…-msvc.zip`, not
 //! `.tar.gz`).
@@ -11,33 +11,78 @@ fn manifest() -> Value {
     toml::from_str(CARGO_TOML).expect("freenet Cargo.toml should be valid TOML")
 }
 
-#[test]
-fn windows_override_uses_zip_archive() {
-    let manifest = manifest();
-    let windows = manifest
+fn binstall_table<'a>(manifest: &'a Value, override_target: Option<&str>) -> &'a Value {
+    let binstall = manifest
         .get("package")
         .and_then(|p| p.get("metadata"))
         .and_then(|m| m.get("binstall"))
-        .and_then(|b| b.get("overrides"))
-        .and_then(|o| o.get("x86_64-pc-windows-msvc"))
-        .expect(
-            "freenet should override x86_64-pc-windows-msvc binstall metadata \
-             — the release uploads .zip on Windows, not .tar.gz",
-        );
+        .expect("freenet should have a [package.metadata.binstall] block");
 
-    let pkg_fmt = windows.get("pkg-fmt").and_then(|f| f.as_str());
-    assert_eq!(
-        pkg_fmt,
-        Some("zip"),
-        "windows override must set pkg-fmt = \"zip\""
+    match override_target {
+        Some(target) => binstall
+            .get("overrides")
+            .and_then(|o| o.get(target))
+            .unwrap_or_else(|| panic!("freenet binstall should override target {target}")),
+        None => binstall,
+    }
+}
+
+fn pkg_field(manifest: &Value, override_target: Option<&str>, field: &str) -> String {
+    binstall_table(manifest, override_target)
+        .get(field)
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("binstall block (target={override_target:?}) is missing {field}"))
+        .to_string()
+}
+
+#[test]
+fn default_pkg_url_uses_version_template() {
+    // Unlike fdev (whose crate version diverges from the release tag),
+    // freenet's crate version IS the release tag, so the standard
+    // `v{ version }` template resolves correctly. Lock that in so a
+    // well-meaning copy of fdev's literal-tag pattern doesn't accidentally
+    // break freenet.
+    let manifest = manifest();
+    let url = pkg_field(&manifest, None, "pkg-url");
+    assert!(
+        url.contains("v{ version }"),
+        "freenet default pkg-url '{url}' should keep the `v{{ version }}` \
+         template — for freenet, the crate version matches the release tag"
     );
+    assert!(
+        url.ends_with(".tar.gz"),
+        "freenet default pkg-url '{url}' should target the .tar.gz asset"
+    );
+}
 
-    let pkg_url = windows
-        .get("pkg-url")
-        .and_then(|u| u.as_str())
-        .expect("windows override must define pkg-url");
+#[test]
+fn windows_override_uses_zip_archive() {
+    let manifest = manifest();
+    assert_eq!(
+        pkg_field(&manifest, Some("x86_64-pc-windows-msvc"), "pkg-fmt"),
+        "zip",
+        "windows override pkg-fmt"
+    );
+    let pkg_url = pkg_field(&manifest, Some("x86_64-pc-windows-msvc"), "pkg-url");
     assert!(
         pkg_url.ends_with(".zip"),
-        "windows pkg-url '{pkg_url}' must end with .zip"
+        "windows pkg-url '{pkg_url}' must end with .zip — release \
+         workflow uploads `freenet-x86_64-pc-windows-msvc.zip`, not .tar.gz"
+    );
+}
+
+#[test]
+fn bin_dir_uses_correct_executable_name() {
+    let manifest = manifest();
+    assert_eq!(
+        pkg_field(&manifest, None, "bin-dir"),
+        "freenet",
+        "default bin-dir must match the unix binary name"
+    );
+    assert_eq!(
+        pkg_field(&manifest, Some("x86_64-pc-windows-msvc"), "bin-dir"),
+        "freenet.exe",
+        "windows bin-dir must include the .exe suffix — without it, \
+         binstall extracts the archive but cannot locate the binary"
     );
 }

--- a/crates/core/tests/binstall_metadata.rs
+++ b/crates/core/tests/binstall_metadata.rs
@@ -1,0 +1,43 @@
+//! Regression test for issue #3995: the freenet crate's binstall metadata
+//! lacked a Windows override, so `cargo binstall freenet` 404'd on
+//! `x86_64-pc-windows-msvc` (the release uploads `freenet-…-msvc.zip`, not
+//! `.tar.gz`).
+
+use toml::Value;
+
+const CARGO_TOML: &str = include_str!("../Cargo.toml");
+
+fn manifest() -> Value {
+    toml::from_str(CARGO_TOML).expect("freenet Cargo.toml should be valid TOML")
+}
+
+#[test]
+fn windows_override_uses_zip_archive() {
+    let manifest = manifest();
+    let windows = manifest
+        .get("package")
+        .and_then(|p| p.get("metadata"))
+        .and_then(|m| m.get("binstall"))
+        .and_then(|b| b.get("overrides"))
+        .and_then(|o| o.get("x86_64-pc-windows-msvc"))
+        .expect(
+            "freenet should override x86_64-pc-windows-msvc binstall metadata \
+             — the release uploads .zip on Windows, not .tar.gz",
+        );
+
+    let pkg_fmt = windows.get("pkg-fmt").and_then(|f| f.as_str());
+    assert_eq!(
+        pkg_fmt,
+        Some("zip"),
+        "windows override must set pkg-fmt = \"zip\""
+    );
+
+    let pkg_url = windows
+        .get("pkg-url")
+        .and_then(|u| u.as_str())
+        .expect("windows override must define pkg-url");
+    assert!(
+        pkg_url.ends_with(".zip"),
+        "windows pkg-url '{pkg_url}' must end with .zip"
+    );
+}

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -10,9 +10,18 @@ repository = "https://github.com/freenet/freenet-core"
 readme = "README.md"
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/v{ version }/fdev-{ target }.tar.gz"
+# fdev's crate version (0.3.x) is independent of the freenet-core release tag
+# (v0.2.x), so we embed the matching freenet version literally — `v{ version }`
+# would expand to the fdev crate version and 404. release.yml rewrites the
+# `vX.Y.Z` segment whenever the freenet version is bumped (issue #3995).
+pkg-url = "{ repo }/releases/download/v0.2.51/fdev-{ target }.tar.gz"
 pkg-fmt = "tgz"
 bin-dir = "fdev"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v0.2.51/fdev-{ target }.zip"
+pkg-fmt = "zip"
+bin-dir = "fdev.exe"
 
 [dependencies]
 bytesize = "2.3"

--- a/crates/fdev/tests/binstall_metadata.rs
+++ b/crates/fdev/tests/binstall_metadata.rs
@@ -23,26 +23,32 @@ fn freenet_dep_version(manifest: &Value) -> String {
         .expect("fdev should declare a freenet dependency with a version")
 }
 
-fn pkg_url(manifest: &Value, override_target: Option<&str>) -> String {
+fn binstall_table<'a>(manifest: &'a Value, override_target: Option<&str>) -> &'a Value {
     let binstall = manifest
         .get("package")
         .and_then(|p| p.get("metadata"))
         .and_then(|m| m.get("binstall"))
         .expect("fdev should have a [package.metadata.binstall] block");
 
-    let table = match override_target {
+    match override_target {
         Some(target) => binstall
             .get("overrides")
             .and_then(|o| o.get(target))
             .unwrap_or_else(|| panic!("fdev binstall should override target {target}")),
         None => binstall,
-    };
+    }
+}
 
-    table
-        .get("pkg-url")
-        .and_then(|u| u.as_str())
-        .unwrap_or_else(|| panic!("binstall block (target={override_target:?}) is missing pkg-url"))
+fn pkg_field(manifest: &Value, override_target: Option<&str>, field: &str) -> String {
+    binstall_table(manifest, override_target)
+        .get(field)
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("binstall block (target={override_target:?}) is missing {field}"))
         .to_string()
+}
+
+fn pkg_url(manifest: &Value, override_target: Option<&str>) -> String {
+    pkg_field(manifest, override_target, "pkg-url")
 }
 
 #[test]
@@ -78,17 +84,9 @@ fn windows_override_uses_zip_archive() {
          workflow uploads `fdev-x86_64-pc-windows-msvc.zip`, not .tar.gz"
     );
 
-    let pkg_fmt = manifest
-        .get("package")
-        .and_then(|p| p.get("metadata"))
-        .and_then(|m| m.get("binstall"))
-        .and_then(|b| b.get("overrides"))
-        .and_then(|o| o.get("x86_64-pc-windows-msvc"))
-        .and_then(|w| w.get("pkg-fmt"))
-        .and_then(|f| f.as_str());
+    let pkg_fmt = pkg_field(&manifest, Some("x86_64-pc-windows-msvc"), "pkg-fmt");
     assert_eq!(
-        pkg_fmt,
-        Some("zip"),
+        pkg_fmt, "zip",
         "windows override must set pkg-fmt = \"zip\""
     );
 }
@@ -109,5 +107,139 @@ fn pkg_url_does_not_use_crate_version_template() {
              template — that expands to fdev's crate version (issue #3995). \
              Embed the freenet release tag literally instead."
         );
+    }
+}
+
+#[test]
+fn bin_dir_uses_correct_executable_name() {
+    let manifest = manifest();
+    assert_eq!(
+        pkg_field(&manifest, None, "bin-dir"),
+        "fdev",
+        "default bin-dir must match the unix binary name"
+    );
+    assert_eq!(
+        pkg_field(&manifest, Some("x86_64-pc-windows-msvc"), "bin-dir"),
+        "fdev.exe",
+        "windows bin-dir must include the .exe suffix — without it, \
+         binstall extracts the archive but cannot locate the binary"
+    );
+}
+
+#[test]
+fn freenet_dep_matches_workspace_freenet_version() {
+    // fdev's pkg-url embeds the freenet release tag literally, and the
+    // `pkg_url_embeds_freenet_release_tag` test asserts the URL stays in
+    // sync with fdev's `freenet` dependency declaration. This test closes
+    // the remaining gap: a hand-edit that bumps the workspace freenet
+    // crate version without bumping fdev's dependency would leave both
+    // fdev manifest and pkg-url consistently stale-but-self-consistent
+    // (issue #3995, skeptical-review finding #3).
+    let manifest = manifest();
+    let dep_version = freenet_dep_version(&manifest);
+
+    let core_manifest_str = std::fs::read_to_string("../core/Cargo.toml")
+        .expect("workspace freenet crate manifest should be readable");
+    let core_manifest: Value =
+        toml::from_str(&core_manifest_str).expect("core Cargo.toml should be valid TOML");
+    let core_version = core_manifest
+        .get("package")
+        .and_then(|p| p.get("version"))
+        .and_then(|v| v.as_str())
+        .expect("freenet crate should declare a version")
+        .to_string();
+
+    assert_eq!(
+        dep_version, core_version,
+        "fdev's freenet dep version ('{dep_version}') must match the \
+         workspace freenet crate version ('{core_version}'). The release \
+         scripts bump both together; if they drift, the embedded binstall \
+         tag will point at a release that doesn't contain this fdev build."
+    );
+}
+
+/// Sed expressions duplicated in `scripts/release.sh` (BRE) and
+/// `.github/workflows/release.yml` (ERE). The tests below verify both
+/// produce the same output and that they correctly rewrite both the
+/// default and Windows-override pkg-url lines.
+mod release_sed_rewrite {
+    use std::process::{Command, Stdio};
+
+    const BRE_SCRIPT: &str = "s|releases/download/v[0-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*/fdev-|releases/download/vNEW/fdev-|g";
+    const ERE_SCRIPT: &str =
+        "s|releases/download/v[0-9]+\\.[0-9]+\\.[0-9]+/fdev-|releases/download/vNEW/fdev-|g";
+
+    fn run_sed(args: &[&str], input: &str) -> String {
+        let mut child = Command::new("sed")
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("sed should be on PATH");
+        use std::io::Write;
+        child
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(input.as_bytes())
+            .unwrap();
+        let output = child.wait_with_output().expect("sed should run");
+        assert!(
+            output.status.success(),
+            "sed exited non-zero: {}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+        String::from_utf8(output.stdout).expect("sed output must be UTF-8")
+    }
+
+    const FIXTURE: &str = "\
+[package.metadata.binstall]
+pkg-url = \"{ repo }/releases/download/v0.2.51/fdev-{ target }.tar.gz\"
+pkg-fmt = \"tgz\"
+bin-dir = \"fdev\"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = \"{ repo }/releases/download/v0.2.51/fdev-{ target }.zip\"
+pkg-fmt = \"zip\"
+bin-dir = \"fdev.exe\"
+";
+
+    fn expected_after(version_segment: &str) -> String {
+        FIXTURE.replace("v0.2.51", version_segment)
+    }
+
+    #[test]
+    fn release_sh_bre_rewrites_both_urls() {
+        let out = run_sed(&[BRE_SCRIPT], FIXTURE);
+        assert_eq!(out, expected_after("vNEW"));
+    }
+
+    #[test]
+    fn release_yml_ere_rewrites_both_urls() {
+        let out = run_sed(&["-E", ERE_SCRIPT], FIXTURE);
+        assert_eq!(out, expected_after("vNEW"));
+    }
+
+    #[test]
+    fn release_sh_and_release_yml_produce_identical_output() {
+        let bre_out = run_sed(&[BRE_SCRIPT], FIXTURE);
+        let ere_out = run_sed(&["-E", ERE_SCRIPT], FIXTURE);
+        assert_eq!(
+            bre_out, ere_out,
+            "scripts/release.sh and .github/workflows/release.yml must \
+             produce identical rewrites — they're two copies of the same \
+             logic and silently diverging would re-break issue #3995"
+        );
+    }
+
+    #[test]
+    fn rewrite_is_idempotent_when_version_unchanged() {
+        // After release.sh runs once, re-running it with the same VERSION
+        // must be a no-op (the regex still matches, but the substitution
+        // produces the same text).
+        let after_first = run_sed(&[BRE_SCRIPT], FIXTURE);
+        let after_second = run_sed(&[BRE_SCRIPT], &after_first);
+        assert_eq!(after_first, after_second, "BRE rewrite must be idempotent");
     }
 }

--- a/crates/fdev/tests/binstall_metadata.rs
+++ b/crates/fdev/tests/binstall_metadata.rs
@@ -1,0 +1,113 @@
+//! Regression test for issue #3995: `cargo binstall fdev` 404'd because the
+//! pkg-url template expanded `v{ version }` against fdev's own crate version
+//! (e.g. `0.3.214`) but the GitHub release tag tracks freenet's version
+//! (e.g. `v0.2.51`). The fix embeds the freenet release tag literally and has
+//! release.sh / release.yml rewrite it on every bump — this test verifies the
+//! invariant that the embedded tag matches the freenet dependency version.
+
+use toml::Value;
+
+const CARGO_TOML: &str = include_str!("../Cargo.toml");
+
+fn manifest() -> Value {
+    toml::from_str(CARGO_TOML).expect("fdev Cargo.toml should be valid TOML")
+}
+
+fn freenet_dep_version(manifest: &Value) -> String {
+    manifest
+        .get("dependencies")
+        .and_then(|d| d.get("freenet"))
+        .and_then(|f| f.get("version"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim_start_matches('=').to_string())
+        .expect("fdev should declare a freenet dependency with a version")
+}
+
+fn pkg_url(manifest: &Value, override_target: Option<&str>) -> String {
+    let binstall = manifest
+        .get("package")
+        .and_then(|p| p.get("metadata"))
+        .and_then(|m| m.get("binstall"))
+        .expect("fdev should have a [package.metadata.binstall] block");
+
+    let table = match override_target {
+        Some(target) => binstall
+            .get("overrides")
+            .and_then(|o| o.get(target))
+            .unwrap_or_else(|| panic!("fdev binstall should override target {target}")),
+        None => binstall,
+    };
+
+    table
+        .get("pkg-url")
+        .and_then(|u| u.as_str())
+        .unwrap_or_else(|| panic!("binstall block (target={override_target:?}) is missing pkg-url"))
+        .to_string()
+}
+
+#[test]
+fn pkg_url_embeds_freenet_release_tag() {
+    let manifest = manifest();
+    let freenet_version = freenet_dep_version(&manifest);
+    let expected_tag = format!("/releases/download/v{freenet_version}/");
+
+    let default_url = pkg_url(&manifest, None);
+    assert!(
+        default_url.contains(&expected_tag),
+        "default binstall pkg-url '{default_url}' must embed the freenet \
+         release tag '{expected_tag}'. fdev's crate version diverges from \
+         the GitHub release tag (issue #3995); release.sh / release.yml \
+         must rewrite this when the freenet version is bumped."
+    );
+
+    let windows_url = pkg_url(&manifest, Some("x86_64-pc-windows-msvc"));
+    assert!(
+        windows_url.contains(&expected_tag),
+        "windows binstall pkg-url '{windows_url}' must embed the freenet \
+         release tag '{expected_tag}'"
+    );
+}
+
+#[test]
+fn windows_override_uses_zip_archive() {
+    let manifest = manifest();
+    let windows_url = pkg_url(&manifest, Some("x86_64-pc-windows-msvc"));
+    assert!(
+        windows_url.ends_with(".zip"),
+        "windows pkg-url '{windows_url}' must end with .zip — release \
+         workflow uploads `fdev-x86_64-pc-windows-msvc.zip`, not .tar.gz"
+    );
+
+    let pkg_fmt = manifest
+        .get("package")
+        .and_then(|p| p.get("metadata"))
+        .and_then(|m| m.get("binstall"))
+        .and_then(|b| b.get("overrides"))
+        .and_then(|o| o.get("x86_64-pc-windows-msvc"))
+        .and_then(|w| w.get("pkg-fmt"))
+        .and_then(|f| f.as_str());
+    assert_eq!(
+        pkg_fmt,
+        Some("zip"),
+        "windows override must set pkg-fmt = \"zip\""
+    );
+}
+
+#[test]
+fn pkg_url_does_not_use_crate_version_template() {
+    // `v{ version }` would expand to fdev's crate version (e.g. 0.3.214) and
+    // 404 against the actual freenet-versioned release tag. Guard against
+    // anyone "simplifying" back to the broken form.
+    let manifest = manifest();
+    let default_url = pkg_url(&manifest, None);
+    let windows_url = pkg_url(&manifest, Some("x86_64-pc-windows-msvc"));
+
+    for (label, url) in [("default", &default_url), ("windows", &windows_url)] {
+        assert!(
+            !url.contains("v{ version }") && !url.contains("v{version}"),
+            "{label} pkg-url '{url}' must not use the `v{{ version }}` \
+             template — that expands to fdev's crate version (issue #3995). \
+             Embed the freenet release tag literally instead."
+        );
+    }
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -647,7 +647,11 @@ update_versions() {
     # binstall pkg-url embeds `vX.Y.Z` (the freenet version) literally rather
     # than `v{ version }`. Re-point it to the current release each bump so
     # that `cargo binstall fdev` resolves to the actual GitHub release assets
-    # (issue #3995).
+    # (issue #3995). The `/g` flag is load-bearing — there are two pkg-url
+    # lines (default + Windows override) that both need the rewrite. Mirror
+    # in `.github/workflows/release.yml`; tests in
+    # `crates/fdev/tests/binstall_metadata.rs::release_sed_rewrite` keep both
+    # copies of the regex in lockstep.
     sed_inplace "s|releases/download/v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/fdev-|releases/download/v${VERSION}/fdev-|g" "$PROJECT_ROOT/crates/fdev/Cargo.toml"
     echo "✓"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -643,6 +643,12 @@ update_versions() {
     echo -n "  Updating fdev to $FDEV_VERSION... "
     sed_inplace "s/^version = \".*\"/version = \"$FDEV_VERSION\"/" "$PROJECT_ROOT/crates/fdev/Cargo.toml"
     sed_inplace "s/\(freenet = { path = \"..\/core\", version = \)\"[^\"]*\"/\1\"$VERSION\"/" "$PROJECT_ROOT/crates/fdev/Cargo.toml"
+    # fdev's crate version is independent of the freenet release tag, so the
+    # binstall pkg-url embeds `vX.Y.Z` (the freenet version) literally rather
+    # than `v{ version }`. Re-point it to the current release each bump so
+    # that `cargo binstall fdev` resolves to the actual GitHub release assets
+    # (issue #3995).
+    sed_inplace "s|releases/download/v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/fdev-|releases/download/v${VERSION}/fdev-|g" "$PROJECT_ROOT/crates/fdev/Cargo.toml"
     echo "✓"
 
     # Update Cargo.lock to match new versions


### PR DESCRIPTION
## Problem

\`cargo binstall fdev\` and \`cargo binstall freenet\` both fall through to a 10-15 minute source build because the published metadata points at release assets that do not exist:

1. **fdev**: \`pkg-url\` template \`v{ version }\` expands to fdev's crate version (e.g. \`v0.3.214\`), but the GitHub release tag tracks the freenet version (\`v0.2.51\`). The two namespaces diverged and the URL has 404'd ever since:
   ```
   $ curl -sIL .../releases/download/v0.3.214/fdev-x86_64-unknown-linux-musl.tar.gz | head -1
   HTTP/2 404
   $ curl -sIL .../releases/download/v0.2.51/fdev-x86_64-unknown-linux-musl.tar.gz | head -1
   HTTP/2 302
   ```
2. **Both crates**: no Windows override. The release uploads \`*-x86_64-pc-windows-msvc.zip\`, not \`.tar.gz\`, so binstall would 404 on Windows even after fixing the tag.

Downstream impact (per the issue): \`freenet/mail\` CI hit this and worked around it by hard-coding the GitHub release URL pattern, which is fragile.

## Approach

- **\`crates/fdev/Cargo.toml\`**: embed the matching freenet release tag literally (\`v0.2.51\`) in \`pkg-url\` instead of \`v{ version }\`. Add a Windows override pointing at the \`.zip\` asset.
- **\`crates/core/Cargo.toml\`**: keep \`v{ version }\` (it correctly matches the release tag for freenet) but add the missing Windows \`.zip\` override.
- **\`scripts/release.sh\` + \`.github/workflows/release.yml\`**: when bumping the freenet version, rewrite the embedded \`vX.Y.Z\` segment in fdev's \`pkg-url\` so successive releases stay in sync. The sed is idempotent and safely covers both the default and Windows-override URLs.

Considered alternatives (separate \`fdev-v0.3.X\` release tags, or collapsing the two version namespaces) but both are larger workflow changes for the same effective outcome — this fix keeps the existing release process intact and just plugs the metadata into it.

## Testing

Two new regression tests, both of which would have caught the original bug:

- **\`crates/fdev/tests/binstall_metadata.rs\`** (3 tests):
  - \`pkg_url_embeds_freenet_release_tag\`: parses fdev's Cargo.toml, asserts the binstall \`pkg-url\` (default + Windows override) embeds the same \`vX.Y.Z\` that fdev's freenet dependency declares.
  - \`windows_override_uses_zip_archive\`: asserts the Windows override sets \`pkg-fmt = "zip"\` and a \`.zip\` URL.
  - \`pkg_url_does_not_use_crate_version_template\`: explicit guard against anyone "simplifying" back to \`v{ version }\`.
- **\`crates/core/tests/binstall_metadata.rs\`**: asserts the freenet manifest's Windows override exists with \`pkg-fmt = "zip"\`.

Both test files passed locally. Also manually verified the release.sh / release.yml sed expressions: substitutes both default and Windows-override URLs to a new version, no-op when the version already matches.

**Note**: fix is forward-only. The already-published \`fdev 0.3.214\` and \`freenet 0.2.51\` cannot be retroactively fixed on crates.io; the next release picks up the corrected metadata.

## Fixes

Closes #3995

[AI-assisted - Claude]