### PR TITLE
build: exclude `mirror / mirror` from release pre-flight CI gate

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -548,8 +548,8 @@ check_prerequisites() {
             # filters so a Dependabot run in either state never gates a
             # release (release blocked by unrelated Dependabot cron,
             # 2026-04-14 v0.2.45 release).
-            in_progress_count=$(echo "$check_runs_json" | jq '[.check_runs[] | select(.status != "completed" and .name != "Dependabot" and (.name | startswith("Build for") | not) and .name != "claude" and .name != "Large Scale Simulation" and .name != "Simulation Tests (Nightly)" and .name != "Notify Matrix on Failure")] | length')
-            failed_count=$(echo "$check_runs_json" | jq '[.check_runs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .name != "Dependabot" and (.name | startswith("Build for") | not) and .name != "claude" and .name != "Large Scale Simulation" and .name != "Simulation Tests (Nightly)" and .name != "Notify Matrix on Failure")] | length')
+            in_progress_count=$(echo "$check_runs_json" | jq '[.check_runs[] | select(.status != "completed" and .name != "Dependabot" and (.name | startswith("Build for") | not) and .name != "claude" and .name != "Large Scale Simulation" and .name != "Simulation Tests (Nightly)" and .name != "Notify Matrix on Failure" and .name != "mirror / mirror")] | length')
+            failed_count=$(echo "$check_runs_json" | jq '[.check_runs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .name != "Dependabot" and (.name | startswith("Build for") | not) and .name != "claude" and .name != "Large Scale Simulation" and .name != "Simulation Tests (Nightly)" and .name != "Notify Matrix on Failure" and .name != "mirror / mirror")] | length')
 
             if [[ "$total_checks" == "0" ]]; then
                 echo "⚠️  (no checks found)"


### PR DESCRIPTION
## Problem

The release script (`scripts/release.sh`) refuses to start when any check on the main branch is failing. It already excludes scheduled / notifier / known-flaky workflows from this pre-flight check (Dependabot, Large Scale Simulation, Simulation Tests (Nightly), Notify Matrix on Failure, claude, Build for *), but `mirror / mirror` was never added.

The `Mirror to Freenet` workflow has been failing on every run since `e2a9c73c` (May 7) because its Matrix-alert step's token is "not active" — a pre-existing infra issue unrelated to any commit under release. This blocked the v0.2.55 release pre-flight this morning even though every actual code/test workflow on the head commit was green.

## Solution

Add `mirror / mirror` to the same exclusion list, in both the `in_progress_count` and `failed_count` jq filters. Same pattern as the existing entries.

## Testing

- `bash -n scripts/release.sh` clean.
- `gh api repos/freenet/freenet-core/commits/main/check-runs` confirms `mirror / mirror` is the exact name returned by the API (workflow `mirror`, job `mirror`).
- Will validate end-to-end by re-running `./scripts/release.sh --version 0.2.55 --skip-tests` once this lands.

[AI-assisted - Claude]