### PR TITLE
chore: bump mirror pin to drop now-redundant git-fetch workaround

### DIFF
--- a/.github/workflows/mirror-to-freenet.yml
+++ b/.github/workflows/mirror-to-freenet.yml
@@ -40,7 +40,7 @@ jobs:
     # under this caller's secrets. Acceptable today because we control
     # crates.io publishing for that crate; if that changes, override
     # `freenet_git_version` here with a pinned semver.
-    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@4a4ab090c5591473f579ce2d1b626aba7b3a8ba3
+    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@41d69feaa48c345ba1c5d95881d5ca897824b784
     with:
       freenet_repo: "3GEERif5ihbf/freenet-core"
       mode: snapshot


### PR DESCRIPTION
## Problem

The previously-pinned reusable workflow at SHA \`4a4ab09\` carried a \`git fetch freenet \"\$BRANCH\"\` workaround for the \`fatal: bad object\` failure in snapshot mode. That bug was fixed properly at the helper level in freenet-git 0.1.14 (PR #26 / issue #21), and freenet-git PR #27 dropped the workaround from the reusable workflow.

## Solution

Bump the SHA from \`4a4ab09\` to \`41d69fe\` (the merge commit of PR #27) so this repo's mirror runs against the cleaner reusable workflow. \`cargo install freenet-git --locked\` (default \`latest\`) currently resolves to 0.1.14.

The behavior change: every snapshot mirror run now skips a redundant ~2.7 MiB fetch before each push.

## Testing

- Workflow YAML parses unchanged besides the SHA.
- Helper fix verified end-to-end against the live demo URL during PR #26 testing.

[AI-assisted - Claude]