### PR TITLE
build: route vega release-agent through HTTPS:8443

### DIFF
--- a/.github/workflows/gateway-update.yml
+++ b/.github/workflows/gateway-update.yml
@@ -93,7 +93,7 @@ jobs:
           # (no inputs available); honor explicit subset on workflow_dispatch.
           REQUESTED="${{ inputs.gateways || 'all' }}"
           if [[ "$REQUESTED" == "all" ]]; then
-            MATRIX='[{"name":"nova","url":"https://nova.locut.us/release-agent"},{"name":"vega","url":"http://vega.locut.us:9876"}]'
+            MATRIX='[{"name":"nova","url":"https://nova.locut.us/release-agent"},{"name":"vega","url":"https://vega.locut.us:8443/release-agent"}]'
           else
             # Build the array by filtering the full list. Cheap, transparent,
             # easy to read in workflow logs.
@@ -101,7 +101,7 @@ jobs:
             for tag in $(echo "$REQUESTED" | tr ',' ' '); do
               case "$tag" in
                 nova) ITEMS=$(echo "$ITEMS" | jq -c '. + [{"name":"nova","url":"https://nova.locut.us/release-agent"}]') ;;
-                vega) ITEMS=$(echo "$ITEMS" | jq -c '. + [{"name":"vega","url":"http://vega.locut.us:9876"}]') ;;
+                vega) ITEMS=$(echo "$ITEMS" | jq -c '. + [{"name":"vega","url":"https://vega.locut.us:8443/release-agent"}]') ;;
                 *) echo "::error::Unknown gateway tag: $tag"; exit 1 ;;
               esac
             done

--- a/docs/release-agent-deployment.md
+++ b/docs/release-agent-deployment.md
@@ -184,10 +184,32 @@ narrowing the SG creates more breakage than it prevents.
 
 ### vega (AWS EC2)
 
-Open inbound TCP/443 on the instance's security group from `0.0.0.0/0`,
-relying on HMAC for authentication. The agent's defense-in-depth layers
-(clock-skew window, rate-limit, version-pin, GitHub-latest cross-check)
-mean the endpoint can be public-Internet-reachable safely.
+Vega differs from nova: `ghostkey-api` (gkapi.freenet.org) already owns
+:80 and :443 on this host, so the release-agent uses a **non-standard
+port and a per-host vhost**.
+
+- AWS Security Group `sg-0f4b9b9b5bf2a8cbb`: open inbound **TCP/8443**
+  from `0.0.0.0/0`. (No need to open :443; Caddy doesn't listen there
+  on vega.) Rely on HMAC for authentication; the agent's defense-in-
+  depth layers (clock-skew window, rate-limit, version-pin, GitHub-
+  latest cross-check) make a public endpoint safe.
+- Caddy config: install
+  [`scripts/release-agent/Caddyfile.vega.snippet`](../scripts/release-agent/Caddyfile.vega.snippet)
+  as `/etc/caddy/Caddyfile`. It uses `auto_https off` so Caddy doesn't
+  try to bind :80/:443, and an explicit `tls` directive pointing at
+  the dedicated `vega.locut.us` Let's Encrypt cert at
+  `/etc/letsencrypt/live/vega.locut.us/{fullchain,privkey}.pem`.
+- Cert permissions: the `caddy` system user must be in the `ssl-cert`
+  group; the cert files in `/etc/letsencrypt/archive/vega.locut.us/`
+  must be chgrp'd to `ssl-cert` with mode `0640` (privkey) / `0644`
+  (the rest). Install
+  [`scripts/release-agent/reload-caddy.sh`](../scripts/release-agent/reload-caddy.sh)
+  as `/etc/letsencrypt/renewal-hooks/deploy/reload-caddy.sh` (mode
+  0755) so certbot re-applies the group ownership and reloads Caddy
+  after each renewal.
+- Smoke test URL: `https://vega.locut.us:8443/release-agent/healthz`
+  (not `update.vega.locut.us`). The workflow's vega matrix entry
+  matches this.
 
 If you want a tighter SG, the alternative is a fronting Caddy on a
 known-IP host that the SG allows in, with the agent's port only

--- a/scripts/release-agent/Caddyfile.vega.snippet
+++ b/scripts/release-agent/Caddyfile.vega.snippet
@@ -1,4 +1,4 @@
-# vega.locut.us — TLS termination for the release-agent on port 8443.
+# vega.locut.us: TLS termination for the release-agent on port 8443.
 #
 # Background: vega already hosts ghostkey-api (gkapi.freenet.org) bound
 # to :80 and :443. Caddy cannot also own those ports, so the release-
@@ -10,8 +10,9 @@
 
 {
     # Disable automatic HTTP→HTTPS redirects and the implicit :80
-    # listener — ghostkey-api owns :80 (for the ACME http-01 challenge
-    # on gkapi.freenet.org) and :443 on this host.
+    # listener. ghostkey-api owns :80 (for the ACME http-01 challenge
+    # on gkapi.freenet.org) and :443 on this host, so Caddy must not
+    # try to bind either.
     auto_https off
 }
 

--- a/scripts/release-agent/Caddyfile.vega.snippet
+++ b/scripts/release-agent/Caddyfile.vega.snippet
@@ -1,0 +1,30 @@
+# vega.locut.us — TLS termination for the release-agent on port 8443.
+#
+# Background: vega already hosts ghostkey-api (gkapi.freenet.org) bound
+# to :80 and :443. Caddy cannot also own those ports, so the release-
+# agent reverse-proxy listens on :8443 with the dedicated Let's Encrypt
+# certificate for vega.locut.us (obtained via certbot --webroot during
+# the v0.2.57 setup).
+#
+# Install path on vega: /etc/caddy/Caddyfile
+
+{
+    # Disable automatic HTTP→HTTPS redirects and the implicit :80
+    # listener — ghostkey-api owns :80 (for the ACME http-01 challenge
+    # on gkapi.freenet.org) and :443 on this host.
+    auto_https off
+}
+
+https://vega.locut.us:8443 {
+    tls /etc/letsencrypt/live/vega.locut.us/fullchain.pem /etc/letsencrypt/live/vega.locut.us/privkey.pem
+
+    # `handle_path` strips the /release-agent prefix before the
+    # reverse-proxy, so the agent sees /update, /version, /healthz.
+    handle_path /release-agent/* {
+        reverse_proxy 127.0.0.1:9876
+    }
+
+    handle {
+        respond "vega.locut.us release-agent" 200
+    }
+}

--- a/scripts/release-agent/README.md
+++ b/scripts/release-agent/README.md
@@ -12,6 +12,8 @@ in `crates/release-agent/`. Tracked in
 | `sudoers.freenet-release-agent` | `/etc/sudoers.d/` (mode 0440) | NOPASSWD only for `gateway-auto-update.sh --force` |
 | `config.example.toml` | `/etc/freenet-release-agent/config.toml` | Per-gateway config; **dry_run = true** by default |
 | `Caddyfile.snippet` | merge into your Caddy config | TLS-terminated public hostname (`update.<host>.locut.us`) |
+| `Caddyfile.vega.snippet` | `/etc/caddy/Caddyfile` on vega | Variant for vega: ghostkey-api owns :80/:443, so Caddy listens on `:8443` with the dedicated LE cert at `/etc/letsencrypt/live/vega.locut.us/` and `auto_https off`. |
+| `reload-caddy.sh` | `/etc/letsencrypt/renewal-hooks/deploy/reload-caddy.sh` on vega (mode 0755) | Certbot deploy hook: re-applies `ssl-cert` group ownership on rotated cert files, then `systemctl reload caddy`. Scoped to `RENEWED_LINEAGE=*/vega.locut.us` so it leaves the gkapi cert renewal alone. |
 | `install.sh` | run once on the gateway | Wires all of the above |
 
 ## Privilege model

--- a/scripts/release-agent/reload-caddy.sh
+++ b/scripts/release-agent/reload-caddy.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Certbot deploy hook for vega.locut.us — fix up cert permissions for the
+# Certbot deploy hook for vega.locut.us. Fixes up cert permissions for the
 # `ssl-cert` group (Caddy reads the cert as the `caddy` user, which is in
 # that group) and tell Caddy to pick up the renewed cert without dropping
 # the listening socket on :8443.

--- a/scripts/release-agent/reload-caddy.sh
+++ b/scripts/release-agent/reload-caddy.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Certbot deploy hook for vega.locut.us — fix up cert permissions for the
+# `ssl-cert` group (Caddy reads the cert as the `caddy` user, which is in
+# that group) and tell Caddy to pick up the renewed cert without dropping
+# the listening socket on :8443.
+#
+# Runs only when at least one cert was actually renewed (certbot only
+# invokes deploy hooks on success). RENEWED_LINEAGE is set to the
+# /etc/letsencrypt/live/<name> directory by certbot.
+#
+# Install path on vega: /etc/letsencrypt/renewal-hooks/deploy/reload-caddy.sh
+# (mode 0755, owner root:root). Filed as part of issue #4120.
+
+set -eu
+
+case "${RENEWED_LINEAGE:-}" in
+  */vega.locut.us)
+    ARCHIVE_DIR="/etc/letsencrypt/archive/vega.locut.us"
+    if [ -d "$ARCHIVE_DIR" ]; then
+      # Re-apply ssl-cert group ownership and group-readable mode on the
+      # newly-rotated cert files. certbot writes them as root:root 0600
+      # for privkey / 0644 for the chain by default.
+      chgrp ssl-cert "$ARCHIVE_DIR"/*.pem
+      chmod 0644 "$ARCHIVE_DIR"/cert*.pem "$ARCHIVE_DIR"/chain*.pem "$ARCHIVE_DIR"/fullchain*.pem
+      chmod 0640 "$ARCHIVE_DIR"/privkey*.pem
+    fi
+    # Reload (not restart) Caddy so existing connections drain gracefully.
+    systemctl reload caddy
+    ;;
+  *)
+    # Different cert renewed (e.g. gkapi.freenet.org). Nothing to do here.
+    ;;
+esac


### PR DESCRIPTION
## Problem

For v0.2.57 the release-agent on vega was reachable as `http://vega.locut.us:9876/*` (plain HTTP). Codex flagged this as P1 in #4115: the HMAC-signed body + `X-Signature` traverse the network in cleartext, so any passive observer within the 5-minute clock-skew window can capture the signature. Rate-limited but still a regression vs. nova's HTTPS.

The plain-HTTP path was the path-of-least-resistance unblock because ghostkey-api owns :80 and :443 on vega (for `gkapi.freenet.org`), leaving no room for Caddy on the standard ports.

## Solution

Use a non-conflicting port + dedicated cert. The Let's Encrypt cert for `vega.locut.us` was already issued during the v0.2.57 setup at `/etc/letsencrypt/live/vega.locut.us/`. This PR adds:

- **`scripts/release-agent/Caddyfile.vega.snippet`** — the vega Caddyfile. `auto_https off` global block stops Caddy trying to bind :80/:443 (ghostkey-api owns them). Listens on `https://vega.locut.us:8443` with explicit `tls` directive pointing at the LE cert. `handle_path /release-agent/*` reverse-proxies to `127.0.0.1:9876`.
- **`scripts/release-agent/reload-caddy.sh`** — certbot deploy hook. Re-applies `ssl-cert` group ownership on rotated archive files (certbot writes them `root:root` by default) and `systemctl reload caddy`. Scoped to `RENEWED_LINEAGE=*/vega.locut.us` so it doesn't interfere with gkapi cert renewals.
- **`.github/workflows/gateway-update.yml`** — vega URL flipped from `http://vega.locut.us:9876` to `https://vega.locut.us:8443/release-agent` in both `all` and explicit-subset branches.

## Deployment (already done on vega in PR prep)

- AWS SG `sg-0f4b9b9b5bf2a8cbb` gained TCP/8443 ingress; the temporary TCP/9876 ingress (`sgr-04c69d7ae23b4c5fe`) is revoked.
- `caddy` system user added to `ssl-cert` group (mirrors how gkapi reads its cert); `/etc/letsencrypt/archive/vega.locut.us/*.pem` chgrp'd to ssl-cert with mode 0640 for privkey / 0644 for the chain.
- `/etc/caddy/Caddyfile` replaced with `Caddyfile.vega.snippet` (backup at `/etc/caddy/Caddyfile.pre-8443-<timestamp>`). `caddy validate` passes; `systemctl restart caddy` is up and healthy.
- `/etc/freenet-release-agent/config.toml` reverted to `listen_addr = "127.0.0.1:9876"`; service restarted.
- `/etc/letsencrypt/renewal-hooks/deploy/reload-caddy.sh` installed, mode 0755.
- `certbot renew --dry-run` succeeds for both `gkapi.freenet.org` and `vega.locut.us`.

## Testing

```
$ curl -sS -i https://vega.locut.us:8443/release-agent/healthz
HTTP/2 200
server: Caddy
content-length: 2
ok

$ curl -sS --max-time 5 -i http://vega.locut.us:9876/healthz
curl: (7) Failed to connect to vega.locut.us port 9876
```

End-to-end smoke test via `gh workflow run gateway-update.yml --field version=0.2.57 --field gateways=vega --field dry_run_workflow=true` will be linked in a comment after this PR is opened.

## Out of scope

- No changes to the nova path — nova continues to be reached at `https://nova.locut.us/release-agent`.
- The `Caddyfile.snippet` (generic `update.<host>.locut.us` form) is left in place for future gateways that don't have the :80/:443 conflict.

Fixes #4120

[AI-assisted - Claude]