### PR TITLE
refactor(ops): retire SUBSCRIBE speculative-retry GC block (#1454 Phase 5-final slice 1)

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -133,21 +133,32 @@ paths:
 > for GET. Phase 5-final retired that block, the `get_retried`
 > per-tick HashMap, the `GetOp::ack_received` /
 > `GetOp::speculative_paths` fields, and the 11 unit tests that
-> simulated the GC retry decision. The shared retry constants
-> (`ACK_TIMEOUT`, `MAX_SPECULATIVE_PATHS`, `PROGRESS_TIMEOUT`) and the
-> SUBSCRIBE retry block stay because legacy intermediate-peer
-> SUBSCRIBE writers (state pushed by `subscribe::process_message` on
-> relay hops) still produce `SubscribeOp`s in `ops.subscribe` that
-> need GC retry coverage. Renewals and executor auto-subscribe were
-> previously also originator-side writers; both have now been
-> migrated to the task-per-tx driver. Retiring the GC retry block
-> requires either migrating the relay-side push-into-`ops.subscribe`
-> to task-per-tx local state OR proving the legacy state-machine
-> entries are short-lived enough that the GC block is dead in
-> practice.
-> `GetMsg::ForwardingAck` survives as a wire variant + telemetry hook
-> (#3570 diagnostics) but its handler now returns the operation
-> unchanged.
+> simulated the GC retry decision.
+>
+> The SUBSCRIBE GC speculative-retry block was retired in the same
+> Phase 5-final pass (slice 1 after GET): all four originator-side
+> writers into `ops.subscribe` (client-initiated, executor
+> auto-subscribe, renewal, PUT/GET sub-op) had migrated to the
+> task-per-tx driver in `operations/subscribe/op_ctx_task.rs` — which
+> owns its own retry loop via `advance_to_next_peer` and never inserts
+> a `SubscribeOp` into the DashMap. The remaining legacy entries in
+> `ops.subscribe` come from relay state during multi-hop forwarding
+> (slice A `start_relay_subscribe` does NOT register; entries arise
+> only when a relay re-enters `subscribe::process_message` for a tx
+> already in the DashMap, which now happens only for `Unsubscribe`
+> routing) and `create_unsubscribe_op` routing entries created by
+> `request_unsubscribe`. Neither is a retry candidate: relay entries
+> fail `is_originator()` and unsubscribe entries fail
+> `failure_routing_info().is_some()`. Slice 1 deletes the block, the
+> `subscribe_retried` per-tick HashMap, and the shared `ACK_TIMEOUT` /
+> `MAX_SPECULATIVE_PATHS` / `PROGRESS_TIMEOUT` constants (also
+> previously used by GET, now fully unreferenced). Slice 2 will delete
+> the `SubscribeOp::ack_received` / `speculative_paths` fields, the
+> `retry_with_next_alternative` helper, and the unit tests that
+> exercised the GC retry decision.
+> `GetMsg::ForwardingAck` and `SubscribeMsg::ForwardingAck` survive as
+> wire variants + telemetry hooks (#3570 diagnostics) but their
+> handlers return the operation unchanged.
 >
 > Sub-operation SUBSCRIBE callers (legacy GET-originator
 > `auto_subscribe_on_get_response` fallback path; PUT/GET task-per-tx

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1482,8 +1482,6 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
     let mut ttl_set = BTreeSet::new();
 
     let mut delayed = vec![];
-    let mut subscribe_retried: std::collections::HashMap<Transaction, usize> =
-        std::collections::HashMap::new();
     loop {
         crate::deterministic_select! {
             tx = new_transactions.recv() => {
@@ -1614,20 +1612,12 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                 }
 
                 // Shared retry constants for SUBSCRIBE speculative retry below.
-                // (GET speculative retry was retired in #1454 Phase 5-final:
-                // client-initiated GETs now drive on a task-per-tx loop, and
-                // the only legacy writer to `ops.get` is `start_targeted_op`
-                // which sets `auto_fetch=true` so `is_client_initiated()` is
-                // false — no entry in `ops.get` could ever satisfy the GET
-                // retry filter.)
-                const ACK_TIMEOUT: Duration = Duration::from_secs(3);
-                const MAX_SPECULATIVE_PATHS: u8 = 2;
-                /// Time to wait after ForwardingAck before re-enabling retry.
-                /// If a relay ACKed but no response arrives within this window,
-                /// the downstream chain has likely stalled. Even a 4-hop chain
-                /// at 500ms/hop completes in ~2.5s; 7s gives ~3x headroom while
-                /// keeping worst-case stall detection under 10s.
-                const PROGRESS_TIMEOUT: Duration = Duration::from_secs(7);
+                // (GET speculative retry was retired in #1454 Phase 5-final
+                // slice 1; SUBSCRIBE speculative retry was retired in
+                // Phase 5-final slice 1 follow-up — see comment below.
+                // The shared `ACK_TIMEOUT` / `MAX_SPECULATIVE_PATHS` /
+                // `PROGRESS_TIMEOUT` constants that both blocks consumed
+                // are no longer referenced and have been removed.)
 
                 // Periodically clean up stale pending_contract_fetches entries.
                 // Entries older than 2x cooldown are removed to prevent unbounded growth.
@@ -1639,148 +1629,23 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                     });
                 }
 
-                // ACK-aware speculative retry for SUBSCRIBE operations.
-                // Same logic as GET: 3s ACK timeout, max 2 speculative paths.
-                // Only the originator retries — relays just forward and ACK.
-                //
-                // Cap retries per GC tick to avoid flooding the notification channel.
-                // The gateway subscribes to 90+ contracts; retrying all at once saturates
-                // the 2048-capacity event loop channel, blocking UPDATEs and broadcasts.
-                const MAX_SUBSCRIBE_RETRIES_PER_TICK: usize = 10;
-                {
-                    // Clean up entries for completed operations
-                    subscribe_retried.retain(|tx, _| ops.subscribe.contains_key(tx));
-
-                    let mut retry_candidates: Vec<Transaction> = Vec::new();
-                    for entry in ops.subscribe.iter() {
-                        let tx = *entry.key();
-                        let sub_op = entry.value();
-
-                        // Only retry at the originator (no requester_addr means we initiated it).
-                        // Also skip ops without routing stats — these are unsubscribe-routing
-                        // ops created by create_unsubscribe_op(), which use the subscribe map
-                        // for address routing but should not be retried as subscribe requests.
-                        if !sub_op.is_originator() || sub_op.failure_routing_info().is_none() {
-                            continue;
-                        }
-
-                        // Cap speculative paths
-                        if sub_op.speculative_paths >= MAX_SPECULATIVE_PATHS {
-                            continue;
-                        }
-
-                        let elapsed = tx.elapsed();
-
-                        if sub_op.ack_received {
-                            // ACK received — trust chain for PROGRESS_TIMEOUT, then
-                            // re-enable retry (matching GET/PUT behavior).
-                            if elapsed <= PROGRESS_TIMEOUT {
-                                continue;
-                            }
-                            tracing::info!(
-                                %tx,
-                                elapsed_ms = elapsed.as_millis(),
-                                "SUBSCRIBE chain stalled after ForwardingAck \
-                                 — re-enabling speculative retry"
-                            );
-                        }
-
-                        let retry_count = subscribe_retried.get(&tx).copied().unwrap_or(0);
-                        let base = if sub_op.ack_received {
-                            PROGRESS_TIMEOUT + ACK_TIMEOUT * (retry_count as u32)
-                        } else {
-                            ACK_TIMEOUT * (retry_count as u32 + 1)
-                        };
-                        // Only consume GlobalRng when elapsed exceeds 80% of base
-                        // (minimum possible jittered threshold). This avoids shifting
-                        // the global RNG state on every GC tick for ops that are
-                        // nowhere near retry time.
-                        let min_jittered = base.mul_f64(0.8);
-                        if elapsed > min_jittered {
-                            let jitter_factor: f64 =
-                                crate::config::GlobalRng::random_range(0.8..=1.2);
-                            let jitter = base.mul_f64(jitter_factor);
-                            if elapsed > jitter {
-                                retry_candidates.push(tx);
-                            }
-                        }
-                    }
-
-                    if !retry_candidates.is_empty() {
-                        // Collect all connected peers for fallback
-                        let all_connected: Vec<_> = ring
-                            .connection_manager
-                            .get_connections_by_location()
-                            .values()
-                            .flat_map(|conns| conns.iter().map(|c| c.location.clone()))
-                            .collect();
-
-                        if retry_candidates.len() > MAX_SUBSCRIBE_RETRIES_PER_TICK {
-                            tracing::debug!(
-                                total = retry_candidates.len(),
-                                processing = MAX_SUBSCRIBE_RETRIES_PER_TICK,
-                                "Capping subscribe retries per tick"
-                            );
-                            // Sort by age (oldest first) to guarantee fairness:
-                            // shuffle would cause probabilistic starvation when
-                            // candidates consistently exceed the per-tick cap.
-                            retry_candidates.sort_by_cached_key(|tx| {
-                                std::cmp::Reverse(tx.elapsed())
-                            });
-                        }
-
-                        for tx in retry_candidates.into_iter().take(MAX_SUBSCRIBE_RETRIES_PER_TICK) {
-                            if let Some((_, sub_op)) = ops.subscribe.remove(&tx) {
-                                let stalled_peer_info = sub_op.failure_routing_info();
-                                let max_htl = ring.max_hops_to_live;
-                                match sub_op.retry_with_next_alternative(max_htl, &all_connected) {
-                                    Ok((mut new_op, msg)) => {
-                                        // Only report failure when alternative found (see GET comment).
-                                        if let Some((peer, contract_location)) = stalled_peer_info
-                                        {
-                                            ring.routing_finished(crate::router::RouteEvent {
-                                                peer,
-                                                contract_location,
-                                                outcome: crate::router::RouteOutcome::Failure,
-                                                op_type: Some(crate::node::network_status::OpType::Subscribe),
-                                            });
-                                        }
-                                        let msg = crate::message::NetMessage::from(msg);
-                                        // Track speculative path for ACK-aware retry bounds
-                                        new_op.speculative_paths += 1;
-                                        new_op.ack_received = false;
-                                        // Insert op BEFORE sending message to avoid race
-                                        ops.subscribe.insert(tx, new_op);
-                                        match tokio::time::timeout(
-                                            Duration::from_secs(1),
-                                            event_loop_notifier
-                                                .notifications_sender
-                                                .send(Either::Left(msg)),
-                                        )
-                                        .await
-                                        {
-                                            Ok(Ok(())) => {
-                                                *subscribe_retried.entry(tx).or_insert(0) += 1;
-                                            }
-                                            Ok(Err(_)) | Err(_) => {
-                                                tracing::warn!(
-                                                    %tx,
-                                                    "Failed to send subscribe retry message, \
-                                                     will retry next tick"
-                                                );
-                                            }
-                                        }
-                                    }
-                                    Err(sub_op) => {
-                                        // No alternatives — put it back for normal timeout
-                                        ops.subscribe.insert(tx, *sub_op);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
+                // SUBSCRIBE speculative-retry GC block was retired in #1454
+                // Phase 5-final: every originator-side writer into
+                // `ops.subscribe` (client-initiated, executor auto-subscribe,
+                // renewal, PUT/GET sub-op) now runs on the task-per-tx
+                // driver in `operations/subscribe/op_ctx_task.rs`, which
+                // owns its own retry loop via `advance_to_next_peer` and
+                // never inserts a `SubscribeOp` into the DashMap. The
+                // remaining legacy entries (relay state during multi-hop
+                // forwarding, `create_unsubscribe_op` routing entries) are
+                // not retry candidates: relay entries fail
+                // `is_originator()` and unsubscribe entries fail
+                // `failure_routing_info().is_some()`. The DashMap, the
+                // `SubscribeOp::ack_received` / `speculative_paths` fields,
+                // and `SubscribeMsg::ForwardingAck` survive only as wire-
+                // and bookkeeping-compat for legacy relay traffic;
+                // they are not load-bearing for retry. Mirrors the GET
+                // Phase 5-final retirement in PR #3974.
 
                 let mut old_missing = std::mem::replace(&mut delayed, Vec::with_capacity(200));
                 for tx in old_missing.drain(..) {
@@ -1816,7 +1681,6 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                     if still_waiting {
                         delayed.push(tx);
                     } else {
-                        subscribe_retried.remove(&tx);
                         ops.under_progress.remove(&tx);
                         ops.completed.remove(&tx);
                         tracing::info!(

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -38,6 +38,10 @@ const MAX_RETRIES: usize = 10;
 /// traversal storms. This floor ensures retries still reach peers 2-3 hops
 /// away, which is the minimum useful search depth in any topology.
 /// Matches GET operation's MIN_RETRY_HTL; change both together.
+/// Used only by `retry_with_next_alternative`, which itself survives
+/// the slice-1 GC retirement only as a test-exercised helper. Allow
+/// `dead_code` until the helper + tests are removed in slice 2.
+#[allow(dead_code)]
 const MIN_RETRY_HTL: usize = 3;
 
 /// Timeout for waiting on contract storage notification.
@@ -603,11 +607,19 @@ pub(crate) struct SubscribeOp {
     is_renewal: bool,
     /// Routing stats for failure reporting.
     stats: Option<SubscribeStats>,
-    /// True when a downstream relay has acknowledged forwarding this request.
-    /// Used by the GC task to distinguish "peer is dead" from "peer is working on it".
+    /// Historically: true when a downstream relay has acknowledged
+    /// forwarding this request. The GC speculative-retry block that
+    /// consumed this signal was retired in #1454 Phase 5-final slice 1
+    /// (mirroring the GET retirement in PR #3974). The field is still
+    /// maintained on the legacy state-machine path and exercised by
+    /// helper tests so the bookkeeping is captured if a future retry
+    /// mechanism reuses it. Allow `dead_code` until the field + tests
+    /// are deleted in slice 2.
+    #[allow(dead_code)]
     pub(crate) ack_received: bool,
-    /// Number of speculative parallel paths launched by the originator's GC task.
-    /// Capped at MAX_SPECULATIVE_PATHS to bound network overhead.
+    /// Historically: number of speculative parallel paths launched by
+    /// the originator's GC task. Same lineage as `ack_received` above.
+    #[allow(dead_code)]
     pub(crate) speculative_paths: u8,
 }
 
@@ -711,6 +723,12 @@ impl SubscribeOp {
     /// from local alternatives, or injects fallback peers if alternatives are exhausted.
     /// Returns `Ok((op, msg))` with the updated op and new Request message,
     /// or `Err(op)` if no alternatives remain.
+    ///
+    /// Historically called by the GC speculative-retry block; that block
+    /// was retired in #1454 Phase 5-final slice 1. Helper retained for
+    /// the existing unit tests until the field + tests are deleted in
+    /// slice 2.
+    #[allow(dead_code)]
     pub(crate) fn retry_with_next_alternative(
         mut self,
         max_hops_to_live: usize,


### PR DESCRIPTION
## Problem

The SUBSCRIBE GC speculative-retry block in `op_state_manager.rs::garbage_cleanup_task` mirrored the GET block retired in PR #3974. As of #1454's executor auto-subscribe migration (#3981) and renewal migration (#3979), every originator-side writer into `ops.subscribe` (client-initiated, executor auto-subscribe, renewal, PUT/GET sub-op) runs on the task-per-tx driver in `operations/subscribe/op_ctx_task.rs`, which owns its own retry loop via `advance_to_next_peer` and never inserts a `SubscribeOp` into the DashMap. The GC retry block had no live producers of retry candidates.

## Solution

Mirrors GET Phase 5-final slice 1 (PR #3974). The remaining legacy entries in `ops.subscribe`:

- **Relay state during multi-hop forwarding** — slice A `start_relay_subscribe` (PR #3932) does NOT register a `SubscribeOp`; entries arise only when a relay re-enters `subscribe::process_message` for an already-tracked tx. These fail the GC filter's `is_originator()` check.
- **`create_unsubscribe_op` routing entries** — created by `request_unsubscribe`. These fail the `failure_routing_info().is_some()` check (the gate at line 1663 explicitly excludes them — see the existing comment).

Block is provably dead: the `is_originator() && failure_routing_info().is_some()` filter has no satisfying entries.

### What this PR deletes

- SUBSCRIBE retry block in `garbage_cleanup_task` (~140 LoC)
- `subscribe_retried` per-tick HashMap declaration + cleanup
- Shared retry constants `ACK_TIMEOUT`, `MAX_SPECULATIVE_PATHS`, `PROGRESS_TIMEOUT` (also previously consumed by the GET block; now fully unreferenced)

### What stays (slice 2 cleanup)

Behind `#[allow(dead_code)]` so this PR stays narrowly scoped:

- `SubscribeOp::ack_received` / `speculative_paths` fields
- `retry_with_next_alternative` helper + `MIN_RETRY_HTL` constant
- The 16 init sites + the `subscribe_retry_candidates_sorted_oldest_first` test

Slice 2 will delete those + the unit tests that simulated the GC retry decision, mirroring PR #3975.

### Wire-format note

`SubscribeMsg::ForwardingAck` survives as a wire variant + telemetry hook (#3570 diagnostics) — its handler is left unchanged on this slice; mirrors how `GetMsg::ForwardingAck` was treated in #3974.

## Testing

- `cargo fmt`: clean
- `cargo clippy -p freenet --lib --tests -- -D warnings`: clean
- `cargo test -p freenet --lib`: 2525 passed, 16 ignored

The retired GC block had no behavioral coverage that would still be reachable post-deletion: every originator-side writer is task-per-tx, so the `ops.subscribe` DashMap holds no entries the block could have acted on. Integration coverage (existing SUBSCRIBE simulation + ping tests) exercises the task-per-tx retry path.

## Fixes

Part of #1454 (Phase 5-final). Slice 2 to follow.