### PR TITLE
feat: allow clipboard + modals in webapp iframe sandbox

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -886,9 +886,8 @@ mod tests {
 
         // Two contracts with deterministic keys; the base58 encoding is
         // long enough to exercise the >12-char truncation path.
-        let code_hash = ContractCode::from(vec![0u8; 32]).hash().clone();
-        let key_a =
-            ContractKey::from_id_and_code(ContractInstanceId::new([0xAA; 32]), code_hash.clone());
+        let code_hash = *ContractCode::from(vec![0u8; 32]).hash();
+        let key_a = ContractKey::from_id_and_code(ContractInstanceId::new([0xAA; 32]), code_hash);
         let key_b = ContractKey::from_id_and_code(ContractInstanceId::new([0xBB; 32]), code_hash);
         let snapshot = vec![
             crate::ring::SubscribedContractSnapshot {

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -3,7 +3,8 @@
 //! Contract web apps are served inside sandboxed iframes to provide origin isolation.
 //! The local API server returns a "shell" page that holds the auth token and
 //! proxies WebSocket connections via postMessage, while the contract runs in an
-//! `<iframe sandbox="allow-scripts allow-forms allow-popups allow-downloads">`
+//! `<iframe sandbox="allow-scripts allow-forms allow-popups allow-downloads allow-modals"
+//!         allow="clipboard-read; clipboard-write">`
 //! with an opaque origin that cannot access other contracts' data.
 //! Popups inherit the sandbox (no `allow-popups-to-escape-sandbox`); external links
 //! are opened via the `open_url` shell bridge message to avoid CORS issues. Sandbox content
@@ -470,7 +471,7 @@ fn shell_page(
 <style>*{{margin:0;padding:0}}html,body{{width:100%;height:100%;overflow:hidden}}iframe{{width:100%;height:100%;border:none;display:block}}</style>
 </head>
 <body>
-<iframe id="app" sandbox="allow-scripts allow-forms allow-popups allow-downloads" data-src="{iframe_src}"></iframe>
+<iframe id="app" sandbox="allow-scripts allow-forms allow-popups allow-downloads allow-modals" allow="clipboard-read; clipboard-write" data-src="{iframe_src}"></iframe>
 <script>
 {SHELL_BRIDGE_JS}
 </script>
@@ -1891,8 +1892,15 @@ mod tests {
 
         // Shell page must contain sandboxed iframe
         assert!(
-            html.contains(r#"sandbox="allow-scripts allow-forms allow-popups allow-downloads"#),
-            "iframe sandbox attribute missing"
+            html.contains(
+                r#"sandbox="allow-scripts allow-forms allow-popups allow-downloads allow-modals""#
+            ),
+            "iframe sandbox attribute missing or wrong allowlist"
+        );
+        // Iframe must grant clipboard via permissions-policy
+        assert!(
+            html.contains(r#"allow="clipboard-read; clipboard-write""#),
+            "iframe permissions-policy missing clipboard grants"
         );
         // Iframe src must include __sandbox=1
         assert!(


### PR DESCRIPTION
## Summary

Sandboxed webapps currently cannot use `navigator.clipboard.{read,write}Text` or native `confirm()` / `alert()` dialogs because the shell iframe is rendered with a static, narrow allowlist:

```
sandbox=\"allow-scripts allow-forms allow-popups allow-downloads\"
```

This PR adds `allow-modals` to the sandbox attribute and a permissions-policy `allow=\"clipboard-read; clipboard-write\"` to the same iframe.

## Why

Discovered while testing `freenet-email`. Two concrete blockers:

1. **Copy / paste contact tokens.** The share-address modal's \"Copy\" button uses `navigator.clipboard.writeText`, which silently rejects in the sandboxed iframe. The button shows a fake \"Copied\" state but the OS clipboard is never written, so contacts on the receiving side have nothing to paste into the import modal — every cross-node introduction is broken.
2. **Destructive-action confirms.** Logout, delete-identity, and similar flows want a `window.confirm(\"are you sure?\")`. Sandbox without `allow-modals` makes that a no-op, so these flows either ship without confirmation (dangerous) or fall back to custom in-DOM modal components for everything (extra work, no native a11y).

Both are baseline browser features that any non-trivial webapp will hit immediately. Verified the patch fixes (1) end-to-end against a live 2-node iso harness — `read_clipboard` after clicking \"Copy\" returns the full `contact://…` token, where it returned an empty string before the patch.

## What changed

- `crates/core/src/server/path_handlers.rs`: shell-page iframe now renders as
  ```
  <iframe id=\"app\"
          sandbox=\"allow-scripts allow-forms allow-popups allow-downloads allow-modals\"
          allow=\"clipboard-read; clipboard-write\"
          data-src=\"…\"></iframe>
  ```
  Header doc comment updated to match. Existing `shell_page_contains_iframe_and_bridge` test now asserts both attributes are present.
- `crates/core/src/node/network_status.rs`: drops two stray `.clone()` calls on `CodeHash` (`Copy`) flagged by clippy on Rust 1.93. Unrelated to the sandbox change but required because the repo's pre-commit hook treats clippy warnings as errors and the lib-test target wouldn't compile without them.

## Risk

Both new flags are additive — they only widen what the iframe can do. They don't grant the iframe access to the parent shell DOM (that requires `allow-same-origin`, which we deliberately do not add). The webapp still has an opaque origin and cannot read shell state or other webapps' storage.

`allow-modals` lets the webapp call `alert()`/`confirm()`/`prompt()`. Worst case is a malicious webapp showing an annoying alert loop — the user can still close the tab, the sandbox boundary is unaffected.

`allow=\"clipboard-read; clipboard-write\"` grants permissions-policy delegation. The browser still gates actual clipboard reads behind a user-gesture check; programmatic background reads remain blocked. Writes from a button click are now allowed, which is the intended behavior.

## Longer-term direction

This is a deliberately small interim fix. The right architecture is a manifest-driven per-webapp allowlist with a first-load consent prompt — see issue #4014. Landing each new browser feature as an upstream PR is the wrong granularity; this PR buys runway for that work without rushing it.

## Test plan

- [x] `cargo test -p freenet --lib server::path_handlers::tests::shell_page_contains_iframe_and_bridge` passes (test updated to assert new attrs).
- [x] `cargo clippy -p freenet --tests -- -D warnings` clean.
- [x] Manual: rebuild freenet, restart 2-node iso harness, publish freenet-email webapp, click \"Copy\" in share modal, verify OS clipboard now contains the contact token. Pre-patch: empty. Post-patch: full token.

Closes part of #4014.