### PR TITLE
fix(runtime): persist delegate ctx.write across process() calls

### DIFF
--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -163,6 +163,8 @@ pub struct RuntimePool {
     shared_contract_modules: SharedModuleCache<ContractKey>,
     /// Shared compiled delegate module cache.
     shared_delegate_modules: SharedModuleCache<DelegateKey>,
+    /// Shared per-delegate `ctx.write()` cache (see `DelegateContextCache`).
+    shared_delegate_contexts: crate::wasm_runtime::DelegateContextCache,
     /// Shared backend engine used by all executors.
     ///
     /// All executors MUST share the same backend engine because compiled modules
@@ -226,6 +228,9 @@ impl RuntimePool {
             Arc::new(Mutex::new(LruCache::new(cache_capacity)));
         let shared_delegate_modules: SharedModuleCache<DelegateKey> =
             Arc::new(Mutex::new(LruCache::new(cache_capacity)));
+        // Shared delegate-context cache so a prompt round-trip routed to a
+        // different pool executor still finds its `ctx.write()` blob.
+        let shared_delegate_contexts = crate::wasm_runtime::new_delegate_context_cache();
 
         // Create shared recovery guard for corrupted-state self-healing.
         // All pool executors share this so recovery tracking is consistent.
@@ -243,6 +248,7 @@ impl RuntimePool {
             Some(op_manager.clone()),
             shared_contract_modules.clone(),
             shared_delegate_modules.clone(),
+            shared_delegate_contexts.clone(),
             None, // No shared backend yet — this executor creates the engine
         )
         .await?;
@@ -264,6 +270,7 @@ impl RuntimePool {
                 Some(op_manager.clone()),
                 shared_contract_modules.clone(),
                 shared_delegate_modules.clone(),
+                shared_delegate_contexts.clone(),
                 Some(shared_backend_engine.clone()),
             )
             .await?;
@@ -302,6 +309,7 @@ impl RuntimePool {
             shared_client_counts,
             shared_contract_modules,
             shared_delegate_modules,
+            shared_delegate_contexts,
             shared_backend_engine,
             shared_recovery_guard,
             delegate_notification_tx,
@@ -452,6 +460,7 @@ impl RuntimePool {
             Some(self.op_manager.clone()),
             self.shared_contract_modules.clone(),
             self.shared_delegate_modules.clone(),
+            self.shared_delegate_contexts.clone(),
             Some(self.shared_backend_engine.clone()),
         )
         .await?;
@@ -2597,6 +2606,10 @@ impl Executor<Runtime> {
     /// If `shared_backend` is `None`, a new backend engine is created (used for
     /// the first executor in a pool). If `Some`, the provided engine is shared
     /// (used for subsequent executors and replacements).
+    // Each parameter is a distinct shared resource the pool wires through
+    // explicitly; bundling them into a struct just to satisfy the lint
+    // would obscure which executor sees which cache.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn from_config_with_shared_modules(
         config: Arc<Config>,
         shared_state_store: StateStore<Storage>,
@@ -2604,6 +2617,7 @@ impl Executor<Runtime> {
         op_manager: Option<Arc<OpManager>>,
         contract_modules: SharedModuleCache<ContractKey>,
         delegate_modules: SharedModuleCache<DelegateKey>,
+        delegate_contexts: crate::wasm_runtime::DelegateContextCache,
         shared_backend: Option<BackendEngine>,
     ) -> anyhow::Result<Self> {
         let db = shared_state_store.storage();
@@ -2616,6 +2630,7 @@ impl Executor<Runtime> {
             false,
             contract_modules,
             delegate_modules,
+            delegate_contexts,
             shared_backend.unwrap_or_else(|| {
                 // First executor — create a fresh backend engine; RuntimePool
                 // will extract and share it with subsequent executors.

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -23,6 +23,7 @@ pub(crate) use error::{ContractError, RuntimeInnerError, RuntimeResult};
 pub use mock_state_storage::MockStateStorage;
 pub(crate) use native_api::{
     CREATED_DELEGATES_COUNT, DELEGATE_INHERITED_ORIGINS, DELEGATE_SUBSCRIPTIONS,
+    DelegateContextCache, new_delegate_context_cache,
 };
 pub use runtime::{ContractExecError, DEFAULT_MODULE_CACHE_CAPACITY, Runtime};
 pub(crate) use runtime::{RuntimeConfig, SharedModuleCache};

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -504,8 +504,21 @@ impl DelegateRuntimeInterface for Runtime {
             "Starting delegate execution"
         );
 
-        // State maintained across process() calls within this conversation
-        let mut context: Vec<u8> = Vec::new();
+        // Context state maintained across process() calls.
+        //
+        // `self.delegate_contexts` persists the delegate's `ctx.write()` bytes
+        // across separate `inbound_app_message` invocations so that, e.g., the
+        // bytes a delegate writes when emitting `RequestUserInput` are still
+        // readable via `ctx.read()` when the executor re-enters with the
+        // matching `UserResponse`. Without this, the delegate hits "received
+        // UserResponse with no pending context" because the Vec only used to
+        // live for one `inbound_app_message` call. See
+        // `native_api::DelegateContextCache`.
+        let mut context: Vec<u8> = self
+            .delegate_contexts
+            .get(delegate_key)
+            .map(|c| c.clone())
+            .unwrap_or_default();
 
         // Process all messages, collecting the result.
         // Cleanup happens after the loop regardless of success/failure.
@@ -674,6 +687,33 @@ impl DelegateRuntimeInterface for Runtime {
 
         process_result?;
 
+        // Persist the (possibly mutated) context so the next call into this
+        // delegate sees what `ctx.write()` left behind. Skip the insert when
+        // empty to keep the map sparse — `unwrap_or_default()` covers the
+        // unset case symmetrically on read.
+        //
+        // Drop contexts that exceed `DelegateContext::MAX_SIZE`: the wire
+        // format would assert on the next call when the runtime threads the
+        // bytes back through `DelegateContext::new(...)`. The `ctx.write()`
+        // host function has no size cap of its own, so a delegate with a
+        // bug — or one trying to wedge the runtime — can otherwise stash a
+        // value that would crash on the very next call. Treat oversize as
+        // "delegate misbehavior, forget it" rather than "crash the node."
+        if context.is_empty() {
+            self.delegate_contexts.remove(delegate_key);
+        } else if context.len() < freenet_stdlib::prelude::DelegateContext::MAX_SIZE {
+            self.delegate_contexts.insert(delegate_key.clone(), context);
+        } else {
+            tracing::warn!(
+                delegate_key = %delegate_key,
+                bytes = context.len(),
+                max = freenet_stdlib::prelude::DelegateContext::MAX_SIZE,
+                "Delegate ctx.write() exceeded DelegateContext::MAX_SIZE; \
+                 dropping the persisted context to avoid a crash on the next call"
+            );
+            self.delegate_contexts.remove(delegate_key);
+        }
+
         tracing::debug!(
             count = results.len(),
             "Final results returned by inbound_app_message"
@@ -696,6 +736,9 @@ impl DelegateRuntimeInterface for Runtime {
     #[inline]
     fn unregister_delegate(&mut self, key: &DelegateKey) -> RuntimeResult<()> {
         self.delegate_modules.lock().unwrap().pop(key);
+        // Drop persisted ctx.write() bytes so an unregistered delegate can't
+        // hold onto stale state if it's later re-registered.
+        self.delegate_contexts.remove(key);
         self.delegate_store.remove_delegate(key)
     }
 }
@@ -1400,8 +1443,21 @@ mod test {
         Ok(())
     }
 
+    /// Regression test for harvest cross-app share / ghostkey RequestAnyAccess
+    /// flow: a delegate's `ctx.write()` MUST survive across separate
+    /// `inbound_app_message` calls. The canonical use is a permission prompt
+    /// where call #1 emits `RequestUserInput` (and stores `PendingPrompt` via
+    /// `ctx.write`), and call #2 receives the user's `UserResponse` and
+    /// expects `ctx.read()` to return that pending blob.
+    ///
+    /// Before the fix in this PR, every `inbound_app_message` started with a
+    /// fresh empty context Vec, so the second call saw nothing and the
+    /// ghostkey delegate hit "received UserResponse with no pending context".
+    /// This test exercises the same failure shape via `IncrementCounter`,
+    /// which reads the counter from context, increments, and writes back: if
+    /// context is reset between calls, the counter stays stuck at 1.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_context_reset_between_calls() -> Result<(), Box<dyn std::error::Error>> {
+    async fn test_context_persists_between_calls() -> Result<(), Box<dyn std::error::Error>> {
         use delegate2_messages::{InboundAppMessage, OutboundAppMessage};
 
         let contract = WrappedContract::new(
@@ -1432,7 +1488,10 @@ mod test {
                 panic!("Expected ApplicationMessage")
             }
         };
-        assert!(matches!(response, OutboundAppMessage::CounterValue(1)));
+        assert!(
+            matches!(response, OutboundAppMessage::CounterValue(1)),
+            "first call: expected CounterValue(1), got {response:?}"
+        );
 
         let payload = bincode::serialize(&InboundAppMessage::IncrementCounter)?;
         let msg = ApplicationMessage::new(payload);
@@ -1455,7 +1514,21 @@ mod test {
                 panic!("Expected ApplicationMessage")
             }
         };
-        assert!(matches!(response, OutboundAppMessage::CounterValue(1)));
+        // Without context persistence this returns CounterValue(1) again
+        // because each call sees a fresh, empty context.
+        assert!(
+            matches!(response, OutboundAppMessage::CounterValue(2)),
+            "second call: expected CounterValue(2) (context persisted), got {response:?}"
+        );
+
+        // Unregister must clear the persisted context so a re-registered
+        // delegate with the same key starts from scratch.
+        let cache = runtime.delegate_contexts.clone();
+        runtime.unregister_delegate(delegate.key())?;
+        assert!(
+            !cache.contains_key(delegate.key()),
+            "unregister_delegate should clear delegate_contexts entry"
+        );
 
         std::mem::drop(temp_dir);
         Ok(())
@@ -2029,7 +2102,13 @@ mod test {
         let (delegate, mut runtime, temp_dir) = setup_runtime(TEST_DELEGATE_2).await?;
         let _app = ContractInstanceId::try_from(contract.key.to_string()).unwrap();
 
-        let large_size = 1024 * 1024;
+        // `DelegateContext::MAX_SIZE` caps the on-wire context size; pick the
+        // largest value that fits with a margin so the persisted bytes still
+        // round-trip through `DelegateContext::new(...)` on the next call.
+        // The pre-fix version of this test wrote 1 MiB, well past the cap;
+        // it only avoided the assertion because context didn't persist
+        // between calls (the bug this PR fixes).
+        let large_size = (freenet_stdlib::prelude::DelegateContext::MAX_SIZE / 2).min(256 * 1024);
 
         let payload = bincode::serialize(&InboundAppMessage::WriteLargeContext(large_size))?;
         let msg = ApplicationMessage::new(payload);
@@ -2093,7 +2172,15 @@ mod test {
         };
         match response {
             OutboundAppMessage::ContextData(data) => {
-                assert!(data.is_empty());
+                // Pre-fix this assertion expected `is_empty()` because the
+                // context was reset between calls. With persistence the
+                // bytes the delegate wrote on the previous call survive
+                // and the read on this call must return them.
+                assert_eq!(
+                    data.len(),
+                    large_size,
+                    "persisted context should round-trip the size the delegate wrote"
+                );
             }
             other @ OutboundAppMessage::CreateInboxResponse(_)
             | other @ OutboundAppMessage::MessageSigned(_)

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -9,7 +9,10 @@ use freenet_stdlib::prelude::{
 };
 
 use super::engine::{InstanceHandle, WasmEngine};
-use super::native_api::{CURRENT_DELEGATE_INSTANCE, DELEGATE_ENV, DelegateCallEnv, InstanceId};
+use super::native_api::{
+    self, CURRENT_DELEGATE_INSTANCE, DELEGATE_ENV, DelegateCallEnv, DelegateContextEntry,
+    InstanceId,
+};
 use super::{Runtime, RuntimeResult};
 use crate::wasm_runtime::delegate_api::DelegateApiVersion;
 
@@ -514,10 +517,15 @@ impl DelegateRuntimeInterface for Runtime {
         // UserResponse with no pending context" because the Vec only used to
         // live for one `inbound_app_message` call. See
         // `native_api::DelegateContextCache`.
+        //
+        // Amortised TTL sweep on every entry prevents the cache from holding
+        // bytes for prompts whose `UserResponse` never arrives (user
+        // dismisses, app crashes, network partition).
+        native_api::prune_expired_contexts(&self.delegate_contexts);
         let mut context: Vec<u8> = self
             .delegate_contexts
             .get(delegate_key)
-            .map(|c| c.clone())
+            .map(|entry| entry.bytes.clone())
             .unwrap_or_default();
 
         // Process all messages, collecting the result.
@@ -702,7 +710,13 @@ impl DelegateRuntimeInterface for Runtime {
         if context.is_empty() {
             self.delegate_contexts.remove(delegate_key);
         } else if context.len() < freenet_stdlib::prelude::DelegateContext::MAX_SIZE {
-            self.delegate_contexts.insert(delegate_key.clone(), context);
+            self.delegate_contexts.insert(
+                delegate_key.clone(),
+                DelegateContextEntry {
+                    bytes: context,
+                    last_write: tokio::time::Instant::now(),
+                },
+            );
         } else {
             tracing::warn!(
                 delegate_key = %delegate_key,
@@ -1528,6 +1542,142 @@ mod test {
         assert!(
             !cache.contains_key(delegate.key()),
             "unregister_delegate should clear delegate_contexts entry"
+        );
+
+        std::mem::drop(temp_dir);
+        Ok(())
+    }
+
+    /// Pin the oversize-context drop path: a delegate that writes a context
+    /// larger than `DelegateContext::MAX_SIZE` must NOT crash the runtime on
+    /// the subsequent call. The runtime drops the persisted bytes (with a
+    /// warn-level log) and the next call sees an empty context.
+    ///
+    /// Without this guard the next `inbound_app_message` would assert inside
+    /// `DelegateContext::new(...)` when threading the bytes back to the WASM
+    /// boundary, taking down the executor pool worker.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_context_oversize_is_dropped_not_crashed() -> Result<(), Box<dyn std::error::Error>>
+    {
+        use delegate2_messages::{InboundAppMessage, OutboundAppMessage};
+
+        let contract = WrappedContract::new(
+            Arc::new(ContractCode::from(vec![1])),
+            Parameters::from(vec![]),
+        );
+        let (delegate, mut runtime, temp_dir) = setup_runtime(TEST_DELEGATE_2).await?;
+        let _app = ContractInstanceId::try_from(contract.key.to_string()).unwrap();
+
+        // Write past MAX_SIZE — `ctx.write` host fn has no size cap of its
+        // own, so the WASM call itself succeeds even though the bytes won't
+        // fit in `DelegateContext`.
+        let oversize = freenet_stdlib::prelude::DelegateContext::MAX_SIZE + 1024;
+        let payload = bincode::serialize(&InboundAppMessage::WriteLargeContext(oversize))?;
+        let outbound = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            vec![InboundDelegateMsg::ApplicationMessage(
+                ApplicationMessage::new(payload),
+            )],
+        )?;
+        assert!(
+            matches!(&outbound[0], OutboundDelegateMsg::ApplicationMessage(_)),
+            "first call should still produce a normal ApplicationMessage outbound"
+        );
+
+        // The persisted entry must be dropped — readers don't get to see
+        // bytes that would crash on the next round-trip.
+        assert!(
+            !runtime.delegate_contexts.contains_key(delegate.key()),
+            "oversize ctx.write should be dropped from the persisted cache"
+        );
+
+        // A follow-up call must succeed (no crash) and the delegate must
+        // observe an empty context (NOT the oversize bytes).
+        let payload = bincode::serialize(&InboundAppMessage::ReadContext)?;
+        let outbound = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            vec![InboundDelegateMsg::ApplicationMessage(
+                ApplicationMessage::new(payload),
+            )],
+        )?;
+        let response: OutboundAppMessage = match &outbound[0] {
+            OutboundDelegateMsg::ApplicationMessage(m) => bincode::deserialize(&m.payload)?,
+            other => panic!("Expected ApplicationMessage, got {other:?}"),
+        };
+        match response {
+            OutboundAppMessage::ContextData(data) => {
+                assert!(
+                    data.is_empty(),
+                    "after oversize drop, next call must read an empty context, got {} bytes",
+                    data.len()
+                );
+            }
+            other => panic!("Expected ContextData, got {other:?}"),
+        }
+
+        std::mem::drop(temp_dir);
+        Ok(())
+    }
+
+    /// Pin the TTL-based eviction: an entry whose `last_write` is older than
+    /// `DELEGATE_CONTEXT_TTL` is dropped on the next sweep, even if
+    /// `unregister_delegate` is never called. Without TTL the cache leaks
+    /// pending-state bytes for any delegate whose `RequestUserInput` doesn't
+    /// receive a matching `UserResponse` (prompt dismissed, app crash,
+    /// network partition) until process restart.
+    ///
+    /// Doesn't go through the WASM path; manipulates the cache and then
+    /// drives a no-op `inbound_app_message` so the loader's `prune_expired`
+    /// runs.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_context_ttl_evicts_stale_entry() -> Result<(), Box<dyn std::error::Error>> {
+        use delegate2_messages::InboundAppMessage;
+
+        let contract = WrappedContract::new(
+            Arc::new(ContractCode::from(vec![1])),
+            Parameters::from(vec![]),
+        );
+        let (delegate, mut runtime, temp_dir) = setup_runtime(TEST_DELEGATE_2).await?;
+        let _app = ContractInstanceId::try_from(contract.key.to_string()).unwrap();
+
+        // Plant an entry whose last_write is older than the TTL. Using
+        // `tokio::time::Instant` matches the entry's storage type and lets
+        // `tokio::time::pause` / `tokio::time::advance` drive the sweep
+        // deterministically in future tests if needed.
+        let stale_at = tokio::time::Instant::now()
+            .checked_sub(super::native_api::DELEGATE_CONTEXT_TTL)
+            .expect("Instant arithmetic on test platform")
+            .checked_sub(std::time::Duration::from_secs(1))
+            .expect("Instant arithmetic on test platform");
+        runtime.delegate_contexts.insert(
+            delegate.key().clone(),
+            super::native_api::DelegateContextEntry {
+                bytes: vec![0xAA; 64],
+                last_write: stale_at,
+            },
+        );
+        assert!(runtime.delegate_contexts.contains_key(delegate.key()));
+
+        // Drive any inbound — the loader's prune sweep runs first.
+        let payload = bincode::serialize(&InboundAppMessage::ReadContext)?;
+        runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            vec![InboundDelegateMsg::ApplicationMessage(
+                ApplicationMessage::new(payload),
+            )],
+        )?;
+
+        // The stale entry must be gone. The ReadContext call wrote nothing,
+        // so no fresh entry was inserted in its place.
+        assert!(
+            !runtime.delegate_contexts.contains_key(delegate.key()),
+            "TTL sweep should evict an entry older than DELEGATE_CONTEXT_TTL"
         );
 
         std::mem::drop(temp_dir);

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -4,6 +4,7 @@ use dashmap::DashMap;
 use freenet_stdlib::prelude::{ContractInstanceId, ContractKey, DelegateKey, SecretsId};
 
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -37,6 +38,35 @@ pub(super) static DELEGATE_ENV: LazyLock<DashMap<InstanceId, DelegateCallEnv>> =
 pub(crate) static DELEGATE_SUBSCRIPTIONS: LazyLock<
     DashMap<ContractInstanceId, HashSet<DelegateKey>>,
 > = LazyLock::new(DashMap::default);
+
+/// Shared, in-memory cache of `DelegateContext` bytes keyed by `DelegateKey`.
+///
+/// The delegate ABI exposes `ctx.write(...)` and `ctx.read()` as a way for a
+/// delegate to stash state across `process()` calls — the canonical use is a
+/// permission prompt: the delegate writes its `PendingPrompt` blob during the
+/// call that emits `RequestUserInput`, then reads it back when the executor
+/// re-enters with the user's `UserResponse`.
+///
+/// The runtime's per-call context `Vec` lives only for the duration of one
+/// `inbound_app_message` invocation, so without persistence between calls
+/// every prompt round-trip would lose its pending state and the delegate
+/// would hit "received UserResponse with no pending context". This cache
+/// closes that gap: `inbound_app_message` seeds its local `Vec` from here on
+/// entry and stores the (possibly-mutated) `Vec` back on exit. Cleared on
+/// `UnregisterDelegate` so an unregistered delegate can't accumulate state.
+///
+/// Concurrency: the runtime serializes calls into a given delegate instance
+/// (one WASM `process()` at a time), so two prompt round-trips on the same
+/// delegate cannot interleave context writes. Wrapped in `Arc` so a
+/// `RuntimePool` of `Runtime`s shares one cache: a delegate's first call
+/// might run on executor A and its `UserResponse` follow-up on executor B,
+/// so per-`Runtime` storage would have the same locality bug as the
+/// per-call `Vec`.
+pub(crate) type DelegateContextCache = Arc<DashMap<DelegateKey, Vec<u8>>>;
+
+pub(crate) fn new_delegate_context_cache() -> DelegateContextCache {
+    Arc::new(DashMap::default())
+}
 
 /// Tracks message origins inherited by child delegates from their parent.
 /// When a delegate with an origin contract creates a child, the child inherits

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -62,10 +62,51 @@ pub(crate) static DELEGATE_SUBSCRIPTIONS: LazyLock<
 /// might run on executor A and its `UserResponse` follow-up on executor B,
 /// so per-`Runtime` storage would have the same locality bug as the
 /// per-call `Vec`.
-pub(crate) type DelegateContextCache = Arc<DashMap<DelegateKey, Vec<u8>>>;
+///
+/// TTL: each entry stores the `Instant` it was last written. On every
+/// `inbound_app_message` call the loader prunes entries older than
+/// `DELEGATE_CONTEXT_TTL`. Without this, a `RequestUserInput` whose
+/// `UserResponse` never arrives (user dismisses the prompt, app crashes,
+/// network partition) leaves bytes pinned until the matching
+/// `UnregisterDelegate` — which may be never for long-lived delegates. The
+/// AGENTS.md GC rule requires that any cleanup-exemption be time-bounded.
+pub(crate) type DelegateContextCache = Arc<DashMap<DelegateKey, DelegateContextEntry>>;
+
+#[derive(Clone)]
+pub(crate) struct DelegateContextEntry {
+    pub bytes: Vec<u8>,
+    /// Last-write timestamp for TTL eviction. `tokio::time::Instant` (not
+    /// `std::time::Instant`) so test code using `tokio::time::pause` /
+    /// `tokio::time::advance` can drive the eviction sweep deterministically,
+    /// matching the convention used by `RealTime` in `simulation/time.rs`.
+    pub last_write: tokio::time::Instant,
+}
+
+/// How long an unconsumed delegate context survives in the cache.
+///
+/// 10 minutes is comfortably longer than any reasonable interactive
+/// `RequestUserInput → UserResponse` round-trip (the prompt itself
+/// auto-denies at 60 s; users who walk away typically come back within
+/// seconds-to-minutes), and shorter than the lifetime of any real
+/// long-lived registered delegate, so genuine in-flight prompts never
+/// expire prematurely. If a future delegate needs context to survive
+/// across longer gaps, that's a sign it should persist via its own
+/// secret store rather than relying on this ephemeral cache.
+pub(crate) const DELEGATE_CONTEXT_TTL: std::time::Duration =
+    std::time::Duration::from_secs(10 * 60);
 
 pub(crate) fn new_delegate_context_cache() -> DelegateContextCache {
     Arc::new(DashMap::default())
+}
+
+/// Drop entries whose last write is older than `DELEGATE_CONTEXT_TTL`.
+///
+/// Called from `inbound_app_message` so eviction is amortised across normal
+/// delegate activity — no background sweep task and no extra lock contention
+/// when the node is idle.
+pub(crate) fn prune_expired_contexts(cache: &DelegateContextCache) {
+    let now = tokio::time::Instant::now();
+    cache.retain(|_, entry| now.duration_since(entry.last_write) < DELEGATE_CONTEXT_TTL);
 }
 
 /// Tracks message origins inherited by child delegates from their parent.

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -194,6 +194,10 @@ pub struct Runtime {
     pub(super) delegate_store: DelegateStore,
     /// LRU cache of compiled delegate modules (shared across pool executors).
     pub(super) delegate_modules: SharedModuleCache<DelegateKey>,
+    /// Persisted `ctx.write()` bytes per delegate, shared across pool
+    /// executors so a prompt round-trip routed to a different `Runtime` still
+    /// sees the pending state. See `native_api::DelegateContextCache`.
+    pub(super) delegate_contexts: super::native_api::DelegateContextCache,
 
     /// Local contract storage.
     pub(crate) contract_store: ContractStore,
@@ -241,6 +245,7 @@ impl Runtime {
 
             contract_store,
             delegate_modules: Arc::new(Mutex::new(LruCache::new(cache_capacity))),
+            delegate_contexts: super::native_api::new_delegate_context_cache(),
             state_store_db: None,
         })
     }
@@ -274,6 +279,10 @@ impl Runtime {
     /// Compiled modules store references to the compiling Engine's internal data
     /// structures. Using a Module compiled by one Engine in a Store backed by a
     /// different Engine causes SIGSEGV.
+    // Each parameter is a distinct shared resource the pool wires through
+    // explicitly; bundling them into a struct just to satisfy the lint
+    // would obscure which executor sees which cache.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn build_with_shared_module_caches(
         contract_store: ContractStore,
         delegate_store: DelegateStore,
@@ -281,6 +290,7 @@ impl Runtime {
         host_mem: bool,
         contract_modules: SharedModuleCache<ContractKey>,
         delegate_modules: SharedModuleCache<DelegateKey>,
+        delegate_contexts: super::native_api::DelegateContextCache,
         shared_backend: BackendEngine,
     ) -> RuntimeResult<Self> {
         let engine =
@@ -292,6 +302,7 @@ impl Runtime {
             contract_modules,
             contract_store,
             delegate_modules,
+            delegate_contexts,
             state_store_db: None,
         })
     }


### PR DESCRIPTION
## Problem

A delegate that writes pending state via `ctx.write(...)` during a `RequestUserInput` round-trip expects to read it back via `ctx.read()` when the executor re-enters with the matching `UserResponse`. The runtime initialised the per-call context `Vec` to empty on every `inbound_app_message` call, so the bytes a delegate stored disappeared between the two calls and the second call hit the delegate's own `received UserResponse with no pending context` guard.

User-visible effect: the ghostkey delegate's `RequestAnyAccess` flow — used by Harvest's "Connect a ghostkey" cross-app share — was completely dead. Reproduction on technic: vault renders the prompt overlay correctly, the user clicks Share, then harvest stays in "Waiting for vault…" forever while the delegate aborts. The same shape would break any prompt-driven delegate that relies on the documented `ctx.write` / `ctx.read` ABI across a prompt round-trip, including the older Allow/Deny single-fingerprint flow.

## Approach

Thread the context `Vec` through a shared `DelegateContextCache` (`Arc<DashMap<DelegateKey, Vec<u8>>>`) seeded into each `Runtime` in the executor pool. `inbound_app_message` loads the persisted bytes on entry and stores the (possibly mutated) `Vec` on exit. `unregister_delegate` clears the entry so a re-registered delegate starts fresh.

The cache is shared across pool executors because a delegate's first call may run on executor A and its `UserResponse` follow-up on executor B; per-`Runtime` storage would have the same locality bug as the per-call `Vec`.

Persisted bytes that exceed `DelegateContext::MAX_SIZE` are dropped with a warning rather than crashing the next call (where the wire format would assert on size). The host `ctx.write` host function does not enforce a size cap of its own.

## Testing

- New `test_context_persists_between_calls` exercises the same shape as the prompt round-trip: writes context on the first call, reads it on the second. Pre-fix returns `CounterValue(1)` twice; with the fix returns `CounterValue(1)` then `CounterValue(2)`. Also asserts that `unregister_delegate` clears the cache.
- `test_large_context_data` previously wrote 1 MiB (well past `DelegateContext::MAX_SIZE`) and asserted the second call read back an empty Vec — only "passing" because context didn't persist. Updated to write a within-bounds size and assert the bytes round-trip.
- All 2553 lib tests pass.
- `cargo clippy --locked -- -D warnings` (the CI invocation) is clean.

## Validation plan

After merge, deploy to technic and re-run the Playwright cross-app validation script (`harvest-cross-app-validate.mjs`) — it should now show "Share ciQaxxSwKF8" → harvest's `My Store` populates with the shared ghostkey within ~5s instead of timing out at "Waiting for vault…".

[AI-assisted - Claude]