### PR TITLE
build(deps): bump tray-icon to 0.23 and muda to 0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4016,9 +4016,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+checksum = "0ae8844f63b5b118e334e205585b8c5c17b984121dbdb179d44aeb087ffad3cb"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -4030,9 +4030,9 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4968,19 +4968,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -7433,9 +7420,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9eb1da86bd0ab8931fad00650d2ba7473260c5bab06d6f24d04339edb88faa"
+checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
  "dirs",
@@ -7447,9 +7434,9 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png 0.18.1",
+ "png",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,8 +144,8 @@ winapi = "0.3"
 tao = { version = "0.35", default-features = false, features = ["rwh_06"] }
 wry = { version = "0.55", default-features = false, features = ["os-webview"] }
 winreg = "0.56"
-tray-icon = "0.22"
-muda = "0.17"
+tray-icon = "0.23"
+muda = "0.19"
 zip = { version = "8", default-features = false, features = ["deflate", "time"] }
 
 # Freenet


### PR DESCRIPTION
## Problem
Dependabot opened #4025 (tray-icon 0.22→0.23) and #4027 (muda 0.17→0.19) as separate PRs, but neither can land on its own. tray-icon 0.23 re-exports `muda::ContextMenu` from muda 0.19, so a tray-icon-only bump leaves two versions of muda in the dep graph and `tray.rs` fails to compile on Windows:

```
error[E0277]: the trait bound `muda::Menu: tray_icon::menu::ContextMenu` is not satisfied
   --> crates/core/src/bin/commands/tray.rs:386:28
note: there are multiple different versions of crate `muda` in the dependency graph
```

(The muda 0.17 `Menu` does not implement the muda 0.19 `ContextMenu` trait that tray-icon 0.23 expects.)

## Solution
Bump both crates in lockstep so the resolver picks a single muda 0.19. The existing `with_menu(Box::new(menu))` call site in `tray.rs:386` is compatible with the new API — `impl ContextMenu for Menu` exists in muda 0.19.

## Testing
- `cargo check -p freenet` passes locally on Linux (tray code is `#[cfg(target_os = ...)]`-gated to Windows/macOS, so the real verification is the CI Windows Check job).
- This PR replaces #4025 and #4027; both will be closed once this lands.

[AI-assisted - Claude]