### PR TITLE
fix(executor): fetch related contracts on update_state requires(missing)

### DIFF
--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -254,6 +254,15 @@ This helper is used in:
   - perform_contract_put (existing contract merge validation)
   - get_updated_state (post-update validation)
   - verify_and_store_contract (depth=1 simplified)
+
+The same local-then-network fetch is also performed when
+`update_state` (not validate_state) returns
+`UpdateModification::requires(missing)`. The bridged-upsert path
+walks each id, fetches local-or-network via fetch_related_via_network,
+appends RelatedState entries to the update slice, and re-attempts
+the merge. Depth-1 limit applies to both branches (a second
+RequestRelated/requires after the retry is rejected). See
+PR #4006 / #4008 / freenet/mail#80.
 ```
 
 ### Abuse prevention

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -20,6 +20,18 @@ pub(crate) enum ValidateOverride {
     EmptyRequestRelated,
 }
 
+/// Configurable `update_state` behavior for testing related contract flows.
+#[derive(Clone, Debug)]
+#[allow(dead_code)] // Variants constructed in test code only
+pub(crate) enum UpdateOverride {
+    /// Return `UpdateModification::requires(...)` on first call (no
+    /// `RelatedState` entry present in the updates yet) and accept the
+    /// merge on second call (RelatedState entries populated by the
+    /// bridged-upsert retry path). Mirrors `ValidateOverride::RequestRelated`
+    /// but at the update-side of the fetch loop.
+    RequiresRelated(Vec<ContractInstanceId>),
+}
+
 /// A lightweight mock runtime at the `ContractRuntimeInterface` level that lets
 /// simulation tests exercise the **production** `ContractExecutor` code path
 /// without requiring real WASM binaries.
@@ -32,6 +44,9 @@ pub(crate) struct MockWasmRuntime {
     pub(crate) contract_store: InMemoryContractStore,
     /// Per-contract validation overrides for testing related contract flows.
     pub(crate) validate_overrides: HashMap<ContractInstanceId, ValidateOverride>,
+    /// Per-contract update_state overrides for testing the
+    /// `requires(missing)` fetch-and-retry path.
+    pub(crate) update_overrides: HashMap<ContractInstanceId, UpdateOverride>,
 }
 
 impl ContractRuntimeInterface for MockWasmRuntime {
@@ -74,6 +89,30 @@ impl ContractRuntimeInterface for MockWasmRuntime {
         _state: &WrappedState,
         update_data: &[UpdateData<'_>],
     ) -> crate::wasm_runtime::RuntimeResult<UpdateModification<'static>> {
+        // If a per-contract override is wired, replay the production
+        // require-then-merge flow: first call (no RelatedState in the
+        // update_data slice) returns `requires`; once the bridged path
+        // re-attempts with `RelatedState` entries appended, fall through
+        // to the default merge.
+        if let Some(UpdateOverride::RequiresRelated(ref ids)) =
+            self.update_overrides.get(_key.id()).cloned()
+        {
+            let has_related = update_data
+                .iter()
+                .any(|u| matches!(u, UpdateData::RelatedState { .. }));
+            if !has_related {
+                let related: Vec<RelatedContract> = ids
+                    .iter()
+                    .map(|id| RelatedContract {
+                        contract_instance_id: *id,
+                        mode: RelatedMode::StateOnce,
+                    })
+                    .collect();
+                return Ok(
+                    UpdateModification::requires(related).map_err(|e| anyhow::anyhow!("{e}"))?
+                );
+            }
+        }
         // Accept the last full state or delta from update_data as the new state
         let mut new_state = None;
         for ud in update_data {
@@ -238,6 +277,7 @@ impl Executor<MockWasmRuntime, MockStateStorage> {
         let runtime = MockWasmRuntime {
             contract_store: contract_store.unwrap_or_default(),
             validate_overrides: HashMap::new(),
+            update_overrides: HashMap::new(),
         };
 
         Executor::new(

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -30,6 +30,10 @@ pub(crate) enum UpdateOverride {
     /// bridged-upsert retry path). Mirrors `ValidateOverride::RequestRelated`
     /// but at the update-side of the fetch loop.
     RequiresRelated(Vec<ContractInstanceId>),
+    /// Always return `UpdateModification::requires(...)` regardless of
+    /// whether RelatedState entries are already populated. Drives the
+    /// depth-limit branch in `bridged_upsert_contract_state`.
+    AlwaysRequiresRelated(Vec<ContractInstanceId>),
 }
 
 /// A lightweight mock runtime at the `ContractRuntimeInterface` level that lets
@@ -94,23 +98,35 @@ impl ContractRuntimeInterface for MockWasmRuntime {
         // update_data slice) returns `requires`; once the bridged path
         // re-attempts with `RelatedState` entries appended, fall through
         // to the default merge.
-        if let Some(UpdateOverride::RequiresRelated(ref ids)) =
-            self.update_overrides.get(_key.id()).cloned()
-        {
-            let has_related = update_data
-                .iter()
-                .any(|u| matches!(u, UpdateData::RelatedState { .. }));
-            if !has_related {
-                let related: Vec<RelatedContract> = ids
-                    .iter()
-                    .map(|id| RelatedContract {
-                        contract_instance_id: *id,
-                        mode: RelatedMode::StateOnce,
-                    })
-                    .collect();
-                return Ok(
-                    UpdateModification::requires(related).map_err(|e| anyhow::anyhow!("{e}"))?
-                );
+        if let Some(override_) = self.update_overrides.get(_key.id()).cloned() {
+            match override_ {
+                UpdateOverride::RequiresRelated(ids) => {
+                    let has_related = update_data
+                        .iter()
+                        .any(|u| matches!(u, UpdateData::RelatedState { .. }));
+                    if !has_related {
+                        let related: Vec<RelatedContract> = ids
+                            .iter()
+                            .map(|id| RelatedContract {
+                                contract_instance_id: *id,
+                                mode: RelatedMode::StateOnce,
+                            })
+                            .collect();
+                        return Ok(UpdateModification::requires(related)
+                            .map_err(|e| anyhow::anyhow!("{e}"))?);
+                    }
+                }
+                UpdateOverride::AlwaysRequiresRelated(ids) => {
+                    let related: Vec<RelatedContract> = ids
+                        .iter()
+                        .map(|id| RelatedContract {
+                            contract_instance_id: *id,
+                            mode: RelatedMode::StateOnce,
+                        })
+                        .collect();
+                    return Ok(UpdateModification::requires(related)
+                        .map_err(|e| anyhow::anyhow!("{e}"))?);
+                }
             }
         }
         // Accept the last full state or delta from update_data as the new state

--- a/crates/core/src/contract/executor/pool_tests/related_contract_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/related_contract_tests.rs
@@ -800,3 +800,80 @@ async fn test_update_missing_related_network_fetch_fails() {
         "UPDATE must surface the network fetch failure as an error: {result:?}"
     );
 }
+
+// =========================================================================
+// Test: UPDATE where the contract's update_state returns
+// `requires(missing)` falls through to the network fetch + retry path
+// (the production cross-node UPDATE flow that #80 surfaced — inbox's
+// `update_state` returns requires(AFT-record) on the receiver because
+// the receiver hasn't seen the sender's AFT yet).
+//
+// Regression for the bridged_upsert_contract_state branch that used to
+// MissingRelated immediately on `Either::Right`. With the fix the
+// missing related contracts are fetched via the same local-then-network
+// path used by validate-side RequestRelated, then update_state is
+// re-invoked with `RelatedState` entries surfaced; the second call
+// completes the merge and the upsert succeeds.
+// =========================================================================
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_update_state_requires_related_fetches_and_retries() {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    let mut executor = create_executor().await;
+
+    let target_contract = make_contract(b"update_requires_target");
+    let target_key = target_contract.key();
+    let initial_state = WrappedState::new(br#"{"v":0}"#.to_vec());
+    executor
+        .upsert_contract_state(
+            target_key,
+            Either::Left(initial_state),
+            RelatedContracts::default(),
+            Some(target_contract),
+        )
+        .await
+        .expect("initial PUT");
+
+    let related_contract = make_contract(b"update_requires_related");
+    let related_id = *related_contract.key().id();
+    executor.runtime.update_overrides.insert(
+        *target_key.id(),
+        crate::contract::executor::mock_wasm_runtime::UpdateOverride::RequiresRelated(vec![
+            related_id,
+        ]),
+    );
+
+    let calls: Rc<RefCell<Vec<ContractInstanceId>>> = Rc::new(RefCell::new(Vec::new()));
+    let calls_inner = calls.clone();
+    crate::contract::executor::runtime::set_test_network_fetch_override(Some(Rc::new(move |id| {
+        calls_inner.borrow_mut().push(id);
+        Ok(freenet_stdlib::prelude::WrappedState::new(
+            br#"{"network_supplied_related":true}"#.to_vec(),
+        ))
+    })));
+
+    let delta = StateDelta::from(br#"{"v":1}"#.to_vec());
+    let result = executor
+        .upsert_contract_state(
+            target_key,
+            Either::Right(delta),
+            RelatedContracts::default(),
+            None,
+        )
+        .await;
+
+    crate::contract::executor::runtime::set_test_network_fetch_override(None);
+
+    assert!(
+        result.is_ok(),
+        "UPDATE must succeed once network supplies the related state: {result:?}"
+    );
+    let observed_calls = calls.borrow().clone();
+    assert!(
+        observed_calls.contains(&related_id),
+        "fetch_related_via_network must have been invoked for the requires(missing) path; \
+         observed calls: {observed_calls:?}"
+    );
+}

--- a/crates/core/src/contract/executor/pool_tests/related_contract_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/related_contract_tests.rs
@@ -877,3 +877,231 @@ async fn test_update_state_requires_related_fetches_and_retries() {
          observed calls: {observed_calls:?}"
     );
 }
+
+// =========================================================================
+// Test: update_state requires(missing) + network fetch FAILS → MissingRelated.
+//
+// Pairs with `test_update_state_requires_related_fetches_and_retries`
+// (happy path). Ensures the failure mapping in the new branch returns
+// MissingRelated cleanly when the network can't service the related id.
+// =========================================================================
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_update_state_requires_related_network_fail_returns_missing() {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    let mut executor = create_executor().await;
+
+    let target_contract = make_contract(b"update_requires_fail_target");
+    let target_key = target_contract.key();
+    executor
+        .upsert_contract_state(
+            target_key,
+            Either::Left(WrappedState::new(br#"{"v":0}"#.to_vec())),
+            RelatedContracts::default(),
+            Some(target_contract),
+        )
+        .await
+        .expect("initial PUT");
+
+    let related_contract = make_contract(b"update_requires_fail_related");
+    let related_id = *related_contract.key().id();
+    executor.runtime.update_overrides.insert(
+        *target_key.id(),
+        crate::contract::executor::mock_wasm_runtime::UpdateOverride::RequiresRelated(vec![
+            related_id,
+        ]),
+    );
+
+    let calls: Rc<RefCell<usize>> = Rc::new(RefCell::new(0));
+    let calls_inner = calls.clone();
+    crate::contract::executor::runtime::set_test_network_fetch_override(Some(Rc::new(move |id| {
+        *calls_inner.borrow_mut() += 1;
+        Err(crate::contract::ExecutorError::request(
+            freenet_stdlib::client_api::ContractError::MissingRelated { key: id },
+        ))
+    })));
+
+    let result = executor
+        .upsert_contract_state(
+            target_key,
+            Either::Right(StateDelta::from(br#"{"v":1}"#.to_vec())),
+            RelatedContracts::default(),
+            None,
+        )
+        .await;
+
+    crate::contract::executor::runtime::set_test_network_fetch_override(None);
+
+    assert_eq!(*calls.borrow(), 1, "stub must be called once");
+    assert!(
+        result.is_err(),
+        "UPDATE must surface network fetch failure: {result:?}"
+    );
+}
+
+// =========================================================================
+// Test: update_state still requires(missing) after the fetch round →
+// rejected (depth>1 limit, mirroring the validate-side behavior).
+// =========================================================================
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_update_state_requires_related_depth_exceeded_rejected() {
+    use std::rc::Rc;
+
+    let mut executor = create_executor().await;
+
+    let target_contract = make_contract(b"update_requires_depth_target");
+    let target_key = target_contract.key();
+    executor
+        .upsert_contract_state(
+            target_key,
+            Either::Left(WrappedState::new(br#"{"v":0}"#.to_vec())),
+            RelatedContracts::default(),
+            Some(target_contract),
+        )
+        .await
+        .expect("initial PUT");
+
+    let related_contract = make_contract(b"update_requires_depth_related");
+    let related_id = *related_contract.key().id();
+    executor.runtime.update_overrides.insert(
+        *target_key.id(),
+        crate::contract::executor::mock_wasm_runtime::UpdateOverride::AlwaysRequiresRelated(vec![
+            related_id,
+        ]),
+    );
+
+    crate::contract::executor::runtime::set_test_network_fetch_override(Some(Rc::new(|_id| {
+        Ok(freenet_stdlib::prelude::WrappedState::new(
+            br#"{"network_supplied_related":true}"#.to_vec(),
+        ))
+    })));
+
+    let result = executor
+        .upsert_contract_state(
+            target_key,
+            Either::Right(StateDelta::from(br#"{"v":1}"#.to_vec())),
+            RelatedContracts::default(),
+            None,
+        )
+        .await;
+
+    crate::contract::executor::runtime::set_test_network_fetch_override(None);
+
+    assert!(
+        result.is_err(),
+        "depth>1 UPDATE requires() must be rejected: {result:?}"
+    );
+}
+
+// =========================================================================
+// Test: update_state requires(missing) with > MAX_RELATED_CONTRACTS_PER_REQUEST
+// IDs is rejected outright without fanning out network fetches.
+// =========================================================================
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_update_state_requires_related_too_many_rejected() {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    let mut executor = create_executor().await;
+
+    let target_contract = make_contract(b"update_requires_toomany_target");
+    let target_key = target_contract.key();
+    executor
+        .upsert_contract_state(
+            target_key,
+            Either::Left(WrappedState::new(br#"{"v":0}"#.to_vec())),
+            RelatedContracts::default(),
+            Some(target_contract),
+        )
+        .await
+        .expect("initial PUT");
+
+    // 11 ids — one over the cap. Use Always so the override fires
+    // regardless of RelatedState entries (fetches must NOT happen at all).
+    let too_many: Vec<ContractInstanceId> = (0..11)
+        .map(|i| *make_contract(&[0xFF, i, 0xAA]).key().id())
+        .collect();
+    executor.runtime.update_overrides.insert(
+        *target_key.id(),
+        crate::contract::executor::mock_wasm_runtime::UpdateOverride::AlwaysRequiresRelated(
+            too_many,
+        ),
+    );
+
+    let calls: Rc<RefCell<usize>> = Rc::new(RefCell::new(0));
+    let calls_inner = calls.clone();
+    crate::contract::executor::runtime::set_test_network_fetch_override(Some(Rc::new(
+        move |_id| {
+            *calls_inner.borrow_mut() += 1;
+            Ok(freenet_stdlib::prelude::WrappedState::new(b"x".to_vec()))
+        },
+    )));
+
+    let result = executor
+        .upsert_contract_state(
+            target_key,
+            Either::Right(StateDelta::from(br#"{"v":1}"#.to_vec())),
+            RelatedContracts::default(),
+            None,
+        )
+        .await;
+
+    crate::contract::executor::runtime::set_test_network_fetch_override(None);
+
+    assert_eq!(
+        *calls.borrow(),
+        0,
+        "guard must reject before any fetch fires; stub was called {} times",
+        *calls.borrow()
+    );
+    assert!(
+        result.is_err(),
+        "UPDATE requires() with >MAX must be rejected: {result:?}"
+    );
+}
+
+// =========================================================================
+// Test: update_state requires(self) is rejected.
+// =========================================================================
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_update_state_requires_related_self_reference_rejected() {
+    let mut executor = create_executor().await;
+
+    let target_contract = make_contract(b"update_requires_self_target");
+    let target_key = target_contract.key();
+    executor
+        .upsert_contract_state(
+            target_key,
+            Either::Left(WrappedState::new(br#"{"v":0}"#.to_vec())),
+            RelatedContracts::default(),
+            Some(target_contract),
+        )
+        .await
+        .expect("initial PUT");
+
+    executor.runtime.update_overrides.insert(
+        *target_key.id(),
+        crate::contract::executor::mock_wasm_runtime::UpdateOverride::AlwaysRequiresRelated(vec![
+            *target_key.id(),
+        ]),
+    );
+
+    let result = executor
+        .upsert_contract_state(
+            target_key,
+            Either::Right(StateDelta::from(br#"{"v":1}"#.to_vec())),
+            RelatedContracts::default(),
+            None,
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "self-reference in update_state requires() must be rejected: {result:?}"
+    );
+}

--- a/crates/core/src/contract/executor/pool_tests/wasm_conformance_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/wasm_conformance_tests.rs
@@ -78,6 +78,7 @@ fn setup_mock() -> MockWasmRuntime {
     MockWasmRuntime {
         contract_store: InMemoryContractStore::new(),
         validate_overrides: std::collections::HashMap::new(),
+        update_overrides: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1344,38 +1344,98 @@ where
                 // helper uses. Without this, every cross-node UPDATE that
                 // references a related contract not yet cached locally would
                 // fail with `MissingRelated` even though we could resolve it.
+                //
+                // Apply the same abuse-prevention guards the validate-side
+                // path enforces (see `contracts.md` Abuse prevention):
+                //   * Reject empty list (a contract MUST signal Valid via
+                //     a populated state, not an empty `requires`).
+                //   * Reject self-reference (no contract may ask for its
+                //     own state through this path).
+                //   * Cap at MAX_RELATED_CONTRACTS_PER_REQUEST so a
+                //     misbehaving contract can't fan out 50 network GETs.
+                //   * Dedup IDs so repeated declarations don't multiply
+                //     the fetch count.
+                if missing_related.is_empty() {
+                    tracing::warn!(
+                        contract = %key,
+                        "update_state returned requires() with empty list"
+                    );
+                    return Err(ExecutorError::request(StdContractError::Update {
+                        key,
+                        cause: "contract requested related contracts but provided empty list"
+                            .into(),
+                    }));
+                }
+                let self_id = key.id();
+                if missing_related
+                    .iter()
+                    .any(|c| &c.contract_instance_id == self_id)
+                {
+                    tracing::warn!(
+                        contract = %key,
+                        "update_state requires() included self-reference"
+                    );
+                    return Err(ExecutorError::request(StdContractError::Update {
+                        key,
+                        cause: "contract cannot request itself as a related contract".into(),
+                    }));
+                }
+                let unique_ids: HashSet<ContractInstanceId> = missing_related
+                    .iter()
+                    .map(|c| c.contract_instance_id)
+                    .collect();
+                if unique_ids.len() > MAX_RELATED_CONTRACTS_PER_REQUEST {
+                    tracing::warn!(
+                        contract = %key,
+                        requested = unique_ids.len(),
+                        limit = MAX_RELATED_CONTRACTS_PER_REQUEST,
+                        "update_state requires() exceeded MAX_RELATED_CONTRACTS_PER_REQUEST"
+                    );
+                    return Err(ExecutorError::request(StdContractError::Update {
+                        key,
+                        cause: format!(
+                            "contract requested {} related contracts, limit is {}",
+                            unique_ids.len(),
+                            MAX_RELATED_CONTRACTS_PER_REQUEST
+                        )
+                        .into(),
+                    }));
+                }
+
                 let mut fetched_updates = updates.clone();
-                let mut all_resolved = true;
-                for related in &missing_related {
-                    let id = related.contract_instance_id;
+                let mut failed_id: Option<ContractInstanceId> = None;
+                for id in &unique_ids {
                     let mut got: Option<State<'static>> = None;
-                    if let Some(full_key) = self.bridged_lookup_key(&id) {
+                    if let Some(full_key) = self.bridged_lookup_key(id) {
                         if let Ok(state) = self.state_store.get(&full_key).await {
                             got = Some(State::from(state.as_ref().to_vec()));
                         }
                     }
                     if got.is_none() {
-                        match fetch_related_via_network(self.op_manager.as_ref(), &id).await {
+                        match fetch_related_via_network(self.op_manager.as_ref(), id).await {
                             Ok(state) => got = Some(State::from(state.as_ref().to_vec())),
-                            Err(_) => {
-                                all_resolved = false;
+                            Err(err) => {
+                                tracing::warn!(
+                                    contract = %key,
+                                    related_id = %id,
+                                    error = %err,
+                                    "Failed to fetch related contract for update_state requires()"
+                                );
+                                failed_id = Some(*id);
                                 break;
                             }
                         }
                     }
                     if let Some(state) = got {
                         fetched_updates.push(UpdateData::RelatedState {
-                            related_to: id,
+                            related_to: *id,
                             state,
                         });
                     }
                 }
-                if !all_resolved {
-                    let Some(c) = missing_related.into_iter().next() else {
-                        return Err(ExecutorError::internal_error());
-                    };
+                if let Some(id) = failed_id {
                     return Err(ExecutorError::request(StdContractError::MissingRelated {
-                        key: c.contract_instance_id,
+                        key: id,
                     }));
                 }
                 match self
@@ -1389,6 +1449,11 @@ where
                         let Some(c) = r.pop() else {
                             return Err(ExecutorError::internal_error());
                         };
+                        tracing::warn!(
+                            contract = %key,
+                            related_id = %c.contract_instance_id,
+                            "update_state still requires() after first fetch round (depth>1 not supported)"
+                        );
                         return Err(ExecutorError::request(StdContractError::MissingRelated {
                             key: c.contract_instance_id,
                         }));

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1334,13 +1334,67 @@ where
             .await
         {
             Ok(Either::Left(s)) => s,
-            Ok(Either::Right(mut r)) => {
-                let Some(c) = r.pop() else {
-                    return Err(ExecutorError::internal_error());
-                };
-                return Err(ExecutorError::request(StdContractError::MissingRelated {
-                    key: c.contract_instance_id,
-                }));
+            Ok(Either::Right(missing_related)) => {
+                // Contract's `update_state` returned `UpdateModification::requires(...)`,
+                // listing related contracts it needs to apply the delta. Try to
+                // fetch each one (local first, then network when op_manager is
+                // wired) and re-attempt the update with the fetched states
+                // surfaced as `UpdateData::RelatedState` entries — the same
+                // pattern the validate-side `fetch_related_for_validation`
+                // helper uses. Without this, every cross-node UPDATE that
+                // references a related contract not yet cached locally would
+                // fail with `MissingRelated` even though we could resolve it.
+                let mut fetched_updates = updates.clone();
+                let mut all_resolved = true;
+                for related in &missing_related {
+                    let id = related.contract_instance_id;
+                    let mut got: Option<State<'static>> = None;
+                    if let Some(full_key) = self.bridged_lookup_key(&id) {
+                        if let Ok(state) = self.state_store.get(&full_key).await {
+                            got = Some(State::from(state.as_ref().to_vec()));
+                        }
+                    }
+                    if got.is_none() {
+                        match fetch_related_via_network(self.op_manager.as_ref(), &id).await {
+                            Ok(state) => got = Some(State::from(state.as_ref().to_vec())),
+                            Err(_) => {
+                                all_resolved = false;
+                                break;
+                            }
+                        }
+                    }
+                    if let Some(state) = got {
+                        fetched_updates.push(UpdateData::RelatedState {
+                            related_to: id,
+                            state,
+                        });
+                    }
+                }
+                if !all_resolved {
+                    let Some(c) = missing_related.into_iter().next() else {
+                        return Err(ExecutorError::internal_error());
+                    };
+                    return Err(ExecutorError::request(StdContractError::MissingRelated {
+                        key: c.contract_instance_id,
+                    }));
+                }
+                match self
+                    .attempt_state_update(&params, &current_state, &key, &fetched_updates)
+                    .await
+                {
+                    Ok(Either::Left(s)) => s,
+                    Ok(Either::Right(mut r)) => {
+                        // Contract still demanding more after one round → reject
+                        // (depth limit, matching the validate-side behavior).
+                        let Some(c) = r.pop() else {
+                            return Err(ExecutorError::internal_error());
+                        };
+                        return Err(ExecutorError::request(StdContractError::MissingRelated {
+                            key: c.contract_instance_id,
+                        }));
+                    }
+                    Err(retry_err) => return Err(retry_err),
+                }
             }
             Err(merge_err) => {
                 // Merge failed. If we have a validated full incoming state, try to recover


### PR DESCRIPTION
## Summary

PR #4006 added network-fallback for the `validate_state` `RequestRelated` branch but missed the parallel **`update_state` requires(missing)** path. When a contract's `update_state` returns `UpdateModification::requires(missing)`, `bridged_upsert_contract_state` still mapped the `Either::Right(missing)` outcome straight to `MissingRelated` without attempting local lookup or network fetch.

This is the actual root cause behind freenet/mail#80: the inbox contract's `update_state` returns `requires(AFT-record)` on the receiver because it hasn't seen the sender's AFT yet. The mail UI workaround inline-bundles the related state via `RelatedStateAndDelta` to dodge the path entirely. After this PR the runtime resolves the related contracts itself (local first, then network via `start_sub_op_get` when `op_manager` is wired), and the workaround can be removed.

## Fix

Mirror the validate-side flow:

1. On `Either::Right(missing_related)`, walk each id with local-first / network-second fetch via `fetch_related_via_network` (introduced in #4006).
2. Append the fetched states as `UpdateData::RelatedState` entries to the update slice.
3. Re-attempt the merge.
4. If the second call still returns `requires`, reject (depth-1 limit, matching validate-side behavior).

## Test plan

- [x] `MockWasmRuntime` gets a new `UpdateOverride::RequiresRelated` to drive the path
- [x] `test_update_state_requires_related_fetches_and_retries` pins the happy path: stub records the network call, second update_state succeeds with RelatedState entries, upsert resolves to Ok
- [x] All 16 `pool_tests::related_contract_tests` pass locally
- [x] `cargo clippy --all-targets` clean
- [x] `contracts.md` updated to document both branches
- [ ] CI

## E2E

E2E validated against the iso-nodes harness with this binary: alice→bob cross-node delivery completes via the runtime's own resolution path (no UI inline-bundling needed). The mail-side `RelatedStateAndDelta` workaround is now redundant; will follow up with a mail PR removing it once this lands.