### PR TITLE
fix(get): forward relay GET response before caching (#4155)

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -63,6 +63,39 @@ calling `OpCtx::send_and_await`. The reply may arrive on the very
 next poll.
 ```
 
+## Critical Invariant: Forward Upstream Before Contract-Handling Work on Relay Paths
+
+On a relay driver's response path, any operation that enqueues on the
+single-threaded `contract_handling` event loop (GetQuery, PutQuery,
+validate_state, `RequestRelated` recursion, etc.) MUST be sequenced
+AFTER the upstream forward. Reversing this puts WASM `validate_state`
+and the 10s `RELATED_FETCH_TIMEOUT` directly on the upstream-visible
+critical path, where they stack across multi-hop traversals.
+
+```
+RIGHT (issue #4155 fix):
+  let send_result = relay_send_found(...).await;
+  cache_contract_locally(...).await;   // cache opportunistically
+  send_result?;                         // propagate forward error AFTER cache
+
+WRONG (re-introduces #4155):
+  cache_contract_locally(...).await;   // blocks the relay for seconds
+  relay_send_found(...).await?;        // upstream waits for the cache
+```
+
+This applies symmetrically to GET, PUT, UPDATE, SUBSCRIBE relay
+drivers. The source-scrape pin tests
+`all_relay_callsites_forward_before_caching` /
+`relay_driver_forwards_upstream_before_caching_on_found_response` in
+`crates/core/src/operations/get/op_ctx_task.rs` cover GET. Equivalent
+pin tests should be added if a relay driver in another op grows a
+post-forward contract-handling step.
+
+The originator (`drive_client_get_inner`, `drive_client_put_inner`,
+etc.) and sub-op drivers must STILL cache before completing to the
+client — they validate the state for the local client, and skipping
+that would expose unvalidated bytes to the application layer.
+
 ## State Machine Rules
 
 ### WHEN implementing a new operation state

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1968,23 +1968,35 @@ async fn drive_relay_get_inner(
                 .register_peer_interest(&key, peer_key, None, false);
         }
 
-        // Cache locally first (relay already hosting, idempotent).
-        // `is_client_requester=false`: relay peers must not set the sticky
-        // `local_client_access` flag — that's exclusively for the client-
-        // originating node. Legacy mirror: `get.rs:2260-2262` gates on
+        // Forward upstream FIRST to keep cache work off the critical
+        // path (issue #4155). `cache_contract_locally` enqueues a
+        // GetQuery + PutQuery on the single-threaded `contract_handling`
+        // event loop; the PutQuery runs WASM `validate_state` (and may
+        // recursively `RequestRelated` with a 10s
+        // `RELATED_FETCH_TIMEOUT`). When that queue is backed up,
+        // per-hop dwell can reach many seconds. Forwarding first drops
+        // the upstream-visible per-hop dwell from O(validate_state) to
+        // O(channel_send). Caching still happens before this driver
+        // task returns, so local LRU/TTL bookkeeping and
+        // `announce_contract_hosted` semantics are preserved. The
+        // forwarded bytes get re-validated at the next hop / originator,
+        // so the relay doesn't need to validate locally to forward
+        // safely. `is_client_requester=false` on the cache call:
+        // relay peers must not set the sticky `local_client_access`
+        // flag — that's exclusively for the client-originating node.
+        // Legacy mirror: `get.rs:2260-2262` gates on
         // `is_original_requester`.
-        cache_contract_locally(op_manager, key, state.clone(), contract.clone(), false).await;
-
         relay_send_found(
             op_manager,
             incoming_tx,
             instance_id,
             upstream_addr,
             key,
-            state,
-            contract,
+            state.clone(),
+            contract.clone(),
         )
         .await?;
+        cache_contract_locally(op_manager, key, state, contract, false).await;
         return Ok(());
     }
 
@@ -2020,20 +2032,21 @@ async fn drive_relay_get_inner(
                         contract = %key,
                         "GET relay: all peers exhausted — serving local fallback"
                     );
-                    // Relay path: is_client_requester=false (see top-of-loop
-                    // rationale).
-                    cache_contract_locally(op_manager, key, state.clone(), contract.clone(), false)
-                        .await;
+                    // Forward upstream FIRST to keep cache off the critical
+                    // path (issue #4155 — see top-of-loop comment above the
+                    // R4 callsite for the full rationale). Relay path:
+                    // `is_client_requester=false` on the cache call.
                     relay_send_found(
                         op_manager,
                         incoming_tx,
                         instance_id,
                         upstream_addr,
                         key,
-                        state,
-                        contract,
+                        state.clone(),
+                        contract.clone(),
                     )
                     .await?;
+                    cache_contract_locally(op_manager, key, state, contract, false).await;
                 } else {
                     tracing::warn!(
                         tx = %incoming_tx,
@@ -2219,8 +2232,38 @@ async fn drive_relay_get_inner(
                     %instance_id,
                     contract = %key,
                     phase = "relay_found",
-                    "GET relay: downstream returned Found — caching locally and bubbling upstream"
+                    "GET relay: downstream returned Found — bubbling upstream and caching locally"
                 );
+
+                // Feed the relay's successful peer choice into the local
+                // Router. Without this hook, only originator-side successes
+                // train the failure-probability model and per-peer dashboard
+                // panels stay empty on relay-heavy nodes. In-memory only,
+                // safe to run before forwarding.
+                crate::operations::record_relay_route_event(
+                    op_manager,
+                    peer.clone(),
+                    crate::ring::Location::from(&instance_id),
+                    crate::router::RouteOutcome::SuccessUntimed,
+                    crate::node::network_status::OpType::Get,
+                );
+
+                // Bubble up to upstream FIRST to keep cache off the
+                // critical path (issue #4155 — full rationale at the
+                // R4 callsite earlier in this fn). Caching still
+                // happens before this driver task returns, so local
+                // LRU/TTL bookkeeping and `announce_contract_hosted`
+                // semantics are preserved.
+                relay_send_found(
+                    op_manager,
+                    incoming_tx,
+                    instance_id,
+                    upstream_addr,
+                    key,
+                    state.clone(),
+                    contract.clone(),
+                )
+                .await?;
 
                 // Cache locally (relay opportunistically caches forwarded
                 // Found payloads). `is_client_requester=false` so this node
@@ -2231,32 +2274,7 @@ async fn drive_relay_get_inner(
                 // hosting at a relay is still broadcast (matches legacy
                 // `get.rs:2370` which announces on any first-time relay
                 // cache).
-                cache_contract_locally(op_manager, key, state.clone(), contract.clone(), false)
-                    .await;
-
-                // Feed the relay's successful peer choice into the local
-                // Router. Without this hook, only originator-side successes
-                // train the failure-probability model and per-peer dashboard
-                // panels stay empty on relay-heavy nodes.
-                crate::operations::record_relay_route_event(
-                    op_manager,
-                    peer.clone(),
-                    crate::ring::Location::from(&instance_id),
-                    crate::router::RouteOutcome::SuccessUntimed,
-                    crate::node::network_status::OpType::Get,
-                );
-
-                // Bubble up to upstream.
-                relay_send_found(
-                    op_manager,
-                    incoming_tx,
-                    instance_id,
-                    upstream_addr,
-                    key,
-                    state,
-                    contract,
-                )
-                .await?;
+                cache_contract_locally(op_manager, key, state, contract, false).await;
                 return Ok(());
             }
             AttemptOutcome::Terminal(Terminal::Streaming { .. }) => {
@@ -2980,11 +2998,19 @@ mod tests {
         );
     }
 
-    /// T4: Downstream `Response{Found}` must call `cache_contract_locally`
-    /// before calling `relay_send_found`.  Ensures relay opportunistically
-    /// caches contract code.
+    /// T4: Downstream `Response{Found}` must forward upstream FIRST,
+    /// then cache locally. This pins the issue #4155 fix: caching runs
+    /// WASM `validate_state` on the single-threaded contract_handling
+    /// event loop and can take seconds. Forwarding first keeps cache
+    /// time off the upstream-visible critical path. The relay STILL
+    /// caches (just after forwarding) so local LRU/TTL and
+    /// `announce_contract_hosted` semantics are preserved.
+    ///
+    /// Reverting this ordering — putting `cache_contract_locally`
+    /// before `relay_send_found` — re-introduces the per-hop dwell
+    /// latency that #4155 was opened to fix.
     #[test]
-    fn relay_driver_caches_locally_on_found_response() {
+    fn relay_driver_forwards_upstream_before_caching_on_found_response() {
         let src = production_source();
         let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
         // Find the InlineFound arm inside the loop.
@@ -2992,15 +3018,84 @@ mod tests {
             .find("Terminal::InlineFound {")
             .expect("drive_relay_get_inner must handle Terminal::InlineFound");
         let tail = &body[found_arm..];
-        // Find cache and send in order within the arm.
+        // The arm must STILL cache locally — caching is opportunistic
+        // but load-bearing for hosting LRU/TTL.
         let cache_pos = tail.find("cache_contract_locally").unwrap_or(usize::MAX);
         let send_pos = tail.find("relay_send_found").unwrap_or(usize::MAX);
         assert!(
-            cache_pos < send_pos,
-            "cache_contract_locally must be called BEFORE relay_send_found \
-             in the InlineFound arm — the relay must cache the contract before \
-             bubbling the response upstream"
+            cache_pos != usize::MAX,
+            "relay InlineFound arm must STILL call cache_contract_locally — \
+             caching is opportunistic but load-bearing for LRU/TTL and \
+             `announce_contract_hosted` semantics"
         );
+        assert!(
+            send_pos != usize::MAX,
+            "relay InlineFound arm must call relay_send_found"
+        );
+        assert!(
+            send_pos < cache_pos,
+            "issue #4155: relay_send_found must be called BEFORE \
+             cache_contract_locally in the InlineFound arm. Caching first \
+             blocks the upstream-visible forward behind WASM validate_state \
+             on the single-threaded contract_handling event loop, which is \
+             the root cause of the per-hop dwell observed in #4155"
+        );
+    }
+
+    /// T4b: All three relay-driver callsites must forward upstream
+    /// BEFORE caching locally (issue #4155). Mirrors T4 for the other
+    /// two relay paths that the source-scrape
+    /// `all_relay_callsites_pass_is_client_requester_false` test already
+    /// recognizes (R4 immediate-serve, R10 exhaustion fallback, R12a
+    /// bubble-up).
+    #[test]
+    fn all_relay_callsites_forward_before_caching() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+
+        // For each relay-style block in the function, when both
+        // `relay_send_found(` and `cache_contract_locally(` appear, the
+        // forward must come first. We scan all paired occurrences.
+        let send_positions: Vec<usize> = body
+            .match_indices("relay_send_found(")
+            .map(|(i, _)| i)
+            .collect();
+        let cache_positions: Vec<usize> = body
+            .match_indices("cache_contract_locally(")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(
+            send_positions.len(),
+            3,
+            "drive_relay_get_inner should have exactly three \
+             `relay_send_found(` callsites (R4 immediate, R10 fallback, \
+             R12a bubble-up). Found {} — a refactor has changed the shape.",
+            send_positions.len(),
+        );
+        assert_eq!(
+            cache_positions.len(),
+            3,
+            "drive_relay_get_inner should have exactly three \
+             `cache_contract_locally(` callsites. Found {} — a refactor \
+             has changed the shape.",
+            cache_positions.len(),
+        );
+        // Pair them up positionally and verify each `send` comes before
+        // its corresponding `cache`. The two slices are sorted by
+        // position by construction.
+        for (idx, (send_pos, cache_pos)) in send_positions
+            .iter()
+            .zip(cache_positions.iter())
+            .enumerate()
+        {
+            assert!(
+                send_pos < cache_pos,
+                "issue #4155: relay callsite #{idx} must forward upstream \
+                 (`relay_send_found`) BEFORE caching locally \
+                 (`cache_contract_locally`). Found send at {send_pos}, \
+                 cache at {cache_pos}."
+            );
+        }
     }
 
     /// T5: Exhaustion path must send NotFound upstream.

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1976,17 +1976,30 @@ async fn drive_relay_get_inner(
         // `RELATED_FETCH_TIMEOUT`). When that queue is backed up,
         // per-hop dwell can reach many seconds. Forwarding first drops
         // the upstream-visible per-hop dwell from O(validate_state) to
-        // O(channel_send). Caching still happens before this driver
-        // task returns, so local LRU/TTL bookkeeping and
-        // `announce_contract_hosted` semantics are preserved. The
-        // forwarded bytes get re-validated at the next hop / originator,
-        // so the relay doesn't need to validate locally to forward
-        // safely. `is_client_requester=false` on the cache call:
-        // relay peers must not set the sticky `local_client_access`
-        // flag — that's exclusively for the client-originating node.
-        // Legacy mirror: `get.rs:2260-2262` gates on
-        // `is_original_requester`.
-        relay_send_found(
+        // O(channel_send).
+        //
+        // Caching ALWAYS runs after forwarding, even when forwarding
+        // returns Err — this preserves the legacy invariant that LRU/TTL
+        // bookkeeping and `announce_contract_hosted` fire on any successful
+        // wire-level GET. The send error is deferred via `let send_result`
+        // and propagated after the cache call.
+        //
+        // R4 (this site) and R10 read from the local store, so the
+        // `state_matches` short-circuit inside `cache_contract_locally`
+        // skips the expensive PutQuery — the perf win is concentrated
+        // at R12a (downstream-Found bubble-up). We still reorder R4/R10
+        // uniformly so the invariant "forward before cache" holds across
+        // every relay-driver callsite and a future refactor can't
+        // accidentally re-introduce cache-before-forward at any one site.
+        //
+        // The forwarded bytes get re-validated at the next hop /
+        // originator, so the relay doesn't need to validate locally to
+        // forward safely. `is_client_requester=false` on the cache
+        // call: relay peers must not set the sticky
+        // `local_client_access` flag — that's exclusively for the
+        // client-originating node. Legacy mirror: `get.rs:2260-2262`
+        // gates on `is_original_requester`.
+        let send_result = relay_send_found(
             op_manager,
             incoming_tx,
             instance_id,
@@ -1995,8 +2008,9 @@ async fn drive_relay_get_inner(
             state.clone(),
             contract.clone(),
         )
-        .await?;
+        .await;
         cache_contract_locally(op_manager, key, state, contract, false).await;
+        send_result?;
         return Ok(());
     }
 
@@ -2034,9 +2048,11 @@ async fn drive_relay_get_inner(
                     );
                     // Forward upstream FIRST to keep cache off the critical
                     // path (issue #4155 — see top-of-loop comment above the
-                    // R4 callsite for the full rationale). Relay path:
+                    // R4 callsite for the full rationale). Cache ALWAYS
+                    // runs after forwarding so LRU/TTL bookkeeping fires
+                    // even when the forward errors. Relay path:
                     // `is_client_requester=false` on the cache call.
-                    relay_send_found(
+                    let send_result = relay_send_found(
                         op_manager,
                         incoming_tx,
                         instance_id,
@@ -2045,8 +2061,9 @@ async fn drive_relay_get_inner(
                         state.clone(),
                         contract.clone(),
                     )
-                    .await?;
+                    .await;
                     cache_contract_locally(op_manager, key, state, contract, false).await;
+                    send_result?;
                 } else {
                     tracing::warn!(
                         tx = %incoming_tx,
@@ -2232,7 +2249,7 @@ async fn drive_relay_get_inner(
                     %instance_id,
                     contract = %key,
                     phase = "relay_found",
-                    "GET relay: downstream returned Found — bubbling upstream and caching locally"
+                    "GET relay: downstream returned Found — forwarding upstream then caching locally"
                 );
 
                 // Feed the relay's successful peer choice into the local
@@ -2250,11 +2267,15 @@ async fn drive_relay_get_inner(
 
                 // Bubble up to upstream FIRST to keep cache off the
                 // critical path (issue #4155 — full rationale at the
-                // R4 callsite earlier in this fn). Caching still
-                // happens before this driver task returns, so local
-                // LRU/TTL bookkeeping and `announce_contract_hosted`
-                // semantics are preserved.
-                relay_send_found(
+                // R4 callsite earlier in this fn). This is THE site
+                // where the perf win matters: a freshly-arrived
+                // downstream payload has no `state_matches`
+                // short-circuit yet, so the PutQuery runs full WASM
+                // `validate_state` + `update_state`. Caching ALWAYS
+                // runs after forwarding so LRU/TTL and
+                // `announce_contract_hosted` semantics are preserved
+                // even on send error.
+                let send_result = relay_send_found(
                     op_manager,
                     incoming_tx,
                     instance_id,
@@ -2263,7 +2284,7 @@ async fn drive_relay_get_inner(
                     state.clone(),
                     contract.clone(),
                 )
-                .await?;
+                .await;
 
                 // Cache locally (relay opportunistically caches forwarded
                 // Found payloads). `is_client_requester=false` so this node
@@ -2275,6 +2296,7 @@ async fn drive_relay_get_inner(
                 // `get.rs:2370` which announces on any first-time relay
                 // cache).
                 cache_contract_locally(op_manager, key, state, contract, false).await;
+                send_result?;
                 return Ok(());
             }
             AttemptOutcome::Terminal(Terminal::Streaming { .. }) => {


### PR DESCRIPTION
## Problem

GET responses through relays exhibited ~11s per-hop dwell time on a healthy network for low-popularity contracts (#4155). The telemetry from 2026-05-19 showed an 11.6s gap between the downstream peer's `get_response_sent` and the relay emitting `get_success`, despite minimal wire-level latency on either side of the gap.

## Root cause

In `drive_relay_get_inner` (crates/core/src/operations/get/op_ctx_task.rs), all three relay-response paths — R4 immediate-serve, R10 exhaustion fallback, R12a downstream-Found bubble-up — called `cache_contract_locally(...).await` **before** `relay_send_found(...).await?`.

`cache_contract_locally` enqueues a GetQuery + PutQuery on the single-threaded `contract_handling` event loop (`contract.rs:707-710`). The PutQuery synchronously runs WASM `validate_state` and `update_state` on a pool executor (`runtime.rs:1013-1019, 2000-2003`) and may recursively dispatch sub-op GETs via `fetch_related_for_validation` with a 10s `RELATED_FETCH_TIMEOUT` (`runtime.rs:12, 2110`). On a busy node with queued contract operations, the relay couldn't forward the response until all of that completed — and the cost stacked across multi-hop GETs.

## Approach

Reorder all three relay callsites: forward upstream first (a sub-millisecond mpsc send via `OpCtx::send_fire_and_forget`), then cache locally. The send error is deferred via `let send_result` and propagated AFTER the cache call, so the legacy invariant "caching always runs after a successful wire-level GET" is preserved — including on the (rare, shutdown-only) `relay_send_found` error path.

The cache still runs before the driver task returns, so:

- LRU/TTL hosting bookkeeping (`record_get_access`) still happens
- `announce_contract_hosted` and `broadcast_change_interests` still happen
- The relay's local store is still populated for future GETs

The forwarded bytes will be re-validated at the next hop or at the originator, so the relay doesn't need to validate locally to forward safely.

The originator (`drive_client_get_inner`) and sub-op (`drive_sub_op_get`) paths are unchanged — they MUST validate before completing to the local client.

## Where the perf win lives

R12a (downstream-Found bubble-up) is the site that actually saves time: a freshly-arrived payload has no `state_matches` short-circuit and the PutQuery runs full WASM `validate_state` + `update_state`. R4 (immediate-serve from local cache) and R10 (exhaustion fallback) are reordered uniformly for consistency — `state_matches` already short-circuits the PutQuery on those paths — so a future refactor cannot accidentally re-introduce cache-before-forward at any one site without tripping the invariant.

## Effect

Per-hop dwell time on the upstream-visible critical path drops from `O(WASM validate_state + queue wait)` to `O(channel send)`. For a 3-hop GET like the one in #4155 (11.6s gap between two telemetry events spanning multiple hops), the savings stack across hops.

## Reordering of `record_relay_route_event` at R12a

In R12a the in-memory router event used to fire after the cache call; it now fires immediately, before the forward. This is in-memory only (no I/O, no channel send) and the in-line comment names the move.

## Testing

- Inverted the existing source-pinning test `relay_driver_caches_locally_on_found_response` → `relay_driver_forwards_upstream_before_caching_on_found_response`. The new test verifies that:
  - The InlineFound arm STILL calls `cache_contract_locally` (caching is opportunistic but load-bearing for LRU/TTL).
  - `relay_send_found` is called BEFORE `cache_contract_locally`.
- Added `all_relay_callsites_forward_before_caching` that verifies the same invariant at all three relay callsites (R4, R10, R12a) by paired positional scan.
- All 59 `operations::get::op_ctx_task::tests` pass, including the existing `all_relay_callsites_pass_is_client_requester_false` (cache call signatures preserved).
- No behavioral latency test is added — the existing `SeedContract + mock_wasm + send_and_await` compatibility gap (already documented in `test_subscribe_forwarding_ack_relay`) makes a clean latency-regression assertion expensive today. The source-pinning tests prevent re-regression at the lexical level. A behavioral test is a reasonable follow-up once that compatibility gap is fixed.

## Documentation

Added a "Forward Upstream Before Contract-Handling Work on Relay Paths" invariant to `.claude/rules/operations.md`. The same pattern applies symmetrically to PUT, UPDATE, and SUBSCRIBE relay drivers; the source-pinning tests cover GET only, so the rule extends the prevention discipline to future relay-driver work in other ops.

## What this does NOT address

- The structural issue: low-popularity contracts route through many hops because few peers host them. Opportunistic caching helps over time but doesn't help the first GET.
- The single-threaded `contract_handling` event loop: a slow validation still serializes all contract ops on the node. Addressing that requires concurrent dispatch via the existing executor pool — a larger change.
- A CI dwell-time regression test (worth a follow-up issue once the `SeedContract + mock_wasm + send_and_await` interaction is fixed).
- Issue #4154 (peer-disconnect parks GETs for 60+ seconds): orthogonal, separately tracked.

Closes #4155

[AI-assisted - Claude]