### PR TITLE
fix: bump mirror pin to include snapshot-fetch fix

### DIFF
--- a/.github/workflows/mirror-to-freenet.yml
+++ b/.github/workflows/mirror-to-freenet.yml
@@ -40,7 +40,7 @@ jobs:
     # under this caller's secrets. Acceptable today because we control
     # crates.io publishing for that crate; if that changes, override
     # `freenet_git_version` here with a pinned semver.
-    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@4a4ab090c5591473f579ce2d1b626aba7b3a8ba3
+    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@868c0724f2fbf4ef320d985fe72fe51501d7e7ed
     with:
       freenet_repo: "3GEERif5ihbf/freenet-core"
       mode: snapshot


### PR DESCRIPTION
## Problem

The five most recent `Mirror to Freenet` runs against this repo have all failed with:

\`\`\`
fatal: bad object a6afd44c68bad8bd12ecb91479dbdad9d25a06fc
 ! [remote rejected] main -> main (git rev-list failed: exit status: 128)
\`\`\`

Root cause was in the reusable workflow at the previously-pinned SHA: in snapshot mode the fresh orphan commit's local repo has no ancestor objects in common with the receiver's tip, so the helper's `git rev-list ^<remote-tip> <new-tip>` bails.

## Solution

freenet/freenet-git#20 (already merged) added `git fetch freenet "\$BRANCH"` before the push so the remote tip is pulled into local objects. This PR bumps our pinned SHA to that fix.

## Testing

Underlying fix verified end-to-end locally before merging freenet-git#20. Demo `freenet:3GEERif5ihbf/freenet-core` was re-published manually to `b2a8836` while diagnosing — fresh `git clone` against the live gateway returns 523 files. Next push to main after this lands will exercise the fixed workflow against the established tip.

## Fixes

Unblocks `Mirror to Freenet` workflow on this repo.

[AI-assisted - Claude]