### PR TITLE
fix(mirror): rename caller secret MATRIX_ROOM_ID -> MATRIX_DEV_ROOM_ID

### DIFF
--- a/.github/workflows/mirror-to-freenet.yml
+++ b/.github/workflows/mirror-to-freenet.yml
@@ -51,4 +51,4 @@ jobs:
       # mirror failure pings the team Matrix room instead of going
       # silent. Both are org-level secrets at freenet.
       MATRIX_ACCESS_TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-      MATRIX_ROOM_ID: ${{ secrets.MATRIX_ROOM_ID }}
+      MATRIX_DEV_ROOM_ID: ${{ secrets.MATRIX_DEV_ROOM_ID }}


### PR DESCRIPTION
## Problem

The mirror-to-freenet workflow has been silently broken for ~20h with `startup_failure` on every push and the daily cron. No `mirror failure` Matrix alert fires because startup_failures occur before any step runs — the failure-notify step inside the reusable workflow never executes, so the only signal is a red X in the Actions UI.

Root cause: PR #4113 bumped the reusable-workflow pin from `a93179` → `8f00293`. Between those commits, freenet-git#39 (`fix(matrix): route mirror/rescue failure alerts to dev channel, not user`) renamed the declared secret `MATRIX_ROOM_ID` → `MATRIX_DEV_ROOM_ID` in the reusable workflow. This caller still passes `MATRIX_ROOM_ID`, an undeclared secret, which GitHub Actions rejects as a workflow-definition error.

## Solution

Rename the caller's secret pass-through to match the new declared name. Routes failure alerts to `#freenet-dev` via `MATRIX_DEV_ROOM_ID`, matching the documented intent in the reusable workflow's header comment and the sibling `rescue-demos` workflow (which already uses the dev secret correctly).

## Testing

YAML-only change. Will validate on the next scheduled cron (11:42 UTC daily) or first push to main after merge — the workflow should reach the `mirror` job instead of failing at startup.

## Fixes

Unblocks `Mirror to Freenet` workflow (no GitHub issue filed; was discovered while investigating a separate freenet-stdlib mirror alert).

[AI-assisted - Claude]