### PR TITLE
chore: bump freenet-git mirror-repo.yml pin a931790 -> 8f00293

### DIFF
--- a/.github/workflows/mirror-to-freenet.yml
+++ b/.github/workflows/mirror-to-freenet.yml
@@ -40,7 +40,7 @@ jobs:
     # under this caller's secrets. Acceptable today because we control
     # crates.io publishing for that crate; if that changes, override
     # `freenet_git_version` here with a pinned semver.
-    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@a93179077a4175ac4de324fc37fe57a3679f6bc8
+    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@8f00293929f39aaee9f0ea7ab334c15856def8f6
     with:
       freenet_repo: "3GEERif5ihbf/freenet-core"
       mode: snapshot


### PR DESCRIPTION
## Summary

Bumps the SHA pin for the reusable mirror workflow from `a9317907` to `8f002939` (latest on freenet-git/main after v0.1.20).

Picks up:
- **0.1.18** `--only-current-tips` filter for snapshot-mode rescue.
- **0.1.19** parallel rescue + auto-detect `mirror-mode` contract extension. `mirror-repo.yml` now sets `FREENET_GIT_MIRROR_MODE: \${{ inputs.mode }}` on the push step, so this caller's `mode: snapshot` records `mirror-mode=snapshot` on the contract starting with the next push.
- **0.1.20** `refs/tags/*` push in history mode (#40). No effect for freenet-core (snapshot mode skips tags by design) but lands alongside everything else.
- Operational fixes: matrix routing (#39), rescue timeout (#41), self-mirror stale-tip force-push (#38).

## Effect on freenet-core mirror

Snapshot mode unchanged in behaviour — fresh orphan commit per push, force-push, no tags. The new env var means the contract will carry `mirror-mode=snapshot` on the next mirror run, which rescue auto-detects so eventually the matrix `include:` column in `freenet-git/rescue-demos.yml` can be dropped (tracked as freenet-git#48).

## Test plan

- [ ] Merge → next push to main triggers the mirror via the new pin.
- [ ] Mirror run succeeds and the helper installs freenet-git 0.1.20 from crates.io.
- [ ] `mirror-mode=snapshot` extension lands on contract `3GEERif5ihbf/freenet-core`.

[AI-assisted - Claude]