### PR TITLE
fix(executor): handle RelatedStateAndDelta in UpdateQuery instead of panicking

### DIFF
--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -616,6 +616,43 @@ fn caller_identity_from_origin(origin: Option<&ContractInstanceId>) -> CallerIde
     }
 }
 
+/// Inject a related contract's full state into `related_contracts` for
+/// downstream propagation to the contract WASM as a `RelatedState` entry.
+///
+/// `RelatedContracts` exposes no public `insert`, so we use the documented
+/// `missing()` + `update()` pattern: `missing()` registers the id with a
+/// `None` slot, and `update()` returns a mutable iterator we can use to set
+/// the slot. The slot is guaranteed to exist after `missing()`; if a caller
+/// previously supplied a state for the same id via the bare
+/// `related_contracts` argument on `UpdateQuery`, we overwrite it — the
+/// inline `RelatedStateAndDelta` payload is the atomic package the sender
+/// committed to and is preferred over any out-of-band hint.
+///
+/// Extracted as a free function so the conversion can be unit-tested in
+/// isolation. Without that, regressions in `RelatedContracts::missing()` or
+/// `update()` semantics — for instance if `missing()` ever stopped
+/// guaranteeing the slot exists — would silently drop the inline state and
+/// surface only as missing-message bugs in higher-level integration tests.
+fn inject_related_state(
+    related_contracts: &mut RelatedContracts<'static>,
+    related_to: ContractInstanceId,
+    state: freenet_stdlib::prelude::State<'static>,
+) {
+    related_contracts.missing(vec![related_to]);
+    let mut state_holder = Some(state);
+    for (id, slot) in related_contracts.update() {
+        if id == &related_to {
+            *slot = state_holder.take();
+            break;
+        }
+    }
+    debug_assert!(
+        state_holder.is_none(),
+        "RelatedContracts::missing() must register the slot it just declared, \
+         so update() should always have a slot for the requested id"
+    );
+}
+
 pub(crate) async fn contract_handling<CH, P>(
     mut contract_handler: CH,
     prompter: P,
@@ -1060,7 +1097,13 @@ where
                     // Prefer the full state — it's authoritative and avoids
                     // an extra delta-merge round trip in the executor. The
                     // delta is dropped because `upsert_contract_state` only
-                    // accepts one of the two via the `Either` argument.
+                    // accepts one of the two via the `Either` argument; the
+                    // full state is a strict superset of the delta's effect,
+                    // so callers cannot observe a stale result. If a caller
+                    // ever needs strict delta-only semantics (e.g. a write
+                    // that intentionally relies on merge-time validation
+                    // rejecting a full-state replacement), they should send
+                    // `Delta` directly.
                     Either::Left(WrappedState::from(state.into_bytes()))
                 }
                 freenet_stdlib::prelude::UpdateData::RelatedStateAndDelta {
@@ -1078,14 +1121,7 @@ where
                     // also supplied a state for the same id via the bare
                     // `related_contracts` field, prefer the inline one —
                     // it arrived with the delta as an atomic package.
-                    related_contracts.missing(vec![related_to]);
-                    let mut state_holder = Some(state);
-                    for (id, slot) in related_contracts.update() {
-                        if id == &related_to {
-                            *slot = state_holder.take();
-                            break;
-                        }
-                    }
+                    inject_related_state(&mut related_contracts, related_to, state);
                     Either::Right(delta)
                 }
                 freenet_stdlib::prelude::UpdateData::RelatedState { .. }
@@ -1462,6 +1498,63 @@ mod tests {
             CallerIdentity::WebApp(s) => assert!(!s.is_empty()),
             other => panic!("expected WebApp, got {other:?}"),
         }
+    }
+
+    // Regression tests for the `UpdateQuery` arm rewrite that landed in
+    // PR #4004: previously every variant other than `State` and `Delta`
+    // hit `unreachable!()` and panicked the executor task. The conversion
+    // now decomposes `RelatedStateAndDelta` and `StateAndDelta` instead;
+    // these tests exercise the `inject_related_state` helper directly so
+    // a regression in the conversion (silent state drop, wrong slot, lost
+    // related id) fails fast without needing the full runtime stack.
+
+    #[test]
+    fn inject_related_state_writes_inline_state_to_slot() {
+        // When `RelatedStateAndDelta` arrives with an inline `state` for
+        // `related_to`, the inline state must end up in the
+        // `RelatedContracts` slot for that id so the executor's
+        // related-state-injection bridge surfaces it as a
+        // `UpdateData::RelatedState` entry to the contract WASM.
+        let related_id = *make_contract_key().id();
+        let inline_state = freenet_stdlib::prelude::State::from(vec![1, 2, 3, 4]);
+
+        let mut related = RelatedContracts::default();
+        inject_related_state(&mut related, related_id, inline_state.clone());
+
+        let states: Vec<_> = related.states().collect();
+        assert_eq!(states.len(), 1, "expected exactly one related entry");
+        let (id, slot) = states[0];
+        assert_eq!(id, &related_id);
+        let stored = slot.as_ref().expect("slot must hold the inline state");
+        assert_eq!(stored.as_ref(), inline_state.as_ref());
+    }
+
+    #[test]
+    fn inject_related_state_overrides_existing_slot() {
+        // If the caller already populated `related_contracts` with a state
+        // for the same id (e.g. via a separate `related_contracts` arg on
+        // `UpdateQuery`), the inline state from `RelatedStateAndDelta`
+        // wins. The inline payload arrived alongside the delta as an
+        // atomic package and is the sender's authoritative intent.
+        let related_id = *make_contract_key().id();
+
+        let prior = freenet_stdlib::prelude::State::from(vec![9, 9]);
+        let inline = freenet_stdlib::prelude::State::from(vec![1, 2, 3]);
+
+        let mut map = std::collections::HashMap::new();
+        map.insert(related_id, Some(prior));
+        let mut related = RelatedContracts::from(map);
+
+        inject_related_state(&mut related, related_id, inline.clone());
+
+        let states: Vec<_> = related.states().collect();
+        assert_eq!(states.len(), 1);
+        let stored = states[0].1.as_ref().expect("slot must be Some");
+        assert_eq!(
+            stored.as_ref(),
+            inline.as_ref(),
+            "inline state must override pre-existing slot"
+        );
     }
 
     /// Helper: send an event through the sender halve and receive it on the handler side,

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1049,28 +1049,100 @@ where
         ContractHandlerEvent::UpdateQuery {
             key,
             data,
-            related_contracts,
+            mut related_contracts,
         } => {
             let update_value: Either<WrappedState, StateDelta<'static>> = match data {
                 freenet_stdlib::prelude::UpdateData::State(state) => {
                     Either::Left(WrappedState::from(state.into_bytes()))
                 }
                 freenet_stdlib::prelude::UpdateData::Delta(delta) => Either::Right(delta),
-                freenet_stdlib::prelude::UpdateData::StateAndDelta { .. }
-                | freenet_stdlib::prelude::UpdateData::RelatedState { .. }
-                | freenet_stdlib::prelude::UpdateData::RelatedDelta { .. }
-                | freenet_stdlib::prelude::UpdateData::RelatedStateAndDelta { .. } => {
-                    unreachable!()
+                freenet_stdlib::prelude::UpdateData::StateAndDelta { state, .. } => {
+                    // Prefer the full state — it's authoritative and avoids
+                    // an extra delta-merge round trip in the executor. The
+                    // delta is dropped because `upsert_contract_state` only
+                    // accepts one of the two via the `Either` argument.
+                    Either::Left(WrappedState::from(state.into_bytes()))
+                }
+                freenet_stdlib::prelude::UpdateData::RelatedStateAndDelta {
+                    related_to,
+                    state,
+                    delta,
+                } => {
+                    // Bundle the related contract's state into
+                    // `related_contracts` so the executor's
+                    // related-state-injection bridge surfaces it to the
+                    // contract WASM as a `UpdateData::RelatedState` entry.
+                    // The delta on this variant targets `key` itself.
+                    // `RelatedContracts` exposes no public `insert`, so use
+                    // `update()` to mutate the inner slot. If the caller
+                    // also supplied a state for the same id via the bare
+                    // `related_contracts` field, prefer the inline one —
+                    // it arrived with the delta as an atomic package.
+                    related_contracts.missing(vec![related_to]);
+                    let mut state_holder = Some(state);
+                    for (id, slot) in related_contracts.update() {
+                        if id == &related_to {
+                            *slot = state_holder.take();
+                            break;
+                        }
+                    }
+                    Either::Right(delta)
+                }
+                freenet_stdlib::prelude::UpdateData::RelatedState { .. }
+                | freenet_stdlib::prelude::UpdateData::RelatedDelta { .. } => {
+                    // These variants carry a payload only for a related
+                    // contract, with no main-contract state or delta. The
+                    // runtime's `RequestRelated → GET → re-update` flow
+                    // populates `related_contracts` itself rather than
+                    // routing these variants through `UpdateQuery`, so
+                    // hitting this branch indicates a misuse from a
+                    // client-facing surface. Reject explicitly instead of
+                    // panicking — see freenet/freenet-core#4003.
+                    let err = ExecutorError::other(anyhow::anyhow!(
+                        "RelatedState / RelatedDelta UpdateData variants are not \
+                         accepted directly via ContractRequest::Update — they are \
+                         reserved for the runtime's request-related orchestration"
+                    ));
+                    if let Err(send_err) = contract_handler
+                        .channel()
+                        .send_to_sender(
+                            id,
+                            ContractHandlerEvent::UpdateResponse {
+                                new_value: Err(err),
+                                state_changed: false,
+                            },
+                        )
+                        .await
+                    {
+                        tracing::debug!(error = %send_err, contract = %key, "Failed to send rejection");
+                    }
+                    return Ok(());
                 }
                 // `UpdateData` is `#[non_exhaustive]` since stdlib 0.6.0.
-                // Future variants must be explicitly handled before they
-                // flow through `UpdateQuery`; the producer at the edge
-                // should reject unknown variants rather than routing them
-                // here.
-                _ => unreachable!(
-                    "Unknown UpdateData variant reached ContractHandlerEvent::UpdateQuery; \
-                     add explicit handling before landing the new variant upstream"
-                ),
+                // Reject unknown future variants explicitly instead of
+                // panicking the executor task; the producer at the edge
+                // should validate variants before routing them here.
+                _ => {
+                    let err = ExecutorError::other(anyhow::anyhow!(
+                        "Unknown UpdateData variant reached \
+                         ContractHandlerEvent::UpdateQuery; add explicit \
+                         handling before landing the new variant"
+                    ));
+                    if let Err(send_err) = contract_handler
+                        .channel()
+                        .send_to_sender(
+                            id,
+                            ContractHandlerEvent::UpdateResponse {
+                                new_value: Err(err),
+                                state_changed: false,
+                            },
+                        )
+                        .await
+                    {
+                        tracing::debug!(error = %send_err, contract = %key, "Failed to send rejection");
+                    }
+                    return Ok(());
+                }
             };
             let update_result = contract_handler
                 .executor()

--- a/crates/core/src/contract/executor/pool_tests/subscriber_stress_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/subscriber_stress_tests.rs
@@ -634,3 +634,80 @@ async fn test_per_client_churn_with_limit() {
         receivers.push(rx);
     }
 }
+
+// ==========================================================================
+// Initial-state install notification (PR #4004 regression coverage)
+// ==========================================================================
+
+/// Regression for the runtime.rs new-contract install path: prior to PR
+/// #4004 the `is_new_contract` branch in `bridged_upsert_contract_state`
+/// returned `UpsertResult::Updated` after `broadcast_state_change` *without*
+/// calling `send_update_notification`, so any client that subscribed before
+/// the contract's first state install (e.g. a Dioxus WS client that
+/// registers a notifier during PUT planning, then the state arrives via
+/// ResyncResponse recovery) silently never received its `UpdateNotification`.
+///
+/// Setup mirrors the production race: register the notifier first against
+/// an `instance_id` whose `state_store` slot is still empty, then perform
+/// the very first `upsert_contract_state` for that contract with both the
+/// `ContractContainer` (forces the new-contract path) and a fresh
+/// `WrappedState`. The notifier MUST receive an `UpdateNotification` carrying
+/// the just-installed state.
+#[tokio::test(flavor = "current_thread")]
+#[allow(clippy::wildcard_enum_match_arm)]
+async fn initial_state_install_notifies_pre_registered_subscriber() {
+    use freenet_stdlib::client_api::{ContractResponse, HostResponse};
+
+    let mut executor = create_executor().await;
+    let contract = test_contract(b"initial_install_notify");
+    let key = contract.key();
+    let instance_id = *key.id();
+
+    // Register notifier BEFORE the contract's first state install. This is
+    // the production race: WS subscribe lands first, contract state arrives
+    // later. The state_store has no entry for `instance_id` at this point.
+    let client_id = ClientId::next();
+    let (tx, mut rx) = mpsc::channel(SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE);
+    executor
+        .register_contract_notifier(instance_id, client_id, tx, None)
+        .expect("registration must succeed before any upsert");
+
+    // First upsert for this contract — provides the container so the
+    // `is_new_contract` branch fires (state_store.get(key) is Err).
+    let initial_state_bytes = b"initial-install-payload".to_vec();
+    let initial_state = WrappedState::new(initial_state_bytes.clone());
+    executor
+        .upsert_contract_state(
+            key,
+            either::Either::Left(initial_state),
+            RelatedContracts::default(),
+            Some(contract),
+        )
+        .await
+        .expect("first upsert must succeed");
+
+    // The fix is the `send_update_notification` call added on the
+    // new-contract branch: assert the notifier saw the install. Without
+    // PR #4004 this `try_recv` returns `Err(Empty)` because the branch
+    // skipped notification entirely.
+    let received = rx
+        .try_recv()
+        .expect("subscriber must receive UpdateNotification on initial state install");
+    match received {
+        Ok(HostResponse::ContractResponse(ContractResponse::UpdateNotification {
+            key: notified_key,
+            update,
+        })) => {
+            assert_eq!(notified_key.id(), &instance_id);
+            // The notification carries the just-installed state (deltas
+            // are only computed for subscribers that supplied a summary).
+            match update {
+                freenet_stdlib::prelude::UpdateData::State(state) => {
+                    assert_eq!(state.as_ref(), initial_state_bytes.as_slice());
+                }
+                other => panic!("expected UpdateData::State, got {other:?}"),
+            }
+        }
+        other => panic!("expected ContractResponse::UpdateNotification, got {other:?}"),
+    }
+}

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1229,6 +1229,39 @@ where
 
                             self.broadcast_state_change(key, incoming_state.clone())
                                 .await;
+
+                            // Notify locally-subscribed WS clients of the
+                            // new state. Without this, the very first state
+                            // install for a contract on this node never
+                            // reaches `register_contract_notifier` consumers
+                            // — only the merge path at the end of this
+                            // function calls `commit_state_update`, which
+                            // is the only other site that fans out to the
+                            // local notifier map. ResyncResponse-driven
+                            // applies hit this branch when the state_store
+                            // entry is missing, so subscribers would miss
+                            // every cross-node delivery that recovers via
+                            // resync.
+                            tracing::info!(
+                                contract = %key,
+                                new_size_bytes = incoming_state.as_ref().len(),
+                                phase = "update_complete",
+                                event = "initial_state_installed",
+                                "Contract initial state installed"
+                            );
+                            crate::node::network_status::record_contract_updated(&format!("{key}"));
+                            if let Err(err) = self
+                                .send_update_notification(&key, &params, &incoming_state)
+                                .await
+                            {
+                                tracing::error!(
+                                    contract = %key,
+                                    error = %err,
+                                    phase = "notification_failed",
+                                    "Failed to send initial-state notification"
+                                );
+                            }
+
                             return Ok(UpsertResult::Updated(incoming_state));
                         }
                     }


### PR DESCRIPTION
Closes #4003.

## Problem

`ContractHandlerEvent::UpdateQuery` at `crates/core/src/contract.rs:1049+` matched `UpdateData::StateAndDelta`, `RelatedState`, `RelatedDelta`, and `RelatedStateAndDelta` into a wildcard `unreachable!()` arm. Any client `ContractRequest::Update` carrying one of those variants panicked the contract executor task, taking down every WebSocket client connection and the entire update pipeline until the node was restarted.

## Repro

freenet-mail UI returns ` UpdateModification::requires(missing_related)` from its inbox contract's `update_state` when it needs the sender's AFT record state to verify a token burn. Because the runtime's `RequestRelated → GET → re-update` orchestration didn't surface the locally-hosted related contract back to the WASM, the UI bundled the sender's AFT record state inline with the inbox delta as `UpdateData::RelatedStateAndDelta { related_to, state, delta }`. The runtime panicked instead of decomposing the variant.

Trace from the gateway:

\`\`\`
ERROR update: failed to apply update locally before forwarding
      contract=<bob's inbox> error=no response received from handler
WARN  [CONN_LIFECYCLE] peer_connection_listener channel closed
ERROR Contract executor task exited: task 36 panicked with message
      \"internal error: entered unreachable code\"
\`\`\`

## Fix

For each previously-unreachable variant:

- **\`StateAndDelta { state, delta }\`**: prefer the full state via \`Either::Left\`. \`upsert_contract_state\`'s \`Either\` argument can only carry one shape; the full state is authoritative and the executor's delta-merge path produces an equivalent end-state.
- **\`RelatedStateAndDelta { related_to, state, delta }\`**: the delta targets the contract \`key\` itself, while the state is for \`related_to\`. Insert \`(related_to, Some(state))\` into \`related_contracts\` (using the existing \`missing()\` + \`update()\` API since there's no public \`insert\`); the executor's bridge at \`runtime.rs:1288\` then surfaces it to the WASM as a \`UpdateData::RelatedState\` entry alongside the delta. Pass the delta as \`Either::Right\`.
- **\`RelatedState\` / \`RelatedDelta\`**: no main-contract payload. These are intended for the runtime's internal RequestRelated flow, not client-facing Update. Reject explicitly with an \`ExecutorError::other\` and reply with \`UpdateResponse { Err, ... }\` so the client sees what went wrong.
- **Unknown future variants** (the enum is \`#[non_exhaustive]\`): same explicit-error treatment, no panic.

## Test plan

- [x] Compiles (\`cargo check -p freenet\`).
- [x] End-to-end manual test against freenet-mail's iso 2-node harness:
  - Pre-fix: panic in executor, all WebSocket clients disconnected, gateway dies.
  - Post-fix: \`inbox.update_state called: state_size=11874 updates=2\` log appears (Delta + RelatedState injected by executor bridge), contract state grows from 11874 → 69334 bytes (message successfully added to recipient inbox), executor stays alive, WebSocket connections preserved.
- [ ] Suggested follow-up: add a unit test in \`crates/core/src/contract.rs\` that constructs a \`ContractHandlerEvent::UpdateQuery\` with each variant and asserts no panic + correct decomposition.

## Notes

- This is the runtime-side fix corresponding to freenet/mail#80 (cross-node inbox UPDATE blocked by missing related contract).
- A more complete fix would also implement the \`RequestRelated → GET → re-update\` flow for locally-hosted related contracts so clients don't have to bundle state inline. Tracked separately.