### PR TITLE
feat(secrets)!: auto-gen per-node delegate cipher; bump stdlib 0.8.0

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -311,6 +311,39 @@ example (the `classify_suspend_jump` helper and its rustdoc). Do not
 add new call sites for any other purpose — every other "I need real
 time" urge in `crates/core/` should still go through `TimeSource`.
 
+#### Exception: `OsRng` for cryptographic key / nonce generation
+
+The other legitimate reason to bypass `GlobalRng` in `crates/core/` is
+cryptographic key material (AEAD keys, AEAD nonces, signing keys,
+ephemeral DH secrets, etc.). Cryptographic randomness MUST come from
+the OS entropy pool (`/dev/urandom`-equivalent), not from a
+deterministic simulation RNG: a `GlobalRng` seed leak would compromise
+every key derived from it, and tests that fix the seed for
+reproducibility would produce on-disk ciphertexts that any reader of
+the test source could decrypt.
+
+When you have this exact need:
+
+1. Use `chacha20poly1305::aead::OsRng` (or another `RngCore`-implementing
+   wrapper over the OS entropy pool — `rand::rngs::OsRng` works too).
+2. Restrict the call site to code that runs at node startup or
+   one-shot key generation paths — NEVER inside per-request hot loops
+   or anything the simulation harness would expect to control.
+3. Add a load-bearing comment on the helper function explaining *why*
+   `OsRng` is correct here (cite cryptographic-key-material reason —
+   a generic "we need randomness" justification is not sufficient).
+
+Canonical examples:
+
+- `crates/core/src/config/secret.rs::generate_cipher_key` — generates
+  the per-node XChaCha20-Poly1305 cipher seeded at first start.
+- `crates/core/src/wasm_runtime/secrets_store.rs::store_secret` —
+  generates a fresh per-write AEAD nonce.
+
+Do not add new `OsRng` call sites outside of crypto key/nonce
+generation. Every other "I need randomness" urge in `crates/core/`
+should still go through `GlobalRng`.
+
 ### WHEN writing documentation
 
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1543,7 +1543,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1774,7 +1774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1851,7 +1851,7 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "freenet",
- "freenet-stdlib 0.6.1",
+ "freenet-stdlib 0.8.0",
  "futures 0.3.32",
  "glob",
  "hex",
@@ -2051,7 +2051,7 @@ dependencies = [
  "flatbuffers 25.12.19",
  "flate2",
  "freenet-macros 0.1.0",
- "freenet-stdlib 0.6.1",
+ "freenet-stdlib 0.8.0",
  "freenet-test-network",
  "futures 0.3.32",
  "gag",
@@ -2167,7 +2167,7 @@ dependencies = [
  "clap",
  "freenet",
  "freenet-ping-types",
- "freenet-stdlib 0.6.1",
+ "freenet-stdlib 0.8.0",
  "freenet-test-network",
  "futures 0.3.32",
  "humantime",
@@ -2189,7 +2189,7 @@ name = "freenet-ping-contract"
 version = "0.1.11"
 dependencies = [
  "freenet-ping-types",
- "freenet-stdlib 0.6.1",
+ "freenet-stdlib 0.8.0",
  "serde_json",
 ]
 
@@ -2199,7 +2199,7 @@ version = "0.1.11"
 dependencies = [
  "chrono",
  "clap",
- "freenet-stdlib 0.6.1",
+ "freenet-stdlib 0.8.0",
  "humantime",
  "humantime-serde",
  "serde",
@@ -2259,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa02deacddb55332a7dcb6ef3b3afef6e633d4fcbc3730df4f1e34cd7ce84d2"
+checksum = "c20c5c395585e1263233eea4b2b3429519ebd05c505c46e48c7adefe65ecf3f2"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -2324,7 +2324,7 @@ dependencies = [
  "byteorder",
  "ciborium",
  "ed25519-dalek",
- "freenet-stdlib 0.6.1",
+ "freenet-stdlib 0.8.0",
  "rand 0.9.4",
  "serde",
 ]
@@ -3487,7 +3487,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4045,7 +4045,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4171,7 +4171,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5753,7 +5753,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6263,7 +6263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6745,7 +6745,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6782,7 +6782,7 @@ dependencies = [
 name = "test-contract-integration"
 version = "0.1.11"
 dependencies = [
- "freenet-stdlib 0.6.1",
+ "freenet-stdlib 0.8.0",
  "serde",
  "serde_json",
 ]
@@ -6792,14 +6792,14 @@ name = "test-contract-mock-aligned"
 version = "0.1.0"
 dependencies = [
  "blake3",
- "freenet-stdlib 0.6.1",
+ "freenet-stdlib 0.8.0",
 ]
 
 [[package]]
 name = "test-contract-update-nochange"
 version = "0.1.0"
 dependencies = [
- "freenet-stdlib 0.6.1",
+ "freenet-stdlib 0.8.0",
  "serde",
  "serde_json",
 ]
@@ -7491,7 +7491,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8476,7 +8476,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8987,7 +8987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ muda = "0.19"
 zip = { version = "8", default-features = false, features = ["deflate", "time"] }
 
 # Freenet
-freenet-stdlib = "0.6.1"
+freenet-stdlib = "0.8.0"
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/apps/freenet-ping/Cargo.toml
+++ b/apps/freenet-ping/Cargo.toml
@@ -4,7 +4,7 @@ members = ["contracts/ping", "app", "types"]
 
 [workspace.dependencies]
 # freenet-stdlib = { path = "./../../stdlib/rust", features = ["contract"] }
-freenet-stdlib = { version = "0.6.1" }
+freenet-stdlib = { version = "0.8.0" }
 freenet-ping-types = { path = "types", default-features = false }
 
 # Core dependencies

--- a/apps/freenet-ping/app/tests/common/mod.rs
+++ b/apps/freenet-ping/app/tests/common/mod.rs
@@ -784,3 +784,20 @@ pub async fn get_all_ping_states(
 
     Ok((ping_gw, ping_node1, ping_node2))
 }
+
+/// 32-byte XChaCha20-Poly1305 cipher used by the freenet-ping integration
+/// tests when issuing `RegisterDelegate` calls. Servers running
+/// freenet-core >= 0.2.59 generate per-write nonces (PR #4143) and replaced
+/// the world-known `DelegateRequest::DEFAULT_CIPHER` constant in
+/// freenet-stdlib 0.8.0 with per-node auto-persisted ciphers. Tests no
+/// longer have a stdlib constant to seed `RegisterDelegate`, so they
+/// supply this arbitrary-but-fixed value instead.
+pub const TEST_DELEGATE_CIPHER: [u8; 32] = [
+    0x5b, 0x73, 0x12, 0xe8, 0xc4, 0x9a, 0x60, 0x2f, 0x88, 0x14, 0xd7, 0x33, 0x16, 0xaa, 0x4e, 0x91,
+    0x07, 0x6b, 0x55, 0xd2, 0x3e, 0xfb, 0x80, 0x29, 0x1c, 0xa5, 0xee, 0x44, 0x6f, 0x32, 0x18, 0xbd,
+];
+
+/// 24-byte registration nonce. Per-write nonces (PR #4143) mean the
+/// server ignores this field for encryption; only legacy-decrypt of
+/// pre-0.2.59 on-disk files consults it. Any constant works.
+pub const TEST_DELEGATE_NONCE: [u8; 24] = [0u8; 24];

--- a/apps/freenet-ping/app/tests/run_app_delegate_wasmtime.rs
+++ b/apps/freenet-ping/app/tests/run_app_delegate_wasmtime.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 use tokio::select;
 
 use common::{
-    allocate_test_node_block, base_node_test_config_with_rng, connect_ws_with_retry,
-    test_ip_for_node, test_node_config,
+    TEST_DELEGATE_CIPHER, TEST_DELEGATE_NONCE, allocate_test_node_block,
+    base_node_test_config_with_rng, connect_ws_with_retry, test_ip_for_node, test_node_config,
 };
 
 /// Message types matching test-delegate-integration's InboundAppMessage
@@ -101,8 +101,8 @@ async fn test_delegate_e2e_wasmtime() -> anyhow::Result<()> {
             .send(ClientRequest::DelegateOp(
                 freenet_stdlib::client_api::DelegateRequest::RegisterDelegate {
                     delegate: delegate.clone(),
-                    cipher: freenet_stdlib::client_api::DelegateRequest::DEFAULT_CIPHER,
-                    nonce: freenet_stdlib::client_api::DelegateRequest::DEFAULT_NONCE,
+                    cipher: TEST_DELEGATE_CIPHER,
+                    nonce: TEST_DELEGATE_NONCE,
                 },
             ))
             .await?;

--- a/apps/freenet-ping/app/tests/run_delegate_creation_e2e.rs
+++ b/apps/freenet-ping/app/tests/run_delegate_creation_e2e.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 use tokio::select;
 
 use common::{
-    allocate_test_node_block, base_node_test_config_with_rng, connect_ws_with_retry,
-    test_ip_for_node, test_node_config,
+    TEST_DELEGATE_CIPHER, TEST_DELEGATE_NONCE, allocate_test_node_block,
+    base_node_test_config_with_rng, connect_ws_with_retry, test_ip_for_node, test_node_config,
 };
 
 /// Message types matching test-delegate-creation's InboundAppMessage
@@ -141,8 +141,8 @@ async fn test_delegate_creation_e2e() -> anyhow::Result<()> {
             .send(ClientRequest::DelegateOp(
                 freenet_stdlib::client_api::DelegateRequest::RegisterDelegate {
                     delegate: parent_delegate.clone(),
-                    cipher: freenet_stdlib::client_api::DelegateRequest::DEFAULT_CIPHER,
-                    nonce: freenet_stdlib::client_api::DelegateRequest::DEFAULT_NONCE,
+                    cipher: TEST_DELEGATE_CIPHER,
+                    nonce: TEST_DELEGATE_NONCE,
                 },
             ))
             .await?;

--- a/apps/freenet-ping/app/tests/run_delegate_messaging_e2e.rs
+++ b/apps/freenet-ping/app/tests/run_delegate_messaging_e2e.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 use tokio::select;
 
 use common::{
-    allocate_test_node_block, base_node_test_config_with_rng, connect_ws_with_retry,
-    test_ip_for_node, test_node_config,
+    TEST_DELEGATE_CIPHER, TEST_DELEGATE_NONCE, allocate_test_node_block,
+    base_node_test_config_with_rng, connect_ws_with_retry, test_ip_for_node, test_node_config,
 };
 
 /// Message types matching test-delegate-messaging's InboundAppMessage
@@ -122,8 +122,8 @@ async fn test_delegate_to_delegate_messaging_e2e() -> anyhow::Result<()> {
             .send(ClientRequest::DelegateOp(
                 freenet_stdlib::client_api::DelegateRequest::RegisterDelegate {
                     delegate: delegate_a.clone(),
-                    cipher: freenet_stdlib::client_api::DelegateRequest::DEFAULT_CIPHER,
-                    nonce: freenet_stdlib::client_api::DelegateRequest::DEFAULT_NONCE,
+                    cipher: TEST_DELEGATE_CIPHER,
+                    nonce: TEST_DELEGATE_NONCE,
                 },
             ))
             .await?;
@@ -141,8 +141,8 @@ async fn test_delegate_to_delegate_messaging_e2e() -> anyhow::Result<()> {
             .send(ClientRequest::DelegateOp(
                 freenet_stdlib::client_api::DelegateRequest::RegisterDelegate {
                     delegate: delegate_b.clone(),
-                    cipher: freenet_stdlib::client_api::DelegateRequest::DEFAULT_CIPHER,
-                    nonce: freenet_stdlib::client_api::DelegateRequest::DEFAULT_NONCE,
+                    cipher: TEST_DELEGATE_CIPHER,
+                    nonce: TEST_DELEGATE_NONCE,
                 },
             ))
             .await?;

--- a/crates/core/src/bin/commands/report.rs
+++ b/crates/core/src/bin/commands/report.rs
@@ -967,13 +967,22 @@ mod tests {
         assert_eq!(states[&key1.to_string()]["size_bytes"], 1234);
     }
 
+    // Superseded by freenet-stdlib 0.8.0: stringified
+    // `NodeDiagnosticsResponse.contract_states` map keys
+    // (freenet-stdlib#70). The pre-condition this test documented —
+    // "native serde_json rejects ContractKey-keyed map, hence
+    // diagnostics_to_json workaround" — no longer holds: the upstream
+    // type now uses String keys and `serde_json::to_string(&diag)`
+    // succeeds, so the `.expect_err` assertion fails. Kept as
+    // `#[ignore]` historical documentation per the superseded-test
+    // convention in `.claude/rules/git-workflow.md`. The
+    // `diagnostics_to_json` helper itself is retained because its
+    // sibling tests still exercise round-trip + field-coverage
+    // properties; a separate refactor could replace it with a direct
+    // `serde_json::to_string` call. See PR #4144.
+    #[ignore]
     #[test]
     fn test_native_serde_json_on_contract_states_fails_documents_root_cause() {
-        // Pin the failure mode so a stdlib-side fix that switches the key type
-        // surfaces here as a tightening, not a silent change. If this test
-        // starts passing, NodeDiagnosticsResponse.contract_states no longer
-        // requires the diagnostics_to_json workaround above and the helper can
-        // be removed in favour of a direct serde_json::to_string call.
         use freenet_stdlib::client_api::ContractState;
         use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
         use std::collections::HashMap;

--- a/crates/core/src/bin/commands/report.rs
+++ b/crates/core/src/bin/commands/report.rs
@@ -921,7 +921,7 @@ mod tests {
         );
         let mut contract_states = HashMap::new();
         contract_states.insert(
-            key1,
+            key1.to_string(),
             ContractState {
                 subscribers: 2,
                 subscriber_peer_ids: vec!["peer-a".to_string(), "peer-b".to_string()],
@@ -929,7 +929,7 @@ mod tests {
             },
         );
         contract_states.insert(
-            key2,
+            key2.to_string(),
             ContractState {
                 subscribers: 0,
                 subscriber_peer_ids: vec![],
@@ -984,7 +984,7 @@ mod tests {
         );
         let mut contract_states = HashMap::new();
         contract_states.insert(
-            key,
+            key.to_string(),
             ContractState {
                 subscribers: 0,
                 subscriber_peer_ids: vec![],
@@ -1052,7 +1052,7 @@ mod tests {
         );
         let mut contract_states = HashMap::new();
         contract_states.insert(
-            key,
+            key.to_string(),
             ContractState {
                 subscribers: 5,
                 subscriber_peer_ids: vec!["peer-z".to_string()],

--- a/crates/core/src/config/secret.rs
+++ b/crates/core/src/config/secret.rs
@@ -1,13 +1,78 @@
 use std::path::Path;
 
 use aes_gcm::KeyInit;
-use chacha20poly1305::{XChaCha20Poly1305, XNonce};
-use freenet_stdlib::client_api::DelegateRequest;
+use chacha20poly1305::{XChaCha20Poly1305, XNonce, aead::OsRng};
 
 use super::*;
 
 const NONCE_SIZE: usize = 24;
 const CIPHER_SIZE: usize = 32;
+
+/// Filename (relative to `secrets_dir`) of the auto-persisted per-node
+/// delegate cipher introduced in freenet-core PR after the removal of
+/// `DelegateRequest::DEFAULT_CIPHER` from freenet-stdlib 0.8.0. Nodes
+/// generate this on first start (if no `--cipher` flag is supplied) and
+/// reuse it across restarts.
+pub(crate) const DELEGATE_CIPHER_FILENAME: &str = "delegate_cipher";
+
+/// Historical `DelegateRequest::DEFAULT_NONCE` value, retained in core
+/// purely for **read-side legacy decrypt** of on-disk delegate secret
+/// files that pre-date the per-write-nonce format (freenet-core PR #4143).
+///
+/// New writes never use this value — every `store_secret` generates a
+/// fresh random 24-byte nonce via `OsRng` and persists it inline with
+/// the ciphertext under the version-prefixed format. This constant
+/// exists only to populate `Secrets::nonce` so the existing
+/// `Encryption::legacy_nonce` fallback in `SecretsStore::get_secret`
+/// can still decrypt pre-#4143 files written under the old default
+/// fallback path.
+///
+/// Removed from `freenet-stdlib` public API in 0.8.0 because exposing
+/// it as a public const was what allowed default-configured nodes to
+/// encrypt under a world-known nonce.
+pub(crate) const LEGACY_DEFAULT_NONCE: [u8; 24] = [
+    57, 18, 79, 116, 63, 134, 93, 39, 208, 161, 156, 229, 222, 247, 111, 79, 210, 126, 127, 55,
+    224, 150, 139, 80,
+];
+
+/// Historical `DelegateRequest::DEFAULT_CIPHER` value, retained in core
+/// purely for **read-side legacy decrypt**. See [`LEGACY_DEFAULT_NONCE`].
+///
+/// Tests in this module use this constant directly to construct legacy
+/// `Secrets` snapshots; production code never seeds `Secrets::cipher`
+/// from it — `SecretArgs::build` auto-generates a fresh cipher per node
+/// and persists it to `secrets_dir/delegate_cipher`.
+pub(crate) const LEGACY_DEFAULT_CIPHER: [u8; 32] = [
+    0, 24, 22, 150, 112, 207, 24, 65, 182, 161, 169, 227, 66, 182, 237, 215, 206, 164, 58, 161, 64,
+    108, 157, 195, 0, 0, 0, 0, 0, 0, 0, 0,
+];
+
+/// Generate a fresh 32-byte XChaCha20-Poly1305 key via `OsRng`.
+fn generate_cipher_key() -> [u8; CIPHER_SIZE] {
+    let key = XChaCha20Poly1305::generate_key(&mut OsRng);
+    let mut out = [0u8; CIPHER_SIZE];
+    out.copy_from_slice(key.as_slice());
+    out
+}
+
+/// Persist a cipher key to disk with 0o600 permissions on Unix.
+fn save_cipher(path: &Path, key: &[u8; CIPHER_SIZE]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = File::create(path)?;
+    file.write_all(key)?;
+    file.sync_all()?;
+    drop(file);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(path)?.permissions();
+        perms.set_mode(0o600);
+        std::fs::set_permissions(path, perms)?;
+    }
+    Ok(())
+}
 
 impl ConfigArgs {
     pub(super) fn read_secrets(
@@ -20,15 +85,30 @@ impl ConfigArgs {
         } else {
             TransportKeypair::new()
         };
+        // Nonces became per-write in PR #4143 — the file-based nonce is no
+        // longer used for encryption. If the operator still has an explicit
+        // `--nonce` path on their config, honor the file content for legacy
+        // decrypt; otherwise use the historical default so pre-#4143 on-disk
+        // files written under the old fallback path remain readable.
         let nonce = if let Some(ref path_to_nonce) = path_to_nonce {
+            tracing::warn!(
+                "`nonce` config is deprecated since per-write nonces landed; the file at \
+                 {path:?} is used only as a legacy-decrypt nonce for pre-existing secrets.",
+                path = path_to_nonce
+            );
             read_nonce(path_to_nonce)?
         } else {
-            DelegateRequest::DEFAULT_NONCE
+            LEGACY_DEFAULT_NONCE
         };
+        // No `--cipher` path → caller is using the legacy "read_secrets"
+        // entry that does not know about secrets_dir; preserve legacy
+        // semantics by populating with the historical default so existing
+        // ciphertexts remain decryptable. New nodes go through
+        // `SecretArgs::build`, which auto-generates a fresh cipher.
         let cipher = if let Some(ref path_to_cipher) = path_to_cipher {
             read_cipher(path_to_cipher)?
         } else {
-            DelegateRequest::DEFAULT_CIPHER
+            LEGACY_DEFAULT_CIPHER
         };
 
         Ok(Secrets {
@@ -91,17 +171,53 @@ impl SecretArgs {
             };
         let nonce = self.nonce.as_ref().map(read_nonce).transpose()?;
         let (nonce_path, nonce) = if let Some(nonce) = nonce {
+            tracing::warn!(
+                "`--nonce` / NONCE config is deprecated since per-write nonces landed; the \
+                 supplied value is used only as a legacy-decrypt nonce for pre-existing secrets."
+            );
             (self.nonce, nonce)
         } else {
-            (None, DelegateRequest::DEFAULT_NONCE)
+            // Pre-#4143 on-disk files were written under the historical
+            // default nonce when the operator did not supply one; keep
+            // it as the legacy-decrypt fallback so upgrades stay
+            // readable. New writes generate per-write random nonces.
+            (None, LEGACY_DEFAULT_NONCE)
         };
 
-        let cipher = self.cipher.as_ref().map(read_cipher).transpose()?;
-
-        let (cipher_path, cipher) = if let Some(cipher) = cipher {
+        // Cipher: explicit `--cipher` path wins. Otherwise auto-generate
+        // and persist under `secrets_dir/delegate_cipher`, mirroring the
+        // existing `transport_keypair` auto-persist pattern. Without a
+        // `secrets_dir` (in tests), fall back to an ephemeral random
+        // cipher — explicitly NOT the historical default, since the
+        // default was a world-known key.
+        let explicit_cipher = self.cipher.as_ref().map(read_cipher).transpose()?;
+        let (cipher_path, cipher) = if let Some(cipher) = explicit_cipher {
             (self.cipher, cipher)
+        } else if let Some(dir) = secrets_dir {
+            let default_path = dir.join(DELEGATE_CIPHER_FILENAME);
+            if default_path.exists() {
+                tracing::info!(
+                    path = %default_path.display(),
+                    "Loading persisted delegate cipher"
+                );
+                let cipher = read_cipher(&default_path)?;
+                (Some(default_path), cipher)
+            } else {
+                std::fs::create_dir_all(dir)?;
+                let cipher = generate_cipher_key();
+                save_cipher(&default_path, &cipher)?;
+                tracing::info!(
+                    path = %default_path.display(),
+                    "Generated and saved new delegate cipher"
+                );
+                (Some(default_path), cipher)
+            }
         } else {
-            (None, DelegateRequest::DEFAULT_CIPHER)
+            // No secrets_dir (tests): ephemeral random cipher. Crucially
+            // NOT the historical world-known default — the whole point of
+            // dropping `DelegateRequest::DEFAULT_CIPHER` was to ensure no
+            // code path silently encrypts under a public constant.
+            (None, generate_cipher_key())
         };
 
         Ok(Secrets {
@@ -150,8 +266,15 @@ pub struct Secrets {
 impl Default for Secrets {
     fn default() -> Self {
         let transport_keypair = TransportKeypair::new();
-        let nonce = DelegateRequest::DEFAULT_NONCE;
-        let cipher = DelegateRequest::DEFAULT_CIPHER;
+        // Random cipher per test instance — explicitly NOT the historical
+        // world-known constant. Production `SecretArgs::build` auto-
+        // generates + persists; tests don't need persistence.
+        let cipher = generate_cipher_key();
+        // Pin the nonce to the legacy default so any test that hand-
+        // crafts a legacy on-disk blob and then calls `SecretsStore::new`
+        // with `Default::default()` exercises the same legacy-decrypt
+        // path that production upgrades use.
+        let nonce = LEGACY_DEFAULT_NONCE;
 
         Secrets {
             transport_keypair,
@@ -307,12 +430,99 @@ mod tests {
         assert_eq!(secrets, loaded_secrets);
     }
 
+    /// `SecretArgs::default().build(None)` (no `--cipher`, no `secrets_dir`)
+    /// MUST produce a random ephemeral cipher — NOT the historical
+    /// `LEGACY_DEFAULT_CIPHER` constant. The whole point of removing
+    /// `DelegateRequest::DEFAULT_CIPHER` from freenet-stdlib 0.8.0 was to
+    /// guarantee that no code path silently encrypts under a public
+    /// constant. This test pins that invariant.
     #[test]
-    fn test_load_default() {
+    fn test_load_default_generates_random_cipher() {
         let secret_args = SecretArgs::default();
         let loaded_secrets = secret_args.build(None).unwrap();
-        assert_eq!(DelegateRequest::DEFAULT_CIPHER, loaded_secrets.cipher);
-        assert_eq!(DelegateRequest::DEFAULT_NONCE, loaded_secrets.nonce);
+        assert_ne!(
+            LEGACY_DEFAULT_CIPHER, loaded_secrets.cipher,
+            "build(None) must NOT seed the historical default cipher"
+        );
+        assert_ne!(
+            [0u8; CIPHER_SIZE], loaded_secrets.cipher,
+            "build(None) must produce a non-zero cipher"
+        );
+        // Two invocations must produce DIFFERENT ciphers — confirms the
+        // RNG is actually being consulted per call.
+        let another = SecretArgs::default().build(None).unwrap();
+        assert_ne!(
+            loaded_secrets.cipher, another.cipher,
+            "two ephemeral builds must produce distinct random ciphers"
+        );
+        // Nonce stays at LEGACY_DEFAULT_NONCE (read-side fallback only).
+        assert_eq!(LEGACY_DEFAULT_NONCE, loaded_secrets.nonce);
+    }
+
+    /// `SecretArgs::default().build(Some(dir))` auto-persists a cipher
+    /// to `dir/delegate_cipher` on first call and reloads the same
+    /// bytes on the second call. Mirrors the existing `transport_keypair`
+    /// auto-persist behavior and is the upgrade path that replaces the
+    /// removed `DEFAULT_CIPHER` fallback.
+    #[test]
+    fn test_cipher_auto_persist_and_reload() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let secrets_dir = tmp_dir.path();
+        let args1 = SecretArgs::default();
+        let secrets1 = args1.build(Some(secrets_dir)).unwrap();
+
+        let cipher_path = secrets_dir.join(DELEGATE_CIPHER_FILENAME);
+        assert!(cipher_path.exists(), "cipher file should be created");
+        assert_eq!(
+            secrets1.cipher_path.as_deref(),
+            Some(cipher_path.as_path()),
+            "cipher_path should point at the persisted file"
+        );
+        assert_ne!(
+            LEGACY_DEFAULT_CIPHER, secrets1.cipher,
+            "auto-generated cipher must NOT equal the historical default"
+        );
+        // File permissions on Unix must be 0o600 (owner read/write only).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&cipher_path)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o600, "cipher file must be 0o600, got {mode:o}");
+        }
+
+        let args2 = SecretArgs::default();
+        let secrets2 = args2.build(Some(secrets_dir)).unwrap();
+        assert_eq!(
+            secrets1.cipher, secrets2.cipher,
+            "second build must reload the persisted cipher"
+        );
+    }
+
+    /// Passing `--cipher /path/that/does/not/exist` MUST error rather
+    /// than silently fall back to any default. The whole behavioral
+    /// contract of removing `DEFAULT_CIPHER` is that there is no
+    /// silent fallback to a known-bad key.
+    #[test]
+    fn test_missing_cipher_path_is_hard_error() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let missing = tmp_dir.path().join("does-not-exist");
+        let args = SecretArgs {
+            cipher: Some(missing),
+            ..Default::default()
+        };
+        let err = args
+            .build(None)
+            .expect_err("missing cipher path must error");
+        // Surface as a file-not-found IO error from read_cipher.
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::NotFound,
+            "expected NotFound, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/core/src/config/secret.rs
+++ b/crates/core/src/config/secret.rs
@@ -295,6 +295,20 @@ pub struct Secrets {
 }
 
 // Only used in tests
+//
+// **Non-reproducible `Default`.** This impl deliberately returns a
+// different `cipher` and `transport_keypair` on each call — both fields
+// are generated from fresh OS entropy. This is required by the
+// production-side security contract (no code path may silently encrypt
+// under a fixed, world-known key), but it breaks the typical `Default`
+// reproducibility expectation: two `Secrets::default()` values are NOT
+// equal, even though `Secrets: Eq`. Any test that constructs two
+// `Default::default()` instances and expects them to share a cipher
+// (e.g. encrypting under one and decrypting under another without a
+// `register_delegate` round-trip) will fail. All current test sites
+// construct exactly one `SecretsStore::new(_, Default::default(), _)`
+// per test and route their crypto through the registered-cipher path,
+// so the non-reproducibility is invisible to them.
 #[cfg(test)]
 impl Default for Secrets {
     fn default() -> Self {

--- a/crates/core/src/config/secret.rs
+++ b/crates/core/src/config/secret.rs
@@ -48,6 +48,13 @@ pub(crate) const LEGACY_DEFAULT_CIPHER: [u8; 32] = [
 ];
 
 /// Generate a fresh 32-byte XChaCha20-Poly1305 key via `OsRng`.
+///
+/// `OsRng` is the documented exception to the project-wide
+/// `.claude/rules/code-style.md` ban on `rand::thread_rng()` /
+/// `rand::random()` in `crates/core/`: cryptographic key material MUST
+/// come from the OS entropy pool (e.g. `/dev/urandom`), not from a
+/// deterministic simulation RNG. This call runs at node startup, before
+/// any `TimeSource` / `GlobalRng` simulation harness would be in scope.
 fn generate_cipher_key() -> [u8; CIPHER_SIZE] {
     let key = XChaCha20Poly1305::generate_key(&mut OsRng);
     let mut out = [0u8; CIPHER_SIZE];
@@ -55,22 +62,31 @@ fn generate_cipher_key() -> [u8; CIPHER_SIZE] {
     out
 }
 
-/// Persist a cipher key to disk with 0o600 permissions on Unix.
-fn save_cipher(path: &Path, key: &[u8; CIPHER_SIZE]) -> std::io::Result<()> {
+/// Persist a cipher key to disk, creating the file atomically with
+/// 0o600 permissions on Unix (no window where another user could open
+/// the file at a more permissive mode).
+///
+/// Uses `OpenOptions::create_new(true)` so the call fails with
+/// `AlreadyExists` if the file appeared between the caller's existence
+/// check and this write — preventing a TOCTOU where two concurrent
+/// freenet processes starting against the same `secrets_dir` overwrite
+/// each other's cipher.
+fn save_cipher_new(path: &Path, key: &[u8; CIPHER_SIZE]) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let mut file = File::create(path)?;
-    file.write_all(key)?;
-    file.sync_all()?;
-    drop(file);
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(path)?.permissions();
-        perms.set_mode(0o600);
-        std::fs::set_permissions(path, perms)?;
+        use std::os::unix::fs::OpenOptionsExt;
+        // Atomic 0o600 — no window between create and chmod where the
+        // file is readable under the process umask.
+        opts.mode(0o600);
     }
+    let mut file = opts.open(path)?;
+    file.write_all(key)?;
+    file.sync_all()?;
     Ok(())
 }
 
@@ -205,12 +221,29 @@ impl SecretArgs {
             } else {
                 std::fs::create_dir_all(dir)?;
                 let cipher = generate_cipher_key();
-                save_cipher(&default_path, &cipher)?;
-                tracing::info!(
-                    path = %default_path.display(),
-                    "Generated and saved new delegate cipher"
-                );
-                (Some(default_path), cipher)
+                match save_cipher_new(&default_path, &cipher) {
+                    Ok(()) => {
+                        tracing::info!(
+                            path = %default_path.display(),
+                            "Generated and saved new delegate cipher"
+                        );
+                        (Some(default_path), cipher)
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                        // Race lost: another freenet process (or our own
+                        // earlier startup attempt) wrote the cipher file
+                        // in the window between `default_path.exists()`
+                        // returning false and our `save_cipher_new`. The
+                        // file is now authoritative — load it.
+                        tracing::info!(
+                            path = %default_path.display(),
+                            "Cipher file appeared concurrently; loading the winning copy"
+                        );
+                        let cipher = read_cipher(&default_path)?;
+                        (Some(default_path), cipher)
+                    }
+                    Err(e) => return Err(e),
+                }
             }
         } else {
             // No secrets_dir (tests): ephemeral random cipher. Crucially

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -1829,8 +1829,10 @@ impl P2pConnManager {
                                         let is_subscribed =
                                             op_manager.ring.is_subscribed(&contract_key);
                                         let subscriber_count = if is_subscribed { 1 } else { 0 };
+                                        // stdlib 0.8.0 keyed contract_states by String
+                                        // (`fix!: stringify NodeDiagnosticsResponse.contract_states keys`).
                                         response.contract_states.insert(
-                                            contract_key,
+                                            contract_key.to_string(),
                                             ContractState {
                                                 subscribers: subscriber_count as u32,
                                                 subscriber_peer_ids: Vec::new(),
@@ -1846,7 +1848,7 @@ impl P2pConnManager {
                                             op_manager.ring.is_subscribed(contract_key);
                                         let subscriber_count = if is_subscribed { 1 } else { 0 };
                                         response.contract_states.insert(
-                                            *contract_key,
+                                            contract_key.to_string(),
                                             ContractState {
                                                 subscribers: subscriber_count as u32,
                                                 subscriber_peer_ids: Vec::new(),

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -1617,7 +1617,7 @@ mod test {
     #[tokio::test]
     async fn register_with_default_cipher_decrypts_legacy_default_blob()
     -> Result<(), Box<dyn std::error::Error>> {
-        use freenet_stdlib::client_api::DelegateRequest;
+        use crate::config::{LEGACY_DEFAULT_CIPHER, LEGACY_DEFAULT_NONCE};
 
         let temp_dir = tempfile::tempdir()?;
         let secrets_dir = temp_dir.path().join("secrets-store-test");
@@ -1626,8 +1626,8 @@ mod test {
         let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
 
         let delegate = Delegate::from((&vec![92].into(), &vec![].into()));
-        let default_cipher = XChaCha20Poly1305::new((&DelegateRequest::DEFAULT_CIPHER).into());
-        let default_nonce: XNonce = DelegateRequest::DEFAULT_NONCE.into();
+        let default_cipher = XChaCha20Poly1305::new((&LEGACY_DEFAULT_CIPHER).into());
+        let default_nonce: XNonce = LEGACY_DEFAULT_NONCE.into();
 
         // Register with the historical defaults. Under the old code this
         // was a silent no-op (skipped). Under the new code the cipher is

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -12,6 +12,7 @@ use std::{
     time::SystemTime,
 };
 
+use aes_gcm::KeyInit;
 use chacha20poly1305::{
     AeadCore, Error as EncryptionError, XChaCha20Poly1305, XNonce,
     aead::{Aead, OsRng},
@@ -104,6 +105,24 @@ pub struct SecretsStore {
     /// ReDb storage for persistent index
     db: Storage,
     default_encryption: Encryption,
+    /// Last-resort decrypt fallback seeded with the historical
+    /// `LEGACY_DEFAULT_CIPHER` + `LEGACY_DEFAULT_NONCE` pair (the world-
+    /// known constants that `freenet-stdlib` 0.8.0 removed).
+    ///
+    /// Used ONLY by `decrypt_secret_blob` for pre-#4143 on-disk files
+    /// that were written under the default-cipher fallback path.
+    /// Without this, a node that auto-generated a fresh cipher on
+    /// upgrade (the new `SecretArgs::build` behavior) would be unable
+    /// to read pre-existing default-encrypted delegate secrets across
+    /// the restart, because `default_encryption.cipher` is now the
+    /// auto-generated value and `register_delegate` (which would
+    /// otherwise supply the legacy cipher) has not yet been called by
+    /// any client.
+    ///
+    /// `None` only when the build path explicitly disabled migration
+    /// (currently never; reserved for a future "drop migration support"
+    /// release).
+    legacy_migration_encryption: Option<Encryption>,
     /// Snapshot retention policy. Snapshots are taken before any overwrite
     /// of an existing secret so a buggy delegate or accidental write cannot
     /// silently destroy prior values.
@@ -136,6 +155,19 @@ impl SecretsStore {
             }
         }
 
+        // Seed the legacy-migration fallback with the historical
+        // (LEGACY_DEFAULT_CIPHER, LEGACY_DEFAULT_NONCE) pair regardless
+        // of what the operator's configured `secrets` carries. This is
+        // the only path that lets pre-#4143 on-disk files written under
+        // the world-known default constants remain decryptable on a
+        // node whose `default_encryption.cipher` is now the
+        // auto-generated random cipher (post-stdlib-0.8.0 upgrade).
+        use crate::config::{LEGACY_DEFAULT_CIPHER, LEGACY_DEFAULT_NONCE};
+        let legacy_migration_encryption = Some(Encryption {
+            cipher: XChaCha20Poly1305::new((&LEGACY_DEFAULT_CIPHER).into()),
+            legacy_nonce: LEGACY_DEFAULT_NONCE.into(),
+        });
+
         Ok(Self {
             base_path: secrets_dir,
             ciphers: std::collections::HashMap::new(),
@@ -145,6 +177,7 @@ impl SecretsStore {
                 cipher: secrets.cipher(),
                 legacy_nonce: secrets.nonce(),
             },
+            legacy_migration_encryption,
             secrets,
             retention: RetentionPolicy::default(),
             snapshots_enabled: std::env::var_os(DISABLE_SNAPSHOTS_ENV).is_none(),
@@ -409,7 +442,12 @@ impl SecretsStore {
 
         let blob =
             fs::read(secret_path).map_err(|_| SecretStoreError::MissingSecret(key.clone()))?;
-        decrypt_secret_blob(encryption, &blob, key)
+        decrypt_secret_blob(
+            encryption,
+            self.legacy_migration_encryption.as_ref(),
+            &blob,
+            key,
+        )
     }
 
     /// Enumerate the snapshot history for a given `(delegate, secret_id)`
@@ -548,17 +586,30 @@ impl SecretsStore {
     }
 }
 
-/// Decrypt an on-disk secret blob, transparently supporting both the new
-/// per-write-nonce format (`[VERSION_V1][nonce][AEAD]`) and the legacy
-/// shared-nonce format (raw `[AEAD]` decrypted with the registration nonce).
+/// Decrypt an on-disk secret blob, transparently supporting:
 ///
-/// Ambiguity handling: a legacy blob's first byte is the first byte of AEAD
-/// output (uniformly random), so 1/256 of legacy files start with
-/// `VERSION_V1`. If the new-format parse fails AEAD validation, we fall back
-/// to the legacy path. This keeps reads working through the migration
-/// window without requiring a separate rewrite step.
+/// 1. New per-write-nonce format `[VERSION_V1][nonce][AEAD]` decrypted
+///    with the registered (or default) cipher.
+/// 2. Legacy shared-nonce format (raw `[AEAD]`) decrypted with the
+///    registered cipher + registration nonce.
+/// 3. Legacy shared-nonce format decrypted with the historical
+///    `LEGACY_DEFAULT_CIPHER` + `LEGACY_DEFAULT_NONCE` pair (the
+///    world-known constants `freenet-stdlib` 0.8.0 removed). This is
+///    the migration path for nodes upgraded past the removal of the
+///    default-cipher fallback: pre-#4143 on-disk files were written
+///    under those constants, and on a fresh restart the in-memory
+///    `ciphers` map is empty until `register_delegate` is called.
+///    Without this fallback, default-configured nodes would lose
+///    access to existing delegate secrets across upgrade.
+///
+/// Ambiguity handling: a legacy blob's first byte is the first byte of
+/// AEAD output (uniformly random), so 1/256 of legacy files start with
+/// `VERSION_V1`. If the new-format parse fails AEAD validation, we fall
+/// back through the legacy paths. Each path is independent — failure of
+/// one does not mask success of another.
 fn decrypt_secret_blob(
     encryption: &Encryption,
+    legacy_migration: Option<&Encryption>,
     blob: &[u8],
     key: &SecretsId,
 ) -> Result<Vec<u8>, SecretStoreError> {
@@ -567,21 +618,39 @@ fn decrypt_secret_blob(
         if let Ok(pt) = encryption.cipher.decrypt(nonce, &blob[HEADER_LEN..]) {
             return Ok(pt);
         }
-        // Falls through to the legacy path: either the file is genuinely
-        // legacy and happened to start with 0x01, or the file is corrupt.
-        // The legacy path will return a precise error if both attempts fail.
+        // Falls through to the legacy paths: either the file is
+        // genuinely legacy and happened to start with 0x01, the
+        // delegate's cipher rotated, or the file is corrupt. Below
+        // returns a precise error only if every attempt fails.
     }
-    encryption
-        .cipher
-        .decrypt(&encryption.legacy_nonce, blob)
-        .inspect(|_| {
-            tracing::debug!(
-                key = %key,
-                "Decrypted legacy-format secret blob; will be migrated to per-write-nonce \
-                 format on next write."
-            );
-        })
-        .map_err(SecretStoreError::Encryption)
+    if let Ok(pt) = encryption.cipher.decrypt(&encryption.legacy_nonce, blob) {
+        tracing::debug!(
+            key = %key,
+            "Decrypted legacy-format secret blob with the registered cipher; \
+             will be migrated to per-write-nonce format on next write."
+        );
+        return Ok(pt);
+    }
+    // Last-resort migration path: try the historical world-known
+    // (LEGACY_DEFAULT_CIPHER, LEGACY_DEFAULT_NONCE) pair. Reads here
+    // are exactly the pre-#4143 "default-configured node" case.
+    if let Some(migration) = legacy_migration
+        && let Ok(pt) = migration.cipher.decrypt(&migration.legacy_nonce, blob)
+    {
+        tracing::warn!(
+            key = %key,
+            "Decrypted secret blob via the legacy-default-cipher migration fallback; \
+             this file was written by a freenet-core version before PR #4143. It will \
+             be re-encrypted under the node's current cipher on next write."
+        );
+        return Ok(pt);
+    }
+    Err(SecretStoreError::Encryption(
+        // The error type is opaque; surface a generic AEAD failure.
+        // Callers cannot tell which of the three attempts failed last,
+        // but the log lines above record which paths were reached.
+        chacha20poly1305::Error,
+    ))
 }
 
 #[cfg(test)]
@@ -678,7 +747,7 @@ mod test {
             .ciphers
             .get(delegate.key())
             .expect("cipher registered");
-        let plaintext = decrypt_secret_blob(encryption, &blob, &secret_id)
+        let plaintext = decrypt_secret_blob(encryption, None, &blob, &secret_id)
             .expect("snapshot blob should decrypt with the registered cipher");
         assert_eq!(plaintext, b"v1".to_vec());
         Ok(())
@@ -1656,6 +1725,63 @@ mod test {
             recovered, plaintext,
             "default-cipher legacy blob must remain readable after register_delegate \
              (behavioral equivalence with the removed skip-on-default-nonce branch)"
+        );
+        Ok(())
+    }
+
+    /// Critical migration regression pin: after the auto-cipher-gen
+    /// upgrade, a node restarts with `default_encryption.cipher` set to
+    /// a fresh random per-node cipher (NOT `LEGACY_DEFAULT_CIPHER`).
+    /// Pre-#4143 on-disk delegate secrets were written under the
+    /// world-known `(LEGACY_DEFAULT_CIPHER, LEGACY_DEFAULT_NONCE)` pair.
+    /// If no client has called `register_delegate` yet, `get_secret`
+    /// MUST still recover the plaintext via the
+    /// `legacy_migration_encryption` fallback.
+    ///
+    /// Without this guarantee, every default-configured node would lose
+    /// access to all existing delegate secrets across the
+    /// freenet-stdlib 0.6.1 -> 0.8.0 upgrade. This test is what catches
+    /// a regression of the B1 fix from PR #4144 review.
+    #[tokio::test]
+    async fn legacy_default_blob_decryptable_without_register_after_upgrade()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use crate::config::{LEGACY_DEFAULT_CIPHER, LEGACY_DEFAULT_NONCE};
+
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        // `Secrets::default()` returns a RANDOM cipher (production
+        // upgrade behavior after PR #4144), NOT the historical default.
+        let secrets = Secrets::default();
+        assert_ne!(
+            secrets.cipher, LEGACY_DEFAULT_CIPHER,
+            "test precondition: Secrets::default() must be random per call (post-PR-#4144)"
+        );
+        let store = SecretsStore::new(secrets_dir.clone(), secrets, db)?;
+
+        // Hand-craft a pre-#4143 on-disk blob: raw AEAD under the
+        // historical world-known constants, no version header.
+        let delegate = Delegate::from((&vec![94].into(), &vec![].into()));
+        let legacy_cipher = XChaCha20Poly1305::new((&LEGACY_DEFAULT_CIPHER).into());
+        let legacy_nonce: XNonce = LEGACY_DEFAULT_NONCE.into();
+        let plaintext = b"survives-the-upgrade".to_vec();
+        let legacy_aead = legacy_cipher
+            .encrypt(&legacy_nonce, plaintext.as_ref())
+            .expect("legacy encrypt");
+        let secret_id = SecretsId::new(vec![95]);
+        let delegate_dir = secrets_dir.join(delegate.key().encode());
+        std::fs::create_dir_all(&delegate_dir)?;
+        std::fs::write(delegate_dir.join(secret_id.encode()), &legacy_aead)?;
+
+        // No `register_delegate` call — this simulates the first
+        // `get_secret` after restart, before any client has issued a
+        // new `RegisterDelegate`. Must still recover the plaintext.
+        let recovered = store.get_secret(delegate.key(), &secret_id)?;
+        assert_eq!(
+            recovered, plaintext,
+            "legacy-default blob MUST be decryptable via legacy_migration_encryption \
+             fallback, even without register_delegate having been called"
         );
         Ok(())
     }

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -15,6 +15,22 @@ use std::time::Duration;
 use tokio::time::timeout;
 use tokio_tungstenite::connect_async;
 
+/// Per-test 32-byte XChaCha20-Poly1305 key used when issuing
+/// `RegisterDelegate` calls in this integration test suite. The value
+/// is arbitrary — these tests exercise the wire protocol and the
+/// server-side encrypt/decrypt round-trip, not key management. Hardcoded
+/// so it is reproducible across runs without pulling in `rand` here.
+const TEST_DELEGATE_CIPHER: [u8; 32] = [
+    0xa1, 0x9c, 0x42, 0x7e, 0x55, 0x3d, 0xe1, 0x08, 0xb4, 0xc7, 0x77, 0x21, 0x1f, 0x09, 0xd5, 0x6a,
+    0x4e, 0x83, 0xee, 0x12, 0x6d, 0xaa, 0x90, 0x35, 0x88, 0x14, 0xc2, 0xfb, 0x29, 0x47, 0x6c, 0xb0,
+];
+/// Per-test 24-byte registration nonce. Servers running freenet-core
+/// 0.2.59 or later ignore this value for encryption (per-write random
+/// nonces landed in PR #4143) and treat it only as a legacy-decrypt
+/// fallback for pre-0.2.59 on-disk files. The test never reads
+/// pre-existing files, so any constant value works.
+const TEST_DELEGATE_NONCE: [u8; 24] = [0u8; 24];
+
 async fn get_contract(
     client: &mut WebApi,
     key: ContractKey,
@@ -2234,8 +2250,8 @@ async fn test_delegate_request(ctx: &mut TestContext) -> TestResult {
         .send(ClientRequest::DelegateOp(
             freenet_stdlib::client_api::DelegateRequest::RegisterDelegate {
                 delegate: delegate.clone(),
-                cipher: freenet_stdlib::client_api::DelegateRequest::DEFAULT_CIPHER,
-                nonce: freenet_stdlib::client_api::DelegateRequest::DEFAULT_NONCE,
+                cipher: TEST_DELEGATE_CIPHER,
+                nonce: TEST_DELEGATE_NONCE,
             },
         ))
         .await?;
@@ -2414,8 +2430,8 @@ async fn test_attested_contract_passed_to_delegate(ctx: &mut TestContext) -> Tes
         .send(ClientRequest::DelegateOp(
             freenet_stdlib::client_api::DelegateRequest::RegisterDelegate {
                 delegate: delegate.clone(),
-                cipher: freenet_stdlib::client_api::DelegateRequest::DEFAULT_CIPHER,
-                nonce: freenet_stdlib::client_api::DelegateRequest::DEFAULT_NONCE,
+                cipher: TEST_DELEGATE_CIPHER,
+                nonce: TEST_DELEGATE_NONCE,
             },
         ))
         .await?;
@@ -3791,8 +3807,8 @@ async fn test_delegate_contract_put_and_update(ctx: &mut TestContext) -> TestRes
         .send(ClientRequest::DelegateOp(
             freenet_stdlib::client_api::DelegateRequest::RegisterDelegate {
                 delegate: delegate.clone(),
-                cipher: freenet_stdlib::client_api::DelegateRequest::DEFAULT_CIPHER,
-                nonce: freenet_stdlib::client_api::DelegateRequest::DEFAULT_NONCE,
+                cipher: TEST_DELEGATE_CIPHER,
+                nonce: TEST_DELEGATE_NONCE,
             },
         ))
         .await?;
@@ -4075,8 +4091,8 @@ async fn test_delegate_contract_get(ctx: &mut TestContext) -> TestResult {
         .send(ClientRequest::DelegateOp(
             freenet_stdlib::client_api::DelegateRequest::RegisterDelegate {
                 delegate: delegate.clone(),
-                cipher: freenet_stdlib::client_api::DelegateRequest::DEFAULT_CIPHER,
-                nonce: freenet_stdlib::client_api::DelegateRequest::DEFAULT_NONCE,
+                cipher: TEST_DELEGATE_CIPHER,
+                nonce: TEST_DELEGATE_NONCE,
             },
         ))
         .await?;

--- a/crates/fdev/src/commands.rs
+++ b/crates/fdev/src/commands.rs
@@ -269,13 +269,19 @@ async fn put_delegate(
     let delegate = DelegateContainer::try_from((config.code.as_path(), params))?;
 
     let (cipher, nonce) = if delegate_config.cipher.is_empty() && delegate_config.nonce.is_empty() {
+        // freenet-stdlib 0.8.0 removed the public `DEFAULT_CIPHER` /
+        // `DEFAULT_NONCE` constants (they seeded a world-known key).
+        // Generate a fresh random cipher per fdev invocation. The nonce
+        // field on the wire is unused by servers running freenet-core
+        // >= 0.2.59 (per-write nonces landed in PR #4143); send zeros.
+        use rand::RngCore;
+        let mut cipher = [0u8; 32];
+        rand::rng().fill_bytes(&mut cipher);
         println!(
-"Using default cipher and nonce.
-For additional hardening is recommended to use a different cipher and nonce to encrypt secrets in storage.");
-        (
-            ::freenet_stdlib::client_api::DelegateRequest::DEFAULT_CIPHER,
-            ::freenet_stdlib::client_api::DelegateRequest::DEFAULT_NONCE,
-        )
+            "No --cipher specified; generated a fresh random delegate cipher for this \
+             session. Pass --cipher / --nonce explicitly to reuse a key across runs."
+        );
+        (cipher, [0u8; 24])
     } else {
         let mut cipher = [0; 32];
         bs58::decode(delegate_config.cipher.as_bytes())


### PR DESCRIPTION
Closes the second half of #4139. Depends on **freenet-stdlib 0.8.0** (published, see [freenet-stdlib#75](https://github.com/freenet/freenet-stdlib/pull/75)).

## Problem

PR #4143 fixed XChaCha20-Poly1305 nonce reuse for delegate secrets via per-write random nonces. But the **default cipher** was still a public constant — `DelegateRequest::DEFAULT_CIPHER` exported by freenet-stdlib. Any node started without an explicit \`--cipher\` flag encrypted under a world-known key. With nonce reuse fixed, the residual attack class (filesystem-only attacker recovers all default-configured nodes' secrets by reading the static stdlib source) remained.

## Solution

**Stdlib half** ([freenet-stdlib#75](https://github.com/freenet/freenet-stdlib/pull/75), already merged + published as 0.8.0): delete the two public constants. Wire format \`RegisterDelegate { cipher, nonce }\` unchanged.

**Core half** (this PR):

- \`SecretArgs::build\`: replace the \`DEFAULT_CIPHER\` fallback with **auto-generation + persistence**. First start (no \`--cipher\` flag, \`secrets_dir\` known): generate fresh 32-byte XChaCha20-Poly1305 key via \`OsRng\`, save to \`secrets_dir/delegate_cipher\` (0o600 on Unix). Subsequent starts reload the persisted key. Mirrors the existing \`transport_keypair\` auto-persist pattern.
- \`--nonce\` flag deprecated: warns at load and at build. The value is used only as a legacy-decrypt nonce for pre-#4143 on-disk files.
- \`Default for Secrets\` (test-only) returns a random cipher instead of the world-known constant.
- \`pub(crate) const LEGACY_DEFAULT_CIPHER\` / \`LEGACY_DEFAULT_NONCE\` embedded in core as read-side legacy fallback only, used by the \`Encryption::legacy_nonce\` path added in PR #4143.
- 10 client/test/fdev call sites updated to supply an arbitrary-but-fixed test cipher instead of naming the removed stdlib constants.
- Incidental stdlib 0.7→0.8 wire-format catch-up: \`NodeDiagnosticsResponse.contract_states\` map keys changed \`ContractKey -> String\` (freenet-stdlib#70), fixed in \`p2p_protoc.rs\` and \`report.rs\`.

## Upgrade compatibility

- **Existing on-disk delegate secret files** (pre-#4143, raw AEAD under \`DEFAULT_CIPHER\` + \`DEFAULT_NONCE\`) remain readable. \`ConfigArgs::read_secrets\` still seeds \`Secrets::cipher\` / \`Secrets::nonce\` with the historical defaults via the in-core \`LEGACY_*\` constants, which feed the legacy-decrypt fallback path in \`SecretsStore::decrypt_secret_blob\`.
- **First restart after this PR** triggers cipher auto-generation. New writes use the per-node cipher + per-write random nonce + version-prefixed on-disk format. Legacy files migrate in place to the new format on next overwrite, per the fallback-then-rewrite pattern established in #4143.
- **Wire format unchanged.** Old clients sending \`DEFAULT_CIPHER\` + \`DEFAULT_NONCE\` literals continue to work — supplied cipher is registered and used for encrypts; supplied nonce is held only for legacy-decrypt fallback.

## Testing

\`cargo test -p freenet --features "trace,websocket,redb,wasmtime-backend" --lib\` — 2502 passed, 14 ignored.
\`cargo fmt --all --check\` clean.
\`cargo clippy --workspace --all-targets --features "trace,websocket,redb,wasmtime-backend" -- -D warnings\` clean.

New regression tests in \`crates/core/src/config/secret.rs\`:
- \`test_load_default_generates_random_cipher\` — \`build(None)\` never produces \`LEGACY_DEFAULT_CIPHER\` and two calls yield distinct random ciphers.
- \`test_cipher_auto_persist_and_reload\` — file is created, contents reload deterministically, 0o600 perms verified on Unix.
- \`test_missing_cipher_path_is_hard_error\` — \`--cipher /missing\` returns \`NotFound\`, not silent fallback.

## Fixes

Closes #4139 (completes both halves).

Refs: #4137 (tracker), freenet-stdlib#75 (stdlib release).