### PR TITLE
fix(server): add allow-downloads to webapp iframe sandbox

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -1867,6 +1867,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shell_page_iframe_sandbox_allows_downloads() {
+        // Regression for freenet/mail#TBD: webapps that emit blob/object-URL
+        // downloads via `<a download>` were silently dropped by Chromium
+        // and Safari because the iframe sandbox omitted `allow-downloads`.
+        // Lock the token in so a future refactor does not regress the fix.
+        let token = AuthToken::generate();
+        let html =
+            response_body(shell_page(&token, "testkey123", ApiVersion::V1, None).unwrap()).await;
+        assert!(
+            html.contains("allow-downloads"),
+            "iframe sandbox missing `allow-downloads` — user-initiated \
+             file downloads from sandboxed webapps will be silently blocked \
+             by the browser. Got HTML:\n{html}"
+        );
+    }
+
+    #[tokio::test]
     async fn shell_page_contains_iframe_and_bridge() {
         let token = AuthToken::generate();
         let html =

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -3,7 +3,7 @@
 //! Contract web apps are served inside sandboxed iframes to provide origin isolation.
 //! The local API server returns a "shell" page that holds the auth token and
 //! proxies WebSocket connections via postMessage, while the contract runs in an
-//! `<iframe sandbox="allow-scripts allow-forms allow-popups">`
+//! `<iframe sandbox="allow-scripts allow-forms allow-popups allow-downloads">`
 //! with an opaque origin that cannot access other contracts' data.
 //! Popups inherit the sandbox (no `allow-popups-to-escape-sandbox`); external links
 //! are opened via the `open_url` shell bridge message to avoid CORS issues. Sandbox content
@@ -470,7 +470,7 @@ fn shell_page(
 <style>*{{margin:0;padding:0}}html,body{{width:100%;height:100%;overflow:hidden}}iframe{{width:100%;height:100%;border:none;display:block}}</style>
 </head>
 <body>
-<iframe id="app" sandbox="allow-scripts allow-forms allow-popups" data-src="{iframe_src}"></iframe>
+<iframe id="app" sandbox="allow-scripts allow-forms allow-popups allow-downloads" data-src="{iframe_src}"></iframe>
 <script>
 {SHELL_BRIDGE_JS}
 </script>
@@ -1874,7 +1874,7 @@ mod tests {
 
         // Shell page must contain sandboxed iframe
         assert!(
-            html.contains(r#"sandbox="allow-scripts allow-forms allow-popups"#),
+            html.contains(r#"sandbox="allow-scripts allow-forms allow-popups allow-downloads"#),
             "iframe sandbox attribute missing"
         );
         // Iframe src must include __sandbox=1
@@ -2088,7 +2088,7 @@ mod tests {
         // immediate load before JS can append the hash fragment).
         assert!(
             !html.contains(
-                r#"<iframe id="app" sandbox="allow-scripts allow-forms allow-popups" src="#
+                r#"<iframe id="app" sandbox="allow-scripts allow-forms allow-popups allow-downloads" src="#
             ),
             "iframe must use data-src, not src, to avoid loading before JS appends the hash"
         );


### PR DESCRIPTION
## Summary
- Adds `allow-downloads` to the shell-page iframe sandbox so webapps can trigger file downloads via `<a download>` / `Content-Disposition: attachment`. Without it Chromium and Safari silently drop the download, breaking export flows.
- First reported casualty: freenet-email's identity backup button is a no-op because the browser blocks the blob URL click.
- `allow-downloads` only enables user-initiated downloads; it does not grant origin or storage access, so the existing sandbox threat model is unchanged.

## Changes
- `crates/core/src/server/path_handlers.rs`: 4 sites updated (module doc, iframe template, two test assertions that pin the exact token list).

## Test plan
- [x] `cargo test -p freenet --lib server::path_handlers` — 53/53 pass
- [ ] Manual: rebuild gateway, click identity export in freenet-email, observe browser save dialog