### PR TITLE
feat(secrets): list_snapshots / restore_snapshot APIs for delegate secrets

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -125,8 +125,10 @@ pub mod dev_tool {
         register_topology_snapshot, set_current_network_name, validate_topology,
         validate_topology_from_snapshots,
     };
+    pub use wasm_runtime::secret_snapshots::SnapshotMetadata;
     pub use wasm_runtime::{
-        ContractStore, DelegateStore, MockStateStorage, Runtime, SecretsStore, StateStore,
+        ContractStore, DelegateStore, MockStateStorage, Runtime, SecretStoreError, SecretsStore,
+        StateStore,
     };
 
     // Re-export simulation types for test infrastructure

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -8,7 +8,7 @@ mod error;
 pub(crate) mod mock_state_storage;
 mod native_api;
 mod runtime;
-mod secret_snapshots;
+pub mod secret_snapshots;
 mod secrets_store;
 pub(crate) mod simulation_runtime;
 mod state_store;
@@ -27,8 +27,7 @@ pub(crate) use native_api::{
 };
 pub use runtime::{ContractExecError, DEFAULT_MODULE_CACHE_CAPACITY, Runtime};
 pub(crate) use runtime::{RuntimeConfig, SharedModuleCache};
-pub(crate) use secrets_store::SecretStoreError;
-pub use secrets_store::SecretsStore;
+pub use secrets_store::{SecretStoreError, SecretsStore};
 // NOTE: InMemoryContractStore and SimulationStores are available but currently unused
 // They provide infrastructure for more sophisticated simulation scenarios
 #[allow(unused_imports)]

--- a/crates/core/src/wasm_runtime/secret_snapshots.rs
+++ b/crates/core/src/wasm_runtime/secret_snapshots.rs
@@ -49,6 +49,19 @@ pub struct RetentionBucket {
     pub max_count: usize,
 }
 
+/// On-disk descriptor for a single snapshot, surfaced through the
+/// list/restore API. The pair `(timestamp_ms, suffix)` is unique within
+/// a snapshot directory and is what `SecretsStore::restore_snapshot`
+/// matches against. `path` and `size_bytes` are advisory metadata for
+/// callers (CLI display, sanity checks).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotMetadata {
+    pub timestamp_ms: u64,
+    pub suffix: Option<u32>,
+    pub path: PathBuf,
+    pub size_bytes: u64,
+}
+
 /// Tiered retention policy. The first `keep_last` snapshots (by recency) are
 /// kept regardless of bucket coverage; each bucket independently selects
 /// representatives at its own granularity; and `max_age` is an absolute
@@ -264,11 +277,69 @@ pub fn thin_snapshots(snap_dir: &Path, policy: &RetentionPolicy, now: SystemTime
     }
 }
 
+/// Enumerate snapshots in `snap_dir`, sorted oldest-first.
+///
+/// Filenames that don't parse as `{digits}` or `{digits}.{digits}` and
+/// non-regular-file entries are silently skipped (same rule that
+/// [`thin_snapshots`] applies). I/O errors reading the directory or any
+/// individual file are returned to the caller; this is a read-only
+/// operation and the caller (CLI, restore) needs to know if the disk
+/// is misbehaving.
+///
+/// Returns an empty vector if `snap_dir` does not exist — a never-written
+/// secret simply has no history, which is not an error.
+pub fn list_snapshots(snap_dir: &Path) -> std::io::Result<Vec<SnapshotMetadata>> {
+    let read_dir = match fs::read_dir(snap_dir) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
+    let mut out: Vec<SnapshotMetadata> = Vec::new();
+    for entry in read_dir {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if !file_type.is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let Some((timestamp_ms, suffix)) = parse_snapshot_name(&path) else {
+            continue;
+        };
+        let size_bytes = entry.metadata()?.len();
+        out.push(SnapshotMetadata {
+            timestamp_ms,
+            suffix,
+            path,
+            size_bytes,
+        });
+    }
+    // Sort key: `None` sorts before `Some(_)` (unsuffixed file came first
+    // chronologically — it's the write that landed on a fresh stamp; the
+    // suffixed variants came from later same-millisecond collisions).
+    out.sort_by_key(|m| {
+        (
+            m.timestamp_ms,
+            match m.suffix {
+                None => (0u8, 0u32),
+                Some(s) => (1, s),
+            },
+        )
+    });
+    Ok(out)
+}
+
 /// Parse a snapshot file name back into its epoch-millis timestamp.
 /// Accepts only `{digits}` or `{digits}.{digits}`; any other shape
 /// (including `42.tmp`, `foo`, `1.2.3`, etc.) returns `None` so stray
 /// files in the snapshot directory are not mistaken for snapshots.
 pub(crate) fn parse_snapshot_stamp(path: &Path) -> Option<u64> {
+    parse_snapshot_name(path).map(|(ts, _)| ts)
+}
+
+/// Like [`parse_snapshot_stamp`] but also returns the optional numeric
+/// collision suffix. Surfaced through [`SnapshotMetadata`] so callers
+/// can disambiguate multiple writes that landed in the same millisecond.
+pub(crate) fn parse_snapshot_name(path: &Path) -> Option<(u64, Option<u32>)> {
     let name = path.file_name()?.to_str()?;
     let (stamp_part, suffix_part) = match name.split_once('.') {
         Some((s, t)) => (s, Some(t)),
@@ -277,12 +348,16 @@ pub(crate) fn parse_snapshot_stamp(path: &Path) -> Option<u64> {
     if stamp_part.is_empty() || !stamp_part.bytes().all(|b| b.is_ascii_digit()) {
         return None;
     }
-    if let Some(suffix) = suffix_part
-        && (suffix.is_empty() || !suffix.bytes().all(|b| b.is_ascii_digit()))
-    {
-        return None;
-    }
-    stamp_part.parse().ok()
+    let suffix = match suffix_part {
+        Some(s) => {
+            if s.is_empty() || !s.bytes().all(|b| b.is_ascii_digit()) {
+                return None;
+            }
+            Some(s.parse().ok()?)
+        }
+        None => None,
+    };
+    Some((stamp_part.parse().ok()?, suffix))
 }
 
 #[cfg(test)]
@@ -538,5 +613,80 @@ mod tests {
         let now = SystemTime::now();
         let ts: Vec<_> = (0..10).map(|i| t(now, i)).collect();
         assert!(p.select_keep(now, &ts).is_empty());
+    }
+
+    #[test]
+    fn parse_snapshot_name_returns_suffix() {
+        use std::path::PathBuf;
+        assert_eq!(
+            parse_snapshot_name(&PathBuf::from("00000000000001234567")),
+            Some((1_234_567, None))
+        );
+        assert_eq!(
+            parse_snapshot_name(&PathBuf::from("00000000000001234567.42")),
+            Some((1_234_567, Some(42)))
+        );
+        // Same garbage cases as parse_snapshot_stamp must still reject.
+        assert_eq!(parse_snapshot_name(&PathBuf::from("foo")), None);
+        assert_eq!(parse_snapshot_name(&PathBuf::from("123.tmp")), None);
+        assert_eq!(parse_snapshot_name(&PathBuf::from("123.4.5")), None);
+        // Suffix that overflows u32 must be rejected (the on-disk format
+        // caps at MAX_SNAPSHOT_COLLISION_SUFFIX, so a 12-digit suffix is
+        // never a snapshot we wrote).
+        assert_eq!(
+            parse_snapshot_name(&PathBuf::from("123.999999999999")),
+            None
+        );
+    }
+
+    #[test]
+    fn list_snapshots_returns_sorted_metadata() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Write three snapshots out of order and a couple of stray files
+        // that must be filtered out.
+        for (stamp, body) in [
+            (20u64, &b"newest"[..]),
+            (5, &b"older"[..]),
+            (10, &b"mid"[..]),
+        ] {
+            std::fs::write(
+                dir.path()
+                    .join(format!("{stamp:0width$}", width = SNAPSHOT_NAME_WIDTH)),
+                body,
+            )
+            .unwrap();
+        }
+        std::fs::write(dir.path().join("README"), b"not a snapshot").unwrap();
+        std::fs::write(dir.path().join("123.tmp"), b"not a snapshot").unwrap();
+
+        let entries = list_snapshots(dir.path()).expect("list");
+        let stamps: Vec<u64> = entries.iter().map(|m| m.timestamp_ms).collect();
+        assert_eq!(stamps, vec![5, 10, 20], "must be sorted oldest-first");
+        assert_eq!(entries[0].size_bytes, 5, "size_bytes wired up");
+        assert!(entries.iter().all(|m| m.suffix.is_none()));
+    }
+
+    #[test]
+    fn list_snapshots_orders_collision_suffixes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let stamp = 42u64;
+        let base = format!("{stamp:0width$}", width = SNAPSHOT_NAME_WIDTH);
+        // Unsuffixed and two collision suffixes — must come out in
+        // (timestamp, suffix) order with `None` first.
+        std::fs::write(dir.path().join(&base), b"a").unwrap();
+        std::fs::write(dir.path().join(format!("{base}.1")), b"bb").unwrap();
+        std::fs::write(dir.path().join(format!("{base}.0")), b"ccc").unwrap();
+
+        let entries = list_snapshots(dir.path()).expect("list");
+        let suffixes: Vec<Option<u32>> = entries.iter().map(|m| m.suffix).collect();
+        assert_eq!(suffixes, vec![None, Some(0), Some(1)]);
+    }
+
+    #[test]
+    fn list_snapshots_missing_dir_is_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("never-existed");
+        let entries = list_snapshots(&missing).expect("missing dir is not an error");
+        assert!(entries.is_empty());
     }
 }

--- a/crates/core/src/wasm_runtime/secret_snapshots.rs
+++ b/crates/core/src/wasm_runtime/secret_snapshots.rs
@@ -281,13 +281,16 @@ pub fn thin_snapshots(snap_dir: &Path, policy: &RetentionPolicy, now: SystemTime
 ///
 /// Filenames that don't parse as `{digits}` or `{digits}.{digits}` and
 /// non-regular-file entries are silently skipped (same rule that
-/// [`thin_snapshots`] applies). I/O errors reading the directory or any
-/// individual file are returned to the caller; this is a read-only
-/// operation and the caller (CLI, restore) needs to know if the disk
-/// is misbehaving.
+/// [`thin_snapshots`] applies).
 ///
-/// Returns an empty vector if `snap_dir` does not exist — a never-written
+/// Returns an empty vector if `snap_dir` does not exist: a never-written
 /// secret simply has no history, which is not an error.
+///
+/// # Errors
+/// Surfaces every I/O error from enumerating the directory or stat'ing
+/// individual entries. This is a read-only operation and the caller
+/// (CLI, restore) needs to know if the disk is misbehaving rather than
+/// silently truncating the listing.
 pub fn list_snapshots(snap_dir: &Path) -> std::io::Result<Vec<SnapshotMetadata>> {
     let read_dir = match fs::read_dir(snap_dir) {
         Ok(rd) => rd,

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -21,7 +21,8 @@ use crate::contract::storages::Storage;
 
 use super::RuntimeResult;
 use super::secret_snapshots::{
-    RetentionPolicy, next_snapshot_path, snapshot_dir_for, thin_snapshots,
+    RetentionPolicy, SnapshotMetadata, list_snapshots, next_snapshot_path, snapshot_dir_for,
+    thin_snapshots,
 };
 
 /// Environment variable that disables snapshot-on-write for delegate secrets.
@@ -41,6 +42,8 @@ pub enum SecretStoreError {
     MissingCipher,
     #[error("missing secret: {0}")]
     MissingSecret(SecretsId),
+    #[error("no snapshot for secret {key} at timestamp_ms {timestamp_ms}")]
+    SnapshotNotFound { key: SecretsId, timestamp_ms: u64 },
 }
 
 #[derive(Clone)]
@@ -368,6 +371,143 @@ impl SecretsStore {
                 }
             })?;
         Ok(plaintext)
+    }
+
+    /// Enumerate the snapshot history for a given `(delegate, secret_id)`
+    /// pair, oldest-first. Returns an empty vector if the secret was never
+    /// overwritten (no snapshot directory exists). Does not decrypt;
+    /// callers that want the plaintext can `restore_snapshot` and then
+    /// `get_secret`.
+    pub fn list_snapshots(
+        &self,
+        delegate: &DelegateKey,
+        key: &SecretsId,
+    ) -> Result<Vec<SnapshotMetadata>, SecretStoreError> {
+        let delegate_path = self.base_path.join(delegate.encode());
+        let snap_dir = snapshot_dir_for(&delegate_path, key);
+        Ok(list_snapshots(&snap_dir)?)
+    }
+
+    /// Promote a previously-captured snapshot back to the active path.
+    ///
+    /// Mirrors the durability discipline of `store_secret`: the current
+    /// active value (if any) is snapshotted first (so restore is itself
+    /// reversible), then the chosen snapshot is copied to a `.tmp` file,
+    /// fsynced, and atomically renamed onto the active path. The ReDb
+    /// index and in-memory cache are updated last so a crash between the
+    /// rename and the index update still leaves the active value
+    /// readable on the next `get_secret`.
+    ///
+    /// If multiple snapshots share `timestamp_ms` (collision suffixes
+    /// from same-millisecond writes), the unsuffixed file wins; absent
+    /// that, the lowest-numbered suffix wins. To restore a specific
+    /// collision-suffix entry, callers can use [`list_snapshots`] and
+    /// pick the entry's `path` directly (a future API may take
+    /// `SnapshotMetadata` directly).
+    ///
+    /// Does NOT require the delegate's cipher to be registered — restore
+    /// is byte-level copy, not re-encryption. The restored ciphertext
+    /// remains decryptable by whatever cipher wrote it.
+    ///
+    /// # Errors
+    /// - `SnapshotNotFound` if no snapshot matches `timestamp_ms`
+    /// - `IO` for filesystem errors during the copy / rename / fsync
+    pub fn restore_snapshot(
+        &mut self,
+        delegate: &DelegateKey,
+        key: &SecretsId,
+        timestamp_ms: u64,
+    ) -> Result<(), SecretStoreError> {
+        let delegate_path = self.base_path.join(delegate.encode());
+        let secret_file_path = delegate_path.join(key.encode());
+        let snap_dir = snapshot_dir_for(&delegate_path, key);
+
+        // Find the requested snapshot. Disambiguation rule: unsuffixed
+        // file wins, then lowest-numbered suffix. `list_snapshots`
+        // already sorts by (timestamp_ms, suffix.unwrap_or(0)), and
+        // `None` < `Some(_)` is encoded via that 0-default — fine because
+        // collision suffixes start at 0, so the unsuffixed entry sorts
+        // alongside `.0`; we explicitly prefer unsuffixed below.
+        let entries = list_snapshots(&snap_dir)?;
+        let chosen = entries
+            .iter()
+            .filter(|m| m.timestamp_ms == timestamp_ms)
+            .min_by_key(|m| match m.suffix {
+                None => (0u32, 0u32),
+                Some(s) => (1, s),
+            })
+            .ok_or_else(|| SecretStoreError::SnapshotNotFound {
+                key: key.clone(),
+                timestamp_ms,
+            })?;
+        let chosen_path = chosen.path.clone();
+
+        // Snapshot the value currently at the active path so the restore
+        // operation is itself reversible. Mirrors store_secret's
+        // best-effort logging — the primary operation (restore) must
+        // not fail just because we couldn't preserve the value being
+        // replaced.
+        if self.snapshots_enabled
+            && secret_file_path.exists()
+            && let Err(e) = self.snapshot_prior_value(&delegate_path, key, &secret_file_path)
+        {
+            tracing::warn!(
+                "failed to snapshot active value before restore for delegate {}: {e}",
+                delegate.encode()
+            );
+        }
+
+        // Read snapshot ciphertext, write through a sibling tmp file with
+        // an atomic rename so the active path never tears. `&mut self`
+        // makes concurrent in-process restore impossible; a stale `.tmp`
+        // from a prior crashed run gets overwritten harmlessly here.
+        let ciphertext = fs::read(&chosen_path)?;
+        fs::create_dir_all(&delegate_path)?;
+        let tmp_path = secret_file_path.with_extension("tmp");
+        {
+            let mut file = File::create(&tmp_path)?;
+            file.write_all(&ciphertext)?;
+            file.sync_all()?;
+        }
+        if let Err(err) = fs::rename(&tmp_path, &secret_file_path) {
+            if let Err(rm_err) = fs::remove_file(&tmp_path) {
+                tracing::debug!(
+                    "failed to clean up tmp file {tmp_path:?} after rename failure: {rm_err}"
+                );
+            }
+            return Err(err.into());
+        }
+
+        // Index update: only needed if the entry was previously removed
+        // (e.g. user called `remove_secret` then realized they wanted a
+        // value back). In the common case the secret is already in the
+        // index and the write below is idempotent.
+        let secret_key = *key.hash();
+        let mut current_secrets: Vec<[u8; 32]> = self
+            .key_to_secret_part
+            .get(delegate)
+            .map(|entry| entry.value().iter().copied().collect())
+            .unwrap_or_default();
+        if !current_secrets.contains(&secret_key) {
+            current_secrets.push(secret_key);
+            self.db
+                .store_secrets_index(delegate, &current_secrets)
+                .map_err(|e| {
+                    std::io::Error::other(format!("Failed to update secrets index: {e}"))
+                })?;
+            let secret_set: HashSet<SecretKey> = current_secrets.into_iter().collect();
+            self.key_to_secret_part.insert(delegate.clone(), secret_set);
+        }
+
+        // Best-effort thin: we may have just doubled the snapshot count
+        // (active-value snapshot above). Failures here only mean we keep
+        // more snapshots than the policy targets, self-correcting on the
+        // next write.
+        if self.snapshots_enabled && snap_dir.exists() {
+            thin_snapshots(&snap_dir, &self.retention, SystemTime::now());
+        }
+
+        Ok(())
     }
 }
 
@@ -751,6 +891,229 @@ mod test {
         assert!(
             !snap_dir.exists(),
             "no snapshot should exist after a single write"
+        );
+        Ok(())
+    }
+
+    /// list_snapshots on a never-written secret returns an empty Vec (not an
+    /// error). This mirrors `next_snapshot_path` + the missing-dir branch of
+    /// `list_snapshots` in secret_snapshots.rs.
+    #[tokio::test]
+    async fn list_snapshots_on_unwritten_secret_is_empty() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let delegate = Delegate::from((&vec![20].into(), &vec![].into()));
+        let secret_id = SecretsId::new(vec![21]);
+
+        let snaps = store.list_snapshots(delegate.key(), &secret_id)?;
+        assert!(snaps.is_empty(), "no writes → no snapshots");
+        Ok(())
+    }
+
+    /// list_snapshots returns each snapshot, oldest-first, with the right
+    /// timestamp_ms. After two overwrites we should see two snapshots
+    /// (the v1 cipher → snapshot from the v2 write, and the v2 cipher →
+    /// snapshot from the v3 write).
+    #[tokio::test]
+    async fn list_snapshots_returns_history() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let delegate = Delegate::from((&vec![30].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![31]);
+
+        store.store_secret(delegate.key(), &secret_id, b"v1".to_vec())?;
+        std::thread::sleep(Duration::from_millis(5));
+        store.store_secret(delegate.key(), &secret_id, b"v2".to_vec())?;
+        std::thread::sleep(Duration::from_millis(5));
+        store.store_secret(delegate.key(), &secret_id, b"v3".to_vec())?;
+
+        let snaps = store.list_snapshots(delegate.key(), &secret_id)?;
+        assert_eq!(snaps.len(), 2, "expected two snapshots after 3 writes");
+        assert!(
+            snaps[0].timestamp_ms <= snaps[1].timestamp_ms,
+            "must be oldest-first"
+        );
+        Ok(())
+    }
+
+    /// Happy-path restore: after writing v1 and v2, restoring v1's snapshot
+    /// must put v1 back at the active path. The snapshot taken before the
+    /// restore preserves v2 so the operation is reversible.
+    #[tokio::test]
+    async fn restore_snapshot_replaces_active_value() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let delegate = Delegate::from((&vec![40].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![41]);
+
+        store.store_secret(delegate.key(), &secret_id, b"v1".to_vec())?;
+        std::thread::sleep(Duration::from_millis(5));
+        store.store_secret(delegate.key(), &secret_id, b"v2".to_vec())?;
+
+        // Confirm active = v2.
+        assert_eq!(
+            store.get_secret(delegate.key(), &secret_id)?,
+            b"v2".to_vec()
+        );
+
+        // Pick the (only) snapshot — it holds the v1 ciphertext.
+        let snaps = store.list_snapshots(delegate.key(), &secret_id)?;
+        assert_eq!(snaps.len(), 1);
+        let v1_ts = snaps[0].timestamp_ms;
+
+        store.restore_snapshot(delegate.key(), &secret_id, v1_ts)?;
+
+        assert_eq!(
+            store.get_secret(delegate.key(), &secret_id)?,
+            b"v1".to_vec(),
+            "restore must put the v1 plaintext back"
+        );
+
+        // After restore there must be a snapshot of v2 (the value that was
+        // replaced) so the operation is reversible.
+        let snaps_after = store.list_snapshots(delegate.key(), &secret_id)?;
+        assert!(
+            !snaps_after.is_empty(),
+            "restore must snapshot the prior active value; got {} snapshots",
+            snaps_after.len()
+        );
+        Ok(())
+    }
+
+    /// Restoring an unknown timestamp must return SnapshotNotFound, not a
+    /// generic IO error, so the CLI can give a precise message.
+    #[tokio::test]
+    async fn restore_snapshot_unknown_timestamp_errors() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let delegate = Delegate::from((&vec![50].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![51]);
+
+        store.store_secret(delegate.key(), &secret_id, b"a".to_vec())?;
+        std::thread::sleep(Duration::from_millis(5));
+        store.store_secret(delegate.key(), &secret_id, b"b".to_vec())?;
+
+        let err = store
+            .restore_snapshot(delegate.key(), &secret_id, 0)
+            .expect_err("timestamp 0 should not exist");
+        match err {
+            SecretStoreError::SnapshotNotFound { timestamp_ms, .. } => {
+                assert_eq!(timestamp_ms, 0);
+            }
+            SecretStoreError::Encryption(_)
+            | SecretStoreError::IO(_)
+            | SecretStoreError::MissingCipher
+            | SecretStoreError::MissingSecret(_) => {
+                panic!("expected SnapshotNotFound, got {err:?}");
+            }
+        }
+        Ok(())
+    }
+
+    /// Restore after remove_secret must re-add the entry to the ReDb index
+    /// and the in-memory map. Without this, `get_secret` would return the
+    /// restored value but the secret would be invisible to delegate code
+    /// that iterates the index.
+    #[tokio::test]
+    async fn restore_after_remove_repopulates_index() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+
+        let delegate = Delegate::from((&vec![60].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![61]);
+
+        store.store_secret(delegate.key(), &secret_id, b"keep".to_vec())?;
+        std::thread::sleep(Duration::from_millis(5));
+        store.store_secret(delegate.key(), &secret_id, b"overwrite".to_vec())?;
+
+        // Grab the snapshot stamp BEFORE removing the secret. `remove_secret`
+        // also deletes the snapshot directory, so we need the timestamp now.
+        let snaps = store.list_snapshots(delegate.key(), &secret_id)?;
+        assert_eq!(snaps.len(), 1);
+        let prior_ts = snaps[0].timestamp_ms;
+
+        // Now copy the snapshot ciphertext aside so we can replay it after
+        // `remove_secret` wipes the .snapshots dir. This simulates an
+        // operator backing up the snapshot file before deletion.
+        let snap_src = snaps[0].path.clone();
+        let snap_backup = temp_dir.path().join("backup-snapshot");
+        std::fs::copy(&snap_src, &snap_backup)?;
+
+        store.remove_secret(delegate.key(), &secret_id)?;
+
+        // Re-stage the saved snapshot at the same on-disk location so the
+        // restore code can find it.
+        let snap_dir = secrets_dir
+            .join(delegate.key().encode())
+            .join(".snapshots")
+            .join(secret_id.encode());
+        std::fs::create_dir_all(&snap_dir)?;
+        std::fs::copy(&snap_backup, snap_src)?;
+
+        // Confirm pre-condition: index does NOT contain the secret yet.
+        let secret_hash = *secret_id.hash();
+        let in_mem_before = store
+            .key_to_secret_part
+            .get(delegate.key())
+            .map(|e| e.value().contains(&secret_hash))
+            .unwrap_or(false);
+        assert!(!in_mem_before, "index should be empty after remove_secret");
+
+        store.restore_snapshot(delegate.key(), &secret_id, prior_ts)?;
+
+        // Post-condition: index contains the secret again AND get_secret
+        // returns the restored value.
+        let post_index = store
+            .db
+            .get_secrets_index(delegate.key())
+            .expect("index lookup")
+            .unwrap_or_default();
+        assert!(
+            post_index.contains(&secret_hash),
+            "ReDb index must re-include the restored secret"
+        );
+        let in_mem_after = store
+            .key_to_secret_part
+            .get(delegate.key())
+            .map(|e| e.value().contains(&secret_hash))
+            .unwrap_or(false);
+        assert!(
+            in_mem_after,
+            "in-memory map must re-include the restored secret"
+        );
+        // The snapshot was taken when "overwrite" was written, but it
+        // holds the PRIOR active value at that point — "keep".
+        assert_eq!(
+            store.get_secret(delegate.key(), &secret_id)?,
+            b"keep".to_vec()
         );
         Ok(())
     }

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -42,6 +42,11 @@ pub enum SecretStoreError {
     MissingCipher,
     #[error("missing secret: {0}")]
     MissingSecret(SecretsId),
+    /// No snapshot file matched the requested `timestamp_ms` in the
+    /// secret's `.snapshots/{secret_id}/` directory. Distinct from
+    /// `IO`/`MissingSecret` so the CLI (issue #4036) can surface a
+    /// "no such snapshot, try `list_snapshots` first" message instead
+    /// of a generic filesystem error.
     #[error("no snapshot for secret {key} at timestamp_ms {timestamp_ms}")]
     SnapshotNotFound { key: SecretsId, timestamp_ms: u64 },
 }
@@ -441,7 +446,6 @@ impl SecretsStore {
                 timestamp_ms,
             })?;
         let chosen_path = chosen.path.clone();
-
         // Snapshot the value currently at the active path so the restore
         // operation is itself reversible. Mirrors store_secret's
         // best-effort logging — the primary operation (restore) must
@@ -506,7 +510,6 @@ impl SecretsStore {
         if self.snapshots_enabled && snap_dir.exists() {
             thin_snapshots(&snap_dir, &self.retention, SystemTime::now());
         }
-
         Ok(())
     }
 }
@@ -1110,10 +1113,92 @@ mod test {
             "in-memory map must re-include the restored secret"
         );
         // The snapshot was taken when "overwrite" was written, but it
-        // holds the PRIOR active value at that point — "keep".
+        // holds the PRIOR active value at that point: "keep".
         assert_eq!(
             store.get_secret(delegate.key(), &secret_id)?,
             b"keep".to_vec()
+        );
+        Ok(())
+    }
+
+    /// When multiple snapshots share `timestamp_ms` (collision suffixes
+    /// from same-millisecond writes), `restore_snapshot` MUST pick the
+    /// unsuffixed file first, then the lowest-numbered suffix. Documented
+    /// as a behavioral contract on the public method, so pin it directly
+    /// rather than relying on the list-side ordering test.
+    #[tokio::test]
+    async fn restore_snapshot_prefers_unsuffixed_collision()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use crate::wasm_runtime::secret_snapshots::SNAPSHOT_NAME_WIDTH;
+
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+        // Permissive retention so thin_snapshots doesn't drop the
+        // hand-crafted ancient-timestamped files between restore calls.
+        store.set_retention_policy(RetentionPolicy {
+            keep_last: 100,
+            buckets: vec![],
+            max_age: None,
+        });
+
+        let delegate = Delegate::from((&vec![70].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![71]);
+
+        // Seed an active value so restore has something to overwrite (and
+        // can take its own pre-restore snapshot). The plaintext doesn't
+        // matter for this test; we compare ciphertext after restore.
+        store.store_secret(delegate.key(), &secret_id, b"active".to_vec())?;
+
+        // Hand-craft three "same timestamp" snapshot files with distinct
+        // ciphertexts, so we can identify which one wins. We do the file
+        // surgery directly instead of going through store_secret because
+        // we need the collision case, which the natural-write path only
+        // hits under extreme contention.
+        let snap_dir = secrets_dir
+            .join(delegate.key().encode())
+            .join(".snapshots")
+            .join(secret_id.encode());
+        std::fs::create_dir_all(&snap_dir)?;
+        let stamp = 1_700_000_000_000u64;
+        let base = format!("{stamp:0width$}", width = SNAPSHOT_NAME_WIDTH);
+        // Encrypt three distinguishable plaintexts with the registered
+        // cipher and write the ciphertexts as the three "collision"
+        // snapshots. After restore + get_secret we identify the winner
+        // by the recovered plaintext.
+        let encryption = store
+            .ciphers
+            .get(delegate.key())
+            .expect("cipher registered");
+        let mk = |pt: &[u8]| -> Vec<u8> {
+            encryption
+                .cipher
+                .encrypt(&encryption.nonce, pt)
+                .expect("encrypt")
+        };
+        std::fs::write(snap_dir.join(&base), mk(b"unsuffixed-winner"))?;
+        std::fs::write(snap_dir.join(format!("{base}.0")), mk(b"suffix-0"))?;
+        std::fs::write(snap_dir.join(format!("{base}.1")), mk(b"suffix-1"))?;
+
+        store.restore_snapshot(delegate.key(), &secret_id, stamp)?;
+        assert_eq!(
+            store.get_secret(delegate.key(), &secret_id)?,
+            b"unsuffixed-winner".to_vec(),
+            "unsuffixed file must win the collision tiebreak"
+        );
+
+        // Now remove the unsuffixed entry and restore again: lowest
+        // surviving suffix wins.
+        std::fs::remove_file(snap_dir.join(&base))?;
+        store.restore_snapshot(delegate.key(), &secret_id, stamp)?;
+        assert_eq!(
+            store.get_secret(delegate.key(), &secret_id)?,
+            b"suffix-0".to_vec(),
+            "with the unsuffixed entry gone, lowest-numbered suffix wins"
         );
         Ok(())
     }


### PR DESCRIPTION
## Problem

#4034 captures snapshots before every overwrite, but there is no API to actually restore one. Users would have to manually move files in `.snapshots/{secret_id}/` over the active path.

## Solution

Two new public methods on `SecretsStore`:

- `list_snapshots(delegate, key) -> Vec<SnapshotMetadata>` — read-only enumeration, oldest first. Empty Vec on a never-written secret (not an error).
- `restore_snapshot(delegate, key, timestamp_ms)` — atomic rename + fsync through the same path `store_secret` uses, plus a fresh pre-restore snapshot of the value being replaced (restore is itself reversible). Re-populates the ReDb index + in-memory map if a prior `remove_secret` had cleared them.

`SecretStoreError::SnapshotNotFound { key, timestamp_ms }` is a new typed variant so the future CLI can give a precise message instead of a generic IO error.

No decryption on restore: snapshots are ciphertext written by the delegate's own cipher and remain decryptable by `get_secret`. That makes restore usable even when the cipher hasn't been registered yet (recovery scenario where the user re-registers and then rolls a value back).

CLI work split per the issue's own guidance ("User-facing recovery UX has its own design questions ... worth its own review cycle"). Re-exports `SnapshotMetadata` + `SecretStoreError` through `freenet::dev_tool` so the CLI lands as a stacked PR on top of this one.

## Testing

- 5 new SecretsStore-level tests (`list_snapshots_on_unwritten_secret_is_empty`, `list_snapshots_returns_history`, `restore_snapshot_replaces_active_value`, `restore_snapshot_unknown_timestamp_errors`, `restore_after_remove_repopulates_index`).
- 4 new `secret_snapshots` tests (`parse_snapshot_name_returns_suffix`, `list_snapshots_returns_sorted_metadata`, `list_snapshots_orders_collision_suffixes`, `list_snapshots_missing_dir_is_empty`).
- One of those caught an actual sort-key bug: `(timestamp_ms, suffix.unwrap_or(0))` collapses `None` with `Some(0)`, so test_list_snapshots_orders_collision_suffixes initially failed. Fixed by explicit `None < Some(_)` ordering.
- `cargo clippy -p freenet --lib --tests -- -D warnings` clean.
- All 209 `wasm_runtime::*` tests pass on this branch.

## Stacked

This PR targets `feat/delegate-snapshots` (PR #4034). Merge that one first, then rebase this onto main.

Refs #4036

[AI-assisted - Claude]