### PR TITLE
refactor(connect): migrate acquire_new to task-per-tx driver (#1454 phase 5 prep, CONNECT slice)

### DIFF
--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -1276,49 +1276,7 @@ impl ConnectOp {
         exclude_addrs: &[SocketAddr],
     ) -> (Transaction, Self, ConnectMsg) {
         let tx = Transaction::new::<ConnectMsg>();
-
-        // Initialize bloom filter with transaction-specific hash keys.
-        // Mark ourself and the target gateway as visited.
-        let mut visited = VisitedPeers::new(&tx);
-        if let Some(own_addr) = own.socket_addr() {
-            visited.mark_visited(own_addr);
-        }
-        if let Some(target_addr) = target.socket_addr() {
-            visited.mark_visited(target_addr);
-        }
-
-        // Exclude already-connected peers and recently-failed NAT addresses so routing
-        // nodes don't forward back to peers we already have a ring connection with.
-        //
-        // Bloom filter saturation note: VisitedPeers uses a 512-bit filter with k=4 hash
-        // functions. Pre-loading N entries raises the false-positive rate; at typical
-        // network sizes (≤ 20 connections in current deployments) the FP rate is negligible
-        // (~0.01%). At DEFAULT_MAX_CONNECTIONS (200), the rate reaches ~39%, which would
-        // cause routing to occasionally skip reachable peers. This is an accepted trade-off
-        // for current network sizes. If production nodes routinely reach high connection
-        // counts, consider capping pre-populated entries to the N closest connected peers
-        // (since greedy routing preferentially selects nearby peers anyway).
-        for addr in exclude_addrs {
-            visited.mark_visited(*addr);
-        }
-        if !exclude_addrs.is_empty() {
-            tracing::debug!(
-                excluded_addrs = exclude_addrs.len(),
-                "connect: pre-populated visited filter with excluded peer addresses (failed + connected)"
-            );
-        }
-
-        // Create joiner with PeerAddr::Unknown - the joiner doesn't know their own
-        // external address (especially behind NAT). The first recipient (gateway)
-        // will fill this in from the packet source address.
-        let joiner = PeerKeyLocation::with_unknown_addr(own.pub_key.clone());
-        let request = ConnectRequest {
-            desired_location,
-            joiner,
-            ttl,
-            visited,
-            uphill_budget: DEFAULT_UPHILL_BUDGET,
-        };
+        let msg = prepare_join_request(tx, &own, &target, desired_location, ttl, exclude_addrs);
 
         let op = ConnectOp::new_joiner(
             tx,
@@ -1328,11 +1286,6 @@ impl ConnectOp {
             Some(target.clone()),
             connect_forward_estimator,
         );
-
-        let msg = ConnectMsg::Request {
-            id: tx,
-            payload: request,
-        };
 
         (tx, op, msg)
     }
@@ -2484,6 +2437,63 @@ pub(super) async fn dispatch_expect_connection_from(
     });
 
     Ok(())
+}
+
+/// Build a `ConnectMsg::Request` for a joiner-initiated CONNECT.
+///
+/// Pure helper extracted from `ConnectOp::initiate_join_request` so the
+/// task-per-tx driver (`op_ctx_task::start_client_connect`) and
+/// `ring::Ring::acquire_new` can construct the wire message without
+/// allocating a legacy `ConnectOp` carrier. The caller is responsible
+/// for the `Transaction`.
+///
+/// Bloom filter saturation note: `VisitedPeers` uses a 512-bit filter
+/// with k=4 hash functions. Pre-loading N entries raises the false-positive
+/// rate; at typical network sizes (≤ 20 connections in current deployments)
+/// the FP rate is negligible (~0.01%). At DEFAULT_MAX_CONNECTIONS (200),
+/// the rate reaches ~39%, which would cause routing to occasionally skip
+/// reachable peers. This is an accepted trade-off for current network sizes.
+pub(crate) fn prepare_join_request(
+    tx: Transaction,
+    own: &PeerKeyLocation,
+    target: &PeerKeyLocation,
+    desired_location: Location,
+    ttl: u8,
+    exclude_addrs: &[SocketAddr],
+) -> ConnectMsg {
+    let mut visited = VisitedPeers::new(&tx);
+    if let Some(own_addr) = own.socket_addr() {
+        visited.mark_visited(own_addr);
+    }
+    if let Some(target_addr) = target.socket_addr() {
+        visited.mark_visited(target_addr);
+    }
+    for addr in exclude_addrs {
+        visited.mark_visited(*addr);
+    }
+    if !exclude_addrs.is_empty() {
+        tracing::debug!(
+            excluded_addrs = exclude_addrs.len(),
+            "connect: pre-populated visited filter with excluded peer addresses (failed + connected)"
+        );
+    }
+
+    // Create joiner with PeerAddr::Unknown - the joiner doesn't know their own
+    // external address (especially behind NAT). The first recipient (gateway)
+    // will fill this in from the packet source address.
+    let joiner = PeerKeyLocation::with_unknown_addr(own.pub_key.clone());
+    let request = ConnectRequest {
+        desired_location,
+        joiner,
+        ttl,
+        visited,
+        uphill_budget: DEFAULT_UPHILL_BUDGET,
+    };
+
+    ConnectMsg::Request {
+        id: tx,
+        payload: request,
+    }
 }
 
 #[tracing::instrument(fields(peer = %op_manager.ring.connection_manager.pub_key), skip_all)]

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -1153,6 +1153,11 @@ impl ConnectOp {
     }
 
     #[allow(clippy::too_many_arguments)]
+    // Retained for in-file unit tests + the legacy initiate_join_request
+    // wrapper; all production joiner-side initiation flows through the
+    // task-per-tx driver via prepare_join_request. Phase 5 final / PR-B
+    // deletes this along with the rest of impl Operation for ConnectOp.
+    #[allow(dead_code)]
     pub(crate) fn new_joiner(
         id: Transaction,
         desired_location: Location,
@@ -1266,6 +1271,12 @@ impl ConnectOp {
         self.first_hop.as_deref().cloned()
     }
 
+    // Retained for in-file unit tests; production callers (ring::acquire_new,
+    // join_ring_request, gateway_version_probe) build the wire message via the
+    // free `prepare_join_request` helper and skip the legacy ConnectOp carrier.
+    // Phase 5 final / PR-B deletes this along with the rest of
+    // impl Operation for ConnectOp.
+    #[allow(dead_code)]
     pub(crate) fn initiate_join_request(
         own: PeerKeyLocation,
         target: PeerKeyLocation,

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -2611,7 +2611,9 @@ pub(crate) async fn join_ring_request(
         // Bootstrap mode: target own location with jitter after failures.
         apply_bootstrap_jitter(base_location)
     };
+    let tx = Transaction::new::<ConnectMsg>();
     op_ctx_task::start_client_connect(
+        tx,
         gateway.clone(),
         gateway_addr,
         op_manager,
@@ -2653,7 +2655,9 @@ pub(crate) async fn gateway_version_probe(
     let own = op_manager.ring.connection_manager.own_location();
     let desired_location = own.location().unwrap_or_else(Location::random);
 
+    let tx = Transaction::new::<ConnectMsg>();
     op_ctx_task::start_client_connect(
+        tx,
         gateway.clone(),
         gateway_addr,
         op_manager,

--- a/crates/core/src/operations/connect/op_ctx_task.rs
+++ b/crates/core/src/operations/connect/op_ctx_task.rs
@@ -46,7 +46,7 @@ use crate::ring::{ConnectionFailureReason, Location, PeerKeyLocation};
 use crate::tracing::NetEventLog;
 
 use super::{
-    ConnectMsg, ConnectOp, ConnectRequest, ForwardAttempt, RelayEnv, RelayState,
+    ConnectMsg, ConnectRequest, ForwardAttempt, RelayEnv, RelayState,
     dispatch_expect_connection_from,
 };
 
@@ -133,7 +133,15 @@ impl Drop for RelayConnectInflightGuard {
 /// to wrapping the future in `tokio::time::timeout`, which would
 /// cancel the future mid-flight and leak the
 /// `pending_op_results` slot until the 60s sweep (#3100).
+///
+/// `tx` is supplied by the caller so the joiner-side transaction id
+/// can be registered with `LiveTransactionTracker` before the driver
+/// task is spawned. Allocating tx inside the driver would race the
+/// caller's `add_transaction` registration against the first inbound
+/// Response, which can arrive before the spawn completes on a busy
+/// runtime.
 pub(crate) async fn start_client_connect(
+    tx: Transaction,
     gateway: PeerKeyLocation,
     gateway_addr: SocketAddr,
     op_manager: &OpManager,
@@ -165,21 +173,8 @@ pub(crate) async fn start_client_connect(
     let mut exclude_addrs = failed_addrs;
     exclude_addrs.extend(connected_addrs);
 
-    // ConnectOp::initiate_join_request still returns a legacy ConnectOp
-    // value; slice 2 originator does not push it into ops.connect (the
-    // driver owns state in task locals). Drop it. Future cleanup: split
-    // the bloom-filter / Request-message construction off into a free
-    // helper so the legacy ConnectOp allocation is avoided entirely.
-    // Tracked for follow-up — addressed alongside Phase 6 cleanup.
-    let (tx, _legacy_op, request_msg) = ConnectOp::initiate_join_request(
-        own.clone(),
-        gateway.clone(),
-        desired_location,
-        ttl,
-        target_connections,
-        op_manager.connect_forward_estimator.clone(),
-        &exclude_addrs,
-    );
+    let request_msg =
+        super::prepare_join_request(tx, &own, &gateway, desired_location, ttl, &exclude_addrs);
 
     if let Some(event) = NetEventLog::connect_request_sent(
         &tx,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -37,9 +37,8 @@ use crate::transport::TransportPublicKey;
 use crate::util::{Contains, time_source::InstantTimeSrc};
 use crate::{
     config::{GlobalExecutor, GlobalRng},
-    message::{NetMessage, NetMessageV1, Transaction},
+    message::Transaction,
     node::{self, EventLoopNotificationsSender, NodeConfig, OpManager, PeerId},
-    operations::{OpEnum, connect::ConnectOp},
     router::Router,
 };
 
@@ -2667,52 +2666,55 @@ impl Ring {
             target_location = %ideal_location,
             "Sending connect request via connection_maintenance"
         );
-        let ttl = self.max_hops_to_live.max(1).min(u8::MAX as usize) as u8;
-        let target_connections = self.connection_manager.min_connections;
 
-        let failed_addrs = self.connection_manager.recently_failed_addrs();
-        let connected_addrs = self.connection_manager.connected_peer_addrs();
-        tracing::debug!(
-            failed = failed_addrs.len(),
-            connected = connected_addrs.len(),
-            "acquire_new: pre-populating bloom filter with excluded peer addresses"
-        );
-        let mut exclude_addrs = failed_addrs;
-        exclude_addrs.extend(connected_addrs);
-        let (tx, op, msg) = ConnectOp::initiate_join_request(
-            joiner.clone(),
-            query_target.clone(),
-            ideal_location,
-            ttl,
-            target_connections,
-            op_manager.connect_forward_estimator.clone(),
-            &exclude_addrs,
-        );
+        // Driver computes ttl / target_connections / exclude_addrs internally
+        // (see start_client_connect at op_ctx_task.rs). acquire_new only
+        // needs to allocate the joiner tx, register it with
+        // live_tx_tracker, and spawn the driver task.
+        let _ = notifier;
+        let tx = Transaction::new::<crate::operations::connect::ConnectMsg>();
 
-        // Emit telemetry for initial connect request sent
-        if let Some(event) = NetEventLog::connect_request_sent(
-            &tx,
-            self,
-            ideal_location,
-            joiner,
-            query_target.clone(),
-            ttl,
-            true, // is_initial
-        ) {
-            self.register_events(Either::Left(event)).await;
-        }
+        let gateway_addr = match query_target.socket_addr() {
+            Some(addr) => addr,
+            None => {
+                tracing::warn!(
+                    target_location = %ideal_location,
+                    "acquire_new: selected query target has no socket address, skipping spawn"
+                );
+                return Ok(None);
+            }
+        };
 
-        if let Some(addr) = query_target.socket_addr() {
-            live_tx_tracker.add_transaction(addr, tx);
-        }
-        op_manager
-            .push(tx, OpEnum::Connect(Box::new(op)))
+        // Register tx with the live transaction tracker BEFORE spawning the
+        // driver. Otherwise the driver's first Response could land on the
+        // bypass before the registration completes, breaking the
+        // active_connect_transaction_count gauge that connection_maintenance
+        // uses to throttle concurrent acquisitions.
+        live_tx_tracker.add_transaction(gateway_addr, tx);
+
+        let op_manager_spawn = op_manager.clone();
+        let gateway = query_target.clone();
+        let joiner_for_driver = joiner;
+        GlobalExecutor::spawn(async move {
+            if let Err(err) = crate::operations::connect::op_ctx_task::start_client_connect(
+                tx,
+                gateway,
+                gateway_addr,
+                &op_manager_spawn,
+                joiner_for_driver,
+                ideal_location,
+                None,
+            )
             .await
-            .map_err(|err| anyhow::anyhow!(err))?;
-        notifier
-            .notifications_sender
-            .send(Either::Left(NetMessage::V1(NetMessageV1::Connect(msg))))
-            .await?;
+            {
+                tracing::debug!(
+                    %tx,
+                    %err,
+                    "acquire_new: CONNECT driver completed with error"
+                );
+            }
+        });
+
         tracing::debug!(tx = %tx, "Connect request sent");
         Ok(Some(tx))
     }


### PR DESCRIPTION
## Problem

CONNECT is the last operation in the #1454 migration without a Phase 5
final retirement of its legacy state machine. SUBSCRIBE, GET, PUT,
UPDATE all landed (PRs #4076, #4065, #4089 etc.). CONNECT has the
driver (`start_client_connect` from Phase 2c slice 2) but
`ring::Ring::acquire_new` — called from `connection_maintenance` for
topology-driven connection acquisition — still goes through the
legacy `ConnectOp::initiate_join_request` + `OpManager::push` +
`EventLoopNotificationsSender` plumbing. That insert is the only
remaining production writer into `ops.connect`, and it blocks the
retirement of `impl Operation for ConnectOp` /
`OpManager.ops.connect` DashMap / `OpEnum::Connect` /
`has_connect_op` / the GC sweep arms / the
`handle_op_request::<ConnectOp>` fallthrough.

## Solution

Three small focused commits, no semantic changes to the wire flow:

1. **Extract `prepare_join_request` helper** — pure free function
   that takes a caller-supplied `Transaction` and returns the
   `ConnectMsg::Request` with bloom-filter + visited-peers
   initialization. Pulled out of
   `ConnectOp::initiate_join_request` so both the driver and
   `acquire_new` can build the wire message without allocating a
   legacy `ConnectOp` carrier. `initiate_join_request` is now a thin
   wrapper kept for in-file unit tests.

2. **`start_client_connect` accepts caller tx** — driver signature
   gains a leading `tx: Transaction` parameter so the caller can
   allocate the tx, register it with `LiveTransactionTracker`, and
   pass it through atomically. Updates `join_ring_request` and
   `gateway_version_probe` accordingly. Removes the in-driver
   `ConnectOp::initiate_join_request` call and the
   "Future cleanup: split the bloom-filter…" TODO comment.

3. **`acquire_new` spawns the driver** — `ring.rs:2682-2716` legacy
   body (push + notifications_sender) replaced with allocation +
   `LiveTransactionTracker.add_transaction` + `GlobalExecutor::spawn`
   of `start_client_connect`. Telemetry emission moves into the
   driver (where it was already a duplicate). Local `ttl` /
   `target_connections` / `exclude_addrs` computes drop because the
   driver computes its own from `op_manager.ring`.

After this PR no production code writes into `ops.connect`. PR-B
will retire the legacy state machine in a sister change.

## Testing

- `cargo build` clean across all features.
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test -p freenet --lib` — 2459 passed, 14 ignored.
- `cargo test -p freenet --lib connect` — 462 passed, 6 ignored.
- `new_joiner` and `initiate_join_request` retained
  `#[allow(dead_code)]` — only in-file tests reference them now;
  PR-B deletes the legacy carrier entirely.

## Behavior preserved

- `acquire_new` remains fire-and-forget — it returns once the spawn
  is scheduled, mirroring the legacy behavior of returning once the
  Request hit `notifications_sender`. Caller signature unchanged.
- `LiveTransactionTracker.add_transaction(addr, tx)` happens
  pre-spawn so the active-connect gauge in `connection_maintenance`
  stays consistent.
- All four entry points (bootstrap `join_ring_request`,
  `gateway_version_probe`, topology-maintenance `acquire_new`,
  contract-directed CONNECT via `acquire_new`) now go through
  `start_client_connect`.

## Fixes

Prerequisite for the #1454 phase 5 final CONNECT slice. No standalone
issue closure.