### PR TITLE
fix(release): anchor fdev freenet-dep sed on version field, not trailing }

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,14 @@ jobs:
           sed "s/^version = \".*\"/version = \"$FDEV_VERSION\"/" crates/fdev/Cargo.toml > crates/fdev/Cargo.toml.tmp
           mv crates/fdev/Cargo.toml.tmp crates/fdev/Cargo.toml
 
-          sed "s/freenet = { path = \"..\/core\", version = \".*\" }/freenet = { path = \"..\/core\", version = \"$VERSION\" }/" crates/fdev/Cargo.toml > crates/fdev/Cargo.toml.tmp2
+          # Anchor on the version field, NOT a trailing ` }`. The line in
+          # crates/fdev/Cargo.toml carries a `, features = [...]` suffix so a
+          # pattern that requires the closing brace silently no-ops, leaving
+          # fdev's freenet-dep version pinned to the previous release (#4119).
+          # Mirror in `scripts/release.sh`; tests in
+          # `crates/fdev/tests/binstall_metadata.rs::release_sed_rewrite`
+          # (the `freenet_dep_*` cases) keep both copies in lockstep.
+          sed -E "s/(freenet = \\{ path = \"\\.\\.\\/core\", version = )\"[^\"]*\"/\\1\"$VERSION\"/" crates/fdev/Cargo.toml > crates/fdev/Cargo.toml.tmp2
           mv crates/fdev/Cargo.toml.tmp2 crates/fdev/Cargo.toml
 
           # The fdev crate version diverged from the freenet release tag, so

--- a/crates/fdev/tests/binstall_metadata.rs
+++ b/crates/fdev/tests/binstall_metadata.rs
@@ -242,4 +242,117 @@ bin-dir = \"fdev.exe\"
         let after_second = run_sed(&[BRE_SCRIPT], &after_first);
         assert_eq!(after_first, after_second, "BRE rewrite must be idempotent");
     }
+
+    // Sed expressions that rewrite the `freenet = { path = "../core",
+    // version = "X.Y.Z", ... }` path-dep version inside fdev/Cargo.toml.
+    // Duplicated between `scripts/release.sh` (BRE) and
+    // `.github/workflows/release.yml` (ERE). Regression for issue #4119:
+    // the old ERE pattern tried to anchor on a trailing ` }`, which
+    // silently failed once the line grew a `, features = [...]` suffix
+    // and the freenet-dep version stayed pinned across releases.
+    const FREENET_DEP_BRE_SCRIPT: &str =
+        "s/\\(freenet = { path = \"..\\/core\", version = \\)\"[^\"]*\"/\\1\"NEW\"/";
+    const FREENET_DEP_ERE_SCRIPT: &str =
+        "s/(freenet = \\{ path = \"\\.\\.\\/core\", version = )\"[^\"]*\"/\\1\"NEW\"/";
+
+    const FREENET_DEP_FIXTURE_PLAIN: &str =
+        "freenet = { path = \"../core\", version = \"0.2.57\" }\n";
+    const FREENET_DEP_FIXTURE_WITH_FEATURES: &str =
+        "freenet = { path = \"../core\", version = \"0.2.57\", features = [\"testing\"] }\n";
+
+    fn expected_freenet_dep_plain() -> String {
+        FREENET_DEP_FIXTURE_PLAIN.replace("0.2.57", "NEW")
+    }
+
+    fn expected_freenet_dep_with_features() -> String {
+        FREENET_DEP_FIXTURE_WITH_FEATURES.replace("0.2.57", "NEW")
+    }
+
+    #[test]
+    fn release_sh_bre_rewrites_freenet_dep_plain() {
+        let out = run_sed(&[FREENET_DEP_BRE_SCRIPT], FREENET_DEP_FIXTURE_PLAIN);
+        assert_eq!(out, expected_freenet_dep_plain());
+    }
+
+    #[test]
+    fn release_sh_bre_rewrites_freenet_dep_with_features() {
+        // Regression for #4119: the path-dep line in fdev/Cargo.toml carries
+        // `features = ["testing"]`; the rewrite must succeed regardless of
+        // what trails after the version field.
+        let out = run_sed(&[FREENET_DEP_BRE_SCRIPT], FREENET_DEP_FIXTURE_WITH_FEATURES);
+        assert_eq!(out, expected_freenet_dep_with_features());
+    }
+
+    #[test]
+    fn release_yml_ere_rewrites_freenet_dep_plain() {
+        let out = run_sed(&["-E", FREENET_DEP_ERE_SCRIPT], FREENET_DEP_FIXTURE_PLAIN);
+        assert_eq!(out, expected_freenet_dep_plain());
+    }
+
+    #[test]
+    fn release_yml_ere_rewrites_freenet_dep_with_features() {
+        // Regression for #4119: the previous ERE anchored on a trailing
+        // ` }` and silently no-op'd against the `, features = [...]` suffix.
+        let out = run_sed(
+            &["-E", FREENET_DEP_ERE_SCRIPT],
+            FREENET_DEP_FIXTURE_WITH_FEATURES,
+        );
+        assert_eq!(out, expected_freenet_dep_with_features());
+    }
+
+    #[test]
+    fn release_sh_and_release_yml_freenet_dep_produce_identical_output() {
+        for fixture in [FREENET_DEP_FIXTURE_PLAIN, FREENET_DEP_FIXTURE_WITH_FEATURES] {
+            let bre_out = run_sed(&[FREENET_DEP_BRE_SCRIPT], fixture);
+            let ere_out = run_sed(&["-E", FREENET_DEP_ERE_SCRIPT], fixture);
+            assert_eq!(
+                bre_out, ere_out,
+                "scripts/release.sh and .github/workflows/release.yml must \
+                 produce identical freenet-dep rewrites — silent drift between \
+                 the two copies is what regressed #4119 in the first place"
+            );
+        }
+    }
+
+    #[test]
+    fn freenet_dep_rewrite_is_idempotent_when_version_unchanged() {
+        for fixture in [FREENET_DEP_FIXTURE_PLAIN, FREENET_DEP_FIXTURE_WITH_FEATURES] {
+            let after_first = run_sed(&[FREENET_DEP_BRE_SCRIPT], fixture);
+            let after_second = run_sed(&[FREENET_DEP_BRE_SCRIPT], &after_first);
+            assert_eq!(
+                after_first, after_second,
+                "freenet-dep BRE rewrite must be idempotent"
+            );
+        }
+    }
+
+    #[test]
+    fn fdev_cargo_toml_freenet_dep_line_is_rewritable() {
+        // Belt-and-braces: take the real fdev/Cargo.toml off disk and confirm
+        // the BRE and ERE rewrites both actually modify the version field.
+        // This is what release.sh / release.yml do at release time; a sed
+        // that silently no-ops here is what regressed #4119.
+        let manifest = std::fs::read_to_string("Cargo.toml")
+            .expect("fdev/Cargo.toml should be readable from the crate dir");
+        let bre_out = run_sed(&[FREENET_DEP_BRE_SCRIPT], &manifest);
+        assert_ne!(
+            bre_out, manifest,
+            "BRE rewrite must actually change the manifest — issue #4119 \
+             regressed because the pattern silently matched nothing"
+        );
+        assert!(
+            bre_out.contains("version = \"NEW\""),
+            "BRE rewrite must produce the new version literal"
+        );
+        let ere_out = run_sed(&["-E", FREENET_DEP_ERE_SCRIPT], &manifest);
+        assert_ne!(
+            ere_out, manifest,
+            "ERE rewrite must actually change the manifest — issue #4119 \
+             regressed because the pattern silently matched nothing"
+        );
+        assert!(
+            ere_out.contains("version = \"NEW\""),
+            "ERE rewrite must produce the new version literal"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`.github/workflows/release.yml`'s `update_versions` step had a sed that bumps fdev's `freenet` path-dep version. The pattern tried to match the whole line including the trailing ` }`:

```bash
sed "s/freenet = { path = \"..\/core\", version = \".*\" }/.../" crates/fdev/Cargo.toml
```

The actual line in `crates/fdev/Cargo.toml` is:

```toml
freenet = { path = "../core", version = "0.2.57", features = ["testing"] }
```

The `, features = [...]` suffix means the trailing ` }` is no longer adjacent to the version field, so the sed silently no-ops and fdev's freenet-dep version stays pinned to the previous release.

v0.2.57's bump PR was caught by the existing `freenet_dep_matches_workspace_freenet_version` regression test and required a manual fixup (`05825532` on `release/v0.2.57`) to unblock the merge_group.

## Approach

Replace the pattern with the same anchor-on-version-field shape that `scripts/release.sh` already uses (the BRE form has been correct all along; only the ERE in release.yml was stale):

```bash
sed -E "s/(freenet = \{ path = \"\.\.\/core\", version = )\"[^\"]*\"/\1\"$VERSION\"/"
```

`scripts/release.sh` is already correct (line 645) and needs no change.

## Testing

Added six new tests in `crates/fdev/tests/binstall_metadata.rs::release_sed_rewrite`:

- `release_sh_bre_rewrites_freenet_dep_plain` / `_with_features` — exercises the BRE on both forms
- `release_yml_ere_rewrites_freenet_dep_plain` / `_with_features` — exercises the ERE on both forms (the `_with_features` case is the #4119 regression)
- `release_sh_and_release_yml_freenet_dep_produce_identical_output` — locks BRE and ERE in lockstep across both fixtures
- `freenet_dep_rewrite_is_idempotent_when_version_unchanged`
- `fdev_cargo_toml_freenet_dep_line_is_rewritable` — belt-and-braces: runs the regexes against the real `fdev/Cargo.toml` on disk and asserts the rewrite actually changes the version literal

Verified the new ERE pattern works against both fixture forms and the real manifest. Verified the old broken ERE no-ops on the with-features fixture (this is what the new tests catch).

All 16 tests in `cargo test -p fdev --test binstall_metadata` pass.

Fixes #4119

[AI-assisted - Claude]