### PR TITLE
feat: mirror freenet-core HEAD to Freenet-hosted demo repo

### DIFF
--- a/.github/workflows/mirror-to-freenet.yml
+++ b/.github/workflows/mirror-to-freenet.yml
@@ -20,8 +20,16 @@ on:
 
 jobs:
   mirror:
-    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@main
+    # Pinned to the merge SHA of freenet-git#17 rather than `@main`.
+    # `secrets: inherit` would pass every secret in this repo (Apple
+    # notarization keys, Claude OAuth, OpenAI key, Matrix tokens,
+    # River signing key) into whatever happens to be on freenet-git's
+    # main, so an unpinned ref + inherit is a textbook supply-chain
+    # pivot. Bump the SHA when the reusable workflow is rev'd.
+    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@362e547c7035d28968651d2f4106fbfa891c31e2
     with:
       freenet_repo: "3GEERif5ihbf/freenet-core"
       mode: snapshot
-    secrets: inherit
+    secrets:
+      FREENET_GIT_IDENTITY_BUNDLE_BASE64: ${{ secrets.FREENET_GIT_IDENTITY_BUNDLE_BASE64 }}
+      FREENET_GIT_WS_URL: ${{ secrets.FREENET_GIT_WS_URL }}

--- a/.github/workflows/mirror-to-freenet.yml
+++ b/.github/workflows/mirror-to-freenet.yml
@@ -1,0 +1,27 @@
+name: Mirror to Freenet
+
+# Pushes the latest freenet-core HEAD to the Freenet-hosted demo repo
+# at `freenet:3GEERif5ihbf/freenet-core` whenever main moves.
+#
+# Mode is `snapshot` because freenet-core's full git history (~176 MiB)
+# does not fit in the repo contract; the demo carries the source tree
+# at HEAD only, as a single orphan commit. The reusable workflow lives
+# in freenet/freenet-git -- see its header comment for details on how
+# to set up the identity bundle and gateway WS URL secrets.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    # Daily safety net in case a push trigger was missed (e.g. a force
+    # push to main that GitHub coalesced). 11:42 UTC = mid-morning US.
+    - cron: "42 11 * * *"
+
+jobs:
+  mirror:
+    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@main
+    with:
+      freenet_repo: "3GEERif5ihbf/freenet-core"
+      mode: snapshot
+    secrets: inherit

--- a/.github/workflows/mirror-to-freenet.yml
+++ b/.github/workflows/mirror-to-freenet.yml
@@ -26,7 +26,7 @@ jobs:
     # River signing key) into whatever happens to be on freenet-git's
     # main, so an unpinned ref + inherit is a textbook supply-chain
     # pivot. Bump the SHA when the reusable workflow is rev'd.
-    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@362e547c7035d28968651d2f4106fbfa891c31e2
+    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@4a4ab090c5591473f579ce2d1b626aba7b3a8ba3
     with:
       freenet_repo: "3GEERif5ihbf/freenet-core"
       mode: snapshot


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/mirror-to-freenet.yml` which calls the reusable workflow at `freenet/freenet-git/.github/workflows/mirror-repo.yml` (merged in [freenet-git#17](https://github.com/freenet/freenet-git/pull/17)).
- Triggers: push to main, workflow_dispatch, daily cron (11:42 UTC) as a safety net for missed pushes.
- Mode is `snapshot` because freenet-core's git history (~176 MiB) is larger than what the repo contract can hold. Each run rebuilds the demo as a single orphan commit of HEAD's tracked tree -- consumers get current source, no history.

## Demo URL

`freenet:3GEERif5ihbf/freenet-core` (replaces the old `AaRxPZVdWrPh` demo, which was created from a passphrase-encrypted bundle that doesn't fit a CI workflow).

## Required secrets (already configured on this repo)

- `FREENET_GIT_IDENTITY_BUNDLE_BASE64` — base64 of the no-passphrase bundle that owns the new prefix.
- `FREENET_GIT_WS_URL` — same value as `RIVER_GATEWAY_URL`.

## Test plan

- [x] Reusable workflow merged on the freenet-git side ([#17](https://github.com/freenet/freenet-git/pull/17)).
- [x] Initial state for `3GEERif5ihbf/freenet-core` already published manually (clonable today via `git clone freenet::3GEERif5ihbf/freenet-core`).
- [x] Rescue workflow on the freenet-git side smoke-tested — green in 3m45s against the live demo URLs.
- [ ] After merge: confirm a push to main triggers the workflow and produces a fresh snapshot. The first run will overwrite the manually-published initial state.

[AI-assisted - Claude]