### PR TITLE
fix(server): push permission prompts to all tabs via SSE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7038,6 +7038,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -104,7 +104,7 @@ opentelemetry_sdk = { workspace = true, optional = true }
 # internal deps
 freenet-stdlib = { features = ["net"], workspace = true }
 console-subscriber = { workspace = true, optional = true }
-tokio-stream = { workspace = true }
+tokio-stream = { workspace = true, features = ["sync"] }
 freenet-test-network = { workspace = true, optional = true }
 turmoil = { workspace = true }  # Deterministic simulation scheduling (always enabled for SimNetwork)
 lru = { workspace = true }

--- a/crates/core/src/contract/user_input.rs
+++ b/crates/core/src/contract/user_input.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use dashmap::DashMap;
 use freenet_stdlib::prelude::{ClientResponse, UserInputRequest};
-use tokio::sync::oneshot;
+use tokio::sync::{broadcast, oneshot};
 
 /// Timeout for user input prompts. After this duration, the request is auto-denied.
 pub(crate) const USER_INPUT_TIMEOUT: Duration = Duration::from_secs(60);
@@ -92,6 +92,53 @@ pub(crate) fn pending_prompts() -> PendingPrompts {
 /// Maximum concurrent pending prompts to prevent memory exhaustion.
 const MAX_PENDING_PROMPTS: usize = 32;
 
+/// Snapshot of a prompt's display fields, sufficient for the SSE handler to
+/// render an `Added` event without holding the DashMap entry. Cloned out of
+/// the registry so the broadcast path doesn't pin the entry's lock.
+#[derive(Clone, Debug)]
+pub(crate) struct PromptSnapshot {
+    pub nonce: String,
+    pub message: String,
+    pub labels: Vec<String>,
+    pub delegate_key: String,
+    pub caller: CallerIdentity,
+}
+
+/// Lifecycle event for a permission prompt. Consumed by the SSE endpoint to
+/// push state changes to every open Freenet tab in real time. The polling
+/// endpoint at `/permission/pending` is retained as a fallback and is not
+/// driven by this stream.
+#[derive(Clone, Debug)]
+pub(crate) enum PromptEvent {
+    Added(PromptSnapshot),
+    Removed { nonce: String },
+}
+
+/// Broadcast capacity. Each lifecycle is two events (Added + Removed), and
+/// MAX_PENDING_PROMPTS caps concurrent in-flight prompts at 32, so 128 leaves
+/// healthy headroom even if a transient SSE subscriber lags briefly. On
+/// `RecvError::Lagged`, the SSE handler resyncs from the DashMap snapshot.
+const PROMPT_EVENT_CAPACITY: usize = 128;
+
+/// Global lifecycle broadcast for permission prompts.
+static PROMPT_EVENTS: std::sync::OnceLock<broadcast::Sender<PromptEvent>> =
+    std::sync::OnceLock::new();
+
+/// Get or initialize the global prompt-event broadcaster.
+pub(crate) fn prompt_events() -> broadcast::Sender<PromptEvent> {
+    PROMPT_EVENTS
+        .get_or_init(|| broadcast::channel(PROMPT_EVENT_CAPACITY).0)
+        .clone()
+}
+
+/// Fire a prompt lifecycle event. `Sender::send` returns `Err` when there
+/// are no live subscribers — that's the common case when the shell page
+/// isn't open yet, and the polling fallback covers it. Slow subscribers
+/// see `Lagged` and resync from the DashMap.
+fn emit_prompt_event(event: PromptEvent) {
+    drop(prompt_events().send(event));
+}
+
 /// Opens the user's browser to the permission page on the local dashboard,
 /// then waits for the user to click a button. The HTTP POST handler sends
 /// the response back via a oneshot channel.
@@ -149,13 +196,24 @@ impl UserInputPrompter for DashboardPrompter {
         self.pending.insert(
             nonce.clone(),
             PendingPrompt {
-                message,
-                labels,
-                delegate_key: stored_delegate_key,
-                caller: stored_caller,
+                message: message.clone(),
+                labels: labels.clone(),
+                delegate_key: stored_delegate_key.clone(),
+                caller: stored_caller.clone(),
                 response_tx: tx,
             },
         );
+
+        // Fire the broadcast Added event AFTER the DashMap insert so any SSE
+        // subscriber that wakes up on the event can immediately find the entry
+        // if it falls back to a registry lookup.
+        emit_prompt_event(PromptEvent::Added(PromptSnapshot {
+            nonce: nonce.clone(),
+            message,
+            labels,
+            delegate_key: stored_delegate_key,
+            caller: stored_caller,
+        }));
 
         // Log at debug, not info -- nonce is the sole auth token for this prompt
         tracing::debug!(
@@ -166,8 +224,19 @@ impl UserInputPrompter for DashboardPrompter {
         // Wait for user response with timeout
         let result = tokio::time::timeout(USER_INPUT_TIMEOUT, rx).await;
 
-        // Clean up if still pending
-        self.pending.remove(&nonce);
+        // Clean up if still pending. The HTTP `respond` handler removes the
+        // entry on a real user click; this remove is a no-op in that case
+        // and otherwise covers the timeout / dropped-channel cleanup paths.
+        // Always emit Removed so subscribers can hide their overlay
+        // regardless of which path retired the prompt — a duplicate Removed
+        // (when both the HTTP handler and this cleanup fire) is harmless,
+        // because the SSE client's hide is idempotent on nonce.
+        let was_present = self.pending.remove(&nonce).is_some();
+        if was_present {
+            emit_prompt_event(PromptEvent::Removed {
+                nonce: nonce.clone(),
+            });
+        }
 
         match result {
             Ok(Ok(idx)) if idx < request.responses.len() => {
@@ -544,5 +613,130 @@ mod tests {
         let (idx, response) = result.unwrap();
         assert_eq!(idx, 0);
         assert_eq!(&*response, b"Allow");
+    }
+
+    /// Verify that `DashboardPrompter::prompt` fires a `PromptEvent::Added`
+    /// after inserting into the pending registry, and a `PromptEvent::Removed`
+    /// after the response cleanup. Without these, the SSE endpoint cannot
+    /// push lifecycle changes to subscribed tabs.
+    #[tokio::test]
+    async fn test_prompt_lifecycle_emits_added_and_removed() {
+        // Subscribe BEFORE spawning the prompter so we don't miss the
+        // synchronous Added event.
+        let mut rx = prompt_events().subscribe();
+
+        let pending: PendingPrompts = Arc::new(DashMap::new());
+        let prompter = DashboardPrompter::new(pending.clone());
+        let req = make_test_request("lifecycle?", vec!["Allow", "Deny"]);
+
+        let pending_clone = pending.clone();
+        let handle =
+            tokio::spawn(async move { prompter.prompt(&req, "dkey-lc", webapp("cid-lc")).await });
+
+        // Drain events until we see our specific Added (other tests in the
+        // same process may fire concurrently against the global broadcast).
+        let mut added_nonce: Option<String> = None;
+        for _ in 0..50 {
+            match tokio::time::timeout(Duration::from_millis(200), rx.recv()).await {
+                Ok(Ok(PromptEvent::Added(snap))) if snap.delegate_key == "dkey-lc" => {
+                    added_nonce = Some(snap.nonce);
+                    break;
+                }
+                Ok(_) => continue, // unrelated event from another test, keep draining
+                Err(_) => break,   // timeout: no event in window
+            }
+        }
+        let nonce = added_nonce.expect("PromptEvent::Added with our delegate_key");
+
+        // Respond so the prompter exits its timeout wait and runs cleanup.
+        let (_, prompt) = pending_clone.remove(&nonce).unwrap();
+        prompt.response_tx.send(0).unwrap();
+        let _ = handle.await.unwrap();
+
+        // Expect a matching Removed for that nonce. May be interleaved with
+        // unrelated events.
+        let mut saw_removed = false;
+        for _ in 0..50 {
+            match tokio::time::timeout(Duration::from_millis(200), rx.recv()).await {
+                Ok(Ok(PromptEvent::Removed { nonce: n })) if n == nonce => {
+                    saw_removed = true;
+                    break;
+                }
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
+        // Note: in this test the response handler ran inside the
+        // pending_clone.remove path (we removed the entry ourselves via
+        // pending_clone.remove). DashboardPrompter's cleanup remove
+        // returned None (was_present=false) so it did NOT emit Removed
+        // — that path is only fired when the prompter's own cleanup
+        // actually removes the entry (timeout / channel-dropped paths).
+        // The HTTP `/respond` handler fires Removed in the success
+        // path; that's covered by the SSE endpoint integration tests.
+        assert!(
+            !saw_removed,
+            "this test exercises the manual-remove path; \
+             Removed should fire only from the prompter's own cleanup \
+             (timeout) or the HTTP respond handler (covered elsewhere)"
+        );
+    }
+
+    /// When the prompter's own timeout cleanup runs, it must emit Removed
+    /// so SSE subscribers dismiss the overlay.
+    #[tokio::test(start_paused = true)]
+    async fn test_prompt_timeout_emits_removed() {
+        let mut rx = prompt_events().subscribe();
+
+        let pending: PendingPrompts = Arc::new(DashMap::new());
+        let prompter = DashboardPrompter::new(pending.clone());
+        let req = make_test_request("timeout?", vec!["Allow"]);
+
+        let handle = tokio::spawn(async move {
+            prompter
+                .prompt(&req, "dkey-timeout", webapp("cid-timeout"))
+                .await
+        });
+
+        // Capture the nonce of our specific Added event.
+        let mut our_nonce: Option<String> = None;
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+            match rx.try_recv() {
+                Ok(PromptEvent::Added(snap)) if snap.delegate_key == "dkey-timeout" => {
+                    our_nonce = Some(snap.nonce);
+                    break;
+                }
+                Ok(_) => continue,
+                Err(tokio::sync::broadcast::error::TryRecvError::Empty) => {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                Err(_) => break,
+            }
+        }
+        let nonce = our_nonce.expect("Added event for the timeout test");
+
+        // Advance virtual time past the prompt timeout.
+        tokio::time::advance(USER_INPUT_TIMEOUT + Duration::from_secs(1)).await;
+        let _ = handle.await.unwrap();
+
+        let mut saw_removed = false;
+        for _ in 0..50 {
+            match rx.try_recv() {
+                Ok(PromptEvent::Removed { nonce: n }) if n == nonce => {
+                    saw_removed = true;
+                    break;
+                }
+                Ok(_) => continue,
+                Err(tokio::sync::broadcast::error::TryRecvError::Empty) => {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                Err(_) => break,
+            }
+        }
+        assert!(
+            saw_removed,
+            "prompter timeout must emit PromptEvent::Removed"
+        );
     }
 }

--- a/crates/core/src/contract/user_input.rs
+++ b/crates/core/src/contract/user_input.rs
@@ -20,10 +20,12 @@ const MAX_LABELS: usize = 10;
 /// hashes come from runtime context that is bounded at the source (BLAKE3
 /// hex / base58 contract id, both well under this limit). Capping at the
 /// insertion point keeps the prompt store from holding arbitrarily large
-/// strings if a future caller passes something larger, and matches the
-/// downstream cap applied in `permission_prompts.rs` at the JSON / HTML
-/// boundary so the two layers can never disagree about the maximum.
-const MAX_IDENTITY_HASH_CHARS: usize = 256;
+/// strings if a future caller passes something larger.
+///
+/// `permission_prompts.rs` re-uses this same cap at the JSON / HTML
+/// rendering boundary, so the two layers cannot disagree about the
+/// maximum.
+pub(crate) const MAX_IDENTITY_HASH_CHARS: usize = 256;
 
 /// Runtime-attested identity of the entity that triggered a permission prompt.
 ///
@@ -132,10 +134,22 @@ pub(crate) fn prompt_events() -> broadcast::Sender<PromptEvent> {
 }
 
 /// Fire a prompt lifecycle event. `Sender::send` returns `Err` when there
-/// are no live subscribers — that's the common case when the shell page
+/// are no live subscribers; that's the common case when the shell page
 /// isn't open yet, and the polling fallback covers it. Slow subscribers
 /// see `Lagged` and resync from the DashMap.
+///
+/// Caps the nonce length on `Removed` so that even if an unusual code path
+/// ever passes a client-supplied nonce here (today the only producers are
+/// `DashboardPrompter` itself and the HTTP `respond` handler, which both
+/// route through validated DashMap keys), the broadcast can't carry an
+/// arbitrarily large string to every connected tab.
 pub(crate) fn emit_prompt_event(event: PromptEvent) {
+    let event = match event {
+        PromptEvent::Removed { nonce } => PromptEvent::Removed {
+            nonce: cap_identity_chars(&nonce),
+        },
+        other => other,
+    };
     drop(prompt_events().send(event));
 }
 
@@ -228,7 +242,7 @@ impl UserInputPrompter for DashboardPrompter {
         // entry on a real user click; this remove is a no-op in that case
         // and otherwise covers the timeout / dropped-channel cleanup paths.
         // Always emit Removed so subscribers can hide their overlay
-        // regardless of which path retired the prompt — a duplicate Removed
+        // regardless of which path retired the prompt; a duplicate Removed
         // (when both the HTTP handler and this cleanup fire) is harmless,
         // because the SSE client's hide is idempotent on nonce.
         let was_present = self.pending.remove(&nonce).is_some();
@@ -617,7 +631,7 @@ mod tests {
 
     /// `DashboardPrompter::prompt` fires `PromptEvent::Added` after inserting
     /// the entry. The cleanup `Removed` is only fired by the prompter when
-    /// the entry was still present at cleanup time — when an external party
+    /// the entry was still present at cleanup time. When an external party
     /// (the HTTP `/respond` handler in production) already removed the
     /// entry, the prompter's cleanup is a no-op and the external remover is
     /// responsible for emitting `Removed`. This test exercises that
@@ -673,8 +687,8 @@ mod tests {
         // Note: in this test the response handler ran inside the
         // pending_clone.remove path (we removed the entry ourselves via
         // pending_clone.remove). DashboardPrompter's cleanup remove
-        // returned None (was_present=false) so it did NOT emit Removed
-        // — that path is only fired when the prompter's own cleanup
+        // returned None (was_present=false) so it did NOT emit Removed.
+        // That path is only fired when the prompter's own cleanup
         // actually removes the entry (timeout / channel-dropped paths).
         // The HTTP `/respond` handler fires Removed in the success
         // path; that's covered by the SSE endpoint integration tests.

--- a/crates/core/src/contract/user_input.rs
+++ b/crates/core/src/contract/user_input.rs
@@ -135,7 +135,7 @@ pub(crate) fn prompt_events() -> broadcast::Sender<PromptEvent> {
 /// are no live subscribers — that's the common case when the shell page
 /// isn't open yet, and the polling fallback covers it. Slow subscribers
 /// see `Lagged` and resync from the DashMap.
-fn emit_prompt_event(event: PromptEvent) {
+pub(crate) fn emit_prompt_event(event: PromptEvent) {
     drop(prompt_events().send(event));
 }
 
@@ -615,12 +615,16 @@ mod tests {
         assert_eq!(&*response, b"Allow");
     }
 
-    /// Verify that `DashboardPrompter::prompt` fires a `PromptEvent::Added`
-    /// after inserting into the pending registry, and a `PromptEvent::Removed`
-    /// after the response cleanup. Without these, the SSE endpoint cannot
-    /// push lifecycle changes to subscribed tabs.
+    /// `DashboardPrompter::prompt` fires `PromptEvent::Added` after inserting
+    /// the entry. The cleanup `Removed` is only fired by the prompter when
+    /// the entry was still present at cleanup time — when an external party
+    /// (the HTTP `/respond` handler in production) already removed the
+    /// entry, the prompter's cleanup is a no-op and the external remover is
+    /// responsible for emitting `Removed`. This test exercises that
+    /// double-emit-avoidance path; the timeout-driven `Removed` path is
+    /// covered by `test_prompt_timeout_emits_removed`.
     #[tokio::test]
-    async fn test_prompt_lifecycle_emits_added_and_removed() {
+    async fn test_prompt_added_emitted_and_external_remove_skips_cleanup_removed() {
         // Subscribe BEFORE spawning the prompter so we don't miss the
         // synchronous Added event.
         let mut rx = prompt_events().subscribe();

--- a/crates/core/src/server/client_api/permission_prompts.rs
+++ b/crates/core/src/server/client_api/permission_prompts.rs
@@ -89,8 +89,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
 use crate::contract::user_input::{
-    CallerIdentity, PendingPrompts, PromptEvent, PromptSnapshot,
-    pending_prompts as pending_prompts_registry, prompt_events,
+    CallerIdentity, PendingPrompts, PromptEvent, PromptSnapshot, emit_prompt_event, prompt_events,
 };
 
 /// Register permission prompt routes.
@@ -515,14 +514,10 @@ async fn permission_respond(
                 }
                 // Notify SSE subscribers so every open Freenet tab dismisses
                 // its overlay immediately instead of waiting for the polling
-                // fallback (#3836 follow-up). `send` returns `Err` only when
-                // there are no live subscribers — that's the polling-only
-                // fallback case and is fine to ignore.
-                drop(crate::contract::user_input::prompt_events().send(
-                    crate::contract::user_input::PromptEvent::Removed {
-                        nonce: nonce.clone(),
-                    },
-                ));
+                // fallback (#3836 follow-up).
+                emit_prompt_event(PromptEvent::Removed {
+                    nonce: nonce.clone(),
+                });
                 (
                     axum::http::StatusCode::OK,
                     Json(serde_json::json!({"ok": true})),
@@ -641,7 +636,7 @@ fn snapshot_to_json(snapshot: &PromptSnapshot) -> serde_json::Value {
 /// idempotent.
 async fn permission_events(
     headers: HeaderMap,
-    Extension(_pending): Extension<PendingPrompts>,
+    Extension(pending): Extension<PendingPrompts>,
 ) -> axum::response::Response {
     // Connection cap. We do this before any expensive setup so a flood of
     // reconnects from a buggy client cannot exhaust per-process resources.
@@ -681,11 +676,10 @@ async fn permission_events(
     // Subscribe FIRST to avoid the race where a prompt is added between the
     // DashMap snapshot and our first broadcast recv.
     let rx = prompt_events().subscribe();
-    let pending_snapshot = pending_prompts_registry();
 
     // Convert each currently-pending entry to a synthetic Added event so
     // a fresh subscriber catches up to current state.
-    let initial: Vec<Result<Event, Infallible>> = pending_snapshot
+    let initial: Vec<Result<Event, Infallible>> = pending
         .iter()
         .map(|entry| {
             let snapshot = PromptSnapshot {
@@ -1399,7 +1393,7 @@ mod tests {
         origin: Option<&str>,
     ) -> std::pin::Pin<Box<dyn futures::stream::Stream<Item = bytes::Bytes> + Send>> {
         use axum::response::IntoResponse;
-        let pending = pending_prompts_registry();
+        let pending = crate::contract::user_input::pending_prompts();
         let mut headers = HeaderMap::new();
         if let Some(o) = origin {
             headers.insert("origin", o.parse().unwrap());
@@ -1531,7 +1525,7 @@ mod tests {
     #[tokio::test]
     async fn test_sse_replays_existing_pending_on_subscribe() {
         // Insert into the global registry before subscribing.
-        let pending = pending_prompts_registry();
+        let pending = crate::contract::user_input::pending_prompts();
         let nonce = "ssetest_bootstrap_003".to_string();
         let _rx = insert_prompt(
             &pending,

--- a/crates/core/src/server/client_api/permission_prompts.rs
+++ b/crates/core/src/server/client_api/permission_prompts.rs
@@ -1,14 +1,17 @@
 //! HTTP endpoints for delegate permission prompts.
 //!
 //! When a delegate emits `RequestUserInput`, the `DashboardPrompter` stores the
-//! pending prompt and the gateway shell page's JS detects it via polling the
-//! `/permission/pending` endpoint. The shell page renders the prompt as an
-//! in-page overlay (see issue #3836) on every open Freenet tab. When the user
-//! clicks a button in any tab the response is POSTed to
-//! `/permission/{nonce}/respond` and the result flows back to the delegate;
-//! other tabs see the nonce disappear on their next poll and hide the overlay.
+//! pending prompt and broadcasts a `PromptEvent::Added`. The gateway shell
+//! page's JS subscribes to `/permission/events` (Server-Sent Events) and
+//! renders the prompt as an in-page overlay (see issue #3836) on every open
+//! Freenet tab. When the user clicks a button in any tab the response is
+//! POSTed to `/permission/{nonce}/respond`; the gateway then emits
+//! `PromptEvent::Removed` and every tab dismisses its overlay.
 //!
-//! The standalone `/permission/{nonce}` HTML page is retained as a fallback
+//! The legacy `/permission/pending` JSON polling endpoint is retained as a
+//! fallback for environments without `EventSource`, for the SSE bootstrap
+//! reconciliation (used on connect/reconnect/resync), and for tests. The
+//! standalone `/permission/{nonce}` HTML page is retained as a fallback
 //! (e.g. if JS is disabled in the shell, or for debugging / manual testing).
 //!
 //! # Trust model and UI rationale (#3857)
@@ -70,21 +73,52 @@
 //! mirrors this same layout. Both code paths must stay in sync — the
 //! standalone page and the in-page overlay are both regression-tested.
 
+use std::convert::Infallible;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
 use axum::extract::Path;
 use axum::http::HeaderMap;
+use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{Html, IntoResponse};
 use axum::routing::{get, post};
 use axum::{Extension, Json, Router};
+use futures::stream::{self, Stream, StreamExt};
 use serde::Deserialize;
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
-use crate::contract::user_input::{CallerIdentity, PendingPrompts};
+use crate::contract::user_input::{
+    CallerIdentity, PendingPrompts, PromptEvent, PromptSnapshot,
+    pending_prompts as pending_prompts_registry, prompt_events,
+};
 
 /// Register permission prompt routes.
 pub(super) fn routes() -> Router {
     Router::new()
         .route("/permission/pending", get(pending_prompts))
+        .route("/permission/events", get(permission_events))
         .route("/permission/{nonce}", get(permission_page))
         .route("/permission/{nonce}/respond", post(permission_respond))
+}
+
+/// Cap on simultaneous SSE subscribers. A single browser typically opens one
+/// EventSource per Freenet tab; 64 is generous headroom and protects against
+/// runaway tab counts or a buggy client looping reconnects.
+const MAX_SSE_CONNECTIONS: usize = 64;
+
+/// Live SSE connection count. Used to enforce `MAX_SSE_CONNECTIONS`.
+static SSE_CONNECTIONS: AtomicUsize = AtomicUsize::new(0);
+
+/// Decrements `SSE_CONNECTIONS` on drop. The connection count must always be
+/// released even if the SSE stream is dropped mid-handshake or panics in a
+/// downstream layer.
+struct SseConnectionGuard;
+
+impl Drop for SseConnectionGuard {
+    fn drop(&mut self) {
+        SSE_CONNECTIONS.fetch_sub(1, Ordering::Relaxed);
+    }
 }
 
 /// Maximum message length returned to the shell-page overlay. Caps the
@@ -479,6 +513,16 @@ async fn permission_respond(
                 if prompt.response_tx.send(body.index).is_err() {
                     tracing::debug!(nonce = %nonce, "Permission response channel already closed");
                 }
+                // Notify SSE subscribers so every open Freenet tab dismisses
+                // its overlay immediately instead of waiting for the polling
+                // fallback (#3836 follow-up). `send` returns `Err` only when
+                // there are no live subscribers — that's the polling-only
+                // fallback case and is fine to ignore.
+                drop(crate::contract::user_input::prompt_events().send(
+                    crate::contract::user_input::PromptEvent::Removed {
+                        nonce: nonce.clone(),
+                    },
+                ));
                 (
                     axum::http::StatusCode::OK,
                     Json(serde_json::json!({"ok": true})),
@@ -557,6 +601,164 @@ fn html_escape(s: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&#x27;")
+}
+
+/// Render a `PromptSnapshot` as the JSON payload sent over SSE. Mirrors the
+/// shape returned by `/permission/pending` so the shell-page renderer can
+/// consume both code paths interchangeably.
+fn snapshot_to_json(snapshot: &PromptSnapshot) -> serde_json::Value {
+    let message = sanitize_display(&snapshot.message, OVERLAY_MESSAGE_MAX);
+    let labels: Vec<String> = snapshot
+        .labels
+        .iter()
+        .take(OVERLAY_LABELS_MAX)
+        .map(|l| sanitize_display(l, OVERLAY_LABEL_CHARS_MAX))
+        .collect();
+    serde_json::json!({
+        "nonce": snapshot.nonce,
+        "message": message,
+        "labels": labels,
+        "delegate_key": sanitize_display(&snapshot.delegate_key, OVERLAY_KEY_CHARS_MAX),
+        "caller": caller_to_json(&snapshot.caller),
+    })
+}
+
+/// Server-Sent Events stream for permission prompts.
+///
+/// Replaces the 3-second polling loop in the shell page with a push-based
+/// channel. A new prompt becomes visible to every open Freenet tab as soon
+/// as the broadcast event lands, with no polling-floor latency.
+///
+/// Origin gating mirrors `/permission/pending`: trusted loopback origins
+/// receive the full event stream; untrusted origins receive a stream that
+/// emits one `:closed` comment and ends, so the browser doesn't surface a
+/// CORS error in the devtools console.
+///
+/// Race avoidance: we subscribe to the broadcast channel BEFORE snapshotting
+/// the DashMap. Any prompt added between the snapshot and our first
+/// `recv()` arrives via the broadcast (possibly duplicated with a snapshot
+/// entry); the shell-page renderer keys on `nonce`, so duplicates are
+/// idempotent.
+async fn permission_events(
+    headers: HeaderMap,
+    Extension(_pending): Extension<PendingPrompts>,
+) -> axum::response::Response {
+    // Connection cap. We do this before any expensive setup so a flood of
+    // reconnects from a buggy client cannot exhaust per-process resources.
+    let prev = SSE_CONNECTIONS.fetch_add(1, Ordering::Relaxed);
+    if prev >= MAX_SSE_CONNECTIONS {
+        SSE_CONNECTIONS.fetch_sub(1, Ordering::Relaxed);
+        tracing::warn!(
+            limit = MAX_SSE_CONNECTIONS,
+            "SSE connection cap reached, refusing new /permission/events subscriber"
+        );
+        let stream = stream::once(async {
+            Ok::<_, Infallible>(Event::default().comment("connection-cap-reached"))
+        });
+        return Sse::new(stream)
+            .keep_alive(KeepAlive::default())
+            .into_response();
+    }
+    let guard = SseConnectionGuard;
+
+    let trusted = match headers.get("origin") {
+        Some(value) => value.to_str().map(is_trusted_origin).unwrap_or(false),
+        None => true,
+    };
+
+    if !trusted {
+        // Drop the guard immediately so the count is released — we're
+        // returning a degenerate stream that closes after one frame.
+        drop(guard);
+        let stream = stream::once(async {
+            Ok::<_, Infallible>(Event::default().comment("untrusted-origin"))
+        });
+        return Sse::new(stream)
+            .keep_alive(KeepAlive::default())
+            .into_response();
+    }
+
+    // Subscribe FIRST to avoid the race where a prompt is added between the
+    // DashMap snapshot and our first broadcast recv.
+    let rx = prompt_events().subscribe();
+    let pending_snapshot = pending_prompts_registry();
+
+    // Convert each currently-pending entry to a synthetic Added event so
+    // a fresh subscriber catches up to current state.
+    let initial: Vec<Result<Event, Infallible>> = pending_snapshot
+        .iter()
+        .map(|entry| {
+            let snapshot = PromptSnapshot {
+                nonce: entry.key().clone(),
+                message: entry.value().message.clone(),
+                labels: entry.value().labels.clone(),
+                delegate_key: entry.value().delegate_key.clone(),
+                caller: entry.value().caller.clone(),
+            };
+            Ok(Event::default()
+                .event("prompt_added")
+                .data(snapshot_to_json(&snapshot).to_string()))
+        })
+        .collect();
+
+    let live = BroadcastStream::new(rx).filter_map(|incoming| async move {
+        match incoming {
+            Ok(PromptEvent::Added(snapshot)) => Some(Ok(Event::default()
+                .event("prompt_added")
+                .data(snapshot_to_json(&snapshot).to_string()))),
+            Ok(PromptEvent::Removed { nonce }) => Some(Ok(Event::default()
+                .event("prompt_removed")
+                .data(serde_json::json!({ "nonce": nonce }).to_string()))),
+            // Lag means our subscriber was slow and missed events. The shell
+            // page reconciles by emitting a `resync` event that tells the
+            // client to drop everything and trust a freshly-fetched
+            // /permission/pending list. Rare in practice — capacity 128,
+            // two events per prompt lifecycle, max 32 concurrent prompts.
+            Err(BroadcastStreamRecvError::Lagged(n)) => {
+                tracing::warn!(skipped = n, "SSE subscriber lagged, requesting resync");
+                Some(Ok(Event::default().event("resync").data("{}")))
+            }
+        }
+    });
+
+    let merged = stream::iter(initial).chain(live);
+    let stream_with_guard = GuardedStream {
+        inner: merged,
+        _guard: guard,
+    };
+
+    Sse::new(stream_with_guard)
+        .keep_alive(
+            KeepAlive::new()
+                .interval(Duration::from_secs(25))
+                .text("keepalive"),
+        )
+        .into_response()
+}
+
+/// Wraps an inner SSE stream together with the connection-count guard so
+/// that dropping the response (client disconnect) decrements the live count.
+/// Without this, an SSE stream that's cancelled mid-flight would leak the
+/// counter slot until process exit.
+#[pin_project::pin_project]
+struct GuardedStream<S> {
+    #[pin]
+    inner: S,
+    _guard: SseConnectionGuard,
+}
+
+impl<S> Stream for GuardedStream<S>
+where
+    S: Stream<Item = Result<Event, Infallible>>,
+{
+    type Item = Result<Event, Infallible>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.project().inner.poll_next(cx)
+    }
 }
 
 #[cfg(test)]
@@ -1186,5 +1388,179 @@ mod tests {
             html.contains("&quot;onload=&quot;evil()"),
             "escaped caller hash quotes must appear"
         );
+    }
+
+    // ----- SSE endpoint regression tests -----
+
+    /// Open the SSE stream for a given test origin and return the data
+    /// stream as a `Stream<Bytes>`. We avoid `http_body_util` (not a direct
+    /// dev-dep) by using axum's `Body::into_data_stream` adapter.
+    async fn open_sse_with_origin(
+        origin: Option<&str>,
+    ) -> std::pin::Pin<Box<dyn futures::stream::Stream<Item = bytes::Bytes> + Send>> {
+        use axum::response::IntoResponse;
+        let pending = pending_prompts_registry();
+        let mut headers = HeaderMap::new();
+        if let Some(o) = origin {
+            headers.insert("origin", o.parse().unwrap());
+        }
+        let resp = permission_events(headers, Extension(pending))
+            .await
+            .into_response();
+        let stream = resp
+            .into_body()
+            .into_data_stream()
+            .filter_map(|r| async move { r.ok() });
+        Box::pin(stream)
+    }
+
+    /// Read the next non-keepalive SSE frame from a body stream, returning
+    /// the raw bytes (`event: ...\ndata: ...\n\n`). Caller parses. Skips
+    /// keepalive comment lines (starting with `:`).
+    async fn next_event_frame(
+        stream: &mut std::pin::Pin<Box<dyn futures::stream::Stream<Item = bytes::Bytes> + Send>>,
+        timeout_ms: u64,
+    ) -> Option<String> {
+        let deadline = std::time::Duration::from_millis(timeout_ms);
+        loop {
+            let chunk = match tokio::time::timeout(deadline, stream.next()).await {
+                Ok(Some(b)) => b,
+                _ => return None,
+            };
+            let text = String::from_utf8_lossy(&chunk).to_string();
+            // Skip pure keepalive comments (lines starting with ':') and
+            // empty chunks.
+            if text.trim().is_empty() || text.trim_start().starts_with(':') {
+                continue;
+            }
+            return Some(text);
+        }
+    }
+
+    /// Walk frames until we see one matching the predicate, or run out of
+    /// budget. Concurrent tests share the global broadcast channel so we
+    /// must filter by our test's own nonce rather than asserting on the
+    /// "next" frame.
+    async fn frame_matching(
+        stream: &mut std::pin::Pin<Box<dyn futures::stream::Stream<Item = bytes::Bytes> + Send>>,
+        predicate: impl Fn(&str) -> bool,
+        max_frames: usize,
+        per_frame_timeout_ms: u64,
+    ) -> Option<String> {
+        for _ in 0..max_frames {
+            let frame = next_event_frame(stream, per_frame_timeout_ms).await?;
+            if predicate(&frame) {
+                return Some(frame);
+            }
+        }
+        None
+    }
+
+    /// The bug this PR closes: a `prompt_added` lifecycle event must be
+    /// pushed to a subscribed SSE client without polling.
+    #[tokio::test]
+    async fn test_sse_emits_added_when_prompt_inserted() {
+        let mut body = open_sse_with_origin(Some("http://localhost:7509")).await;
+
+        let nonce = "ssetest_added_001".to_string();
+        let snapshot = PromptSnapshot {
+            nonce: nonce.clone(),
+            message: "approve?".into(),
+            labels: vec!["Allow".into(), "Deny".into()],
+            delegate_key: "dkey-added-001".into(),
+            caller: webapp_caller("cid-added-001"),
+        };
+        // Wait briefly so the SSE handler has time to subscribe before we
+        // emit the broadcast. Without this, the test would race the spawn.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        drop(prompt_events().send(PromptEvent::Added(snapshot)));
+
+        let frame = frame_matching(
+            &mut body,
+            |f| f.contains("event: prompt_added") && f.contains(&nonce),
+            32,
+            500,
+        )
+        .await
+        .unwrap_or_else(|| panic!("did not see prompt_added for {nonce}"));
+        assert!(frame.contains("dkey-added-001"));
+    }
+
+    /// `prompt_removed` must arrive over SSE so every tab dismisses its
+    /// overlay simultaneously when one tab clicks a button.
+    #[tokio::test]
+    async fn test_sse_emits_removed_when_prompt_responded() {
+        let mut body = open_sse_with_origin(Some("http://localhost:7509")).await;
+
+        let nonce = "ssetest_removed_002".to_string();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        drop(prompt_events().send(PromptEvent::Removed {
+            nonce: nonce.clone(),
+        }));
+
+        let frame = frame_matching(
+            &mut body,
+            |f| f.contains("event: prompt_removed") && f.contains(&nonce),
+            32,
+            500,
+        )
+        .await
+        .unwrap_or_else(|| panic!("did not see prompt_removed for {nonce}"));
+        assert!(frame.contains(&nonce));
+    }
+
+    /// Untrusted-origin SSE subscribers must receive a closed stream rather
+    /// than the live event flow. Mirrors the gating on `/permission/pending`.
+    #[tokio::test]
+    async fn test_sse_untrusted_origin_returns_closed_stream() {
+        let mut body = open_sse_with_origin(Some("http://evil.example")).await;
+        let frame = next_event_frame(&mut body, 200).await;
+        // The stream emits exactly one `:untrusted-origin` comment then
+        // closes. Comments are stripped by next_event_frame, so we expect
+        // None (no data events ever arrive on this stream).
+        assert!(
+            frame.is_none(),
+            "untrusted origin must not receive any data events, got: {frame:?}"
+        );
+    }
+
+    /// Initial-state bootstrap: a fresh subscriber must receive
+    /// `prompt_added` events for every currently-pending prompt before any
+    /// new live events arrive. Avoids the race where a prompt added between
+    /// the page load and the SSE subscribe would be invisible.
+    #[tokio::test]
+    async fn test_sse_replays_existing_pending_on_subscribe() {
+        // Insert into the global registry before subscribing.
+        let pending = pending_prompts_registry();
+        let nonce = "ssetest_bootstrap_003".to_string();
+        let _rx = insert_prompt(
+            &pending,
+            &nonce,
+            "bootstrap?",
+            vec!["OK"],
+            "dkey-bootstrap",
+            webapp_caller("cid-bootstrap"),
+        );
+
+        let mut body = open_sse_with_origin(Some("http://localhost:7509")).await;
+
+        // Walk frames until we see one referencing our nonce. Other tests
+        // running in parallel may have left additional pending entries in
+        // the shared global registry; any of them being replayed first is
+        // fine.
+        let mut found = false;
+        for _ in 0..16 {
+            let Some(frame) = next_event_frame(&mut body, 500).await else {
+                break;
+            };
+            if frame.contains("event: prompt_added") && frame.contains(&nonce) {
+                found = true;
+                break;
+            }
+        }
+        // Cleanup: remove from the shared registry so other tests aren't
+        // affected.
+        pending.remove(&nonce);
+        assert!(found, "bootstrap replay did not include {nonce}");
     }
 }

--- a/crates/core/src/server/client_api/permission_prompts.rs
+++ b/crates/core/src/server/client_api/permission_prompts.rs
@@ -1509,9 +1509,9 @@ mod tests {
     /// timing on slow CI runners.
     async fn wait_subscribers_then_send(target: usize, event: PromptEvent) {
         let sender = prompt_events();
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
         while sender.receiver_count() < target {
-            if std::time::Instant::now() >= deadline {
+            if tokio::time::Instant::now() >= deadline {
                 panic!(
                     "timed out waiting for {target} SSE subscribers; have {}",
                     sender.receiver_count()
@@ -1765,9 +1765,9 @@ mod tests {
         // counter to settle to zero. (No SSE responses should be live at
         // this point because the only test that opens them is this one,
         // serialised by the mutex above.)
-        let deadline0 = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let deadline0 = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
         while SSE_CONNECTIONS.load(Ordering::Relaxed) != 0 {
-            if std::time::Instant::now() >= deadline0 {
+            if tokio::time::Instant::now() >= deadline0 {
                 // A leaked connection from a previous test indicates a real
                 // bug in GuardedStream's drop, but for the purposes of this
                 // test, accept the baseline rather than panic.
@@ -1799,12 +1799,12 @@ mod tests {
         // Drop one held subscriber; the cap-counter must release a slot.
         let dropped = held.pop().unwrap();
         drop(dropped);
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
         loop {
             if SSE_CONNECTIONS.load(Ordering::Relaxed) < MAX_SSE_CONNECTIONS {
                 break;
             }
-            if std::time::Instant::now() >= deadline {
+            if tokio::time::Instant::now() >= deadline {
                 panic!("SSE_CONNECTIONS did not decrement after dropping a subscriber");
             }
             tokio::task::yield_now().await;
@@ -1855,9 +1855,9 @@ mod tests {
 
         // Drain until we see the matching Removed (concurrent tests on the
         // global broadcaster may interleave their own events).
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
         let mut saw = false;
-        while std::time::Instant::now() < deadline {
+        while tokio::time::Instant::now() < deadline {
             match tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await {
                 Ok(Ok(PromptEvent::Removed { nonce: n })) if n == nonce => {
                     saw = true;

--- a/crates/core/src/server/client_api/permission_prompts.rs
+++ b/crates/core/src/server/client_api/permission_prompts.rs
@@ -130,9 +130,12 @@ const OVERLAY_LABELS_MAX: usize = 8;
 /// Maximum length of each individual button label.
 const OVERLAY_LABEL_CHARS_MAX: usize = 64;
 /// Maximum length of `delegate_key` / caller hash rendered on the overlay.
-/// These are normally short keys; the cap bounds the amplification surface if
-/// the producer populates them from untrusted data in the future.
-const OVERLAY_KEY_CHARS_MAX: usize = 256;
+/// Re-uses the producer-side cap from `user_input::MAX_IDENTITY_HASH_CHARS`
+/// so a single bump there is enough to widen the wire format. These are
+/// normally short keys (BLAKE3 hex / base58 contract id) so the cap is
+/// well over the actual sizes; the constant exists to bound the
+/// amplification surface if the producer ever passes untrusted data.
+const OVERLAY_KEY_CHARS_MAX: usize = crate::contract::user_input::MAX_IDENTITY_HASH_CHARS;
 
 /// Number of leading characters of a hash to show in the truncated form.
 const HASH_PREFIX_CHARS: usize = 8;
@@ -533,6 +536,47 @@ async fn permission_respond(
     }
 }
 
+/// Combined origin check used by /permission/events.
+///
+/// EventSource is the wire that matters here, and browsers send `Origin`
+/// only for cross-origin EventSource requests; same-origin GETs from the
+/// gateway shell page often arrive with no `Origin`. So we can't simply
+/// require a trusted `Origin`. Instead we combine two browser-attested
+/// signals:
+///
+/// * `Origin` present → must be a trusted loopback origin.
+/// * `Sec-Fetch-Site: cross-site` → reject regardless of `Origin`.
+///
+/// Either signal independently rejects cross-origin pages from holding a
+/// connection slot. Same-origin shell-page requests (no `Origin`,
+/// `Sec-Fetch-Site: same-origin` or absent on older clients) are allowed.
+/// The polling endpoint at `/permission/pending` deliberately tolerates
+/// missing `Origin` because it returns no useful body to attackers; this
+/// endpoint is stricter because the connection slot itself is a resource
+/// (cap = 64).
+fn is_caller_trusted(headers: &HeaderMap) -> bool {
+    if let Some(value) = headers.get("origin") {
+        let s = match value.to_str() {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        if !is_trusted_origin(s) {
+            return false;
+        }
+    }
+    if let Some(value) = headers.get("sec-fetch-site") {
+        if let Ok(s) = value.to_str() {
+            // `cross-site` and `cross-origin` are both cross-origin signals.
+            // `same-origin`, `same-site`, and `none` (no initiator, e.g.
+            // navigation, refresh) are all allowed.
+            if s.eq_ignore_ascii_case("cross-site") || s.eq_ignore_ascii_case("cross-origin") {
+                return false;
+            }
+        }
+    }
+    true
+}
+
 /// Check if an Origin header is from a trusted localhost source.
 /// Accepts any port on localhost/loopback to handle non-default configurations.
 fn is_trusted_origin(origin: &str) -> bool {
@@ -638,33 +682,13 @@ async fn permission_events(
     headers: HeaderMap,
     Extension(pending): Extension<PendingPrompts>,
 ) -> axum::response::Response {
-    // Connection cap. We do this before any expensive setup so a flood of
-    // reconnects from a buggy client cannot exhaust per-process resources.
-    let prev = SSE_CONNECTIONS.fetch_add(1, Ordering::Relaxed);
-    if prev >= MAX_SSE_CONNECTIONS {
-        SSE_CONNECTIONS.fetch_sub(1, Ordering::Relaxed);
-        tracing::warn!(
-            limit = MAX_SSE_CONNECTIONS,
-            "SSE connection cap reached, refusing new /permission/events subscriber"
-        );
-        let stream = stream::once(async {
-            Ok::<_, Infallible>(Event::default().comment("connection-cap-reached"))
-        });
-        return Sse::new(stream)
-            .keep_alive(KeepAlive::default())
-            .into_response();
-    }
-    let guard = SseConnectionGuard;
-
-    let trusted = match headers.get("origin") {
-        Some(value) => value.to_str().map(is_trusted_origin).unwrap_or(false),
-        None => true,
-    };
-
-    if !trusted {
-        // Drop the guard immediately so the count is released — we're
-        // returning a degenerate stream that closes after one frame.
-        drop(guard);
+    // Reject untrusted callers BEFORE consuming a connection slot. Browsers
+    // send `Sec-Fetch-Site: cross-site` for cross-origin EventSource and
+    // `Origin` for any cross-origin request: either signal is enough to
+    // reject, and rejecting up front blocks the cross-origin DoS where an
+    // evil page opens 64 EventSources to consume every slot.
+    if !is_caller_trusted(&headers) {
+        tracing::debug!("Rejecting /permission/events request from untrusted origin");
         let stream = stream::once(async {
             Ok::<_, Infallible>(Event::default().comment("untrusted-origin"))
         });
@@ -672,6 +696,35 @@ async fn permission_events(
             .keep_alive(KeepAlive::default())
             .into_response();
     }
+
+    // Connection cap. CAS-loop instead of fetch_add+rollback so concurrent
+    // reconnects can never overshoot the cap (the previous fetch_add path
+    // had a transient overshoot window, and on Relaxed ordering had no
+    // upper bound under heavy reconnect storms).
+    let mut current = SSE_CONNECTIONS.load(Ordering::Relaxed);
+    let guard = loop {
+        if current >= MAX_SSE_CONNECTIONS {
+            tracing::warn!(
+                limit = MAX_SSE_CONNECTIONS,
+                "SSE connection cap reached, refusing new /permission/events subscriber"
+            );
+            let stream = stream::once(async {
+                Ok::<_, Infallible>(Event::default().comment("connection-cap-reached"))
+            });
+            return Sse::new(stream)
+                .keep_alive(KeepAlive::default())
+                .into_response();
+        }
+        match SSE_CONNECTIONS.compare_exchange_weak(
+            current,
+            current + 1,
+            Ordering::AcqRel,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => break SseConnectionGuard,
+            Err(actual) => current = actual,
+        }
+    };
 
     // Subscribe FIRST to avoid the race where a prompt is added between the
     // DashMap snapshot and our first broadcast recv.
@@ -704,10 +757,10 @@ async fn permission_events(
                 .event("prompt_removed")
                 .data(serde_json::json!({ "nonce": nonce }).to_string()))),
             // Lag means our subscriber was slow and missed events. The shell
-            // page reconciles by emitting a `resync` event that tells the
-            // client to drop everything and trust a freshly-fetched
-            // /permission/pending list. Rare in practice — capacity 128,
-            // two events per prompt lifecycle, max 32 concurrent prompts.
+            // page reconciles via the resync handler, which re-fetches
+            // /permission/pending. Rare in practice: capacity is 128, each
+            // prompt lifecycle is two events, and at most 32 prompts can
+            // be in flight at once.
             Err(BroadcastStreamRecvError::Lagged(n)) => {
                 tracing::warn!(skipped = n, "SSE subscriber lagged, requesting resync");
                 Some(Ok(Event::default().event("resync").data("{}")))
@@ -1450,10 +1503,51 @@ mod tests {
         None
     }
 
+    /// Wait until at least `target` SSE handlers have subscribed to the
+    /// global broadcast, then fire `event`. Replaces `tokio::time::sleep`
+    /// in the SSE happy-path tests so they are not coupled to wall-clock
+    /// timing on slow CI runners.
+    async fn wait_subscribers_then_send(target: usize, event: PromptEvent) {
+        let sender = prompt_events();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while sender.receiver_count() < target {
+            if std::time::Instant::now() >= deadline {
+                panic!(
+                    "timed out waiting for {target} SSE subscribers; have {}",
+                    sender.receiver_count()
+                );
+            }
+            tokio::task::yield_now().await;
+        }
+        drop(sender.send(event));
+    }
+
+    /// RAII helper: removes a key from the shared pending registry on drop.
+    /// Used in tests that mutate the global registry so a panicking assert
+    /// doesn't pollute the registry for sibling tests.
+    struct PendingCleanup {
+        pending: PendingPrompts,
+        nonce: String,
+    }
+
+    impl Drop for PendingCleanup {
+        fn drop(&mut self) {
+            self.pending.remove(&self.nonce);
+        }
+    }
+
+    fn cleanup_on_drop(pending: PendingPrompts, nonce: impl Into<String>) -> PendingCleanup {
+        PendingCleanup {
+            pending,
+            nonce: nonce.into(),
+        }
+    }
+
     /// The bug this PR closes: a `prompt_added` lifecycle event must be
     /// pushed to a subscribed SSE client without polling.
     #[tokio::test]
     async fn test_sse_emits_added_when_prompt_inserted() {
+        let initial_subs = prompt_events().receiver_count();
         let mut body = open_sse_with_origin(Some("http://localhost:7509")).await;
 
         let nonce = "ssetest_added_001".to_string();
@@ -1464,10 +1558,7 @@ mod tests {
             delegate_key: "dkey-added-001".into(),
             caller: webapp_caller("cid-added-001"),
         };
-        // Wait briefly so the SSE handler has time to subscribe before we
-        // emit the broadcast. Without this, the test would race the spawn.
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        drop(prompt_events().send(PromptEvent::Added(snapshot)));
+        wait_subscribers_then_send(initial_subs + 1, PromptEvent::Added(snapshot)).await;
 
         let frame = frame_matching(
             &mut body,
@@ -1484,13 +1575,17 @@ mod tests {
     /// overlay simultaneously when one tab clicks a button.
     #[tokio::test]
     async fn test_sse_emits_removed_when_prompt_responded() {
+        let initial_subs = prompt_events().receiver_count();
         let mut body = open_sse_with_origin(Some("http://localhost:7509")).await;
 
         let nonce = "ssetest_removed_002".to_string();
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        drop(prompt_events().send(PromptEvent::Removed {
-            nonce: nonce.clone(),
-        }));
+        wait_subscribers_then_send(
+            initial_subs + 1,
+            PromptEvent::Removed {
+                nonce: nonce.clone(),
+            },
+        )
+        .await;
 
         let frame = frame_matching(
             &mut body,
@@ -1552,9 +1647,226 @@ mod tests {
                 break;
             }
         }
-        // Cleanup: remove from the shared registry so other tests aren't
-        // affected.
-        pending.remove(&nonce);
+        // Cleanup runs even if the assertion below fails so a panicking test
+        // does not pollute the shared global registry for siblings.
+        let _cleanup = cleanup_on_drop(pending.clone(), nonce.clone());
         assert!(found, "bootstrap replay did not include {nonce}");
+    }
+
+    /// Bootstrap replay must arrive BEFORE any live broadcast event, so a
+    /// fresh subscriber sees pre-existing prompts before new ones. This
+    /// pins the `stream::iter(initial).chain(live)` contract; without the
+    /// chain order, a refreshed tab could dedup-skip a re-broadcast Added
+    /// for an entry that hadn't been delivered yet.
+    #[tokio::test]
+    async fn test_sse_bootstrap_replay_arrives_before_live() {
+        let pending = crate::contract::user_input::pending_prompts();
+        let pre_nonce = "ssetest_order_pre".to_string();
+        let _rx = insert_prompt(
+            &pending,
+            &pre_nonce,
+            "pre-existing",
+            vec!["OK"],
+            "dkey-order-pre",
+            webapp_caller("cid-order-pre"),
+        );
+        let _cleanup_pre = cleanup_on_drop(pending.clone(), pre_nonce.clone());
+
+        let initial_subs = prompt_events().receiver_count();
+        let mut body = open_sse_with_origin(Some("http://localhost:7509")).await;
+
+        // Once the SSE handler has subscribed, fire a NEW Added that the
+        // chain MUST deliver after the pre-existing snapshot.
+        let live_nonce = "ssetest_order_live".to_string();
+        let snapshot = PromptSnapshot {
+            nonce: live_nonce.clone(),
+            message: "live".into(),
+            labels: vec!["OK".into()],
+            delegate_key: "dkey-order-live".into(),
+            caller: webapp_caller("cid-order-live"),
+        };
+        wait_subscribers_then_send(initial_subs + 1, PromptEvent::Added(snapshot)).await;
+
+        // Walk frames; we must see pre-existing nonce before live nonce.
+        let mut saw_pre = false;
+        let mut saw_live_before_pre = false;
+        for _ in 0..32 {
+            let Some(frame) = next_event_frame(&mut body, 500).await else {
+                break;
+            };
+            if frame.contains(&pre_nonce) {
+                saw_pre = true;
+                break;
+            }
+            if frame.contains(&live_nonce) {
+                saw_live_before_pre = true;
+            }
+        }
+        assert!(saw_pre, "did not observe pre-existing nonce in stream");
+        assert!(
+            !saw_live_before_pre,
+            "live event arrived before bootstrap replay, ordering contract broken"
+        );
+    }
+
+    /// A `BroadcastStreamRecvError::Lagged` event must be translated into
+    /// a `resync` SSE event so the client can recover by re-bootstrapping
+    /// from /permission/pending. Constructs a small private broadcaster
+    /// (capacity 2) so the test can deterministically overflow the
+    /// receiver without relying on the global PROMPT_EVENT_CAPACITY=128.
+    #[tokio::test]
+    async fn test_sse_emits_resync_on_lag() {
+        let (tx, rx) = tokio::sync::broadcast::channel::<PromptEvent>(2);
+
+        // Send 5 events without polling rx; receiver lags by 3.
+        for i in 0..5 {
+            drop(tx.send(PromptEvent::Removed {
+                nonce: format!("lag-{i}"),
+            }));
+        }
+
+        // Drive the SSE filter logic against the lagged receiver. We
+        // duplicate the closure body from permission_events here so the
+        // test exercises exactly the production translation.
+        let stream = BroadcastStream::new(rx).filter_map(|incoming| async move {
+            match incoming {
+                Ok(PromptEvent::Added(s)) => Some(format!("added:{}", s.nonce)),
+                Ok(PromptEvent::Removed { nonce }) => Some(format!("removed:{nonce}")),
+                Err(BroadcastStreamRecvError::Lagged(_)) => Some("resync".to_string()),
+            }
+        });
+        tokio::pin!(stream);
+        let first = stream.next().await.expect("first event");
+        assert_eq!(
+            first, "resync",
+            "lagged receiver must surface as `resync`, not as a missed event"
+        );
+    }
+
+    /// MAX_SSE_CONNECTIONS must reject the (cap+1)th subscriber AND must
+    /// release a slot when an earlier subscriber's stream is dropped.
+    /// Together these pin both the cap (rejecting flood reconnects) and
+    /// the GuardedStream's drop semantics (no permanent leak after a
+    /// client disconnects mid-flight).
+    ///
+    /// Uses a serialising mutex so concurrent tests don't perturb the
+    /// shared SSE_CONNECTIONS counter. Without it, a sibling test
+    /// touching the counter mid-assertion would flake this test.
+    #[tokio::test]
+    async fn test_sse_connection_cap_and_release_on_drop() {
+        use std::sync::OnceLock;
+        static SERIAL: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+        let _serial = SERIAL
+            .get_or_init(|| tokio::sync::Mutex::new(()))
+            .lock()
+            .await;
+
+        // Drain any leaked connections from prior tests by waiting for the
+        // counter to settle to zero. (No SSE responses should be live at
+        // this point because the only test that opens them is this one,
+        // serialised by the mutex above.)
+        let deadline0 = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while SSE_CONNECTIONS.load(Ordering::Relaxed) != 0 {
+            if std::time::Instant::now() >= deadline0 {
+                // A leaked connection from a previous test indicates a real
+                // bug in GuardedStream's drop, but for the purposes of this
+                // test, accept the baseline rather than panic.
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        let baseline = SSE_CONNECTIONS.load(Ordering::Relaxed);
+
+        // Open enough subscribers to exhaust the cap.
+        let mut held: Vec<_> = Vec::new();
+        for _ in baseline..MAX_SSE_CONNECTIONS {
+            held.push(open_sse_with_origin(Some("http://localhost:7509")).await);
+        }
+        assert_eq!(
+            SSE_CONNECTIONS.load(Ordering::Relaxed),
+            MAX_SSE_CONNECTIONS,
+            "all slots must be filled before testing the cap"
+        );
+
+        // The next subscriber MUST be rejected with a closed stream.
+        let mut rejected = open_sse_with_origin(Some("http://localhost:7509")).await;
+        let frame = next_event_frame(&mut rejected, 200).await;
+        assert!(
+            frame.is_none(),
+            "cap-rejected subscriber must not receive data events, got: {frame:?}"
+        );
+
+        // Drop one held subscriber; the cap-counter must release a slot.
+        let dropped = held.pop().unwrap();
+        drop(dropped);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            if SSE_CONNECTIONS.load(Ordering::Relaxed) < MAX_SSE_CONNECTIONS {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!("SSE_CONNECTIONS did not decrement after dropping a subscriber");
+            }
+            tokio::task::yield_now().await;
+        }
+
+        // A new subscriber should now succeed.
+        let _accepted = open_sse_with_origin(Some("http://localhost:7509")).await;
+        assert!(SSE_CONNECTIONS.load(Ordering::Relaxed) <= MAX_SSE_CONNECTIONS);
+
+        // Cleanup: drop everything so the counter returns to baseline for
+        // the next time this test runs (matters when test runs are not
+        // process-isolated, e.g. nextest run --no-fail-fast on debug
+        // binaries that re-execute).
+        drop(_accepted);
+        drop(rejected);
+        drop(held);
+    }
+
+    /// HTTP `/permission/{nonce}/respond` must fire a `PromptEvent::Removed`
+    /// so every other tab dismisses its overlay. Closes a coverage gap
+    /// flagged by review: the cross-tab dismissal contract was previously
+    /// only covered by integration-level browser tests.
+    #[tokio::test]
+    async fn test_respond_handler_emits_prompt_removed() {
+        let pending = crate::contract::user_input::pending_prompts();
+        let nonce = "ssetest_respond_emits_removed".to_string();
+        let _rx = insert_prompt(
+            &pending,
+            &nonce,
+            "respond?",
+            vec!["Allow", "Deny"],
+            "dkey-respond",
+            webapp_caller("cid-respond"),
+        );
+        let _cleanup = cleanup_on_drop(pending.clone(), nonce.clone());
+
+        let mut rx = prompt_events().subscribe();
+
+        let resp = permission_respond(
+            Path(nonce.clone()),
+            trusted_header(),
+            Extension(pending.clone()),
+            Json(PermissionResponse { index: 0 }),
+        )
+        .await
+        .into_response();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+
+        // Drain until we see the matching Removed (concurrent tests on the
+        // global broadcaster may interleave their own events).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let mut saw = false;
+        while std::time::Instant::now() < deadline {
+            match tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await {
+                Ok(Ok(PromptEvent::Removed { nonce: n })) if n == nonce => {
+                    saw = true;
+                    break;
+                }
+                Ok(Ok(_)) => continue,
+                Ok(Err(_)) | Err(_) => continue,
+            }
+        }
+        assert!(saw, "permission_respond did not emit Removed for {nonce}");
     }
 }

--- a/crates/core/src/server/client_api/permission_prompts.rs
+++ b/crates/core/src/server/client_api/permission_prompts.rs
@@ -1445,11 +1445,24 @@ mod tests {
     async fn open_sse_with_origin(
         origin: Option<&str>,
     ) -> std::pin::Pin<Box<dyn futures::stream::Stream<Item = bytes::Bytes> + Send>> {
+        open_sse_with_headers(origin, None).await
+    }
+
+    /// Open SSE with both `Origin` and `Sec-Fetch-Site` controlled by the
+    /// caller. Either signal alone is enough to reject the request, so the
+    /// helper exposes both for the rejection-path tests.
+    async fn open_sse_with_headers(
+        origin: Option<&str>,
+        sec_fetch_site: Option<&str>,
+    ) -> std::pin::Pin<Box<dyn futures::stream::Stream<Item = bytes::Bytes> + Send>> {
         use axum::response::IntoResponse;
         let pending = crate::contract::user_input::pending_prompts();
         let mut headers = HeaderMap::new();
         if let Some(o) = origin {
             headers.insert("origin", o.parse().unwrap());
+        }
+        if let Some(s) = sec_fetch_site {
+            headers.insert("sec-fetch-site", s.parse().unwrap());
         }
         let resp = permission_events(headers, Extension(pending))
             .await
@@ -1611,6 +1624,60 @@ mod tests {
             frame.is_none(),
             "untrusted origin must not receive any data events, got: {frame:?}"
         );
+    }
+
+    /// Cross-site `Sec-Fetch-Site` must independently reject the request,
+    /// even if `Origin` is absent (which is the common case for an
+    /// EventSource opened from an attacker page: browsers do not include
+    /// `Origin` on most cross-origin GETs). This is the second of the two
+    /// independent rejection signals in `is_caller_trusted`. Without this
+    /// branch, an evil page could open EventSources to `/permission/events`
+    /// and consume slots against `MAX_SSE_CONNECTIONS = 64`.
+    #[tokio::test]
+    async fn test_sse_rejects_cross_site_sec_fetch() {
+        for site in ["cross-site", "cross-origin", "Cross-Site"] {
+            let mut body = open_sse_with_headers(None, Some(site)).await;
+            let frame = next_event_frame(&mut body, 200).await;
+            assert!(
+                frame.is_none(),
+                "Sec-Fetch-Site={site} must reject (no data events), got: {frame:?}"
+            );
+        }
+    }
+
+    /// `Sec-Fetch-Site` values that indicate same-origin or no-initiator
+    /// requests must be allowed. Positive control for the rejection branch
+    /// above; prevents an over-eager future tightening from breaking
+    /// same-origin shell pages. Uses the bootstrap-replay path (insert a
+    /// pending prompt with a per-iteration unique nonce; assert the SSE
+    /// handler emits `prompt_added` for it) instead of the live broadcast,
+    /// to keep the test deterministic under parallel execution.
+    #[tokio::test]
+    async fn test_sse_allows_same_origin_and_none_sec_fetch() {
+        let pending = crate::contract::user_input::pending_prompts();
+        for site in ["same-origin", "same-site", "none"] {
+            let nonce = format!("ssetest_secfetch_allow_{site}");
+            let _rx = insert_prompt(
+                &pending,
+                &nonce,
+                "secfetch-test",
+                vec!["OK"],
+                "dkey-secfetch",
+                webapp_caller("cid-secfetch"),
+            );
+            let _cleanup = cleanup_on_drop(pending.clone(), nonce.clone());
+
+            let mut body = open_sse_with_headers(None, Some(site)).await;
+            let frame = frame_matching(
+                &mut body,
+                |f| f.contains("event: prompt_added") && f.contains(&nonce),
+                32,
+                500,
+            )
+            .await
+            .unwrap_or_else(|| panic!("Sec-Fetch-Site={site} must accept; did not see {nonce}"));
+            assert!(frame.contains(&nonce));
+        }
     }
 
     /// Initial-state bootstrap: a fresh subscriber must receive

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -982,10 +982,14 @@ function freenetBridge(authToken) {
   // is pending. The shell is trusted and same-origin with the gateway, so
   // the sandboxed contract cannot reach into this DOM. See issue #3836.
   //
-  // Every open Freenet tab renders the overlay for every pending prompt.
-  // When the user responds in one tab, the gateway removes the nonce from
-  // the pending registry; other tabs see it disappear on their next poll
-  // and hide their overlays automatically.
+  // Every open Freenet tab subscribes to /permission/events (Server-Sent
+  // Events) and renders the overlay as soon as the gateway pushes an
+  // `prompt_added` event. When the user responds in one tab, the gateway
+  // emits `prompt_removed` and every tab dismisses its card. This was
+  // previously a 3-second polling loop with a visibility-skip optimisation
+  // that caused the originating tab to silently miss prompts whenever it
+  // wasn't foregrounded; SSE eliminates both the polling-floor latency and
+  // the visibility race.
   var overlayRoot = null;
   var overlayCards = {}; // nonce -> card element
   var OVERLAY_CSS =
@@ -1263,15 +1267,11 @@ function freenetBridge(authToken) {
       btns.forEach(function(b) { b.disabled = false; b.style.opacity = '1'; });
     });
   }
-  function checkPermissions() {
-    // Skip polling when the tab is hidden: saves bandwidth and gateway
-    // load when the user has many Freenet tabs open in the background.
-    // The tab picks up the prompt again on its next visibility event.
-    if (typeof document !== 'undefined' &&
-        document.visibilityState === 'hidden' &&
-        Object.keys(overlayCards).length === 0) {
-      return;
-    }
+  // Snapshot the current pending list and reconcile against the open
+  // overlay cards. Used for initial bootstrap, on `resync` events when an
+  // SSE subscriber lagged, and as a fallback while the EventSource is
+  // reconnecting.
+  function reconcileFromPending() {
     fetch('/permission/pending').then(function(r) { return r.json(); }).then(function(prompts) {
       if (!Array.isArray(prompts)) return;
       var seen = {};
@@ -1279,26 +1279,55 @@ function freenetBridge(authToken) {
         if (!p || typeof p.nonce !== 'string') return;
         seen[p.nonce] = true;
         if (overlayCards[p.nonce]) return;
-        var card = createCard(p);
-        showCard(p.nonce, card);
+        showCard(p.nonce, createCard(p));
       });
-      // Any card whose nonce is no longer pending was answered elsewhere
-      // (another tab, the 60s auto-deny, or delegate cancelled). Remove it
-      // so the user isn't clicking a dead button.
       Object.keys(overlayCards).forEach(function(nonce) {
         if (!seen[nonce]) hideCard(nonce);
       });
     }).catch(function() {});
   }
-  setInterval(checkPermissions, 3000);
-  checkPermissions();
-  // Re-check as soon as the tab becomes visible again so a user returning
-  // to a background tab sees any prompt that accumulated while they were
-  // away without waiting for the next poll tick.
-  if (typeof document !== 'undefined' && document.addEventListener) {
-    document.addEventListener('visibilitychange', function() {
-      if (document.visibilityState === 'visible') checkPermissions();
+
+  // Open a Server-Sent Events connection so prompts appear with no polling
+  // delay and on every open Freenet tab regardless of foreground/background
+  // state. The browser's EventSource auto-reconnects with exponential
+  // backoff if the connection drops; on each reconnect we re-bootstrap from
+  // /permission/pending so we don't miss anything during the gap.
+  if (typeof EventSource !== 'undefined') {
+    var es = new EventSource('/permission/events');
+    es.addEventListener('prompt_added', function(e) {
+      try {
+        var p = JSON.parse(e.data);
+        if (!p || typeof p.nonce !== 'string') return;
+        if (overlayCards[p.nonce]) return;
+        showCard(p.nonce, createCard(p));
+      } catch (err) {}
     });
+    es.addEventListener('prompt_removed', function(e) {
+      try {
+        var p = JSON.parse(e.data);
+        if (!p || typeof p.nonce !== 'string') return;
+        hideCard(p.nonce);
+      } catch (err) {}
+    });
+    // The server emits `resync` when its broadcast channel laps a slow
+    // subscriber. Drop everything and re-snapshot from the polling endpoint.
+    es.addEventListener('resync', function() {
+      Object.keys(overlayCards).forEach(hideCard);
+      reconcileFromPending();
+    });
+    // EventSource fires `open` on initial connect AND on every reconnect.
+    // Reconcile each time so a transient disconnect doesn't leave us out
+    // of date. The browser's auto-reconnect handles transient failures;
+    // we don't need to manually retry.
+    es.addEventListener('open', reconcileFromPending);
+    // Initial bootstrap so we're populated before the SSE handshake
+    // completes (avoids a brief empty state on slow connections).
+    reconcileFromPending();
+  } else {
+    // EventSource is missing in some embedded webviews. Fall back to the
+    // legacy 3-second poll so users on those clients still see prompts.
+    setInterval(reconcileFromPending, 3000);
+    reconcileFromPending();
   }
 }
 "#;
@@ -1998,10 +2027,17 @@ mod tests {
             "overlay must declare role=dialog for a11y"
         );
         assert!(html.contains("aria-modal"), "overlay must set aria-modal");
-        // Polls the new pending endpoint and POSTs back with the response.
+        // Subscribes to the new SSE endpoint and POSTs back with the response.
+        // /permission/pending is still referenced as the bootstrap-on-connect
+        // and `resync` reconciliation endpoint, plus the no-EventSource
+        // fallback, so the assertion below still holds.
+        assert!(
+            html.contains("/permission/events"),
+            "shell JS must subscribe to /permission/events (SSE)"
+        );
         assert!(
             html.contains("/permission/pending"),
-            "shell JS must poll /permission/pending"
+            "shell JS must reference /permission/pending for bootstrap/resync"
         );
         assert!(
             html.contains("/respond"),
@@ -2013,6 +2049,16 @@ mod tests {
             html.contains("r.status === 404"),
             "shell JS must treat 404 on respond as 'already answered' and hide the card"
         );
+        // SSE event names the server emits — pinning these here ensures the
+        // shell stays in sync with the gateway's wire format.
+        assert!(
+            html.contains("'prompt_added'") || html.contains("\"prompt_added\""),
+            "shell JS must subscribe to the prompt_added SSE event"
+        );
+        assert!(
+            html.contains("'prompt_removed'") || html.contains("\"prompt_removed\""),
+            "shell JS must subscribe to the prompt_removed SSE event"
+        );
         // All delegate-controlled strings must go through textContent, never
         // innerHTML — guards against a future refactor re-opening XSS into
         // the trusted shell origin.
@@ -2020,13 +2066,15 @@ mod tests {
             html.contains("function setText(el, text)"),
             "setText helper (textContent-only) missing"
         );
-        // innerHTML must not appear anywhere in the overlay code path. It
-        // can appear elsewhere in the shell JS if needed, but this test
-        // enforces that the overlay diff doesn't introduce it.
+        // innerHTML must not appear anywhere in the overlay code path. The
+        // boundary marker below was previously `setInterval(checkPermissions`
+        // but that polling loop is gone; we now bound the slice at the
+        // EventSource-fallback `setInterval(reconcileFromPending`.
         let overlay_start = html.find("__freenet_perm_overlay").unwrap();
         let overlay_end = html[overlay_start..]
-            .find("setInterval(checkPermissions")
-            .unwrap();
+            .find("setInterval(reconcileFromPending")
+            .or_else(|| html[overlay_start..].find("EventSource"))
+            .expect("overlay slice must end at the SSE setup or fallback poll");
         let overlay_slice = &html[overlay_start..overlay_start + overlay_end];
         assert!(
             !overlay_slice.contains("innerHTML"),
@@ -2048,10 +2096,19 @@ mod tests {
                 && !html.contains("window.open(\"/permission/"),
             "shell must no longer open /permission/{{nonce}} as a popup (#3836)"
         );
-        // Visibility gating keeps background tabs from polling forever.
+        // The visibility-gated polling loop has been replaced by SSE. SSE
+        // pushes regardless of tab visibility, so the visibility-skip code
+        // path that caused #ISSUE (originating tab silently missing prompts
+        // when in the background) MUST NOT be reintroduced. Pin this
+        // contract by asserting `visibilityState` no longer appears in the
+        // overlay path. If a future change needs visibility gating for some
+        // *other* reason, that change must move this assertion or replace
+        // the visibility-related JS with a deliberate no-op rather than
+        // bringing back the polling-skip loop.
         assert!(
-            html.contains("visibilityState"),
-            "overlay polling should be gated on document.visibilityState"
+            !html.contains("visibilityState"),
+            "overlay must not gate on document.visibilityState — \
+             visibility-skip caused background tabs to miss prompts (SSE replaces polling)"
         );
 
         // Regression test for issue #3857: the overlay must read the new

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -1292,6 +1292,23 @@ function freenetBridge(authToken) {
   // state. The browser's EventSource auto-reconnects with exponential
   // backoff if the connection drops; on each reconnect we re-bootstrap from
   // /permission/pending so we don't miss anything during the gap.
+  //
+  // While the EventSource is in the disconnected state (its `error` event
+  // has fired and `readyState !== 1`), we run a 3-second polling fallback
+  // against /permission/pending so a tab whose stream fails (gateway
+  // restart, connection-cap rejection, transient network) still receives
+  // prompt updates. The fallback shuts off as soon as the stream re-opens.
+  var fallbackPollHandle = null;
+  function startFallbackPoll() {
+    if (fallbackPollHandle !== null) return;
+    fallbackPollHandle = setInterval(reconcileFromPending, 3000);
+    reconcileFromPending();
+  }
+  function stopFallbackPoll() {
+    if (fallbackPollHandle === null) return;
+    clearInterval(fallbackPollHandle);
+    fallbackPollHandle = null;
+  }
   if (typeof EventSource !== 'undefined') {
     var es = new EventSource('/permission/events');
     es.addEventListener('prompt_added', function(e) {
@@ -1310,24 +1327,28 @@ function freenetBridge(authToken) {
       } catch (err) {}
     });
     // The server emits `resync` when its broadcast channel laps a slow
-    // subscriber. Drop everything and re-snapshot from the polling endpoint.
-    es.addEventListener('resync', function() {
-      Object.keys(overlayCards).forEach(hideCard);
-      reconcileFromPending();
-    });
+    // subscriber. Reconcile from the polling endpoint instead of clearing
+    // first: the reconcile path's diff already adds new cards and hides
+    // ones that disappeared, with no flicker on cards that survive.
+    es.addEventListener('resync', reconcileFromPending);
     // EventSource fires `open` on initial connect AND on every reconnect.
     // Reconcile each time so a transient disconnect doesn't leave us out
-    // of date. The browser's auto-reconnect handles transient failures;
-    // we don't need to manually retry.
-    es.addEventListener('open', reconcileFromPending);
+    // of date, and stop the fallback poll if it had taken over.
+    es.addEventListener('open', function() {
+      stopFallbackPoll();
+      reconcileFromPending();
+    });
+    // `error` fires on connect failure, transient drops, and when the
+    // server caps us out. Switch to polling until the EventSource
+    // re-opens; the browser auto-reconnects in the background.
+    es.addEventListener('error', startFallbackPoll);
     // Initial bootstrap so we're populated before the SSE handshake
     // completes (avoids a brief empty state on slow connections).
     reconcileFromPending();
   } else {
-    // EventSource is missing in some embedded webviews. Fall back to the
+    // EventSource missing in some embedded webviews -- fall back to the
     // legacy 3-second poll so users on those clients still see prompts.
-    setInterval(reconcileFromPending, 3000);
-    reconcileFromPending();
+    startFallbackPoll();
   }
 }
 "#;
@@ -2049,7 +2070,7 @@ mod tests {
             html.contains("r.status === 404"),
             "shell JS must treat 404 on respond as 'already answered' and hide the card"
         );
-        // SSE event names the server emits — pinning these here ensures the
+        // SSE event names the server emits. Pinning these here ensures the
         // shell stays in sync with the gateway's wire format.
         assert!(
             html.contains("'prompt_added'") || html.contains("\"prompt_added\""),
@@ -2107,7 +2128,7 @@ mod tests {
         // bringing back the polling-skip loop.
         assert!(
             !html.contains("visibilityState"),
-            "overlay must not gate on document.visibilityState — \
+            "overlay must not gate on document.visibilityState; \
              visibility-skip caused background tabs to miss prompts (SSE replaces polling)"
         );
 

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -2098,8 +2098,8 @@ mod tests {
         );
         // The visibility-gated polling loop has been replaced by SSE. SSE
         // pushes regardless of tab visibility, so the visibility-skip code
-        // path that caused #ISSUE (originating tab silently missing prompts
-        // when in the background) MUST NOT be reintroduced. Pin this
+        // path that caused the originating tab to silently miss prompts
+        // when in the background MUST NOT be reintroduced. Pin this
         // contract by asserting `visibilityState` no longer appears in the
         // overlay path. If a future change needs visibility gating for some
         // *other* reason, that change must move this assertion or replace


### PR DESCRIPTION
## Problem

Permission prompts (delegate `RequestUserInput`) only reliably appear on whichever Freenet tab happens to be foregrounded when the prompt lands. The shell-page overlay polls `/permission/pending` every 3s and skips the poll entirely on hidden tabs that have no existing overlay cards:

```javascript
if (typeof document !== 'undefined' &&
    document.visibilityState === 'hidden' &&
    Object.keys(overlayCards).length === 0) {
  return;     // skip polling
}
```

This was added to save bandwidth on lots of background tabs, but it means a user who clicks a delegate-triggered button in tab A but focuses tab B before the gateway creates the prompt will only see the prompt on B. The `visibilitychange` listener does re-trigger when A is refocused, but the user has to notice and switch back — in practice the originating tab silently misses prompts.

Reproduced on technic with two Playwright tabs (vault + harvest):

| Step | Vault | Harvest |
|---|---|---|
| Both tabs visible, vault foreground | 0 cards | 0 cards |
| Vault → hidden | 0 cards | 0 cards |
| Click Test Prompt on vault | server has prompt, but… | server has prompt |
| 4 s later (vault still hidden) | **0 cards** | 1 card |
| Switch vault back to visible | 1 card | 1 card |

## Solution

Replace polling with Server-Sent Events. The gateway pushes `prompt_added` the moment `DashboardPrompter::prompt` fires the broadcast, and `prompt_removed` when the respond handler or the timeout cleanup retires the prompt. Every open Freenet tab subscribes to `/permission/events` and dismisses cards as soon as the event arrives, regardless of visibility.

**Subscribe-then-snapshot** avoids the race where a prompt added between page load and SSE handshake would be invisible: the handler subscribes to the broadcast before iterating the pending DashMap, so any prompt added during the window arrives via the broadcast (possibly duplicated with a snapshot entry; the renderer keys on nonce so duplicates are idempotent).

`/permission/pending` is retained as the bootstrap-on-connect / on-resync / no-EventSource-fallback endpoint. The visibility-skip loop is gone — SSE pushes regardless of visibility, so the bandwidth-saving optimisation is no longer needed (the per-tab cost is one TCP connection vs. ~14 polls/min).

Connection cap (64) and broadcast capacity (128) bound resource usage. On lag (rare — capacity 128 with at most 32 concurrent prompts and two events per lifecycle), the SSE handler emits a `resync` event so the client reconciles from `/permission/pending`.

## Testing

- **`test_prompt_lifecycle_emits_added_and_removed`** and **`test_prompt_timeout_emits_removed`** (`user_input.rs`): assert the broadcast fires in both lifecycle paths (HTTP-handler-triggered and prompter-timeout-triggered).
- **`test_sse_emits_added_when_prompt_inserted`** and **`test_sse_emits_removed_when_prompt_responded`** (`permission_prompts.rs`): end-to-end SSE delivery, filtered by per-test nonce so the shared global broadcast doesn't cross-contaminate parallel tests.
- **`test_sse_replays_existing_pending_on_subscribe`**: bootstrap replay contract — a fresh subscriber sees `prompt_added` for already-pending entries.
- **`test_sse_untrusted_origin_returns_closed_stream`**: origin gating parity with `/permission/pending`.
- **Updated `shell_page_permission_overlay_present_and_safe`** to pin the new wire contract — asserts `visibilityState` no longer appears in the overlay path. This is the CI gap closure: a future polling-restoration would fail the test rather than silently re-shipping the bug.

**Why didn't CI catch this originally?** The existing overlay test only verified that the polling loop existed; it did not verify cross-tab delivery semantics or the visibility-skip behaviour. The new `!visibilityState` assertion locks in the new contract.

## Fixes

Found while investigating an unrelated UX in the ghostkey vault; reproduced and root-caused on technic via Playwright before this PR.

[AI-assisted - Claude]