### PR TITLE
fix(put): mark originator PUT as locally-accessed for renewal

### DIFF
--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -53,6 +53,25 @@ pub(super) async fn finalize_put_at_originator(
         op_manager.ring.register_events(Either::Left(event)).await;
     }
 
+    // Mark the contract as locally-accessed now that the originator's PUT
+    // has succeeded and the local cache entry exists (created by the
+    // shared `relay_put_store_locally` path during `put_contract` +
+    // `host_contract`). Without this, self-hosted contracts that were
+    // PUT'd by a local client but never GET'd would never get the
+    // `local_client_access` flag — the GET path is the only other call
+    // site for `mark_local_client_access`. Missing the flag excludes the
+    // contract from `contracts_needing_renewal`, the subscription expires,
+    // the entry eventually gets evicted under byte-budget pressure, and
+    // the next cold remote GET fails the `is_locally_hosted` shortcut and
+    // routes to the network — where, for a contract no other peer is
+    // subscribed to, the GetOp hangs until the WS client times out.
+    // (freenet-stdlib mirror demo, 2026-05-14: 180s timeouts on
+    // freenet:96rknpy1GYhZ/freenet-stdlib for exactly this reason.)
+    //
+    // This is the originator-side mark the relay-helper doc-comment in
+    // `op_ctx_task::relay_put_store_locally` was waiting for.
+    op_manager.ring.mark_local_client_access(&key);
+
     if subscribe {
         start_subscription_after_put(op_manager, id, key, blocking_subscribe).await;
     }
@@ -400,6 +419,51 @@ mod tests {
         assert!(
             !src.contains(&needle),
             "ForwardingAck senders must not be reintroduced"
+        );
+    }
+
+    /// Regression guard for the freenet-stdlib mirror demo 180s timeout
+    /// (2026-05-14). `finalize_put_at_originator` MUST call
+    /// `mark_local_client_access` so PUT'd-but-never-GET'd contracts get
+    /// the local-client flag set on their hosting cache entry. Without
+    /// this, `contracts_needing_renewal` excludes them, the subscription
+    /// expires, the entry eventually gets evicted, and the next cold
+    /// remote GET fails the `is_locally_hosted` shortcut and routes to
+    /// the network — where, for a contract no other peer subscribes to,
+    /// the GetOp hangs until the WS client's 180s timeout fires.
+    ///
+    /// The GET path already calls `mark_local_client_access` (see
+    /// `client_events::serve_get`); this PR adds the symmetric call on
+    /// the originator-PUT path so the flag is no longer GET-only.
+    #[test]
+    fn finalize_put_at_originator_marks_local_client_access() {
+        const SOURCE: &str = include_str!("put.rs");
+
+        // Locate the function definition.
+        let fn_start = SOURCE
+            .find("pub(super) async fn finalize_put_at_originator(")
+            .expect("finalize_put_at_originator definition not found");
+        // Body extent: from the opening `{` of the body to the matching
+        // closing `}\n`. Use a coarse scan that's robust enough for the
+        // small function — we just need the call site to be inside.
+        let body_start = SOURCE[fn_start..]
+            .find('{')
+            .map(|p| fn_start + p)
+            .expect("function body opening brace not found");
+        let body_end = SOURCE[body_start..]
+            .find("\n}\n")
+            .map(|p| body_start + p)
+            .expect("function body closing brace not found");
+        let body = &SOURCE[body_start..body_end];
+
+        assert!(
+            body.contains("mark_local_client_access"),
+            "finalize_put_at_originator MUST call mark_local_client_access \
+             so self-hosted contracts get the local-client flag set on the \
+             hosting cache entry. Without this call, the freenet-stdlib \
+             mirror demo cold-GET timeout (2026-05-14) returns. See \
+             contracts_needing_renewal at hosting.rs:971-991 for the \
+             downstream gate that depends on this flag."
         );
     }
 }

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -54,22 +54,19 @@ pub(super) async fn finalize_put_at_originator(
     }
 
     // Mark the contract as locally-accessed now that the originator's PUT
-    // has succeeded and the local cache entry exists (created by the
-    // shared `relay_put_store_locally` path during `put_contract` +
-    // `host_contract`). Without this, self-hosted contracts that were
-    // PUT'd by a local client but never GET'd would never get the
-    // `local_client_access` flag — the GET path is the only other call
-    // site for `mark_local_client_access`. Missing the flag excludes the
-    // contract from `contracts_needing_renewal`, the subscription expires,
-    // the entry eventually gets evicted under byte-budget pressure, and
-    // the next cold remote GET fails the `is_locally_hosted` shortcut and
-    // routes to the network — where, for a contract no other peer is
-    // subscribed to, the GetOp hangs until the WS client times out.
-    // (freenet-stdlib mirror demo, 2026-05-14: 180s timeouts on
+    // has succeeded and the local cache entry exists (created earlier by
+    // the put pipeline's `put_contract` + `host_contract`). Without this,
+    // self-hosted contracts that were PUT'd by a local client but never
+    // GET'd would never get the `local_client_access` flag — the GET path
+    // is the only other production call site for `mark_local_client_access`.
+    // Missing the flag excludes the contract from
+    // `contracts_needing_renewal`, the subscription expires, the entry
+    // eventually gets evicted under byte-budget pressure, and the next
+    // cold remote GET fails the `is_locally_hosted` shortcut and routes
+    // to the network — where, for a contract no other peer is subscribed
+    // to, the GetOp hangs until the WS client times out. (freenet-stdlib
+    // mirror demo, 2026-05-14: 180s timeouts on
     // freenet:96rknpy1GYhZ/freenet-stdlib for exactly this reason.)
-    //
-    // This is the originator-side mark the relay-helper doc-comment in
-    // `op_ctx_task::relay_put_store_locally` was waiting for.
     op_manager.ring.mark_local_client_access(&key);
 
     if subscribe {

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -423,29 +423,26 @@ mod tests {
     }
 
     /// Regression guard for the freenet-stdlib mirror demo 180s timeout
-    /// (2026-05-14). `finalize_put_at_originator` MUST call
-    /// `mark_local_client_access` so PUT'd-but-never-GET'd contracts get
-    /// the local-client flag set on their hosting cache entry. Without
-    /// this, `contracts_needing_renewal` excludes them, the subscription
+    /// (2026-05-14). `finalize_put_at_originator` MUST call the
+    /// originator-side mark so PUT'd-but-never-GET'd contracts get the
+    /// local-client flag set on their hosting cache entry. Without this,
+    /// `contracts_needing_renewal` excludes them, the subscription
     /// expires, the entry eventually gets evicted, and the next cold
     /// remote GET fails the `is_locally_hosted` shortcut and routes to
     /// the network — where, for a contract no other peer subscribes to,
     /// the GetOp hangs until the WS client's 180s timeout fires.
     ///
-    /// The GET path already calls `mark_local_client_access` (see
-    /// `client_events::serve_get`); this PR adds the symmetric call on
-    /// the originator-PUT path so the flag is no longer GET-only.
+    /// Implementation note: matches on the exact executable call syntax
+    /// AFTER stripping line comments, so the assertion can't be satisfied
+    /// by a doc comment that merely mentions the function name (Codex
+    /// caught this in PR #4133's first review iteration).
     #[test]
     fn finalize_put_at_originator_marks_local_client_access() {
         const SOURCE: &str = include_str!("put.rs");
 
-        // Locate the function definition.
         let fn_start = SOURCE
             .find("pub(super) async fn finalize_put_at_originator(")
             .expect("finalize_put_at_originator definition not found");
-        // Body extent: from the opening `{` of the body to the matching
-        // closing `}\n`. Use a coarse scan that's robust enough for the
-        // small function — we just need the call site to be inside.
         let body_start = SOURCE[fn_start..]
             .find('{')
             .map(|p| fn_start + p)
@@ -456,14 +453,23 @@ mod tests {
             .expect("function body closing brace not found");
         let body = &SOURCE[body_start..body_end];
 
+        // Strip line comments before matching so a doc comment that
+        // mentions the function name doesn't false-pass the assertion.
+        let executable: String = body
+            .lines()
+            .map(|line| line.split("//").next().unwrap_or(""))
+            .collect::<Vec<_>>()
+            .join("\n");
+
         assert!(
-            body.contains("mark_local_client_access"),
-            "finalize_put_at_originator MUST call mark_local_client_access \
-             so self-hosted contracts get the local-client flag set on the \
-             hosting cache entry. Without this call, the freenet-stdlib \
-             mirror demo cold-GET timeout (2026-05-14) returns. See \
-             contracts_needing_renewal at hosting.rs:971-991 for the \
-             downstream gate that depends on this flag."
+            executable.contains("ring.mark_local_client_access(&key)"),
+            "finalize_put_at_originator MUST call \
+             `op_manager.ring.mark_local_client_access(&key)` (executable \
+             code, not just a comment mention) so self-hosted contracts \
+             get the local-client flag set. Without this call, the \
+             freenet-stdlib mirror demo 180s cold-GET timeout (2026-05-14) \
+             returns. See contracts_needing_renewal at hosting.rs:971-991 \
+             for the downstream gate that depends on this flag."
         );
     }
 }


### PR DESCRIPTION
## Problem

The hosting cache's `local_client_access` flag is what gates a contract into `contracts_needing_renewal` (`crates/core/src/ring/hosting.rs:971-991`). Without it, the contract gets excluded from renewal, the subscription expires, the entry eventually evicts under byte-budget pressure, and the next cold remote GET fails the `is_locally_hosted` shortcut and routes to the network — where, for a contract no other peer subscribes to, the GetOp hangs until the WS client's 180s timeout.

The GET path has called `mark_local_client_access` since #3769 (`client_events::serve_get`), but **the PUT path never did**. So a contract PUT'd by a local client and never GET'd locally — the freenet-git mirror demo's exact pattern (bot pushes daily, no GETs until the next day's cron) — accumulated this exact failure mode.

Confirmed via nova gateway log analysis: three independent 180s timeouts on 2026-05-14 against `freenet:96rknpy1GYhZ/freenet-stdlib` (07:24, 13:27, 19:00 UTC). On May 15 the same contract served fine via the local-cache shortcut, indicating the LRU regained the entry between failures (likely from a fresh push warming `record_access` again, but without the flag set the cycle was bound to repeat).

## Solution

Single line addition in `finalize_put_at_originator` (`crates/core/src/operations/put.rs:36`) — the originator-only finalization helper that fires after a PUT successfully completes:

```rust
op_manager.ring.mark_local_client_access(&key);
```

At this point the cache entry exists (the put pipeline already ran `put_contract` → `host_contract` via the shared `relay_put_store_locally` path), so the mark sets the flag on the existing entry. Relay-side PUTs bypass this helper, so they correctly do not get the flag — matching the relay-helper's existing doc-comment in `op_ctx_task::relay_put_store_locally`:

> This helper is **relay-only** — it never sets `mark_local_client_access` (that's originator-side).

This was the symmetric call site that was missing until this commit. No cache-layer changes, no `is_locally_hosted` gate changes; the freshness semantics established by #3340 are preserved.

## Why not the previous approach (#4132 closed)

#4132 attempted to make the access flag survive main-cache eviction via a separate history LRU + dropped the `is_hosting_contract` clause from the gate. Skeptical + Codex review caught two HIGH-severity issues: (a) the new gate bypassed the freshness guard from PR #3340 for relay-cached evicted contracts, and (b) the shortcut returned without re-adding the contract to the hosting cache, leaving renewal bookkeeping permanently broken. Both surfaced the deeper design problem — PUT was never marking — which this PR fixes directly without touching the cache layer or freshness gate.

## Testing

`finalize_put_at_originator_marks_local_client_access` in `crates/core/src/operations/put.rs::tests` — structural source-scrape that asserts the call stays in place. Mirrors the existing `finalize_put_at_originator_never_subscribes_from_driver` pin-test pattern in `op_ctx_task.rs`. Catches accidental removal of the call.

The behavioral invariant ("flag enables renewal") is already covered by `test_local_client_access_enables_renewal` at `hosting.rs:2601`. No new behavioral test needed since the cache and renewal layers are unchanged.

All 43 `operations::put` + 62 `ring::hosting` tests pass. `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.

## Fixes

No GitHub issue filed — discovered while investigating recurring rescue-demos Matrix failure alerts for the freenet-stdlib mirror.

[AI-assisted - Claude]