### PR TITLE
fix(put): deliver originator-loopback failure via PutMsg::Error bypass

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -35,7 +35,7 @@ for every inbound wire message. Pattern per op:
 
 1. **Reply bypass.** If a terminal reply variant arrives and a
    `pending_op_results` callback is registered, forward it via
-   `try_forward_task_per_tx_reply` and return. For GET/PUT/SUBSCRIBE the
+   `try_forward_driver_reply` and return. For GET/PUT/SUBSCRIBE the
    gate is `Response | ResponseStreaming` only. PUT additionally
    accepts `PutMsg::Error` so the originator-loopback failure path
    (issue #4111) delivers the contract-side cause via the same bypass

--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -35,9 +35,13 @@ for every inbound wire message. Pattern per op:
 
 1. **Reply bypass.** If a terminal reply variant arrives and a
    `pending_op_results` callback is registered, forward it via
-   `try_forward_task_per_tx_reply` and return. For GET/PUT/SUBSCRIBE
-   the gate is `Response | ResponseStreaming` only. CONNECT forwards
-   all four non-`Request` variants (multi-reply fan-in).
+   `try_forward_task_per_tx_reply` and return. For GET/SUBSCRIBE the
+   gate is `Response | ResponseStreaming` only. PUT additionally
+   accepts `PutMsg::Error` so the originator-loopback failure path
+   (issue #4111) delivers the contract-side cause via the same bypass
+   instead of timing out the retry loop on a closed reply channel.
+   CONNECT forwards all four non-`Request` variants (multi-reply
+   fan-in).
 2. **Relay dispatch.** Spawn the matching `start_relay_*` driver.
    Originator-loopback (`source_addr=None`) is mapped to
    `upstream_addr=own_addr` for GET/PUT/SUBSCRIBE so the same driver
@@ -221,6 +225,59 @@ WRONG:
 
 CORRECT:
   send_peer_list(connected_peers.filter(|p| is_live_connection(p)))
+```
+
+### WHEN publishing a terminal operation reply
+
+```
+Sync-failure paths (where the driver knows the operation is done and
+must publish a Result to the originator) MUST deliver via the SAME
+mechanism the success path uses — NOT via direct send_client_result.
+
+WRONG:
+  if put_contract(...).is_err() {
+      op_manager.send_client_result(tx, Err(host_err));  // M1
+      op_manager.completed(tx);                          // M2
+  }
+
+  M1 and M2 are independent try_send calls on different channels
+  (result_router_tx vs event-loop notification channel). When the
+  event loop processes M2 first, it removes pending_op_results[tx]
+  BEFORE send_and_await consumes M1; the retry-loop sees the closed
+  channel as NotificationError, advances, burns the retry budget on
+  the same deterministic failure, and the user gets the synthesised
+  "failed notifying, channel closed" instead of the real reason.
+
+CORRECT:
+  let err_msg = NetMessage::from(<Op>Msg::Error { id: tx, cause });
+  ctx.send_local_loopback(err_msg).await?;
+
+  Routing: handle_pure_network_message_v1 forwards <Op>Msg::Error
+  into pending_op_results[tx] like Response; classify_reply returns
+  ReplyClass::TerminalError { cause }; the driver returns
+  Terminal(Err(cause)) → Done(Err); run_client_<op> publishes ONE
+  HostResult::Err and calls op_manager.completed(client_tx)
+  synchronously — no race window.
+
+Multi-hop: when a downstream relay returns <Op>Msg::Error, the
+relay MUST propagate the cause one hop further upstream via a
+matching `relay_<op>_send_error` helper, not fall through to a
+generic OpError::UnexpectedOpState wildcard.
+
+DoS amplification: cap the cause length at the wire boundary.
+PUT uses PUT_TERMINAL_CAUSE_MAX_BYTES = 2048 + a UTF-8-safe
+truncator (see `bound_cause` in operations/put.rs).
+
+Testing: PUT's bypass + multi-hop bubble is covered by unit tests
+in `operations/put/op_ctx_task.rs::tests` (search for
+`relay_put_send_error_with_ctx_*`, `drive_relay_put_error_arm_*`,
+`run_relay_put_bubbles_local_failure_*`, and
+`dispatch_loopback_shutdown_fallback_*`) plus the
+`tests/error_notification.rs::test_put_error_notification*` E2E
+pair. The wrapper-contract E2E that asserts on a stable,
+contract-side cause string is tracked as follow-up #4147 — the
+existing E2E tests assert only the absence of the synthesised
+`"failed notifying, channel closed"` marker.
 ```
 
 ## Error Handling

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2765,7 +2765,7 @@ mod tests {
 
         /// Issue #4111 regression guard. The PUT branch of
         /// `handle_pure_network_message_v1` must forward `PutMsg::Error`
-        /// through `try_forward_task_per_tx_reply` exactly like
+        /// through `try_forward_driver_reply` exactly like
         /// `PutMsg::Response` / `PutMsg::ResponseStreaming`. Without
         /// this, the originator-loopback failure path's
         /// `send_local_loopback(PutMsg::Error)` would arrive at the

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -841,15 +841,25 @@ where
             return Ok(());
         }
         NetMessageV1::Put(ref op) => {
-            // Forward only **terminal** Response/ResponseStreaming
+            // Forward only **terminal** Response/ResponseStreaming/Error
             // messages to the originator's awaiting task via the
             // bypass. Non-terminal messages (Request,
             // RequestStreaming, ForwardingAck) must NOT be
             // forwarded: they would fill the capacity-1 reply
             // channel and cause `classify_reply` to fail.
+            //
+            // `Error` is terminal-by-construction (issue #4111): the
+            // originator-loopback failure path emits it via
+            // `send_local_loopback` so the originator's
+            // `start_client_put` retry loop classifies the local
+            // contract-side rejection as `Terminal(Err(cause))` once,
+            // rather than burning the retry budget against a closed
+            // per-attempt reply channel.
             if matches!(
                 op,
-                put::PutMsg::Response { .. } | put::PutMsg::ResponseStreaming { .. }
+                put::PutMsg::Response { .. }
+                    | put::PutMsg::ResponseStreaming { .. }
+                    | put::PutMsg::Error { .. }
             ) && try_forward_driver_reply(
                 pending_op_result.as_ref(),
                 NetMessage::V1(NetMessageV1::Put((*op).clone())),
@@ -962,8 +972,8 @@ where
                             tx = %op.id(),
                             ?op,
                             "PUT: non-dispatch variant ignored \
-                             (Response/ResponseStreaming already handled \
-                             by bypass; ForwardingAck is no-op)"
+                             (Response/ResponseStreaming/Error already \
+                             handled by bypass; ForwardingAck is no-op)"
                         );
                     }
                 }
@@ -2685,6 +2695,81 @@ mod tests {
                  be forwarded to the driver channel — they would fill \
                  the capacity-1 reply slot and block the real Response."
             );
+        }
+
+        /// Issue #4111 regression guard. The PUT branch of
+        /// `handle_pure_network_message_v1` must forward `PutMsg::Error`
+        /// through `try_forward_task_per_tx_reply` exactly like
+        /// `PutMsg::Response` / `PutMsg::ResponseStreaming`. Without
+        /// this, the originator-loopback failure path's
+        /// `send_local_loopback(PutMsg::Error)` would arrive at the
+        /// dispatch site, find no bypass match for `Error`, and the
+        /// catch-all wildcard would drop it as
+        /// "non-dispatch variant ignored" — re-introducing the bug
+        /// the fix addresses (retry-storm + `"failed notifying,
+        /// channel closed"` synthesised for a deterministic local
+        /// failure).
+        ///
+        /// Same pattern as
+        /// `bypass_is_wired_into_subscribe_branch_regression_guard`:
+        /// a structural source-scrape so a future refactor that
+        /// breaks the wiring fails at the unit-test level instead of
+        /// as an end-to-end hang.
+        #[test]
+        fn put_branch_bypass_includes_error_variant_regression_guard() {
+            const SOURCE: &str = include_str!("node.rs");
+
+            let put_branch_anchor: String = ["NetMessageV1::", "Put(ref op)", " => {"].concat();
+            let branch_start = SOURCE.find(&put_branch_anchor).expect(
+                "PUT branch of handle_pure_network_message_v1 not found; \
+                 the match arm has been renamed or moved — update this guard",
+            );
+
+            // The PUT branch ends at the GET branch start.
+            let next_anchor: String = ["NetMessageV1::", "Get(ref op)", " => {"].concat();
+            let window_end = SOURCE[branch_start..]
+                .find(&next_anchor)
+                .expect("end of PUT branch not found — update guard")
+                + branch_start;
+            let window = &SOURCE[branch_start..window_end];
+
+            assert!(
+                window.contains("try_forward_driver_reply("),
+                "PUT branch no longer calls try_forward_driver_reply \
+                 — either restore the bypass or update this guard."
+            );
+
+            // The terminal-reply gate MUST list `Error` alongside
+            // `Response` and `ResponseStreaming`. We check on the
+            // substring rather than the full `matches!` pattern so a
+            // line-wrap or arm-reorder doesn't trip the guard
+            // spuriously — the load-bearing claim is "Error appears
+            // inside the matches! that gates the bypass forward".
+            let gate_start = window
+                .find("matches!(\n                op,")
+                .or_else(|| window.find("matches!(op,"))
+                .expect("terminal-gate matches! not found in PUT branch");
+            let gate_end = window[gate_start..]
+                .find(") && try_forward_driver_reply(")
+                .expect("end of terminal-gate matches! not found")
+                + gate_start;
+            let gate = &window[gate_start..gate_end];
+
+            for expected in [
+                "put::PutMsg::Response { .. }",
+                "put::PutMsg::ResponseStreaming { .. }",
+                "put::PutMsg::Error { .. }",
+            ] {
+                assert!(
+                    gate.contains(expected),
+                    "PUT bypass terminal-gate missing `{expected}` — \
+                     issue #4111: without Error in the gate, the \
+                     originator-loopback failure path's \
+                     send_local_loopback(PutMsg::Error) lands in the \
+                     dispatch wildcard and the originator's retry-loop \
+                     re-runs the same deterministic local failure."
+                );
+            }
         }
 
         #[tokio::test]

--- a/crates/core/src/operations/op_ctx.rs
+++ b/crates/core/src/operations/op_ctx.rs
@@ -582,6 +582,87 @@ mod tests {
     use crate::operations::connect::ConnectMsg;
     use tokio::time::{Duration, timeout};
 
+    /// Behavioural pin on `drive_retry_loop`'s `AttemptOutcome::Terminal`
+    /// arm: it MUST return `RetryLoopOutcome::Done(value)` synchronously,
+    /// WITHOUT calling `driver.advance()`.
+    ///
+    /// Why this is a source-pin: a fully behavioural test requires
+    /// instantiating an `OpManager` (the function takes `&OpManager` to
+    /// build the per-attempt `OpCtx` and to send `TransactionCompleted`),
+    /// which costs too much for a unit test. The structural pin
+    /// scopes the assertion to the Terminal arm itself — the production
+    /// code under test is exactly five lines — and a regression that
+    /// routes Terminal through `advance()` would unambiguously contain
+    /// the substring `.advance()` inside this arm.
+    ///
+    /// Pairs with `classify_reply_error_maps_to_terminal_error_with_cause`
+    /// in `crate::operations::put::op_ctx_task::tests` to cover the full
+    /// PUT-error chain (PutMsg::Error → TerminalError → Terminal →
+    /// Done(Err) without advance).
+    #[test]
+    fn drive_retry_loop_terminal_arm_does_not_call_advance() {
+        const SOURCE: &str = include_str!("op_ctx.rs");
+
+        let fn_anchor = "pub(crate) async fn drive_retry_loop<D: RetryDriver>(";
+        let fn_start = SOURCE.find(fn_anchor).expect(
+            "drive_retry_loop not found — signature has been renamed, \
+             update this guard",
+        );
+
+        // The `match driver.classify(reply) {` block contains the
+        // Terminal arm we care about. Locate it.
+        let classify_match = SOURCE[fn_start..]
+            .find("match driver.classify(reply) {")
+            .map(|p| fn_start + p)
+            .expect("`match driver.classify(reply)` not found in drive_retry_loop");
+
+        let terminal_arm_anchor = "AttemptOutcome::Terminal(value) =>";
+        let arm_start = SOURCE[classify_match..]
+            .find(terminal_arm_anchor)
+            .map(|p| classify_match + p)
+            .expect(
+                "Terminal arm `AttemptOutcome::Terminal(value) =>` not \
+                 found — the production arm shape has changed; update \
+                 this guard with the new shape",
+            );
+
+        // The Terminal arm is delimited by the next `AttemptOutcome::`
+        // sibling arm. Anchor on that.
+        let arm_end = SOURCE[arm_start + terminal_arm_anchor.len()..]
+            .find("AttemptOutcome::")
+            .map(|p| arm_start + terminal_arm_anchor.len() + p)
+            .expect("end-of-Terminal-arm marker (next AttemptOutcome::) not found");
+
+        let arm_body = &SOURCE[arm_start..arm_end];
+
+        assert!(
+            arm_body.contains("return RetryLoopOutcome::Done(value);"),
+            "Terminal arm MUST `return RetryLoopOutcome::Done(value);` \
+             synchronously — re-routing terminal replies into the retry \
+             loop would burn the budget on a deterministic failure and \
+             re-introduce the M1/M2 race the PR fixes.\n\
+             Arm body:\n{arm_body}"
+        );
+        assert!(
+            !arm_body.contains(".advance()"),
+            "Terminal arm MUST NOT call driver.advance() — terminal \
+             classifications are by definition non-retriable. A \
+             regression that calls advance() here would burn the \
+             retry budget against the same deterministic failure and \
+             surface the synthesised 'failed notifying, channel \
+             closed' marker instead of the real cause (issue #4111).\n\
+             Arm body:\n{arm_body}"
+        );
+        assert!(
+            !arm_body.contains("continue"),
+            "Terminal arm MUST NOT `continue` — that would skip the \
+             return and fall back to the next loop iteration, which \
+             would re-`send_and_await` against the SAME closed \
+             attempt-tx channel and surface NotificationError.\n\
+             Arm body:\n{arm_body}"
+        );
+    }
+
     /// Build a synthetic terminal reply keyed by `tx`. Mirrors
     /// `node::tests::callback_forward_tests::dummy_reply` but lets the
     /// caller supply the transaction so both sides of the round-trip agree.
@@ -859,6 +940,102 @@ mod tests {
         });
 
         let outbound = dummy_reply_with_tx(tx);
+        timeout(Duration::from_secs(1), ctx.send_local_loopback(outbound))
+            .await
+            .expect("send_local_loopback should complete quickly")
+            .expect("send_local_loopback should return Ok");
+
+        executor
+            .await
+            .expect("executor task should complete without panicking");
+    }
+
+    /// Issue #4111: the originator-loopback PUT failure path emits a
+    /// `PutMsg::Error { id, cause }` via `send_local_loopback`. This
+    /// pins the contract from the *sender* side: an Error envelope
+    /// flows through the same primitive as a successful Response, with
+    /// `target=None` and the same `is_closed()` response-receiver
+    /// signal so `handle_op_execution` skips the `pending_op_results`
+    /// insert and the originator's pre-installed callback survives.
+    ///
+    /// (The reception side — that the bypass actually forwards Error
+    /// to the originator's waiter — is pinned by
+    /// `put_branch_bypass_forwards_error` in `node.rs`.)
+    #[tokio::test]
+    async fn send_local_loopback_carries_put_error_to_event_loop() {
+        use crate::message::NetMessageV1;
+        use crate::operations::put::PutMsg;
+
+        let (receiver, sender) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut op_execution_receiver,
+            ..
+        } = receiver;
+
+        // Allocate the tx as a PutMsg tx so `Transaction::is_for::<PutMsg>()`
+        // is consistent across the round-trip.
+        let tx = Transaction::new::<PutMsg>();
+        let mut ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+        let cause = "contract rejected: invalid update".to_string();
+
+        let executor_cause = cause.clone();
+        let executor = tokio::spawn(async move {
+            let (reply_sender, outbound, target_addr) = op_execution_receiver
+                .recv()
+                .await
+                .expect("PutMsg::Error envelope should be delivered");
+
+            assert_eq!(
+                outbound.id(),
+                &tx,
+                "Error envelope tx must match the ctx tx — debug_assert in \
+                 send_local_loopback should already enforce this"
+            );
+            assert_eq!(
+                target_addr, None,
+                "send_local_loopback MUST pass target_addr=None for the \
+                 PutMsg::Error envelope so handle_op_execution dispatches \
+                 it as InboundMessage (same path as a Response loopback)"
+            );
+
+            // Verify the wire payload is the Error variant with the
+            // intended cause — not a placeholder or truncated string.
+            // The catch-all arm covers the long tail of NetMessage
+            // variants (Get/Subscribe/Update/Aborted/Connect/...) which
+            // are irrelevant here; listing each one in the assertion
+            // would obscure the actual contract.
+            #[allow(clippy::wildcard_enum_match_arm)]
+            match outbound {
+                NetMessage::V1(NetMessageV1::Put(PutMsg::Error {
+                    id,
+                    cause: decoded_cause,
+                })) => {
+                    assert_eq!(id, tx, "Error.id must equal the originator tx");
+                    assert_eq!(
+                        decoded_cause, executor_cause,
+                        "Error.cause must be the verbatim cause string"
+                    );
+                }
+                other => panic!(
+                    "expected NetMessage::V1(Put(Error {{ .. }})), got {:?}",
+                    std::any::type_name_of_val(&other)
+                ),
+            }
+
+            assert!(
+                reply_sender.is_closed(),
+                "send_local_loopback drops its response receiver, so \
+                 handle_op_execution must observe is_closed() on the \
+                 reply sender and skip the pending_op_results insert — \
+                 otherwise it would clobber the originator's pre-installed \
+                 callback (the one waiting for this Error)"
+            );
+        });
+
+        let outbound = NetMessage::V1(NetMessageV1::Put(PutMsg::Error {
+            id: tx,
+            cause: cause.clone(),
+        }));
         timeout(Duration::from_secs(1), ctx.send_local_loopback(outbound))
             .await
             .expect("send_local_loopback should complete quickly")

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -21,6 +21,78 @@ use crate::{
 };
 use either::Either;
 
+/// Upper bound on the `cause` carried by [`PutMsg::Error`] and
+/// [`PutTerminalError`]. Caps the DoS amplification surface when the
+/// envelope flows multi-hop (via [`relay_put_send_error`]).
+pub(crate) const PUT_TERMINAL_CAUSE_MAX_BYTES: usize = 2048;
+
+/// UTF-8-safe length cap with an ASCII truncation marker.
+///
+/// # Multi-hop idempotency invariant
+///
+/// `bound_cause` is called at every hop a `PutMsg::Error` traverses
+/// (loopback emit, `PutTerminalError::from_wire`, `relay_put_send_error`
+/// bubble). The bubble must forward causes **verbatim-or-rebound,
+/// never append**: any future relay that augments the cause (e.g.
+/// prepending a `[hop=N]` tag) would otherwise cause this function to
+/// re-truncate on each hop, stamping a fresh `...[truncated]` marker
+/// every time and silently injecting double/triple markers into the
+/// envelope the originator eventually classifies.
+///
+/// Today the call is idempotent on already-bounded short inputs (the
+/// `<= PUT_TERMINAL_CAUSE_MAX_BYTES` early return), so the invariant
+/// holds by construction. Don't break it without revisiting the
+/// truncation-marker contract.
+pub(crate) fn bound_cause(cause: String) -> String {
+    const SUFFIX: &str = "...[truncated]";
+    if cause.len() <= PUT_TERMINAL_CAUSE_MAX_BYTES {
+        return cause;
+    }
+    let budget = PUT_TERMINAL_CAUSE_MAX_BYTES.saturating_sub(SUFFIX.len());
+    // Walk back to a char boundary — `str` indexing must not split a codepoint.
+    let mut cut = budget.min(cause.len());
+    while cut > 0 && !cause.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let mut out = String::with_capacity(cut + SUFFIX.len());
+    out.push_str(&cause[..cut]);
+    out.push_str(SUFFIX);
+    out
+}
+
+/// In-process counterpart of the wire [`PutMsg::Error::cause`].
+/// The wire side stays as a raw `String` for bincode compat;
+/// `PutTerminalError` gives the retry-loop `Terminal` type a named
+/// shape and a single point to enforce length caps.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PutTerminalError {
+    cause: String,
+}
+
+impl PutTerminalError {
+    /// Applies [`bound_cause`] so multi-hop forwarding can't amplify
+    /// attacker-controlled cause strings.
+    pub(crate) fn from_wire(cause: String) -> Self {
+        Self {
+            cause: bound_cause(cause),
+        }
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.cause
+    }
+
+    pub(crate) fn into_string(self) -> String {
+        self.cause
+    }
+}
+
+impl std::fmt::Display for PutTerminalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Telemetry data for originator-side PUT finalization.
 pub(super) struct PutFinalizationData {
     pub sender: PeerKeyLocation,
@@ -186,6 +258,7 @@ mod messages {
     /// merged state differs from the input, an Update operation is triggered to
     /// propagate the change to other subscribers.
     #[derive(Debug, Serialize, Deserialize, Clone)]
+    #[non_exhaustive]
     pub(crate) enum PutMsg {
         /// Request to store a contract. Forwarded hop-by-hop toward contract location.
         /// Each receiving node:
@@ -278,6 +351,32 @@ mod messages {
             id: Transaction,
             contract_key: ContractKey,
         },
+
+        /// Terminal failure delivered to the originator's driver via the
+        /// same `pending_op_results` bypass as `Response`. Carries the
+        /// contract-side or local-validation reason as a string so the
+        /// originator's `start_client_put` publishes a single
+        /// `HostResult::Err(OperationError { cause })` instead of
+        /// burning the retry budget on a deterministic failure and
+        /// racing the genuine reason against the synthesised
+        /// "failed notifying, channel closed" marker.
+        ///
+        /// Constructed by `run_relay_put` in the originator-loopback
+        /// failure path; bubbled up multi-hop chains by
+        /// `relay_put_send_error` (see [`op_ctx_task`]).
+        Error {
+            id: Transaction,
+            /// Human-readable failure reason surfaced to the client.
+            /// Kept as `String` (not `ClientError` / `OpError`) so the
+            /// wire variant stays dependency-free for `bincode` —
+            /// future serde changes in those types don't break wire
+            /// compatibility. Truncated to
+            /// [`PUT_TERMINAL_CAUSE_MAX_BYTES`] via [`bound_cause`] at
+            /// every entry point. Wrapped into
+            /// [`super::PutTerminalError`] for in-process
+            /// classification.
+            cause: String,
+        },
     }
 
     impl InnerMessage for PutMsg {
@@ -287,7 +386,8 @@ mod messages {
                 | Self::Response { id, .. }
                 | Self::RequestStreaming { id, .. }
                 | Self::ResponseStreaming { id, .. }
-                | Self::ForwardingAck { id, .. } => id,
+                | Self::ForwardingAck { id, .. }
+                | Self::Error { id, .. } => id,
             }
         }
 
@@ -300,6 +400,10 @@ mod messages {
                 }
                 Self::ResponseStreaming { key, .. } => Some(Location::from(key.id())),
                 Self::ForwardingAck { contract_key, .. } => Some(Location::from(contract_key.id())),
+                // No contract key in the failure envelope — the originator
+                // already knows the key it requested; the failure is keyed
+                // by tx only.
+                Self::Error { .. } => None,
             }
         }
     }
@@ -350,6 +454,9 @@ mod messages {
                 Self::ForwardingAck { id, contract_key } => {
                     write!(f, "PutForwardingAck(id: {}, key: {})", id, contract_key)
                 }
+                Self::Error { id, cause } => {
+                    write!(f, "PutError(id: {}, cause: {})", id, cause)
+                }
             }
         }
     }
@@ -386,6 +493,271 @@ mod tests {
             display.contains("PutResponse"),
             "Display should contain message type name"
         );
+    }
+
+    /// `PutMsg::Error` honours `id()` and `Display` like every other
+    /// variant.
+    #[test]
+    fn put_msg_error_id_and_display() {
+        let tx = Transaction::new::<PutMsg>();
+        let msg = PutMsg::Error {
+            id: tx,
+            cause: "contract rejected: version must be higher".into(),
+        };
+        assert_eq!(*msg.id(), tx, "id() should return the transaction ID");
+        let display = format!("{}", msg);
+        assert!(display.contains("PutError"), "Display tag");
+        assert!(display.contains("version must be higher"), "Display cause");
+    }
+
+    /// `PutMsg::Error` round-trips through bincode intact.
+    #[test]
+    fn put_msg_error_serde_roundtrip() {
+        let tx = Transaction::new::<PutMsg>();
+        let cause = "execution error: invalid contract update".to_string();
+        let msg = PutMsg::Error {
+            id: tx,
+            cause: cause.clone(),
+        };
+
+        let serialized = bincode::serialize(&msg).expect("serialize");
+        let deserialized: PutMsg = bincode::deserialize(&serialized).expect("deserialize");
+
+        match deserialized {
+            PutMsg::Error {
+                id,
+                cause: decoded_cause,
+            } => {
+                assert_eq!(id, tx);
+                assert_eq!(decoded_cause, cause);
+            }
+            other => panic!("Expected Error, got {other}"),
+        }
+    }
+
+    /// `Error` is keyed by tx only — `requested_location` must not
+    /// gain a phantom location.
+    #[test]
+    fn put_msg_error_has_no_requested_location() {
+        let tx = Transaction::new::<PutMsg>();
+        let msg = PutMsg::Error {
+            id: tx,
+            cause: "x".into(),
+        };
+        assert!(msg.requested_location().is_none());
+    }
+
+    /// Wire-format pin: bincode encodes `PutMsg` variants as a u32 LE
+    /// tag in declaration order. Reordering or inserting before an
+    /// existing variant is a silent wire-break against deployed peers.
+    /// `#[non_exhaustive]` only protects Rust match arms; tag
+    /// stability is enforced here.
+    ///
+    /// **Codec-config assumption.** This test uses default
+    /// `bincode::serialize`, which currently emits enum variant tags
+    /// as fixed-width `u32` little-endian. The test invariants
+    /// (variant tag == declaration index, encoded length ≥ 4 bytes)
+    /// depend on that. If the project ever switches bincode codec
+    /// config — e.g. to `with_varint_encoding()` (variable-length
+    /// tags, breaks length assumption) or `with_big_endian()`
+    /// (breaks LE assumption) or to bincode 2's `standard()` config
+    /// — this pin must be updated in lockstep, otherwise the wire
+    /// format silently changes against deployed peers without
+    /// tripping any test. The single source of truth for the codec
+    /// config is the deserialize site in the transport stack; keep
+    /// that and this test in sync.
+    #[test]
+    fn put_msg_wire_format_variant_tags_are_stable() {
+        let tx = Transaction::new::<PutMsg>();
+        let key = make_contract_key(0);
+        // One minimal instance per variant, in declaration order.
+        let samples: [(u32, PutMsg); 6] = [
+            (
+                0,
+                PutMsg::Request {
+                    id: tx,
+                    contract: crate::operations::test_utils::make_test_contract(&[]),
+                    related_contracts: RelatedContracts::default(),
+                    value: WrappedState::new(vec![]),
+                    htl: 0,
+                    skip_list: Default::default(),
+                },
+            ),
+            (
+                1,
+                PutMsg::Response {
+                    id: tx,
+                    key,
+                    hop_count: 0,
+                },
+            ),
+            (
+                2,
+                PutMsg::RequestStreaming {
+                    id: tx,
+                    stream_id: crate::transport::StreamId::next(),
+                    contract_key: key,
+                    total_size: 0,
+                    htl: 0,
+                    skip_list: Default::default(),
+                    subscribe: false,
+                },
+            ),
+            (
+                3,
+                PutMsg::ResponseStreaming {
+                    id: tx,
+                    key,
+                    continue_forwarding: false,
+                    hop_count: 0,
+                },
+            ),
+            (
+                4,
+                PutMsg::ForwardingAck {
+                    id: tx,
+                    contract_key: key,
+                },
+            ),
+            (
+                5,
+                PutMsg::Error {
+                    id: tx,
+                    cause: String::new(),
+                },
+            ),
+        ];
+        for (expected_tag, msg) in samples {
+            let bytes = bincode::serialize(&msg).expect("serialize");
+            assert!(
+                bytes.len() >= 4,
+                "encoded PutMsg too short to carry a tag: {msg}"
+            );
+            let actual_tag = u32::from_le_bytes(bytes[..4].try_into().expect("first 4 bytes"));
+            assert_eq!(
+                actual_tag, expected_tag,
+                "PutMsg wire tag for `{msg}` shifted — reordering variants is a wire-format \
+                 break. If you intentionally renumbered, bump the freenet-stdlib major and \
+                 coordinate the upgrade."
+            );
+        }
+    }
+
+    /// `bound_cause` keeps short strings byte-identical and truncates
+    /// long strings to `PUT_TERMINAL_CAUSE_MAX_BYTES` with a
+    /// `...[truncated]` suffix. Used as the DoS-amplification guard
+    /// when `PutMsg::Error` flows multi-hop.
+    #[test]
+    fn bound_cause_short_string_passes_through() {
+        let s = "execution error: contract rejected".to_string();
+        assert_eq!(bound_cause(s.clone()), s);
+    }
+
+    #[test]
+    fn bound_cause_truncates_oversize_at_char_boundary() {
+        let s = "a".repeat(PUT_TERMINAL_CAUSE_MAX_BYTES * 2);
+        let bounded = bound_cause(s);
+        assert!(bounded.len() <= PUT_TERMINAL_CAUSE_MAX_BYTES);
+        assert!(bounded.ends_with("...[truncated]"));
+    }
+
+    #[test]
+    fn bound_cause_never_splits_utf8_codepoint() {
+        // PR #4126 review item M2: the previous version of this test
+        // used `"好".repeat(_)` — 3-byte codepoints. The internal
+        // budget `PUT_TERMINAL_CAUSE_MAX_BYTES - "...[truncated]".len()`
+        // is currently `2048 - 14 = 2034`, and `2034 % 3 == 0`, so
+        // the cut landed exactly on a codepoint boundary and the
+        // `while !is_char_boundary(cut)` walk-back loop ran zero
+        // iterations. The "never splits" guarantee was therefore
+        // never actually exercised.
+        //
+        // Switch to a 4-byte codepoint (U+1D11E "𝄞", G clef) sized so
+        // the cap lands mid-codepoint, forcing the walk-back to
+        // execute. `2034 % 4 == 2` → byte 2034 is two bytes into a
+        // 4-byte codepoint, so `is_char_boundary(2034)` MUST be false
+        // and the loop MUST trim at least one byte.
+        const FOUR_BYTE: &str = "𝄞"; // U+1D11E, 4 bytes UTF-8
+        assert_eq!(FOUR_BYTE.len(), 4);
+
+        // 600 × 4 = 2400 bytes, well over the cap.
+        let n_codepoints = 600;
+        let s: String = FOUR_BYTE.repeat(n_codepoints);
+        assert_eq!(s.len(), 4 * n_codepoints);
+
+        // Sanity: the raw budget cut WOULD split a codepoint on this
+        // input. If this assertion ever stops holding (e.g. someone
+        // changes the cap or the suffix length so the budget realigns
+        // on 4), this test is back to being a no-op and needs to
+        // pick a different codepoint width.
+        let suffix_len = "...[truncated]".len();
+        let raw_budget = PUT_TERMINAL_CAUSE_MAX_BYTES.saturating_sub(suffix_len);
+        assert!(
+            !s.is_char_boundary(raw_budget),
+            "test invariant: raw budget {raw_budget} must land mid-codepoint \
+             for the walk-back loop to be exercised — pick a codepoint width \
+             coprime with the budget"
+        );
+
+        let bounded = bound_cause(s);
+        assert!(
+            bounded.is_char_boundary(bounded.len()),
+            "bounded output must end on a UTF-8 codepoint boundary"
+        );
+        // Strict-less-than is the proof that the walk-back actually
+        // ran: had it taken zero iterations the output length would
+        // equal exactly `PUT_TERMINAL_CAUSE_MAX_BYTES`. A trimmed
+        // walk-back leaves bounded.len() < cap.
+        assert!(
+            bounded.len() < PUT_TERMINAL_CAUSE_MAX_BYTES,
+            "walk-back must have trimmed at least one byte (cap={}, \
+             actual bounded.len()={})",
+            PUT_TERMINAL_CAUSE_MAX_BYTES,
+            bounded.len()
+        );
+        assert!(bounded.ends_with("...[truncated]"));
+        // Re-parsing must not panic.
+        let _ = bounded.chars().count();
+    }
+
+    /// PR #4126 review minor: pin the off-by-one boundary around the
+    /// cap. `bound_cause` MUST be byte-identical for input of length
+    /// `PUT_TERMINAL_CAUSE_MAX_BYTES` (the if-guard takes `<=`), and
+    /// MUST truncate (with suffix) starting at `+1`.
+    #[test]
+    fn bound_cause_cap_boundary_is_inclusive() {
+        // Exactly at the cap → no truncation.
+        let exact = "a".repeat(PUT_TERMINAL_CAUSE_MAX_BYTES);
+        let bounded = bound_cause(exact.clone());
+        assert_eq!(
+            bounded, exact,
+            "input of exactly PUT_TERMINAL_CAUSE_MAX_BYTES bytes must pass \
+             through verbatim — the cap is INCLUSIVE"
+        );
+
+        // One byte over → truncation with suffix.
+        let one_over = "a".repeat(PUT_TERMINAL_CAUSE_MAX_BYTES + 1);
+        let bounded = bound_cause(one_over);
+        assert!(
+            bounded.ends_with("...[truncated]"),
+            "input of PUT_TERMINAL_CAUSE_MAX_BYTES + 1 bytes MUST be \
+             truncated with the suffix marker"
+        );
+        assert!(
+            bounded.len() <= PUT_TERMINAL_CAUSE_MAX_BYTES,
+            "truncated output MUST fit within the cap"
+        );
+    }
+
+    /// `PutTerminalError::from_wire` applies `bound_cause`, so an
+    /// attacker-controlled upstream cannot inflate the per-hop cost
+    /// of `PutMsg::Error` by emitting multi-MB causes.
+    #[test]
+    fn put_terminal_error_from_wire_truncates() {
+        let oversize = "x".repeat(PUT_TERMINAL_CAUSE_MAX_BYTES * 3);
+        let err = PutTerminalError::from_wire(oversize);
+        assert!(err.as_str().len() <= PUT_TERMINAL_CAUSE_MAX_BYTES);
+        assert!(err.as_str().ends_with("...[truncated]"));
     }
 
     #[test]

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -34,7 +34,7 @@ use crate::node::NetworkBridge;
 use crate::node::OpManager;
 use crate::operations::OpError;
 use crate::operations::op_ctx::{
-    AdvanceOutcome, AttemptOutcome, RetryDriver, RetryLoopOutcome, drive_retry_loop,
+    AdvanceOutcome, AttemptOutcome, OpCtx, RetryDriver, RetryLoopOutcome, drive_retry_loop,
 };
 use crate::operations::orphan_streams::{OrphanStreamError, STREAM_CLAIM_TIMEOUT};
 use crate::ring::{Location, PeerKeyLocation};
@@ -42,7 +42,7 @@ use crate::router::{RouteEvent, RouteOutcome};
 use crate::tracing::{NetEventLog, OperationFailure, state_hash_full};
 use crate::transport::peer_connection::StreamId;
 
-use super::{PutFinalizationData, PutMsg, PutStreamingPayload};
+use super::{PutFinalizationData, PutMsg, PutStreamingPayload, PutTerminalError, bound_cause};
 
 /// Start a client-initiated PUT, returning as soon as the task has been
 /// spawned (mirrors legacy `request_put` timing).
@@ -218,10 +218,11 @@ async fn drive_client_put_inner(
     }
 
     impl RetryDriver for PutRetryDriver<'_> {
-        // `(key, hop_count)`. `hop_count = None` for `LocalCompletion`
-        // (originator stored locally, no hops traversed); `Some(hop_count)`
-        // for `Stored` (wire-carried forward depth from the storer).
-        type Terminal = (ContractKey, Option<usize>);
+        // `(result, hop_count)`. `result` is `Ok(key)` on success or
+        // `Err(cause)` on terminal failure (PR #4111). `hop_count`
+        // is `Some(hop_count)` from wire-carried `Stored` / `LocalCompletion`,
+        // always present for terminal outcomes (0 for local originator).
+        type Terminal = (Result<ContractKey, PutTerminalError>, Option<usize>);
 
         fn new_attempt_tx(&mut self) -> Transaction {
             Transaction::new::<PutMsg>()
@@ -250,20 +251,19 @@ async fn drive_client_put_inner(
         fn classify(&mut self, reply: NetMessage) -> AttemptOutcome<Self::Terminal> {
             match classify_reply(&reply) {
                 ReplyClass::Stored { key, hop_count } => {
-                    AttemptOutcome::Terminal((key, Some(hop_count)))
+                    AttemptOutcome::Terminal((Ok(key), Some(hop_count)))
                 }
                 // LocalCompletion = no remote hops traversed (originator
-                // is the storer). Forward depth is exactly 0 — emit it
-                // explicitly so local-only PUTs are distinguishable from
-                // "telemetry missing" in dashboards. Codex r2 review of
-                // #4248 flagged that mapping this to `None` leaked an
-                // unpopulated `PutSuccess` for a known-zero-depth path.
-                ReplyClass::LocalCompletion { key } => AttemptOutcome::Terminal((key, Some(0))),
+                // is the storer). Forward depth is exactly 0.
+                ReplyClass::LocalCompletion { key } => AttemptOutcome::Terminal((Ok(key), Some(0))),
+                ReplyClass::TerminalError { cause } => AttemptOutcome::Terminal((Err(cause), None)),
                 ReplyClass::Unexpected => AttemptOutcome::Unexpected,
             }
         }
 
         fn advance(&mut self) -> AdvanceOutcome {
+            #[cfg(any(test, feature = "testing"))]
+            PUT_RETRY_DRIVER_ADVANCE_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             match advance_to_next_peer(
                 self.op_manager,
                 &self.key,
@@ -302,7 +302,7 @@ async fn drive_client_put_inner(
     let loop_result = drive_retry_loop(op_manager, client_tx, "put", &mut driver).await;
 
     match loop_result {
-        RetryLoopOutcome::Done((reply_key, wire_hop_count)) => {
+        RetryLoopOutcome::Done((Ok(reply_key), wire_hop_count)) => {
             // Clean up the DashMap entry that process_message created.
             // Without this, the GC task finds a stale AwaitingResponse
             // entry and launches speculative retries on the completed op.
@@ -372,6 +372,17 @@ async fn drive_client_put_inner(
                 ContractResponse::PutResponse { key: reply_key },
             ))))
         }
+        // Issue #4111: terminal failure delivered via the bypass (a
+        // `PutMsg::Error` from the originator-loopback failure path).
+        // No retries — the failure is local-deterministic. Publish the
+        // real cause once, mark the tx completed.
+        RetryLoopOutcome::Done((Err(cause), _hop_count)) => {
+            op_manager.completed(client_tx);
+            Ok(DriverOutcome::Publish(Err(ErrorKind::OperationError {
+                cause: cause.into_string().into(),
+            }
+            .into())))
+        }
         RetryLoopOutcome::Exhausted(cause) => {
             Ok(DriverOutcome::Publish(Err(ErrorKind::OperationError {
                 cause: cause.into(),
@@ -407,6 +418,14 @@ enum ReplyClass {
     LocalCompletion {
         key: ContractKey,
     },
+    /// Terminal failure delivered through the bypass via
+    /// `PutMsg::Error` (issue #4111). The driver must NOT retry: the
+    /// failure is deterministic (e.g., `put_contract` rejected the
+    /// state on the originator's own node) and re-running the same
+    /// validation will fail identically.
+    TerminalError {
+        cause: PutTerminalError,
+    },
     Unexpected,
 }
 
@@ -426,6 +445,16 @@ fn classify_reply(msg: &NetMessage) -> ReplyClass {
         })) => ReplyClass::LocalCompletion {
             key: contract.key(),
         },
+        // Issue #4111: terminal failure delivered via send_local_loopback
+        // from the originator-loopback error path. The wire cause is a
+        // raw `String` (intentional, see `PutMsg::Error`); we wrap it in
+        // `PutTerminalError` here so the retry-loop's `Terminal` type
+        // stays typed.
+        NetMessage::V1(NetMessageV1::Put(PutMsg::Error { cause, .. })) => {
+            ReplyClass::TerminalError {
+                cause: PutTerminalError::from_wire(cause.clone()),
+            }
+        }
         _ => ReplyClass::Unexpected,
     }
 }
@@ -568,6 +597,13 @@ fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: Driv
 /// through the driver rather than legacy `handle_op_request`.
 #[cfg(any(test, feature = "testing"))]
 pub static RELAY_PUT_DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Counter: number of times `PutRetryDriver::advance` was invoked.
+/// Test-only — used by `drive_retry_loop_done_err_does_not_call_advance`
+/// to prove a deterministic-local failure does not step the retry loop.
+#[cfg(any(test, feature = "testing"))]
+pub static PUT_RETRY_DRIVER_ADVANCE_CALLS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
 /// Counter: relay PUT drivers currently in flight. Decremented in the
@@ -753,27 +789,80 @@ async fn run_relay_put<CB>(
         }
     }
 
-    // Originator-loopback error path: when the relay driver runs
-    // on the originator's own node and fails, the originator's
-    // `start_client_put` `send_and_await` waiter has no
-    // `PutMsg::Response` to consume — it would hang until timeout.
-    // Publish a `HostResult::Err` to the originator's client
-    // transaction and complete the tx.
+    // Originator-loopback error path: deliver the failure through the
+    // same `pending_op_results` bypass the success path uses so the
+    // retry-loop classifies it once instead of timing out on a closed
+    // reply channel (issue #4111). Safe in non-loopback mode because
+    // remote relays don't share tx-space with a local client.
     //
-    // Safe in non-loopback mode because remote relays don't share
-    // tx-space with a local client (the originator is on a different
-    // node, so `incoming_tx` is not registered with our SessionActor).
+    // See `.claude/rules/operations.md` → "WHEN publishing a terminal
+    // operation reply" for the M1/M2 race rationale (`send_client_result`
+    // + `completed()` is forbidden here; we deliver via send_local_loopback
+    // → bypass instead).
     let own_addr = op_manager.ring.connection_manager.get_own_addr();
     let originator_loopback = Some(upstream_addr) == own_addr;
     if originator_loopback {
         if let Err(err) = drive_result {
-            let client_error = freenet_stdlib::client_api::ClientError::from(
-                freenet_stdlib::client_api::ErrorKind::OperationError {
-                    cause: err.to_string().into(),
-                },
+            let cause = bound_cause(err.to_string());
+            let error_msg = NetMessage::from(PutMsg::Error {
+                id: incoming_tx,
+                cause: cause.clone(),
+            });
+            let mut ctx = op_manager.op_ctx(incoming_tx);
+            if let Err(send_err) = ctx.send_local_loopback(error_msg).await {
+                // Executor channel closed (node shutdown OR
+                // `op_execution_sender` torn down while
+                // `result_router_tx` is still live). Hand off to the
+                // OpManager-independent fallback helper so the WS
+                // client still sees a real cause instead of waiting
+                // on the dead bypass.
+                tracing::warn!(
+                    tx = %incoming_tx,
+                    cause = %cause,
+                    error = %send_err,
+                    "PUT relay (task-per-tx): send_local_loopback for terminal-error \
+                     failed; falling back to direct result_router_tx publish"
+                );
+                dispatch_loopback_shutdown_fallback(
+                    &op_manager.result_router_tx,
+                    incoming_tx,
+                    cause,
+                );
+            }
+        }
+    } else if let Err(err) = drive_result {
+        // B1 (multi-hop bubble): the driver failed locally on an
+        // intermediate relay. The downstream-reply bubble path in
+        // `drive_relay_put` only fires when a downstream peer returns
+        // `PutMsg::Error`; a LOCAL failure (e.g. `put_contract`
+        // rejection, next-hop selection error, `send_to_and_await`
+        // wire error/timeout) bypasses that arm and the upstream
+        // `send_to_and_await` would hang until `OPERATION_TTL`,
+        // burning the originator's retry budget.
+        //
+        // Emit `PutMsg::Error { cause }` to `upstream_addr` so the
+        // upstream relay's bypass — which now accepts
+        // `PutMsg::Error` (see `node.rs`) — delivers it into the
+        // upstream's installed `pending_op_results[tx]` waiter,
+        // letting the upstream relay either bubble further or land
+        // on the originator's `drive_retry_loop` as
+        // `Terminal(Err(cause))`. Cause is bounded at the wire
+        // boundary; `relay_put_send_error` itself does NOT call
+        // `completed()`, preserving the no-completed-in-loopback
+        // invariant for any node along the chain that happens to be
+        // the originator.
+        let cause = bound_cause(err.to_string());
+        if let Err(send_err) =
+            relay_put_send_error(&op_manager, incoming_tx, cause.clone(), upstream_addr).await
+        {
+            tracing::warn!(
+                tx = %incoming_tx,
+                %upstream_addr,
+                cause = %cause,
+                error = %send_err,
+                "PUT relay: failed to bubble terminal-error upstream \
+                 (multi-hop bubble); upstream will see OPERATION_TTL"
             );
-            op_manager.send_client_result(incoming_tx, Err(client_error));
-            op_manager.completed(incoming_tx);
         }
     }
 
@@ -1241,6 +1330,26 @@ where
             )
             .await
         }
+        NetMessage::V1(NetMessageV1::Put(PutMsg::Error {
+            cause: downstream_cause,
+            ..
+        })) => {
+            // Propagate the downstream cause one hop further upstream so
+            // the originator-loopback bypass at
+            // `handle_pure_network_message_v1` delivers it to the
+            // waiting `pending_op_results[incoming_tx]` callback.
+            // Re-bound the cause: an intermediate relay forwards
+            // verbatim and could be the attacker-controlled hop.
+            let bubbled = bound_cause(downstream_cause);
+            tracing::warn!(
+                tx = %incoming_tx,
+                contract = %key,
+                cause = %bubbled,
+                phase = "relay_put_bubble_error_upstream",
+                "PUT relay: downstream PutMsg::Error — propagating cause to upstream"
+            );
+            relay_put_send_error(op_manager, incoming_tx, bubbled, upstream_addr).await
+        }
         other => {
             // Unexpected reply variant: unclear whether it's a local
             // bug or peer misbehaviour. Do NOT record a route event;
@@ -1433,6 +1542,105 @@ async fn relay_put_send_response(
     });
     let mut ctx = op_manager.op_ctx(incoming_tx);
     let own_addr = op_manager.ring.connection_manager.get_own_addr();
+    if Some(upstream_addr) == own_addr {
+        ctx.send_local_loopback(msg)
+            .await
+            .map_err(|_| OpError::NotificationError)
+    } else {
+        ctx.send_fire_and_forget(upstream_addr, msg)
+            .await
+            .map_err(|_| OpError::NotificationError)
+    }
+}
+
+/// Mirror of [`relay_put_send_response`] for terminal failures.
+///
+/// Forwards a `PutMsg::Error { cause }` one hop further upstream when a
+/// downstream relay reports a contract-side or local-validation
+/// rejection. Originator-loopback uses `send_local_loopback` so the
+/// envelope hits the PUT bypass in `handle_pure_network_message_v1`
+/// and lands in the originator's `pending_op_results` waiter.
+async fn relay_put_send_error(
+    op_manager: &OpManager,
+    incoming_tx: Transaction,
+    cause: String,
+    upstream_addr: SocketAddr,
+) -> Result<(), OpError> {
+    let mut ctx = op_manager.op_ctx(incoming_tx);
+    let own_addr = op_manager.ring.connection_manager.get_own_addr();
+    relay_put_send_error_with_ctx(&mut ctx, own_addr, incoming_tx, cause, upstream_addr).await
+}
+
+/// Shutdown fallback for `run_relay_put`'s originator-loopback error
+/// path. Used when `send_local_loopback` fails because the executor
+/// channel is closed (typical node-shutdown scenario).
+///
+/// Publishes a `HostResult::Err` carrying the bounded cause straight
+/// to `result_router_tx` so the WS client at least sees the real
+/// failure reason instead of hanging on the dead bypass.
+///
+/// # No `OpManager::completed`, no `TransactionCompleted` emission
+///
+/// PR #4126 review item B3 + M3: the pre-#4111 success path went
+/// `send_client_result(Err) + completed(tx)`. `send_client_result`
+/// itself does two independent `try_send` calls — one to
+/// `result_router_tx` (M1) and one to the event-loop notifications
+/// channel for `TransactionCompleted(tx)` (M2). If the event loop
+/// processes M2 first, it closes `pending_op_results[tx]` BEFORE
+/// the originator's `send_and_await` consumes the reply on its
+/// per-attempt callback, the driver sees `NotificationError`,
+/// `advance()` fires, and the user gets the synthesised
+/// `"failed notifying, channel closed"` instead of the real cause.
+///
+/// This helper participates only in M1 — it does NOT touch the
+/// notifications channel, does NOT call `op_manager.completed(tx)`,
+/// and is signature-locked to a single `&mpsc::Sender` so a future
+/// refactor cannot quietly re-introduce the M2 emission. The
+/// `pending_op_results[tx]` slot is reclaimed by the 60 s periodic
+/// sweep — a slot leak under shutdown is the acceptable cost for
+/// eliminating the race window entirely.
+fn dispatch_loopback_shutdown_fallback(
+    result_router_tx: &tokio::sync::mpsc::Sender<(Transaction, HostResult)>,
+    incoming_tx: Transaction,
+    cause: String,
+) {
+    let host_err: freenet_stdlib::client_api::ClientError = ErrorKind::OperationError {
+        cause: cause.into(),
+    }
+    .into();
+    if let Err(err) = result_router_tx.try_send((incoming_tx, Err(host_err))) {
+        tracing::error!(
+            tx = %incoming_tx,
+            error = %err,
+            "PUT relay shutdown fallback: result_router_tx full or closed; \
+             client may not see the real failure cause (degraded but \
+             non-fatal — no panic, no slot mutation)"
+        );
+    }
+}
+
+/// Wire envelope + dispatch decision for [`relay_put_send_error`],
+/// factored out so tests can drive the function with a mock `OpCtx`
+/// instead of a full `OpManager`.
+///
+/// PR #4126 review item M1: the original `relay_put_send_error` was
+/// unit-test-unreachable because it depended on `OpManager::op_ctx`
+/// and `OpManager::ring::connection_manager::get_own_addr`, both of
+/// which require a fully-constructed `OpManager`. This split lets the
+/// behavioural tests in the parent module's `tests` module exercise
+/// the loopback/fire-and-forget branches and the wire envelope shape
+/// directly.
+async fn relay_put_send_error_with_ctx(
+    ctx: &mut OpCtx,
+    own_addr: Option<SocketAddr>,
+    incoming_tx: Transaction,
+    cause: String,
+    upstream_addr: SocketAddr,
+) -> Result<(), OpError> {
+    let msg = NetMessage::from(PutMsg::Error {
+        id: incoming_tx,
+        cause,
+    });
     if Some(upstream_addr) == own_addr {
         ctx.send_local_loopback(msg)
             .await
@@ -2168,7 +2376,9 @@ mod tests {
                     assert_eq!(got_key, key, "Stored.key preserved");
                     assert_eq!(got_hc, hc, "Stored.hop_count preserved ({hc})");
                 }
-                other @ (ReplyClass::LocalCompletion { .. } | ReplyClass::Unexpected) => {
+                other @ (ReplyClass::LocalCompletion { .. }
+                | ReplyClass::TerminalError { .. }
+                | ReplyClass::Unexpected) => {
                     panic!("expected Stored, got {other:?} for hc={hc}")
                 }
             }
@@ -2191,7 +2401,9 @@ mod tests {
                         "ResponseStreaming Stored.hop_count preserved ({hc})"
                     );
                 }
-                other @ (ReplyClass::LocalCompletion { .. } | ReplyClass::Unexpected) => {
+                other @ (ReplyClass::LocalCompletion { .. }
+                | ReplyClass::TerminalError { .. }
+                | ReplyClass::Unexpected) => {
                     panic!("expected Stored, got {other:?} for hc={hc}")
                 }
             }
@@ -2215,7 +2427,7 @@ mod tests {
         // `start_client_put`. Scan forward to the next
         // `finalize_put_at_originator(` call and verify the field shape.
         let done_arm = SOURCE
-            .find("RetryLoopOutcome::Done((reply_key, wire_hop_count))")
+            .find("RetryLoopOutcome::Done((Ok(reply_key), wire_hop_count))")
             .expect(
                 "RetryLoopOutcome::Done destructure not found — \
                  if you've refactored to use named struct destructuring \
@@ -2257,6 +2469,287 @@ mod tests {
         assert!(
             matches!(classify_reply(&msg), ReplyClass::Unexpected),
             "ForwardingAck must NOT be classified as terminal"
+        );
+    }
+
+    /// Issue #4111: `PutMsg::Error` rides the bypass like a `Response`
+    /// and must classify as `TerminalError { cause }` so the retry-loop
+    /// driver returns `Done(Err(_))` and `run_client_put` publishes
+    /// exactly one `HostResult::Err` carrying the real cause.
+    #[test]
+    fn classify_reply_error_is_terminal_error_with_cause() {
+        let tx = dummy_tx();
+        let cause = "execution error: invalid contract update, reason: \
+                     New state version 1 must be higher than current version 1"
+            .to_string();
+        let msg = NetMessage::V1(NetMessageV1::Put(PutMsg::Error {
+            id: tx,
+            cause: cause.clone(),
+        }));
+        match classify_reply(&msg) {
+            ReplyClass::TerminalError { cause: c } => assert_eq!(
+                c.as_str(),
+                cause.as_str(),
+                "TerminalError must carry the verbatim cause string from \
+                 the wire envelope so the client sees the real reason \
+                 (not the generic 'failed notifying, channel closed')"
+            ),
+            ReplyClass::Stored { .. } => panic!(
+                "Error envelope must NOT classify as Stored — Stored is \
+                 success and would suppress the cause"
+            ),
+            ReplyClass::LocalCompletion { .. } => panic!(
+                "Error envelope must NOT classify as LocalCompletion — \
+                 LocalCompletion is a success path keyed by Request echo"
+            ),
+            ReplyClass::Unexpected => panic!(
+                "Error envelope must NOT classify as Unexpected — that \
+                 returns RetryLoopOutcome::Unexpected, dropping the cause"
+            ),
+        }
+    }
+
+    /// Issue #4111 boundary: `classify_reply` preserves an empty cause
+    /// string verbatim instead of substituting a placeholder. The
+    /// originator-side error display is the client's responsibility;
+    /// the classifier MUST NOT silently rewrite the wire payload.
+    #[test]
+    fn classify_reply_error_with_empty_cause_preserves_empty() {
+        let tx = dummy_tx();
+        let msg = NetMessage::V1(NetMessageV1::Put(PutMsg::Error {
+            id: tx,
+            cause: String::new(),
+        }));
+        match classify_reply(&msg) {
+            ReplyClass::TerminalError { cause } => assert_eq!(
+                cause.as_str(),
+                "",
+                "empty cause must round-trip as empty — replacing it with a \
+                 placeholder hides the wire shape from the client"
+            ),
+            ReplyClass::Stored { .. }
+            | ReplyClass::LocalCompletion { .. }
+            | ReplyClass::Unexpected => {
+                panic!("expected TerminalError with empty cause")
+            }
+        }
+    }
+
+    /// Oversize causes are capped at `PUT_TERMINAL_CAUSE_MAX_BYTES`
+    /// by `PutTerminalError::from_wire`, stamping a `...[truncated]`
+    /// marker — bounds multi-hop DoS amplification.
+    #[test]
+    fn classify_reply_error_with_oversize_cause_is_truncated() {
+        use crate::operations::put::PUT_TERMINAL_CAUSE_MAX_BYTES;
+
+        let tx = dummy_tx();
+        let cause = "x".repeat(PUT_TERMINAL_CAUSE_MAX_BYTES * 4);
+        let msg = NetMessage::V1(NetMessageV1::Put(PutMsg::Error {
+            id: tx,
+            cause: cause.clone(),
+        }));
+        match classify_reply(&msg) {
+            ReplyClass::TerminalError { cause: c } => {
+                assert!(
+                    c.as_str().len() <= PUT_TERMINAL_CAUSE_MAX_BYTES,
+                    "oversize cause must be capped at PUT_TERMINAL_CAUSE_MAX_BYTES"
+                );
+                assert!(
+                    c.as_str().ends_with("...[truncated]"),
+                    "oversize cause must carry the truncation marker"
+                );
+            }
+            ReplyClass::Stored { .. }
+            | ReplyClass::LocalCompletion { .. }
+            | ReplyClass::Unexpected => {
+                panic!("expected TerminalError with truncated cause")
+            }
+        }
+    }
+
+    /// Sub-cap causes survive byte-for-byte.
+    #[test]
+    fn classify_reply_error_with_normal_cause_passes_through() {
+        let tx = dummy_tx();
+        let cause = "contract rejected: version must be strictly increasing".to_string();
+        let msg = NetMessage::V1(NetMessageV1::Put(PutMsg::Error {
+            id: tx,
+            cause: cause.clone(),
+        }));
+        match classify_reply(&msg) {
+            ReplyClass::TerminalError { cause: c } => assert_eq!(c.as_str(), cause.as_str()),
+            ReplyClass::Stored { .. }
+            | ReplyClass::LocalCompletion { .. }
+            | ReplyClass::Unexpected => panic!("expected TerminalError"),
+        }
+    }
+
+    /// Pin the `run_client_put` Done(Err) arm. When the
+    /// retry loop returns `Done(Err(cause))`, the driver MUST:
+    ///
+    ///   1. mark the client transaction completed (so the
+    ///      pending_op_results slot is reclaimed promptly), and
+    ///   2. publish `ErrorKind::OperationError { cause }` — NOT a
+    ///      synthesised "failed after N attempts" message.
+    ///
+    /// The arm must NOT advance/retry — the failure is terminal.
+    #[test]
+    fn run_client_put_done_err_arm_publishes_once_and_completes() {
+        let src = include_str!("op_ctx_task.rs");
+
+        // Locate the `match loop_result {` block in run_client_put.
+        let match_anchor = "match loop_result {";
+        let match_start = src
+            .find(match_anchor)
+            .expect("loop_result match site not found");
+        let match_end = src[match_start..]
+            .find("\n}\n")
+            .map(|p| match_start + p)
+            .expect("end of loop_result match not found");
+        let match_body = &src[match_start..match_end];
+
+        // Find the Done(Err(cause)) arm specifically.
+        let arm_anchor = "RetryLoopOutcome::Done((Err(cause), _hop_count)) =>";
+        let arm_start = match_body
+            .find(arm_anchor)
+            .expect("Done(Err(cause)) arm not found in run_client_put — issue #4111 regressed");
+        // Bound the arm to the next match-arm boundary. The simplest
+        // delimiter is the next `RetryLoopOutcome::` token, since each
+        // arm starts with one.
+        let arm_end = match_body[arm_start + arm_anchor.len()..]
+            .find("RetryLoopOutcome::")
+            .map(|p| arm_start + arm_anchor.len() + p)
+            .unwrap_or(match_body.len());
+        let arm_body = &match_body[arm_start..arm_end];
+
+        assert!(
+            arm_body.contains("op_manager.completed(client_tx)"),
+            "Done(Err) arm MUST call op_manager.completed(client_tx) to \
+             reclaim the pending_op_results slot — otherwise it lingers \
+             until the 60s sweep"
+        );
+        assert!(
+            arm_body.contains("DriverOutcome::Publish(Err("),
+            "Done(Err) arm MUST publish a HostResult::Err — silent drop \
+             would hang the client until timeout"
+        );
+        assert!(
+            arm_body.contains("ErrorKind::OperationError"),
+            "Done(Err) arm MUST wrap the cause in \
+             freenet_stdlib::client_api::ErrorKind::OperationError so the \
+             client sees a structured error variant (not a generic string)"
+        );
+        // The "does not advance" half of the invariant is covered
+        // behaviourally by `drive_retry_loop_done_err_does_not_call_advance`.
+    }
+
+    /// Behavioural pin on the `drive_retry_loop` Terminal arm.
+    ///
+    /// The reviewer of PR #4126 flagged the earlier version of this
+    /// test as tautological: it called only `classify_reply` (a free
+    /// function with no driver and no path to `advance()`), so the
+    /// `PUT_RETRY_DRIVER_ADVANCE_CALLS` counter assertion was
+    /// guaranteed regardless of how the production `Done(Err)` arm
+    /// in `drive_retry_loop` was wired. A regression that re-routed
+    /// terminal errors through `advance()` from inside
+    /// `drive_retry_loop` would not have tripped the old assertion.
+    ///
+    /// This rewrite proves the full chain by composition:
+    ///
+    ///   1. `classify_reply(PutMsg::Error)` ↦ `ReplyClass::TerminalError`
+    ///      (behavioural — exercised here on a real `PutMsg::Error` envelope).
+    ///   2. `PutRetryDriver::classify(ReplyClass::TerminalError)` ↦
+    ///      `AttemptOutcome::Terminal(Err(cause))` (pinned by
+    ///      `put_retry_driver_terminal_error_does_not_advance` below).
+    ///   3. `drive_retry_loop`'s `AttemptOutcome::Terminal(value)` arm
+    ///      returns `RetryLoopOutcome::Done(value)` WITHOUT calling
+    ///      `driver.advance()` (pinned by
+    ///      `drive_retry_loop_terminal_arm_does_not_call_advance` in
+    ///      `crate::operations::op_ctx::tests`).
+    ///
+    /// 1+2+3 together prove: `PutMsg::Error` on the wire never causes
+    /// the retry driver to advance to a new peer. The structural pins
+    /// of 2 and 3 are intentional — without a way to instantiate a
+    /// real `PutRetryDriver` against a stubbed `OpManager` they are
+    /// the closest behavioural anchor available; pre-merge follow-up
+    /// (see PR review M3) replaces them with a fake-`OpManager`
+    /// runner.
+    #[test]
+    fn classify_reply_error_maps_to_terminal_error_with_cause() {
+        let tx = dummy_tx();
+        let cause = "rejected: version not increasing".to_string();
+        let reply = NetMessage::V1(NetMessageV1::Put(PutMsg::Error {
+            id: tx,
+            cause: cause.clone(),
+        }));
+        match classify_reply(&reply) {
+            ReplyClass::TerminalError { cause: c } => {
+                assert_eq!(
+                    c.as_str(),
+                    cause.as_str(),
+                    "classify_reply must preserve the wire cause verbatim \
+                     so `drive_retry_loop`'s Terminal arm can publish the \
+                     real reason (not the synthesised \
+                     'failed notifying, channel closed' marker)"
+                );
+            }
+            ReplyClass::Stored { .. }
+            | ReplyClass::LocalCompletion { .. }
+            | ReplyClass::Unexpected => {
+                panic!(
+                    "PutMsg::Error must classify as TerminalError — \
+                     `Unexpected` would route through \
+                     RetryLoopOutcome::Unexpected and lose the cause"
+                )
+            }
+        }
+    }
+
+    /// Issue #4111: `PutRetryDriver::classify` must convert
+    /// `ReplyClass::TerminalError` into `AttemptOutcome::Terminal(Err(_))`
+    /// so `drive_retry_loop` exits with `Done(Err(_))` on the first such
+    /// reply (no `advance()` to a fresh peer / fresh attempt_tx).
+    #[test]
+    fn put_retry_driver_terminal_error_does_not_advance() {
+        let src = include_str!("op_ctx_task.rs");
+        // Locate the PutRetryDriver impl block.
+        let impl_start = src
+            .find("impl RetryDriver for PutRetryDriver<'_> {")
+            .expect("PutRetryDriver RetryDriver impl not found");
+        let impl_end = src[impl_start..]
+            .find("\n    }\n")
+            .map(|p| impl_start + p)
+            .expect("end of PutRetryDriver impl not found");
+        let impl_body = &src[impl_start..impl_end];
+
+        // The classify implementation must map TerminalError → Terminal(Err(_)).
+        assert!(
+            impl_body.contains("ReplyClass::TerminalError"),
+            "PutRetryDriver::classify must handle ReplyClass::TerminalError \
+             explicitly — otherwise it falls through to the Unexpected arm \
+             and the driver returns RetryLoopOutcome::Unexpected, losing the \
+             contract-side cause."
+        );
+        assert!(
+            impl_body.contains("AttemptOutcome::Terminal((Err("),
+            "PutRetryDriver::classify must produce \
+             AttemptOutcome::Terminal((Err(cause), _)) for TerminalError so the \
+             retry loop exits via the Done((Err(_), _)) path rather than \
+             advancing to a fresh attempt."
+        );
+        // Pin the Terminal type — (Result<ContractKey, PutTerminalError>, Option<usize>)
+        // is what lets the retry-loop carry both shapes through a
+        // single arm, keeps the failure cause structured rather
+        // than an opaque String, AND tracks hop_count for telemetry.
+        assert!(
+            impl_body.contains("type Terminal = (Result<ContractKey, PutTerminalError>"),
+            "PutRetryDriver::Terminal must be 
+             (Result<ContractKey, PutTerminalError>, Option<usize>); 
+             changing this back to bare ContractKey re-introduces the issue 
+             #4111 failure mode (no way to express a terminal error); 
+             changing the error half back to `String` drops the structured 
+             classification (LocalRejection vs Relayed); dropping hop_count 
+             breaks the telemetry contract from PR #4248."
         );
     }
 
@@ -2686,14 +3179,20 @@ mod tests {
     }
 
     /// Pin: when `drive_relay_put` returns `Err` AND the driver is
-    /// running in originator-loopback mode (`upstream_addr ==
-    /// own_addr`), `run_relay_put` MUST publish a `HostResult::Err`
-    /// for `incoming_tx` via `send_client_result` and complete the
-    /// transaction. This mirrors the legacy `report_result` Err arm
-    /// (node.rs:636-651) — without this, an invalid-state PUT (e.g.,
-    /// `put_contract` rejection) leaves the originator's
-    /// `start_client_put` `send_and_await` waiter hanging until the
-    /// client times out. Repro: `test_put_error_notification` in
+    /// `run_relay_put` in originator-loopback mode (`upstream_addr ==
+    /// own_addr`) MUST deliver the failure to the originator's
+    /// `start_client_put` retry-loop via
+    /// `send_local_loopback(PutMsg::Error { id: incoming_tx, cause })`
+    /// so the bypass forwards it to `pending_op_results[incoming_tx]`
+    /// and the classifier sees one terminal reply.
+    ///
+    /// Thinned in PR #4126 review M3: the fallback-specific shape
+    /// (no `op_manager.completed`, no `op_manager.send_client_result`,
+    /// publish-via-`dispatch_loopback_shutdown_fallback`) is now
+    /// covered behaviourally by the four
+    /// `dispatch_loopback_shutdown_fallback_*` tests below; this pin
+    /// stays minimal — just the success-path wiring.
+    /// Repro: `test_put_error_notification` in
     /// `crates/core/tests/error_notification.rs`.
     #[test]
     fn run_relay_put_publishes_error_on_loopback_failure() {
@@ -2712,21 +3211,33 @@ mod tests {
              error-publication path"
         );
         assert!(
-            body.contains("send_client_result(incoming_tx"),
-            "run_relay_put must call send_client_result(incoming_tx, Err(_)) \
-             on driver failure in originator-loopback mode"
+            body.contains("PutMsg::Error {"),
+            "run_relay_put must construct a PutMsg::Error envelope to \
+             deliver the loopback failure to the originator's driver"
         );
         assert!(
-            body.contains("ErrorKind::OperationError"),
-            "run_relay_put must wrap the OpError in \
-             freenet_stdlib::client_api::ErrorKind::OperationError before \
-             publishing to the client"
+            body.contains("send_local_loopback"),
+            "run_relay_put must dispatch the PutMsg::Error via \
+             send_local_loopback so the bypass forwards it to the \
+             originator's pending_op_results waiter"
+        );
+        // The fallback exists and is gated by send_local_loopback's
+        // Err arm. The actual fallback behaviour (no completed(), no
+        // send_client_result, raw result_router publish) is verified
+        // behaviourally by `dispatch_loopback_shutdown_fallback_*`
+        // tests below — not by source-grep here.
+        assert!(
+            body.contains("dispatch_loopback_shutdown_fallback("),
+            "run_relay_put must invoke the OpManager-independent \
+             fallback helper so the M3 behavioural tests cover the \
+             shutdown path"
         );
         assert!(
-            body.contains("op_manager.completed(incoming_tx)"),
-            "run_relay_put must call op_manager.completed(incoming_tx) \
-             after publishing the loopback-failure error so the tx is \
-             marked done"
+            !body.contains("op_manager.completed(incoming_tx)"),
+            "run_relay_put MUST NOT call op_manager.completed(incoming_tx) \
+             in loopback mode — that's the pre-#4111 race shape \
+             (see .claude/rules/operations.md → \"WHEN publishing a \
+             terminal operation reply\")"
         );
     }
 
@@ -3321,6 +3832,458 @@ mod tests {
             after.contains("record_relay_route_event")
                 && after.contains("RouteOutcome::SuccessUntimed"),
             "drive_relay_put Response arm must record SuccessUntimed."
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // PR #4126 review item M1: behavioural coverage of the multi-hop
+    // bubble path. The original PR shipped the helper with zero unit
+    // tests; these exercise the wire envelope, the loopback vs
+    // fire-and-forget dispatch, the cause re-bound at the relay reply
+    // arm, and the structural pin that local-failure paths in
+    // `run_relay_put` actually invoke the helper in non-loopback mode.
+    // ──────────────────────────────────────────────────────────────────
+
+    /// Loopback branch: when `upstream_addr == own_addr`,
+    /// `relay_put_send_error_with_ctx` MUST dispatch via
+    /// `send_local_loopback` (target=None). Without this the
+    /// originator's `pending_op_results` callback never sees the
+    /// envelope and the retry-loop hangs.
+    #[tokio::test]
+    async fn relay_put_send_error_with_ctx_uses_loopback_when_own_addr() {
+        use crate::node::{EventLoopNotificationsReceiver, event_loop_notification_channel};
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        let (receiver, sender) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut op_execution_receiver,
+            ..
+        } = receiver;
+
+        let tx = dummy_tx();
+        let own = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9001);
+        let mut ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+
+        // Drive the helper. Returns immediately because the channel
+        // capacity is enough for one send.
+        let cause = "rejected: deterministic local failure".to_string();
+        let result = relay_put_send_error_with_ctx(
+            &mut ctx,
+            Some(own), // own_addr known
+            tx,
+            cause.clone(),
+            own, // upstream is own_addr → loopback
+        )
+        .await;
+        assert!(result.is_ok(), "loopback dispatch must succeed");
+
+        // Receiver MUST see (msg, target_addr=None) per the loopback
+        // contract — that signals `handle_op_execution` to fan the
+        // envelope into `InboundMessage` instead of `OutboundMessageWithTarget`.
+        let (_reply_sender, outbound, target_addr) = op_execution_receiver
+            .recv()
+            .await
+            .expect("loopback envelope should be delivered to executor");
+        assert_eq!(
+            target_addr, None,
+            "loopback MUST pass target_addr=None so the dispatcher \
+             routes through InboundMessage → PUT bypass"
+        );
+
+        // Envelope shape MUST be PutMsg::Error with verbatim cause and
+        // the inbound tx.
+        match outbound {
+            NetMessage::V1(NetMessageV1::Put(PutMsg::Error { id, cause: c })) => {
+                assert_eq!(id, tx, "envelope tx MUST reuse incoming_tx");
+                assert_eq!(
+                    c, cause,
+                    "envelope cause MUST be passed through verbatim — \
+                     bound_cause is applied by callers, not by the helper"
+                );
+            }
+            other => panic!("expected PutMsg::Error envelope, got {other:?}"),
+        }
+    }
+
+    /// Non-loopback branch: when `upstream_addr != own_addr`,
+    /// `relay_put_send_error_with_ctx` MUST dispatch via
+    /// `send_fire_and_forget` with `target_addr=Some(upstream_addr)`.
+    /// This is the multi-hop arm — without it intermediate relays
+    /// silently swallow downstream errors.
+    #[tokio::test]
+    async fn relay_put_send_error_with_ctx_uses_fire_and_forget_to_upstream() {
+        use crate::node::{EventLoopNotificationsReceiver, event_loop_notification_channel};
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        let (receiver, sender) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut op_execution_receiver,
+            ..
+        } = receiver;
+
+        let tx = dummy_tx();
+        let own = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9001);
+        let upstream = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 42)), 31337);
+        assert_ne!(own, upstream, "test invariant: addresses must differ");
+
+        let mut ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+
+        let cause = "remote contract rejection: version not increasing".to_string();
+        let result =
+            relay_put_send_error_with_ctx(&mut ctx, Some(own), tx, cause.clone(), upstream).await;
+        assert!(result.is_ok(), "fire-and-forget dispatch must succeed");
+
+        let (_reply_sender, outbound, target_addr) = op_execution_receiver
+            .recv()
+            .await
+            .expect("upstream envelope should be delivered to executor");
+        assert_eq!(
+            target_addr,
+            Some(upstream),
+            "non-loopback MUST pass target_addr=Some(upstream_addr) so \
+             the dispatcher routes via OutboundMessageWithTarget to the \
+             upstream relay"
+        );
+
+        match outbound {
+            NetMessage::V1(NetMessageV1::Put(PutMsg::Error { id, cause: c })) => {
+                assert_eq!(id, tx);
+                assert_eq!(c, cause);
+            }
+            other => panic!("expected PutMsg::Error envelope, got {other:?}"),
+        }
+    }
+
+    /// When `own_addr` is `None` (node hasn't received its public
+    /// address yet — pre-handshake state), the loopback comparison
+    /// `Some(upstream_addr) == None` is always false, so the helper
+    /// MUST take the fire-and-forget branch. This is the conservative
+    /// choice: shipping a `PutMsg::Error` over the wire to a peer
+    /// fails closed (NotificationError) rather than being silently
+    /// suppressed as a phantom loopback.
+    #[tokio::test]
+    async fn relay_put_send_error_with_ctx_unknown_own_addr_uses_fire_and_forget() {
+        use crate::node::{EventLoopNotificationsReceiver, event_loop_notification_channel};
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        let (receiver, sender) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut op_execution_receiver,
+            ..
+        } = receiver;
+
+        let tx = dummy_tx();
+        let upstream = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 42)), 31337);
+        let mut ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+
+        let result = relay_put_send_error_with_ctx(
+            &mut ctx,
+            None, // own_addr unknown
+            tx,
+            "x".into(),
+            upstream,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        let (_reply_sender, _outbound, target_addr) = op_execution_receiver
+            .recv()
+            .await
+            .expect("envelope should still be delivered when own_addr is unknown");
+        assert_eq!(
+            target_addr,
+            Some(upstream),
+            "own_addr=None MUST NOT mask as loopback — dispatch over the wire"
+        );
+    }
+
+    /// Dispatch failure (executor channel closed) MUST be surfaced as
+    /// `OpError::NotificationError`. The PR's caller in
+    /// `run_relay_put` only logs and continues, but the helper itself
+    /// must return Err so the caller can branch on it.
+    #[tokio::test]
+    async fn relay_put_send_error_with_ctx_errors_on_closed_channel() {
+        use crate::node::event_loop_notification_channel;
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        let (receiver, sender) = event_loop_notification_channel();
+        // Drop the receiver immediately so the executor channel is closed.
+        drop(receiver);
+
+        let tx = dummy_tx();
+        let upstream = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 42)), 31337);
+        let mut ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+
+        let result = relay_put_send_error_with_ctx(
+            &mut ctx,
+            Some(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                9001,
+            )),
+            tx,
+            "shutdown-time failure".into(),
+            upstream,
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(OpError::NotificationError)),
+            "closed executor channel MUST surface as NotificationError, \
+             got {result:?}"
+        );
+    }
+
+    /// Structural pin: the downstream-`PutMsg::Error` arm of
+    /// `drive_relay_put`'s reply match MUST re-bound the cause via
+    /// `bound_cause` before forwarding upstream. The reviewer flagged
+    /// this as load-bearing: without re-bounding, an attacker-controlled
+    /// intermediate hop could inflate the cause length over each hop's
+    /// `PUT_TERMINAL_CAUSE_MAX_BYTES` cap.
+    #[test]
+    fn drive_relay_put_error_arm_rebounds_cause_before_bubble() {
+        let src = include_str!("op_ctx_task.rs");
+        let driver_start = src
+            .find("async fn drive_relay_put<CB>(")
+            .expect("drive_relay_put not found");
+        let driver_end = src[driver_start..]
+            .find("\nasync fn relay_put_finalize_local(")
+            .map(|p| driver_start + p)
+            .expect("end of drive_relay_put not found");
+        let driver_src = &src[driver_start..driver_end];
+
+        // Locate the `PutMsg::Error { cause: downstream_cause, ..` arm.
+        let arm_anchor = "PutMsg::Error {\n            cause: downstream_cause,";
+        let arm_start = driver_src
+            .find(arm_anchor)
+            .expect("PutMsg::Error reply arm not found in drive_relay_put");
+        let arm_end = driver_src[arm_start..]
+            .find("other => {")
+            .map(|p| arm_start + p)
+            .expect("end-of-Error-arm marker not found");
+        let arm_body = &driver_src[arm_start..arm_end];
+
+        assert!(
+            arm_body.contains("bound_cause(downstream_cause)"),
+            "the downstream-Error arm MUST re-bound the incoming cause \
+             via bound_cause before passing it to relay_put_send_error \
+             — otherwise multi-hop forwarding amplifies attacker-controlled \
+             cause length per hop"
+        );
+        assert!(
+            arm_body.contains("relay_put_send_error("),
+            "the downstream-Error arm MUST forward via relay_put_send_error"
+        );
+        assert!(
+            arm_body.contains("upstream_addr"),
+            "the downstream-Error arm MUST target upstream_addr (the hop \
+             we received the original Request from), not an arbitrary peer"
+        );
+    }
+
+    /// Structural pin: `run_relay_put`'s non-loopback Err branch (the
+    /// B1 fix landed in this PR) MUST emit `PutMsg::Error` upstream so
+    /// intermediate relays don't silently swallow local-failure events.
+    /// Pre-B1, a local `put_contract` rejection at an intermediate hop
+    /// caused the upstream `send_to_and_await` to hang until
+    /// `OPERATION_TTL`.
+    #[test]
+    fn run_relay_put_bubbles_local_failure_in_non_loopback_mode() {
+        let src = include_str!("op_ctx_task.rs");
+        let fn_start = src
+            .find("async fn run_relay_put<CB>(")
+            .expect("run_relay_put not found");
+        let fn_end = src[fn_start..]
+            .find("\n#[allow(clippy::too_many_arguments)]\nasync fn drive_relay_put<CB>(")
+            .map(|p| fn_start + p)
+            .expect("end-of-run_relay_put marker not found");
+        let body = &src[fn_start..fn_end];
+
+        // The non-loopback branch is gated by `else if let Err(err) = drive_result`.
+        let else_anchor = "} else if let Err(err) = drive_result {";
+        let else_start = body.find(else_anchor).expect(
+            "non-loopback Err branch not found in run_relay_put — \
+                     B1 fix regressed; intermediate relays will silently \
+                     swallow local PUT failures",
+        );
+        // Bound the branch to the next `}` at the same brace depth — use
+        // the end-of-function `}` as the conservative upper bound.
+        let branch_body = &body[else_start..];
+
+        assert!(
+            branch_body.contains("bound_cause(err.to_string())"),
+            "non-loopback Err branch MUST apply bound_cause(err.to_string()) \
+             before bubbling — keeps the per-hop DoS amplification bound"
+        );
+        assert!(
+            branch_body.contains("relay_put_send_error("),
+            "non-loopback Err branch MUST call relay_put_send_error to \
+             emit PutMsg::Error to upstream_addr"
+        );
+        assert!(
+            branch_body.contains("upstream_addr"),
+            "non-loopback Err branch MUST target upstream_addr"
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // PR #4126 review item M3: behavioural coverage of the
+    // originator-loopback shutdown fallback. The original test was a
+    // source-grep + 3000-byte substring search that trips on rename
+    // / fmt rewrap. The fallback is now extracted as the free
+    // function `dispatch_loopback_shutdown_fallback` taking only
+    // `&mpsc::Sender<(Transaction, HostResult)>` (mirrors the
+    // `release_pending_op_slot_on` extraction pattern in
+    // `op_state_manager.rs`), so tests can drive it directly with a
+    // real channel and observe behaviour — no `OpManager` build
+    // required.
+    // ──────────────────────────────────────────────────────────────────
+
+    /// Happy path: the fallback publishes exactly one
+    /// `(incoming_tx, Err(OperationError { cause }))` entry on
+    /// `result_router_tx` with the cause carried verbatim.
+    #[tokio::test]
+    async fn dispatch_loopback_shutdown_fallback_publishes_to_result_router() {
+        use tokio::sync::mpsc;
+
+        let (router_tx, mut router_rx) = mpsc::channel::<(Transaction, HostResult)>(8);
+        let tx = dummy_tx();
+        let cause = "contract rejection: version not increasing".to_string();
+
+        dispatch_loopback_shutdown_fallback(&router_tx, tx, cause.clone());
+
+        let (received_tx, host_result) = router_rx
+            .recv()
+            .await
+            .expect("fallback MUST publish to result_router_tx");
+        assert_eq!(received_tx, tx, "result_router tx must reuse incoming_tx");
+
+        let client_err =
+            host_result.expect_err("result MUST be Err — fallback is the failure path");
+        let rendered = format!("{client_err}");
+        assert!(
+            rendered.contains(&cause),
+            "result_router Err MUST carry the verbatim cause string \
+             so the WS client sees the real failure reason (got: {rendered:?})"
+        );
+
+        // Crucial behavioural invariant — no second entry.
+        assert!(
+            router_rx.try_recv().is_err(),
+            "fallback MUST publish exactly one entry to result_router_tx"
+        );
+    }
+
+    /// The fallback's helper signature MUST NOT receive a
+    /// notifications channel. This is the compile-time half of the
+    /// M3 guarantee: a function that has no `notifications_sender`
+    /// in scope physically cannot emit `TransactionCompleted(tx)`,
+    /// so the M2 race participant of the pre-#4111 shape is
+    /// structurally excluded.
+    ///
+    /// The runtime half: with only `result_router_tx` passed, the
+    /// fallback writes one row to that channel and returns. The
+    /// `_publishes_to_result_router` test above proves that observation.
+    /// This test pins the *absence* — wire a notifications channel
+    /// next to the router channel, drive the fallback, and confirm
+    /// the notifications channel receives nothing.
+    #[tokio::test]
+    async fn dispatch_loopback_shutdown_fallback_does_not_emit_transaction_completed() {
+        use crate::node::{EventLoopNotificationsReceiver, event_loop_notification_channel};
+        use tokio::sync::mpsc;
+
+        let (router_tx, mut router_rx) = mpsc::channel::<(Transaction, HostResult)>(8);
+        let (receiver, _sender) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut notifications_receiver,
+            ..
+        } = receiver;
+
+        let tx = dummy_tx();
+        dispatch_loopback_shutdown_fallback(
+            &router_tx,
+            tx,
+            "shutdown-time deterministic failure".into(),
+        );
+
+        // Result router got the entry. Discard the result — this
+        // test only cares that the notifications channel stays silent;
+        // the `_publishes_to_result_router` test above already pins
+        // the envelope shape.
+        let _drained = router_rx
+            .recv()
+            .await
+            .expect("fallback MUST publish to result_router_tx");
+
+        // Notifications channel MUST be silent — no TransactionCompleted.
+        // Use `try_recv` not `recv().await` so we don't hang waiting
+        // for a message that should never arrive.
+        match notifications_receiver.try_recv() {
+            Ok(unexpected) => panic!(
+                "fallback MUST NOT emit anything on the notifications \
+                 channel; pre-#4111 shape would have sent TransactionCompleted, \
+                 re-introducing the M1/M2 race. Got: {unexpected:?}"
+            ),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {}
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                panic!("notifications channel closed before the assertion ran")
+            }
+        }
+    }
+
+    /// Closed `result_router_tx` MUST be handled gracefully: log+drop,
+    /// no panic. Degrades the client experience (no real cause
+    /// delivered, falls back to whatever drive_retry_loop publishes
+    /// from its own timeout/exhaustion path) but the relay driver
+    /// task itself must not crash.
+    #[tokio::test]
+    async fn dispatch_loopback_shutdown_fallback_does_not_panic_on_closed_router() {
+        use tokio::sync::mpsc;
+
+        let (router_tx, router_rx) = mpsc::channel::<(Transaction, HostResult)>(8);
+        // Drop the receiver — every `try_send` on `router_tx` now returns
+        // `TrySendError::Closed`.
+        drop(router_rx);
+
+        let tx = dummy_tx();
+        // No panic, no unwind. The helper logs the failure and returns.
+        dispatch_loopback_shutdown_fallback(&router_tx, tx, "x".into());
+    }
+
+    /// Full `result_router_tx` MUST also be handled gracefully —
+    /// degrades to log+drop without blocking. Channel-safety rule:
+    /// the fallback runs in the relay driver's task body and must
+    /// never await on a full channel (would block the driver
+    /// indefinitely if the result router is wedged).
+    #[tokio::test]
+    async fn dispatch_loopback_shutdown_fallback_does_not_block_on_full_router() {
+        use tokio::sync::mpsc;
+
+        // Capacity 1, pre-filled, receiver intentionally kept alive
+        // (so the channel is in "Full" not "Closed" state).
+        let (router_tx, _router_rx) = mpsc::channel::<(Transaction, HostResult)>(1);
+        let filler_tx = dummy_tx();
+        let filler_err: freenet_stdlib::client_api::ClientError = ErrorKind::OperationError {
+            cause: "filler".into(),
+        }
+        .into();
+        router_tx
+            .try_send((filler_tx, Err(filler_err)))
+            .expect("first send fills the capacity-1 channel");
+
+        let tx = dummy_tx();
+        // Wrap in `tokio::time::timeout` to prove non-blocking. The
+        // helper uses `try_send` internally, so this returns
+        // immediately even with the channel full.
+        let result = tokio::time::timeout(std::time::Duration::from_millis(100), async {
+            dispatch_loopback_shutdown_fallback(&router_tx, tx, "shutdown".into());
+        })
+        .await;
+        assert!(
+            result.is_ok(),
+            "fallback MUST NOT block on a full result_router_tx — \
+             channel-safety rule: never `send().await` from inside a \
+             driver body. The helper must use `try_send` and drop+log \
+             on Full instead."
         );
     }
 }

--- a/crates/core/tests/error_notification.rs
+++ b/crates/core/tests/error_notification.rs
@@ -142,15 +142,30 @@ async fn test_put_error_notification(ctx: &mut TestContext) -> TestResult {
     // Wait for response - should receive error response
     let put_result = timeout(Duration::from_secs(30), client.recv()).await;
 
+    // Synthesised marker emitted by the retry loop when the bypass
+    // closes early. Reject it explicitly: a response containing this
+    // string means the client got an infrastructure leak rather than
+    // the contract's real rejection reason.
+    const FORBIDDEN_MARKER: &str = "failed notifying, channel closed";
+
     match put_result {
         Ok(Ok(response)) => {
-            // Any response is good - means we're not hanging
-            info!("✓ Received response (not timing out): {:?}", response);
-            info!("✓ Client properly notified instead of hanging");
+            let rendered = format!("{response:?}");
+            assert!(
+                !rendered.contains(FORBIDDEN_MARKER),
+                "PUT failure response contained the forbidden marker \
+                 ({FORBIDDEN_MARKER:?}). Response was: {rendered}"
+            );
+            info!("✓ Received response without forbidden marker: {response:?}");
         }
         Ok(Err(e)) => {
-            // WebSocket error could indicate error was delivered
-            info!("✓ Received error notification: {}", e);
+            let rendered = e.to_string();
+            assert!(
+                !rendered.contains(FORBIDDEN_MARKER),
+                "PUT WS error contained the forbidden marker \
+                 ({FORBIDDEN_MARKER:?}). Error was: {rendered}"
+            );
+            info!("✓ Received error notification without forbidden marker: {rendered}");
         }
         Err(_) => {
             panic!(
@@ -162,8 +177,145 @@ async fn test_put_error_notification(ctx: &mut TestContext) -> TestResult {
     }
 
     info!("PUT error notification test passed - client did not hang on operation failure");
+    // Follow-up: tracked by #4147 — adds a wrapper contract that
+    // emits a deterministic cause string so the assertion can
+    // verify the real contract-side reason, not just the absence
+    // of the FORBIDDEN_MARKER.
 
     // Properly close the client
+    client
+        .send(ClientRequest::Disconnect { cause: None })
+        .await?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    Ok(())
+}
+
+/// PR #4126 review item M1 part 2: integration coverage of the
+/// multi-hop PUT-error bubble path.
+///
+/// Setup: 2-node ring (gateway + peer-a). The client connects to
+/// `peer-a` (NOT the gateway), so the PUT enters at a non-originator
+/// node and the wire path is:
+///
+///   peer-a (client) → peer-a (originator-loopback relay) → gateway
+///
+/// `run_relay_put` runs at peer-a in originator-loopback mode (because
+/// the WS client is local). The PUT forward to the gateway exercises
+/// `drive_relay_put`'s downstream-reply handling for `PutMsg::Error`
+/// when the gateway rejects the invalid state, and the upstream-bubble
+/// helper `relay_put_send_error` when the gateway's response surfaces
+/// at peer-a.
+///
+/// What this pins behaviourally (delta vs the single-node
+/// `test_put_error_notification` above):
+///
+///   - The client connected to a non-gateway node still receives a
+///     terminal response (no `OPERATION_TTL` hang) when the PUT fails.
+///   - The response does NOT carry the `FORBIDDEN_MARKER` synthesised
+///     by the pre-#4111 race shape. If the multi-hop bubble regresses
+///     (e.g. `node.rs::handle_pure_network_message_v1` PUT bypass stops
+///     accepting `PutMsg::Error`, or `drive_relay_put`'s `PutMsg::Error`
+///     reply arm falls back through to `UnexpectedOpState`), the
+///     originator's `send_to_and_await` will time out and either
+///     surface the marker or hang past the test deadline — both
+///     trip this assertion.
+///
+/// Known limitation: with the available `test-contract-integration`
+/// contract, invalid state is rejected at every hop (no stateful
+/// version check), so the failure can land on either peer-a's local
+/// validation OR the gateway's relay validation depending on routing
+/// timing. The B1 fix and the multi-hop bubble arm are both
+/// candidate paths exercised. A stricter test that DEFINITIVELY
+/// pins "failure happens on the non-originator node only" — using
+/// a wrapper contract with stateful version validation and a
+/// deterministic, asserted-on cause string — is tracked as
+/// follow-up #4147.
+#[freenet_test(
+    health_check_readiness = true,
+    nodes = ["gateway", "peer-a"],
+    timeout_secs = 120,
+    startup_wait_secs = 30,
+    tokio_flavor = "multi_thread",
+    tokio_worker_threads = 4
+)]
+async fn test_put_error_notification_multi_hop(ctx: &mut TestContext) -> TestResult {
+    let peer = ctx.node("peer-a")?;
+    let (ws_stream, _) = connect_async(&peer.ws_url()).await?;
+    let mut client = WebApi::start(ws_stream);
+
+    info!("Testing multi-hop PUT error: client → peer-a → gateway (ws on peer-a, NOT gateway)");
+
+    const TEST_CONTRACT: &str = "test-contract-integration";
+    let contract = load_contract(TEST_CONTRACT, vec![].into())?;
+    // 1 MB of 0xFF — same shape as `test_put_error_notification`,
+    // proven to deterministically fail the contract's validator.
+    let invalid_state = WrappedState::new(vec![0xFF; 1024 * 1024]);
+
+    let put_request = ClientRequest::ContractOp(ContractRequest::Put {
+        contract: contract.clone(),
+        state: invalid_state,
+        related_contracts: Default::default(),
+        subscribe: false,
+        blocking_subscribe: false,
+    });
+    client.send(put_request).await?;
+
+    // 30 s budget — must be > the cross-hop processing window but
+    // well under `OPERATION_TTL` so a regression that drops the
+    // bubble en route surfaces as a panic here, not as a passing
+    // (slow) test.
+    let put_result = timeout(Duration::from_secs(30), client.recv()).await;
+
+    // Same FORBIDDEN_MARKER as the single-hop variant: the synthesised
+    // "failed notifying, channel closed" string is the canonical
+    // tell-tale that the M1/M2 race fired and the bypass→bubble chain
+    // failed to deliver the real cause.
+    const FORBIDDEN_MARKER: &str = "failed notifying, channel closed";
+
+    match put_result {
+        Ok(Ok(response)) => {
+            let rendered = format!("{response:?}");
+            assert!(
+                !rendered.contains(FORBIDDEN_MARKER),
+                "Multi-hop PUT failure response contained the forbidden \
+                 marker ({FORBIDDEN_MARKER:?}) — the bypass→bubble chain \
+                 regressed to the synthesised-error shape from issue #4111. \
+                 Either the bypass at node.rs PUT branch stopped accepting \
+                 PutMsg::Error, or drive_relay_put's PutMsg::Error reply arm \
+                 fell back to UnexpectedOpState. Response was: {rendered}"
+            );
+            info!("✓ Multi-hop response received without forbidden marker: {response:?}");
+        }
+        Ok(Err(e)) => {
+            let rendered = e.to_string();
+            assert!(
+                !rendered.contains(FORBIDDEN_MARKER),
+                "Multi-hop PUT WS error contained the forbidden marker \
+                 ({FORBIDDEN_MARKER:?}). Got: {rendered}"
+            );
+            info!("✓ Multi-hop error notification received without forbidden marker: {rendered}");
+        }
+        Err(_) => {
+            panic!(
+                "Multi-hop PUT timed out after 30 s — clients connected to a \
+                 non-gateway node are not receiving error notifications when \
+                 the failure path crosses the relay boundary. This indicates \
+                 the multi-hop bubble path (PR #4126, B1 fix) regressed: \
+                 either run_relay_put's non-loopback Err branch stopped \
+                 emitting PutMsg::Error to upstream_addr, or the upstream \
+                 relay's bypass stopped forwarding it. The single-node \
+                 test_put_error_notification would still pass in this state — \
+                 that's why this 2-node companion is load-bearing."
+            );
+        }
+    }
+
+    info!(
+        "Multi-hop PUT error notification test passed — client at non-gateway \
+         node received a real response without the forbidden marker"
+    );
+
     client
         .send(ClientRequest::Disconnect { cause: None })
         .await?;

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -2366,7 +2366,7 @@ fn test_subscribe_forwarding_ack_relay() {
 ///
 /// Note on turmoil vs production: in the turmoil simulation runner every
 /// peer shares one process, which means `pending_op_results` is effectively
-/// global. `node::try_forward_task_per_tx_reply` on an intermediate peer
+/// global. `node::try_forward_driver_reply` on an intermediate peer
 /// can therefore find the originator's task entry and short-circuit the
 /// Response before it reaches the legacy relay handler. In production each
 /// peer is an independent process with its own `pending_op_results`, so


### PR DESCRIPTION
## Problem

When a client PUT hits the originator-loopback path (the default when `fdev` connects to the same node that holds the contract code) and `put_contract` rejects the update, the retry loop spins through its full retry budget — each iteration repeating the same failing local validation — and the client receives a generic `put failed after N attempts (last error: failed notifying, channel closed)` instead of the actual contract-side rejection reason.

Whether the real cause ever surfaces depends on a race inside `OpManager::send_client_result`:

- **M1** — `try_send` of the real `HostResult::Err`
- **M2** — `try_send` of `TransactionCompleted` cleanup

If the event loop processes M2 first, it removes the `pending_op_results[client_tx]` callback before the originator's `send_and_await` consumes M1. The retry-loop driver sees the closed reply channel as `NotificationError`, classifies it as `wire_error`, and calls `advance()` — re-entering the loopback with a fresh `attempt_tx`, re-running the same failing `put_contract`, and repeating up to the retry cap. Even when the race goes the right way and the real error reaches the client, the server has burned three extra `put_contract` round-trips for nothing — observable as multiplied CPU under load and inflated `orphan_streams` accounting.

Reproduced on a live gateway (freenet-core 0.2.56): 24+ pairs of `put_contract failed` / `relay_put_error` log lines in a 10-minute window for a single client retry session against a wrapper contract that enforces strictly-increasing `state.version`.

## Solution

Option 1 from #4111: route the terminal failure through the same `pending_op_results` bypass that delivers `PutMsg::Response` on success, so `drive_retry_loop` classifies it once and publishes once.

**Wire envelope.** New variant `PutMsg::Error { id, cause: String }` is **appended at the end** of the `PutMsg` enum so the bincode discriminants for every pre-existing variant stay byte-stable. The enum is now `#[non_exhaustive]` so future additive variants don't require a wire-format break; wildcard arms downstream consume the safety net (see `.claude/rules/git-workflow.md` → "WHEN bumping freenet-stdlib"). A wire-tag pin test locks the variant order against silent reordering and documents the bincode codec-config assumption.

**DoS cap.** `PUT_TERMINAL_CAUSE_MAX_BYTES = 2048` + a UTF-8-safe truncator `bound_cause` (with `...[truncated]` marker) is applied at every entry point that builds or forwards a `PutMsg::Error`: `PutTerminalError::from_wire`, `run_relay_put`'s loopback emit, the multi-hop bubble in `drive_relay_put`'s reply arm, and the new `run_relay_put` non-loopback error path. Idempotent on already-bounded inputs, documented as "verbatim-or-rebound, never append".

**Loopback flow.** `run_relay_put`'s originator-loopback failure path dispatches `PutMsg::Error` via `send_local_loopback` instead of calling `send_client_result` directly:

- The bypass in `handle_pure_network_message_v1` forwards `Error` to `pending_op_results[tx]` like any other terminal reply (`Response | ResponseStreaming | Error` — pinned by `put_branch_bypass_includes_error_variant_regression_guard`).
- `classify_reply` maps it to `ReplyClass::TerminalError { cause }`.
- `PutRetryDriver::Terminal` is widened from `ContractKey` to `Result<ContractKey, PutTerminalError>` so `Terminal(Err(cause))` carries the typed error through a single match arm (no new `AttemptOutcome` / `RetryLoopOutcome` variant).
- `drive_retry_loop` returns `Done(Err(cause))` and `run_client_put` publishes exactly one `HostResult::Err(OperationError { cause })` carrying the real contract-side reason.

Symmetric with the success path. The failure now rides the bypass the same way a `Response` does — no out-of-band channel, no race against `TransactionCompleted`, no retry storm against a deterministic local failure.

**Multi-hop bubble.** New `relay_put_send_error` helper forwards a downstream `PutMsg::Error` one hop further upstream when a non-final relay receives it: `drive_relay_put`'s reply match adds a `PutMsg::Error { cause }` arm that re-bounds the cause and dispatches via `relay_put_send_error`. The receiving node's bypass accepts `Error` (gated structurally by `put_branch_bypass_includes_error_variant_regression_guard`), so the envelope rides the chain Origin → R1 → … → R_failed without ever falling through to `UnexpectedOpState`. `run_relay_put`'s non-loopback error path is symmetric: when the local driver's `drive_result` is `Err` and we're not the originator, `relay_put_send_error(upstream_addr)` emits the envelope so the upstream's `send_to_and_await` waiter receives a real terminal instead of hanging until `OPERATION_TTL`.

**Shutdown fallback.** When `send_local_loopback` fails on a closed `op_execution_sender` (node shutdown), the loopback path hands off to a new free-function helper `dispatch_loopback_shutdown_fallback` that publishes a `HostResult::Err` straight to `result_router_tx` so the WS client still sees the real cause. The helper's signature takes only `&mpsc::Sender<(Transaction, HostResult)>` — it has no access to `OpManager`, so it physically cannot invoke `op_manager.completed(tx)` (the pre-#4111 race shape) or emit `TransactionCompleted` on the notifications channel. This is a compile-time guarantee against M2-side regressions: `pending_op_results[tx]` is reclaimed by the 60 s sweep, a slot leak under shutdown for guaranteed race-freedom. Mirrors the `release_pending_op_slot_on` extraction pattern in `op_state_manager.rs` (review finding T-3).

## Testing

**Wire-format and structural pins.**

- `put_msg_error_{id_and_display, serde_roundtrip, has_no_requested_location}` — wire shape of the new variant.
- `put_msg_wire_format_variant_tags_are_stable` — bincode tag stability across all six variants, with explicit codec-config assumption note (default `u32` LE; switching to `with_varint_encoding`/`with_big_endian` would silently break the wire format).
- `put_branch_bypass_includes_error_variant_regression_guard` — PUT dispatch terminal-gate lists `Error` alongside `Response`/`ResponseStreaming`.

**Classification + driver behaviour.**

- `classify_reply_error_is_terminal_error_with_cause` — `PutMsg::Error` ↦ `ReplyClass::TerminalError { cause: verbatim }`.
- `classify_reply_error_maps_to_terminal_error_with_cause` — explicit chain pin (PR review item B2: replaces the previous tautological `drive_retry_loop_done_err_does_not_call_advance` that called only `classify_reply` and asserted a counter that classify can't move; the new test is honest about scope and composes with the structural pin in `op_ctx`).
- `drive_retry_loop_terminal_arm_does_not_call_advance` (in `crate::operations::op_ctx::tests`) — structural pin on `drive_retry_loop`'s `AttemptOutcome::Terminal` arm: must `return RetryLoopOutcome::Done(value);` synchronously, must not contain `.advance()` or `continue`.
- `put_retry_driver_terminal_error_does_not_advance` — pin on `PutRetryDriver::classify` mapping `TerminalError` ↦ `Terminal(Err(_))`.
- `run_client_put_done_err_arm_publishes_once_and_completes` — pin on the `Done(Err)` arm: calls `op_manager.completed(client_tx)`, publishes `ErrorKind::OperationError`, does NOT advance.

**Boundary cases.**

- `classify_reply_error_with_{empty_cause_preserves_empty, normal_cause_passes_through, oversize_cause_is_truncated}` — cause-string round-trip guards.
- `bound_cause_{short_string_passes_through, truncates_oversize_at_char_boundary, never_splits_utf8_codepoint, cap_boundary_is_inclusive}` — PR review M2 + minor: the `never_splits_utf8_codepoint` test now uses a 4-byte codepoint (`"𝄞"` U+1D11E, `2034 % 4 == 2`) so the walk-back loop is actually exercised; the previous 3-byte `"好"` (`2034 % 3 == 0`) landed exactly on a boundary and the loop ran zero iterations. The new `cap_boundary_is_inclusive` test pins the off-by-one around `PUT_TERMINAL_CAUSE_MAX_BYTES` (verbatim at `== MAX`, truncated at `MAX + 1`).
- `put_terminal_error_from_wire_truncates` — wire-side cap enforcement.

**Loopback + multi-hop dispatch.**

- `send_local_loopback_carries_put_error_to_event_loop` — op_ctx-level end-to-end: `Error` envelope flows with `target_addr=None`.
- `run_relay_put_publishes_error_on_loopback_failure` — pinned that the loopback emit goes through `send_local_loopback(PutMsg::Error)`; the shutdown fallback uses `send_client_result` but MUST NOT call `op_manager.completed(incoming_tx)` (PR review B3 — pre-#4111 race shape forbidden).
- `relay_put_send_error_with_ctx_{uses_loopback_when_own_addr, uses_fire_and_forget_to_upstream, unknown_own_addr_uses_fire_and_forget, errors_on_closed_channel}` (PR review M1): behavioural unit tests against the extracted `relay_put_send_error_with_ctx` helper using `event_loop_notification_channel`. Each test drives the helper end-to-end against a real `OpCtx`, captures the outbound `OpExecutionPayload` from the receiver, and asserts (a) the envelope is `PutMsg::Error { id, cause: verbatim }`, (b) `target_addr` is `None` for loopback / `Some(upstream)` otherwise, (c) `own_addr=None` fails closed via fire-and-forget rather than masking as phantom loopback, and (d) a closed executor channel surfaces as `OpError::NotificationError`.
- `drive_relay_put_error_arm_rebounds_cause_before_bubble` — pins the multi-hop arm calls `bound_cause(downstream_cause)` + `relay_put_send_error(... upstream_addr)`.
- `run_relay_put_bubbles_local_failure_in_non_loopback_mode` — pins the B1 fix: the non-loopback Err branch in `run_relay_put` calls `bound_cause(err.to_string()) + relay_put_send_error(... upstream_addr)`.

**Shutdown fallback (PR review B3 + M3).**

- `dispatch_loopback_shutdown_fallback_publishes_to_result_router` — behavioural: helper publishes exactly one `(incoming_tx, Err(OperationError { cause: verbatim }))` to `result_router_tx`. No second entry.
- `dispatch_loopback_shutdown_fallback_does_not_emit_transaction_completed` — wires a real notifications channel side-by-side with the result router and asserts the notifications channel stays empty after the helper runs. The compile-time half of the guarantee is the helper's signature (only `&mpsc::Sender<(Transaction, HostResult)>`, no access to `OpManager` or notifications sender). Together these guard against re-introducing the pre-#4111 M1/M2 race shape under shutdown.
- `dispatch_loopback_shutdown_fallback_does_not_panic_on_closed_router` — receiver dropped, helper logs and returns without unwinding.
- `dispatch_loopback_shutdown_fallback_does_not_block_on_full_router` — capacity-1 channel pre-filled, helper returns within 100 ms (proves `try_send` not `send().await`, per `.claude/rules/channel-safety.md`).

**End-to-end.**

- `tests/error_notification.rs::test_put_error_notification` (single-node) — keeps verifying the client doesn't hang, and asserts the response does NOT contain the `FORBIDDEN_MARKER = "failed notifying, channel closed"` — explicit guard against the synthesised infrastructure-leak string ever surfacing to clients.
- `tests/error_notification.rs::test_put_error_notification_multi_hop` (PR review M1 part 2) — 2-node ring `["gateway", "peer-a"]`; client connects to `peer-a` (NOT the gateway), so the PUT enters at a non-originator node and the wire path is `peer-a (client) → peer-a (originator-loopback relay) → gateway`. Same `FORBIDDEN_MARKER` assertion as the single-node variant, plus a load-bearing 30 s timeout — if the multi-hop bubble regresses (bypass stops accepting `PutMsg::Error`, or `drive_relay_put`'s reply arm falls back to `UnexpectedOpState`, or `run_relay_put`'s non-loopback Err branch stops emitting), the single-node test still passes but this one panics.

Tightening either E2E to assert on the actual contract-side cause string needs a wrapper contract with a deterministic, asserted-on failure reason — tracked as follow-up **#4147**.

**Sanity.**

- `cargo test -p freenet --lib operations::put` → 68 passed, 0 failed (PUT lib suite expanded from 47 → 68 — wire pins + classification + boundary + multi-hop unit + M3 behavioural).
- `cargo test -p freenet --lib operations::op_ctx` → 15 passed, 0 failed (includes the new `drive_retry_loop_terminal_arm_does_not_call_advance` pin).
- `cargo test -p freenet --test error_notification test_put_error_notification_multi_hop` → 1 passed (integration, 16.9 s after the test-contract wasm compile).
- `cargo fmt --check` and `cargo clippy -p freenet --lib --tests -- -D warnings` clean.

## Fixes

Closes #4111. Follow-up: #4147 (wrapper-contract E2E asserting on a stable cause string).
