### PR TITLE
chore: route release-agent through existing per-host vhosts

### DIFF
--- a/.github/workflows/gateway-update.yml
+++ b/.github/workflows/gateway-update.yml
@@ -93,15 +93,15 @@ jobs:
           # (no inputs available); honor explicit subset on workflow_dispatch.
           REQUESTED="${{ inputs.gateways || 'all' }}"
           if [[ "$REQUESTED" == "all" ]]; then
-            MATRIX='[{"name":"nova","url":"https://update.nova.locut.us"},{"name":"vega","url":"https://update.vega.locut.us"}]'
+            MATRIX='[{"name":"nova","url":"https://nova.locut.us/release-agent"},{"name":"vega","url":"http://vega.locut.us:9876"}]'
           else
             # Build the array by filtering the full list. Cheap, transparent,
             # easy to read in workflow logs.
             ITEMS="[]"
             for tag in $(echo "$REQUESTED" | tr ',' ' '); do
               case "$tag" in
-                nova) ITEMS=$(echo "$ITEMS" | jq -c '. + [{"name":"nova","url":"https://update.nova.locut.us"}]') ;;
-                vega) ITEMS=$(echo "$ITEMS" | jq -c '. + [{"name":"vega","url":"https://update.vega.locut.us"}]') ;;
+                nova) ITEMS=$(echo "$ITEMS" | jq -c '. + [{"name":"nova","url":"https://nova.locut.us/release-agent"}]') ;;
+                vega) ITEMS=$(echo "$ITEMS" | jq -c '. + [{"name":"vega","url":"http://vega.locut.us:9876"}]') ;;
                 *) echo "::error::Unknown gateway tag: $tag"; exit 1 ;;
               esac
             done

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -8,7 +8,7 @@
 #      MATRIX_ACCESS_TOKEN secrets.
 #
 #   2. The Freenet Official River room, by HMAC-signing a request to
-#      nova's release-agent at https://update.nova.locut.us/announce/river.
+#      nova's release-agent at https://nova.locut.us/release-agent/announce/river.
 #      The agent invokes `riverctl` locally as the user who owns the
 #      room signing key. Needs RELEASE_AGENT_HMAC_NOVA secret.
 #
@@ -154,13 +154,13 @@ jobs:
           SIG=$(printf '%s' "$BODY" \
             | openssl dgst -sha256 -mac HMAC -macopt "hexkey:$SECRET" \
             | awk '{print $NF}')
-          echo "Posting to https://update.nova.locut.us/announce/river"
+          echo "Posting to https://nova.locut.us/release-agent/announce/river"
           # riverctl can take up to ~180s on a cold cargo run; the agent's
           # internal probe is 1s and it returns 202 before the script
           # completes. The HTTP request itself returns fast.
           HTTP_STATUS=$(curl -sS -o /tmp/river-response.json -w '%{http_code}' \
             --connect-timeout 30 --max-time 30 \
-            -X POST 'https://update.nova.locut.us/announce/river' \
+            -X POST 'https://nova.locut.us/release-agent/announce/river' \
             -H 'Content-Type: application/json' \
             -H "X-Signature: $SIG" \
             --data-raw "$BODY")

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ worktrees/
 logs/
 .grepai/
 .codex
+
+# Local-only: release-agent binary staged for install.sh (built per-machine)
+scripts/release-agent/freenet-release-agent


### PR DESCRIPTION
## Problem

After merging the auto-trigger workflows in #4114, the URLs they POST to (`update.{nova,vega}.locut.us`) need their own DNS records and Caddy vhosts. Joker.com (DNS for `locut.us`) has no API access here, and vega's :443 is occupied by an unrelated service (`gkapi.freenet.org`), so the originally-planned subdomain approach can't be set up automatically.

## Approach

Both gateways already have working `<host>.locut.us` vhosts. Use **path-based routing under those existing hostnames** instead of new subdomains.

- **nova** (`https://nova.locut.us/release-agent/*`): Caddy `handle_path /release-agent/*` strips the prefix and reverse-proxies to `127.0.0.1:9876`. Reuses the existing Let's Encrypt cert.

- **vega** (`http://vega.locut.us:9876/*`): no Caddy needed — agent listens on `0.0.0.0:9876` directly, plain HTTP. AWS SG inbound TCP/9876 added (rule `sgr-04c69d7ae23b4c5fe`). HMAC + clock-skew are the actual auth boundary; the body (`{version, issued_at}` or `{message, issued_at}`) is non-secret.

## Testing

Both endpoints verified live with HMAC-signed POSTs returning `200 {"no_op":true,"dry_run":true}` for current version:

```
$ curl ... https://nova.locut.us/release-agent/update      # 200 no_op
$ curl ... http://vega.locut.us:9876/update                # 200 no_op
```

Both /healthz and /version respond externally as expected.

## Follow-up (not blocking)

When vega's :443 frees up or DNS API access becomes available, the URL can be re-unified back to a TLS-terminated path for vega without breaking anything (agent endpoint paths stay the same).

[AI-assisted - Claude]