### PR TITLE
docs: fix stale ops.{put,update,subscribe} rustdoc refs

### DIFF
--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1,8 +1,9 @@
 //! Task-per-transaction PUT drivers.
 //!
 //! Each entry point — client-initiated, relay non-streaming, relay
-//! streaming — owns routing state in task locals. No `PutOp` is
-//! pushed into `OpManager.ops.put`.
+//! streaming — owns routing state in task locals. There is no
+//! `ops.put` DashMap; per-node dedup is enforced via
+//! `OpManager.active_relay_put_txs`.
 //!
 //! # Client-initiated flow
 //!
@@ -557,10 +558,9 @@ pub static RELAY_PUT_DEDUP_REJECTS: std::sync::atomic::AtomicUsize =
 /// Spawn a relay driver for a fresh inbound non-streaming `PutMsg::Request`.
 ///
 /// Gated by the dispatch site in `node.rs::handle_pure_network_message_v1`
-/// on `source_addr.is_some() && !has_put_op(id)`. The driver owns local
-/// store + optional downstream forward + upstream bubble-up in its task
-/// locals — no `PutOp` is stored in `OpManager.ops.put` for this
-/// transaction.
+/// on `source_addr.is_some()`. Per-node dedup against concurrent inbound
+/// retries is enforced by `OpManager.active_relay_put_txs` inside the
+/// driver. State lives in task locals.
 ///
 /// Returns immediately after spawning. Driver publishes its own side
 /// effects (local put_contract / host_contract / interest broadcast,
@@ -2392,9 +2392,10 @@ mod tests {
         );
     }
 
-    /// Pin: driver forward must reuse `incoming_tx` — legacy PUT relay
+    /// Pin: driver forward must reuse `incoming_tx` — the PUT relay
     /// uses the same tx end-to-end. Minting a fresh tx per hop breaks
-    /// the dispatch gate's has_put_op check at the downstream peer.
+    /// the downstream peer's `active_relay_put_txs` dedup gate and
+    /// detaches the response from the originator's waiter.
     #[test]
     fn drive_relay_put_reuses_incoming_tx_on_forward() {
         let src = include_str!("op_ctx_task.rs");
@@ -2415,7 +2416,7 @@ mod tests {
         assert!(
             forward_window.contains("id: incoming_tx"),
             "relay forward must reuse incoming_tx; minting a fresh tx per hop \
-             breaks the downstream dispatch gate's has_put_op check"
+             breaks the downstream `active_relay_put_txs` dedup gate"
         );
         assert!(
             !forward_window.contains("Transaction::new::<PutMsg>()"),

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1,8 +1,9 @@
 //! Task-per-transaction SUBSCRIBE drivers.
 //!
 //! Each entry point — client-initiated, executor auto-subscribe,
-//! renewal, relay — owns its routing state in task locals. No
-//! `SubscribeOp` is pushed into `OpManager.ops.subscribe`.
+//! renewal, relay — owns its routing state in task locals. There is
+//! no `ops.subscribe` DashMap; per-node dedup is enforced via
+//! `OpManager.active_relay_subscribe_txs`.
 //!
 //! # Architecture
 //!

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -529,8 +529,9 @@ fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: Driv
 
 /// Spawn a relay driver for a fresh inbound `UpdateMsg::RequestUpdate`.
 ///
-/// Caller-side gates (in `node.rs`): `source_addr.is_some()` AND no
-/// existing `UpdateOp` in `OpManager.ops.update` for `incoming_tx`.
+/// Caller-side gates (in `node.rs`): `source_addr.is_some()`. Per-node
+/// dedup against concurrent inbound retries is enforced by
+/// `OpManager.active_relay_update_txs` inside this driver.
 ///
 /// Returns immediately after spawning. Driver publishes its own side
 /// effects (local merge → BroadcastStateChange via the executor, OR a
@@ -1208,8 +1209,9 @@ async fn drive_relay_broadcast_to(
 /// Spawn a relay driver for a fresh inbound
 /// `UpdateMsg::RequestUpdateStreaming`.
 ///
-/// Caller-side gates (in `node.rs`): `source_addr.is_some()` AND no
-/// existing `UpdateOp` in `OpManager.ops.update` for `incoming_tx`.
+/// Caller-side gates (in `node.rs`): `source_addr.is_some()`. Per-node
+/// dedup against concurrent inbound retries is enforced by
+/// `OpManager.active_relay_update_txs` inside this driver.
 pub(crate) async fn start_relay_request_update_streaming(
     op_manager: Arc<OpManager>,
     incoming_tx: Transaction,


### PR DESCRIPTION
## Problem

Started this session intending to execute the Phase 5 final UPDATE slice from \`/Users/nacho/.claude/plans/woolly-painting-russell.md\` — delete \`ops.update\` DashMap, the \`Operation\` impl, the \`UpdateContract\` executor adapter, etc. On re-auditing main, every one of those deletions had already landed in earlier PRs:

- \`ops.{get,put,update,subscribe}\` DashMaps: gone
- \`OpEnum::{Get,Put,Update,Subscribe}\`: gone
- \`impl Operation for {Get,Put,Update,Subscribe}Op\`: gone
- \`UpdateContract\` / \`ComposeNetworkMessage<UpdateOp>\` impl: gone
- \`handle_op_request::<UpdateOp>\` fallthrough: gone

Only CONNECT remains on the legacy mediator path, as documented.

What survived from the migration was a handful of rustdoc lines and pin-test comments still referencing the retired structures.

## Solution

Three call sites updated to describe the **current** dispatch invariant rather than the retired one:

- \`put/op_ctx_task.rs\` (module preamble, \`start_relay_put\` rustdoc, \`drive_relay_put_reuses_incoming_tx_on_forward\` pin)
- \`update/op_ctx_task.rs\` (\`start_relay_request_update\`, \`start_relay_request_update_streaming\` rustdoc)
- \`subscribe/op_ctx_task.rs\` (module preamble)

Net effect: the docs now say \"per-node dedup is enforced by \`active_relay_{op}_txs\`\" instead of \"no \`{Op}Op\` is pushed into \`OpManager.ops.{op}\`\" — same invariant, current vocabulary.

## Testing

- \`cargo fmt\`
- \`cargo clippy --all-targets -- -D warnings\` clean
- \`cargo test -p freenet --lib --features testing\` → 2489 passed, 14 ignored

No behavioral change. Doc-only fixes.

## Fixes

Followup to #1454; no individual issue.