### PR TITLE
feat: auto-trigger gateway updates + announcements on release.published

### DIFF
--- a/.github/workflows/gateway-update.yml
+++ b/.github/workflows/gateway-update.yml
@@ -49,13 +49,19 @@ jobs:
     steps:
       - name: Resolve version
         id: ver
+        # Pass values via env: rather than ${{ }} interpolation — a tag
+        # name like `1.2.3"; curl evil; "` would otherwise template into
+        # the script at expression-eval time, before the regex below
+        # could reject it. Env binding makes it a regular shell string.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          DISPATCH_VERSION: ${{ inputs.version }}
         run: |
-          # On release-trigger, version comes from the tag; on
-          # workflow_dispatch, from the user input. Strip leading `v`.
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            RAW="${{ github.event.release.tag_name }}"
+          if [[ "$EVENT_NAME" == "release" ]]; then
+            RAW="$TAG_NAME"
           else
-            RAW="${{ inputs.version }}"
+            RAW="$DISPATCH_VERSION"
           fi
           VERSION="${RAW#v}"
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then

--- a/.github/workflows/gateway-update.yml
+++ b/.github/workflows/gateway-update.yml
@@ -1,27 +1,18 @@
-# Gateway update workflow (Phase 2 — manual trigger only)
+# Gateway update workflow.
 #
-# Status: draft. This workflow is `workflow_dispatch` only and intentionally
-# NOT wired into release.yml or cross-compile.yml. Before flipping to
-# automatic triggering on `release: { types: [published] }`, the following
-# must be true:
+# Auto-triggers on `release.published` — once a release is published on
+# GitHub (after release.yml runs cargo publish + creates the release with
+# binaries attached), this workflow signs HMAC-authed `POST /update`
+# requests to each gateway's `freenet-release-agent`.
 #
-#   - freenet-release-agent deployed on each gateway in dry_run mode and
-#     validated per docs/release-agent-deployment.md
-#   - RELEASE_AGENT_HMAC_NOVA and RELEASE_AGENT_HMAC_VEGA secrets set
-#   - Gateway URLs reachable from GitHub Actions runners
-#   - At least one manual run completed end-to-end without errors
-#
-# When all of the above is true, add a second `on:` trigger:
-#
-#   release:
-#     types: [published]
-#
-# and remove the `workflow_dispatch.inputs.version` field (the release tag
-# becomes the version).
+# `workflow_dispatch` is kept for manual re-rollouts and for the smoke
+# test (`dry_run_workflow: true`).
 
-name: Gateway Update (Phase 2 draft)
+name: Gateway Update
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -43,7 +34,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: gateway-update-${{ inputs.version }}
+  # On release-trigger the version is in github.event.release.tag_name;
+  # on workflow_dispatch it's in inputs.version. The `||` coalesces.
+  group: gateway-update-${{ github.event.release.tag_name || inputs.version }}
   cancel-in-progress: false
 
 jobs:
@@ -52,29 +45,37 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
+      version: ${{ steps.ver.outputs.version }}
     steps:
-      - name: Validate version
+      - name: Resolve version
+        id: ver
         run: |
-          VERSION="${{ inputs.version }}"
-          if [[ "$VERSION" == v* ]]; then
-            echo "::error::Version must not have a leading 'v'. Got: $VERSION"
-            exit 1
+          # On release-trigger, version comes from the tag; on
+          # workflow_dispatch, from the user input. Strip leading `v`.
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            RAW="${{ github.event.release.tag_name }}"
+          else
+            RAW="${{ inputs.version }}"
           fi
+          VERSION="${RAW#v}"
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Version must be X.Y.Z. Got: $VERSION"
+            echo "::error::Version must be X.Y.Z. Got: $VERSION (raw: $RAW)"
             exit 1
           fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
 
       - name: Verify GitHub release exists and is latest
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION="${{ inputs.version }}"
+          VERSION="${{ steps.ver.outputs.version }}"
           LATEST=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name)
           LATEST="${LATEST#v}"
           if [[ "$LATEST" != "$VERSION" ]]; then
-            echo "::error::Requested version $VERSION is not the GitHub 'latest' release ($LATEST). Refusing to roll out."
+            echo "::error::Version $VERSION is not the GitHub 'latest' release ($LATEST). Refusing to roll out."
             echo "::error::The agent will reject this anyway (403 not_github_latest); failing fast here."
+            echo "::error::Note: when triggered by release.published, the freshly-created release is normally already 'latest'."
             exit 1
           fi
           echo "GitHub /releases/latest confirms $VERSION is current."
@@ -82,7 +83,9 @@ jobs:
       - name: Build matrix
         id: plan
         run: |
-          REQUESTED="${{ inputs.gateways }}"
+          # Default to all gateways when triggered by release.published
+          # (no inputs available); honor explicit subset on workflow_dispatch.
+          REQUESTED="${{ inputs.gateways || 'all' }}"
           if [[ "$REQUESTED" == "all" ]]; then
             MATRIX='[{"name":"nova","url":"https://update.nova.locut.us"},{"name":"vega","url":"https://update.vega.locut.us"}]'
           else
@@ -140,7 +143,7 @@ jobs:
         env:
           SECRET: ${{ steps.secret.outputs.secret }}
           GATEWAY_URL: ${{ matrix.gateway.url }}
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ needs.plan.outputs.version }}
           DRY_RUN_WORKFLOW: ${{ inputs.dry_run_workflow }}
         run: |
           set -euo pipefail
@@ -190,7 +193,7 @@ jobs:
         if: ${{ inputs.dry_run_workflow != true }}
         env:
           GATEWAY_URL: ${{ matrix.gateway.url }}
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ needs.plan.outputs.version }}
         run: |
           set -euo pipefail
           # The agent restarts the freenet service after the script

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -1,0 +1,158 @@
+# Release announcement fan-out.
+#
+# Triggers on release.published — after release.yml has finished its
+# cargo publish + GitHub Release creation. Posts to:
+#
+#   1. Matrix room !ygHfYcXtXmivTbOwjX:matrix.org via the Matrix
+#      client-server API (one curl). Needs MATRIX_HOMESERVER_URL and
+#      MATRIX_ACCESS_TOKEN secrets.
+#
+#   2. The Freenet Official River room, by HMAC-signing a request to
+#      nova's release-agent at https://update.nova.locut.us/announce/river.
+#      The agent invokes `riverctl` locally as the user who owns the
+#      room signing key. Needs RELEASE_AGENT_HMAC_NOVA secret.
+#
+# Each announcement runs in its own job and the workflow does NOT
+# fail-fast: a Matrix outage shouldn't block the River post (or vice
+# versa). Both are non-critical in the sense that the release itself
+# is already published — these are just notifications.
+
+name: Release Announcements
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (e.g. 0.2.57, no leading v)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-announce-${{ github.event.release.tag_name || inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve version + message
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      release_url: ${{ steps.v.outputs.release_url }}
+      message: ${{ steps.v.outputs.message }}
+    steps:
+      - name: Resolve version
+        id: v
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            RAW="${{ github.event.release.tag_name }}"
+          else
+            RAW="${{ inputs.version }}"
+          fi
+          VERSION="${RAW#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version must be X.Y.Z. Got: $VERSION (raw: $RAW)"
+            exit 1
+          fi
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/v${VERSION}"
+          MESSAGE="Freenet v${VERSION} released: ${RELEASE_URL}"
+          {
+            echo "version=$VERSION"
+            echo "release_url=$RELEASE_URL"
+            echo "message<<EOF"
+            echo "$MESSAGE"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved: $MESSAGE"
+
+  matrix:
+    name: Post to Matrix
+    needs: resolve
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Matrix message
+        env:
+          HOMESERVER: ${{ secrets.MATRIX_HOMESERVER_URL }}
+          TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+          MESSAGE: ${{ needs.resolve.outputs.message }}
+        run: |
+          set -euo pipefail
+          # Room: #freenet-locutus:matrix.org. Use the room ID rather
+          # than the alias for reliability.
+          ROOM_ID='!ygHfYcXtXmivTbOwjX:matrix.org'
+          if [[ -z "$HOMESERVER" ]]; then
+            echo "::warning::MATRIX_HOMESERVER_URL not set; skipping Matrix announcement"
+            exit 0
+          fi
+          if [[ -z "$TOKEN" ]]; then
+            echo "::warning::MATRIX_ACCESS_TOKEN not set; skipping Matrix announcement"
+            exit 0
+          fi
+          # Random txn ID so retries don't get deduped (Matrix client-server
+          # API treats identical txn IDs as the same message).
+          TXN_ID="freenet-release-$(date +%s)-$RANDOM"
+          BODY=$(jq -nc \
+            --arg msg "$MESSAGE" \
+            '{msgtype: "m.text", body: $msg}')
+          # URL-encode the room ID. ! and : are reserved chars.
+          ROOM_ENC=$(printf '%s' "$ROOM_ID" | jq -sRr @uri)
+          URL="${HOMESERVER%/}/_matrix/client/v3/rooms/${ROOM_ENC}/send/m.room.message/${TXN_ID}"
+          HTTP_STATUS=$(curl -sS -o /tmp/matrix-response.json -w '%{http_code}' \
+            -X PUT "$URL" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H 'Content-Type: application/json' \
+            --data-raw "$BODY")
+          echo "HTTP $HTTP_STATUS"
+          cat /tmp/matrix-response.json || true
+          echo
+          if [[ "$HTTP_STATUS" != "200" ]]; then
+            echo "::error::Matrix returned HTTP $HTTP_STATUS"
+            exit 1
+          fi
+          echo "✓ Matrix announcement posted."
+
+  river:
+    name: Post to River (via nova webhook)
+    needs: resolve
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sign and POST /announce/river
+        env:
+          SECRET: ${{ secrets.RELEASE_AGENT_HMAC_NOVA }}
+          MESSAGE: ${{ needs.resolve.outputs.message }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$SECRET" ]]; then
+            echo "::warning::RELEASE_AGENT_HMAC_NOVA not set; skipping River announcement"
+            exit 0
+          fi
+          ISSUED_AT=$(date +%s)
+          BODY=$(jq -nc \
+            --arg msg "$MESSAGE" \
+            --argjson t "$ISSUED_AT" \
+            '{message: $msg, issued_at: $t}')
+          SIG=$(printf '%s' "$BODY" \
+            | openssl dgst -sha256 -mac HMAC -macopt "hexkey:$SECRET" \
+            | awk '{print $NF}')
+          echo "Posting to https://update.nova.locut.us/announce/river"
+          # riverctl can take up to ~180s on a cold cargo run; the agent's
+          # internal probe is 1s and it returns 202 before the script
+          # completes. The HTTP request itself returns fast.
+          HTTP_STATUS=$(curl -sS -o /tmp/river-response.json -w '%{http_code}' \
+            --connect-timeout 30 --max-time 30 \
+            -X POST 'https://update.nova.locut.us/announce/river' \
+            -H 'Content-Type: application/json' \
+            -H "X-Signature: $SIG" \
+            --data-raw "$BODY")
+          echo "HTTP $HTTP_STATUS"
+          cat /tmp/river-response.json || true
+          echo
+          if [[ "$HTTP_STATUS" != "200" && "$HTTP_STATUS" != "202" ]]; then
+            echo "::error::nova /announce/river returned HTTP $HTTP_STATUS"
+            exit 1
+          fi
+          echo "✓ River announcement dispatched to nova."

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -47,18 +47,28 @@ jobs:
     steps:
       - name: Resolve version
         id: v
+        # Pass the raw values via env: rather than ${{ }} interpolation
+        # into the shell. A tag name like `1.2.3"; curl evil; "` would
+        # otherwise template directly into the script at expression-eval
+        # time, before the regex check below could reject it. Env-var
+        # binding makes the variable a regular string in the shell.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          DISPATCH_VERSION: ${{ inputs.version }}
+          REPO: ${{ github.repository }}
         run: |
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            RAW="${{ github.event.release.tag_name }}"
+          if [[ "$EVENT_NAME" == "release" ]]; then
+            RAW="$TAG_NAME"
           else
-            RAW="${{ inputs.version }}"
+            RAW="$DISPATCH_VERSION"
           fi
           VERSION="${RAW#v}"
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Version must be X.Y.Z. Got: $VERSION (raw: $RAW)"
             exit 1
           fi
-          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/v${VERSION}"
+          RELEASE_URL="https://github.com/${REPO}/releases/tag/v${VERSION}"
           MESSAGE="Freenet v${VERSION} released: ${RELEASE_URL}"
           {
             echo "version=$VERSION"
@@ -93,8 +103,14 @@ jobs:
             exit 0
           fi
           # Random txn ID so retries don't get deduped (Matrix client-server
-          # API treats identical txn IDs as the same message).
-          TXN_ID="freenet-release-$(date +%s)-$RANDOM"
+          # API treats identical txn IDs as the same message). Prefer
+          # uuidgen for collision-resistance vs $RANDOM + 1s clock; fall
+          # back to date+$RANDOM if uuidgen isn't present on the runner.
+          if command -v uuidgen >/dev/null 2>&1; then
+            TXN_ID="freenet-release-$(uuidgen)"
+          else
+            TXN_ID="freenet-release-$(date +%s%N)-${RANDOM}-${RANDOM}"
+          fi
           BODY=$(jq -nc \
             --arg msg "$MESSAGE" \
             '{msgtype: "m.text", body: $msg}')
@@ -154,5 +170,14 @@ jobs:
           if [[ "$HTTP_STATUS" != "200" && "$HTTP_STATUS" != "202" ]]; then
             echo "::error::nova /announce/river returned HTTP $HTTP_STATUS"
             exit 1
+          fi
+          # 200 means the agent was in dry-run mode and DID NOT post to
+          # River. Surface a warning so the operator notices that the
+          # workflow "succeeded" but the announcement never went out.
+          if [[ "$HTTP_STATUS" == "200" ]]; then
+            DRY_RUN=$(jq -r '.dry_run // false' < /tmp/river-response.json 2>/dev/null || echo "false")
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "::warning::nova returned 200 with dry_run=true — River was NOT posted. Flip dry_run=false on the agent if this was intended to be live."
+            fi
           fi
           echo "✓ River announcement dispatched to nova."

--- a/crates/release-agent/src/announcer.rs
+++ b/crates/release-agent/src/announcer.rs
@@ -1,0 +1,135 @@
+//! River announcement runner.
+//!
+//! Posts a release announcement to the Freenet Official River room by
+//! invoking a small `announce-to-river.sh` shell script via `sudo -n`.
+//! The script lives on nova alongside the room owner signing key — both
+//! resources are owned by the `ian` user and never leave the box. The
+//! agent passes the announcement text on argv; the script is responsible
+//! for converting it into a `riverctl` invocation with the right paths.
+//!
+//! This module is structurally parallel to [`crate::updater::Updater`]:
+//! same `dry_run` short-circuit, same sudo-wrapping, same 1-second
+//! early-exit probe so an immediate sudo rejection surfaces as `Err`.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::process::Command;
+
+#[derive(Clone, Debug)]
+pub struct Announcer {
+    /// Path to the river-announce script (e.g.
+    /// `/usr/local/bin/announce-to-river.sh`). Empty path means the
+    /// endpoint is disabled (returns 503).
+    pub command: PathBuf,
+    pub dry_run: bool,
+    /// Privilege-escalation wrapper. Production: `sudo`. Tests inject a
+    /// fake-sudo script that records argv.
+    pub sudo_command: PathBuf,
+    /// The user under which `riverctl` must run (typically `ian` on
+    /// nova, since the signing key + rooms.json live in their home dir).
+    pub run_as_user: String,
+}
+
+const EARLY_EXIT_PROBE: Duration = Duration::from_secs(1);
+
+impl Announcer {
+    pub fn new_with_sudo(command: PathBuf, dry_run: bool, run_as_user: impl Into<String>) -> Self {
+        Self {
+            command,
+            dry_run,
+            sudo_command: PathBuf::from("sudo"),
+            run_as_user: run_as_user.into(),
+        }
+    }
+
+    pub fn is_configured(&self) -> bool {
+        !self.command.as_os_str().is_empty()
+    }
+
+    /// Invoke the announce script with `message` on argv. Returns `Ok` if
+    /// the script either kept running past the 1s probe or exited 0 within
+    /// it; returns `Err` for immediate non-zero exit so the HTTP layer
+    /// returns 500 and the caller can retry.
+    pub async fn run(&self, message: &str) -> Result<()> {
+        if self.dry_run {
+            tracing::info!(
+                command = %self.command.display(),
+                len = message.len(),
+                "dry-run: would invoke `sudo -n -u {} {} <message>`",
+                self.run_as_user,
+                self.command.display()
+            );
+            return Ok(());
+        }
+
+        tracing::info!(
+            command = %self.command.display(),
+            len = message.len(),
+            "spawning announce command"
+        );
+
+        let mut child = Command::new(&self.sudo_command)
+            .arg("--non-interactive")
+            .arg("-u")
+            .arg(&self.run_as_user)
+            .arg(&self.command)
+            .arg(message)
+            .stdin(Stdio::null())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(false)
+            .spawn()
+            .context("spawn announce command")?;
+
+        match tokio::time::timeout(EARLY_EXIT_PROBE, child.wait()).await {
+            Ok(Ok(status)) if !status.success() => {
+                anyhow::bail!("announce command exited early with {status}");
+            }
+            Ok(Err(e)) => {
+                anyhow::bail!("wait() on announce command failed: {e}");
+            }
+            Ok(Ok(_)) => {}
+            Err(_timeout) => {
+                let cmd_path = self.command.clone();
+                tokio::spawn(async move {
+                    match child.wait().await {
+                        Ok(status) => tracing::info!(
+                            %status,
+                            command = %cmd_path.display(),
+                            "announce command exited"
+                        ),
+                        Err(e) => tracing::error!(
+                            error = %e,
+                            command = %cmd_path.display(),
+                            "wait() on announce command failed"
+                        ),
+                    }
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn dry_run_does_not_execute() {
+        let a = Announcer::new_with_sudo(PathBuf::from("/nonexistent/announce.sh"), true, "nobody");
+        a.run("test message")
+            .await
+            .expect("dry_run must not invoke");
+    }
+
+    #[test]
+    fn empty_command_is_unconfigured() {
+        let a = Announcer::new_with_sudo(PathBuf::new(), false, "ian");
+        assert!(!a.is_configured());
+    }
+}

--- a/crates/release-agent/src/config.rs
+++ b/crates/release-agent/src/config.rs
@@ -23,6 +23,19 @@ pub struct Config {
     pub rate_limit_seconds: u64,
     #[serde(default = "default_skew")]
     pub clock_skew_tolerance_seconds: u32,
+
+    /// Path to the `announce-to-river.sh` script. Empty (default) disables
+    /// the `POST /announce/river` endpoint; the endpoint returns 503.
+    /// Only nova has this configured today — vega has no Freenet node /
+    /// signing key, so it can't post to River.
+    #[serde(default)]
+    pub river_announce_command: PathBuf,
+
+    /// User under which `riverctl` runs (typically `ian` on nova). The
+    /// agent itself runs as `freenet-update`; it `sudo -u <user>`s to
+    /// the owner of `~/.config/freenet-river-official/`. Default empty.
+    #[serde(default)]
+    pub river_announce_user: String,
 }
 
 fn default_repo() -> String {
@@ -170,6 +183,8 @@ dry-run = false
             dry_run: true,
             rate_limit_seconds: 0,
             clock_skew_tolerance_seconds: 0,
+            river_announce_command: PathBuf::new(),
+            river_announce_user: String::new(),
         }
     }
 }

--- a/crates/release-agent/src/lib.rs
+++ b/crates/release-agent/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod announcer;
 pub mod auth;
 pub mod config;
 pub mod github;

--- a/crates/release-agent/src/main.rs
+++ b/crates/release-agent/src/main.rs
@@ -8,6 +8,7 @@ use reqwest::Client as HttpClient;
 use tokio::sync::Mutex;
 
 use freenet_release_agent::{
+    announcer::Announcer,
     config::Config,
     github::GitHubLatest,
     server::{AppState, build_router, serve},
@@ -46,6 +47,11 @@ async fn main() -> Result<()> {
         .context("build reqwest client")?;
 
     let updater = Updater::new_with_sudo(config.update_command.clone(), config.dry_run);
+    let announcer = Announcer::new_with_sudo(
+        config.river_announce_command.clone(),
+        config.dry_run,
+        config.river_announce_user.clone(),
+    );
 
     let listen_addr = config.listen_addr;
     let latest_source = Arc::new(GitHubLatest {
@@ -57,8 +63,10 @@ async fn main() -> Result<()> {
         secret: Arc::new(secret),
         latest_source,
         updater,
+        announcer,
         version_cache: VersionCache::new(),
         last_update_attempt: Arc::new(Mutex::new(None)),
+        last_announce_attempt: Arc::new(Mutex::new(None)),
     };
 
     serve(listen_addr, build_router(state)).await

--- a/crates/release-agent/src/server.rs
+++ b/crates/release-agent/src/server.rs
@@ -290,19 +290,11 @@ async fn announce_river_handler(
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {
-    // Endpoint is opt-in via config. Off-by-default means a vega-style
-    // install (no Freenet node, no signing key) returns 503 instead of
-    // pretending to succeed.
-    if !state.announcer.is_configured() {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "river announcements not configured on this gateway",
-        )
-            .into_response();
-    }
-
-    // 1. HMAC over raw body (same secret as /update for now; separation
-    //    can come later if the operator wants per-endpoint secrets).
+    // 1. HMAC over raw body. We verify FIRST so an unauthenticated
+    //    caller can't distinguish "endpoint disabled" (503) from
+    //    "endpoint enabled, wrong key" (401) — both look the same.
+    //    Otherwise an attacker can fingerprint which gateway runs
+    //    `/announce/river` without proving knowledge of the secret.
     let sig = match headers.get(&HEADER_SIGNATURE).and_then(|v| v.to_str().ok()) {
         Some(s) => s,
         None => return (StatusCode::UNAUTHORIZED, "missing X-Signature").into_response(),
@@ -310,6 +302,17 @@ async fn announce_river_handler(
     if let Err(e) = verify_signature(&state.secret, &body, sig) {
         tracing::warn!(error = %e, "announce signature verification failed");
         return (StatusCode::UNAUTHORIZED, "invalid signature").into_response();
+    }
+
+    // 2. Endpoint is opt-in via config. Off-by-default means a vega-style
+    //    install (no Freenet node, no signing key) returns 503 instead of
+    //    pretending to succeed.
+    if !state.announcer.is_configured() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "river announcements not configured on this gateway",
+        )
+            .into_response();
     }
 
     // 2. Parse body

--- a/crates/release-agent/src/server.rs
+++ b/crates/release-agent/src/server.rs
@@ -15,6 +15,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
+use crate::announcer::Announcer;
 use crate::auth::{HEADER_SIGNATURE, check_clock_skew, verify_signature};
 use crate::config::Config;
 use crate::github::LatestSource;
@@ -26,14 +27,26 @@ use crate::version::VersionCache;
 /// floods before they reach HMAC verification.
 const UPDATE_BODY_LIMIT_BYTES: usize = 4 * 1024;
 
+/// Cap on `POST /announce/river`. River chat messages are typically
+/// 100-500 bytes; 8 KiB leaves room for multi-line release notes while
+/// still rejecting outright floods.
+const ANNOUNCE_BODY_LIMIT_BYTES: usize = 8 * 1024;
+
+/// Cap on announcement payload text. Prevents an authenticated client
+/// from posting megabyte-sized "messages" that would still pass the
+/// body limit at the HTTP layer.
+const ANNOUNCE_MESSAGE_MAX_LEN: usize = 4 * 1024;
+
 #[derive(Clone)]
 pub struct AppState {
     pub config: Arc<Config>,
     pub secret: Arc<Vec<u8>>,
     pub latest_source: Arc<dyn LatestSource>,
     pub updater: Updater,
+    pub announcer: Announcer,
     pub version_cache: VersionCache,
     pub last_update_attempt: Arc<Mutex<Option<Instant>>>,
+    pub last_announce_attempt: Arc<Mutex<Option<Instant>>>,
 }
 
 #[derive(Serialize)]
@@ -46,6 +59,20 @@ pub struct VersionResponse {
 pub struct UpdateRequest {
     pub version: String,
     pub issued_at: i64,
+}
+
+/// Request body for `POST /announce/river`.
+#[derive(Deserialize, Serialize)]
+pub struct AnnounceRequest {
+    pub message: String,
+    pub issued_at: i64,
+}
+
+/// Successful response from `POST /announce/river`.
+#[derive(Serialize)]
+pub struct AnnounceResponse {
+    pub accepted: bool,
+    pub dry_run: bool,
 }
 
 /// Successful response from `POST /update`.
@@ -70,6 +97,10 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/update",
             post(update_handler).layer(DefaultBodyLimit::max(UPDATE_BODY_LIMIT_BYTES)),
+        )
+        .route(
+            "/announce/river",
+            post(announce_river_handler).layer(DefaultBodyLimit::max(ANNOUNCE_BODY_LIMIT_BYTES)),
         )
         .with_state(state)
 }
@@ -249,6 +280,120 @@ async fn update_handler(
             current_version: current.to_string(),
             target_version: target.to_string(),
             no_op: false,
+        }),
+    )
+        .into_response()
+}
+
+async fn announce_river_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    // Endpoint is opt-in via config. Off-by-default means a vega-style
+    // install (no Freenet node, no signing key) returns 503 instead of
+    // pretending to succeed.
+    if !state.announcer.is_configured() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "river announcements not configured on this gateway",
+        )
+            .into_response();
+    }
+
+    // 1. HMAC over raw body (same secret as /update for now; separation
+    //    can come later if the operator wants per-endpoint secrets).
+    let sig = match headers.get(&HEADER_SIGNATURE).and_then(|v| v.to_str().ok()) {
+        Some(s) => s,
+        None => return (StatusCode::UNAUTHORIZED, "missing X-Signature").into_response(),
+    };
+    if let Err(e) = verify_signature(&state.secret, &body, sig) {
+        tracing::warn!(error = %e, "announce signature verification failed");
+        return (StatusCode::UNAUTHORIZED, "invalid signature").into_response();
+    }
+
+    // 2. Parse body
+    let req: AnnounceRequest = match serde_json::from_slice(&body) {
+        Ok(r) => r,
+        Err(e) => return (StatusCode::BAD_REQUEST, format!("bad body: {e}")).into_response(),
+    };
+
+    // 3. Replay protection
+    if let Err(e) = check_clock_skew(req.issued_at, state.config.clock_skew_tolerance_seconds) {
+        return (StatusCode::UNAUTHORIZED, format!("{e}")).into_response();
+    }
+
+    // 4. Sanity-check the message itself. Reject empty, oversize, or
+    //    control-character payloads before paying for the sudo spawn.
+    if req.message.is_empty() {
+        return (StatusCode::BAD_REQUEST, "message must not be empty").into_response();
+    }
+    if req.message.len() > ANNOUNCE_MESSAGE_MAX_LEN {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!(
+                "message too long ({} bytes; max {})",
+                req.message.len(),
+                ANNOUNCE_MESSAGE_MAX_LEN
+            ),
+        )
+            .into_response();
+    }
+    if req.message.chars().any(|c| c == '\0') {
+        return (
+            StatusCode::BAD_REQUEST,
+            "message must not contain NUL bytes",
+        )
+            .into_response();
+    }
+
+    // 5. Rate-limit + spawn. 1-minute window: announcements are
+    //    idempotent-ish from the caller's view (CI re-running would
+    //    just re-announce), but rate-limiting prevents accidental
+    //    storms from a stuck workflow.
+    let mut guard = match tokio::time::timeout(
+        Duration::from_secs(5),
+        state.last_announce_attempt.lock(),
+    )
+    .await
+    {
+        Ok(g) => g,
+        Err(_) => {
+            return (StatusCode::SERVICE_UNAVAILABLE, "announce in progress").into_response();
+        }
+    };
+    if let Some(prev) = *guard {
+        if prev.elapsed() < Duration::from_secs(60) {
+            return (
+                StatusCode::TOO_MANY_REQUESTS,
+                "rate-limited; announcements throttled to 1/min",
+            )
+                .into_response();
+        }
+    }
+
+    if let Err(e) = state.announcer.run(&req.message).await {
+        tracing::error!(error = %e, "announcer spawn failed");
+        // Same contract as /update: failure does NOT consume the window.
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("announce command failed: {e}"),
+        )
+            .into_response();
+    }
+    *guard = Some(Instant::now());
+    drop(guard);
+
+    let status = if state.config.dry_run {
+        StatusCode::OK
+    } else {
+        StatusCode::ACCEPTED
+    };
+    (
+        status,
+        Json(AnnounceResponse {
+            accepted: true,
+            dry_run: state.config.dry_run,
         }),
     )
         .into_response()

--- a/crates/release-agent/tests/update_handler.rs
+++ b/crates/release-agent/tests/update_handler.rs
@@ -490,15 +490,21 @@ async fn build_with_announcer(announce_script: &str, record_file: &Path) -> Harn
 
     let fake_sudo = tmp.path().join("fake-sudo");
     // The agent invokes `sudo -n -u <user> <command> <message>`.
-    // Our stub: shift past `-n -u <user>`, record the rest, then exec.
+    // Record TWICE: full pre-shift argv to `<record>.full` (so tests
+    // can pin the `-u <user>` shape against the sudoers allowlist),
+    // and post-shift argv to `<record>` for legacy "argv contains
+    // message" assertions.
+    let record_full_path = format!("{}.full", record_file.display());
     let sudo_script = format!(
         "#!/bin/sh\n\
+         echo \"$@\" > {record_full}\n\
          shift # --non-interactive\n\
          shift # -u\n\
          shift # <user>\n\
          echo \"$@\" > {record}\n\
          exec \"$@\"\n",
-        record = record_file.display()
+        record = record_file.display(),
+        record_full = record_full_path,
     );
     std::fs::write(&fake_sudo, sudo_script).unwrap();
     let mut perms = std::fs::metadata(&fake_sudo).unwrap().permissions();
@@ -560,7 +566,7 @@ fn signed_announce(secret: &[u8], message: &str, issued_at: i64) -> (String, Str
 }
 
 #[tokio::test]
-async fn announce_disabled_returns_503() {
+async fn announce_disabled_returns_503_with_valid_signature() {
     // The default-built Harness has an unconfigured announcer (empty
     // command path) — that gateway can't post to River.
     let h = Harness::build("0.2.55", Version::new(0, 2, 56), 600).await;
@@ -573,6 +579,34 @@ async fn announce_disabled_returns_503() {
         .await
         .unwrap();
     assert_eq!(resp.status(), 503);
+}
+
+#[tokio::test]
+async fn announce_disabled_still_requires_signature() {
+    // Pins the validation order: HMAC verify runs BEFORE the
+    // is_configured check, so an unauthenticated probe can't
+    // distinguish "endpoint disabled on this gateway" from
+    // "endpoint enabled, wrong secret". Both return 401 today.
+    // A future refactor that moves the 503 above the signature
+    // verify would re-enable the fingerprint and fail this test.
+    let h = Harness::build("0.2.55", Version::new(0, 2, 56), 600).await;
+    let body = serde_json::to_string(&json!({
+        "message": "hello",
+        "issued_at": now_secs(),
+    }))
+    .unwrap();
+    let resp = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        // No X-Signature header at all.
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        401,
+        "unsigned request must 401 even when announce is unconfigured (no fingerprint leak)"
+    );
 }
 
 #[tokio::test]
@@ -597,6 +631,22 @@ async fn announce_happy_path() {
     assert!(
         recorded.contains("Freenet v0.2.57 released"),
         "argv should contain the message, got: {recorded:?}"
+    );
+
+    // Pin the FULL pre-shift argv against the sudoers allowlist:
+    //   sudo --non-interactive -u <user> <command> <message>
+    // A refactor that drops --non-interactive or -u would otherwise
+    // silently work in tests but fail at production sudoers.
+    let recorded_full = std::fs::read_to_string(format!("{}.full", record.display()))
+        .expect("fake-sudo recorded full argv");
+    let full = recorded_full.trim();
+    assert!(
+        full.starts_with("--non-interactive -u nobody "),
+        "full argv must start with `--non-interactive -u nobody`, got: {full:?}"
+    );
+    assert!(
+        full.ends_with(" Freenet v0.2.57 released"),
+        "full argv must end with the message, got: {full:?}"
     );
 }
 
@@ -679,6 +729,132 @@ async fn announce_spawn_failure_does_not_consume_rate_limit() {
         429,
         "failed spawn must not consume the announce rate-limit window"
     );
+}
+
+#[tokio::test]
+async fn announce_tampered_body_is_401() {
+    // Pins HMAC-verify-before-parse on the announce path. If the parse
+    // ran first, a tampered body would 400 instead of 401.
+    let tmp = tempfile::tempdir().unwrap();
+    let record = tmp.path().join("argv.log");
+    let h = build_with_announcer("#!/bin/sh\nexit 0\n", &record).await;
+    let (body, sig) = signed_announce(&h.secret, "real message", now_secs());
+    let tampered = body.replace("real message", "tampered!!!!");
+    let resp = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig)
+        .body(tampered)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn announce_stale_issued_at_is_401() {
+    let tmp = tempfile::tempdir().unwrap();
+    let record = tmp.path().join("argv.log");
+    let h = build_with_announcer("#!/bin/sh\nexit 0\n", &record).await;
+    let (body, sig) = signed_announce(&h.secret, "hello", now_secs() - 3600);
+    let resp = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig)
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn announce_nul_byte_is_400() {
+    // serde_json decodes \u{0} into a real NUL char; the handler
+    // rejects them defensively before they reach argv.
+    let tmp = tempfile::tempdir().unwrap();
+    let record = tmp.path().join("argv.log");
+    let h = build_with_announcer("#!/bin/sh\nexit 0\n", &record).await;
+    let body = serde_json::to_string(&json!({
+        "message": "hello\u{0}world",
+        "issued_at": now_secs(),
+    }))
+    .unwrap();
+    let sig = sign(&h.secret, body.as_bytes());
+    let resp = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig)
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn announce_exactly_at_message_limit_is_accepted() {
+    // 4096 bytes (ANNOUNCE_MESSAGE_MAX_LEN). Handler check is `> MAX`,
+    // so 4096 passes. One-over (4097) goes 413 — see next test.
+    let tmp = tempfile::tempdir().unwrap();
+    let record = tmp.path().join("argv.log");
+    let h = build_with_announcer("#!/bin/sh\nsleep 5\n", &record).await;
+    let exact = "x".repeat(4096);
+    let (body, sig) = signed_announce(&h.secret, &exact, now_secs());
+    let resp = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig)
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status() == 200 || resp.status() == 202,
+        "exactly-at-limit must pass; got {}",
+        resp.status()
+    );
+}
+
+#[tokio::test]
+async fn announce_one_over_message_limit_is_413() {
+    let tmp = tempfile::tempdir().unwrap();
+    let record = tmp.path().join("argv.log");
+    let h = build_with_announcer("#!/bin/sh\nexit 0\n", &record).await;
+    let over = "x".repeat(4097);
+    let (body, sig) = signed_announce(&h.secret, &over, now_secs());
+    let resp = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig)
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 413);
+}
+
+#[tokio::test]
+async fn announce_rate_limit_kicks_in_after_first_success() {
+    // 1-minute window: two back-to-back announces, second must 429.
+    let tmp = tempfile::tempdir().unwrap();
+    let record = tmp.path().join("argv.log");
+    let h = build_with_announcer("#!/bin/sh\nexit 0\n", &record).await;
+
+    let (b1, s1) = signed_announce(&h.secret, "first", now_secs());
+    let r1 = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &s1)
+        .body(b1)
+        .send()
+        .await
+        .unwrap();
+    assert!(r1.status() == 200 || r1.status() == 202);
+
+    let (b2, s2) = signed_announce(&h.secret, "second", now_secs());
+    let r2 = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &s2)
+        .body(b2)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r2.status(), 429);
 }
 
 #[tokio::test]

--- a/crates/release-agent/tests/update_handler.rs
+++ b/crates/release-agent/tests/update_handler.rs
@@ -70,6 +70,8 @@ impl Harness {
             dry_run: true,
             rate_limit_seconds,
             clock_skew_tolerance_seconds: 300,
+            river_announce_command: std::path::PathBuf::new(),
+            river_announce_user: String::new(),
         };
 
         let latest_source: Arc<dyn LatestSource> = Arc::new(StaticLatest(latest_on_github));
@@ -78,8 +80,14 @@ impl Harness {
             secret: Arc::new(secret.clone()),
             latest_source,
             updater: Updater::new_with_sudo(config.update_command.clone(), true),
+            announcer: freenet_release_agent::announcer::Announcer::new_with_sudo(
+                std::path::PathBuf::new(),
+                true,
+                String::new(),
+            ),
             version_cache: VersionCache::new(),
             last_update_attempt: Arc::new(Mutex::new(None)),
+            last_announce_attempt: Arc::new(Mutex::new(None)),
         };
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -148,6 +156,8 @@ impl Harness {
             dry_run: false,
             rate_limit_seconds,
             clock_skew_tolerance_seconds: 300,
+            river_announce_command: std::path::PathBuf::new(),
+            river_announce_user: String::new(),
         };
 
         let latest_source: Arc<dyn LatestSource> = Arc::new(StaticLatest(latest_on_github));
@@ -161,8 +171,14 @@ impl Harness {
             secret: Arc::new(secret.clone()),
             latest_source,
             updater,
+            announcer: freenet_release_agent::announcer::Announcer::new_with_sudo(
+                std::path::PathBuf::new(),
+                true,
+                String::new(),
+            ),
             version_cache: VersionCache::new(),
             last_update_attempt: Arc::new(Mutex::new(None)),
+            last_announce_attempt: Arc::new(Mutex::new(None)),
         };
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -454,6 +470,214 @@ async fn sudoers_argv_matches_allowlist() {
     assert!(
         argv.ends_with("--force --target-version v0.2.56"),
         "argv suffix must match sudoers allowlist (got: {argv:?})"
+    );
+}
+
+/// Build a Harness whose announcer points at a stub announce script.
+/// Used by the /announce/river tests below.
+async fn build_with_announcer(announce_script: &str, record_file: &Path) -> Harness {
+    let tmp = tempfile::tempdir().unwrap();
+    let binary_path = write_stub_freenet(tmp.path(), "0.2.56");
+    let secret: Vec<u8> = (0..32).map(|i| i as u8).collect();
+    let secret_path = tmp.path().join("hmac.key");
+    std::fs::write(&secret_path, hex::encode(&secret)).unwrap();
+
+    let announce_command = tmp.path().join("announce.sh");
+    std::fs::write(&announce_command, announce_script).unwrap();
+    let mut perms = std::fs::metadata(&announce_command).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&announce_command, perms).unwrap();
+
+    let fake_sudo = tmp.path().join("fake-sudo");
+    // The agent invokes `sudo -n -u <user> <command> <message>`.
+    // Our stub: shift past `-n -u <user>`, record the rest, then exec.
+    let sudo_script = format!(
+        "#!/bin/sh\n\
+         shift # --non-interactive\n\
+         shift # -u\n\
+         shift # <user>\n\
+         echo \"$@\" > {record}\n\
+         exec \"$@\"\n",
+        record = record_file.display()
+    );
+    std::fs::write(&fake_sudo, sudo_script).unwrap();
+    let mut perms = std::fs::metadata(&fake_sudo).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&fake_sudo, perms).unwrap();
+
+    let config = Config {
+        listen_addr: "127.0.0.1:0".parse().unwrap(),
+        binary_path,
+        update_command: tmp.path().join("unused.sh"),
+        hmac_secret_path: secret_path,
+        github_repo: "freenet/freenet-core".into(),
+        dry_run: false,
+        rate_limit_seconds: 600,
+        clock_skew_tolerance_seconds: 300,
+        river_announce_command: announce_command.clone(),
+        river_announce_user: "nobody".into(),
+    };
+    let latest_source: Arc<dyn LatestSource> = Arc::new(StaticLatest(Version::new(0, 2, 56)));
+    let announcer = freenet_release_agent::announcer::Announcer {
+        command: announce_command,
+        dry_run: false,
+        sudo_command: fake_sudo,
+        run_as_user: "nobody".into(),
+    };
+    let state = AppState {
+        config: Arc::new(config),
+        secret: Arc::new(secret.clone()),
+        latest_source,
+        updater: Updater::new_with_sudo(std::path::PathBuf::from("/bin/true"), true),
+        announcer,
+        version_cache: VersionCache::new(),
+        last_update_attempt: Arc::new(Mutex::new(None)),
+        last_announce_attempt: Arc::new(Mutex::new(None)),
+    };
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let router = build_router(state);
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    Harness {
+        base: format!("http://{addr}"),
+        secret,
+        _tmp: tmp,
+    }
+}
+
+fn signed_announce(secret: &[u8], message: &str, issued_at: i64) -> (String, String) {
+    let body = serde_json::to_string(&json!({
+        "message": message,
+        "issued_at": issued_at,
+    }))
+    .unwrap();
+    let sig = sign(secret, body.as_bytes());
+    (body, sig)
+}
+
+#[tokio::test]
+async fn announce_disabled_returns_503() {
+    // The default-built Harness has an unconfigured announcer (empty
+    // command path) — that gateway can't post to River.
+    let h = Harness::build("0.2.55", Version::new(0, 2, 56), 600).await;
+    let (body, sig) = signed_announce(&h.secret, "hello", now_secs());
+    let resp = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig)
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 503);
+}
+
+#[tokio::test]
+async fn announce_happy_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let record = tmp.path().join("argv.log");
+    let h = build_with_announcer("#!/bin/sh\nsleep 5\n", &record).await;
+    let (body, sig) = signed_announce(&h.secret, "Freenet v0.2.57 released", now_secs());
+    let resp = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig)
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status() == 200 || resp.status() == 202,
+        "got {}",
+        resp.status()
+    );
+    let recorded = std::fs::read_to_string(&record).expect("fake-sudo recorded argv");
+    assert!(
+        recorded.contains("Freenet v0.2.57 released"),
+        "argv should contain the message, got: {recorded:?}"
+    );
+}
+
+#[tokio::test]
+async fn announce_missing_signature_is_401() {
+    let tmp = tempfile::tempdir().unwrap();
+    let record = tmp.path().join("argv.log");
+    let h = build_with_announcer("#!/bin/sh\nexit 0\n", &record).await;
+    let (body, _) = signed_announce(&h.secret, "x", now_secs());
+    let resp = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn announce_empty_message_is_400() {
+    let tmp = tempfile::tempdir().unwrap();
+    let record = tmp.path().join("argv.log");
+    let h = build_with_announcer("#!/bin/sh\nexit 0\n", &record).await;
+    let (body, sig) = signed_announce(&h.secret, "", now_secs());
+    let resp = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig)
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn announce_oversize_message_is_413() {
+    let tmp = tempfile::tempdir().unwrap();
+    let record = tmp.path().join("argv.log");
+    let h = build_with_announcer("#!/bin/sh\nexit 0\n", &record).await;
+    // Just over the 4 KiB message cap — but under the 8 KiB HTTP body cap
+    // so we hit the message-len check, not the body-limit middleware.
+    let big = "x".repeat(4 * 1024 + 50);
+    let (body, sig) = signed_announce(&h.secret, &big, now_secs());
+    let resp = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig)
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 413);
+}
+
+#[tokio::test]
+async fn announce_spawn_failure_does_not_consume_rate_limit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let record = tmp.path().join("argv.log");
+    // Script exits 1 immediately → 500 + window NOT consumed.
+    let h = build_with_announcer("#!/bin/sh\nexit 1\n", &record).await;
+    let (body, sig) = signed_announce(&h.secret, "first", now_secs());
+    let r1 = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig)
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r1.status(), 500);
+
+    let (body2, sig2) = signed_announce(&h.secret, "second", now_secs());
+    let r2 = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig2)
+        .body(body2)
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(
+        r2.status(),
+        429,
+        "failed spawn must not consume the announce rate-limit window"
     );
 }
 

--- a/docs/release-agent-deployment.md
+++ b/docs/release-agent-deployment.md
@@ -45,6 +45,47 @@ whitespace (per `man 5 sudoers`); the safety comes from the dual regex
 validation in the agent and script, not from sudoers alone. Do NOT
 loosen either validation site.
 
+### River announcement path (nova only)
+
+```
+GitHub Actions runner (release-announce.yml)
+        │  HTTPS POST /announce/river
+        │  X-Signature: HMAC-SHA256(body, secret)
+        ▼
+update.nova.locut.us → Caddy → 127.0.0.1:9876
+        │
+        ▼
+freenet-release-agent (as freenet-update)
+        │  verify HMAC, clock-skew; length+NUL check on message
+        │  rate-limit: 1 announcement / minute
+        ▼
+sudo -n -u ian /usr/local/bin/announce-to-river.sh "<message>"
+        │  (sudoers: `freenet-update ALL=(ian) NOPASSWD: ...`)
+        ▼
+cargo run -p riverctl message send <ROOM_VK> "<message>"
+   via local Freenet node at http://127.0.0.1:7509/
+```
+
+This endpoint is **opt-in via config** (`river_announce_command` and
+`river_announce_user` in `config.toml`). Gateways without a local
+Freenet node + room signing key (e.g. vega) leave both fields blank;
+`POST /announce/river` returns 503 there.
+
+## GitHub Actions secrets
+
+The end-to-end pipeline needs these repository secrets (set with
+`gh secret set <name> --repo freenet/freenet-core`):
+
+| Secret | Used by | Source |
+|---|---|---|
+| `RELEASE_AGENT_HMAC_NOVA` | `gateway-update.yml` + `release-announce.yml` | nova's `/etc/freenet-release-agent/hmac.key` (echoed once by `install.sh`) |
+| `RELEASE_AGENT_HMAC_VEGA` | `gateway-update.yml` | vega's `/etc/freenet-release-agent/hmac.key` |
+| `MATRIX_HOMESERVER_URL` | `release-announce.yml` | e.g. `https://matrix.org` |
+| `MATRIX_ACCESS_TOKEN` | `release-announce.yml` | Matrix bot user's access token (from `Settings → Help & About → Advanced → Access Token`) |
+
+The Matrix announcement job is a no-op (with a workflow warning) if
+the Matrix secrets are absent — useful while bootstrapping.
+
 ## Prerequisites per gateway
 
 1. **`gateway-auto-update.sh` installed at `/usr/local/bin/`** (or wherever

--- a/scripts/release-agent/announce-to-river.sh
+++ b/scripts/release-agent/announce-to-river.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Post a message to the Freenet Official River room.
+#
+# Invoked by freenet-release-agent's `POST /announce/river` endpoint via:
+#
+#     sudo -n -u <river_announce_user> /usr/local/bin/announce-to-river.sh "<message>"
+#
+# The sudoers entry (see scripts/release-agent/sudoers.freenet-release-agent)
+# narrows what `freenet-update` can invoke to this exact path with a single
+# (sudoers-wildcard) message arg.
+#
+# Configuration is via environment variables with defaults appropriate for
+# the nova install. Override them in `freenet-release-agent.service`'s
+# Environment= lines or in /etc/freenet-release-agent/announce.env (sourced
+# below if present).
+
+set -euo pipefail
+
+if [[ -f /etc/freenet-release-agent/announce.env ]]; then
+    # shellcheck disable=SC1091
+    source /etc/freenet-release-agent/announce.env
+fi
+
+RIVER_DIR="${RIVER_DIR:-$HOME/code/freenet/river/main}"
+ROOM_OWNER_VK="${ROOM_OWNER_VK:-4uNUKFzZQCnzo4K2ecZ16cMsYEEfoaRS35z6exEsbvm4}"
+SIGNING_KEY_FILE="${SIGNING_KEY_FILE:-$HOME/.config/freenet-river-official/room_owner_signing_key.bin}"
+ROOMS_JSON="${ROOMS_JSON:-$HOME/.local/share/river/rooms.json}"
+FREENET_NODE_URL="${FREENET_NODE_URL:-http://127.0.0.1:7509/}"
+LOG_FILE="${LOG_FILE:-/var/log/freenet-release-agent-river.log}"
+
+log() {
+    local timestamp
+    timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+    echo "[$timestamp] $*" >&2
+    # Best-effort persistent log; non-fatal if not writable.
+    echo "[$timestamp] $*" >> "$LOG_FILE" 2>/dev/null || true
+}
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 <message>
+
+Posts <message> to the Freenet Official River room.
+EOF
+    exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+    usage
+fi
+
+MESSAGE="$1"
+
+# Defense in depth: empty/oversized payloads should have been rejected
+# upstream, but the privilege-boundary script re-checks. The cap matches
+# the agent's ANNOUNCE_MESSAGE_MAX_LEN (4 KiB).
+if [[ -z "$MESSAGE" ]]; then
+    log "ERROR: empty message"
+    exit 1
+fi
+if [[ ${#MESSAGE} -gt 4096 ]]; then
+    log "ERROR: message too long (${#MESSAGE} bytes; max 4096)"
+    exit 1
+fi
+
+if [[ ! -d "$RIVER_DIR" ]]; then
+    log "ERROR: river repo not found at $RIVER_DIR (set RIVER_DIR)"
+    exit 1
+fi
+if [[ ! -f "$SIGNING_KEY_FILE" ]]; then
+    log "ERROR: signing key not found at $SIGNING_KEY_FILE"
+    exit 1
+fi
+if [[ ! -f "$ROOMS_JSON" ]]; then
+    log "ERROR: rooms.json not found at $ROOMS_JSON (run 'riverctl room create' once)"
+    exit 1
+fi
+
+# Check that the Freenet node is reachable. riverctl will hang otherwise.
+if ! curl -s --max-time 3 "$FREENET_NODE_URL" >/dev/null 2>&1; then
+    log "ERROR: Freenet node not reachable at $FREENET_NODE_URL"
+    exit 1
+fi
+
+# Ensure the room owner signing key in rooms.json matches the on-disk
+# key. This mirrors the equivalent block in scripts/release.sh — without
+# it, posting fails if the local rooms.json drifted.
+python3 - <<PY 2>/dev/null || true
+import json, sys
+signing_key_file = "$SIGNING_KEY_FILE"
+rooms_file = "$ROOMS_JSON"
+room_vk = "$ROOM_OWNER_VK"
+with open(signing_key_file, 'rb') as f:
+    key_bytes = list(f.read())
+with open(rooms_file, 'r') as f:
+    data = json.load(f)
+if room_vk not in data.get('rooms', {}):
+    sys.exit(0)
+current_key = data['rooms'][room_vk].get('signing_key_bytes', [])
+if current_key != key_bytes:
+    data['rooms'][room_vk]['signing_key_bytes'] = key_bytes
+    with open(rooms_file, 'w') as f:
+        json.dump(data, f)
+PY
+
+log "posting to River room $ROOM_OWNER_VK (msg ${#MESSAGE} bytes)"
+
+# Use `cargo run -p riverctl` from the source repo, NOT the installed
+# binary. The installed binary embeds room_contract.wasm at install
+# time, which can become stale when the contract WASM changes. The
+# repo version uses build.rs to copy the current WASM at build time.
+# RIVER_SKIP_CONTRACT_CHECK=1 bypasses the publish-time WASM staleness
+# check (only relevant when publishing riverctl, not when running it).
+cd "$RIVER_DIR"
+if RIVER_SKIP_CONTRACT_CHECK=1 timeout 180 \
+       cargo run --quiet -p riverctl -- message send "$ROOM_OWNER_VK" "$MESSAGE"; then
+    log "OK"
+    exit 0
+else
+    rc=$?
+    log "FAILED with rc=$rc"
+    exit "$rc"
+fi

--- a/scripts/release-agent/announce-to-river.sh
+++ b/scripts/release-agent/announce-to-river.sh
@@ -85,23 +85,42 @@ fi
 # Ensure the room owner signing key in rooms.json matches the on-disk
 # key. This mirrors the equivalent block in scripts/release.sh — without
 # it, posting fails if the local rooms.json drifted.
-python3 - <<PY 2>/dev/null || true
-import json, sys
+#
+# Failure modes are logged and abort (no `|| true` swallowing): if the
+# rooms.json schema drifted, posting with a stale key would be confusing
+# at best and identity-impersonation at worst. We'd rather fail loud.
+#
+# Writes are atomic (temp file + os.replace) so a crash mid-rewrite
+# can't leave rooms.json half-written for the human user.
+if ! python3 - <<PY; then
+import json, os, sys
 signing_key_file = "$SIGNING_KEY_FILE"
 rooms_file = "$ROOMS_JSON"
 room_vk = "$ROOM_OWNER_VK"
-with open(signing_key_file, 'rb') as f:
-    key_bytes = list(f.read())
-with open(rooms_file, 'r') as f:
-    data = json.load(f)
-if room_vk not in data.get('rooms', {}):
-    sys.exit(0)
-current_key = data['rooms'][room_vk].get('signing_key_bytes', [])
-if current_key != key_bytes:
-    data['rooms'][room_vk]['signing_key_bytes'] = key_bytes
-    with open(rooms_file, 'w') as f:
-        json.dump(data, f)
+try:
+    with open(signing_key_file, 'rb') as f:
+        key_bytes = list(f.read())
+    with open(rooms_file, 'r') as f:
+        data = json.load(f)
+    if room_vk not in data.get('rooms', {}):
+        # No-op if the room isn't in local storage — riverctl will
+        # itself fail with a clear error in that case.
+        sys.exit(0)
+    current_key = data['rooms'][room_vk].get('signing_key_bytes', [])
+    if current_key != key_bytes:
+        data['rooms'][room_vk]['signing_key_bytes'] = key_bytes
+        tmp = rooms_file + '.tmp'
+        with open(tmp, 'w') as f:
+            json.dump(data, f)
+        os.replace(tmp, rooms_file)
+        print("rooms.json signing key resynced", file=sys.stderr)
+except Exception as e:
+    print(f"rooms.json sync failed: {e}", file=sys.stderr)
+    sys.exit(1)
 PY
+    log "ERROR: rooms.json signing-key sync failed (see above)"
+    exit 1
+fi
 
 log "posting to River room $ROOM_OWNER_VK (msg ${#MESSAGE} bytes)"
 

--- a/scripts/release-agent/config.example.toml
+++ b/scripts/release-agent/config.example.toml
@@ -21,3 +21,13 @@ rate_limit_seconds = 600
 # Reject requests whose `issued_at` timestamp is more than this many seconds
 # from the agent's clock. Defends against replay attacks.
 clock_skew_tolerance_seconds = 300
+
+# River announcement endpoint. Set both to enable `POST /announce/river`.
+# Leave blank (default) on gateways that don't have a Freenet node + room
+# signing key (e.g. vega) — the endpoint will return 503 there.
+#
+# `river_announce_user` is the local user under which `riverctl` runs;
+# they own the signing key and rooms.json. The sudoers entry must
+# authorize `freenet-update` to `sudo -u <user>` to this script.
+river_announce_command = ""
+river_announce_user = ""

--- a/scripts/release-agent/install.sh
+++ b/scripts/release-agent/install.sh
@@ -82,6 +82,13 @@ else
     echo "WARNING: $GATEWAY_UPDATE_SCRIPT not found yet. Install it with the existing gateway-auto-update bootstrap before flipping dry_run=false." >&2
 fi
 
+echo "==> Installing announce-to-river.sh (gateways without a Freenet node + signing key should omit this)"
+ANNOUNCE_SCRIPT=/usr/local/bin/announce-to-river.sh
+install -m 0755 -o root -g root \
+    "$SCRIPT_DIR/announce-to-river.sh" \
+    "$ANNOUNCE_SCRIPT"
+echo "  Installed $ANNOUNCE_SCRIPT (no-op on gateways without river_announce_command set in config)"
+
 echo "==> Installing sudoers entry"
 install -m 0440 -o root -g root \
     "$SCRIPT_DIR/sudoers.freenet-release-agent" \

--- a/scripts/release-agent/install.sh
+++ b/scripts/release-agent/install.sh
@@ -82,12 +82,17 @@ else
     echo "WARNING: $GATEWAY_UPDATE_SCRIPT not found yet. Install it with the existing gateway-auto-update bootstrap before flipping dry_run=false." >&2
 fi
 
-echo "==> Installing announce-to-river.sh (gateways without a Freenet node + signing key should omit this)"
+echo "==> Installing announce-to-river.sh"
+# Always install the script — it's harmless when the agent's config
+# leaves `river_announce_command` blank (the endpoint returns 503 in
+# that case). Set `river_announce_command = "/usr/local/bin/announce-to-river.sh"`
+# in config.toml AND make sure ~/.config/freenet-river-official/ +
+# the local Freenet node are present on this gateway before enabling.
 ANNOUNCE_SCRIPT=/usr/local/bin/announce-to-river.sh
 install -m 0755 -o root -g root \
     "$SCRIPT_DIR/announce-to-river.sh" \
     "$ANNOUNCE_SCRIPT"
-echo "  Installed $ANNOUNCE_SCRIPT (no-op on gateways without river_announce_command set in config)"
+echo "  Installed $ANNOUNCE_SCRIPT (endpoint disabled until config opts in)"
 
 echo "==> Installing sudoers entry"
 install -m 0440 -o root -g root \

--- a/scripts/release-agent/sudoers.freenet-release-agent
+++ b/scripts/release-agent/sudoers.freenet-release-agent
@@ -24,3 +24,14 @@
 # Install path: /etc/sudoers.d/freenet-release-agent (mode 0440, owner root:root).
 # Validate with: visudo -c -f /etc/sudoers.d/freenet-release-agent
 freenet-update ALL=(root) NOPASSWD: /usr/local/bin/gateway-auto-update.sh --force --target-version *
+
+# Allow the release-agent to invoke the River announcement script as the
+# user who owns the room signing key + Freenet node (typically `ian` on
+# nova; absent on vega — that install simply omits this entry).
+#
+# The `*` after the script path is a sudoers wildcard matching the
+# entire message argv. As with --target-version above, the safety comes
+# from the agent's validation (length cap + NUL rejection in
+# server.rs::announce_river_handler) plus the script's own length check;
+# not from sudoers.
+freenet-update ALL=(ian) NOPASSWD: /usr/local/bin/announce-to-river.sh *

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1134,6 +1134,15 @@ trigger_gateway_updates() {
     # SSH path remains the production trigger until the new workflow has been
     # validated against 1-2 real releases on nova.
 
+    # The gateway-update.yml workflow auto-rolls out updates on
+    # release.published. Setting FREENET_RELEASE_SKIP_GATEWAY_SSH=1
+    # opts the local script out so we don't double-update.
+    if [[ "${FREENET_RELEASE_SKIP_GATEWAY_SSH:-0}" == "1" ]]; then
+        echo "  ⏭  Skipping SSH-based gateway update (FREENET_RELEASE_SKIP_GATEWAY_SSH=1 — workflow handles it)"
+        mark_completed "GATEWAYS_UPDATED"
+        return 0
+    fi
+
     if is_step_completed "GATEWAYS_UPDATED"; then
         echo "  ✓ [GATEWAYS_UPDATED] Gateways already updated (skipping)"
         return 0
@@ -1331,6 +1340,18 @@ wait_for_binaries() {
 announce_to_matrix() {
     echo "Announcing release to Matrix:"
 
+    # If the GitHub workflow path is wired up (release-announce.yml has
+    # been merged and the gateway has the Matrix secret), the workflow
+    # will post automatically when the release is undrafted. Skip here
+    # to avoid a duplicate Matrix message. Setting
+    # FREENET_RELEASE_SKIP_ANNOUNCEMENTS=1 in your env (or sourcing it
+    # from .freenet-release-rc) opts out of the local announcements.
+    if [[ "${FREENET_RELEASE_SKIP_ANNOUNCEMENTS:-0}" == "1" ]]; then
+        echo "  ⏭  Skipping (FREENET_RELEASE_SKIP_ANNOUNCEMENTS=1 — workflow handles announcements)"
+        mark_completed "MATRIX_ANNOUNCED"
+        return 0
+    fi
+
     # Skip if already announced
     if is_step_completed "MATRIX_ANNOUNCED"; then
         echo "  ✓ [MATRIX_ANNOUNCED] Matrix announcement already sent (skipping)"
@@ -1365,6 +1386,15 @@ Published to crates.io (freenet v$VERSION, fdev v$FDEV_VERSION)"
 
 announce_to_river() {
     echo "Announcing release to River (Freenet Official room):"
+
+    # Same workflow-handoff gate as announce_to_matrix. When the
+    # release-announce.yml workflow is wired up, it posts via nova's
+    # /announce/river endpoint. Local riverctl post would duplicate.
+    if [[ "${FREENET_RELEASE_SKIP_ANNOUNCEMENTS:-0}" == "1" ]]; then
+        echo "  ⏭  Skipping (FREENET_RELEASE_SKIP_ANNOUNCEMENTS=1 — workflow handles announcements)"
+        mark_completed "RIVER_ANNOUNCED"
+        return 0
+    fi
 
     # Skip if already announced
     if is_step_completed "RIVER_ANNOUNCED"; then


### PR DESCRIPTION
## Problem

PR #4082 landed the gateway-side HTTP listener (Phase 1, agent in dry-run mode), but a developer creating a GitHub release still has to manually drive the release cascade — SSH to gateways, post to Matrix, run `riverctl` locally. The agent is in place, but nothing in CI uses it.

## Approach

Wire the rest of the chain so a published GitHub Release auto-cascades:

1. **`gateway-update.yml`** — flipped from `workflow_dispatch`-only to also trigger on `release: { types: [published] }`. Resolves the version from `github.event.release.tag_name` when fired by release. Manual dispatch retained for re-rollouts and the `dry_run_workflow: true` smoke test.

2. **`release-announce.yml`** (new) — fires on `release.published`, two parallel jobs (no fail-fast — Matrix outage shouldn't block River):
   - **Matrix**: direct `curl PUT` to client-server API. Needs `MATRIX_HOMESERVER_URL` + `MATRIX_ACCESS_TOKEN` secrets.
   - **River**: HMAC-signs a request to nova's release-agent at `/announce/river`. The agent invokes `sudo -u ian announce-to-river.sh "<message>"` locally — signing key and Freenet node stay on nova; CI never holds either.

3. **Agent gains `POST /announce/river`** — new `src/announcer.rs` module structurally parallel to `updater.rs` (same sudo-wrapping, 1s probe, dry-run short-circuit). The endpoint:
   - HMAC over body, clock-skew check (reuses `/update`'s validators)
   - Message must be non-empty, ≤ 4 KiB, NUL-free
   - 1-minute rate limit (separate window from `/update`'s 10-minute one)
   - Opt-in via `river_announce_command` + `river_announce_user` config fields. Unconfigured gateways (vega) return 503.

4. **`announce-to-river.sh`** (new) — mirrors the `announce_to_river` block in `scripts/release.sh`: locates `rooms.json` + signing key, re-syncs the signing key into rooms.json, runs `RIVER_SKIP_CONTRACT_CHECK=1 cargo run -p riverctl message send`. Configurable via `/etc/freenet-release-agent/announce.env`.

5. **Sudoers extended** for the new script: `freenet-update ALL=(ian) NOPASSWD: /usr/local/bin/announce-to-river.sh *`. Same wildcard-safety pattern as gateway-update: agent validates before invoking; sudoers itself doesn't constrain argv shape.

## Testing

6 new integration tests under `crates/release-agent/tests/update_handler.rs`:

- `announce_disabled_returns_503` — opt-in contract
- `announce_happy_path` — full pipeline with fake-sudo argv recorder confirming `sudo -n -u <user> <script> <message>` shape
- `announce_missing_signature_is_401`
- `announce_empty_message_is_400`
- `announce_oversize_message_is_413` (4 KiB+ message cap)
- `announce_spawn_failure_does_not_consume_rate_limit` — script `exit 1` → 500 + window NOT consumed

Test totals: 23 unit + 20 integration = 43 (was 37 before this PR). `cargo fmt` + `cargo clippy --all-targets -D warnings` clean.

## After merge — operational steps

To make the chain live:

1. Install the updated agent on nova (re-run `install.sh`)
2. Set `river_announce_command = "/usr/local/bin/announce-to-river.sh"` + `river_announce_user = "ian"` in nova's config; restart agent
3. Configure GitHub secrets: `MATRIX_HOMESERVER_URL`, `MATRIX_ACCESS_TOKEN`, plus the existing `RELEASE_AGENT_HMAC_NOVA`/`VEGA` from PR #4082
4. Cut a release — the `release.published` event will drive the full cascade

Documented in `docs/release-agent-deployment.md` (new GitHub Actions secrets section + River-path architecture diagram).

## Risk

The new endpoint is opt-in (off by default) and the workflows are no-ops when their respective secrets aren't set, so merging this PR is safe even before the operational steps above. The first cascade-triggering release will be the live test.

Builds on #4082 ([AI-assisted - Claude])