### PR TITLE
fix(server): redirect /v1/contract/web/<key> (no slash) to canonical /

### DIFF
--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -333,6 +333,34 @@ fn redirect_to_shell_root(
     api_version: ApiVersion,
     query_string: Option<&str>,
 ) -> Result<axum::response::Response, WebSocketApiError> {
+    let shell_url = build_canonical_shell_url(key, api_version, query_string)?;
+    Ok(axum::response::Redirect::to(&shell_url).into_response())
+}
+
+/// Validate `key`, filter sensitive query params, and return the
+/// canonical `/{prefix}/contract/web/{key}/[?query]` URL. Shared
+/// between `redirect_to_shell_root` (303 See Other for cross-contract
+/// HTML subpath redirects) and the no-trailing-slash redirect handlers
+/// in `v1.rs`/`v2.rs` (308 Permanent Redirect for canonical URL form,
+/// freenet/freenet-core#4019).
+///
+/// `key` is interpolated into a `Location` header by the caller, so
+/// validation MUST reject CRLF-bearing input here before
+/// `HeaderValue::try_from` ever sees it. The check via
+/// `ContractInstanceId::from_bytes` also rejects path-traversal-style
+/// inputs like `../../etc/passwd` that would point the redirect at an
+/// attacker-chosen URL on the reader's gateway.
+///
+/// Sensitive query params (`__sandbox`, `authToken`) are stripped:
+/// `__sandbox` would otherwise drop the redirect victim straight into
+/// `web_home`'s sandbox branch, bypassing shell generation; `authToken`
+/// is the shell's auth credential, which must only come from
+/// `AuthToken::generate()` and never from an attacker-supplied URL.
+pub(super) fn build_canonical_shell_url(
+    key: &str,
+    api_version: ApiVersion,
+    query_string: Option<&str>,
+) -> Result<String, WebSocketApiError> {
     if key.is_empty() {
         return Err(WebSocketApiError::InvalidParam {
             error_cause: "empty contract key in redirect target".into(),
@@ -354,11 +382,10 @@ fn redirect_to_shell_root(
         .filter(|s| !s.is_empty());
 
     let prefix = api_version.prefix();
-    let shell_url = match filtered_query {
+    Ok(match filtered_query {
         Some(qs) => format!("/{prefix}/contract/web/{key}/?{qs}"),
         None => format!("/{prefix}/contract/web/{key}/"),
-    };
-    Ok(axum::response::Redirect::to(&shell_url).into_response())
+    })
 }
 
 /// Query parameters that must be stripped before forwarding a user URL

--- a/crates/core/src/server/client_api/v1.rs
+++ b/crates/core/src/server/client_api/v1.rs
@@ -1,4 +1,9 @@
-use axum::{Extension, Router, extract::Path, response::Redirect, routing::get};
+use axum::{
+    Extension, Router,
+    extract::{Path, RawQuery},
+    response::IntoResponse,
+    routing::get,
+};
 
 use super::*;
 
@@ -15,8 +20,8 @@ pub(super) fn routes(config: Config) -> Router {
         // (freenet/freenet-core#4019)
         .route("/v1/contract/web/{key}", get(web_root_redirect_v1))
         .route("/v1/contract/web/{key}/", get(web_home_v1))
-        .with_state(config)
         .route("/v1/contract/web/{key}/{*path}", get(web_subpages_v1))
+        .with_state(config)
 }
 
 async fn web_home_v1(
@@ -40,49 +45,140 @@ async fn web_subpages_v1(
 
 /// Redirect `/v1/contract/web/{key}` (no trailing slash) to
 /// `/v1/contract/web/{key}/` (with trailing slash, the canonical form
-/// the rest of the routing already understands). 308 preserves the
-/// method and any query string the browser carries forward.
-async fn web_root_redirect_v1(Path(key): Path<String>) -> Redirect {
-    Redirect::permanent(&format!("/v1/contract/web/{key}/"))
+/// the rest of the routing already understands).
+///
+/// Routes the redirect target through `build_canonical_shell_url` so
+/// the same key validation (CRLF / path-traversal rejection) and
+/// sensitive-query-param filter (`__sandbox`, `authToken`) that
+/// `redirect_to_shell_root` applies are also applied here. Returning
+/// a 308 (instead of 303 like the cross-contract subpage redirect)
+/// preserves the request method and lets the browser cache the
+/// redirect — the address bar lands on the canonical URL on
+/// subsequent visits.
+async fn web_root_redirect_v1(
+    Path(key): Path<String>,
+    RawQuery(query): RawQuery,
+) -> Result<axum::response::Response, WebSocketApiError> {
+    let canonical = build_canonical_shell_url(&key, ApiVersion::V1, query.as_deref())?;
+    Ok(axum::response::Redirect::permanent(&canonical).into_response())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use axum::http::{StatusCode, header::LOCATION};
-    use axum::response::IntoResponse;
+
+    fn valid_key() -> &'static str {
+        "EqJ5YpEEV3XLqEvKWLQHFhGAac2qXzSUoE6k2zbdnXBr"
+    }
 
     /// Regression test for freenet/freenet-core#4019.
     ///
     /// Pasting `/v1/contract/web/<key>` (no trailing slash) into a browser
-    /// used to 404 because no route matched. Now the no-slash form 308s
-    /// to the canonical trailing-slash form, which the rest of the
-    /// routing recognises. 308 (not 301) is intentional: it preserves
-    /// the request method and is the modern equivalent for permanent
-    /// redirects of GETs.
+    /// used to 404. Now the no-slash form 308s to the canonical
+    /// trailing-slash form. 308 preserves the request method and lets
+    /// the browser cache the redirect.
     #[tokio::test]
     async fn no_trailing_slash_redirects_to_canonical_root_v1() {
-        let key = "EqJ5YpEEV3XLqEvKWLQHFhGAac2qXzSUoE6k2zbdnXBr";
-        let redirect = web_root_redirect_v1(Path(key.to_string())).await;
-        let response = redirect.into_response();
+        let response = web_root_redirect_v1(Path(valid_key().to_string()), RawQuery(None))
+            .await
+            .unwrap();
 
-        assert_eq!(
-            response.status(),
-            StatusCode::PERMANENT_REDIRECT,
-            "must return 308 so the browser repeats the request method \
-             at the canonical URL (#4019)"
-        );
+        assert_eq!(response.status(), StatusCode::PERMANENT_REDIRECT);
         let location = response
             .headers()
             .get(LOCATION)
-            .expect("redirect must set Location header")
+            .expect("redirect must set Location")
             .to_str()
             .unwrap();
         assert_eq!(
-            location, "/v1/contract/web/EqJ5YpEEV3XLqEvKWLQHFhGAac2qXzSUoE6k2zbdnXBr/",
-            "Location must be the canonical trailing-slash form so the \
-             browser's follow-up request hits `/v1/contract/web/{{key}}/` \
-             which web_home_v1 already handles"
+            location,
+            format!("/v1/contract/web/{}/", valid_key()),
+            "Location must be the canonical trailing-slash form"
         );
+    }
+
+    /// Regression test for the H1 review finding on PR #4020. The
+    /// no-slash redirect MUST forward the original query string —
+    /// pasting `/v1/contract/web/<key>?invite=abc` is exactly the
+    /// flow River invite links produce, and dropping `?invite=abc`
+    /// silently breaks them.
+    #[tokio::test]
+    async fn no_trailing_slash_redirect_preserves_query_string_v1() {
+        let response = web_root_redirect_v1(
+            Path(valid_key().to_string()),
+            RawQuery(Some("invite=abc&room=42".into())),
+        )
+        .await
+        .unwrap();
+
+        let location = response
+            .headers()
+            .get(LOCATION)
+            .expect("redirect must set Location")
+            .to_str()
+            .unwrap();
+        assert_eq!(
+            location,
+            format!("/v1/contract/web/{}/?invite=abc&room=42", valid_key()),
+            "query string must be carried through the redirect so \
+             `?invite=…` no-slash links keep working"
+        );
+    }
+
+    /// Regression test for the M1 review finding. The same
+    /// `__sandbox` / `authToken` filter `redirect_to_shell_root`
+    /// applies must apply here too — otherwise `/v1/contract/web/<key>?
+    /// authToken=attacker` becomes a 308 to a URL that injects an
+    /// attacker-chosen token into the destination shell.
+    #[tokio::test]
+    async fn no_trailing_slash_redirect_strips_sensitive_query_params_v1() {
+        let response = web_root_redirect_v1(
+            Path(valid_key().to_string()),
+            RawQuery(Some("authToken=evil&invite=ok&__sandbox=1".into())),
+        )
+        .await
+        .unwrap();
+
+        let location = response.headers().get(LOCATION).unwrap().to_str().unwrap();
+        assert!(
+            location.contains("invite=ok"),
+            "non-sensitive query params must survive: {location}"
+        );
+        assert!(
+            !location.contains("authToken"),
+            "authToken must be stripped: {location}"
+        );
+        assert!(
+            !location.contains("__sandbox"),
+            "__sandbox must be stripped: {location}"
+        );
+    }
+
+    /// Regression test for the H2 review finding. The path parameter
+    /// must be validated before being interpolated into a `Location`
+    /// header. `redirect_to_shell_root` already does this on the
+    /// sibling redirect; the no-slash redirect must too — without it,
+    /// CRLF in `key` could inject arbitrary headers, and a
+    /// path-traversal-style key would point the redirect at an
+    /// attacker-chosen URL.
+    #[tokio::test]
+    async fn no_trailing_slash_redirect_rejects_invalid_key_v1() {
+        // CRLF-bearing key — the header-injection case.
+        assert!(matches!(
+            web_root_redirect_v1(Path("AAAA\r\nInjected: x".into()), RawQuery(None)).await,
+            Err(WebSocketApiError::InvalidParam { .. })
+        ));
+        // Obvious garbage.
+        assert!(matches!(
+            web_root_redirect_v1(Path("not-a-real-contract-key".into()), RawQuery(None)).await,
+            Err(WebSocketApiError::InvalidParam { .. })
+        ));
+        // Empty string (axum would normally reject this at routing
+        // time, but defend against an internal caller too).
+        assert!(matches!(
+            web_root_redirect_v1(Path(String::new()), RawQuery(None)).await,
+            Err(WebSocketApiError::InvalidParam { .. })
+        ));
     }
 }

--- a/crates/core/src/server/client_api/v1.rs
+++ b/crates/core/src/server/client_api/v1.rs
@@ -1,4 +1,4 @@
-use axum::{Extension, Router, extract::Path, routing::get};
+use axum::{Extension, Router, extract::Path, response::Redirect, routing::get};
 
 use super::*;
 
@@ -6,6 +6,14 @@ use super::*;
 pub(super) fn routes(config: Config) -> Router {
     Router::new()
         .route("/v1", get(home))
+        // No-trailing-slash redirect to the canonical contract root URL.
+        // Without this, pasting `/v1/contract/web/<key>` (no slash)
+        // into the address bar 404s — common HTTP UX is to either
+        // accept both forms or redirect, so we 308 to the canonical
+        // form. 308 (Permanent Redirect) preserves the request method
+        // and is the modern equivalent of 301 for GETs.
+        // (freenet/freenet-core#4019)
+        .route("/v1/contract/web/{key}", get(web_root_redirect_v1))
         .route("/v1/contract/web/{key}/", get(web_home_v1))
         .with_state(config)
         .route("/v1/contract/web/{key}/{*path}", get(web_subpages_v1))
@@ -28,4 +36,53 @@ async fn web_subpages_v1(
     Extension(rs): Extension<HttpClientApiRequest>,
 ) -> Result<axum::response::Response, WebSocketApiError> {
     web_subpages(key, last_path, ApiVersion::V1, query, headers, rs).await
+}
+
+/// Redirect `/v1/contract/web/{key}` (no trailing slash) to
+/// `/v1/contract/web/{key}/` (with trailing slash, the canonical form
+/// the rest of the routing already understands). 308 preserves the
+/// method and any query string the browser carries forward.
+async fn web_root_redirect_v1(Path(key): Path<String>) -> Redirect {
+    Redirect::permanent(&format!("/v1/contract/web/{key}/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{StatusCode, header::LOCATION};
+    use axum::response::IntoResponse;
+
+    /// Regression test for freenet/freenet-core#4019.
+    ///
+    /// Pasting `/v1/contract/web/<key>` (no trailing slash) into a browser
+    /// used to 404 because no route matched. Now the no-slash form 308s
+    /// to the canonical trailing-slash form, which the rest of the
+    /// routing recognises. 308 (not 301) is intentional: it preserves
+    /// the request method and is the modern equivalent for permanent
+    /// redirects of GETs.
+    #[tokio::test]
+    async fn no_trailing_slash_redirects_to_canonical_root_v1() {
+        let key = "EqJ5YpEEV3XLqEvKWLQHFhGAac2qXzSUoE6k2zbdnXBr";
+        let redirect = web_root_redirect_v1(Path(key.to_string())).await;
+        let response = redirect.into_response();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::PERMANENT_REDIRECT,
+            "must return 308 so the browser repeats the request method \
+             at the canonical URL (#4019)"
+        );
+        let location = response
+            .headers()
+            .get(LOCATION)
+            .expect("redirect must set Location header")
+            .to_str()
+            .unwrap();
+        assert_eq!(
+            location, "/v1/contract/web/EqJ5YpEEV3XLqEvKWLQHFhGAac2qXzSUoE6k2zbdnXBr/",
+            "Location must be the canonical trailing-slash form so the \
+             browser's follow-up request hits `/v1/contract/web/{{key}}/` \
+             which web_home_v1 already handles"
+        );
+    }
 }

--- a/crates/core/src/server/client_api/v2.rs
+++ b/crates/core/src/server/client_api/v2.rs
@@ -1,4 +1,9 @@
-use axum::{Extension, Router, extract::Path, response::Redirect, routing::get};
+use axum::{
+    Extension, Router,
+    extract::{Path, RawQuery},
+    response::IntoResponse,
+    routing::get,
+};
 
 use super::*;
 
@@ -12,8 +17,8 @@ pub(super) fn routes(config: Config) -> Router {
         // No-trailing-slash redirect — see v1.rs for the rationale.
         .route("/v2/contract/web/{key}", get(web_root_redirect_v2))
         .route("/v2/contract/web/{key}/", get(web_home_v2))
-        .with_state(config)
         .route("/v2/contract/web/{key}/{*path}", get(web_subpages_v2))
+        .with_state(config)
 }
 
 async fn web_home_v2(
@@ -37,6 +42,54 @@ async fn web_subpages_v2(
 
 /// Redirect `/v2/contract/web/{key}` (no trailing slash) to
 /// `/v2/contract/web/{key}/` — see v1.rs for the rationale.
-async fn web_root_redirect_v2(Path(key): Path<String>) -> Redirect {
-    Redirect::permanent(&format!("/v2/contract/web/{key}/"))
+async fn web_root_redirect_v2(
+    Path(key): Path<String>,
+    RawQuery(query): RawQuery,
+) -> Result<axum::response::Response, WebSocketApiError> {
+    let canonical = build_canonical_shell_url(&key, ApiVersion::V2, query.as_deref())?;
+    Ok(axum::response::Redirect::permanent(&canonical).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{StatusCode, header::LOCATION};
+
+    fn valid_key() -> &'static str {
+        "EqJ5YpEEV3XLqEvKWLQHFhGAac2qXzSUoE6k2zbdnXBr"
+    }
+
+    /// Smoke test pinning that the v2 redirect carries the v2 prefix
+    /// and applies the same validation + filtering that v1 does. The
+    /// behaviour is otherwise identical, so the v1 tests cover the
+    /// detailed cases — but a copy-paste mistake in v2.rs (e.g.
+    /// `ApiVersion::V1` left over from copy) is exactly the kind of
+    /// regression a one-shot smoke test catches.
+    #[tokio::test]
+    async fn no_trailing_slash_redirect_uses_v2_prefix_and_validates_v2() {
+        // Happy path: v2 prefix + query preservation + sensitive-param stripping.
+        let response = web_root_redirect_v2(
+            Path(valid_key().to_string()),
+            RawQuery(Some("invite=abc&authToken=evil".into())),
+        )
+        .await
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::PERMANENT_REDIRECT);
+        let location = response.headers().get(LOCATION).unwrap().to_str().unwrap();
+        assert!(
+            location.starts_with("/v2/contract/web/"),
+            "v2 handler must produce a /v2/ prefix, not /v1/: {location}"
+        );
+        assert!(location.contains("invite=abc"), "query lost: {location}");
+        assert!(
+            !location.contains("authToken"),
+            "authToken kept: {location}"
+        );
+
+        // Invalid-key path: same validation as v1.
+        assert!(matches!(
+            web_root_redirect_v2(Path("AAAA\r\nInjected: x".into()), RawQuery(None)).await,
+            Err(WebSocketApiError::InvalidParam { .. })
+        ));
+    }
 }

--- a/crates/core/src/server/client_api/v2.rs
+++ b/crates/core/src/server/client_api/v2.rs
@@ -1,4 +1,4 @@
-use axum::{Extension, Router, extract::Path, routing::get};
+use axum::{Extension, Router, extract::Path, response::Redirect, routing::get};
 
 use super::*;
 
@@ -9,6 +9,8 @@ use super::*;
 pub(super) fn routes(config: Config) -> Router {
     Router::new()
         .route("/v2", get(home))
+        // No-trailing-slash redirect — see v1.rs for the rationale.
+        .route("/v2/contract/web/{key}", get(web_root_redirect_v2))
         .route("/v2/contract/web/{key}/", get(web_home_v2))
         .with_state(config)
         .route("/v2/contract/web/{key}/{*path}", get(web_subpages_v2))
@@ -31,4 +33,10 @@ async fn web_subpages_v2(
     Extension(rs): Extension<HttpClientApiRequest>,
 ) -> Result<axum::response::Response, WebSocketApiError> {
     web_subpages(key, last_path, ApiVersion::V2, query, headers, rs).await
+}
+
+/// Redirect `/v2/contract/web/{key}` (no trailing slash) to
+/// `/v2/contract/web/{key}/` — see v1.rs for the rationale.
+async fn web_root_redirect_v2(Path(key): Path<String>) -> Redirect {
+    Redirect::permanent(&format!("/v2/contract/web/{key}/"))
 }


### PR DESCRIPTION
## Problem

freenet/freenet-core#4019: pasting \`/v1/contract/web/<key>\` (no trailing slash) into the address bar returns 404. The trailing-slash form \`/v1/contract/web/<key>/\` works. Common HTTP UX is to accept both forms or redirect the no-slash form to the canonical one — silently 404'ing on a missing-slash paste is hostile. Same applies to \`/v2/contract/web/<key>\`.

Reported by @kerbo7.

## Solution

Register a no-slash route for both \`/v1/contract/web/{key}\` and \`/v2/contract/web/{key}\` that returns a **308 Permanent Redirect** to the trailing-slash form. The canonical route handler (\`web_home_v1\` / \`web_home_v2\`) is unchanged — the redirect funnels into it.

**308 not 301** because:
- 308 preserves the request method (GET stays GET, future POSTs stay POST). 301 historically did not, though browsers largely converged to method-preserving behaviour. 308 is the modern, unambiguous choice for permanent redirects of GETs.
- The *Permanent* semantics let the browser cache the redirect and rewrite the address bar to the canonical form on subsequent visits, so the user's history reflects the trailing-slash URL.

## Testing

New regression test \`no_trailing_slash_redirects_to_canonical_root_v1\` calls the redirect handler directly and asserts status 308 + Location header points at the trailing-slash form. The v2 handler is a one-line shim around the same \`Redirect::permanent\` pattern with the version segment changed; not duplicating the test for it.

\`cargo fmt --check\` clean, \`cargo clippy --all-targets -- -D warnings\` clean, \`cargo test -p freenet --lib server::client_api::v1\` green (1 new test).

## Why CI didn't catch this

There were no tests covering the contract URL routing layer — the existing tests focused on \`path_handlers\` content generation (sandbox HTML, shell page, asset rewriting) rather than which paths route to which handlers. The new test closes that gap for the trailing-slash case; a broader routing test suite would be a good follow-up but is out of scope for a single bug fix.

## Fixes

Closes #4019

[AI-assisted - Claude]