### PR TITLE
refactor(node): add SendNetMessage event for raw outbound sends (#1454 phase 2c prep)

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -671,6 +671,24 @@ pub(crate) enum NodeEvent {
         target: SocketAddr,
         message: InterestMessage,
     },
+    /// Send an arbitrary `NetMessage` to a specific peer without registering
+    /// a `pending_op_results` callback.
+    ///
+    /// Use case (#1454 phase 2c): the CONNECT task-per-tx originator driver
+    /// holds an active multi-reply receiver for its transaction. When the
+    /// joiner's hole-punch to an acceptor fails, it must emit
+    /// `ConnectMsg::ConnectFailed` upstream so the relay chain can re-route.
+    /// Routing that emission through `op_execution_sender`
+    /// (`OpCtx::send_fire_and_forget` or similar) would overwrite the
+    /// existing `pending_op_results` slot for the same tx, tearing down
+    /// the multi-reply receiver. This event delivers the message via
+    /// `ConnEvent::OutboundMessageWithTarget` without touching
+    /// `pending_op_results`.
+    #[allow(dead_code)] // Wired by #1454 phase 2c slice 2 (CONNECT originator driver).
+    SendNetMessage {
+        target: SocketAddr,
+        msg: Box<NetMessage>,
+    },
     /// Broadcast state change to interested network peers.
     /// Emitted by executor when local state changes.
     /// Handled by p2p_protoc which has access to OpManager and network.
@@ -805,6 +823,9 @@ impl Display for NodeEvent {
                     }
                 };
                 write!(f, "SendInterestMessage (to: {target}, {msg_summary})")
+            }
+            NodeEvent::SendNetMessage { target, msg } => {
+                write!(f, "SendNetMessage (to: {target}, tx: {})", msg.id())
             }
             NodeEvent::BroadcastStateChange { key, .. } => {
                 write!(f, "BroadcastStateChange (contract: {key})")
@@ -1145,6 +1166,40 @@ mod tests {
         assert!(
             display.contains("ChangeInterests(+2 -1 hashes)"),
             "{display}"
+        );
+    }
+
+    #[test]
+    fn test_send_net_message_display_includes_target_and_tx() {
+        use std::net::SocketAddr;
+
+        use crate::message::{NetMessageV1, Transaction};
+        use crate::operations::connect::ConnectMsg;
+
+        let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+        let tx = Transaction::new::<ConnectMsg>();
+        let net_msg = NetMessage::V1(NetMessageV1::Connect(ConnectMsg::ConnectFailed {
+            id: tx,
+            failed_acceptor_addr: "10.0.0.1:1000".parse().unwrap(),
+        }));
+
+        let event = NodeEvent::SendNetMessage {
+            target: addr,
+            msg: Box::new(net_msg),
+        };
+
+        let display = format!("{event}");
+        assert!(
+            display.contains("SendNetMessage"),
+            "should name event: {display}"
+        );
+        assert!(
+            display.contains("127.0.0.1:9000"),
+            "should include target: {display}"
+        );
+        assert!(
+            display.contains(&tx.to_string()),
+            "should include tx id: {display}"
         );
     }
 }

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -2147,6 +2147,9 @@ impl P2pConnManager {
                             NodeEvent::SendInterestMessage { target, message } => {
                                 ctx.handle_send_interest_message(target, message).await;
                             }
+                            NodeEvent::SendNetMessage { target, msg } => {
+                                ctx.handle_send_net_message(target, *msg).await;
+                            }
                             NodeEvent::Disconnect { cause } => {
                                 tracing::info!(
                                     cause = ?cause,
@@ -4114,6 +4117,34 @@ impl P2pConnManager {
                 peer_addr = %target,
                 error = %e,
                 "Failed to send interest message to peer"
+            );
+        }
+    }
+
+    /// Send an arbitrary `NetMessage` to a target peer without registering
+    /// a `pending_op_results` callback for the message's transaction.
+    ///
+    /// Mirrors `handle_send_interest_message` but accepts a fully-formed
+    /// `NetMessage`. Introduced for #1454 phase 2c (CONNECT originator
+    /// task-per-tx driver) so the joiner can emit `ConnectFailed` upstream
+    /// without disturbing its own multi-reply receiver slot.
+    #[allow(dead_code)] // Reachable only via NodeEvent::SendNetMessage which is dormant until slice 2.
+    async fn handle_send_net_message(
+        &mut self,
+        target: SocketAddr,
+        msg: crate::message::NetMessage,
+    ) {
+        tracing::debug!(
+            target = %target,
+            tx = %msg.id(),
+            "Sending net message to peer"
+        );
+
+        if let Err(e) = self.bridge.send(target, msg).await {
+            tracing::warn!(
+                peer_addr = %target,
+                error = %e,
+                "Failed to send net message to peer"
             );
         }
     }


### PR DESCRIPTION
## Problem

The CONNECT phase 2c originator task-per-tx driver (slice 2, coming
next) needs to emit `ConnectMsg::ConnectFailed` upstream when its
hole-punch to an acceptor fails, so the relay chain can re-route to
a different acceptor.

The driver holds an active multi-reply receiver registered in
`p2p_protoc::pending_op_results` for the CONNECT transaction (via the
`OpCtx::send_to_and_collect_replies` primitive landed in slice 0,
PR #4038). Routing the ConnectFailed emission through any path that
calls `op_execution_sender.send` would invoke
`pending_op_results.insert(tx, callback)` a second time for the same
tx, **replacing** — and therefore tearing down — the live multi-reply
receiver.

There is no existing event that delivers an arbitrary `NetMessage` to
a specific peer without touching `pending_op_results`. The closest
neighbours all either fan-out (`BroadcastStateChange`) or are
type-restricted (`SendInterestMessage` only takes `InterestMessage`,
not `NetMessage`).

## Solution

Add `NodeEvent::SendNetMessage { target, msg: Box<NetMessage> }` and a
paired `P2pListener::handle_send_net_message` handler. Mirrors the
existing `SendInterestMessage` pattern but accepts a fully-formed
`NetMessage`. Delivers via
`P2pBridge::send` -> `P2pBridgeEvent::Message` ->
`ConnEvent::OutboundMessageWithTarget`, bypassing
`pending_op_results` entirely so the originator's reply slot stays
intact.

## Scope

Variant + handler are dormant in this PR (no callers). Both are
annotated `#[allow(dead_code)]`; both attributes are removed when
slice 2 wires the production call site.

## Testing

One new unit test
(`message::tests::test_send_net_message_display_includes_target_and_tx`)
asserts the Display formatter renders the target address and the
transaction id, matching the compactness rules followed by the
existing `SendInterestMessage` Display test.

Local checks:
- `cargo fmt`
- `cargo clippy -p freenet -- -D warnings`
- `cargo test -p freenet --lib` (2540 passed, 16 ignored)

## Fixes

Refs #1454 (phase 2c prep — does not close)