### PR TITLE
fix(update): auto-fetch contract on non-hosting originator (#4071)

### DIFF
--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -260,6 +260,36 @@ impl ExecutorError {
         }
     }
 
+    /// Narrow discriminator for the specific failure that the
+    /// originator-side UPDATE auto-fetch heals: contract code/params
+    /// are not present in the local `state_store`, so
+    /// `update_contract` cannot run the merge.
+    ///
+    /// Distinct from `is_contract_exec_rejection` (which negates a
+    /// broader set including other contract-side validation errors
+    /// like `Deser`/`InvalidState`/`InvalidDelta`/`Other`/`DoublePut`/
+    /// `InvalidArrayLength` and storage errors). Auto-fetching on
+    /// those broader failures is wasted work — the contract IS
+    /// present, the input is bad. Use this narrow predicate at
+    /// originator UPDATE call sites so a malformed delta or a disk
+    /// error never triggers auto-fetch storms.
+    ///
+    /// Discriminator: stdlib's `ContractError::Update` with a cause
+    /// containing the literal "missing contract parameters" string
+    /// (produced by `runtime.rs`'s `get_params` failure path,
+    /// approx. lines 920–953). Any other `Update` variant cause
+    /// returns false.
+    pub fn is_missing_contract_parameters(&self) -> bool {
+        match &self.inner {
+            Either::Left(req_err) => matches!(
+                req_err.as_ref(),
+                RequestError::ContractError(StdContractError::Update { cause, .. })
+                    if cause.contains("missing contract parameters")
+            ),
+            Either::Right(_) => false,
+        }
+    }
+
     /// Returns true ONLY when the contract WASM merge function ran to completion
     /// and returned a typed `InvalidUpdate` / `InvalidUpdateWithInfo` rejection
     /// (e.g., "New state version N must be higher than current version N"). This

--- a/crates/core/src/node/network_bridge/priority_select/tests.rs
+++ b/crates/core/src/node/network_bridge/priority_select/tests.rs
@@ -2629,7 +2629,7 @@ async fn test_handshake_yields_during_p7_buffer_drain() {
                     self.counter.fetch_add(1, Ordering::SeqCst);
                     Poll::Ready(Some(item))
                 }
-                other => other,
+                other @ Poll::Ready(None) | other @ Poll::Pending => other,
             }
         }
     }

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -472,6 +472,14 @@ impl OpError {
         matches!(self, Self::ExecutorError(e) if e.is_contract_exec_rejection())
     }
 
+    /// Narrow predicate for the originator-side UPDATE auto-fetch
+    /// trigger: returns true only for "missing contract parameters"
+    /// from `runtime.rs::get_params`. See
+    /// `ExecutorError::is_missing_contract_parameters` for rationale.
+    pub fn is_missing_contract_parameters(&self) -> bool {
+        matches!(self, Self::ExecutorError(e) if e.is_missing_contract_parameters())
+    }
+
     /// Returns true ONLY when the contract WASM merge function rejected the
     /// update with a typed `InvalidUpdate{,WithInfo}` error (the benign
     /// stale-state case from issue #3914). Use this for log-severity

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -2124,6 +2124,7 @@ mod tests {
     /// - upgrade-to-streaming: `ctx.send_to_and_register_waiter(...) +
     ///   conn_manager.send_stream(...)` — pinned by
     ///   `drive_relay_put_upgrades_when_payload_exceeds_threshold`
+    ///
     /// Both await downstream Response via `pending_op_results` (waiter
     /// receiver in the streaming branch, callback in the non-streaming
     /// branch). Neither uses `send_fire_and_forget`.

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -235,12 +235,47 @@ async fn drive_client_update(
                 return Err(OpError::RingError(RingError::NoHostingPeers(*key.id())));
             }
 
+            // No remote target → no peer to auto-fetch from. If
+            // `is_hosting_contract` reports true but `state_store`
+            // doesn't have params, that's an internal inconsistency
+            // (the ring's hosting registry is the announce/subscribe
+            // layer, not the executor's StateStore — they CAN
+            // diverge if a hosting announcement races with state
+            // eviction). Surface the missing-params case explicitly
+            // so operators can correlate the inconsistency, instead
+            // of letting it bubble as an opaque OpError.
             let UpdateExecution {
                 value: _,
                 summary,
                 changed,
                 ..
-            } = super::update_contract(op_manager, key, update_data, related_contracts).await?;
+            } = match super::update_contract(op_manager, key, update_data, related_contracts).await
+            {
+                Ok(execution) => execution,
+                Err(err) if err.is_missing_contract_parameters() => {
+                    tracing::error!(
+                        tx = %client_tx,
+                        contract = %key,
+                        error = %err,
+                        phase = "ring_state_store_inconsistency",
+                        "update (task-per-tx): is_hosting_contract reports true \
+                         but state_store has no params for this contract; cannot \
+                         auto-fetch (no remote target) — the ring/state-store \
+                         divergence must be repaired by a re-PUT or a manual \
+                         seeding step (#4066)"
+                    );
+                    return Ok(DriverOutcome::Publish(Err(ErrorKind::OperationError {
+                        cause: format!(
+                            "originator hosts {key} per ring but local state_store \
+                             is missing contract code/params; no remote peer \
+                             available to auto-fetch from"
+                        )
+                        .into(),
+                    }
+                    .into())));
+                }
+                Err(err) => return Err(err),
+            };
 
             if !changed {
                 tracing::debug!(
@@ -307,35 +342,61 @@ async fn drive_client_update(
                 Err(err) => {
                     // The wire format `UpdateMsg::RequestUpdate.value:
                     // WrappedState` carries a post-merge full state, so this
-                    // branch must produce one before forwarding. When the
-                    // failure is NOT a contract-exec rejection (i.e. the
-                    // contract code/params aren't local — the only example in
-                    // production is the "missing contract parameters" error
-                    // from `runtime.rs:920-953`), we cannot fabricate the
-                    // merged state. Self-heal by triggering a background GET
-                    // from the target peer (which the proximity cache /
-                    // ring routing chose, so it likely hosts the contract)
-                    // and synthesise a retriable `OperationError` so the
-                    // client retries — by then the auto-fetch will have
-                    // primed the local store and the second attempt will
-                    // succeed (#4066).
-                    if !err.is_contract_exec_rejection() {
+                    // branch must produce one before forwarding. The narrow
+                    // failure mode self-heal addresses is "missing contract
+                    // parameters" from `runtime.rs::get_params` (the local
+                    // `state_store` has no entry for this contract because
+                    // the originator never PUT/GET'd it).
+                    //
+                    // Self-heal by triggering a background GET from the
+                    // target peer chosen by proximity / ring routing for
+                    // this contract key. After the auto-fetch lands, the
+                    // local store is primed and a client retry succeeds.
+                    //
+                    // Why `target_addr` and not some other peer: the
+                    // auto-fetch is a directed `start_targeted_op` GET to
+                    // a SocketAddr, and `target_addr` is the only addr we
+                    // have at this site that the routing layer just
+                    // confirmed is reachable AND closer to the key than
+                    // we are. It may not host the contract directly, but
+                    // its own proximity cache / closest_hosting routing
+                    // is far more likely to land on a hoster on the next
+                    // hop than ours is (we don't host the contract, by
+                    // definition of being in this branch).
+                    //
+                    // Discriminator is the NARROW
+                    // `is_missing_contract_parameters` predicate, NOT the
+                    // broader `!is_contract_exec_rejection`: an
+                    // `is_contract_exec_rejection`-negation also matches
+                    // `Deser` / `InvalidState` / `InvalidDelta` / `Other`
+                    // / `DoublePut` / `InvalidArrayLength` and storage
+                    // errors. Auto-fetching on a malformed-input or
+                    // disk-error case is wasted work and an
+                    // amplification vector (every malformed delta
+                    // triggers a wire-level GET). Skeptical-review
+                    // callout on PR #4072 #4 (#4066).
+                    if err.is_missing_contract_parameters() {
                         tracing::warn!(
                             tx = %client_tx,
                             contract = %key,
                             error = %err,
                             target = %target_addr,
                             phase = "auto_fetch_originator",
-                            "update (task-per-tx): cannot apply locally on \
-                             non-hosting originator (likely missing contract \
-                             parameters); triggering auto-fetch from target \
-                             and asking client to retry"
+                            "update (task-per-tx): originator has no contract \
+                             code/params for this contract; triggering \
+                             auto-fetch from target and asking client to retry"
                         );
                         op_manager.try_auto_fetch_contract(&key, target_addr);
                         return Ok(DriverOutcome::Publish(Err(ErrorKind::OperationError {
                             cause: format!(
                                 "originator missing contract code/params for {key}; \
-                                     auto-fetch triggered, client should retry"
+                                     auto-fetch triggered from {target_addr}, \
+                                     client should retry after the local store \
+                                     is primed (typically <5s in healthy \
+                                     networks). Note: `try_auto_fetch_contract` \
+                                     is rate-limited 5min/contract, so retries \
+                                     within that window will surface the same \
+                                     error until the in-flight GET completes."
                             )
                             .into(),
                         }
@@ -2436,9 +2497,14 @@ mod tests {
     /// originator returns a hard failure to the client and never
     /// primes the local store, so subsequent retries also fail.
     ///
-    /// Pin the structure: the `Some(target) =>` branch must distinguish
-    /// `is_contract_exec_rejection() == false` (auto-fetch path) from
-    /// real WASM exec rejections (propagate as before).
+    /// The discriminator is the NARROW
+    /// `is_missing_contract_parameters` predicate, NOT the broader
+    /// `!is_contract_exec_rejection` (skeptical-review callout on
+    /// PR #4072). The broad form negates errors like `Deser`,
+    /// `InvalidState`, `InvalidDelta`, `Other`, `DoublePut`,
+    /// `InvalidArrayLength`, and storage errors — auto-fetching on
+    /// any of those is wasted work and an amplification vector
+    /// (every malformed delta would trigger a wire-level GET).
     #[test]
     fn drive_client_update_remote_target_auto_fetches_on_missing_params() {
         const SOURCE: &str = include_str!("op_ctx_task.rs");
@@ -2454,19 +2520,67 @@ mod tests {
         let arm_body = &body[arm..];
 
         assert!(
-            arm_body.contains("is_contract_exec_rejection"),
+            arm_body.contains("is_missing_contract_parameters"),
             "remote-target arm must distinguish missing-code/params errors \
-             from real WASM merge rejections via `is_contract_exec_rejection` \
-             — see #4066. Without this, every UPDATE from a non-hosting \
-             originator surfaces \"missing contract parameters\" to the \
-             client and never primes the local store."
+             via the NARROW `is_missing_contract_parameters` predicate, \
+             NOT `!is_contract_exec_rejection` — see #4066. Auto-fetching \
+             on the broader negation triggers unnecessary GETs for \
+             malformed-input and storage failures."
+        );
+        assert!(
+            !arm_body.contains("!err.is_contract_exec_rejection()"),
+            "remote-target arm must NOT use the broad \
+             `!is_contract_exec_rejection` discriminator — see the \
+             skeptical-review callout on PR #4072 #4. Use the narrow \
+             `is_missing_contract_parameters` predicate instead."
         );
         assert!(
             arm_body.contains("try_auto_fetch_contract"),
             "remote-target arm must call `op_manager.try_auto_fetch_contract` \
-             when the local apply fails with a non-rejection error so the \
+             when the local apply fails with the missing-params error so the \
              contract code/params get pulled from the chosen target peer. \
              See #4066."
+        );
+    }
+
+    /// The local-only branch (`None =>`, no remote target) must
+    /// surface `is_hosting_contract` / `state_store` divergence
+    /// explicitly instead of letting it bubble as an opaque
+    /// `OpError`. There is no remote peer to auto-fetch from, so the
+    /// only correct behavior is a structured error so operators can
+    /// correlate the inconsistency. Skeptical-review callout on
+    /// PR #4072 #1.
+    #[test]
+    fn drive_client_update_local_branch_surfaces_ring_state_store_divergence() {
+        const SOURCE: &str = include_str!("op_ctx_task.rs");
+        let prod = production_source(SOURCE);
+        let body = extract_fn_body(prod, "async fn drive_client_update(");
+
+        // Locate the local-only branch (no remote target).
+        let arm = body
+            .find("None =>")
+            .expect("drive_client_update must have a None local-only arm");
+        // Bound at the next match arm.
+        let arm_body = &body[arm..];
+        let arm_end = arm_body[1..]
+            .find("Some(target) =>")
+            .map(|p| p + 1)
+            .unwrap_or(arm_body.len());
+        let arm_slice = &arm_body[..arm_end];
+
+        assert!(
+            arm_slice.contains("is_missing_contract_parameters"),
+            "local-only arm must explicitly handle the \
+             `is_missing_contract_parameters` failure — see #4066. \
+             Without this, an `is_hosting_contract`/`state_store` \
+             divergence surfaces as an opaque OpError rather than a \
+             structured error operators can act on."
+        );
+        assert!(
+            arm_slice.contains("ring_state_store_inconsistency"),
+            "local-only arm must log the divergence with phase = \
+             \"ring_state_store_inconsistency\" so the inconsistency \
+             is searchable in operator dashboards (#4066)"
         );
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -289,28 +289,69 @@ async fn drive_client_update(
                 "update (task-per-tx): applying locally before forwarding"
             );
 
-            let UpdateExecution {
-                value: updated_value,
-                summary,
-                changed: _,
-                ..
-            } = super::update_contract(
+            let local_apply = super::update_contract(
                 op_manager,
                 key,
                 update_data.clone(),
                 related_contracts.clone(),
             )
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    tx = %client_tx,
-                    contract = %key,
-                    error = %e,
-                    phase = "error",
-                    "update (task-per-tx): failed to apply update locally before forwarding"
-                );
-                e
-            })?;
+            .await;
+
+            let UpdateExecution {
+                value: updated_value,
+                summary,
+                changed: _,
+                ..
+            } = match local_apply {
+                Ok(execution) => execution,
+                Err(err) => {
+                    // The wire format `UpdateMsg::RequestUpdate.value:
+                    // WrappedState` carries a post-merge full state, so this
+                    // branch must produce one before forwarding. When the
+                    // failure is NOT a contract-exec rejection (i.e. the
+                    // contract code/params aren't local — the only example in
+                    // production is the "missing contract parameters" error
+                    // from `runtime.rs:920-953`), we cannot fabricate the
+                    // merged state. Self-heal by triggering a background GET
+                    // from the target peer (which the proximity cache /
+                    // ring routing chose, so it likely hosts the contract)
+                    // and synthesise a retriable `OperationError` so the
+                    // client retries — by then the auto-fetch will have
+                    // primed the local store and the second attempt will
+                    // succeed (#4066).
+                    if !err.is_contract_exec_rejection() {
+                        tracing::warn!(
+                            tx = %client_tx,
+                            contract = %key,
+                            error = %err,
+                            target = %target_addr,
+                            phase = "auto_fetch_originator",
+                            "update (task-per-tx): cannot apply locally on \
+                             non-hosting originator (likely missing contract \
+                             parameters); triggering auto-fetch from target \
+                             and asking client to retry"
+                        );
+                        op_manager.try_auto_fetch_contract(&key, target_addr);
+                        return Ok(DriverOutcome::Publish(Err(ErrorKind::OperationError {
+                            cause: format!(
+                                "originator missing contract code/params for {key}; \
+                                     auto-fetch triggered, client should retry"
+                            )
+                            .into(),
+                        }
+                        .into())));
+                    }
+
+                    tracing::error!(
+                        tx = %client_tx,
+                        contract = %key,
+                        error = %err,
+                        phase = "error",
+                        "update (task-per-tx): failed to apply update locally before forwarding"
+                    );
+                    return Err(err);
+                }
+            };
 
             // Emit telemetry: UPDATE request initiated (mirrors legacy line 2047)
             if let Some(event) =
@@ -2382,6 +2423,51 @@ mod tests {
         assert!(classify_update_outcome_for_op_stats(&publish_ok));
         assert!(!classify_update_outcome_for_op_stats(&publish_err));
         assert!(!classify_update_outcome_for_op_stats(&infra));
+    }
+
+    /// Regression for #4066: when the originator is non-hosting and
+    /// `super::update_contract` fails because the local executor lacks
+    /// contract code/params (the "missing contract parameters" error
+    /// from `runtime.rs:920-953`), the client-initiated remote-target
+    /// branch must self-heal by triggering `try_auto_fetch_contract`
+    /// against the chosen forward target and synthesise a retriable
+    /// `OperationError` instead of returning a raw `OpError` to the
+    /// driver loop. Without this, every UPDATE from a non-hosting
+    /// originator returns a hard failure to the client and never
+    /// primes the local store, so subsequent retries also fail.
+    ///
+    /// Pin the structure: the `Some(target) =>` branch must distinguish
+    /// `is_contract_exec_rejection() == false` (auto-fetch path) from
+    /// real WASM exec rejections (propagate as before).
+    #[test]
+    fn drive_client_update_remote_target_auto_fetches_on_missing_params() {
+        const SOURCE: &str = include_str!("op_ctx_task.rs");
+        let prod = production_source(SOURCE);
+        let body = extract_fn_body(prod, "async fn drive_client_update(");
+
+        // Locate the remote-target arm. The `Some(target) =>` arm of the
+        // match on the proximity/ring-routed target peer is the only
+        // place `update_contract` is called for forwarding.
+        let arm = body
+            .find("Some(target) =>")
+            .expect("drive_client_update must have a Some(target) remote-target arm");
+        let arm_body = &body[arm..];
+
+        assert!(
+            arm_body.contains("is_contract_exec_rejection"),
+            "remote-target arm must distinguish missing-code/params errors \
+             from real WASM merge rejections via `is_contract_exec_rejection` \
+             — see #4066. Without this, every UPDATE from a non-hosting \
+             originator surfaces \"missing contract parameters\" to the \
+             client and never primes the local store."
+        );
+        assert!(
+            arm_body.contains("try_auto_fetch_contract"),
+            "remote-target arm must call `op_manager.try_auto_fetch_contract` \
+             when the local apply fails with a non-rejection error so the \
+             contract code/params get pulled from the chosen target peer. \
+             See #4066."
+        );
     }
 
     /// Truncate the source at the `#[cfg(test)]` marker so the pin


### PR DESCRIPTION
## Problem

The client-initiated UPDATE remote-target branch in
`drive_client_update` unconditionally calls `super::update_contract`
to apply the update locally before forwarding. On a non-hosting
originator the local executor lacks the contract's code and params,
so `Executor::upsert_contract_state` fails with
\"missing contract parameters\" and the UPDATE never reaches the
recipient.

```
ERROR ... update (task-per-tx): failed to apply update locally
      before forwarding
      contract=<key>
      error=put error for contract <key>, reason: missing contract
      parameters phase=\"error\"
```

See #4071 for full failure-mode analysis. Subset of #4066.

## Why we can't just skip local apply

The wire format `UpdateMsg::RequestUpdate.value: WrappedState` carries
a *post-merge full state*, not a delta. The originator MUST produce
one before forwarding, which requires the contract's params to merge
the delta. A raw-delta wire format would be a cleaner fix but it's a
wire-format change needing stdlib coordination and a
`min-compatible-version` bump (deferred).

The relay path at `drive_relay_request_update` (~line 698) already
handles non-hosting correctly: it checks `state_before.is_some()`
first and forwards without local apply when the contract isn't
hosted. The originator can't do that for the wire-format reason
above.

## Solution

Self-heal. When `update_contract` fails with an error where
`is_contract_exec_rejection() == false` (i.e. not a real WASM merge
rejection — the only production case is \"missing contract
parameters\"), trigger
`op_manager.try_auto_fetch_contract(&key, target_addr)` against the
chosen forward target (which the proximity cache / ring routing
picked, so it likely hosts the contract) and synthesise a retriable
`OperationError`. The next client retry sees the primed store and
succeeds.

`try_auto_fetch_contract` is rate-limited to one attempt per contract
per 5 minutes via `OpManager::pending_contract_fetches`, so multiple
writes queueing while the fetch is in flight don't hammer the target
peer. The mechanism was already used by the relay paths
(`BroadcastTo`, `RequestUpdate`); extending it to the
client-initiated branch matches existing self-heal semantics.

Real WASM-exec rejections (out-of-gas, traps, invalid update) keep
their existing ERROR-level log + raw `OpError` propagation.

## Test plan

- [x] `cargo test -p freenet --lib drive_client_update_remote_target_auto_fetches_on_missing_params` (regression: passes after fix, fails before)
- [x] `cargo test -p freenet --lib operations::update::` (53 passed)
- [x] `cargo clippy -p freenet --lib --tests -- -D warnings`
- [x] `cargo fmt`

## Drive-by

First commit fixes two pre-existing clippy warnings on `main` (same
as PR #4070 — needed to make pre-commit hooks pass).

## Fixes

Closes #4071. Partial fix for #4066 (the GET phantom timeout / leak
is tracked in #4069 / PR #4070).