### PR TITLE
chore: sweep stale #1454 migration commentary

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -6,400 +6,73 @@ paths:
 
 # Operations Module Rules
 
-> **Path-scoped rule, legacy state-machine path.** As of #1454 Phase 2b
-> (PR #3806) SUBSCRIBE's client-initiated path was migrated to a
-> task-per-transaction driver in `operations/subscribe/op_ctx_task.rs`.
-> Phase 3a (PR #3843) migrated client-initiated PUT to
-> `operations/put/op_ctx_task.rs`, Phase 3b migrated client-initiated
-> GET to `operations/get/op_ctx_task.rs` (both using the shared
-> `RetryDriver` trait from `op_ctx.rs`), Phase 4 migrated
-> client-initiated UPDATE to `operations/update/op_ctx_task.rs` (using
-> the fire-and-forget `OpCtx::send_fire_and_forget` — no retry loop
-> needed since UPDATE has no response to await), and Phase 5 (#3883)
-> migrated fresh inbound relay GETs to the task-per-tx driver in
-> `operations/get/op_ctx_task.rs::start_relay_get`. On these paths,
-> op state lives in task locals and is never pushed into
-> `OpManager.ops.*`, so rules below that talk about "pushing state" /
-> `load_or_init` / `handle_op_result` apply only to the **legacy
-> state-machine path**, which now serves only:
-> CONNECT's joiner
-> branches reachable only from in-file unit tests + the legacy
-> stateless `ObservedAddress` path in `load_or_init` (relay CONNECT
-> fully migrated to `connect::op_ctx_task::start_relay_connect` in
-> Phase 2c slice 1 — fresh `Request`s with `source_addr.is_some()`
-> AND `!has_connect_op(id)` route to the task-per-tx driver, all four
-> non-Request `ConnectMsg` variants flow through the per-tx waiter
-> receiver via the bypass extension at `node.rs`), and SUBSCRIBE's
-> executor / intermediate-peer entry points (PUT-sub-op SUBSCRIBE
-> migrated in Phase 3a/3b; renewal migrated in the SUBSCRIBE renewal
-> slice — see below). Phase 5 follow-up slice A (PR #3910) migrated fresh
-> inbound non-streaming relay `UpdateMsg::RequestUpdate` and
-> `UpdateMsg::BroadcastTo` to
-> `operations/update/op_ctx_task.rs::start_relay_request_update` /
-> `start_relay_broadcast_to` (originally gated on
-> `source_addr.is_some()` AND `!has_update_op(id)`).
->
-> **#1454 phase 5 final (UPDATE slice) retired the entire legacy
-> UPDATE state-machine path.** `OpEnum::Update`, `OpManager.ops.update`
-> DashMap, `impl Operation for UpdateOp`, `request_update` /
-> `start_op` / `start_op_with_id`, `has_update_op`,
-> `remove_update_and_report_failure`, and the
-> `handle_op_request<UpdateOp>` fallthrough in node.rs are all gone.
-> Every UPDATE wire variant now dispatches unconditionally to a
-> task-per-tx driver — the `!has_update_op(id)` guard was redundant
-> because the DashMap could no longer be populated (every writer
-> lived inside the deleted `process_message`). The dead executor
-> network UPDATE path (`UpdateContract` /
-> `ComposeNetworkMessage<UpdateOp>` / network branch of
-> `perform_contract_update`) was retired in commit 1; it had been
-> unreachable in production because no `OperationMode::Network`
-> constructor exists in the tree. **Phase 6 (UPDATE slice)** deleted
-> the surviving `UpdateOp`, `UpdateState`, `UpdateStats`,
-> `FinishedData` scaffolding, the inline outcome / failure-routing
-> pin tests, and the two stale `process_message`-anchored pin tests
-> (driver-side pin tests in `update/op_ctx_task.rs:2063` / `:2345`
-> cover the same `send_summary_back_on_rejection` invariant). The
-> wire-format types, `BroadcastDedupCache`, `BroadcastTargetResult`,
-> `OpManager::try_auto_fetch_contract`, `update_contract` +
-> `UpdateExecution` + the log helpers, and the post-merge propagation
-> helpers + the `log_severity` regression suite (#3914) + the
-> `summary_back_helper_gates_on_summary_equality` pin remain because
-> the task-per-tx drivers consume them. Phase 5
-> follow-up slice A (PR #3917) migrated fresh inbound non-streaming
-> relay `PutMsg::Request` to
-> `operations/put/op_ctx_task.rs::start_relay_put` (originally gated on
-> `source_addr.is_some()` AND `!has_put_op(id)` AND the payload size
-> would not upgrade to streaming on forward). PUT GC speculative
-> retries and the per-op `ack_received` / `speculative_paths` fields
-> have since been retired (PR #3964) along with `PutMsg::ForwardingAck`
-> senders; the receiver was a no-op carried for backward-compat with
-> pre-#3964 peers. Phase 5 follow-up slice B migrated fresh inbound
-> streaming relay `PutMsg::RequestStreaming` to
-> `operations/put/op_ctx_task.rs::start_relay_put_streaming` (same
-> `source_addr.is_some()` AND `!has_put_op(id)` gate). The streaming
-> driver claims the inbound stream via
-> `orphan_stream_registry().claim_or_wait`, forks the handle for
-> downstream piping via `NetworkBridge::pipe_stream`, assembles
-> locally via the shared `relay_put_store_locally` helper, and
-> bubbles a non-streaming `PutMsg::Response` upstream (mirrors the
-> legacy downgrade at `put.rs:1517`). The dispatch site passes a
-> cloned `NetworkBridge` into the spawn so the driver can call
-> `pipe_stream` without a detour through `OpCtx`.
->
-> **Upgrade-on-forward (PR #4063):** `start_relay_put` (slice A's
-> driver) now performs the upgrade-on-forward decision itself:
-> after `relay_put_store_locally` it re-serializes the merged
-> payload, calls `should_use_streaming`, and conditionally builds
-> either `PutMsg::Request` or `PutMsg::RequestStreaming +
-> NetworkBridge::send_stream` for the forward. The streaming branch
-> uses `OpCtx::send_to_and_register_waiter` to install the reply
-> waiter BEFORE dispatching stream fragments (closes the race where
-> a fast downstream Response arrives before `pending_op_results` is
-> populated). The dispatch gate in node.rs no longer pre-checks
-> `should_use_streaming` — every fresh inbound non-streaming
-> Request dispatches via `start_relay_put`, which owns the upgrade
-> decision. This closed the legacy-only edge case (a non-streaming
-> `Request` that needs streaming on forward but has no inbound
-> `StreamId` to claim via `orphan_stream_registry`) and is the
-> prerequisite for PUT slice retirement of the legacy state machine.
->
-> **#1454 phase 5 final (PUT slice) retired the legacy PUT
-> state-machine path.** `OpEnum::Put`, `OpManager.ops.put` DashMap,
-> `impl Operation for PutOp`, `has_put_op`,
-> `remove_put_and_report_failure`, the `OpEnum::Put` arm in
-> `IsOperationCompleted for OpEnum`, the `OpEnum::Put` arm in the
-> abort handler, the `try_from_op_enum!(OpEnum::Put, ...)` macro
-> entry, and the `handle_op_request<PutOp>` fallthrough in node.rs
-> are all gone. Every PUT wire variant now dispatches unconditionally
-> to a task-per-tx driver — the `!has_put_op(id)` guard was redundant
-> because the DashMap could no longer be populated (every writer
-> lived inside the deleted `process_message`). **Phase 6 (PUT slice)**
-> deleted `PutOp`, `PutState`, `PutStats`, `AwaitingResponseData`,
-> `FinishedData`, the 22 inline outcome / failure-routing /
-> type-state pin tests, and the four anti-regression pins for the
-> retired speculative-retry fields (#3964). The wire-format types,
-> `op_state_manager.rs` GC pin tests, the
-> `put_forwarding_ack_senders` source-grep pin, and the originator
-> finalization helpers (`finalize_put_at_originator` /
-> `PutFinalizationData`) + the local-store helper (`put_contract`)
-> remain because the task-per-tx drivers consume them.
->
-> **Originator-loopback fix.** `start_client_put`'s
-> `send_and_await(target=None)` loops the Request back as
-> `InboundMessage` with `source_addr=None`. With the legacy
-> fallthrough gone, the dispatch site in node.rs maps
-> `source_addr=None` → `upstream_addr=own_addr` so the same
-> `start_relay_put` driver handles both true relay hops and
-> originator-loopback. The driver's local-store + forward-or-finalize
-> logic is identical for both: store, find next hop (excluding
-> own_addr → loopback skips itself), forward OR finalize and send
-> Response upstream (lands at the originator's `pending_op_results`
-> waiter via the bypass).
->
-> **#1454 phase 5 final (GET slice) retired the legacy GET
-> state-machine path.** `OpEnum::Get`, `OpManager.ops.get` DashMap,
-> `impl Operation for GetOp`, `start_op` / `start_op_with_id` /
-> `start_targeted_op`, `request_get`, `has_get_op`,
-> `remove_get_and_report_failure`, the `OpEnum::Get` arm in
-> `IsOperationCompleted for OpEnum`, the `OpEnum::Get` arm in the
-> abort handler, the `try_from_op_enum!(OpEnum::Get, ...)` macro
-> entry, and the `handle_op_request<GetOp>` fallthrough in node.rs
-> are all gone. Every GET wire variant now dispatches unconditionally
-> to a task-per-tx driver. The dispatch site in node.rs maps
-> `source_addr=None` → `upstream_addr=own_addr` (mirrors the PUT
-> originator-loopback fix) so the same `start_relay_get` driver
-> handles both true relay hops and originator-loopback. UPDATE
-> auto-fetch (`OpManager::try_auto_fetch_contract`) was migrated to
-> a new `start_targeted_sub_op_get` adapter that reuses the existing
-> `run_sub_op_get` body with an `initial_target` override — the
-> legacy `start_targeted_op` constructor and its
-> `notify_op_change(OpEnum::Get(...))` round-trip are gone.
-> **Phase 6 (GET slice)** deleted `GetOp`, `GetState`, `GetStats`,
-> `AwaitingResponseData`, `PrepareRequestData`, `FinishedData`,
-> `TryFrom<GetOp> for GetResult`, the inline outcome /
-> failure-routing / type-state / relay-cache-decision pin tests, and
-> the unused `GetResult.key` field. The wire-format types and the
-> originator result envelope `GetResult` (state + contract only)
-> remain because the task-per-tx drivers and the executor consume them.
->
-> **#1454 phase 5 final (SUBSCRIBE slice) retired the legacy SUBSCRIBE
-> state-machine path.** `OpEnum::Subscribe`, `OpManager.ops.subscribe`
-> DashMap, `impl Operation for SubscribeOp`, `has_subscribe_op`,
-> `remove_subscribe_and_notify_timeout`, the `OpEnum::Subscribe` arms in
-> `IsOperationCompleted for OpEnum` and the abort handler, the
-> `try_from_op_enum!(OpEnum::Subscribe, ...)` macro entry, the
-> `OpEnum::is_subscription_renewal` helper, `OpError::StatePushed`
-> (no remaining live constructor across all five ops), the
-> `ContractHandlerEvent::NotifySubscriptionError` /
-> `NotifySubscriptionErrorResponse` chain (executor trait method,
-> `bridged_notify_subscription_error`, `send_subscription_error_to_clients`),
-> and the `handle_op_request<SubscribeOp>` fallthrough in node.rs are
-> all gone. Every SUBSCRIBE wire variant now dispatches unconditionally:
->
-> - `SubscribeMsg::Request` → `start_relay_subscribe` (source_addr=None
->   loopback maps to `upstream_addr=own_addr`, mirroring the GET / PUT
->   originator-loopback fix; relay driver owns both true relay hops and
->   originator-loopback).
-> - `SubscribeMsg::Response` → bypass to originator's `pending_op_results`
->   waiter (terminal-reply fast path).
-> - `SubscribeMsg::Unsubscribe` → `handle_unsubscribe_inbound`
->   (free function: removes downstream subscriber tracking + chains
->   unsubscribe upstream when interest hits zero — replaces the legacy
->   `process_message::Unsubscribe` arm).
-> - `SubscribeMsg::ForwardingAck` → no-op (telemetry hook preserved for
->   pre-#3964 peer compatibility).
->
-> The surviving `OpManager::send_unsubscribe_upstream` writer sends
-> Unsubscribe through `OpCtx::send_fire_and_forget(target_addr, msg)`
-> directly, bypassing `ops.subscribe` entirely — no synthetic
-> `create_unsubscribe_op` push, no `notify_op_change_nonblocking`
-> round-trip. **Phase 6 (SUBSCRIBE slice)** deleted `SubscribeOp`,
-> `SubscribeState`, `SubscribeStats`, `AwaitingResponseData`,
-> `PrepareRequestData`, `CompletedData`, `SubscribeResult`, the
-> `start_op` / `start_op_with_id` test fixtures, the dead
-> `fetch_contract_if_missing` helper, and the inline state-machine /
-> retry / outcome / lifecycle pin tests. The wire-format types,
-> `handle_unsubscribe_inbound` (the post-#1454 inbound handler),
-> `register_downstream_subscriber`, `prepare_initial_request` /
-> `InitialRequest` (shared by all driver entry points), and
-> `complete_local_subscription` remain because the task-per-tx
-> drivers consume them.
->
-> Phase 5 follow-up slice A (PR
-> #3932) migrated fresh inbound relay `SubscribeMsg::Request` to
-> `operations/subscribe/op_ctx_task.rs::start_relay_subscribe`
-> (gated on `source_addr.is_some()` AND `!has_subscribe_op(id)`);
-> GC-spawned retries that pre-register a `SubscribeOp`,
-> `SubscribeMsg::Unsubscribe`, and `SubscribeMsg::ForwardingAck` all
-> stay on legacy. Executor auto-subscribe (the executor's
-> `SubscribeContract::resume_op` adapter) was the last legacy
-> originator-side writer into `ops.subscribe`; it has been migrated to
-> `subscribe::run_executor_subscribe` (reuses
-> `drive_client_subscribe_inner` with `is_renewal=false`, returns
-> `Result<(), OpError>` to the executor, bypasses the `op_request`
-> mediator path entirely). Renewals were
-> previously routed to legacy at this dispatch site so the relay
-> would emit `ForwardingAck` back to the renewal originator (the
-> originator's GC retry timer used `ack_received` for retry-base
-> selection); the SUBSCRIBE renewal migration moved the renewal
-> originator to the same task-per-tx driver as client-initiated
-> subscribe (`subscribe::run_renewal_subscribe` reuses
-> `drive_client_subscribe_inner` with `is_renewal=true`, returning
-> the outcome to the renewal task instead of through
-> `result_router_tx`), so renewals now flow through
-> `start_relay_subscribe` like any other Request. The driver caps relay-hop retries at 1 (originator
-> owns cross-peer retry), reuses `incoming_tx` end-to-end, omits
-> `ForwardingAck` emission, and calls `register_downstream_subscriber`
-> on BOTH local-hit and relayed-Subscribed paths — but DELIBERATELY
-> omits `ring.subscribe` / `complete_subscription_request` /
-> `announce_contract_hosted` on the relayed path (relay is not itself
-> a subscriber; prevents the #3763 subscription-storm feedback loop).
-> Slices B (streaming variants for GET/PUT/UPDATE) and C (legacy arm
-> cleanup) follow. Phase 5 follow-up slice C migrated fresh inbound
-> streaming relay `UpdateMsg::RequestUpdateStreaming` and
-> `UpdateMsg::BroadcastToStreaming` to
-> `operations/update/op_ctx_task.rs::start_relay_request_update_streaming`
-> / `start_relay_broadcast_to_streaming` (same
-> `source_addr.is_some()` AND `!has_update_op(id)` gate as slice A).
-> Streaming UPDATE relays are fire-and-forget — the drivers claim the
-> inbound stream via `orphan_stream_registry().claim_or_wait`,
-> assemble the payload, apply locally via `update_contract`, and rely
-> on `BroadcastStateChange` for network propagation. No downstream
-> `pipe_stream`, no upstream reply. The `BroadcastToStreaming` driver
-> reuses the shared `log_broadcast_to_streaming_failure` classifier
-> and triggers `try_auto_fetch_contract` / `send_summary_back_on_rejection`
-> on the same branches as the legacy handler. The deprecated
-> `UpdateMsg::Broadcasting` wire variant has been removed; the
-> `min-compatible-version` floor was bumped to 0.2.50 to gate the
-> incompatible bincode discriminant shift.
->
-> Task-per-tx drivers have their own invariants documented in the
-> `op_ctx_task.rs` module doc and in `OpCtx::send_and_await`'s rustdoc.
-> The spirit of push-before-send is preserved (initialize task-local
-> state before calling `send_and_await`), but the mechanical
-> `op_manager.push(...)` call is absent. Phase 6 of #1454 will rewrite
-> this rules file in full once all ops have migrated.
->
-> Sub-operation GETs (subscribe's `fetch_contract_if_missing` and
-> executor's `local_state_or_from_network`) now route through
-> `operations/get/op_ctx_task.rs::start_sub_op_get` — same retry
-> driver as `start_client_get` but skips auto-subscribe,
-> explicit-subscribe hand-off, telemetry route-events
-> (`NetEventLog::get_request` is intentionally not emitted on any
-> task-per-tx originator path — matches `start_client_get`), and
-> `result_router_tx` publication; outcome delivered through a
-> oneshot (`SubOpGetOutcome`). The legacy `request_get` driver and
-> `get::start_op` constructor were retired in this migration; the
-> executor's `GetContract` / `ComposeNetworkMessage<GetOp>` impl is
-> deleted. `start_targeted_op` (the GET legacy entry point that
-> UPDATE's auto-fetch spawns as a `OpEnum::Get`) remains on the
-> legacy GET path. The executor's `op_request` mediator path is
-> bypassed for GET; the spawned sub-op task can outlive its caller's
-> outer timeout (e.g., `RELATED_FETCH_TIMEOUT = 10s` wrapping
-> `local_state_or_from_network`'s 120 s receiver timeout) — receiver
-> drop is silent so no leak, just a longer-lived background task.
-> After this migration, no caller PURPOSEFULLY pushes a
-> client-initiated `GetOp` into `ops.get`, so the GC
-> speculative-retry block was provably dead for GET. Phase 5-final
-> retired that block, the `get_retried` per-tick HashMap, the
-> `GetOp::ack_received` / `GetOp::speculative_paths` fields, and the
-> 11 unit tests that simulated the GC retry decision.
->
-> **Loopback corner case (#4066):** the originator's first
-> `OpCtx::send_and_await(target=None)` loops back as an
-> `InboundMessage` with `source_addr=None`. The relay-driver
-> dispatch in `node.rs::handle_pure_network_message_v1` is gated on
-> `source_addr.is_some()`, so the loopback Request falls through to
-> legacy `process_message::GetMsg::Request` and incidentally pushes
-> a `GetOp` into `ops.get` keyed by `client_tx`. The entry's state
-> is never read (the bypass at the top of
-> `handle_pure_network_message_v1` intercepts terminal Responses
-> before `handle_op_request` runs), but the GC sweep at
-> `OPERATION_TTL=60s` still reaps it and used to emit a phantom
-> `phase=get_timeout` log + duplicate `OperationError`. Closed by
-> `ClientGetCompletionGuard` / `SubOpGetCompletionGuard` in
-> `get/op_ctx_task.rs`: a Drop guard on the driver task calls
-> `op_manager.completed(tx)` on every exit path including panics,
-> clearing the legacy entry before the GC sweep can race it. A
-> cleaner architectural fix would be a dedicated thin handler for
-> originator-loopback Requests that emits the Request-echo without
-> inserting into `ops.get` at all — phase 6 cleanup item.
->
-> The SUBSCRIBE GC speculative-retry block was retired in the same
-> Phase 5-final pass (slice 1 after GET): all four originator-side
-> writers into `ops.subscribe` (client-initiated, executor
-> auto-subscribe, renewal, PUT/GET sub-op) had migrated to the
-> task-per-tx driver in `operations/subscribe/op_ctx_task.rs` — which
-> owns its own retry loop via `advance_to_next_peer` and never inserts
-> a `SubscribeOp` into the DashMap. The remaining legacy entries in
-> `ops.subscribe` come from relay state during multi-hop forwarding
-> (slice A `start_relay_subscribe` does NOT register; entries arise
-> only when a relay re-enters `subscribe::process_message` for a tx
-> already in the DashMap, which now happens only for `Unsubscribe`
-> routing) and `create_unsubscribe_op` routing entries created by
-> `request_unsubscribe`. Neither is a retry candidate: relay entries
-> fail `is_originator()` and unsubscribe entries fail
-> `failure_routing_info().is_some()`. Slice 1 deletes the block, the
-> `subscribe_retried` per-tick HashMap, and the shared `ACK_TIMEOUT` /
-> `MAX_SPECULATIVE_PATHS` / `PROGRESS_TIMEOUT` constants (also
-> previously used by GET, now fully unreferenced). Slice 2 deleted
-> the `SubscribeOp::ack_received` / `speculative_paths` fields, the
-> `retry_with_next_alternative` helper, the `MIN_RETRY_HTL` constant,
-> and the unit tests that exercised the GC retry decision (the 11
-> `test_retry_*` cases in `subscribe/tests.rs` and the
-> `subscribe_retry_candidates_sorted_oldest_first` test in
-> `op_state_manager.rs`). The `SubscribeMsg::ForwardingAck` handler
-> on the legacy state-machine path was simplified to a no-op (mirrors
-> the GET treatment).
-> `GetMsg::ForwardingAck` and `SubscribeMsg::ForwardingAck` survive as
-> wire variants + telemetry hooks (#3570 diagnostics) but their
-> handlers return the operation unchanged.
->
-> Sub-operation SUBSCRIBE callers (legacy GET-originator
-> `auto_subscribe_on_get_response` fallback path; PUT/GET task-per-tx
-> drivers already routed via `maybe_subscribe_child`) spawn
-> `subscribe::run_client_subscribe` directly.
-> `start_subscription_request` keeps the `blocking` parameter for API
-> stability but it is no longer behaviorally distinct: blocking
-> semantics in the task-per-tx world are obtained by `await`ing
-> `run_client_subscribe` inline (see `maybe_subscribe_child` in
-> `put/op_ctx_task.rs` and `get/op_ctx_task.rs`);
-> `start_subscription_request` is a fire-and-forget spawner.
->
-> Phase 3c of #1454 has retired the `SubOperationTracker` entirely:
-> the struct, the OpManager methods (`expect_and_register_sub_operation`,
-> `sub_operation_failed`, `all_sub_operations_completed`,
-> `count_pending_sub_operations`, `root_ops_awaiting_sub_ops`,
-> `failed_parents`), the `parent_of` index, the GC parent-propagation
-> blocks, and the finalized-parent-parking branch in
-> `operations.rs::handle_op_result` are all gone. `OperationResult::ContinueOp`
-> with a finalized state now completes the op directly. Sub-operation
-> identity is structural (`Transaction::is_sub_operation()` via the
-> parent field set by `Transaction::new_child_of`); failure
-> propagation is via the task-per-tx driver's own `HostResult::Err`
-> publication, never through a tracker.
+## Execution Model
 
-## Critical Invariant: Push-Before-Send (legacy path)
+Every operation runs as a task-per-transaction driver: each `Transaction`
+is owned and driven by a single spawned task; state lives in task
+locals, never in `OpManager.ops.*`. The only exception is **CONNECT**,
+which still uses a `OpManager.ops.connect` DashMap + `Operation` impl
+for joiner-side branches reachable from in-file tests and the legacy
+stateless `ObservedAddress` side-effect path.
 
-**This is the most important rule for code on the legacy state-machine path.**
+Driver entry points:
+
+| Op | Entry points |
+|----|--------------|
+| CONNECT | `connect/op_ctx_task.rs::start_client_connect`, `start_relay_connect` |
+| GET | `get/op_ctx_task.rs::start_client_get`, `start_relay_get`, `start_sub_op_get`, `start_targeted_sub_op_get` |
+| PUT | `put/op_ctx_task.rs::start_client_put`, `start_relay_put`, `start_relay_put_streaming` |
+| UPDATE | `update/op_ctx_task.rs::start_client_update`, `start_relay_request_update`, `start_relay_broadcast_to`, `start_relay_request_update_streaming`, `start_relay_broadcast_to_streaming` |
+| SUBSCRIBE | `subscribe/op_ctx_task.rs::start_client_subscribe`, `run_executor_subscribe`, `run_renewal_subscribe`, `start_relay_subscribe`; `subscribe.rs::handle_unsubscribe_inbound` for `Unsubscribe` |
+
+The shared retry-loop driver lives in `op_ctx.rs` (`RetryDriver` trait
++ `drive_retry_loop`). UPDATE is fire-and-forget (no retry loop, no
+upstream reply); GET/PUT/SUBSCRIBE share the retry driver.
+
+## Wire-variant dispatch
+
+`node.rs::handle_pure_network_message_v1` is the single dispatch site
+for every inbound wire message. Pattern per op:
+
+1. **Reply bypass.** If a terminal reply variant arrives and a
+   `pending_op_results` callback is registered, forward it via
+   `try_forward_task_per_tx_reply` and return. For GET/PUT/SUBSCRIBE
+   the gate is `Response | ResponseStreaming` only. CONNECT forwards
+   all four non-`Request` variants (multi-reply fan-in).
+2. **Relay dispatch.** Spawn the matching `start_relay_*` driver.
+   Originator-loopback (`source_addr=None`) is mapped to
+   `upstream_addr=own_addr` for GET/PUT/SUBSCRIBE so the same driver
+   handles both relay hops and originator loopback. UPDATE has no
+   loopback (fire-and-forget end-to-end).
+3. **No legacy fallthrough** for GET/PUT/UPDATE/SUBSCRIBE — every wire
+   variant either bypasses to a waiter, dispatches a driver, or hits a
+   dedicated free-function handler (e.g. `handle_unsubscribe_inbound`,
+   `ForwardingAck` no-op). CONNECT still has a
+   `handle_op_request::<ConnectOp>` fallthrough for joiner-side legacy
+   re-entries.
+
+## OpEnum and DashMaps
+
+- `OpEnum::Connect` and `OpManager.ops.connect` are the only surviving
+  DashMap-backed op state. Used by joiner-side legacy paths.
+- `OpEnum::{Get,Put,Update,Subscribe}` are gone. `ops.{get,put,update,subscribe}`
+  DashMaps are gone. `has_{get,put,update,subscribe}_op` accessors are
+  gone.
+- `pending_op_counts()` returns `[connect, 0, 0, 0, 0]` — kept for
+  telemetry API stability.
+
+## Critical Invariant: Initialize-Before-Send
 
 ```
-ALWAYS save state BEFORE sending network message:
-
-CORRECT:
-  op_manager.push(tx, updated_state).await?;  // 1. SAVE FIRST
-  network_bridge.send(target, msg).await?;    // 2. THEN SEND
-
-WRONG:
-  network_bridge.send(target, msg).await?;    // NO! Race condition!
-  op_manager.push(tx, updated_state).await?;  // Response may arrive first
+All task-local state the reply handler will read (retry counters,
+visited-peers filter, routing state) MUST be initialized BEFORE
+calling `OpCtx::send_and_await`. The reply may arrive on the very
+next poll.
 ```
 
-**Why:** If response arrives before state is saved, `load_or_init` will fail because the operation doesn't exist in storage.
-
-**Task-per-tx equivalent (#1454 Phase 2b+):** callers of
-`OpCtx::send_and_await` must have all fields the reply handler will read
-(retry counters, visited-peers filter, routing state) set in task locals
-BEFORE calling `send_and_await`. State is never published to the
-`OpManager` DashMap; the conceptual ordering rule is the same. See the
-`OpCtx::send_and_await` docstring for the full reasoning.
-
-**GET-specific note (Phase 3b):** for client-initiated GETs the
-bypass at `node.rs::handle_pure_network_message_v1` returns BEFORE
-`handle_op_request` runs, so `process_message` does NOT execute on
-the originator for `GetMsg::Response` / `ResponseStreaming` replies.
-This is by design — there is no `GetOp` in `OpManager.ops.get` for a
-task-per-tx transaction, so `load_or_init` would return
-`OpNotPresent`. The driver (`operations/get/op_ctx_task.rs`) therefore
-owns the originator-side side effects that the legacy Response{Found}
-branch at `get.rs:2329` does: `PutQuery` to cache the state,
-`record_get_access`, `mark_local_client_access`,
-`announce_contract_hosted`, `register_local_hosting`, and
-`broadcast_change_interests`. If you add a new side effect to the
-legacy Response{Found} branch, mirror it in
-`op_ctx_task.rs::cache_contract_locally`. Relay GETs still go through
-`process_message` — the bypass only fires when the originator's
-`pending_op_results` callback is installed, which relays never have.
+For CONNECT's surviving legacy path: state MUST be pushed via
+`op_manager.push(tx, state)` before any `network_bridge.send(...)` —
+a fast response that beats the push would hit `OpNotPresent`.
 
 ## State Machine Rules
 
@@ -539,20 +212,10 @@ This is usually benign (duplicate message, already completed)
 → Do NOT treat as error
 ```
 
-**Note (#1454 Phase 2b/3a/3b):** For op kinds with a task-per-tx driver
-(SUBSCRIBE, PUT, and GET client-initiated), the pure-network-message
-handler checks `pending_op_results` FIRST and forwards the reply to
-the awaiting task via `node::try_forward_task_per_tx_reply` before
-reaching `load_or_init`. Do NOT "fix" `load_or_init`'s `OpNotPresent`
-handling by trying to look up a task-owned tx there — it will never
-find one, and it shouldn't. The bypass is the load-bearing piece;
-confirm by reading the SUBSCRIBE, PUT, and GET branches of
-`handle_pure_network_message_v1` in `node.rs`. For GET the bypass is
-gated on `GetMsg::Response | GetMsg::ResponseStreaming` only —
-non-terminal GetMsg variants (Request, ResponseStreamingAck,
-ForwardingAck) fall through to the legacy state machine, and relay
-nodes (which have no entry in `pending_op_results` for the tx)
-continue handling forwarded messages via `process_message`.
+Do NOT "fix" `load_or_init`'s `OpNotPresent` for non-CONNECT ops by
+trying to look up the tx there — the bypass at the top of
+`handle_pure_network_message_v1` already forwarded the reply to the
+driver's waiter, and `load_or_init` no longer runs for those ops.
 
 ### WHEN encountering InvalidStateTransition
 
@@ -575,7 +238,7 @@ continue handling forwarded messages via `process_message`.
 
 ## Common Patterns
 
-### Load or Initialize
+### Load or Initialize (CONNECT only)
 
 ```rust
 let init = Op::load_or_init(op_manager, msg, source_addr).await?;
@@ -585,7 +248,7 @@ match init {
 }
 ```
 
-### Handle Operation Result
+### Handle Operation Result (CONNECT only)
 
 ```rust
 let result = op.process_message(conn_manager, op_manager, msg, source_addr).await?;
@@ -607,3 +270,4 @@ if let Some(return_msg) = result.return_msg {
 - Architecture: `docs/architecture/operations/README.md`
 - OpManager: `crates/core/src/node/op_state_manager.rs`
 - Operation trait: `crates/core/src/operations.rs:32-56`
+- Round-trip primitive: `crates/core/src/operations/op_ctx.rs`

--- a/crates/core/CLAUDE.md
+++ b/crates/core/CLAUDE.md
@@ -44,210 +44,39 @@ Key decision points:
 ### WHEN modifying operations/
 
 ```
-Each file is a state machine:
-  connect.rs    → CONNECT operation
-  get.rs        → GET operation
-  put.rs        → PUT operation
-  update.rs     → UPDATE operation
-  subscribe.rs  → SUBSCRIBE operation (legacy state-machine path)
+Each op has wire-format types + helpers in `<op>.rs` and one or more
+task-per-transaction drivers under `<op>/op_ctx_task.rs`. CONNECT
+also retains a legacy `Operation` state machine in `connect.rs` for
+joiner-side branches reachable from in-file tests.
 
-Plus task-per-transaction drivers from #1454 Phase 2b onwards:
-  subscribe/op_ctx_task.rs → client-initiated SUBSCRIBE driver
-                             + fresh inbound relay SUBSCRIBE driver
-                             (Phase 5 follow-up slice A, `start_relay_subscribe`).
-                             **Phase 5 final (SUBSCRIBE slice)** retired the
-                             legacy carrier: `OpEnum::Subscribe`,
-                             `OpManager.ops.subscribe` DashMap, `impl
-                             Operation for SubscribeOp`, `has_subscribe_op`,
-                             `remove_subscribe_and_notify_timeout`, the
-                             `OpEnum::Subscribe` arm in
-                             `IsOperationCompleted for OpEnum`, the
-                             `OpEnum::Subscribe` arm in the abort
-                             handler, the `try_from_op_enum!(OpEnum::Subscribe, ...)`
-                             macro entry, `OpError::StatePushed` (no
-                             remaining live constructor),
-                             `OpEnum::is_subscription_renewal`, the
-                             `ContractHandlerEvent::NotifySubscriptionError`
-                             / `...ErrorResponse` chain (executor
-                             trait method, bridged helper,
-                             send_subscription_error_to_clients), and
-                             the `handle_op_request<SubscribeOp>`
-                             fallthrough in node.rs are all gone.
-                             Every SUBSCRIBE wire variant dispatches
-                             unconditionally: Request → `start_relay_subscribe`,
-                             Unsubscribe → `handle_unsubscribe_inbound`,
-                             Response → bypass to originator waiter,
-                             ForwardingAck → no-op. The
-                             surviving `OpManager::send_unsubscribe_upstream`
-                             sends Unsubscribe through
-                             `OpCtx::send_fire_and_forget` directly
-                             (bypasses `ops.subscribe`). **Phase 6
-                             (SUBSCRIBE slice)** retired the surviving
-                             scaffolding: `SubscribeOp`,
-                             `SubscribeState`, `SubscribeStats`,
-                             `AwaitingResponseData`,
-                             `PrepareRequestData`, `CompletedData`,
-                             `SubscribeResult`, the `start_op` /
-                             `start_op_with_id` test fixtures, the
-                             dead `fetch_contract_if_missing` helper
-                             plus the inline state-machine / retry
-                             matrix / outcome / lifecycle pin tests
-                             are all gone. The surviving wire-format
-                             types, `handle_unsubscribe_inbound` (the
-                             post-#1454 inbound handler),
-                             `register_downstream_subscriber`,
-                             `prepare_initial_request` /
-                             `InitialRequest` (shared by all driver
-                             entry points), and
-                             `complete_local_subscription` remain
-                             because the task-per-tx drivers consume
-                             them.
-  put/op_ctx_task.rs       → client-initiated PUT driver (Phase 3a)
-                             + fresh inbound non-streaming relay PUT
-                             driver (Phase 5 follow-up slice A, PR #3917,
-                             `start_relay_put`)
-                             + fresh inbound streaming relay PUT
-                             driver (Phase 5 follow-up slice B,
-                             `start_relay_put_streaming`: claims
-                             inbound stream via orphan_stream_registry,
-                             pipes fragments downstream via
-                             NetworkBridge::pipe_stream, bubbles a
-                             downgraded non-streaming Response upstream).
-                             **Phase 5 final (PUT slice)** retired the
-                             legacy carrier: `OpEnum::Put`,
-                             `OpManager.ops.put` DashMap, `impl Operation
-                             for PutOp`, `has_put_op`,
-                             `remove_put_and_report_failure`, and the
-                             `handle_op_request<PutOp>` fallthrough in
-                             node.rs are all gone. Every PUT wire variant
-                             dispatches unconditionally to a task-per-tx
-                             driver. **Phase 6 (PUT slice)** retired
-                             the surviving scaffolding: `PutOp`,
-                             `PutState`, `PutStats`,
-                             `AwaitingResponseData`, `FinishedData`,
-                             the 22 inline outcome / failure-routing /
-                             type-state pin tests, and the four
-                             anti-regression pins for retired
-                             speculative-retry fields (#3964) are all
-                             gone. The surviving wire-format types,
-                             the `op_state_manager.rs` GC pin tests,
-                             the `put_forwarding_ack_senders` source
-                             grep, and the originator finalization
-                             helpers (`finalize_put_at_originator` /
-                             `PutFinalizationData`) + the local-store
-                             helper (`put_contract`) remain because
-                             the task-per-tx drivers consume them. The
-                             legacy upgrade-on-forward branch (non-stream
-                             `Request` whose serialized payload exceeds
-                             `streaming_threshold`) now dispatches
-                             through `start_relay_put`; the driver itself
-                             owns the upgrade decision.
-  get/op_ctx_task.rs       → client-initiated GET driver (Phase 3b)
-                             + fresh inbound relay GET driver (Phase 5,
-                             PR #3896, `start_relay_get`)
-                             + sub-op GET driver (`start_sub_op_get`)
-                             + targeted sub-op GET driver
-                             (`start_targeted_sub_op_get`, replaces
-                             legacy `start_targeted_op`).
-                             **Phase 5 final (GET slice)** retired the
-                             legacy carrier: `OpEnum::Get`,
-                             `OpManager.ops.get` DashMap, `impl Operation
-                             for GetOp`, `start_op` / `start_op_with_id`
-                             / `start_targeted_op`, `request_get`,
-                             `has_get_op`, `remove_get_and_report_failure`,
-                             and the `handle_op_request<GetOp>`
-                             fallthrough in node.rs are all gone.
-                             Every GET wire variant dispatches
-                             unconditionally to a task-per-tx driver.
-                             **Phase 6 (GET slice)** retired the
-                             surviving scaffolding: `GetOp`,
-                             `GetState`, `GetStats`,
-                             `AwaitingResponseData`,
-                             `PrepareRequestData`, `FinishedData`,
-                             `TryFrom<GetOp> for GetResult`, the
-                             inline outcome / failure-routing /
-                             type-state / relay-cache-decision pin
-                             tests, and the unused `GetResult.key`
-                             field are all gone. The surviving
-                             wire-format types and the originator
-                             result envelope `GetResult` (state +
-                             contract only) remain because the
-                             task-per-tx drivers and the executor
-                             consume them.
-  update/op_ctx_task.rs    → client-initiated UPDATE driver (Phase 4,
-                             fire-and-forget) + fresh inbound non-streaming
-                             relay UPDATE drivers (Phase 5 follow-up slice
-                             A, PR #3910: `start_relay_request_update`,
-                             `start_relay_broadcast_to`) + fresh inbound
-                             streaming relay UPDATE drivers (Phase 5
-                             follow-up slice C:
-                             `start_relay_request_update_streaming`,
-                             `start_relay_broadcast_to_streaming` —
-                             claim inbound stream, assemble, apply
-                             locally; BroadcastStateChange propagates).
-                             **Phase 5 final** retired the legacy carrier:
-                             `OpEnum::Update`, `OpManager.ops.update`
-                             DashMap, `impl Operation for UpdateOp`,
-                             `request_update`, `start_op`,
-                             `has_update_op`, `remove_update_and_report_failure`,
-                             and the `handle_op_request<UpdateOp>`
-                             fallthrough in node.rs are all gone. Every
-                             UPDATE wire variant now dispatches
-                             unconditionally to a task-per-tx driver.
-                             **Phase 6 (UPDATE slice)** retired the
-                             surviving scaffolding: `UpdateOp`,
-                             `UpdateState`, `UpdateStats`,
-                             `FinishedData`, the inline outcome /
-                             failure-routing pin tests, and the two
-                             stale `process_message`-anchored pin
-                             tests (driver-side pin tests in
-                             `update/op_ctx_task.rs:2063` /
-                             `:2345` cover the same
-                             `send_summary_back_on_rejection`
-                             invariant). The surviving wire-format
-                             types, `BroadcastDedupCache`,
-                             `BroadcastTargetResult`,
-                             `OpManager::try_auto_fetch_contract`,
-                             `update_contract` + `UpdateExecution` +
-                             the log helpers, and the
-                             post-merge propagation helpers
-                             (`send_proactive_summary_notification` /
-                             `send_summary_back_on_rejection`) +
-                             the `log_severity` regression suite (#3914)
-                             + the `summary_back_helper_gates_on_summary_equality`
-                             pin remain because the task-per-tx
-                             drivers consume them.
-  connect/op_ctx_task.rs   → client-initiated CONNECT driver (Phase 2c
-                             slice 2, `start_client_connect`) + fresh
-                             inbound relay CONNECT driver (Phase 2c
-                             slice 1, `start_relay_connect`: full
-                             state machine in task locals — initial
-                             `handle_request` decision, downstream
-                             forward, upstream emits, plus re-entry
-                             handling for Response/Rejected/
-                             ObservedAddress/ConnectFailed via
-                             `OpCtx::send_to_and_collect_replies`)
-    All five relay drivers share the per-node dedup gate pattern
-    (`active_relay_{get,update,put,subscribe,connect}_txs`) and the
-    `Relay*InflightGuard` RAII. PUT and UPDATE streaming relays now run
-    on the task-per-tx path. The deprecated UPDATE `Broadcasting` wire
-    variant has been removed (gated by a `min-compatible-version`
-    bump). SUBSCRIBE has no streaming variants. CONNECT relay's
-    admission RAII guard is scoped to the initial-actions block (NOT
-    held across the recv loop) to avoid admission slot starvation
-    under load. Renewals migrated to
-    `subscribe::run_renewal_subscribe` (reuses the client-initiated
-    driver with `is_renewal=true`, returns the outcome to the renewal
-    task instead of through `result_router_tx`). PUT sub-op subscribes
-    are dispatched via `subscribe::run_client_subscribe`. Executor
-    auto-subscribe migrated to `subscribe::run_executor_subscribe`
-    (returns `Result<(), OpError>` directly; bypasses the `op_request`
-    mediator). `Unsubscribe` now routes to
-    `subscribe::handle_unsubscribe_inbound` (free function — removes
-    downstream subscriber + propagates upstream when interest hits
-    zero; replaces the legacy `process_message::Unsubscribe` arm
-    retired in #1454 phase 5 final SUBSCRIBE slice). `ForwardingAck`
-    is a no-op telemetry hook with no state mutation.
+Driver entry points:
+
+  connect/op_ctx_task.rs    → start_client_connect, start_relay_connect
+  get/op_ctx_task.rs        → start_client_get, start_relay_get,
+                              start_sub_op_get, start_targeted_sub_op_get
+  put/op_ctx_task.rs        → start_client_put, start_relay_put,
+                              start_relay_put_streaming
+  update/op_ctx_task.rs     → start_client_update,
+                              start_relay_request_update,
+                              start_relay_broadcast_to,
+                              start_relay_request_update_streaming,
+                              start_relay_broadcast_to_streaming
+  subscribe/op_ctx_task.rs  → start_client_subscribe,
+                              run_executor_subscribe,
+                              run_renewal_subscribe,
+                              start_relay_subscribe
+
+All five relay drivers share the per-node dedup gate pattern
+(`active_relay_{get,update,put,subscribe,connect}_txs`) and the
+`Relay*InflightGuard` RAII. CONNECT relay's admission RAII guard is
+scoped to the initial-actions block (NOT held across the recv loop)
+to avoid admission slot starvation under load. UPDATE is
+fire-and-forget end-to-end; the others share `op_ctx.rs::drive_retry_loop`.
+
+`Unsubscribe` routes to `subscribe::handle_unsubscribe_inbound` (free
+function). `ForwardingAck` is a no-op telemetry hook.
+
+See `.claude/rules/operations.md` for dispatch and invariants.
 ```
 
 ## Module Map

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -660,11 +660,10 @@ async fn process_open_request(
 
                         let contract_key = contract.key();
 
-                        // Phase 3a (#1454): task-per-tx driver handles both
-                        // local-only and network PUTs. The driver calls
-                        // put_contract locally first, then finds peers and
-                        // sends the request. No request-router dedup needed
-                        // — each task owns its own operation lifecycle.
+                        // Driver handles both local-only and network
+                        // PUTs: calls put_contract locally, finds
+                        // peers, sends the request. Each task owns
+                        // its own operation lifecycle.
                         let client_tx = crate::message::Transaction::new::<put::PutMsg>();
 
                         op_manager
@@ -1160,11 +1159,9 @@ async fn process_open_request(
                             })));
                         }
 
-                        // Phase 3b (#1454): task-per-tx driver handles network
-                        // GETs. The driver owns its routing state in task locals
-                        // and calls notify_contract_handler locally as needed.
-                        // No request-router dedup — each task owns its own
-                        // operation lifecycle (matching PUT 3a's decision).
+                        // Driver owns its routing state in task
+                        // locals and calls notify_contract_handler
+                        // locally as needed.
                         tracing::debug!(
                             client_id = %client_id,
                             request_id = %request_id,
@@ -1174,7 +1171,7 @@ async fn process_open_request(
                             is_subscribed,
                             connection_count,
                             phase = "network_routing",
-                            "Routing GET request through network (task-per-tx driver)"
+                            "Routing GET request through network"
                         );
 
                         let client_tx = crate::message::Transaction::new::<get::GetMsg>();
@@ -1424,9 +1421,10 @@ async fn process_open_request(
                                     );
                                 })?;
 
-                            // Start dedicated operation for this client AFTER registration.
-                            // `subscribe_with_id` is client-initiated-only since #1454 Phase 2b;
-                            // no `is_renewal` parameter.
+                            // Start dedicated operation for this
+                            // client AFTER registration.
+                            // `subscribe_with_id` is
+                            // client-initiated-only; no `is_renewal`.
                             let _result_tx = crate::node::subscribe_with_id(
                                 op_manager.clone(),
                                 key,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -88,47 +88,17 @@ pub mod dev_tool {
     pub use ring::Location;
     pub use transport::{TransportKeypair, TransportPublicKey};
 
-    // #1454 Phase 3b — test hook to verify client-initiated GETs
-    // actually route through the task-per-tx driver rather than being
-    // satisfied by the `client_events.rs` local-cache shortcut.
+    // Test hooks: per-op driver call counters. Tests assert these
+    // increment to confirm wire variants dispatch through their
+    // task-per-tx driver (not a local-cache shortcut or legacy path).
     #[cfg(any(test, feature = "testing"))]
     pub use crate::operations::get::op_ctx_task::DRIVER_CALL_COUNT as GET_DRIVER_CALL_COUNT;
-
-    // #1454 Phase 5 / #3883 — test hook to verify the dispatch site in
-    // `handle_pure_network_message_v1` routes fresh inbound relay
-    // GETs through the task-per-tx driver. Phase 5 final (GET slice)
-    // retired the legacy `handle_op_request<GetOp>` fallthrough; every
-    // GET wire variant now dispatches unconditionally to a task-per-tx
-    // driver. The originator-loopback case (`source_addr=None`) is
-    // mapped to `upstream_addr=own_addr` at the dispatch site, so the
-    // same `start_relay_get` driver handles both true relay hops and
-    // originator-loopback. UPDATE auto-fetch was migrated to
-    // `start_targeted_sub_op_get` in the same slice.
     #[cfg(any(test, feature = "testing"))]
     pub use crate::operations::get::op_ctx_task::RELAY_DRIVER_CALL_COUNT as GET_RELAY_DRIVER_CALL_COUNT;
-
-    // #1454 Phase 5 follow-up slice A (#3917) — test hook to verify
-    // the dispatch gate in `handle_pure_network_message_v1` actually
-    // routes fresh inbound relay PUTs through the task-per-tx driver
-    // (vs. the legacy `handle_op_request` fallthrough used for
-    // client-initiated loopback and GC-spawned retries).
     #[cfg(any(test, feature = "testing"))]
     pub use crate::operations::put::op_ctx_task::RELAY_PUT_DRIVER_CALL_COUNT;
-
-    // #1454 Phase 5 follow-up slice B — test hook for streaming PUT
-    // relay dispatch. Fires when the streaming driver is spawned for
-    // a fresh inbound `PutMsg::RequestStreaming` (vs. legacy
-    // `handle_op_request` fallthrough for GC retries / loopback /
-    // variants that stay on the legacy path).
     #[cfg(any(test, feature = "testing"))]
     pub use crate::operations::put::op_ctx_task::RELAY_PUT_STREAMING_DRIVER_CALL_COUNT;
-
-    // #1454 Phase 5 follow-up slice A (#3932) — test hook to verify
-    // the dispatch gate in `handle_pure_network_message_v1` actually
-    // routes fresh inbound relay SUBSCRIBEs through the task-per-tx
-    // driver (vs. the legacy `handle_op_request` fallthrough used
-    // for renewals, PUT sub-op subscribes, executor auto-subscribe,
-    // and GC-spawned retries).
     #[cfg(any(test, feature = "testing"))]
     pub use crate::operations::subscribe::op_ctx_task::RELAY_SUBSCRIBE_DRIVER_CALL_COUNT;
 

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -674,8 +674,8 @@ pub(crate) enum NodeEvent {
     /// Send an arbitrary `NetMessage` to a specific peer without registering
     /// a `pending_op_results` callback.
     ///
-    /// Use case (#1454 phase 2c): the CONNECT task-per-tx originator driver
-    /// holds an active multi-reply receiver for its transaction. When the
+    /// Use case: the CONNECT originator driver holds an active
+    /// multi-reply receiver for its transaction. When the
     /// joiner's hole-punch to an acceptor fails, it must emit
     /// `ConnectMsg::ConnectFailed` upstream so the relay chain can re-route.
     /// Routing that emission through `op_execution_sender`

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -536,11 +536,6 @@ async fn report_result(
 
     match op_result {
         Ok(Some(op_res)) => {
-            // (UPDATE-specific completion log retired in #1454 phase 5
-            // final together with `OpEnum::Update`; client-initiated
-            // UPDATEs publish their own host result from
-            // `update::op_ctx_task::start_client_update`.)
-
             // Send to result router (skip for sub-operations and subscription renewals)
             if let Some(transaction) = tx {
                 // Sub-operations (e.g., Subscribe spawned by PUT) don't notify clients directly;
@@ -761,70 +756,32 @@ fn op_retry_backoff(attempt: usize) -> Duration {
     Duration::from_millis((5u64 << attempt.min(8)).min(1_000))
 }
 
-/// Route an inbound task-per-tx reply directly to an awaiting
-/// [`OpCtx::send_and_await`][ocxawait] caller, bypassing the legacy op
-/// state machine entirely.
+/// Forward an inbound reply directly to the awaiting
+/// [`OpCtx::send_and_await`][ocxawait] caller.
 ///
-/// Returns `true` if a callback was registered and the message was forwarded
-/// (or dropped due to a closed receiver, which is also a successful
-/// "bypass taken" from the pipeline's point of view — the legacy path must
-/// not run). Returns `false` if no callback is registered; the caller then
-/// falls through to the legacy `handle_op_request` path.
+/// Returns `true` if a callback was registered (message forwarded or
+/// dropped on a closed receiver — either way the caller must not fall
+/// through to other handling). Returns `false` if no callback is
+/// registered.
 ///
-/// # Why this exists
-///
-/// Phase 1 (#3802) wired [`forward_pending_op_result_if_completed`] to fire
-/// the callback after the legacy state machine classified the reply as
-/// completed. That only works when a [`crate::operations::OpEnum`] was
-/// previously pushed into [`crate::node::OpManager`]'s per-op DashMap:
-/// `load_or_init` pops it, `process_message` produces
-/// [`crate::operations::OperationResult::SendAndComplete`], and
-/// `is_operation_completed` returns `true`.
-///
-/// Phase 2b's task-per-tx callers (starting with client-initiated SUBSCRIBE,
-/// #1454) never push an op into that DashMap: state lives in the task's
-/// locals. When a reply arrives, `load_or_init` sees an empty slot and
-/// returns [`crate::operations::OpError::OpNotPresent`] (this is the
-/// legacy guard against stale responses arriving after GC cleanup, e.g.
-/// `operations/subscribe.rs:1181-1192`). `handle_op_result` swallows
-/// `OpNotPresent` as benign and returns `Ok(None)`, so
-/// `forward_pending_op_result_if_completed` short-circuits and the
-/// awaiting task hangs forever.
-///
-/// This helper is the fix: any branch of
-/// [`handle_pure_network_message_v1`] that wants to support a task-per-tx
-/// caller checks this first, and on a hit returns without ever touching
-/// `handle_op_request`. Phase 2b adds this guard to the SUBSCRIBE branch
-/// only; Phases 2c/3/4 will add it to their own branches when they
-/// introduce their first task-per-tx callers.
-///
-/// # Safety argument for the bypass
+/// # Safety argument
 ///
 /// `p2p_protoc::pending_op_results` is only populated via
-/// `p2p_protoc::handle_op_execution`, which is only driven by the
-/// `op_execution_sender` channel. The only way to obtain a clone of that
-/// sender is through [`crate::node::OpManager::op_ctx`] (production
-/// factory) or the in-module `OpCtx` unit tests — both of which construct
-/// an [`OpCtx`][ocx] whose only round-trip method is
+/// `p2p_protoc::handle_op_execution`, driven by `op_execution_sender`.
+/// The only way to obtain a clone of that sender is through
+/// [`crate::node::OpManager::op_ctx`], whose round-trip method is
 /// [`OpCtx::send_and_await`][ocxawait]. This is a **structural
-/// invariant**, not a convention: the sender field is `pub(crate)` and
-/// there is no other `pub` accessor on `EventLoopNotificationsSender`.
+/// invariant**: the sender field is `pub(crate)` and there is no other
+/// `pub` accessor on `EventLoopNotificationsSender`.
 ///
-/// Consequence: legacy paths (SUBSCRIBE renewals, PUT sub-op subscribes,
-/// contract-executor-initiated subscribes, intermediate-peer forwarding)
-/// never appear in `pending_op_results` for their own txs, so the bypass
-/// never triggers for them and their behavior is unchanged.
-///
-/// [ocx]: crate::operations::OpCtx
 /// [ocxawait]: crate::operations::OpCtx::send_and_await
 ///
 /// # Channel safety
 ///
 /// Uses `try_send` on the bounded capacity-1 channel created by
-/// [`OpCtx::send_and_await`][ocxawait]. On a closed receiver (e.g., caller
-/// timed out or was cancelled) the send fails and is logged; the
-/// pure-network-message handler still makes progress. See
-/// `.claude/rules/channel-safety.md`.
+/// `OpCtx::send_and_await`. On a closed receiver (caller cancelled or
+/// timed out) the send fails and is logged; the handler still makes
+/// progress. See `.claude/rules/channel-safety.md`.
 fn try_forward_task_per_tx_reply(
     pending_op_result: Option<&tokio::sync::mpsc::Sender<NetMessage>>,
     reply: NetMessage,
@@ -845,16 +802,16 @@ fn try_forward_task_per_tx_reply(
     true
 }
 
-/// Mirror the legacy joiner-side fill at `connect.rs:1723-1745`: an
-/// acceptor behind NAT does not know its own external address, so when
-/// a `ConnectMsg::Response` arrives with `acceptor.peer_addr =
-/// Unknown`, the inbound transport's `source_addr` is used to backstop
-/// the missing address before the driver reads it. The task-per-tx
-/// driver does not see `source_addr`, so the rewrite must happen at
-/// the bypass site.
+/// Fill in an acceptor's external address from `source_addr` when the
+/// `ConnectMsg::Response` arrives with `acceptor.peer_addr = Unknown`.
 ///
-/// Non-`Response` variants pass through unchanged. `Response` with an
-/// already-`Known` acceptor address passes through unchanged.
+/// An acceptor behind NAT does not know its own external address; the
+/// inbound transport's `source_addr` is used to backstop the missing
+/// value before the driver reads it. The driver itself does not see
+/// `source_addr`, so the rewrite must happen at the dispatch site.
+///
+/// Non-`Response` variants and `Response` with an already-`Known`
+/// acceptor address pass through unchanged.
 fn fill_connect_response_acceptor_addr(
     op: connect::ConnectMsg,
     source_addr: Option<std::net::SocketAddr>,
@@ -883,47 +840,19 @@ fn fill_connect_response_acceptor_addr(
     }
 }
 
-/// If `op_result` indicates the operation completed and a `pending_op_result`
-/// callback is wired, forward `reply` to the awaiting caller of
-/// [`crate::operations::OpCtx::send_and_await`].
-///
-/// This is the reply side of the async sub-transaction round-trip primitive
-/// introduced by #1454. The caller side — [`OpCtx::send_and_await`][ocx] —
-/// installs a one-shot bounded [`tokio::sync::mpsc::Sender`] into
-/// `p2p_protoc::pending_op_results` keyed by its `Transaction`, and each
-/// branch of `handle_pure_network_message_v1` calls this helper after
-/// `handle_op_request` so the caller can `await` a single reply keyed by
-/// the same `Transaction`.
-///
-/// Wired for PUT and GET historically; extended to SUBSCRIBE, CONNECT, and
-/// UPDATE in Phase 1 of the async-transaction refactor (#1454) so every op
-/// kind can terminate an `OpCtx::send_and_await` round-trip without hanging.
-/// (Phase 1 predates `OpCtx`; the caller side used to live directly on
-/// `OpManager::notify_op_execution`, now deleted. Phase 2a moved the caller
-/// side into `OpCtx` behind an `OpManager::op_ctx` factory.)
-///
-/// [ocx]: crate::operations::OpCtx::send_and_await
+/// If `op_result` indicates the operation completed and a
+/// `pending_op_result` callback is wired, forward `reply` to the
+/// awaiting caller of [`crate::operations::OpCtx::send_and_await`].
 ///
 /// # Channel safety
 ///
-/// Uses `try_send` rather than `.send().await` on the bounded capacity-1
-/// mpsc channel created by `OpCtx::send_and_await`. This is sound because
-/// the callback is fired **at most once per transaction**: the
-/// `is_operation_completed` guard above combined with the `completed` /
-/// `under_progress` dedup sets in `OpManager` ensures that subsequent
-/// messages for the same tx short-circuit before reaching this code. So
-/// `try_send` on an empty capacity-1 channel cannot fail with `Full` —
-/// it can only fail with `Closed` when the `OpCtx` owner has dropped its
-/// receiver. Using `try_send` eliminates any risk of blocking the
-/// pure-network-message handler if a future consumer ever ends up unable
-/// to drain the reply, satisfying the preference for non-blocking sends
-/// in `.claude/rules/channel-safety.md`.
-///
-/// As of Phase 2a (#1454) this path is still dormant: `pending_op_result`
-/// is always `None` because no production caller of `OpCtx::send_and_await`
-/// exists yet. Phase 2b will introduce the first real caller (SUBSCRIBE
-/// client-initiated path); the `try_send` choice here means Phase 2b does
-/// not need to touch this function.
+/// Uses `try_send` on the bounded capacity-1 channel created by
+/// `OpCtx::send_and_await`. The callback fires at most once per
+/// transaction (the `is_operation_completed` guard plus the
+/// `completed`/`under_progress` dedup sets in `OpManager` short-circuit
+/// subsequent messages), so `try_send` cannot fail with `Full` — only
+/// `Closed` when the receiver was dropped. See
+/// `.claude/rules/channel-safety.md`.
 fn forward_pending_op_result_if_completed(
     op_result: &Result<Option<OpEnum>, OpError>,
     pending_op_result: Option<&tokio::sync::mpsc::Sender<NetMessage>>,
@@ -970,44 +899,15 @@ where
 
         match msg {
             NetMessageV1::Connect(ref op) => {
-                // Phase 2c slice 0 (#1454): task-per-tx reply forwarding for
-                // CONNECT. Mirrors the SUBSCRIBE/PUT/GET bypass: when a
-                // task-per-tx CONNECT driver has registered a reply waiter
-                // in `pending_op_results`, forward terminal `ConnectMsg`
-                // variants to it.
+                // CONNECT reply forwarding: the joiner expects fan-in
+                // (up to `target_connections` `Response`s over time).
+                // The waiter (`OpCtx::send_and_collect_replies`) has a
+                // multi-reply receiver, so this bypass forwards every
+                // non-`Request` variant without short-circuiting after
+                // the first hit.
                 //
-                // CONNECT differs from the other ops in that the joiner
-                // expects fan-in: up to `target_connections` `Response`s
-                // arrive over time as relay branches accept the joiner.
-                // The waiter side uses `OpCtx::send_and_collect_replies`
-                // with capacity > 1 so multiple replies can buffer without
-                // dropping each other; the bypass below opts in to this
-                // multi-forward shape by NOT short-circuiting on the first
-                // forward — we still return `Ok(None)` (so the legacy
-                // pipeline does not re-process the message) but the next
-                // inbound reply for the same tx will hit this same code
-                // path and forward to the same channel.
-                //
-                // Phase 2c slice 1 (#1454): the bypass forwards every non-
-                // `Request` `ConnectMsg` variant to the per-tx driver inbox
-                // when a waiter is registered. The relay-CONNECT driver
-                // (`operations::connect::op_ctx_task::start_relay_connect`)
-                // owns the entire tx lifetime — Request handling, downstream
-                // forward, and re-entry processing for Response / Rejected /
-                // ObservedAddress / ConnectFailed — in task locals, so all
-                // four reply variants must reach the driver's
-                // `send_to_and_collect_replies` receiver.
-                //
-                // `Request` is NEVER forwarded here: it is the spawn signal
-                // handled by the dispatch gate below (commit 3) which
-                // checks `!has_connect_op(id) && !active_relay_connect_txs
-                // .contains(id)` to avoid spawning duplicate drivers.
-                //
-                // `ObservedAddress` was previously left on the legacy
-                // `load_or_init` stateless side-effect path
-                // (`connect.rs:1473-1490`); the joiner driver now handles
-                // it on its inbox match arm in `op_ctx_task.rs:481-499`,
-                // calling `set_own_addr` + `update_location` itself.
+                // `Request` is NEVER forwarded here: it spawns a relay
+                // driver via the dispatch gate below.
                 if matches!(
                     op,
                     connect::ConnectMsg::Response { .. }
@@ -1025,27 +925,16 @@ where
                     }
                 }
 
-                // Phase 2c slice 1 commit 3 (#1454): relay-CONNECT
-                // task-per-tx dispatch.
+                // Relay-CONNECT dispatch: fresh inbound `Request` with
+                // a real upstream address and no in-flight `ConnectOp`
+                // or running relay driver spawns `start_relay_connect`.
+                // The driver owns the entire transaction lifetime in
+                // task locals. Negative checks dedup against GC-spawned
+                // retries and duplicate Requests.
                 //
-                // Fresh inbound `ConnectMsg::Request` with a real
-                // upstream address (`source_addr.is_some()`) and no
-                // existing `ConnectOp` (`!has_connect_op(id)`) and no
-                // already-spawned relay driver (`!active_relay_connect_txs
-                // .contains(id)`) spawns `start_relay_connect`. The
-                // driver owns the entire transaction lifetime in
-                // task locals. The negative checks dedup against:
-                //   - GC-spawned retries that pre-register a `ConnectOp`
-                //   - already-running drivers from a duplicate Request
-                //
-                // `source_addr.is_none()` (originator loop-back from
-                // `start_client_connect`'s `send_to_and_collect_replies`)
-                // never reaches this branch — the bypass above handles
+                // `source_addr.is_none()` (originator loopback) cannot
+                // reach this branch — the reply bypass above handles
                 // joiner-side replies first.
-                //
-                // After commit 4 retires the relay branches of
-                // `connect::process_message`, this dispatch is the only
-                // entry point for relay CONNECT handling.
                 if let connect::ConnectMsg::Request { id, payload } = op {
                     if let Some(upstream_addr) = source_addr {
                         if !op_manager.has_connect_op(id)
@@ -1126,19 +1015,12 @@ where
                 .await;
             }
             NetMessageV1::Put(ref op) => {
-                // #1454 phase 5 final (PUT slice): every PUT wire variant
-                // routes to a task-per-tx driver. The legacy
-                // `OpManager.ops.put` DashMap, `Operation` impl, and
-                // legacy state-machine fallthrough were retired in this
-                // PR. The slice-A/B DashMap-existence dispatch gate is
-                // gone: the DashMap can no longer be populated.
-                //
-                // Only forward **terminal** Response/ResponseStreaming messages
-                // to the originator's awaiting task via the bypass.
-                // Non-terminal messages (Request, RequestStreaming,
-                // ForwardingAck) must NOT be forwarded: they would fill
-                // the capacity-1 reply channel and cause classify_reply
-                // to fail with Unexpected (Phase 2b bug 2).
+                // Forward only **terminal** Response/ResponseStreaming
+                // messages to the originator's awaiting task via the
+                // bypass. Non-terminal messages (Request,
+                // RequestStreaming, ForwardingAck) must NOT be
+                // forwarded: they would fill the capacity-1 reply
+                // channel and cause `classify_reply` to fail.
                 if matches!(
                     op,
                     put::PutMsg::Response { .. } | put::PutMsg::ResponseStreaming { .. }
@@ -1150,22 +1032,18 @@ where
                     return Ok(None);
                 }
 
-                // Relay PUT dispatch: spawn the appropriate task-per-tx
-                // driver. `start_relay_put` handles non-streaming
-                // Request (with upgrade-on-forward to streaming when
-                // payload > threshold, PR #4063);
+                // Relay PUT dispatch. `start_relay_put` handles
+                // non-streaming Request (with upgrade-on-forward to
+                // streaming when payload > threshold);
                 // `start_relay_put_streaming` handles direct
                 // `RequestStreaming` inbound. `ForwardingAck` is a
-                // no-op kept for backward compatibility with pre-#3964
-                // peers.
+                // no-op kept for backward compatibility.
                 //
-                // `start_client_put`'s `send_and_await(target=None)`
-                // loops the Request back into the local event loop as
-                // an InboundMessage with `source_addr=None`. Map that
-                // to `upstream_addr = own_addr` so the same
-                // `start_relay_put` driver handles both true relay hops
-                // and originator-loopback. The driver's local-store +
-                // forward-or-finalize logic is identical for both.
+                // Originator loopback: `start_client_put`'s
+                // `send_and_await(target=None)` arrives with
+                // `source_addr=None`. Map to `upstream_addr=own_addr`
+                // so the same driver handles both relay hops and
+                // originator loopback.
                 let effective_upstream =
                     source_addr.or_else(|| op_manager.ring.connection_manager.get_own_addr());
                 if let Some(upstream_addr) = effective_upstream {
@@ -1252,20 +1130,10 @@ where
                 return Ok(None);
             }
             NetMessageV1::Get(ref op) => {
-                // #1454 phase 5 final (GET slice): every GET wire variant
-                // routes to a task-per-tx driver. The legacy
-                // `OpManager.ops.get` DashMap, `Operation` impl, and
-                // legacy state-machine fallthrough were retired in this
-                // PR. The slice-A DashMap-existence dispatch gate is
-                // gone: the DashMap can no longer be populated.
-                //
-                // Only forward **terminal** Response/ResponseStreaming
-                // messages to the originator's awaiting task via the
-                // bypass. Non-terminal messages (Request,
-                // ResponseStreamingAck, ForwardingAck) must NOT be
-                // forwarded: they would fill the capacity-1 reply
-                // channel and cause classify_reply to fail with
-                // Unexpected (Phase 2b bug 2).
+                // Forward only **terminal** Response/ResponseStreaming
+                // messages to the originator's awaiting task. Other
+                // variants must NOT be forwarded — they would fill the
+                // capacity-1 reply channel.
                 if matches!(
                     op,
                     get::GetMsg::Response { .. } | get::GetMsg::ResponseStreaming { .. }
@@ -1277,15 +1145,10 @@ where
                     return Ok(None);
                 }
 
-                // Relay GET dispatch: spawn `start_relay_get`. Mirrors
-                // the PUT branch above. `start_client_get`'s
-                // `send_and_await(target=None)` loops the Request back
-                // into the local event loop as an InboundMessage with
-                // `source_addr=None`. Map that to
-                // `upstream_addr = own_addr` so the same
-                // `start_relay_get` driver handles both true relay hops
-                // and originator-loopback. The driver's local-cache +
-                // forward-or-finalize logic is identical for both.
+                // Relay GET dispatch. Originator loopback
+                // (`source_addr=None`) is mapped to
+                // `upstream_addr=own_addr` so the same `start_relay_get`
+                // driver handles both relay hops and loopback.
                 let effective_upstream =
                     source_addr.or_else(|| op_manager.ring.connection_manager.get_own_addr());
                 if let Some(upstream_addr) = effective_upstream {
@@ -1341,21 +1204,11 @@ where
                 return Ok(None);
             }
             NetMessageV1::Update(ref op) => {
-                // #1454 phase 5 final: every UPDATE wire variant routes
-                // to a task-per-tx driver. The legacy `OpManager.ops`
-                // DashMap, `Operation` impl, and re-entry fallthrough
-                // were retired in this PR (commits 1–4).
-                //
-                // For relay hops (source_addr.is_some()) we dispatch the
-                // matching driver and return. UPDATE is fire-and-forget
-                // end-to-end — there's no upstream reply to await. The
-                // dispatch gate from the slice-A/C era is gone: the
-                // DashMap can no longer be populated, so the gate always
-                // evaluated to false.
-                //
-                // source_addr.is_none() means the caller is internal.
-                // After the executor UPDATE path was retired in commit 1
-                // there are no remaining internal originators; the else
+                // UPDATE is fire-and-forget end-to-end — no upstream
+                // reply to await. For relay hops
+                // (`source_addr.is_some()`) dispatch the matching
+                // driver and return. `source_addr.is_none()` would
+                // mean an internal caller; there are none, so the else
                 // branch logs and drops.
                 if let Some(sender_addr) = source_addr {
                     #[allow(clippy::wildcard_enum_match_arm)]
@@ -1410,10 +1263,8 @@ where
                             }
                             return Ok(None);
                         }
-                        // #1454 phase 5 follow-up (slice C): streaming
-                        // relay UPDATE dispatch. Fire-and-forget:
-                        // claim stream → assemble → apply →
-                        // BroadcastStateChange fans out automatically.
+                        // Streaming relay UPDATE: claim stream → assemble
+                        // → apply → BroadcastStateChange fans out.
                         update::UpdateMsg::RequestUpdateStreaming {
                             id,
                             key,
@@ -1468,33 +1319,19 @@ where
                         }
                     }
                 } else {
-                    // source_addr.is_none() — internal caller. Phase 4
-                    // migrated client UPDATEs to `start_client_update`;
-                    // there are no other internal originators after the
-                    // executor UPDATE path was retired in commit 1.
                     tracing::debug!(
                         tx = %op.id(),
                         ?op,
-                        "UPDATE: internal-source variant ignored — no legacy \
-                         fallthrough after #1454 phase 5 final"
+                        "UPDATE: internal-source variant ignored"
                     );
                 }
                 return Ok(None);
             }
             NetMessageV1::Subscribe(ref op) => {
-                // #1454 phase 5 final (SUBSCRIBE slice): every SUBSCRIBE
-                // wire variant routes to a task-per-tx driver or a thin
-                // inbound handler. The legacy `OpManager.ops.subscribe`
-                // DashMap, `Operation` impl, and re-entry fallthrough
-                // were retired in this PR. The slice-A DashMap-existence
-                // dispatch gate is gone: the DashMap can no longer be
-                // populated.
-                //
-                // Only forward **terminal** Response messages to the
-                // originator's awaiting task via the bypass. Non-terminal
-                // messages (Request, ForwardingAck) must NOT be forwarded:
-                // they would fill the capacity-1 reply channel and cause
-                // classify_reply to fail with Unexpected.
+                // Forward only **terminal** Response messages to the
+                // originator's awaiting task. Other variants must NOT
+                // be forwarded — they would fill the capacity-1 reply
+                // channel.
                 if matches!(op, subscribe::SubscribeMsg::Response { .. })
                     && try_forward_task_per_tx_reply(
                         pending_op_result.as_ref(),
@@ -1505,14 +1342,10 @@ where
                     return Ok(None);
                 }
 
-                // Relay SUBSCRIBE dispatch: spawn `start_relay_subscribe`.
-                // Mirrors the GET / PUT / UPDATE branches above.
-                // `start_client_subscribe`'s `send_and_await(target=None)`
-                // loops the Request back as an InboundMessage with
-                // `source_addr=None`. Map that to
-                // `upstream_addr = own_addr` so the same
-                // `start_relay_subscribe` driver handles both true relay
-                // hops and originator-loopback.
+                // Relay SUBSCRIBE dispatch. Originator loopback
+                // (`source_addr=None`) is mapped to
+                // `upstream_addr=own_addr` so the same
+                // `start_relay_subscribe` driver handles both.
                 let effective_upstream =
                     source_addr.or_else(|| op_manager.ring.connection_manager.get_own_addr());
                 if let Some(upstream_addr) = effective_upstream {
@@ -1554,9 +1387,9 @@ where
                             .await;
                         }
                         _ => {
-                            // Response handled by bypass above; ForwardingAck
-                            // is a wire-only telemetry hook (#3570 diagnostics)
-                            // with no state mutation post-#1454 phase 5.
+                            // Response handled by bypass above;
+                            // ForwardingAck is a wire-only telemetry
+                            // hook (#3570) with no state mutation.
                             tracing::debug!(
                                 tx = %op.id(),
                                 ?op,
@@ -2331,44 +2164,24 @@ pub async fn subscribe(
     subscribe_with_id(op_manager, instance_id, client_id, None).await
 }
 
-/// Attempts to subscribe to a contract with a specific transaction ID (for deduplication).
+/// Subscribe to a contract with a specific transaction ID (for
+/// deduplication).
 ///
-/// Since #1454 Phase 2b, this function is the entry point for
-/// **client-initiated** SUBSCRIBE only — it spawns a task-per-tx driver via
-/// [`crate::operations::subscribe::start_client_subscribe`] rather than going
-/// through the legacy `request_subscribe` + `handle_op_result` re-entry loop.
-///
-/// The executor/WASM-initiated path (`executor::subscribe`) now goes
-/// through the task-per-tx executor driver
-/// (`subscribe::run_executor_subscribe`) — same retry loop as
-/// client-initiated subscribe, with the outcome returned to the
-/// executor as `Result<(), OpError>` rather than published via
-/// `result_router_tx` (the executor is an internal caller with no
-/// client waiter). Bypasses the `op_request` mediator entirely
-/// (mirrors `local_state_or_from_network` for GET).
-///
-/// The renewal-initiated path (`ring::connection_maintenance`) now goes
-/// through the task-per-tx renewal driver (`subscribe::run_renewal_subscribe`)
-/// — same retry loop as client-initiated subscribe, with the outcome
-/// returned to the renewal task for backoff bookkeeping rather than
-/// published via `result_router_tx`. Renewal jitter and spam-prevention
-/// remain owned by `ring::connection_maintenance` (above this layer).
-///
-/// PUT/GET sub-op fallback paths (`operations::start_subscription_request`,
-/// `maybe_subscribe_child`) route through `subscribe::run_client_subscribe`,
-/// which is hard-wired to `is_renewal=false`. Misrouting a renewal through
-/// any of those is a compile error: `start_client_subscribe` /
-/// `run_client_subscribe` no longer accept `is_renewal` — only
-/// `subscribe::run_renewal_subscribe` does.
+/// Entry point for **client-initiated** SUBSCRIBE only. Other callers
+/// (executor auto-subscribe, ring renewals, PUT/GET sub-op fallback)
+/// invoke their own drivers directly — `run_executor_subscribe`,
+/// `run_renewal_subscribe`, `run_client_subscribe`. `is_renewal` is
+/// accepted only by `run_renewal_subscribe`, so renewal misrouting is
+/// a compile error.
 ///
 /// # Parameters
 ///
-/// - `client_id`: If set, registers a legacy subscription-result waiter via
-///   `ch_outbound.waiting_for_subscription_result`. Both WS call sites in
-///   `client_events.rs` leave this `None` because they pre-register a
-///   transaction-result waiter via `waiting_for_transaction_result`.
-/// - `transaction_id`: The client-visible transaction id. If `None`, a fresh
-///   one is allocated — currently only the dead-code wrapper `subscribe()`
+/// - `client_id`: If set, registers a subscription-result waiter via
+///   `ch_outbound.waiting_for_subscription_result`. Both WS call sites
+///   in `client_events.rs` leave this `None` because they pre-register
+///   a transaction-result waiter via `waiting_for_transaction_result`.
+/// - `transaction_id`: Client-visible tx id. If `None`, a fresh one is
+///   allocated — currently only the dead-code wrapper `subscribe()`
 ///   does this.
 pub async fn subscribe_with_id(
     op_manager: Arc<OpManager>,
@@ -2397,16 +2210,9 @@ pub async fn subscribe_with_id(
         }
     }
 
-    // Task-per-tx: spawn the driver and return the client-visible tx
-    // immediately. The spawned task owns retries, peer selection, local
-    // completion, and result delivery via `result_router_tx`.
-    //
-    // Renewals do NOT come through here. `ring::connection_maintenance`
-    // calls `subscribe::run_renewal_subscribe` directly — same task-per-tx
-    // machinery (`drive_client_subscribe_inner`) with `is_renewal=true`
-    // and a custom delivery path that returns `RenewalOutcome` to the
-    // renewal task instead of publishing through `result_router_tx`
-    // (renewals have no client waiter to publish to).
+    // Spawn the driver and return the client-visible tx immediately.
+    // The driver owns retries, peer selection, local completion, and
+    // result delivery via `result_router_tx`.
     subscribe::start_client_subscribe(op_manager, instance_id, client_tx).await
 }
 
@@ -2507,11 +2313,9 @@ async fn handle_aborted_op(
         | TransactionType::Put
         | TransactionType::Update
         | TransactionType::Subscribe => {
-            // GET, PUT, UPDATE and SUBSCRIBE have no DashMap entry
-            // post-#1454 phase 5 final; the task-per-tx driver owns abort
-            // handling through its own cancellation surface (the
-            // `result_router_tx` publication path is the only externally
-            // observable result).
+            // No DashMap entry: each driver owns abort handling
+            // through its own cancellation surface. `result_router_tx`
+            // publication is the only externally observable result.
         }
     }
     Ok(())
@@ -3000,17 +2804,14 @@ mod tests {
         }
     }
 
-    // Phase 1 (#1454) tests for forward_pending_op_result_if_completed.
+    // Tests for `forward_pending_op_result_if_completed`.
     //
-    // These exercise the callback-forwarding helper used by every branch of
-    // `handle_pure_network_message_v1`. The helper is the only place that
-    // drives the `pending_op_result` oneshot channel from a completed op
-    // result back to a caller of `OpCtx::send_and_await`. Phase 1 extended
-    // the hook from PUT/GET only to cover SUBSCRIBE/CONNECT/UPDATE as well,
-    // so these tests verify the helper forwards correctly for every op
-    // variant and short-circuits in the negative cases. (The caller side
-    // used to live on `OpManager::notify_op_execution`, which Phase 2a
-    // replaced with `OpCtx::send_and_await` — see #1454.)
+    // Exercises the callback-forwarding helper used by every branch
+    // of `handle_pure_network_message_v1`. It drives the
+    // `pending_op_result` channel from a completed op result back to
+    // a caller of `OpCtx::send_and_await`. These tests verify the
+    // helper forwards for every op variant and short-circuits in the
+    // negative cases.
     mod callback_forward_tests {
         use super::super::{
             OpError, OpNotAvailable, forward_pending_op_result_if_completed,
@@ -3139,16 +2940,12 @@ mod tests {
         }
 
         // ───────────────────────────────────────────────────────────
-        // Phase 2b (#1454) task-per-tx bypass tests for
-        // `try_forward_task_per_tx_reply`.
+        // Tests for `try_forward_task_per_tx_reply`.
         //
         // The bypass routes a reply directly to an awaiting
-        // `OpCtx::send_and_await` caller, skipping the legacy
-        // `handle_op_request` path entirely. These tests cover the
-        // helper's contract; end-to-end "the SUBSCRIBE branch of
-        // `handle_pure_network_message_v1` actually invokes the helper"
-        // coverage comes from the `run_client_subscribe` tests added
-        // alongside the Phase 2b migration.
+        // `OpCtx::send_and_await` caller. These tests cover the
+        // helper's contract; end-to-end branch coverage lives in the
+        // per-driver tests.
         // ───────────────────────────────────────────────────────────
 
         #[tokio::test]
@@ -3247,12 +3044,10 @@ mod tests {
             //   (b) the branch was restructured (update this guard).
             assert!(
                 window.contains("try_forward_task_per_tx_reply("),
-                "SUBSCRIBE branch no longer calls try_forward_task_per_tx_reply \
-                 before handle_op_request. This is the bypass Phase 2b (#1454) \
-                 added to prevent task-per-tx callers from hanging on replies \
-                 that load_or_init would drop as OpNotPresent. Either restore \
-                 the bypass invocation or update this regression guard if the \
-                 branch has been legitimately refactored."
+                "SUBSCRIBE branch no longer calls \
+                 try_forward_task_per_tx_reply before relay dispatch. \
+                 Either restore the bypass or update this regression \
+                 guard if the branch was legitimately refactored."
             );
 
             // The bypass MUST be gated on Response-only. Without this
@@ -3270,15 +3065,10 @@ mod tests {
 
         #[tokio::test]
         async fn bypass_does_not_block_when_channel_already_full() {
-            // Defensive regression: `try_send` on a full channel must
-            // fail without blocking the pure-network-message handler.
-            // Although Phase 1's dedup guarantees the callback fires at
-            // most once per tx (so a "full" capacity-1 channel
-            // shouldn't happen in practice), this test pins the
-            // non-blocking contract so future refactors can't
-            // accidentally switch to `.send().await` and reintroduce
-            // the class of bug documented in
-            // `.claude/rules/channel-safety.md`.
+            // Pin the non-blocking contract: `try_send` on a full
+            // channel must fail without blocking the handler. Future
+            // refactors must not switch to `.send().await` (see
+            // `.claude/rules/channel-safety.md`).
             let (tx, _rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
             // Pre-fill the capacity-1 channel.
             tx.try_send(dummy_reply())
@@ -3443,9 +3233,8 @@ mod tests {
 
         // ───────────────────────────────────────────────────────────
         // Regression guard: PUT branch of handle_pure_network_message_v1
-        // must call try_forward_task_per_tx_reply before handle_op_request,
-        // gated on Response|ResponseStreaming only. Mirror of the SUBSCRIBE
-        // guard above. Added in Phase 3a (#1454).
+        // must call try_forward_task_per_tx_reply before relay dispatch,
+        // gated on Response|ResponseStreaming only.
         // ───────────────────────────────────────────────────────────
 
         #[test]
@@ -3470,8 +3259,7 @@ mod tests {
             assert!(
                 window.contains("try_forward_task_per_tx_reply("),
                 "PUT branch no longer calls try_forward_task_per_tx_reply. \
-                 This is the bypass Phase 3a (#1454) added to prevent \
-                 task-per-tx callers from hanging on replies."
+                 Restore the bypass or update this regression guard."
             );
 
             assert!(
@@ -3486,31 +3274,25 @@ mod tests {
                  Both terminal variants must be forwarded."
             );
 
-            // #1454 phase 5 final (PUT slice): legacy fallthrough is
-            // gone. The arm must NOT call handle_op_request<PutOp> and
-            // must NOT gate on the retired DashMap-existence check.
-            // Compose needles at runtime so the assert source itself
-            // does not contain them.
+            // The legacy fallthrough must NOT return. Compose needles
+            // at runtime so the assert source itself does not contain
+            // them.
             let legacy_dispatch_needle = format!("handle{}::<put::PutOp, _>", "_op_request");
             assert!(
                 !window.contains(&legacy_dispatch_needle),
-                "PUT branch must not call legacy state-machine dispatch — \
-                 retired in #1454 phase 5 final (PUT slice)"
+                "PUT branch must not call legacy state-machine dispatch"
             );
             let dashmap_gate_needle = format!("has{}_op", "_put");
             assert!(
                 !window.contains(&dashmap_gate_needle),
-                "PUT branch must not gate dispatch on the retired DashMap \
-                 existence check — gate retired in #1454 phase 5 final (PUT slice)"
+                "PUT branch must not gate dispatch on the retired DashMap existence check"
             );
         }
 
         // ───────────────────────────────────────────────────────────
         // Per-variant filter tests for the PUT branch bypass.
-        // Mirror of the subscribe filter tests above. Verifies that
-        // only Response and ResponseStreaming are forwarded to the
-        // task-per-tx channel; all other variants must fall through
-        // to handle_op_request.
+        // Only Response and ResponseStreaming may be forwarded; all
+        // other variants must fall through to relay dispatch.
         // ───────────────────────────────────────────────────────────
 
         use crate::operations::put::PutMsg;
@@ -3626,28 +3408,14 @@ mod tests {
         }
 
         // ───────────────────────────────────────────────────────────
-        // Regression guards for the GET branch of
-        // handle_pure_network_message_v1 added in #3883 (phase 5).
+        // Regression guards for the GET branch.
         //
-        // The GET branch has two distinct dispatch layers:
-        //
-        //   1. Phase-3b bypass: terminal Response/ResponseStreaming for an
-        //      active client driver → try_forward_task_per_tx_reply (unchanged).
-        //
-        //   2. Relay dispatch (new in commit 2): GetMsg::Request with
-        //      source_addr.is_some() and no existing GetOp in OpManager →
-        //      start_relay_get (task-per-tx relay driver).
-        //
-        // Layer 1 is the same as PUT/SUBSCRIBE; the guards below cover
-        // layer 2 (source-literal, not runtime dispatch).
+        // Two dispatch layers:
+        //   1. Reply bypass: terminal Response/ResponseStreaming for
+        //      an active client driver → `try_forward_task_per_tx_reply`.
+        //   2. Relay dispatch: `GetMsg::Request` →  `start_relay_get`,
+        //      with originator loopback mapped to `upstream=own_addr`.
         // ───────────────────────────────────────────────────────────
-
-        // Source-literal guard: verify the GET branch invokes
-        // try_forward_task_per_tx_reply before start_relay_get dispatch,
-        // gated on Response|ResponseStreaming only (phase-3b bypass).
-        // ── Relay GET dispatch structural pin tests
-        // (#1454 phase 5 final, GET slice). Mirror of the PUT/UPDATE
-        // tests below.
 
         #[test]
         fn get_branch_dispatches_relay_driver() {
@@ -3666,11 +3434,11 @@ mod tests {
                 + branch_start;
             let window = &SOURCE[branch_start..window_end];
 
-            // Phase-3b bypass must still be present (gated on terminal variants).
+            // Reply bypass must precede relay dispatch.
             assert!(
                 window.contains("try_forward_task_per_tx_reply("),
                 "GET branch no longer calls try_forward_task_per_tx_reply \
-                 before relay dispatch. Phase-3b (#1454) bypass removed — restore it."
+                 before relay dispatch. Restore the bypass."
             );
             assert!(
                 window.contains("get::GetMsg::Response { .. }"),
@@ -3689,11 +3457,9 @@ mod tests {
                 "GET branch no longer calls start_relay_get for relay dispatch."
             );
 
-            // After #1454 phase 5 final (GET slice), the originator-
-            // loopback case (source_addr=None) is mapped to
-            // upstream=own_addr instead of falling through to legacy.
-            // The dispatch is therefore conditional on an effective
-            // upstream rather than on source_addr.is_some() directly.
+            // Originator loopback (source_addr=None) is mapped to
+            // upstream=own_addr, so dispatch is conditional on an
+            // effective upstream rather than `source_addr.is_some()`.
             assert!(
                 window.contains("effective_upstream") || window.contains("upstream_addr"),
                 "GET relay dispatch must thread an effective upstream address \
@@ -3706,14 +3472,12 @@ mod tests {
             let legacy_dispatch_needle = format!("handle{}::<get::GetOp, _>", "_op_request");
             assert!(
                 !window.contains(&legacy_dispatch_needle),
-                "GET branch must NOT call legacy state-machine dispatch — \
-                 retired in #1454 phase 5 final (GET slice)"
+                "GET branch must NOT call legacy state-machine dispatch"
             );
             let dashmap_gate_needle = format!("has{}_op", "_get");
             assert!(
                 !window.contains(&dashmap_gate_needle),
-                "GET branch must NOT gate on the retired DashMap existence \
-                 check — retired in #1454 phase 5 final (GET slice)"
+                "GET branch must NOT gate on the retired DashMap existence check"
             );
 
             // Bypass must precede relay dispatch in source order
@@ -3726,27 +3490,24 @@ mod tests {
                 .expect("start_relay_get not found in GET branch");
             assert!(
                 bypass_pos < relay_pos,
-                "Phase-3b bypass (try_forward_task_per_tx_reply) must appear \
-                 BEFORE relay dispatch (start_relay_get) in the GET branch. \
-                 Swapping order would break the client-driver terminal-reply fast path."
+                "Reply bypass (try_forward_task_per_tx_reply) must \
+                 appear BEFORE relay dispatch (start_relay_get) — \
+                 swapping order would break the terminal-reply fast \
+                 path."
             );
         }
 
         // ───────────────────────────────────────────────────────────
-        // Regression guards for the UPDATE branch of
-        // handle_pure_network_message_v1 added in #1454 phase 5
-        // follow-up (slice A: relay UPDATE task-per-tx).
+        // Regression guards for the UPDATE branch.
         //
-        // UPDATE is fire-and-forget end-to-end — there is no
-        // upstream reply to await, so there is no phase-3b bypass
-        // (no reply channel to forward into). Only relay dispatch
+        // UPDATE is fire-and-forget end-to-end — no upstream reply
+        // to await, so no reply bypass exists. Only relay dispatch
         // is wired here.
         // ───────────────────────────────────────────────────────────
 
-        /// Pin: every UPDATE wire variant dispatches to a task-per-tx
-        /// relay driver. After #1454 phase 5 final there is no legacy
-        /// `handle_op_request::<UpdateOp>` fallthrough — every reachable
-        /// arm spawns a driver and returns Ok(None).
+        /// Pin: every UPDATE wire variant dispatches to a relay
+        /// driver. No legacy fallthrough remains — every reachable
+        /// arm spawns a driver and returns `Ok(None)`.
         #[test]
         fn update_branch_dispatches_all_relay_drivers() {
             const SOURCE: &str = include_str!("node.rs");
@@ -3774,8 +3535,7 @@ mod tests {
             ] {
                 assert!(
                     window.contains(driver),
-                    "UPDATE branch must call {driver} for relay dispatch \
-                     (#1454 phase 5 follow-up slice A/C)."
+                    "UPDATE branch must call {driver} for relay dispatch."
                 );
             }
 
@@ -3785,22 +3545,18 @@ mod tests {
             let legacy_call = ["handle_op_request::<update::", "UpdateOp", ", _>"].concat();
             assert!(
                 !window.contains(&legacy_call),
-                "UPDATE branch must NOT call handle_op_request — \
-                 retired in #1454 phase 5 final"
+                "UPDATE branch must NOT call handle_op_request"
             );
             let dispatch_gate = ["has_", "update_op"].concat();
             assert!(
                 !window.contains(&dispatch_gate),
-                "UPDATE relay dispatch must NOT consult has_update_op — \
-                 the gate was retired together with the ops.update DashMap \
-                 in #1454 phase 5 final"
+                "UPDATE relay dispatch must NOT consult has_update_op"
             );
         }
 
-        /// Pin: relay UPDATE dispatch is still gated on
-        /// `source_addr.is_some()` so internal callers do not spawn
-        /// drivers (the executor UPDATE path that used to land here was
-        /// retired in #1454 phase 5 final commit 1).
+        /// Pin: relay UPDATE dispatch is gated on
+        /// `source_addr.is_some()`; internal callers must not spawn
+        /// drivers.
         #[test]
         fn update_branch_dispatch_gates_on_source_addr() {
             const SOURCE: &str = include_str!("node.rs");
@@ -3821,9 +3577,7 @@ mod tests {
             );
         }
 
-        // ── Relay PUT dispatch structural pin tests
-        // (#1454 phase 5 final, PUT slice). Mirror of the UPDATE
-        // tests above.
+        // ── Relay PUT dispatch structural pin tests.
 
         #[test]
         fn put_branch_dispatches_relay_drivers() {
@@ -3849,11 +3603,9 @@ mod tests {
                 window.contains("start_relay_put_streaming("),
                 "PUT branch must call start_relay_put_streaming for streaming relay hops."
             );
-            // After #1454 phase 5 final (PUT slice), the originator-
-            // loopback case (source_addr=None) is mapped to
-            // upstream=own_addr instead of falling through to legacy.
-            // The dispatch is therefore conditional on an effective
-            // upstream rather than on source_addr.is_some() directly.
+            // Originator loopback (source_addr=None) is mapped to
+            // upstream=own_addr, so dispatch is conditional on an
+            // effective upstream rather than `source_addr.is_some()`.
             assert!(
                 window.contains("effective_upstream") || window.contains("upstream_addr"),
                 "PUT relay dispatch must thread an effective upstream address \
@@ -3865,14 +3617,12 @@ mod tests {
             let legacy_dispatch_needle = format!("handle{}::<put::PutOp, _>", "_op_request");
             assert!(
                 !window.contains(&legacy_dispatch_needle),
-                "PUT branch must NOT call legacy state-machine dispatch — \
-                 retired in #1454 phase 5 final (PUT slice)"
+                "PUT branch must NOT call legacy state-machine dispatch"
             );
             let dashmap_gate_needle = format!("has{}_op", "_put");
             assert!(
                 !window.contains(&dashmap_gate_needle),
-                "PUT branch must NOT gate on the retired DashMap existence \
-                 check — retired in #1454 phase 5 final (PUT slice)"
+                "PUT branch must NOT gate on the retired DashMap existence check"
             );
         }
 
@@ -3915,12 +3665,11 @@ mod tests {
             );
         }
 
-        // ── Relay SUBSCRIBE dispatch structural pin tests (#1454 phase 5
-        // final, SUBSCRIBE slice). After the legacy state-machine
-        // fallthrough was retired, every SUBSCRIBE wire variant routes
-        // either to the task-per-tx relay driver (Request) or to a
-        // dedicated inbound handler (Unsubscribe). Mirror the GET-slice
-        // pin pattern.
+        // ── Relay SUBSCRIBE dispatch structural pin tests.
+        //
+        // Every SUBSCRIBE wire variant routes either to the relay
+        // driver (Request) or to a dedicated inbound handler
+        // (Unsubscribe). Response is forwarded via the reply bypass.
 
         #[test]
         fn subscribe_branch_dispatches_relay_driver() {
@@ -3961,14 +3710,12 @@ mod tests {
             );
             assert!(
                 window.contains("handle_unsubscribe_inbound("),
-                "SUBSCRIBE branch must call handle_unsubscribe_inbound for \
-                 Unsubscribe wire messages — replaces the legacy state-machine \
-                 Unsubscribe arm retired in #1454 phase 5 final."
+                "SUBSCRIBE branch must call handle_unsubscribe_inbound \
+                 for Unsubscribe wire messages."
             );
 
-            // After #1454 phase 5 final (SUBSCRIBE slice), the
-            // originator-loopback case (source_addr=None) is mapped to
-            // upstream=own_addr instead of falling through to legacy.
+            // Originator loopback (source_addr=None) is mapped to
+            // upstream=own_addr.
             assert!(
                 window.contains("effective_upstream") || window.contains("upstream_addr"),
                 "SUBSCRIBE relay dispatch must thread an effective upstream address \
@@ -3982,14 +3729,12 @@ mod tests {
                 format!("handle{}::<subscribe::SubscribeOp, _>", "_op_request");
             assert!(
                 !window.contains(&legacy_dispatch_needle),
-                "SUBSCRIBE branch must NOT call legacy state-machine dispatch — \
-                 retired in #1454 phase 5 final (SUBSCRIBE slice)"
+                "SUBSCRIBE branch must NOT call legacy state-machine dispatch"
             );
             let dashmap_gate_needle = format!("has{}_op", "_subscribe");
             assert!(
                 !window.contains(&dashmap_gate_needle),
-                "SUBSCRIBE branch must NOT gate on the retired DashMap existence \
-                 check — retired in #1454 phase 5 final (SUBSCRIBE slice)"
+                "SUBSCRIBE branch must NOT gate on the retired DashMap existence check"
             );
 
             // Bypass must precede relay dispatch in source order
@@ -4009,10 +3754,9 @@ mod tests {
         }
     }
 
-    /// Tests for `fill_connect_response_acceptor_addr` (#1454 phase 2c
-    /// slice 2 review M1). Mirrors the legacy joiner-side fill at
-    /// `connect.rs:1723-1745`. The driver does not see `source_addr`,
-    /// so the bypass must rewrite the payload before forwarding.
+    /// Tests for `fill_connect_response_acceptor_addr`. The driver
+    /// does not see `source_addr`, so the dispatch site must rewrite
+    /// the payload before forwarding.
     mod fill_connect_response_acceptor_addr_tests {
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
@@ -4134,13 +3878,13 @@ mod tests {
         }
     }
 
-    /// Regression guards for the CONNECT bypass `matches!` predicate
-    /// (#1454 phase 2c slice 1 commit 1). The relay-CONNECT driver
-    /// (`start_relay_connect`, commit 2) owns the entire tx lifetime
-    /// in task locals, so all four non-Request `ConnectMsg` variants
-    /// (Response, Rejected, ObservedAddress, ConnectFailed) must reach
-    /// the per-tx waiter receiver. `Request` is the spawn signal and
-    /// is handled by the dispatch gate, never the bypass forward.
+    /// Regression guards for the CONNECT bypass `matches!` predicate.
+    ///
+    /// The relay-CONNECT driver owns the entire tx lifetime in task
+    /// locals, so all four non-`Request` `ConnectMsg` variants
+    /// (Response, Rejected, ObservedAddress, ConnectFailed) must
+    /// reach the per-tx waiter receiver. `Request` is the spawn
+    /// signal and is handled by the dispatch gate.
     mod connect_bypass_coverage_guards {
         const SOURCE: &str = include_str!("node.rs");
 
@@ -4183,11 +3927,10 @@ mod tests {
         fn connect_branch_bypass_forwards_observed_address() {
             assert!(
                 connect_branch_window().contains("connect::ConnectMsg::ObservedAddress { .. }"),
-                "Connect bypass `matches!` no longer forwards ObservedAddress. \
-                 Phase 2c slice 1 (#1454) moved the set_own_addr / \
-                 update_location side effect into the joiner driver inbox; \
-                 dropping ObservedAddress here would prevent NAT-discovery \
-                 from completing."
+                "Connect bypass `matches!` no longer forwards \
+                 ObservedAddress. The joiner driver inbox owns the \
+                 set_own_addr / update_location side effect; dropping \
+                 ObservedAddress here breaks NAT discovery."
             );
         }
 
@@ -4195,10 +3938,10 @@ mod tests {
         fn connect_branch_bypass_forwards_connect_failed() {
             assert!(
                 connect_branch_window().contains("connect::ConnectMsg::ConnectFailed { .. }"),
-                "Connect bypass `matches!` no longer forwards ConnectFailed. \
-                 Phase 2c slice 1 (#1454) moved hole-punch failure re-route \
-                 into the relay driver inbox; dropping ConnectFailed here \
-                 would strand re-route attempts on legacy `process_message`."
+                "Connect bypass `matches!` no longer forwards \
+                 ConnectFailed. The relay driver inbox owns hole-punch \
+                 failure re-route; dropping ConnectFailed here strands \
+                 the re-route on legacy `process_message`."
             );
         }
 
@@ -4231,15 +3974,14 @@ mod tests {
             );
         }
 
-        /// Phase 2c slice 1 commit 3: the Connect branch MUST dispatch
-        /// to `start_relay_connect` for fresh inbound Requests.
+        /// The Connect branch MUST dispatch to `start_relay_connect`
+        /// for fresh inbound Requests.
         #[test]
         fn connect_branch_dispatches_start_relay_connect_for_fresh_request() {
             let window = connect_branch_window();
             assert!(
                 window.contains("start_relay_connect("),
-                "Connect branch no longer calls start_relay_connect for \
-                 relay dispatch. Slice 1 commit 3 (#1454) wired this; \
+                "Connect branch no longer calls start_relay_connect — \
                  removing it strands relay CONNECT on legacy."
             );
         }

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -4143,10 +4143,10 @@ impl P2pConnManager {
     /// Send an arbitrary `NetMessage` to a target peer without registering
     /// a `pending_op_results` callback for the message's transaction.
     ///
-    /// Mirrors `handle_send_interest_message` but accepts a fully-formed
-    /// `NetMessage`. Introduced for #1454 phase 2c (CONNECT originator
-    /// task-per-tx driver) so the joiner can emit `ConnectFailed` upstream
-    /// without disturbing its own multi-reply receiver slot.
+    /// Mirrors `handle_send_interest_message` but accepts a
+    /// fully-formed `NetMessage`. Used by the CONNECT joiner to
+    /// emit `ConnectFailed` upstream without disturbing its own
+    /// multi-reply receiver slot.
     async fn handle_send_net_message(
         &mut self,
         target: SocketAddr,

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -305,7 +305,7 @@ pub fn record_peer_disconnected(addr: SocketAddr) {
 ///   and never publishes via `result_router_tx`).
 ///
 /// Audit: `grep -rn "record_op_result" crates/core/src/operations/`
-/// must show coverage for every op type that has a task-per-tx driver.
+/// must show coverage for every op type with a driver.
 pub fn record_op_result(op_type: OpType, success: bool) {
     if let Some(status) = NETWORK_STATUS.get() {
         if let Ok(mut s) = status.write() {
@@ -840,8 +840,8 @@ mod tests {
         record_op_result(OpType::Get, true);
         record_op_result(OpType::Get, false);
         record_op_result(OpType::Put, true);
-        // Issue #4010: SUBSCRIBE / UPDATE counters were stuck at zero
-        // because the task-per-tx drivers stopped recording outcomes.
+        // Issue #4010: SUBSCRIBE / UPDATE counters were stuck at
+        // zero because the drivers stopped recording outcomes.
         // Cover both op types and both outcomes (success + failure) so
         // the per-op tabulation is pinned end to end. The two
         // `OpType::Update, true` calls are intentional, not a copy
@@ -877,11 +877,11 @@ mod tests {
     /// registered and yields contracts, `get_snapshot().contracts`
     /// renders them with the same field shape (`key_short`, `key_full`,
     /// `subscribed_secs`, `last_updated_secs`) the dashboard template
-    /// expects. The bug this PR fixes was a silent break in this path
-    /// after SUBSCRIBE migrated to the task-per-tx driver and stopped
-    /// invoking the legacy mirror — without a test that exercises the
-    /// provider end-to-end, the same break could happen at the
-    /// `set_subscription_provider` seam in a future refactor.
+    /// expects. The bug this PR fixed was a silent break in this
+    /// path after the SUBSCRIBE migration stopped invoking the
+    /// legacy mirror — without an end-to-end test, the same break
+    /// could happen at the `set_subscription_provider` seam in a
+    /// future refactor.
     #[test]
     fn test_subscription_provider_wired_renders_contracts() {
         use freenet_stdlib::prelude::{ContractCode, ContractInstanceId, ContractKey};

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -67,14 +67,9 @@ pub(crate) enum OpNotAvailable {
 #[derive(Default)]
 struct Ops {
     connect: DashMap<Transaction, crate::operations::connect::ConnectOp>,
-    // `get`, `put`, `update` and `subscribe` DashMaps retired in #1454
-    // phase 5 final (UPDATE slice, PUT slice, GET slice, SUBSCRIBE
-    // slice): every wire path (client + non-streaming relay + streaming
-    // relay) now runs on `op_ctx_task::*` task-per-tx drivers that own
-    // their state in task locals. The legacy `Operation` impls, the
-    // `request_*` / `start_op*` originator helpers, and the
-    // `OpEnum::{Get,Put,Update,Subscribe}` carriers were deleted in
-    // earlier commits.
+    // GET, PUT, UPDATE, and SUBSCRIBE have no DashMap here — every
+    // wire path for those ops runs on `op_ctx_task::*` drivers that
+    // own their state in task locals.
     completed: DashSet<Transaction>,
     under_progress: DashSet<Transaction>,
 }
@@ -172,46 +167,31 @@ pub(crate) struct OpManager {
     /// amplification observed in workflow run 24600634908 (6.8M spawns
     /// in 100s, 63GB RSS).
     pub(crate) active_relay_get_txs: Arc<DashSet<Transaction>>,
-    /// Set of transactions currently being driven by a relay UPDATE
-    /// task-per-tx driver on this node. Same role as
-    /// `active_relay_get_txs` but for UPDATE relay (#1454 phase 5
-    /// follow-up). UPDATE relay has no retry loop and no upstream
-    /// reply, so the amplification risk is structurally lower than GET
-    /// — the dedup gate exists primarily for robustness against
-    /// GC-spawned re-entries and routing-bloom false-positive
-    /// retransmissions.
+    /// Same role as `active_relay_get_txs` but for UPDATE relay.
+    /// UPDATE relay has no retry loop and no upstream reply, so the
+    /// amplification risk is structurally lower than GET — the gate
+    /// exists primarily for robustness against GC-spawned re-entries
+    /// and routing-bloom false-positive retransmissions.
     pub(crate) active_relay_update_txs: Arc<DashSet<Transaction>>,
-    /// Set of transactions currently being driven by a relay PUT
-    /// task-per-tx driver on this node. Same role as
-    /// `active_relay_get_txs` but for PUT relay (#1454 phase 5
-    /// follow-up slice A). PUT relay has req/response semantics like
-    /// GET (but forwards once — no per-hop retry), so the amplification
-    /// risk is comparable to GET. The dedup gate rejects duplicate
-    /// inbound `PutMsg::Request` for a tx that already has a live
-    /// relay driver — prevents GC-spawned re-entries and routing-bloom
-    /// false-positive retransmissions from spawning redundant drivers.
+    /// Same role as `active_relay_get_txs` but for PUT relay. PUT
+    /// relay has req/response semantics like GET (but forwards once
+    /// — no per-hop retry), so amplification risk is comparable.
+    /// Rejects duplicate inbound `PutMsg::Request` for a tx that
+    /// already has a live driver.
     pub(crate) active_relay_put_txs: Arc<DashSet<Transaction>>,
-    /// Set of transactions currently being driven by a relay SUBSCRIBE
-    /// task-per-tx driver on this node. Same role as
-    /// `active_relay_get_txs` but for SUBSCRIBE relay (#1454 phase 5
-    /// follow-up slice A). SUBSCRIBE relay has req/response semantics
-    /// like GET/PUT but forwards once — no per-hop retry — because the
-    /// client-init driver (Phase 2b) owns cross-peer retry. The dedup
-    /// gate rejects duplicate inbound `SubscribeMsg::Request` for a tx
-    /// that already has a live relay driver.
+    /// Same role as `active_relay_get_txs` but for SUBSCRIBE relay.
+    /// SUBSCRIBE relay forwards once — no per-hop retry — because
+    /// the client driver owns cross-peer retry. Rejects duplicate
+    /// inbound `SubscribeMsg::Request`.
     pub(crate) active_relay_subscribe_txs: Arc<DashSet<Transaction>>,
-    /// Set of transactions currently being driven by a relay CONNECT
-    /// task-per-tx driver on this node. Same role as
-    /// `active_relay_get_txs` but for CONNECT relay (#1454 phase 2c
-    /// slice 1). The dedup gate rejects duplicate inbound
-    /// `ConnectMsg::Request` for a tx that already has a live relay
-    /// driver — prevents bloom-filter rekey re-entries and
-    /// uphill-retry false-positive retransmissions from spawning
-    /// redundant drivers. Phase 2c slice 1 covers the
-    /// Request→Response forward path; Rejected within-relay retries
-    /// and ConnectFailed downstream propagation stay on legacy
-    /// `process_message`, gated by the dedup set's absence on those
-    /// branches.
+    /// Same role as `active_relay_get_txs` but for CONNECT relay.
+    /// Rejects duplicate inbound `ConnectMsg::Request` — prevents
+    /// bloom-filter rekey re-entries and uphill-retry false-positive
+    /// retransmissions from spawning
+    /// redundant drivers. The driver covers the Request→Response
+    /// forward path; Rejected within-relay retries and ConnectFailed
+    /// downstream propagation stay on legacy `process_message`, gated
+    /// by the dedup set's absence on those branches.
     pub(crate) active_relay_connect_txs: Arc<DashSet<Transaction>>,
 }
 
@@ -427,12 +407,9 @@ impl OpManager {
     /// If the channel is full for this long, the event loop is stuck and sending will never succeed.
     const NOTIFICATION_SEND_TIMEOUT: Duration = Duration::from_secs(30);
 
-    // `notify_op_change` was the legacy state-machine re-entry primitive
-    // (push to ops DashMap + send NetMessage on notifications channel).
-    // Retired in #1454 phase 5 final after all five ops (GET/PUT/UPDATE/
-    // SUBSCRIBE + CONNECT relay) migrated to task-per-tx drivers that
-    // route outbound messages through `op_execution_sender` and own
-    // their own state in task locals.
+    // `notify_op_change` (legacy state-machine re-entry primitive)
+    // is gone: every op routes outbound messages through
+    // `op_execution_sender` and owns its state in task locals.
 
     // An early, fast path, return for communicating events in the node to the main message handler,
     // without any transmission in the network whatsoever and avoiding any state transition.
@@ -534,12 +511,8 @@ impl OpManager {
             instance_id,
         });
 
-        // #1454 phase 5 final (SUBSCRIBE slice): fire-and-forget the
-        // Unsubscribe wire message through OpCtx. The legacy path pushed
-        // a synthetic SubscribeOp into `ops.subscribe` so the event
-        // loop's `peek_next_hop_addr` SUBSCRIBE arm could recover the
-        // target address; both that arm and the DashMap were retired in
-        // this slice. The op-execution channel routes directly to
+        // Fire-and-forget the Unsubscribe wire message through
+        // `OpCtx`. The op-execution channel routes directly to
         // `OutboundMessageWithTarget` given `Some(target_addr)`, so no
         // operation state is required (Unsubscribe has no reply).
         let mut ctx = self.op_ctx(tx);
@@ -568,12 +541,10 @@ impl OpManager {
 
     /// Build a per-transaction [`OpCtx`] bound to `tx`.
     ///
-    /// Phase 2a factory for the async sub-transaction refactor (#1454). The
-    /// returned context clones the event-loop `op_execution_sender` and is
-    /// the only supported way to obtain an `OpCtx` outside this crate's
-    /// unit tests. See [`OpCtx`] for scope, single-use semantics, and the
-    /// "where to call this" guidance.
-    #[allow(dead_code)] // Phase 2a scaffolding: first production caller lands in Phase 2b (#1454).
+    /// Construct an [`OpCtx`] for `tx`. Clones the event-loop
+    /// `op_execution_sender`; the only supported way to obtain an
+    /// `OpCtx` outside this crate's unit tests.
+    #[allow(dead_code)]
     pub fn op_ctx(&self, tx: Transaction) -> OpCtx {
         OpCtx::new(tx, self.to_event_listener.op_execution_sender.clone())
     }
@@ -640,9 +611,8 @@ impl OpManager {
                 .connect
                 .get(id)
                 .and_then(|op| op.get_next_hop_addr()),
-            // GET, PUT, UPDATE and SUBSCRIBE have no DashMap entry
-            // post-#1454 phase 5 final; task-per-tx drivers manage
-            // their own routing.
+            // GET, PUT, UPDATE and SUBSCRIBE have no DashMap entry;
+            // their drivers manage routing in task locals.
             TransactionType::Get
             | TransactionType::Put
             | TransactionType::Update
@@ -669,16 +639,10 @@ impl OpManager {
     }
 
     /// Get the current hop count (remaining HTL) for an operation.
-    /// Used for calculating hop_count in success/failure events.
+    /// Always returns `None` — no live op reports a hop here.
+    /// Kept for API compatibility with the tracing consumer at
+    /// `crates/core/src/tracing.rs:1266`.
     pub fn get_current_hop(&self, _id: &Transaction) -> Option<usize> {
-        // GET, PUT and UPDATE have no DashMap entry post-#1454 phase 5
-        // final; SUBSCRIBE doesn't track HTL; CONNECT has no current
-        // hop concept exposed. The `get_current_hop` getter is kept for
-        // API compatibility with the tracing/telemetry consumer at
-        // `crates/core/src/tracing.rs:1266` (which uses it to decorate
-        // event logs with the operation's remaining HTL when known).
-        // Post-GET-slice retirement, no live operation reports a hop
-        // here — telemetry sites get `None` and skip the decoration.
         None
     }
 
@@ -700,8 +664,7 @@ impl OpManager {
                 .remove(id)
                 .map(|(_k, v)| v)
                 .map(|op| OpEnum::Connect(Box::new(op))),
-            // GET, PUT, UPDATE and SUBSCRIBE have no DashMap entry
-            // post-#1454 phase 5 final.
+            // GET, PUT, UPDATE and SUBSCRIBE have no DashMap entry.
             TransactionType::Get
             | TransactionType::Put
             | TransactionType::Update
@@ -714,17 +677,15 @@ impl OpManager {
     /// Emit a `NodeEvent::TransactionCompleted(tx)` to the event loop,
     /// triggering cleanup of any `pending_op_results` entry keyed by `tx`.
     ///
-    /// Used by Phase 2b's task-per-tx subscribe path (#1454) to release
-    /// the per-attempt callback slot in `p2p_protoc::pending_op_results`
-    /// after each `OpCtx::send_and_await` round-trip finishes. Without
-    /// this emission the attempt-tx entries accumulate until either the
-    /// periodic 60 s cleanup sweeps closed senders or the node shuts
-    /// down — see `test_pending_op_results_bounded` for the regression
-    /// guard.
+    /// Releases the per-attempt callback slot in
+    /// `p2p_protoc::pending_op_results` after each
+    /// `OpCtx::send_and_await` round-trip finishes. Without this,
+    /// attempt-tx entries accumulate until the 60 s sweep —
+    /// `test_pending_op_results_bounded` is the regression guard.
     ///
-    /// Distinct from [`Self::send_client_result`] which also emits this
-    /// event but additionally pushes a `HostResult` through
-    /// `result_router_tx`. The task-per-tx path has many attempt txs
+    /// Distinct from [`Self::send_client_result`], which also emits
+    /// this event but additionally pushes a `HostResult` through
+    /// `result_router_tx`. The driver has many attempt txs
     /// per client tx, so per-attempt cleanup can't go through
     /// `send_client_result` (that would publish N duplicate results to
     /// the client).
@@ -746,12 +707,12 @@ impl OpManager {
     ///
     /// The `p2p_protoc::handle_notification_message` branch for
     /// `TransactionCompleted` (lines 2030–2036) also calls
-    /// `state.tx_to_client.remove(&tx)`. For task-per-tx attempt txs this
+    /// `state.tx_to_client.remove(&tx)`. For per-attempt txs this
     /// is a tolerated no-op: `tx_to_client` is only populated on
     /// client-visible txs via `ch_outbound.waiting_for_subscription_result`
-    /// / `waiting_for_transaction_result`, never on per-attempt txs. If a
-    /// future change starts keying `tx_to_client` by attempt tx, this
-    /// eager cleanup will silently drop mappings and must be revisited.
+    /// / `waiting_for_transaction_result`. If a future change starts
+    /// keying `tx_to_client` by attempt tx, this eager cleanup will
+    /// silently drop mappings and must be revisited.
     pub(crate) async fn release_pending_op_slot(&self, tx: Transaction) {
         release_pending_op_slot_on(
             self.to_event_listener.notifications_sender(),
@@ -761,50 +722,16 @@ impl OpManager {
         .await
     }
 
-    // `has_get_op` was the relay GET dispatch gate; retired in
-    // #1454 phase 5 final (GET slice) together with the `ops.get`
-    // DashMap. Every GET wire variant now spawns its task-per-tx
-    // driver unconditionally (the legacy `handle_op_request<GetOp>`
-    // fallthrough is gone), so the gate has no remaining decision
-    // value. The dispatch site in `node.rs::NetMessageV1::Get` was
-    // simplified in this slice.
+    // `has_{get,update,put,subscribe}_op` were the legacy relay
+    // dispatch gates; gone with their DashMaps. Every wire variant
+    // for those ops now spawns a driver unconditionally.
 
-    // `has_update_op` was the relay UPDATE dispatch gate; retired in
-    // #1454 phase 5 final together with the `ops.update` DashMap.
-    // Every UPDATE wire variant now spawns its task-per-tx driver
-    // unconditionally (the legacy `handle_op_request<UpdateOp>`
-    // fallthrough is gone), so the gate has no remaining decision
-    // value. The dispatch sites in `node.rs` were simplified in
-    // commit 3.
-
-    // `has_put_op` was the relay PUT dispatch gate; retired in
-    // #1454 phase 5 final (PUT slice) together with the `ops.put`
-    // DashMap. Every PUT wire variant now spawns its task-per-tx
-    // driver unconditionally (the legacy `handle_op_request<PutOp>`
-    // fallthrough is gone), so the gate has no remaining decision
-    // value. The dispatch sites in `node.rs` were simplified in
-    // commit 3.
-
-    // `has_subscribe_op` was the relay SUBSCRIBE dispatch gate; retired
-    // in #1454 phase 5 final (SUBSCRIBE slice) together with the
-    // `ops.subscribe` DashMap. Every SUBSCRIBE wire variant now spawns
-    // its task-per-tx driver or runs through a dedicated inbound
-    // handler unconditionally (the legacy `handle_op_request<SubscribeOp>`
-    // fallthrough is gone), so the gate has no remaining decision value.
-    // The dispatch site in `node.rs::NetMessageV1::Subscribe` was
-    // simplified in this slice.
-
-    /// Returns `true` if a `ConnectOp` is currently registered for this
-    /// transaction in `OpManager.ops.connect`.
-    ///
-    /// Same role as `has_get_op` but for the relay CONNECT dispatch
-    /// gate (#1454 phase 2c slice 1). Used by `node.rs` to distinguish
-    /// a fresh inbound relay CONNECT Request (no existing op → spawn
-    /// the task-per-tx driver) from a within-relay Rejected retry, a
-    /// ConnectFailed downstream re-route, or any other re-entry that
-    /// already has a `ConnectOp` from a prior `process_message` call
-    /// (existing op → fall through to the legacy `handle_op_request`
-    /// path).
+    /// Relay CONNECT dispatch gate. `true` if a `ConnectOp` is
+    /// registered in `OpManager.ops.connect` for `id`. Used by
+    /// `node.rs` to distinguish a fresh inbound CONNECT Request
+    /// (no existing op → spawn the driver) from a within-relay
+    /// re-entry (existing op → fall through to legacy
+    /// `handle_op_request`).
     pub fn has_connect_op(&self, id: &Transaction) -> bool {
         self.ops.connect.contains_key(id)
     }
@@ -833,8 +760,7 @@ impl OpManager {
             TransactionType::Connect => {
                 self.ops.connect.remove(&id);
             }
-            // GET, PUT, UPDATE and SUBSCRIBE have no DashMap entry
-            // post-#1454 phase 5 final.
+            // GET, PUT, UPDATE and SUBSCRIBE have no DashMap entry.
             TransactionType::Get
             | TransactionType::Put
             | TransactionType::Update
@@ -899,11 +825,10 @@ impl OpManager {
         }
     }
 
-    /// Returns pending operation counts: [connect, put, get, subscribe, update].
-    /// GET, PUT, UPDATE and SUBSCRIBE slots are always 0 after #1454
-    /// phase 5 final retired the corresponding DashMaps; kept in the
-    /// array for API stability with the home-page renderer / telemetry
-    /// consumers.
+    /// Returns pending operation counts: [connect, put, get,
+    /// subscribe, update]. Non-connect slots are always 0 (their
+    /// DashMaps are gone); kept for API stability with the
+    /// home-page renderer and telemetry consumers.
     pub fn pending_op_counts(&self) -> [u32; 5] {
         [self.ops.connect.len() as u32, 0, 0, 0, 0]
     }
@@ -1005,12 +930,11 @@ impl OpManager {
 /// `OpManager` (review finding T-3). The `OpManager` method is a thin
 /// wrapper around this free function.
 ///
-/// Uses `send().await` (wrapped in `timeout`) rather than `try_send`
-/// because the caller is Phase 2b's task-per-tx subscribe driver
-/// spawned via `GlobalExecutor::spawn` — a short blocking wait is
-/// within the channel-safety rules for that context, and dropping the
-/// event on transient backpressure would re-introduce the
-/// `test_pending_op_results_bounded` leak.
+/// Uses `send().await` (wrapped in `timeout`) rather than
+/// `try_send`. The caller runs in a `GlobalExecutor::spawn`'d task,
+/// so a short blocking wait is within the channel-safety rules;
+/// dropping the event on transient backpressure would re-introduce
+/// the `test_pending_op_results_bounded` leak.
 async fn release_pending_op_slot_on(
     notifications_sender: &mpsc::Sender<Either<NetMessage, NodeEvent>>,
     tx: Transaction,
@@ -1075,37 +999,11 @@ fn notify_transaction_timeout(
     }
 }
 
-// `notify_subscription_timeout` and `report_timeout_failure` retired in
-// #1454 phase 5 final (SUBSCRIBE slice). They were called only from
-// `remove_subscribe_and_notify_timeout`, which was deleted in the same
-// commit. The task-per-tx subscribe driver owns its own timeout
-// reporting via `result_router_tx` publication, and relays route any
-// per-hop failure through their own per-tx drivers — neither needs a
-// GC-sweep notifier.
-
-// `remove_put_and_report_failure` and `remove_update_and_report_failure`
-// were retired in #1454 phase 5 final (PUT slice / UPDATE slice 1)
-// together with the `ops.put` / `ops.update` DashMaps. Client-initiated
-// PUTs and UPDATEs now own their timeout reporting in the task-per-tx
-// driver (`{put,update}::op_ctx_task::start_client_*`); relay PUTs and
-// UPDATEs are owned by their per-tx drivers and have no client to
-// report to.
-
-// `remove_subscribe_and_notify_timeout` retired in #1454 phase 5 final
-// (SUBSCRIBE slice) together with the `ops.subscribe` DashMap. Client-,
-// renewal-, executor-, and sub-op-initiated SUBSCRIBEs now own their
-// timeout reporting in the task-per-tx driver
-// (`subscribe::op_ctx_task::*`); relay SUBSCRIBEs are owned by their
-// per-tx drivers (`start_relay_subscribe`) which expire their inflight
-// guards naturally. The Unsubscribe wire variant is fire-and-forget and
-// has no timeout reporter.
-
-// `remove_get_and_report_failure` retired in #1454 phase 5 final
-// (GET slice) together with the `ops.get` DashMap. Originator-side
-// timeout reporting is now owned by the task-per-tx driver via the
-// `RetryLoopOutcome::Exhausted` → `result_router_tx` publication
-// path. Relay drivers expire their inflight guards naturally; no GC
-// sweep is needed.
+// Per-op GC sweep helpers (`remove_*_and_report_failure` /
+// `notify_subscription_timeout`) are gone — each non-CONNECT op
+// owns its own timeout reporting in its driver via
+// `RetryLoopOutcome::Exhausted` → `result_router_tx`, and relay
+// drivers expire their inflight guards naturally.
 
 /// Log when a connect operation in Relaying state with an outstanding uphill forward times out,
 /// and record the unresponsive peer as an acceptor failure for reliability scoring.
@@ -1255,8 +1153,8 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                         target: "memory_stats",
                         tick = tick_count,
                         ops_connect = ops_sizes.connect,
-                        // ops_get / ops_put / ops_update / ops_subscribe
-                        // retired in #1454 phase 5 final.
+                        // No DashMaps for ops_get / ops_put /
+                        // ops_update / ops_subscribe — always 0.
                         ops_put = 0,
                         ops_get = 0,
                         ops_subscribe = 0,
@@ -1312,13 +1210,6 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                     }
                 }
 
-                // Shared retry constants for SUBSCRIBE speculative retry below.
-                // (GET speculative retry was retired in #1454 Phase 5-final
-                // slice 1; SUBSCRIBE speculative retry was retired in
-                // Phase 5-final slice 1 follow-up — see comment below.
-                // The shared `ACK_TIMEOUT` / `MAX_SPECULATIVE_PATHS` /
-                // `PROGRESS_TIMEOUT` constants that both blocks consumed
-                // are no longer referenced and have been removed.)
 
                 // Periodically clean up stale pending_contract_fetches entries.
                 // Entries older than 2x cooldown are removed to prevent unbounded growth.
@@ -1329,17 +1220,6 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                         now_ms.saturating_sub(*ts) < cooldown_ms * 2
                     });
                 }
-
-                // SUBSCRIBE speculative-retry GC block was retired in #1454
-                // Phase 5-final. The `ops.subscribe` DashMap itself was
-                // then retired in the SUBSCRIBE slice (this PR): every
-                // SUBSCRIBE wire variant now runs on the task-per-tx
-                // driver in `operations/subscribe/op_ctx_task.rs`
-                // (Request) or a dedicated free function
-                // (`handle_unsubscribe_inbound` for Unsubscribe), and
-                // the surviving `send_unsubscribe_upstream` writer uses
-                // `OpCtx::send_fire_and_forget` directly. There is no
-                // longer a DashMap to GC-sweep.
 
                 let mut old_missing = std::mem::replace(&mut delayed, Vec::with_capacity(200));
                 for tx in old_missing.drain(..) {
@@ -1365,9 +1245,9 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                                 true
                             }
                         }
-                        // GET, PUT, UPDATE and SUBSCRIBE have no DashMap
-                        // entry post-#1454 phase 5 final; task-per-tx
-                        // drivers own their own timeout reporting.
+                        // GET, PUT, UPDATE and SUBSCRIBE have no
+                        // DashMap entry; drivers own their own
+                        // timeout reporting.
                         TransactionType::Get
                         | TransactionType::Put
                         | TransactionType::Update
@@ -1438,9 +1318,9 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                                 false
                             }
                         }
-                        // GET, PUT, UPDATE and SUBSCRIBE have no DashMap
-                        // entry post-#1454 phase 5 final; task-per-tx
-                        // drivers own their own timeout reporting.
+                        // GET, PUT, UPDATE and SUBSCRIBE have no
+                        // DashMap entry; drivers own their own
+                        // timeout reporting.
                         TransactionType::Get
                         | TransactionType::Put
                         | TransactionType::Update
@@ -1524,9 +1404,8 @@ mod tests {
     }
 
     // ──────────────────────────────────────────────────────────
-    // `release_pending_op_slot_on` tests (#1454 Phase 2b,
-    // review finding T-3). Tests the extracted helper directly
-    // so we don't need to build a full OpManager.
+    // `release_pending_op_slot_on` tests. Tests the extracted
+    // helper directly without building a full OpManager.
     // ──────────────────────────────────────────────────────────
 
     #[tokio::test]
@@ -1827,9 +1706,7 @@ mod tests {
         }
     }
 
-    // `has_get_op_*`, `has_update_op_returns_*` and
-    // `has_put_op_returns_*` tests were retired in #1454 phase 5 final
-    // together with the corresponding APIs and DashMaps. Equivalent
-    // coverage for the surviving ops (CONNECT, SUBSCRIBE) lives in the
-    // relay-driver dedup tests under `op_ctx_task` modules.
+    // Equivalent coverage for the surviving DashMap-backed op
+    // (CONNECT) lives in the relay-driver dedup tests under
+    // `op_ctx_task` modules.
 }

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -1153,10 +1153,10 @@ impl ConnectOp {
     }
 
     #[allow(clippy::too_many_arguments)]
-    // Retained for in-file unit tests + the legacy initiate_join_request
-    // wrapper; all production joiner-side initiation flows through the
-    // task-per-tx driver via prepare_join_request. Phase 5 final / PR-B
-    // deletes this along with the rest of impl Operation for ConnectOp.
+    // Retained for in-file unit tests + the legacy
+    // `initiate_join_request` wrapper. Production joiner-side
+    // initiation flows through `prepare_join_request`. Pending
+    // deletion alongside the rest of `impl Operation for ConnectOp`.
     #[allow(dead_code)]
     pub(crate) fn new_joiner(
         id: Transaction,
@@ -1186,20 +1186,13 @@ impl ConnectOp {
         }
     }
 
-    /// Construct a new relay-side `ConnectOp` from an inbound `Request`.
+    /// Construct a new relay-side `ConnectOp` from an inbound
+    /// `Request`.
     ///
-    /// **Phase 2c slice 1 (#1454):** this constructor is no longer called
-    /// from production. The relay-CONNECT dispatch site at
-    /// `node.rs::handle_pure_network_message_v1` routes fresh inbound
-    /// `Request`s through `op_ctx_task::start_relay_connect`, which
-    /// builds an equivalent `RelayState` in driver task locals and never
-    /// calls this constructor.
-    ///
-    /// Retained for in-file unit tests under `#[cfg(test)] mod tests`
-    /// that exercise `RelayState::handle_request` semantics inline.
-    /// Phase 6 cleanup will migrate those tests to drive the task-per-tx
-    /// driver and delete this constructor (along with `RelayState`,
-    /// `RelayState::handle_request`, and `RelayActions`).
+    /// Not called from production: fresh inbound `Request`s route
+    /// through `op_ctx_task::start_relay_connect`. Retained for
+    /// in-file unit tests that exercise `RelayState::handle_request`
+    /// semantics inline.
     pub(crate) fn new_relay(
         id: Transaction,
         upstream_addr: SocketAddr,
@@ -1271,11 +1264,9 @@ impl ConnectOp {
         self.first_hop.as_deref().cloned()
     }
 
-    // Retained for in-file unit tests; production callers (ring::acquire_new,
-    // join_ring_request, gateway_version_probe) build the wire message via the
-    // free `prepare_join_request` helper and skip the legacy ConnectOp carrier.
-    // Phase 5 final / PR-B deletes this along with the rest of
-    // impl Operation for ConnectOp.
+    // Retained for in-file unit tests. Production callers build the
+    // wire message via the free `prepare_join_request` helper and
+    // skip the legacy `ConnectOp` carrier.
     #[allow(dead_code)]
     pub(crate) fn initiate_join_request(
         own: PeerKeyLocation,
@@ -1432,16 +1423,12 @@ impl Operation for ConnectOp {
             }),
             Ok(None) => {
                 let op = match (msg, source_addr) {
-                    // Phase 2c slice 1 (#1454): the dispatch site at
-                    // `node.rs::handle_pure_network_message_v1` already
-                    // routed fresh `Request`s with `source_addr.is_some()`
-                    // through `op_ctx_task::start_relay_connect`, so this
-                    // arm should be unreachable in production. It remains
-                    // as defense-in-depth and to keep `process_message`'s
-                    // joiner-side branches usable from in-file unit tests
-                    // that construct relay ops directly. Phase 6 cleanup
-                    // deletes this arm (along with `ConnectOp::new_relay`
-                    // and the relay arms of `process_message`).
+                    // Unreachable in production: fresh `Request`s
+                    // with `source_addr.is_some()` route through
+                    // `op_ctx_task::start_relay_connect`. Retained as
+                    // defense-in-depth and to keep
+                    // `process_message`'s joiner-side branches usable
+                    // from in-file unit tests.
                     (ConnectMsg::Request { payload, .. }, Some(upstream_addr)) => {
                         ConnectOp::new_relay(
                             tx,
@@ -1506,30 +1493,19 @@ impl Operation for ConnectOp {
         }
     }
 
-    /// **Phase 2c slice 1 (#1454):** the relay branches of this method
-    /// (`ConnectState::Relaying(_)` matches in each variant arm) are
-    /// dead from production after the dispatch site at
-    /// `node.rs::handle_pure_network_message_v1` started routing every
-    /// fresh inbound `ConnectMsg::Request` (with `source_addr.is_some()`
-    /// AND `!has_connect_op(id)`) through `op_ctx_task::start_relay_connect`.
+    /// The relay branches (`ConnectState::Relaying(_)`) are dead
+    /// from production: fresh inbound `ConnectMsg::Request`s route
+    /// through `op_ctx_task::start_relay_connect`. They are
+    /// preserved for:
     ///
-    /// The legacy relay arms are preserved here for two reasons:
-    ///
-    /// 1. Unit tests in this file (`relay_accepts_when_policy_allows`,
-    ///    `relay_forwards_when_not_accepting`, etc.) construct
-    ///    `ConnectOp::new_relay` directly and exercise `handle_request`
-    ///    and `process_message` inline. Migrating those tests to drive
-    ///    the task-per-tx driver requires standing up a mock OpManager
-    ///    with a real `op_execution_sender` — out of scope for this
-    ///    slice; tracked for phase 6 cleanup.
-    /// 2. The joiner branches (`ConnectState::WaitingForResponses(_)`)
-    ///    of each arm remain LIVE for the legacy `load_or_init`
-    ///    stateless `ObservedAddress` side-effect path at
-    ///    connect.rs:1473-1490 (defensive belt-and-suspenders; the
-    ///    joiner driver also handles ObservedAddress).
-    ///
-    /// Phase 6 cleanup will delete the relay arms, `ConnectOp::new_relay`,
-    /// `RelayState`, `RelayState::handle_request`, and `RelayActions`.
+    /// 1. Unit tests in this file that construct
+    ///    `ConnectOp::new_relay` directly and exercise
+    ///    `handle_request` / `process_message` inline.
+    /// 2. The joiner branches (`ConnectState::WaitingForResponses(_)`),
+    ///    which remain LIVE for the legacy `load_or_init` stateless
+    ///    `ObservedAddress` side-effect path (defensive
+    ///    belt-and-suspenders; the joiner driver also handles
+    ///    ObservedAddress).
     fn process_message<'a, NB: NetworkBridge>(
         mut self,
         network_bridge: &'a mut NB,
@@ -2452,11 +2428,10 @@ pub(super) async fn dispatch_expect_connection_from(
 
 /// Build a `ConnectMsg::Request` for a joiner-initiated CONNECT.
 ///
-/// Pure helper extracted from `ConnectOp::initiate_join_request` so the
-/// task-per-tx driver (`op_ctx_task::start_client_connect`) and
+/// Pure helper so `op_ctx_task::start_client_connect` and
 /// `ring::Ring::acquire_new` can construct the wire message without
-/// allocating a legacy `ConnectOp` carrier. The caller is responsible
-/// for the `Transaction`.
+/// allocating a legacy `ConnectOp` carrier. Caller owns the
+/// `Transaction`.
 ///
 /// Bloom filter saturation note: `VisitedPeers` uses a 512-bit filter
 /// with k=4 hash functions. Pre-loading N entries raises the false-positive

--- a/crates/core/src/operations/connect/op_ctx_task.rs
+++ b/crates/core/src/operations/connect/op_ctx_task.rs
@@ -1,34 +1,25 @@
-//! Task-per-transaction driver for client-initiated CONNECT (#1454 phase 2c slice 2).
+//! Task-per-transaction drivers for CONNECT.
 //!
-//! Replaces the legacy `WaitingForResponses` joiner state machine. Driver
-//! holds joiner state in task locals, sends a single `ConnectMsg::Request`
-//! to the first-hop gateway via `OpCtx::send_to_and_collect_replies`, and
-//! drains a multi-reply receiver until `target_connections` acceptances
-//! land or an overall timeout fires.
+//! The joiner driver holds state in task locals, sends a single
+//! `ConnectMsg::Request` to the first-hop gateway via
+//! `OpCtx::send_to_and_collect_replies`, and drains a multi-reply
+//! receiver until `target_connections` acceptances arrive or an
+//! overall timeout fires.
 //!
-//! Side effects mirrored from legacy `process_message::ConnectMsg::Response`:
+//! Side effects per reply variant:
 //!
-//! - `NetEventLog::connect_request_sent` before send
-//! - `NetEventLog::connect_response_received` per Response
-//! - `NodeEvent::ExpectPeerConnection { addr }` per new acceptor
-//! - `NodeEvent::ConnectPeer { peer, tx, callback, is_gw: false }` then
-//!   await callback (sequential per acceptor — matches legacy)
-//! - on hole-punch success: `record_acceptor_outcome(addr, true, now)`
-//! - on hole-punch failure: emit `ConnectMsg::ConnectFailed` to gateway,
-//!   stay in loop awaiting next Response (legacy behavior)
-//! - on `accepted >= target_connections`: reset jitter counter,
-//!   `gateway_backoff.record_success(gw_addr)`, `record_connection_success(target_loc)`
-//!
-//! `Rejected`: `record_connection_failure(desired_location, Rejected)`,
-//! `gateway_backoff.record_failure(gw_addr)`, exit driver.
-//!
-//! `ObservedAddress` stays on legacy `load_or_init` path — that path
-//! already does `set_own_addr` / `update_location` as a stateless side
-//! effect even when no op exists (connect.rs:1471-1488, 1498-1517).
-//!
-//! `ConnectFailed` is emitted by this driver but never received by it —
-//! it flows downstream toward the relay chain. Relay handling lands in
-//! slice 1.
+//! - `Response`: `NetEventLog::connect_response_received`,
+//!   `NodeEvent::ExpectPeerConnection`, `NodeEvent::ConnectPeer`,
+//!   then await the callback (sequential per acceptor). On
+//!   hole-punch success: `record_acceptor_outcome(addr, true, now)`.
+//!   On hole-punch failure: emit `ConnectMsg::ConnectFailed`
+//!   downstream; stay in loop awaiting more Responses. When
+//!   `accepted >= target_connections`: reset jitter, record gateway
+//!   + location success.
+//! - `Rejected`: record connection failure, exit driver.
+//! - `ObservedAddress`: handled by the joiner driver inbox —
+//!   `set_own_addr` / `update_location`.
+//! - `ConnectFailed`: emitted by this driver, never received by it.
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -50,13 +41,9 @@ use super::{
     dispatch_expect_connection_from,
 };
 
-// ─── Relay CONNECT scaffolding (#1454 phase 2c slice 1, commit 1) ───
+// ─── Relay CONNECT scaffolding ───────────────────────────────────────
 //
-// Counters and RAII guard for the upcoming `start_relay_connect`
-// driver. Unused by this commit; the driver body and dispatch site
-// land in slice 1 commit 2. Defined now so the counter symbols are
-// stable across commits and the scaffolding lands as a single
-// reviewable unit before the larger semantic change.
+// Counters and RAII guard for `start_relay_connect`.
 
 /// Test-only counter incremented every time a relay-CONNECT driver is
 /// spawned. Used by test_relay_driver_calls_per_op-style guards to
@@ -476,14 +463,11 @@ async fn drive_client_connect_inner(
                 return Ok(());
             }
             ConnectMsg::ObservedAddress { address, .. } => {
-                // Phase 2c slice 1 (#1454): the bypass at node.rs forwards
-                // ObservedAddress to the joiner driver inbox. The joiner
-                // doesn't know its external IP behind NAT, so the gateway
-                // observes it from the UDP packet source and ships it back
-                // here. We update both `own_addr` (for diagnostics) and
-                // `own_location` (for routing) — mirrors legacy at
-                // connect.rs:1956-1974. Idempotent: subsequent observations
-                // for the same tx overwrite, which is the legacy semantic.
+                // The joiner doesn't know its external IP behind NAT;
+                // the gateway observes it from the UDP packet source
+                // and ships it back. Update both `own_addr` (for
+                // diagnostics) and `own_location` (for routing).
+                // Idempotent: subsequent observations overwrite.
                 let location = Location::from_address(&address);
                 op_manager.ring.connection_manager.set_own_addr(address);
                 op_manager
@@ -552,19 +536,16 @@ fn compute_reply_capacity(target_connections: usize) -> usize {
     target_connections.saturating_mul(2).max(2)
 }
 
-// ─── Relay CONNECT driver (#1454 phase 2c slice 1, commit 2) ─────────
+// ─── Relay CONNECT driver ────────────────────────────────────────────
 //
-// Mirrors the relay-side behaviour of the legacy
-// `connect.rs::process_message` for `Request → forward + observed +
-// (optional accept) + (optional reject)` plus the `Response /
-// Rejected / ObservedAddress / ConnectFailed` re-entries that arrive
-// for the same tx after the initial Request. State (`RelayState`,
-// `recency`, `forward_attempts`) lives in driver task locals; nothing
-// is pushed into `OpManager.ops.connect` for a relay-driven tx.
+// Owns the relay-side `Request → forward + observed + (optional
+// accept) + (optional reject)` flow plus the `Response / Rejected
+// / ObservedAddress / ConnectFailed` re-entries that arrive for the
+// same tx after the initial Request. State (`RelayState`, `recency`,
+// `forward_attempts`) lives in driver task locals.
 //
-// Re-entries land in the driver inbox via the bypass at
-// `node.rs::handle_pure_network_message_v1` (commit 1, this slice),
-// which forwards Response/Rejected/ObservedAddress/ConnectFailed
+// Re-entries arrive via the bypass at
+// `node.rs::handle_pure_network_message_v1`, which forwards them
 // into the per-tx multi-reply receiver registered by
 // `OpCtx::send_to_and_collect_replies`.
 

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -1,15 +1,10 @@
-// #1454 phase 5 final (GET slice) retired the legacy GET state machine.
-// Every GET wire variant now dispatches unconditionally to a task-per-tx
-// driver — see `op_ctx_task::start_client_get`, `start_relay_get`,
-// `start_sub_op_get`, and `start_targeted_sub_op_get`.
-//
-// Phase 6 (#1454) retired the surviving `#[allow(dead_code)]` scaffolding
-// (`GetOp`, `GetState`, `GetStats`, `AwaitingResponseData`,
-// `PrepareRequestData`, `FinishedData`, the inline outcome / failure-routing
-// pin tests + the `apply_relay_cache_decision` self-test). The wire format
-// (`GetMsg`, `GetMsgResult`, `GetStreamingPayload`) and the originator-side
-// result envelope (`GetResult`) survive because both are still produced and
-// consumed by the task-per-tx drivers and by external crates.
+// Every GET wire variant dispatches to a task-per-tx driver —
+// `op_ctx_task::start_client_get`, `start_relay_get`,
+// `start_sub_op_get`, and `start_targeted_sub_op_get`. The
+// wire-format types (`GetMsg`, `GetMsgResult`,
+// `GetStreamingPayload`) and the originator result envelope
+// (`GetResult`) survive here because the drivers and external
+// crates consume them.
 
 pub(crate) mod op_ctx_task;
 

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1,57 +1,32 @@
-//! Task-per-transaction client-initiated GET (#1454 Phase 3b).
+//! Task-per-transaction GET drivers.
 //!
-//! Mirrors [`crate::operations::put::op_ctx_task`] — the Phase 3a
-//! production consumer of [`OpCtx::send_and_await`] for PUT, which in
-//! turn follows the Phase 2b SUBSCRIBE driver shape. This module
-//! applies the same pattern to client-initiated GET.
+//! Each entry point — client-initiated, relay, sub-op, targeted
+//! sub-op — owns routing state in task locals. No `GetOp` is pushed
+//! into `OpManager.ops.get`.
 //!
-//! # Scope (Phase 3b)
+//! # Client-initiated flow
 //!
-//! Only the **client-initiated originator** GET runs through this
-//! module. Relay GETs (non-terminal hops), GC-spawned retries, and
-//! `start_targeted_op()` (UPDATE-triggered auto-fetch) stay on the
-//! legacy re-entry loop. Relay migration is tracked in #3883.
-//!
-//! # Architecture
-//!
-//! The task owns all routing state in its locals — there is no `GetOp`
-//! in `OpManager.ops.get` for any attempt this task makes. The task:
-//!
-//! 1. Loops, calling [`OpCtx::send_and_await`] with a fresh
+//! 1. Loop calling [`OpCtx::send_and_await`] with a fresh
 //!    `Transaction` per attempt (single-use-per-tx constraint).
-//!    `process_message` handles routing/forwarding on remote hops and
-//!    the originator's own loop-back for the local-completion (cache
-//!    hit) case, which echoes the `GetMsg::Request` back as the
-//!    terminal "reply" via `forward_pending_op_result_if_completed`
-//!    (same mechanism PUT 3a relies on for `LocalCompletion`).
-//! 2. On terminal `Response{Found}`: the driver stores the returned
-//!    state into the local executor via `PutQuery`, runs hosting /
-//!    access-tracking / announce side effects, and publishes
-//!    `HostResponse::ContractResponse::GetResponse` to the client.
-//!    These side effects mirror what the legacy `process_message`
-//!    Response{Found} branch does at `get.rs:2329` — for task-per-tx
-//!    ops the bypass at `node.rs::handle_pure_network_message_v1`
-//!    intercepts the terminal reply before `process_message` runs on
-//!    the originator (because `load_or_init` would fail with
-//!    `OpNotPresent`), so the driver is the only place they can
+//! 2. Terminal `Response{Found}`: store the returned state into the
+//!    local executor via `PutQuery`, run hosting / access-tracking /
+//!    announce side effects, publish
+//!    `HostResponse::ContractResponse::GetResponse`. The reply
+//!    bypass intercepts before `process_message` would run on the
+//!    originator, so the driver is the only place these side effects
 //!    happen.
-//! 3. On terminal `ResponseStreaming`: Phase 3b delivers the final
-//!    payload via a store re-query using the contract key from the
-//!    envelope. Stream assembly and local caching for streamed
-//!    payloads remain on the legacy path for now — full migration is
-//!    tracked in #3883.
-//! 4. On terminal Request-echo: the pre-send local-cache shortcut in
-//!    `client_events.rs` already returned the state directly, so the
-//!    driver just resolves the ContractKey from the store for
-//!    telemetry and client delivery.
-//! 5. On `Response{NotFound}`: advance to the next peer.
-//! 6. On timeout / wire-error: advance to next peer or exhaust.
+//! 3. Terminal `ResponseStreaming`: deliver the final payload via a
+//!    store re-query using the contract key from the envelope.
+//! 4. Terminal Request-echo: the pre-send local-cache shortcut in
+//!    `client_events.rs` already returned the state; the driver
+//!    resolves the `ContractKey` for telemetry and client delivery.
+//! 5. `Response{NotFound}`: advance to next peer.
+//! 6. Timeout / wire-error: advance or exhaust.
 //!
-//! # Connection-drop latency (R6)
+//! # Connection-drop latency
 //!
-//! Legacy `handle_abort` detects disconnects in <1s. Task-per-tx
-//! relies on the `OPERATION_TTL` (60s) timeout. Accepted ceiling,
-//! matching Phase 2b/3a.
+//! Disconnect detection relies on `OPERATION_TTL` (60s) — accepted
+//! ceiling.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -320,10 +295,8 @@ async fn drive_client_get_inner(
             //
             // The bypass at `node.rs::handle_pure_network_message_v1`
             // intercepts the terminal reply BEFORE `process_message`
-            // runs on the originator (by design — process_message
-            // would fail with OpNotPresent for a task-per-tx op), so
-            // the driver is the only place these side effects can
-            // happen for Phase 3b.
+            // runs on the originator, so the driver is the only
+            // place these side effects can happen.
             // Payload accounting for the router's `transfer_rate_estimator`
             // (router.rs:443) and `response_start_time_estimator`
             // (router.rs:405). Set on the InlineFound/Streaming success
@@ -579,9 +552,7 @@ async fn drive_client_get_inner(
             // as `ContractResponse::NotFound` so client integrations
             // (`fdev`, `apps/freenet-ping`, integration tests) can
             // distinguish "contract genuinely absent" from "operation
-            // failed". Mirrors the legacy `process_message`
-            // Response{NotFound} terminal arm at `get.rs:2470-2496`
-            // (pre-#1454 phase 5 final).
+            // failed".
             Ok(DriverOutcome::Publish(Ok(HostResponse::ContractResponse(
                 freenet_stdlib::client_api::ContractResponse::NotFound { instance_id },
             ))))
@@ -706,17 +677,17 @@ fn classify(reply: NetMessage) -> AttemptOutcome<Terminal> {
         // Explicit non-terminal `GetMsg` variants. These should never
         // reach the driver — the bypass at
         // `node.rs::handle_pure_network_message_v1` gates forwarding
-        // on terminal variants only — so their arrival here indicates
-        // a bug in the bypass gate (Phase 2b Bug 2 class).
+        // on terminal variants only — so their arrival here
+        // indicates a bug in the bypass gate.
         NetMessage::V1(NetMessageV1::Get(
             GetMsg::ForwardingAck { .. } | GetMsg::ResponseStreamingAck { .. },
         )) => AttemptOutcome::Unexpected,
         // Non-GET NetMessage variants (or any future `GetMsg` variant
         // added without updating this match) fall through to
         // Unexpected. If a new GetMsg variant is added, this arm must
-        // be audited — the Phase 3b GET driver has explicit handling
-        // for every variant above, and the bypass filter in node.rs
-        // must be extended in lockstep.
+        // be audited — this driver has explicit handling for every
+        // variant above, and the bypass filter in node.rs must be
+        // extended in lockstep.
         _ => AttemptOutcome::Unexpected,
     }
 }
@@ -1664,17 +1635,16 @@ async fn run_relay_get(
     // removes the entry immediately so `test_pending_op_results_bounded`
     // stays under its leak ceiling.
     //
-    // Originator-loopback exception (#1454 phase 5 final GET slice,
-    // mirrors PUT slice): when this driver runs on the originator's
-    // own node (`upstream_addr == own_addr`), the
+    // Originator-loopback exception: when this driver runs on the
+    // originator's own node (`upstream_addr == own_addr`), the
     // `pending_op_results` callback for `incoming_tx` is the
     // originator's `send_and_await` waiter — NOT one this driver
     // installed. Releasing it here would emit `TransactionCompleted`
     // and remove the originator's callback BEFORE the loopback
     // `GetMsg::Response` arrives at the bypass, racing the
-    // originator's wait. The originator's own driver completion path
-    // (via `ClientGetCompletionGuard` → `release_pending_op_slot`)
-    // cleans up the slot.
+    // originator's wait. The originator's own driver completion
+    // path (via `ClientGetCompletionGuard` →
+    // `release_pending_op_slot`) cleans up the slot.
     //
     // Yield first so any in-flight `send_fire_and_forget` has time to
     // run through the event loop's `handle_op_execution` and actually
@@ -1865,8 +1835,7 @@ async fn relay_send_not_found(
     // `send_local_loopback` to route as `InboundMessage` instead, so
     // the bypass at `handle_pure_network_message_v1` can forward the
     // terminal Response to the originator's `pending_op_results`
-    // waiter. Mirrors PUT slice's `relay_put_send_response` loopback
-    // branch (#1454 phase 5 final, GET slice fixup).
+    // waiter. Mirrors `relay_put_send_response`'s loopback branch.
     let own_addr = op_manager.ring.connection_manager.get_own_addr();
     let send_result = if Some(upstream_addr) == own_addr {
         ctx.send_local_loopback(msg).await
@@ -1909,7 +1878,7 @@ async fn relay_send_found(
     let mut ctx = op_manager.op_ctx(tx);
     // Originator-loopback: route via `send_local_loopback` to avoid
     // the wire-bound self-connection failure. See `relay_send_not_found`
-    // for the full rationale (#1454 phase 5 final, GET slice fixup).
+    // for the full rationale.
     let own_addr = op_manager.ring.connection_manager.get_own_addr();
     if Some(upstream_addr) == own_addr {
         ctx.send_local_loopback(msg)
@@ -2173,9 +2142,7 @@ async fn drive_relay_get_inner(
         // `handle_pure_network_message_v1` forwards it to the
         // originator's still-installed callback. The client driver
         // owns retry semantics; the relay driver has nothing to add.
-        // Mirrors PUT slice (#1454 phase 5 final, PUT slice) which
-        // uses the same fire-and-forget pattern in
-        // `drive_relay_put`'s originator-loopback branch.
+        // Mirrors `drive_relay_put`'s originator-loopback branch.
         let own_addr = op_manager.ring.connection_manager.get_own_addr();
         let originator_loopback = Some(upstream_addr) == own_addr;
         let mut ctx = op_manager.op_ctx(incoming_tx);
@@ -2445,7 +2412,7 @@ mod tests {
         }));
         assert!(
             matches!(classify(msg), AttemptOutcome::Unexpected),
-            "ForwardingAck must NOT be classified as terminal (Phase 2b bug 2)"
+            "ForwardingAck must NOT be classified as terminal"
         );
     }
 
@@ -3171,15 +3138,12 @@ mod tests {
     // already provided by `test_get_routing_coverage_low_htl` and
     // `test_get_reliability_*` (nightly).
 
-    // ── Dispatch shape pin (#1454 phase 5 final, GET slice) ───────────────
+    // ── Dispatch shape pin ────────────────────────────────────────────────
     //
-    // After the GET slice retired the legacy state machine, the GET arm
-    // in node.rs no longer falls through to `handle_op_request<GetOp>`
-    // and no longer gates relay dispatch on `has_get_op` /
-    // `source_addr.is_some()`. Originator-loopback (source_addr=None)
-    // is mapped to `upstream_addr=own_addr` so the same `start_relay_get`
-    // driver handles both true relay hops and originator-loopback. The
-    // structural guard for that shape lives at
+    // The GET arm in node.rs dispatches every wire variant
+    // unconditionally to a driver. Originator loopback
+    // (`source_addr=None`) is mapped to `upstream_addr=own_addr`.
+    // Structural guard lives at
     // `node::tests::callback_forward_tests::get_branch_dispatches_relay_driver`.
 
     #[test]
@@ -3603,13 +3567,12 @@ mod tests {
         );
     }
 
-    // ── Per-tx independence pin (#1454 phase 5 final, GET slice) ──────────
+    // ── Per-tx independence pin ───────────────────────────────────────────
     //
-    // The legacy `has_get_op(id)` dispatch gate is gone. Per-tx
-    // independence is now enforced by `active_relay_get_txs` —
+    // Per-tx independence is enforced by `active_relay_get_txs` —
     // `start_relay_get` rejects a duplicate inbound Request whose
     // `incoming_tx` already has a live driver via the
-    // `Relay*InflightGuard` RAII pattern. Dedup remains keyed on
+    // `Relay*InflightGuard` RAII pattern. Dedup is keyed on
     // transaction id (NOT contract instance id), so two concurrent
     // relay GETs for the *same* contract from different upstreams each
     // get their own driver task and their own upstream reply.
@@ -3644,8 +3607,8 @@ mod tests {
     /// `TransactionCompleted` and remove the originator's callback
     /// BEFORE the loopback `GetMsg::Response` reaches the bypass
     /// (notifications channel has higher priority than op_execution
-    /// in priority_select). Repro: `test_get_notfound_no_forwarding_targets`
-    /// (#1454 phase 5 final, GET slice follow-up commit 6cb3ca18).
+    /// in priority_select). Repro:
+    /// `test_get_notfound_no_forwarding_targets`.
     #[test]
     fn run_relay_get_skips_release_in_originator_loopback() {
         let src = include_str!("../get/op_ctx_task.rs");
@@ -3689,8 +3652,7 @@ mod tests {
     /// attempt a UDP self-connection that has no peer entry, failing
     /// silently. Routing as `InboundMessage` via `send_local_loopback`
     /// lands at the bypass in `handle_pure_network_message_v1` and
-    /// forwards to the originator's `pending_op_results` waiter
-    /// (#1454 phase 5 final, GET slice fixup commit 8107da8a).
+    /// forwards to the originator's `pending_op_results` waiter.
     #[test]
     fn relay_send_responses_use_local_loopback_on_own_addr() {
         let src = include_str!("../get/op_ctx_task.rs");
@@ -3730,9 +3692,8 @@ mod tests {
     /// callback and never reach the client driver. After loopback
     /// dispatch, the driver returns immediately so the client
     /// driver's still-installed callback receives the Response via
-    /// the bypass and owns retry semantics. Mirrors PUT slice's
-    /// `drive_relay_put` originator-loopback branch (#1454 phase 5
-    /// final, GET slice fixup commit 8107da8a).
+    /// the bypass and owns retry semantics. Mirrors
+    /// `drive_relay_put`'s originator-loopback branch.
     #[test]
     fn drive_relay_get_loopback_uses_fire_and_forget() {
         let src = include_str!("../get/op_ctx_task.rs");
@@ -3988,8 +3949,7 @@ mod tests {
 
     /// Pin: `start_sub_op_get` MUST exist as the sub-op GET entry
     /// point. Removing it would force legacy `get::start_op` +
-    /// `request_get` revival and re-leak GetOp into `ops.get` for
-    /// sub-op GETs. (#1454 phase 5 follow-up.)
+    /// `request_get` revival.
     #[test]
     fn start_sub_op_get_entry_must_exist() {
         let src = include_str!("op_ctx_task.rs");

--- a/crates/core/src/operations/op_ctx.rs
+++ b/crates/core/src/operations/op_ctx.rs
@@ -1,11 +1,9 @@
-//! Per-transaction execution context for the task-per-tx model (#1454).
+//! Per-transaction execution context for the task-per-tx model.
 //!
-//! This module ships the `OpCtx` struct and its `send_and_await` round-trip
-//! primitive. Phase 2a (PR #3803) landed `OpCtx` as dormant scaffolding
-//! with only unit-test callers; Phase 2b wires in the first production
-//! caller (client-initiated SUBSCRIBE, via
-//! [`crate::operations::subscribe::start_client_subscribe`]) so the
-//! `#[allow(dead_code)]` attributes from Phase 2a have been lifted.
+//! Ships the `OpCtx` struct and its `send_and_await` round-trip
+//! primitive. Each transaction is owned and driven by a single
+//! task; state lives in task locals rather than the legacy
+//! `OpManager.ops.*` DashMap.
 
 use std::net::SocketAddr;
 
@@ -15,22 +13,11 @@ use crate::message::{MessageStats, NetMessage, Transaction};
 use crate::node::OpExecutionPayload;
 use crate::operations::OpError;
 
-/// Per-transaction execution context for the task-per-tx model (#1454).
+/// Per-transaction execution context for the task-per-tx model.
 ///
-/// An `OpCtx` binds a single [`Transaction`] to the channel used to drive its
-/// network round-trip through the event loop. Each transaction is owned and
-/// driven by a single task; the context is [`Send`] but intentionally not
-/// [`Clone`].
-///
-/// # Phase 2a / 2b scope
-///
-/// Phase 2a (#1454) shipped this type with only the round-trip primitive
-/// `send_and_await`. The wider API sketched in the design doc
-/// (`spawn_sub`, per-tx WS fanout via `notify`, per-tx inbox,
-/// `OpRegistry`, and so on) is still deferred to later phases. Phase 2b
-/// activated the primitive by migrating SUBSCRIBE's client-initiated path
-/// onto it (see
-/// [`crate::operations::subscribe::start_client_subscribe`]).
+/// An `OpCtx` binds a single [`Transaction`] to the channel used to
+/// drive its network round-trip through the event loop. The context
+/// is [`Send`] but intentionally not [`Clone`].
 pub(crate) struct OpCtx {
     tx: Transaction,
     op_execution_sender: mpsc::Sender<OpExecutionPayload>,
@@ -53,105 +40,63 @@ impl OpCtx {
 
     /// The transaction this context is bound to.
     ///
-    /// Unused by the Phase 2b production caller (the task holds the
-    /// attempt tx in a local), but kept on the API because later phases
-    /// (per-tx inbox, `OpRegistry`) will need the identity accessor to
-    /// look up per-tx state owned by other components. Dropping and
-    /// re-adding the getter would churn the public surface of `OpCtx`
-    /// without benefit.
-    #[allow(dead_code)] // Kept as stable API surface for later task-per-tx phases (#1454).
+    /// Kept on the API for future per-tx inbox / `OpRegistry`
+    /// lookups; current production callers hold the attempt tx in a
+    /// local instead.
+    #[allow(dead_code)]
     pub fn tx(&self) -> Transaction {
         self.tx
     }
 
-    /// Send `msg` through the event loop and await a single reply keyed by
-    /// the same [`Transaction`]. This is the "round-trip primitive" for the
-    /// async sub-transaction refactor tracked in #1454.
+    /// Send `msg` through the event loop and await a single reply
+    /// keyed by the same [`Transaction`].
     ///
-    /// # Scaffolding reach
+    /// # Single-use per [`Transaction`]
     ///
-    /// As of Phase 1 (#1454, PR #3802), the reply callback inserted into
-    /// `p2p_protoc::pending_op_results` is fired for every network-terminating
-    /// op variant: PUT, GET, SUBSCRIBE, CONNECT, and UPDATE (see
-    /// `node::forward_pending_op_result_if_completed` and the branches of
-    /// `handle_pure_network_message_v1`). SUBSCRIBE's
-    /// `complete_local_subscription` path (`operations/subscribe.rs`) does
-    /// NOT pass through `handle_pure_network_message_v1`, so a caller
-    /// targeting a locally-completed subscribe would still hang on
-    /// `response_receiver.recv()` below. Closing that gap is Phase 2b work.
+    /// The reply callback fires exactly once per tx because the
+    /// `completed`/`under_progress` dedup sets suppress subsequent
+    /// dispatches. A second call with the same tx will hang on
+    /// `response_receiver.recv()`. Multi-attempt protocols (e.g.
+    /// SUBSCRIBE's fallback to alternative peers) must allocate a
+    /// fresh [`Transaction`] per attempt.
     ///
     /// # Deadlock risk
     ///
     /// `response_receiver.recv()` has no timeout. The reply side
-    /// (`node::forward_pending_op_result_if_completed`) uses `try_send`
-    /// against this capacity-1 channel so it can never block the
-    /// pure-network-message handler; the remaining risk is strictly on the
-    /// caller side (the task awaiting below). Phase 2b's author must
-    /// guarantee that the awaiting task is not the sole driver of completion,
-    /// or add an explicit timeout around `response_receiver.recv()`
-    /// (see `.claude/rules/channel-safety.md`).
-    ///
-    /// # Single-use per [`Transaction`]
-    ///
-    /// The Phase 1 helper fires exactly once per tx because the `completed` /
-    /// `under_progress` dedup sets suppress subsequent dispatches. Calling
-    /// `send_and_await` a second time on the same `OpCtx` (or a different
-    /// `OpCtx` sharing the same `Transaction`) will hang forever on
-    /// `response_receiver.recv()` because no second callback will fire.
-    /// Callers that need to retry a multi-attempt protocol (e.g.,
-    /// SUBSCRIBE's fallback to alternative peers) must use a fresh
-    /// [`Transaction`] per attempt. This is a known constraint; Phase 2b's
-    /// planner must work around it.
+    /// uses `try_send` so the pure-network-message handler cannot
+    /// block; the remaining risk is on the caller side. Callers
+    /// must guarantee the awaiting task is not the sole driver of
+    /// completion, or wrap the await in an explicit timeout (see
+    /// `.claude/rules/channel-safety.md`).
     ///
     /// # Where to call this
     ///
-    /// Must be called from an op task (e.g., one spawned via
-    /// [`crate::config::GlobalExecutor::spawn`]), not from within the main
-    /// event loop or a `priority_select` arm. The internal `.send().await`
-    /// on `op_execution_sender` is bounded and can block; spawned tasks are
-    /// OK, event loops are not. See `.claude/rules/channel-safety.md`.
+    /// Must be called from an op task (spawned via
+    /// [`crate::config::GlobalExecutor::spawn`]), not from the main
+    /// event loop. The internal `.send().await` on
+    /// `op_execution_sender` is bounded and can block; spawned tasks
+    /// are OK, event loops are not.
     ///
-    /// # Push-before-send
+    /// # Set up state, then send
     ///
-    /// `send_and_await` is the task-per-tx model's network send primitive,
-    /// so the push-before-send invariant from `.claude/rules/operations.md`
-    /// applies here directly: **any state the op will need when the reply
-    /// arrives must be in place before calling this method**. The exact
-    /// meaning of "in place" depends on which execution path the caller
-    /// sits on:
-    ///
-    /// - **Legacy path** (ops still using `handle_op_result` and
-    ///   `notify_op_change`): the caller must have already called
-    ///   `op_manager.push(tx, updated_state).await?` for the same `tx`
-    ///   before `send_and_await`, otherwise a fast response can race the
-    ///   push and hit `OpNotAvailable` when the pipeline tries to look up
-    ///   the op.
-    /// - **Task-per-tx path** (Phase 2b and later): the op state lives in
-    ///   task locals owned by the task that created this `OpCtx`. The
-    ///   invariant becomes "initialize task-local state before calling
-    ///   `send_and_await`": all fields the task will need when processing
-    ///   the reply (retry counters, `visited` peer filters, pending
-    ///   sub-operations, etc.) must be set before the `await` so that the
-    ///   reply handler reads consistent state. There is no `op_manager`
-    ///   DashMap race in this path because the state never leaves the
-    ///   task, but the conceptual ordering rule is the same.
-    ///
-    /// In both cases, the rule is simple: **set up state, then send**.
+    /// All task-local state the reply handler will read (retry
+    /// counters, visited-peer filters, pending sub-ops) must be
+    /// initialized before calling this method.
     ///
     /// # Terminal reply, not success reply
     ///
-    /// The returned [`NetMessage`] is whatever the op pipeline produced when
-    /// `is_operation_completed` flipped true, including non-success terminal
-    /// states (e.g., a `SubscribeMsg::Response::NotFound`). Callers inspect
-    /// the reply to decide what happened. `Ok(reply)` does NOT imply the
-    /// underlying protocol succeeded.
+    /// The returned [`NetMessage`] is whatever the pipeline produced
+    /// when `is_operation_completed` flipped true, including
+    /// non-success terminal states (e.g.
+    /// `SubscribeMsg::Response::NotFound`). `Ok(reply)` does NOT
+    /// imply protocol success — callers must inspect the reply.
     ///
     /// # Errors
     ///
-    /// Returns [`OpError::NotificationError`] if the executor channel is
-    /// closed (send failure) or the reply receiver is dropped (receiver
-    /// hang-up). Both indicate the round-trip could not complete.
-    #[allow(dead_code)] // Kept as stable API surface for later task-per-tx phases (#1454).
+    /// Returns [`OpError::NotificationError`] if the executor channel
+    /// is closed (send failure) or the reply receiver is dropped
+    /// (receiver hang-up).
+    #[allow(dead_code)]
     pub async fn send_and_await(&mut self, msg: NetMessage) -> Result<NetMessage, OpError> {
         self.send_and_await_inner(msg, None).await
     }
@@ -201,9 +146,9 @@ impl OpCtx {
     /// subsequent `send_client_result` emit `TransactionCompleted`, which
     /// runs after `handle_op_execution` has processed the outbound message.
     ///
-    /// This is the load-bearing primitive for UPDATE's task-per-tx driver,
-    /// which applies the update locally and fires a `RequestUpdate` to a
-    /// remote peer without waiting for acknowledgement (#1454 Phase 4).
+    /// Load-bearing primitive for UPDATE: applies the update locally
+    /// and fires a `RequestUpdate` to a remote peer without waiting
+    /// for acknowledgement.
     pub async fn send_fire_and_forget(
         &mut self,
         target_addr: SocketAddr,
@@ -230,16 +175,13 @@ impl OpCtx {
     /// as an `InboundMessage` (target=None semantics) without awaiting
     /// a reply.
     ///
-    /// Used by `relay_put_finalize_local` when the relay driver is
-    /// running on the originator's own node (originator-loopback PUT,
-    /// added in #1454 phase 5 final PUT slice). Sending a wire-bound
-    /// `PutMsg::Response` to `own_addr` fails — there's no
-    /// self-connection. Routing it through `InboundMessage` instead
+    /// Used by `relay_put_finalize_local` when the relay driver runs
+    /// on the originator's own node (originator-loopback PUT).
+    /// Sending a wire-bound `PutMsg::Response` to `own_addr` fails —
+    /// there's no self-connection. Routing it through `InboundMessage`
     /// lands at `handle_pure_network_message_v1`'s PUT bypass and
     /// forwards to the originator's `pending_op_results` waiter via
-    /// `try_forward_task_per_tx_reply`, mirroring the legacy
-    /// `LocalCompletion` echo semantics (where the looped-back Request
-    /// satisfied the driver as a terminal reply).
+    /// `try_forward_task_per_tx_reply`.
     pub async fn send_local_loopback(&mut self, msg: NetMessage) -> Result<(), OpError> {
         debug_assert_eq!(
             msg.id(),
@@ -309,14 +251,12 @@ impl OpCtx {
     /// Dispatch `msg` and return a multi-reply receiver. Caller drains
     /// the receiver until its own completion predicate fires.
     ///
-    /// This is the load-bearing primitive for ops with fan-in semantics:
-    /// CONNECT (#1454 Phase 2c) sends a single Request and expects up to
-    /// `target_connections` ConnectResponses arriving over time as relay
+    /// Load-bearing primitive for ops with fan-in semantics:
+    /// CONNECT sends a single Request and expects up to
+    /// `target_connections` ConnectResponses over time as relay
     /// branches accept the joiner. `send_and_await` and
-    /// `send_to_and_register_waiter` both use a capacity-1 channel that
-    /// is consumed-and-dropped after one reply, so they cannot model
-    /// fan-in. This primitive accepts a `capacity` argument so the caller
-    /// sizes the channel to the expected fan-in.
+    /// `send_to_and_register_waiter` use a capacity-1 channel and
+    /// cannot model fan-in.
     ///
     /// # When the bypass forwards multiple replies
     ///
@@ -341,7 +281,7 @@ impl OpCtx {
     /// Returns [`OpError::NotificationError`] if the event-loop
     /// `op_execution_sender` channel is closed (receiver dropped —
     /// typically only happens during node shutdown).
-    #[allow(dead_code)] // Phase 2c slice 0: dormant scaffolding for CONNECT originator (#1454).
+    #[allow(dead_code)]
     pub async fn send_and_collect_replies(
         &mut self,
         msg: NetMessage,
@@ -440,11 +380,10 @@ impl OpCtx {
 }
 
 // ─────────────────────────────────────────────────────────────────
-// Shared retry-loop driver (#3807).
+// Shared retry-loop driver.
 //
 // Encapsulates the tx-split + timeout + cleanup + classification
-// boilerplate that every task-per-tx op migration repeats. The
-// op-specific pieces are provided via the `RetryDriver` trait.
+// boilerplate. Op-specific pieces are provided via `RetryDriver`.
 // ─────────────────────────────────────────────────────────────────
 
 use crate::config::OPERATION_TTL;
@@ -516,7 +455,7 @@ pub(crate) trait RetryDriver {
     }
 }
 
-/// Drive a task-per-tx retry loop against the network.
+/// Drive a retry loop against the network.
 ///
 /// The first attempt reuses `client_tx` so telemetry correlates with the
 /// client-visible transaction. Subsequent attempts use
@@ -877,25 +816,13 @@ mod tests {
             .expect("executor task should complete without panicking");
     }
 
-    /// Regression for #1454 phase 5 final (PUT slice): the originator-
-    /// loopback PUT path uses `send_local_loopback` to deliver
-    /// `PutMsg::Response` back to the originator's `pending_op_results`
-    /// waiter when the relay driver runs on the originator's own node
-    /// (`upstream_addr == own_addr`). The contract of
-    /// `send_local_loopback` is "fire-and-forget with target=None" —
-    /// the executor sees `target_addr == None`, which causes
-    /// `handle_op_execution` to dispatch as `InboundMessage` rather
-    /// than try to ship over a non-existent self-connection. This
-    /// test pins that channel-level contract.
-    ///
-    /// Bug repro: `test_minimal_state_put_get` (and the rest of the
-    /// `edge_case_state_sizes` suite) failed with "put failed after 1
-    /// attempts (last error: failed notifying, channel closed)" because
-    /// the legacy `relay_put_send_response` used
-    /// `send_fire_and_forget(own_addr, ...)` which routed to
-    /// `OutboundMessageWithTarget` and tried to ship over a wire that
-    /// wasn't there. `send_local_loopback` fixes that by passing
-    /// `None` for the target.
+    /// Regression: the originator-loopback PUT path uses
+    /// `send_local_loopback` to deliver `PutMsg::Response` back to
+    /// the originator's `pending_op_results` waiter when the relay
+    /// driver runs on the originator's own node
+    /// (`upstream_addr == own_addr`). Contract: target=None so
+    /// `handle_op_execution` dispatches as `InboundMessage` rather
+    /// than trying to ship over a non-existent self-connection.
     #[tokio::test]
     async fn send_local_loopback_passes_none_target() {
         let (receiver, sender) = event_loop_notification_channel();
@@ -990,38 +917,17 @@ mod tests {
     }
 
     /// Documents the "single-use per `Transaction`" constraint on
-    /// [`OpCtx::send_and_await`]. The doc comment asserts that a second
-    /// call on the same context "will hang forever" because Phase 1's
-    /// reply helper fires exactly once per tx — this test drives that
-    /// scenario with a fake executor that replies to the first outbound
-    /// message and then **keeps the second `reply_sender` alive without
-    /// firing it**, which is exactly what Phase 1's real dedup
-    /// (`completed` / `under_progress` sets in `OpManager`) does at the
-    /// pipeline level: the second `send_and_await` call arrives, its
-    /// callback is registered in `pending_op_results`, and
-    /// `forward_pending_op_result_if_completed` never runs because the
-    /// op is already `completed`. From `send_and_await`'s perspective
-    /// the reply channel stays open forever with no message.
+    /// Pin the doc claim that a second `send_and_await` on the same
+    /// tx hangs forever. The reply helper fires exactly once per tx
+    /// (the `completed`/`under_progress` dedup sets short-circuit
+    /// subsequent dispatches in `OpManager`); the second
+    /// `send_and_await` call has its callback registered but
+    /// `forward_pending_op_result_if_completed` never runs.
     ///
-    /// The assertion wraps the second call in a short [`timeout`] and
-    /// asserts it elapses with `Err(Elapsed)` rather than resolving to
-    /// `Ok(_)` or `Err(NotificationError)`. A regression that made the
-    /// second call *fail fast* (e.g., by adding a runtime check or a
-    /// timeout inside `send_and_await`) would surface as `Ok(_)` from
-    /// the outer `timeout` and break this assertion — at which point
-    /// the doc comment on `send_and_await` must be updated to match.
-    ///
-    /// What this test does and does not guard against:
-    /// - **Does** guard against doc drift: if a future refactor adds a
-    ///   timeout or error path to the second call, the assertion shape
-    ///   breaks and the doc must be updated.
-    /// - **Does not** guard against the structural source of the hang
-    ///   (Phase 1's `completed` / `under_progress` dedup sets). Those
-    ///   live in `OpManager` and are not constructed here; this test
-    ///   simulates their effect directly by holding the reply sender
-    ///   alive without firing. A regression in the real dedup logic
-    ///   would not be caught here — it would be caught by integration
-    ///   tests that exercise the full pipeline.
+    /// The test simulates the dedup effect by holding the second
+    /// `reply_sender` alive without firing it. It does NOT guard the
+    /// real dedup logic — that lives in `OpManager` and is covered
+    /// by integration tests.
     #[tokio::test]
     async fn send_and_await_second_call_hangs_as_documented() {
         use tokio::sync::oneshot;
@@ -1052,14 +958,12 @@ mod tests {
                 .try_send(dummy_reply_with_tx(tx))
                 .expect("first reply accepted");
 
-            // Second outbound: hold `reply_sender_2` alive — do NOT drop
-            // it, do NOT fire it. This models what Phase 1's real dedup
+            // Second outbound: hold `reply_sender_2` alive — do NOT
+            // drop it, do NOT fire it. Models what the real dedup
             // does at the `OpManager` level: the reply callback is
             // installed, `forward_pending_op_result_if_completed`
-            // never runs again (because the op is already in the
-            // `completed` set), so the reply channel simply never
-            // produces a message or closes. From `send_and_await`'s
-            // viewpoint this is indistinguishable from a hang.
+            // never runs again (the op is already in `completed`),
+            // so the reply channel never produces a message.
             let (reply_sender_2, _second, _target_addr_2) = op_execution_receiver
                 .recv()
                 .await
@@ -1148,16 +1052,14 @@ mod tests {
         assert_eq!(d.attempt_timeout(), OPERATION_TTL);
     }
 
-    /// `send_and_collect_replies` returns a receiver that buffers multiple
-    /// inbound replies for the same tx. Phase 2c (#1454) needs this for
-    /// CONNECT joiners that fan-in N `ConnectResponse`s from distinct
-    /// relay branches against a single outbound `ConnectMsg::Request`.
+    /// `send_and_collect_replies` returns a receiver that buffers
+    /// multiple inbound replies for the same tx. Used by CONNECT
+    /// joiners that fan-in N `ConnectResponse`s from distinct relay
+    /// branches against a single outbound `ConnectMsg::Request`.
     ///
-    /// This test exercises the channel-level invariant only: the executor
-    /// fires three replies before the caller drains, all three must land
-    /// in the receiver in order. The full integration path (bypass
-    /// forwarding, capacity exhaustion behaviour, slot cleanup via
-    /// `release_pending_op_slot`) is covered by slice-1/slice-2 tests.
+    /// Channel-level invariant only: the executor fires three
+    /// replies before the caller drains, all three must land in
+    /// order.
     #[tokio::test]
     async fn send_and_collect_replies_buffers_multiple_inbound_replies() {
         let (receiver, sender) = event_loop_notification_channel();

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -1,19 +1,13 @@
-//! A contract is PUT within a location distance, this entails that all nodes within
-//! a given radius will cache a copy of the contract and it's current value,
-//! as well as will broadcast updates to the contract value to all subscribers.
+//! A contract is PUT within a location distance: all nodes within a
+//! given radius cache a copy of the contract and its current value,
+//! and broadcast updates to subscribers.
 //!
-//! #1454 phase 5 final (PUT slice) retired the legacy state machine.
-//! Every PUT wire variant now dispatches unconditionally to a task-per-tx
-//! driver — see `op_ctx_task::start_client_put`, `start_relay_put`, and
-//! `start_relay_put_streaming`.
-//!
-//! Phase 6 (#1454) retired the surviving `#[allow(dead_code)]` scaffolding
-//! (`PutOp`, `PutState`, `PutStats`, `AwaitingResponseData`,
-//! `FinishedData` + the inline outcome / failure-routing / type-state pin
-//! tests). The wire format types (`PutMsg`, `PutStreamingPayload`), the
-//! originator finalization helpers (`finalize_put_at_originator`,
-//! `PutFinalizationData`), and the local-store helper (`put_contract`) all
-//! survive because they are consumed by the task-per-tx drivers.
+//! Every PUT wire variant dispatches to a task-per-tx driver —
+//! `op_ctx_task::start_client_put`, `start_relay_put`, and
+//! `start_relay_put_streaming`. The wire-format types
+//! (`PutMsg`, `PutStreamingPayload`), the originator finalization
+//! helpers, and `put_contract` survive here because the drivers
+//! consume them.
 
 pub(crate) mod op_ctx_task;
 
@@ -37,8 +31,8 @@ pub(super) struct PutFinalizationData {
 
 /// Originator-side finalization after a PUT has been accepted by the network.
 ///
-/// Emits `put_success` telemetry and, if `subscribe` is true, starts a
-/// post-PUT subscription. Called by the task-per-tx driver (Phase 3a).
+/// Emits `put_success` telemetry and, if `subscribe` is true,
+/// starts a post-PUT subscription.
 pub(super) async fn finalize_put_at_originator(
     op_manager: &OpManager,
     id: Transaction,
@@ -371,9 +365,8 @@ mod tests {
 
     /// Pin: `OpManager::completed` MUST keep removing the per-type
     /// DashMap entry for the remaining DashMap-backed op (Connect).
-    /// GET, PUT, UPDATE and SUBSCRIBE no longer have DashMap entries
-    /// post-#1454 phase 5 final. Without this the Phase 3a-style leak
-    /// comes back for the remaining op.
+    /// GET, PUT, UPDATE and SUBSCRIBE no longer have DashMap entries.
+    /// Without this the per-tx DashMap leak comes back for Connect.
     #[test]
     fn completed_must_remove_per_type_dashmap_entry() {
         let src = include_str!("../node/op_state_manager.rs");
@@ -387,29 +380,28 @@ mod tests {
         let body = &src[fn_start..fn_end];
         assert!(
             body.contains("self.ops.connect.remove"),
-            "OpManager::completed must call `self.ops.connect.remove(&id)` \
-             to prevent the Phase 3a-style task-per-tx DashMap leak"
+            "OpManager::completed must call \
+             `self.ops.connect.remove(&id)` to prevent a per-tx \
+             DashMap leak"
         );
         for retired in ["self.ops.put", "self.ops.get", "self.ops.subscribe"] {
             assert!(
                 !body.contains(retired),
-                "OpManager::completed must not reference `{retired}` after \
-                 #1454 phase 5 final retired the corresponding DashMap"
+                "OpManager::completed must not reference `{retired}` — the corresponding DashMap was retired"
             );
         }
     }
 
-    /// Pin: legacy ForwardingAck senders MUST NOT come back at the
-    /// legacy relay forward sites. Slice A/B drivers omit them
-    /// (would race the capacity-1 task-per-tx waiter), and PR #3964
-    /// removed the legacy senders since the consumer is now a no-op.
+    /// Pin: legacy ForwardingAck senders MUST NOT come back. The
+    /// relay drivers omit them (would race the capacity-1 reply
+    /// waiter), and the consumer is a no-op (PR #3964).
     #[test]
     fn put_forwarding_ack_senders_must_stay_deleted() {
         let src = include_str!("put.rs");
         let needle = format!("NetMessage::from({}::ForwardingAck", "PutMsg",);
         assert!(
             !src.contains(&needle),
-            "ForwardingAck senders retired in PR #3964 — slice A/B drivers omit them"
+            "ForwardingAck senders retired in PR #3964"
         );
     }
 }

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1,43 +1,22 @@
-//! Task-per-transaction client-initiated PUT (#1454 Phase 3a).
+//! Task-per-transaction PUT drivers.
 //!
-//! Mirrors [`crate::operations::subscribe::op_ctx_task`] — the first
-//! production consumer of [`OpCtx::send_and_await`] for SUBSCRIBE.
-//! This module applies the same pattern to client-initiated PUT.
+//! Each entry point — client-initiated, relay non-streaming, relay
+//! streaming — owns routing state in task locals. No `PutOp` is
+//! pushed into `OpManager.ops.put`.
 //!
-//! # Scope (Phase 3a)
+//! # Client-initiated flow
 //!
-//! Only the **client-initiated originator** PUT runs through this module.
-//! Relay PUTs (with `upstream_addr: Some`), GC-spawned speculative retries,
-//! and streaming request setup stay on the legacy re-entry loop.
+//! 1. [`super::put_contract`] stores the contract locally.
+//! 2. Find k-closest peers to forward to.
+//! 3. No remote peers: deliver directly via `send_client_result`.
+//! 4. Loop: [`OpCtx::send_and_await`] with a fresh `Transaction`
+//!    per attempt (single-use-per-tx).
+//! 5. Terminal `Response`/`ResponseStreaming`:
+//!    [`super::finalize_put_at_originator`] + `send_client_result`.
+//! 6. Timeout/wire-error: advance to next peer or exhaust.
 //!
-//! # Architecture
-//!
-//! The task owns all routing state in its locals — there is no `PutOp` in
-//! `OpManager.ops.put` for any attempt this task makes. The task:
-//!
-//! 1. Calls [`super::put_contract`] to store the contract locally.
-//! 2. Finds the k-closest peers to forward the PUT to.
-//! 3. If no remote peers: delivers directly via `send_client_result`.
-//! 4. Otherwise: loops, calling [`OpCtx::send_and_await`] with a fresh
-//!    `Transaction` per attempt (single-use-per-tx constraint).
-//! 5. On terminal `Response`/`ResponseStreaming`: calls
-//!    [`super::finalize_put_at_originator`] for telemetry + subscription,
-//!    then delivers via `send_client_result`.
-//! 6. On timeout/wire-error: advances to next peer or exhausts.
-//!
-//! # Speculative retries (R2)
-//!
-//! The driver uses serial retries only. Speculative parallel paths
-//! (GC-spawned via `speculative_paths`) are not supported — the driver
-//! has no DashMap entry for the GC task to find. This is an accepted
-//! regression for Phase 3a; the driver's retry loop covers the same
-//! failure modes, just sequentially.
-//!
-//! # Connection-drop latency (R6)
-//!
-//! Legacy `handle_abort` detects disconnects in <1s. Task-per-tx relies
-//! on the `OPERATION_TTL` (60s) timeout. Accepted ceiling, matching
-//! Phase 2b's SUBSCRIBE driver.
+//! Retries are serial only. Connection-drop detection relies on
+//! `OPERATION_TTL` (60s).
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
@@ -547,7 +526,7 @@ fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: Driv
     }
 }
 
-// ── Relay PUT driver (#1454 phase 5 follow-up slice A) ──────────────────────
+// ── Relay PUT driver ─────────────────────────────────────────────────────────
 
 /// Counter: number of times `start_relay_put` was invoked. Incremented
 /// under test/testing feature only — used by structural pin tests to
@@ -731,14 +710,12 @@ async fn run_relay_put<CB>(
         );
     }
 
-    // Originator-loopback error path (#1454 phase 5 final PUT slice
-    // follow-up): when the relay driver runs on the originator's own
-    // node and fails (e.g., `put_contract` rejects an invalid state),
-    // the originator's `start_client_put` `send_and_await` waiter has
-    // no `PutMsg::Response` to consume — it would hang until the test
-    // / client times out. Mirror the legacy `report_result` Err arm
-    // (node.rs:636-651) by publishing a `HostResult::Err` to the
-    // originator's client transaction, then completing the tx.
+    // Originator-loopback error path: when the relay driver runs
+    // on the originator's own node and fails, the originator's
+    // `start_client_put` `send_and_await` waiter has no
+    // `PutMsg::Response` to consume — it would hang until timeout.
+    // Publish a `HostResult::Err` to the originator's client
+    // transaction and complete the tx.
     //
     // Safe in non-loopback mode because remote relays don't share
     // tx-space with a local client (the originator is on a different
@@ -762,8 +739,8 @@ async fn run_relay_put<CB>(
     // sender in the slot that only the 60s sweep would reclaim without
     // this explicit release.
     //
-    // Originator-loopback exception (#1454 phase 5 final PUT slice):
-    // when this driver runs on the originator's own node
+    // Originator-loopback exception: when this driver runs on the
+    // originator's own node
     // (`upstream_addr == own_addr`), the `pending_op_results` callback
     // for `incoming_tx` is the *originator's* `send_and_await` waiter,
     // NOT one this driver installed. Releasing it here would emit
@@ -897,9 +874,9 @@ where
         "PUT relay (task-per-tx): forwarding to next hop"
     );
 
-    // Originator-loopback mode (`upstream_addr == own_addr`, #1454
-    // phase 5 final PUT slice): the originator's `send_and_await`
-    // already installed a `pending_op_results` callback under
+    // Originator-loopback mode (`upstream_addr == own_addr`): the
+    // originator's `send_and_await` already installed a
+    // `pending_op_results` callback under
     // `incoming_tx`. Using `send_to_and_await` here would overwrite
     // that callback with the relay's own waiter, then the relay
     // consumes the reply and the originator's wait dangles forever.
@@ -914,11 +891,10 @@ where
     // Streaming upgrade on forward: serialize the payload, and if it
     // exceeds `streaming_threshold`, send a `RequestStreaming` metadata
     // message + raw stream fragments via `network_bridge.send_stream`.
-    // Mirrors legacy `put.rs:480-528` (pre-#1454 phase 5 final, PUT
-    // slice retirement). Different from `start_relay_put_streaming`'s
-    // `pipe_stream` path because there's no inbound stream handle to
-    // fork — the payload is materialized locally as `merged_value` and
-    // we send raw fragments.
+    // Different from `start_relay_put_streaming`'s `pipe_stream`
+    // path because there's no inbound stream handle to fork — the
+    // payload is materialized locally as `merged_value` and we send
+    // raw fragments.
     let payload = PutStreamingPayload {
         contract: contract.clone(),
         related_contracts: related_contracts.clone(),
@@ -1324,17 +1300,12 @@ async fn relay_put_finalize_local(
 /// Send `PutMsg::Response` upstream (fire-and-forget: upstream relay
 /// awaits via its own `send_to_and_await`, no reply expected).
 ///
-/// Originator-loopback case (`upstream_addr == own_addr`, added in
-/// #1454 phase 5 final PUT slice): when the relay driver is running
-/// on the originator's own node — because `start_client_put`'s
-/// `send_and_await(target=None)` looped the Request back into the
-/// local event loop and the dispatch site mapped `source_addr=None`
-/// to `upstream=own_addr` — the Response cannot ship over the wire
-/// (no self-connection). Route via `send_local_loopback` so the
-/// message lands as an `InboundMessage`, hits the PUT bypass in
-/// `handle_pure_network_message_v1`, and forwards to the originator's
-/// `pending_op_results` waiter. Mirrors the legacy `LocalCompletion`
-/// terminal-reply contract.
+/// Originator-loopback case (`upstream_addr == own_addr`): when
+/// the relay driver runs on the originator's own node, the
+/// Response cannot ship over the wire (no self-connection). Route
+/// via `send_local_loopback` so the message lands as an
+/// `InboundMessage`, hits the PUT bypass, and forwards to the
+/// originator's `pending_op_results` waiter.
 async fn relay_put_send_response(
     op_manager: &OpManager,
     incoming_tx: Transaction,
@@ -1358,7 +1329,7 @@ async fn relay_put_send_response(
     }
 }
 
-// ── Relay streaming PUT driver (#1454 phase 5 follow-up slice B) ────────────
+// ── Relay streaming PUT driver ───────────────────────────────────────────────
 
 /// Counter: number of times `start_relay_put_streaming` was invoked
 /// (BEFORE the dedup gate). Incremented under test/testing feature
@@ -1948,7 +1919,7 @@ mod tests {
         }));
         assert!(
             matches!(classify_reply(&msg), ReplyClass::Unexpected),
-            "ForwardingAck must NOT be classified as terminal (Phase 2b bug 2)"
+            "ForwardingAck must NOT be classified as terminal"
         );
     }
 
@@ -2164,10 +2135,9 @@ mod tests {
         ));
     }
 
-    // ── Relay PUT driver structural pin tests (#1454 phase 5 follow-up,
-    // slice A). Anchor the relay section on the entry-point fn so
-    // module-level doc comments (which reference variant names by
-    // design) don't enter scope.
+    // ── Relay PUT driver structural pin tests. Anchor the relay
+    // section on the entry-point fn so module-level doc comments
+    // (which reference variant names by design) don't enter scope.
 
     fn relay_section(src: &str) -> &str {
         let start = src
@@ -2293,8 +2263,8 @@ mod tests {
              Response bubbles back to the relay's waiter"
         );
         // The driver MAY use `send_fire_and_forget` in the
-        // originator-loopback branch (#1454 phase 5 final PUT slice):
-        // when `upstream_addr == own_addr`, installing a waiter would
+        // originator-loopback branch: when
+        // `upstream_addr == own_addr`, installing a waiter would
         // overwrite the originator's pending_op_results callback. The
         // fire-and-forget forward lets the downstream Response return
         // directly to the originator's still-installed callback. The
@@ -2313,7 +2283,7 @@ mod tests {
     /// non-existent self-connection and the originator-loopback PUT
     /// fails with "Cannot establish connection - peer not found".
     /// Repro: `test_minimal_state_put_get` and the rest of
-    /// `edge_case_state_sizes` (#1454 phase 5 final, PUT slice fixup).
+    /// `edge_case_state_sizes`.
     #[test]
     fn relay_put_send_response_uses_loopback_when_upstream_is_own_addr() {
         let src = include_str!("op_ctx_task.rs");
@@ -2599,10 +2569,10 @@ mod tests {
         );
     }
 
-    /// Bound the upgrade-on-forward analysis to the *relay-non-loopback*
-    /// branch of `drive_relay_put`. The originator-loopback branch
-    /// (added in #1454 phase 5 final PUT slice) intentionally does NOT
-    /// install a reply waiter — the originator's
+    /// Bound the upgrade-on-forward analysis to the
+    /// *relay-non-loopback* branch of `drive_relay_put`. The
+    /// originator-loopback branch intentionally does NOT install a
+    /// reply waiter — the originator's
     /// `pending_op_results` callback already exists and the loopback
     /// forward is fire-and-forget. The relay branch (`let round_trip =
     /// if upgrade_to_streaming`) is the one that must install a

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -1,24 +1,19 @@
-//! SUBSCRIBE operation: registers downstream interest in a contract and
-//! threads UPDATE broadcasts back through the subscription tree.
+//! SUBSCRIBE operation: registers downstream interest in a contract
+//! and threads UPDATE broadcasts back through the subscription tree.
 //!
-//! #1454 phase 5 final (SUBSCRIBE slice) retired the legacy state machine.
-//! Every SUBSCRIBE wire variant now dispatches unconditionally:
+//! Every SUBSCRIBE wire variant dispatches unconditionally:
 //!
 //! - `SubscribeMsg::Request` → `op_ctx_task::start_relay_subscribe`
-//! - `SubscribeMsg::Response` → bypass to originator's `pending_op_results`
-//!   waiter
-//! - `SubscribeMsg::Unsubscribe` → `handle_unsubscribe_inbound` (this module)
+//! - `SubscribeMsg::Response` → reply bypass to originator waiter
+//! - `SubscribeMsg::Unsubscribe` → `handle_unsubscribe_inbound`
 //! - `SubscribeMsg::ForwardingAck` → no-op telemetry hook
 //!
-//! Phase 6 (#1454) retired the surviving `#[allow(dead_code)]` scaffolding
-//! `SubscribeOp`, `SubscribeState`, `SubscribeStats`, the type-state data
-//! structs, `start_op` / `start_op_with_id` test fixtures, and the inline
-//! pin tests they backed. The wire format types (`SubscribeMsg`,
-//! `SubscribeMsgResult`), the originator-shared helpers (`InitialRequest`,
-//! `prepare_initial_request`, `complete_local_subscription`,
-//! `wait_for_contract_with_timeout`), the inbound `Unsubscribe` handler,
-//! and `register_downstream_subscriber` all survive because the
-//! task-per-tx drivers still consume them.
+//! The wire-format types, the originator-shared helpers
+//! (`InitialRequest`, `prepare_initial_request`,
+//! `complete_local_subscription`, `wait_for_contract_with_timeout`),
+//! the inbound `Unsubscribe` handler, and
+//! `register_downstream_subscriber` survive here because the
+//! task-per-tx drivers consume them.
 
 use either::Either;
 
@@ -416,9 +411,8 @@ pub(crate) async fn register_downstream_subscriber(
 /// Removes the sender's downstream subscriber tracking for the contract and
 /// chains the unsubscribe upstream if no remaining interest is present.
 ///
-/// Replaces the legacy `process_message::SubscribeMsg::Unsubscribe` arm
-/// retired in #1454 phase 5 final (SUBSCRIBE slice). The node.rs dispatch
-/// site calls this directly for inbound Unsubscribe variants.
+/// Called from the node.rs dispatch site for inbound Unsubscribe
+/// wire messages.
 pub(crate) async fn handle_unsubscribe_inbound(
     op_manager: &OpManager,
     tx: Transaction,
@@ -502,8 +496,7 @@ pub(crate) async fn handle_unsubscribe_inbound(
 #[cfg(test)]
 mod tests;
 
-/// Task-per-transaction client-initiated SUBSCRIBE path (#1454 Phase 2b).
-/// First production consumer of `OpCtx::send_and_await`.
+/// Task-per-transaction SUBSCRIBE drivers.
 pub(crate) mod op_ctx_task;
 
 pub(crate) use op_ctx_task::{

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1,73 +1,32 @@
-//! Task-per-transaction client-initiated SUBSCRIBE (#1454 Phase 2b).
+//! Task-per-transaction SUBSCRIBE drivers.
 //!
-//! This module hosts the first production consumer of [`OpCtx::send_and_await`][ocx],
-//! driving a client-initiated SUBSCRIBE end-to-end inside a single spawned
-//! task instead of the legacy re-entry loop through `handle_op_result` +
-//! `OpManager.ops.subscribe` DashMap.
-//!
-//! # Scope (Phase 2b)
-//!
-//! Only the **client-initiated** SUBSCRIBE entry point (via
-//! [`crate::node::subscribe_with_id`]) runs through this module. The other
-//! three entry points stay on the legacy path for reasons documented on
-//! issue #1454 Phase 2b:
-//!
-//! - **Renewals** (`ring.rs::connection_maintenance` loop) — their jitter
-//!   and spam-prevention in `can_request_subscription()` are load-bearing.
-//! - **PUT/GET sub-ops** (`start_subscription_request` and
-//!   `maybe_subscribe_child` in `put/op_ctx_task.rs` /
-//!   `get/op_ctx_task.rs`) — historically used `SubOperationTracker`
-//!   for blocking semantics; migrated to `run_client_subscribe` (PUT
-//!   in Phase 3a, GET in Phase 3b, the legacy
-//!   `auto_subscribe_on_get_response` fallback in the sub-op
-//!   SUBSCRIBE migration follow-up).
-//! - **Intermediate-peer forwarding** (`SubscribeOp::load_or_init` on
-//!   incoming `Request`) — server-side response role; migrated in Phase 5.
-//!
-//! Only the **client-initiated** path goes through `subscribe_with_id`;
-//! the three legacy paths never call it, so migrating the body of
-//! `subscribe_with_id` wholesale is sufficient to gate the new path.
+//! Each entry point — client-initiated, executor auto-subscribe,
+//! renewal, relay — owns its routing state in task locals. No
+//! `SubscribeOp` is pushed into `OpManager.ops.subscribe`.
 //!
 //! # Architecture
 //!
-//! The task owns all routing state in its locals — there is no
-//! `SubscribeOp` in the `OpManager.ops.subscribe` DashMap for any attempt
-//! this task makes. The task:
-//!
-//! 1. Calls [`super::prepare_initial_request`] to decide target peer vs
+//! 1. [`super::prepare_initial_request`] decides target peer vs
 //!    local-completion vs give-up.
-//! 2. If network target: loops, calling [`OpCtx::send_and_await`][ocx]
-//!    with a **fresh `Transaction` per attempt** (required by
-//!    `send_and_await`'s single-use-per-tx contract). Each attempt
-//!    inserts a capacity-1 reply channel into `p2p_protoc::pending_op_results`
-//!    keyed by the attempt tx; the pure-network-message handler routes
-//!    replies via the SUBSCRIBE bypass added in Phase 2b (see
-//!    `node::try_forward_task_per_tx_reply`).
-//! 3. On `Subscribed`: delivers via `result_router_tx` keyed by the
-//!    **client-visible** `Transaction` (the one returned to the caller
-//!    and registered with `ch_outbound.waiting_for_transaction_result`).
-//! 4. On `NotFound`: applies breadth retry → fresh k_closest round →
-//!    exhaustion, mirroring the legacy retry logic in
-//!    `subscribe::handle_op_response`.
-//! 5. On `send_and_await` timeout: treats the attempt as a peer timeout
-//!    and applies the same retry logic.
+//! 2. Network target: loop calls [`OpCtx::send_and_await`][ocx] with
+//!    a **fresh `Transaction` per attempt** (required by
+//!    `send_and_await`'s single-use-per-tx contract). Replies route
+//!    via the SUBSCRIBE bypass in `handle_pure_network_message_v1`.
+//! 3. `Subscribed` → delivers via `result_router_tx` keyed by
+//!    `client_tx`.
+//! 4. `NotFound` → breadth retry → fresh k_closest → exhaustion.
+//! 5. `send_and_await` timeout → treated as peer timeout.
 //!
 //! # Client-visible tx vs per-attempt tx
 //!
-//! Legacy SUBSCRIBE reuses one `Transaction` end-to-end. Phase 2b splits
-//! this into two tx lifetimes:
+//! - **`client_tx`**: allocated once by the WS handler, registered
+//!   with `ch_outbound.waiting_for_transaction_result`, delivered to
+//!   via `result_router_tx`. Never passed to `send_and_await`.
+//! - **`attempt_tx`**: fresh per retry. Used for the wire Request,
+//!   the `OpCtx`, and the `pending_op_results` callback slot.
 //!
-//! - **`client_tx`**: allocated once by the WS handler, registered with
-//!   `ch_outbound.waiting_for_transaction_result`, delivered to via
-//!   `result_router_tx`. Never passed to `send_and_await`.
-//! - **`attempt_tx`**: fresh per retry. Used for the wire Request, the
-//!   `OpCtx`, and the `pending_op_results` callback slot. Never surfaced
-//!   to the client.
-//!
-//! The split is mandatory: `OpCtx::send_and_await` can only fire once per
-//! Transaction (the `completed` / `under_progress` dedup sets in
-//! `OpManager` suppress second callbacks). Attempt isolation is the
-//! simplest reconciliation with that constraint.
+//! The split is mandatory: `OpCtx::send_and_await` fires once per
+//! Transaction.
 //!
 //! [ocx]: crate::operations::OpCtx::send_and_await
 
@@ -161,8 +120,8 @@ pub(crate) async fn start_client_subscribe(
 /// Runs inside a spawned task. Never panics — any error is converted into
 /// a `HostResult::Err` and delivered through `result_router_tx`.
 ///
-/// `pub(crate)` so PUT's task-per-tx driver (Phase 3a) can `.await` this
-/// inline for blocking-subscribe children without spawning a separate task.
+/// `pub(crate)` so PUT's driver can `.await` this inline for
+/// blocking-subscribe children without spawning a separate task.
 pub(crate) async fn run_client_subscribe(
     op_manager: Arc<OpManager>,
     instance_id: ContractInstanceId,
@@ -903,9 +862,8 @@ fn classify_reply(msg: &NetMessage) -> ReplyClass {
     }
 }
 
-/// Advance the task-local routing state to the next peer to try, mirroring
-/// the legacy `subscribe::handle_op_response` NotFound + alternatives-exhausted
-/// logic (`subscribe.rs` ~1675–1842 before Phase 2b).
+/// Advance the task-local routing state to the next peer to try
+/// (NotFound + alternatives-exhausted logic).
 ///
 /// Thin wrapper around [`advance_to_next_peer_impl`] that binds the
 /// `fresh_candidates` hook to `op_manager.ring.k_closest_potentially_hosting`.
@@ -1113,7 +1071,7 @@ fn deliver_outcome(
     }
 }
 
-// ── Relay SUBSCRIBE driver (#1454 phase 5 follow-up slice A) ─────────────────
+// ── Relay SUBSCRIBE driver ───────────────────────────────────────────────────
 
 /// Counter: relay SUBSCRIBE drivers currently in flight. Decremented in
 /// the RAII guard on driver exit. Diagnostic for `FREENET_MEMORY_STATS`.
@@ -1141,39 +1099,20 @@ pub static RELAY_SUBSCRIBE_DEDUP_REJECTS: std::sync::atomic::AtomicUsize =
 pub static RELAY_SUBSCRIBE_DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
-/// Spawn a relay driver for a fresh inbound `SubscribeMsg::Request`.
+/// Spawn a relay driver for a fresh inbound
+/// `SubscribeMsg::Request`.
 ///
-/// Gated by the dispatch site in `node.rs::handle_pure_network_message_v1`
-/// on `source_addr.is_some() && !has_subscribe_op(id)`. The driver owns
-/// local-hit response + single downstream forward + upstream bubble-up
-/// in its task locals — no `SubscribeOp` is stored in
-/// `OpManager.ops.subscribe` for this transaction.
+/// The driver owns local-hit response + single downstream forward +
+/// upstream bubble-up in its task locals.
 ///
-/// # Slice A
+/// Notable omissions:
 ///
-/// Migrated:
-/// - `SubscribeMsg::Request` relay arm: has-contract check (including the
-///   brief wait-for-in-flight-PUT helper), `register_downstream_subscriber`
-///   on local hit, forward-and-await-Response on next hop, bubble
-///   `SubscribeMsg::Response` back upstream after registering the
-///   requester as a downstream subscriber.
-/// - `ForwardingAck` OMITTED deliberately — same reasoning as GET/PUT/
-///   UPDATE slice A: the ack shares `incoming_tx` with the reply and
-///   would satisfy upstream's capacity-1 `pending_op_results` waiter
-///   before the real `Response`.
-/// - Cross-peer retries OMITTED at the relay — legacy breadth/retry loop
-///   at relay hops is the phase-5 memory-explosion amplifier (see
-///   `project_1454_phase5_memory.md`). Originator-side driver (Phase 2b)
-///   owns cross-peer retry; relay forwards once.
-///
-/// NOT migrated (stays on legacy path):
-/// - `SubscribeMsg::Response` originator arm (Phase 2b driver handles it
-///   via `pending_op_results` bypass).
-/// - `SubscribeMsg::Unsubscribe` and `SubscribeMsg::ForwardingAck` — fire
-///   and forget fast-path, no op state needed.
-/// - Renewals, PUT sub-op subscribes, and intermediate-peer forwarding
-///   through renewal/executor entry points — no `source_addr` or
-///   pre-existing `SubscribeOp` makes them fall through.
+/// - `ForwardingAck` is NOT emitted — the ack shares `incoming_tx`
+///   with the reply and would satisfy upstream's capacity-1
+///   `pending_op_results` waiter before the real `Response`.
+/// - Cross-peer retries are NOT attempted at the relay — the relay
+///   breadth/retry loop was the memory-explosion amplifier (see
+///   `project_1454_phase5_memory.md`). Originator owns retry.
 pub(crate) async fn start_relay_subscribe(
     op_manager: Arc<OpManager>,
     incoming_tx: Transaction,
@@ -2042,10 +1981,9 @@ mod tests {
         assert!(alt_addrs.contains(&p3_addr));
     }
 
-    // ── Relay SUBSCRIBE driver structural pin tests (#1454 phase 5
-    // follow-up slice A). Anchor on the `start_relay_subscribe`
-    // entry-point fn so module-level docs referencing variant names
-    // don't contaminate the scan.
+    // ── Relay SUBSCRIBE driver structural pin tests. Anchor on
+    // the `start_relay_subscribe` entry-point fn so module-level
+    // docs referencing variant names don't contaminate the scan.
 
     fn relay_section(src: &str) -> &str {
         let start = src
@@ -2294,7 +2232,7 @@ mod tests {
         );
     }
 
-    // ── classify_renewal_result tests (#1454 SUBSCRIBE renewal slice) ────
+    // ── classify_renewal_result tests ────────────────────────────────────
     //
     // The renewal classifier is the load-bearing decision point for
     // backoff bookkeeping. Misclassification of a transient channel error
@@ -2413,8 +2351,7 @@ mod tests {
         ));
     }
 
-    // ── classify_executor_subscribe_result tests (#1454 SUBSCRIBE
-    //    executor migration) ───────────────────────────────────────────
+    // ── classify_executor_subscribe_result tests ─────────────────────
     //
     // Executor auto-subscribe delivers Result<(), OpError> directly.
     // These pin the mapping so a future `OpError` / `DriverOutcome`
@@ -2485,7 +2422,7 @@ mod tests {
         }
     }
 
-    // ── run_executor_subscribe body pin tests (#1454) ────────────────
+    // ── run_executor_subscribe body pin tests ─────────────────────────
     //
     // Behavioral end-to-end tests of `run_executor_subscribe` would
     // require spinning a full `OpManager` (no shared test fixture

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -1,18 +1,15 @@
-//! Structural pin tests for the SUBSCRIBE module after #1454 phase 5/6
-//! cleanup. The legacy `SubscribeOp` state machine + state-transition /
-//! retry / outcome tests have been retired (the driver in
-//! `op_ctx_task.rs` owns these behaviors and is covered by its own tests).
-//! The pins below anchor the load-bearing invariants that survived the
-//! retirement: the unsubscribe inbound handler shape, the SUBSCRIBE
+//! Structural pin tests for the SUBSCRIBE module.
+//!
+//! Anchors: the unsubscribe inbound handler shape, the SUBSCRIBE
 //! dispatch site in `node.rs`, the wire-format compatibility of
 //! `SubscribeMsg::ForwardingAck`, and the sub-op GET migration.
 
 use super::*;
 
-/// Pin: `handle_unsubscribe_inbound` (the post-#1454 phase 5 final SUBSCRIBE
-/// inbound entry point) preserves the four behavioral branches inherited
-/// from the retired legacy `process_message::Unsubscribe` arm, plus the
-/// counter-symmetry guard on the global downstream counter.
+/// Pin: `handle_unsubscribe_inbound` preserves the four behavioral
+/// branches inherited from the legacy
+/// `process_message::Unsubscribe` arm, plus the counter-symmetry
+/// guard on the global downstream counter.
 #[test]
 fn handle_unsubscribe_inbound_preserves_legacy_branches() {
     const SOURCE: &str = include_str!("../subscribe.rs");

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1,20 +1,13 @@
-//! UPDATE operation: applies a state change to a contract and broadcasts to subscribers.
+//! UPDATE operation: applies a state change to a contract and
+//! broadcasts to subscribers.
 //!
-//! #1454 phase 5 final (UPDATE slice) retired the legacy state machine.
-//! Every UPDATE wire variant now dispatches unconditionally to a
-//! task-per-tx driver — see `op_ctx_task::start_client_update`,
-//! `start_relay_request_update`, `start_relay_broadcast_to`,
-//! `start_relay_request_update_streaming`, and
-//! `start_relay_broadcast_to_streaming`.
-//!
-//! Phase 6 (#1454) retired the surviving `#[allow(dead_code)]` scaffolding
-//! `UpdateOp`, `UpdateState`, `UpdateStats`, `FinishedData` and the inline
-//! outcome / failure-routing pin tests. The wire format types,
-//! `BroadcastDedupCache`, `BroadcastTargetResult`,
-//! `OpManager::try_auto_fetch_contract`, `update_contract`,
-//! `log_update_contract_failure`, `log_broadcast_to_streaming_failure`,
-//! `send_proactive_summary_notification`, and `send_summary_back_on_rejection`
-//! all survive because the task-per-tx drivers still consume them.
+//! Every UPDATE wire variant dispatches to a task-per-tx driver —
+//! `op_ctx_task::start_client_update`, `start_relay_request_update`,
+//! `start_relay_broadcast_to`, `start_relay_request_update_streaming`,
+//! and `start_relay_broadcast_to_streaming`. The wire-format types,
+//! `BroadcastDedupCache`, `update_contract`, the log helpers, and
+//! the post-merge propagation helpers survive here because the
+//! drivers consume them.
 
 pub(crate) mod op_ctx_task;
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1,24 +1,14 @@
-//! Task-per-transaction client-initiated UPDATE (#1454 Phase 4).
+//! Task-per-transaction UPDATE drivers.
 //!
-//! UPDATE is fire-and-forget: the originator applies the update locally,
-//! optionally forwards a `RequestUpdate` to a remote peer, and delivers
-//! the result to the client immediately. There is no response to await
-//! and no retry loop.
+//! UPDATE is fire-and-forget end-to-end: the originator applies the
+//! update locally, optionally forwards a `RequestUpdate` to a remote
+//! peer, and delivers the result to the client immediately. No
+//! response is awaited, no retry loop.
 //!
-//! # Scope (Phase 4)
-//!
-//! Only the **client-initiated originator** UPDATE runs through this
-//! module. Relay UPDATEs (RequestUpdate arriving from network),
-//! BroadcastTo fan-out, and streaming variants stay on the legacy
-//! state-machine path.
-//!
-//! # Improvements over legacy path
-//!
-//! - Uses [`OpManager::send_client_result`] instead of raw
-//!   `result_router_tx.try_send`, ensuring [`NodeEvent::TransactionCompleted`]
-//!   is emitted for cleanup of `tx_to_client` and `pending_op_results`.
-//! - Never pushes to `OpManager.ops.update` DashMap, eliminating stale
-//!   entry retention between completion and GC timeout.
+//! Drivers use [`OpManager::send_client_result`] (which emits
+//! [`NodeEvent::TransactionCompleted`] for `tx_to_client` and
+//! `pending_op_results` cleanup) and never push state into a
+//! `OpManager.ops.*` DashMap.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -40,11 +30,10 @@ use super::{BroadcastStreamingPayload, UpdateExecution, UpdateMsg, UpdateStreami
 use crate::transport::peer_connection::StreamId;
 
 /// Counter: number of times `start_relay_request_update` or
-/// `start_relay_broadcast_to` was invoked. Incremented under test/testing
-/// feature only — used by structural pin tests in #1454 phase 5
-/// follow-up to prove the dispatch gate routes fresh inbound traffic
-/// through the task-per-tx driver rather than legacy
-/// `handle_op_request`.
+/// `start_relay_broadcast_to` was invoked. Incremented under
+/// test/testing feature only; used by structural pin tests to prove
+/// the dispatch gate routes fresh inbound traffic through the
+/// driver.
 #[cfg(any(test, feature = "testing"))]
 pub static RELAY_UPDATE_DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
@@ -67,13 +56,12 @@ pub static RELAY_UPDATE_COMPLETED_TOTAL: std::sync::atomic::AtomicUsize =
 pub static RELAY_UPDATE_DEDUP_REJECTS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
-// ── Slice C streaming relay UPDATE counters (#1454 phase 5) ──────────────
+// ── Streaming relay UPDATE counters ──────────────────────────────────────
 //
-// Separate from slice A's `RELAY_UPDATE_*` counters so operators can
-// ramp-compare observability between non-streaming and streaming
-// relay drivers. The tx dedup set (`active_relay_update_txs`) is shared
-// across both slices since tx identity is unified; the
-// `RELAY_UPDATE_DEDUP_REJECTS` counter is also shared.
+// Separate from the non-streaming `RELAY_UPDATE_*` counters so
+// operators can ramp-compare observability between the two. The tx
+// dedup set (`active_relay_update_txs`) and
+// `RELAY_UPDATE_DEDUP_REJECTS` are shared.
 
 /// Counter: number of times `start_relay_request_update_streaming` or
 /// `start_relay_broadcast_to_streaming` was invoked. Used by dispatch
@@ -355,8 +343,8 @@ async fn drive_client_update(
                     //
                     // Why `target_addr` and not some other peer: the
                     // auto-fetch is a directed `start_targeted_sub_op_get`
-                    // GET (post-#1454 phase 5 final, GET slice) targeting
-                    // a SocketAddr, and `target_addr` is the only addr we
+                    // targeting a SocketAddr, and `target_addr` is the
+                    // only addr we
                     // have at this site that the routing layer just
                     // confirmed is reachable AND closer to the key than
                     // we are. It may not host the contract directly, but
@@ -515,41 +503,29 @@ fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: Driv
     op_manager.completed(client_tx);
 }
 
-// ── Relay UPDATE drivers (#1454 phase 5 follow-up — slice A) ────────────────
+// ── Relay UPDATE drivers (non-streaming) ─────────────────────────────────────
 //
-// UPDATE has no end-to-end response, so the relay drivers below are
-// strictly fire-and-forget: they apply state changes locally (or forward
-// once downstream) and exit.  No `send_and_await`, no
-// `pending_op_results` slot, no upstream reply.  This makes the relay
-// drivers immune to the four amplifiers that hit phase-5 GET (workflow
-// runs 24600168871 / 24600634908 / 24601267577 / 24601908758):
+// UPDATE has no end-to-end response, so the relay drivers are
+// strictly fire-and-forget: they apply state changes locally (or
+// forward once downstream) and exit. No `send_and_await`, no
+// `pending_op_results` slot, no upstream reply.
 //
+// Amplifier audit (vs GET relay):
 //   1. No retry loop at relay → no MAX_RELAY_RETRIES needed.
 //   2. No fresh `attempt_tx` → forwarding reuses `incoming_tx`.
 //   3. No `ForwardingAck` → never had one.
-//   4. Per-node dedup gate (`active_relay_update_txs`) drops duplicate
-//      inbound Requests for an in-flight tx, mirroring GET phase-5 even
-//      though the structural risk is lower.
+//   4. Per-node dedup gate (`active_relay_update_txs`) drops
+//      duplicate inbound Requests for an in-flight tx.
 //
-// # Scope
-//
-// Migrated:
-//   - `UpdateMsg::RequestUpdate` (non-streaming relay arm:
-//      `update.rs::process_message`, lines 347–594).
+// Migrated wire variants:
+//   - `UpdateMsg::RequestUpdate` (non-streaming relay arm).
 //   - `UpdateMsg::BroadcastTo`  (non-streaming relay arm:
 //      `update.rs::process_message`, lines 595–825).
 //
-// NOT migrated (stays on legacy path; see port plan §3 / §9):
-//   - `UpdateMsg::RequestUpdateStreaming` /
-//     `UpdateMsg::BroadcastToStreaming` — migrated in slice C.
-//
-// UPDATE auto-fetch (`OpManager::try_auto_fetch_contract`) used to
-// invoke the legacy `get::start_targeted_op` constructor. Phase 5
-// final (GET slice) migrated it to
-// `get::op_ctx_task::start_targeted_sub_op_get` (a directed
-// task-per-tx GET that pre-seeds the UPDATE sender as the first
-// hop and falls back to `k_closest_potentially_hosting` for
-// retries). The legacy `OpEnum::Get` carrier is gone.
+// UPDATE auto-fetch (`OpManager::try_auto_fetch_contract`)
+// dispatches `get::op_ctx_task::start_targeted_sub_op_get` (a
+// directed GET that pre-seeds the UPDATE sender as the first hop
+// and falls back to `k_closest_potentially_hosting` for retries).
 
 /// Spawn a relay driver for a fresh inbound `UpdateMsg::RequestUpdate`.
 ///
@@ -1186,7 +1162,7 @@ async fn drive_relay_broadcast_to(
     Ok(())
 }
 
-// ── Relay UPDATE streaming drivers (#1454 phase 5 — slice C) ────────────
+// ── Relay UPDATE streaming drivers ───────────────────────────────────────
 //
 // Streaming UPDATE relays are qualitatively simpler than streaming PUT
 // relays:
@@ -1897,9 +1873,9 @@ mod tests {
         );
     }
 
-    // ── Relay UPDATE driver structural pin tests (#1454 phase 5 follow-up,
-    // slice A scaffold). These pin the driver SOURCE against documented
-    // invariants; a future change that breaks any invariant should fail
+    // ── Relay UPDATE driver structural pin tests. These pin the
+    // driver SOURCE against documented invariants; a future change
+    // that breaks any invariant should fail
     // these before sim runs catch the consequence. Behavioral tests for
     // the dispatch gate live in commit 2.
 
@@ -2068,9 +2044,9 @@ mod tests {
         );
     }
 
-    /// Pin: both relay drivers MUST gate on `active_relay_update_txs` to
-    /// reject duplicate inbound messages for an in-flight tx (matches the
-    /// pattern that GET phase 5 needed to avoid amplification).
+    /// Pin: both relay drivers MUST gate on
+    /// `active_relay_update_txs` to reject duplicate inbound
+    /// messages for an in-flight tx (amplification guard).
     #[test]
     fn relay_drivers_use_per_node_dedup_gate() {
         let src = include_str!("op_ctx_task.rs");
@@ -2180,11 +2156,9 @@ mod tests {
         }
     }
 
-    // ── Slice C streaming relay driver structural pin tests ─────────────
-    // (#1454 phase 5) — pin the streaming drivers against their
-    // documented invariants.
+    // ── Streaming relay driver structural pin tests ─────────────────────
 
-    /// Pin: slice C streaming drivers must exist and be public at the
+    /// Pin: streaming drivers must exist and be public at the
     /// crate level.
     #[test]
     fn slice_c_streaming_drivers_exist() {
@@ -2395,19 +2369,17 @@ mod tests {
         );
     }
 
-    /// Pin: `log_broadcast_to_streaming_failure` must stay `pub(crate)`
-    /// so the slice C driver can reuse the shared classifier. If Phase 6
-    /// cleanup re-privatises it, the driver's failure branch breaks
-    /// silently — this pin trips at compile-ish time (source-level scan)
-    /// instead.
+    /// Pin: `log_broadcast_to_streaming_failure` must stay
+    /// `pub(crate)` so the streaming driver can reuse the shared
+    /// classifier. Re-privatising it would silently break the
+    /// driver's failure branch.
     #[test]
     fn log_broadcast_to_streaming_failure_is_pub_crate() {
         let src = include_str!("../update.rs");
         assert!(
             src.contains("pub(crate) fn log_broadcast_to_streaming_failure("),
             "log_broadcast_to_streaming_failure must remain pub(crate) — \
-             slice C driver reuses it for failure classification; \
-             re-privatising breaks drive_relay_broadcast_to_streaming"
+             reused by drive_relay_broadcast_to_streaming"
         );
     }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1052,10 +1052,11 @@ impl Ring {
                             SubscriptionRecoveryGuard::new(op_manager_clone.clone(), contract_key);
 
                         let instance_id = *contract_key.id();
-                        // Renewal driver (#1454): same task-per-tx machinery as
-                        // client-initiated SUBSCRIBE, with delivery returned to
-                        // this task instead of routed via `result_router_tx`.
-                        // `is_renewal=true` so the responder skips sending state.
+                        // Renewal driver: same machinery as
+                        // client-initiated SUBSCRIBE, with delivery
+                        // returned to this task instead of via
+                        // `result_router_tx`. `is_renewal=true` so
+                        // the responder skips sending state.
                         //
                         // Outer renewal-cycle timeout: cap each renewal task at
                         // a fraction of the renewal interval so a stuck driver
@@ -3316,9 +3317,7 @@ pub(crate) enum RingError {
     #[error(transparent)]
     ConnError(#[from] Box<node::ConnectionError>),
     /// Retained for completeness; client_events maps it to a stable
-    /// `ClientError::EmptyRing`. Currently unconstructed since the
-    /// `request_get` legacy path that produced it was retired in the
-    /// #1454 sub-op GET migration.
+    /// `ClientError::EmptyRing`. Currently unconstructed.
     #[error("No ring connections found")]
     #[allow(dead_code)]
     EmptyRing,

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -315,10 +315,10 @@ impl HostingManager {
 
     /// Snapshot of every active subscription for the local-peer dashboard.
     ///
-    /// Reads directly from the canonical lease map (no parallel mirror).
-    /// The earlier `network_status::subscribed_contracts` mirror silently
-    /// drifted after SUBSCRIBE moved to the task-per-tx driver and lost
-    /// its recording hook.
+    /// Reads directly from the canonical lease map (no parallel
+    /// mirror). The earlier `network_status::subscribed_contracts`
+    /// mirror silently drifted when SUBSCRIBE migrated to its driver
+    /// and lost its recording hook.
     pub fn dashboard_subscription_snapshot(&self) -> Vec<SubscribedContractSnapshot> {
         let now = self.time_source.now();
         let mut snapshot: Vec<SubscribedContractSnapshot> = self
@@ -1500,11 +1500,10 @@ mod tests {
         assert!(subscribed.contains(&c3));
     }
 
-    /// Pins the dashboard contract: `subscribe(...)` must be visible in
-    /// `dashboard_subscription_snapshot()` immediately, with no separate
-    /// recording call. The previous parallel `network_status` mirror
-    /// silently drifted when SUBSCRIBE migrated to the task-per-tx driver
-    /// (PR #3806 → #3981); this test prevents the regression.
+    /// Pin: `subscribe(...)` must be visible in
+    /// `dashboard_subscription_snapshot()` immediately. The
+    /// previous parallel `network_status` mirror silently drifted
+    /// after the SUBSCRIBE migration (PR #3806 → #3981).
     #[tokio::test]
     async fn dashboard_snapshot_reflects_active_subscriptions() {
         let manager = HostingManager::new();

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -240,14 +240,10 @@ pub(crate) struct NetEventLog<'a> {
     kind: EventKind,
 }
 
-// `get_failure`, `get_success`, `get_forwarding_ack_*` constructors retired
-// alongside the legacy GET state machine in #1454 phase 5 final (GET
-// slice). The task-per-tx driver does not emit these `NetEventLog`
-// variants — telemetry has migrated to `record_get_access` /
-// `mark_local_client_access` and operator-facing tracing spans. The
-// constructors are kept for symmetry with the surviving PUT/UPDATE/
-// SUBSCRIBE/CONNECT counterparts and as reference for any future
-// re-introduction of GET-specific event-log variants.
+// GET telemetry migrated to `record_get_access` /
+// `mark_local_client_access` and operator-facing tracing spans;
+// these `NetEventLog` constructors are no longer emitted but kept
+// for symmetry with the surviving counterparts.
 #[allow(dead_code)]
 impl<'a> NetEventLog<'a> {
     /// Safely get the peer_id from the ring's connection manager.

--- a/docs/architecture/operations/README.md
+++ b/docs/architecture/operations/README.md
@@ -117,14 +117,11 @@ stateDiagram-v2
     Finished : stored successfully
 ```
 
-**Note:** Since #1454 Phase 3a, PUT originators no longer transition
-through a `PrepareRequest` state — the task-per-transaction driver
+**Note:** The originator driver
 (`operations/put/op_ctx_task.rs::start_client_put`) constructs the
-`Request` message and registers the op directly in `AwaitingResponse`.
-Relay PUTs (inbound `Request`/`RequestStreaming` from peers) are
-driven by `start_relay_put` / `start_relay_put_streaming` without
-materializing an `AwaitingResponse` state at all — the driver bubbles
-the upstream `Response` when the downstream ack arrives.
+`Request` directly; there is no `PrepareRequest` state. Relay PUTs
+(`start_relay_put` / `start_relay_put_streaming`) bubble the
+upstream `Response` when the downstream ack arrives.
 
 **Key features:**
 - Hop-by-hop routing toward contract location


### PR DESCRIPTION
## Problem

The #1454 async-tx migration is complete: every op runs on
task-per-tx drivers; the legacy
`OpManager.ops.{get,put,update,subscribe}` DashMaps are gone. But
~550 source comments still carry phase/PR/slice annotations that
described *how we got here*. They no longer pin invariants — they
narrate a transition that finished.

## Solution

Drop the phase scaffolding; keep the load-bearing reasoning.

- Inline doc comments and code annotations collapse from \"how we
  got here\" to \"what the code does now\". Cache-race notes,
  channel-capacity contracts, dedup-gate rationale, originator-
  loopback exceptions stay — only the phase tags are stripped.
- \`.claude/rules/operations.md\` rewritten from a 360-line phase
  changelog into a current-state guide: execution model, dispatch
  pattern, initialize-before-send invariant, surviving state-
  machine / sub-op / streaming / transaction rules.
- \`crates/core/CLAUDE.md\` operations table compressed: per-
  driver entry-point list survives; per-phase retirement narrative
  is gone.
- Stale log-decoration strings like \`(task-per-tx)\` (predated
  migration completion) removed.

Structural pin tests keep their guardrails; only the historical
narrative around them is trimmed.

\`-1262\` net LoC.

## Testing

- \`cargo fmt\`
- \`cargo clippy --all-targets -- -D warnings\` (clean)
- \`cargo test -p freenet --lib --features testing\` (2473 passed,
  14 ignored)

## Fixes

None — pure documentation/comment cleanup. Closes the followup
item from issue #1454's phase-6 sweep.