### PR TITLE
refactor(ops): connect relay scaffolding (#1454 phase 2c slice 1 commit 1)

### DIFF
--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -208,6 +208,19 @@ pub(crate) struct OpManager {
     /// gate rejects duplicate inbound `SubscribeMsg::Request` for a tx
     /// that already has a live relay driver.
     pub(crate) active_relay_subscribe_txs: Arc<DashSet<Transaction>>,
+    /// Set of transactions currently being driven by a relay CONNECT
+    /// task-per-tx driver on this node. Same role as
+    /// `active_relay_get_txs` but for CONNECT relay (#1454 phase 2c
+    /// slice 1). The dedup gate rejects duplicate inbound
+    /// `ConnectMsg::Request` for a tx that already has a live relay
+    /// driver — prevents bloom-filter rekey re-entries and
+    /// uphill-retry false-positive retransmissions from spawning
+    /// redundant drivers. Phase 2c slice 1 covers the
+    /// Request→Response forward path; Rejected within-relay retries
+    /// and ConnectFailed downstream propagation stay on legacy
+    /// `process_message`, gated by the dedup set's absence on those
+    /// branches.
+    pub(crate) active_relay_connect_txs: Arc<DashSet<Transaction>>,
 }
 
 impl Clone for OpManager {
@@ -238,6 +251,7 @@ impl Clone for OpManager {
             active_relay_update_txs: self.active_relay_update_txs.clone(),
             active_relay_put_txs: self.active_relay_put_txs.clone(),
             active_relay_subscribe_txs: self.active_relay_subscribe_txs.clone(),
+            active_relay_connect_txs: self.active_relay_connect_txs.clone(),
         }
     }
 }
@@ -281,6 +295,7 @@ impl OpManager {
         let active_relay_update_txs: Arc<DashSet<Transaction>> = Arc::new(DashSet::new());
         let active_relay_put_txs: Arc<DashSet<Transaction>> = Arc::new(DashSet::new());
         let active_relay_subscribe_txs: Arc<DashSet<Transaction>> = Arc::new(DashSet::new());
+        let active_relay_connect_txs: Arc<DashSet<Transaction>> = Arc::new(DashSet::new());
 
         task_monitor.register(
             "garbage_cleanup",
@@ -301,6 +316,7 @@ impl OpManager {
                     active_relay_update_txs.clone(),
                     active_relay_put_txs.clone(),
                     active_relay_subscribe_txs.clone(),
+                    active_relay_connect_txs.clone(),
                 )
                 .instrument(garbage_span),
             ),
@@ -372,6 +388,7 @@ impl OpManager {
             active_relay_update_txs,
             active_relay_put_txs,
             active_relay_subscribe_txs,
+            active_relay_connect_txs,
         })
     }
 
@@ -915,6 +932,25 @@ impl OpManager {
     /// path).
     pub fn has_subscribe_op(&self, id: &Transaction) -> bool {
         self.ops.subscribe.contains_key(id)
+    }
+
+    /// Returns `true` if a `ConnectOp` is currently registered for this
+    /// transaction in `OpManager.ops.connect`.
+    ///
+    /// Same role as `has_get_op` but for the relay CONNECT dispatch
+    /// gate (#1454 phase 2c slice 1). Used by `node.rs` to distinguish
+    /// a fresh inbound relay CONNECT Request (no existing op → spawn
+    /// the task-per-tx driver) from a within-relay Rejected retry, a
+    /// ConnectFailed downstream re-route, or any other re-entry that
+    /// already has a `ConnectOp` from a prior `process_message` call
+    /// (existing op → fall through to the legacy `handle_op_request`
+    /// path).
+    ///
+    /// `#[allow(dead_code)]` because the dispatch site lands in slice 1
+    /// commit 2; this commit only adds the scaffolding.
+    #[allow(dead_code)]
+    pub fn has_connect_op(&self, id: &Transaction) -> bool {
+        self.ops.connect.contains_key(id)
     }
 
     pub fn completed(&self, id: Transaction) {
@@ -1471,6 +1507,7 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
     active_relay_update_txs: Arc<DashSet<Transaction>>,
     active_relay_put_txs: Arc<DashSet<Transaction>>,
     active_relay_subscribe_txs: Arc<DashSet<Transaction>>,
+    active_relay_connect_txs: Arc<DashSet<Transaction>>,
 ) {
     const CLEANUP_INTERVAL: Duration = Duration::from_secs(5);
     /// How often to clean up stale contract_waiters entries (every N ticks).
@@ -1553,6 +1590,7 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                         crate::operations::subscribe::op_ctx_task::RELAY_SUBSCRIBE_DEDUP_REJECTS
                             .load(Ordering::Relaxed);
                     let relay_subscribe_active_txs = active_relay_subscribe_txs.len();
+                    let relay_connect_active_txs = active_relay_connect_txs.len();
                     tracing::info!(
                         target: "memory_stats",
                         tick = tick_count,
@@ -1585,6 +1623,7 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                         relay_subscribe_completed = relay_subscribe_completed,
                         relay_subscribe_dedup_rejects = relay_subscribe_dedup_rejects,
                         relay_subscribe_active_txs = relay_subscribe_active_txs,
+                        relay_connect_active_txs = relay_connect_active_txs,
                         "memory stats"
                     );
                 }

--- a/crates/core/src/operations/connect/op_ctx_task.rs
+++ b/crates/core/src/operations/connect/op_ctx_task.rs
@@ -44,6 +44,72 @@ use crate::tracing::NetEventLog;
 
 use super::{ConnectMsg, ConnectOp};
 
+// ─── Relay CONNECT scaffolding (#1454 phase 2c slice 1, commit 1) ───
+//
+// Counters and RAII guard for the upcoming `start_relay_connect`
+// driver. Unused by this commit; the driver body and dispatch site
+// land in slice 1 commit 2. Defined now so the counter symbols are
+// stable across commits and the scaffolding lands as a single
+// reviewable unit before the larger semantic change.
+
+/// Test-only counter incremented every time a relay-CONNECT driver is
+/// spawned. Used by test_relay_driver_calls_per_op-style guards to
+/// confirm the dispatch site actually routed a fresh inbound Request
+/// through the task-per-tx driver vs. the legacy
+/// `handle_op_request` path.
+#[cfg(any(test, feature = "testing"))]
+#[allow(dead_code)]
+pub static RELAY_CONNECT_DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Number of relay-CONNECT driver tasks currently executing.
+/// Incremented on spawn, decremented on completion.
+#[allow(dead_code)]
+pub static RELAY_CONNECT_INFLIGHT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Lifetime count of relay-CONNECT driver spawns. Paired with
+/// `RELAY_CONNECT_COMPLETED_TOTAL`.
+#[allow(dead_code)]
+pub static RELAY_CONNECT_SPAWNED_TOTAL: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Lifetime count of relay-CONNECT driver completions.
+#[allow(dead_code)]
+pub static RELAY_CONNECT_COMPLETED_TOTAL: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Lifetime count of relay-CONNECT spawns rejected by the dedup gate
+/// because a driver for the same `incoming_tx` was already active on
+/// this node.
+#[allow(dead_code)]
+pub static RELAY_CONNECT_DEDUP_REJECTS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// RAII guard that decrements `RELAY_CONNECT_INFLIGHT`, bumps
+/// `RELAY_CONNECT_COMPLETED_TOTAL`, and removes the driver's
+/// `incoming_tx` from `active_relay_connect_txs` on drop. Mirrors
+/// `RelaySubscribeInflightGuard` / `RelayInflightGuard` patterns for
+/// the other relay drivers.
+///
+/// Defined now (slice 1 commit 1) so the lifecycle is locked even
+/// before `start_relay_connect` lands in commit 2.
+#[allow(dead_code)]
+pub(crate) struct RelayConnectInflightGuard {
+    pub(crate) op_manager: std::sync::Arc<OpManager>,
+    pub(crate) incoming_tx: Transaction,
+}
+
+impl Drop for RelayConnectInflightGuard {
+    fn drop(&mut self) {
+        self.op_manager
+            .active_relay_connect_txs
+            .remove(&self.incoming_tx);
+        RELAY_CONNECT_INFLIGHT.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        RELAY_CONNECT_COMPLETED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
 /// Drive a client-initiated CONNECT to completion.
 ///
 /// Replaces the legacy `send_gateway_connect` + `process_message`


### PR DESCRIPTION
## Problem

Phase 2c slice 1 (CONNECT relay migration) is the largest remaining
slice of #1454. Splitting it lets reviewers verify the
field/counter/RAII scaffolding in isolation before the larger
dispatch + driver change in commit 2.

## What's in this PR

Pure additions, no semantic change:

- `OpManager.active_relay_connect_txs: Arc<DashSet<Transaction>>` —
  per-node dedup gate (mirrors `active_relay_{get,update,put,subscribe}_txs`).
- `OpManager::has_connect_op(id)` — predicate the eventual dispatch
  gate uses to distinguish a fresh inbound Request (no `ConnectOp`
  in `ops.connect` → spawn driver) from a within-relay Rejected
  retry / ConnectFailed re-route (existing op → fall through to
  legacy).
- `RELAY_CONNECT_*` counters (`INFLIGHT`, `SPAWNED_TOTAL`,
  `COMPLETED_TOTAL`, `DEDUP_REJECTS`, test-only `DRIVER_CALL_COUNT`).
- `RelayConnectInflightGuard` RAII type — Drop decrements
  `INFLIGHT`, bumps `COMPLETED_TOTAL`, removes from
  `active_relay_connect_txs`.

The new `active_relay_connect_txs` field is plumbed into
`garbage_cleanup_task`'s signature and surfaced in the periodic
`memory_stats` dump alongside the other relay-active-tx counts.

## Out of scope

Driver body (`start_relay_connect`) and dispatch wiring at
`node.rs::handle_pure_network_message_v1` land in slice 1 commit 2.

## Scope per the phase 2c plan

Per the slicing decision in https://github.com/freenet/freenet-core/issues/1454
(comment 2026-05-05) and confirmed at PR-time, slice 1 covers the
**Request → Response forward path only**. Within-relay Rejected
retries and ConnectFailed downstream propagation stay on legacy
`process_message`, gated by `has_connect_op` returning true on those
re-entry paths.

## Testing

- `cargo fmt`
- `cargo clippy -p freenet --lib -- -D warnings -D clippy::wildcard_enum_match_arm`
- `cargo test -p freenet --lib` (2550 pass, 16 ignored)

## Fixes

Phase 2c slice 1 commit 1 of #1454.