### PR TITLE
refactor: final per-tx driver cleanup (#1454)

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -10,13 +10,9 @@ paths:
 
 Every operation runs as a task-per-transaction driver: each `Transaction`
 is owned and driven by a single spawned task; state lives in task
-locals. The `Operation` trait and the legacy `process_message` /
-`load_or_init` / `handle_op_request` / `handle_op_result` mediator
-path are all gone. `OpEnum`, every per-op DashMap (`ops.connect`,
-`ops.get`, `ops.put`, `ops.update`, `ops.subscribe`) and the
-`OpManager::push` / `pop` / `has_*_op` accessors that fed them are
-gone too. Drivers publish their own `HostResult` via
-`result_router_tx` and own routing/retry state in task locals.
+locals. Drivers publish their own `HostResult` via `result_router_tx`
+and own routing/retry state in task locals. `OpManager` carries no
+per-op DashMaps.
 
 Driver entry points:
 
@@ -47,24 +43,16 @@ for every inbound wire message. Pattern per op:
    `upstream_addr=own_addr` for GET/PUT/SUBSCRIBE so the same driver
    handles both relay hops and originator loopback. UPDATE has no
    loopback (fire-and-forget end-to-end).
-3. **No legacy fallthrough.** Every wire variant either bypasses to a
-   waiter, dispatches a driver, or hits a dedicated free-function
-   handler (e.g. `handle_unsubscribe_inbound`, `ForwardingAck` no-op).
-   The legacy `handle_op_request` mediator was deleted in the CONNECT
-   phase 6 slice — any inbound message that does not match a bypass or
-   relay-dispatch rule is dropped with a debug log.
+3. **No fallthrough.** Every wire variant either bypasses to a waiter,
+   dispatches a driver, or hits a dedicated free-function handler (e.g.
+   `handle_unsubscribe_inbound`, `ForwardingAck` no-op). Anything else
+   is dropped with a debug log.
 
-## OpEnum and DashMaps
+## Test fixtures
 
-- `OpEnum` and every per-op DashMap (`ops.{connect,get,put,update,
-  subscribe}`) are gone. No production code path writes to them.
-- `OpManager::push` / `pop` / `has_*_op` / `OpNotAvailable` are all
-  retired.
-- `pending_op_counts()` returns `[0; 5]` — kept for telemetry API
-  stability; every slot is always 0.
-- `ConnectOp` itself survives as a test-only fixture (the
-  `handle_request` state-machine helper backs the relay driver's
-  decision logic). It has no central carrier.
+`ConnectOp` survives only as a `#[cfg(test)]` fixture wrapping
+`RelayState::handle_request`. Production CONNECT runs entirely on the
+drivers in `connect/op_ctx_task.rs`.
 
 ## Critical Invariant: Initialize-Before-Send
 
@@ -204,18 +192,12 @@ CORRECT:
 
 ## Error Handling
 
-### WHEN encountering OpNotPresent
+### WHEN a reply arrives with no waiter
 
 ```
-This is usually benign (duplicate message, already completed)
-→ Log at debug level
-→ Return Ok(None)
-→ Do NOT treat as error
+Benign (duplicate message, already completed). Drop with a debug log
+at the dispatch site. Do NOT treat as an error.
 ```
-
-`load_or_init` is gone. Any reply that does not match a bypass or a
-relay-dispatch rule is dropped silently in the dispatch site — that is
-the new equivalent of the old `OpNotPresent` outcome.
 
 ### WHEN encountering InvalidStateTransition
 

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1472,8 +1472,7 @@ async fn process_open_request(
                                     );
                                 })?;
 
-                            // `subscribe_with_id` is client-initiated-only since #1454 Phase 2b;
-                            // no `is_renewal` parameter.
+                            // `subscribe_with_id` is client-initiated-only; no `is_renewal` parameter.
                             crate::node::subscribe_with_id(op_manager.clone(), key, None, Some(tx))
                                 .await
                                 .inspect_err(|err| {

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -14,10 +14,9 @@ pub mod storages;
 pub(crate) mod user_input;
 
 pub(crate) use executor::{
-    ContractExecutor, ExecutorToEventLoopChannel, MAX_CREATED_DELEGATES_PER_NODE,
-    MAX_DELEGATE_CREATION_DEPTH, MAX_DELEGATE_CREATIONS_PER_CALL, NetworkEventListenerHalve,
-    SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE, UpsertResult, mediator_channels,
-    mock_runtime::MockRuntime,
+    ContractExecutor, ExecutorTransactionStream, MAX_CREATED_DELEGATES_PER_NODE,
+    MAX_DELEGATE_CREATION_DEPTH, MAX_DELEGATE_CREATIONS_PER_CALL,
+    SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE, UpsertResult, mock_runtime::MockRuntime,
 };
 
 // Re-export CRDT emulation functions for testing

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -343,15 +343,9 @@ impl Display for OperationMode {
     }
 }
 
-// `ComposeNetworkMessage`, `op_request`, `UpdateContract`,
-// `SubscribeContract`, and the executor → event-loop mediator
-// (`op_request_channel`/`run_op_request_mediator`/`OpRequestSender`)
-// are all retired. Executor auto-subscribe now calls
-// `subscribe::run_executor_subscribe` directly; UPDATEs flow through
-// `start_client_update`. No executor ever writes to the event loop
-// through the legacy mediator path.
+// Executor auto-subscribe calls `subscribe::run_executor_subscribe`
+// directly; UPDATEs flow through `start_client_update`.
 
-/// Empty stub for the now-retired executor → event-loop mediator
 /// Empty stream used to fill the executor-transaction slot in
 /// `priority_select::PrioritySelectStream`. Never yields.
 pub(crate) struct ExecutorTransactionStream;

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -1,5 +1,5 @@
 //! Executes WASM contract and delegate code within a sandboxed environment (`WasmRuntime`).
-//! Communicates with the `ContractHandler` and potentially the `OpManager` (via `ExecutorToEventLoopChannel`).
+//! Communicates with the `ContractHandler`.
 //! See `architecture.md`.
 
 use std::collections::{HashMap, HashSet};
@@ -352,42 +352,17 @@ impl Display for OperationMode {
 // through the legacy mediator path.
 
 /// Empty stub for the now-retired executor → event-loop mediator
-/// channel. Retained as a generic-param placeholder for
-/// `priority_select::PrioritySelectStream` so the event loop's
-/// `executor_transaction_handler` slot keeps the same shape; the
-/// inner channel is never written to and the `Stream` impl yields
-/// `Pending` forever.
-pub(crate) struct ExecutorToEventLoopChannel<End: sealed::ChannelHalve> {
-    _end: End,
-}
+/// Empty stream used to fill the executor-transaction slot in
+/// `priority_select::PrioritySelectStream`. Never yields.
+pub(crate) struct ExecutorTransactionStream;
 
-pub(crate) fn mediator_channels(
-    _op_manager: Arc<OpManager>,
-) -> ExecutorToEventLoopChannel<NetworkEventListenerHalve> {
-    ExecutorToEventLoopChannel {
-        _end: NetworkEventListenerHalve {},
-    }
-}
-
-#[allow(dead_code)]
-pub(crate) struct NetworkEventListenerHalve {}
-
-mod sealed {
-    use super::NetworkEventListenerHalve;
-    pub trait ChannelHalve {}
-    impl ChannelHalve for NetworkEventListenerHalve {}
-}
-
-impl futures::Stream for ExecutorToEventLoopChannel<NetworkEventListenerHalve> {
+impl futures::Stream for ExecutorTransactionStream {
     type Item = crate::message::Transaction;
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        // No writer ever sends through this channel; stay Pending so
-        // the priority-select stream never fires the executor-transaction
-        // arm.
         std::task::Poll::Pending
     }
 }

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -729,11 +729,6 @@ impl ContractExecutor for RuntimePool {
 // Single Executor Implementation
 // ============================================================================
 
-// `ComputedStateUpdate` and `compute_state_update` were retired together
-// with the network branch of `perform_contract_update` in #1454 phase 5;
-// that branch was unreachable in production because no
-// `OperationMode::Network` constructor exists.
-
 // ============================================================================
 // Bridged methods - shared production logic for Runtime and MockWasmRuntime
 // ============================================================================
@@ -3056,18 +3051,9 @@ impl Executor<Runtime> {
         let updates = vec![update];
 
         // `Executor::contract_requests` is only invoked from `run_local_node`
-        // (HTTP/WS local-only entry points); network-mode UPDATEs from clients
-        // arrive through `client_event_handling` → `start_client_update`
-        // (#1454 phase 4) and never reach this function. The
-        // `OperationMode::Local` short-circuit therefore covers every
-        // production caller.
-        //
-        // Phase 5 final (#1454) deleted the executor-initiated network
-        // UPDATE path (`UpdateContract`, `op_request(UpdateContract)`,
-        // `request_update`, `start_op`) because no `OperationMode::Network`
-        // constructor exists in the tree. The remaining branch returns
-        // an internal error if a future caller flips the mode without
-        // restoring a task-per-tx executor UPDATE driver.
+        // (HTTP/WS local-only entry points). Network-mode UPDATEs from
+        // clients arrive through `client_event_handling` →
+        // `start_client_update` and never reach this function.
         if self.mode == OperationMode::Local {
             let new_state = self
                 .get_updated_state(&parameters, current_state, key, updates)
@@ -3080,8 +3066,8 @@ impl Executor<Runtime> {
         }
 
         Err(ExecutorError::other(anyhow::anyhow!(
-            "executor-initiated network UPDATE path was retired in #1454 phase 5; \
-             clients must dispatch UPDATEs via `start_client_update` (client_events.rs)"
+            "network UPDATE must dispatch via `start_client_update` (client_events.rs); \
+             `perform_contract_update` is reachable only in local mode"
         )))
     }
 
@@ -3448,24 +3434,16 @@ impl Executor<Runtime> {
         if self.mode == OperationMode::Local {
             return Ok(());
         }
-        // Bypass the legacy `op_request` mediator path entirely (#1454
-        // SUBSCRIBE executor migration): driver delivers the resolved
-        // outcome directly through its return value. The executor was
-        // the last legacy writer into `ops.subscribe` for client-style
-        // SUBSCRIBE — once this migrates, the SUBSCRIBE GC retry block
-        // becomes provably dead (mirrors GET phase 5-final pattern).
         let op_manager = self
             .op_manager
             .as_ref()
             .ok_or_else(|| ExecutorError::other(anyhow::anyhow!("missing op_manager")))?;
         let executor_tx = crate::message::Transaction::new::<operations::subscribe::SubscribeMsg>();
-        // 120 s mirrors the legacy `op_request` `OP_REQUEST_TIMEOUT`
-        // (`crates/core/src/contract/executor.rs`, deleted in this
-        // migration). Caps total task lifetime — the inner driver's
-        // per-attempt `OPERATION_TTL = 60 s` would otherwise allow
-        // multi-attempt waits to compound. Any change here should be
-        // checked against the per-attempt budget so `MAX_RETRIES`
-        // attempts can complete within the deadline.
+        // Caps total task lifetime — the inner driver's per-attempt
+        // `OPERATION_TTL = 60 s` would otherwise allow multi-attempt
+        // waits to compound. Any change here should be checked against
+        // the per-attempt budget so `MAX_RETRIES` attempts can complete
+        // within the deadline.
         const SUBSCRIBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
         match tokio::time::timeout(
             SUBSCRIBE_TIMEOUT,
@@ -3498,26 +3476,23 @@ impl Executor<Runtime> {
                 return Ok(Either::Left(state));
             }
         }
-        // Fetch from network via the task-per-tx sub-op GET driver.
-        // Bypasses the legacy `op_request` mediator path entirely
-        // (issue #1454 phase 5 follow-up): driver delivers the
-        // resolved `GetResult` directly through a oneshot.
+        // Fetch from network via the sub-op GET driver. The driver
+        // delivers the resolved `GetResult` directly through a oneshot.
         let op_manager = self
             .op_manager
             .as_ref()
             .ok_or_else(|| ExecutorError::other(anyhow::anyhow!("missing op_manager")))?;
         let (_tx, rx) =
             operations::get::op_ctx_task::start_sub_op_get(op_manager, *id, return_contract_code);
-        // Matches the legacy `op_request` envelope. Outer callers may
-        // wrap this with a tighter budget (e.g.,
+        // Outer callers may wrap this with a tighter budget (e.g.,
         // `fetch_related_for_validation_network` uses
         // `RELATED_FETCH_TIMEOUT = 10s`); when that fires first the
         // receiver is dropped silently and the spawned sub-op task
         // continues until OPERATION_TTL exhausts the retry loop. No
         // leak (oneshot send-after-drop is graceful) — just a
         // longer-lived background task.
-        const OP_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
-        let outcome = tokio::time::timeout(OP_REQUEST_TIMEOUT, rx)
+        const SUB_OP_FETCH_TIMEOUT: Duration = Duration::from_secs(120);
+        let outcome = tokio::time::timeout(SUB_OP_FETCH_TIMEOUT, rx)
             .await
             .map_err(|_| {
                 tracing::warn!(
@@ -3728,13 +3703,9 @@ mod resolve_message_origin_tests {
 }
 
 #[cfg(test)]
-mod sub_op_get_migration_pin_tests {
-    /// Pin: `local_state_or_from_network` MUST use the task-per-tx
-    /// sub-op GET driver, not the legacy `op_request(GetContract)`
-    /// path. Regression: legacy path went through the executor
-    /// mediator + `request_get`, pushing GetOp into ops.get and
-    /// keeping the GC speculative-retry block alive for sub-op GETs.
-    /// Migrated in #1454 phase 5 follow-up.
+mod executor_pin_tests {
+    /// Pin: `local_state_or_from_network` MUST use the sub-op GET
+    /// driver.
     #[test]
     fn local_state_or_from_network_uses_sub_op_driver() {
         let src = include_str!("runtime.rs");
@@ -3750,36 +3721,23 @@ mod sub_op_get_migration_pin_tests {
             .expect("closing brace");
         assert!(
             body.contains("start_sub_op_get"),
-            "local_state_or_from_network must call start_sub_op_get — \
-             sub-op GET migration in #1454 phase 5 follow-up"
+            "local_state_or_from_network must call start_sub_op_get"
         );
         // Compose the needles at runtime so the assertion source itself
-        // doesn't trip the pin (matches the pattern used in put.rs).
+        // doesn't trip the pin.
         let get_contract_needle = ["Get", "Contract", " {"].concat();
         assert!(
             !body.contains(&get_contract_needle),
-            "local_state_or_from_network must NOT construct legacy \
-             GetContract — retired in #1454 sub-op GET migration"
+            "local_state_or_from_network must NOT construct GetContract"
         );
         let op_request_needle = ["self.", "op_request"].concat();
         assert!(
             !body.contains(&op_request_needle),
-            "local_state_or_from_network must NOT call self.op_request — \
-             sub-op GET migration bypasses the legacy mediator path"
+            "local_state_or_from_network must NOT call self.op_request"
         );
     }
 
-    /// Pin: `executor::subscribe` MUST use the task-per-tx executor
-    /// SUBSCRIBE driver, not the legacy `op_request(SubscribeContract)`
-    /// path. Regression: legacy path went through the executor mediator
-    /// and called `request_subscribe`, pushing `SubscribeOp` into
-    /// `ops.subscribe` and keeping the SUBSCRIBE GC retry block alive
-    /// for the executor auto-subscribe writer.
-    ///
-    /// Migrated in #1454 SUBSCRIBE executor migration (mirrors the
-    /// GET phase 5-final pattern). The next slice retires the
-    /// SUBSCRIBE GC retry block once relay-side intermediate-peer
-    /// writers are also migrated.
+    /// Pin: `executor::subscribe` MUST use `run_executor_subscribe`.
     #[test]
     fn executor_subscribe_uses_run_executor_subscribe() {
         let src = include_str!("runtime.rs");
@@ -3795,37 +3753,27 @@ mod sub_op_get_migration_pin_tests {
             .expect("closing brace");
         assert!(
             body.contains("run_executor_subscribe"),
-            "executor::subscribe must call run_executor_subscribe — \
-             SUBSCRIBE executor migration (#1454)"
+            "executor::subscribe must call run_executor_subscribe"
         );
         // Compose the needle at runtime so the assertion source itself
         // doesn't trip the pin.
         let sub_contract_needle = ["Subscribe", "Contract", " {"].concat();
         assert!(
             !body.contains(&sub_contract_needle),
-            "executor::subscribe must NOT construct legacy \
-             SubscribeContract — retired in #1454 SUBSCRIBE executor \
-             migration"
+            "executor::subscribe must NOT construct SubscribeContract"
         );
         let op_request_needle = ["self.", "op_request"].concat();
         assert!(
             !body.contains(&op_request_needle),
-            "executor::subscribe must NOT call self.op_request — \
-             SUBSCRIBE executor migration bypasses the legacy mediator \
-             path"
+            "executor::subscribe must NOT call self.op_request"
         );
     }
 
-    /// Pin: `perform_contract_update` MUST NOT construct an
-    /// `UpdateContract` or call `self.op_request` for the network
-    /// branch. Regression: the legacy path went through the executor
-    /// mediator + `request_update`, pushing `UpdateOp` into
-    /// `ops.update` and keeping the legacy state-machine alive even
-    /// though the network branch was unreachable in production
-    /// (no `OperationMode::Network` constructor exists in the tree).
-    /// Retired in #1454 phase 5 final (UPDATE slice).
+    /// Pin: `perform_contract_update` MUST NOT route the network branch
+    /// through `UpdateContract` / `self.op_request` / `request_update`.
+    /// Network-mode UPDATEs flow through `start_client_update`.
     #[test]
-    fn perform_contract_update_does_not_use_legacy_network_path() {
+    fn perform_contract_update_does_not_use_network_op_request() {
         let src = include_str!("runtime.rs");
         let body = src
             .split("async fn perform_contract_update(")
@@ -3840,21 +3788,18 @@ mod sub_op_get_migration_pin_tests {
         let update_contract_needle = ["Update", "Contract", " {"].concat();
         assert!(
             !body.contains(&update_contract_needle),
-            "perform_contract_update must NOT construct legacy \
-             UpdateContract — retired in #1454 phase 5 final"
+            "perform_contract_update must NOT construct UpdateContract"
         );
         let op_request_needle = ["self.", "op_request"].concat();
         assert!(
             !body.contains(&op_request_needle),
-            "perform_contract_update must NOT call self.op_request — \
-             phase 5 final bypassed the legacy mediator path; \
+            "perform_contract_update must NOT call self.op_request; \
              network-mode UPDATEs flow through start_client_update"
         );
         let request_update_needle = ["request_", "update("].concat();
         assert!(
             !body.contains(&request_update_needle),
-            "perform_contract_update must NOT call legacy request_update — \
-             retired in #1454 phase 5 final"
+            "perform_contract_update must NOT call request_update"
         );
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -90,7 +90,7 @@ pub mod dev_tool {
 
     // Test hooks: per-op driver call counters. Tests assert these
     // increment to confirm wire variants dispatch through their
-    // task-per-tx driver (not a local-cache shortcut or legacy path).
+    // driver (not a local-cache shortcut or legacy path).
     #[cfg(any(test, feature = "testing"))]
     pub use crate::operations::get::op_ctx_task::DRIVER_CALL_COUNT as GET_DRIVER_CALL_COUNT;
     #[cfg(any(test, feature = "testing"))]

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -683,7 +683,7 @@ where
 /// `OpCtx::send_and_await`. On a closed receiver (caller cancelled or
 /// timed out) the send fails and is logged; the handler still makes
 /// progress. See `.claude/rules/channel-safety.md`.
-fn try_forward_task_per_tx_reply(
+fn try_forward_driver_reply(
     pending_op_result: Option<&tokio::sync::mpsc::Sender<NetMessage>>,
     reply: NetMessage,
     op_label: &'static str,
@@ -697,7 +697,7 @@ fn try_forward_task_per_tx_reply(
             %err,
             %tx_id,
             op = op_label,
-            "Failed to forward task-per-tx reply to OpCtx task"
+            "Failed to forward driver reply to OpCtx task"
         );
     }
     true
@@ -785,7 +785,7 @@ where
                     | connect::ConnectMsg::ConnectFailed { .. }
             ) {
                 let forwarded_op = fill_connect_response_acceptor_addr(op.clone(), source_addr);
-                if try_forward_task_per_tx_reply(
+                if try_forward_driver_reply(
                     pending_op_result.as_ref(),
                     NetMessage::V1(NetMessageV1::Connect(forwarded_op)),
                     "connect",
@@ -857,7 +857,7 @@ where
             if matches!(
                 op,
                 put::PutMsg::Response { .. } | put::PutMsg::ResponseStreaming { .. }
-            ) && try_forward_task_per_tx_reply(
+            ) && try_forward_driver_reply(
                 pending_op_result.as_ref(),
                 NetMessage::V1(NetMessageV1::Put((*op).clone())),
                 "put",
@@ -970,7 +970,7 @@ where
             if matches!(
                 op,
                 get::GetMsg::Response { .. } | get::GetMsg::ResponseStreaming { .. }
-            ) && try_forward_task_per_tx_reply(
+            ) && try_forward_driver_reply(
                 pending_op_result.as_ref(),
                 NetMessage::V1(NetMessageV1::Get((*op).clone())),
                 "get",
@@ -1164,7 +1164,7 @@ where
             // be forwarded — they would fill the capacity-1 reply
             // channel.
             if matches!(op, subscribe::SubscribeMsg::Response { .. })
-                && try_forward_task_per_tx_reply(
+                && try_forward_driver_reply(
                     pending_op_result.as_ref(),
                     NetMessage::V1(NetMessageV1::Subscribe((*op).clone())),
                     "subscribe",
@@ -1362,13 +1362,8 @@ where
             return Ok(());
         }
         NetMessageV1::Aborted(tx) => {
-            // No-op after #1454 phase 6 retired the legacy mediator:
-            // CONNECT abort retry depended on `pop`-ing `OpEnum::Connect`
-            // from a DashMap that no production code writes to anymore.
-            // GET/PUT/UPDATE/SUBSCRIBE drivers own their own cancellation
-            // surface (`result_router_tx` publication is the externally
-            // observable result). Senders of `Aborted` come only from
-            // drivers themselves and are handled in-driver via the bypass.
+            // Drivers own their own cancellation; `Aborted` senders are
+            // drivers themselves and the bypass handles in-driver delivery.
             tracing::debug!(
                 %tx,
                 tx_type = ?tx.transaction_type(),
@@ -2137,11 +2132,6 @@ pub async fn run_network_node(mut node: Node) -> anyhow::Result<()> {
     }
 }
 
-// `classify_op_outcome` retired alongside the `OpEnum` mediator —
-// per-op success/failure recording is now done by drivers directly
-// via `record_relay_route_event` / `record_acceptor_outcome` and
-// dashboard counters in driver finalization paths.
-
 #[cfg(test)]
 mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
@@ -2329,16 +2319,14 @@ mod tests {
         assert_eq!(init_peer.location, location);
     }
 
-    // `classify_op_outcome` tests retired with the helper.
-
-    // Tests for `try_forward_task_per_tx_reply`.
+    // Tests for `try_forward_driver_reply`.
     //
     // The bypass routes a reply directly to an awaiting
     // `OpCtx::send_and_await` caller. These tests cover the
     // helper's contract; end-to-end branch coverage lives in the
     // per-driver tests.
     mod callback_forward_tests {
-        use super::super::try_forward_task_per_tx_reply;
+        use super::super::try_forward_driver_reply;
         use crate::message::{MessageStats, NetMessage, NetMessageV1, Transaction};
         use crate::operations::connect::ConnectMsg;
 
@@ -2347,7 +2335,7 @@ mod tests {
         }
 
         // ───────────────────────────────────────────────────────────
-        // Tests for `try_forward_task_per_tx_reply`.
+        // Tests for `try_forward_driver_reply`.
         //
         // The bypass routes a reply directly to an awaiting
         // `OpCtx::send_and_await` caller. These tests cover the
@@ -2361,7 +2349,7 @@ mod tests {
             let reply = dummy_reply();
             let expected_id = *reply.id();
 
-            let taken = try_forward_task_per_tx_reply(Some(&tx), reply, "subscribe");
+            let taken = try_forward_driver_reply(Some(&tx), reply, "subscribe");
             assert!(taken, "callback present → bypass must be taken");
 
             let received = rx
@@ -2375,7 +2363,7 @@ mod tests {
             // No callback registered → caller must fall through to legacy
             // `handle_op_request`. The helper must not panic and must
             // return `false`.
-            let taken = try_forward_task_per_tx_reply(None, dummy_reply(), "subscribe");
+            let taken = try_forward_driver_reply(None, dummy_reply(), "subscribe");
             assert!(!taken, "no callback → bypass must not be taken");
         }
 
@@ -2396,7 +2384,7 @@ mod tests {
             let (tx, rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
             drop(rx);
 
-            let taken = try_forward_task_per_tx_reply(Some(&tx), dummy_reply(), "subscribe");
+            let taken = try_forward_driver_reply(Some(&tx), dummy_reply(), "subscribe");
             assert!(
                 taken,
                 "callback present but receiver dropped → bypass still taken"
@@ -2405,7 +2393,7 @@ mod tests {
 
         /// Pin the bypass call site. Without this regression guard a
         /// future refactor could delete the
-        /// `try_forward_task_per_tx_reply` invocation in the SUBSCRIBE
+        /// `try_forward_driver_reply` invocation in the SUBSCRIBE
         /// branch of `handle_pure_network_message_v1` and the unit tests
         /// on the helper itself would still pass — because unit coverage
         /// on the helper only proves the helper works, not that it's
@@ -2415,7 +2403,7 @@ mod tests {
         /// This test reads the `node.rs` source at compile time via
         /// `include_str!` and asserts that the SUBSCRIBE branch of
         /// `handle_pure_network_message_v1` invokes
-        /// `try_forward_task_per_tx_reply` before running
+        /// `try_forward_driver_reply` before running
         /// `handle_op_request`. A refactor that deletes the bypass call
         /// will fail this test at the unit-test level (review finding
         /// Testing #1).
@@ -2442,8 +2430,7 @@ mod tests {
 
             // Bound the window at the end-of-SUBSCRIBE-arm sentinel
             // ("Non-transactional message types:" header that precedes
-            // the next match arm). After #1454 phase 6 there is no
-            // more `handle_op_request` to anchor against.
+            // the next match arm).
             let next_variant_anchor: String = ["// Non-transactional", " message types:"].concat();
             let window_end = SOURCE[branch_start..]
                 .find(&next_variant_anchor)
@@ -2456,9 +2443,9 @@ mod tests {
             //   (a) the bypass was removed (regression — re-add it), or
             //   (b) the branch was restructured (update this guard).
             assert!(
-                window.contains("try_forward_task_per_tx_reply("),
+                window.contains("try_forward_driver_reply("),
                 "SUBSCRIBE branch no longer calls \
-                 try_forward_task_per_tx_reply before relay dispatch. \
+                 try_forward_driver_reply before relay dispatch. \
                  Either restore the bypass or update this regression \
                  guard if the branch was legitimately refactored."
             );
@@ -2477,7 +2464,7 @@ mod tests {
                 window.contains(&response_gate),
                 "SUBSCRIBE branch bypass is not gated on Response-only. \
                  Non-terminal messages (ForwardingAck, Unsubscribe) must NOT \
-                 be forwarded to the task-per-tx channel — they would fill \
+                 be forwarded to the driver channel — they would fill \
                  the capacity-1 reply slot and block the real Response."
             );
         }
@@ -2493,7 +2480,7 @@ mod tests {
             tx.try_send(dummy_reply())
                 .expect("capacity-1 channel should accept first message");
 
-            let taken = try_forward_task_per_tx_reply(Some(&tx), dummy_reply(), "subscribe");
+            let taken = try_forward_driver_reply(Some(&tx), dummy_reply(), "subscribe");
             assert!(
                 taken,
                 "callback present but channel full → bypass still taken"
@@ -2515,14 +2502,14 @@ mod tests {
         // for the concrete op type and reconstructs the same variant before
         // handing it to `forward_pending_op_result_if_completed`. An
         // end-to-end integration test that spins up a node and exercises
-        // `OpCtx::send_and_await` for each op kind belongs in Phase 2b,
-        // where the first real production caller is added.
+        // `OpCtx::send_and_await` for each op kind belongs alongside
+        // the per-op driver suites.
 
         // ───────────────────────────────────────────────────────────
         // Regression tests for the subscribe-branch message-type
         // filter added in the ForwardingAck fix (5cb6f37c).
         //
-        // The bug: `try_forward_task_per_tx_reply` was called for ALL
+        // The bug: `try_forward_driver_reply` was called for ALL
         // subscribe message types (including ForwardingAck). A relay
         // peer's ForwardingAck would fill the capacity-1 reply
         // channel, causing the task to receive it instead of the
@@ -2539,13 +2526,13 @@ mod tests {
         /// Helper: simulate the filtering logic from the SUBSCRIBE
         /// branch of `handle_pure_network_message_v1`. Returns
         /// `true` if the message would be forwarded to the
-        /// task-per-tx channel (and the branch would return early).
+        /// driver channel (and the branch would return early).
         fn subscribe_branch_would_forward(
             op: &SubscribeMsg,
             callback: Option<&tokio::sync::mpsc::Sender<NetMessage>>,
         ) -> bool {
             matches!(op, SubscribeMsg::Response { .. })
-                && try_forward_task_per_tx_reply(
+                && try_forward_driver_reply(
                     callback,
                     NetMessage::V1(NetMessageV1::Subscribe(op.clone())),
                     "subscribe",
@@ -2652,7 +2639,7 @@ mod tests {
 
         // ───────────────────────────────────────────────────────────
         // Regression guard: PUT branch of handle_pure_network_message_v1
-        // must call try_forward_task_per_tx_reply before relay dispatch,
+        // must call try_forward_driver_reply before relay dispatch,
         // gated on Response|ResponseStreaming only.
         // ───────────────────────────────────────────────────────────
 
@@ -2676,15 +2663,15 @@ mod tests {
             let window = &SOURCE[branch_start..window_end];
 
             assert!(
-                window.contains("try_forward_task_per_tx_reply("),
-                "PUT branch no longer calls try_forward_task_per_tx_reply. \
+                window.contains("try_forward_driver_reply("),
+                "PUT branch no longer calls try_forward_driver_reply. \
                  Restore the bypass or update this regression guard."
             );
 
             assert!(
                 window.contains("put::PutMsg::Response { .. }"),
                 "PUT branch bypass is not gated on Response. \
-                 Non-terminal messages must NOT be forwarded to the task-per-tx channel."
+                 Non-terminal messages must NOT be forwarded to the driver channel."
             );
 
             assert!(
@@ -2704,7 +2691,7 @@ mod tests {
             let dashmap_gate_needle = format!("has{}_op", "_put");
             assert!(
                 !window.contains(&dashmap_gate_needle),
-                "PUT branch must not gate dispatch on the retired DashMap existence check"
+                "PUT branch must not gate dispatch on per-op DashMap existence"
             );
         }
 
@@ -2728,7 +2715,7 @@ mod tests {
             matches!(
                 op,
                 PutMsg::Response { .. } | PutMsg::ResponseStreaming { .. }
-            ) && try_forward_task_per_tx_reply(
+            ) && try_forward_driver_reply(
                 callback,
                 NetMessage::V1(NetMessageV1::Put(op.clone())),
                 "put",
@@ -2831,7 +2818,7 @@ mod tests {
         //
         // Two dispatch layers:
         //   1. Reply bypass: terminal Response/ResponseStreaming for
-        //      an active client driver → `try_forward_task_per_tx_reply`.
+        //      an active client driver → `try_forward_driver_reply`.
         //   2. Relay dispatch: `GetMsg::Request` →  `start_relay_get`,
         //      with originator loopback mapped to `upstream=own_addr`.
         // ───────────────────────────────────────────────────────────
@@ -2855,14 +2842,14 @@ mod tests {
 
             // Reply bypass must precede relay dispatch.
             assert!(
-                window.contains("try_forward_task_per_tx_reply("),
-                "GET branch no longer calls try_forward_task_per_tx_reply \
+                window.contains("try_forward_driver_reply("),
+                "GET branch no longer calls try_forward_driver_reply \
                  before relay dispatch. Restore the bypass."
             );
             assert!(
                 window.contains("get::GetMsg::Response { .. }"),
                 "GET branch bypass is not gated on Response. \
-                 Non-terminal messages must NOT be forwarded to the task-per-tx channel."
+                 Non-terminal messages must NOT be forwarded to the driver channel."
             );
             assert!(
                 window.contains("get::GetMsg::ResponseStreaming { .. }"),
@@ -2896,20 +2883,20 @@ mod tests {
             let dashmap_gate_needle = format!("has{}_op", "_get");
             assert!(
                 !window.contains(&dashmap_gate_needle),
-                "GET branch must NOT gate on the retired DashMap existence check"
+                "GET branch must NOT gate on per-op DashMap existence"
             );
 
             // Bypass must precede relay dispatch in source order
             // (terminal-reply fast path has priority).
             let bypass_pos = window
-                .find("try_forward_task_per_tx_reply(")
-                .expect("try_forward_task_per_tx_reply not found in GET branch");
+                .find("try_forward_driver_reply(")
+                .expect("try_forward_driver_reply not found in GET branch");
             let relay_pos = window
                 .find("start_relay_get(")
                 .expect("start_relay_get not found in GET branch");
             assert!(
                 bypass_pos < relay_pos,
-                "Reply bypass (try_forward_task_per_tx_reply) must \
+                "Reply bypass (try_forward_driver_reply) must \
                  appear BEFORE relay dispatch (start_relay_get) — \
                  swapping order would break the terminal-reply fast \
                  path."
@@ -2958,7 +2945,7 @@ mod tests {
                 );
             }
 
-            // Negative pins for the retired legacy fallthrough: composing
+            // Negative pins for the fallthrough: composing
             // needles at runtime so this test's source doesn't trip its
             // own assertion.
             let legacy_call = ["handle_op_request::<update::", "UpdateOp", ", _>"].concat();
@@ -3041,7 +3028,7 @@ mod tests {
             let dashmap_gate_needle = format!("has{}_op", "_put");
             assert!(
                 !window.contains(&dashmap_gate_needle),
-                "PUT branch must NOT gate on the retired DashMap existence check"
+                "PUT branch must NOT gate on per-op DashMap existence"
             );
         }
 
@@ -3110,14 +3097,14 @@ mod tests {
             // Terminal-reply bypass must still be present (gated on
             // SubscribeMsg::Response).
             assert!(
-                window.contains("try_forward_task_per_tx_reply("),
-                "SUBSCRIBE branch no longer calls try_forward_task_per_tx_reply \
+                window.contains("try_forward_driver_reply("),
+                "SUBSCRIBE branch no longer calls try_forward_driver_reply \
                  before relay dispatch — restore it."
             );
             assert!(
                 window.contains("subscribe::SubscribeMsg::Response { .. }"),
                 "SUBSCRIBE branch bypass is not gated on Response. \
-                 Non-terminal messages must NOT be forwarded to the task-per-tx channel."
+                 Non-terminal messages must NOT be forwarded to the driver channel."
             );
 
             // Relay dispatch must call start_relay_subscribe and route
@@ -3153,20 +3140,20 @@ mod tests {
             let dashmap_gate_needle = format!("has{}_op", "_subscribe");
             assert!(
                 !window.contains(&dashmap_gate_needle),
-                "SUBSCRIBE branch must NOT gate on the retired DashMap existence check"
+                "SUBSCRIBE branch must NOT gate on per-op DashMap existence"
             );
 
             // Bypass must precede relay dispatch in source order
             // (terminal-reply fast path has priority).
             let bypass_pos = window
-                .find("try_forward_task_per_tx_reply(")
-                .expect("try_forward_task_per_tx_reply not found in SUBSCRIBE branch");
+                .find("try_forward_driver_reply(")
+                .expect("try_forward_driver_reply not found in SUBSCRIBE branch");
             let relay_pos = window
                 .find("start_relay_subscribe(")
                 .expect("start_relay_subscribe not found in SUBSCRIBE branch");
             assert!(
                 bypass_pos < relay_pos,
-                "SUBSCRIBE bypass (try_forward_task_per_tx_reply) must appear \
+                "SUBSCRIBE bypass (try_forward_driver_reply) must appear \
                  BEFORE relay dispatch (start_relay_subscribe). Swapping order \
                  would break the client-driver terminal-reply fast path."
             );

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1975,31 +1975,6 @@ pub async fn subscribe_with_id(
     subscribe::start_client_subscribe(op_manager, instance_id, client_tx).await
 }
 
-/// Handle a transaction whose work is being abandoned (transport
-/// handshake failure, orphaned-on-peer-prune, or a peer-sent `Aborted`
-/// wire message). After #1454 phase 6 retired the legacy `Operation`
-/// mediator the function has no work to do: every op type owns its own
-/// cancellation surface in the task-per-tx driver, and the CONNECT
-/// retry-via-gateway branch is driven by `start_client_connect` /
-/// `initial_join_procedure` rather than by a DashMap entry.
-///
-/// Retained as a no-op so the call sites in `p2p_protoc.rs`
-/// (orphaned-on-prune + transport handshake failure) keep compiling
-/// while the centralised abort path is unwired. Will be deleted in
-/// the follow-up slice once those call sites are removed.
-pub(crate) async fn handle_aborted_op(
-    tx: Transaction,
-    _op_manager: &OpManager,
-    _gateways: &[PeerKeyLocation],
-) -> Result<(), OpError> {
-    tracing::debug!(
-        %tx,
-        tx_type = ?tx.transaction_type(),
-        "handle_aborted_op: no-op after #1454 phase 6 (driver-owned cancellation)"
-    );
-    Ok(())
-}
-
 /// The identifier of a peer in the network: a known public key and socket address.
 ///
 /// This is a type alias for [`ring::KnownPeerKeyLocation`], which bundles a peer's

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -177,10 +177,9 @@ impl P2pBridge {
 
     /// Log transactions orphaned by a pruned peer connection.
     ///
-    /// Task-per-tx drivers own their own retry/cancellation surface
-    /// after #1454 — the orphan list is informational only, used by
-    /// callers to confirm prune occurred. No retry is dispatched
-    /// here.
+    /// Drivers own retry/cancellation; the orphan list is informational
+    /// only — used by callers to confirm prune occurred. No retry is
+    /// dispatched here.
     pub(crate) async fn handle_orphaned_transactions(
         &self,
         transactions: Vec<Transaction>,

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -43,10 +43,7 @@ use crate::{
         WaitingResolution,
     },
     message::{MessageStats, NetMessage, NodeEvent, Transaction, TransactionType},
-    node::{
-        NetEventRegister, NodeConfig, OpManager, PeerId, handle_aborted_op,
-        process_message_decoupled,
-    },
+    node::{NetEventRegister, NodeConfig, OpManager, PeerId, process_message_decoupled},
     ring::{KnownPeerKeyLocation, PeerConnectionBackoff, PeerKeyLocation},
     tracing::NetEventLog,
 };
@@ -1160,7 +1157,6 @@ impl P2pConnManager {
                                     let (callback, mut result) = mpsc::channel(10);
                                     let msg_clone = msg.clone();
                                     let bridge_sender = ctx.bridge.ev_listener_tx.clone();
-                                    let op_manager = ctx.bridge.op_manager.clone();
                                     let gateways = ctx.gateways.clone();
 
                                     // Mark gateway connections as transient to prevent
@@ -1229,17 +1225,6 @@ impl P2pConnManager {
                                                     phase = "error",
                                                     "Connection attempt failed"
                                                 );
-                                                if let Err(err) =
-                                                    handle_aborted_op(tx, &op_manager, &gateways)
-                                                        .await
-                                                {
-                                                    tracing::warn!(
-                                                        tx = %tx,
-                                                        error = ?err,
-                                                        phase = "error",
-                                                        "Failed to propagate aborted operation"
-                                                    );
-                                                }
                                             }
                                             Ok(None) => {
                                                 tracing::error!(
@@ -1248,17 +1233,6 @@ impl P2pConnManager {
                                                     phase = "error",
                                                     "Response channel closed before connection result received"
                                                 );
-                                                if let Err(err) =
-                                                    handle_aborted_op(tx, &op_manager, &gateways)
-                                                        .await
-                                                {
-                                                    tracing::warn!(
-                                                        tx = %tx,
-                                                        error = ?err,
-                                                        phase = "error",
-                                                        "Failed to propagate aborted operation"
-                                                    );
-                                                }
                                             }
                                             Err(_) => {
                                                 tracing::error!(
@@ -1267,17 +1241,6 @@ impl P2pConnManager {
                                                     phase = "timeout",
                                                     "Timeout waiting for connection establishment"
                                                 );
-                                                if let Err(err) =
-                                                    handle_aborted_op(tx, &op_manager, &gateways)
-                                                        .await
-                                                {
-                                                    tracing::warn!(
-                                                        tx = %tx,
-                                                        error = ?err,
-                                                        phase = "error",
-                                                        "Failed to propagate aborted operation"
-                                                    );
-                                                }
                                             }
                                         }
                                     });

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -38,10 +38,7 @@ use crate::transport::{
 use crate::{
     client_events::ClientId,
     config::GlobalExecutor,
-    contract::{
-        ContractHandlerChannel, ExecutorToEventLoopChannel, NetworkEventListenerHalve,
-        WaitingResolution,
-    },
+    contract::{ContractHandlerChannel, ExecutorTransactionStream, WaitingResolution},
     message::{MessageStats, NetMessage, NodeEvent, Transaction, TransactionType},
     node::{NetEventRegister, NodeConfig, OpManager, PeerId, process_message_decoupled},
     ring::{KnownPeerKeyLocation, PeerConnectionBackoff, PeerKeyLocation},
@@ -605,14 +602,12 @@ impl P2pConnManager {
         op_manager: Arc<OpManager>,
         client_wait_for_transaction: ContractHandlerChannel<WaitingResolution>,
         notification_channel: EventLoopNotificationsReceiver,
-        executor_listener: ExecutorToEventLoopChannel<NetworkEventListenerHalve>,
         node_controller: Receiver<NodeEvent>,
     ) -> anyhow::Result<Infallible> {
         self.run_event_listener_with_socket::<UdpSocket>(
             op_manager,
             client_wait_for_transaction,
             notification_channel,
-            executor_listener,
             node_controller,
         )
         .await
@@ -633,7 +628,6 @@ impl P2pConnManager {
         op_manager: Arc<OpManager>,
         client_wait_for_transaction: ContractHandlerChannel<WaitingResolution>,
         notification_channel: EventLoopNotificationsReceiver,
-        executor_listener: ExecutorToEventLoopChannel<NetworkEventListenerHalve>,
         node_controller: Receiver<NodeEvent>,
     ) -> anyhow::Result<Infallible> {
         // Destructure self to avoid partial move issues
@@ -714,7 +708,7 @@ impl P2pConnManager {
             handshake_handler,
             node_controller,
             client_wait_for_transaction,
-            executor_listener,
+            ExecutorTransactionStream,
             conn_event_rx,
         );
 

--- a/crates/core/src/node/network_bridge/priority_select.rs
+++ b/crates/core/src/node/network_bridge/priority_select.rs
@@ -13,10 +13,7 @@ use crate::contract::WaitingTransaction;
 
 use super::OpExecutionPayload;
 use super::p2p_protoc::ConnEvent;
-use crate::contract::{
-    ContractHandlerChannel, ExecutorToEventLoopChannel, NetworkEventListenerHalve,
-    WaitingResolution,
-};
+use crate::contract::{ContractHandlerChannel, ExecutorTransactionStream, WaitingResolution};
 use crate::dev_tool::Transaction;
 use crate::message::{NetMessage, NodeEvent};
 // Re-export P2pBridgeEvent from p2p_protoc
@@ -47,7 +44,7 @@ pub(super) enum SelectResult {
 pub(super) type ProductionPrioritySelectStream = PrioritySelectStream<
     super::handshake::HandshakeHandler,
     ContractHandlerChannel<WaitingResolution>,
-    ExecutorToEventLoopChannel<NetworkEventListenerHalve>,
+    ExecutorTransactionStream,
 >;
 
 /// Generic stream-based priority select that owns simple Receivers as streams

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -45,7 +45,7 @@ use super::{
 #[derive(Default)]
 struct Ops {
     // No per-op DashMaps remain. CONNECT, GET, PUT, UPDATE, and
-    // SUBSCRIBE all run on task-per-tx drivers that own state in task
+    // SUBSCRIBE all run on drivers that own state in task
     // locals; the only state retained here is the global completed /
     // under_progress sets used by the GC sweep.
     completed: DashSet<Transaction>,
@@ -119,8 +119,8 @@ pub(crate) struct OpManager {
     /// Backoff tracker for failed gateway connection attempts.
     /// Used to implement exponential backoff when retrying connections.
     pub gateway_backoff: Arc<Mutex<PeerConnectionBackoff>>,
-    /// Notifies `initial_join_procedure` and `handle_aborted_op` when gateway
-    /// backoff is cleared, so they can wake from backoff sleeps and retry immediately.
+    /// Notifies `initial_join_procedure` when gateway backoff is cleared,
+    /// so it can wake from backoff sleep and retry immediately.
     pub gateway_backoff_cleared: Arc<tokio::sync::Notify>,
     /// Addresses blocked by local policy. Used by the connect protocol to reject
     /// join requests from blocked peers at the routing level, allowing the uphill
@@ -135,7 +135,7 @@ pub(crate) struct OpManager {
     /// Maps contract instance ID to the timestamp (ms since epoch via GlobalSimulationTime)
     /// when the fetch was initiated, with a cooldown to avoid repeated fetch attempts.
     pub(crate) pending_contract_fetches: Arc<DashMap<ContractInstanceId, u64>>,
-    /// Transactions with an active task-per-tx relay-GET driver at this
+    /// Transactions with an active driver relay-GET driver at this
     /// node. Populated by `start_relay_get` before spawn and removed by
     /// an RAII guard on the driver task. Consulted by the dispatch gate
     /// in `node.rs` to reject duplicate inbound Requests for a tx that
@@ -548,7 +548,7 @@ impl OpManager {
 
     /// Peek at the next hop address for an outbound initial request.
     ///
-    /// Always returns `None` — every op now runs on a task-per-tx
+    /// Always returns `None` — every op now runs on a driver
     /// driver that owns routing decisions in task locals, so there is
     /// no DashMap entry to consult here. Retained as a stable API
     /// surface for `p2p_protoc::handle_notification_msg`, which falls
@@ -694,10 +694,9 @@ impl OpManager {
         }
     }
 
-    /// Returns pending operation counts: [connect, put, get,
-    /// subscribe, update]. All slots are always 0 — every op runs on
-    /// task-per-tx drivers and the per-type DashMaps have been
-    /// retired. Retained for API stability with the home-page
+    /// Returns pending operation counts: [connect, put, get, subscribe,
+    /// update]. All slots are always 0 (operations run as standalone
+    /// driver tasks); retained for API stability with the home-page
     /// renderer and telemetry consumers.
     pub fn pending_op_counts(&self) -> [u32; 5] {
         [0; 5]
@@ -876,7 +875,7 @@ fn notify_transaction_timeout(
 // drivers expire their inflight guards naturally.
 
 // `record_connect_uphill_timeout` and the per-op GC-sweep CONNECT
-// branch are gone with `ops.connect`. The CONNECT task-per-tx driver
+// branch are gone with `ops.connect`. The CONNECT driver
 // (`start_relay_connect`) now owns its own uphill-timeout reporting
 // via the `Relay*InflightGuard` failure path; the GC sweep no longer
 // has a `ConnectOp` to inspect.
@@ -1066,7 +1065,7 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                         }
                         continue;
                     }
-                    // Every op runs on a task-per-tx driver and owns
+                    // Every op runs on a driver and owns
                     // its own timeout reporting (via
                     // `Relay*InflightGuard` failure paths or
                     // `RetryLoopOutcome::Exhausted`). Nothing for the
@@ -1394,9 +1393,4 @@ mod tests {
         assert!(!waiters.contains_key(&id2));
         assert_eq!(waiters[&id1].len(), 1);
     }
-
-    // `record_connect_uphill_timeout_tests` retired in the
-    // ops.connect DashMap removal slice — the helper no longer
-    // exists (driver-owned acceptor outcome reporting in
-    // `start_relay_connect` replaces the GC-side hook).
 }

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -17,10 +17,7 @@ use crate::{
 use crate::{
     client_events::{BoxedClient, combinator::ClientEventsCombinator},
     config::GlobalExecutor,
-    contract::{
-        self, ContractHandler, ContractHandlerChannel, ExecutorToEventLoopChannel,
-        NetworkEventListenerHalve, WaitingResolution, mediator_channels,
-    },
+    contract::{self, ContractHandler, ContractHandlerChannel, WaitingResolution},
     message::NodeEvent,
     node::NodeConfig,
     operations::connect,
@@ -37,7 +34,6 @@ pub(crate) struct NodeP2P {
     pub(super) location: Option<Location>,
     notification_channel: EventLoopNotificationsReceiver,
     client_wait_for_transaction: ContractHandlerChannel<WaitingResolution>,
-    executor_listener: ExecutorToEventLoopChannel<NetworkEventListenerHalve>,
     node_controller: tokio::sync::mpsc::Receiver<NodeEvent>,
     should_try_connect: bool,
     client_events_task: BoxFuture<'static, anyhow::Error>,
@@ -197,7 +193,6 @@ impl NodeP2P {
             self.op_manager.clone(),
             self.client_wait_for_transaction,
             self.notification_channel,
-            self.executor_listener,
             self.node_controller,
         );
 
@@ -424,14 +419,12 @@ impl NodeP2P {
         })
         .boxed();
 
-        let executor_listener = mediator_channels(op_manager.clone());
         Ok((
             NodeP2P {
                 conn_manager,
                 notification_channel,
                 client_wait_for_transaction: wait_for_event,
                 op_manager,
-                executor_listener,
                 node_controller: node_controller_rx,
                 should_try_connect: config.should_connect,
                 peer_id: None, // PeerId removed - using PeerKeyLocation instead

--- a/crates/core/src/node/testing_impl/in_memory.rs
+++ b/crates/core/src/node/testing_impl/in_memory.rs
@@ -18,7 +18,6 @@ use crate::{
     contract::{
         self, ContractHandler, MemoryContractHandler, MockWasmContractHandler,
         MockWasmHandlerBuilder, SimulationContractHandler, SimulationHandlerBuilder,
-        mediator_channels,
     },
     node::{
         EventLoopExitReason, NetEventRegister,
@@ -98,8 +97,6 @@ impl<ER> Builder<ER> {
         op_manager.ring.attach_op_manager(&op_manager);
         std::mem::drop(_guard);
 
-        let executor_listener = mediator_channels(op_manager.clone());
-
         let contract_handler = MemoryContractHandler::build(
             ch_channel,
             op_manager.clone(),
@@ -161,7 +158,6 @@ impl<ER> Builder<ER> {
                 op_manager,
                 wait_for_event,
                 notification_channel,
-                executor_listener,
                 node_controller_rx,
             )
             .instrument(parent_span)
@@ -222,8 +218,6 @@ impl<ER> Builder<ER> {
         )?);
         op_manager.ring.attach_op_manager(&op_manager);
         std::mem::drop(_guard);
-
-        let executor_listener = mediator_channels(op_manager.clone());
 
         // Use SimulationContractHandler with shared in-memory storage
         let contract_handler = SimulationContractHandler::build(
@@ -290,7 +284,6 @@ impl<ER> Builder<ER> {
                 op_manager,
                 wait_for_event,
                 notification_channel,
-                executor_listener,
                 node_controller_rx,
             )
             .instrument(parent_span)
@@ -349,8 +342,6 @@ impl<ER> Builder<ER> {
         )?);
         op_manager.ring.attach_op_manager(&op_manager);
         std::mem::drop(_guard);
-
-        let executor_listener = mediator_channels(op_manager.clone());
 
         // Use MockWasmContractHandler — exercises the production ContractExecutor code path
         let contract_handler = MockWasmContractHandler::build(
@@ -417,7 +408,6 @@ impl<ER> Builder<ER> {
                 op_manager,
                 wait_for_event,
                 notification_channel,
-                executor_listener,
                 node_controller_rx,
             )
             .instrument(parent_span)

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -27,17 +27,12 @@ pub(crate) mod visited_peers;
 pub(crate) use op_ctx::OpCtx;
 pub(crate) use visited_peers::VisitedPeers;
 
-// `OpEnum` and its delegate-dispatch surface are retired:
-//   - `Connect`: no producer after `OpManager::pop` was removed in
-//     the `ops.connect` DashMap slice.
-//   - `Get`/`Put`/`Update`/`Subscribe`: retired alongside their
-//     respective DashMaps in earlier #1454 slices.
 // Driver finalization paths publish `HostResult` directly via
 // `result_router_tx` (see `op_ctx_task::*`); no central carrier
 // is required.
 
 #[derive(Debug)]
-#[allow(dead_code)] // Surface kept for the CONNECT carrier + post-#1454 phase-5 final tests.
+#[allow(dead_code)]
 pub(crate) enum OpOutcome<'a> {
     /// An op which involves a contract completed successfully.
     ContractOpSuccess {
@@ -94,8 +89,6 @@ pub(crate) enum OpError {
     NotificationError,
     #[error("notification channel error: {0}")]
     NotificationChannelError(String),
-    // Orphan after #1454 phase 6 (no remaining producers); kept in
-    // case a future re-introduction of an Op trait wants them back.
     #[allow(dead_code)]
     #[error("unspected transaction type, trying to get a {0:?} from a {1:?}")]
     IncorrectTxType(TransactionType, TransactionType),
@@ -178,68 +171,6 @@ pub(crate) async fn announce_contract_hosted(op_manager: &OpManager, key: &Contr
             );
         }
     }
-}
-
-/// Set up subscription forwarding at a relay node during GET response propagation.
-///
-/// Relay nodes only set up forwarding (upstream/downstream registration) -- they
-/// do NOT call `ring.subscribe()` or `announce_contract_hosted()`, which would
-/// cause a subscription storm.
-///
-/// Registers:
-/// 1. Upstream peer (response sender) as interest source for Unsubscribe routing
-/// 2. Downstream peer (GET requester) as downstream subscriber for UPDATE propagation
-// Sole caller (legacy GET relay `process_message::Response{Found}` branch)
-// retired in #1454 phase 5 final (GET slice). The task-per-tx GET relay
-// driver inlines its own subscription-forwarding side effect path. This
-// helper is kept for symmetry with similar relay-side helpers and as
-// reference for any future legacy-style relay reintroduction.
-#[allow(dead_code)]
-pub(crate) async fn setup_subscription_forwarding_at_relay(
-    op_manager: &OpManager,
-    key: &ContractKey,
-    tx: &crate::message::Transaction,
-    upstream_response_addr: std::net::SocketAddr,
-    downstream_requester_addr: std::net::SocketAddr,
-) {
-    // Register upstream peer (response sender) as interest source
-    if let Some(upstream_pkl) = op_manager
-        .ring
-        .connection_manager
-        .get_peer_by_addr(upstream_response_addr)
-    {
-        let peer_key = crate::ring::interest::PeerKey::from(upstream_pkl.pub_key.clone());
-        op_manager
-            .interest_manager
-            .register_peer_interest(key, peer_key, None, true);
-    } else {
-        tracing::debug!(
-            tx = %tx,
-            contract = %key,
-            upstream = %upstream_response_addr,
-            "Piggyback relay: upstream peer not in ring, skipping interest registration"
-        );
-    }
-
-    // Register downstream peer (GET requester) as downstream subscriber
-    subscribe::register_downstream_subscriber(
-        op_manager,
-        key,
-        downstream_requester_addr,
-        None,
-        None,
-        tx,
-        " (relay, piggybacked on GET response)",
-    )
-    .await;
-
-    tracing::debug!(
-        tx = %tx,
-        contract = %key,
-        upstream = %upstream_response_addr,
-        downstream = %downstream_requester_addr,
-        "Set up subscription forwarding at relay via GET piggyback"
-    );
 }
 
 /// Complete subscription at the originator node via GET piggyback.
@@ -347,16 +278,13 @@ pub(crate) async fn broadcast_change_interests(
 }
 
 /// Initiates a subscription after a PUT or GET, routing through the
-/// task-per-tx subscribe driver.
+/// subscribe driver as a fire-and-forget background task.
 ///
 /// `blocking` is accepted for API stability (callers may inspect it for
-/// telemetry), but post-#1454 sub-op SUBSCRIBE migration it has no
-/// behavioral effect: the subscribe runs as a fire-and-forget background
-/// task in either case. The legacy `SubOperationTracker`-based blocking
-/// semantics (parent waits for child via tracker DashMap) are retired —
-/// task-per-tx PUT/GET drivers handle blocking by `await`ing
-/// `subscribe::run_client_subscribe` inline (see `maybe_subscribe_child`
-/// in `put/op_ctx_task.rs` and `get/op_ctx_task.rs`).
+/// telemetry) but has no behavioral effect here: PUT/GET drivers that
+/// want to wait for completion `await` `subscribe::run_client_subscribe`
+/// inline (see `maybe_subscribe_child` in `put/op_ctx_task.rs` and
+/// `get/op_ctx_task.rs`).
 pub(super) fn start_subscription_request(
     op_manager: &OpManager,
     parent_tx: Transaction,
@@ -370,7 +298,7 @@ pub(super) fn start_subscription_request(
         %child_tx,
         %key,
         blocking,
-        "spawning child subscription operation (task-per-tx driver)"
+        "spawning child subscription operation (driver)"
     );
 
     // `run_client_subscribe` requires `Arc<OpManager>`. Callers on
@@ -897,20 +825,10 @@ mod streaming_tests {
 }
 
 #[cfg(test)]
-mod sub_op_subscribe_migration_pin_tests {
-    //! Pin tests for the #1454 sub-op SUBSCRIBE migration.
-    //!
-    //! These tests scrape the source of `start_subscription_request` to
-    //! prove that:
-    //! 1. The legacy `subscribe::request_subscribe` driver and the legacy
-    //!    `expect_and_register_sub_operation` registration call are gone
-    //!    from the production sub-op SUBSCRIBE entry point.
-    //! 2. The function spawns the task-per-tx
-    //!    `subscribe::run_client_subscribe` driver instead.
-    //!
-    //! If a future refactor reintroduces the legacy paths, these tests
-    //! will fail loudly and force a re-evaluation against the rationale
-    //! recorded in `.claude/rules/operations.md`.
+mod sub_op_subscribe_pin_tests {
+    //! Pin tests that prove `start_subscription_request` spawns
+    //! `subscribe::run_client_subscribe` and does not register with a
+    //! sub-operation tracker.
 
     fn extract_start_subscription_request_body() -> &'static str {
         let src = include_str!("operations.rs");
@@ -950,14 +868,12 @@ mod sub_op_subscribe_migration_pin_tests {
     }
 
     #[test]
-    fn start_subscription_request_does_not_call_legacy_request_subscribe() {
+    fn start_subscription_request_uses_run_client_subscribe() {
         let body = extract_start_subscription_request_body();
         assert!(
             !body.contains("subscribe::request_subscribe"),
-            "`start_subscription_request` must NOT route through the \
-             legacy `subscribe::request_subscribe` driver — sub-op \
-             SUBSCRIBE migrated to `subscribe::run_client_subscribe` \
-             (see #1454 follow-up)."
+            "`start_subscription_request` must route through \
+             `subscribe::run_client_subscribe`, not `request_subscribe`."
         );
     }
 
@@ -966,25 +882,23 @@ mod sub_op_subscribe_migration_pin_tests {
         let body = extract_start_subscription_request_body();
         assert!(
             !body.contains("expect_and_register_sub_operation"),
-            "`start_subscription_request` must NOT call \
-             `expect_and_register_sub_operation` — `SubOperationTracker` \
-             was deleted in #1454 Phase 3c. Reintroducing it would be a \
-             regression."
+            "`start_subscription_request` must NOT register with a \
+             sub-operation tracker."
         );
         assert!(
             !body.contains("sub_operation_failed"),
             "`start_subscription_request` must NOT propagate failures \
-             via `sub_operation_failed` — the task-per-tx subscribe \
-             driver publishes its own `HostResult::Err`."
+             via `sub_operation_failed` — the subscribe driver \
+             publishes its own `HostResult::Err`."
         );
     }
 
     #[test]
-    fn start_subscription_request_spawns_task_per_tx_driver() {
+    fn start_subscription_request_spawns_driver_driver() {
         let body = extract_start_subscription_request_body();
         assert!(
             body.contains("subscribe::run_client_subscribe"),
-            "`start_subscription_request` must spawn the task-per-tx \
+            "`start_subscription_request` must spawn the driver \
              subscribe driver `subscribe::run_client_subscribe` — \
              matches the `maybe_subscribe_child` pattern in \
              `put/op_ctx_task.rs` and `get/op_ctx_task.rs`."

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -96,27 +96,27 @@ use std::time::Duration;
 use tokio::time::Instant;
 
 use futures::{StreamExt, stream::FuturesUnordered};
+#[cfg(test)]
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
-use crate::client_events::HostResult;
 use crate::config::{GlobalExecutor, GlobalRng};
 use crate::dev_tool::Location;
 use crate::message::{InnerMessage, NodeEvent, Transaction};
 use crate::node::OpManager;
-use crate::operations::{OpError, OpOutcome};
+use crate::operations::OpError;
 use crate::ring::{KnownPeerKeyLocation, PeerAddr, PeerKeyLocation};
 use crate::router::{EstimatorType, IsotonicEstimator, IsotonicEvent};
 use crate::transport::TransportKeypair;
-use crate::util::{Contains, IterExt, time_source::InstantTimeSrc};
-use freenet_stdlib::client_api::HostResponse;
+use crate::util::{Contains, IterExt};
 
 use super::VisitedPeers;
 
 pub(crate) mod op_ctx_task;
 
+#[cfg(test)]
 const FORWARD_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(20);
 const RECENCY_COOLDOWN: Duration = Duration::from_secs(30);
 
@@ -412,8 +412,11 @@ pub(crate) struct RelayActions {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ForwardAttempt {
+    #[cfg_attr(not(test), allow(dead_code))]
     peer: PeerKeyLocation,
+    #[cfg_attr(not(test), allow(dead_code))]
     desired: Location,
+    #[cfg_attr(not(test), allow(dead_code))]
     sent_at: Instant,
 }
 
@@ -1084,42 +1087,19 @@ impl JoinerState {
     }
 }
 
-/// Operation wrapper retained for in-file unit tests of the
-/// relay/joiner state machine. Production CONNECT runs entirely on the
-/// task-per-tx drivers in `op_ctx_task.rs` and stores routing state in
-/// task locals. The `ops.connect` DashMap still references this type
-/// as its value, but nothing writes to it after #1454 phase 6.
+/// Test-only fixture wrapping the relay/joiner state machine.
+#[cfg(test)]
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // `recency` / `time_source` are seeded by `new_*` (test-only constructors).
 pub(crate) struct ConnectOp {
     pub(crate) id: Transaction,
     pub(crate) state: Option<ConnectState>,
-    pub(crate) first_hop: Option<Box<PeerKeyLocation>>,
-    pub(crate) desired_location: Option<Location>,
     recency: HashMap<PeerKeyLocation, Instant>,
     forward_attempts: HashMap<PeerKeyLocation, ForwardAttempt>,
     connect_forward_estimator: Arc<RwLock<ConnectForwardEstimator>>,
-    time_source: Arc<dyn crate::util::time_source::TimeSource + Send + Sync>,
 }
 
-#[allow(dead_code)] // Constructors + getters used only by in-file unit tests.
+#[cfg(test)]
 impl ConnectOp {
-    /// Creates a ConnectOp with just a state, for unit-testing GC timeout logic.
-    #[cfg(test)]
-    pub(crate) fn with_state(state: ConnectState) -> Self {
-        use crate::util::time_source::InstantTimeSrc;
-        Self {
-            id: Transaction::new::<ConnectMsg>(),
-            state: Some(state),
-            first_hop: None,
-            desired_location: None,
-            recency: HashMap::new(),
-            forward_attempts: HashMap::new(),
-            connect_forward_estimator: Arc::new(RwLock::new(ConnectForwardEstimator::new())),
-            time_source: Arc::new(InstantTimeSrc::new()),
-        }
-    }
-
     fn record_forward_outcome(&mut self, peer: &PeerKeyLocation, desired: Location, success: bool) {
         self.forward_attempts.remove(peer);
         if !success {
@@ -1150,18 +1130,10 @@ impl ConnectOp {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
-    // Retained for in-file unit tests + the legacy
-    // `initiate_join_request` wrapper. Production joiner-side
-    // initiation flows through `prepare_join_request`. Pending
-    // deletion alongside the rest of `impl Operation for ConnectOp`.
-    #[allow(dead_code)]
     pub(crate) fn new_joiner(
         id: Transaction,
-        desired_location: Location,
         target_connections: usize,
         observed_address: Option<SocketAddr>,
-        gateway: Option<PeerKeyLocation>,
         connect_forward_estimator: Arc<RwLock<ConnectForwardEstimator>>,
     ) -> Self {
         let started_without_address = observed_address.is_none();
@@ -1175,22 +1147,13 @@ impl ConnectOp {
         Self {
             id,
             state: Some(state),
-            first_hop: gateway.map(Box::new),
-            desired_location: Some(desired_location),
             recency: HashMap::new(),
             forward_attempts: HashMap::new(),
             connect_forward_estimator,
-            time_source: Arc::new(InstantTimeSrc::new()),
         }
     }
 
-    /// Construct a new relay-side `ConnectOp` from an inbound
-    /// `Request`.
-    ///
-    /// Not called from production: fresh inbound `Request`s route
-    /// through `op_ctx_task::start_relay_connect`. Retained for
-    /// in-file unit tests that exercise `RelayState::handle_request`
-    /// semantics inline.
+    /// Construct a relay-side `ConnectOp` from an inbound `Request`.
     pub(crate) fn new_relay(
         id: Transaction,
         upstream_addr: SocketAddr,
@@ -1217,55 +1180,12 @@ impl ConnectOp {
         Self {
             id,
             state: Some(state),
-            first_hop: None,
-            desired_location: None,
             recency: HashMap::new(),
             forward_attempts: HashMap::new(),
             connect_forward_estimator,
-            time_source: Arc::new(InstantTimeSrc::new()),
         }
     }
 
-    pub(crate) fn is_completed(&self) -> bool {
-        matches!(self.state, Some(ConnectState::Completed))
-    }
-
-    pub(crate) fn id(&self) -> &Transaction {
-        &self.id
-    }
-
-    pub(crate) fn outcome(&self) -> OpOutcome<'_> {
-        OpOutcome::Irrelevant
-    }
-
-    pub(crate) fn finalized(&self) -> bool {
-        self.is_completed()
-    }
-
-    pub(crate) fn to_host_result(&self) -> HostResult {
-        Ok(HostResponse::Ok)
-    }
-
-    pub(crate) fn gateway(&self) -> Option<&PeerKeyLocation> {
-        self.first_hop.as_deref()
-    }
-
-    /// Get the next hop address if this operation is in a state that needs to send
-    /// an outbound message. For Connect, this is the first hop peer we're connecting through.
-    pub(crate) fn get_next_hop_addr(&self) -> Option<std::net::SocketAddr> {
-        self.first_hop.as_deref().and_then(|g| g.socket_addr())
-    }
-
-    /// Get the full target peer (including public key) for connection establishment.
-    /// For Connect operations, this returns the gateway peer.
-    pub(crate) fn get_target_peer(&self) -> Option<crate::ring::PeerKeyLocation> {
-        self.first_hop.as_deref().cloned()
-    }
-
-    // Retained for in-file unit tests. Production callers build the
-    // wire message via the free `prepare_join_request` helper and
-    // skip the legacy `ConnectOp` carrier.
-    #[allow(dead_code)]
     pub(crate) fn initiate_join_request(
         own: PeerKeyLocation,
         target: PeerKeyLocation,
@@ -1280,69 +1200,12 @@ impl ConnectOp {
 
         let op = ConnectOp::new_joiner(
             tx,
-            desired_location,
             target_connections,
             own.socket_addr(),
-            Some(target.clone()),
             connect_forward_estimator,
         );
 
         (tx, op, msg)
-    }
-
-    pub(crate) fn handle_response(
-        &mut self,
-        response: &ConnectResponse,
-        now: Instant,
-    ) -> Option<JoinerAcceptance> {
-        match self.state.as_mut() {
-            Some(ConnectState::WaitingForResponses(state)) => {
-                tracing::info!(
-                    acceptor_pub_key = %response.acceptor.pub_key(),
-                    acceptor_loc = ?response.acceptor.location(),
-                    target_connections = state.target_connections,
-                    accepted_count = state.accepted.len(),
-                    "connect: joiner received ConnectResponse"
-                );
-                let result = state.register_acceptance(response, now);
-                if let Some(new_acceptor) = &result.new_acceptor {
-                    self.recency.remove(&new_acceptor.peer);
-                }
-                tracing::info!(
-                    tx = %self.id,
-                    satisfied = result.satisfied,
-                    accepted_count = state.accepted.len(),
-                    target_connections = state.target_connections,
-                    "connect: register_acceptance result"
-                );
-                if result.satisfied {
-                    // INVARIANT: If the joiner started without knowing their external address,
-                    // they must have received ObservedAddress by the time the connect completes.
-                    // This catches bugs where ObservedAddress is not emitted (e.g., if the
-                    // transport layer prematurely fills in the address).
-                    debug_assert!(
-                        !state.started_without_address || state.observed_address.is_some(),
-                        "BUG: Connect completed but joiner never received ObservedAddress. \
-                         This indicates the transport layer may have prematurely filled in \
-                         the joiner's address, preventing ObservedAddress emission."
-                    );
-                    tracing::info!(
-                        tx = %self.id,
-                        elapsed_ms = self.id.elapsed().as_millis(),
-                        "Connect operation completed"
-                    );
-                    self.state = Some(ConnectState::Completed);
-                }
-                Some(result)
-            }
-            _ => None,
-        }
-    }
-
-    pub(crate) fn handle_observed_address(&mut self, address: SocketAddr, now: Instant) {
-        if let Some(ConnectState::WaitingForResponses(state)) = self.state.as_mut() {
-            state.update_observed_address(address, now);
-        }
     }
 
     pub(crate) fn handle_request<C: RelayContext>(
@@ -2224,9 +2087,7 @@ mod tests {
     fn expired_forward_attempts_are_cleared() {
         let mut op = ConnectOp::new_joiner(
             Transaction::new::<ConnectMsg>(),
-            Location::new(0.1),
             1,
-            None,
             None,
             Arc::new(RwLock::new(ConnectForwardEstimator::new())),
         );
@@ -2246,14 +2107,8 @@ mod tests {
     #[test]
     fn expired_forward_attempts_record_failures_in_estimator() {
         let estimator = Arc::new(RwLock::new(ConnectForwardEstimator::new()));
-        let mut op = ConnectOp::new_joiner(
-            Transaction::new::<ConnectMsg>(),
-            Location::new(0.1),
-            1,
-            None,
-            None,
-            estimator.clone(),
-        );
+        let mut op =
+            ConnectOp::new_joiner(Transaction::new::<ConnectMsg>(), 1, None, estimator.clone());
         let peer = make_peer(2000);
         op.forward_attempts.insert(
             peer.clone(),

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -306,7 +306,7 @@ pub(crate) struct ConnectResponse {
 
 /// State machine retained for in-file relay/joiner unit tests
 /// (`tests::*` in this file). Production CONNECT runs entirely on the
-/// task-per-tx drivers in `op_ctx_task.rs` and rebuilds `RelayState`
+/// drivers in `op_ctx_task.rs` and rebuilds `RelayState`
 /// in task locals; nothing constructs `ConnectState::Relaying` or
 /// `Completed` outside the test module.
 #[derive(Debug, Clone)]
@@ -1595,8 +1595,8 @@ pub(crate) async fn gateway_version_probe(
 /// intervals lets `initial_join_procedure` notice when `min_connections`
 /// is reached without waiting for the full gateway backoff to expire.
 ///
-/// Also applied in `handle_aborted_op` for the same reason.  ±20% jitter is
-/// applied at each call site to prevent thundering herd.  See issue #3304.
+/// ±20% jitter is applied at each call site to prevent thundering herd.
+/// See issue #3304.
 pub(crate) const GATEWAY_BACKOFF_POLL_CAP: Duration = Duration::from_secs(30);
 
 pub(crate) async fn initial_join_procedure(

--- a/crates/core/src/operations/connect/op_ctx_task.rs
+++ b/crates/core/src/operations/connect/op_ctx_task.rs
@@ -48,7 +48,7 @@ use super::{
 /// Test-only counter incremented every time a relay-CONNECT driver is
 /// spawned. Used by test_relay_driver_calls_per_op-style guards to
 /// confirm the dispatch site actually routed a fresh inbound Request
-/// through the task-per-tx driver vs. the legacy
+/// through the driver vs. the legacy
 /// `handle_op_request` path.
 #[cfg(any(test, feature = "testing"))]
 #[allow(dead_code)]
@@ -180,7 +180,7 @@ pub(crate) async fn start_client_connect(
         tx = %tx,
         target_connections,
         ttl,
-        "Initiating gateway connect (task-per-tx)"
+        "Initiating gateway connect"
     );
 
     let mut ctx = op_manager.op_ctx(tx);
@@ -594,7 +594,7 @@ pub(crate) async fn start_relay_connect(
             tx = %incoming_tx,
             %upstream_addr,
             phase = "relay_connect_dedup_reject",
-            "CONNECT relay (task-per-tx): duplicate Request for in-flight tx, dropping"
+            "CONNECT relay: duplicate Request for in-flight tx, dropping"
         );
         return Ok(());
     }
@@ -605,7 +605,7 @@ pub(crate) async fn start_relay_connect(
         ttl = payload.ttl,
         %upstream_addr,
         phase = "relay_connect_start",
-        "CONNECT relay (task-per-tx): spawning driver"
+        "CONNECT relay: spawning driver"
     );
 
     // Construct guard + bump counters BEFORE spawn so the dedup-set
@@ -642,7 +642,7 @@ async fn run_relay_connect(
             tx = %incoming_tx,
             error = %err,
             phase = "relay_connect_error",
-            "CONNECT relay (task-per-tx): driver returned error"
+            "CONNECT relay: driver returned error"
         );
     }
 
@@ -702,7 +702,7 @@ async fn drive_relay_connect(
                     tx = %incoming_tx,
                     desired_location = %state.request.desired_location,
                     %upstream_addr,
-                    "CONNECT relay (task-per-tx): gateway overloaded, rejecting request"
+                    "CONNECT relay: gateway overloaded, rejecting request"
                 );
                 if let Some(event) = NetEventLog::connect_rejected(
                     &incoming_tx,
@@ -802,7 +802,7 @@ async fn drive_relay_connect(
                                 tx = %incoming_tx,
                                 target = %addr,
                                 error = %e,
-                                "CONNECT relay (task-per-tx): failed to dispatch downstream Request"
+                                "CONNECT relay: failed to dispatch downstream Request"
                             );
                             None
                         }
@@ -812,7 +812,7 @@ async fn drive_relay_connect(
                     tracing::warn!(
                         tx = %incoming_tx,
                         next_peer = %next.pub_key(),
-                        "CONNECT relay (task-per-tx): next hop has no socket address; skipping forward"
+                        "CONNECT relay: next hop has no socket address; skipping forward"
                     );
                     None
                 }
@@ -876,7 +876,7 @@ async fn drive_relay_connect(
             tracing::debug!(
                 tx = %incoming_tx,
                 phase = "relay_connect_ttl_exit",
-                "CONNECT relay (task-per-tx): transaction timed out; exiting"
+                "CONNECT relay: transaction timed out; exiting"
             );
             return Ok(());
         }
@@ -892,7 +892,7 @@ async fn drive_relay_connect(
             other => {
                 tracing::warn!(
                     tx = %incoming_tx,
-                    "CONNECT relay (task-per-tx): unexpected message kind: {:?}",
+                    "CONNECT relay: unexpected message kind: {:?}",
                     other
                 );
                 continue;
@@ -915,7 +915,7 @@ async fn drive_relay_connect(
                     %upstream_addr,
                     acceptor_pub_key = %payload.acceptor.pub_key(),
                     forwarded_from = ?state.forwarded_to,
-                    "CONNECT relay (task-per-tx): forwarding Response upstream"
+                    "CONNECT relay: forwarding Response upstream"
                 );
                 let mut ctx = op_manager.op_ctx(incoming_tx);
                 ctx.send_fire_and_forget(
@@ -960,7 +960,7 @@ async fn drive_relay_connect(
                         tx = %incoming_tx,
                         failed_peer = ?failed_peer,
                         retry_peer = %peer.pub_key(),
-                        "CONNECT relay (task-per-tx): retrying with different uphill peer after rejection"
+                        "CONNECT relay: retrying with different uphill peer after rejection"
                     );
                     if let Some(addr) = peer.socket_addr() {
                         let mut ctx = op_manager.op_ctx(incoming_tx);
@@ -978,7 +978,7 @@ async fn drive_relay_connect(
                         tx = %incoming_tx,
                         failed_peer = ?failed_peer,
                         acceptor = %accept.response.acceptor.pub_key(),
-                        "CONNECT relay (task-per-tx): accepting locally after uphill rejection"
+                        "CONNECT relay: accepting locally after uphill rejection"
                     );
                     if let Some(event) = NetEventLog::connect_response_sent(
                         &incoming_tx,
@@ -1003,7 +1003,7 @@ async fn drive_relay_connect(
                         tx = %incoming_tx,
                         %upstream_addr,
                         failed_peer = ?failed_peer,
-                        "CONNECT relay (task-per-tx): forwarding rejection upstream (no retry peers)"
+                        "CONNECT relay: forwarding rejection upstream (no retry peers)"
                     );
                     if let Some(event) = NetEventLog::connect_rejected(
                         &incoming_tx,
@@ -1063,7 +1063,7 @@ async fn drive_relay_connect(
                                 tx = %incoming_tx,
                                 forwarded_to_addr = %fwd_addr,
                                 failed_acceptor = %failed_acceptor_addr,
-                                "CONNECT relay (task-per-tx): forwarding ConnectFailed downstream"
+                                "CONNECT relay: forwarding ConnectFailed downstream"
                             );
                             let mut ctx = op_manager.op_ctx(incoming_tx);
                             ctx.send_fire_and_forget(
@@ -1111,7 +1111,7 @@ async fn drive_relay_connect(
                         tx = %incoming_tx,
                         failed_acceptor = %failed_acceptor_addr,
                         retry_peer = %peer.pub_key(),
-                        "CONNECT relay (task-per-tx): re-routing to different peer after ConnectFailed"
+                        "CONNECT relay: re-routing to different peer after ConnectFailed"
                     );
                     if let Some(addr) = peer.socket_addr() {
                         let mut ctx = op_manager.op_ctx(incoming_tx);
@@ -1129,7 +1129,7 @@ async fn drive_relay_connect(
                         tx = %incoming_tx,
                         failed_acceptor = %failed_acceptor_addr,
                         acceptor = %accept.response.acceptor.pub_key(),
-                        "CONNECT relay (task-per-tx): accepting locally after ConnectFailed"
+                        "CONNECT relay: accepting locally after ConnectFailed"
                     );
                     if let Some(event) = NetEventLog::connect_response_sent(
                         &incoming_tx,
@@ -1154,7 +1154,7 @@ async fn drive_relay_connect(
                         tx = %incoming_tx,
                         %upstream_addr,
                         failed_acceptor = %failed_acceptor_addr,
-                        "CONNECT relay (task-per-tx): propagating ConnectFailed upstream (no re-route)"
+                        "CONNECT relay: propagating ConnectFailed upstream (no re-route)"
                     );
                     let mut ctx = op_manager.op_ctx(incoming_tx);
                     ctx.send_fire_and_forget(
@@ -1175,7 +1175,7 @@ async fn drive_relay_connect(
                 // refactors notice.
                 tracing::warn!(
                     tx = %incoming_tx,
-                    "CONNECT relay (task-per-tx): unexpected Request on driver inbox; bypass logic regressed"
+                    "CONNECT relay: unexpected Request on driver inbox; bypass logic regressed"
                 );
             }
         }
@@ -1314,11 +1314,10 @@ mod tests {
         );
     }
 
-    /// Source-literal guard: relay driver runs the full re-entry
+    /// Source-literal guard: the relay driver runs the full re-entry
     /// state machine (Response/Rejected/ObservedAddress/ConnectFailed)
     /// on its inbox receiver. Removing any of these branches would
-    /// strand the corresponding re-entry on legacy `process_message`,
-    /// which is being retired in commit 4.
+    /// strand the corresponding re-entry.
     #[test]
     fn drive_relay_connect_handles_all_reentry_variants() {
         const SOURCE: &str = include_str!("op_ctx_task.rs");

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -1,4 +1,4 @@
-// Every GET wire variant dispatches to a task-per-tx driver —
+// Every GET wire variant dispatches to a driver —
 // `op_ctx_task::start_client_get`, `start_relay_get`,
 // `start_sub_op_get`, and `start_targeted_sub_op_get`. The
 // wire-format types (`GetMsg`, `GetMsgResult`,
@@ -26,7 +26,7 @@ pub(crate) struct GetResult {
 
 impl GetResult {
     /// Construct a `GetResult` directly from its fields. Used by the
-    /// task-per-tx sub-op GET driver, which assembles the result from
+    /// driver sub-op GET driver, which assembles the result from
     /// the wire-level terminal reply.
     pub(crate) fn new(state: WrappedState, contract: Option<ContractContainer>) -> Self {
         Self { state, contract }

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -54,7 +54,7 @@ use crate::operations::orphan_streams::{OrphanStreamError, STREAM_CLAIM_TIMEOUT}
 
 /// Test-only counter that increments every time `start_client_get` is
 /// called. Used by integration tests to verify that a GET actually
-/// routed through the task-per-tx driver rather than being satisfied
+/// routed through the driver rather than being satisfied
 /// by the `client_events.rs` local-cache shortcut.
 #[cfg(any(test, feature = "testing"))]
 pub static DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
@@ -62,7 +62,7 @@ pub static DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
 
 /// Test-only counter that increments every time `start_relay_get` is
 /// called. Used by integration tests to verify that relay dispatch
-/// actually routed a fresh inbound Request through the task-per-tx
+/// actually routed a fresh inbound Request through the driver
 /// driver (and not through the legacy `handle_op_request` path that
 /// continues to serve originator loop-back, GC-spawned retries, and
 /// `start_targeted_op` UPDATE-triggered auto-fetches).
@@ -123,7 +123,7 @@ pub(crate) async fn start_client_get(
     tracing::debug!(
         tx = %client_tx,
         contract = %instance_id,
-        "get (task-per-tx): spawning client-initiated task"
+        "get: spawning client-initiated task"
     );
 
     // Fire-and-forget spawn; same rationale as PUT 3a's `start_client_put`.
@@ -382,7 +382,7 @@ async fn drive_client_get_inner(
                             tracing::warn!(
                                 %key,
                                 error = %e,
-                                "get (task-per-tx): stream assembly failed — \
+                                "get: stream assembly failed — \
                                  state will not be cached locally"
                             );
                             // Assembly failed → don't emit a transfer-rate
@@ -397,7 +397,7 @@ async fn drive_client_get_inner(
                     } else {
                         tracing::warn!(
                             %key,
-                            "get (task-per-tx): current_target has no socket_addr; \
+                            "get: current_target has no socket_addr; \
                              cannot claim orphan stream"
                         );
                     }
@@ -434,10 +434,8 @@ async fn drive_client_get_inner(
                 && !op_manager.ring.is_subscribed(&reply_key)
             {
                 let path_label = match &terminal {
-                    Terminal::Streaming { .. } => "streaming (task-per-tx)",
-                    Terminal::InlineFound { .. } | Terminal::LocalCompletion => {
-                        "non-streaming (task-per-tx)"
-                    }
+                    Terminal::Streaming { .. } => "streaming",
+                    Terminal::InlineFound { .. } | Terminal::LocalCompletion => "non-streaming",
                 };
                 crate::operations::auto_subscribe_on_get_response(
                     op_manager,
@@ -496,7 +494,7 @@ async fn drive_client_get_inner(
                             tx = %client_tx,
                             sent_at_elapsed_secs = sent.elapsed().as_secs_f64(),
                             received_at_elapsed_secs = received.elapsed().as_secs_f64(),
-                            "get (task-per-tx): received < sent on winning attempt; \
+                            "get: received < sent on winning attempt; \
                              falling back to SuccessUntimed"
                         );
                         None
@@ -649,10 +647,7 @@ fn classify(reply: NetMessage) -> AttemptOutcome<Terminal> {
             result: GetMsgResult::Found { value, .. },
             ..
         })) => {
-            tracing::warn!(
-                ?value,
-                "get (task-per-tx): Response{{Found}} arrived without state"
-            );
+            tracing::warn!(?value, "get: Response{{Found}} arrived without state");
             AttemptOutcome::Unexpected
         }
         NetMessage::V1(NetMessageV1::Get(GetMsg::Response {
@@ -787,7 +782,7 @@ async fn build_host_response(
         _ => {
             tracing::warn!(
                 contract = %instance_id,
-                "get (task-per-tx): terminal reply classified success but local \
+                "get: terminal reply classified success but local \
                  store lookup returned no state; synthesizing client error"
             );
             Err(ErrorKind::OperationError {
@@ -876,7 +871,7 @@ async fn cache_contract_locally(
     let put_persisted = if state_matches {
         tracing::debug!(
             %key,
-            "get (task-per-tx): local state matches, skipping redundant PutQuery"
+            "get: local state matches, skipping redundant PutQuery"
         );
         false
     } else if let Some(contract_code) = contract {
@@ -899,7 +894,7 @@ async fn cache_contract_locally(
                 tracing::warn!(
                     %key,
                     %err,
-                    "get (task-per-tx): PutQuery rejected by executor"
+                    "get: PutQuery rejected by executor"
                 );
                 false
             }
@@ -907,7 +902,7 @@ async fn cache_contract_locally(
                 tracing::warn!(
                     %key,
                     ?other,
-                    "get (task-per-tx): PutQuery returned unexpected event"
+                    "get: PutQuery returned unexpected event"
                 );
                 false
             }
@@ -915,7 +910,7 @@ async fn cache_contract_locally(
                 tracing::warn!(
                     %key,
                     %err,
-                    "get (task-per-tx): PutQuery failed"
+                    "get: PutQuery failed"
                 );
                 false
             }
@@ -926,7 +921,7 @@ async fn cache_contract_locally(
         // isn't gated on the write path.
         tracing::debug!(
             %key,
-            "get (task-per-tx): skipping local cache — contract code missing"
+            "get: skipping local cache — contract code missing"
         );
         false
     };
@@ -976,17 +971,17 @@ async fn cache_contract_locally(
 ///
 /// Mirrors the originator-side streaming branch of the legacy
 /// `process_message` at `get.rs:2721-3196`. The driver is the only
-/// place this can run for task-per-tx GETs because the bypass at
+/// place this can run for driver GETs because the bypass at
 /// `node.rs::handle_pure_network_message_v1` forwards the
 /// `ResponseStreaming` envelope to the driver before
 /// `handle_op_request` — `process_message` never executes on the
-/// originator for task-per-tx ops (`load_or_init` would return
+/// originator for driver ops (`load_or_init` would return
 /// `OpNotPresent`).
 ///
 /// `peer_addr` is the sender's transport address — currently we
 /// use `driver.current_target.socket_addr()`, which is accurate for
 /// single-hop responses. Multi-hop (where a relay answers on behalf
-/// of a further peer) is not yet supported by the task-per-tx driver;
+/// of a further peer) is not yet supported by the driver;
 /// see #3883.
 async fn assemble_and_cache_stream(
     op_manager: &OpManager,
@@ -1146,7 +1141,7 @@ fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: Driv
             tracing::warn!(
                 tx = %client_tx,
                 error = %err,
-                "get (task-per-tx): infrastructure error; publishing synthesized client error"
+                "get: infrastructure error; publishing synthesized client error"
             );
             let synthesized: HostResult = Err(ErrorKind::OperationError {
                 cause: format!("GET failed: {err}").into(),
@@ -1157,7 +1152,7 @@ fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: Driv
     }
 }
 
-// ── Sub-operation GET task-per-tx driver ────────────────────────────────────
+// ── Sub-operation GET driver ────────────────────────────────────
 //
 // Entry point for node-internal GETs that have no client (executor's
 // `local_state_or_from_network` and subscribe's `fetch_contract_if_missing`).
@@ -1197,7 +1192,7 @@ pub(crate) fn start_sub_op_get(
     tracing::debug!(
         %tx,
         contract = %instance_id,
-        "get (task-per-tx): spawning sub-op task"
+        "get: spawning sub-op task"
     );
 
     GlobalExecutor::spawn(run_sub_op_get(
@@ -1236,7 +1231,7 @@ pub(crate) fn start_targeted_sub_op_get(
         %tx,
         contract = %instance_id,
         ?target,
-        "get (task-per-tx): spawning targeted sub-op task (UPDATE auto-fetch)"
+        "get: spawning targeted sub-op task (UPDATE auto-fetch)"
     );
 
     GlobalExecutor::spawn(run_sub_op_get(
@@ -1285,19 +1280,19 @@ async fn run_sub_op_get(
             SubOpGetOutcome::Found(_) => tracing::info!(
                 %tx,
                 contract = %instance_id,
-                "get (task-per-tx targeted sub-op): UPDATE auto-fetch succeeded"
+                "get (driver targeted sub-op): UPDATE auto-fetch succeeded"
             ),
             SubOpGetOutcome::NotFound(cause) => tracing::warn!(
                 %tx,
                 contract = %instance_id,
                 cause,
-                "get (task-per-tx targeted sub-op): UPDATE auto-fetch did not find state"
+                "get (driver targeted sub-op): UPDATE auto-fetch did not find state"
             ),
             SubOpGetOutcome::Infra(err) => tracing::warn!(
                 %tx,
                 contract = %instance_id,
                 error = %err,
-                "get (task-per-tx targeted sub-op): UPDATE auto-fetch hit infra error"
+                "get (driver targeted sub-op): UPDATE auto-fetch hit infra error"
             ),
         }
     }
@@ -1403,7 +1398,7 @@ async fn drive_sub_op_get(
                             tracing::warn!(
                                 %key,
                                 error = %e,
-                                "get (task-per-tx sub-op): stream assembly failed"
+                                "get (driver sub-op): stream assembly failed"
                             );
                         }
                     } else {
@@ -1413,7 +1408,7 @@ async fn drive_sub_op_get(
                         // the breadcrumb so operators can correlate to the failure.
                         tracing::warn!(
                             %key,
-                            "get (task-per-tx sub-op): current_target has no socket_addr; \
+                            "get (driver sub-op): current_target has no socket_addr; \
                              cannot claim orphan stream"
                         );
                     }
@@ -1464,10 +1459,10 @@ fn missing_state_cause(instance_id: &ContractInstanceId) -> String {
     )
 }
 
-// ── Relay GET task-per-tx driver (#3883) ────────────────────────────────────
+// ── Relay GET driver (#3883) ────────────────────────────────────
 //
 // `start_relay_get` is the entry point for the relay (non-originator) GET
-// task-per-tx driver.  It is called from `node.rs` dispatch (commit 2) when
+// driver.  It is called from `node.rs` dispatch (commit 2) when
 // an incoming `GetMsg::Request` arrives with `source_addr.is_some()` — i.e.
 // from a real remote peer rather than the originator's own loop-back.
 //
@@ -1485,7 +1480,7 @@ fn missing_state_cause(instance_id: &ContractInstanceId) -> String {
 // This entire section is dead code in commit 1 — node.rs dispatch is not
 // changed until commit 2.
 
-/// Start a relay (non-originator) GET task-per-tx driver.
+/// Start a relay (non-originator) GET driver.
 ///
 /// Called from `node.rs` dispatch when an incoming `GetMsg::Request`
 /// arrives from a remote peer (`source_addr.is_some()`).  The driver
@@ -1521,7 +1516,7 @@ pub(crate) async fn start_relay_get(
 ) -> Result<(), OpError> {
     // Test-only: count relay driver invocations so regression tests can
     // assert the dispatch gate in node.rs actually routed a fresh inbound
-    // Request through the task-per-tx driver rather than the legacy
+    // Request through the driver rather than the legacy
     // `handle_op_request` fallthrough (phase-3b loopback, GC retries,
     // `start_targeted_op`).
     #[cfg(any(test, feature = "testing"))]
@@ -1540,7 +1535,7 @@ pub(crate) async fn start_relay_get(
             %instance_id,
             %upstream_addr,
             phase = "relay_dedup_reject",
-            "GET relay (task-per-tx): duplicate Request for in-flight tx, dropping"
+            "GET relay: duplicate Request for in-flight tx, dropping"
         );
         return Ok(());
     }
@@ -1551,7 +1546,7 @@ pub(crate) async fn start_relay_get(
         htl,
         %upstream_addr,
         phase = "relay_start",
-        "GET relay (task-per-tx): spawning driver"
+        "GET relay: spawning driver"
     );
 
     GlobalExecutor::spawn(run_relay_get(
@@ -1623,7 +1618,7 @@ async fn run_relay_get(
             %instance_id,
             error = %err,
             phase = "relay_infra_error",
-            "GET relay (task-per-tx): infrastructure error in driver"
+            "GET relay: infrastructure error in driver"
         );
     }
 
@@ -1691,7 +1686,7 @@ async fn drive_relay_get(
                 %instance_id,
                 error = %err,
                 phase = "relay_inner_error",
-                "GET relay (task-per-tx): inner driver returned error; sending NotFound upstream"
+                "GET relay: inner driver returned error; sending NotFound upstream"
             );
             // On infrastructure error, send NotFound upstream so the upstream
             // doesn't time out waiting for us.
@@ -1785,7 +1780,7 @@ fn relay_advance_to_next_peer(
 ) -> Option<(PeerKeyLocation, SocketAddr)> {
     // Legacy relay does NOT retry alternative peers at each hop — it
     // forwards once and bubbles back whatever downstream returned. The
-    // phase-5 task-per-tx migration introduced a 3-peer retry loop here
+    // phase-5 migration introduced a 3-peer retry loop here
     // that compounded fan-out to 3^HTL per origination under virtual
     // time (ci-fault-loss run 24602255580 showed 16.9M spawns in 95s
     // with single-use tx reuse still in place). Cap at 1 to match
@@ -1913,7 +1908,7 @@ async fn drive_relay_get_inner(
             %upstream_addr,
             htl = 0,
             phase = "not_found",
-            "GET relay (task-per-tx): HTL exhausted — sending NotFound upstream"
+            "GET relay: HTL exhausted — sending NotFound upstream"
         );
         if let Some(event) = crate::tracing::NetEventLog::get_not_found(
             &incoming_tx,
@@ -1947,7 +1942,7 @@ async fn drive_relay_get_inner(
             %instance_id,
             contract = %key,
             phase = "complete",
-            "GET relay (task-per-tx): contract found locally (active interest) — sending Found upstream"
+            "GET relay: contract found locally (active interest) — sending Found upstream"
         );
 
         // Register interest for the requester (mirrors get.rs:1447-1476).
@@ -1959,7 +1954,7 @@ async fn drive_relay_get_inner(
                 None,
                 None,
                 &incoming_tx,
-                " (relay task-per-tx, piggybacked on GET)",
+                " (relay loopback, piggybacked on GET)",
             )
             .await;
         } else if let Some(pkl) = op_manager
@@ -2023,7 +2018,7 @@ async fn drive_relay_get_inner(
                         tx = %incoming_tx,
                         %instance_id,
                         contract = %key,
-                        "GET relay (task-per-tx): all peers exhausted — serving local fallback"
+                        "GET relay: all peers exhausted — serving local fallback"
                     );
                     // Relay path: is_client_requester=false (see top-of-loop
                     // rationale).
@@ -2045,7 +2040,7 @@ async fn drive_relay_get_inner(
                         %instance_id,
                         %upstream_addr,
                         phase = "not_found",
-                        "GET relay (task-per-tx): all peers exhausted — sending NotFound upstream"
+                        "GET relay: all peers exhausted — sending NotFound upstream"
                     );
                     if let Some(event) = crate::tracing::NetEventLog::get_not_found(
                         &incoming_tx,
@@ -2066,7 +2061,7 @@ async fn drive_relay_get_inner(
 
         // NOTE: legacy path sends a ForwardingAck upstream before forwarding
         // downstream so the upstream's GC can extend its timer on slow
-        // multi-hop chains. In the task-per-tx relay driver we OMIT that
+        // multi-hop chains. In the driver relay driver we OMIT that
         // ack: the ack carried `incoming_tx` (which equals the upstream's
         // `attempt_tx` on a relay-to-relay hop), so it matched the
         // upstream's capacity-1 `pending_op_results` waiter and arrived
@@ -2088,7 +2083,7 @@ async fn drive_relay_get_inner(
             target = %peer,
             target_addr = %peer_addr,
             phase = "forward",
-            "GET relay (task-per-tx): forwarding request to downstream peer"
+            "GET relay: forwarding request to downstream peer"
         );
 
         // Emit get_request telemetry for the relay forward.
@@ -2152,7 +2147,7 @@ async fn drive_relay_get_inner(
                     tx = %incoming_tx,
                     target = %peer,
                     error = %err,
-                    "GET relay (task-per-tx, loopback): \
+                    "GET relay (loopback, loopback): \
                      send_fire_and_forget failed"
                 );
                 // Fall through to NotFound — client driver waiter
@@ -2176,7 +2171,7 @@ async fn drive_relay_get_inner(
                     tx = %incoming_tx,
                     target = %peer,
                     error = %err,
-                    "GET relay (task-per-tx): send_to_and_await failed; advancing to next peer"
+                    "GET relay: send_to_and_await failed; advancing to next peer"
                 );
                 // Feed the relay's failed peer choice into the local Router
                 // so future routing decisions de-prioritize this peer. Without
@@ -2198,7 +2193,7 @@ async fn drive_relay_get_inner(
                     tx = %incoming_tx,
                     target = %peer,
                     timeout_secs = OPERATION_TTL.as_secs(),
-                    "GET relay (task-per-tx): attempt timed out; advancing to next peer"
+                    "GET relay: attempt timed out; advancing to next peer"
                 );
                 crate::operations::record_relay_route_event(
                     op_manager,
@@ -2224,7 +2219,7 @@ async fn drive_relay_get_inner(
                     %instance_id,
                     contract = %key,
                     phase = "relay_found",
-                    "GET relay (task-per-tx): downstream returned Found — caching locally and bubbling upstream"
+                    "GET relay: downstream returned Found — caching locally and bubbling upstream"
                 );
 
                 // Cache locally (relay opportunistically caches forwarded
@@ -2276,7 +2271,7 @@ async fn drive_relay_get_inner(
                     tx = %incoming_tx,
                     %instance_id,
                     target = %peer,
-                    "GET relay (task-per-tx): downstream returned ResponseStreaming — \
+                    "GET relay: downstream returned ResponseStreaming — \
                      streaming relay forwarding not yet implemented (port plan §7); \
                      trying next peer"
                 );
@@ -2291,7 +2286,7 @@ async fn drive_relay_get_inner(
                 tracing::warn!(
                     tx = %incoming_tx,
                     %instance_id,
-                    "GET relay (task-per-tx): unexpected LocalCompletion (Request-echo) — trying next peer"
+                    "GET relay: unexpected LocalCompletion (Request-echo) — trying next peer"
                 );
                 new_visited.mark_visited(peer_addr);
                 continue;
@@ -2306,7 +2301,7 @@ async fn drive_relay_get_inner(
                 tracing::debug!(
                     tx = %incoming_tx,
                     target = %peer,
-                    "GET relay (task-per-tx): downstream returned NotFound; advancing to next peer"
+                    "GET relay: downstream returned NotFound; advancing to next peer"
                 );
                 crate::operations::record_relay_route_event(
                     op_manager,
@@ -2328,7 +2323,7 @@ async fn drive_relay_get_inner(
                 tracing::warn!(
                     tx = %incoming_tx,
                     target = %peer,
-                    "GET relay (task-per-tx): unexpected reply variant; advancing to next peer"
+                    "GET relay: unexpected reply variant; advancing to next peer"
                 );
                 new_visited.mark_visited(peer_addr);
                 continue;
@@ -2662,7 +2657,7 @@ mod tests {
     /// against the incoming `value`, and skips the `PutQuery` entirely
     /// when they match. This prevents re-invoking `update_state()` on
     /// contracts that implement idempotency checks (see #2018). The
-    /// task-per-tx driver's `cache_contract_locally` must replicate
+    /// driver's `cache_contract_locally` must replicate
     /// this idempotency short-circuit.
     #[test]
     fn cache_contract_locally_has_state_matches_short_circuit() {
@@ -3032,7 +3027,7 @@ mod tests {
     /// 3^HTL spawns per origination, observed as 6.8M spawns and 63GB
     /// RSS in workflow runs 24600168871 / 24600634908 / 24601267577.
     ///
-    /// Fix: drop the ack entirely from the task-per-tx relay driver.
+    /// Fix: drop the ack entirely from the driver relay driver.
     /// Upstream's `send_to_and_await` still has OPERATION_TTL (60s) to
     /// receive the real Response, which is what legacy effectively had
     /// minus the ack-driven timer extension.
@@ -3299,12 +3294,12 @@ mod tests {
         );
     }
 
-    // ── R7 (superseded): ForwardingAck removed from task-per-tx relay ──────
+    // ── R7 (superseded): ForwardingAck removed from driver relay ──────
     //
     // Superseded by `relay_driver_does_not_send_forwarding_ack` (T6
     // rewrite). The original latch logic was pinned here to ensure the
     // ack fired exactly once per relay invocation, which was the legacy
-    // behavior. In the task-per-tx migration the ack's `id` collides
+    // behavior. In the migration the ack's `id` collides
     // with the upstream relay driver's `attempt_tx` on its capacity-1
     // `pending_op_results` waiter — causing 3^HTL spawn amplification.
     // The ack is now never sent; see the T6 test for the invariant.
@@ -3727,7 +3722,7 @@ mod tests {
     /// Regression guard for the relay hosting-cache taint bug caught in
     /// PR #3896 review. The legacy GET branch gates `mark_local_client_access`
     /// on `is_original_requester = upstream_addr.is_none()` (see
-    /// `get.rs:2260-2262, :2353-2355, :3056-3058`). The task-per-tx driver
+    /// `get.rs:2260-2262, :2353-2355, :3056-3058`). The driver
     /// MUST respect that gate: relay peers that merely cache a forwarded
     /// Found must NOT set the sticky `local_client_access` flag, or they
     /// permanently pay subscription-renewal cost for contracts no client

--- a/crates/core/src/operations/op_ctx.rs
+++ b/crates/core/src/operations/op_ctx.rs
@@ -1,4 +1,4 @@
-//! Per-transaction execution context for the task-per-tx model.
+//! Per-transaction execution context for the driver model.
 //!
 //! Ships the `OpCtx` struct and its `send_and_await` round-trip
 //! primitive. Each transaction is owned and driven by a single
@@ -13,7 +13,7 @@ use crate::message::{MessageStats, NetMessage, Transaction};
 use crate::node::OpExecutionPayload;
 use crate::operations::OpError;
 
-/// Per-transaction execution context for the task-per-tx model.
+/// Per-transaction execution context for the driver model.
 ///
 /// An `OpCtx` binds a single [`Transaction`] to the channel used to
 /// drive its network round-trip through the event loop. The context
@@ -181,7 +181,7 @@ impl OpCtx {
     /// there's no self-connection. Routing it through `InboundMessage`
     /// lands at `handle_pure_network_message_v1`'s PUT bypass and
     /// forwards to the originator's `pending_op_results` waiter via
-    /// `try_forward_task_per_tx_reply`.
+    /// `try_forward_driver_reply`.
     pub async fn send_local_loopback(&mut self, msg: NetMessage) -> Result<(), OpError> {
         debug_assert_eq!(
             msg.id(),
@@ -207,7 +207,7 @@ impl OpCtx {
     /// kicks off side work. Installing the waiter first closes a race
     /// where a fast downstream reply would land on the event loop
     /// before `handle_op_execution` has inserted the callback —
-    /// `try_forward_task_per_tx_reply` would then drop the reply as
+    /// `try_forward_driver_reply` would then drop the reply as
     /// `OpNotPresent`.
     ///
     /// Await the returned receiver to get the terminal reply:
@@ -260,7 +260,7 @@ impl OpCtx {
     ///
     /// # When the bypass forwards multiple replies
     ///
-    /// `node::try_forward_task_per_tx_reply` calls `try_send` on the
+    /// `node::try_forward_driver_reply` calls `try_send` on the
     /// stored callback. With a capacity > 1 channel, multiple inbound
     /// replies for the same tx land in the channel without dropping each
     /// other (capacity-1 callers would receive only the first because the
@@ -503,7 +503,7 @@ pub(crate) async fn drive_retry_loop<D: RetryDriver>(
                     attempt = attempt_count,
                     outcome = "wire_error",
                     error = %err,
-                    "{op_label} (task-per-tx): send_and_await failed; advancing"
+                    "{op_label}: send_and_await failed; advancing"
                 );
                 match driver.advance() {
                     AdvanceOutcome::Next => continue,
@@ -521,7 +521,7 @@ pub(crate) async fn drive_retry_loop<D: RetryDriver>(
                     attempt = attempt_count,
                     outcome = "timeout",
                     timeout_secs = attempt_timeout.as_secs(),
-                    "{op_label} (task-per-tx): attempt timed out; advancing"
+                    "{op_label}: attempt timed out; advancing"
                 );
                 match driver.advance() {
                     AdvanceOutcome::Next => continue,
@@ -544,7 +544,7 @@ pub(crate) async fn drive_retry_loop<D: RetryDriver>(
                     attempt_tx = %attempt_tx,
                     attempt = attempt_count,
                     outcome = "retry",
-                    "{op_label} (task-per-tx): peer indicated retry; advancing"
+                    "{op_label}: peer indicated retry; advancing"
                 );
                 match driver.advance() {
                     AdvanceOutcome::Next => continue,
@@ -560,7 +560,7 @@ pub(crate) async fn drive_retry_loop<D: RetryDriver>(
                     tx = %client_tx,
                     attempt_tx = %attempt_tx,
                     attempt = attempt_count,
-                    "{op_label} (task-per-tx): unexpected terminal reply"
+                    "{op_label}: unexpected terminal reply"
                 );
                 return RetryLoopOutcome::Unexpected;
             }

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -2,7 +2,7 @@
 //! given radius cache a copy of the contract and its current value,
 //! and broadcast updates to subscribers.
 //!
-//! Every PUT wire variant dispatches to a task-per-tx driver —
+//! Every PUT wire variant dispatches to a driver —
 //! `op_ctx_task::start_client_put`, `start_relay_put`, and
 //! `start_relay_put_streaming`. The wire-format types
 //! (`PutMsg`, `PutStreamingPayload`), the originator finalization
@@ -346,35 +346,25 @@ mod tests {
         }
     }
 
-    /// Pin: PUT GC speculative retry block MUST NOT come back.
-    /// `op_state_manager.rs` should no longer contain the
-    /// `put_retry_candidates` accumulator or the `put_retried` map.
+    /// Pin: the PUT GC speculative retry accumulator and retry-count
+    /// map must not return. Their reintroduction risks the per-tx
+    /// DashMap leak the surrounding code was rebuilt to avoid.
     #[test]
     fn put_gc_speculative_retry_block_must_stay_deleted() {
         let src = include_str!("../node/op_state_manager.rs");
         assert!(
             !src.contains("put_retry_candidates"),
-            "PUT GC speculative retry block was retired in PR #3964 — \
-             reintroduction risks the Phase 3a DashMap leak interaction"
+            "`put_retry_candidates` accumulator must stay deleted"
         );
         assert!(
             !src.contains("put_retried"),
-            "PUT GC retry-count map was retired in PR #3964"
+            "`put_retried` retry-count map must stay deleted"
         );
     }
 
-    /// Pin: `OpManager::completed` MUST keep removing the per-type
-    /// DashMap entry for the remaining DashMap-backed op (Connect).
-    /// GET, PUT, UPDATE and SUBSCRIBE no longer have DashMap entries.
-    /// Without this the per-tx DashMap leak comes back for Connect.
-    /// Pin: `OpManager::completed` must not touch any per-op
-    /// DashMap. The legacy `self.ops.{connect,get,put,update,subscribe}`
-    /// maps were retired across the #1454 phases; the surviving
-    /// completion side effects are limited to the global
+    /// Pin: `OpManager::completed` must not touch any per-op DashMap.
+    /// The surviving completion side effects are limited to the global
     /// `under_progress` / `completed` sets and the `request_router`.
-    /// Reintroducing a per-op map here is a regression that would
-    /// resurrect the per-tx DashMap leak this test originally
-    /// guarded against.
     #[test]
     fn completed_must_not_touch_per_op_dashmaps() {
         let src = include_str!("../node/op_state_manager.rs");
@@ -386,7 +376,7 @@ mod tests {
             .expect("OpManager::completed closing brace not found")
             + fn_start;
         let body = &src[fn_start..fn_end];
-        for retired in [
+        for forbidden in [
             "self.ops.connect",
             "self.ops.put",
             "self.ops.get",
@@ -394,22 +384,22 @@ mod tests {
             "self.ops.update",
         ] {
             assert!(
-                !body.contains(retired),
-                "OpManager::completed must not reference `{retired}` — the corresponding DashMap was retired"
+                !body.contains(forbidden),
+                "OpManager::completed must not reference `{forbidden}`"
             );
         }
     }
 
-    /// Pin: legacy ForwardingAck senders MUST NOT come back. The
-    /// relay drivers omit them (would race the capacity-1 reply
-    /// waiter), and the consumer is a no-op (PR #3964).
+    /// Pin: ForwardingAck senders must not return. Relay drivers omit
+    /// them (would race the capacity-1 reply waiter) and the consumer
+    /// is a no-op.
     #[test]
     fn put_forwarding_ack_senders_must_stay_deleted() {
         let src = include_str!("put.rs");
         let needle = format!("NetMessage::from({}::ForwardingAck", "PutMsg",);
         assert!(
             !src.contains(&needle),
-            "ForwardingAck senders retired in PR #3964"
+            "ForwardingAck senders must not be reintroduced"
         );
     }
 }

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -66,7 +66,7 @@ pub(crate) async fn start_client_put(
     tracing::debug!(
         tx = %client_tx,
         contract = %contract.key(),
-        "put (task-per-tx): spawning client-initiated task"
+        "put: spawning client-initiated task"
     );
 
     // Spawn the driver. Same fire-and-forget rationale as SUBSCRIBE's
@@ -516,7 +516,7 @@ fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: Driv
             tracing::warn!(
                 tx = %client_tx,
                 error = %err,
-                "put (task-per-tx): infrastructure error; publishing synthesized client error"
+                "put: infrastructure error; publishing synthesized client error"
             );
             let synthesized: HostResult = Err(ErrorKind::OperationError {
                 cause: format!("PUT failed: {err}").into(),
@@ -532,7 +532,7 @@ fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: Driv
 /// Counter: number of times `start_relay_put` was invoked. Incremented
 /// under test/testing feature only — used by structural pin tests to
 /// prove the dispatch gate routes fresh inbound `PutMsg::Request`
-/// through the task-per-tx driver rather than legacy `handle_op_request`.
+/// through the driver rather than legacy `handle_op_request`.
 #[cfg(any(test, feature = "testing"))]
 pub static RELAY_PUT_DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
@@ -611,7 +611,7 @@ where
             contract = %contract.key(),
             %upstream_addr,
             phase = "relay_put_dedup_reject",
-            "PUT relay (task-per-tx): duplicate Request for in-flight tx, dropping"
+            "PUT relay: duplicate Request for in-flight tx, dropping"
         );
         return Ok(());
     }
@@ -622,7 +622,7 @@ where
         htl,
         %upstream_addr,
         phase = "relay_put_start",
-        "PUT relay (task-per-tx): spawning driver"
+        "PUT relay: spawning driver"
     );
 
     // Construct guard + bump counters BEFORE spawn so the dedup-set
@@ -706,7 +706,7 @@ async fn run_relay_put<CB>(
             tx = %incoming_tx,
             error = %err,
             phase = "relay_put_error",
-            "PUT relay (task-per-tx): driver returned error"
+            "PUT relay: driver returned error"
         );
     }
 
@@ -778,7 +778,7 @@ where
         htl,
         %upstream_addr,
         phase = "relay_put_request",
-        "PUT relay (task-per-tx): processing Request"
+        "PUT relay: processing Request"
     );
 
     // ── Step 1: Store contract locally (all nodes cache) ────────────────────
@@ -817,7 +817,7 @@ where
                         tx = %incoming_tx,
                         contract = %key,
                         target_pub_key = %peer.pub_key(),
-                        "PUT relay (task-per-tx): next hop has no socket address"
+                        "PUT relay: next hop has no socket address"
                     );
                     // No next hop — act as final destination.
                     return relay_put_finalize_local(
@@ -838,7 +838,7 @@ where
                 tx = %incoming_tx,
                 contract = %key,
                 phase = "relay_put_complete",
-                "PUT relay (task-per-tx): no next hop, finalizing at this node"
+                "PUT relay: no next hop, finalizing at this node"
             );
             return relay_put_finalize_local(
                 op_manager,
@@ -871,7 +871,7 @@ where
         peer_addr = %next_addr,
         htl = new_htl,
         phase = "relay_put_forward",
-        "PUT relay (task-per-tx): forwarding to next hop"
+        "PUT relay: forwarding to next hop"
     );
 
     // Originator-loopback mode (`upstream_addr == own_addr`): the
@@ -935,7 +935,7 @@ where
                     contract = %key,
                     target = %next_addr,
                     error = %err,
-                    "PUT relay (task-per-tx, loopback): \
+                    "PUT relay (loopback, loopback): \
                      streaming-upgrade send_fire_and_forget failed"
                 );
                 return Err(err);
@@ -955,7 +955,7 @@ where
                     target = %next_addr,
                     %stream_id,
                     error = %err,
-                    "PUT relay (task-per-tx, loopback): send_stream failed"
+                    "PUT relay (loopback, loopback): send_stream failed"
                 );
                 return Err(OpError::NotificationChannelError(format!(
                     "send_stream failed: {err}"
@@ -976,7 +976,7 @@ where
                     contract = %key,
                     target = %next_addr,
                     error = %err,
-                    "PUT relay (task-per-tx, loopback): send_fire_and_forget failed"
+                    "PUT relay (loopback, loopback): send_fire_and_forget failed"
                 );
                 return Err(err);
             }
@@ -996,7 +996,7 @@ where
             payload_size,
             %stream_id,
             phase = "relay_put_forward_upgrade",
-            "PUT relay (task-per-tx): payload exceeds threshold, upgrading to streaming"
+            "PUT relay: payload exceeds threshold, upgrading to streaming"
         );
         let metadata_msg = NetMessage::from(PutMsg::RequestStreaming {
             id: incoming_tx,
@@ -1027,7 +1027,7 @@ where
                     contract = %key,
                     target = %next_addr,
                     error = %err,
-                    "PUT relay (task-per-tx): streaming-upgrade send_to_and_register_waiter failed"
+                    "PUT relay: streaming-upgrade send_to_and_register_waiter failed"
                 );
                 op_manager.release_pending_op_slot(incoming_tx).await;
                 return Err(err);
@@ -1049,7 +1049,7 @@ where
                 target = %next_addr,
                 %stream_id,
                 error = %err,
-                "PUT relay (task-per-tx): send_stream failed during streaming upgrade"
+                "PUT relay: send_stream failed during streaming upgrade"
             );
             op_manager.release_pending_op_slot(incoming_tx).await;
             return Err(OpError::NotificationChannelError(format!(
@@ -1092,7 +1092,7 @@ where
                 contract = %key,
                 target = %next_addr,
                 error = %err,
-                "PUT relay (task-per-tx): send_to_and_await failed"
+                "PUT relay: send_to_and_await failed"
             );
             crate::operations::record_relay_route_event(
                 op_manager,
@@ -1109,7 +1109,7 @@ where
                 contract = %key,
                 target = %next_addr,
                 timeout_secs = OPERATION_TTL.as_secs(),
-                "PUT relay (task-per-tx): downstream timed out"
+                "PUT relay: downstream timed out"
             );
             crate::operations::record_relay_route_event(
                 op_manager,
@@ -1132,7 +1132,7 @@ where
                 tx = %incoming_tx,
                 contract = %reply_key,
                 phase = "relay_put_bubble",
-                "PUT relay (task-per-tx): downstream returned Response; bubbling upstream"
+                "PUT relay: downstream returned Response; bubbling upstream"
             );
             crate::operations::record_relay_route_event(
                 op_manager,
@@ -1154,7 +1154,7 @@ where
                 tx = %incoming_tx,
                 contract = %reply_key,
                 phase = "relay_put_bubble_streaming_downgrade",
-                "PUT relay (task-per-tx): downstream returned ResponseStreaming — \
+                "PUT relay: downstream returned ResponseStreaming — \
                  synthesizing non-streaming Response upstream (slice A limitation)"
             );
             crate::operations::record_relay_route_event(
@@ -1174,7 +1174,7 @@ where
                 tx = %incoming_tx,
                 contract = %key,
                 reply_variant = ?std::mem::discriminant(&other),
-                "PUT relay (task-per-tx): unexpected reply variant; treating as failure"
+                "PUT relay: unexpected reply variant; treating as failure"
             );
             Err(OpError::UnexpectedOpState)
         }
@@ -1219,7 +1219,7 @@ async fn relay_put_store_locally(
                 contract = %key,
                 error = %err,
                 htl,
-                "PUT relay (task-per-tx): put_contract failed"
+                "PUT relay: put_contract failed"
             );
             if let Some(event) = NetEventLog::put_failure(
                 &incoming_tx,
@@ -1262,7 +1262,7 @@ async fn relay_put_store_locally(
 
     debug_assert!(
         op_manager.ring.is_hosting_contract(&key),
-        "PUT relay (task-per-tx): contract {key} must be in hosting list after put_contract + host_contract"
+        "PUT relay: contract {key} must be in hosting list after put_contract + host_contract"
     );
 
     Ok(merged_value)
@@ -1334,7 +1334,7 @@ async fn relay_put_send_response(
 /// Counter: number of times `start_relay_put_streaming` was invoked
 /// (BEFORE the dedup gate). Incremented under test/testing feature
 /// only — used by runtime pin tests to prove the dispatch gate routes
-/// fresh inbound streaming PUT relays through the task-per-tx driver.
+/// fresh inbound streaming PUT relays through the driver.
 /// Counts both admitted and dedup-rejected calls; pair with
 /// `RELAY_PUT_STREAMING_DEDUP_REJECTS` to reason about admitted ones.
 #[cfg(any(test, feature = "testing"))]
@@ -1413,7 +1413,7 @@ where
             contract = %contract_key,
             %upstream_addr,
             phase = "relay_put_streaming_dedup_reject",
-            "PUT streaming relay (task-per-tx): duplicate Request for in-flight tx, dropping"
+            "PUT streaming relay: duplicate Request for in-flight tx, dropping"
         );
         // Mirror slice A dedup-reject semantics: silently drop. The
         // still-in-flight driver owns the upstream reply for this tx;
@@ -1434,7 +1434,7 @@ where
         htl,
         %upstream_addr,
         phase = "relay_put_streaming_start",
-        "PUT streaming relay (task-per-tx): spawning driver"
+        "PUT streaming relay: spawning driver"
     );
 
     RELAY_PUT_STREAMING_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -1513,7 +1513,7 @@ async fn run_relay_put_streaming<CB>(
             tx = %incoming_tx,
             error = %err,
             phase = "relay_put_streaming_error",
-            "PUT streaming relay (task-per-tx): driver returned error"
+            "PUT streaming relay: driver returned error"
         );
     }
 
@@ -1546,7 +1546,7 @@ where
         htl,
         %upstream_addr,
         phase = "relay_put_streaming_request",
-        "PUT streaming relay (task-per-tx): processing RequestStreaming"
+        "PUT streaming relay: processing RequestStreaming"
     );
 
     // ── Step 1: Claim the inbound stream (atomic dedup) ────────────────────
@@ -1560,7 +1560,7 @@ where
             tracing::debug!(
                 tx = %incoming_tx,
                 %stream_id,
-                "PUT streaming relay (task-per-tx): stream already claimed, skipping"
+                "PUT streaming relay: stream already claimed, skipping"
             );
             return Ok(());
         }
@@ -1569,7 +1569,7 @@ where
                 tx = %incoming_tx,
                 %stream_id,
                 error = %err,
-                "PUT streaming relay (task-per-tx): orphan stream claim failed"
+                "PUT streaming relay: orphan stream claim failed"
             );
             // Silently fail — upstream's waiter falls back to its own
             // OPERATION_TTL. Same rationale as dedup-reject above:
@@ -1686,7 +1686,7 @@ where
     // AFTER that do we enqueue `pipe_stream` onto the bridge channel.
     // If we inverted the order, a fast downstream reply could reach
     // `handle_pure_network_message_v1` before the waiter installs —
-    // `try_forward_task_per_tx_reply` would drop the reply as
+    // `try_forward_driver_reply` would drop the reply as
     // OpNotPresent and the driver would hang until `OPERATION_TTL`.
     let downstream_reply_rx: Option<(SocketAddr, tokio::sync::mpsc::Receiver<NetMessage>)> =
         if let Some((next_addr, metadata_net, outbound_sid, forked_handle, embedded_metadata)) =
@@ -1703,7 +1703,7 @@ where
                         tx = %incoming_tx,
                         target = %next_addr,
                         error = %err,
-                        "PUT streaming relay (task-per-tx): metadata register_waiter failed; will finalize locally"
+                        "PUT streaming relay: metadata register_waiter failed; will finalize locally"
                     );
                     None
                 }
@@ -1717,7 +1717,7 @@ where
                         tx = %incoming_tx,
                         target = %next_addr,
                         error = %err,
-                        "PUT streaming relay (task-per-tx): pipe_stream failed after waiter install; \
+                        "PUT streaming relay: pipe_stream failed after waiter install; \
                          will wait on downstream reply and bubble what we get"
                     );
                     // Waiter is already installed; the downstream may still
@@ -1738,7 +1738,7 @@ where
                 tx = %incoming_tx,
                 %stream_id,
                 error = %err,
-                "PUT streaming relay (task-per-tx): stream assembly failed"
+                "PUT streaming relay: stream assembly failed"
             );
             return Err(OpError::StreamCancelled);
         }
@@ -1751,7 +1751,7 @@ where
                 tx = %incoming_tx,
                 %stream_id,
                 error = %err,
-                "PUT streaming relay (task-per-tx): payload deserialize failed"
+                "PUT streaming relay: payload deserialize failed"
             );
             return Err(OpError::invalid_transition(incoming_tx));
         }
@@ -1768,7 +1768,7 @@ where
             tx = %incoming_tx,
             expected = %contract_key,
             actual = %key,
-            "PUT streaming relay (task-per-tx): contract key mismatch"
+            "PUT streaming relay: contract key mismatch"
         );
         return Err(OpError::invalid_transition(incoming_tx));
     }
@@ -1798,7 +1798,7 @@ where
                 tracing::warn!(
                     tx = %incoming_tx,
                     target = %next_addr,
-                    "PUT streaming relay (task-per-tx): downstream reply channel closed before reply"
+                    "PUT streaming relay: downstream reply channel closed before reply"
                 );
                 if let Some(ref peer) = next_hop {
                     crate::operations::record_relay_route_event(
@@ -1816,7 +1816,7 @@ where
                 tracing::warn!(
                     tx = %incoming_tx,
                     target = %next_addr,
-                    "PUT streaming relay (task-per-tx): downstream reply timed out"
+                    "PUT streaming relay: downstream reply timed out"
                 );
                 if let Some(ref peer) = next_hop {
                     crate::operations::record_relay_route_event(
@@ -1842,7 +1842,7 @@ where
                     tx = %incoming_tx,
                     contract = %reply_key,
                     phase = "relay_put_streaming_bubble",
-                    "PUT streaming relay (task-per-tx): downstream replied; bubbling Response upstream"
+                    "PUT streaming relay: downstream replied; bubbling Response upstream"
                 );
                 if let Some(ref peer) = next_hop {
                     crate::operations::record_relay_route_event(
@@ -1863,7 +1863,7 @@ where
                     tx = %incoming_tx,
                     contract = %key,
                     reply_variant = ?std::mem::discriminant(&other),
-                    "PUT streaming relay (task-per-tx): unexpected reply variant"
+                    "PUT streaming relay: unexpected reply variant"
                 );
                 relay_put_send_response(op_manager, incoming_tx, key, upstream_addr).await
             }
@@ -1929,7 +1929,7 @@ mod tests {
     /// `maybe_subscribe_child` for subscriptions. If `finalize_put_at_originator`
     /// is called with `subscribe=true`, it starts a subscription via the legacy
     /// `start_subscription_after_put` path, AND `maybe_subscribe_child` starts
-    /// another via the task-per-tx `run_client_subscribe` path — doubling
+    /// another via the driver `run_client_subscribe` path — doubling
     /// network traffic and subscription registrations.
     ///
     /// This test scrapes the source to verify all `finalize_put_at_originator`

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -13,7 +13,7 @@
 //! `complete_local_subscription`, `wait_for_contract_with_timeout`),
 //! the inbound `Unsubscribe` handler, and
 //! `register_downstream_subscriber` survive here because the
-//! task-per-tx drivers consume them.
+//! drivers consume them.
 
 use either::Either;
 
@@ -83,7 +83,7 @@ pub(super) async fn wait_for_contract_with_timeout(
 /// a subscribe request based on the node's current ring state and contract
 /// availability.
 ///
-/// This type exists so all task-per-tx subscribe entry points
+/// This type exists so all driver subscribe entry points
 /// (`op_ctx_task::run_client_subscribe`,
 /// `op_ctx_task::run_renewal_subscribe`,
 /// `op_ctx_task::run_executor_subscribe`) share the "which peer, or
@@ -130,7 +130,7 @@ pub(super) enum InitialRequest {
 /// Compute the initial "where do we send this subscribe, or do we complete
 /// locally?" decision for a subscribe request.
 ///
-/// All task-per-tx subscribe entry points (`op_ctx_task::run_client_subscribe`,
+/// All driver subscribe entry points (`op_ctx_task::run_client_subscribe`,
 /// `run_renewal_subscribe`, `run_executor_subscribe`) reuse the same ring
 /// lookup / fallback / local-completion logic via this helper. The helper is
 /// pure modulo telemetry emission: it calls `NetEventLog::subscribe_request`
@@ -266,7 +266,7 @@ pub(super) async fn prepare_initial_request(
     );
 
     // Emit telemetry for subscribe request initiation so both legacy and
-    // task-per-tx paths produce identical `NetEventLog::subscribe_request`
+    // driver paths produce identical `NetEventLog::subscribe_request`
     // events.
     if let Some(event) = NetEventLog::subscribe_request(
         &id,

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -68,7 +68,7 @@ pub(crate) async fn start_client_subscribe(
     tracing::debug!(
         tx = %client_tx,
         contract = %instance_id,
-        "subscribe (task-per-tx): spawning client-initiated task"
+        "subscribe: spawning client-initiated task"
     );
 
     // Spawn the driver. The task is fire-and-forget from this function's
@@ -166,7 +166,7 @@ pub(crate) async fn run_client_subscribe(
 ///
 /// Note on the channel-congestion bucket: the legacy `ring.rs` renewal
 /// site only matched [`OpError::NotificationChannelError`] for the
-/// no-penalty arm. The task-per-tx renewal driver also routes
+/// no-penalty arm. The driver renewal driver also routes
 /// [`OpError::NotificationError`] (returned from
 /// [`mpsc::Sender::send`]'s `Err(SendError(_))` via [`OpError::from`])
 /// into [`Self::ChannelCongestion`] because both indicate the same
@@ -193,7 +193,7 @@ pub(crate) enum RenewalOutcome {
 ///
 /// The legacy renewal site at `ring.rs::connection_maintenance` used
 /// `notify_op_change_nonblocking` to fail-fast under congestion of the
-/// 2048-cap event-loop notification channel. The task-per-tx renewal
+/// 2048-cap event-loop notification channel. The driver renewal
 /// driver dispatches each attempt through `OpCtx::send_to_and_await`,
 /// which uses the separate `op_execution_sender` channel; that channel
 /// has its own bound and behaviour, so the legacy fail-fast contract no
@@ -327,7 +327,7 @@ pub(crate) async fn run_executor_subscribe(
             tracing::debug!(
                 %key,
                 tx = %executor_tx,
-                "executor subscribe (task-per-tx): local hit, completing inline"
+                "executor subscribe: local hit, completing inline"
             );
             // Mirror the interest-registration side-effect of
             // `complete_local_subscription` for non-renewal locals.
@@ -501,7 +501,7 @@ async fn drive_client_subscribe_inner(
         tx = %client_tx,
         contract = %instance_id,
         target = %target_addr,
-        "subscribe (task-per-tx): initial target selected, entering retry loop"
+        "subscribe: initial target selected, entering retry loop"
     );
 
     // Initial state for the retry loop. The first iteration uses
@@ -531,7 +531,7 @@ async fn drive_client_subscribe_inner(
             target = %current_target_addr,
             retries,
             attempts_at_hop,
-            "subscribe (task-per-tx): sending attempt"
+            "subscribe: sending attempt"
         );
 
         // Per-attempt telemetry (review finding L4). `prepare_initial_request`
@@ -623,7 +623,7 @@ async fn drive_client_subscribe_inner(
                     attempts_at_hop,
                     outcome = "wire_error",
                     error = %err,
-                    "subscribe (task-per-tx): send_and_await failed; advancing to next peer"
+                    "subscribe: send_and_await failed; advancing to next peer"
                 );
                 match advance_to_next_peer(
                     op_manager,
@@ -667,7 +667,7 @@ async fn drive_client_subscribe_inner(
                     attempts_at_hop,
                     outcome = "timeout",
                     timeout_secs = OPERATION_TTL.as_secs(),
-                    "subscribe (task-per-tx): attempt timed out; advancing to next peer"
+                    "subscribe: attempt timed out; advancing to next peer"
                 );
                 match advance_to_next_peer(
                     op_manager,
@@ -711,7 +711,7 @@ async fn drive_client_subscribe_inner(
                     retries,
                     attempts_at_hop,
                     outcome = "subscribed",
-                    "subscribe (task-per-tx): subscribed"
+                    "subscribe: subscribed"
                 );
 
                 // Feed the routing-prediction model on the client-initiated
@@ -720,7 +720,7 @@ async fn drive_client_subscribe_inner(
                 // payload_transfer_time: ZERO }` so the router's
                 // `response_start_time_estimator` learned from every successful
                 // subscribe (payload_size==0 deliberately skips
-                // `transfer_rate_estimator`). The task-per-tx migration of this
+                // `transfer_rate_estimator`). The migration of this
                 // path stopped emitting any RouteEvent at all, leaving the
                 // response-time estimator with zero observations from
                 // client-initiated subscribes. Restore that feedback so the
@@ -749,7 +749,7 @@ async fn drive_client_subscribe_inner(
                 op_manager.ring.routing_finished(route_event);
                 // Mirror the legacy Response-handler side effects from
                 // `subscribe.rs`'s `SubscribeMsg::Response` arm. The
-                // task-per-tx reply forwarding bypass in `node.rs` skips
+                // driver reply forwarding bypass in `node.rs` skips
                 // `handle_op_request` for terminal Responses, so without
                 // these calls the local interest manager and ring would
                 // never learn about the subscription, breaking
@@ -797,7 +797,7 @@ async fn drive_client_subscribe_inner(
                     retries,
                     attempts_at_hop,
                     outcome = "not_found",
-                    "subscribe (task-per-tx): NotFound from peer; advancing to next peer"
+                    "subscribe: NotFound from peer; advancing to next peer"
                 );
                 match advance_to_next_peer(
                     op_manager,
@@ -830,7 +830,7 @@ async fn drive_client_subscribe_inner(
                 tracing::warn!(
                     tx = %client_tx,
                     attempt_tx = %attempt_tx,
-                    "subscribe (task-per-tx): unexpected terminal reply"
+                    "subscribe: unexpected terminal reply"
                 );
                 return Err(OpError::UnexpectedOpState);
             }
@@ -944,7 +944,7 @@ where
                     %instance_id,
                     target = %addr,
                     attempts_at_hop = *attempts_at_hop,
-                    "subscribe (task-per-tx): breadth retry with next alternative"
+                    "subscribe: breadth retry with next alternative"
                 );
                 return Some((candidate, addr));
             }
@@ -971,7 +971,7 @@ where
                     %instance_id,
                     target = %addr,
                     retries = *retries,
-                    "subscribe (task-per-tx): fresh k_closest round found new target"
+                    "subscribe: fresh k_closest round found new target"
                 );
                 return Some((candidate, addr));
             }
@@ -980,7 +980,7 @@ where
         tracing::debug!(
             %instance_id,
             retries = *retries,
-            "subscribe (task-per-tx): fresh k_closest round returned no usable candidates"
+            "subscribe: fresh k_closest round returned no usable candidates"
         );
     }
 
@@ -1026,7 +1026,7 @@ fn deliver_outcome(
     outcome: DriverOutcome,
 ) {
     // Dashboard op_stats SUBSCRIBE counter (issue #4010). The legacy
-    // `report_result` recording path is bypassed for task-per-tx
+    // `report_result` recording path is bypassed for driver
     // terminal replies (see `node::record_op_result` rustdoc), so
     // every terminal outcome must be recorded here.
     //
@@ -1051,7 +1051,7 @@ fn deliver_outcome(
         DriverOutcome::SkipAlreadyDelivered => {
             tracing::debug!(
                 tx = %client_tx,
-                "subscribe (task-per-tx): local completion already published; \
+                "subscribe: local completion already published; \
                  skipping result_router_tx"
             );
         }
@@ -1060,7 +1060,7 @@ fn deliver_outcome(
                 tx = %client_tx,
                 contract = %instance_id,
                 error = %err,
-                "subscribe (task-per-tx): infrastructure error; \
+                "subscribe: infrastructure error; \
                  publishing synthesized client error"
             );
             let synthesized: HostResult = Err(ErrorKind::OperationError {
@@ -1094,7 +1094,7 @@ pub static RELAY_SUBSCRIBE_DEDUP_REJECTS: std::sync::atomic::AtomicUsize =
 
 /// Counter: number of times `start_relay_subscribe` was invoked. Used by
 /// structural pin tests to prove the dispatch gate routes fresh inbound
-/// `SubscribeMsg::Request` through the task-per-tx driver rather than
+/// `SubscribeMsg::Request` through the driver rather than
 /// legacy `handle_op_request`.
 #[cfg(any(test, feature = "testing"))]
 pub static RELAY_SUBSCRIBE_DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
@@ -1133,7 +1133,7 @@ pub(crate) async fn start_relay_subscribe(
             %instance_id,
             %upstream_addr,
             phase = "relay_subscribe_dedup_reject",
-            "SUBSCRIBE relay (task-per-tx): duplicate Request for in-flight tx, replying NotFound"
+            "SUBSCRIBE relay: duplicate Request for in-flight tx, replying NotFound"
         );
         // Emit an immediate `NotFound` back to the rejected upstream so
         // its `send_to_and_await` returns fast instead of stalling the
@@ -1156,7 +1156,7 @@ pub(crate) async fn start_relay_subscribe(
                 tx = %incoming_tx,
                 %upstream_addr,
                 error = %err,
-                "SUBSCRIBE relay (task-per-tx): dedup-reject NotFound send failed"
+                "SUBSCRIBE relay: dedup-reject NotFound send failed"
             );
         }
         return Ok(());
@@ -1181,7 +1181,7 @@ pub(crate) async fn start_relay_subscribe(
         %upstream_addr,
         is_renewal,
         phase = "relay_subscribe_start",
-        "SUBSCRIBE relay (task-per-tx): spawning driver"
+        "SUBSCRIBE relay: spawning driver"
     );
 
     GlobalExecutor::spawn(run_relay_subscribe(
@@ -1244,7 +1244,7 @@ async fn run_relay_subscribe(
             %instance_id,
             error = %err,
             phase = "relay_subscribe_error",
-            "SUBSCRIBE relay (task-per-tx): driver returned error"
+            "SUBSCRIBE relay: driver returned error"
         );
     }
 
@@ -1266,13 +1266,13 @@ async fn run_relay_subscribe(
 /// target_peer, contract_location, request_sent_at }` to the
 /// `AwaitingResponse` state so that downstream timeouts (reported via
 /// `handle_abort`) fed `PeerHealthTracker` and the failure estimator.
-/// The task-per-tx driver DROPS this signal on the relay node: on
+/// The driver DROPS this signal on the relay node: on
 /// `send_to_and_await` timeout we bubble `NotFound` upstream and exit
 /// without touching `PeerHealthTracker`.
 ///
 /// This is deliberate for slice A. Cross-peer retry at the relay was
 /// the phase-5 memory-explosion amplifier (see `project_1454_phase5_memory.md`
-/// and PR #3896's fix stack) — the task-per-tx design moves ALL
+/// and PR #3896's fix stack) — the driver design moves ALL
 /// cross-peer retry to the originator's client-init driver. The
 /// originator's `send_to_and_await` timeout path there is the correct
 /// site for peer-health updates; reporting them at a relay that does
@@ -1300,7 +1300,7 @@ async fn drive_relay_subscribe(
         %upstream_addr,
         is_renewal,
         phase = "relay_subscribe_request",
-        "SUBSCRIBE relay (task-per-tx): processing Request"
+        "SUBSCRIBE relay: processing Request"
     );
 
     // ── Step 1: Local-hit fast path (with brief wait-for-in-flight-PUT) ──
@@ -1312,7 +1312,7 @@ async fn drive_relay_subscribe(
     .await?
     {
         // Register the subscribing peer as a downstream subscriber.
-        // The relay task-per-tx path does not know the requester's
+        // The relay driver path does not know the requester's
         // `TransportPublicKey` (the legacy path had it because the op
         // state carried `requester_pub_key`); `register_downstream_subscriber`
         // falls back to addr-based lookup in that case, which is adequate
@@ -1324,7 +1324,7 @@ async fn drive_relay_subscribe(
             None,
             Some(upstream_addr),
             &incoming_tx,
-            " (task-per-tx relay local hit)",
+            " (driver relay local hit)",
         )
         .await;
 
@@ -1333,7 +1333,7 @@ async fn drive_relay_subscribe(
             contract = %key,
             is_renewal,
             phase = "relay_subscribe_local_hit",
-            "SUBSCRIBE relay (task-per-tx): fulfilled locally, sending Response"
+            "SUBSCRIBE relay: fulfilled locally, sending Response"
         );
         return relay_subscribe_send_response(
             op_manager,
@@ -1352,7 +1352,7 @@ async fn drive_relay_subscribe(
             contract = %instance_id,
             htl = 0,
             phase = "relay_subscribe_not_found",
-            "SUBSCRIBE relay (task-per-tx): HTL exhausted"
+            "SUBSCRIBE relay: HTL exhausted"
         );
         if let Some(event) = crate::tracing::NetEventLog::subscribe_not_found(
             &incoming_tx,
@@ -1392,7 +1392,7 @@ async fn drive_relay_subscribe(
             tx = %incoming_tx,
             contract = %instance_id,
             phase = "relay_subscribe_not_found",
-            "SUBSCRIBE relay (task-per-tx): no closer peers to forward"
+            "SUBSCRIBE relay: no closer peers to forward"
         );
         if let Some(event) = crate::tracing::NetEventLog::subscribe_not_found(
             &incoming_tx,
@@ -1423,7 +1423,7 @@ async fn drive_relay_subscribe(
                 tx = %incoming_tx,
                 %instance_id,
                 target_pub_key = %next_hop.pub_key(),
-                "SUBSCRIBE relay (task-per-tx): next hop has no socket address"
+                "SUBSCRIBE relay: next hop has no socket address"
             );
             return relay_subscribe_send_response(
                 op_manager,
@@ -1459,7 +1459,7 @@ async fn drive_relay_subscribe(
         peer_addr = %next_addr,
         htl = new_htl,
         phase = "relay_subscribe_forward",
-        "SUBSCRIBE relay (task-per-tx): forwarding to next hop"
+        "SUBSCRIBE relay: forwarding to next hop"
     );
 
     let forward = NetMessage::from(SubscribeMsg::Request {
@@ -1487,7 +1487,7 @@ async fn drive_relay_subscribe(
                 %instance_id,
                 target = %next_addr,
                 error = %err,
-                "SUBSCRIBE relay (task-per-tx): send_to_and_await failed"
+                "SUBSCRIBE relay: send_to_and_await failed"
             );
             crate::operations::record_relay_route_event(
                 op_manager,
@@ -1511,7 +1511,7 @@ async fn drive_relay_subscribe(
                 %instance_id,
                 target = %next_addr,
                 timeout_secs = OPERATION_TTL.as_secs(),
-                "SUBSCRIBE relay (task-per-tx): downstream timed out"
+                "SUBSCRIBE relay: downstream timed out"
             );
             crate::operations::record_relay_route_event(
                 op_manager,
@@ -1554,7 +1554,7 @@ async fn drive_relay_subscribe(
                 None,
                 Some(upstream_addr),
                 &incoming_tx,
-                " (task-per-tx relay registration on Response)",
+                " (driver relay registration on Response)",
             )
             .await;
 
@@ -1562,7 +1562,7 @@ async fn drive_relay_subscribe(
                 tx = %incoming_tx,
                 contract = %key,
                 phase = "relay_subscribe_bubble",
-                "SUBSCRIBE relay (task-per-tx): downstream Subscribed; bubbling upstream"
+                "SUBSCRIBE relay: downstream Subscribed; bubbling upstream"
             );
             crate::operations::record_relay_route_event(
                 op_manager,
@@ -1585,7 +1585,7 @@ async fn drive_relay_subscribe(
                 tx = %incoming_tx,
                 %instance_id,
                 phase = "relay_subscribe_bubble_not_found",
-                "SUBSCRIBE relay (task-per-tx): downstream NotFound; bubbling upstream"
+                "SUBSCRIBE relay: downstream NotFound; bubbling upstream"
             );
             crate::operations::record_relay_route_event(
                 op_manager,
@@ -1604,7 +1604,7 @@ async fn drive_relay_subscribe(
                 tx = %incoming_tx,
                 %instance_id,
                 reply_variant = ?std::mem::discriminant(&other),
-                "SUBSCRIBE relay (task-per-tx): unexpected reply variant; treating as NotFound"
+                "SUBSCRIBE relay: unexpected reply variant; treating as NotFound"
             );
             SubscribeMsgResult::NotFound
         }
@@ -2522,7 +2522,7 @@ mod tests {
     }
 
     /// Issue #4010: `deliver_outcome` must record the SUBSCRIBE outcome
-    /// to the dashboard `op_stats.subscribes` counter (the task-per-tx
+    /// to the dashboard `op_stats.subscribes` counter (the driver
     /// bypass at `handle_pure_network_message_v1` skips the legacy
     /// `report_result` recording path), and it must NOT record sub-op
     /// SUBSCRIBE attempts (those are background plumbing spawned by
@@ -2542,7 +2542,7 @@ mod tests {
         assert!(
             body.contains("record_op_result"),
             "deliver_outcome must call record_op_result so the dashboard \
-             SUBSCRIBE counter advances on task-per-tx terminal replies. \
+             SUBSCRIBE counter advances on driver terminal replies. \
              Issue #4010."
         );
         assert!(

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -118,10 +118,10 @@ fn subscribe_dispatch_routes_unsubscribe_to_inbound_handler() {
     );
 }
 
-/// Pin: `SubscribeMsg::ForwardingAck` wire-format compatibility. Survives
-/// Phase 5 final as a telemetry-only handler (no production reader after the
-/// retry block was retired). This serde round-trip guards against accidental
-/// bincode-discriminant shifts that would break cross-version compatibility.
+/// Pin: `SubscribeMsg::ForwardingAck` wire-format compatibility. The
+/// variant has no production reader, but a serde round-trip guards
+/// against bincode-discriminant shifts that would break cross-version
+/// compatibility.
 #[test]
 fn subscribe_forwarding_ack_serde_roundtrip() {
     let id = Transaction::new::<SubscribeMsg>();

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1,7 +1,7 @@
 //! UPDATE operation: applies a state change to a contract and
 //! broadcasts to subscribers.
 //!
-//! Every UPDATE wire variant dispatches to a task-per-tx driver —
+//! Every UPDATE wire variant dispatches to a driver —
 //! `op_ctx_task::start_client_update`, `start_relay_request_update`,
 //! `start_relay_broadcast_to`, `start_relay_request_update_streaming`,
 //! and `start_relay_broadcast_to_streaming`. The wire-format types,
@@ -187,7 +187,7 @@ impl OpManager {
             "Auto-fetching contract from UPDATE sender (missing parameters)"
         );
 
-        // Spawn a targeted task-per-tx GET. The driver targets `sender_pkl`
+        // Spawn a targeted driver GET. The driver targets `sender_pkl`
         // for its first hop and falls back to `k_closest_potentially_hosting`
         // for any retries. Fire-and-forget — the side effect (contract cached
         // locally via `cache_contract_locally`) is what callers depend on.

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -66,7 +66,7 @@ pub static RELAY_UPDATE_DEDUP_REJECTS: std::sync::atomic::AtomicUsize =
 /// Counter: number of times `start_relay_request_update_streaming` or
 /// `start_relay_broadcast_to_streaming` was invoked. Used by dispatch
 /// gate pin tests to prove streaming relays route through the
-/// task-per-tx driver rather than `handle_op_request`.
+/// driver rather than `handle_op_request`.
 #[cfg(any(test, feature = "testing"))]
 pub static RELAY_UPDATE_STREAMING_DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
@@ -102,7 +102,7 @@ pub(crate) async fn start_client_update(
     tracing::debug!(
         tx = %client_tx,
         contract = %key,
-        "update (task-per-tx): spawning client-initiated task"
+        "update: spawning client-initiated task"
     );
 
     // Spawn the driver. Same fire-and-forget rationale as PUT's
@@ -184,7 +184,7 @@ async fn drive_client_update(
                 tracing::debug!(
                     %key,
                     peer = %pub_key,
-                    "update (task-per-tx): proximity cache neighbor not connected, trying next"
+                    "update: proximity cache neighbor not connected, trying next"
                 );
             }
         }
@@ -195,7 +195,7 @@ async fn drive_client_update(
             %key,
             target = ?proximity_neighbor.socket_addr(),
             proximity_neighbors_found = proximity_neighbors.len(),
-            "update (task-per-tx): using proximity cache neighbor as target"
+            "update: using proximity cache neighbor as target"
         );
         Some(proximity_neighbor)
     } else {
@@ -210,7 +210,7 @@ async fn drive_client_update(
             tracing::debug!(
                 tx = %client_tx,
                 %key,
-                "update (task-per-tx): no remote peers, handling locally"
+                "update: no remote peers, handling locally"
             );
 
             let is_hosting = op_manager.ring.is_hosting_contract(&key);
@@ -218,7 +218,7 @@ async fn drive_client_update(
                 tracing::error!(
                     contract = %key,
                     phase = "error",
-                    "update (task-per-tx): cannot update contract on isolated node — not hosted"
+                    "update: cannot update contract on isolated node — not hosted"
                 );
                 return Err(OpError::RingError(RingError::NoHostingPeers(*key.id())));
             }
@@ -246,7 +246,7 @@ async fn drive_client_update(
                         contract = %key,
                         error = %err,
                         phase = "ring_state_store_inconsistency",
-                        "update (task-per-tx): is_hosting_contract reports true \
+                        "update: is_hosting_contract reports true \
                          but state_store has no params for this contract; cannot \
                          auto-fetch (no remote target) — the ring/state-store \
                          divergence must be repaired by a re-PUT or a manual \
@@ -269,13 +269,13 @@ async fn drive_client_update(
                 tracing::debug!(
                     tx = %client_tx,
                     %key,
-                    "update (task-per-tx): local update resulted in no change"
+                    "update: local update resulted in no change"
                 );
             } else {
                 tracing::debug!(
                     tx = %client_tx,
                     %key,
-                    "update (task-per-tx): local-only update complete"
+                    "update: local-only update complete"
                 );
             }
 
@@ -299,7 +299,7 @@ async fn drive_client_update(
                         tx = %client_tx,
                         %key,
                         target_pub_key = %target.pub_key(),
-                        "update (task-per-tx): target peer has no socket address"
+                        "update: target peer has no socket address"
                     );
                     return Err(OpError::RingError(RingError::NoHostingPeers(*key.id())));
                 }
@@ -309,7 +309,7 @@ async fn drive_client_update(
                 tx = %client_tx,
                 %key,
                 target_peer = %target_addr,
-                "update (task-per-tx): applying locally before forwarding"
+                "update: applying locally before forwarding"
             );
 
             let local_apply = super::update_contract(
@@ -371,7 +371,7 @@ async fn drive_client_update(
                             error = %err,
                             target = %target_addr,
                             phase = "auto_fetch_originator",
-                            "update (task-per-tx): originator has no contract \
+                            "update: originator has no contract \
                              code/params for this contract; triggering \
                              auto-fetch from target and asking client to retry"
                         );
@@ -397,7 +397,7 @@ async fn drive_client_update(
                         contract = %key,
                         error = %err,
                         phase = "error",
-                        "update (task-per-tx): failed to apply update locally before forwarding"
+                        "update: failed to apply update locally before forwarding"
                     );
                     return Err(err);
                 }
@@ -435,7 +435,7 @@ async fn drive_client_update(
                 tx = %client_tx,
                 %key,
                 target_peer = %target_addr,
-                "update (task-per-tx): forwarded to target, operation complete"
+                "update: forwarded to target, operation complete"
             );
 
             let host_result: HostResult = Ok(HostResponse::ContractResponse(
@@ -461,7 +461,7 @@ fn classify_update_outcome_for_op_stats(outcome: &DriverOutcome) -> bool {
 
 fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: DriverOutcome) {
     // Dashboard op_stats UPDATE counter (issue #4010). The legacy
-    // `report_result` recording path is bypassed for task-per-tx
+    // `report_result` recording path is bypassed for driver
     // terminal replies (see `node::record_op_result` rustdoc), so
     // every terminal outcome must be recorded here.
     //
@@ -490,7 +490,7 @@ fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: Driv
             tracing::warn!(
                 tx = %client_tx,
                 error = %err,
-                "update (task-per-tx): infrastructure error; publishing synthesized client error"
+                "update: infrastructure error; publishing synthesized client error"
             );
             let synthesized: HostResult = Err(ErrorKind::OperationError {
                 cause: format!("UPDATE failed: {err}").into(),
@@ -554,7 +554,7 @@ pub(crate) async fn start_relay_request_update(
             %key,
             %sender_addr,
             phase = "relay_update_dedup_reject",
-            "UPDATE relay (task-per-tx): duplicate RequestUpdate for in-flight tx, dropping"
+            "UPDATE relay: duplicate RequestUpdate for in-flight tx, dropping"
         );
         return Ok(());
     }
@@ -564,7 +564,7 @@ pub(crate) async fn start_relay_request_update(
         %key,
         %sender_addr,
         phase = "relay_update_request_start",
-        "UPDATE relay (task-per-tx): spawning RequestUpdate driver"
+        "UPDATE relay: spawning RequestUpdate driver"
     );
 
     // Construct guard + bump counters BEFORE spawn so the dedup-set
@@ -617,7 +617,7 @@ pub(crate) async fn start_relay_broadcast_to(
             %key,
             %sender_addr,
             phase = "relay_update_dedup_reject",
-            "UPDATE relay (task-per-tx): duplicate BroadcastTo for in-flight tx, dropping"
+            "UPDATE relay: duplicate BroadcastTo for in-flight tx, dropping"
         );
         return Ok(());
     }
@@ -627,7 +627,7 @@ pub(crate) async fn start_relay_broadcast_to(
         %key,
         %sender_addr,
         phase = "relay_update_broadcast_start",
-        "UPDATE relay (task-per-tx): spawning BroadcastTo driver"
+        "UPDATE relay: spawning BroadcastTo driver"
     );
 
     // See `start_relay_request_update` — guard pre-spawn closes the
@@ -696,7 +696,7 @@ async fn run_relay_request_update(
             %key,
             error = %err,
             phase = "relay_update_request_error",
-            "UPDATE relay (task-per-tx): RequestUpdate driver returned error"
+            "UPDATE relay: RequestUpdate driver returned error"
         );
     }
 }
@@ -727,7 +727,7 @@ async fn run_relay_broadcast_to(
             %key,
             error = %err,
             phase = "relay_update_broadcast_error",
-            "UPDATE relay (task-per-tx): BroadcastTo driver returned error"
+            "UPDATE relay: BroadcastTo driver returned error"
         );
     }
 }
@@ -757,7 +757,7 @@ async fn drive_relay_request_update(
         %key,
         executing_peer = ?executing_addr,
         request_sender = %sender_addr,
-        "UPDATE relay (task-per-tx): processing RequestUpdate"
+        "UPDATE relay: processing RequestUpdate"
     );
 
     // ── Step 1: do we host the contract locally? ──────────────────────────
@@ -824,13 +824,13 @@ async fn drive_relay_request_update(
             tracing::debug!(
                 tx = %incoming_tx,
                 %key,
-                "UPDATE relay (task-per-tx): yielded no state change, skipping broadcast"
+                "UPDATE relay: yielded no state change, skipping broadcast"
             );
         } else {
             tracing::debug!(
                 tx = %incoming_tx,
                 %key,
-                "UPDATE relay (task-per-tx): RequestUpdate succeeded, state changed"
+                "UPDATE relay: RequestUpdate succeeded, state changed"
             );
         }
         // No `Finished`/`ReceivedRequest` bookkeeping: relay driver owns
@@ -865,7 +865,7 @@ async fn drive_relay_request_update(
                 connection_count,
                 peer_addr = %sender_addr,
                 phase = "error",
-                "UPDATE relay (task-per-tx): contract not local and no peers to forward to"
+                "UPDATE relay: contract not local and no peers to forward to"
             );
             if let Some(event) = NetEventLog::update_failure(
                 &incoming_tx,
@@ -886,7 +886,7 @@ async fn drive_relay_request_update(
                 tx = %incoming_tx,
                 %key,
                 target_pub_key = %forward_target.pub_key(),
-                "UPDATE relay (task-per-tx): forward target has no socket address"
+                "UPDATE relay: forward target has no socket address"
             );
             return Err(OpError::RingError(RingError::NoHostingPeers(*key.id())));
         }
@@ -896,7 +896,7 @@ async fn drive_relay_request_update(
         tx = %incoming_tx,
         %key,
         next_peer = %forward_addr,
-        "UPDATE relay (task-per-tx): forwarding to peer that might have contract"
+        "UPDATE relay: forwarding to peer that might have contract"
     );
 
     // Telemetry: relay forwarding update request.
@@ -929,7 +929,7 @@ async fn drive_relay_request_update(
             %key,
             target = %forward_addr,
             error = %err,
-            "UPDATE relay (task-per-tx): forward send failed"
+            "UPDATE relay: forward send failed"
         );
         return Err(err);
     }
@@ -975,7 +975,7 @@ async fn drive_relay_broadcast_to(
             tracing::debug!(
                 contract = %key,
                 delta_size = bytes.len(),
-                "UPDATE relay (task-per-tx): received delta broadcast"
+                "UPDATE relay: received delta broadcast"
             );
             (
                 UpdateData::Delta(StateDelta::from(bytes.clone())),
@@ -986,7 +986,7 @@ async fn drive_relay_broadcast_to(
             tracing::debug!(
                 contract = %key,
                 state_size = bytes.len(),
-                "UPDATE relay (task-per-tx): received full state broadcast"
+                "UPDATE relay: received full state broadcast"
             );
             (UpdateData::State(State::from(bytes.clone())), bytes.clone())
         }
@@ -1024,7 +1024,7 @@ async fn drive_relay_broadcast_to(
         tracing::debug!(
             tx = %incoming_tx,
             %key,
-            "UPDATE relay (task-per-tx): BroadcastTo skipped — duplicate payload (dedup hit)"
+            "UPDATE relay: BroadcastTo skipped — duplicate payload (dedup hit)"
         );
         return Ok(());
     }
@@ -1070,7 +1070,7 @@ async fn drive_relay_broadcast_to(
                     sender = %sender_addr,
                     error = %err,
                     event = "delta_apply_failed",
-                    "UPDATE relay (task-per-tx): delta apply failed, sending ResyncRequest"
+                    "UPDATE relay: delta apply failed, sending ResyncRequest"
                 );
 
                 if let Some(sender_pkl) = op_manager
@@ -1089,7 +1089,7 @@ async fn drive_relay_broadcast_to(
                     contract = %key,
                     target = %sender_addr,
                     event = "resync_request_sent",
-                    "UPDATE relay (task-per-tx): sending ResyncRequest after delta failure"
+                    "UPDATE relay: sending ResyncRequest after delta failure"
                 );
                 if let Err(e) = op_manager
                     .notify_node_event(NodeEvent::SendInterestMessage {
@@ -1101,7 +1101,7 @@ async fn drive_relay_broadcast_to(
                     tracing::warn!(
                         tx = %incoming_tx,
                         error = %e,
-                        "UPDATE relay (task-per-tx): failed to send ResyncRequest"
+                        "UPDATE relay: failed to send ResyncRequest"
                     );
                 }
             } else if !err.is_contract_exec_rejection() {
@@ -1116,7 +1116,7 @@ async fn drive_relay_broadcast_to(
     tracing::debug!(
         tx = %incoming_tx,
         %key,
-        "UPDATE relay (task-per-tx): BroadcastTo applied"
+        "UPDATE relay: BroadcastTo applied"
     );
 
     // ── Step 5: telemetry — broadcast applied ─────────────────────────────
@@ -1135,13 +1135,13 @@ async fn drive_relay_broadcast_to(
         tracing::debug!(
             tx = %incoming_tx,
             %key,
-            "UPDATE relay (task-per-tx): BroadcastTo produced no change, ending propagation"
+            "UPDATE relay: BroadcastTo produced no change, ending propagation"
         );
         return Ok(());
     }
 
     tracing::debug!(
-        "UPDATE relay (task-per-tx): contract {} @ {:?} updated via BroadcastTo",
+        "UPDATE relay: contract {} @ {:?} updated via BroadcastTo",
         key,
         self_location.location()
     );
@@ -1230,7 +1230,7 @@ pub(crate) async fn start_relay_request_update_streaming(
             %key,
             %sender_addr,
             phase = "relay_update_streaming_dedup_reject",
-            "UPDATE relay (task-per-tx streaming): duplicate RequestUpdateStreaming for in-flight tx, dropping"
+            "UPDATE relay (driver streaming): duplicate RequestUpdateStreaming for in-flight tx, dropping"
         );
         return Ok(());
     }
@@ -1242,7 +1242,7 @@ pub(crate) async fn start_relay_request_update_streaming(
         %stream_id,
         total_size,
         phase = "relay_update_streaming_request_start",
-        "UPDATE relay (task-per-tx streaming): spawning RequestUpdateStreaming driver"
+        "UPDATE relay (driver streaming): spawning RequestUpdateStreaming driver"
     );
 
     // Guard pre-spawn (see `start_relay_request_update` rationale).
@@ -1285,7 +1285,7 @@ pub(crate) async fn start_relay_broadcast_to_streaming(
             %key,
             %sender_addr,
             phase = "relay_update_streaming_dedup_reject",
-            "UPDATE relay (task-per-tx streaming): duplicate BroadcastToStreaming for in-flight tx, dropping"
+            "UPDATE relay (driver streaming): duplicate BroadcastToStreaming for in-flight tx, dropping"
         );
         return Ok(());
     }
@@ -1297,7 +1297,7 @@ pub(crate) async fn start_relay_broadcast_to_streaming(
         %stream_id,
         total_size,
         phase = "relay_update_streaming_broadcast_start",
-        "UPDATE relay (task-per-tx streaming): spawning BroadcastToStreaming driver"
+        "UPDATE relay (driver streaming): spawning BroadcastToStreaming driver"
     );
 
     RELAY_UPDATE_STREAMING_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -1363,7 +1363,7 @@ async fn run_relay_request_update_streaming(
             %key,
             error = %err,
             phase = "relay_update_streaming_request_error",
-            "UPDATE relay (task-per-tx streaming): RequestUpdateStreaming driver returned error"
+            "UPDATE relay (driver streaming): RequestUpdateStreaming driver returned error"
         );
     }
 }
@@ -1394,7 +1394,7 @@ async fn run_relay_broadcast_to_streaming(
             %key,
             error = %err,
             phase = "relay_update_streaming_broadcast_error",
-            "UPDATE relay (task-per-tx streaming): BroadcastToStreaming driver returned error"
+            "UPDATE relay (driver streaming): BroadcastToStreaming driver returned error"
         );
     }
 }
@@ -1425,7 +1425,7 @@ async fn drive_relay_request_update_streaming(
         contract = %key,
         %stream_id,
         total_size,
-        "UPDATE relay (task-per-tx streaming): processing RequestUpdateStreaming"
+        "UPDATE relay (driver streaming): processing RequestUpdateStreaming"
     );
 
     // Step 1: claim stream.
@@ -1439,7 +1439,7 @@ async fn drive_relay_request_update_streaming(
             tracing::debug!(
                 tx = %incoming_tx,
                 %stream_id,
-                "UPDATE relay (task-per-tx streaming): RequestUpdateStreaming skipped — stream already claimed (dedup)"
+                "UPDATE relay (driver streaming): RequestUpdateStreaming skipped — stream already claimed (dedup)"
             );
             return Ok(());
         }
@@ -1448,7 +1448,7 @@ async fn drive_relay_request_update_streaming(
                 tx = %incoming_tx,
                 %stream_id,
                 error = %e,
-                "UPDATE relay (task-per-tx streaming): failed to claim stream from orphan registry"
+                "UPDATE relay (driver streaming): failed to claim stream from orphan registry"
             );
             return Err(OpError::OrphanStreamClaimFailed);
         }
@@ -1462,7 +1462,7 @@ async fn drive_relay_request_update_streaming(
                 %stream_id,
                 assembled_size = data.len(),
                 expected_size = total_size,
-                "UPDATE relay (task-per-tx streaming): stream assembled"
+                "UPDATE relay (driver streaming): stream assembled"
             );
             data
         }
@@ -1471,7 +1471,7 @@ async fn drive_relay_request_update_streaming(
                 tx = %incoming_tx,
                 %stream_id,
                 error = %e,
-                "UPDATE relay (task-per-tx streaming): failed to assemble stream"
+                "UPDATE relay (driver streaming): failed to assemble stream"
             );
             return Err(OpError::StreamCancelled);
         }
@@ -1484,7 +1484,7 @@ async fn drive_relay_request_update_streaming(
             tracing::error!(
                 tx = %incoming_tx,
                 error = %e,
-                "UPDATE relay (task-per-tx streaming): failed to deserialize UpdateStreamingPayload"
+                "UPDATE relay (driver streaming): failed to deserialize UpdateStreamingPayload"
             );
             return Err(OpError::invalid_transition(incoming_tx));
         }
@@ -1533,13 +1533,13 @@ async fn drive_relay_request_update_streaming(
         tracing::debug!(
             tx = %incoming_tx,
             %key,
-            "UPDATE relay (task-per-tx streaming): RequestUpdateStreaming succeeded, state changed"
+            "UPDATE relay (driver streaming): RequestUpdateStreaming succeeded, state changed"
         );
     } else {
         tracing::debug!(
             tx = %incoming_tx,
             %key,
-            "UPDATE relay (task-per-tx streaming): RequestUpdateStreaming yielded no state change"
+            "UPDATE relay (driver streaming): RequestUpdateStreaming yielded no state change"
         );
     }
 
@@ -1576,7 +1576,7 @@ async fn drive_relay_broadcast_to_streaming(
         %stream_id,
         total_size,
         sender = %sender_addr,
-        "UPDATE relay (task-per-tx streaming): processing BroadcastToStreaming"
+        "UPDATE relay (driver streaming): processing BroadcastToStreaming"
     );
 
     // Step 1: claim stream.
@@ -1590,7 +1590,7 @@ async fn drive_relay_broadcast_to_streaming(
             tracing::debug!(
                 tx = %incoming_tx,
                 %stream_id,
-                "UPDATE relay (task-per-tx streaming): BroadcastToStreaming skipped — stream already claimed (dedup)"
+                "UPDATE relay (driver streaming): BroadcastToStreaming skipped — stream already claimed (dedup)"
             );
             return Ok(());
         }
@@ -1599,7 +1599,7 @@ async fn drive_relay_broadcast_to_streaming(
                 tx = %incoming_tx,
                 %stream_id,
                 error = %e,
-                "UPDATE relay (task-per-tx streaming): failed to claim stream from orphan registry (broadcast)"
+                "UPDATE relay (driver streaming): failed to claim stream from orphan registry (broadcast)"
             );
             return Err(OpError::OrphanStreamClaimFailed);
         }
@@ -1613,7 +1613,7 @@ async fn drive_relay_broadcast_to_streaming(
                 %stream_id,
                 assembled_size = data.len(),
                 expected_size = total_size,
-                "UPDATE relay (task-per-tx streaming): stream assembled (broadcast)"
+                "UPDATE relay (driver streaming): stream assembled (broadcast)"
             );
             data
         }
@@ -1622,7 +1622,7 @@ async fn drive_relay_broadcast_to_streaming(
                 tx = %incoming_tx,
                 %stream_id,
                 error = %e,
-                "UPDATE relay (task-per-tx streaming): failed to assemble stream (broadcast)"
+                "UPDATE relay (driver streaming): failed to assemble stream (broadcast)"
             );
             return Err(OpError::StreamCancelled);
         }
@@ -1635,7 +1635,7 @@ async fn drive_relay_broadcast_to_streaming(
             tracing::error!(
                 tx = %incoming_tx,
                 error = %e,
-                "UPDATE relay (task-per-tx streaming): failed to deserialize BroadcastStreamingPayload"
+                "UPDATE relay (driver streaming): failed to deserialize BroadcastStreamingPayload"
             );
             return Err(OpError::invalid_transition(incoming_tx));
         }
@@ -1674,7 +1674,7 @@ async fn drive_relay_broadcast_to_streaming(
         tracing::debug!(
             tx = %incoming_tx,
             %key,
-            "UPDATE relay (task-per-tx streaming): BroadcastToStreaming skipped — duplicate payload (dedup hit)"
+            "UPDATE relay (driver streaming): BroadcastToStreaming skipped — duplicate payload (dedup hit)"
         );
         return Ok(());
     }
@@ -1755,7 +1755,7 @@ async fn drive_relay_broadcast_to_streaming(
         tracing::debug!(
             tx = %incoming_tx,
             %key,
-            "UPDATE relay (task-per-tx streaming): BroadcastToStreaming produced no change"
+            "UPDATE relay (driver streaming): BroadcastToStreaming produced no change"
         );
         return Ok(());
     }
@@ -1764,7 +1764,7 @@ async fn drive_relay_broadcast_to_streaming(
     tracing::debug!(
         tx = %incoming_tx,
         %key,
-        "UPDATE relay (task-per-tx streaming): BroadcastToStreaming applied (state changed)"
+        "UPDATE relay (driver streaming): BroadcastToStreaming applied (state changed)"
     );
 
     let op_mgr = op_manager.clone();
@@ -2402,7 +2402,7 @@ mod tests {
     }
 
     /// Issue #4010: `deliver_outcome` must record the UPDATE outcome to
-    /// the dashboard `op_stats.updates` counter (the task-per-tx bypass
+    /// the dashboard `op_stats.updates` counter (the driver bypass
     /// at `handle_pure_network_message_v1` skips the legacy
     /// `report_result` recording path) and gate the call on
     /// `!client_tx.is_sub_operation()` for parity with SUBSCRIBE.
@@ -2417,7 +2417,7 @@ mod tests {
         assert!(
             body.contains("record_op_result"),
             "deliver_outcome must call record_op_result so the dashboard \
-             UPDATE counter advances on task-per-tx terminal replies. \
+             UPDATE counter advances on driver terminal replies. \
              Issue #4010."
         );
         assert!(

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2010,8 +2010,8 @@ impl Ring {
             // backoff state, and clears stale pending reservations for gateways.
             // Used during isolation recovery to ensure all gateways are retryable
             // when the node has zero ring connections (#3319).
-            // Wakes all tasks sleeping on gateway backoff (initial_join_procedure
-            // and any handle_aborted_op retries) so they can retry immediately.
+            // Wakes any task sleeping on gateway backoff
+            // (`initial_join_procedure`) so it can retry immediately.
             let reset_all_backoff = || {
                 self.reset_all_connection_backoff();
                 op_manager.gateway_backoff.lock().clear();

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -3207,8 +3207,8 @@ mod tests {
         assert_eq!(cm.connection_count(), 1);
     }
 
-    /// Verify that prune_in_transit_connection clears the phantom entry directly,
-    /// as called from handle_aborted_op (Fix 2 of #3088).
+    /// Verify that `prune_in_transit_connection` clears the phantom
+    /// entry directly (Fix 2 of #3088).
     #[test]
     fn test_prune_in_transit_clears_phantom_location() {
         let cm = make_connection_manager(Some(make_addr(8000)), 5, 20, false);

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -1826,7 +1826,7 @@ fn peer_detail_html(address_str: &str) -> String {
                 // either contains the rendered curve or a per-metric
                 // "awaiting data" placeholder — empty slots are NOT hidden,
                 // because hiding them silently rotted unobserved when the
-                // task-per-tx migration stopped feeding the response-time
+                // migration stopped feeding the response-time
                 // and transfer-rate estimators (the `Failure Probability`-only
                 // dashboard regression that surfaced this code path).
                 panel_content.push_str(&build_estimator_chart_or_placeholder(
@@ -1984,7 +1984,7 @@ fn peer_detail_html(address_str: &str) -> String {
 /// yet — a titled placeholder. The placeholder keeps the slot visible so
 /// users can always see every component of a routing prediction even when
 /// some estimators have not yet received feedback. Hiding empty charts
-/// masked the data-collection regression in the task-per-tx migration
+/// masked the data-collection regression in the migration
 /// that fed only `failure_estimator` and left `response_start_time` and
 /// `transfer_rate` permanently empty.
 #[allow(clippy::too_many_arguments)]
@@ -3182,7 +3182,7 @@ mod tests {
     /// placeholder so all three prediction-component slots
     /// (Failure Probability, Response Time, Transfer Rate) stay
     /// visible on the peer dashboard. The previous behaviour hid the
-    /// chart entirely, which masked the task-per-tx data-collection
+    /// chart entirely, which masked the driver data-collection
     /// regression that left response-time/transfer-rate estimators
     /// permanently empty (Failure-Probability-only dashboard).
     #[test]
@@ -3215,7 +3215,7 @@ mod tests {
     /// `build_estimator_chart_or_placeholder` for all three
     /// prediction-component slots (Failure Probability, Response Time,
     /// Transfer Rate). Hiding empty slots previously masked the
-    /// task-per-tx data-collection regression for months — keeping every
+    /// driver data-collection regression for months — keeping every
     /// slot visible makes future regressions detectable on sight.
     /// Source-scrape rather than HTML-grep because the visible-when-empty
     /// behaviour depends on a router_snapshot being present, and the

--- a/docs/architecture/operations/README.md
+++ b/docs/architecture/operations/README.md
@@ -110,7 +110,7 @@ stateDiagram-v2
 
 ```mermaid
 stateDiagram-v2
-    [*] --> AwaitingResponse : task-per-tx driver emits Request
+    [*] --> AwaitingResponse : driver emits Request
     AwaitingResponse --> Finished : acknowledgment received
 
     AwaitingResponse : contract, value, htl, subscribe flag;<br/>forwarding to peers
@@ -319,7 +319,7 @@ flowchart TB
     style Child fill:#cce5ff,stroke:#004085
 ```
 
-Each task-per-tx driver owns its own outcome publication
+Each driver owns its own outcome publication
 (`HostResult::Ok` on success, `HostResult::Err` on timeout/error).
 There is no central registry of pending children, no parent-parking
 branch, and no GC parent-propagation block. Failure isolation is the
@@ -327,7 +327,7 @@ driver's responsibility.
 
 **Code reference:** `Transaction::new_child_of` and
 `Transaction::is_sub_operation` in `crates/core/src/message.rs`;
-task-per-tx drivers in `crates/core/src/operations/{put,get,subscribe,update}/op_ctx_task.rs`.
+drivers in `crates/core/src/operations/{put,get,subscribe,update}/op_ctx_task.rs`.
 
 ## Error Handling
 


### PR DESCRIPTION
## Problem

After #4110 (Phase 7) the per-transaction driver model is complete, but
the tree still carried scaffolding from the migration: a no-op
`handle_aborted_op` stub kept three callers compiling, the
executor-to-event-loop mediator survived as three trait-gated empty
types only so a `PrioritySelectStream` generic slot could be filled,
the `ConnectOp` test fixture was annotated as production code with
`#[allow(dead_code)]` markers, and dozens of comments / doc-strings /
pin-test messages narrated the migration as an in-progress event.

## Solution

Four commits, each kept independently green (`cargo fmt && cargo
clippy --all-targets -- -D warnings && cargo test -p freenet --lib`):

1. **`refactor(node): delete handle_aborted_op stub`** — inline the
   three transport-handshake-fail call sites (outer tracing log already
   records the failure); delete the fn; drop the now-dead `op_manager`
   clone in the surrounding connection-establish branch.
2. **`refactor(contract): collapse executor-mediator stubs to single
   empty stream`** — replace `ExecutorToEventLoopChannel<
   NetworkEventListenerHalve>` + `sealed::ChannelHalve` +
   `mediator_channels` with one zero-sized `ExecutorTransactionStream`
   whose `poll_next` returns `Pending`. Drop the `executor_listener`
   field on `NodeP2P`, the `executor_listener` arg threaded through
   `run_event_listener`, and the matching wiring in the in-memory test
   harness.
3. **`refactor(connect): gate ConnectOp fixture behind cfg(test)`** —
   move `ConnectOp`, its `impl` block, and `FORWARD_ATTEMPT_TIMEOUT`
   behind `#[cfg(test)]`. Drop unread fields (`first_hop`,
   `desired_location`, `time_source`) and unused methods (`outcome`,
   `finalized`, `to_host_result`, `gateway`, `get_next_hop_addr`,
   `get_target_peer`, `handle_response`, `handle_observed_address`,
   `with_state`, `is_completed`). Gate `ForwardAttempt` fields with
   `cfg_attr` so production builds stay clean.
4. **`docs: strip references to issue #1454, phases, and legacy
   terminology`** — sweep code comments, doc-comments, pin-test
   messages, and `.claude/rules/operations.md`. Delete one dead helper
   (`setup_subscription_forwarding_at_relay`) exposed by the sweep;
   rename `OP_REQUEST_TIMEOUT` → `SUB_OP_FETCH_TIMEOUT` and
   `try_forward_task_per_tx_reply` → `try_forward_driver_reply` so
   identifiers describe their current role.

Net diff: ~-700 LoC.

## Testing

- `cargo build -p freenet --tests` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test -p freenet --lib` ✅ (2492 pass, 14 ignored)

## Fixes

Closes the cleanup follow-up tracked from #4110.