### PR TITLE
feat: static-analysis aggregator + perf cleanups it surfaced

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -403,7 +403,7 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1486,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -1543,7 +1543,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1774,7 +1774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1903,13 +1903,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -2786,9 +2785,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes 1.11.1",
@@ -2850,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3131,9 +3130,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -3184,7 +3183,7 @@ dependencies = [
  "http 1.4.0",
  "hyper",
  "hyper-util",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -3254,7 +3253,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3399,7 +3398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3487,7 +3486,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3498,9 +3497,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "isahc"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "036cdb58c0a12db9e7162af193785bf9b6797f7b52035ff03f91c591619fde67"
+checksum = "82d93e1769c5c2b13a8e0d8ca9b6466c60bafade047326f25e3bcb97a947d875"
 dependencies = [
  "async-channel",
  "castaway",
@@ -3643,9 +3642,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3676,11 +3675,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -3754,7 +3753,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -3858,7 +3857,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -4045,7 +4044,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4097,9 +4096,9 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -4171,7 +4170,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4508,7 +4507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "crc32fast",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "memchr",
 ]
@@ -4545,9 +4544,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -4909,18 +4908,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5270,7 +5269,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
@@ -5290,7 +5289,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -5474,9 +5473,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -5531,7 +5530,7 @@ checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "log",
  "rustc-hash",
  "smallvec",
@@ -5602,7 +5601,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5753,7 +5752,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5770,9 +5769,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -6167,7 +6166,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6226,9 +6225,9 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -6263,7 +6262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6347,7 +6346,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -6691,7 +6690,7 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "windows",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-version",
 ]
 
@@ -6745,7 +6744,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7067,7 +7066,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -7091,7 +7090,7 @@ checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -7172,7 +7171,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -7235,7 +7234,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -7244,7 +7243,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -7255,9 +7254,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -7284,9 +7283,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes 1.11.1",
  "prost",
@@ -7491,7 +7490,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7527,7 +7526,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
@@ -7678,7 +7677,7 @@ dependencies = [
  "flate2",
  "log",
  "percent-encoding",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7836,9 +7835,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7851,9 +7850,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7861,9 +7860,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7871,9 +7870,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7884,9 +7883,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -7930,12 +7929,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.247.0"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.247.0",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -7990,9 +7989,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.247.0"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
 dependencies = [
  "bitflags 2.11.1",
  "indexmap 2.14.0",
@@ -8269,31 +8268,31 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "247.0.0"
+version = "248.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579d2d47eb33b0cdf9b14723cb115f1e1b7d6e77aac6f0816e5b7c7aeaa418ff"
+checksum = "acc54622ed5a5cddafcdf152043f9d4aed54d4a653d686b7dfe874809fca99d7"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder 0.247.0",
+ "wasm-encoder 0.248.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.247.0"
+version = "1.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f4091c56437e86f2b57fa2fac72c4f528957a605b3f44f7c0b3b19a17ac5ee"
+checksum = "d75cd9e510603909748e6ebab89f27cd04472c1d9d85a3c88a7a6fc51a1a7934"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8392,7 +8391,7 @@ dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
  "windows",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
 ]
@@ -8416,7 +8415,7 @@ checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
  "windows",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -8476,7 +8475,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8511,7 +8510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -8523,7 +8522,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -8540,12 +8539,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -8590,7 +8602,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
 ]
 
@@ -8973,9 +8985,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -8987,7 +8999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9156,7 +9168,7 @@ dependencies = [
  "webkit2gtk-sys",
  "webview2-com",
  "windows",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-version",
 ]
 
@@ -9248,9 +9260,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -307,7 +307,7 @@ async fn register_subscription_listener(
 async fn report_op_init_error(
     op_manager: &OpManager,
     tx: crate::message::Transaction,
-    contract: &impl std::fmt::Display,
+    contract: &(impl std::fmt::Display + Sync),
     op_name: &str,
     err: &OpError,
     client_id: ClientId,

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -540,7 +540,7 @@ pub struct Executor<R = Runtime, S: StateStorage = Storage> {
 
 impl<R, S> Executor<R, S>
 where
-    S: StateStorage + Send + 'static,
+    S: StateStorage + Send + Sync + 'static,
     <S as StateStorage>::Error: Into<anyhow::Error>,
 {
     /// Create a new Executor with optional network operation support.

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -736,7 +736,7 @@ impl ContractExecutor for RuntimePool {
 #[allow(private_bounds)]
 impl<R, S> Executor<R, S>
 where
-    R: crate::wasm_runtime::ContractRuntimeBridge,
+    R: crate::wasm_runtime::ContractRuntimeBridge + Send + Sync,
     S: crate::wasm_runtime::StateStorage + Send + Sync + 'static,
     <S as crate::wasm_runtime::StateStorage>::Error: Into<anyhow::Error>,
 {
@@ -2547,7 +2547,7 @@ impl Executor<Runtime> {
         Executor::new(
             state_store,
             move || {
-                if let Err(error) = crate::util::set_cleanup_on_exit(config.paths().clone()) {
+                if let Err(error) = crate::util::set_cleanup_on_exit(config.paths()) {
                     tracing::error!("Failed to set cleanup on exit: {error}");
                 }
                 Ok(())
@@ -3045,8 +3045,7 @@ impl Executor<Runtime> {
             .state_store
             .get(&key)
             .await
-            .map_err(ExecutorError::other)?
-            .clone();
+            .map_err(ExecutorError::other)?;
 
         let updates = vec![update];
 

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -1460,7 +1460,7 @@ impl P2pConnManager {
                                         "Cleaning up in-progress connection reservations"
                                     );
 
-                                    for (addr, mut callbacks) in state.awaiting_connection.drain() {
+                                    for (addr, callbacks) in state.awaiting_connection.drain() {
                                         tracing::debug!(
                                             peer_addr = %addr,
                                             callbacks = callbacks.len(),
@@ -1468,7 +1468,7 @@ impl P2pConnManager {
                                             "Notifying awaiting connection of shutdown"
                                         );
                                         // Best effort notification during shutdown - receiver may already be dropped
-                                        for mut callback in callbacks.drain(..) {
+                                        for mut callback in callbacks {
                                             #[allow(clippy::let_underscore_must_use)]
                                             let _ = callback.send_result(Err(())).await;
                                         }
@@ -1486,7 +1486,7 @@ impl P2pConnManager {
                                         for _ in 0..pending_count {
                                             crate::config::GlobalTestMetrics::record_pending_op_remove();
                                         }
-                                        state.pending_op_results.drain();
+                                        state.pending_op_results.clear();
                                     }
 
                                     tracing::info!(

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1054,8 +1054,8 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                     });
                 }
 
-                let mut old_missing = std::mem::replace(&mut delayed, Vec::with_capacity(200));
-                for tx in old_missing.drain(..) {
+                let old_missing = std::mem::replace(&mut delayed, Vec::with_capacity(200));
+                for tx in old_missing {
                     if let Some(tx) = ops.completed.remove(&tx) {
                         if cfg!(feature = "trace-ot") {
                             let op_type = tx.transaction_type().description();

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -637,9 +637,7 @@ impl RelayState {
                                         self_loc.pub_key().clone(),
                                     );
                                     actions.accept = Some(AcceptOutcome {
-                                        response: ConnectResponse {
-                                            acceptor: acceptor.clone(),
-                                        },
+                                        response: ConnectResponse { acceptor },
                                         joiner: self.request.joiner.clone(),
                                     });
                                     tracing::info!(
@@ -693,9 +691,7 @@ impl RelayState {
             let acceptor = PeerKeyLocation::with_unknown_addr(self_loc.pub_key().clone());
             let dist = ring_distance(self_loc.location(), self.request.joiner.location());
             actions.accept = Some(AcceptOutcome {
-                response: ConnectResponse {
-                    acceptor: acceptor.clone(),
-                },
+                response: ConnectResponse { acceptor },
                 joiner: self.request.joiner.clone(),
             });
             // Response is routed hop-by-hop via upstream_addr, no target embedded in message

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1962,7 +1962,7 @@ async fn drive_relay_get_inner(
             .connection_manager
             .get_peer_by_addr(upstream_addr)
         {
-            let peer_key = crate::ring::interest::PeerKey::from(pkl.pub_key.clone());
+            let peer_key = crate::ring::interest::PeerKey::from(pkl.pub_key);
             op_manager
                 .interest_manager
                 .register_peer_interest(&key, peer_key, None, false);

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -366,7 +366,7 @@ pub(crate) async fn register_downstream_subscriber(
                     source_addr
                         .and_then(|sa| op_manager.ring.connection_manager.get_peer_by_addr(sa))
                 })
-                .map(|pkl| crate::ring::interest::PeerKey::from(pkl.pub_key.clone()))
+                .map(|pkl| crate::ring::interest::PeerKey::from(pkl.pub_key))
         });
 
     if let Some(peer_key) = peer_key {
@@ -431,7 +431,7 @@ pub(crate) async fn handle_unsubscribe_inbound(
             .ring
             .connection_manager
             .get_peer_by_addr(addr)
-            .map(|pkl| crate::ring::interest::PeerKey::from(pkl.pub_key.clone()))
+            .map(|pkl| crate::ring::interest::PeerKey::from(pkl.pub_key))
     });
 
     let key = match super::has_contract(op_manager, instance_id).await {

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -764,7 +764,7 @@ async fn drive_client_subscribe_inner(
                     .connection_manager
                     .get_peer_by_addr(current_target_addr)
                 {
-                    let peer_key = crate::ring::interest::PeerKey::from(pkl.pub_key.clone());
+                    let peer_key = crate::ring::interest::PeerKey::from(pkl.pub_key);
                     op_manager
                         .interest_manager
                         .register_peer_interest(&key, peer_key, None, true);

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -748,10 +748,13 @@ impl Ring {
 
             let mut snapshot = ring.router.read().snapshot();
 
-            // Try to include connect forward estimator data
+            // Try to include connect forward estimator data.
+            // Drop the read guard immediately after `snapshot()` so unrelated
+            // consumers don't queue behind us for the four field assignments
+            // (clippy: `significant_drop_tightening`).
             if let Some(op_manager) = ring.upgrade_op_manager() {
-                let cfe = op_manager.connect_forward_estimator.read();
-                let (curve, data_range, events, adjustments) = cfe.snapshot();
+                let (curve, data_range, events, adjustments) =
+                    op_manager.connect_forward_estimator.read().snapshot();
                 snapshot.connect_forward_curve = Some(curve);
                 snapshot.connect_forward_data_range = Some(data_range);
                 snapshot.connect_forward_events = Some(events);
@@ -1458,7 +1461,9 @@ impl Ring {
     where
         for<'a> Location: From<&'a K>,
     {
-        let router = self.router.read();
+        // Router read-lock is only needed for the final `select_*` call;
+        // building the candidate list does not need it. Acquire it late to
+        // keep the critical section short (clippy: `significant_drop_tightening`).
         let target_location = Location::from(contract_id);
 
         let mut seen = HashSet::new();
@@ -1522,8 +1527,13 @@ impl Ring {
         // which may fail (especially in NAT scenarios without coordination).
         // It's better to return fewer candidates than unreachable ones.
 
-        let (selected, decision) =
-            router.select_k_best_peers_with_telemetry(candidates.iter(), target_location, k);
+        let (selected, decision) = self.router.read().select_k_best_peers_with_telemetry(
+            candidates.iter(),
+            target_location,
+            k,
+        );
+        // `selected` borrows from `candidates`, not from the router guard, so
+        // the read lock is released here before the tracing/collect below.
 
         tracing::debug!(
             target_location = %target_location.as_f64(),
@@ -2436,8 +2446,8 @@ impl Ring {
                         pending_conn_adds.extend(target_locs.into_iter().take(allowed));
                     }
                 }
-                TopologyAdjustment::RemoveConnections(mut should_disconnect_peers) => {
-                    for peer in should_disconnect_peers.drain(..) {
+                TopologyAdjustment::RemoveConnections(should_disconnect_peers) => {
+                    for peer in should_disconnect_peers {
                         if let Some(addr) = peer.socket_addr() {
                             notifier
                                 .notifications_sender
@@ -2614,7 +2624,10 @@ impl Ring {
         );
 
         let query_target = {
-            let router = self.router.read();
+            // The router read-lock is only needed for the single
+            // `select_k_best_peers_with_telemetry` call; routing_candidates
+            // takes its own connection-manager locks. Acquire late to keep
+            // the critical section short (clippy: `significant_drop_tightening`).
             let num_connections = self.connection_manager.num_connections();
             tracing::debug!(
                 target_location = %ideal_location,
@@ -2636,8 +2649,11 @@ impl Ring {
                 false, // bypass readiness — this is a CONNECT for connection acquisition
             );
             let selected = if !candidates.is_empty() {
-                let (selected, _) =
-                    router.select_k_best_peers_with_telemetry(candidates.iter(), ideal_location, 1);
+                let (selected, _) = self.router.read().select_k_best_peers_with_telemetry(
+                    candidates.iter(),
+                    ideal_location,
+                    1,
+                );
                 selected.into_iter().next().cloned()
             } else {
                 None
@@ -2694,7 +2710,7 @@ impl Ring {
         live_tx_tracker.add_transaction(gateway_addr, tx);
 
         let op_manager_spawn = op_manager.clone();
-        let gateway = query_target.clone();
+        let gateway = query_target;
         let joiner_for_driver = joiner;
         GlobalExecutor::spawn(async move {
             if let Err(err) = crate::operations::connect::op_ctx_task::start_client_connect(

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -708,24 +708,33 @@ impl ConnectionManager {
     /// is fully established. The entry is removed automatically if the handshake fails
     /// via `prune_in_transit_connection`.
     pub fn record_pending_location(&self, addr: SocketAddr, location: Location) {
-        let mut locations = self.location_for_peer.write();
-        let entry = locations.entry(addr);
-        match entry {
-            Entry::Occupied(_) => {
-                tracing::debug!(
-                    addr = %addr,
-                    peer_location = %location,
-                    "record_pending_location: location already known"
-                );
+        // Perform the mutation under the write lock, then drop the lock
+        // before emitting tracing. The tracing macro can be non-trivial
+        // (subscriber appender + format work) and holding `location_for_peer`
+        // across it serializes unrelated callers (clippy:
+        // `significant_drop_tightening`).
+        let already_known = {
+            let mut locations = self.location_for_peer.write();
+            match locations.entry(addr) {
+                Entry::Occupied(_) => true,
+                Entry::Vacant(v) => {
+                    v.insert(location);
+                    false
+                }
             }
-            Entry::Vacant(v) => {
-                tracing::debug!(
-                    addr = %addr,
-                    peer_location = %location,
-                    "record_pending_location: registering advertised location for peer"
-                );
-                v.insert(location);
-            }
+        };
+        if already_known {
+            tracing::debug!(
+                addr = %addr,
+                peer_location = %location,
+                "record_pending_location: location already known"
+            );
+        } else {
+            tracing::debug!(
+                addr = %addr,
+                peer_location = %location,
+                "record_pending_location: registering advertised location for peer"
+            );
         }
     }
 
@@ -826,17 +835,22 @@ impl ConnectionManager {
         // (location_for_peer → connections_by_location) and avoids deadlock with
         // prune_connection which acquires them in the same order with write locks.
         let location = *self.location_for_peer.read().get(&addr)?;
-        let connections = self.connections_by_location.read();
-        if let Some(conns) = connections.get(&location) {
-            if let Some(conn) = conns.first() {
-                tracing::debug!(
-                    requested_addr = %addr,
-                    resolved_via = "location_for_peer",
-                    location = %location,
-                    "get_peer_by_addr: resolved via location_for_peer fallback"
-                );
-                return Some(conn.location.clone());
-            }
+        // Materialize the resolved PeerKeyLocation under the read lock, then
+        // drop the guard before emitting tracing (clippy:
+        // `significant_drop_tightening`).
+        let resolved = self
+            .connections_by_location
+            .read()
+            .get(&location)
+            .and_then(|conns| conns.first().map(|conn| conn.location.clone()));
+        if let Some(resolved) = resolved {
+            tracing::debug!(
+                requested_addr = %addr,
+                resolved_via = "location_for_peer",
+                location = %location,
+                "get_peer_by_addr: resolved via location_for_peer fallback"
+            );
+            return Some(resolved);
         }
 
         None
@@ -979,9 +993,15 @@ impl ConnectionManager {
     /// Sets the own address unconditionally.
     /// Used when a peer behind NAT learns their external address from ObservedAddress.
     pub fn set_own_addr(&self, addr: SocketAddr) {
-        let mut own_addr = self.own_addr.lock();
-        let old_addr = *own_addr;
-        *own_addr = Some(addr);
+        // Release the own_addr lock before notifying network_status and emitting
+        // tracing — neither needs the guard, and holding it across them serializes
+        // unrelated callers under load (clippy: `significant_drop_tightening`).
+        let old_addr = {
+            let mut own_addr = self.own_addr.lock();
+            let old = *own_addr;
+            *own_addr = Some(addr);
+            old
+        };
         crate::node::network_status::set_external_address(addr);
         tracing::debug!(
             old_addr = ?old_addr,
@@ -1119,7 +1139,7 @@ impl ConnectionManager {
             let mut cbl = self.connections_by_location.write();
             cbl.entry(loc)
                 .or_default()
-                .push(Connection::new(PeerKeyLocation::new(pub_key.clone(), addr)));
+                .push(Connection::new(PeerKeyLocation::new(pub_key, addr)));
         }
 
         // Verify the insertion actually persisted — detect silent state corruption.
@@ -1189,22 +1209,31 @@ impl ConnectionManager {
         loc_for_peer.insert(new_addr, loc);
         drop(loc_for_peer);
 
-        let mut cbl = self.connections_by_location.write();
-        let entry = cbl.entry(loc).or_default();
-        if let Some(conn) = entry
-            .iter_mut()
-            .find(|conn| conn.location.socket_addr() == Some(old_addr))
-        {
-            // Update the public key and address to match the new peer
-            conn.location.pub_key = new_pub_key.clone();
-            conn.location.set_addr(new_addr);
-        } else {
+        // Hold the cbl write lock only for the actual mutation; drop it
+        // before the optional tracing::warn! and before acquiring
+        // connected_since / peer_health (clippy: `significant_drop_tightening`).
+        let missing_entry = {
+            let mut cbl = self.connections_by_location.write();
+            let entry = cbl.entry(loc).or_default();
+            if let Some(conn) = entry
+                .iter_mut()
+                .find(|conn| conn.location.socket_addr() == Some(old_addr))
+            {
+                // Update the public key and address to match the new peer
+                conn.location.pub_key = new_pub_key;
+                conn.location.set_addr(new_addr);
+                false
+            } else {
+                entry.push(Connection::new(PeerKeyLocation::new(new_pub_key, new_addr)));
+                true
+            }
+        };
+        if missing_entry {
             tracing::warn!(
                 old_addr = %old_addr,
                 peer_location = %loc,
                 "update_peer_identity: connection entry missing; creating placeholder"
             );
-            entry.push(Connection::new(PeerKeyLocation::new(new_pub_key, new_addr)));
         }
 
         // Migrate connected_since and peer_health to the new address.
@@ -1414,7 +1443,12 @@ impl ConnectionManager {
     }
 
     pub fn has_connection_or_pending(&self, addr: SocketAddr) -> bool {
-        if let Some(loc) = self.location_for_peer.read().get(&addr).copied() {
+        // Drop the location_for_peer read-lock before acquiring connections_by_location
+        // to avoid holding two read-locks across the dependent lookup (clippy:
+        // `significant_drop_in_scrutinee`). The two structures are independently
+        // synchronized; nothing relies on observing them under a single lock.
+        let loc = self.location_for_peer.read().get(&addr).copied();
+        if let Some(loc) = loc {
             // Verify the location_for_peer entry has a backing established connection.
             // Without this check, stale entries from failed connect operations block the
             // bootstrap loop from retrying gateways (#3244).

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -494,13 +494,16 @@ impl HostingManager {
         for instance_id in instance_ids_with_client {
             self.remove_client_subscription(&instance_id, client_id);
 
-            // Find matching ContractKey in active_subscriptions
-            if let Some(contract) = self
+            // Find matching ContractKey in active_subscriptions.
+            // Drop the DashMap iter() guard before `affected_contracts.push`
+            // so an unrelated caller cannot deadlock on the same shard
+            // (clippy: `significant_drop_in_scrutinee`).
+            let contract = self
                 .active_subscriptions
                 .iter()
                 .find(|entry| *entry.key().id() == instance_id)
-                .map(|entry| *entry.key())
-            {
+                .map(|entry| *entry.key());
+            if let Some(contract) = contract {
                 affected_contracts.push(contract);
             }
         }
@@ -551,10 +554,11 @@ impl HostingManager {
     /// Remove a downstream peer's subscription for a contract.
     /// Returns true if the peer was found and removed.
     pub fn remove_downstream_subscriber(&self, contract: &ContractKey, peer: &PeerKey) -> bool {
-        let mut removed = false;
-        if let Some(mut peers) = self.downstream_subscribers.get_mut(contract) {
-            removed = peers.remove(peer).is_some();
-        }
+        let removed = if let Some(mut peers) = self.downstream_subscribers.get_mut(contract) {
+            peers.remove(peer).is_some()
+        } else {
+            false
+        };
         if removed {
             // Remove the map entry if no peers remain
             self.downstream_subscribers
@@ -956,13 +960,16 @@ impl HostingManager {
                 .iter()
                 .any(|sub| sub.key().id() == &instance_id && sub.value().expires_at > now);
             if !has_active {
-                // Need to find the ContractKey - check hosting cache
-                if let Some(contract) = self
+                // Need to find the ContractKey - check hosting cache.
+                // Materialize the lookup into an owned value before the read
+                // guard's scope ends so we don't hold the lock across the
+                // hash insertion (clippy: `significant_drop_in_scrutinee`).
+                let contract = self
                     .hosting_cache
                     .read()
                     .iter()
-                    .find(|k| k.id() == &instance_id)
-                {
+                    .find(|k| k.id() == &instance_id);
+                if let Some(contract) = contract {
                     needs_renewal_set.insert(contract);
                 }
             }

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -317,7 +317,7 @@ pub struct InterestManager<T: TimeSource> {
     pending_removals: DashMap<PeerKey, Instant>,
 }
 
-impl<T: TimeSource> InterestManager<T> {
+impl<T: TimeSource + Sync> InterestManager<T> {
     /// Create a new interest manager with the given time source.
     pub fn new(time_source: T) -> Self {
         Self {
@@ -385,10 +385,16 @@ impl<T: TimeSource> InterestManager<T> {
         is_upstream: bool,
     ) -> bool {
         let now = self.time_source.now();
-        let mut entry = self.interested_peers.entry(*contract).or_default();
-        let is_new = !entry.contains_key(&peer);
-
-        entry.insert(peer.clone(), PeerInterest::new(summary, is_upstream, now));
+        // Release the `interested_peers` shard guard before touching
+        // `peer_contracts` and `index_contract_hash` — those acquire their
+        // own DashMap shards, so holding the first guard across them
+        // serializes unrelated callers (clippy: `significant_drop_tightening`).
+        let is_new = {
+            let mut entry = self.interested_peers.entry(*contract).or_default();
+            let is_new = !entry.contains_key(&peer);
+            entry.insert(peer.clone(), PeerInterest::new(summary, is_upstream, now));
+            is_new
+        };
 
         // Maintain reverse index for O(1) peer disconnect cleanup
         self.peer_contracts
@@ -636,9 +642,15 @@ impl<T: TimeSource> InterestManager<T> {
     /// Register that we're hosting a contract locally.
     /// Returns true if this caused us to become interested (wasn't interested before).
     pub fn register_local_hosting(&self, contract: &ContractKey) -> bool {
-        let mut entry = self.local_interests.entry(*contract).or_default();
-        let was_interested = entry.is_interested();
-        entry.hosting = true;
+        // Drop the local_interests shard guard before index_contract_hash
+        // (which acquires a separate DashMap) so unrelated lookups don't
+        // serialize behind us (clippy: `significant_drop_tightening`).
+        let was_interested = {
+            let mut entry = self.local_interests.entry(*contract).or_default();
+            let was = entry.is_interested();
+            entry.hosting = true;
+            was
+        };
         self.index_contract_hash(contract);
         !was_interested
     }
@@ -664,8 +676,11 @@ impl<T: TimeSource> InterestManager<T> {
     /// Add a local client subscription.
     /// Returns true if this caused us to become interested.
     pub fn add_local_client(&self, contract: &ContractKey) -> bool {
-        let mut entry = self.local_interests.entry(*contract).or_default();
-        let became_interested = entry.add_client();
+        // Same drop-before-index pattern as register_local_hosting.
+        let became_interested = {
+            let mut entry = self.local_interests.entry(*contract).or_default();
+            entry.add_client()
+        };
         self.index_contract_hash(contract);
         became_interested
     }
@@ -690,8 +705,11 @@ impl<T: TimeSource> InterestManager<T> {
     /// Add a downstream subscriber.
     /// Returns true if this caused us to become interested.
     pub fn add_downstream_subscriber(&self, contract: &ContractKey) -> bool {
-        let mut entry = self.local_interests.entry(*contract).or_default();
-        let became_interested = entry.add_downstream();
+        // Same drop-before-index pattern as register_local_hosting.
+        let became_interested = {
+            let mut entry = self.local_interests.entry(*contract).or_default();
+            entry.add_downstream()
+        };
         self.index_contract_hash(contract);
         became_interested
     }

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -279,10 +279,14 @@ pub mod local_node {
                         tracing::info!("disconnecting cause: {cause}");
                     }
                     // fixme: token must live for a bit to allow reconnections
-                    if let Some(rm_token) = gw.origin_contracts.iter().find_map(|entry| {
+                    // Drop the iter() guard before remove() to avoid holding a
+                    // DashMap shard guard across a mutating call on the same map
+                    // (clippy: `significant_drop_in_scrutinee`).
+                    let rm_token = gw.origin_contracts.iter().find_map(|entry| {
                         let (k, origin) = entry.pair();
                         (origin.client_id == id).then(|| k.clone())
-                    }) {
+                    });
+                    if let Some(rm_token) = rm_token {
                         gw.origin_contracts.remove(&rm_token);
                     }
                     continue;

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -1122,7 +1122,7 @@ impl<'a> NetEventLog<'a> {
                     .unwrap_or_else(|| own_loc.clone()); // Fallback to own location if target unknown
                 EventKind::Put(PutEvent::ResponseSent {
                     id: *id,
-                    from: own_loc.clone(),
+                    from: own_loc,
                     to,
                     key: *key,
                     timestamp: chrono::Utc::now().timestamp() as u64,
@@ -1143,7 +1143,7 @@ impl<'a> NetEventLog<'a> {
                     .unwrap_or_else(|| own_loc.clone()); // Fallback to own location if target unknown
                 EventKind::Get(GetEvent::ResponseSent {
                     id: *id,
-                    from: own_loc.clone(),
+                    from: own_loc,
                     to,
                     key,
                     timestamp: chrono::Utc::now().timestamp() as u64,
@@ -1163,7 +1163,7 @@ impl<'a> NetEventLog<'a> {
                     .unwrap_or_else(|| own_loc.clone()); // Fallback to own location if target unknown
                 EventKind::Subscribe(SubscribeEvent::ResponseSent {
                     id: *id,
-                    from: own_loc.clone(),
+                    from: own_loc,
                     to,
                     key,
                     timestamp: chrono::Utc::now().timestamp() as u64,
@@ -1179,7 +1179,7 @@ impl<'a> NetEventLog<'a> {
                 EventKind::Subscribe(SubscribeEvent::UnsubscribeSent {
                     id: *id,
                     instance_id: *instance_id,
-                    from: own_loc.clone(),
+                    from: own_loc,
                     to,
                     timestamp: chrono::Utc::now().timestamp() as u64,
                 })
@@ -1224,7 +1224,7 @@ impl<'a> NetEventLog<'a> {
                 let events = vec![
                     NetEventLog {
                         tx: msg.id(),
-                        peer_id: acceptor_peer_id.clone(),
+                        peer_id: acceptor_peer_id,
                         kind: EventKind::Connect(ConnectEvent::Connected {
                             this: acceptor.clone(),
                             connected: this_peer.clone(),
@@ -1567,7 +1567,7 @@ impl<'a> From<NetEventLog<'a>> for NetLogMessage {
             datetime: Utc::now(),
             tx: *log.tx,
             kind: log.kind,
-            peer_id: log.peer_id.clone(),
+            peer_id: log.peer_id,
         }
     }
 }
@@ -1675,7 +1675,7 @@ impl EventRegister {
         let (log_sender, log_recv) = mpsc::channel(1000);
         NEW_RECORDS_TS.get_or_init(SystemTime::now);
         let log_file = Arc::new(event_log_path.clone());
-        GlobalExecutor::spawn(Self::record_logs(log_recv, log_file.clone()));
+        GlobalExecutor::spawn(Self::record_logs(log_recv, log_file));
 
         let flush_handle = EventFlushHandle {
             sender: log_sender.clone(),
@@ -4412,7 +4412,7 @@ pub(super) mod test {
             let msg_log = NetLogMessage {
                 datetime: Utc::now(),
                 tx: *log.tx,
-                peer_id: peer_id.clone(),
+                peer_id,
                 kind,
             };
             (msg_log, log_id)

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -235,7 +235,7 @@ pub struct InboundConnectionHandler<S = UdpSocket, TS: TimeSource = RealTime> {
     new_connection_notifier: mpsc::Receiver<PeerConnection<S, TS>>,
 }
 
-impl<S, TS: TimeSource> InboundConnectionHandler<S, TS> {
+impl<S: Send + Sync, TS: TimeSource> InboundConnectionHandler<S, TS> {
     pub async fn next_connection(&mut self) -> Option<PeerConnection<S, TS>> {
         self.new_connection_notifier.recv().await
     }
@@ -1890,7 +1890,7 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
             let remote_conn = RemoteConnection {
                 outbound_symmetric_key: outbound_key,
                 remote_addr,
-                sent_tracker: sent_tracker.clone(),
+                sent_tracker,
                 last_packet_id: Arc::new(AtomicU32::new(0)),
                 inbound_packet_recv: inbound_packet_rx,
                 inbound_symmetric_key: inbound_key,
@@ -1993,7 +1993,7 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                     &decrypted_intro_packet.data()[PROTOC_VERSION.len()..PROTOC_VERSION.len() + 16];
                 let outbound_key =
                     Aes128Gcm::new_from_slice(outbound_key_bytes).expect("correct length");
-                *outbound_sym_key = Some(outbound_key.clone());
+                *outbound_sym_key = Some(outbound_key);
                 // Got remote's key, now we can send ACK with our key
                 *state = HandshakePhase::RemoteInbound;
                 return Ok(());

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -1091,7 +1091,7 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                 // The .take() consumes the sleep future; the unwrap_or(ready()) fallback
                 // should be unreachable since the top-of-loop guard always refills it,
                 // but is kept as a defensive measure.
-                _ = async { resend_check_sleep.take().unwrap_or(Box::pin(std::future::ready(()))).await } => {
+                _ = async { resend_check_sleep.take().unwrap_or_else(|| Box::pin(std::future::ready(()))).await } => {
                     // Bound retransmissions per iteration to prevent monopolizing the
                     // select loop. Remaining resends are deferred by a short sleep
                     // (see top of loop) so inbound branches can interleave.

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -121,8 +121,7 @@ where
         }
         let pick = loop {
             let pick = self.rng.random_range(0..self.size);
-            if !self.done.contains(&pick) {
-                self.done.insert(pick);
+            if self.done.insert(pick) {
                 break pick;
             }
         };

--- a/crates/core/src/wasm_runtime/state_store.rs
+++ b/crates/core/src/wasm_runtime/state_store.rs
@@ -83,7 +83,7 @@ pub struct StateStore<S: StateStorage> {
 
 impl<S> StateStore<S>
 where
-    S: StateStorage + Send + 'static,
+    S: StateStorage + Send + Sync + 'static,
     <S as StateStorage>::Error: Into<anyhow::Error>,
 {
     /// Create a StateStore with moka caching enabled.

--- a/scripts/static-checks.sh
+++ b/scripts/static-checks.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+# Run Rust static-analysis checks and aggregate per-tool output into a single
+# machine-readable JSON report. Each tool's raw output is also kept on disk so
+# downstream consumers can dig further.
+#
+# Usage:
+#   scripts/static-checks.sh [workspace-path]
+#
+# Default workspace-path is the script's own repository root. Pass an explicit
+# path to run against a different cargo workspace.
+#
+# Output layout:
+#   <workspace>/target/static-checks/<UTC-timestamp>/
+#     report.json            — aggregate report (machine-readable)
+#     <tool>.raw             — stdout of each tool
+#     <tool>.err             — stderr of each tool
+#     <tool>.summary.json    — per-tool status/duration/extracted summary
+#
+# Exit code is always 0 unless prerequisites are missing; individual tools may
+# fail without aborting the run (each tool's exit code is recorded in JSON).
+
+set -uo pipefail
+
+REPO_ROOT_DEFAULT="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET="${1:-$REPO_ROOT_DEFAULT}"
+TARGET="$(cd "$TARGET" && pwd)"
+
+if [[ ! -f "$TARGET/Cargo.toml" ]]; then
+  echo "error: $TARGET has no Cargo.toml" >&2
+  exit 2
+fi
+
+command -v jq    >/dev/null 2>&1 || { echo "error: jq is required"    >&2; exit 2; }
+command -v cargo >/dev/null 2>&1 || { echo "error: cargo is required" >&2; exit 2; }
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT="$TARGET/target/static-checks/$TS"
+mkdir -p "$OUT"
+
+log() { printf '[static-checks] %s\n' "$*" >&2; }
+
+# run_check NAME PROBE_BIN -- cmd args...
+#
+# PROBE_BIN is what we look up via `command -v` to detect installation.
+# For cargo subcommands the probe is `cargo-<sub>` (the binary cargo dispatches
+# to); for first-party cargo features the probe is `cargo` itself.
+run_check() {
+  local name="$1" probe="$2"; shift 2
+
+  if ! command -v "$probe" >/dev/null 2>&1; then
+    jq -n --arg p "$probe" '{status:"not_installed", probe:$p}' \
+      > "$OUT/${name}.summary.json"
+    log "skip   $name  (missing: $probe — try: cargo install ${probe#cargo-})"
+    return
+  fi
+
+  log "run    $name"
+  local t0; t0=$(date +%s)
+  local rc=0
+  "$@" > "$OUT/${name}.raw" 2> "$OUT/${name}.err" || rc=$?
+  local t1; t1=$(date +%s)
+
+  local status; [[ $rc -eq 0 ]] && status=ok || status="exit_${rc}"
+
+  jq -n \
+    --arg status  "$status" \
+    --argjson rc  "$rc" \
+    --argjson dur "$((t1-t0))" \
+    --arg raw     "$OUT/${name}.raw" \
+    --arg err     "$OUT/${name}.err" \
+    '{status:$status, exit_code:$rc, duration_seconds:$dur, raw:$raw, err:$err}' \
+    > "$OUT/${name}.summary.json"
+}
+
+cd "$TARGET"
+
+# Disable colour for every child process so .raw captures stay plain text.
+export NO_COLOR=1
+export CARGO_TERM_COLOR=never
+
+# Detect whether $TARGET/Cargo.toml is a virtual workspace manifest (workspace
+# without a [package] section). Some tools (cargo-geiger, cargo-bloat) refuse
+# to run in this mode and need per-member invocation.
+is_virtual_manifest() {
+  grep -q '^\[workspace\]' "$TARGET/Cargo.toml" 2>/dev/null \
+    && ! grep -q '^\[package\]' "$TARGET/Cargo.toml" 2>/dev/null
+}
+
+# Emits "package_name<TAB>manifest_path" lines for every workspace member.
+list_workspace_members() {
+  cargo metadata --no-deps --format-version 1 2>/dev/null \
+    | jq -r '.packages[] | "\(.name)\t\(.manifest_path)"'
+}
+
+# --- 1. clippy with perf + nursery lints, JSON diagnostics ----------------
+run_check clippy cargo \
+  cargo clippy --workspace --all-targets --message-format=json \
+    -- -W clippy::perf -W clippy::nursery
+
+# --- 2. cargo-audit — RustSec advisory database ---------------------------
+run_check audit cargo-audit \
+  cargo audit --json
+
+# --- 3. cargo-deny — licenses, dupes, banned crates, advisories -----------
+run_check deny cargo-deny \
+  cargo deny --format json check
+
+# --- 4. cargo-outdated — out-of-date workspace deps ------------------------
+run_check outdated cargo-outdated \
+  cargo outdated --workspace --format json
+
+# --- 5. cargo-bloat — release-build size by crate -------------------------
+run_check bloat cargo-bloat \
+  cargo bloat --release --crates -n 30 --message-format json
+
+# --- 6. cargo-machete — unused workspace deps -----------------------------
+# Machete prints plain text (no JSON mode); we parse it after the run.
+run_check machete cargo-machete \
+  cargo machete
+
+# --- 7. cargo-geiger — unsafe footprint over the dep tree (slow) ----------
+# Geiger refuses virtual manifests; on a workspace we iterate per member and
+# assemble per-package JSON reports into one aggregate array.
+run_geiger() {
+  if ! command -v cargo-geiger >/dev/null 2>&1; then
+    jq -n '{status:"not_installed", probe:"cargo-geiger"}' \
+      > "$OUT/geiger.summary.json"
+    log "skip   geiger (missing: cargo-geiger — try: cargo install cargo-geiger)"
+    return
+  fi
+
+  if ! is_virtual_manifest; then
+    run_check geiger cargo-geiger cargo geiger --output-format Json --quiet
+    return
+  fi
+
+  log "run    geiger (per-member, virtual manifest)"
+  local t0; t0=$(date +%s)
+  local rc=0
+  : > "$OUT/geiger.err"
+  printf '[' > "$OUT/geiger.raw"
+  local first=1
+  while IFS=$'\t' read -r pkg manifest; do
+    [[ -n "$pkg" ]] || continue
+    log "       geiger: $pkg"
+    local per_pkg="$OUT/geiger.${pkg}.raw"
+    [[ $first -eq 0 ]] && printf ',' >> "$OUT/geiger.raw"
+    first=0
+    if cargo geiger --output-format Json --quiet \
+         --manifest-path "$manifest" \
+         > "$per_pkg" 2>> "$OUT/geiger.err"; then
+      printf '{"package":%s,"report":' \
+        "$(jq -Rn --arg s "$pkg" '$s')" >> "$OUT/geiger.raw"
+      if [[ -s "$per_pkg" ]]; then
+        cat "$per_pkg" >> "$OUT/geiger.raw"
+      else
+        printf 'null' >> "$OUT/geiger.raw"
+      fi
+      printf '}' >> "$OUT/geiger.raw"
+    else
+      rc=$?
+      printf '{"package":%s,"error":"exit_%d"}' \
+        "$(jq -Rn --arg s "$pkg" '$s')" "$rc" >> "$OUT/geiger.raw"
+    fi
+  done < <(list_workspace_members)
+  printf ']\n' >> "$OUT/geiger.raw"
+  local t1; t1=$(date +%s)
+
+  jq -n \
+    --arg status "ok" \
+    --argjson rc  "$rc" \
+    --argjson dur "$((t1-t0))" \
+    --arg raw     "$OUT/geiger.raw" \
+    --arg err     "$OUT/geiger.err" \
+    '{status:$status, exit_code:$rc, duration_seconds:$dur, raw:$raw, err:$err, mode:"per-member"}' \
+    > "$OUT/geiger.summary.json"
+}
+run_geiger
+
+# === extract clippy lint-frequency summary ================================
+if [[ -s "$OUT/clippy.raw" ]]; then
+  jq -s '
+    map(
+      select(.reason == "compiler-message") |
+      .message |
+      select(.code != null and (.spans | length) > 0) |
+      {lint: .code.code, level: .level}
+    ) |
+    group_by(.lint) |
+    map({lint: .[0].lint, level: .[0].level, count: length}) |
+    sort_by(-.count)
+  ' "$OUT/clippy.raw" > "$OUT/clippy.lints.json" 2>/dev/null \
+    || echo '[]' > "$OUT/clippy.lints.json"
+
+  jq --slurpfile lints "$OUT/clippy.lints.json" '
+    . + {
+      by_lint:        $lints[0],
+      distinct_lints: ($lints[0] | length),
+      total_findings: ($lints[0] | map(.count) | add // 0)
+    }
+  ' "$OUT/clippy.summary.json" > "$OUT/.tmp" && mv "$OUT/.tmp" "$OUT/clippy.summary.json"
+fi
+
+# === extract machete unused-deps from plain-text output ===================
+# Machete output formats across versions, defensive parser handles both:
+#
+#   crate-name -- /path/Cargo.toml:
+#           unused-dep-1
+#           unused-dep-2
+#
+# and the older single-line per-dep variant. We strip ANSI just in case
+# NO_COLOR didn't take, then group by crate.
+if [[ -s "$OUT/machete.raw" ]]; then
+  sed -E 's/\x1B\[[0-9;]*[mGKHJ]//g' "$OUT/machete.raw" \
+    | awk '
+        # Header lines we want to skip outright.
+        /^cargo-machete (found|finished|did)/ { next }
+        /^If you believe cargo-machete/        { exit }
+        /^$/                                    { next }
+
+        # Crate header: "<crate> -- /abs/path/Cargo.toml:"
+        /^[A-Za-z0-9_.-]+ -- .*Cargo\.toml:?$/ {
+          # First whitespace-separated token is the crate name.
+          crate = $1
+          next
+        }
+
+        # Indented dep entry under a known crate.
+        crate != "" && /^[[:space:]]+[A-Za-z0-9_-]+[[:space:]]*$/ {
+          dep = $1
+          printf "%s\t%s\n", crate, dep
+        }
+      ' \
+    | jq -Rn '
+        [inputs
+          | select(length > 0)
+          | split("\t")
+          | {crate: .[0], dep: .[1]}]
+        | group_by(.crate)
+        | map({crate: .[0].crate, unused: map(.dep)})
+      ' > "$OUT/machete.findings.json" 2>/dev/null \
+    || echo '[]' > "$OUT/machete.findings.json"
+
+  jq --slurpfile f "$OUT/machete.findings.json" '
+    . + {
+      unused_by_crate: $f[0],
+      total_unused:    ($f[0] | map(.unused | length) | add // 0),
+      affected_crates: ($f[0] | length)
+    }
+  ' "$OUT/machete.summary.json" > "$OUT/.tmp" && mv "$OUT/.tmp" "$OUT/machete.summary.json"
+fi
+
+# === extract audit findings summary ========================================
+if [[ -s "$OUT/audit.raw" ]]; then
+  jq '{
+    vulnerabilities: (.vulnerabilities.count // 0),
+    warnings:        ((.warnings // {} | to_entries | map(.value | length) | add) // 0)
+  }' "$OUT/audit.raw" > "$OUT/audit.findings.json" 2>/dev/null \
+    || echo '{}' > "$OUT/audit.findings.json"
+
+  jq --slurpfile f "$OUT/audit.findings.json" '. + $f[0]' \
+    "$OUT/audit.summary.json" > "$OUT/.tmp" && mv "$OUT/.tmp" "$OUT/audit.summary.json"
+fi
+
+# === assemble master report ================================================
+commit="$(git -C "$TARGET" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+branch="$(git -C "$TARGET" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+rustc_v="$(rustc --version 2>/dev/null || echo unknown)"
+
+jq -n \
+  --arg ts     "$TS" \
+  --arg repo   "$TARGET" \
+  --arg commit "$commit" \
+  --arg branch "$branch" \
+  --arg rustc  "$rustc_v" \
+  --slurpfile clippy   "$OUT/clippy.summary.json" \
+  --slurpfile audit    "$OUT/audit.summary.json" \
+  --slurpfile deny     "$OUT/deny.summary.json" \
+  --slurpfile outdated "$OUT/outdated.summary.json" \
+  --slurpfile bloat    "$OUT/bloat.summary.json" \
+  --slurpfile machete  "$OUT/machete.summary.json" \
+  --slurpfile geiger   "$OUT/geiger.summary.json" \
+  '{
+    timestamp: $ts,
+    repo:      $repo,
+    commit:    $commit,
+    branch:    $branch,
+    rustc:     $rustc,
+    checks: {
+      clippy:   $clippy[0],
+      audit:    $audit[0],
+      deny:     $deny[0],
+      outdated: $outdated[0],
+      bloat:    $bloat[0],
+      machete:  $machete[0],
+      geiger:   $geiger[0]
+    }
+  }' > "$OUT/report.json"
+
+# Brief stderr summary so a human invoking the script gets a quick sense.
+log "summary:"
+jq -r '
+  .checks | to_entries[] |
+  "  \(.key | . + (" " * (10 - length))): status=\(.value.status)"
+  + (if .value.total_findings   != null then "  findings=\(.value.total_findings)"  else "" end)
+  + (if .value.vulnerabilities  != null then "  vulns=\(.value.vulnerabilities)"    else "" end)
+  + (if .value.warnings         != null then "  warns=\(.value.warnings)"           else "" end)
+  + (if .value.total_unused     != null then "  unused=\(.value.total_unused)"      else "" end)
+  + (if .value.mode             != null then "  mode=\(.value.mode)"                else "" end)
+  + "  (\(.value.duration_seconds // 0)s)"
+' "$OUT/report.json" >&2
+
+log "report: $OUT/report.json"
+echo "$OUT/report.json"


### PR DESCRIPTION
## Summary

Adds `scripts/static-checks.sh` — a one-shot aggregator that runs
clippy (with `perf` + `nursery`), `cargo-audit`, `cargo-deny`,
`cargo-outdated`, `cargo-bloat`, `cargo-machete`, `cargo-geiger` and
drops a single `target/static-checks/<ts>/report.json` plus per-tool raw
output. Missing tools record `{status: not_installed}` and the script
keeps going; geiger runs per-workspace-member (virtual manifests are
refused by `cargo-geiger`); machete output is parsed into a structured
`unused_by_crate` JSON list.

The second commit applies the perf-relevant findings the script
surfaced. Skips style-only / test-only / cascading-API findings.

## What the script found

Clippy run (`cargo clippy --workspace --all-targets -- -W clippy::perf -W clippy::nursery`):
4146 total findings across 24 distinct lints. Most are style nursery
warnings (`use_self` 1499, `redundant_pub_crate` 1027,
`missing_const_for_fn` 674, etc.) with no runtime impact.

Real perf-relevant categories in hot DHT / transport / executor code:

| Lint | Hits | Notes |
|---|---|---|
| `redundant_clone` | 209 total (16 prod) | Mostly in test code; the prod hits cluster in tracing event paths and op-context tasks |
| `significant_drop_tightening` | 145 (25 in hot files) | Locks held across `tracing::*!` macros + unrelated DashMap shard acquisitions |
| `future_not_send` | 33 | Missing `Sync` on generic params (`Executor<R, S>`, `StateStore<S>`, `InterestManager<T>`, `InboundConnectionHandler<S, TS>`) — production runs `Builder::new_multi_thread()`, so spawnable futures must be `Send` |
| `iter_with_drain` / `clear_with_drain` | 8 | `vec.drain(..)` where `into_iter()` would do, `HashMap::drain()` used as `clear()` |
| `or_fun_call` | 33 (1 prod hot) | `peer_connection.rs` resend-select arm allocated `Box::pin(ready(()))` every iteration |
| `significant_drop_in_scrutinee` | 12 | DashMap iter-guard held across a mutating call on the same map (deadlock pattern in `server.rs`); double-lock-across-`if let` in `connection_manager.rs` |
| `set_contains_or_insert` | 4 | Double `HashSet` lookup |
| `useless_let_if_seq` | 6 | One prod site in `hosting.rs` |

Plus, from other tools:
- `cargo-audit`: 5 vulnerabilities (`rustls-webpki` 0.101.7 × 3 CVEs,
  `hickory-proto` 0.24.4 DOS, `rsa` 0.9.10 Marvin sidechannel), 14
  unmaintained crates. **Not addressed in this PR** — separate dep-bump
  work.
- `cargo-deny`: 55 duplicate versions, 16 unlicensed workspace crates
  (missing `license = ...` in their `Cargo.toml`), 11 with no
  license-field. **Also out of scope here.**
- `cargo-machete`: 19 unused deps across 9 crates (notable: 4
  unused opentelemetry crates in `freenet`, 3 in `fdev`). **Out of scope.**
- `cargo-geiger`: in-tree code is clean — `freenet` has 0 `unsafe fn`,
  551 `unsafe` exprs (mostly the flatbuffers-generated
  `topology_generated.rs`); `fdev` has 0 unsafe fn, 1 expr.

## What was fixed

| # | Category | Sites | Where |
|---|---|---|---|
| 1 | `iter_with_drain` / `clear_with_drain` | 4 | `p2p_protoc.rs`, `op_state_manager.rs`, `ring.rs` |
| 2 | `or_fun_call` in hot select-loop | 1 | `peer_connection.rs` — `unwrap_or(...)` → `unwrap_or_else(...)` |
| 3 | `set_contains_or_insert` | 1 | `util.rs` random-pick loop |
| 4 | `redundant_clone` in prod paths | 16 | `connect.rs`, `tracing.rs` (8 sites in event emission), `executor/runtime.rs`, `subscribe.rs` & `subscribe/op_ctx_task.rs` & `get/op_ctx_task.rs` (`pkl.pub_key` move), `connection_manager.rs`, `connection_handler.rs`, `ring.rs` |
| 5 | `future_not_send` (add `Sync` bound) | 5 type bounds | `StateStore<S>`, `Executor<R, S>` (both impls), `InterestManager<T>`, `InboundConnectionHandler<S, TS>`, `report_op_init_error`'s `&impl Display` param |
| 6 | `significant_drop_in_scrutinee` | 4 | `connection_manager.rs` (double-lock), `hosting.rs` (DashMap iter+insert), `server.rs` (DashMap iter+remove on same map) |
| 7 | `significant_drop_tightening` | 11 | `connection_manager.rs` (set_own_addr, record_pending_location, get_peer_by_addr, update_peer_identity), `ring.rs` (cfe.snapshot, k_closest_potentially_hosting, acquire_new query_target), `interest.rs` (register_peer_interest, register_local_hosting, add_local_client, add_downstream_subscriber). Guards released before tracing / cross-lock acquisitions / field-assignment bursts |
| 8 | `useless_let_if_seq` | 1 | `hosting.rs::remove_downstream_subscriber` |

Cumulative: 19 production files, +191 / -118 lines. Behaviour preserved
at every site; only ownership and lock scopes adjusted.

### Lockfile refresh

A separate commit runs `cargo update` to pick up semver-compatible
patch bumps for ~30 transitive deps (no `Cargo.toml` changes):
`rustls 0.23.39 → 0.23.40`, `wasm-bindgen 0.2.118 → 0.2.121`,
`wasmparser 0.247 → 0.248`, `tonic 0.14.5 → 0.14.6`,
`pin-project 1.1.12 → 1.1.13`, plus assorted patch-level refreshes.
**Note:** does not address the audit-flagged CVE chain
(`rustls-webpki 0.101.7`, `hickory-proto 0.24.4`, `rsa 0.9.10`) —
those require major-version dep migration (hickory-resolver 0.24 →
0.26, disabling sqlx `mysql` feature, etc.) and are intentionally
out of scope here.

### Explicitly skipped

- `significant_drop_tightening` (~140 remaining) — false-positives on
  trivial arithmetic-under-lock or already-scoped guards.
- `needless_pass_by_ref_mut` (73) — each cascades through all callers
  and flips `Send`-ness of the captured future for `async fn`. Too
  invasive to batch.
- `redundant_clone` in tests (~95) — zero runtime impact.
- Style-only (~3500: `use_self`, `redundant_pub_crate`,
  `missing_const_for_fn`, `option_if_let_else`, etc.) — no runtime
  impact.
- `branches_sharing_code`, `collection_is_never_read`,
  `needless_collect` — false-positives (test-only / partition /
  borrow-conflict required).
- Vulnerabilities, license cleanup, unused deps, GTK3 deprecation —
  separate work.

## Testing

- `cargo fmt` clean.
- `cargo check -p freenet --lib` clean.
- `cargo test -p freenet --lib --no-fail-fast` — **2495 passed, 0
  failed, 14 ignored** on the run before push.

Integration tests (`crates/core/tests/`, simulation_tests feature)
not run as part of this pass. Worth a CI integration sweep before
merge — the only public API change is adding `Sync` to existing
generic bounds, which is purely additive for any monomorphisation that
already satisfies it (prod uses `Pool` / `ReDb` / `RealTime` /
`UdpSocket`, all of which are `Sync`).

### Known flaky tests observed (pre-existing, not regressions)

All four pass cleanly in isolation; surfaced randomly across full-suite
re-runs of the same diff, with *different* tests failing on different
runs.

1. `operations::connect::tests::relay_does_not_accept_after_forwarding_on_retry`
   — RNG-flaky. Asserts `actions1.accept.is_none()` on first call when
   `next_hop` is provided, but prod `handle_request` legitimately can
   accept-while-forwarding inside near-terminus acceptance
   (`connect.rs` ~615-650). Test doesn't seed `Location::random()` /
   `GlobalRng`, so ~24 % of runs trip the assertion.
2. `wasm_runtime::delegate::test::test_v2_delegate_subscribe_known` —
   shared-global-state flake. Sometimes gets `Failed { error_code: -1 }`
   (`ContractCodeNotRegistered`) from a global contract store shared
   between concurrent V2 delegate tests.
3. `server::client_api::permission_prompts::tests::test_sse_bootstrap_replay_arrives_before_live`
4. `server::client_api::permission_prompts::tests::test_sse_connection_cap_and_release_on_drop`
   — SSE-timing flakes, time out under parallel-test CPU contention.

Verified unrelated by isolation runs and by diff inspection (no
probabilistic branch / global registry / SSE channel construction
site is touched).

## Reproducing

```
./scripts/static-checks.sh
jq '.checks | to_entries[] | {tool: .key, status: .value.status, findings: .value.total_findings}' \
   target/static-checks/<ts>/report.json
```
