### PR TITLE
refactor(dashboard): read subscribed contracts from canonical ring state

### DIFF
--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1249,7 +1249,11 @@ where
                                 event = "initial_state_installed",
                                 "Contract initial state installed"
                             );
-                            crate::node::network_status::record_contract_updated(&format!("{key}"));
+                            // Dashboard "last updated" telemetry; no-op if
+                            // we're not subscribed to this contract.
+                            if let Some(op_manager) = &self.op_manager {
+                                op_manager.ring.record_contract_update(&key);
+                            }
                             if let Err(err) = self
                                 .send_update_notification(&key, &params, &incoming_state)
                                 .await
@@ -1916,8 +1920,12 @@ where
             "Contract state updated"
         );
 
-        // Record update timestamp for dashboard display
-        crate::node::network_status::record_contract_updated(&format!("{key}"));
+        // Record update timestamp for dashboard display. No-op if we're
+        // not subscribed (e.g., a relay forwarding an UPDATE for a
+        // contract this peer doesn't track).
+        if let Some(op_manager) = &self.op_manager {
+            op_manager.ring.record_contract_update(key);
+        }
 
         if let Err(err) = self
             .send_update_notification(key, parameters, new_state)

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -9,12 +9,13 @@ use std::net::SocketAddr;
 use std::sync::{Arc, OnceLock, RwLock};
 use std::time::Instant;
 
-use crate::ring::PeerKeyLocation;
+use crate::ring::{PeerKeyLocation, Ring};
 use crate::router::Router;
 use crate::transport::metrics::TRANSPORT_METRICS;
 
 static NETWORK_STATUS: OnceLock<Arc<RwLock<NetworkStatus>>> = OnceLock::new();
 static ROUTER: OnceLock<Arc<parking_lot::RwLock<Router>>> = OnceLock::new();
+static RING: OnceLock<Arc<Ring>> = OnceLock::new();
 
 /// Store a reference to the Router for the dashboard.
 pub fn set_router(router: Arc<parking_lot::RwLock<Router>>) {
@@ -28,6 +29,14 @@ pub(crate) fn get_router() -> Option<Arc<parking_lot::RwLock<Router>>> {
     ROUTER.get().cloned()
 }
 
+/// Store a reference to the Ring so the dashboard can read canonical
+/// subscription / hosting state directly instead of mirroring it.
+pub fn set_ring(ring: Arc<Ring>) {
+    // OnceLock::set returns Err if already initialized; this is expected on repeated calls
+    #[allow(clippy::let_underscore_must_use)]
+    let _ = RING.set(ring);
+}
+
 /// Tracked network connection status for diagnostic display.
 pub struct NetworkStatus {
     pub gateway_failures: Vec<GatewayFailure>,
@@ -38,8 +47,6 @@ pub struct NetworkStatus {
     pub gateway_addresses: HashSet<SocketAddr>,
     /// Active peer connections.
     pub connected_peers: Vec<ConnectedPeer>,
-    /// Subscribed contracts keyed by encoded contract key.
-    pub subscribed_contracts: HashMap<String, ContractInfo>,
     /// Freenet version string.
     pub version: String,
     /// This node's ring location.
@@ -59,13 +66,6 @@ pub struct ConnectedPeer {
     pub location: Option<f64>,
     pub connected_since: Instant,
     pub peer_key_location: Option<PeerKeyLocation>,
-}
-
-/// Info about a subscribed contract.
-pub struct ContractInfo {
-    pub key_encoded: String,
-    pub subscribed_since: Instant,
-    pub last_updated: Option<Instant>,
 }
 
 /// Counters for each operation type: (success, failure).
@@ -171,7 +171,6 @@ pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: St
         started_at: Instant::now(),
         gateway_addresses: gateway_addrs,
         connected_peers: Vec::new(),
-        subscribed_contracts: HashMap::new(),
         version,
         own_location: None,
         external_address: None,
@@ -237,41 +236,6 @@ pub fn record_peer_disconnected(addr: SocketAddr) {
     if let Some(status) = NETWORK_STATUS.get() {
         if let Ok(mut s) = status.write() {
             s.connected_peers.retain(|p| p.address != addr);
-        }
-    }
-}
-
-/// Record a new subscription.
-pub fn record_subscription(key_encoded: String) {
-    if let Some(status) = NETWORK_STATUS.get() {
-        if let Ok(mut s) = status.write() {
-            s.subscribed_contracts
-                .entry(key_encoded.clone())
-                .or_insert_with(|| ContractInfo {
-                    key_encoded,
-                    subscribed_since: Instant::now(),
-                    last_updated: None,
-                });
-        }
-    }
-}
-
-/// Record that a contract was updated.
-pub fn record_contract_updated(key_encoded: &str) {
-    if let Some(status) = NETWORK_STATUS.get() {
-        if let Ok(mut s) = status.write() {
-            if let Some(info) = s.subscribed_contracts.get_mut(key_encoded) {
-                info.last_updated = Some(Instant::now());
-            }
-        }
-    }
-}
-
-/// Record a subscription removal.
-pub fn record_subscription_removed(key_encoded: &str) {
-    if let Some(status) = NETWORK_STATUS.get() {
-        if let Ok(mut s) = status.write() {
-            s.subscribed_contracts.remove(key_encoded);
         }
     }
 }
@@ -504,32 +468,35 @@ pub fn get_snapshot() -> Option<NetworkStatusSnapshot> {
     let open_connections = peers.len() as u32;
     let gateway_only = open_connections > 0 && peers.iter().all(|p| p.is_gateway);
 
-    let mut contracts: Vec<ContractSnapshot> = s
-        .subscribed_contracts
-        .values()
-        .map(|c| {
-            // Use char boundary for safe truncation (contract keys are base58/ASCII,
-            // but be defensive against future encoding changes).
-            let key_short = if c.key_encoded.chars().count() > 12 {
-                let trunc: String = c.key_encoded.chars().take(12).collect();
-                format!("{trunc}...")
-            } else {
-                c.key_encoded.clone()
-            };
-            ContractSnapshot {
-                key_short,
-                key_full: c.key_encoded.clone(),
-                subscribed_secs: now.duration_since(c.subscribed_since).as_secs(),
-                last_updated_secs: c.last_updated.map(|t| now.duration_since(t).as_secs()),
-            }
+    // Read subscribed contracts directly from the canonical lease map in
+    // `HostingManager`. Sort order is set inside the snapshot helper
+    // (most recently updated first; never-updated entries fall to the end).
+    let contracts: Vec<ContractSnapshot> = RING
+        .get()
+        .map(|ring| {
+            ring.dashboard_subscription_snapshot()
+                .into_iter()
+                .map(|c| {
+                    let key_full = c.key.to_string();
+                    // Use char boundary for safe truncation (contract keys
+                    // are base58/ASCII, but be defensive against future
+                    // encoding changes).
+                    let key_short = if key_full.chars().count() > 12 {
+                        let trunc: String = key_full.chars().take(12).collect();
+                        format!("{trunc}...")
+                    } else {
+                        key_full.clone()
+                    };
+                    ContractSnapshot {
+                        key_short,
+                        key_full,
+                        subscribed_secs: c.subscribed_secs,
+                        last_updated_secs: c.last_updated_secs,
+                    }
+                })
+                .collect()
         })
-        .collect();
-    // Sort by most recently updated first
-    contracts.sort_by(|a, b| {
-        let a_time = a.last_updated_secs.unwrap_or(u64::MAX);
-        let b_time = b.last_updated_secs.unwrap_or(u64::MAX);
-        a_time.cmp(&b_time)
-    });
+        .unwrap_or_default();
 
     let elapsed_secs = s.started_at.elapsed().as_secs();
     let has_version_mismatch = s
@@ -812,20 +779,14 @@ mod tests {
     }
 
     #[test]
-    fn test_subscription_tracking() {
+    fn test_subscription_tracking_no_ring_wired() {
+        // Without a Ring registered (the default in unit tests),
+        // `get_snapshot()` reports zero subscribed contracts. Subscription
+        // state lives in `HostingManager.active_subscriptions`; see
+        // hosting.rs::dashboard_snapshot_reflects_active_subscriptions for
+        // the regression test that pins the contracts-list pipeline.
         let _lock = TEST_MUTEX.lock().unwrap();
         init(31341, HashSet::new(), "0.1.148".to_string());
-
-        record_subscription("ABC123DEF456".to_string());
-        let snap = get_snapshot().unwrap();
-        assert_eq!(snap.contracts.len(), 1);
-        assert_eq!(snap.contracts[0].key_full, "ABC123DEF456");
-
-        record_contract_updated("ABC123DEF456");
-        let snap = get_snapshot().unwrap();
-        assert!(snap.contracts[0].last_updated_secs.is_some());
-
-        record_subscription_removed("ABC123DEF456");
         let snap = get_snapshot().unwrap();
         assert!(snap.contracts.is_empty());
     }

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -9,13 +9,29 @@ use std::net::SocketAddr;
 use std::sync::{Arc, OnceLock, RwLock};
 use std::time::Instant;
 
-use crate::ring::{PeerKeyLocation, Ring};
+use crate::ring::{PeerKeyLocation, SubscribedContractSnapshot};
 use crate::router::Router;
 use crate::transport::metrics::TRANSPORT_METRICS;
 
 static NETWORK_STATUS: OnceLock<Arc<RwLock<NetworkStatus>>> = OnceLock::new();
 static ROUTER: OnceLock<Arc<parking_lot::RwLock<Router>>> = OnceLock::new();
-static RING: OnceLock<Arc<Ring>> = OnceLock::new();
+
+/// Provider returning the current dashboard view of subscribed contracts.
+///
+/// In production this closure captures the node's `Arc<Ring>` and calls
+/// `Ring::dashboard_subscription_snapshot()`; tests can register an
+/// arbitrary closure to pin the wiring without constructing a Ring.
+pub type SubscriptionProvider =
+    Arc<dyn Fn() -> Vec<SubscribedContractSnapshot> + Send + Sync + 'static>;
+
+/// Replaceable storage for the subscription provider. Wrapped in a
+/// `RwLock<Option<…>>` rather than `OnceLock` so multi-node in-process
+/// harnesses can re-wire the dashboard to the live node — and so a
+/// repeated wiring is loud (replaces the previous provider) rather than
+/// silently retaining the first one set, which is precisely the
+/// silent-mirror failure mode this refactor exists to remove.
+static SUBSCRIPTION_PROVIDER: parking_lot::RwLock<Option<SubscriptionProvider>> =
+    parking_lot::RwLock::new(None);
 
 /// Store a reference to the Router for the dashboard.
 pub fn set_router(router: Arc<parking_lot::RwLock<Router>>) {
@@ -29,12 +45,18 @@ pub(crate) fn get_router() -> Option<Arc<parking_lot::RwLock<Router>>> {
     ROUTER.get().cloned()
 }
 
-/// Store a reference to the Ring so the dashboard can read canonical
-/// subscription / hosting state directly instead of mirroring it.
-pub fn set_ring(ring: Arc<Ring>) {
-    // OnceLock::set returns Err if already initialized; this is expected on repeated calls
-    #[allow(clippy::let_underscore_must_use)]
-    let _ = RING.set(ring);
+/// Register the dashboard's subscription data source. Replaces any
+/// previously-registered provider so multi-node in-process harnesses
+/// can re-wire to the current node.
+pub fn set_subscription_provider(provider: SubscriptionProvider) {
+    *SUBSCRIPTION_PROVIDER.write() = Some(provider);
+}
+
+/// Clear the subscription provider. Used by tests; not called from
+/// production.
+#[cfg(test)]
+pub(crate) fn clear_subscription_provider() {
+    *SUBSCRIPTION_PROVIDER.write() = None;
 }
 
 /// Tracked network connection status for diagnostic display.
@@ -468,13 +490,16 @@ pub fn get_snapshot() -> Option<NetworkStatusSnapshot> {
     let open_connections = peers.len() as u32;
     let gateway_only = open_connections > 0 && peers.iter().all(|p| p.is_gateway);
 
-    // Read subscribed contracts directly from the canonical lease map in
-    // `HostingManager`. Sort order is set inside the snapshot helper
-    // (most recently updated first; never-updated entries fall to the end).
-    let contracts: Vec<ContractSnapshot> = RING
-        .get()
-        .map(|ring| {
-            ring.dashboard_subscription_snapshot()
+    // Read subscribed contracts from the registered provider, which in
+    // production points at the canonical lease map in `HostingManager`.
+    // Sort order is set inside the provider (most recently updated first;
+    // never-updated entries fall to the end with a deterministic key
+    // tie-break).
+    let contracts: Vec<ContractSnapshot> = SUBSCRIPTION_PROVIDER
+        .read()
+        .as_ref()
+        .map(|provider| {
+            provider()
                 .into_iter()
                 .map(|c| {
                     let key_full = c.key.to_string();
@@ -779,16 +804,73 @@ mod tests {
     }
 
     #[test]
-    fn test_subscription_tracking_no_ring_wired() {
-        // Without a Ring registered (the default in unit tests),
-        // `get_snapshot()` reports zero subscribed contracts. Subscription
-        // state lives in `HostingManager.active_subscriptions`; see
-        // hosting.rs::dashboard_snapshot_reflects_active_subscriptions for
-        // the regression test that pins the contracts-list pipeline.
+    fn test_subscription_tracking_no_provider_wired() {
+        // With no provider registered, `get_snapshot()` reports zero
+        // subscribed contracts (rather than panicking).
         let _lock = TEST_MUTEX.lock().unwrap();
         init(31341, HashSet::new(), "0.1.148".to_string());
+        clear_subscription_provider();
         let snap = get_snapshot().unwrap();
         assert!(snap.contracts.is_empty());
+    }
+
+    /// Regression test for the dashboard "Subscribed Contracts" panel.
+    ///
+    /// Pins the production wiring: when the subscription provider is
+    /// registered and yields contracts, `get_snapshot().contracts`
+    /// renders them with the same field shape (`key_short`, `key_full`,
+    /// `subscribed_secs`, `last_updated_secs`) the dashboard template
+    /// expects. The bug this PR fixes was a silent break in this path
+    /// after SUBSCRIBE migrated to the task-per-tx driver and stopped
+    /// invoking the legacy mirror — without a test that exercises the
+    /// provider end-to-end, the same break could happen at the
+    /// `set_subscription_provider` seam in a future refactor.
+    #[test]
+    fn test_subscription_provider_wired_renders_contracts() {
+        use freenet_stdlib::prelude::{ContractCode, ContractInstanceId, ContractKey};
+
+        let _lock = TEST_MUTEX.lock().unwrap();
+        init(31350, HashSet::new(), "0.1.148".to_string());
+
+        // Two contracts with deterministic keys; the base58 encoding is
+        // long enough to exercise the >12-char truncation path.
+        let code_hash = ContractCode::from(vec![0u8; 32]).hash().clone();
+        let key_a =
+            ContractKey::from_id_and_code(ContractInstanceId::new([0xAA; 32]), code_hash.clone());
+        let key_b = ContractKey::from_id_and_code(ContractInstanceId::new([0xBB; 32]), code_hash);
+        let snapshot = vec![
+            crate::ring::SubscribedContractSnapshot {
+                key: key_a,
+                subscribed_secs: 30,
+                last_updated_secs: Some(5),
+            },
+            crate::ring::SubscribedContractSnapshot {
+                key: key_b,
+                subscribed_secs: 30,
+                last_updated_secs: None,
+            },
+        ];
+        set_subscription_provider(Arc::new(move || snapshot.clone()));
+
+        let snap = get_snapshot().unwrap();
+        assert_eq!(snap.contracts.len(), 2);
+        assert_eq!(snap.contracts[0].key_full, key_a.to_string());
+        assert_eq!(snap.contracts[0].subscribed_secs, 30);
+        assert_eq!(snap.contracts[0].last_updated_secs, Some(5));
+        // key_short should be truncated to the first 12 chars + ellipsis
+        // for any base58-encoded ContractKey.
+        assert!(snap.contracts[0].key_short.ends_with("..."));
+        assert_eq!(snap.contracts[0].key_short.chars().count(), 15);
+
+        // Replacing the provider must take effect immediately — the
+        // OnceLock-style "first set wins" pattern would silently fail
+        // multi-node test harnesses, exactly the failure mode this
+        // refactor exists to remove.
+        set_subscription_provider(Arc::new(Vec::new));
+        let snap = get_snapshot().unwrap();
+        assert!(snap.contracts.is_empty());
+
+        clear_subscription_provider();
     }
 
     #[test]

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -139,10 +139,13 @@ impl NodeP2P {
             gateway_addrs,
             crate::config::PCK_VERSION.to_string(),
         );
-        // Wire the ring so the dashboard can read canonical subscription /
-        // hosting state directly instead of mirroring it through
-        // `record_subscription` callbacks.
-        super::network_status::set_ring(self.op_manager.ring.clone());
+        // Wire the dashboard's subscription view directly to canonical
+        // ring state so the panel doesn't drift the way the legacy
+        // `record_subscription` mirror did.
+        let ring = self.op_manager.ring.clone();
+        super::network_status::set_subscription_provider(std::sync::Arc::new(move || {
+            ring.dashboard_subscription_snapshot()
+        }));
 
         // Emit peer startup event
         if let Some(event) = crate::tracing::NetEventLog::peer_startup(

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -139,6 +139,10 @@ impl NodeP2P {
             gateway_addrs,
             crate::config::PCK_VERSION.to_string(),
         );
+        // Wire the ring so the dashboard can read canonical subscription /
+        // hosting state directly instead of mirroring it through
+        // `record_subscription` callbacks.
+        super::network_status::set_ring(self.op_manager.ring.clone());
 
         // Emit peer startup event
         if let Some(event) = crate::tracing::NetEventLog::peer_startup(

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -1592,8 +1592,8 @@ impl Operation for SubscribeOp {
                                 // an upstream fulfilling peer back to a downstream requester.
                                 //
                                 // Critically, we do NOT call `ring.subscribe()`,
-                                // `record_subscription()`, `announce_contract_hosted()`, or
-                                // register ourselves as having an upstream. Relays are not
+                                // `announce_contract_hosted()`, or register ourselves as
+                                // having an upstream. Relays are not
                                 // subscribers in their own right; they only mediate updates
                                 // between the upstream fulfilling node and the downstream
                                 // requester. Doing any of the above on a relay would:
@@ -1669,7 +1669,9 @@ impl Operation for SubscribeOp {
                                 contract = %format!("{:.8}", key),
                                 "SUBSCRIPTION_ACCEPTED: registered lease-based subscription"
                             );
-                            crate::node::network_status::record_subscription(format!("{key}"));
+                            // Dashboard "Subscribed Contracts" reads from the canonical lease
+                            // map via `Ring::dashboard_subscription_snapshot`; the prior
+                            // `network_status::record_subscription` mirror has been removed.
 
                             // Fetch contract if we don't have it.
                             // This is non-fatal - if it fails, we still complete the

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1510,10 +1510,10 @@ async fn drive_relay_subscribe(
         })) => {
             // Relay-side Subscribed registration — mirror legacy
             // subscribe.rs:1690 arm. DO NOT call ring.subscribe /
-            // record_subscription / announce_contract_hosted here; a
-            // relay is not itself a subscriber. See subscribe.rs:1655–1688
-            // for the full reasoning (prevents the #3763 subscription
-            // storm feedback loop).
+            // announce_contract_hosted here; a relay is not itself a
+            // subscriber. See subscribe.rs:1655–1688 for the full
+            // reasoning (prevents the #3763 subscription storm feedback
+            // loop).
             register_downstream_subscriber(
                 op_manager,
                 &key,
@@ -2140,8 +2140,8 @@ mod tests {
         );
     }
 
-    /// Pin: relay driver MUST NOT call `ring.subscribe`, `record_subscription`,
-    /// or `announce_contract_hosted` on behalf of the relayed Subscribed
+    /// Pin: relay driver MUST NOT call `ring.subscribe` or
+    /// `announce_contract_hosted` on behalf of the relayed Subscribed
     /// response. A relay is not itself a subscriber; doing so would
     /// install a lease and trigger #3763 subscription-storm feedback
     /// loops via the renewal cycle.

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -2222,8 +2222,10 @@ async fn deliver_update_result(
     };
 
     let host_result = op.to_host_result();
-    // Note: record_contract_updated is called in commit_state_update (the single
-    // chokepoint for all state updates), so we don't call it here to avoid double-counting.
+    // Note: dashboard "last updated" telemetry is recorded via
+    // `Ring::record_contract_update` from `commit_state_update` (the single
+    // chokepoint for all state updates); we don't call it here to avoid
+    // double-counting.
 
     // Use try_send to avoid blocking spawned executor tasks (see channel-safety.md).
     op_manager

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1736,7 +1736,8 @@ mod tests {
 
     /// Guard: the driver must call `update_contract` to preserve all side
     /// effects (WASM merge, state persistence, BroadcastStateChange emission,
-    /// delegate notifications, record_contract_updated telemetry).
+    /// delegate notifications, dashboard last-updated telemetry via
+    /// `Ring::record_contract_update`).
     #[test]
     fn driver_calls_update_contract() {
         let src = include_str!("op_ctx_task.rs");

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -23,7 +23,10 @@ use either::Either;
 use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
 use parking_lot::{Mutex, RwLock};
 
-pub use hosting::{AddClientSubscriptionResult, ClientDisconnectResult, SubscribeResult};
+pub use hosting::{
+    AddClientSubscriptionResult, ClientDisconnectResult, SubscribeResult,
+    SubscribedContractSnapshot,
+};
 
 use crate::message::TransactionType;
 use crate::topology::TopologyAdjustment;
@@ -1701,6 +1704,18 @@ impl Ring {
     /// Returns: (contract, has_client_subscription, is_active_subscription, expires_at)
     pub fn get_subscription_states(&self) -> Vec<(ContractKey, bool, bool, Option<Instant>)> {
         self.hosting_manager.get_subscription_states()
+    }
+
+    /// Snapshot of every active subscription for the local-peer dashboard.
+    /// Reads directly from the canonical lease map.
+    pub fn dashboard_subscription_snapshot(&self) -> Vec<SubscribedContractSnapshot> {
+        self.hosting_manager.dashboard_subscription_snapshot()
+    }
+
+    /// Record that a state update was observed for `contract`.
+    /// No-op if the contract is not currently subscribed.
+    pub fn record_contract_update(&self, contract: &ContractKey) {
+        self.hosting_manager.record_contract_update(contract)
     }
 
     // ==================== Subscription Retry Spam Prevention ====================

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -108,6 +108,31 @@ pub struct SubscribeResult {
     pub expires_at: Instant,
 }
 
+/// Lease-tracked active subscription state.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SubscriptionLease {
+    /// First successful subscribe — preserved across renewals so the
+    /// dashboard can show continuous subscription duration.
+    pub subscribed_since: Instant,
+    /// When the lease expires unless renewed.
+    pub expires_at: Instant,
+    /// Most recent state update observed (for dashboard display).
+    pub last_updated: Option<Instant>,
+}
+
+/// Public dashboard snapshot of one subscribed contract.
+///
+/// Durations are computed inside `HostingManager` so the dashboard does
+/// not need to hold a `tokio::time::Instant` reference.
+#[derive(Debug, Clone)]
+pub struct SubscribedContractSnapshot {
+    pub key: ContractKey,
+    /// Seconds since the subscription was first established (preserved across renewals).
+    pub subscribed_secs: u64,
+    /// Seconds since the most recent observed state update, if any.
+    pub last_updated_secs: Option<u64>,
+}
+
 // =============================================================================
 // HostingManager
 // =============================================================================
@@ -130,9 +155,11 @@ pub struct SubscribeResult {
 /// - Active subscriptions and client subscriptions prevent eviction
 /// - TTL protects recently accessed contracts from premature eviction
 pub(crate) struct HostingManager {
-    /// Active subscriptions with lease expiry timestamps.
-    /// Key: ContractKey, Value: expiry timestamp
-    active_subscriptions: DashMap<ContractKey, Instant>,
+    /// Active subscriptions with lease state and dashboard telemetry.
+    /// Holds the lease expiry plus enough history (subscribed_since,
+    /// last_updated) for the local-peer dashboard to render this map
+    /// directly without a parallel mirror.
+    active_subscriptions: DashMap<ContractKey, SubscriptionLease>,
 
     /// Contracts where a local client (WebSocket) is actively subscribed.
     /// Prevents hosting cache eviction while client subscriptions exist.
@@ -203,12 +230,26 @@ impl HostingManager {
     ///
     /// Creates a new subscription or renews an existing one. The subscription
     /// will expire after `SUBSCRIPTION_LEASE_DURATION` unless renewed.
+    /// `subscribed_since` is preserved on renewal so the dashboard reports
+    /// the continuous subscription duration, not the most recent renewal.
     pub fn subscribe(&self, contract: ContractKey) -> SubscribeResult {
-        let expires_at = self.time_source.now() + SUBSCRIPTION_LEASE_DURATION;
-        let is_new = self
-            .active_subscriptions
-            .insert(contract, expires_at)
-            .is_none();
+        use dashmap::mapref::entry::Entry;
+        let now = self.time_source.now();
+        let expires_at = now + SUBSCRIPTION_LEASE_DURATION;
+        let is_new = match self.active_subscriptions.entry(contract) {
+            Entry::Occupied(mut e) => {
+                e.get_mut().expires_at = expires_at;
+                false
+            }
+            Entry::Vacant(e) => {
+                e.insert(SubscriptionLease {
+                    subscribed_since: now,
+                    expires_at,
+                    last_updated: None,
+                });
+                true
+            }
+        };
 
         debug!(
             %contract,
@@ -228,7 +269,7 @@ impl HostingManager {
     #[allow(dead_code)] // Used in tests, may be used for explicit renewal in future
     pub fn renew_subscription(&self, contract: &ContractKey) -> bool {
         if let Some(mut entry) = self.active_subscriptions.get_mut(contract) {
-            *entry = self.time_source.now() + SUBSCRIPTION_LEASE_DURATION;
+            entry.expires_at = self.time_source.now() + SUBSCRIPTION_LEASE_DURATION;
             debug!(%contract, "renew_subscription: lease extended");
             true
         } else {
@@ -243,7 +284,6 @@ impl HostingManager {
     /// (in the hosting cache) until evicted by LRU.
     pub fn unsubscribe(&self, contract: &ContractKey) {
         if self.active_subscriptions.remove(contract).is_some() {
-            crate::node::network_status::record_subscription_removed(&format!("{contract}"));
             debug!(%contract, "unsubscribe: removed active subscription");
         }
     }
@@ -252,7 +292,7 @@ impl HostingManager {
     pub fn is_subscribed(&self, contract: &ContractKey) -> bool {
         self.active_subscriptions
             .get(contract)
-            .map(|expires_at| *expires_at > self.time_source.now())
+            .map(|lease| lease.expires_at > self.time_source.now())
             .unwrap_or(false)
     }
 
@@ -262,12 +302,57 @@ impl HostingManager {
         let mut contracts: Vec<ContractKey> = self
             .active_subscriptions
             .iter()
-            .filter(|entry| *entry.value() > now)
+            .filter(|entry| entry.value().expires_at > now)
             .map(|entry| *entry.key())
             .collect();
         // Sort for deterministic ordering (critical for simulation tests)
         contracts.sort_by(|a, b| a.id().as_bytes().cmp(b.id().as_bytes()));
         contracts
+    }
+
+    /// Snapshot of every active subscription for the local-peer dashboard.
+    ///
+    /// Reads directly from the canonical lease map (no parallel mirror).
+    /// The earlier `network_status::subscribed_contracts` mirror silently
+    /// drifted after SUBSCRIBE moved to the task-per-tx driver and lost
+    /// its recording hook.
+    pub fn dashboard_subscription_snapshot(&self) -> Vec<SubscribedContractSnapshot> {
+        let now = self.time_source.now();
+        let mut snapshot: Vec<SubscribedContractSnapshot> = self
+            .active_subscriptions
+            .iter()
+            .filter(|entry| entry.value().expires_at > now)
+            .map(|entry| {
+                let lease = *entry.value();
+                SubscribedContractSnapshot {
+                    key: *entry.key(),
+                    subscribed_secs: now
+                        .saturating_duration_since(lease.subscribed_since)
+                        .as_secs(),
+                    last_updated_secs: lease
+                        .last_updated
+                        .map(|t| now.saturating_duration_since(t).as_secs()),
+                }
+            })
+            .collect();
+        // Most recently updated first; never-updated entries fall to the end.
+        snapshot.sort_by(|a, b| match (a.last_updated_secs, b.last_updated_secs) {
+            (Some(a_secs), Some(b_secs)) => a_secs.cmp(&b_secs),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => a.key.id().as_bytes().cmp(b.key.id().as_bytes()),
+        });
+        snapshot
+    }
+
+    /// Record that a state update was observed for `contract`.
+    ///
+    /// Updates the dashboard "last seen update" timestamp. No-op if we
+    /// are not currently subscribed.
+    pub fn record_contract_update(&self, contract: &ContractKey) {
+        if let Some(mut entry) = self.active_subscriptions.get_mut(contract) {
+            entry.last_updated = Some(self.time_source.now());
+        }
     }
 
     /// Expire stale subscriptions and return the contracts that were expired.
@@ -290,8 +375,8 @@ impl HostingManager {
         let mut expired = Vec::new();
 
         // Collect expired subscriptions
-        self.active_subscriptions.retain(|contract, expires_at| {
-            if *expires_at <= now {
+        self.active_subscriptions.retain(|contract, lease| {
+            if lease.expires_at <= now {
                 expired.push(*contract);
                 false
             } else {
@@ -300,9 +385,6 @@ impl HostingManager {
         });
 
         if !expired.is_empty() {
-            for contract in &expired {
-                crate::node::network_status::record_subscription_removed(&format!("{contract}"));
-            }
             info!(
                 expired_count = expired.len(),
                 "expire_stale_subscriptions: expired stale subscriptions"
@@ -318,7 +400,7 @@ impl HostingManager {
         let now = self.time_source.now();
         self.active_subscriptions
             .iter()
-            .filter(|entry| *entry.value() > now)
+            .filter(|entry| entry.value().expires_at > now)
             .count()
     }
 
@@ -807,7 +889,7 @@ impl HostingManager {
             .iter()
             .map(|entry| {
                 let contract = *entry.key();
-                let expires_at = *entry.value();
+                let expires_at = entry.value().expires_at;
                 let is_active = expires_at > now;
                 let has_client = self.has_client_subscriptions(contract.id());
                 (contract, has_client, is_active, Some(expires_at))
@@ -841,7 +923,7 @@ impl HostingManager {
         let mut active_subs: Vec<_> = self
             .active_subscriptions
             .iter()
-            .map(|entry| (*entry.key(), *entry.value()))
+            .map(|entry| (*entry.key(), entry.value().expires_at))
             .collect();
         active_subs.sort_by(|(a, _), (b, _)| a.id().as_bytes().cmp(b.id().as_bytes()));
 
@@ -862,7 +944,7 @@ impl HostingManager {
             let has_active = self
                 .active_subscriptions
                 .iter()
-                .any(|sub| sub.key().id() == &instance_id && *sub.value() > now);
+                .any(|sub| sub.key().id() == &instance_id && sub.value().expires_at > now);
             if !has_active {
                 // Need to find the ContractKey - check hosting cache
                 if let Some(contract) = self
@@ -890,7 +972,7 @@ impl HostingManager {
                     && !self
                         .active_subscriptions
                         .get(&key)
-                        .map(|e| *e > now)
+                        .map(|e| e.expires_at > now)
                         .unwrap_or(false)
                 {
                     needs_renewal_set.insert(key);
@@ -933,7 +1015,7 @@ impl HostingManager {
         // `contracts` map below, which hides active_subscriptions entries
         // behind hosting cache presence when both exist.
         for entry in self.active_subscriptions.iter() {
-            if *entry.value() > now {
+            if entry.value().expires_at > now {
                 snapshot.active_subscription_keys.insert(*entry.key().id());
             }
         }
@@ -965,7 +1047,7 @@ impl HostingManager {
         let mut active_subs: Vec<_> = self
             .active_subscriptions
             .iter()
-            .map(|entry| (*entry.key(), *entry.value()))
+            .map(|entry| (*entry.key(), entry.value().expires_at))
             .collect();
         active_subs.sort_by(|(a, _), (b, _)| a.id().as_bytes().cmp(b.id().as_bytes()));
 
@@ -1406,6 +1488,83 @@ mod tests {
         assert!(subscribed.contains(&c1));
         assert!(!subscribed.contains(&c2));
         assert!(subscribed.contains(&c3));
+    }
+
+    /// Pins the dashboard contract: `subscribe(...)` must be visible in
+    /// `dashboard_subscription_snapshot()` immediately, with no separate
+    /// recording call. The previous parallel `network_status` mirror
+    /// silently drifted when SUBSCRIBE migrated to the task-per-tx driver
+    /// (PR #3806 → #3981); this test prevents the regression.
+    #[tokio::test]
+    async fn dashboard_snapshot_reflects_active_subscriptions() {
+        let manager = HostingManager::new();
+        let c1 = make_contract_key(1);
+        let c2 = make_contract_key(2);
+
+        // Empty before any subscription.
+        assert!(manager.dashboard_subscription_snapshot().is_empty());
+
+        // Subscribing makes the contract visible to the dashboard.
+        manager.subscribe(c1);
+        let snap = manager.dashboard_subscription_snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].key, c1);
+        assert!(snap[0].last_updated_secs.is_none());
+
+        // record_contract_update populates last_updated_secs.
+        manager.record_contract_update(&c1);
+        let snap = manager.dashboard_subscription_snapshot();
+        assert!(snap[0].last_updated_secs.is_some());
+
+        // Multiple subscriptions are reflected.
+        manager.subscribe(c2);
+        let snap = manager.dashboard_subscription_snapshot();
+        assert_eq!(snap.len(), 2);
+
+        // Unsubscribe removes the entry.
+        manager.unsubscribe(&c1);
+        let snap = manager.dashboard_subscription_snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].key, c2);
+
+        // record_contract_update on a non-subscribed contract is a no-op
+        // (matches the legacy network_status::record_contract_updated
+        // semantics, which silently dropped updates for unknown keys).
+        manager.record_contract_update(&c1);
+        let snap = manager.dashboard_subscription_snapshot();
+        assert_eq!(snap.len(), 1);
+        assert!(snap.iter().all(|s| s.key != c1));
+    }
+
+    /// Subscription renewal must not reset `subscribed_since`, otherwise
+    /// the dashboard's "subscribed for X seconds" reading would flip back
+    /// to ~0 every renewal interval (2 min) for every River user.
+    #[tokio::test]
+    async fn dashboard_snapshot_preserves_subscribed_since_across_renewals() {
+        let manager = HostingManager::new();
+        let c = make_contract_key(1);
+
+        let read_lease = || {
+            *manager
+                .active_subscriptions
+                .get(&c)
+                .expect("subscription must exist")
+        };
+
+        manager.subscribe(c);
+        let initial = read_lease();
+
+        manager.subscribe(c);
+        let renewed = read_lease();
+
+        assert_eq!(
+            renewed.subscribed_since, initial.subscribed_since,
+            "subscribed_since must be preserved across renewals"
+        );
+        assert!(
+            renewed.expires_at >= initial.expires_at,
+            "expires_at must monotonically advance on renewal"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -238,6 +238,9 @@ impl HostingManager {
         let expires_at = now + SUBSCRIPTION_LEASE_DURATION;
         let is_new = match self.active_subscriptions.entry(contract) {
             Entry::Occupied(mut e) => {
+                // Renewal: advance the lease but DELIBERATELY preserve
+                // `subscribed_since` (continuous duration) and
+                // `last_updated` (most-recent UPDATE timestamp).
                 e.get_mut().expires_at = expires_at;
                 false
             }
@@ -335,12 +338,19 @@ impl HostingManager {
                 }
             })
             .collect();
-        // Most recently updated first; never-updated entries fall to the end.
-        snapshot.sort_by(|a, b| match (a.last_updated_secs, b.last_updated_secs) {
-            (Some(a_secs), Some(b_secs)) => a_secs.cmp(&b_secs),
-            (Some(_), None) => std::cmp::Ordering::Less,
-            (None, Some(_)) => std::cmp::Ordering::Greater,
-            (None, None) => a.key.id().as_bytes().cmp(b.key.id().as_bytes()),
+        // Most recently updated first; never-updated entries fall to the
+        // end. Ties on `last_updated_secs` (including the (None, None)
+        // case) break by key bytes so the dashboard renders a stable
+        // order across refreshes — DashMap iteration order would
+        // otherwise leak through and reshuffle rows on every poll.
+        snapshot.sort_by(|a, b| {
+            let primary = match (a.last_updated_secs, b.last_updated_secs) {
+                (Some(a_secs), Some(b_secs)) => a_secs.cmp(&b_secs),
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => std::cmp::Ordering::Equal,
+            };
+            primary.then_with(|| a.key.id().as_bytes().cmp(b.key.id().as_bytes()))
         });
         snapshot
     }
@@ -1534,6 +1544,54 @@ mod tests {
         let snap = manager.dashboard_subscription_snapshot();
         assert_eq!(snap.len(), 1);
         assert!(snap.iter().all(|s| s.key != c1));
+    }
+
+    /// Sort order of `dashboard_subscription_snapshot()` must be
+    /// deterministic — DashMap iteration order would otherwise leak
+    /// through to the rendered dashboard, reshuffling rows on every
+    /// 5-second poll. Ties (including `None`/`None` for never-updated
+    /// entries) must break by contract-key bytes.
+    #[tokio::test]
+    async fn dashboard_snapshot_sort_is_deterministic_on_ties() {
+        let manager = HostingManager::new();
+        // Three contracts with distinct, ordered key-byte prefixes
+        // (`make_contract_key(seed)` writes `[seed; 32]` into the
+        // ContractInstanceId, so seeds 0x10/0x40/0xF0 sort low/mid/high).
+        let low = make_contract_key(0x10);
+        let mid = make_contract_key(0x40);
+        let high = make_contract_key(0xF0);
+
+        // Subscribe all three, then drive `last_updated` to the same
+        // wall-clock timestamp for `low` and `high`. `mid` stays
+        // never-updated, so it must sort to the end.
+        manager.subscribe(low);
+        manager.subscribe(mid);
+        manager.subscribe(high);
+        manager.record_contract_update(&high);
+        manager.record_contract_update(&low);
+
+        let snap = manager.dashboard_subscription_snapshot();
+        assert_eq!(snap.len(), 3);
+        // `low` and `high` share `last_updated_secs` (both 0 immediately
+        // after `record_contract_update`); the byte-key tie-break must
+        // place `low` before `high`. `mid` (never updated) goes last.
+        assert_eq!(
+            snap.iter().map(|s| s.key).collect::<Vec<_>>(),
+            vec![low, high, mid],
+            "snapshot must be ordered (low, high, mid); got {:?}",
+            snap.iter().map(|s| s.key).collect::<Vec<_>>()
+        );
+
+        // Re-poll: the order MUST be the same. (Pre-fix: DashMap
+        // iteration order would shuffle on every call.)
+        for _ in 0..5 {
+            let again = manager.dashboard_subscription_snapshot();
+            assert_eq!(
+                again.iter().map(|s| s.key).collect::<Vec<_>>(),
+                vec![low, high, mid],
+                "repeated snapshots must be byte-stable"
+            );
+        }
     }
 
     /// Subscription renewal must not reset `subscribed_since`, otherwise


### PR DESCRIPTION
## Problem

The local-peer dashboard's "Subscribed Contracts" panel mirrored
subscription state in `network_status::subscribed_contracts`, populated
by `record_subscription()` callbacks from the SUBSCRIBE op. When
SUBSCRIBE was migrated to the task-per-tx driver (PRs #3806 → #3981),
no client-initiated path called the recording hook anymore — so the
panel silently showed "No active subscriptions" for every node, even
while UPDATEs were flowing through and River's room contract was
clearly subscribed.

Verified on `technic` before fixing: dashboard reported 0 subscribed
contracts while UPDATE counter was 7.

## Approach

Rather than re-add the missing callback (the same gap would reopen on
the next migration that touches subscribe), eliminate the parallel
mirror entirely: the dashboard now reads from a `SubscriptionProvider`
closure that production wires to `Ring::dashboard_subscription_snapshot()`,
which reads `HostingManager.active_subscriptions` directly. Subscription
state has exactly one home.

The lease value type was a bare `Instant` (the expiry); it's now a
`SubscriptionLease { subscribed_since, expires_at, last_updated }`,
with `subscribed_since` preserved across renewals so the dashboard
shows continuous duration rather than resetting every 2 minutes when
the lease renews.

The dashboard pipeline:
- `Ring` exposes `dashboard_subscription_snapshot()` and
  `record_contract_update()` (both passthroughs to `HostingManager`).
- `network_status::set_subscription_provider(Arc<dyn Fn -> ...>)` is
  wired from `p2p_impl::run_node` after `init()`. The provider is held
  in a `RwLock<Option<...>>` (not `OnceLock`) so multi-node in-process
  test harnesses can re-wire to the live node — and so a second
  registration *replaces* the first rather than silently retaining the
  stale one (which is precisely the silent-failure mode this refactor
  exists to remove).
- `get_snapshot()` calls the provider; with no provider registered
  (e.g. unit tests that don't boot a node), the contracts list is
  empty.

Removed the parallel state:
- `subscribed_contracts: HashMap<String, ContractInfo>` field on
  `NetworkStatus`
- `ContractInfo` struct
- `record_subscription`, `record_subscription_removed`,
  `record_contract_updated` — including `record_subscription_removed`
  calls from `unsubscribe()` and `expire_stale_subscriptions()` (no
  longer needed; the canonical map *is* the source).

Migrated call sites:
- `runtime.rs::commit_state_update` and the new
  `initial_state_installed` site (added in #4007) now call
  `op_manager.ring.record_contract_update`.
- The dead `record_subscription` line at the legacy
  `subscribe.rs::SubscribeMsg::Response` arm is removed; that path
  hadn't been reached by client-initiated subscribes since #3981. The
  arm itself stays — its `ring.subscribe(*key)` call still does real
  work for any future caller.

User-visible behavior changes:
- Sort order in the dashboard "Subscribed Contracts" list. Old code
  put never-updated entries first (`unwrap_or(u64::MAX)` + ascending
  sort); new code puts most-recently-updated first, never-updated
  last, with a deterministic byte-key tie-break for entries with
  identical `last_updated_secs`. This eliminates a UX glitch where
  rows would reshuffle on every 5-second dashboard poll due to
  DashMap iteration order leaking through.
- The "subscribed for X seconds" reading no longer resets every 2
  minutes (when the lease renews). It now reflects the continuous
  subscription duration since first subscribe.

## Testing

Unit tests added (in `crates/core/src/`):

- `ring/hosting.rs::dashboard_snapshot_reflects_active_subscriptions`
  — pins that `subscribe()` is visible in the snapshot directly,
  covers `record_contract_update`, multi-subscription, unsubscribe,
  and the "update on non-subscribed = no-op" semantic.
- `ring/hosting.rs::dashboard_snapshot_preserves_subscribed_since_across_renewals`
  — pins that lease renewal does not reset `subscribed_since`.
- `ring/hosting.rs::dashboard_snapshot_sort_is_deterministic_on_ties`
  — pins the byte-key tie-break for entries with identical
  `last_updated_secs`. Re-polls 5× to confirm stability across
  refreshes.
- `node/network_status.rs::test_subscription_provider_wired_renders_contracts`
  — pins the **production seam**: registers a provider, asserts the
  rendered `ContractSnapshot` field shape (`key_short`, `key_full`,
  `subscribed_secs`, `last_updated_secs`), and verifies that
  re-registering replaces the previous provider.

Local validation:
- `cargo fmt -p freenet` clean
- `cargo check -p freenet --tests` clean (clippy has a pre-existing
  warning in `transport.rs:941` unrelated to this PR)
- `cargo test -p freenet --lib ring::hosting::` — 62 passed (was 59;
  +3 new), 5 ignored (pre-existing)
- `cargo test -p freenet --lib node::network_status` — 19 passed
- `cargo test -p freenet --lib server::home_page` — 30 passed

### Why didn't CI catch this?

The pre-existing `network_status::test_subscription_tracking` only
tested the `record_subscription` mirror functions in isolation; it
never exercised the path from `HostingManager::subscribe` through to
`get_snapshot()`. After #3981 finished migrating every client-initiated
SUBSCRIBE off the legacy path, that unit test still passed (the mirror
functions still worked) while the production pipeline was broken end
to end. The new `test_subscription_provider_wired_renders_contracts`
exercises the seam as it's actually used, so a future regression
where `set_subscription_provider` is forgotten or wired wrong fails CI.

## Follow-up

The same silent-mirror class of bug almost certainly affects
`network_status::record_op_result` for SUBSCRIBE and UPDATE on the
task-per-tx originator path: only PUT and GET task-per-tx drivers call
`record_op_result`, so the dashboard's `op_stats.subscribes` and
`op_stats.updates` counters are silently stuck on whatever the legacy
state-machine path produces. Out of scope for this PR; will file a
separate issue.

## Fixes

Closes the silent-dashboard regression observed in production.

[AI-assisted - Claude]