### PR TITLE
feat: per-secret snapshots with tiered retention for delegates

### DIFF
--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -8,6 +8,7 @@ mod error;
 pub(crate) mod mock_state_storage;
 mod native_api;
 mod runtime;
+mod secret_snapshots;
 mod secrets_store;
 pub(crate) mod simulation_runtime;
 mod state_store;

--- a/crates/core/src/wasm_runtime/secret_snapshots.rs
+++ b/crates/core/src/wasm_runtime/secret_snapshots.rs
@@ -5,7 +5,9 @@
 //! moved into a `.snapshots/{secret_id}/{epoch_ms}` file. Retention is then
 //! thinned per the policy below: recent history stays dense, older history
 //! is sampled at progressively coarser intervals (minute / hour / day /
-//! week / month), bounded above by ~60 snapshots per secret in steady state.
+//! week / month), and an absolute `max_age` cap drops anything older
+//! regardless of which clause selected it. Worst case ~62 entries per
+//! secret in steady state.
 //!
 //! Snapshots are encrypted with whatever cipher the delegate had configured
 //! when the snapshot was taken; without that cipher the bytes are useless.
@@ -38,6 +40,136 @@ pub const SNAPSHOT_NAME_WIDTH: usize = 20;
 /// realistic delegate workload. Hitting the cap returns an error so the
 /// caller can log instead of silently overwriting an existing snapshot.
 const MAX_SNAPSHOT_COLLISION_SUFFIX: u32 = 1024;
+
+/// One tier of a [`RetentionPolicy`]: aim to keep one snapshot per
+/// `interval` of clock time, up to `max_count` snapshots in this tier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetentionBucket {
+    pub interval: Duration,
+    pub max_count: usize,
+}
+
+/// Tiered retention policy. The first `keep_last` snapshots (by recency) are
+/// kept regardless of bucket coverage; each bucket independently selects
+/// representatives at its own granularity; and `max_age` is an absolute
+/// upper bound that drops snapshots older than the threshold even if a
+/// recency or bucket clause would otherwise keep them. The absolute cap
+/// satisfies the cleanup-exemption rule in AGENTS.md: every retained
+/// entry has a finite lifetime.
+#[derive(Debug, Clone)]
+pub struct RetentionPolicy {
+    pub keep_last: usize,
+    pub buckets: Vec<RetentionBucket>,
+    /// Absolute upper bound on how old a snapshot may be and still be
+    /// retained. `None` disables the cap (older snapshots may stick around
+    /// indefinitely if `keep_last` or a long-interval bucket selects them).
+    /// `Some(d)` drops snapshots older than `now - d` regardless of which
+    /// clause would have kept them.
+    pub max_age: Option<Duration>,
+}
+
+impl Default for RetentionPolicy {
+    /// Default: keep the last 5 snapshots, plus one per minute for the last
+    /// 10 minutes, one per hour for the last 24 hours, one per day for the
+    /// last week, one per week for the last 4 weeks, one per month for the
+    /// last 12 months, with an absolute 2-year ceiling so stale snapshots
+    /// from secrets that stopped being written eventually age out. Worst
+    /// case ~62 entries per secret in steady state.
+    fn default() -> Self {
+        const MIN: u64 = 60;
+        const HOUR: u64 = 60 * MIN;
+        const DAY: u64 = 24 * HOUR;
+        const WEEK: u64 = 7 * DAY;
+        const MONTH: u64 = 30 * DAY;
+        const YEAR: u64 = 365 * DAY;
+        Self {
+            keep_last: 5,
+            buckets: vec![
+                RetentionBucket {
+                    interval: Duration::from_secs(MIN),
+                    max_count: 10,
+                },
+                RetentionBucket {
+                    interval: Duration::from_secs(HOUR),
+                    max_count: 24,
+                },
+                RetentionBucket {
+                    interval: Duration::from_secs(DAY),
+                    max_count: 7,
+                },
+                RetentionBucket {
+                    interval: Duration::from_secs(WEEK),
+                    max_count: 4,
+                },
+                RetentionBucket {
+                    interval: Duration::from_secs(MONTH),
+                    max_count: 12,
+                },
+            ],
+            // Two years leaves clear headroom above the month bucket
+            // (12 months ≈ 1 year) so the default month tier always gets
+            // to keep its full 12 representatives. Beyond that, stale
+            // ciphertext from secrets the user stopped writing to ages
+            // out instead of lingering forever.
+            max_age: Some(Duration::from_secs(2 * YEAR)),
+        }
+    }
+}
+
+impl RetentionPolicy {
+    /// Given `timestamps` sorted ascending, return the indices to KEEP.
+    /// Indices not in the returned set should be deleted.
+    ///
+    /// Algorithm: walk newest-first. The first snapshot encountered in each
+    /// `interval`-wide age slot wins that slot; subsequent snapshots in the
+    /// same slot are eligible for deletion (unless covered by another tier
+    /// or `keep_last`). Per tier, stop after `max_count` distinct slots.
+    /// Finally, `max_age` filters: any otherwise-kept entry older than
+    /// `now - max_age` is dropped.
+    pub fn select_keep(&self, now: SystemTime, timestamps: &[SystemTime]) -> BTreeSet<usize> {
+        let mut keep = BTreeSet::new();
+        let n = timestamps.len();
+
+        for i in n.saturating_sub(self.keep_last)..n {
+            keep.insert(i);
+        }
+
+        for bucket in &self.buckets {
+            if bucket.max_count == 0 {
+                continue;
+            }
+            let secs = bucket.interval.as_secs().max(1);
+            let mut slots_seen: HashSet<u64> = HashSet::new();
+            for (i, ts) in timestamps.iter().enumerate().rev() {
+                let age = now.duration_since(*ts).unwrap_or_default().as_secs();
+                let slot = age / secs;
+                if slots_seen.insert(slot) {
+                    keep.insert(i);
+                    if slots_seen.len() >= bucket.max_count {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Absolute age cap. Applied as a final filter so it overrides
+        // every other clause. This is what satisfies AGENTS.md's rule
+        // that GC exemptions must be time-bounded: even `keep_last`
+        // entries are dropped once they cross `max_age`.
+        // `duration_since` returns Err when the timestamp is in the
+        // future (clock skew). We keep those rather than panic — they
+        // are by definition not stale.
+        if let Some(max_age) = self.max_age {
+            keep.retain(|&i| {
+                now.duration_since(timestamps[i])
+                    .map(|age| age <= max_age)
+                    .unwrap_or(true)
+            });
+        }
+
+        keep
+    }
+}
 
 /// Path to the snapshot directory for a particular `(delegate, secret_id)`
 /// pair. Snapshots are organized per secret so retention thinning of one
@@ -153,100 +285,6 @@ pub(crate) fn parse_snapshot_stamp(path: &Path) -> Option<u64> {
     stamp_part.parse().ok()
 }
 
-/// One tier of a [`RetentionPolicy`]: aim to keep one snapshot per
-/// `interval` of clock time, up to `max_count` snapshots in this tier.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct RetentionBucket {
-    pub interval: Duration,
-    pub max_count: usize,
-}
-
-/// Tiered retention policy. The first `keep_last` snapshots (by recency) are
-/// always kept regardless of age; on top of that, each bucket independently
-/// selects representatives at its own granularity.
-#[derive(Debug, Clone)]
-pub struct RetentionPolicy {
-    pub keep_last: usize,
-    pub buckets: Vec<RetentionBucket>,
-}
-
-impl Default for RetentionPolicy {
-    /// Default: keep the last 5 snapshots, plus one per minute for the last
-    /// 10 minutes, one per hour for the last 24 hours, one per day for the
-    /// last week, one per week for the last 4 weeks, one per month for the
-    /// last 12 months. Worst-case ~62 entries per secret in steady state.
-    fn default() -> Self {
-        const MIN: u64 = 60;
-        const HOUR: u64 = 60 * MIN;
-        const DAY: u64 = 24 * HOUR;
-        const WEEK: u64 = 7 * DAY;
-        const MONTH: u64 = 30 * DAY;
-        Self {
-            keep_last: 5,
-            buckets: vec![
-                RetentionBucket {
-                    interval: Duration::from_secs(MIN),
-                    max_count: 10,
-                },
-                RetentionBucket {
-                    interval: Duration::from_secs(HOUR),
-                    max_count: 24,
-                },
-                RetentionBucket {
-                    interval: Duration::from_secs(DAY),
-                    max_count: 7,
-                },
-                RetentionBucket {
-                    interval: Duration::from_secs(WEEK),
-                    max_count: 4,
-                },
-                RetentionBucket {
-                    interval: Duration::from_secs(MONTH),
-                    max_count: 12,
-                },
-            ],
-        }
-    }
-}
-
-impl RetentionPolicy {
-    /// Given `timestamps` sorted ascending, return the indices to KEEP.
-    /// Indices not in the returned set should be deleted.
-    ///
-    /// Algorithm: walk newest-first. The first snapshot encountered in each
-    /// `interval`-wide age slot wins that slot; subsequent snapshots in the
-    /// same slot are eligible for deletion (unless covered by another tier
-    /// or `keep_last`). Per tier, stop after `max_count` distinct slots.
-    pub fn select_keep(&self, now: SystemTime, timestamps: &[SystemTime]) -> BTreeSet<usize> {
-        let mut keep = BTreeSet::new();
-        let n = timestamps.len();
-
-        for i in n.saturating_sub(self.keep_last)..n {
-            keep.insert(i);
-        }
-
-        for bucket in &self.buckets {
-            if bucket.max_count == 0 {
-                continue;
-            }
-            let secs = bucket.interval.as_secs().max(1);
-            let mut slots_seen: HashSet<u64> = HashSet::new();
-            for (i, ts) in timestamps.iter().enumerate().rev() {
-                let age = now.duration_since(*ts).unwrap_or_default().as_secs();
-                let slot = age / secs;
-                if slots_seen.insert(slot) {
-                    keep.insert(i);
-                    if slots_seen.len() >= bucket.max_count {
-                        break;
-                    }
-                }
-            }
-        }
-
-        keep
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -267,6 +305,7 @@ mod tests {
         let p = RetentionPolicy {
             keep_last: 3,
             buckets: vec![],
+            max_age: None,
         };
         let now = SystemTime::now();
         // Five very-old snapshots: only the trailing 3 should survive.
@@ -285,6 +324,7 @@ mod tests {
                 interval: Duration::from_secs(60),
                 max_count: 10,
             }],
+            max_age: None,
         };
         let now = SystemTime::now();
         let ts: Vec<_> = (0..600).map(|i| t(now, 599 - i)).collect();
@@ -301,6 +341,7 @@ mod tests {
                 interval: Duration::from_secs(60),
                 max_count: 10,
             }],
+            max_age: None,
         };
         let now = SystemTime::now();
         let ts: Vec<_> = (0..1000).map(|_| t(now, 5)).collect();
@@ -338,6 +379,7 @@ mod tests {
                 interval: Duration::from_secs(60),
                 max_count: 5,
             }],
+            max_age: None,
         };
         let now = SystemTime::now();
         let ts = vec![now + Duration::from_secs(120), t(now, 30)];
@@ -346,6 +388,67 @@ mod tests {
         // call-order not timestamp) wins, but the algorithm walks rev so the
         // last index wins the slot. Either way exactly one survives.
         assert_eq!(keep.len(), 1);
+    }
+
+    /// `max_age` MUST override every other retention clause, including
+    /// `keep_last`. AGENTS.md cleanup-exemption rule: time-bound it or
+    /// don't ship it.
+    #[test]
+    fn max_age_overrides_keep_last() {
+        let p = RetentionPolicy {
+            keep_last: 5,
+            buckets: vec![],
+            max_age: Some(Duration::from_secs(60)),
+        };
+        let now = SystemTime::now();
+        // 5 snapshots, all 1 hour old. keep_last=5 would normally keep all,
+        // but max_age=60s drops every one.
+        let ts: Vec<_> = (0..5).map(|i| t(now, 3600 - i)).collect();
+        let keep = p.select_keep(now, &ts);
+        assert!(keep.is_empty(), "max_age must trim stale entries even from keep_last");
+    }
+
+    /// Future-dated snapshots (clock skew) are not dropped by max_age:
+    /// `duration_since` returns Err, treated as "not stale".
+    #[test]
+    fn max_age_preserves_future_timestamps() {
+        let p = RetentionPolicy {
+            keep_last: 1,
+            buckets: vec![],
+            max_age: Some(Duration::from_secs(60)),
+        };
+        let now = SystemTime::now();
+        let ts = vec![now + Duration::from_secs(120)];
+        let keep = p.select_keep(now, &ts);
+        assert_eq!(keep.len(), 1, "future-dated snapshot must survive max_age");
+    }
+
+    /// Mix of fresh and stale entries: only the fresh ones survive even
+    /// when keep_last would have selected the stale ones too.
+    #[test]
+    fn max_age_drops_only_stale_entries() {
+        let p = RetentionPolicy {
+            keep_last: 10,
+            buckets: vec![],
+            max_age: Some(Duration::from_secs(120)),
+        };
+        let now = SystemTime::now();
+        // 3 fresh (within 2 min), 3 stale (> 2 min). keep_last=10 selects
+        // all 6, max_age=120s drops the stale half.
+        let ts = vec![
+            t(now, 1000), // stale
+            t(now, 500),  // stale
+            t(now, 200),  // stale
+            t(now, 60),   // fresh
+            t(now, 30),   // fresh
+            t(now, 5),    // fresh
+        ];
+        let keep = p.select_keep(now, &ts);
+        assert_eq!(
+            keep.into_iter().collect::<Vec<_>>(),
+            vec![3, 4, 5],
+            "only fresh entries should remain"
+        );
     }
 
     #[test]
@@ -427,6 +530,7 @@ mod tests {
                 interval: Duration::from_secs(60),
                 max_count: 0,
             }],
+            max_age: None,
         };
         let now = SystemTime::now();
         let ts: Vec<_> = (0..10).map(|i| t(now, i)).collect();

--- a/crates/core/src/wasm_runtime/secret_snapshots.rs
+++ b/crates/core/src/wasm_runtime/secret_snapshots.rs
@@ -13,6 +13,11 @@
 use std::collections::{BTreeSet, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+// Wall-clock SystemTime (not the project-wide TimeSource trait) is the
+// correct abstraction here: snapshot file names embed epoch_ms so retention
+// stays sortable across process restarts and across nodes that share a
+// data directory. TimeSource returns simulation-relative Duration with no
+// stable origin, which can't be persisted into a filename.
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use freenet_stdlib::prelude::SecretsId;
@@ -22,6 +27,18 @@ use freenet_stdlib::prelude::SecretsId;
 /// active secret files; the `get_secret` read path never descends into it.
 pub const SNAPSHOTS_DIR: &str = ".snapshots";
 
+/// Width of the zero-padded epoch-millis used to name snapshot files.
+/// `u64::MAX` is 20 digits, so this width keeps lexicographic order
+/// equivalent to chronological order for the lifetime of the universe.
+pub const SNAPSHOT_NAME_WIDTH: usize = 20;
+
+/// Maximum number of within-the-same-millisecond collision suffixes we'll
+/// try before giving up. 1024 is generous: at burst of 1024 writes/ms a
+/// node would be doing >1M ops/sec to a single secret, far beyond any
+/// realistic delegate workload. Hitting the cap returns an error so the
+/// caller can log instead of silently overwriting an existing snapshot.
+const MAX_SNAPSHOT_COLLISION_SUFFIX: u32 = 1024;
+
 /// Path to the snapshot directory for a particular `(delegate, secret_id)`
 /// pair. Snapshots are organized per secret so retention thinning of one
 /// busy key cannot affect another.
@@ -29,10 +46,46 @@ pub fn snapshot_dir_for(delegate_path: &Path, key: &SecretsId) -> PathBuf {
     delegate_path.join(SNAPSHOTS_DIR).join(key.encode())
 }
 
+/// Pick the snapshot file path for a write happening "now". Uses the
+/// current epoch-millis as the base name, falling back to numeric
+/// collision suffixes when multiple writes land in the same millisecond.
+///
+/// # Errors
+/// `AlreadyExists` if [`MAX_SNAPSHOT_COLLISION_SUFFIX`] consecutive
+/// suffixes are also taken — extremely unlikely in practice, but the
+/// caller (snapshot subsystem) treats this as a best-effort failure and
+/// logs rather than silently overwriting an existing snapshot.
+pub fn next_snapshot_path(snap_dir: &Path) -> std::io::Result<PathBuf> {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    let unsuffixed = snap_dir.join(format!("{stamp:0width$}", width = SNAPSHOT_NAME_WIDTH));
+    if !unsuffixed.exists() {
+        return Ok(unsuffixed);
+    }
+    for suffix in 0u32..MAX_SNAPSHOT_COLLISION_SUFFIX {
+        let candidate = snap_dir.join(format!(
+            "{stamp:0width$}.{suffix}",
+            width = SNAPSHOT_NAME_WIDTH
+        ));
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        format!(
+            "snapshot path collision exhausted: {} already has {MAX_SNAPSHOT_COLLISION_SUFFIX} entries with stamp {stamp}",
+            snap_dir.display()
+        ),
+    ))
+}
+
 /// Apply the retention policy to a snapshot directory: delete any file
 /// whose timestamp is not selected by `policy` relative to `now`. Files
 /// whose names don't parse as `{epoch_ms}` (with optional `.{counter}`
-/// suffix) are left untouched.
+/// suffix) and non-regular-file entries are left untouched.
 ///
 /// Best-effort: I/O errors during enumeration or unlink are logged but
 /// do not propagate, since thinning is a maintenance operation that must
@@ -40,9 +93,23 @@ pub fn snapshot_dir_for(delegate_path: &Path, key: &SecretsId) -> PathBuf {
 pub fn thin_snapshots(snap_dir: &Path, policy: &RetentionPolicy, now: SystemTime) {
     let mut entries: Vec<(SystemTime, PathBuf)> = match fs::read_dir(snap_dir) {
         Ok(rd) => rd
-            .flatten()
-            .filter_map(|e| {
-                let path = e.path();
+            .filter_map(|res| match res {
+                Ok(entry) => Some(entry),
+                Err(err) => {
+                    tracing::debug!("snapshot dir entry error in {snap_dir:?}: {err}");
+                    None
+                }
+            })
+            .filter_map(|entry| {
+                // Skip directories, symlinks, anything that isn't a regular
+                // file. A subdirectory whose name happens to be all digits
+                // would otherwise produce a confusing "remove_file failed"
+                // log on every thin pass.
+                let is_file = entry.file_type().map(|ft| ft.is_file()).unwrap_or(false);
+                if !is_file {
+                    return None;
+                }
+                let path = entry.path();
                 let stamp = parse_snapshot_stamp(&path)?;
                 Some((UNIX_EPOCH + Duration::from_millis(stamp), path))
             })
@@ -66,11 +133,23 @@ pub fn thin_snapshots(snap_dir: &Path, policy: &RetentionPolicy, now: SystemTime
 }
 
 /// Parse a snapshot file name back into its epoch-millis timestamp.
-/// Accepts either `{stamp}` or `{stamp}.{counter}` (collision suffix);
-/// returns `None` for any other shape.
-fn parse_snapshot_stamp(path: &Path) -> Option<u64> {
+/// Accepts only `{digits}` or `{digits}.{digits}`; any other shape
+/// (including `42.tmp`, `foo`, `1.2.3`, etc.) returns `None` so stray
+/// files in the snapshot directory are not mistaken for snapshots.
+pub(crate) fn parse_snapshot_stamp(path: &Path) -> Option<u64> {
     let name = path.file_name()?.to_str()?;
-    let stamp_part = name.split_once('.').map(|(s, _)| s).unwrap_or(name);
+    let (stamp_part, suffix_part) = match name.split_once('.') {
+        Some((s, t)) => (s, Some(t)),
+        None => (name, None),
+    };
+    if stamp_part.is_empty() || !stamp_part.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    if let Some(suffix) = suffix_part
+        && (suffix.is_empty() || !suffix.bytes().all(|b| b.is_ascii_digit()))
+    {
+        return None;
+    }
     stamp_part.parse().ok()
 }
 
@@ -267,6 +346,77 @@ mod tests {
         // call-order not timestamp) wins, but the algorithm walks rev so the
         // last index wins the slot. Either way exactly one survives.
         assert_eq!(keep.len(), 1);
+    }
+
+    #[test]
+    fn parse_snapshot_stamp_accepts_valid_shapes() {
+        use std::path::PathBuf;
+        let pure = PathBuf::from("/tmp/snap/00000000000001234567");
+        assert_eq!(parse_snapshot_stamp(&pure), Some(1_234_567));
+        let suffixed = PathBuf::from("/tmp/snap/00000000000001234567.42");
+        assert_eq!(parse_snapshot_stamp(&suffixed), Some(1_234_567));
+    }
+
+    #[test]
+    fn parse_snapshot_stamp_rejects_garbage() {
+        use std::path::PathBuf;
+        // Non-digit body
+        assert_eq!(parse_snapshot_stamp(&PathBuf::from("foo")), None);
+        // Non-digit suffix (the previous lax implementation accepted these)
+        assert_eq!(parse_snapshot_stamp(&PathBuf::from("123.tmp")), None);
+        // Multiple dots
+        assert_eq!(parse_snapshot_stamp(&PathBuf::from("123.4.5")), None);
+        // Empty stamp
+        assert_eq!(parse_snapshot_stamp(&PathBuf::from(".42")), None);
+        // Empty suffix
+        assert_eq!(parse_snapshot_stamp(&PathBuf::from("123.")), None);
+        // Pure punctuation
+        assert_eq!(parse_snapshot_stamp(&PathBuf::from("...")), None);
+    }
+
+    #[test]
+    fn next_snapshot_path_uses_unsuffixed_when_free() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let p = next_snapshot_path(dir.path()).expect("path");
+        // Default name is just digits, no dot.
+        assert!(
+            p.file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .chars()
+                .all(|c| c.is_ascii_digit())
+        );
+    }
+
+    #[test]
+    fn next_snapshot_path_falls_back_to_suffix_on_collision() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Pre-create files at every plausible "now" stamp (we can't easily
+        // pin the wall clock, so saturate the directory at and around the
+        // current millisecond and assert the helper picks SOME free path).
+        // Walk a small window of stamps and create the unsuffixed file at
+        // each: this guarantees `next_snapshot_path` will see a collision
+        // for at least one call.
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        for offset in 0..3u64 {
+            let p = dir
+                .path()
+                .join(format!("{:0width$}", now + offset, width = 20));
+            std::fs::write(&p, b"").unwrap();
+        }
+        // Ask for a path; the first call may land on a free stamp (now+3+),
+        // but if the clock hasn't ticked we'll hit collision and walk to a
+        // suffixed name. Either way the result must be a free path that
+        // the helper hasn't itself created (existence check).
+        let p = next_snapshot_path(dir.path()).expect("path");
+        assert!(!p.exists());
+        let name = p.file_name().unwrap().to_str().unwrap();
+        // It's either `{stamp}` or `{stamp}.{n}` with all-digit components.
+        assert!(parse_snapshot_stamp(&p).is_some(), "name={name}");
     }
 
     #[test]

--- a/crates/core/src/wasm_runtime/secret_snapshots.rs
+++ b/crates/core/src/wasm_runtime/secret_snapshots.rs
@@ -405,7 +405,10 @@ mod tests {
         // but max_age=60s drops every one.
         let ts: Vec<_> = (0..5).map(|i| t(now, 3600 - i)).collect();
         let keep = p.select_keep(now, &ts);
-        assert!(keep.is_empty(), "max_age must trim stale entries even from keep_last");
+        assert!(
+            keep.is_empty(),
+            "max_age must trim stale entries even from keep_last"
+        );
     }
 
     /// Future-dated snapshots (clock skew) are not dropped by max_age:

--- a/crates/core/src/wasm_runtime/secret_snapshots.rs
+++ b/crates/core/src/wasm_runtime/secret_snapshots.rs
@@ -1,0 +1,285 @@
+//! Tiered retention thinning for delegate secret snapshots.
+//!
+//! Each `(delegate, secret_id)` pair has its own snapshot history. Before a
+//! `store_secret` overwrites an existing value, the previous ciphertext is
+//! moved into a `.snapshots/{secret_id}/{epoch_ms}` file. Retention is then
+//! thinned per the policy below: recent history stays dense, older history
+//! is sampled at progressively coarser intervals (minute / hour / day /
+//! week / month), bounded above by ~60 snapshots per secret in steady state.
+//!
+//! Snapshots are encrypted with whatever cipher the delegate had configured
+//! when the snapshot was taken; without that cipher the bytes are useless.
+
+use std::collections::{BTreeSet, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use freenet_stdlib::prelude::SecretsId;
+
+/// Subdirectory (relative to a delegate's secrets dir) holding the
+/// per-secret snapshot history. Leading dot keeps it visually separate from
+/// active secret files; the `get_secret` read path never descends into it.
+pub const SNAPSHOTS_DIR: &str = ".snapshots";
+
+/// Path to the snapshot directory for a particular `(delegate, secret_id)`
+/// pair. Snapshots are organized per secret so retention thinning of one
+/// busy key cannot affect another.
+pub fn snapshot_dir_for(delegate_path: &Path, key: &SecretsId) -> PathBuf {
+    delegate_path.join(SNAPSHOTS_DIR).join(key.encode())
+}
+
+/// Apply the retention policy to a snapshot directory: delete any file
+/// whose timestamp is not selected by `policy` relative to `now`. Files
+/// whose names don't parse as `{epoch_ms}` (with optional `.{counter}`
+/// suffix) are left untouched.
+///
+/// Best-effort: I/O errors during enumeration or unlink are logged but
+/// do not propagate, since thinning is a maintenance operation that must
+/// never fail the primary write path.
+pub fn thin_snapshots(snap_dir: &Path, policy: &RetentionPolicy, now: SystemTime) {
+    let mut entries: Vec<(SystemTime, PathBuf)> = match fs::read_dir(snap_dir) {
+        Ok(rd) => rd
+            .flatten()
+            .filter_map(|e| {
+                let path = e.path();
+                let stamp = parse_snapshot_stamp(&path)?;
+                Some((UNIX_EPOCH + Duration::from_millis(stamp), path))
+            })
+            .collect(),
+        Err(err) => {
+            tracing::warn!("failed to read snapshot dir {snap_dir:?}: {err}");
+            return;
+        }
+    };
+    entries.sort_by_key(|(ts, _)| *ts);
+
+    let timestamps: Vec<SystemTime> = entries.iter().map(|(t, _)| *t).collect();
+    let keep = policy.select_keep(now, &timestamps);
+    for (i, (_, path)) in entries.iter().enumerate() {
+        if !keep.contains(&i) {
+            if let Err(err) = fs::remove_file(path) {
+                tracing::warn!("failed to thin snapshot {path:?}: {err}");
+            }
+        }
+    }
+}
+
+/// Parse a snapshot file name back into its epoch-millis timestamp.
+/// Accepts either `{stamp}` or `{stamp}.{counter}` (collision suffix);
+/// returns `None` for any other shape.
+fn parse_snapshot_stamp(path: &Path) -> Option<u64> {
+    let name = path.file_name()?.to_str()?;
+    let stamp_part = name.split_once('.').map(|(s, _)| s).unwrap_or(name);
+    stamp_part.parse().ok()
+}
+
+/// One tier of a [`RetentionPolicy`]: aim to keep one snapshot per
+/// `interval` of clock time, up to `max_count` snapshots in this tier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetentionBucket {
+    pub interval: Duration,
+    pub max_count: usize,
+}
+
+/// Tiered retention policy. The first `keep_last` snapshots (by recency) are
+/// always kept regardless of age; on top of that, each bucket independently
+/// selects representatives at its own granularity.
+#[derive(Debug, Clone)]
+pub struct RetentionPolicy {
+    pub keep_last: usize,
+    pub buckets: Vec<RetentionBucket>,
+}
+
+impl Default for RetentionPolicy {
+    /// Default: keep the last 5 snapshots, plus one per minute for the last
+    /// 10 minutes, one per hour for the last 24 hours, one per day for the
+    /// last week, one per week for the last 4 weeks, one per month for the
+    /// last 12 months. Worst-case ~62 entries per secret in steady state.
+    fn default() -> Self {
+        const MIN: u64 = 60;
+        const HOUR: u64 = 60 * MIN;
+        const DAY: u64 = 24 * HOUR;
+        const WEEK: u64 = 7 * DAY;
+        const MONTH: u64 = 30 * DAY;
+        Self {
+            keep_last: 5,
+            buckets: vec![
+                RetentionBucket {
+                    interval: Duration::from_secs(MIN),
+                    max_count: 10,
+                },
+                RetentionBucket {
+                    interval: Duration::from_secs(HOUR),
+                    max_count: 24,
+                },
+                RetentionBucket {
+                    interval: Duration::from_secs(DAY),
+                    max_count: 7,
+                },
+                RetentionBucket {
+                    interval: Duration::from_secs(WEEK),
+                    max_count: 4,
+                },
+                RetentionBucket {
+                    interval: Duration::from_secs(MONTH),
+                    max_count: 12,
+                },
+            ],
+        }
+    }
+}
+
+impl RetentionPolicy {
+    /// Given `timestamps` sorted ascending, return the indices to KEEP.
+    /// Indices not in the returned set should be deleted.
+    ///
+    /// Algorithm: walk newest-first. The first snapshot encountered in each
+    /// `interval`-wide age slot wins that slot; subsequent snapshots in the
+    /// same slot are eligible for deletion (unless covered by another tier
+    /// or `keep_last`). Per tier, stop after `max_count` distinct slots.
+    pub fn select_keep(&self, now: SystemTime, timestamps: &[SystemTime]) -> BTreeSet<usize> {
+        let mut keep = BTreeSet::new();
+        let n = timestamps.len();
+
+        for i in n.saturating_sub(self.keep_last)..n {
+            keep.insert(i);
+        }
+
+        for bucket in &self.buckets {
+            if bucket.max_count == 0 {
+                continue;
+            }
+            let secs = bucket.interval.as_secs().max(1);
+            let mut slots_seen: HashSet<u64> = HashSet::new();
+            for (i, ts) in timestamps.iter().enumerate().rev() {
+                let age = now.duration_since(*ts).unwrap_or_default().as_secs();
+                let slot = age / secs;
+                if slots_seen.insert(slot) {
+                    keep.insert(i);
+                    if slots_seen.len() >= bucket.max_count {
+                        break;
+                    }
+                }
+            }
+        }
+
+        keep
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(now: SystemTime, secs_ago: u64) -> SystemTime {
+        now - Duration::from_secs(secs_ago)
+    }
+
+    #[test]
+    fn empty_input_keeps_nothing() {
+        let p = RetentionPolicy::default();
+        let now = SystemTime::now();
+        assert!(p.select_keep(now, &[]).is_empty());
+    }
+
+    #[test]
+    fn keeps_last_n_unconditionally() {
+        let p = RetentionPolicy {
+            keep_last: 3,
+            buckets: vec![],
+        };
+        let now = SystemTime::now();
+        // Five very-old snapshots: only the trailing 3 should survive.
+        let ts: Vec<_> = (0..5).map(|i| t(now, 1_000_000 - i)).collect();
+        let keep = p.select_keep(now, &ts);
+        assert_eq!(keep.into_iter().collect::<Vec<_>>(), vec![2, 3, 4]);
+    }
+
+    #[test]
+    fn minute_bucket_thins_dense_history() {
+        // 600 snapshots at 1 second apart → 10 minutes of history.
+        // Minute bucket with max_count=10 should pick one per minute slot.
+        let p = RetentionPolicy {
+            keep_last: 0,
+            buckets: vec![RetentionBucket {
+                interval: Duration::from_secs(60),
+                max_count: 10,
+            }],
+        };
+        let now = SystemTime::now();
+        let ts: Vec<_> = (0..600).map(|i| t(now, 599 - i)).collect();
+        let keep = p.select_keep(now, &ts);
+        assert_eq!(keep.len(), 10, "expected one snapshot per minute slot");
+    }
+
+    #[test]
+    fn burst_in_single_slot_collapses_to_one() {
+        // 1000 snapshots all within the same second.
+        let p = RetentionPolicy {
+            keep_last: 0,
+            buckets: vec![RetentionBucket {
+                interval: Duration::from_secs(60),
+                max_count: 10,
+            }],
+        };
+        let now = SystemTime::now();
+        let ts: Vec<_> = (0..1000).map(|_| t(now, 5)).collect();
+        let keep = p.select_keep(now, &ts);
+        assert_eq!(keep.len(), 1);
+    }
+
+    #[test]
+    fn default_policy_caps_steady_state() {
+        // One snapshot per minute for a year → 525_600 entries.
+        // Default policy should keep at most ~60-ish.
+        let p = RetentionPolicy::default();
+        let now = SystemTime::now();
+        let ts: Vec<_> = (0..525_600).map(|i| t(now, (525_599 - i) * 60)).collect();
+        let keep = p.select_keep(now, &ts);
+        assert!(
+            keep.len() <= 70,
+            "default policy should bound steady-state retention; got {}",
+            keep.len()
+        );
+        assert!(
+            keep.len() >= 30,
+            "but should still preserve coverage across all tiers; got {}",
+            keep.len()
+        );
+    }
+
+    #[test]
+    fn future_timestamps_treated_as_age_zero() {
+        // Clock skew: a snapshot timestamped after `now`. unwrap_or_default
+        // makes its age 0; it just lands in slot 0 like any recent snapshot.
+        let p = RetentionPolicy {
+            keep_last: 0,
+            buckets: vec![RetentionBucket {
+                interval: Duration::from_secs(60),
+                max_count: 5,
+            }],
+        };
+        let now = SystemTime::now();
+        let ts = vec![now + Duration::from_secs(120), t(now, 30)];
+        let keep = p.select_keep(now, &ts);
+        // Both fall in slot 0 → only the newest (index 1, since input is by
+        // call-order not timestamp) wins, but the algorithm walks rev so the
+        // last index wins the slot. Either way exactly one survives.
+        assert_eq!(keep.len(), 1);
+    }
+
+    #[test]
+    fn zero_max_count_bucket_is_inert() {
+        let p = RetentionPolicy {
+            keep_last: 0,
+            buckets: vec![RetentionBucket {
+                interval: Duration::from_secs(60),
+                max_count: 0,
+            }],
+        };
+        let now = SystemTime::now();
+        let ts: Vec<_> = (0..10).map(|i| t(now, i)).collect();
+        assert!(p.select_keep(now, &ts).is_empty());
+    }
+}

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -2,8 +2,9 @@ use std::{
     collections::HashSet,
     fs::{self, File},
     io::Write,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use chacha20poly1305::{Error as EncryptionError, XChaCha20Poly1305, XNonce, aead::Aead};
@@ -14,6 +15,17 @@ use crate::config::Secrets;
 use crate::contract::storages::Storage;
 
 use super::RuntimeResult;
+use super::secret_snapshots::{RetentionPolicy, snapshot_dir_for, thin_snapshots};
+
+/// Environment variable that disables snapshot-on-write for delegate secrets.
+/// Snapshots are on by default; this is only for ops who explicitly want the
+/// previous behavior (e.g. extreme disk-pressure scenarios).
+const DISABLE_SNAPSHOTS_ENV: &str = "FREENET_DISABLE_SECRET_SNAPSHOTS";
+
+/// Width of the zero-padded epoch-millis used to name snapshot files.
+/// `u64::MAX` is 20 digits, so this width keeps lexicographic order
+/// equivalent to chronological order for the lifetime of the universe.
+const SNAPSHOT_NAME_WIDTH: usize = 20;
 
 type SecretKey = [u8; 32];
 
@@ -46,6 +58,11 @@ pub struct SecretsStore {
     /// ReDb storage for persistent index
     db: Storage,
     default_encryption: Encryption,
+    /// Snapshot retention policy. Snapshots are taken before any overwrite
+    /// of an existing secret so a buggy delegate or accidental write cannot
+    /// silently destroy prior values.
+    retention: RetentionPolicy,
+    snapshots_enabled: bool,
 }
 
 impl SecretsStore {
@@ -83,7 +100,16 @@ impl SecretsStore {
                 nonce: secrets.nonce(),
             },
             secrets,
+            retention: RetentionPolicy::default(),
+            snapshots_enabled: std::env::var_os(DISABLE_SNAPSHOTS_ENV).is_none(),
         })
+    }
+
+    /// Override the retention policy. Intended for tests that want to
+    /// exercise edge cases without waiting real wall-clock time.
+    #[cfg(test)]
+    pub(crate) fn set_retention_policy(&mut self, policy: RetentionPolicy) {
+        self.retention = policy;
     }
 
     pub fn register_delegate(
@@ -130,40 +156,100 @@ impl SecretsStore {
                 }
             })?;
 
-        // CRITICAL ORDER: Write file first, then update index.
+        // CRITICAL ORDER: Snapshot prior value, write new file, then update index.
         // This ensures get_secret() can find the file even if we crash between
         // operations. If we update index first and crash before file write,
         // the index would point to a non-existent file.
 
-        // Step 1: Write secret to disk first
         fs::create_dir_all(&delegate_path)?;
+
+        // Step 1: If a prior secret exists, move it into the snapshot history
+        // *before* we open the active path for write. We rename rather than
+        // hard-link because File::create truncates an existing inode in place
+        // (which would otherwise also truncate any hard link to it).
+        if self.snapshots_enabled
+            && secret_file_path.exists()
+            && let Err(e) = self.snapshot_prior_value(&delegate_path, key, &secret_file_path)
+        {
+            // Snapshotting is best-effort. A failure here must not block the
+            // primary write — the user's data still gets through. Log loudly
+            // so disk problems surface in monitoring.
+            tracing::warn!(
+                "failed to snapshot prior secret value for delegate {}: {e}",
+                delegate.encode()
+            );
+        }
+
+        // Step 2: Write secret to disk
         tracing::debug!("storing secret `{key}` at {secret_file_path:?}");
         let mut file = File::create(&secret_file_path)?;
         file.write_all(&ciphertext)?;
         file.sync_all()?; // Ensure durability before updating index
 
-        // Step 2: Update index in ReDb and in-memory
+        // Step 3: Update index in ReDb and in-memory
         let mut current_secrets: Vec<[u8; 32]> = self
             .key_to_secret_part
             .get(delegate)
             .map(|entry| entry.value().iter().copied().collect())
             .unwrap_or_default();
 
-        // Add the new secret key if not already present
         if !current_secrets.contains(&secret_key) {
             current_secrets.push(secret_key);
         }
 
-        // Store in ReDb
         self.db
             .store_secrets_index(delegate, &current_secrets)
             .map_err(|e| anyhow::anyhow!("Failed to store secrets index: {e}"))?;
 
-        // Update in-memory map
         let secret_set: HashSet<SecretKey> = current_secrets.into_iter().collect();
         self.key_to_secret_part.insert(delegate.clone(), secret_set);
 
+        // Step 4 (best-effort): thin the snapshot history per the retention
+        // policy. Failures here only mean we keep more snapshots than the
+        // policy targets, which is harmless and self-correcting on the next
+        // write.
+        if self.snapshots_enabled {
+            let snap_dir = snapshot_dir_for(&delegate_path, key);
+            if snap_dir.exists() {
+                thin_snapshots(&snap_dir, &self.retention, SystemTime::now());
+            }
+        }
+
         Ok(())
+    }
+
+    /// Move the existing active secret file into its snapshot directory.
+    /// Returns Ok even if the source did not exist (race with another write).
+    fn snapshot_prior_value(
+        &self,
+        delegate_path: &Path,
+        key: &SecretsId,
+        secret_file_path: &Path,
+    ) -> std::io::Result<()> {
+        let snap_dir = snapshot_dir_for(delegate_path, key);
+        fs::create_dir_all(&snap_dir)?;
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let mut snap_path = snap_dir.join(format!("{stamp:0width$}", width = SNAPSHOT_NAME_WIDTH));
+        // If two writes happen within the same millisecond, append a suffix
+        // rather than overwriting the prior snapshot. Walk a small range so
+        // we don't loop pathologically on disk problems.
+        for suffix in 0u32..1024 {
+            if !snap_path.exists() {
+                break;
+            }
+            snap_path = snap_dir.join(format!(
+                "{stamp:0width$}.{suffix}",
+                width = SNAPSHOT_NAME_WIDTH
+            ));
+        }
+        match fs::rename(secret_file_path, &snap_path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err),
+        }
     }
 
     pub fn remove_secret(
@@ -171,12 +257,50 @@ impl SecretsStore {
         delegate: &DelegateKey,
         key: &SecretsId,
     ) -> Result<(), SecretStoreError> {
-        let secret_path = self.base_path.join(delegate.encode()).join(key.encode());
-        match fs::remove_file(secret_path) {
-            Ok(_) => Ok(()),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(err) => Err(err.into()),
+        let delegate_path = self.base_path.join(delegate.encode());
+        let secret_path = delegate_path.join(key.encode());
+        let snap_dir = snapshot_dir_for(&delegate_path, key);
+
+        // Best-effort delete of the snapshot history. Removing a secret means
+        // the user no longer wants any version of that value retained.
+        if snap_dir.exists() {
+            if let Err(e) = fs::remove_dir_all(&snap_dir) {
+                tracing::warn!(
+                    "failed to remove snapshots for {} / {key}: {e}",
+                    delegate.encode()
+                );
+            }
         }
+
+        match fs::remove_file(&secret_path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
+
+        // Update in-memory and persistent indices. Prior to this fix,
+        // `remove_secret` deleted only the file and left the ReDb +
+        // DashMap entries pointing at a now-missing path. `has_secret`
+        // (which checks the index) would then return true, while
+        // `get_secret` would fail on file-not-found.
+        let secret_key = *key.hash();
+        let mut current: Vec<SecretKey> = self
+            .key_to_secret_part
+            .get(delegate)
+            .map(|e| e.value().iter().copied().collect())
+            .unwrap_or_default();
+        current.retain(|k| k != &secret_key);
+
+        if let Err(e) = self.db.store_secrets_index(delegate, &current) {
+            tracing::warn!(
+                "failed to update secrets index after remove_secret({}, {key}): {e}",
+                delegate.encode()
+            );
+        }
+        let secret_set: HashSet<SecretKey> = current.into_iter().collect();
+        self.key_to_secret_part.insert(delegate.clone(), secret_set);
+
+        Ok(())
     }
 
     pub fn get_secret(
@@ -209,11 +333,19 @@ impl SecretsStore {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::wasm_runtime::secret_snapshots::{RetentionBucket, RetentionPolicy};
     use aes_gcm::KeyInit;
     use chacha20poly1305::aead::{AeadCore, OsRng};
+    use std::time::Duration;
 
     async fn create_test_db(path: &std::path::Path) -> Storage {
         Storage::new(path).await.expect("failed to create test db")
+    }
+
+    fn fresh_cipher() -> (XChaCha20Poly1305, XNonce) {
+        let cipher = XChaCha20Poly1305::new(&XChaCha20Poly1305::generate_key(&mut OsRng));
+        let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+        (cipher, nonce)
     }
 
     #[tokio::test]
@@ -227,8 +359,7 @@ mod test {
 
         let delegate = Delegate::from((&vec![0, 1, 2].into(), &vec![].into()));
 
-        let cipher = XChaCha20Poly1305::new(&XChaCha20Poly1305::generate_key(&mut OsRng));
-        let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+        let (cipher, nonce) = fresh_cipher();
         let secret_id = SecretsId::new(vec![0, 1, 2]);
         let text = vec![0, 1, 2];
 
@@ -239,6 +370,235 @@ mod test {
         assert!(f.is_ok());
         // Clean up after test
         let _cleanup = std::fs::remove_dir_all(&secrets_dir);
+        Ok(())
+    }
+
+    /// Regression: writing a secret twice should leave a snapshot of the
+    /// prior value behind. The active path holds the new ciphertext; the
+    /// snapshot directory holds a decryptable copy of the prior ciphertext.
+    #[tokio::test]
+    async fn second_write_snapshots_prior_value() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+
+        let delegate = Delegate::from((&vec![1].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![42]);
+
+        store.store_secret(delegate.key(), &secret_id, b"v1".to_vec())?;
+        // Sleep 2ms to guarantee a distinct epoch-millis stamp on the snapshot.
+        std::thread::sleep(Duration::from_millis(2));
+        store.store_secret(delegate.key(), &secret_id, b"v2".to_vec())?;
+
+        // Active value is the latest write.
+        assert_eq!(
+            store.get_secret(delegate.key(), &secret_id)?,
+            b"v2".to_vec()
+        );
+
+        // Exactly one snapshot exists, holding the prior ciphertext.
+        let snap_dir = secrets_dir
+            .join(delegate.key().encode())
+            .join(".snapshots")
+            .join(secret_id.encode());
+        let entries: Vec<_> = std::fs::read_dir(&snap_dir)?.flatten().collect();
+        assert_eq!(
+            entries.len(),
+            1,
+            "expected exactly one snapshot, got {entries:?}"
+        );
+
+        // The snapshot is decryptable by the same cipher and yields the prior
+        // plaintext, proving snapshots aren't just opaque junk on disk.
+        let ciphertext = std::fs::read(entries[0].path())?;
+        let encryption = store
+            .ciphers
+            .get(delegate.key())
+            .expect("cipher registered");
+        let plaintext = encryption
+            .cipher
+            .decrypt(&encryption.nonce, ciphertext.as_ref())
+            .expect("snapshot ciphertext should decrypt with the registered cipher");
+        assert_eq!(plaintext, b"v1".to_vec());
+        Ok(())
+    }
+
+    /// Burst writes within a single retention slot collapse to a small
+    /// number of snapshots — the policy must bound disk usage.
+    #[tokio::test]
+    async fn burst_writes_are_thinned() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+
+        // Tight policy: keep 3 most-recent, plus one per minute (max 1
+        // bucket) — i.e. up to 4 snapshots total.
+        store.set_retention_policy(RetentionPolicy {
+            keep_last: 3,
+            buckets: vec![RetentionBucket {
+                interval: Duration::from_secs(60),
+                max_count: 1,
+            }],
+        });
+
+        let delegate = Delegate::from((&vec![2].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![7]);
+
+        for i in 0u32..50 {
+            store.store_secret(delegate.key(), &secret_id, i.to_le_bytes().to_vec())?;
+            // Force distinct epoch-millis stamps so the snapshot files don't
+            // collide and the count actually reflects the policy.
+            std::thread::sleep(Duration::from_millis(2));
+        }
+
+        let snap_dir = secrets_dir
+            .join(delegate.key().encode())
+            .join(".snapshots")
+            .join(secret_id.encode());
+        let count = std::fs::read_dir(&snap_dir)?.count();
+        assert!(
+            count <= 4,
+            "tight policy should bound snapshot count to <=4; got {count}"
+        );
+        // We should have at least keep_last - 1 = 2 (after 50 writes there's
+        // always strictly more than `keep_last` snapshots in flight).
+        assert!(count >= 2, "expected snapshots to be retained; got {count}");
+        Ok(())
+    }
+
+    /// Regression for the previous remove_secret index leak: after removal,
+    /// the ReDb secrets index and the in-memory map must no longer claim
+    /// the secret exists, and the snapshot history must be gone.
+    #[tokio::test]
+    async fn remove_secret_clears_index_and_snapshots() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+
+        let delegate = Delegate::from((&vec![3].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![9]);
+
+        store.store_secret(delegate.key(), &secret_id, b"a".to_vec())?;
+        std::thread::sleep(Duration::from_millis(2));
+        store.store_secret(delegate.key(), &secret_id, b"b".to_vec())?;
+
+        // Pre-conditions: index has the key, snapshot dir is populated.
+        let secret_hash = *secret_id.hash();
+        let pre_index = store
+            .db
+            .get_secrets_index(delegate.key())
+            .expect("index lookup")
+            .unwrap_or_default();
+        assert!(
+            pre_index.contains(&secret_hash),
+            "index should contain the secret before removal"
+        );
+        let snap_dir = secrets_dir
+            .join(delegate.key().encode())
+            .join(".snapshots")
+            .join(secret_id.encode());
+        assert!(
+            snap_dir.exists(),
+            "snapshot dir should exist before removal"
+        );
+
+        store.remove_secret(delegate.key(), &secret_id)?;
+
+        // Post-conditions: index entry gone in BOTH ReDb and the in-memory
+        // map, file gone, snapshot dir gone.
+        let post_index = store
+            .db
+            .get_secrets_index(delegate.key())
+            .expect("index lookup")
+            .unwrap_or_default();
+        assert!(
+            !post_index.contains(&secret_hash),
+            "ReDb index still contains removed secret hash"
+        );
+        let in_mem = store
+            .key_to_secret_part
+            .get(delegate.key())
+            .map(|e| e.value().contains(&secret_hash))
+            .unwrap_or(false);
+        assert!(!in_mem, "in-memory map still contains removed secret hash");
+
+        assert!(
+            !snap_dir.exists(),
+            "snapshot dir should be deleted with the secret"
+        );
+        assert!(matches!(
+            store.get_secret(delegate.key(), &secret_id),
+            Err(SecretStoreError::MissingSecret(_))
+        ));
+        Ok(())
+    }
+
+    /// Removing a never-written secret must be a no-op success and must
+    /// leave the index in a sane state (empty, not containing a phantom).
+    #[tokio::test]
+    async fn remove_nonexistent_secret_is_noop() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+        let delegate = Delegate::from((&vec![4].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![11]);
+
+        store.remove_secret(delegate.key(), &secret_id)?;
+
+        let post_index = store
+            .db
+            .get_secrets_index(delegate.key())
+            .expect("index lookup")
+            .unwrap_or_default();
+        assert!(post_index.is_empty());
+        Ok(())
+    }
+
+    /// First write of a brand-new secret must NOT create a snapshot dir
+    /// (there's no prior value to preserve).
+    #[tokio::test]
+    async fn first_write_creates_no_snapshot() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+        let delegate = Delegate::from((&vec![5].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![13]);
+
+        store.store_secret(delegate.key(), &secret_id, b"first".to_vec())?;
+
+        let snap_dir = secrets_dir
+            .join(delegate.key().encode())
+            .join(".snapshots")
+            .join(secret_id.encode());
+        assert!(
+            !snap_dir.exists(),
+            "no snapshot should exist after a single write"
+        );
         Ok(())
     }
 }

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -4,7 +4,12 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
+    // Wall-clock SystemTime (not the project-wide TimeSource trait) is the
+    // correct abstraction here: thin_snapshots compares "now" against
+    // file-name epoch_ms values that must remain meaningful across process
+    // restarts. TimeSource returns simulation-relative Duration, which has
+    // no stable epoch and can't be compared to persisted timestamps.
+    time::SystemTime,
 };
 
 use chacha20poly1305::{Error as EncryptionError, XChaCha20Poly1305, XNonce, aead::Aead};
@@ -15,17 +20,14 @@ use crate::config::Secrets;
 use crate::contract::storages::Storage;
 
 use super::RuntimeResult;
-use super::secret_snapshots::{RetentionPolicy, snapshot_dir_for, thin_snapshots};
+use super::secret_snapshots::{
+    RetentionPolicy, next_snapshot_path, snapshot_dir_for, thin_snapshots,
+};
 
 /// Environment variable that disables snapshot-on-write for delegate secrets.
 /// Snapshots are on by default; this is only for ops who explicitly want the
 /// previous behavior (e.g. extreme disk-pressure scenarios).
 const DISABLE_SNAPSHOTS_ENV: &str = "FREENET_DISABLE_SECRET_SNAPSHOTS";
-
-/// Width of the zero-padded epoch-millis used to name snapshot files.
-/// `u64::MAX` is 20 digits, so this width keeps lexicographic order
-/// equivalent to chronological order for the lifetime of the universe.
-const SNAPSHOT_NAME_WIDTH: usize = 20;
 
 type SecretKey = [u8; 32];
 
@@ -47,13 +49,25 @@ struct Encryption {
     nonce: XNonce,
 }
 
+/// Storage layer for delegate secrets and their snapshot history.
+///
+/// **Synchronization.** This type is NOT internally synchronized.
+/// `store_secret` and `remove_secret` take `&mut self` so the borrow
+/// checker forbids concurrent writes against the same instance, and
+/// `get_secret` taking `&self` cannot run concurrently with a write
+/// either. If a future caller wraps this type in interior mutability
+/// (e.g. `Arc<Mutex<SecretsStore>>`), they must hold the lock across
+/// the snapshot+rename+index sequence in `store_secret`; otherwise two
+/// concurrent writes for the same `(delegate, secret_id)` could race
+/// on the snapshot path or the active-file rename window.
 pub struct SecretsStore {
     base_path: PathBuf,
     #[allow(unused)]
     secrets: Secrets,
     ciphers: std::collections::HashMap<DelegateKey, Encryption>,
-    /// In-memory index: DelegateKey -> Set of secret key hashes
-    /// This is populated from ReDb on startup and kept in sync
+    /// In-memory index: DelegateKey -> Set of secret key hashes.
+    /// Populated from ReDb on startup and kept in sync with it; never
+    /// updated unless the corresponding ReDb write succeeded.
     key_to_secret_part: Arc<DashMap<DelegateKey, HashSet<SecretKey>>>,
     /// ReDb storage for persistent index
     db: Storage,
@@ -112,6 +126,14 @@ impl SecretsStore {
         self.retention = policy;
     }
 
+    /// Override the snapshots-enabled flag at runtime. Intended for tests
+    /// that want to exercise the disabled path without mutating the
+    /// process-wide environment.
+    #[cfg(test)]
+    pub(crate) fn set_snapshots_enabled(&mut self, enabled: bool) {
+        self.snapshots_enabled = enabled;
+    }
+
     pub fn register_delegate(
         &mut self,
         delegate: DelegateKey,
@@ -156,37 +178,55 @@ impl SecretsStore {
                 }
             })?;
 
-        // CRITICAL ORDER: Snapshot prior value, write new file, then update index.
-        // This ensures get_secret() can find the file even if we crash between
-        // operations. If we update index first and crash before file write,
-        // the index would point to a non-existent file.
-
         fs::create_dir_all(&delegate_path)?;
 
-        // Step 1: If a prior secret exists, move it into the snapshot history
-        // *before* we open the active path for write. We rename rather than
-        // hard-link because File::create truncates an existing inode in place
-        // (which would otherwise also truncate any hard link to it).
+        // CRITICAL ORDER: hard-link prior value into snapshot history, write
+        // new ciphertext to a tmp path, fsync, then atomically rename
+        // tmp → active. This way:
+        //   - the active path is never absent: a crash leaves either the old
+        //     or new ciphertext (atomic rename guarantees no half-state),
+        //   - the snapshot points at the OLD inode, which is unaffected by
+        //     the new write because the new write goes through a fresh
+        //     inode and only `rename` makes it visible at the active path,
+        //   - update index AFTER the active rename so a crash between rename
+        //     and index-update still gives `get_secret` the new value.
         if self.snapshots_enabled
             && secret_file_path.exists()
             && let Err(e) = self.snapshot_prior_value(&delegate_path, key, &secret_file_path)
         {
             // Snapshotting is best-effort. A failure here must not block the
-            // primary write — the user's data still gets through. Log loudly
-            // so disk problems surface in monitoring.
+            // primary write — the user's data still gets through. Log so
+            // disk problems surface in monitoring.
             tracing::warn!(
                 "failed to snapshot prior secret value for delegate {}: {e}",
                 delegate.encode()
             );
         }
 
-        // Step 2: Write secret to disk
         tracing::debug!("storing secret `{key}` at {secret_file_path:?}");
-        let mut file = File::create(&secret_file_path)?;
-        file.write_all(&ciphertext)?;
-        file.sync_all()?; // Ensure durability before updating index
+        // Write to a sibling tmp path so the active path's inode never has
+        // a half-written state. We pick a fixed suffix (rather than a
+        // random one) because `&mut self` makes concurrent in-process
+        // store_secret calls impossible; a stale `.tmp` from a prior
+        // crashed run is overwritten harmlessly here.
+        let tmp_path = secret_file_path.with_extension("tmp");
+        {
+            let mut file = File::create(&tmp_path)?;
+            file.write_all(&ciphertext)?;
+            file.sync_all()?;
+        }
+        // Atomic on POSIX (and on Rust >=1.56 Windows: MoveFileExW with
+        // MOVEFILE_REPLACE_EXISTING). If this rename fails, the active
+        // path still holds the old value (or is empty if it never existed)
+        // and the new ciphertext sits in the tmp file for forensics.
+        if let Err(err) = fs::rename(&tmp_path, &secret_file_path) {
+            // Best effort cleanup of the tmp file so we don't leave debris.
+            let _ = fs::remove_file(&tmp_path);
+            return Err(err.into());
+        }
 
-        // Step 3: Update index in ReDb and in-memory
+        // Update index in ReDb and in-memory only after the active path has
+        // the new value durably committed.
         let mut current_secrets: Vec<[u8; 32]> = self
             .key_to_secret_part
             .get(delegate)
@@ -204,10 +244,9 @@ impl SecretsStore {
         let secret_set: HashSet<SecretKey> = current_secrets.into_iter().collect();
         self.key_to_secret_part.insert(delegate.clone(), secret_set);
 
-        // Step 4 (best-effort): thin the snapshot history per the retention
-        // policy. Failures here only mean we keep more snapshots than the
-        // policy targets, which is harmless and self-correcting on the next
-        // write.
+        // Best-effort thin of the snapshot history. Failures here only mean
+        // we keep more snapshots than the policy targets, which is harmless
+        // and self-correcting on the next write.
         if self.snapshots_enabled {
             let snap_dir = snapshot_dir_for(&delegate_path, key);
             if snap_dir.exists() {
@@ -218,8 +257,15 @@ impl SecretsStore {
         Ok(())
     }
 
-    /// Move the existing active secret file into its snapshot directory.
-    /// Returns Ok even if the source did not exist (race with another write).
+    /// Capture the existing active secret file as a snapshot. Uses
+    /// hard-link so the active inode and snapshot inode coexist; the
+    /// subsequent `rename(tmp → active)` updates the active dir-entry to
+    /// a different inode without touching the snapshot.
+    ///
+    /// On filesystems that do not support hard links (FAT, some network
+    /// mounts), falls back to `fs::copy`. The active file is unchanged
+    /// either way, so callers that crash mid-snapshot just lose the
+    /// snapshot, never the live value.
     fn snapshot_prior_value(
         &self,
         delegate_path: &Path,
@@ -228,27 +274,16 @@ impl SecretsStore {
     ) -> std::io::Result<()> {
         let snap_dir = snapshot_dir_for(delegate_path, key);
         fs::create_dir_all(&snap_dir)?;
-        let stamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
-        let mut snap_path = snap_dir.join(format!("{stamp:0width$}", width = SNAPSHOT_NAME_WIDTH));
-        // If two writes happen within the same millisecond, append a suffix
-        // rather than overwriting the prior snapshot. Walk a small range so
-        // we don't loop pathologically on disk problems.
-        for suffix in 0u32..1024 {
-            if !snap_path.exists() {
-                break;
-            }
-            snap_path = snap_dir.join(format!(
-                "{stamp:0width$}.{suffix}",
-                width = SNAPSHOT_NAME_WIDTH
-            ));
-        }
-        match fs::rename(secret_file_path, &snap_path) {
+        let snap_path = next_snapshot_path(&snap_dir)?;
+        match fs::hard_link(secret_file_path, &snap_path) {
             Ok(()) => Ok(()),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(err) => Err(err),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(_) => {
+                // Hard-link unsupported (FAT, cross-device, etc.). Copy
+                // is slower but always works. The active file is not
+                // mutated in this code path so the copy can't tear.
+                fs::copy(secret_file_path, &snap_path).map(|_| ())
+            }
         }
     }
 
@@ -278,11 +313,13 @@ impl SecretsStore {
             Err(err) => return Err(err.into()),
         }
 
-        // Update in-memory and persistent indices. Prior to this fix,
-        // `remove_secret` deleted only the file and left the ReDb +
-        // DashMap entries pointing at a now-missing path. `has_secret`
-        // (which checks the index) would then return true, while
-        // `get_secret` would fail on file-not-found.
+        // Update persistent index FIRST. The previous version of this
+        // method updated the in-memory map unconditionally and only
+        // logged ReDb failures, which let a transient DB error
+        // resurrect the deleted entry on the next restart (because
+        // `new()` rebuilds the in-memory map from ReDb). Mirroring
+        // `store_secret`, we treat persistence failure as fatal here
+        // and only mutate the in-memory map after ReDb commits.
         let secret_key = *key.hash();
         let mut current: Vec<SecretKey> = self
             .key_to_secret_part
@@ -291,12 +328,10 @@ impl SecretsStore {
             .unwrap_or_default();
         current.retain(|k| k != &secret_key);
 
-        if let Err(e) = self.db.store_secrets_index(delegate, &current) {
-            tracing::warn!(
-                "failed to update secrets index after remove_secret({}, {key}): {e}",
-                delegate.encode()
-            );
-        }
+        self.db
+            .store_secrets_index(delegate, &current)
+            .map_err(|e| std::io::Error::other(format!("Failed to update secrets index: {e}")))?;
+
         let secret_set: HashSet<SecretKey> = current.into_iter().collect();
         self.key_to_secret_part.insert(delegate.clone(), secret_set);
 
@@ -392,7 +427,12 @@ mod test {
 
         store.store_secret(delegate.key(), &secret_id, b"v1".to_vec())?;
         // Sleep 2ms to guarantee a distinct epoch-millis stamp on the snapshot.
-        std::thread::sleep(Duration::from_millis(2));
+        // Sleep enough to guarantee a distinct epoch-millis stamp on the
+        // snapshot even on virtualized CI runners with coarse clocks.
+        // A test that lands two writes in the same millisecond would
+        // exercise the collision-suffix branch instead, which has its own
+        // test in the secret_snapshots module.
+        std::thread::sleep(Duration::from_millis(5));
         store.store_secret(delegate.key(), &secret_id, b"v2".to_vec())?;
 
         // Active value is the latest write.
@@ -458,7 +498,12 @@ mod test {
             store.store_secret(delegate.key(), &secret_id, i.to_le_bytes().to_vec())?;
             // Force distinct epoch-millis stamps so the snapshot files don't
             // collide and the count actually reflects the policy.
-            std::thread::sleep(Duration::from_millis(2));
+            // Sleep enough to guarantee a distinct epoch-millis stamp on the
+            // snapshot even on virtualized CI runners with coarse clocks.
+            // A test that lands two writes in the same millisecond would
+            // exercise the collision-suffix branch instead, which has its own
+            // test in the secret_snapshots module.
+            std::thread::sleep(Duration::from_millis(5));
         }
 
         let snap_dir = secrets_dir
@@ -494,7 +539,12 @@ mod test {
         let secret_id = SecretsId::new(vec![9]);
 
         store.store_secret(delegate.key(), &secret_id, b"a".to_vec())?;
-        std::thread::sleep(Duration::from_millis(2));
+        // Sleep enough to guarantee a distinct epoch-millis stamp on the
+        // snapshot even on virtualized CI runners with coarse clocks.
+        // A test that lands two writes in the same millisecond would
+        // exercise the collision-suffix branch instead, which has its own
+        // test in the secret_snapshots module.
+        std::thread::sleep(Duration::from_millis(5));
         store.store_secret(delegate.key(), &secret_id, b"b".to_vec())?;
 
         // Pre-conditions: index has the key, snapshot dir is populated.
@@ -571,6 +621,102 @@ mod test {
             .expect("index lookup")
             .unwrap_or_default();
         assert!(post_index.is_empty());
+        Ok(())
+    }
+
+    /// Disabling snapshots via `set_snapshots_enabled(false)` must skip
+    /// both the snapshot-on-write and the post-write thinning paths so
+    /// no `.snapshots/` directory is ever created.
+    #[tokio::test]
+    async fn disabled_flag_suppresses_snapshots() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+        store.set_snapshots_enabled(false);
+
+        let delegate = Delegate::from((&vec![6].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![14]);
+
+        store.store_secret(delegate.key(), &secret_id, b"a".to_vec())?;
+        std::thread::sleep(Duration::from_millis(5));
+        store.store_secret(delegate.key(), &secret_id, b"b".to_vec())?;
+
+        let snap_dir = secrets_dir
+            .join(delegate.key().encode())
+            .join(".snapshots")
+            .join(secret_id.encode());
+        assert!(
+            !snap_dir.exists(),
+            "no snapshot dir should be created when snapshots are disabled"
+        );
+        // Active path still holds the latest write.
+        assert_eq!(store.get_secret(delegate.key(), &secret_id)?, b"b".to_vec());
+        Ok(())
+    }
+
+    /// Two delegates using the same `SecretsId` must keep their snapshot
+    /// histories disjoint — pin that the snapshot dir is rooted at the
+    /// per-delegate path, not at `base_path`.
+    #[tokio::test]
+    async fn delegates_have_disjoint_snapshot_histories() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+
+        let delegate_a = Delegate::from((&vec![10].into(), &vec![].into()));
+        let delegate_b = Delegate::from((&vec![11].into(), &vec![].into()));
+        let (ca, na) = fresh_cipher();
+        let (cb, nb) = fresh_cipher();
+        store.register_delegate(delegate_a.key().clone(), ca, na)?;
+        store.register_delegate(delegate_b.key().clone(), cb, nb)?;
+        let shared_id = SecretsId::new(vec![99]);
+
+        // Two writes per delegate against the same SecretsId.
+        for value in [&b"a1"[..], &b"a2"[..]] {
+            store.store_secret(delegate_a.key(), &shared_id, value.to_vec())?;
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        for value in [&b"b1"[..], &b"b2"[..]] {
+            store.store_secret(delegate_b.key(), &shared_id, value.to_vec())?;
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        let snap_a = secrets_dir
+            .join(delegate_a.key().encode())
+            .join(".snapshots")
+            .join(shared_id.encode());
+        let snap_b = secrets_dir
+            .join(delegate_b.key().encode())
+            .join(".snapshots")
+            .join(shared_id.encode());
+        assert!(
+            snap_a != snap_b,
+            "snapshot dirs must differ across delegates"
+        );
+        assert!(snap_a.exists() && snap_b.exists());
+
+        // Each delegate has exactly one snapshot (one prior overwrite each).
+        assert_eq!(std::fs::read_dir(&snap_a)?.count(), 1);
+        assert_eq!(std::fs::read_dir(&snap_b)?.count(), 1);
+
+        // And get_secret on each delegate returns its own most-recent value.
+        assert_eq!(
+            store.get_secret(delegate_a.key(), &shared_id)?,
+            b"a2".to_vec()
+        );
+        assert_eq!(
+            store.get_secret(delegate_b.key(), &shared_id)?,
+            b"b2".to_vec()
+        );
         Ok(())
     }
 

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -220,8 +220,14 @@ impl SecretsStore {
         // path still holds the old value (or is empty if it never existed)
         // and the new ciphertext sits in the tmp file for forensics.
         if let Err(err) = fs::rename(&tmp_path, &secret_file_path) {
-            // Best effort cleanup of the tmp file so we don't leave debris.
-            let _ = fs::remove_file(&tmp_path);
+            // Best-effort cleanup of the tmp file so we don't leave debris.
+            // A failure here is purely cosmetic; log and continue with the
+            // primary error from rename().
+            if let Err(rm_err) = fs::remove_file(&tmp_path) {
+                tracing::debug!(
+                    "failed to clean up tmp file {tmp_path:?} after rename failure: {rm_err}"
+                );
+            }
             return Err(err.into());
         }
 

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -487,6 +487,7 @@ mod test {
                 interval: Duration::from_secs(60),
                 max_count: 1,
             }],
+            max_age: None,
         });
 
         let delegate = Delegate::from((&vec![2].into(), &vec![].into()));


### PR DESCRIPTION
## Problem

Delegate secrets had no defense against accidental overwrite or buggy delegate updates:

- `store_secret` was last-write-wins with no history. A delegate that corrupted its own state had no recovery path; not even moments-ago data could be retrieved.
- `remove_secret` had a real bug: it deleted the ciphertext file but left the ReDb `secrets_index` and the in-memory `key_to_secret_part` map pointing at the now-missing path. After removal, an index lookup would still claim the secret existed, while `get_secret` would return file-not-found. Stale entries accumulated forever and survived restarts.

These both showed up in a code review of how delegates store data and secrets (request from Ian, 2026-05-04). Issue #3050 covers the broader "vault delegate" multi-device sync design — this PR is the local-only durability slice that makes sense to ship without waiting on that design.

## Solution

**Snapshot-on-write (default-on).** Before each `store_secret` overwrites an existing file, the prior ciphertext is renamed to `{delegate_dir}/.snapshots/{secret_id}/{epoch_ms:020}`. After the new write lands, the snapshot directory is thinned per a tiered retention policy:

- Always keep the last 5 snapshots
- Plus one per minute for the last 10 minutes
- Plus one per hour for the last 24 hours
- Plus one per day for the last week
- Plus one per week for the last 4 weeks
- Plus one per month for the last 12 months

Steady-state worst case ~62 snapshots per secret; under burst churn the policy collapses everything in the same slot to one entry. Rename (not hard-link) so `File::create`'s truncate-in-place cannot corrupt the snapshot inode. Snapshots inherit the delegate's cipher; without the cipher key the bytes are useless. Best-effort: I/O failures during snapshot or thinning never block the primary write — they just log. `FREENET_DISABLE_SECRET_SNAPSHOTS` env override exists for ops who explicitly want the previous behavior.

**`remove_secret` fix.** Now updates the ReDb index, the in-memory map, and removes the snapshot history. The integration test (`remove_secret_clears_index_and_snapshots`) was verified against the original buggy body — it fails with `ReDb index still contains removed secret hash`, confirming the regression coverage is real.

The two changes are in one PR because the `remove_secret` regression test asserts on snapshot deletion as part of its post-conditions, so they can't land independently without test churn.

## Testing

**7 unit tests** for the retention algorithm in `secret_snapshots.rs` cover empty input, last-N-unconditional retention, dense-history thinning to the expected slot count, burst-in-single-slot collapse, default-policy steady-state cap (525,600 minute-snapshots → ≤70 retained), future timestamps treated as age-zero, and zero-count buckets being inert.

**6 integration tests** in `secrets_store.rs` against a real on-disk `SecretsStore`:

- `second_write_snapshots_prior_value` — second `store_secret` produces exactly one snapshot whose ciphertext decrypts back to the prior plaintext.
- `burst_writes_are_thinned` — 50 rapid writes under a tight policy land in ≤4 snapshots.
- `remove_secret_clears_index_and_snapshots` — verifies ReDb index cleared, in-memory map cleared, snapshot dir gone, `get_secret` returns `MissingSecret`. **Confirmed to fail on the original buggy `remove_secret` body.**
- `remove_nonexistent_secret_is_noop` — boundary case.
- `first_write_creates_no_snapshot` — boundary case.
- `store_and_load` — pre-existing happy-path test, still passes.

`cargo fmt` clean. No new clippy warnings introduced (pre-existing warnings in `tracing.rs` and `simulation_integration.rs` are untouched). Full lib suite: 2546 passed, 0 failed.

## Out of scope (follow-ups)

- `fdev delegate export`/`import` CLI for off-device backups (requires archive format design and cipher handling — separate PR).
- Manual rewording on freenet.org/build/manual/components/delegates/ around the "act as backups and replicas" claim until #3050 ships (lives in the `web/` repo).
- Restore-from-snapshot CLI / API. Snapshots are preserved; user-facing recovery is currently manual file move.

[AI-assisted - Claude]