### PR TITLE
build(release): set git user.name/email before tag in create_release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,6 +348,12 @@ jobs:
       - name: Create and push tag
         if: ${{ !inputs.dry_run }}
         run: |
+          # `git tag -a` needs user.name/email. The `update_versions` job
+          # set these in its runner, but this job runs on a fresh runner
+          # where git config is empty — without these two lines the tag
+          # step fails with `fatal: empty ident name not allowed`.
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           VERSION="${{ needs.validate.outputs.version }}"
           git tag -a "v$VERSION" -m "Release v$VERSION"
           git push origin "v$VERSION"


### PR DESCRIPTION
## Problem

v0.2.58 release dry-run got past validate, bump-PR auto-CI/merge, and crates.io publish (so the RELEASE_PAT + sed-regex + CARGO_REGISTRY_TOKEN fixes from #4122/#4123 all work). But the final `Create GitHub release` job failed at the `Create and push tag` step with:

```
fatal: empty ident name (for <runner@...>) not allowed
```

`git tag -a` requires `user.name` + `user.email` configured. The `update_versions` job sets these (`git config user.name "github-actions[bot]"` etc.) for its own commit, but `create_release` runs on a fresh runner where that config doesn't exist.

## Solution

Add the same two `git config` lines inside `Create and push tag` so the runner has identity before `git tag -a` runs. Identical pattern to `update_versions`.

## Testing

No automated test possible — bug only surfaces on a clean GitHub-hosted runner. Re-firing `release.yml` for v0.2.58 (or any subsequent release) is the verification.

Fixes the residual cascade failure observed on `release.yml` run [25961855138](https://github.com/freenet/freenet-core/actions/runs/25961855138).

[AI-assisted - Claude]