### PR TITLE
refactor(ops): delete dead SUBSCRIBE retry helpers/fields/tests (#1454 Phase 5-final slice 2)

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -152,10 +152,15 @@ paths:
 > `failure_routing_info().is_some()`. Slice 1 deletes the block, the
 > `subscribe_retried` per-tick HashMap, and the shared `ACK_TIMEOUT` /
 > `MAX_SPECULATIVE_PATHS` / `PROGRESS_TIMEOUT` constants (also
-> previously used by GET, now fully unreferenced). Slice 2 will delete
+> previously used by GET, now fully unreferenced). Slice 2 deleted
 > the `SubscribeOp::ack_received` / `speculative_paths` fields, the
-> `retry_with_next_alternative` helper, and the unit tests that
-> exercised the GC retry decision.
+> `retry_with_next_alternative` helper, the `MIN_RETRY_HTL` constant,
+> and the unit tests that exercised the GC retry decision (the 11
+> `test_retry_*` cases in `subscribe/tests.rs` and the
+> `subscribe_retry_candidates_sorted_oldest_first` test in
+> `op_state_manager.rs`). The `SubscribeMsg::ForwardingAck` handler
+> on the legacy state-machine path was simplified to a no-op (mirrors
+> the GET treatment).
 > `GetMsg::ForwardingAck` and `SubscribeMsg::ForwardingAck` survive as
 > wire variants + telemetry hooks (#3570 diagnostics) but their
 > handlers return the operation unchanged.

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -2131,66 +2131,6 @@ mod tests {
         }
     }
 
-    /// Regression test for #3535: age-based retry prioritization prevents starvation.
-    ///
-    /// When retry candidates exceed MAX_SUBSCRIBE_RETRIES_PER_TICK, the oldest
-    /// transactions must be processed first (FIFO fairness). Random shuffling
-    /// would cause probabilistic starvation where some transactions could timeout
-    /// without ever being retried.
-    #[test]
-    fn subscribe_retry_candidates_sorted_oldest_first() {
-        use crate::config::GlobalSimulationTime;
-        use crate::operations::subscribe::SubscribeMsg;
-
-        let base_time: u64 = 1_700_000_000_000; // arbitrary epoch ms
-
-        // Create transactions at different simulation times so they have
-        // different ages. Oldest transaction is created first (lowest timestamp).
-        let mut txs = Vec::new();
-        for i in 0..20u64 {
-            GlobalSimulationTime::set_time_ms(base_time + i * 1000);
-            txs.push(Transaction::new::<SubscribeMsg>());
-        }
-
-        // Advance simulation time so elapsed() returns meaningful durations.
-        // tx[0] was created at base_time, tx[19] at base_time + 19s.
-        // At base_time + 30s: tx[0].elapsed() = 30s, tx[19].elapsed() = 11s.
-        GlobalSimulationTime::set_time_ms(base_time + 30_000);
-
-        // Shuffle to simulate arbitrary DashMap iteration order.
-        let mut candidates = txs.clone();
-        candidates.reverse();
-
-        // Apply the same sorting logic used in garbage_cleanup_task.
-        candidates.sort_by_cached_key(|tx| std::cmp::Reverse(tx.elapsed()));
-
-        // Verify: oldest transactions (largest elapsed) come first.
-        for window in candidates.windows(2) {
-            assert!(
-                window[0].elapsed() >= window[1].elapsed(),
-                "candidates not sorted oldest-first: {:?} < {:?}",
-                window[0].elapsed(),
-                window[1].elapsed(),
-            );
-        }
-
-        // The first candidate should be the oldest transaction (txs[0]).
-        assert_eq!(
-            candidates[0].elapsed(),
-            txs[0].elapsed(),
-            "oldest transaction should be first after sorting"
-        );
-
-        // The last candidate should be the newest transaction (txs[19]).
-        assert_eq!(
-            candidates[19].elapsed(),
-            txs[19].elapsed(),
-            "newest transaction should be last after sorting"
-        );
-
-        GlobalSimulationTime::clear_time();
-    }
-
     // ── has_get_op unit tests ─────────────────────────────────────────────
     //
     // `has_get_op` is a thin wrapper over `self.ops.get.contains_key`.

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -32,18 +32,6 @@ const MAX_BREADTH: usize = 3;
 /// Matches GET operation's MAX_RETRIES; change both together.
 const MAX_RETRIES: usize = 10;
 
-/// Minimum HTL for speculative retries.
-///
-/// Retries use a reduced HTL (capped at current_hop) to avoid full-depth
-/// traversal storms. This floor ensures retries still reach peers 2-3 hops
-/// away, which is the minimum useful search depth in any topology.
-/// Matches GET operation's MIN_RETRY_HTL; change both together.
-/// Used only by `retry_with_next_alternative`, which itself survives
-/// the slice-1 GC retirement only as a test-exercised helper. Allow
-/// `dead_code` until the helper + tests are removed in slice 2.
-#[allow(dead_code)]
-const MIN_RETRY_HTL: usize = 3;
-
 /// Timeout for waiting on contract storage notification.
 /// Used when a subscription arrives before the contract has been propagated via PUT.
 pub(super) const CONTRACT_WAIT_TIMEOUT_MS: u64 = 2_000;
@@ -247,8 +235,6 @@ pub(crate) fn start_op(instance_id: ContractInstanceId, is_renewal: bool) -> Sub
         requester_pub_key: None,
         is_renewal,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     }
 }
 
@@ -268,8 +254,6 @@ pub(crate) fn start_op_with_id(
         requester_pub_key: None,
         is_renewal,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     }
 }
 
@@ -299,8 +283,6 @@ pub(crate) fn create_unsubscribe_op(
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     }
 }
 
@@ -607,20 +589,6 @@ pub(crate) struct SubscribeOp {
     is_renewal: bool,
     /// Routing stats for failure reporting.
     stats: Option<SubscribeStats>,
-    /// Historically: true when a downstream relay has acknowledged
-    /// forwarding this request. The GC speculative-retry block that
-    /// consumed this signal was retired in #1454 Phase 5-final slice 1
-    /// (mirroring the GET retirement in PR #3974). The field is still
-    /// maintained on the legacy state-machine path and exercised by
-    /// helper tests so the bookkeeping is captured if a future retry
-    /// mechanism reuses it. Allow `dead_code` until the field + tests
-    /// are deleted in slice 2.
-    #[allow(dead_code)]
-    pub(crate) ack_received: bool,
-    /// Historically: number of speculative parallel paths launched by
-    /// the originator's GC task. Same lineage as `ack_received` above.
-    #[allow(dead_code)]
-    pub(crate) speculative_paths: u8,
 }
 
 impl SubscribeOp {
@@ -715,119 +683,6 @@ impl SubscribeOp {
     /// The originator has no `requester_addr` (no upstream peer to respond to).
     pub(crate) fn is_originator(&self) -> bool {
         self.requester_addr.is_none()
-    }
-
-    /// Retry the subscribe operation with the next alternative peer.
-    ///
-    /// Similar to GET's `retry_with_next_alternative`: picks the next untried peer
-    /// from local alternatives, or injects fallback peers if alternatives are exhausted.
-    /// Returns `Ok((op, msg))` with the updated op and new Request message,
-    /// or `Err(op)` if no alternatives remain.
-    ///
-    /// Historically called by the GC speculative-retry block; that block
-    /// was retired in #1454 Phase 5-final slice 1. Helper retained for
-    /// the existing unit tests until the field + tests are deleted in
-    /// slice 2.
-    #[allow(dead_code)]
-    pub(crate) fn retry_with_next_alternative(
-        mut self,
-        max_hops_to_live: usize,
-        fallback_peers: &[PeerKeyLocation],
-    ) -> Result<(SubscribeOp, SubscribeMsg), Box<SubscribeOp>> {
-        match self.state {
-            SubscribeState::AwaitingResponse(ref mut data) => {
-                // If local alternatives exhausted, inject fallback peers we haven't tried.
-                // Filter through both tried_peers and visited bloom filter (#3570).
-                if data.alternatives.is_empty() && !fallback_peers.is_empty() {
-                    for peer in fallback_peers {
-                        if let Some(addr) = peer.socket_addr() {
-                            if !data.tried_peers.contains(&addr)
-                                && !data.visited.probably_visited(addr)
-                            {
-                                data.alternatives.push(peer.clone());
-                            }
-                        }
-                    }
-                    if !data.alternatives.is_empty() {
-                        tracing::info!(
-                            tx = %self.id,
-                            contract = %data.instance_id,
-                            new_candidates = data.alternatives.len(),
-                            "Subscribe broadening search to all connected peers (fallback)"
-                        );
-                    }
-                }
-
-                if data.alternatives.is_empty() {
-                    return Err(Box::new(self));
-                }
-
-                // Take ownership of state to modify it
-                let SubscribeState::AwaitingResponse(mut data) =
-                    std::mem::replace(&mut self.state, SubscribeState::Failed)
-                else {
-                    unreachable!();
-                };
-
-                let instance_id = data.instance_id;
-                let is_renewal = self.is_renewal;
-
-                // Find next alternative with a known socket address.
-                // Skip peers without addresses — they can't be contacted.
-                let (next_target, addr) = loop {
-                    if data.alternatives.is_empty() {
-                        // All remaining alternatives lack addresses
-                        self.state = SubscribeState::AwaitingResponse(data);
-                        return Err(Box::new(self));
-                    }
-                    let candidate = data.alternatives.remove(0);
-                    if let Some(addr) = candidate.socket_addr() {
-                        break (candidate, addr);
-                    }
-                };
-                data.tried_peers.insert(addr);
-                // Mark in bloom filter so future retries skip this peer (#3570).
-                data.visited.mark_visited(addr);
-                data.next_hop = Some(addr);
-                data.attempts_at_hop += 1;
-                let visited = data.visited.clone();
-
-                tracing::info!(
-                    tx = %self.id,
-                    contract = %instance_id,
-                    target = ?next_target.socket_addr(),
-                    remaining_alternatives = data.alternatives.len(),
-                    "Subscribe retrying with alternative peer after timeout"
-                );
-
-                // Update stats for the new target (reset timing for new attempt)
-                self.stats = Some(SubscribeStats {
-                    target_peer: next_target,
-                    contract_location: Location::from(&instance_id),
-                    request_sent_at: Instant::now(),
-                });
-
-                // Reduce HTL on each retry, floored at MIN_RETRY_HTL (#3570).
-                let retry_htl = (max_hops_to_live / (data.attempts_at_hop.max(1)))
-                    .max(MIN_RETRY_HTL)
-                    .min(max_hops_to_live);
-
-                self.state = SubscribeState::AwaitingResponse(data);
-
-                let msg = SubscribeMsg::Request {
-                    id: self.id,
-                    instance_id,
-                    htl: retry_htl,
-                    visited,
-                    is_renewal,
-                };
-
-                Ok((self, msg))
-            }
-            SubscribeState::PrepareRequest(_)
-            | SubscribeState::Completed(_)
-            | SubscribeState::Failed => Err(Box::new(self)),
-        }
     }
 
     /// Build a NotFound result to send back to the requester, or fail locally if we're the originator.
@@ -952,8 +807,6 @@ impl SubscribeOp {
                             s.target_peer = next_target.clone();
                             s
                         }),
-                        ack_received: false,
-                        speculative_paths: 0,
                     };
 
                     op_manager
@@ -1017,8 +870,6 @@ impl SubscribeOp {
                                 s.target_peer = next_target.clone();
                                 s
                             }),
-                            ack_received: false,
-                            speculative_paths: 0,
                         };
 
                         op_manager
@@ -1054,8 +905,6 @@ impl SubscribeOp {
                     requester_pub_key,
                     is_renewal,
                     stats,
-                    ack_received: false,
-                    speculative_paths: 0,
                 };
 
                 op_manager
@@ -1298,8 +1147,6 @@ impl Operation for SubscribeOp {
                         requester_pub_key,
                         is_renewal,
                         stats: None,
-                        ack_received: false,
-                        speculative_paths: 0,
                     },
                     source_addr,
                 })
@@ -1380,8 +1227,6 @@ impl Operation for SubscribeOp {
                                     requester_pub_key: None,
                                     is_renewal: self.is_renewal,
                                     stats: self.stats,
-                                    ack_received: false,
-                                    speculative_paths: 0,
                                 },
                             )));
                         }
@@ -1430,8 +1275,6 @@ impl Operation for SubscribeOp {
                                     requester_pub_key: None,
                                     is_renewal: self.is_renewal,
                                     stats: self.stats,
-                                    ack_received: false,
-                                    speculative_paths: 0,
                                 },
                             )));
                         }
@@ -1576,8 +1419,6 @@ impl Operation for SubscribeOp {
                                 contract_location: Location::from(instance_id),
                                 request_sent_at: Instant::now(),
                             }),
-                            ack_received: false,
-                            speculative_paths: 0,
                         }),
                         stream_data: None,
                     })
@@ -1767,8 +1608,6 @@ impl Operation for SubscribeOp {
                                     requester_pub_key: None,
                                     is_renewal: self.is_renewal,
                                     stats: self.stats,
-                                    ack_received: false,
-                                    speculative_paths: 0,
                                 },
                             )))
                         }
@@ -1862,8 +1701,6 @@ impl Operation for SubscribeOp {
                                                 s.target_peer = next_target.clone();
                                                 s
                                             }),
-                                            ack_received: false,
-                                            speculative_paths: 0,
                                         }),
                                         stream_data: None,
                                     });
@@ -1931,8 +1768,6 @@ impl Operation for SubscribeOp {
                                                     s.target_peer = next_target.clone();
                                                     s
                                                 }),
-                                                ack_received: false,
-                                                speculative_paths: 0,
                                             }),
                                             stream_data: None,
                                         });
@@ -2030,8 +1865,6 @@ impl Operation for SubscribeOp {
                                             requester_pub_key: None,
                                             is_renewal: self.is_renewal,
                                             stats: self.stats,
-                                            ack_received: false,
-                                            speculative_paths: 0,
                                         },
                                     )))
                                 } else {
@@ -2083,8 +1916,6 @@ impl Operation for SubscribeOp {
                                             requester_pub_key: None,
                                             is_renewal: self.is_renewal,
                                             stats: self.stats,
-                                            ack_received: false,
-                                            speculative_paths: 0,
                                         },
                                     )))
                                 }
@@ -2177,19 +2008,16 @@ impl Operation for SubscribeOp {
                 }
 
                 SubscribeMsg::ForwardingAck { id, instance_id } => {
-                    // A downstream relay has acknowledged forwarding our request.
-                    // Mark the op so the GC task knows the chain is alive.
+                    // Wire variant survives as a telemetry hook (#3570 diagnostics)
+                    // after the SUBSCRIBE GC speculative-retry block was retired in
+                    // #1454 Phase 5-final. No state mutation; mirrors GET's
+                    // ForwardingAck no-op handler.
                     tracing::debug!(
                         tx = %id,
                         %instance_id,
                         "Received forwarding ACK from downstream relay"
                     );
-                    Ok(OperationResult::ContinueOp(OpEnum::Subscribe(
-                        SubscribeOp {
-                            ack_received: true,
-                            ..self
-                        },
-                    )))
+                    Ok(OperationResult::ContinueOp(OpEnum::Subscribe(self)))
                 }
             }
         })

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -476,8 +476,6 @@ async fn test_subscription_validates_k_closest_usage() {
             requester_pub_key: None,
             is_renewal: false,
             stats: None,
-            ack_received: false,
-            speculative_paths: 0,
         };
 
         // State is simplified - skip list is now in the Request message, not state
@@ -574,8 +572,6 @@ fn test_subscribe_op_state_lifecycle() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
 
     assert!(
@@ -604,8 +600,6 @@ fn test_subscribe_op_state_lifecycle() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
 
     assert!(
@@ -630,8 +624,6 @@ fn test_subscribe_op_state_lifecycle() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
 
     assert!(
@@ -666,8 +658,6 @@ fn test_subscribe_op_failed_state_returns_error() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
 
     // Verify to_host_result returns error
@@ -703,8 +693,6 @@ fn test_local_subscription_completion_state() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
 
     // Verify operation is in completed state
@@ -742,8 +730,6 @@ fn test_is_renewal_flag() {
         requester_pub_key: None,
         is_renewal: true,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
     assert!(renewal_op.is_renewal());
 
@@ -754,8 +740,6 @@ fn test_is_renewal_flag() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
     assert!(!client_op.is_renewal());
 }
@@ -775,8 +759,6 @@ fn test_op_enum_is_subscription_renewal() {
         requester_pub_key: None,
         is_renewal: true,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     });
     assert!(renewal.is_subscription_renewal());
 
@@ -787,8 +769,6 @@ fn test_op_enum_is_subscription_renewal() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     });
     assert!(!non_renewal.is_subscription_renewal());
 }
@@ -816,8 +796,6 @@ fn test_subscribe_failure_outcome() {
             contract_location,
             request_sent_at: Instant::now(),
         }),
-        ack_received: false,
-        speculative_paths: 0,
     };
 
     match op_with_stats.outcome() {
@@ -850,8 +828,6 @@ fn test_subscribe_failure_outcome() {
             contract_location,
             request_sent_at: Instant::now(),
         }),
-        ack_received: false,
-        speculative_paths: 0,
     };
     match op_completed.outcome() {
         OpOutcome::ContractOpSuccess {
@@ -878,8 +854,6 @@ fn test_subscribe_failure_outcome() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
     assert!(
         matches!(op_no_stats.outcome(), OpOutcome::Incomplete),
@@ -898,8 +872,6 @@ fn test_subscribe_failure_outcome() {
             contract_location,
             request_sent_at: Instant::now(),
         }),
-        ack_received: false,
-        speculative_paths: 0,
     };
     let (peer, loc) = op_for_info
         .failure_routing_info()
@@ -936,8 +908,6 @@ fn test_subscribe_outcome_success_untimed_with_stats() {
             contract_location,
             request_sent_at: Instant::now(),
         }),
-        ack_received: false,
-        speculative_paths: 0,
     };
     match op.outcome() {
         OpOutcome::ContractOpSuccessUntimed {
@@ -971,8 +941,6 @@ fn test_subscribe_outcome_irrelevant_without_stats() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
     assert!(matches!(op.outcome(), OpOutcome::Irrelevant));
 }
@@ -997,8 +965,6 @@ fn test_subscribe_outcome_failure_with_stats() {
             contract_location,
             request_sent_at: Instant::now(),
         }),
-        ack_received: false,
-        speculative_paths: 0,
     };
     match op.outcome() {
         OpOutcome::ContractOpFailure {
@@ -1027,8 +993,6 @@ fn test_subscribe_outcome_incomplete_without_stats() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
     assert!(matches!(op.outcome(), OpOutcome::Incomplete));
 }
@@ -1061,8 +1025,6 @@ fn test_subscribe_stats_lifecycle() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
     assert!(matches!(op.outcome(), OpOutcome::Incomplete));
 
@@ -1130,8 +1092,6 @@ fn test_subscribe_renewal_reports_outcome() {
             contract_location,
             request_sent_at: Instant::now(),
         }),
-        ack_received: false,
-        speculative_paths: 0,
     };
     // Renewal should still report success with timing
     match op.outcome() {
@@ -1494,8 +1454,6 @@ fn test_retry_phase3_intermediate_node_forwards_notfound() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
 
     // Intermediate node has requester_addr → should forward NotFound
@@ -1539,8 +1497,6 @@ fn test_retry_phase3_originator_fails_locally() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
 
     // Originator has no requester_addr → should fail locally
@@ -1569,8 +1525,6 @@ fn test_non_awaiting_response_states_skip_retry() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
     assert!(
         !matches!(op_prepare.state, SubscribeState::AwaitingResponse(_)),
@@ -1585,8 +1539,6 @@ fn test_non_awaiting_response_states_skip_retry() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
     assert!(
         !matches!(op_completed.state, SubscribeState::AwaitingResponse(_)),
@@ -1601,8 +1553,6 @@ fn test_non_awaiting_response_states_skip_retry() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
     assert!(
         !matches!(op_failed.state, SubscribeState::AwaitingResponse(_)),
@@ -1743,8 +1693,6 @@ fn awaiting_op(
         requester_pub_key: None,
         is_renewal: false,
         stats,
-        ack_received: false,
-        speculative_paths: 0,
     }
 }
 
@@ -1805,8 +1753,6 @@ fn completed_subscribe_reports_success() {
             contract_location,
             request_sent_at: Instant::now(),
         }),
-        ack_received: false,
-        speculative_paths: 0,
     };
 
     assert!(op.finalized());
@@ -1835,267 +1781,6 @@ fn completed_subscribe_reports_success() {
     }
 }
 
-// ── Subscribe retry tests ──────────────────────────────────────────────
-
-/// Build a SubscribeOp in AwaitingResponse state for retry tests.
-/// Mirrors GET's `make_awaiting_op` helper.
-fn make_retry_op(alternatives: Vec<PeerKeyLocation>, tried: &[PeerKeyLocation]) -> SubscribeOp {
-    let tx_id = Transaction::new::<SubscribeMsg>();
-    let instance_id = ContractInstanceId::new([50u8; 32]);
-    let mut tried_peers = HashSet::new();
-    for p in tried {
-        if let Some(addr) = p.socket_addr() {
-            tried_peers.insert(addr);
-        }
-    }
-    SubscribeOp {
-        id: tx_id,
-        state: SubscribeState::AwaitingResponse(super::AwaitingResponseData {
-            next_hop: tried.first().and_then(|p| p.socket_addr()),
-            instance_id,
-            retries: 0,
-            current_hop: 10,
-            tried_peers,
-            alternatives,
-            attempts_at_hop: 1,
-            visited: crate::operations::VisitedPeers::new(&tx_id),
-        }),
-        requester_addr: None,
-        requester_pub_key: None,
-        is_renewal: false,
-        stats: None,
-        ack_received: false,
-        speculative_paths: 0,
-    }
-}
-
-/// Extract HTL from a SubscribeMsg::Request, panicking on other variants.
-fn extract_request_htl(msg: &SubscribeMsg) -> usize {
-    match msg {
-        SubscribeMsg::Request { htl, .. } => *htl,
-        other @ SubscribeMsg::Response { .. }
-        | other @ SubscribeMsg::Unsubscribe { .. }
-        | other @ SubscribeMsg::ForwardingAck { .. } => {
-            panic!("Expected Request, got {other:?}")
-        }
-    }
-}
-
-/// Extract the AwaitingResponseData from a SubscribeOp, panicking if in wrong state.
-fn extract_awaiting_data(op: &SubscribeOp) -> &super::AwaitingResponseData {
-    match &op.state {
-        SubscribeState::AwaitingResponse(data) => data,
-        other @ SubscribeState::PrepareRequest(_)
-        | other @ SubscribeState::Completed(_)
-        | other @ SubscribeState::Failed => {
-            panic!("Expected AwaitingResponse, got {other:?}")
-        }
-    }
-}
-
-/// Test that `retry_with_next_alternative` picks the next untried peer.
-#[test]
-fn test_retry_with_next_alternative_picks_next_peer() {
-    let peer1 = random_peer();
-    let peer2 = random_peer();
-    let peer3 = random_peer();
-
-    let op = make_retry_op(vec![peer2.clone(), peer3.clone()], &[peer1]);
-    assert!(op.is_originator(), "No requester_addr means originator");
-
-    let (new_op, msg) = op
-        .retry_with_next_alternative(10, &[])
-        .map_err(|_| "retry should succeed with alternatives available")
-        .unwrap();
-
-    // attempts_at_hop was 1, incremented to 2 before HTL calc: 10/2 = 5
-    assert_eq!(extract_request_htl(&msg), 5);
-
-    let data = extract_awaiting_data(&new_op);
-    assert!(data.tried_peers.contains(&peer2.socket_addr().unwrap()));
-    assert_eq!(data.alternatives.len(), 1, "peer3 should remain");
-}
-
-/// Test that `retry_with_next_alternative` returns Err when no alternatives remain.
-#[test]
-fn test_retry_with_no_alternatives_returns_err() {
-    let op = make_retry_op(vec![], &[]);
-    let result = op.retry_with_next_alternative(10, &[]);
-    assert!(result.is_err(), "Should fail when no alternatives remain");
-}
-
-/// Test that `retry_with_next_alternative` uses fallback peers when alternatives are exhausted.
-#[test]
-fn test_retry_uses_fallback_peers() {
-    let fallback_peer = random_peer();
-    let op = make_retry_op(vec![], &[]);
-
-    let (new_op, _msg) = op
-        .retry_with_next_alternative(10, std::slice::from_ref(&fallback_peer))
-        .map_err(|_| "retry should succeed with fallback peers")
-        .unwrap();
-
-    let data = extract_awaiting_data(&new_op);
-    assert!(
-        data.tried_peers
-            .contains(&fallback_peer.socket_addr().unwrap()),
-        "Fallback peer should be marked as tried"
-    );
-}
-
-/// Test that `retry_with_next_alternative` skips already-tried fallback peers.
-#[test]
-fn test_retry_skips_tried_fallback_peers() {
-    let tried_peer = random_peer();
-    let op = make_retry_op(vec![], std::slice::from_ref(&tried_peer));
-
-    let result = op.retry_with_next_alternative(10, &[tried_peer]);
-    assert!(
-        result.is_err(),
-        "Should fail when all fallback peers already tried"
-    );
-}
-
-/// Verify that retry HTL decreases with each attempt (#3570).
-///
-/// Formula: max_hops_to_live / attempts_at_hop, floored at MIN_RETRY_HTL.
-#[test]
-fn test_retry_htl_decreases_with_attempts() {
-    let op = make_retry_op(vec![random_peer(), random_peer(), random_peer()], &[]);
-
-    // First retry: attempts_at_hop becomes 2 -> 10/2 = 5
-    let (op, msg) = op
-        .retry_with_next_alternative(10, &[])
-        .unwrap_or_else(|_| panic!("retry 1 failed"));
-    assert_eq!(extract_request_htl(&msg), 5);
-
-    // Second retry: attempts_at_hop becomes 3 -> 10/3 = 3 = MIN_RETRY_HTL
-    let (op, msg) = op
-        .retry_with_next_alternative(10, &[])
-        .unwrap_or_else(|_| panic!("retry 2 failed"));
-    assert_eq!(extract_request_htl(&msg), super::MIN_RETRY_HTL);
-
-    // Third retry: attempts_at_hop becomes 4 -> 10/4 = 2, clamped to MIN_RETRY_HTL
-    let (_op, msg) = op
-        .retry_with_next_alternative(10, &[])
-        .unwrap_or_else(|_| panic!("retry 3 failed"));
-    assert_eq!(extract_request_htl(&msg), super::MIN_RETRY_HTL);
-}
-
-/// Verify that MIN_RETRY_HTL floor is applied even with many prior attempts.
-#[test]
-fn test_retry_htl_floor_at_min() {
-    let tx_id = Transaction::new::<SubscribeMsg>();
-    let instance_id = ContractInstanceId::new([61u8; 32]);
-    let op = SubscribeOp {
-        id: tx_id,
-        state: SubscribeState::AwaitingResponse(super::AwaitingResponseData {
-            next_hop: None,
-            instance_id,
-            retries: 0,
-            current_hop: 10,
-            tried_peers: HashSet::new(),
-            alternatives: vec![random_peer()],
-            attempts_at_hop: 20,
-            visited: crate::operations::VisitedPeers::new(&tx_id),
-        }),
-        requester_addr: None,
-        requester_pub_key: None,
-        is_renewal: false,
-        stats: None,
-        ack_received: false,
-        speculative_paths: 0,
-    };
-
-    let (_op, msg) = op
-        .retry_with_next_alternative(10, &[])
-        .unwrap_or_else(|_| panic!("retry failed"));
-    assert!(
-        extract_request_htl(&msg) >= super::MIN_RETRY_HTL,
-        "HTL should not fall below MIN_RETRY_HTL"
-    );
-}
-
-/// Verify that HTL never exceeds max_hops_to_live, even when MIN_RETRY_HTL is higher.
-///
-/// When max_hops_to_live=2 (< MIN_RETRY_HTL=3), the .min(max_hops_to_live) clamp
-/// must prevent the retry from exceeding the network's configured maximum.
-#[test]
-fn test_retry_htl_capped_at_max_hops() {
-    let alt = random_peer();
-    let op = make_retry_op(vec![alt], &[]);
-
-    let (_op, msg) = op
-        .retry_with_next_alternative(2, &[])
-        .unwrap_or_else(|_| panic!("retry failed"));
-    assert_eq!(
-        extract_request_htl(&msg),
-        2,
-        "HTL must not exceed max_hops_to_live even when MIN_RETRY_HTL is higher"
-    );
-}
-
-/// Verify that bloom-filter-visited peers are excluded from fallback injection (#3570).
-#[test]
-fn test_retry_fallback_skips_bloom_visited() {
-    let visited_peer = random_peer();
-    let fresh_peer = random_peer();
-    let visited_addr = visited_peer.socket_addr().unwrap();
-
-    let tx_id = Transaction::new::<SubscribeMsg>();
-    let mut visited = crate::operations::VisitedPeers::new(&tx_id);
-    visited.mark_visited(visited_addr);
-
-    let op = SubscribeOp {
-        id: tx_id,
-        state: SubscribeState::AwaitingResponse(super::AwaitingResponseData {
-            next_hop: None,
-            instance_id: ContractInstanceId::new([62u8; 32]),
-            retries: 0,
-            current_hop: 10,
-            tried_peers: HashSet::new(),
-            alternatives: vec![],
-            attempts_at_hop: 1,
-            visited,
-        }),
-        requester_addr: None,
-        requester_pub_key: None,
-        is_renewal: false,
-        stats: None,
-        ack_received: false,
-        speculative_paths: 0,
-    };
-
-    let (new_op, _msg) = op
-        .retry_with_next_alternative(10, &[visited_peer, fresh_peer])
-        .unwrap_or_else(|_| panic!("retry failed"));
-
-    let data = extract_awaiting_data(&new_op);
-    assert_eq!(
-        data.alternatives.len(),
-        0,
-        "Only fresh_peer should be injected (visited_peer filtered by bloom)"
-    );
-}
-
-/// Verify that retry targets are marked in the bloom filter (#3570).
-#[test]
-fn test_retry_marks_target_in_bloom_filter() {
-    let alt = random_peer();
-    let alt_addr = alt.socket_addr().unwrap();
-    let op = make_retry_op(vec![alt], &[]);
-
-    let (new_op, _msg) = op
-        .retry_with_next_alternative(10, &[])
-        .unwrap_or_else(|_| panic!("retry failed"));
-
-    let data = extract_awaiting_data(&new_op);
-    assert!(
-        data.visited.probably_visited(alt_addr),
-        "Retry target should be marked in bloom filter"
-    );
-}
-
 /// Test that non-originator subscribe ops are correctly identified.
 #[test]
 fn test_is_originator_false_for_intermediate_hop() {
@@ -2119,8 +1804,6 @@ fn test_is_originator_false_for_intermediate_hop() {
         requester_pub_key: None,
         is_renewal: false,
         stats: None,
-        ack_received: false,
-        speculative_paths: 0,
     };
 
     assert!(
@@ -2128,57 +1811,6 @@ fn test_is_originator_false_for_intermediate_hop() {
         "Op with requester_addr should not be originator"
     );
 }
-
-/// Test that retry doesn't work on non-AwaitingResponse states.
-#[test]
-fn test_retry_fails_on_wrong_state() {
-    let instance_id = ContractInstanceId::new([55u8; 32]);
-    let contract_key = ContractKey::from_id_and_code(instance_id, CodeHash::new([56u8; 32]));
-    let tx_id = Transaction::new::<SubscribeMsg>();
-
-    // PrepareRequest state
-    let op = SubscribeOp {
-        id: tx_id,
-        state: SubscribeState::PrepareRequest(super::PrepareRequestData {
-            id: tx_id,
-            instance_id,
-        }),
-        requester_addr: None,
-        requester_pub_key: None,
-        is_renewal: false,
-        stats: None,
-        ack_received: false,
-        speculative_paths: 0,
-    };
-    assert!(op.retry_with_next_alternative(10, &[]).is_err());
-
-    // Completed state
-    let op = SubscribeOp {
-        id: tx_id,
-        state: SubscribeState::Completed(super::CompletedData { key: contract_key }),
-        requester_addr: None,
-        requester_pub_key: None,
-        is_renewal: false,
-        stats: None,
-        ack_received: false,
-        speculative_paths: 0,
-    };
-    assert!(op.retry_with_next_alternative(10, &[]).is_err());
-
-    // Failed state
-    let op = SubscribeOp {
-        id: tx_id,
-        state: SubscribeState::Failed,
-        requester_addr: None,
-        requester_pub_key: None,
-        is_renewal: false,
-        stats: None,
-        ack_received: false,
-        speculative_paths: 0,
-    };
-    assert!(op.retry_with_next_alternative(10, &[]).is_err());
-}
-
 // === Tests for ForwardingAck serde round-trip ===
 
 #[test]


### PR DESCRIPTION
## Problem

Slice 1 (PR #4018) retired the SUBSCRIBE GC speculative-retry block. The
per-op `SubscribeOp::ack_received` / `speculative_paths` fields, the
`retry_with_next_alternative` helper, the `MIN_RETRY_HTL` constant, and
the unit tests that exercised the retry decision became dead — kept
behind `#[allow(dead_code)]` only because deleting them in the same PR
would have inflated the diff and obscured the GC-block deletion review.

## Solution

This slice does the mechanical cleanup that slice 1 deferred:

- Delete `SubscribeOp::ack_received` and `SubscribeOp::speculative_paths`
  fields. Strip 16 init sites across `subscribe.rs` and the test file.
- Delete the `retry_with_next_alternative` helper (~140 LoC) and the
  `MIN_RETRY_HTL` constant.
- Delete 11 `test_retry_*` unit tests in `subscribe/tests.rs` plus the
  `make_retry_op` / `extract_request_htl` / `extract_awaiting_data`
  helpers (no other callers).
- Delete `subscribe_retry_candidates_sorted_oldest_first` in
  `op_state_manager.rs` (exercised the deleted GC sort logic).
- Simplify the legacy `SubscribeMsg::ForwardingAck` handler to a
  state-preserving no-op. Mirrors the GET treatment from PR #3974;
  the wire variant survives as a telemetry hook (#3570 diagnostics).
- Update `.claude/rules/operations.md` to mark slice 2 complete.

## Wire format

`SubscribeMsg::ForwardingAck` discriminant and field layout are
unchanged. Only the originator-side write of `ack_received: true`
disappears — the field itself is gone, so there is nothing to mutate.
Relays still emit `ForwardingAck`; the originator still logs receipt
at debug level.

## Testing

- `cargo fmt` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --lib`: 2519 passed, 16 ignored (vs 2525 pre-deletion;
  the 6-test delta matches the 11 deleted retry tests minus
  test-helper-removed cascades, and the 2 op_state_manager tests
  reduce by 1)

## Diff

608 deletions / 13 insertions / net -595 LoC.

## Stack

Stacked on top of #4018 (slice 1, merged 2026-05-04).

## Fixes

Refs #1454.