### PR TITLE
chore: bump mirror pin to a93179, add Matrix failure alerts

### DIFF
--- a/.github/workflows/mirror-to-freenet.yml
+++ b/.github/workflows/mirror-to-freenet.yml
@@ -40,10 +40,15 @@ jobs:
     # under this caller's secrets. Acceptable today because we control
     # crates.io publishing for that crate; if that changes, override
     # `freenet_git_version` here with a pinned semver.
-    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@41d69feaa48c345ba1c5d95881d5ca897824b784
+    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@a93179077a4175ac4de324fc37fe57a3679f6bc8
     with:
       freenet_repo: "3GEERif5ihbf/freenet-core"
       mode: snapshot
     secrets:
       FREENET_GIT_IDENTITY_BUNDLE_BASE64: ${{ secrets.FREENET_GIT_IDENTITY_BUNDLE_BASE64 }}
       FREENET_GIT_WS_URL: ${{ secrets.FREENET_GIT_WS_URL }}
+      # Optional in the reusable workflow; passed through here so a
+      # mirror failure pings the team Matrix room instead of going
+      # silent. Both are org-level secrets at freenet.
+      MATRIX_ACCESS_TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+      MATRIX_ROOM_ID: ${{ secrets.MATRIX_ROOM_ID }}


### PR DESCRIPTION
## Problem

This repo's mirror workflow has no failure visibility beyond GitHub email-on-failure-to-author. When five consecutive push-triggered runs failed on 2026-05-07 nobody noticed for hours.

freenet-git PR #28 added Matrix failure alerts to the reusable mirror workflow, gated on optional \`MATRIX_ACCESS_TOKEN\` / \`MATRIX_ROOM_ID\` pass-through. The current caller pin lacks that support; the explicit \`secrets:\` map also wouldn't pass the secrets even after a SHA bump alone.

## Solution

- Bump pinned SHA from \`4a4ab09\` to \`a93179\` (merge commit of freenet-git #28). This SHA bundles the helper bug fix (#26), the workaround removal (#27), and the Matrix alert (#28).
- Add \`MATRIX_ACCESS_TOKEN\` and \`MATRIX_ROOM_ID\` to the explicit \`secrets:\` pass-through. Both are org-level secrets at freenet, already populated for this repo.

After merge, a failed mirror run posts to the team Matrix room with a link to the failed run.

## Testing

YAML parses unchanged structurally. Observe on next genuine failure.

## Fixes

Caller-side completion of freenet-git #23.

[AI-assisted - Claude]