### PR TITLE
fix(router): restore timed RouteOutcome::Success on task-per-tx GET/SUBSCRIBE

### DIFF
--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -325,11 +325,14 @@ async fn drive_client_get_inner(
             // the driver is the only place these side effects can
             // happen for Phase 3b.
             // Payload accounting for the router's `transfer_rate_estimator`
-            // and `response_start_time_estimator` (see router.rs:798 +
-            // router.rs:443). Set on the InlineFound/Streaming success
-            // paths; LocalCompletion is a request-echo with no network
-            // transfer so both stay zero (the router will skip the
-            // transfer-rate observation when payload_size==0).
+            // (router.rs:443) and `response_start_time_estimator`
+            // (router.rs:405). Set on the InlineFound/Streaming success
+            // paths; `Terminal::LocalCompletion` is the loopback
+            // Request-echo with no network round-trip — both stay zero
+            // AND we explicitly null the captured per-attempt timing
+            // below (see `timed_outcome`) to avoid poisoning the
+            // response-time model with sub-millisecond loopback latency
+            // samples attributed to `driver.current_target`.
             let mut payload_size: usize = 0;
             let mut transfer_duration: std::time::Duration = std::time::Duration::ZERO;
 
@@ -342,7 +345,13 @@ async fn drive_client_get_inner(
                     // InlineFound delivers state + optional contract in
                     // the same envelope as the Response header, so the
                     // payload transfer time is effectively zero — the
-                    // bytes arrived alongside the timing-of-first-response.
+                    // bytes arrived alongside the response. The router
+                    // deliberately skips `transfer_rate_estimator`
+                    // observations with `transfer_time.is_zero()`
+                    // (router.rs:443) so InlineFound feeds response-time
+                    // only; the legacy `GetStats` shape did the same
+                    // thing for the same reason (no measurable transfer
+                    // phase for an envelope-bundled payload).
                     payload_size =
                         state.size() + contract.as_ref().map(|c| c.data().len()).unwrap_or(0);
                     cache_contract_locally(
@@ -359,7 +368,18 @@ async fn drive_client_get_inner(
                     key,
                     stream_id,
                     includes_contract,
+                    total_size,
                 } => {
+                    // `total_size` is the wire-authoritative payload byte
+                    // count from the `ResponseStreaming` header. Using it
+                    // here (rather than re-querying the local store after
+                    // `cache_contract_locally`) prevents a TOCTOU race
+                    // where a concurrent UPDATE for the same contract
+                    // would mis-attribute a different payload's size to
+                    // this GET's transfer-rate observation, and side-steps
+                    // a separate "store evicted before re-query"
+                    // failure mode (the LRU has finite capacity).
+                    payload_size = *total_size as usize;
                     // Assemble the stream and cache locally. Mirrors
                     // the legacy `process_message` streaming branch
                     // at `get.rs:2721-3196`. Uses `current_target`
@@ -367,7 +387,16 @@ async fn drive_client_get_inner(
                     // single-hop response case where the responder
                     // equals the selected target.
                     if let Some(peer_addr) = driver.current_target.socket_addr() {
-                        let stream_start = std::time::Instant::now();
+                        // `transfer_duration` covers stream claim +
+                        // assemble + deserialize + local cache write —
+                        // the same composite measurement the legacy
+                        // `GetStats::record_transfer_end` captured at
+                        // `get.rs:1542`. For small payloads near the
+                        // streaming threshold the local-work component
+                        // is non-negligible, but keeping the metric
+                        // composite matches the existing router prior
+                        // built on the legacy code path.
+                        let stream_start = tokio::time::Instant::now();
                         if let Err(e) = assemble_and_cache_stream(
                             op_manager,
                             peer_addr,
@@ -383,27 +412,14 @@ async fn drive_client_get_inner(
                                 "get (task-per-tx): stream assembly failed — \
                                  state will not be cached locally"
                             );
+                            // Assembly failed → don't emit a transfer-rate
+                            // observation (transfer_duration stays ZERO,
+                            // which makes the router skip the rate sample
+                            // at router.rs:443). The response-time
+                            // observation still goes through because the
+                            // header DID arrive.
                         } else {
                             transfer_duration = stream_start.elapsed();
-                            // Re-query the store to learn the actual
-                            // assembled payload size. We do this here
-                            // rather than threading the size out of
-                            // `assemble_and_cache_stream` to keep that
-                            // helper focused on side-effects; the
-                            // store lookup is fast (in-memory LRU).
-                            if let Ok(ContractHandlerEvent::GetResponse {
-                                response: Ok(StoreResponse { state, contract }),
-                                ..
-                            }) = op_manager
-                                .notify_contract_handler(ContractHandlerEvent::GetQuery {
-                                    instance_id: *key.id(),
-                                    return_contract_code: *includes_contract,
-                                })
-                                .await
-                            {
-                                payload_size = state.map(|s| s.size()).unwrap_or(0)
-                                    + contract.map(|c| c.data().len()).unwrap_or(0);
-                            }
                         }
                     } else {
                         tracing::warn!(
@@ -470,24 +486,50 @@ async fn drive_client_get_inner(
             // Prefer the timed `Success` variant so the router's
             // `response_start_time_estimator` and
             // `transfer_rate_estimator` receive observations. Fall back
-            // to `SuccessUntimed` only when timing capture failed
-            // (e.g., synthetic Request-echo from a non-network path).
-            // Without this, the dashboard's Response Time and
-            // Transfer Rate charts stay permanently empty because
-            // those estimators are fed exclusively from
+            // to `SuccessUntimed` only when the reply was a loopback
+            // Request-echo (`Terminal::LocalCompletion`) — there is no
+            // wire round-trip to measure, so the captured per-attempt
+            // timing reflects pure in-process latency and would poison
+            // the response-time model with sub-millisecond samples
+            // attributed to the selected target peer. The other paths
+            // (InlineFound + Streaming) do measure real wire round-trip
+            // time. Without timed Success on those paths the dashboard's
+            // Response Time and Transfer Rate charts stay permanently
+            // empty because those estimators are fed exclusively from
             // `RouteOutcome::Success`. The success flag tracks the
-            // actual client-visible outcome (`host_result.is_ok()`),
-            // not the wire-level reply — if the store re-query
-            // returned nothing, the client sees OperationError and
-            // telemetry must agree.
+            // actual client-visible outcome (`host_result.is_ok()`), not
+            // the wire-level reply — if the store re-query returned
+            // nothing the client sees `OperationError` and telemetry
+            // must agree.
             let contract_location = Location::from(&reply_key);
-            let timed_outcome = match (driver.request_sent_at, driver.response_received_at) {
-                (Some(sent), Some(received)) if received >= sent => Some(RouteOutcome::Success {
-                    time_to_response_start: received.duration_since(sent),
-                    payload_size,
-                    payload_transfer_time: transfer_duration,
-                }),
-                _ => None,
+            let timed_outcome = if matches!(terminal, Terminal::LocalCompletion) {
+                None
+            } else {
+                match (driver.request_sent_at, driver.response_received_at) {
+                    (Some(sent), Some(received)) if received >= sent => {
+                        Some(RouteOutcome::Success {
+                            time_to_response_start: received.duration_since(sent),
+                            payload_size,
+                            payload_transfer_time: transfer_duration,
+                        })
+                    }
+                    (Some(sent), Some(received)) => {
+                        // `tokio::time::Instant` is monotonic, so this
+                        // arm should be unreachable on real hardware.
+                        // Logging instead of silently masking guards
+                        // against a clock-source regression slipping in
+                        // unnoticed.
+                        tracing::warn!(
+                            tx = %client_tx,
+                            sent_at_elapsed_secs = sent.elapsed().as_secs_f64(),
+                            received_at_elapsed_secs = received.elapsed().as_secs_f64(),
+                            "get (task-per-tx): received < sent on winning attempt; \
+                             falling back to SuccessUntimed"
+                        );
+                        None
+                    }
+                    _ => None,
+                }
             };
             let route_event = RouteEvent {
                 peer: driver.current_target.clone(),
@@ -562,13 +604,16 @@ struct GetRetryDriver<'a> {
     /// Wall-clock at the start of the most recent `build_request` call.
     /// Paired with `response_received_at` (captured in `classify`) to
     /// feed `time_to_response_start` into the router's isotonic
-    /// regression. The winning attempt's values are used.
-    request_sent_at: Option<std::time::Instant>,
+    /// regression. The winning attempt's values are used. `tokio::time::Instant`
+    /// is auto-paused in test builds with `start_paused(true)`, so
+    /// simulation tests see virtual elapsed time rather than wall-clock —
+    /// matches the rest of `crates/core/`'s timing primitives.
+    request_sent_at: Option<tokio::time::Instant>,
     /// Wall-clock when `classify` last returned a `Terminal` outcome.
     /// Reset to `None` until a terminal arrives; non-terminal classify
     /// outcomes (Retry / Unexpected) leave it untouched and the next
     /// `build_request` overwrites `request_sent_at`.
-    response_received_at: Option<std::time::Instant>,
+    response_received_at: Option<tokio::time::Instant>,
 }
 
 /// Terminal value for the GET driver.
@@ -592,11 +637,15 @@ enum Terminal {
     /// driver claims the stream, awaits assembly, and caches the
     /// assembled state + contract locally — mirroring what the
     /// legacy `process_message` streaming branch does at
-    /// `get.rs:2721-3196`.
+    /// `get.rs:2721-3196`. `total_size` carries the wire-authoritative
+    /// payload byte count from the streaming header so the driver
+    /// doesn't have to re-query the store post-assembly (which would
+    /// race a concurrent UPDATE for the same contract).
     Streaming {
         key: ContractKey,
         stream_id: StreamId,
         includes_contract: bool,
+        total_size: u64,
     },
     /// Request-echo from `forward_pending_op_result_if_completed` —
     /// state was already in the local store (via the pre-send
@@ -643,11 +692,13 @@ fn classify(reply: NetMessage) -> AttemptOutcome<Terminal> {
             key,
             stream_id,
             includes_contract,
+            total_size,
             ..
         })) => AttemptOutcome::Terminal(Terminal::Streaming {
             key,
             stream_id,
             includes_contract,
+            total_size,
         }),
         NetMessage::V1(NetMessageV1::Get(GetMsg::Request { .. })) => {
             AttemptOutcome::Terminal(Terminal::LocalCompletion)
@@ -683,7 +734,7 @@ impl RetryDriver for GetRetryDriver<'_> {
         // Capture send time per attempt. The winning attempt's timestamp
         // is read after the retry loop returns to compute
         // `time_to_response_start` for routing-prediction telemetry.
-        self.request_sent_at = Some(std::time::Instant::now());
+        self.request_sent_at = Some(tokio::time::Instant::now());
         NetMessage::from(GetMsg::Request {
             id: attempt_tx,
             instance_id: self.instance_id,
@@ -699,7 +750,7 @@ impl RetryDriver for GetRetryDriver<'_> {
         if matches!(outcome, AttemptOutcome::Terminal(_)) {
             // Only capture on Terminal so non-terminal Retry/Unexpected
             // outcomes leave the field as None until a terminal arrives.
-            self.response_received_at = Some(std::time::Instant::now());
+            self.response_received_at = Some(tokio::time::Instant::now());
         }
         outcome
     }
@@ -1364,6 +1415,10 @@ async fn drive_sub_op_get(
                     key,
                     stream_id,
                     includes_contract,
+                    // Sub-op GETs don't feed the router (no RouteEvent
+                    // is emitted on the sub-op path), so payload size
+                    // attribution is irrelevant here.
+                    total_size: _,
                 } => {
                     if let Some(peer_addr) = driver.current_target.socket_addr() {
                         if let Err(e) = assemble_and_cache_stream(
@@ -2490,17 +2545,23 @@ mod tests {
             extract_fn_body(src, "fn build_request(&mut self, attempt_tx: Transaction)");
         let classify_body = extract_fn_body(src, "fn classify(&mut self, reply: NetMessage)");
 
-        // Driver must capture send time at attempt construction.
+        // Driver must capture send time at attempt construction. The
+        // body must use `tokio::time::Instant::now()` — `std::time::Instant::now()`
+        // is banned in `crates/core/` by Rule Lint (see
+        // .claude/rules/code-style.md) AND would not virtualize under
+        // `start_paused(true)` in DST simulation tests.
         assert!(
-            build_body.contains("self.request_sent_at = Some(std::time::Instant::now())"),
-            "GetRetryDriver::build_request must capture request_sent_at; \
-             without this the Done branch has no `time_to_response_start`."
+            build_body.contains("self.request_sent_at = Some(tokio::time::Instant::now())"),
+            "GetRetryDriver::build_request must capture request_sent_at via \
+             tokio::time::Instant::now(); without this the Done branch has \
+             no `time_to_response_start`."
         );
         // Driver must capture receive time on Terminal classification.
         assert!(
-            classify_body.contains("self.response_received_at = Some(std::time::Instant::now())"),
-            "GetRetryDriver::classify must capture response_received_at on Terminal; \
-             without this the Done branch has no `time_to_response_start`."
+            classify_body.contains("self.response_received_at = Some(tokio::time::Instant::now())"),
+            "GetRetryDriver::classify must capture response_received_at on \
+             Terminal via tokio::time::Instant::now(); without this the Done \
+             branch has no `time_to_response_start`."
         );
         // Done branch must construct a timed Success with all three fields.
         assert!(
@@ -2520,6 +2581,58 @@ mod tests {
             inner_body.contains("RouteOutcome::SuccessUntimed"),
             "Done branch must keep a SuccessUntimed fallback for paths \
              without timing capture."
+        );
+        // The streaming path must use the wire-authoritative `total_size`
+        // rather than re-querying the store after assembly. Re-querying
+        // races a concurrent UPDATE on the same contract and can also
+        // return 0 if the LRU evicted the entry under cache pressure —
+        // both failure modes silently zero out the transfer-rate sample.
+        assert!(
+            inner_body.contains("payload_size = *total_size as usize"),
+            "Streaming branch must use wire-authoritative total_size for \
+             payload_size, not a post-assembly store re-query."
+        );
+        // The `Terminal::LocalCompletion` arm is a loopback Request-echo
+        // with no wire round-trip. Emitting timed Success there would
+        // poison the response-time model with sub-millisecond loopback
+        // samples attributed to the selected target peer.
+        assert!(
+            inner_body.contains("matches!(terminal, Terminal::LocalCompletion)"),
+            "Done branch must skip timed Success for Terminal::LocalCompletion \
+             (loopback Request-echo — no network round-trip to measure)."
+        );
+    }
+
+    /// Regression: when the GET retry loop exhausts all peers without a
+    /// Terminal classification, no `RouteOutcome::Success` is emitted.
+    /// A future "always emit a final route-event" refactor would silently
+    /// poison the success estimator with timed entries from peers that
+    /// returned NotFound for the whole retry chain.
+    #[test]
+    fn drive_client_get_inner_exhausted_does_not_emit_success() {
+        let src = production_source();
+        let inner_body = extract_fn_body(src, "async fn drive_client_get_inner(");
+        let exhausted_pos = inner_body
+            .find("RetryLoopOutcome::Exhausted(")
+            .expect("Done/Exhausted match must exist");
+        let exhausted_arm = &inner_body[exhausted_pos..];
+        // Bound the arm to the next match-arm by clipping at the next
+        // top-level `RetryLoopOutcome::` token.
+        let arm_end = exhausted_arm[1..]
+            .find("RetryLoopOutcome::")
+            .map(|p| p + 1)
+            .unwrap_or(exhausted_arm.len());
+        let arm_body = &exhausted_arm[..arm_end];
+        assert!(
+            !arm_body.contains("RouteOutcome::Success {"),
+            "Exhausted arm must NOT emit a timed RouteOutcome::Success — \
+             that would poison the response-time/transfer-rate estimators \
+             with synthetic data for peers that never produced a Terminal."
+        );
+        assert!(
+            !arm_body.contains("routing_finished("),
+            "Exhausted arm must NOT call routing_finished — no wire success \
+             attribution is appropriate for a peer set that returned NotFound."
         );
     }
 

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -288,6 +288,8 @@ async fn drive_client_get_inner(
         retries: 0,
         current_target,
         attempt_visited: VisitedPeers::new(&client_tx),
+        request_sent_at: None,
+        response_received_at: None,
     };
 
     let loop_result = drive_retry_loop(op_manager, client_tx, "get", &mut driver).await;
@@ -322,12 +324,27 @@ async fn drive_client_get_inner(
             // would fail with OpNotPresent for a task-per-tx op), so
             // the driver is the only place these side effects can
             // happen for Phase 3b.
+            // Payload accounting for the router's `transfer_rate_estimator`
+            // and `response_start_time_estimator` (see router.rs:798 +
+            // router.rs:443). Set on the InlineFound/Streaming success
+            // paths; LocalCompletion is a request-echo with no network
+            // transfer so both stay zero (the router will skip the
+            // transfer-rate observation when payload_size==0).
+            let mut payload_size: usize = 0;
+            let mut transfer_duration: std::time::Duration = std::time::Duration::ZERO;
+
             let reply_key = match &terminal {
                 Terminal::InlineFound {
                     key,
                     state,
                     contract,
                 } => {
+                    // InlineFound delivers state + optional contract in
+                    // the same envelope as the Response header, so the
+                    // payload transfer time is effectively zero — the
+                    // bytes arrived alongside the timing-of-first-response.
+                    payload_size =
+                        state.size() + contract.as_ref().map(|c| c.data().len()).unwrap_or(0);
                     cache_contract_locally(
                         op_manager,
                         *key,
@@ -350,6 +367,7 @@ async fn drive_client_get_inner(
                     // single-hop response case where the responder
                     // equals the selected target.
                     if let Some(peer_addr) = driver.current_target.socket_addr() {
+                        let stream_start = std::time::Instant::now();
                         if let Err(e) = assemble_and_cache_stream(
                             op_manager,
                             peer_addr,
@@ -365,6 +383,27 @@ async fn drive_client_get_inner(
                                 "get (task-per-tx): stream assembly failed — \
                                  state will not be cached locally"
                             );
+                        } else {
+                            transfer_duration = stream_start.elapsed();
+                            // Re-query the store to learn the actual
+                            // assembled payload size. We do this here
+                            // rather than threading the size out of
+                            // `assemble_and_cache_stream` to keep that
+                            // helper focused on side-effects; the
+                            // store lookup is fast (in-memory LRU).
+                            if let Ok(ContractHandlerEvent::GetResponse {
+                                response: Ok(StoreResponse { state, contract }),
+                                ..
+                            }) = op_manager
+                                .notify_contract_handler(ContractHandlerEvent::GetQuery {
+                                    instance_id: *key.id(),
+                                    return_contract_code: *includes_contract,
+                                })
+                                .await
+                            {
+                                payload_size = state.map(|s| s.size()).unwrap_or(0)
+                                    + contract.map(|c| c.data().len()).unwrap_or(0);
+                            }
                         }
                     } else {
                         tracing::warn!(
@@ -428,16 +467,33 @@ async fn drive_client_get_inner(
             // intercepted the Response. Without this, the router's
             // prediction model never receives GET success feedback.
             //
-            // The success flag tracks the actual client-visible
-            // outcome (`host_result.is_ok()`), not the wire-level
-            // reply — if the store re-query returned nothing, the
-            // client sees OperationError and telemetry must agree.
+            // Prefer the timed `Success` variant so the router's
+            // `response_start_time_estimator` and
+            // `transfer_rate_estimator` receive observations. Fall back
+            // to `SuccessUntimed` only when timing capture failed
+            // (e.g., synthetic Request-echo from a non-network path).
+            // Without this, the dashboard's Response Time and
+            // Transfer Rate charts stay permanently empty because
+            // those estimators are fed exclusively from
+            // `RouteOutcome::Success`. The success flag tracks the
+            // actual client-visible outcome (`host_result.is_ok()`),
+            // not the wire-level reply — if the store re-query
+            // returned nothing, the client sees OperationError and
+            // telemetry must agree.
             let contract_location = Location::from(&reply_key);
+            let timed_outcome = match (driver.request_sent_at, driver.response_received_at) {
+                (Some(sent), Some(received)) if received >= sent => Some(RouteOutcome::Success {
+                    time_to_response_start: received.duration_since(sent),
+                    payload_size,
+                    payload_transfer_time: transfer_duration,
+                }),
+                _ => None,
+            };
             let route_event = RouteEvent {
                 peer: driver.current_target.clone(),
                 contract_location,
                 outcome: if host_result.is_ok() {
-                    RouteOutcome::SuccessUntimed
+                    timed_outcome.unwrap_or(RouteOutcome::SuccessUntimed)
                 } else {
                     RouteOutcome::Failure
                 },
@@ -503,6 +559,16 @@ struct GetRetryDriver<'a> {
     retries: usize,
     current_target: PeerKeyLocation,
     attempt_visited: VisitedPeers,
+    /// Wall-clock at the start of the most recent `build_request` call.
+    /// Paired with `response_received_at` (captured in `classify`) to
+    /// feed `time_to_response_start` into the router's isotonic
+    /// regression. The winning attempt's values are used.
+    request_sent_at: Option<std::time::Instant>,
+    /// Wall-clock when `classify` last returned a `Terminal` outcome.
+    /// Reset to `None` until a terminal arrives; non-terminal classify
+    /// outcomes (Retry / Unexpected) leave it untouched and the next
+    /// `build_request` overwrites `request_sent_at`.
+    response_received_at: Option<std::time::Instant>,
 }
 
 /// Terminal value for the GET driver.
@@ -614,6 +680,10 @@ impl RetryDriver for GetRetryDriver<'_> {
     }
 
     fn build_request(&mut self, attempt_tx: Transaction) -> NetMessage {
+        // Capture send time per attempt. The winning attempt's timestamp
+        // is read after the retry loop returns to compute
+        // `time_to_response_start` for routing-prediction telemetry.
+        self.request_sent_at = Some(std::time::Instant::now());
         NetMessage::from(GetMsg::Request {
             id: attempt_tx,
             instance_id: self.instance_id,
@@ -625,7 +695,13 @@ impl RetryDriver for GetRetryDriver<'_> {
     }
 
     fn classify(&mut self, reply: NetMessage) -> AttemptOutcome<Terminal> {
-        classify(reply)
+        let outcome = classify(reply);
+        if matches!(outcome, AttemptOutcome::Terminal(_)) {
+            // Only capture on Terminal so non-terminal Retry/Unexpected
+            // outcomes leave the field as None until a terminal arrives.
+            self.response_received_at = Some(std::time::Instant::now());
+        }
+        outcome
     }
 
     fn advance(&mut self) -> AdvanceOutcome {
@@ -1256,6 +1332,8 @@ async fn drive_sub_op_get(
         retries: 0,
         current_target,
         attempt_visited: VisitedPeers::new(&tx),
+        request_sent_at: None,
+        response_received_at: None,
     };
 
     let loop_result = drive_retry_loop(op_manager, tx, "get-subop", &mut driver).await;
@@ -2393,6 +2471,55 @@ mod tests {
         assert!(
             retries >= MAX_RETRIES,
             "should exhaust at MAX_RETRIES={MAX_RETRIES}"
+        );
+    }
+
+    /// Regression for the peer-dashboard prediction-graph data-collection
+    /// regression: the client GET driver must emit a TIMED
+    /// `RouteOutcome::Success { time_to_response_start, payload_size,
+    /// payload_transfer_time }` on the success path so the router's
+    /// `response_start_time_estimator` and `transfer_rate_estimator`
+    /// receive observations. Before this fix the driver always emitted
+    /// `RouteOutcome::SuccessUntimed`, leaving the Response Time and
+    /// Transfer Rate charts on the peer dashboard permanently empty.
+    #[test]
+    fn drive_client_get_inner_emits_timed_success_on_success_path() {
+        let src = production_source();
+        let inner_body = extract_fn_body(src, "async fn drive_client_get_inner(");
+        let build_body =
+            extract_fn_body(src, "fn build_request(&mut self, attempt_tx: Transaction)");
+        let classify_body = extract_fn_body(src, "fn classify(&mut self, reply: NetMessage)");
+
+        // Driver must capture send time at attempt construction.
+        assert!(
+            build_body.contains("self.request_sent_at = Some(std::time::Instant::now())"),
+            "GetRetryDriver::build_request must capture request_sent_at; \
+             without this the Done branch has no `time_to_response_start`."
+        );
+        // Driver must capture receive time on Terminal classification.
+        assert!(
+            classify_body.contains("self.response_received_at = Some(std::time::Instant::now())"),
+            "GetRetryDriver::classify must capture response_received_at on Terminal; \
+             without this the Done branch has no `time_to_response_start`."
+        );
+        // Done branch must construct a timed Success with all three fields.
+        assert!(
+            inner_body.contains("RouteOutcome::Success {")
+                && inner_body.contains("time_to_response_start")
+                && inner_body.contains("payload_size")
+                && inner_body.contains("payload_transfer_time"),
+            "drive_client_get_inner Done branch must build RouteOutcome::Success \
+             with time_to_response_start + payload_size + payload_transfer_time. \
+             Emitting SuccessUntimed instead leaves the router's response-time \
+             and transfer-rate estimators with zero observations forever \
+             (Failure-Probability-only peer-dashboard regression)."
+        );
+        // SuccessUntimed remains as a fallback when timing was not captured
+        // (e.g., Request-echo / LocalCompletion paths).
+        assert!(
+            inner_body.contains("RouteOutcome::SuccessUntimed"),
+            "Done branch must keep a SuccessUntimed fallback for paths \
+             without timing capture."
         );
     }
 

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -615,7 +615,11 @@ async fn drive_client_subscribe_inner(
         // winning attempt's `request_sent_at` paired with the time of
         // terminal-reply arrival feeds the router's
         // `response_start_time_estimator` via `RouteOutcome::Success`.
-        let request_sent_at = std::time::Instant::now();
+        // `tokio::time::Instant` is auto-paused in test builds with
+        // `start_paused(true)`, so simulation tests see virtual elapsed
+        // time rather than wall-clock — matches the rest of
+        // `crates/core/`'s timing primitives.
+        let request_sent_at = tokio::time::Instant::now();
         let round_trip = tokio::time::timeout(
             OPERATION_TTL,
             ctx.send_to_and_await(current_target_addr, NetMessage::from(request)),
@@ -2708,12 +2712,17 @@ mod tests {
         let prod = production_source(SOURCE);
         let body = extract_fn_body(prod, "async fn drive_client_subscribe_inner(");
 
-        // Send-time capture must precede the round-trip await.
+        // Send-time capture must precede the round-trip await and MUST
+        // use `tokio::time::Instant` — `std::time::Instant` is banned in
+        // `crates/core/` by Rule Lint (see .claude/rules/code-style.md)
+        // and would not virtualize under `start_paused(true)` in DST
+        // simulation tests.
         assert!(
-            body.contains("let request_sent_at = std::time::Instant::now();"),
-            "drive_client_subscribe_inner must capture request_sent_at before \
-             send_to_and_await; without this the Subscribed branch has no \
-             time_to_response_start for the router."
+            body.contains("let request_sent_at = tokio::time::Instant::now();"),
+            "drive_client_subscribe_inner must capture request_sent_at via \
+             tokio::time::Instant::now() before send_to_and_await; without \
+             this the Subscribed branch has no time_to_response_start for \
+             the router."
         );
 
         // Subscribed branch must build a timed RouteOutcome::Success with

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -611,6 +611,11 @@ async fn drive_client_subscribe_inner(
         // never reach this peer. See issue #3838 and the doc comment on
         // `OpCtx::send_to_and_await`.
         let mut ctx = op_manager.op_ctx(attempt_tx);
+        // Capture wall-clock at send for routing-prediction telemetry. The
+        // winning attempt's `request_sent_at` paired with the time of
+        // terminal-reply arrival feeds the router's
+        // `response_start_time_estimator` via `RouteOutcome::Success`.
+        let request_sent_at = std::time::Instant::now();
         let round_trip = tokio::time::timeout(
             OPERATION_TTL,
             ctx.send_to_and_await(current_target_addr, NetMessage::from(request)),
@@ -733,6 +738,7 @@ async fn drive_client_subscribe_inner(
         // Classify the terminal reply.
         match classify_reply(&reply) {
             ReplyClass::Subscribed { key } => {
+                let time_to_response_start = request_sent_at.elapsed();
                 tracing::info!(
                     tx = %client_tx,
                     attempt_tx = %attempt_tx,
@@ -743,6 +749,40 @@ async fn drive_client_subscribe_inner(
                     outcome = "subscribed",
                     "subscribe (task-per-tx): subscribed"
                 );
+
+                // Feed the routing-prediction model on the client-initiated
+                // SUBSCRIBE success path. The legacy `subscribe.rs::outcome()`
+                // emitted `ContractOpSuccess { first_response_time, payload_size: 0,
+                // payload_transfer_time: ZERO }` so the router's
+                // `response_start_time_estimator` learned from every successful
+                // subscribe (payload_size==0 deliberately skips
+                // `transfer_rate_estimator`). The task-per-tx migration of this
+                // path stopped emitting any RouteEvent at all, leaving the
+                // response-time estimator with zero observations from
+                // client-initiated subscribes. Restore that feedback so the
+                // peer dashboard's Response Time chart populates again.
+                let contract_location = crate::ring::Location::from(&key);
+                let route_event = crate::router::RouteEvent {
+                    peer: current_target.clone(),
+                    contract_location,
+                    outcome: crate::router::RouteOutcome::Success {
+                        time_to_response_start,
+                        payload_size: 0,
+                        payload_transfer_time: std::time::Duration::ZERO,
+                    },
+                    op_type: Some(crate::node::network_status::OpType::Subscribe),
+                };
+                if let Some(log_event) = crate::tracing::NetEventLog::route_event(
+                    &client_tx,
+                    &op_manager.ring,
+                    &route_event,
+                ) {
+                    op_manager
+                        .ring
+                        .register_events(either::Either::Left(log_event))
+                        .await;
+                }
+                op_manager.ring.routing_finished(route_event);
                 // Mirror the legacy Response-handler side effects from
                 // `subscribe.rs`'s `SubscribeMsg::Response` arm. The
                 // task-per-tx reply forwarding bypass in `node.rs` skips
@@ -2650,6 +2690,55 @@ mod tests {
         assert!(!classify_subscribe_outcome_for_op_stats(&publish_err));
         assert!(classify_subscribe_outcome_for_op_stats(&skip));
         assert!(!classify_subscribe_outcome_for_op_stats(&infra));
+    }
+
+    /// Regression for the peer-dashboard prediction-graph data-collection
+    /// regression: the client-initiated SUBSCRIBE driver must emit a
+    /// `RouteEvent` carrying `RouteOutcome::Success { time_to_response_start,
+    /// payload_size: 0, payload_transfer_time: ZERO }` on the Subscribed
+    /// terminal branch. Before this fix the driver emitted NO route event
+    /// at all on the originator's success path (the relay branch did, but
+    /// the originator did not), so the router's
+    /// `response_start_time_estimator` saw zero observations from
+    /// client-initiated subscribes — contributing to the
+    /// Failure-Probability-only peer-dashboard regression.
+    #[test]
+    fn drive_client_subscribe_inner_emits_timed_success_on_subscribed() {
+        const SOURCE: &str = include_str!("op_ctx_task.rs");
+        let prod = production_source(SOURCE);
+        let body = extract_fn_body(prod, "async fn drive_client_subscribe_inner(");
+
+        // Send-time capture must precede the round-trip await.
+        assert!(
+            body.contains("let request_sent_at = std::time::Instant::now();"),
+            "drive_client_subscribe_inner must capture request_sent_at before \
+             send_to_and_await; without this the Subscribed branch has no \
+             time_to_response_start for the router."
+        );
+
+        // Subscribed branch must build a timed RouteOutcome::Success with
+        // payload_size=0 (matches the legacy `subscribe.rs::outcome()`
+        // semantics — SUBSCRIBE has no payload, so transfer_rate_estimator
+        // is intentionally not fed).
+        let subscribed_pos = body
+            .find("ReplyClass::Subscribed { key }")
+            .expect("Subscribed arm must exist");
+        let after = &body[subscribed_pos..];
+        assert!(
+            after.contains("RouteOutcome::Success")
+                && after.contains("time_to_response_start")
+                && after.contains("payload_size: 0")
+                && after.contains("payload_transfer_time: std::time::Duration::ZERO"),
+            "Subscribed branch must build RouteOutcome::Success with \
+             time_to_response_start + payload_size: 0 + payload_transfer_time: ZERO. \
+             Emitting nothing leaves the router's response-time estimator \
+             with zero observations from client-initiated subscribes."
+        );
+        assert!(
+            after.contains("op_manager.ring.routing_finished("),
+            "Subscribed branch must hand the RouteEvent to \
+             `routing_finished` so the router actually learns from it."
+        );
     }
 
     /// Truncate the source string at the `#[cfg(test)]` marker so the

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2905,6 +2905,56 @@ mod tests {
         );
     }
 
+    /// Regression: the per-tab "Routing Predictions" panel must call
+    /// `build_estimator_chart_or_placeholder` for all three
+    /// prediction-component slots (Failure Probability, Response Time,
+    /// Transfer Rate). Hiding empty slots previously masked the
+    /// task-per-tx data-collection regression for months — keeping every
+    /// slot visible makes future regressions detectable on sight.
+    /// Source-scrape rather than HTML-grep because the visible-when-empty
+    /// behaviour depends on a router_snapshot being present, and the
+    /// `home_page.rs::tests` module does not have a snapshot fixture
+    /// builder.
+    #[test]
+    fn peer_detail_panel_calls_estimator_helper_for_all_three_components() {
+        let src = include_str!("home_page.rs");
+        // Truncate at the test marker so the assertion below doesn't
+        // match against this very test's source.
+        let cutoff = src
+            .find("#[cfg(test)]")
+            .expect("home_page.rs must have a #[cfg(test)] section");
+        let prod = &src[..cutoff];
+        for title in [
+            "Failure Probability",
+            "Response Time (s)",
+            "Transfer Rate (B/s)",
+        ] {
+            // Find the helper call site and walk forward up to 200 bytes
+            // for the title literal. Whitespace-tolerant so rustfmt
+            // doesn't churn this pin.
+            let mut found = false;
+            let mut cursor = 0;
+            while let Some(call) = prod[cursor..].find("build_estimator_chart_or_placeholder(") {
+                let abs = cursor + call;
+                let tail_end = (abs + 400).min(prod.len());
+                let needle = format!("\"{title}\"");
+                if prod[abs..tail_end].contains(&needle) {
+                    found = true;
+                    break;
+                }
+                cursor = abs + 1;
+            }
+            assert!(
+                found,
+                "peer-detail panel builder must call \
+                 build_estimator_chart_or_placeholder with title {title:?} so the slot is \
+                 always visible. Without this every prediction-component \
+                 slot can silently disappear when its estimator has no \
+                 data — the original regression."
+            );
+        }
+    }
+
     #[test]
     fn build_estimator_chart_or_placeholder_renders_chart_when_data_present() {
         let curve = vec![(0.0, 0.1), (0.25, 0.5), (0.5, 0.9)];

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -1515,47 +1515,44 @@ fn peer_detail_html(address_str: &str) -> String {
                 )
                 .ok();
             } else {
-                // Only show charts that have data
-                if !f_curve.is_empty() {
-                    panel_content.push_str(&build_estimator_chart(
-                        "Failure Probability",
-                        f_curve,
-                        f_range,
-                        if tab_name == "All" { fail_adj } else { None },
-                        ploc,
-                        "0.0",
-                        "1.0",
-                    ));
-                }
-                if !rt_curve.is_empty() {
-                    panel_content.push_str(&build_estimator_chart(
-                        "Response Time (s)",
-                        rt_curve,
-                        rt_range,
-                        if tab_name == "All" { rt_adj } else { None },
-                        ploc,
-                        "0",
-                        "auto",
-                    ));
-                }
-                if !xfer_curve.is_empty() {
-                    panel_content.push_str(&build_estimator_chart(
-                        "Transfer Rate (B/s)",
-                        xfer_curve,
-                        xfer_range,
-                        if tab_name == "All" { xfer_adj } else { None },
-                        ploc,
-                        "auto",
-                        "0",
-                    ));
-                }
-                if panel_content.is_empty() {
-                    write!(
-                        panel_content,
-                        r#"<div class="empty-chart">Awaiting routing events</div>"#,
-                    )
-                    .ok();
-                }
+                // Always render all three prediction-component slots so the
+                // user can see every dimension the router models. Each slot
+                // either contains the rendered curve or a per-metric
+                // "awaiting data" placeholder — empty slots are NOT hidden,
+                // because hiding them silently rotted unobserved when the
+                // task-per-tx migration stopped feeding the response-time
+                // and transfer-rate estimators (the `Failure Probability`-only
+                // dashboard regression that surfaced this code path).
+                panel_content.push_str(&build_estimator_chart_or_placeholder(
+                    "Failure Probability",
+                    f_curve,
+                    f_range,
+                    if tab_name == "All" { fail_adj } else { None },
+                    ploc,
+                    "0.0",
+                    "1.0",
+                    "No success/failure observations have routed through this peer yet.",
+                ));
+                panel_content.push_str(&build_estimator_chart_or_placeholder(
+                    "Response Time (s)",
+                    rt_curve,
+                    rt_range,
+                    if tab_name == "All" { rt_adj } else { None },
+                    ploc,
+                    "0",
+                    "auto",
+                    "No timed responses have been observed from this peer yet.",
+                ));
+                panel_content.push_str(&build_estimator_chart_or_placeholder(
+                    "Transfer Rate (B/s)",
+                    xfer_curve,
+                    xfer_range,
+                    if tab_name == "All" { xfer_adj } else { None },
+                    ploc,
+                    "auto",
+                    "0",
+                    "No payload transfers have been observed from this peer yet.",
+                ));
             }
 
             let panel_active = if i == 0 { " tab-panel-active" } else { "" };
@@ -1674,6 +1671,42 @@ fn peer_detail_html(address_str: &str) -> String {
         charts = charts,
         renegade_chart = renegade_chart,
         prediction_card = prediction_card,
+    )
+}
+
+/// Render the named estimator chart, or — when no data has been observed
+/// yet — a titled placeholder. The placeholder keeps the slot visible so
+/// users can always see every component of a routing prediction even when
+/// some estimators have not yet received feedback. Hiding empty charts
+/// masked the data-collection regression in the task-per-tx migration
+/// that fed only `failure_estimator` and left `response_start_time` and
+/// `transfer_rate` permanently empty.
+#[allow(clippy::too_many_arguments)]
+fn build_estimator_chart_or_placeholder(
+    title: &str,
+    curve_points: &[(f64, f64)],
+    data_range: (f64, f64),
+    peer_adjustment: Option<f64>,
+    peer_location: Option<f64>,
+    y_min_hint: &str,
+    y_max_hint: &str,
+    empty_message: &str,
+) -> String {
+    if curve_points.is_empty() {
+        return format!(
+            r#"<div class="chart-section"><h3>{title}</h3><div class="empty-chart">{msg}</div></div>"#,
+            title = title,
+            msg = empty_message,
+        );
+    }
+    build_estimator_chart(
+        title,
+        curve_points,
+        data_range,
+        peer_adjustment,
+        peer_location,
+        y_min_hint,
+        y_max_hint,
     )
 }
 
@@ -2837,6 +2870,59 @@ mod tests {
         assert_eq!(fmt_prediction_speed(f64::NAN), "N/A");
         assert_eq!(fmt_prediction_speed(f64::INFINITY), "N/A");
         assert_eq!(fmt_prediction_speed(1024.0), "1024 B/s");
+    }
+
+    /// Regression: with no data the helper must still emit a titled
+    /// placeholder so all three prediction-component slots
+    /// (Failure Probability, Response Time, Transfer Rate) stay
+    /// visible on the peer dashboard. The previous behaviour hid the
+    /// chart entirely, which masked the task-per-tx data-collection
+    /// regression that left response-time/transfer-rate estimators
+    /// permanently empty (Failure-Probability-only dashboard).
+    #[test]
+    fn build_estimator_chart_or_placeholder_empty_renders_titled_placeholder() {
+        let html = build_estimator_chart_or_placeholder(
+            "Response Time (s)",
+            &[],
+            (0.0, 0.0),
+            None,
+            None,
+            "0",
+            "auto",
+            "No timed responses have been observed from this peer yet.",
+        );
+        assert!(
+            html.contains("<h3>Response Time (s)</h3>"),
+            "empty placeholder must still display the chart title so the user sees the slot is part of the model, got: {html}"
+        );
+        assert!(
+            html.contains("No timed responses have been observed"),
+            "empty placeholder must explain why no curve is shown, got: {html}"
+        );
+        assert!(
+            !html.contains("<svg"),
+            "empty placeholder must not render an SVG, got: {html}"
+        );
+    }
+
+    #[test]
+    fn build_estimator_chart_or_placeholder_renders_chart_when_data_present() {
+        let curve = vec![(0.0, 0.1), (0.25, 0.5), (0.5, 0.9)];
+        let html = build_estimator_chart_or_placeholder(
+            "Failure Probability",
+            &curve,
+            (0.0, 0.5),
+            None,
+            None,
+            "0.0",
+            "1.0",
+            "should not see this",
+        );
+        assert!(html.contains("<svg"), "non-empty curve must render an SVG");
+        assert!(
+            !html.contains("should not see this"),
+            "non-empty curve must not show the empty-message text"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The peer dashboard at `/peer/<addr>` was rendering only the **Failure Probability** chart; **Response Time** and **Transfer Rate** were permanently hidden.

Both estimators are fed exclusively by `RouteOutcome::Success { time_to_response_start, payload_size, payload_transfer_time }` (router.rs:405 + router.rs:443). After the #1454 task-per-tx migrations of GET (Phase 3b / Phase 5 final) and SUBSCRIBE (Phase 2b), **no production code path emits that variant on the originator any more**:

- client-initiated GET emitted `RouteOutcome::SuccessUntimed` (`operations/get/op_ctx_task.rs:411`)
- client-initiated SUBSCRIBE emitted **no** RouteEvent at all on the originator's success branch

So `response_start_time_estimator` and `transfer_rate_estimator` got zero observations forever; `failure_estimator` kept being fed. Hiding empty charts then masked the regression entirely.

This is the same "manually-mirrored telemetry rotted by task-per-tx migration" anti-pattern called out in `bug-prevention-patterns.md` (#4009 / #4010 precedents).

## Solution

1. **GET driver** — `GetRetryDriver` captures `request_sent_at` per attempt in `build_request` and `response_received_at` on Terminal classification. The client Done branch computes `time_to_response_start = received - sent`, sums `payload_size` from the InlineFound state + contract bytes (or from a post-assembly store re-query for streaming), and measures `payload_transfer_time` around `assemble_and_cache_stream`. Emits the timed `RouteOutcome::Success { .. }` when timing is available, falling back to `SuccessUntimed` only for Request-echo / LocalCompletion. Relay GETs continue to emit `SuccessUntimed` (no first-hop timing context).
2. **SUBSCRIBE driver** — capture `request_sent_at = Instant::now()` before `send_to_and_await`. On the `Subscribed` arm, build a `RouteEvent` with `RouteOutcome::Success { time_to_response_start, payload_size: 0, payload_transfer_time: ZERO }` and feed it through `routing_finished` (mirrors legacy `subscribe.rs::outcome()` semantics — SUBSCRIBE has no payload, so `transfer_rate_estimator` is deliberately not fed).
3. **Dashboard** — render all three prediction-component slots unconditionally. Empty curves now show a titled per-metric placeholder via a new `build_estimator_chart_or_placeholder` helper. Keeping the slots visible makes future data-collection regressions detectable on sight instead of silently hiding the affected dimension.

## Testing

- Source-scrape pin tests assert the GET driver captures request/response timing and emits `RouteOutcome::Success { .. }` on the success path, and that SUBSCRIBE's `Subscribed` arm builds a timed `RouteOutcome::Success` and hands it to `routing_finished`. These pin the data-collection contract that the task-per-tx migrations silently broke.
- Unit tests cover the new placeholder behaviour: empty curves render a titled placeholder; non-empty curves render the SVG.
- `cargo test -p freenet --lib` passes (2560 tests).
- `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.

## Test plan

- [x] Source-scrape pin tests for the GET and SUBSCRIBE timed-Success contract
- [x] Dashboard placeholder unit tests
- [x] Full `cargo test -p freenet --lib`
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [ ] CI green

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)