### PR TITLE
feat(router): record routing events on relay hops, not just originator

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -127,6 +127,18 @@ pub mod dev_tool {
     #[cfg(any(test, feature = "testing"))]
     pub use crate::operations::subscribe::op_ctx_task::RELAY_SUBSCRIBE_DRIVER_CALL_COUNT;
 
+    // Test hooks for the relay-hop routing-event plumbing. Each counter
+    // increments every time `operations::record_relay_route_event` fires
+    // for the corresponding op type. Used by simulation tests to verify
+    // that relay-forwarded operations actually feed the local Router's
+    // failure-probability model — without these hooks, the router would
+    // only see events from originator paths (the bug this work fixes).
+    #[cfg(any(test, feature = "testing"))]
+    pub use crate::operations::{
+        RELAY_GET_ROUTE_EVENT_COUNT, RELAY_PUT_ROUTE_EVENT_COUNT,
+        RELAY_SUBSCRIBE_ROUTE_EVENT_COUNT, RELAY_UPDATE_ROUTE_EVENT_COUNT,
+    };
+
     // Re-export state verification for telemetry-based consistency analysis
     pub use crate::tracing::state_verifier::{StateAnomaly, StateVerifier, VerificationReport};
 

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -828,6 +828,35 @@ pub(crate) fn streaming_aware_attempt_timeout(
     total.min(STREAMING_ATTEMPT_TIMEOUT_CAP)
 }
 
+/// Records a routing event observed by a relay/forwarding hop.
+///
+/// Without this hook, only the operation's originator feeds events into the
+/// router. `OpOutcome::ContractOp*` is only produced for ops where
+/// `upstream_addr.is_none()`, and relay hops return `SendAndComplete` without
+/// going through `outcome()`. On a relay-heavy node the router would see
+/// almost no per-peer data, leaving the failure-probability model untrained
+/// and the per-peer dashboard panels empty even when MB of traffic flowed
+/// through each connection.
+///
+/// Call this at the relay-side response sites in each operation when the
+/// downstream peer the relay chose returns success or failure. Timeout and
+/// disconnect paths are already covered by `report_timeout_failure` in
+/// `node/op_state_manager.rs` via `failure_routing_info`.
+pub(crate) fn record_relay_route_event(
+    op_manager: &OpManager,
+    next_hop: PeerKeyLocation,
+    contract_location: Location,
+    outcome: crate::router::RouteOutcome,
+    op_type: crate::node::network_status::OpType,
+) {
+    op_manager.ring.routing_finished(crate::router::RouteEvent {
+        peer: next_hop,
+        contract_location,
+        outcome,
+        op_type: Some(op_type),
+    });
+}
+
 #[cfg(test)]
 mod ordering_invariant_tests {
     //! Tests documenting critical ordering invariants in the operations module.

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -871,12 +871,29 @@ pub(crate) fn record_relay_route_event(
         };
         counter.fetch_add(1, Ordering::Relaxed);
     }
-    op_manager.ring.routing_finished(crate::router::RouteEvent {
-        peer: next_hop,
-        contract_location,
-        outcome,
-        op_type: Some(op_type),
-    });
+    // Feed only the routing model — NOT peer_health or topology_manager.
+    //
+    // Why bypass `Ring::routing_finished` and call `router.add_event`
+    // directly: `routing_finished` also updates `peer_health` (which
+    // uses `std::time::Instant::now()` — a pre-existing TimeSource
+    // rule violation in `connection_manager.rs:185`) and the
+    // topology_manager's `request_density_tracker`. Both are reached
+    // from the originator path; amplifying their call rate from relay
+    // paths can compound wall-clock-driven divergence in
+    // strict-determinism simulation tests. The router itself reads
+    // its event log via failure-probability and Renegade ML
+    // estimators that don't use real wall-clock time, so feeding it
+    // from relay sites is determinism-safe.
+    op_manager
+        .ring
+        .router
+        .write()
+        .add_event(crate::router::RouteEvent {
+            peer: next_hop,
+            contract_location,
+            outcome,
+            op_type: Some(op_type),
+        });
 }
 
 /// Test hook: counter incremented every time `record_relay_route_event`

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -843,6 +843,30 @@ pub(crate) fn streaming_aware_attempt_timeout(
 /// disconnect paths are already covered by `report_timeout_failure` in
 /// `node/op_state_manager.rs` via `failure_routing_info`.
 ///
+/// # Outcome attribution
+///
+/// The `outcome` argument matches the legacy originator-side semantics
+/// (see `OpOutcome::Contract*` and the per-op `outcome()` methods). In
+/// particular, **prompt `NotFound` from a downstream peer is recorded
+/// as `RouteOutcome::Failure`**, not Success. A peer that promptly
+/// answers "I don't host this contract" behaved correctly at the
+/// transport level, but the failure-probability model is asking "will
+/// this peer deliver the contract at this location?" and a `NotFound`
+/// reply means it won't — so for routing-decision purposes it's a
+/// negative signal for *that contract location*. The relay sites
+/// follow the same convention used by the originator's stalled-peer
+/// retry path (`get.rs:2686` and `report_timeout_failure` in
+/// `op_state_manager.rs`). Splitting transport-success from
+/// content-availability would require a new `RouteOutcome::NotHosted`
+/// variant and is out of scope here.
+///
+/// `LocalCompletion` and unexpected-reply variants are also recorded as
+/// `Failure` against the downstream peer; these are "shouldn't happen"
+/// paths and recording them as failures matches the relay's decision to
+/// abandon that peer and try another.
+///
+/// # UPDATE exclusion
+///
 /// **UPDATE is intentionally not covered by this helper at relay sites.**
 /// UPDATE relays use `send_fire_and_forget` for downstream forwarding
 /// (`drive_relay_request_update`, `drive_relay_broadcast_to`, and the
@@ -873,17 +897,25 @@ pub(crate) fn record_relay_route_event(
     }
     // Feed only the routing model — NOT peer_health or topology_manager.
     //
-    // Why bypass `Ring::routing_finished` and call `router.add_event`
-    // directly: `routing_finished` also updates `peer_health` (which
-    // uses `std::time::Instant::now()` — a pre-existing TimeSource
-    // rule violation in `connection_manager.rs:185`) and the
-    // topology_manager's `request_density_tracker`. Both are reached
-    // from the originator path; amplifying their call rate from relay
-    // paths can compound wall-clock-driven divergence in
-    // strict-determinism simulation tests. The router itself reads
-    // its event log via failure-probability and Renegade ML
-    // estimators that don't use real wall-clock time, so feeding it
-    // from relay sites is determinism-safe.
+    // `Ring::routing_finished` also updates `peer_health` (which uses
+    // `std::time::Instant::now()` in `connection_manager.rs::PeerHealthTracker`
+    // around lines 182-203, a pre-existing TimeSource rule violation)
+    // and the topology_manager's `request_density_tracker`. An earlier
+    // iteration of this branch routed relay events through
+    // `routing_finished` and broke three strict-determinism tests
+    // (`test_strict_determinism_*` / `test_direct_runner_determinism` /
+    // `test_thundering_herd_connect_storm`). Bypassing those side
+    // effects fixed all three.
+    //
+    // CAVEAT: `Router::add_event` itself transitively calls
+    // `RoutingPredictor::record` → `wall_clock_hours()` → `SystemTime::now()`
+    // (see `router/routing_predictor.rs:608-614`). So the router path is
+    // not strictly TimeSource-clean either; the determinism tests pass
+    // because the wall-clock variance there is well below the events
+    // each test counts. Migrating both `peer_health` and
+    // `routing_predictor` to `TimeSource` would let
+    // `record_relay_route_event` go back to calling `routing_finished`
+    // straightforwardly. Tracked as a follow-up.
     op_manager
         .ring
         .router

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -849,6 +849,17 @@ pub(crate) fn record_relay_route_event(
     outcome: crate::router::RouteOutcome,
     op_type: crate::node::network_status::OpType,
 ) {
+    #[cfg(any(test, feature = "testing"))]
+    {
+        use std::sync::atomic::Ordering;
+        let counter = match op_type {
+            crate::node::network_status::OpType::Get => &RELAY_GET_ROUTE_EVENT_COUNT,
+            crate::node::network_status::OpType::Put => &RELAY_PUT_ROUTE_EVENT_COUNT,
+            crate::node::network_status::OpType::Update => &RELAY_UPDATE_ROUTE_EVENT_COUNT,
+            crate::node::network_status::OpType::Subscribe => &RELAY_SUBSCRIBE_ROUTE_EVENT_COUNT,
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
     op_manager.ring.routing_finished(crate::router::RouteEvent {
         peer: next_hop,
         contract_location,
@@ -856,6 +867,25 @@ pub(crate) fn record_relay_route_event(
         op_type: Some(op_type),
     });
 }
+
+/// Test hook: counter incremented every time `record_relay_route_event`
+/// fires for a relay-forwarded GET. Used by simulation tests to verify
+/// the per-op-type relay hooks are reached. See `dev_tool` re-export.
+#[cfg(any(test, feature = "testing"))]
+pub static RELAY_GET_ROUTE_EVENT_COUNT: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(any(test, feature = "testing"))]
+pub static RELAY_PUT_ROUTE_EVENT_COUNT: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(any(test, feature = "testing"))]
+pub static RELAY_UPDATE_ROUTE_EVENT_COUNT: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(any(test, feature = "testing"))]
+pub static RELAY_SUBSCRIBE_ROUTE_EVENT_COUNT: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
 
 #[cfg(test)]
 mod ordering_invariant_tests {

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -842,6 +842,17 @@ pub(crate) fn streaming_aware_attempt_timeout(
 /// downstream peer the relay chose returns success or failure. Timeout and
 /// disconnect paths are already covered by `report_timeout_failure` in
 /// `node/op_state_manager.rs` via `failure_routing_info`.
+///
+/// **UPDATE is intentionally not covered by this helper at relay sites.**
+/// UPDATE relays use `send_fire_and_forget` for downstream forwarding
+/// (`drive_relay_request_update`, `drive_relay_broadcast_to`, and the
+/// streaming variants), so the relay never observes whether the downstream
+/// peer succeeded or failed. Recording only the local send-error path
+/// would bias the per-peer UPDATE failure rate to 100% by construction.
+/// `report_timeout_failure` in `op_state_manager.rs` still records UPDATE
+/// timeouts via `failure_routing_info` on the originator side; this is
+/// the same signal as for the other ops, just not augmented by relay
+/// observations.
 pub(crate) fn record_relay_route_event(
     op_manager: &OpManager,
     next_hop: PeerKeyLocation,

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -2378,6 +2378,22 @@ impl Operation for GetOp {
                             });
                         }
                         tracing::debug!(tx = %id, %key, upstream = ?self.upstream_addr, "Returning contract to upstream");
+                        // Feed the relay's downstream-peer choice into the
+                        // local Router's failure-probability model. Without
+                        // this, a relay-heavy node only learns from ops it
+                        // originated and the per-peer dashboard panels stay
+                        // empty even with MB of forwarded traffic.
+                        if let Some(ref s) = stats {
+                            if let Some(ref next_peer) = s.next_peer {
+                                super::record_relay_route_event(
+                                    op_manager,
+                                    next_peer.clone(),
+                                    s.contract_location,
+                                    crate::router::RouteOutcome::SuccessUntimed,
+                                    crate::node::network_status::OpType::Get,
+                                );
+                            }
+                        }
                         result = Some(GetResult {
                             key,
                             state: value.clone(),

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -1478,6 +1478,24 @@ impl Operation for GetOp {
                                 tried_peers.insert(addr);
                             }
 
+                            // The downstream peer correctly answered NotFound:
+                            // it behaved well at the protocol level, just
+                            // doesn't host this contract. Record SuccessUntimed
+                            // so the failure-probability model treats this peer
+                            // as healthy, even though the relay tries another
+                            // candidate for *this* contract location. See
+                            // `operations::record_relay_route_event` rustdoc
+                            // for the attribution policy.
+                            if let Some(ref answered_peer) = sender {
+                                super::record_relay_route_event(
+                                    op_manager,
+                                    answered_peer.clone(),
+                                    crate::ring::Location::from(&instance_id),
+                                    crate::router::RouteOutcome::SuccessUntimed,
+                                    crate::node::network_status::OpType::Get,
+                                );
+                            }
+
                             // First, check if we have alternatives at this hop level
                             if !alternatives.is_empty() && attempts_at_hop < DEFAULT_MAX_BREADTH {
                                 // Try the next alternative
@@ -3007,6 +3025,20 @@ impl Operation for GetOp {
                             phase = "forward",
                             "GET response piping in progress to upstream"
                         );
+                        // Relay observed a streaming Found from downstream and
+                        // is piping it upstream. Feed the Router so this peer's
+                        // routing-quality stats reflect streaming relays too.
+                        if let Some(ref s) = stats {
+                            if let Some(ref next_peer) = s.next_peer {
+                                super::record_relay_route_event(
+                                    op_manager,
+                                    next_peer.clone(),
+                                    s.contract_location,
+                                    crate::router::RouteOutcome::SuccessUntimed,
+                                    crate::node::network_status::OpType::Get,
+                                );
+                            }
+                        }
                         return_msg = None;
                         new_state = None;
                     } else {
@@ -3019,6 +3051,19 @@ impl Operation for GetOp {
                             "Forwarding GET response as non-streaming to upstream"
                         );
 
+                        // Same relay-Success accounting as the piping branch
+                        // and the non-streaming Response handler at line ~2386.
+                        if let Some(ref s) = stats {
+                            if let Some(ref next_peer) = s.next_peer {
+                                super::record_relay_route_event(
+                                    op_manager,
+                                    next_peer.clone(),
+                                    s.contract_location,
+                                    crate::router::RouteOutcome::SuccessUntimed,
+                                    crate::node::network_status::OpType::Get,
+                                );
+                            }
+                        }
                         return_msg = Some(GetMsg::Response {
                             id,
                             instance_id: *instance_id,

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1962,8 +1962,12 @@ async fn drive_relay_get_inner(
             }
             AttemptOutcome::Terminal(Terminal::Streaming { .. }) => {
                 // Streaming relay forwarding is out of scope for #3883 commit 1.
-                // Log and fall through to next peer (treat as NotFound for now).
-                // A follow-up PR will add proper chunk pipe-through.
+                // The downstream peer answered correctly with a streaming
+                // response; the relay's inability to forward streams is a
+                // local implementation gap, not a peer-routing failure. Do
+                // NOT record a route event here — penalising the peer for
+                // a relay-side limitation would systematically de-prioritise
+                // peers that happen to host large contracts.
                 tracing::warn!(
                     tx = %incoming_tx,
                     %instance_id,
@@ -1972,36 +1976,29 @@ async fn drive_relay_get_inner(
                      streaming relay forwarding not yet implemented (port plan §7); \
                      trying next peer"
                 );
-                crate::operations::record_relay_route_event(
-                    op_manager,
-                    peer.clone(),
-                    crate::ring::Location::from(&instance_id),
-                    crate::router::RouteOutcome::Failure,
-                    crate::node::network_status::OpType::Get,
-                );
                 new_visited.mark_visited(peer_addr);
                 continue;
             }
             AttemptOutcome::Terminal(Terminal::LocalCompletion) => {
                 // A relay driver should never receive a Request-echo because
-                // `send_to_and_await` targets a specific remote peer (not loopback).
-                // If this arrives, treat it as Unexpected.
+                // `send_to_and_await` targets a specific remote peer (not
+                // loopback). If this arrives, it is a local protocol bug —
+                // not a peer-routing failure. Do NOT record a route event.
                 tracing::warn!(
                     tx = %incoming_tx,
                     %instance_id,
                     "GET relay (task-per-tx): unexpected LocalCompletion (Request-echo) — trying next peer"
                 );
-                crate::operations::record_relay_route_event(
-                    op_manager,
-                    peer.clone(),
-                    crate::ring::Location::from(&instance_id),
-                    crate::router::RouteOutcome::Failure,
-                    crate::node::network_status::OpType::Get,
-                );
                 new_visited.mark_visited(peer_addr);
                 continue;
             }
             AttemptOutcome::Retry => {
+                // Downstream peer correctly answered NotFound. The peer
+                // behaved well at the protocol level — it just doesn't host
+                // this contract. Record `SuccessUntimed`: the failure-
+                // probability model should treat this peer as healthy, even
+                // though the relay tries another candidate for *this*
+                // contract location.
                 tracing::debug!(
                     tx = %incoming_tx,
                     target = %peer,
@@ -2011,7 +2008,7 @@ async fn drive_relay_get_inner(
                     op_manager,
                     peer.clone(),
                     crate::ring::Location::from(&instance_id),
-                    crate::router::RouteOutcome::Failure,
+                    crate::router::RouteOutcome::SuccessUntimed,
                     crate::node::network_status::OpType::Get,
                 );
                 // Mark the failed peer so future iterations don't re-select it.
@@ -2020,17 +2017,14 @@ async fn drive_relay_get_inner(
                 continue;
             }
             AttemptOutcome::Unexpected => {
+                // Unexpected reply variant — could be a local bug or a peer
+                // misbehaviour. Without knowing which, do NOT record a route
+                // event; the helper's invariant is one event per
+                // unambiguously-attributable observation.
                 tracing::warn!(
                     tx = %incoming_tx,
                     target = %peer,
                     "GET relay (task-per-tx): unexpected reply variant; advancing to next peer"
-                );
-                crate::operations::record_relay_route_event(
-                    op_manager,
-                    peer.clone(),
-                    crate::ring::Location::from(&instance_id),
-                    crate::router::RouteOutcome::Failure,
-                    crate::node::network_status::OpType::Get,
                 );
                 new_visited.mark_visited(peer_addr);
                 continue;

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1874,6 +1874,17 @@ async fn drive_relay_get_inner(
                     error = %err,
                     "GET relay (task-per-tx): send_to_and_await failed; advancing to next peer"
                 );
+                // Feed the relay's failed peer choice into the local Router
+                // so future routing decisions de-prioritize this peer. Without
+                // this hook, only originator-side failures train the router
+                // and per-peer dashboard panels stay empty on relay-heavy nodes.
+                crate::operations::record_relay_route_event(
+                    op_manager,
+                    peer.clone(),
+                    crate::ring::Location::from(&instance_id),
+                    crate::router::RouteOutcome::Failure,
+                    crate::node::network_status::OpType::Get,
+                );
                 // Continue loop to try next peer.
                 new_visited.mark_visited(peer_addr);
                 continue;
@@ -1884,6 +1895,13 @@ async fn drive_relay_get_inner(
                     target = %peer,
                     timeout_secs = OPERATION_TTL.as_secs(),
                     "GET relay (task-per-tx): attempt timed out; advancing to next peer"
+                );
+                crate::operations::record_relay_route_event(
+                    op_manager,
+                    peer.clone(),
+                    crate::ring::Location::from(&instance_id),
+                    crate::router::RouteOutcome::Failure,
+                    crate::node::network_status::OpType::Get,
                 );
                 new_visited.mark_visited(peer_addr);
                 continue;
@@ -1917,6 +1935,18 @@ async fn drive_relay_get_inner(
                 cache_contract_locally(op_manager, key, state.clone(), contract.clone(), false)
                     .await;
 
+                // Feed the relay's successful peer choice into the local
+                // Router. Without this hook, only originator-side successes
+                // train the failure-probability model and per-peer dashboard
+                // panels stay empty on relay-heavy nodes.
+                crate::operations::record_relay_route_event(
+                    op_manager,
+                    peer.clone(),
+                    crate::ring::Location::from(&instance_id),
+                    crate::router::RouteOutcome::SuccessUntimed,
+                    crate::node::network_status::OpType::Get,
+                );
+
                 // Bubble up to upstream.
                 relay_send_found(
                     op_manager,
@@ -1942,6 +1972,13 @@ async fn drive_relay_get_inner(
                      streaming relay forwarding not yet implemented (port plan §7); \
                      trying next peer"
                 );
+                crate::operations::record_relay_route_event(
+                    op_manager,
+                    peer.clone(),
+                    crate::ring::Location::from(&instance_id),
+                    crate::router::RouteOutcome::Failure,
+                    crate::node::network_status::OpType::Get,
+                );
                 new_visited.mark_visited(peer_addr);
                 continue;
             }
@@ -1954,6 +1991,13 @@ async fn drive_relay_get_inner(
                     %instance_id,
                     "GET relay (task-per-tx): unexpected LocalCompletion (Request-echo) — trying next peer"
                 );
+                crate::operations::record_relay_route_event(
+                    op_manager,
+                    peer.clone(),
+                    crate::ring::Location::from(&instance_id),
+                    crate::router::RouteOutcome::Failure,
+                    crate::node::network_status::OpType::Get,
+                );
                 new_visited.mark_visited(peer_addr);
                 continue;
             }
@@ -1962,6 +2006,13 @@ async fn drive_relay_get_inner(
                     tx = %incoming_tx,
                     target = %peer,
                     "GET relay (task-per-tx): downstream returned NotFound; advancing to next peer"
+                );
+                crate::operations::record_relay_route_event(
+                    op_manager,
+                    peer.clone(),
+                    crate::ring::Location::from(&instance_id),
+                    crate::router::RouteOutcome::Failure,
+                    crate::node::network_status::OpType::Get,
                 );
                 // Mark the failed peer so future iterations don't re-select it.
                 new_visited.mark_visited(peer_addr);
@@ -1973,6 +2024,13 @@ async fn drive_relay_get_inner(
                     tx = %incoming_tx,
                     target = %peer,
                     "GET relay (task-per-tx): unexpected reply variant; advancing to next peer"
+                );
+                crate::operations::record_relay_route_event(
+                    op_manager,
+                    peer.clone(),
+                    crate::ring::Location::from(&instance_id),
+                    crate::router::RouteOutcome::Failure,
+                    crate::node::network_status::OpType::Get,
                 );
                 new_visited.mark_visited(peer_addr);
                 continue;

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -3617,4 +3617,75 @@ mod tests {
         assert!(matches!(not_found, super::SubOpGetOutcome::NotFound(_)));
         assert!(matches!(infra, super::SubOpGetOutcome::Infra(_)));
     }
+
+    /// Pin: each transport-level failure arm of `drive_relay_get_inner`
+    /// records a routing event for the failing peer. Without these
+    /// hooks, the per-peer dashboard's failure-probability model is
+    /// trained only on originated ops and the symptom this PR fixes
+    /// reappears for the relay path. Source-scrape because the
+    /// behaviour is positional inside the retry loop and a deletion
+    /// would not break any unit-test assertion otherwise.
+    #[test]
+    fn drive_relay_get_inner_records_route_events_on_transport_failure() {
+        let src = include_str!("op_ctx_task.rs");
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+
+        // The send_to_and_await error arm and the timeout arm must
+        // record `Failure` for the chosen peer. Identify each by its
+        // log-message phrase, then check the arm's body up to the
+        // `continue` for the helper call.
+        for log_phrase in [
+            "send_to_and_await failed; advancing to next peer",
+            "attempt timed out; advancing to next peer",
+        ] {
+            let pos = body.unwrap_or_default_pos(log_phrase);
+            let after = &body[pos..pos + 1500.min(body.len() - pos)];
+            assert!(
+                after.contains("record_relay_route_event")
+                    && after.contains("RouteOutcome::Failure"),
+                "drive_relay_get_inner arm for `{log_phrase}` must call \
+                 record_relay_route_event with RouteOutcome::Failure. \
+                 Without this, transport failures from relay-forwarded \
+                 GETs are dropped and the per-peer failure-probability \
+                 model regresses to the originator-only state that \
+                 motivated PR #4051."
+            );
+        }
+
+        // The InlineFound success arm must record SuccessUntimed.
+        let pos = body.unwrap_or_default_pos("downstream returned Found");
+        let after = &body[pos..pos + 1500.min(body.len() - pos)];
+        assert!(
+            after.contains("record_relay_route_event")
+                && after.contains("RouteOutcome::SuccessUntimed"),
+            "drive_relay_get_inner InlineFound arm must call \
+             record_relay_route_event with RouteOutcome::SuccessUntimed."
+        );
+
+        // The Retry/NotFound arm must record SuccessUntimed too — see
+        // the outcome-attribution rationale in operations.rs::record_relay_route_event
+        // rustdoc. A peer answering NotFound has not failed.
+        let pos = body.unwrap_or_default_pos("downstream returned NotFound; advancing");
+        let after = &body[pos..pos + 1500.min(body.len() - pos)];
+        assert!(
+            after.contains("record_relay_route_event")
+                && after.contains("RouteOutcome::SuccessUntimed"),
+            "drive_relay_get_inner Retry (NotFound) arm must call \
+             record_relay_route_event with RouteOutcome::SuccessUntimed \
+             (NotFound is a correct protocol response, not a routing \
+             failure). Recording it as Failure would systematically \
+             de-prioritise peers that don't host the queried contract."
+        );
+    }
+
+    trait FindOrPanic {
+        fn unwrap_or_default_pos(&self, needle: &str) -> usize;
+    }
+    impl FindOrPanic for str {
+        fn unwrap_or_default_pos(&self, needle: &str) -> usize {
+            self.find(needle).unwrap_or_else(|| {
+                panic!("expected `{needle}` to appear in drive_relay_get_inner body")
+            })
+        }
+    }
 }

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -691,6 +691,20 @@ impl Operation for PutOp {
                             "Forwarding PUT Response to upstream"
                         );
 
+                        // Feed the relay's downstream-peer choice into the
+                        // local Router. See operations.rs::record_relay_route_event
+                        // for rationale: without this, a relay-heavy node only
+                        // trains its routing model on originated ops.
+                        if let Some(ref s) = stats {
+                            super::record_relay_route_event(
+                                op_manager,
+                                s.target_peer.clone(),
+                                s.contract_location,
+                                crate::router::RouteOutcome::SuccessUntimed,
+                                crate::node::network_status::OpType::Put,
+                            );
+                        }
+
                         let response = PutMsg::Response { id, key: *key };
 
                         Ok(OperationResult::SendAndComplete {
@@ -1248,6 +1262,16 @@ impl Operation for PutOp {
                             phase = "response",
                             "Forwarding PUT ResponseStreaming to upstream"
                         );
+
+                        if let Some(ref s) = stats {
+                            super::record_relay_route_event(
+                                op_manager,
+                                s.target_peer.clone(),
+                                s.contract_location,
+                                crate::router::RouteOutcome::SuccessUntimed,
+                                crate::node::network_status::OpType::Put,
+                            );
+                        }
 
                         // Forward as regular Response for simplicity
                         // (streaming is only needed for large payloads, responses are small)

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -885,6 +885,13 @@ async fn drive_relay_put(
                 error = %err,
                 "PUT relay (task-per-tx): send_to_and_await failed"
             );
+            crate::operations::record_relay_route_event(
+                op_manager,
+                next_peer.clone(),
+                crate::ring::Location::from(&key),
+                crate::router::RouteOutcome::Failure,
+                crate::node::network_status::OpType::Put,
+            );
             return Err(err);
         }
         Err(_elapsed) => {
@@ -895,11 +902,21 @@ async fn drive_relay_put(
                 timeout_secs = OPERATION_TTL.as_secs(),
                 "PUT relay (task-per-tx): downstream timed out"
             );
+            crate::operations::record_relay_route_event(
+                op_manager,
+                next_peer.clone(),
+                crate::ring::Location::from(&key),
+                crate::router::RouteOutcome::Failure,
+                crate::node::network_status::OpType::Put,
+            );
             return Err(OpError::UnexpectedOpState);
         }
     };
 
     // ── Step 4: Classify reply and bubble Response upstream ────────────────
+    // Feed the relay's downstream-peer choice into the local Router so
+    // future routing decisions are informed by relay-observed outcomes,
+    // not just events from ops this node originated.
     match reply {
         NetMessage::V1(NetMessageV1::Put(PutMsg::Response { key: reply_key, .. })) => {
             tracing::info!(
@@ -907,6 +924,13 @@ async fn drive_relay_put(
                 contract = %reply_key,
                 phase = "relay_put_bubble",
                 "PUT relay (task-per-tx): downstream returned Response; bubbling upstream"
+            );
+            crate::operations::record_relay_route_event(
+                op_manager,
+                next_peer.clone(),
+                crate::ring::Location::from(&reply_key),
+                crate::router::RouteOutcome::SuccessUntimed,
+                crate::node::network_status::OpType::Put,
             );
             relay_put_send_response(op_manager, incoming_tx, reply_key, upstream_addr).await
         }
@@ -924,6 +948,13 @@ async fn drive_relay_put(
                 "PUT relay (task-per-tx): downstream returned ResponseStreaming — \
                  synthesizing non-streaming Response upstream (slice A limitation)"
             );
+            crate::operations::record_relay_route_event(
+                op_manager,
+                next_peer.clone(),
+                crate::ring::Location::from(&reply_key),
+                crate::router::RouteOutcome::SuccessUntimed,
+                crate::node::network_status::OpType::Put,
+            );
             relay_put_send_response(op_manager, incoming_tx, reply_key, upstream_addr).await
         }
         other => {
@@ -932,6 +963,13 @@ async fn drive_relay_put(
                 contract = %key,
                 reply_variant = ?std::mem::discriminant(&other),
                 "PUT relay (task-per-tx): unexpected reply variant; treating as failure"
+            );
+            crate::operations::record_relay_route_event(
+                op_manager,
+                next_peer.clone(),
+                crate::ring::Location::from(&key),
+                crate::router::RouteOutcome::Failure,
+                crate::node::network_status::OpType::Put,
             );
             Err(OpError::UnexpectedOpState)
         }
@@ -1529,6 +1567,11 @@ where
     .await?;
 
     // ── Step 7: Await downstream reply (if piping), then bubble upstream ──
+    //
+    // Per-relay routing-event recording: the relay's chosen `next_hop`
+    // either responded usefully (Success) or didn't (Failure). Feeding
+    // these into the local Router lets the failure-probability model
+    // learn from forwarded traffic, not just originator-side ops.
     if let Some((next_addr, mut rx)) = downstream_reply_rx {
         let reply = match tokio::time::timeout(OPERATION_TTL, rx.recv()).await {
             Ok(Some(reply)) => reply,
@@ -1538,6 +1581,15 @@ where
                     target = %next_addr,
                     "PUT streaming relay (task-per-tx): downstream reply channel closed before reply"
                 );
+                if let Some(ref peer) = next_hop {
+                    crate::operations::record_relay_route_event(
+                        op_manager,
+                        peer.clone(),
+                        crate::ring::Location::from(&key),
+                        crate::router::RouteOutcome::Failure,
+                        crate::node::network_status::OpType::Put,
+                    );
+                }
                 op_manager.release_pending_op_slot(incoming_tx).await;
                 return relay_put_send_response(op_manager, incoming_tx, key, upstream_addr).await;
             }
@@ -1547,6 +1599,15 @@ where
                     target = %next_addr,
                     "PUT streaming relay (task-per-tx): downstream reply timed out"
                 );
+                if let Some(ref peer) = next_hop {
+                    crate::operations::record_relay_route_event(
+                        op_manager,
+                        peer.clone(),
+                        crate::ring::Location::from(&key),
+                        crate::router::RouteOutcome::Failure,
+                        crate::node::network_status::OpType::Put,
+                    );
+                }
                 op_manager.release_pending_op_slot(incoming_tx).await;
                 return relay_put_send_response(op_manager, incoming_tx, key, upstream_addr).await;
             }
@@ -1564,6 +1625,15 @@ where
                     phase = "relay_put_streaming_bubble",
                     "PUT streaming relay (task-per-tx): downstream replied; bubbling Response upstream"
                 );
+                if let Some(ref peer) = next_hop {
+                    crate::operations::record_relay_route_event(
+                        op_manager,
+                        peer.clone(),
+                        crate::ring::Location::from(&reply_key),
+                        crate::router::RouteOutcome::SuccessUntimed,
+                        crate::node::network_status::OpType::Put,
+                    );
+                }
                 relay_put_send_response(op_manager, incoming_tx, reply_key, upstream_addr).await
             }
             other => {
@@ -1573,6 +1643,15 @@ where
                     reply_variant = ?std::mem::discriminant(&other),
                     "PUT streaming relay (task-per-tx): unexpected reply variant"
                 );
+                if let Some(ref peer) = next_hop {
+                    crate::operations::record_relay_route_event(
+                        op_manager,
+                        peer.clone(),
+                        crate::ring::Location::from(&key),
+                        crate::router::RouteOutcome::Failure,
+                        crate::node::network_status::OpType::Put,
+                    );
+                }
                 relay_put_send_response(op_manager, incoming_tx, key, upstream_addr).await
             }
         }

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -958,18 +958,14 @@ async fn drive_relay_put(
             relay_put_send_response(op_manager, incoming_tx, reply_key, upstream_addr).await
         }
         other => {
+            // Unexpected reply variant: unclear whether it's a local
+            // bug or peer misbehaviour. Do NOT record a route event;
+            // the helper invariant is one event per unambiguous attribution.
             tracing::warn!(
                 tx = %incoming_tx,
                 contract = %key,
                 reply_variant = ?std::mem::discriminant(&other),
                 "PUT relay (task-per-tx): unexpected reply variant; treating as failure"
-            );
-            crate::operations::record_relay_route_event(
-                op_manager,
-                next_peer.clone(),
-                crate::ring::Location::from(&key),
-                crate::router::RouteOutcome::Failure,
-                crate::node::network_status::OpType::Put,
             );
             Err(OpError::UnexpectedOpState)
         }
@@ -1637,21 +1633,15 @@ where
                 relay_put_send_response(op_manager, incoming_tx, reply_key, upstream_addr).await
             }
             other => {
+                // Unexpected reply variant: unclear attribution. Skip the
+                // route-event hook (matches the non-streaming relay's
+                // unexpected-variant arm).
                 tracing::warn!(
                     tx = %incoming_tx,
                     contract = %key,
                     reply_variant = ?std::mem::discriminant(&other),
                     "PUT streaming relay (task-per-tx): unexpected reply variant"
                 );
-                if let Some(ref peer) = next_hop {
-                    crate::operations::record_relay_route_event(
-                        op_manager,
-                        peer.clone(),
-                        crate::ring::Location::from(&key),
-                        crate::router::RouteOutcome::Failure,
-                        crate::node::network_status::OpType::Put,
-                    );
-                }
                 relay_put_send_response(op_manager, incoming_tx, key, upstream_addr).await
             }
         }

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -2380,7 +2380,10 @@ mod tests {
         let pos = b
             .find("downstream reply timed out")
             .expect("timeout arm not found");
-        let arm = &b[pos..pos + 400.min(b.len() - pos)];
+        // Window widened from 400 → 800 bytes to accommodate the
+        // record_relay_route_event hook inserted between the timeout
+        // log and the bubble-Response call.
+        let arm = &b[pos..pos + 800.min(b.len() - pos)];
         assert!(
             arm.contains("relay_put_send_response"),
             "timeout arm must still call relay_put_send_response so the \

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -2441,4 +2441,52 @@ mod tests {
              land downstream (otherwise a fast reply races past the waiter)"
         );
     }
+
+    /// Pin: each transport-failure arm of `drive_relay_put` records a
+    /// routing event for the chosen peer. Without these hooks, the
+    /// per-peer dashboard's failure-probability model is trained only
+    /// on originated PUT ops and the symptom this PR fixes reappears
+    /// for the relay path. Source-scrape because the behaviour is
+    /// positional inside the match and a deletion would not break any
+    /// unit-test assertion otherwise.
+    #[test]
+    fn drive_relay_put_records_route_events_on_transport_failure() {
+        let src = include_str!("op_ctx_task.rs");
+        // drive_relay_put body — non-streaming relay.
+        let body_start = src
+            .find("async fn drive_relay_put(")
+            .expect("drive_relay_put fn must exist");
+        let body_end = src[body_start..]
+            .find("/// Store a relayed PUT")
+            .map(|i| body_start + i)
+            .unwrap_or(src.len());
+        let body = &src[body_start..body_end];
+
+        for log_phrase in ["send_to_and_await failed", "downstream timed out"] {
+            let pos = body
+                .find(log_phrase)
+                .unwrap_or_else(|| panic!("expected `{log_phrase}` in drive_relay_put"));
+            let after = &body[pos..pos + 1500.min(body.len() - pos)];
+            assert!(
+                after.contains("record_relay_route_event")
+                    && after.contains("RouteOutcome::Failure"),
+                "drive_relay_put arm for `{log_phrase}` must call \
+                 record_relay_route_event with RouteOutcome::Failure. \
+                 Without this, transport failures from relay-forwarded \
+                 PUTs are dropped — the regression PR #4051 fixes."
+            );
+        }
+
+        // Success arms (Response and ResponseStreaming downgrade) must
+        // record SuccessUntimed.
+        let pos = body
+            .find("downstream returned Response; bubbling upstream")
+            .expect("Response success arm not found");
+        let after = &body[pos..pos + 1500.min(body.len() - pos)];
+        assert!(
+            after.contains("record_relay_route_event")
+                && after.contains("RouteOutcome::SuccessUntimed"),
+            "drive_relay_put Response arm must record SuccessUntimed."
+        );
+    }
 }

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1505,6 +1505,13 @@ async fn drive_relay_subscribe(
                 error = %err,
                 "SUBSCRIBE relay (task-per-tx): send_to_and_await failed"
             );
+            crate::operations::record_relay_route_event(
+                op_manager,
+                next_hop.clone(),
+                crate::ring::Location::from(&instance_id),
+                crate::router::RouteOutcome::Failure,
+                crate::node::network_status::OpType::Subscribe,
+            );
             return relay_subscribe_send_response(
                 op_manager,
                 incoming_tx,
@@ -1522,6 +1529,13 @@ async fn drive_relay_subscribe(
                 timeout_secs = OPERATION_TTL.as_secs(),
                 "SUBSCRIBE relay (task-per-tx): downstream timed out"
             );
+            crate::operations::record_relay_route_event(
+                op_manager,
+                next_hop.clone(),
+                crate::ring::Location::from(&instance_id),
+                crate::router::RouteOutcome::Failure,
+                crate::node::network_status::OpType::Subscribe,
+            );
             return relay_subscribe_send_response(
                 op_manager,
                 incoming_tx,
@@ -1534,6 +1548,10 @@ async fn drive_relay_subscribe(
     };
 
     // ── Step 4: Classify reply, register requester if Subscribed, bubble up ──
+    //
+    // Feed the relay's downstream-peer choice into the local Router so
+    // future routing decisions are informed by relay-observed outcomes
+    // (see operations.rs::record_relay_route_event).
     let result = match reply {
         NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Response {
             result: SubscribeMsgResult::Subscribed { key },
@@ -1562,6 +1580,13 @@ async fn drive_relay_subscribe(
                 phase = "relay_subscribe_bubble",
                 "SUBSCRIBE relay (task-per-tx): downstream Subscribed; bubbling upstream"
             );
+            crate::operations::record_relay_route_event(
+                op_manager,
+                next_hop.clone(),
+                crate::ring::Location::from(&key),
+                crate::router::RouteOutcome::SuccessUntimed,
+                crate::node::network_status::OpType::Subscribe,
+            );
             SubscribeMsgResult::Subscribed { key }
         }
         NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Response {
@@ -1574,6 +1599,13 @@ async fn drive_relay_subscribe(
                 phase = "relay_subscribe_bubble_not_found",
                 "SUBSCRIBE relay (task-per-tx): downstream NotFound; bubbling upstream"
             );
+            crate::operations::record_relay_route_event(
+                op_manager,
+                next_hop.clone(),
+                crate::ring::Location::from(&instance_id),
+                crate::router::RouteOutcome::Failure,
+                crate::node::network_status::OpType::Subscribe,
+            );
             SubscribeMsgResult::NotFound
         }
         other => {
@@ -1582,6 +1614,13 @@ async fn drive_relay_subscribe(
                 %instance_id,
                 reply_variant = ?std::mem::discriminant(&other),
                 "SUBSCRIBE relay (task-per-tx): unexpected reply variant; treating as NotFound"
+            );
+            crate::operations::record_relay_route_event(
+                op_manager,
+                next_hop.clone(),
+                crate::ring::Location::from(&instance_id),
+                crate::router::RouteOutcome::Failure,
+                crate::node::network_status::OpType::Subscribe,
             );
             SubscribeMsgResult::NotFound
         }

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1593,6 +1593,10 @@ async fn drive_relay_subscribe(
             result: SubscribeMsgResult::NotFound,
             ..
         })) => {
+            // Downstream peer correctly answered NotFound. The peer
+            // behaved well at the protocol level — it just doesn't host
+            // this contract. Record SuccessUntimed so the model treats
+            // this peer as healthy. See `record_relay_route_event` rustdoc.
             tracing::debug!(
                 tx = %incoming_tx,
                 %instance_id,
@@ -1603,24 +1607,20 @@ async fn drive_relay_subscribe(
                 op_manager,
                 next_hop.clone(),
                 crate::ring::Location::from(&instance_id),
-                crate::router::RouteOutcome::Failure,
+                crate::router::RouteOutcome::SuccessUntimed,
                 crate::node::network_status::OpType::Subscribe,
             );
             SubscribeMsgResult::NotFound
         }
         other => {
+            // Unexpected reply variant: unclear whether it's a local
+            // bug or peer misbehaviour. Do NOT record a route event;
+            // the helper invariant is one event per unambiguous attribution.
             tracing::warn!(
                 tx = %incoming_tx,
                 %instance_id,
                 reply_variant = ?std::mem::discriminant(&other),
                 "SUBSCRIBE relay (task-per-tx): unexpected reply variant; treating as NotFound"
-            );
-            crate::operations::record_relay_route_event(
-                op_manager,
-                next_hop.clone(),
-                crate::ring::Location::from(&instance_id),
-                crate::router::RouteOutcome::Failure,
-                crate::node::network_status::OpType::Subscribe,
             );
             SubscribeMsgResult::NotFound
         }

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -1510,7 +1510,7 @@ fn peer_detail_html(address_str: &str) -> String {
             if event_count == 0 && tab_name != "All" {
                 write!(
                     panel_content,
-                    r#"<div class="empty-chart">No {name} operations have routed through this peer yet — chart will populate as the network sends or relays {name}s through this connection</div>"#,
+                    r#"<div class="empty-chart">No {name} operations have routed through this peer yet. The chart will populate as the network sends or relays {name}s through this connection.</div>"#,
                     name = tab_name,
                 )
                 .ok();
@@ -1620,7 +1620,7 @@ fn peer_detail_html(address_str: &str) -> String {
                 ts = fmt_prediction_speed(pred.transfer_speed_bps),
             )
         } else {
-            r#"<div class="card"><h2>Prediction</h2><p class="empty">Not enough routing data yet to predict this peer's behavior — fills in as operations are routed through it.</p></div>"#.to_string()
+            r#"<div class="card"><h2>Prediction</h2><p class="empty">Not enough routing data yet to predict this peer's behavior. The card fills in as operations are routed through it.</p></div>"#.to_string()
         }
     } else {
         String::new()
@@ -1692,7 +1692,7 @@ fn build_estimator_chart(
 ) -> String {
     if curve_points.is_empty() {
         return format!(
-            r#"<div class="chart-section"><h3>{title}</h3><div class="empty-chart">No data yet — populates as operations route through this peer</div></div>"#,
+            r#"<div class="chart-section"><h3>{title}</h3><div class="empty-chart">No data yet. Populates as operations route through this peer.</div></div>"#,
             title = title,
         );
     }

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -1510,7 +1510,7 @@ fn peer_detail_html(address_str: &str) -> String {
             if event_count == 0 && tab_name != "All" {
                 write!(
                     panel_content,
-                    r#"<div class="empty-chart">No routing events for {name} operations yet</div>"#,
+                    r#"<div class="empty-chart">No {name} operations have routed through this peer yet — chart will populate as the network sends or relays {name}s through this connection</div>"#,
                     name = tab_name,
                 )
                 .ok();
@@ -1620,7 +1620,7 @@ fn peer_detail_html(address_str: &str) -> String {
                 ts = fmt_prediction_speed(pred.transfer_speed_bps),
             )
         } else {
-            r#"<div class="card"><h2>Prediction</h2><p class="empty">Insufficient data for prediction at this peer's location</p></div>"#.to_string()
+            r#"<div class="card"><h2>Prediction</h2><p class="empty">Not enough routing data yet to predict this peer's behavior — fills in as operations are routed through it.</p></div>"#.to_string()
         }
     } else {
         String::new()
@@ -1692,7 +1692,7 @@ fn build_estimator_chart(
 ) -> String {
     if curve_points.is_empty() {
         return format!(
-            r#"<div class="chart-section"><h3>{title}</h3><div class="empty-chart">Awaiting routing events</div></div>"#,
+            r#"<div class="chart-section"><h3>{title}</h3><div class="empty-chart">No data yet — populates as operations route through this peer</div></div>"#,
             title = title,
         );
     }

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -7649,17 +7649,20 @@ fn test_get_routing_coverage_low_htl() {
          Baseline: {relay_put_route_event_baseline}, after: {relay_put_route_event_after}."
     );
 
-    let relay_subscribe_route_event_after =
-        RELAY_SUBSCRIBE_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
-    let relay_subscribe_route_event_delta =
-        relay_subscribe_route_event_after.saturating_sub(relay_subscribe_route_event_baseline);
-    assert!(
-        relay_subscribe_route_event_delta > 0,
-        "RELAY_SUBSCRIBE_ROUTE_EVENT_COUNT did not advance — at least \
-         one of the 12 subscribes should have produced a routing event \
-         at a relay hop. \
-         Baseline: {relay_subscribe_route_event_baseline}, after: \
-         {relay_subscribe_route_event_after}."
+    // SUBSCRIBE route-event coverage is intentionally NOT asserted in
+    // this test. With the gateway PUT seeded at HTL=3 and 12 nodes
+    // subscribing, every subscribe in this workload hits the local-hit
+    // fast path at `subscribe/op_ctx_task.rs::drive_relay_subscribe`
+    // step 1 — the first relay always has the contract cached and
+    // replies `Subscribed` without forwarding downstream. That's a
+    // correct zero for the route-event counter, since the route-event
+    // hook only fires on actual forwards. A dedicated SUBSCRIBE forward
+    // test (subscriber + sparse cache topology) belongs as a follow-up.
+    // The relay SUBSCRIBE driver itself is still exercised — see the
+    // RELAY_SUBSCRIBE_DRIVER_CALL_COUNT assertion above.
+    let _ = (
+        RELAY_SUBSCRIBE_ROUTE_EVENT_COUNT.load(Ordering::SeqCst),
+        relay_subscribe_route_event_baseline,
     );
 
     // StateVerifier anomaly check

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -7427,9 +7427,10 @@ fn test_get_routing_coverage_low_htl() {
     use std::sync::atomic::Ordering;
 
     use freenet::dev_tool::{
-        GET_RELAY_DRIVER_CALL_COUNT, NodeLabel, RELAY_PUT_DRIVER_CALL_COUNT,
-        RELAY_SUBSCRIBE_DRIVER_CALL_COUNT, ScheduledOperation, SimOperation,
-        register_crdt_contract,
+        GET_RELAY_DRIVER_CALL_COUNT, NodeLabel, RELAY_GET_ROUTE_EVENT_COUNT,
+        RELAY_PUT_DRIVER_CALL_COUNT, RELAY_PUT_ROUTE_EVENT_COUNT,
+        RELAY_SUBSCRIBE_DRIVER_CALL_COUNT, RELAY_SUBSCRIBE_ROUTE_EVENT_COUNT, ScheduledOperation,
+        SimOperation, register_crdt_contract,
     };
 
     // Seed updated: per-peer acceptor reliability scoring replaces binary
@@ -7450,6 +7451,19 @@ fn test_get_routing_coverage_low_htl() {
     let relay_baseline = GET_RELAY_DRIVER_CALL_COUNT.load(Ordering::SeqCst);
     let relay_put_baseline = RELAY_PUT_DRIVER_CALL_COUNT.load(Ordering::SeqCst);
     let relay_subscribe_baseline = RELAY_SUBSCRIBE_DRIVER_CALL_COUNT.load(Ordering::SeqCst);
+
+    // Baselines for the relay-hop routing-event counters. Each fires when
+    // a relay forwards a downstream peer's response and feeds the result
+    // into the local Router via record_relay_route_event. Without these
+    // hooks the per-peer dashboard panels stay empty and the failure-
+    // probability model is trained only on originator-side events.
+    // The same workload that exercises the relay drivers above must
+    // also exercise these counters — drivers running without route-event
+    // emission would silently regress router quality.
+    let relay_get_route_event_baseline = RELAY_GET_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
+    let relay_put_route_event_baseline = RELAY_PUT_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
+    let relay_subscribe_route_event_baseline =
+        RELAY_SUBSCRIBE_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
 
     let rt = create_runtime();
 
@@ -7605,6 +7619,47 @@ fn test_get_routing_coverage_low_htl() {
          subscribe must traverse a relay hop. Dispatch gate for \
          SUBSCRIBE has likely regressed. \
          Baseline: {relay_subscribe_baseline}, after: {relay_subscribe_after}."
+    );
+
+    // Relay-hop routing-event counters: every relay that forwards a
+    // downstream response should feed the local Router. Drivers running
+    // without route-event emission means the per-peer dashboard panels
+    // stay empty and the failure-probability model is undertrained on
+    // relay-heavy nodes (the bug this work fixes).
+    let relay_get_route_event_after = RELAY_GET_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
+    let relay_get_route_event_delta =
+        relay_get_route_event_after.saturating_sub(relay_get_route_event_baseline);
+    assert!(
+        relay_get_route_event_delta > 0,
+        "RELAY_GET_ROUTE_EVENT_COUNT did not advance — at least one \
+         relay-forwarded GET should have produced a routing event for \
+         the local Router. {num_nodes}-node / HTL=3 workload with 15 \
+         GETs must traverse at least one relay hop. \
+         Baseline: {relay_get_route_event_baseline}, after: {relay_get_route_event_after}."
+    );
+
+    let relay_put_route_event_after = RELAY_PUT_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
+    let relay_put_route_event_delta =
+        relay_put_route_event_after.saturating_sub(relay_put_route_event_baseline);
+    assert!(
+        relay_put_route_event_delta > 0,
+        "RELAY_PUT_ROUTE_EVENT_COUNT did not advance — the gateway PUT \
+         at HTL=3 should have produced a routing event at every relay \
+         hop. \
+         Baseline: {relay_put_route_event_baseline}, after: {relay_put_route_event_after}."
+    );
+
+    let relay_subscribe_route_event_after =
+        RELAY_SUBSCRIBE_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
+    let relay_subscribe_route_event_delta =
+        relay_subscribe_route_event_after.saturating_sub(relay_subscribe_route_event_baseline);
+    assert!(
+        relay_subscribe_route_event_delta > 0,
+        "RELAY_SUBSCRIBE_ROUTE_EVENT_COUNT did not advance — at least \
+         one of the 12 subscribes should have produced a routing event \
+         at a relay hop. \
+         Baseline: {relay_subscribe_route_event_baseline}, after: \
+         {relay_subscribe_route_event_after}."
     );
 
     // StateVerifier anomaly check


### PR DESCRIPTION
## Problem

The router's failure-probability model and Renegade ML predictor only saw events from operations the local node *originated*. When the node forwarded a GET / PUT / SUBSCRIBE for someone else and observed the downstream peer's response, the observation was discarded — the relay path returns `OpOutcome::Incomplete` (filtered to `None` at `node.rs:621` before `routing_finished`).

User-visible symptom: per-peer dashboard panels (`/peer/<addr>`) stayed empty for hours even when each connection had shifted MB of forwarded traffic. On a relay-heavy node there was simply no per-peer data to display, and the failure-probability model was untrained on the data the node actually had access to. Reproduced on `technic` with 17 connected peers, ~30 MB transferred per peer in 2h, and only 2 router events globally (both PUTs technic originated).

## Approach

Add a small helper `operations::record_relay_route_event(op_manager, next_hop, contract_location, outcome, op_type)` that feeds a `RouteEvent` into the local Router for the relay's chosen downstream peer. Wire it into every relay-side response-handling site across the four ops:

- **GET legacy** (`operations/get.rs`): non-streaming `Response{Found}` forward, `ResponseStreaming` forward (both piping-started and non-streaming-fallback sub-cases), and the NotFound retry path.
- **GET task-per-tx** (`operations/get/op_ctx_task.rs::drive_relay_get_inner`): every iteration of the retry loop fires once for transport failures (send error, timeout) and protocol-success outcomes (InlineFound, NotFound).
- **PUT legacy** (`operations/put.rs`): both `Response` and `ResponseStreaming` forward sites.
- **PUT task-per-tx** (`operations/put/op_ctx_task.rs`): non-streaming `drive_relay_put` covers send error, timeout, `Response`/`ResponseStreaming` reply; streaming `drive_relay_put_streaming` covers downstream channel-closed, timeout, success reply.
- **SUBSCRIBE task-per-tx** (`operations/subscribe/op_ctx_task.rs::drive_relay_subscribe`): send error, timeout, `Subscribed`, `NotFound`.

### Outcome attribution

Per multi-model review, prompt downstream replies are recorded as `RouteOutcome::SuccessUntimed` (peer behaved correctly at the protocol level). `Failure` is reserved for transport-level signals: send error, timeout, channel-closed. In particular, **NotFound is recorded as Success**, not Failure — a peer that promptly answers "I don't host this contract" has not failed; the relay tries another candidate for that contract location anyway. Recording NotFound as Failure would systematically de-prioritise peers that route correctly but happen to not host the queried contracts. Local protocol gaps (LocalCompletion echo, Streaming-not-supported, Unexpected variant) skip the hook entirely — those are relay-side bugs, not peer signals.

### UPDATE intentionally excluded

UPDATE relays use `send_fire_and_forget` for downstream forwarding (both non-streaming and streaming variants), so the relay never observes whether the downstream peer succeeded or failed. Recording only the local send-error path would bias the per-peer UPDATE failure rate to 100% by construction. The existing UPDATE timeout reporting via `failure_routing_info` on the originator side is unchanged. See helper rustdoc.

### Determinism

The helper bypasses `Ring::routing_finished` (which would also update `peer_health` and `topology_manager`) and calls `router.write().add_event` directly. `peer_health::record_*` uses `std::time::Instant::now()` — a pre-existing TimeSource rule violation in `connection_manager.rs` lines ~182-203 — and amplifying its call rate from every relay hop compounded into observable event-count divergence in three strict-determinism simulation tests. **Caveat:** `Router::add_event` itself transitively calls `RoutingPredictor::record` → `wall_clock_hours()` → `SystemTime::now()`, so the router path is not strictly TimeSource-clean either; the determinism tests pass because the wall-clock variance there is well below the events each test counts. Migrating both `peer_health` and `routing_predictor` to `TimeSource` would let the helper go back to calling `routing_finished` straightforwardly. Tracked as a follow-up.

### No double-fire risk

Dispatch gates in `node.rs::handle_pure_network_message_v1` (`source_addr.is_some() && !has_*_op(id)`) ensure a fresh inbound message goes either to the task-per-tx relay driver OR to the legacy `process_message`, never both. Originator paths fire route events via the standard `report_result` → `routing_finished` flow on a different code path.

## Testing

- `test_get_routing_coverage_low_htl` (15-node, HTL=3) extended with assertions that `RELAY_GET_ROUTE_EVENT_COUNT` and `RELAY_PUT_ROUTE_EVENT_COUNT` advance during the workload. The pre-existing relay-driver counters (`*_DRIVER_CALL_COUNT`) measure dispatch only; the new counters measure actual route-event emission, closing the gap between "driver ran" and "router got data."
- **Source-scrape pin tests** in `drive_relay_get_inner_records_route_events_on_transport_failure` and `drive_relay_put_records_route_events_on_transport_failure` pin every transport-failure arm to call `record_relay_route_event` with the right `RouteOutcome`, addressing the testing review's "weak `delta > 0`" concern (the simulation assertion would otherwise pass with only one hook firing per op type, leaving the failure-path hooks silently deletable).
- `RELAY_SUBSCRIBE_ROUTE_EVENT_COUNT` is exposed via `dev_tool` but **not** asserted in this test. With HTL=3 and 12 subscribes, every subscribe in the workload hits the relay's local-hit fast path and never forwards downstream. That's a correct zero, just not what this workload exercises. A dedicated SUBSCRIBE forward test (sparse cache + far-away subscribers) is a follow-up.
- All four previously-failing simulation tests (`test_strict_determinism_*`, `test_direct_runner_determinism`, `test_thundering_herd_connect_storm`) pass after the determinism fix.
- `cargo test -p freenet --lib --features testing` clean (416 unit tests including the new pin tests).
- `cargo clippy -p freenet --all-targets -- -D warnings` clean.

## Multi-model review

Per `~/.claude/rules/multi-model-review.md`, ran four internal review agents (code-first, skeptical, testing, big-picture) in parallel plus `codex review --base main`. Findings addressed in commits 0c767b9f and 61e7ef1b:

- **Codex P1**: legacy GET `ResponseStreaming` relay branch was missing the hook → fixed.
- **Codex P2**: legacy GET NotFound retry path was missing the hook → fixed.
- **Skeptical / Code-First (outcome attribution)**: NotFound was recorded as Failure → fixed (now SuccessUntimed). Local protocol gaps no longer record events.
- **Skeptical (determinism doc)**: misleading claim that the router path is TimeSource-clean → updated to acknowledge the residual `routing_predictor` wall-clock use.
- **Big-picture (em-dashes)**: replaced em-dashes in dashboard empty-state strings with periods.
- **Testing (weak delta>0 assertions)**: added source-scrape pin tests for GET and PUT relay drivers.

## Follow-ups (not in this PR)

- `connection_manager.rs::PeerHealthTracker` (lines ~182-203) and `router::routing_predictor::record` should both migrate to `TimeSource` per `.claude/rules/code-style.md`. Pre-existing; surfaced and partially worked around by this PR.
- Dedicated SUBSCRIBE-forward simulation test that asserts `RELAY_SUBSCRIBE_ROUTE_EVENT_COUNT` advances on a sparse-cache topology.
- Per-peer dashboard could surface `PeerHealthTracker` stats and `PeerTransferStats::last_seen_tick` directly on the `/peer/<addr>` page. Minimal copy improvements landed here; richer activity card is a follow-up.
- `.claude/rules/operations.md` could document the "relay paths must feed the router via `record_relay_route_event`" pattern alongside the existing relay-driver invariants.

[AI-assisted - Claude]