### PR TITLE
fix: record SUBSCRIBE/UPDATE op_stats counters from task-per-tx drivers

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -821,13 +821,10 @@ mod tests {
         record_op_result(OpType::Get, true);
         record_op_result(OpType::Get, false);
         record_op_result(OpType::Put, true);
-        // SUBSCRIBE / UPDATE counters were silently stuck at zero before
-        // issue #4010 (the task-per-tx drivers stopped invoking the
-        // recording hook after the #1454 migrations). Cover both op
-        // types and both outcomes here so any regression in the
-        // counter wiring fails this test alongside the source-grep
-        // pin tests in `subscribe/op_ctx_task.rs` and
-        // `update/op_ctx_task.rs`.
+        // Issue #4010: SUBSCRIBE / UPDATE counters were stuck at zero
+        // because the task-per-tx drivers stopped recording outcomes.
+        // Pin both op types and both outcomes so the wiring regression
+        // is caught here in addition to the source-grep pin tests.
         record_op_result(OpType::Subscribe, true);
         record_op_result(OpType::Subscribe, false);
         record_op_result(OpType::Update, true);

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -280,10 +280,24 @@ pub fn record_peer_disconnected(addr: SocketAddr) {
 /// - `operations/update/op_ctx_task.rs::deliver_outcome` (client-
 ///   initiated UPDATE; covers all `DriverOutcome` variants).
 ///
-/// Internal-only operations (subscription renewals, sub-operation
-/// SUBSCRIBE/GET spawned by PUT/GET, executor auto-subscribe) are
-/// intentionally NOT recorded: they would inflate the user-facing
-/// counter with background traffic.
+/// Internal-only operations are intentionally NOT recorded; counting
+/// them would inflate the user-facing counter with background traffic
+/// (renewals fire every 2 minutes per active subscription, sub-op
+/// SUBSCRIBE fires once per PUT/GET completion). Specifically:
+///
+/// - `operations/subscribe/op_ctx_task.rs::run_renewal_subscribe`
+///   (subscription renewal driver, called from
+///   `ring::connection_maintenance`).
+/// - `operations/subscribe/op_ctx_task.rs::run_executor_subscribe`
+///   (executor auto-subscribe, called from
+///   `contract::executor::runtime`).
+/// - Sub-operation SUBSCRIBE spawned by PUT/GET via
+///   `Transaction::new_child_of` (gated in
+///   `subscribe::op_ctx_task::deliver_outcome` by
+///   `!client_tx.is_sub_operation()`).
+/// - Sub-operation GET spawned by subscribe / executor
+///   (`get::op_ctx_task::start_sub_op_get` returns through a oneshot
+///   and never publishes via `result_router_tx`).
 ///
 /// Audit: `grep -rn "record_op_result" crates/core/src/operations/`
 /// must show coverage for every op type that has a task-per-tx driver.
@@ -823,8 +837,11 @@ mod tests {
         record_op_result(OpType::Put, true);
         // Issue #4010: SUBSCRIBE / UPDATE counters were stuck at zero
         // because the task-per-tx drivers stopped recording outcomes.
-        // Pin both op types and both outcomes so the wiring regression
-        // is caught here in addition to the source-grep pin tests.
+        // Cover both op types and both outcomes (success + failure) so
+        // the per-op tabulation is pinned end to end. The two
+        // `OpType::Update, true` calls are intentional, not a copy
+        // paste: we want the success counter to assert `2`, paired
+        // with one failure for `1`.
         record_op_result(OpType::Subscribe, true);
         record_op_result(OpType::Subscribe, false);
         record_op_result(OpType::Update, true);

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -262,7 +262,31 @@ pub fn record_peer_disconnected(addr: SocketAddr) {
     }
 }
 
-/// Record an operation result.
+/// Record an operation result for the dashboard "Operations" panel.
+///
+/// # Required call sites
+///
+/// This is a manually-mirrored counter: every code path that delivers a
+/// terminal client-visible op result MUST call this exactly once with
+/// the matching outcome. Forgetting a call site silently rots the
+/// counter (issue #4009 / #4010 prior incidents). Current writers:
+///
+/// - `node.rs::report_result` for legacy state-machine ops (PUT/GET/
+///   UPDATE/SUBSCRIBE that still flow through `OpManager.ops.*`).
+/// - `operations/get/op_ctx_task.rs` `Done` arm (client-initiated GET).
+/// - `operations/put/op_ctx_task.rs` `Done` arm (client-initiated PUT).
+/// - `operations/subscribe/op_ctx_task.rs::deliver_outcome` (client-
+///   initiated SUBSCRIBE; covers all `DriverOutcome` variants).
+/// - `operations/update/op_ctx_task.rs::deliver_outcome` (client-
+///   initiated UPDATE; covers all `DriverOutcome` variants).
+///
+/// Internal-only operations (subscription renewals, sub-operation
+/// SUBSCRIBE/GET spawned by PUT/GET, executor auto-subscribe) are
+/// intentionally NOT recorded: they would inflate the user-facing
+/// counter with background traffic.
+///
+/// Audit: `grep -rn "record_op_result" crates/core/src/operations/`
+/// must show coverage for every op type that has a task-per-tx driver.
 pub fn record_op_result(op_type: OpType, success: bool) {
     if let Some(status) = NETWORK_STATUS.get() {
         if let Ok(mut s) = status.write() {
@@ -797,10 +821,24 @@ mod tests {
         record_op_result(OpType::Get, true);
         record_op_result(OpType::Get, false);
         record_op_result(OpType::Put, true);
+        // SUBSCRIBE / UPDATE counters were silently stuck at zero before
+        // issue #4010 (the task-per-tx drivers stopped invoking the
+        // recording hook after the #1454 migrations). Cover both op
+        // types and both outcomes here so any regression in the
+        // counter wiring fails this test alongside the source-grep
+        // pin tests in `subscribe/op_ctx_task.rs` and
+        // `update/op_ctx_task.rs`.
+        record_op_result(OpType::Subscribe, true);
+        record_op_result(OpType::Subscribe, false);
+        record_op_result(OpType::Update, true);
+        record_op_result(OpType::Update, true);
+        record_op_result(OpType::Update, false);
 
         let snap = get_snapshot().unwrap();
         assert_eq!(snap.op_stats.gets, (2, 1));
         assert_eq!(snap.op_stats.puts, (1, 0));
+        assert_eq!(snap.op_stats.subscribes, (1, 1));
+        assert_eq!(snap.op_stats.updates, (2, 1));
     }
 
     #[test]

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1010,6 +1010,24 @@ fn deliver_outcome(
     instance_id: ContractInstanceId,
     outcome: DriverOutcome,
 ) {
+    // Record dashboard op_stats counter (issue #4010). Mirrors what
+    // `report_result` does for legacy state-machine ops via
+    // `node.rs::record_op_result`. The task-per-tx bypass at
+    // `handle_pure_network_message_v1` returns Ok(None) for forwarded
+    // replies, so `report_result` never sees the terminal classification
+    // for client-initiated SUBSCRIBE; the recording must happen here.
+    // Without it the dashboard "Operations" panel SUBSCRIBE counter
+    // sticks on whatever the legacy path produces (rarely hit on the
+    // originator side after the migrations in #3806 / #3981).
+    let success = matches!(
+        outcome,
+        DriverOutcome::Publish(Ok(_)) | DriverOutcome::SkipAlreadyDelivered
+    );
+    crate::node::network_status::record_op_result(
+        crate::node::network_status::OpType::Subscribe,
+        success,
+    );
+
     match outcome {
         DriverOutcome::Publish(result) => {
             op_manager.send_client_result(client_tx, result);
@@ -2466,6 +2484,56 @@ mod tests {
             body.contains("ExecutorSubscribeError::Infra"),
             "run_executor_subscribe early-return error branches must \
              wrap as ExecutorSubscribeError::Infra(...)"
+        );
+    }
+
+    /// Issue #4010 regression (source-level): client-initiated SUBSCRIBE
+    /// must record its outcome to the dashboard `op_stats.subscribes`
+    /// counter. The legacy `report_result` recording path does not run
+    /// for task-per-tx terminal replies (the bypass at
+    /// `handle_pure_network_message_v1` returns Ok(None)), so
+    /// `deliver_outcome` MUST call `record_op_result(OpType::Subscribe, _)`
+    /// itself. Without this the dashboard "Operations" panel SUBSCRIBE
+    /// counter is silently stuck at zero.
+    #[test]
+    fn deliver_outcome_records_subscribe_op_result() {
+        const SOURCE: &str = include_str!("op_ctx_task.rs");
+        let cutoff = SOURCE
+            .find("#[cfg(test)]")
+            .expect("file must have a #[cfg(test)] section");
+        let prod = &SOURCE[..cutoff];
+
+        let fn_start = prod
+            .find("fn deliver_outcome(")
+            .expect("deliver_outcome must exist");
+        // Walk to the matching closing brace.
+        let body_start = fn_start
+            + prod[fn_start..]
+                .find('{')
+                .expect("deliver_outcome must have a body");
+        let bytes = prod.as_bytes();
+        let mut depth: i32 = 1;
+        let mut i = body_start + 1;
+        while i < bytes.len() && depth > 0 {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => depth -= 1,
+                _ => {}
+            }
+            i += 1;
+        }
+        let body = &prod[body_start..i];
+
+        assert!(
+            body.contains("record_op_result"),
+            "deliver_outcome must call record_op_result so the dashboard \
+             SUBSCRIBE counter advances on task-per-tx terminal replies. \
+             Issue #4010."
+        );
+        assert!(
+            body.contains("OpType::Subscribe"),
+            "record_op_result inside deliver_outcome must be passed \
+             OpType::Subscribe (not Get/Put/Update)."
         );
     }
 }

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1010,15 +1010,10 @@ fn deliver_outcome(
     instance_id: ContractInstanceId,
     outcome: DriverOutcome,
 ) {
-    // Record dashboard op_stats counter (issue #4010). Mirrors what
-    // `report_result` does for legacy state-machine ops via
-    // `node.rs::record_op_result`. The task-per-tx bypass at
-    // `handle_pure_network_message_v1` returns Ok(None) for forwarded
-    // replies, so `report_result` never sees the terminal classification
-    // for client-initiated SUBSCRIBE; the recording must happen here.
-    // Without it the dashboard "Operations" panel SUBSCRIBE counter
-    // sticks on whatever the legacy path produces (rarely hit on the
-    // originator side after the migrations in #3806 / #3981).
+    // Dashboard op_stats SUBSCRIBE counter (issue #4010). The legacy
+    // `report_result` recording path is bypassed for task-per-tx
+    // terminal replies (see `node::record_op_result` rustdoc), so
+    // every terminal outcome must be recorded here.
     let success = matches!(
         outcome,
         DriverOutcome::Publish(Ok(_)) | DriverOutcome::SkipAlreadyDelivered
@@ -2487,42 +2482,20 @@ mod tests {
         );
     }
 
-    /// Issue #4010 regression (source-level): client-initiated SUBSCRIBE
-    /// must record its outcome to the dashboard `op_stats.subscribes`
-    /// counter. The legacy `report_result` recording path does not run
-    /// for task-per-tx terminal replies (the bypass at
-    /// `handle_pure_network_message_v1` returns Ok(None)), so
-    /// `deliver_outcome` MUST call `record_op_result(OpType::Subscribe, _)`
-    /// itself. Without this the dashboard "Operations" panel SUBSCRIBE
-    /// counter is silently stuck at zero.
+    /// Issue #4010 regression (source-level): `deliver_outcome` must
+    /// record the SUBSCRIBE outcome to the dashboard `op_stats.subscribes`
+    /// counter. Without this the counter is silently stuck at zero
+    /// because the task-per-tx bypass at
+    /// `handle_pure_network_message_v1` skips the legacy `report_result`
+    /// recording path.
     #[test]
     fn deliver_outcome_records_subscribe_op_result() {
         const SOURCE: &str = include_str!("op_ctx_task.rs");
-        let cutoff = SOURCE
-            .find("#[cfg(test)]")
-            .expect("file must have a #[cfg(test)] section");
-        let prod = &SOURCE[..cutoff];
-
-        let fn_start = prod
-            .find("fn deliver_outcome(")
-            .expect("deliver_outcome must exist");
-        // Walk to the matching closing brace.
-        let body_start = fn_start
-            + prod[fn_start..]
-                .find('{')
-                .expect("deliver_outcome must have a body");
-        let bytes = prod.as_bytes();
-        let mut depth: i32 = 1;
-        let mut i = body_start + 1;
-        while i < bytes.len() && depth > 0 {
-            match bytes[i] {
-                b'{' => depth += 1,
-                b'}' => depth -= 1,
-                _ => {}
-            }
-            i += 1;
-        }
-        let body = &prod[body_start..i];
+        let body = SOURCE
+            .split_once("fn deliver_outcome(")
+            .and_then(|(_, after)| after.split_once("// ── Relay SUBSCRIBE driver"))
+            .map(|(body, _)| body)
+            .expect("deliver_outcome body must precede the relay SUBSCRIBE driver section");
 
         assert!(
             body.contains("record_op_result"),

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1004,6 +1004,18 @@ where
 ///   user-visible error shape (e.g., `OpError::NotificationError` from
 ///   `send_and_await`) — everything else the driver builds an explicit
 ///   `DriverOutcome::Publish(Err(...))` for.
+///
+/// Dashboard op_stats success classifier (issue #4010). Extracted so the
+/// success/failure mapping per `DriverOutcome` variant has direct unit
+/// coverage; `deliver_outcome` itself takes an `OpManager` which is
+/// expensive to construct in tests.
+fn classify_subscribe_outcome_for_op_stats(outcome: &DriverOutcome) -> bool {
+    matches!(
+        outcome,
+        DriverOutcome::Publish(Ok(_)) | DriverOutcome::SkipAlreadyDelivered
+    )
+}
+
 fn deliver_outcome(
     op_manager: &OpManager,
     client_tx: Transaction,
@@ -1014,14 +1026,20 @@ fn deliver_outcome(
     // `report_result` recording path is bypassed for task-per-tx
     // terminal replies (see `node::record_op_result` rustdoc), so
     // every terminal outcome must be recorded here.
-    let success = matches!(
-        outcome,
-        DriverOutcome::Publish(Ok(_)) | DriverOutcome::SkipAlreadyDelivered
-    );
-    crate::node::network_status::record_op_result(
-        crate::node::network_status::OpType::Subscribe,
-        success,
-    );
+    //
+    // Sub-operation gate: `run_client_subscribe` is also the entry point
+    // for sub-op SUBSCRIBE spawned by PUT/GET (`maybe_subscribe_child`)
+    // and `start_subscription_request`, both of which create a child tx
+    // via `Transaction::new_child_of`. Those are background plumbing,
+    // not user-initiated SUBSCRIBE attempts; counting them would inflate
+    // the user-facing dashboard counter every time a PUT/GET completes.
+    if !client_tx.is_sub_operation() {
+        let success = classify_subscribe_outcome_for_op_stats(&outcome);
+        crate::node::network_status::record_op_result(
+            crate::node::network_status::OpType::Subscribe,
+            success,
+        );
+    }
 
     match outcome {
         DriverOutcome::Publish(result) => {
@@ -2482,20 +2500,23 @@ mod tests {
         );
     }
 
-    /// Issue #4010 regression (source-level): `deliver_outcome` must
-    /// record the SUBSCRIBE outcome to the dashboard `op_stats.subscribes`
-    /// counter. Without this the counter is silently stuck at zero
-    /// because the task-per-tx bypass at
-    /// `handle_pure_network_message_v1` skips the legacy `report_result`
-    /// recording path.
+    /// Issue #4010: `deliver_outcome` must record the SUBSCRIBE outcome
+    /// to the dashboard `op_stats.subscribes` counter (the task-per-tx
+    /// bypass at `handle_pure_network_message_v1` skips the legacy
+    /// `report_result` recording path), and it must NOT record sub-op
+    /// SUBSCRIBE attempts (those are background plumbing spawned by
+    /// PUT/GET, not user-initiated subscribes).
+    ///
+    /// Source-level regression pin: `deliver_outcome` must call
+    /// `record_op_result(OpType::Subscribe, ...)` and gate the call on
+    /// `!client_tx.is_sub_operation()`. Walks brace depth from the
+    /// opening `{` so the test does not depend on any nearby section
+    /// comments staying named the same.
     #[test]
     fn deliver_outcome_records_subscribe_op_result() {
         const SOURCE: &str = include_str!("op_ctx_task.rs");
-        let body = SOURCE
-            .split_once("fn deliver_outcome(")
-            .and_then(|(_, after)| after.split_once("// ── Relay SUBSCRIBE driver"))
-            .map(|(body, _)| body)
-            .expect("deliver_outcome body must precede the relay SUBSCRIBE driver section");
+        let prod = production_source(SOURCE);
+        let body = extract_fn_body(prod, "fn deliver_outcome(");
 
         assert!(
             body.contains("record_op_result"),
@@ -2508,5 +2529,128 @@ mod tests {
             "record_op_result inside deliver_outcome must be passed \
              OpType::Subscribe (not Get/Put/Update)."
         );
+        assert!(
+            body.contains("!client_tx.is_sub_operation()"),
+            "deliver_outcome must gate record_op_result on \
+             `!client_tx.is_sub_operation()` (note the leading `!`) so \
+             sub-op SUBSCRIBE spawned by PUT/GET \
+             (`maybe_subscribe_child`, `start_subscription_request`) \
+             does not inflate the user-facing dashboard counter. \
+             A flipped guard would silently re-introduce the inflation \
+             reported by Codex review. Issue #4010."
+        );
+    }
+
+    /// Issue #4010 negative-path pin: renewal subscribes
+    /// (`run_renewal_subscribe`) and executor auto-subscribes
+    /// (`run_executor_subscribe`) MUST NOT call `deliver_outcome` or
+    /// `record_op_result` directly. They have their own return-value
+    /// delivery paths and are background traffic that would inflate the
+    /// user-facing dashboard counter (renewals fire every 2 minutes per
+    /// active subscription).
+    #[test]
+    fn renewal_and_executor_subscribe_do_not_record_op_stats() {
+        const SOURCE: &str = include_str!("op_ctx_task.rs");
+        let prod = production_source(SOURCE);
+
+        let renewal_body = extract_fn_body(prod, "pub(crate) async fn run_renewal_subscribe(");
+        assert!(
+            !renewal_body.contains("deliver_outcome"),
+            "run_renewal_subscribe must NOT route through deliver_outcome \
+             — that would record renewals against the dashboard SUBSCRIBE \
+             counter. Issue #4010."
+        );
+        assert!(
+            !renewal_body.contains("record_op_result"),
+            "run_renewal_subscribe must NOT call record_op_result. \
+             Issue #4010."
+        );
+
+        let executor_body = extract_fn_body(prod, "pub(crate) async fn run_executor_subscribe(");
+        assert!(
+            !executor_body.contains("deliver_outcome"),
+            "run_executor_subscribe must NOT route through deliver_outcome \
+             — that would record executor auto-subscribes against the \
+             dashboard SUBSCRIBE counter. Issue #4010."
+        );
+        assert!(
+            !executor_body.contains("record_op_result"),
+            "run_executor_subscribe must NOT call record_op_result. \
+             Issue #4010."
+        );
+    }
+
+    /// Pure-function unit test: `classify_subscribe_outcome_for_op_stats`
+    /// covers every `DriverOutcome` variant. Pins the success/failure
+    /// mapping against accidental `success: !success` flips and against
+    /// dropping `SkipAlreadyDelivered` from the success arm (which would
+    /// silently undercount local-hit subscribes). Issue #4010.
+    #[test]
+    fn classify_subscribe_outcome_covers_all_variants() {
+        use freenet_stdlib::client_api::{ContractResponse, ErrorKind, HostResponse};
+        use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([7u8; 32]),
+            CodeHash::new([8u8; 32]),
+        );
+        let publish_ok = DriverOutcome::Publish(Ok(HostResponse::ContractResponse(
+            ContractResponse::SubscribeResponse {
+                key,
+                subscribed: true,
+            },
+        )));
+        let publish_err = DriverOutcome::Publish(Err(ErrorKind::OperationError {
+            cause: "synthetic".into(),
+        }
+        .into()));
+        let skip = DriverOutcome::SkipAlreadyDelivered;
+        let infra = DriverOutcome::InfrastructureError(OpError::UnexpectedOpState);
+
+        assert!(classify_subscribe_outcome_for_op_stats(&publish_ok));
+        assert!(!classify_subscribe_outcome_for_op_stats(&publish_err));
+        assert!(classify_subscribe_outcome_for_op_stats(&skip));
+        assert!(!classify_subscribe_outcome_for_op_stats(&infra));
+    }
+
+    /// Truncate the source string at the `#[cfg(test)]` marker so the
+    /// pin tests never see code or comments inside the test module
+    /// (avoids false positives where a test asserts a substring that
+    /// also appears in a sibling test).
+    fn production_source(full: &str) -> &str {
+        let cutoff = full
+            .find("#[cfg(test)]")
+            .expect("file must have a #[cfg(test)] section");
+        &full[..cutoff]
+    }
+
+    /// Walk brace depth from the opening `{` of the named fn to the
+    /// matching `}`. Returns the body slice (excluding the braces).
+    /// Robust to nearby section comments being renamed.
+    fn extract_fn_body<'a>(source: &'a str, signature_prefix: &str) -> &'a str {
+        let start = source
+            .find(signature_prefix)
+            .unwrap_or_else(|| panic!("could not find {signature_prefix}"));
+        let brace = source[start..]
+            .find('{')
+            .expect("fn signature must have a body");
+        let body_start = start + brace + 1;
+        let bytes = source.as_bytes();
+        let mut depth: i32 = 1;
+        let mut i = body_start;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &source[body_start..i];
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        panic!("unterminated fn body for {signature_prefix}");
     }
 }

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -361,6 +361,21 @@ async fn drive_client_update(
 // --- Outcome delivery ---
 
 fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: DriverOutcome) {
+    // Record dashboard op_stats counter (issue #4010). Mirrors what
+    // `report_result` does for legacy state-machine ops via
+    // `node.rs::record_op_result`. The task-per-tx bypass at
+    // `handle_pure_network_message_v1` returns Ok(None) for forwarded
+    // replies, so `report_result` never sees the terminal classification
+    // for client-initiated UPDATE; the recording must happen here.
+    // Without it the dashboard "Operations" panel UPDATE counter sticks
+    // on whatever the legacy path produces (rarely hit on the originator
+    // side after the #1454 Phase 4 migration).
+    let success = matches!(outcome, DriverOutcome::Publish(Ok(_)));
+    crate::node::network_status::record_op_result(
+        crate::node::network_status::OpType::Update,
+        success,
+    );
+
     match outcome {
         DriverOutcome::Publish(result) => {
             // send_client_result handles both result_router_tx.try_send AND
@@ -2288,6 +2303,55 @@ mod tests {
             !src.contains("Broadcasting {"),
             "UpdateMsg::Broadcasting must remain deleted; appending new variants \
              at the end of UpdateMsg preserves bincode discriminant tags."
+        );
+    }
+
+    /// Issue #4010 regression (source-level): client-initiated UPDATE
+    /// must record its outcome to the dashboard `op_stats.updates`
+    /// counter. The legacy `report_result` recording path does not run
+    /// for task-per-tx terminal replies (the bypass at
+    /// `handle_pure_network_message_v1` returns Ok(None)), so
+    /// `deliver_outcome` MUST call `record_op_result(OpType::Update, _)`
+    /// itself. Without this the dashboard "Operations" panel UPDATE
+    /// counter is silently stuck at zero.
+    #[test]
+    fn deliver_outcome_records_update_op_result() {
+        const SOURCE: &str = include_str!("op_ctx_task.rs");
+        let cutoff = SOURCE
+            .find("#[cfg(test)]")
+            .expect("file must have a #[cfg(test)] section");
+        let prod = &SOURCE[..cutoff];
+
+        let fn_start = prod
+            .find("fn deliver_outcome(")
+            .expect("deliver_outcome must exist");
+        let body_start = fn_start
+            + prod[fn_start..]
+                .find('{')
+                .expect("deliver_outcome must have a body");
+        let bytes = prod.as_bytes();
+        let mut depth: i32 = 1;
+        let mut i = body_start + 1;
+        while i < bytes.len() && depth > 0 {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => depth -= 1,
+                _ => {}
+            }
+            i += 1;
+        }
+        let body = &prod[body_start..i];
+
+        assert!(
+            body.contains("record_op_result"),
+            "deliver_outcome must call record_op_result so the dashboard \
+             UPDATE counter advances on task-per-tx terminal replies. \
+             Issue #4010."
+        );
+        assert!(
+            body.contains("OpType::Update"),
+            "record_op_result inside deliver_outcome must be passed \
+             OpType::Update (not Get/Put/Subscribe)."
         );
     }
 }

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -360,16 +360,33 @@ async fn drive_client_update(
 
 // --- Outcome delivery ---
 
+/// Dashboard op_stats success classifier (issue #4010). Extracted so the
+/// success/failure mapping per `DriverOutcome` variant has direct unit
+/// coverage; `deliver_outcome` itself takes an `OpManager` which is
+/// expensive to construct in tests.
+fn classify_update_outcome_for_op_stats(outcome: &DriverOutcome) -> bool {
+    matches!(outcome, DriverOutcome::Publish(Ok(_)))
+}
+
 fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: DriverOutcome) {
     // Dashboard op_stats UPDATE counter (issue #4010). The legacy
     // `report_result` recording path is bypassed for task-per-tx
     // terminal replies (see `node::record_op_result` rustdoc), so
     // every terminal outcome must be recorded here.
-    let success = matches!(outcome, DriverOutcome::Publish(Ok(_)));
-    crate::node::network_status::record_op_result(
-        crate::node::network_status::OpType::Update,
-        success,
-    );
+    //
+    // Sub-operation gate: defensive. Today UPDATE has no sub-operation
+    // entry points (it's fire-and-forget at the originator), so
+    // `client_tx.is_sub_operation()` is always false on this path. The
+    // explicit gate matches SUBSCRIBE's pattern so a future change that
+    // routes a sub-op tx through `run_client_update` doesn't silently
+    // start inflating the user-facing dashboard counter.
+    if !client_tx.is_sub_operation() {
+        let success = classify_update_outcome_for_op_stats(&outcome);
+        crate::node::network_status::record_op_result(
+            crate::node::network_status::OpType::Update,
+            success,
+        );
+    }
 
     match outcome {
         DriverOutcome::Publish(result) => {
@@ -1676,6 +1693,8 @@ async fn drive_relay_broadcast_to_streaming(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     /// Guard: `client_events.rs` must call `start_client_update` for both the
     /// routed and legacy UPDATE paths, not the legacy `request_update`.
     #[test]
@@ -2301,20 +2320,18 @@ mod tests {
         );
     }
 
-    /// Issue #4010 regression (source-level): `deliver_outcome` must
-    /// record the UPDATE outcome to the dashboard `op_stats.updates`
-    /// counter. Without this the counter is silently stuck at zero
-    /// because the task-per-tx bypass at
-    /// `handle_pure_network_message_v1` skips the legacy `report_result`
-    /// recording path.
+    /// Issue #4010: `deliver_outcome` must record the UPDATE outcome to
+    /// the dashboard `op_stats.updates` counter (the task-per-tx bypass
+    /// at `handle_pure_network_message_v1` skips the legacy
+    /// `report_result` recording path) and gate the call on
+    /// `!client_tx.is_sub_operation()` for parity with SUBSCRIBE.
+    /// Walks brace depth so the test does not depend on any nearby
+    /// section comments staying named the same.
     #[test]
     fn deliver_outcome_records_update_op_result() {
         const SOURCE: &str = include_str!("op_ctx_task.rs");
-        let body = SOURCE
-            .split_once("fn deliver_outcome(")
-            .and_then(|(_, after)| after.split_once("// ── Relay UPDATE drivers"))
-            .map(|(body, _)| body)
-            .expect("deliver_outcome body must precede the relay UPDATE drivers section");
+        let prod = production_source(SOURCE);
+        let body = extract_fn_body(prod, "fn deliver_outcome(");
 
         assert!(
             body.contains("record_op_result"),
@@ -2327,5 +2344,84 @@ mod tests {
             "record_op_result inside deliver_outcome must be passed \
              OpType::Update (not Get/Put/Subscribe)."
         );
+        assert!(
+            body.contains("!client_tx.is_sub_operation()"),
+            "deliver_outcome must gate record_op_result on \
+             `!client_tx.is_sub_operation()` (note the leading `!`) for \
+             parity with SUBSCRIBE; defensive against a future change \
+             that routes a sub-op tx through run_client_update and \
+             silently inflates the user-facing dashboard counter. \
+             Issue #4010."
+        );
+    }
+
+    /// Pure-function unit test: `classify_update_outcome_for_op_stats`
+    /// covers every `DriverOutcome` variant. Pins the success/failure
+    /// mapping against accidental `success: !success` flips. Issue #4010.
+    #[test]
+    fn classify_update_outcome_covers_all_variants() {
+        use freenet_stdlib::client_api::{ContractResponse, ErrorKind, HostResponse};
+        use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey, StateSummary};
+
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([7u8; 32]),
+            CodeHash::new([8u8; 32]),
+        );
+        let publish_ok = DriverOutcome::Publish(Ok(HostResponse::ContractResponse(
+            ContractResponse::UpdateResponse {
+                key,
+                summary: StateSummary::from(Vec::<u8>::new()),
+            },
+        )));
+        let publish_err = DriverOutcome::Publish(Err(ErrorKind::OperationError {
+            cause: "synthetic".into(),
+        }
+        .into()));
+        let infra = DriverOutcome::InfrastructureError(OpError::UnexpectedOpState);
+
+        assert!(classify_update_outcome_for_op_stats(&publish_ok));
+        assert!(!classify_update_outcome_for_op_stats(&publish_err));
+        assert!(!classify_update_outcome_for_op_stats(&infra));
+    }
+
+    /// Truncate the source at the `#[cfg(test)]` marker so the pin
+    /// tests don't see test-module code or comments (avoids false
+    /// positives where a test asserts a substring that also appears in
+    /// a sibling test).
+    fn production_source(full: &str) -> &str {
+        let cutoff = full
+            .find("#[cfg(test)]")
+            .expect("file must have a #[cfg(test)] section");
+        &full[..cutoff]
+    }
+
+    /// Walk brace depth from the opening `{` of the named fn to the
+    /// matching `}`. Returns the body slice. Robust to nearby section
+    /// comments being renamed.
+    fn extract_fn_body<'a>(source: &'a str, signature_prefix: &str) -> &'a str {
+        let start = source
+            .find(signature_prefix)
+            .unwrap_or_else(|| panic!("could not find {signature_prefix}"));
+        let brace = source[start..]
+            .find('{')
+            .expect("fn signature must have a body");
+        let body_start = start + brace + 1;
+        let bytes = source.as_bytes();
+        let mut depth: i32 = 1;
+        let mut i = body_start;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &source[body_start..i];
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        panic!("unterminated fn body for {signature_prefix}");
     }
 }

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -361,15 +361,10 @@ async fn drive_client_update(
 // --- Outcome delivery ---
 
 fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: DriverOutcome) {
-    // Record dashboard op_stats counter (issue #4010). Mirrors what
-    // `report_result` does for legacy state-machine ops via
-    // `node.rs::record_op_result`. The task-per-tx bypass at
-    // `handle_pure_network_message_v1` returns Ok(None) for forwarded
-    // replies, so `report_result` never sees the terminal classification
-    // for client-initiated UPDATE; the recording must happen here.
-    // Without it the dashboard "Operations" panel UPDATE counter sticks
-    // on whatever the legacy path produces (rarely hit on the originator
-    // side after the #1454 Phase 4 migration).
+    // Dashboard op_stats UPDATE counter (issue #4010). The legacy
+    // `report_result` recording path is bypassed for task-per-tx
+    // terminal replies (see `node::record_op_result` rustdoc), so
+    // every terminal outcome must be recorded here.
     let success = matches!(outcome, DriverOutcome::Publish(Ok(_)));
     crate::node::network_status::record_op_result(
         crate::node::network_status::OpType::Update,
@@ -2306,41 +2301,20 @@ mod tests {
         );
     }
 
-    /// Issue #4010 regression (source-level): client-initiated UPDATE
-    /// must record its outcome to the dashboard `op_stats.updates`
-    /// counter. The legacy `report_result` recording path does not run
-    /// for task-per-tx terminal replies (the bypass at
-    /// `handle_pure_network_message_v1` returns Ok(None)), so
-    /// `deliver_outcome` MUST call `record_op_result(OpType::Update, _)`
-    /// itself. Without this the dashboard "Operations" panel UPDATE
-    /// counter is silently stuck at zero.
+    /// Issue #4010 regression (source-level): `deliver_outcome` must
+    /// record the UPDATE outcome to the dashboard `op_stats.updates`
+    /// counter. Without this the counter is silently stuck at zero
+    /// because the task-per-tx bypass at
+    /// `handle_pure_network_message_v1` skips the legacy `report_result`
+    /// recording path.
     #[test]
     fn deliver_outcome_records_update_op_result() {
         const SOURCE: &str = include_str!("op_ctx_task.rs");
-        let cutoff = SOURCE
-            .find("#[cfg(test)]")
-            .expect("file must have a #[cfg(test)] section");
-        let prod = &SOURCE[..cutoff];
-
-        let fn_start = prod
-            .find("fn deliver_outcome(")
-            .expect("deliver_outcome must exist");
-        let body_start = fn_start
-            + prod[fn_start..]
-                .find('{')
-                .expect("deliver_outcome must have a body");
-        let bytes = prod.as_bytes();
-        let mut depth: i32 = 1;
-        let mut i = body_start + 1;
-        while i < bytes.len() && depth > 0 {
-            match bytes[i] {
-                b'{' => depth += 1,
-                b'}' => depth -= 1,
-                _ => {}
-            }
-            i += 1;
-        }
-        let body = &prod[body_start..i];
+        let body = SOURCE
+            .split_once("fn deliver_outcome(")
+            .and_then(|(_, after)| after.split_once("// ── Relay UPDATE drivers"))
+            .map(|(body, _)| body)
+            .expect("deliver_outcome body must precede the relay UPDATE drivers section");
 
         assert!(
             body.contains("record_op_result"),


### PR DESCRIPTION
## Problem

The local-peer dashboard's "Operations" panel counters for SUBSCRIBE
and UPDATE were silently stuck at zero on every node. After the
task-per-tx migrations (`#3806` / `#3981` for SUBSCRIBE,
`#1454` Phase 4 for UPDATE), the only remaining writer for these
counters was the legacy `report_result` path in `node.rs`, which is
bypassed for task-per-tx terminal replies:
`handle_pure_network_message_v1` returns `Ok(None)` once it forwards
the reply to the awaiting task, so `report_result` never sees the
classification and never calls `record_op_result`.

GET and PUT survived the equivalent migration because their drivers
explicitly call `record_op_result` in the Done arm of the retry loop.
SUBSCRIBE and UPDATE drivers were missed.

This is the same class of telemetry-rot bug as `#4009` (subscribed
contracts panel silently empty after the SUBSCRIBE migration).

## Solution

Add the recording call to `deliver_outcome` in both
`subscribe/op_ctx_task.rs` and `update/op_ctx_task.rs`. Every
terminal client-visible result flows through this single chokepoint:
- `Publish(Ok(_))` -> success
- `Publish(Err(_))` -> failure
- `SkipAlreadyDelivered` (subscribe only, local hit) -> success
- `InfrastructureError` -> failure

Internal-only operations stay uncounted by design: subscription
renewals (`run_renewal_subscribe`) and executor auto-subscribe
(`run_executor_subscribe`) have separate return-value delivery paths
and never call `deliver_outcome`. Sub-operation SUBSCRIBE spawned by
PUT/GET also doesn't go through `deliver_outcome`. This is a
deliberate behavior change vs. the legacy state-machine path, which
counted renewals and inflated the counter with 2-minute background
traffic per active subscription.

Documented the manual-mirror pattern on `record_op_result` itself so
future migrations have a single place that lists the required call
sites.

## Why didn't CI catch this?

The pre-existing `test_op_stats_recording` only exercised
`record_op_result(OpType::Get/Put, _)` directly. It never followed
the path from a real `deliver_outcome` call into the counter, so
when the task-per-tx drivers stopped invoking the recording hook the
unit test still passed end-to-end while the dashboard pipeline broke.

The new tests close that gap two ways:
- Source-grep pin tests in `subscribe/op_ctx_task.rs` and
  `update/op_ctx_task.rs` assert that `deliver_outcome` calls
  `record_op_result(OpType::{Subscribe,Update}, _)`. A future
  migration that drops the call fails CI immediately, with a
  message that points back at this issue.
- `test_op_stats_recording` extended to cover SUBSCRIBE and UPDATE
  counters at the runtime level so a regression in `record_op_result`
  itself also surfaces.

## Testing

- `cargo fmt -p freenet` clean
- `cargo clippy --locked -- -D warnings` clean (matches CI)
- `cargo test -p freenet --lib`:
  - `node::network_status::tests::test_op_stats_recording` ok
  - `operations::subscribe::op_ctx_task::tests::deliver_outcome_records_subscribe_op_result` ok
  - `operations::update::op_ctx_task::tests::deliver_outcome_records_update_op_result` ok

## Follow-up (not in scope)

The legacy state-machine path in `report_result` still counts
sub-operation SUBSCRIBE/GET and renewals. With the migrations
nearly complete those code paths are mostly dead, but the long-term
plan from `#4009`'s "Follow-up" section is to compute the dashboard
op_stats from event-log aggregates rather than maintain mirror
counters. That refactor is the proper fix for the broader bug class
and is left for a separate PR.

GET and PUT task-per-tx drivers also undercount the
`Exhausted` / `InfrastructureError` failure cases: the success
recording is in the Done arm only, and `deliver_outcome` for those
ops doesn't record failures. This is a related but smaller bug; not
covered here to keep scope tight.

## Fixes

Closes #4010

[AI-assisted - Claude]