### PR TITLE
feat(fdev): add --as-state flag to `execute update`

### DIFF
--- a/crates/fdev/src/commands.rs
+++ b/crates/fdev/src/commands.rs
@@ -343,7 +343,11 @@ pub async fn update(config: UpdateConfig, other: BaseConfig) -> anyhow::Result<(
     let data = {
         let mut buf = vec![];
         File::open(&config.delta)?.read_to_end(&mut buf)?;
-        StateDelta::from(buf).into()
+        if config.as_state {
+            UpdateData::State(State::from(buf))
+        } else {
+            UpdateData::Delta(StateDelta::from(buf))
+        }
     };
     let request = ContractRequest::Update { key, data }.into();
     let mut client = start_api_client(other).await?;

--- a/crates/fdev/src/commands.rs
+++ b/crates/fdev/src/commands.rs
@@ -343,11 +343,7 @@ pub async fn update(config: UpdateConfig, other: BaseConfig) -> anyhow::Result<(
     let data = {
         let mut buf = vec![];
         File::open(&config.delta)?.read_to_end(&mut buf)?;
-        if config.as_state {
-            UpdateData::State(State::from(buf))
-        } else {
-            UpdateData::Delta(StateDelta::from(buf))
-        }
+        wrap_update_payload(buf, config.as_state)
     };
     let request = ContractRequest::Update { key, data }.into();
     let mut client = start_api_client(other).await?;
@@ -581,6 +577,17 @@ fn describe_update_variant(update: &UpdateData<'_>) -> &'static str {
     }
 }
 
+/// Wrap raw bytes read from the user-supplied file as either a full-state
+/// replacement or a delta payload. Pulled out of `update()` so the branching
+/// logic is unit-testable without spinning up the async client path.
+fn wrap_update_payload(buf: Vec<u8>, as_state: bool) -> UpdateData<'static> {
+    if as_state {
+        UpdateData::State(State::from(buf))
+    } else {
+        UpdateData::Delta(StateDelta::from(buf))
+    }
+}
+
 /// Write to a file atomically (write to temp, then rename) to prevent partial reads.
 fn atomic_write(path: &std::path::Path, data: &[u8]) -> anyhow::Result<()> {
     let dir = path.parent().unwrap_or(std::path::Path::new("."));
@@ -608,5 +615,31 @@ pub(crate) async fn execute_command(
             tracing::error!("Server returned error: {}", e);
             Err(e)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `--as-state` flag toggles wrapping between `State` (full replacement,
+    /// required by facade-style contracts whose `update_state` only matches
+    /// `UpdateData::State`) and the default `Delta` variant.
+    #[test]
+    fn wrap_update_payload_state_variant() {
+        let bytes = vec![1u8, 2, 3, 4];
+        let wrapped = wrap_update_payload(bytes.clone(), true);
+        assert!(matches!(wrapped, UpdateData::State(_)));
+        assert_eq!(extract_update_bytes(&wrapped), bytes.as_slice());
+        assert_eq!(describe_update_variant(&wrapped), "state");
+    }
+
+    #[test]
+    fn wrap_update_payload_delta_variant_default() {
+        let bytes = vec![9u8, 8, 7];
+        let wrapped = wrap_update_payload(bytes.clone(), false);
+        assert!(matches!(wrapped, UpdateData::Delta(_)));
+        assert_eq!(extract_update_bytes(&wrapped), bytes.as_slice());
+        assert_eq!(describe_update_variant(&wrapped), "delta");
     }
 }

--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -144,6 +144,11 @@ pub struct UpdateConfig {
     pub(crate) address: IpAddr,
     /// A path to the update/delta being pushed to the contract.
     pub(crate) delta: PathBuf,
+    /// Send the file contents as a full state replacement (`UpdateData::State`)
+    /// instead of the default delta (`UpdateData::Delta`). Use this when the
+    /// contract's `update_state` only accepts full-state replacements.
+    #[arg(long)]
+    pub(crate) as_state: bool,
     /// Whether this contract will be updated in the network or is just a dry run
     /// to be executed in local mode only. By default puts are performed in local.
     pub(crate) release: bool,

--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -142,7 +142,9 @@ pub struct UpdateConfig {
     /// The default value is `127.0.0.1`
     #[arg(short, long, default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST))]
     pub(crate) address: IpAddr,
-    /// A path to the update/delta being pushed to the contract.
+    /// Path to the file being pushed to the contract. Interpreted as a
+    /// `UpdateData::Delta` by default, or as a full-state replacement
+    /// (`UpdateData::State`) when `--as-state` is set.
     pub(crate) delta: PathBuf,
     /// Send the file contents as a full state replacement (`UpdateData::State`)
     /// instead of the default delta (`UpdateData::Delta`). Use this when the


### PR DESCRIPTION
## Summary

- Add `--as-state` flag to `fdev execute update`. Wraps file as
  `UpdateData::State` instead of the default `UpdateData::Delta`.
- Default behavior is unchanged.

## Why

`fdev execute update` always sends the on-disk file as
`UpdateData::Delta`. Contracts whose `update_state` only matches
`UpdateData::State` then return `InvalidUpdate` and the failure
surfaces only as a generic "invalid contract update" log line.

This breaks the freenet-email facade contract used to give users a
stable bookmarkable URL across releases (see freenet/mail#200). Every
prior mail release silently fails to flip the facade pointer; users
hitting the bookmark URL see whatever stale state happened to be on
the network.

## Testing

- `cargo test -p fdev` — 35/35 pass, including two new unit tests
  covering `wrap_update_payload` (State arm + default Delta arm).
- `cargo clippy -p fdev --tests` — clean (no `items-after-test-module`
  or other warnings).
- Manual: rebuilt fdev release binary, ran
  `fdev execute update --as-state <FACADE_ID> <STATE_FILE>` against a
  live `freenet network` daemon. UPDATE accepted by facade contract
  (was rejected as `InvalidUpdate` without the flag). Gateway then
  served the loader HTML at the facade URL with HTTP 200.
- Default behavior (no `--as-state`) is unit-test verified to
  produce `UpdateData::Delta`, unchanged from prior behavior.

## Fixes

- Unblocks freenet/mail#200 (stable bookmarkable URL across releases).
  Without this flag the mail-side facade pointer flip silently fails
  on every release. Paired mail-side PR: freenet/mail#215.

## Tangential: pre-existing `release` positional bug

`UpdateConfig::release` is declared as a bare `bool` without
`#[arg(long)]`, so clap treats it as a positional with `SetTrue`,
which fails clap's debug_asserts the moment you try to
`try_parse_from` an `UpdateConfig` in a unit test. I noticed this
while trying to add a clap-level integration test for `--as-state`;
the helper-level tests in this PR sidestep the issue by exercising
`wrap_update_payload` directly. Recommend a follow-up to switch
`release` to `#[arg(long)]` like `PutConfig` already does.