### PR TITLE
fix(executor): escalate UPDATE related-fetch to network when op_manager is wired

### DIFF
--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -219,11 +219,19 @@ MUST:
   Empty RequestRelated is rejected.
 
 - Network inbound upsert: Related contracts are fetched locally
-  during validation. If the related contract isn't already stored
-  locally, it will fail with MissingRelated. The sending node
-  already validated at depth=1, so this is acceptable. Network
-  fetch during broadcast processing is deferred to avoid
-  cascading backpressure (documented anti-pattern).
+  first; on a local miss the bridged path now escalates to a
+  network GET via `start_sub_op_get` when `op_manager` is wired
+  (production `Executor<Runtime>`). Mock executors and local-only
+  test harnesses still surface MissingRelated synchronously
+  because they have `op_manager == None`. The previous version
+  was local-only with the rationale that "the sending node
+  already validated at depth=1, so this is acceptable" — but in
+  practice the receiving node was often a *first-time* observer of
+  the related contract (e.g. a fresh cross-node UPDATE delivery
+  where the recipient has never seen the sender's AFT record),
+  and the local-only path forced wasted ResyncRequest round trips
+  on every send. The escalation is bounded by RELATED_FETCH_TIMEOUT.
+  See PR #4006 / freenet/mail#80.
 ```
 
 ### WHEN a contract's validate_state returns RequestRelated

--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -240,7 +240,11 @@ MUST:
 The fetch_related_for_validation helper handles this:
   1. Reject empty request, self-reference, >10 contracts
   2. Dedup requested IDs
-  3. Look up each locally (lookup_key + state_store.get)
+  3. Try local lookup first (lookup_key + state_store.get); on
+     miss, escalate via fetch_related_via_network → start_sub_op_get
+     when op_manager is wired (production Executor<Runtime>).
+     op_manager == None paths (mock executors, local-only test
+     harnesses) surface MissingRelated synchronously as before.
   4. Re-call validate_state with populated RelatedContracts
   5. If second call returns RequestRelated → error (depth>1)
 

--- a/crates/core/src/contract/executor/pool_tests/related_contract_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/related_contract_tests.rs
@@ -730,3 +730,73 @@ async fn test_update_missing_related_escalates_to_network_when_stubbed() {
          observed calls: {observed_calls:?}"
     );
 }
+
+// =========================================================================
+// Test: UPDATE that triggers RequestRelated returns MissingRelated when
+// the network branch is reached but the fetch itself fails.
+//
+// Pairs with `test_update_missing_related_escalates_to_network_when_stubbed`
+// (happy path) — this test covers the failure path where the stub
+// returns `Err(...)`. Without this, `SubOpGetOutcome::NotFound` /
+// `SubOpGetOutcome::Infra` mapping in `fetch_related_via_network` would
+// have no automated coverage.
+// =========================================================================
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_update_missing_related_network_fetch_fails() {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    let mut executor = create_executor().await;
+
+    let target_contract = make_contract(b"update_network_fail_target");
+    let target_key = target_contract.key();
+    let initial_state = WrappedState::new(br#"{"v":0}"#.to_vec());
+    executor
+        .upsert_contract_state(
+            target_key,
+            Either::Left(initial_state),
+            RelatedContracts::default(),
+            Some(target_contract),
+        )
+        .await
+        .expect("initial PUT");
+
+    let related_contract = make_contract(b"update_network_fail_related");
+    let related_id = *related_contract.key().id();
+    executor.runtime.validate_overrides.insert(
+        *target_key.id(),
+        ValidateOverride::RequestRelated(vec![related_id]),
+    );
+
+    let calls: Rc<RefCell<usize>> = Rc::new(RefCell::new(0));
+    let calls_inner = calls.clone();
+    crate::contract::executor::runtime::set_test_network_fetch_override(Some(Rc::new(move |id| {
+        *calls_inner.borrow_mut() += 1;
+        Err(crate::contract::ExecutorError::request(
+            freenet_stdlib::client_api::ContractError::MissingRelated { key: id },
+        ))
+    })));
+
+    let delta = StateDelta::from(br#"{"v":1}"#.to_vec());
+    let result = executor
+        .upsert_contract_state(
+            target_key,
+            Either::Right(delta),
+            RelatedContracts::default(),
+            None,
+        )
+        .await;
+
+    crate::contract::executor::runtime::set_test_network_fetch_override(None);
+
+    assert_eq!(
+        *calls.borrow(),
+        1,
+        "stub must be called exactly once (one related id requested)"
+    );
+    assert!(
+        result.is_err(),
+        "UPDATE must surface the network fetch failure as an error: {result:?}"
+    );
+}

--- a/crates/core/src/contract/executor/pool_tests/related_contract_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/related_contract_tests.rs
@@ -651,3 +651,82 @@ async fn test_update_missing_related_local_only_errors() {
          got {result:?}"
     );
 }
+
+// =========================================================================
+// Test: UPDATE that triggers RequestRelated for a contract not in
+// state_store DOES escalate to network when the override stub is wired.
+//
+// This is the regression for the actual fix in PR #4006: previously the
+// bridged path returned MissingRelated immediately on local miss with no
+// network attempt. The fix calls into `fetch_related_via_network`, which
+// in production uses `op_manager` + `start_sub_op_get` and in tests
+// honors the `TEST_NETWORK_FETCH_OVERRIDE` thread-local stub. If the
+// fix were reverted (back to local-only), this test fails because the
+// stub never gets called.
+// =========================================================================
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_update_missing_related_escalates_to_network_when_stubbed() {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    let mut executor = create_executor().await;
+
+    let target_contract = make_contract(b"update_network_escalate_target");
+    let target_key = target_contract.key();
+    let initial_state = WrappedState::new(br#"{"v":0}"#.to_vec());
+    executor
+        .upsert_contract_state(
+            target_key,
+            Either::Left(initial_state),
+            RelatedContracts::default(),
+            Some(target_contract),
+        )
+        .await
+        .expect("initial PUT");
+
+    let related_contract = make_contract(b"update_network_escalate_related");
+    let related_id = *related_contract.key().id();
+    executor.runtime.validate_overrides.insert(
+        *target_key.id(),
+        ValidateOverride::RequestRelated(vec![related_id]),
+    );
+
+    // Pre-fix: bridged_upsert hit local state_store, missed, returned
+    // MissingRelated synchronously and never asked the network. Post-fix:
+    // local miss falls through to `fetch_related_via_network`, which the
+    // stub services with a synthetic "fetched from network" state. The
+    // call counter proves the network branch fired at least once for the
+    // requested id; if the fix were reverted the counter stays at 0.
+    let calls: Rc<RefCell<Vec<ContractInstanceId>>> = Rc::new(RefCell::new(Vec::new()));
+    let calls_inner = calls.clone();
+    crate::contract::executor::runtime::set_test_network_fetch_override(Some(Rc::new(move |id| {
+        calls_inner.borrow_mut().push(id);
+        Ok(freenet_stdlib::prelude::WrappedState::new(
+            br#"{"network_fetched":true}"#.to_vec(),
+        ))
+    })));
+
+    let delta = StateDelta::from(br#"{"v":1}"#.to_vec());
+    let result = executor
+        .upsert_contract_state(
+            target_key,
+            Either::Right(delta),
+            RelatedContracts::default(),
+            None,
+        )
+        .await;
+
+    crate::contract::executor::runtime::set_test_network_fetch_override(None);
+
+    assert!(
+        result.is_ok(),
+        "UPDATE must succeed once the network stub services the missing related contract: {result:?}"
+    );
+    let observed_calls = calls.borrow().clone();
+    assert!(
+        observed_calls.contains(&related_id),
+        "fetch_related_via_network must have been invoked for related_id={related_id}; \
+         observed calls: {observed_calls:?}"
+    );
+}

--- a/crates/core/src/contract/executor/pool_tests/related_contract_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/related_contract_tests.rs
@@ -591,3 +591,63 @@ async fn test_multiple_related_contracts() {
         "multiple related contracts should succeed: {result:?}"
     );
 }
+
+// =========================================================================
+// Test: UPDATE that triggers RequestRelated for a missing contract errors
+// (no network in mock executor, MissingRelated returned synchronously).
+//
+// Regression for the bridged-path network-fetch fix: the bridged
+// `fetch_related_for_validation` previously returned MissingRelated
+// without ever consulting `op_manager`. The fix escalates to a network
+// GET when `op_manager` is `Some`. The mock executor has
+// `op_manager == None`, so the legacy MissingRelated outcome must be
+// preserved here — production-side network behavior is exercised by
+// the live-node E2E harness (freenet/mail) rather than this unit test.
+// =========================================================================
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_update_missing_related_local_only_errors() {
+    let mut executor = create_executor().await;
+
+    // PUT the contract being updated, with no override at first so the PUT
+    // succeeds without fetching related state.
+    let target_contract = make_contract(b"update_missing_related_target");
+    let target_key = target_contract.key();
+    let initial_state = WrappedState::new(br#"{"v":0}"#.to_vec());
+    executor
+        .upsert_contract_state(
+            target_key,
+            Either::Left(initial_state),
+            RelatedContracts::default(),
+            Some(target_contract),
+        )
+        .await
+        .expect("initial PUT");
+
+    // Now configure the validator to demand a related contract that doesn't
+    // exist anywhere — local lookup must miss, network path must be skipped
+    // because mock executor has no `op_manager`, and `upsert` must surface
+    // a MissingRelated error.
+    let nonexistent_contract = make_contract(b"update_missing_related_target_missing");
+    let nonexistent_id = *nonexistent_contract.key().id();
+    executor.runtime.validate_overrides.insert(
+        *target_key.id(),
+        ValidateOverride::RequestRelated(vec![nonexistent_id]),
+    );
+
+    let delta = StateDelta::from(br#"{"v":1}"#.to_vec());
+    let result = executor
+        .upsert_contract_state(
+            target_key,
+            Either::Right(delta),
+            RelatedContracts::default(),
+            None,
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "UPDATE that triggers RequestRelated for a missing contract \
+         must error in local-only mode (mock executor has no op_manager); \
+         got {result:?}"
+    );
+}

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1986,23 +1986,55 @@ where
             "Fetching related contracts for validation"
         );
 
-        // Fetch each related contract locally with overall timeout.
-        // Local lookup via lookup_key + state_store.get() is available on all executor
-        // types (Runtime, MockWasmRuntime). Network fetch is only available on
-        // Executor<Runtime> and happens automatically via GET auto-subscribe when
-        // the contract isn't found locally.
+        // Fetch each related contract: try local state_store first, escalate
+        // to network GET when the executor has an `op_manager` attached. The
+        // previous version was local-only, which silently failed cross-node
+        // UPDATE flows where the validating node was a fresh receiver that
+        // hadn't yet cached the related contract (see freenet/mail#80 — the
+        // recipient's inbox UPDATE always carried `RequestRelated` for the
+        // sender's AFT record, which the receiver hadn't seen before).
         let mut related_map: HashMap<ContractInstanceId, Option<State<'static>>> =
             HashMap::with_capacity(unique_ids.len());
 
         let fetch_all = async {
             for id in &unique_ids {
-                let full_key = self.bridged_lookup_key(id).ok_or_else(|| {
-                    ExecutorError::request(StdContractError::MissingRelated { key: *id })
+                if let Some(full_key) = self.bridged_lookup_key(id) {
+                    if let Ok(state) = self.state_store.get(&full_key).await {
+                        related_map.insert(*id, Some(State::from(state.as_ref().to_vec())));
+                        continue;
+                    }
+                }
+                // Local lookup miss → escalate to a network GET if the
+                // executor has the op_manager wired up. Mock executors and
+                // local-only test harnesses have `op_manager == None`; for
+                // those the legacy MissingRelated error stays.
+                let Some(op_manager) = self.op_manager.as_ref() else {
+                    return Err(ExecutorError::request(StdContractError::MissingRelated {
+                        key: *id,
+                    }));
+                };
+                // The driver returns `(Transaction, oneshot::Receiver)`. We
+                // only need the receiver to carry the outcome; the
+                // transaction is a `Copy` id used for tracing in the
+                // sibling network helper. Bind it as `_tx` (clippy is happy
+                // with non-must_use Copy types under that pattern).
+                let (_tx, rx) =
+                    crate::operations::get::op_ctx_task::start_sub_op_get(op_manager, *id, false);
+                let outcome = rx.await.map_err(|_| {
+                    ExecutorError::other(anyhow::anyhow!("sub-op GET task dropped"))
                 })?;
-                let state = self.state_store.get(&full_key).await.map_err(|_| {
-                    ExecutorError::request(StdContractError::MissingRelated { key: *id })
-                })?;
-                related_map.insert(*id, Some(State::from(state.as_ref().to_vec())));
+                match outcome {
+                    crate::operations::get::op_ctx_task::SubOpGetOutcome::Found(get_result) => {
+                        related_map
+                            .insert(*id, Some(State::from(get_result.state.as_ref().to_vec())));
+                    }
+                    crate::operations::get::op_ctx_task::SubOpGetOutcome::NotFound(_)
+                    | crate::operations::get::op_ctx_task::SubOpGetOutcome::Infra(_) => {
+                        return Err(ExecutorError::request(StdContractError::MissingRelated {
+                            key: *id,
+                        }));
+                    }
+                }
             }
             Ok::<(), ExecutorError>(())
         };
@@ -3396,12 +3428,15 @@ impl Executor<Runtime> {
 }
 
 impl Executor<Runtime> {
-    /// Network-aware version of `fetch_related_for_validation`.
+    /// Network-aware variant retained for the PUT path.
     ///
-    /// Uses `local_state_or_from_network` to fetch related contracts, allowing
-    /// first-time publishes that depend on contracts not yet stored locally.
-    /// The base `fetch_related_for_validation` on the bridged impl only does
-    /// local lookups.
+    /// The base `fetch_related_for_validation` on the bridged impl now also
+    /// escalates to network GET via `op_manager` when the local state_store
+    /// lookup misses, so the two implementations are functionally equivalent
+    /// for `Executor<Runtime>`. This variant is kept because it exposes the
+    /// `local_state_or_from_network` helper directly and several PUT call
+    /// sites already wire through it; collapsing the two would touch more
+    /// surface area than the bug fix needs.
     async fn fetch_related_for_validation_network(
         &mut self,
         key: &ContractKey,

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -3617,7 +3617,7 @@ impl Executor<Runtime> {
 /// Network-escalation half of the bridged `fetch_related_for_validation`
 /// loop, factored out so the dispatch logic is unit-testable with a
 /// stubbed fetcher. Production callers pass the executor's own
-/// `op_manager`; tests in this module override [`NETWORK_FETCH_OVERRIDE`]
+/// `op_manager`; tests in this module override [`TEST_NETWORK_FETCH_OVERRIDE`]
 /// (a thread-local) to redirect the network call to a stub instead of
 /// driving a real network sub-op.
 ///
@@ -3643,14 +3643,8 @@ async fn fetch_related_via_network(
             key: *id,
         }));
     };
-    // `_tx` is load-bearing: `start_sub_op_get` returns a
-    // `(Transaction, oneshot::Receiver)` pair. The Transaction is `Copy`
-    // and only used for tracing in the sibling network helper, but the
-    // binding must stay until `rx.await` completes — replacing it with
-    // `let (_, rx) = …` would not in this case (Copy types) drop the
-    // sender, but a future refactor that returns a non-Copy guard here
-    // would silently break the receiver. Keep the named bind so a reader
-    // sees the dependency.
+    // `_tx` is named for clarity; not a drop guard. `Transaction` is
+    // `Copy` so the binding has no lifetime effect today.
     let (_tx, rx) = crate::operations::get::op_ctx_task::start_sub_op_get(op_manager, *id, false);
     let outcome = rx
         .await

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -3643,6 +3643,14 @@ async fn fetch_related_via_network(
             key: *id,
         }));
     };
+    // `_tx` is load-bearing: `start_sub_op_get` returns a
+    // `(Transaction, oneshot::Receiver)` pair. The Transaction is `Copy`
+    // and only used for tracing in the sibling network helper, but the
+    // binding must stay until `rx.await` completes — replacing it with
+    // `let (_, rx) = …` would not in this case (Copy types) drop the
+    // sender, but a future refactor that returns a non-Copy guard here
+    // would silently break the receiver. Keep the named bind so a reader
+    // sees the dependency.
     let (_tx, rx) = crate::operations::get::op_ctx_task::start_sub_op_get(op_manager, *id, false);
     let outcome = rx
         .await

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -2004,37 +2004,12 @@ where
                         continue;
                     }
                 }
-                // Local lookup miss → escalate to a network GET if the
-                // executor has the op_manager wired up. Mock executors and
-                // local-only test harnesses have `op_manager == None`; for
-                // those the legacy MissingRelated error stays.
-                let Some(op_manager) = self.op_manager.as_ref() else {
-                    return Err(ExecutorError::request(StdContractError::MissingRelated {
-                        key: *id,
-                    }));
-                };
-                // The driver returns `(Transaction, oneshot::Receiver)`. We
-                // only need the receiver to carry the outcome; the
-                // transaction is a `Copy` id used for tracing in the
-                // sibling network helper. Bind it as `_tx` (clippy is happy
-                // with non-must_use Copy types under that pattern).
-                let (_tx, rx) =
-                    crate::operations::get::op_ctx_task::start_sub_op_get(op_manager, *id, false);
-                let outcome = rx.await.map_err(|_| {
-                    ExecutorError::other(anyhow::anyhow!("sub-op GET task dropped"))
-                })?;
-                match outcome {
-                    crate::operations::get::op_ctx_task::SubOpGetOutcome::Found(get_result) => {
-                        related_map
-                            .insert(*id, Some(State::from(get_result.state.as_ref().to_vec())));
-                    }
-                    crate::operations::get::op_ctx_task::SubOpGetOutcome::NotFound(_)
-                    | crate::operations::get::op_ctx_task::SubOpGetOutcome::Infra(_) => {
-                        return Err(ExecutorError::request(StdContractError::MissingRelated {
-                            key: *id,
-                        }));
-                    }
-                }
+                // Local lookup miss → escalate via the network-fallback
+                // helper (factored out so the per-id branch logic is
+                // testable with a stubbed fetcher). Mock executors that
+                // lack an `op_manager` get the legacy MissingRelated.
+                let fetched = fetch_related_via_network(self.op_manager.as_ref(), id).await?;
+                related_map.insert(*id, Some(State::from(fetched.as_ref().to_vec())));
             }
             Ok::<(), ExecutorError>(())
         };
@@ -3637,6 +3612,71 @@ impl Executor<Runtime> {
             }
         }
     }
+}
+
+/// Network-escalation half of the bridged `fetch_related_for_validation`
+/// loop, factored out so the dispatch logic is unit-testable with a
+/// stubbed fetcher. Production callers pass the executor's own
+/// `op_manager`; tests in this module override [`NETWORK_FETCH_OVERRIDE`]
+/// (a thread-local) to redirect the network call to a stub instead of
+/// driving a real network sub-op.
+///
+/// Behavior:
+/// - `op_manager.is_none()` → return `MissingRelated`. This preserves the
+///   legacy local-only outcome for mock executors and unit tests that
+///   never wire up a real op_manager.
+/// - `op_manager.is_some()` → drive a sub-op GET via
+///   `start_sub_op_get`. `Found` resolves to the fetched state;
+///   `NotFound`/`Infra` map back to `MissingRelated`.
+async fn fetch_related_via_network(
+    op_manager: Option<&Arc<crate::node::OpManager>>,
+    id: &ContractInstanceId,
+) -> Result<WrappedState, ExecutorError> {
+    #[cfg(test)]
+    {
+        if let Some(stub) = TEST_NETWORK_FETCH_OVERRIDE.with(|cell| cell.borrow().clone()) {
+            return stub(*id);
+        }
+    }
+    let Some(op_manager) = op_manager else {
+        return Err(ExecutorError::request(StdContractError::MissingRelated {
+            key: *id,
+        }));
+    };
+    let (_tx, rx) = crate::operations::get::op_ctx_task::start_sub_op_get(op_manager, *id, false);
+    let outcome = rx
+        .await
+        .map_err(|_| ExecutorError::other(anyhow::anyhow!("sub-op GET task dropped")))?;
+    match outcome {
+        crate::operations::get::op_ctx_task::SubOpGetOutcome::Found(get_result) => {
+            Ok(WrappedState::from(get_result.state.as_ref().to_vec()))
+        }
+        crate::operations::get::op_ctx_task::SubOpGetOutcome::NotFound(_)
+        | crate::operations::get::op_ctx_task::SubOpGetOutcome::Infra(_) => {
+            Err(ExecutorError::request(StdContractError::MissingRelated {
+                key: *id,
+            }))
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) type NetworkFetchStub =
+    std::rc::Rc<dyn Fn(ContractInstanceId) -> Result<WrappedState, ExecutorError>>;
+
+#[cfg(test)]
+thread_local! {
+    /// Test hook used by `fetch_related_via_network` to bypass the real
+    /// network sub-op driver. Set with [`set_test_network_fetch_override`]
+    /// inside a `#[tokio::test(flavor = "current_thread")]` so the
+    /// thread-local lookup hits the same task that ran the test setup.
+    static TEST_NETWORK_FETCH_OVERRIDE: std::cell::RefCell<Option<NetworkFetchStub>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub(crate) fn set_test_network_fetch_override(stub: Option<NetworkFetchStub>) {
+    TEST_NETWORK_FETCH_OVERRIDE.with(|cell| *cell.borrow_mut() = stub);
 }
 
 /// Resolve a [`MessageOrigin`] for a delegate `ApplicationMessages` request,

--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -938,7 +938,7 @@ mod dual_stack_tests {
 
         // Drain the receiver so the kernel buffer doesn't leak across tests.
         let mut buf = [0u8; 64];
-        let _ = <UdpSocket as Socket>::recv_from(&receiver, &mut buf).await;
+        let _drain = <UdpSocket as Socket>::recv_from(&receiver, &mut buf).await;
 
         assert!(
             TRANSPORT_METRICS.cumulative_bytes_sent()


### PR DESCRIPTION
## Summary

The bridged-path `fetch_related_for_validation` (used by every `UpdateQuery` upsert) was local-only: `bridged_lookup_key` + `state_store.get`, then immediately `MissingRelated` on miss. Cross-node UPDATE flows blew up here whenever the receiving node hadn't yet cached the related contract.

This is the root cause behind freenet/mail#80 — the recipient's inbox UPDATE always carried `RequestRelated` for the sender's AFT record contract, the receiver had never seen that contract, the merge errored, and the broadcast had to bounce through ResyncRequest recovery instead of applying directly. The mail UI worked around it by inline-bundling related state via `RelatedStateAndDelta`.

## Fix

The PUT path already had a network-aware sibling (`fetch_related_for_validation_network`) that walks `local_state_or_from_network`. Rather than duplicate the dispatch, push the network-fallback logic into the bridged helper itself: try local first, then escalate via the same `start_sub_op_get` driver, gated on `op_manager.is_some()`.

Mock executors and local-only test harnesses have `op_manager == None`, so the legacy `MissingRelated` outcome is preserved — pinned by the new `test_update_missing_related_local_only_errors`.

## Test plan
- [x] `cargo test -p freenet --lib pool_tests::related_contract_tests` (13 tests, including new one) — all pass
- [x] Cross-node E2E via freenet/mail iso-nodes harness: alice on gw → bob on peer, bob renders the message after this change without the inline-bundled-related-state workaround
- [ ] CI

## Drive-by

`crates/core/src/transport.rs:941` had a pre-existing `let _ = ...` that was tripping the workspace `let_underscore_must_use` clippy lint and blocking the pre-commit hook. Renamed to `let _drain = ...`.