### PR TITLE
fix(transport): meter recv-side wire bytes post-authentication + LRU evict per-peer table

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -260,6 +260,11 @@ pub fn record_peer_disconnected(addr: SocketAddr) {
             s.connected_peers.retain(|p| p.address != addr);
         }
     }
+    // Free the per-peer metrics slot so the bounded table doesn't accumulate
+    // stale entries across the lifetime of long-running gateways. LRU
+    // eviction in `record_per_peer` is the safety net; this is the
+    // best-effort eager cleanup.
+    TRANSPORT_METRICS.remove_peer(addr);
 }
 
 /// Record an operation result for the dashboard "Operations" panel.

--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -439,7 +439,11 @@ impl Socket for UdpSocket {
         // Normalize ::ffff:x.x.x.x → plain IPv4 so the rest of the system
         // sees a consistent address regardless of socket type.
         let addr = normalize_mapped_addr(addr);
-        metrics::TRANSPORT_METRICS.record_packet_received(addr, len as u64);
+        // Receive-side dashboard metering happens post-authentication — see
+        // `peer_connection::PeerConnection::recv` after `try_decrypt_sym`
+        // succeeds. Doing it here would let an attacker spoofing UDP source
+        // addresses inflate the dashboard counters and crowd legitimate
+        // peers out of the bounded per-peer table (#3999).
         Ok((len, addr))
     }
 
@@ -807,12 +811,15 @@ mod dual_stack_tests {
         assert_eq!(&buf[..len], b"pong");
     }
 
-    /// Regression: every successful send_to / recv_from on the production
-    /// `UdpSocket` must update both the cumulative wire-byte counters and the
-    /// per-peer counters used by the local dashboard. Before this fix, those
-    /// counters only moved on stream-transfer completion, so a node connected
-    /// for hours could legitimately show "—" for SENT/RECV despite real
-    /// keep-alive traffic flowing.
+    /// Regression: every successful send_to on the production `UdpSocket`
+    /// must update the cumulative + per-peer counters used by the local
+    /// dashboard. Before #3996, those counters only moved on stream-transfer
+    /// completion, so a node connected for hours could legitimately show "—"
+    /// for SENT despite real keep-alive traffic flowing.
+    ///
+    /// Receive-side accounting is owned by the post-authentication hook in
+    /// `peer_connection.rs` (see #3999), so this test only asserts send
+    /// behavior — `recv_from` deliberately does NOT bump any counter.
     #[tokio::test]
     async fn udp_socket_records_packet_metrics() {
         use crate::transport::metrics::TRANSPORT_METRICS;
@@ -837,21 +844,24 @@ mod dual_stack_tests {
             .unwrap();
         assert_eq!(len, payload.len());
 
-        // Cumulative counters must move at least by the payload size each way.
-        // Other tests running in parallel may push them higher, hence the >=.
+        // Send-side cumulative counter must move at least by the payload.
+        // Other tests running in parallel may push it higher, hence the >=.
         assert!(
             TRANSPORT_METRICS.cumulative_bytes_sent()
                 >= cumulative_sent_before + payload.len() as u64,
             "cumulative_bytes_sent must include the payload"
         );
-        assert!(
-            TRANSPORT_METRICS.cumulative_bytes_received()
-                >= cumulative_recv_before + payload.len() as u64,
-            "cumulative_bytes_received must include the payload"
-        );
 
-        // Per-peer counters keyed by the un-mapped target / normalized source
-        // (both plain IPv4 here) must include the payload.
+        // recv_from does NOT bump the receive-side counters — that hook is
+        // post-authentication in PeerConnection::recv. We can only assert
+        // that *this* recv didn't bump them on its own; concurrent tests
+        // exercising the post-auth path can still increment the counter,
+        // so we cannot demand strict equality here.
+        let _ = cumulative_recv_before;
+
+        // Per-peer entry for the send target must exist with bytes_sent
+        // covering the payload. The recv-side `bytes_received` for that
+        // entry, on the other hand, is NOT touched by `recv_from`.
         let peers = TRANSPORT_METRICS.per_peer_snapshot();
         let receiver_entry = peers
             .iter()
@@ -862,14 +872,15 @@ mod dual_stack_tests {
             "per-peer bytes_sent must include the payload (got {})",
             receiver_entry.1
         );
-        let sender_entry = peers
-            .iter()
-            .find(|(a, _, _)| *a == sender_addr)
-            .expect("per-peer entry for recv source must exist");
+
+        // The reverse-direction entry (keyed by the sender's address) must
+        // NOT be created by recv_from alone — it can only appear if some
+        // other test in the same process drove an authenticated path
+        // against this sender_addr, which is impossible since this test
+        // owns these ephemeral sockets.
         assert!(
-            sender_entry.2 >= payload.len() as u64,
-            "per-peer bytes_received must include the payload (got {})",
-            sender_entry.2
+            peers.iter().all(|(a, _, _)| *a != sender_addr),
+            "recv_from must not create a per-peer entry pre-authentication"
         );
     }
 
@@ -997,6 +1008,55 @@ mod dual_stack_tests {
         assert!(
             peers.iter().all(|(a, _, _)| *a != mapped),
             "mapped form must not produce a duplicate per-peer entry"
+        );
+    }
+
+    /// Regression for #3999: an attacker that fabricates UDP packets from
+    /// many spoofed source IPs MUST NOT be able to inflate the dashboard
+    /// cumulative_bytes_received counter or fill the bounded per-peer
+    /// table. `recv_from` is the kernel handoff point that sees every
+    /// packet regardless of authentication, so the fix is "don't meter
+    /// here" — receive-side metering moved to the post-`try_decrypt_sym`
+    /// hook in `peer_connection::PeerConnection::recv`.
+    #[tokio::test]
+    async fn udp_socket_recv_from_does_not_record_pre_authentication() {
+        use crate::transport::metrics::TRANSPORT_METRICS;
+
+        let v4_addr = SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0);
+        let attacker = <UdpSocket as Socket>::bind(v4_addr).await.unwrap();
+        let victim = <UdpSocket as Socket>::bind(v4_addr).await.unwrap();
+        let victim_addr = victim.local_addr().unwrap();
+        let attacker_addr = attacker.local_addr().unwrap();
+
+        let cumulative_recv_before = TRANSPORT_METRICS.cumulative_bytes_received();
+
+        // Simulate a single forged UDP packet arriving at the listening
+        // port. The "attacker" socket here stands in for any unauthenticated
+        // sender — its source IP is a spoof from the victim's perspective.
+        let payload = vec![0xAB; 1024];
+        attacker.send_to(&payload, victim_addr).await.unwrap();
+
+        let mut buf = [0u8; 2048];
+        let (len, src) = <UdpSocket as Socket>::recv_from(&victim, &mut buf)
+            .await
+            .unwrap();
+        assert_eq!(len, payload.len());
+        assert_eq!(src, attacker_addr);
+
+        // The bounded receive-side counter must NOT include this packet —
+        // it never got past `try_decrypt_sym`. Other tests running in
+        // parallel may push the counter higher (via authenticated paths
+        // they exercise), but this test's spoofed packet contributes
+        // nothing on its own — pinned by snapshotting the table for the
+        // attacker's address.
+        assert!(
+            TRANSPORT_METRICS.cumulative_bytes_received() >= cumulative_recv_before,
+            "cumulative counter is monotonic"
+        );
+        let peers = TRANSPORT_METRICS.per_peer_snapshot();
+        assert!(
+            peers.iter().all(|(a, _, _)| *a != attacker_addr),
+            "spoofed (un-authenticated) source MUST NOT create a per-peer entry"
         );
     }
 }

--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -831,7 +831,6 @@ mod dual_stack_tests {
         let sender_addr = sender.local_addr().unwrap();
 
         let cumulative_sent_before = TRANSPORT_METRICS.cumulative_bytes_sent();
-        let cumulative_recv_before = TRANSPORT_METRICS.cumulative_bytes_received();
 
         let payload = b"keep-alive-sized-control-packet";
         <UdpSocket as Socket>::send_to(&sender, payload, receiver_addr)
@@ -852,16 +851,11 @@ mod dual_stack_tests {
             "cumulative_bytes_sent must include the payload"
         );
 
-        // recv_from does NOT bump the receive-side counters — that hook is
-        // post-authentication in PeerConnection::recv. We can only assert
-        // that *this* recv didn't bump them on its own; concurrent tests
-        // exercising the post-auth path can still increment the counter,
-        // so we cannot demand strict equality here.
-        let _ = cumulative_recv_before;
-
         // Per-peer entry for the send target must exist with bytes_sent
-        // covering the payload. The recv-side `bytes_received` for that
-        // entry, on the other hand, is NOT touched by `recv_from`.
+        // covering the payload. The reverse-direction entry (keyed by the
+        // sender's address) must NOT be created by `recv_from` alone —
+        // recv-side accounting moved to the post-auth hook in #3999, so
+        // an unauthenticated packet contributes nothing to per-peer state.
         let peers = TRANSPORT_METRICS.per_peer_snapshot();
         let receiver_entry = peers
             .iter()
@@ -872,12 +866,6 @@ mod dual_stack_tests {
             "per-peer bytes_sent must include the payload (got {})",
             receiver_entry.1
         );
-
-        // The reverse-direction entry (keyed by the sender's address) must
-        // NOT be created by recv_from alone — it can only appear if some
-        // other test in the same process drove an authenticated path
-        // against this sender_addr, which is impossible since this test
-        // owns these ephemeral sockets.
         assert!(
             peers.iter().all(|(a, _, _)| *a != sender_addr),
             "recv_from must not create a per-peer entry pre-authentication"
@@ -1028,11 +1016,8 @@ mod dual_stack_tests {
         let victim_addr = victim.local_addr().unwrap();
         let attacker_addr = attacker.local_addr().unwrap();
 
-        let cumulative_recv_before = TRANSPORT_METRICS.cumulative_bytes_received();
-
-        // Simulate a single forged UDP packet arriving at the listening
-        // port. The "attacker" socket here stands in for any unauthenticated
-        // sender — its source IP is a spoof from the victim's perspective.
+        // Simulate a forged UDP packet arriving at the listening port: the
+        // "attacker" socket stands in for any unauthenticated sender.
         let payload = vec![0xAB; 1024];
         attacker.send_to(&payload, victim_addr).await.unwrap();
 
@@ -1043,16 +1028,10 @@ mod dual_stack_tests {
         assert_eq!(len, payload.len());
         assert_eq!(src, attacker_addr);
 
-        // The bounded receive-side counter must NOT include this packet —
-        // it never got past `try_decrypt_sym`. Other tests running in
-        // parallel may push the counter higher (via authenticated paths
-        // they exercise), but this test's spoofed packet contributes
-        // nothing on its own — pinned by snapshotting the table for the
-        // attacker's address.
-        assert!(
-            TRANSPORT_METRICS.cumulative_bytes_received() >= cumulative_recv_before,
-            "cumulative counter is monotonic"
-        );
+        // The packet never reached `try_decrypt_sym`, so it must not have
+        // created a per-peer entry. (Cumulative is process-global and may
+        // be moved by concurrent authenticated paths; only per-peer
+        // absence is reliably observable from this test.)
         let peers = TRANSPORT_METRICS.per_peer_snapshot();
         assert!(
             peers.iter().all(|(a, _, _)| *a != attacker_addr),

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -1800,6 +1800,10 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                             cause: "invalid symmetric key".into(),
                         }
                     })?;
+                    // Authenticated handshake-completion ACK; meter it just
+                    // like any other authenticated inbound packet (#3999).
+                    crate::transport::TRANSPORT_METRICS
+                        .record_packet_received(remote_addr, packet.data().len() as u64);
                 }
                 Some(None) => {
                     return Err(TransportError::ConnectionEstablishmentFailure {
@@ -2092,6 +2096,13 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                                 if let Ok(decrypted_packet) =
                                     packet.try_decrypt_sym(&inbound_sym_key)
                                 {
+                                    // Authenticated handshake-completion ACK; meter
+                                    // it just like any other authenticated inbound
+                                    // packet (#3999).
+                                    crate::transport::TRANSPORT_METRICS.record_packet_received(
+                                        remote_addr,
+                                        packet.data().len() as u64,
+                                    );
                                     // Remote decrypted our intro and is sending ACK with their key
                                     let symmetric_message =
                                         SymmetricMessage::deser(decrypted_packet.data())?;

--- a/crates/core/src/transport/metrics.rs
+++ b/crates/core/src/transport/metrics.rs
@@ -354,21 +354,18 @@ impl TransportMetrics {
     ) {
         let tick = self.per_peer_tick.fetch_add(1, Ordering::Relaxed) + 1;
 
-        // Fast path: existing entry — update bytes and refresh tick.
         if let Some(entry) = self.per_peer_stats.get(&addr) {
             field(&entry).fetch_add(bytes, Ordering::Relaxed);
             entry.last_seen_tick.store(tick, Ordering::Relaxed);
             return;
         }
 
-        // Slow path: insert. If the table is full, evict the LRU entry first.
         // The capacity check / eviction / insert isn't atomic across threads,
         // so the table may transiently hold up to MAX_TRACKED_PEERS + a small
         // burst — acceptable for a dashboard counter.
         if self.per_peer_stats.len() >= MAX_TRACKED_PEERS {
             self.evict_oldest_peer();
         }
-
         let entry = self.per_peer_stats.entry(addr).or_default();
         field(&entry).fetch_add(bytes, Ordering::Relaxed);
         entry.last_seen_tick.store(tick, Ordering::Relaxed);
@@ -963,7 +960,7 @@ mod tests {
     }
 
     #[test]
-    fn test_record_per_peer_is_idempotent_under_remove() {
+    fn test_remove_peer_is_idempotent() {
         // Removing a non-existent peer is a no-op (e.g. when
         // record_peer_disconnected fires for a peer whose stats slot was
         // already evicted by LRU).

--- a/crates/core/src/transport/metrics.rs
+++ b/crates/core/src/transport/metrics.rs
@@ -81,8 +81,21 @@ pub struct TransportMetrics {
     slowdowns_triggered: AtomicU32,
 
     // Per-peer wire-byte stats (bounded to MAX_TRACKED_PEERS entries).
-    // Updated at the UDP socket layer alongside the cumulative counters above.
+    //
+    // Receive side is metered post-authentication in
+    // `transport::peer_connection::PeerConnection::recv` — only packets that
+    // pass `try_decrypt_sym` for an established connection contribute. Send
+    // side is metered at the socket layer because outbound targets are
+    // controlled by us, not influenced by remote peers.
+    //
+    // When the table is full a new entry evicts the least-recently-updated
+    // entry (LRU on `last_seen_tick`).
     per_peer_stats: DashMap<SocketAddr, PeerTransferStats>,
+
+    // Monotonically increasing tick stamped onto each per-peer entry on
+    // update. Used purely for LRU ordering — no wall-clock semantics, so
+    // simulation determinism is unaffected.
+    per_peer_tick: AtomicU64,
 
     // RTT tracking (in microseconds for precision)
     min_rtt_us: AtomicU64,
@@ -99,6 +112,9 @@ const MAX_TRACKED_PEERS: usize = 256;
 pub struct PeerTransferStats {
     pub bytes_sent: AtomicU64,
     pub bytes_received: AtomicU64,
+    /// Monotonic tick of the most recent update; smallest tick = oldest entry,
+    /// used for LRU eviction when the table is full.
+    last_seen_tick: AtomicU64,
 }
 
 impl Default for PeerTransferStats {
@@ -106,6 +122,7 @@ impl Default for PeerTransferStats {
         Self {
             bytes_sent: AtomicU64::new(0),
             bytes_received: AtomicU64::new(0),
+            last_seen_tick: AtomicU64::new(0),
         }
     }
 }
@@ -138,6 +155,7 @@ impl TransportMetrics {
             rtt_sum_us: AtomicU64::new(0),
             rtt_samples: AtomicU32::new(0),
             per_peer_stats: DashMap::new(),
+            per_peer_tick: AtomicU64::new(0),
         }
     }
 
@@ -281,6 +299,11 @@ impl TransportMetrics {
     /// keep-alives, ACKs, and other small control messages all show up on the
     /// local dashboard, not just large stream transfers.
     ///
+    /// Outbound is metered at the socket layer because send targets are
+    /// controlled by us — there is no spoof vector — and we want to surface
+    /// every byte we put on the wire (including NAT-traversal probes that
+    /// never produce a stream).
+    ///
     /// `remote_addr` MUST be the canonical (un-mapped) form used elsewhere in
     /// the system — the same form `recv_from` returns after
     /// `normalize_mapped_addr`. Mismatched callers (e.g. passing a
@@ -293,10 +316,16 @@ impl TransportMetrics {
         self.record_per_peer(remote_addr, bytes, |s| &s.bytes_sent);
     }
 
-    /// Record an inbound UDP packet at the socket layer.
+    /// Record an inbound UDP packet that has passed authentication.
     ///
-    /// See [`Self::record_packet_sent`] for the counter semantics and the
-    /// canonical-address contract on `remote_addr`.
+    /// MUST only be called for packets that have been successfully decrypted
+    /// against an established symmetric session key — see the call site in
+    /// [`crate::transport::peer_connection::PeerConnection::recv`]. Calling
+    /// this on raw `recv_from` output would let an attacker inflate the
+    /// dashboard by spoofing UDP packets from many source IPs (#3999).
+    ///
+    /// See [`Self::record_packet_sent`] for the canonical-address contract on
+    /// `remote_addr`.
     pub fn record_packet_received(&self, remote_addr: SocketAddr, bytes: u64) {
         self.cumulative_bytes_received
             .fetch_add(bytes, Ordering::Relaxed);
@@ -310,27 +339,62 @@ impl TransportMetrics {
 
     /// Record per-peer bytes for the given direction.
     ///
-    /// Bounded to [`MAX_TRACKED_PEERS`] entries: once full, new peers' bytes
-    /// are silently dropped (existing entries continue to update). There is no
-    /// LRU eviction. Combined with the fact that `record_packet_received`
-    /// runs at the raw socket before authentication, an attacker that
-    /// fabricates packets from many spoofed source IPs can fill the table
-    /// with abandoned entries and crowd out legitimate new peers from the
-    /// dashboard's per-peer view. Memory damage is still bounded (256 entries
-    /// × ~16 bytes), and authenticated traffic on the existing connections
-    /// continues to be metered correctly. Follow-up tracked in #3999.
+    /// Bounded to [`MAX_TRACKED_PEERS`] entries with LRU eviction: when the
+    /// table is full, the entry whose `last_seen_tick` is smallest is
+    /// removed before the new entry is inserted. This keeps the dashboard's
+    /// per-peer view current as peers come and go without unbounded growth,
+    /// and combined with the post-authentication call site in
+    /// [`Self::record_packet_received`] closes the spoof inflation vector
+    /// described in #3999.
     fn record_per_peer(
         &self,
         addr: SocketAddr,
         bytes: u64,
         field: impl Fn(&PeerTransferStats) -> &AtomicU64,
     ) {
+        let tick = self.per_peer_tick.fetch_add(1, Ordering::Relaxed) + 1;
+
+        // Fast path: existing entry — update bytes and refresh tick.
         if let Some(entry) = self.per_peer_stats.get(&addr) {
             field(&entry).fetch_add(bytes, Ordering::Relaxed);
-        } else if self.per_peer_stats.len() < MAX_TRACKED_PEERS {
-            let entry = self.per_peer_stats.entry(addr).or_default();
-            field(&entry).fetch_add(bytes, Ordering::Relaxed);
+            entry.last_seen_tick.store(tick, Ordering::Relaxed);
+            return;
         }
+
+        // Slow path: insert. If the table is full, evict the LRU entry first.
+        // The capacity check / eviction / insert isn't atomic across threads,
+        // so the table may transiently hold up to MAX_TRACKED_PEERS + a small
+        // burst — acceptable for a dashboard counter.
+        if self.per_peer_stats.len() >= MAX_TRACKED_PEERS {
+            self.evict_oldest_peer();
+        }
+
+        let entry = self.per_peer_stats.entry(addr).or_default();
+        field(&entry).fetch_add(bytes, Ordering::Relaxed);
+        entry.last_seen_tick.store(tick, Ordering::Relaxed);
+    }
+
+    /// Remove the per-peer entry whose `last_seen_tick` is smallest.
+    ///
+    /// O(MAX_TRACKED_PEERS) but called only on insert into a full table.
+    fn evict_oldest_peer(&self) {
+        let oldest = self
+            .per_peer_stats
+            .iter()
+            .min_by_key(|entry| entry.value().last_seen_tick.load(Ordering::Relaxed))
+            .map(|entry| *entry.key());
+        if let Some(addr) = oldest {
+            self.per_peer_stats.remove(&addr);
+        }
+    }
+
+    /// Remove a peer's per-peer stats.
+    ///
+    /// Called when the connection to `addr` is torn down so the slot becomes
+    /// available for a new peer immediately, instead of relying on LRU
+    /// eviction to clean up after the connection-level state is gone.
+    pub fn remove_peer(&self, addr: SocketAddr) {
+        self.per_peer_stats.remove(&addr);
     }
 
     /// Snapshot per-peer transfer stats: `(addr, bytes_sent, bytes_received)`.
@@ -810,18 +874,108 @@ mod tests {
 
         assert_eq!(metrics.per_peer_snapshot().len(), MAX_TRACKED_PEERS);
 
-        // Beyond capacity: new peer not tracked, but cumulative still counts.
+        // Beyond capacity: cumulative still counts AND the new peer is now
+        // tracked because LRU evicts the oldest entry — that's the #3999
+        // behavior change. Pre-fix the new peer would have been silently
+        // dropped from the per-peer view.
         let extra: std::net::SocketAddr = "192.168.1.1:9999".parse().unwrap();
         metrics.record_packet_received(extra, 500);
 
         assert_eq!(metrics.per_peer_snapshot().len(), MAX_TRACKED_PEERS);
-        let snapshot = metrics.per_peer_snapshot();
         assert!(
-            snapshot.iter().all(|(a, _, _)| *a != extra),
-            "over-capacity peer must not be tracked"
+            metrics
+                .per_peer_snapshot()
+                .iter()
+                .any(|(a, _, _)| *a == extra),
+            "new peer must be tracked after LRU evicts the oldest entry"
         );
 
         let total: u64 = (MAX_TRACKED_PEERS as u64 * 100) + 500;
         assert_eq!(metrics.cumulative_bytes_received(), total);
+    }
+
+    #[test]
+    fn test_per_peer_lru_evicts_oldest() {
+        // Fill the table, then record activity on the second-oldest entry to
+        // refresh its tick. The first-inserted entry must be the one evicted
+        // when a brand-new peer is recorded. This pins the LRU ordering
+        // (least-recently-updated, not least-recently-inserted).
+        let metrics = TransportMetrics::new();
+
+        let oldest: std::net::SocketAddr = "10.0.0.1:1000".parse().unwrap();
+        metrics.record_packet_received(oldest, 1);
+
+        let next_oldest: std::net::SocketAddr = "10.0.0.2:1000".parse().unwrap();
+        metrics.record_packet_received(next_oldest, 1);
+
+        // Fill the rest of the table.
+        for i in 2..MAX_TRACKED_PEERS {
+            let addr: std::net::SocketAddr = format!("10.0.{}.{}:{}", i / 256, i % 256, 5000 + i)
+                .parse()
+                .unwrap();
+            metrics.record_packet_received(addr, 1);
+        }
+        assert_eq!(metrics.per_peer_snapshot().len(), MAX_TRACKED_PEERS);
+
+        // Refresh `next_oldest` so it is no longer the LRU candidate.
+        metrics.record_packet_received(next_oldest, 1);
+
+        // Insert a new peer. LRU eviction should remove `oldest`.
+        let newcomer: std::net::SocketAddr = "192.168.7.7:9999".parse().unwrap();
+        metrics.record_packet_received(newcomer, 1);
+
+        let peers = metrics.per_peer_snapshot();
+        assert_eq!(peers.len(), MAX_TRACKED_PEERS);
+        assert!(
+            peers.iter().all(|(a, _, _)| *a != oldest),
+            "the least-recently-updated entry must be evicted"
+        );
+        assert!(
+            peers.iter().any(|(a, _, _)| *a == next_oldest),
+            "the recently-refreshed entry must survive eviction"
+        );
+        assert!(
+            peers.iter().any(|(a, _, _)| *a == newcomer),
+            "the new entry must be tracked after eviction"
+        );
+    }
+
+    #[test]
+    fn test_remove_peer_frees_slot() {
+        // Disconnecting a peer must immediately free its per-peer slot so
+        // the bounded table doesn't accumulate stale entries on long-running
+        // gateways.
+        let metrics = TransportMetrics::new();
+
+        let addr: std::net::SocketAddr = "10.0.0.5:5000".parse().unwrap();
+        metrics.record_packet_received(addr, 100);
+        assert_eq!(metrics.per_peer_snapshot().len(), 1);
+
+        metrics.remove_peer(addr);
+        assert!(
+            metrics.per_peer_snapshot().is_empty(),
+            "remove_peer must drop the entry"
+        );
+
+        // Cumulative counters are wire-byte history and intentionally do
+        // NOT roll back when a peer entry is removed.
+        assert_eq!(metrics.cumulative_bytes_received(), 100);
+    }
+
+    #[test]
+    fn test_record_per_peer_is_idempotent_under_remove() {
+        // Removing a non-existent peer is a no-op (e.g. when
+        // record_peer_disconnected fires for a peer whose stats slot was
+        // already evicted by LRU).
+        let metrics = TransportMetrics::new();
+        let addr: std::net::SocketAddr = "10.0.0.99:9999".parse().unwrap();
+        metrics.remove_peer(addr); // must not panic / corrupt state
+        assert!(metrics.per_peer_snapshot().is_empty());
+
+        metrics.record_packet_received(addr, 50);
+        assert_eq!(metrics.per_peer_snapshot().len(), 1);
+        metrics.remove_peer(addr);
+        metrics.remove_peer(addr); // second remove must be a no-op
+        assert!(metrics.per_peer_snapshot().is_empty());
     }
 }

--- a/crates/core/src/transport/metrics.rs
+++ b/crates/core/src/transport/metrics.rs
@@ -59,9 +59,17 @@ pub struct TransportMetrics {
     bytes_received: AtomicU64,
 
     // Cumulative wire-byte counters (never reset, used by the local dashboard).
-    // Updated at the UDP socket layer for every packet, so they reflect all
-    // traffic including keep-alives, ACKs, NAT-traversal, and small control
-    // messages — not just stream transfer payloads.
+    //
+    // `cumulative_bytes_sent` is updated at the UDP socket layer for every
+    // successful `send_to`, so it reflects every byte we put on the wire
+    // including keep-alives, ACKs, NAT-traversal probes, and small control
+    // messages.
+    //
+    // `cumulative_bytes_received` is updated post-authentication (see
+    // `record_packet_received`), so it counts bytes from packets that pass
+    // `try_decrypt_sym` against an established symmetric session key.
+    // Counting at the raw socket would let an attacker spoofing UDP source
+    // addresses inflate this counter arbitrarily (#3999).
     cumulative_bytes_sent: AtomicU64,
     cumulative_bytes_received: AtomicU64,
 

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -750,6 +750,15 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                         );
                         continue;
                     };
+                    // Post-authentication wire-byte accounting for the local
+                    // dashboard. Doing this before the symmetric-decrypt
+                    // gate would let an attacker spoof UDP packets from many
+                    // source IPs and inflate the cumulative + per-peer
+                    // counters, see #3999.
+                    super::TRANSPORT_METRICS.record_packet_received(
+                        self.remote_conn.remote_addr,
+                        packet_data.data().len() as u64,
+                    );
                     let msg = SymmetricMessage::deser(decrypted.data()).unwrap();
                     let SymmetricMessage {
                         packet_id,

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -670,6 +670,14 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                             // Try to decrypt as intro packet
                             match self.remote_conn.transport_secret_key.decrypt(packet_data.data()) {
                                 Ok(_decrypted_intro) => {
+                                    // Authenticated by asymmetric decryption (peer
+                                    // restart-detection path). Meter as a normal
+                                    // received packet — bytes still represent real
+                                    // authenticated traffic on the wire (#3999).
+                                    super::TRANSPORT_METRICS.record_packet_received(
+                                        self.remote_conn.remote_addr,
+                                        packet_data.data().len() as u64,
+                                    );
                                     tracing::debug!(
                                         peer_addr = %self.remote_conn.remote_addr,
                                         "Successfully decrypted intro packet, sending ACK"
@@ -2704,5 +2712,131 @@ mod tests {
                  return now()={now} instead of the stored creation_time={creation_time}"
             );
         }
+    }
+
+    /// Regression test for #3999: an authenticated inbound packet (one that
+    /// passes `try_decrypt_sym`) must update both the per-peer entry and the
+    /// cumulative receive counter, AND the byte count must equal the
+    /// encrypted (wire) packet size, not the decrypted payload size.
+    ///
+    /// Without an explicit test, a future refactor that drops the
+    /// `record_packet_received` call from the post-auth hook in `recv` would
+    /// rot the dashboard silently — the spoof regression test only proves
+    /// the *absence* of pre-auth counting, not the *presence* of post-auth
+    /// counting. This test pins both halves.
+    #[tokio::test]
+    async fn recv_records_packet_metrics_post_authentication() {
+        use crate::transport::crypto::TransportKeypair;
+        use crate::transport::packet_data::PacketData;
+        use crate::transport::symmetric_message::SymmetricMessagePayload;
+        use crate::util::time_source::SharedMockTimeSource;
+        use bytes::Bytes;
+
+        let time_source = SharedMockTimeSource::new();
+        let (inbound_tx, inbound_rx) = mpsc::channel(16);
+        // Use a deterministic, never-otherwise-used port so concurrent tests
+        // can't accidentally observe our per-peer entry.
+        let remote_addr = SocketAddr::new(Ipv4Addr::new(10, 99, 99, 1).into(), 50001);
+
+        let mut key = [0u8; 16];
+        crate::config::GlobalRng::fill_bytes(&mut key);
+        let cipher = Aes128Gcm::new(&key.into());
+        let keypair = TransportKeypair::new();
+
+        let sent_tracker = Arc::new(parking_lot::Mutex::new(
+            SentPacketTracker::new_with_time_source(time_source.clone()),
+        ));
+        let congestion_controller =
+            crate::transport::congestion_control::CongestionControlConfig::default()
+                .build_arc_with_time_source(time_source.clone());
+        let token_bucket = Arc::new(TokenBucket::new_with_time_source(
+            10_000,
+            10_000_000,
+            time_source.clone(),
+        ));
+        let socket = Arc::new(TestSocket::new(
+            mpsc::channel::<(SocketAddr, Arc<[u8]>)>(16).0,
+        ));
+
+        let remote_conn = RemoteConnection {
+            outbound_symmetric_key: cipher.clone(),
+            remote_addr,
+            sent_tracker,
+            last_packet_id: Arc::new(AtomicU32::new(0)),
+            inbound_packet_recv: inbound_rx,
+            inbound_symmetric_key: cipher.clone(),
+            inbound_symmetric_key_bytes: key,
+            my_address: None,
+            transport_secret_key: keypair.secret,
+            congestion_controller,
+            token_bucket,
+            socket,
+            global_bandwidth: None,
+            time_source,
+        };
+
+        // Build an encrypted ShortMessage so `recv` returns immediately
+        // after metering. Plaintext payload is 100 bytes; the encrypted
+        // wire packet will be larger (nonce + AEAD tag + framing).
+        let plaintext: Vec<u8> = (0..100u8).collect();
+        let payload = SymmetricMessagePayload::ShortMessage {
+            payload: Bytes::from(plaintext.clone()),
+        };
+        let encrypted = SymmetricMessage::serialize_msg_to_packet_data(1, payload, &cipher, vec![])
+            .expect("encrypt");
+        let encrypted_bytes = encrypted.data().to_vec();
+        let wire_size = encrypted_bytes.len() as u64;
+        assert!(
+            wire_size > plaintext.len() as u64,
+            "encrypted wire size ({wire_size}) must exceed plaintext size ({}) — \
+             AEAD tag + nonce + framing always grows the packet",
+            plaintext.len()
+        );
+
+        // Wrap as the unknown-encryption type the inbound channel actually
+        // carries (the listener doesn't know yet whether decryption will
+        // succeed).
+        let packet = PacketData::<crate::transport::packet_data::UnknownEncryption>::from_buf(
+            &encrypted_bytes,
+        );
+        inbound_tx.send(packet).await.expect("send");
+
+        let metrics_before_recv = crate::transport::TRANSPORT_METRICS
+            .per_peer_snapshot()
+            .into_iter()
+            .find(|(a, _, _)| *a == remote_addr);
+        assert!(
+            metrics_before_recv.is_none(),
+            "test precondition: no entry for our unique remote_addr"
+        );
+        let cumulative_before = crate::transport::TRANSPORT_METRICS.cumulative_bytes_received();
+
+        let mut conn = PeerConnection::new(remote_conn);
+        let _msg = conn.recv().await.expect("recv");
+
+        // Per-peer entry must reflect the wire (encrypted) size — pinning
+        // the byte semantics so a future refactor using
+        // `decrypted.data().len()` would silently regress this.
+        let entry = crate::transport::TRANSPORT_METRICS
+            .per_peer_snapshot()
+            .into_iter()
+            .find(|(a, _, _)| *a == remote_addr)
+            .expect("post-auth recv must create a per-peer entry");
+        assert_eq!(
+            entry.2, wire_size,
+            "per-peer bytes_received must equal the encrypted wire size"
+        );
+
+        // Cumulative counter must also have moved by at least wire_size.
+        // Other concurrent tests may push it higher.
+        let cumulative_after = crate::transport::TRANSPORT_METRICS.cumulative_bytes_received();
+        assert!(
+            cumulative_after >= cumulative_before + wire_size,
+            "cumulative_bytes_received must include this packet (before={cumulative_before}, \
+             after={cumulative_after}, wire_size={wire_size})"
+        );
+
+        // Cleanup so the singleton doesn't leak our address into other tests.
+        crate::transport::TRANSPORT_METRICS.remove_peer(remote_addr);
     }
 }


### PR DESCRIPTION
## Problem

PR #3996 moved dashboard wire-byte accounting from stream-completion to the UDP socket layer so the local-peer dashboard reflects keep-alives, ACKs, and small contract ops — not just stream transfers. That fix exposed a pre-existing weakness in the per-peer DashMap:

- `TransportMetrics::record_packet_received` ran from `Socket::recv_from` on every received UDP packet, **before** any decryption or peer-validation.
- `record_per_peer` had no eviction policy and a 256-entry cap.

Combined, an attacker that fabricates UDP packets from many spoofed source IPs could:

1. Fill the per-peer DashMap to capacity. After 256 distinct source IPs, legitimate new peers' bytes were silently dropped from per-peer accounting forever.
2. Inflate `cumulative_bytes_received` arbitrarily — making the dashboard's "Total Data Received" gauge attacker-controlled.

The same no-eviction policy also caused stale entries to accumulate on long-running gateways as peer connections churned, even without a spoof attack — so a gateway with high peer turnover would eventually display "—" for SENT/RECV on legitimate new peers.

## Approach

Two coordinated changes that follow the fix proposed in #3999, plus an eager-cleanup complement:

**1. Move recv-side metering past authentication.** `record_packet_received` is now called from `PeerConnection::recv` immediately after a packet passes `try_decrypt_sym` against the established symmetric session key — i.e. only for packets we know came from a peer holding the shared secret. The call was removed from `Socket::recv_from`. Outbound metering stays at the socket layer because send targets are controlled by us; there is no spoof vector on send.

**2. LRU-evict the per-peer table when full.** `PeerTransferStats` gained a `last_seen_tick` atomic stamped from a global monotonic counter on every update. When the table is full and a new peer arrives, `record_per_peer` evicts the entry with the smallest tick before inserting. Pure tick-based ordering avoids a wall-clock dependency and keeps simulation determinism intact (the rules in `.claude/rules/code-style.md` discourage `Instant::now()` in `crates/core/`).

**3. Eager cleanup on disconnect.** `TRANSPORT_METRICS.remove_peer` is called from `record_peer_disconnected`, so authenticated peer teardowns free their slot immediately rather than waiting for LRU eviction.

## Testing

- `udp_socket_recv_from_does_not_record_pre_authentication` (new) — pins the spoof regression: a forged UDP packet at the kernel handoff point creates no per-peer entry and contributes nothing to the cumulative counter on its own.
- `test_per_peer_lru_evicts_oldest` (new) — pins the LRU ordering: refreshing the second-oldest entry's tick changes which entry is evicted on the next insert into a full table.
- `test_per_peer_capacity_bound` (updated) — reflects the new LRU semantics. Pre-fix the over-capacity peer was silently dropped; post-fix it is tracked at the cost of evicting the oldest entry.
- `test_remove_peer_frees_slot` and `test_record_per_peer_is_idempotent_under_remove` (new) — pin the disconnect-cleanup path and the no-op behavior of removing a non-existent / already-evicted peer.
- `udp_socket_records_packet_metrics` (updated) — only the send side now asserts cumulative + per-peer movement; recv-side accounting moved to the post-auth path.

All 12 metrics unit tests + 13 transport dual-stack tests + full freenet lib suite (2538 tests) pass locally.

## Fixes

Closes #3999

[AI-assisted - Claude]