### PR TITLE
fix(networking): wake parked op drivers on peer disconnect

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -3859,19 +3859,30 @@ impl P2pConnManager {
                     Some(target_addr) => {
                         // Track `tx → target_addr` so disconnect-cancellation in
                         // `prune_connection` / `handle_orphaned_transactions` can
-                        // wake the parked driver (#4154). The `P2pBridge::send`
-                        // path registers via `sending_transaction`; this branch
-                        // covers the `op_execution_sender` path
-                        // (`send_to_and_await` / `send_fire_and_forget`), which
-                        // bypasses `P2pBridge::send`. Cleanup happens in the
-                        // `TransactionCompleted` handler; duplicate entries from
-                        // CONNECT's `Ring::initiate_connect` registration are
-                        // tolerated by `remove_finished_transaction`.
-                        self.bridge
-                            .op_manager
-                            .ring
-                            .live_tx_tracker
-                            .add_transaction(target_addr, *msg.id());
+                        // wake the parked driver (#4154). Two cases register here:
+                        //   - `send_to_and_await`: this branch just installed a
+                        //     waiter into `pending_op_results` above.
+                        //   - `send_fire_and_forget` from a relay driver running
+                        //     on the originator: the callback is closed (no insert
+                        //     above) but the originator's client driver has an
+                        //     earlier `pending_op_results[tx]` waiter that needs
+                        //     waking.
+                        // Skip when no waiter is present (e.g. cancelled-driver
+                        // teardown races) — registering with nothing to wake would
+                        // leak a live_tx_tracker entry until the peer disconnects.
+                        // `add_transaction` is idempotent + rebind-safe, so the
+                        // CONNECT ride-along (also registered at
+                        // `Ring::initiate_connect`) does not double-count, and a
+                        // relay that response-sends back to its upstream after
+                        // forwarding downstream cleanly migrates the entry.
+                        let tx = *msg.id();
+                        if state.pending_op_results.contains_key(&tx) {
+                            self.bridge
+                                .op_manager
+                                .ring
+                                .live_tx_tracker
+                                .add_transaction(target_addr, tx);
+                        }
                         EventResult::Event(
                             ConnEvent::OutboundMessageWithTarget { target_addr, msg }.into(),
                         )

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -175,11 +175,20 @@ impl P2pBridge {
         }
     }
 
-    /// Log transactions orphaned by a pruned peer connection.
+    /// Wake any drivers whose downstream peer just disconnected.
     ///
-    /// Drivers own retry/cancellation; the orphan list is informational
-    /// only — used by callers to confirm prune occurred. No retry is
-    /// dispatched here.
+    /// For each orphaned `tx` we emit
+    /// `NodeEvent::TransactionCompleted(tx)` via `try_send`. The event-
+    /// loop handler at `NodeEvent::TransactionCompleted` drops the
+    /// matching `pending_op_results` sender, which closes the channel
+    /// the driver is awaiting in `OpCtx::send_and_await`. The driver
+    /// then sees `Err(OpError::NotificationError)`; the shared retry
+    /// loop (`drive_retry_loop`) routes that to `advance()` and tries
+    /// the next peer.
+    ///
+    /// Without this hop, a GET (or other relayed op) issued just before
+    /// its downstream peer disconnected would block for the full
+    /// `OPERATION_TTL` (60 s) before retrying — see #4154.
     pub(crate) async fn handle_orphaned_transactions(
         &self,
         transactions: Vec<Transaction>,
@@ -190,8 +199,11 @@ impl P2pBridge {
         }
         tracing::debug!(
             count = transactions.len(),
-            "Orphaned transactions from pruned connection (driver-owned cancellation)"
+            "Orphaned transactions from pruned connection — waking parked drivers"
         );
+        for tx in transactions {
+            self.op_manager.try_release_pending_op_slot(tx);
+        }
     }
 
     /// Send stream data with an explicit completion signal.
@@ -1968,6 +1980,18 @@ impl P2pConnManager {
                                 if state.pending_op_results.remove(&tx).is_some() {
                                     crate::config::GlobalTestMetrics::record_pending_op_remove();
                                 }
+                                // Clean up live_tx_tracker too. `handle_op_execution`
+                                // registers `(tx → target_addr)` for messages with an
+                                // explicit target (#4154) so that disconnect-cancellation
+                                // can find the tx. Without this cleanup those entries
+                                // would leak past op completion. Idempotent with the
+                                // explicit `op_manager.completed(client_tx)` that
+                                // drivers call on terminal exit.
+                                ctx.bridge
+                                    .op_manager
+                                    .ring
+                                    .live_tx_tracker
+                                    .remove_finished_transaction(tx);
                             }
                             NodeEvent::LocalSubscribeComplete {
                                 tx,
@@ -3833,9 +3857,34 @@ impl P2pConnManager {
                 // would otherwise short-circuit in `process_message` and never
                 // register as a downstream subscriber on the home node.
                 match target_addr {
-                    Some(target_addr) => EventResult::Event(
-                        ConnEvent::OutboundMessageWithTarget { target_addr, msg }.into(),
-                    ),
+                    Some(target_addr) => {
+                        // Track `tx → target_addr` so that if the downstream
+                        // peer disconnects before the reply arrives,
+                        // `prune_connection` enumerates this tx and
+                        // `handle_orphaned_transactions` wakes the parked
+                        // driver (#4154). `send()`-path messages already
+                        // registered via `sending_transaction`; this
+                        // covers the `op_execution_sender` path used by
+                        // `send_to_and_await` / `send_fire_and_forget`
+                        // (originator-loopback relay forward), which
+                        // bypasses `P2pBridge::send` entirely.
+                        //
+                        // Cleanup happens in the `TransactionCompleted`
+                        // handler which calls `remove_finished_transaction`.
+                        // A duplicate entry from CONNECT (which also
+                        // registers at `Ring::initiate_connect`) is
+                        // tolerated — `remove_finished_transaction` /
+                        // `prune_transactions_from_peer` clear all matching
+                        // entries.
+                        self.bridge
+                            .op_manager
+                            .ring
+                            .live_tx_tracker
+                            .add_transaction(target_addr, *msg.id());
+                        EventResult::Event(
+                            ConnEvent::OutboundMessageWithTarget { target_addr, msg }.into(),
+                        )
+                    }
                     None => EventResult::Event(ConnEvent::InboundMessage(msg.into()).into()),
                 }
             }
@@ -5409,6 +5458,39 @@ mod tests {
             GlobalTestMetrics::pending_op_removes() - removes_before,
             3,
             "Drop must record one pending_op_remove per resident entry"
+        );
+    }
+
+    /// Regression guard for #4154: `handle_orphaned_transactions` must not
+    /// revert to a logging-only stub. The orphan handler must actively
+    /// wake parked drivers — otherwise a GET (or relayed op) issued just
+    /// before its downstream peer disconnects blocks the full
+    /// `OPERATION_TTL` (60 s) before retrying.
+    ///
+    /// We assert the function body calls `try_release_pending_op_slot`
+    /// (the standalone helper that emits `TransactionCompleted` so the
+    /// event loop drops the matching `pending_op_results` sender). If a
+    /// future refactor renames the helper, update both the call site and
+    /// this guard together.
+    #[test]
+    fn handle_orphaned_transactions_wakes_parked_drivers() {
+        let src = include_str!("p2p_protoc.rs");
+        let handler_start = src
+            .find("pub(crate) async fn handle_orphaned_transactions(")
+            .expect("handle_orphaned_transactions must exist");
+        // Take everything up to the end of the function (the next `}` at
+        // column 0 — `async fn` impl methods close at indent level 4, so
+        // `\n    }\n` reliably bounds it).
+        let body_after = &src[handler_start..];
+        let end = body_after
+            .find("\n    }\n")
+            .expect("handle_orphaned_transactions must close cleanly");
+        let body = &body_after[..end];
+        assert!(
+            body.contains("try_release_pending_op_slot"),
+            "handle_orphaned_transactions must call \
+             try_release_pending_op_slot to wake parked drivers (#4154). \
+             Found body:\n{body}"
         );
     }
 

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -1980,12 +1980,11 @@ impl P2pConnManager {
                                 if state.pending_op_results.remove(&tx).is_some() {
                                     crate::config::GlobalTestMetrics::record_pending_op_remove();
                                 }
-                                // Clean up live_tx_tracker too. `handle_op_execution`
-                                // registers `(tx → target_addr)` for messages with an
-                                // explicit target (#4154) so that disconnect-cancellation
-                                // can find the tx. Without this cleanup those entries
-                                // would leak past op completion. Idempotent with the
-                                // explicit `op_manager.completed(client_tx)` that
+                                // Clean up the `live_tx_tracker` entry registered
+                                // by `handle_op_execution` for messages with an
+                                // explicit target (#4154); otherwise per-attempt
+                                // entries leak past op completion. Idempotent with
+                                // the `op_manager.completed(client_tx)` that
                                 // drivers call on terminal exit.
                                 ctx.bridge
                                     .op_manager
@@ -3858,24 +3857,16 @@ impl P2pConnManager {
                 // register as a downstream subscriber on the home node.
                 match target_addr {
                     Some(target_addr) => {
-                        // Track `tx → target_addr` so that if the downstream
-                        // peer disconnects before the reply arrives,
-                        // `prune_connection` enumerates this tx and
-                        // `handle_orphaned_transactions` wakes the parked
-                        // driver (#4154). `send()`-path messages already
-                        // registered via `sending_transaction`; this
-                        // covers the `op_execution_sender` path used by
-                        // `send_to_and_await` / `send_fire_and_forget`
-                        // (originator-loopback relay forward), which
-                        // bypasses `P2pBridge::send` entirely.
-                        //
-                        // Cleanup happens in the `TransactionCompleted`
-                        // handler which calls `remove_finished_transaction`.
-                        // A duplicate entry from CONNECT (which also
-                        // registers at `Ring::initiate_connect`) is
-                        // tolerated — `remove_finished_transaction` /
-                        // `prune_transactions_from_peer` clear all matching
-                        // entries.
+                        // Track `tx → target_addr` so disconnect-cancellation in
+                        // `prune_connection` / `handle_orphaned_transactions` can
+                        // wake the parked driver (#4154). The `P2pBridge::send`
+                        // path registers via `sending_transaction`; this branch
+                        // covers the `op_execution_sender` path
+                        // (`send_to_and_await` / `send_fire_and_forget`), which
+                        // bypasses `P2pBridge::send`. Cleanup happens in the
+                        // `TransactionCompleted` handler; duplicate entries from
+                        // CONNECT's `Ring::initiate_connect` registration are
+                        // tolerated by `remove_finished_transaction`.
                         self.bridge
                             .op_manager
                             .ring
@@ -5462,25 +5453,16 @@ mod tests {
     }
 
     /// Regression guard for #4154: `handle_orphaned_transactions` must not
-    /// revert to a logging-only stub. The orphan handler must actively
-    /// wake parked drivers — otherwise a GET (or relayed op) issued just
-    /// before its downstream peer disconnects blocks the full
-    /// `OPERATION_TTL` (60 s) before retrying.
-    ///
-    /// We assert the function body calls `try_release_pending_op_slot`
-    /// (the standalone helper that emits `TransactionCompleted` so the
-    /// event loop drops the matching `pending_op_results` sender). If a
-    /// future refactor renames the helper, update both the call site and
-    /// this guard together.
+    /// revert to a logging-only stub. If a future refactor renames the
+    /// helper, update both the call site and this guard together.
     #[test]
     fn handle_orphaned_transactions_wakes_parked_drivers() {
         let src = include_str!("p2p_protoc.rs");
         let handler_start = src
             .find("pub(crate) async fn handle_orphaned_transactions(")
             .expect("handle_orphaned_transactions must exist");
-        // Take everything up to the end of the function (the next `}` at
-        // column 0 — `async fn` impl methods close at indent level 4, so
-        // `\n    }\n` reliably bounds it).
+        // Bound the body at the next `\n    }\n` — `async fn` impl methods
+        // close at indent level 4.
         let body_after = &src[handler_start..];
         let end = body_after
             .find("\n    }\n")

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -3870,9 +3870,13 @@ impl P2pConnManager {
                         // Skip when no waiter is present (e.g. cancelled-driver
                         // teardown races) — registering with nothing to wake would
                         // leak a live_tx_tracker entry until the peer disconnects.
-                        // Duplicate entries from CONNECT's `Ring::initiate_connect`
-                        // registration are tolerated by `remove_finished_transaction`,
-                        // which uses `retain` to clear all matching entries.
+                        // Same-peer duplicates (e.g. CONNECT's parallel
+                        // `Ring::initiate_connect` registration) are tolerated by
+                        // `remove_finished_transaction`'s per-peer `retain`. Cross-
+                        // peer rebinds (same tx forwarded to two peers in turn) leave
+                        // a stale entry on the earlier peer until that peer
+                        // disconnects — a known limitation documented in
+                        // `LiveTransactionTracker::add_transaction`'s rustdoc.
                         let tx = *msg.id();
                         if state.pending_op_results.contains_key(&tx) {
                             self.bridge

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -3870,11 +3870,9 @@ impl P2pConnManager {
                         // Skip when no waiter is present (e.g. cancelled-driver
                         // teardown races) — registering with nothing to wake would
                         // leak a live_tx_tracker entry until the peer disconnects.
-                        // `add_transaction` is idempotent + rebind-safe, so the
-                        // CONNECT ride-along (also registered at
-                        // `Ring::initiate_connect`) does not double-count, and a
-                        // relay that response-sends back to its upstream after
-                        // forwarding downstream cleanly migrates the entry.
+                        // Duplicate entries from CONNECT's `Ring::initiate_connect`
+                        // registration are tolerated by `remove_finished_transaction`,
+                        // which uses `retain` to clear all matching entries.
                         let tx = *msg.id();
                         if state.pending_op_results.contains_key(&tx) {
                             self.bridge

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -378,6 +378,21 @@ impl OpManager {
         }
     }
 
+    /// Non-blocking variant of [`Self::release_pending_op_slot`]: emits
+    /// `NodeEvent::TransactionCompleted(tx)` via `try_send`.
+    ///
+    /// Safe to call from the network event loop, where awaiting the
+    /// notification channel would risk deadlock. The notification is
+    /// best-effort: if the channel is momentarily full, the driver
+    /// parked in `OpCtx::send_and_await` for `tx` falls back to waiting
+    /// for the `OPERATION_TTL` timeout.
+    ///
+    /// Used by `P2pBridge::handle_orphaned_transactions` to wake
+    /// drivers whose downstream peer has just disconnected (#4154).
+    pub(crate) fn try_release_pending_op_slot(&self, tx: Transaction) {
+        try_release_pending_op_slot_on(&self.to_event_listener.notifications_sender, tx);
+    }
+
     /// Timeout for sending notifications to the event loop.
     /// If the channel is full for this long, the event loop is stuck and sending will never succeed.
     const NOTIFICATION_SEND_TIMEOUT: Duration = Duration::from_secs(30);
@@ -835,6 +850,42 @@ async fn release_pending_op_slot_on(
     }
 }
 
+/// Non-blocking emit of `NodeEvent::TransactionCompleted(tx)` on the
+/// event-loop notification channel.
+///
+/// Extracted from [`OpManager::try_release_pending_op_slot`] so it can be
+/// exercised in unit tests without building a full `OpManager`. Returns
+/// `true` when the notification was enqueued.
+///
+/// Safe to call from inside the network event loop (where `send().await`
+/// could deadlock). Best-effort: a momentarily-full channel produces a
+/// warning, and the parked driver falls back to its `OPERATION_TTL`
+/// timeout. See #4154 for the disconnect-orphan scenario this powers.
+fn try_release_pending_op_slot_on(
+    notifications_sender: &mpsc::Sender<Either<NetMessage, NodeEvent>>,
+    tx: Transaction,
+) -> bool {
+    match notifications_sender.try_send(Either::Right(NodeEvent::TransactionCompleted(tx))) {
+        Ok(()) => true,
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            tracing::warn!(
+                %tx,
+                "try_release_pending_op_slot: notification channel full; \
+                 driver will wait for OPERATION_TTL timeout"
+            );
+            false
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            tracing::warn!(
+                %tx,
+                "try_release_pending_op_slot: notification channel closed; \
+                 receiver likely dropped"
+            );
+            false
+        }
+    }
+}
+
 /// Notify the event loop about a timed-out transaction without blocking.
 ///
 /// Uses `try_send` instead of `.send().await` to avoid blocking the garbage
@@ -1238,7 +1289,9 @@ mod tests {
             Either::Right(NodeEvent::TransactionCompleted(observed)) => {
                 assert_eq!(observed, tx, "emitted tx must match the argument");
             }
-            other => panic!("expected TransactionCompleted, got {other:?}"),
+            other @ Either::Left(_) | other @ Either::Right(_) => {
+                panic!("expected TransactionCompleted, got {other:?}")
+            }
         }
     }
 
@@ -1356,6 +1409,146 @@ mod tests {
             result.is_ok(),
             "helper must return promptly on closed channel"
         );
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // Regression tests for #4154: parked GET drivers must be woken
+    // when their downstream peer disconnects, not wait `OPERATION_TTL`.
+    //
+    // Before the fix, `P2pBridge::handle_orphaned_transactions` only
+    // logged the orphan list (`driver-owned cancellation` was
+    // aspirational — nothing ever cancelled). A GET op forwarded to a
+    // peer that then disconnected blocked in
+    // `OpCtx::send_and_await::response_receiver.recv()` for the full
+    // 60 s `OPERATION_TTL` before retrying — exactly the 62 s stall
+    // captured in the issue's telemetry.
+    //
+    // The fix wires `handle_orphaned_transactions` to emit
+    // `TransactionCompleted(tx)` for each orphan via the standalone
+    // helper `try_release_pending_op_slot_on`. The event-loop handler
+    // drops the matching `pending_op_results` sender, which closes the
+    // driver's response channel; `recv()` returns `None`, mapped to
+    // `OpError::NotificationError` by `send_and_await`; the retry loop
+    // advances to the next peer in milliseconds rather than seconds.
+    // ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn try_release_pending_op_slot_emits_transaction_completed() {
+        // Happy path: the standalone helper enqueues exactly one
+        // `TransactionCompleted(tx)` on the notification channel.
+        let (receiver, notifier) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut notifications_receiver,
+            ..
+        } = receiver;
+
+        let tx = Transaction::ttl_transaction();
+
+        let delivered = super::try_release_pending_op_slot_on(notifier.notifications_sender(), tx);
+        assert!(delivered, "helper must enqueue on a live channel");
+
+        let received = timeout(Duration::from_millis(100), notifications_receiver.recv())
+            .await
+            .expect("timed out waiting for TransactionCompleted emission")
+            .expect("notification channel closed");
+
+        match received {
+            Either::Right(NodeEvent::TransactionCompleted(observed)) => {
+                assert_eq!(observed, tx, "emitted tx must match the argument");
+            }
+            other @ Either::Left(_) | other @ Either::Right(_) => {
+                panic!("expected TransactionCompleted, got {other:?}")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn try_release_pending_op_slot_handles_dropped_receiver() {
+        // Closed channel: helper must return `false` rather than panic
+        // — disconnect cleanup must remain robust when the event loop
+        // has already torn down (e.g. shutdown races).
+        let (receiver, notifier) = event_loop_notification_channel();
+        drop(receiver);
+
+        let tx = Transaction::ttl_transaction();
+        let delivered = super::try_release_pending_op_slot_on(notifier.notifications_sender(), tx);
+        assert!(
+            !delivered,
+            "helper must return false once receiver is dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn orphaned_transaction_wakes_parked_pending_op_results_waiter() {
+        // End-to-end pipeline test for #4154 without standing up a
+        // full node:
+        //
+        // 1. Driver calls `OpCtx::send_and_await` → event loop installs
+        //    a `Sender<NetMessage>` in `pending_op_results[tx]`. The
+        //    driver holds the `Receiver` and awaits `recv()`.
+        // 2. Downstream peer disconnects → `prune_connection` returns
+        //    `[tx]` from `live_tx_tracker`.
+        // 3. `handle_orphaned_transactions` calls
+        //    `try_release_pending_op_slot(tx)` (via the helper) to emit
+        //    `TransactionCompleted(tx)`.
+        // 4. Event loop processes the event → drops the sender from
+        //    `pending_op_results`.
+        // 5. Driver's `Receiver::recv()` returns `None` immediately
+        //    (channel closed) — driver advances to the next peer.
+        //
+        // Pre-fix, step 3 was a no-op and step 5 never happened; the
+        // driver blocked the full `OPERATION_TTL` (60 s). This test
+        // forces the wake to complete in well under a second.
+        let (mut event_loop_receiver, notifier) = event_loop_notification_channel();
+
+        // (1) Simulate the `pending_op_results[tx] = sender` registration
+        // and the driver's pending `recv()`.
+        let (response_sender, mut driver_response_rx) =
+            tokio::sync::mpsc::channel::<crate::message::NetMessage>(1);
+        let mut pending_op_results: std::collections::HashMap<
+            Transaction,
+            tokio::sync::mpsc::Sender<crate::message::NetMessage>,
+        > = std::collections::HashMap::new();
+        let tx = Transaction::ttl_transaction();
+        pending_op_results.insert(tx, response_sender);
+
+        // (3) Trigger the wake — the orphan-handler path under test.
+        let delivered = super::try_release_pending_op_slot_on(notifier.notifications_sender(), tx);
+        assert!(delivered, "orphan-handler helper must enqueue notification");
+
+        // (4) Mimic the event loop's `TransactionCompleted` arm:
+        // drop the sender from `pending_op_results`.
+        let event = timeout(
+            Duration::from_millis(100),
+            event_loop_receiver.notifications_receiver.recv(),
+        )
+        .await
+        .expect("event loop never received TransactionCompleted")
+        .expect("notification channel closed before TransactionCompleted arrived");
+        match event {
+            Either::Right(NodeEvent::TransactionCompleted(observed)) => {
+                assert_eq!(observed, tx);
+                pending_op_results.remove(&observed);
+            }
+            other @ Either::Left(_) | other @ Either::Right(_) => {
+                panic!("expected TransactionCompleted, got {other:?}")
+            }
+        }
+
+        // (5) The driver's `recv()` must now resolve to `None`
+        // immediately. Pre-fix this would have hung the full
+        // `OPERATION_TTL`; we cap the test at 100 ms to fail fast.
+        let driver_wakeup = timeout(Duration::from_millis(100), driver_response_rx.recv()).await;
+        match driver_wakeup {
+            Ok(None) => {
+                // Channel closed, driver wakes with `Err(NotificationError)` — correct.
+            }
+            Ok(Some(msg)) => panic!("driver received unexpected message: {msg:?}"),
+            Err(_) => panic!(
+                "driver did not wake after orphan handling — \
+                 pre-#4154 behavior reproduced"
+            ),
+        }
     }
 
     #[test]

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -378,17 +378,13 @@ impl OpManager {
         }
     }
 
-    /// Non-blocking variant of [`Self::release_pending_op_slot`]: emits
-    /// `NodeEvent::TransactionCompleted(tx)` via `try_send`.
-    ///
-    /// Safe to call from the network event loop, where awaiting the
-    /// notification channel would risk deadlock. The notification is
-    /// best-effort: if the channel is momentarily full, the driver
-    /// parked in `OpCtx::send_and_await` for `tx` falls back to waiting
-    /// for the `OPERATION_TTL` timeout.
-    ///
-    /// Used by `P2pBridge::handle_orphaned_transactions` to wake
-    /// drivers whose downstream peer has just disconnected (#4154).
+    /// Non-blocking variant of [`Self::release_pending_op_slot`] for callers
+    /// that run on the network event loop (where `send().await` could
+    /// deadlock). Used by `P2pBridge::handle_orphaned_transactions` to wake
+    /// drivers whose downstream peer has just disconnected (#4154). The
+    /// notification is best-effort: on a transiently-full channel the
+    /// driver falls back to its `OPERATION_TTL` timeout. See
+    /// [`try_release_pending_op_slot_on`] for the underlying send logic.
     pub(crate) fn try_release_pending_op_slot(&self, tx: Transaction) {
         try_release_pending_op_slot_on(&self.to_event_listener.notifications_sender, tx);
     }
@@ -851,16 +847,12 @@ async fn release_pending_op_slot_on(
 }
 
 /// Non-blocking emit of `NodeEvent::TransactionCompleted(tx)` on the
-/// event-loop notification channel.
+/// event-loop notification channel; returns `true` when enqueued.
 ///
 /// Extracted from [`OpManager::try_release_pending_op_slot`] so it can be
-/// exercised in unit tests without building a full `OpManager`. Returns
-/// `true` when the notification was enqueued.
-///
-/// Safe to call from inside the network event loop (where `send().await`
-/// could deadlock). Best-effort: a momentarily-full channel produces a
-/// warning, and the parked driver falls back to its `OPERATION_TTL`
-/// timeout. See #4154 for the disconnect-orphan scenario this powers.
+/// exercised in unit tests without building a full `OpManager`. Best-effort:
+/// a momentarily-full or closed channel produces a warning and the parked
+/// driver falls back to its `OPERATION_TTL` timeout (#4154).
 fn try_release_pending_op_slot_on(
     notifications_sender: &mpsc::Sender<Either<NetMessage, NodeEvent>>,
     tx: Transaction,
@@ -1284,7 +1276,6 @@ mod tests {
             .expect("timed out waiting for TransactionCompleted emission")
             .expect("notification channel closed");
 
-        #[allow(clippy::wildcard_enum_match_arm)]
         match received {
             Either::Right(NodeEvent::TransactionCompleted(observed)) => {
                 assert_eq!(observed, tx, "emitted tx must match the argument");
@@ -1412,24 +1403,15 @@ mod tests {
     }
 
     // ──────────────────────────────────────────────────────────
-    // Regression tests for #4154: parked GET drivers must be woken
-    // when their downstream peer disconnects, not wait `OPERATION_TTL`.
-    //
-    // Before the fix, `P2pBridge::handle_orphaned_transactions` only
-    // logged the orphan list (`driver-owned cancellation` was
-    // aspirational — nothing ever cancelled). A GET op forwarded to a
-    // peer that then disconnected blocked in
-    // `OpCtx::send_and_await::response_receiver.recv()` for the full
-    // 60 s `OPERATION_TTL` before retrying — exactly the 62 s stall
-    // captured in the issue's telemetry.
-    //
-    // The fix wires `handle_orphaned_transactions` to emit
-    // `TransactionCompleted(tx)` for each orphan via the standalone
-    // helper `try_release_pending_op_slot_on`. The event-loop handler
-    // drops the matching `pending_op_results` sender, which closes the
-    // driver's response channel; `recv()` returns `None`, mapped to
-    // `OpError::NotificationError` by `send_and_await`; the retry loop
-    // advances to the next peer in milliseconds rather than seconds.
+    // Regression tests for #4154: parked drivers must be woken when
+    // their downstream peer disconnects, not wait `OPERATION_TTL`.
+    // Pre-fix, `handle_orphaned_transactions` only logged orphans and
+    // a forwarded GET blocked the full 60 s before retrying. The fix
+    // emits `TransactionCompleted(tx)` per orphan via
+    // `try_release_pending_op_slot_on`, the event loop drops the
+    // matching `pending_op_results` sender, and the driver's `recv()`
+    // returns `None` — `send_and_await` maps that to
+    // `OpError::NotificationError` and the retry loop advances.
     // ──────────────────────────────────────────────────────────
 
     #[tokio::test]
@@ -1480,29 +1462,14 @@ mod tests {
 
     #[tokio::test]
     async fn orphaned_transaction_wakes_parked_pending_op_results_waiter() {
-        // End-to-end pipeline test for #4154 without standing up a
-        // full node:
-        //
-        // 1. Driver calls `OpCtx::send_and_await` → event loop installs
-        //    a `Sender<NetMessage>` in `pending_op_results[tx]`. The
-        //    driver holds the `Receiver` and awaits `recv()`.
-        // 2. Downstream peer disconnects → `prune_connection` returns
-        //    `[tx]` from `live_tx_tracker`.
-        // 3. `handle_orphaned_transactions` calls
-        //    `try_release_pending_op_slot(tx)` (via the helper) to emit
-        //    `TransactionCompleted(tx)`.
-        // 4. Event loop processes the event → drops the sender from
-        //    `pending_op_results`.
-        // 5. Driver's `Receiver::recv()` returns `None` immediately
-        //    (channel closed) — driver advances to the next peer.
-        //
-        // Pre-fix, step 3 was a no-op and step 5 never happened; the
-        // driver blocked the full `OPERATION_TTL` (60 s). This test
-        // forces the wake to complete in well under a second.
+        // End-to-end pipeline test for #4154 without standing up a full
+        // node. Reproduces the driver → notification-channel → event-
+        // loop → sender-drop → driver-wakeup sequence and asserts it
+        // completes in under 100 ms (pre-fix it would hang `OPERATION_TTL`).
         let (mut event_loop_receiver, notifier) = event_loop_notification_channel();
 
-        // (1) Simulate the `pending_op_results[tx] = sender` registration
-        // and the driver's pending `recv()`.
+        // Stand in for `pending_op_results[tx] = sender` and the driver's
+        // pending `recv()` on the matching receiver.
         let (response_sender, mut driver_response_rx) =
             tokio::sync::mpsc::channel::<crate::message::NetMessage>(1);
         let mut pending_op_results: std::collections::HashMap<
@@ -1512,12 +1479,12 @@ mod tests {
         let tx = Transaction::ttl_transaction();
         pending_op_results.insert(tx, response_sender);
 
-        // (3) Trigger the wake — the orphan-handler path under test.
+        // Trigger the wake — this is the orphan-handler path under test.
         let delivered = super::try_release_pending_op_slot_on(notifier.notifications_sender(), tx);
         assert!(delivered, "orphan-handler helper must enqueue notification");
 
-        // (4) Mimic the event loop's `TransactionCompleted` arm:
-        // drop the sender from `pending_op_results`.
+        // Mimic the event loop's `TransactionCompleted` arm by dropping the
+        // sender out of `pending_op_results`.
         let event = timeout(
             Duration::from_millis(100),
             event_loop_receiver.notifications_receiver.recv(),
@@ -1535,9 +1502,8 @@ mod tests {
             }
         }
 
-        // (5) The driver's `recv()` must now resolve to `None`
-        // immediately. Pre-fix this would have hung the full
-        // `OPERATION_TTL`; we cap the test at 100 ms to fail fast.
+        // The driver's `recv()` must now resolve to `None` immediately —
+        // pre-fix this hung the full `OPERATION_TTL`. Cap at 100 ms.
         let driver_wakeup = timeout(Duration::from_millis(100), driver_response_rx.recv()).await;
         match driver_wakeup {
             Ok(None) => {

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -25,8 +25,14 @@
 //!
 //! # Connection-drop latency
 //!
-//! Disconnect detection relies on `OPERATION_TTL` (60s) — accepted
-//! ceiling.
+//! Disconnect detection is event-driven: when a peer disconnects,
+//! `Ring::prune_connection` enumerates `LiveTransactionTracker` orphans
+//! and `P2pBridge::handle_orphaned_transactions` emits
+//! `NodeEvent::TransactionCompleted` for each, which closes the
+//! parked driver's `pending_op_results` waiter. Wake latency is
+//! sub-millisecond (#4154). `OPERATION_TTL` (60 s) remains the upper
+//! bound for cases where the downstream peer never formally
+//! disconnects — silent stalls, slow-loris, partition-without-prune.
 
 use std::net::SocketAddr;
 use std::sync::Arc;

--- a/crates/core/src/ring/live_tx.rs
+++ b/crates/core/src/ring/live_tx.rs
@@ -261,4 +261,34 @@ mod tests {
         let pruned = tracker.prune_transactions_from_peer(addr1);
         assert!(pruned.is_empty());
     }
+
+    /// Pins the load-bearing invariant for `Ring::connection_maintenance`
+    /// (`crates/core/src/ring.rs:2360-2365`): once a `tx` has been
+    /// registered against a peer, `has_live_connection(that_peer)` must
+    /// remain `true` until the tx is explicitly cleared, even after the
+    /// same `tx` is re-registered against another peer.
+    ///
+    /// Tightening this (`add_transaction` made rebind-safe in an earlier
+    /// commit of #4164) caused `test_six_peer_contract_lifecycle` to
+    /// diverge: topology saw a wider candidate-neighbor set and made a
+    /// different RemoveConnections decision, breaking a CRDT broadcast
+    /// chain. See the topology-coupling note in
+    /// `LiveTransactionTracker::add_transaction`'s rustdoc.
+    #[test]
+    fn add_transaction_rebind_preserves_old_peer_has_live_connection() {
+        let tracker = LiveTransactionTracker::new();
+        let addr1: SocketAddr = "127.0.0.1:9001".parse().unwrap();
+        let addr2: SocketAddr = "127.0.0.1:9002".parse().unwrap();
+        let tx = Transaction::new::<GetMsg>();
+
+        tracker.add_transaction(addr1, tx);
+        tracker.add_transaction(addr2, tx);
+
+        assert!(
+            tracker.has_live_connection(addr1),
+            "old peer must retain has_live_connection=true after rebind \
+             (topology-coupling invariant for Ring::connection_maintenance)"
+        );
+        assert!(tracker.has_live_connection(addr2));
+    }
 }

--- a/crates/core/src/ring/live_tx.rs
+++ b/crates/core/src/ring/live_tx.rs
@@ -19,47 +19,23 @@ pub struct LiveTransactionTracker {
 }
 
 impl LiveTransactionTracker {
-    /// Register that transaction `tx` is in flight to `peer_addr`.
-    ///
-    /// Single-writer-per-tx semantics: callers ARE expected to serialize
-    /// registrations for the same `tx` (typically a single driver task
-    /// owns each transaction). Under that contract:
-    /// - Same `(peer_addr, tx)` re-registration is a no-op (no Vec duplication).
-    /// - Re-registering `tx` to a different peer scrubs the previous
-    ///   peer's forward-index entry, so a tx that flows through multiple
-    ///   peers ends up tracked against exactly the most recent one.
-    ///   Pre-#4154 a CONNECT ride-along (`Ring::initiate_connect` +
-    ///   `handle_op_execution`) silently double-counted in
-    ///   `active_connect_transaction_count`; a relay re-sending
-    ///   response-side to its upstream after sending the request-side
-    ///   downstream left a stale entry on the downstream peer that only
-    ///   cleaned up on disconnect.
-    ///
-    /// Concurrency caveat: the two DashMap operations (reverse-index
-    /// insert + forward-index push/scrub) are individually atomic but
-    /// NOT serialized as a pair. If a racing `remove_finished_transaction`
-    /// slips between them, an orphan forward-index entry can remain
-    /// until the peer disconnects — `prune_transactions_from_peer`
-    /// reaps it then. This matches the pre-#4154 fallback behavior,
-    /// not the wake-on-disconnect fast path. Hold single-writer
-    /// discipline or add per-tx serialization at the call site if the
-    /// race becomes problematic.
     pub fn add_transaction(&self, peer_addr: SocketAddr, tx: Transaction) {
-        let prev = self.peer_for_tx.insert(tx, peer_addr);
-        match prev {
-            Some(prev_addr) if prev_addr == peer_addr => {
-                // Idempotent re-registration; don't duplicate in tx_per_peer's Vec.
-                return;
-            }
-            Some(prev_addr) => {
-                // Different peer: scrub the stale forward-index entry.
-                self.tx_per_peer.remove_if_mut(&prev_addr, |_, v| {
-                    v.retain(|otx| otx != &tx);
-                    v.is_empty()
-                });
-            }
-            None => {}
-        }
+        // Insert to reverse index first to prevent race condition:
+        // If remove_finished_transaction runs concurrently, it will find the tx
+        // in peer_for_tx and clean up properly. If we did tx_per_peer first,
+        // a concurrent remove could miss the tx in peer_for_tx and leave orphans.
+        //
+        // NOTE: this is the pre-#4154 behavior. Re-registering the same
+        // `tx` against multiple peers leaves stale entries in the older
+        // peers' `tx_per_peer` Vec. Rebind-safe semantics were attempted
+        // in PR #4164 but interacted badly with topology maintenance:
+        // the "inflated" Vec entries acted as a soft signal that masked
+        // peers from neighbor consideration, and tightening that
+        // semantic caused `test_six_peer_contract_lifecycle` to diverge
+        // (CRDT broadcast missed one peer). Until topology maintenance
+        // is decoupled from `has_live_connection`, keep the loose
+        // semantics here.
+        self.peer_for_tx.insert(tx, peer_addr);
         self.tx_per_peer.entry(peer_addr).or_default().push(tx);
     }
 
@@ -284,72 +260,5 @@ mod tests {
         // Prune nonexistent peer returns empty
         let pruned = tracker.prune_transactions_from_peer(addr1);
         assert!(pruned.is_empty());
-    }
-
-    /// Regression for #4154: re-registering the same `(peer, tx)` pair
-    /// must be a no-op (no Vec duplication). The CONNECT ride-along
-    /// path (`Ring::initiate_connect` adds `(gw, tx)`, then
-    /// `handle_op_execution` re-adds the same pair when the request
-    /// flows through `send_to_and_collect_replies`) otherwise inflates
-    /// `active_connect_transaction_count` and throttles concurrent
-    /// CONNECT acquisitions.
-    #[test]
-    fn add_transaction_is_idempotent_for_same_pair() {
-        let tracker = LiveTransactionTracker::new();
-        let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
-        let tx = Transaction::new::<ConnectMsg>();
-
-        tracker.add_transaction(addr, tx);
-        tracker.add_transaction(addr, tx);
-        tracker.add_transaction(addr, tx);
-
-        assert_eq!(tracker.active_transaction_count(), 1);
-        assert_eq!(tracker.active_connect_transaction_count(), 1);
-        assert_eq!(tracker.peer_for_tx.len(), 1);
-
-        // Single removal must clean both indices fully.
-        tracker.remove_finished_transaction(tx);
-        assert_eq!(tracker.active_transaction_count(), 0);
-        assert!(!tracker.has_live_connection(addr));
-        assert_eq!(tracker.peer_for_tx.len(), 0);
-    }
-
-    /// Regression for #4154: a relay that forwards a request downstream
-    /// then later sends a response back upstream re-registers the same
-    /// tx against a different peer. Before the fix, the old peer's
-    /// forward-index Vec retained the tx until that peer disconnected.
-    /// After the fix, the second registration scrubs the stale entry.
-    #[test]
-    fn add_transaction_rebinds_to_new_peer() {
-        let tracker = LiveTransactionTracker::new();
-        let downstream: SocketAddr = "127.0.0.1:9001".parse().unwrap();
-        let upstream: SocketAddr = "127.0.0.1:9002".parse().unwrap();
-        let tx = Transaction::new::<GetMsg>();
-
-        // Relay first forwards request to downstream.
-        tracker.add_transaction(downstream, tx);
-        assert!(tracker.has_live_connection(downstream));
-        assert!(!tracker.has_live_connection(upstream));
-
-        // Then forwards the response back to upstream — `tx` migrates.
-        tracker.add_transaction(upstream, tx);
-        assert!(
-            !tracker.has_live_connection(downstream),
-            "downstream's stale forward-index entry must be scrubbed"
-        );
-        assert!(tracker.has_live_connection(upstream));
-        assert_eq!(tracker.peer_for_tx.len(), 1);
-        assert_eq!(tracker.active_transaction_count(), 1);
-
-        // Pruning the (now-stale) downstream peer must NOT find `tx`.
-        let pruned = tracker.prune_transactions_from_peer(downstream);
-        assert!(
-            pruned.is_empty(),
-            "rebinding must leave the old peer with no orphan claim on tx"
-        );
-
-        // Upstream's prune still picks up tx as expected.
-        let pruned = tracker.prune_transactions_from_peer(upstream);
-        assert_eq!(pruned, vec![tx]);
     }
 }

--- a/crates/core/src/ring/live_tx.rs
+++ b/crates/core/src/ring/live_tx.rs
@@ -19,12 +19,40 @@ pub struct LiveTransactionTracker {
 }
 
 impl LiveTransactionTracker {
+    /// Register that transaction `tx` is in flight to `peer_addr`.
+    ///
+    /// Idempotent and rebind-safe:
+    /// - Same `(peer_addr, tx)` re-registration is a no-op (no Vec duplication).
+    /// - Re-registering `tx` to a different peer scrubs the previous
+    ///   peer's entry, so a tx that flows through multiple peers ends up
+    ///   tracked against exactly the most recent one. Pre-#4154 a CONNECT
+    ///   ride-along (`Ring::initiate_connect` + `handle_op_execution`)
+    ///   silently double-counted in `active_connect_transaction_count`;
+    ///   a relay re-sending response-side to its upstream after sending
+    ///   the request-side downstream left a stale entry on the
+    ///   downstream peer that only cleaned up on disconnect.
+    ///
+    /// Concurrency note: the reverse-index insert happens first so a
+    /// racing `remove_finished_transaction` always sees a consistent
+    /// `(tx → peer)` mapping and cleans the matching forward-index
+    /// entry. The cross-peer scrub uses `remove_if_mut`'s atomic
+    /// retain-and-prune.
     pub fn add_transaction(&self, peer_addr: SocketAddr, tx: Transaction) {
-        // Insert to reverse index first to prevent race condition:
-        // If remove_finished_transaction runs concurrently, it will find the tx
-        // in peer_for_tx and clean up properly. If we did tx_per_peer first,
-        // a concurrent remove could miss the tx in peer_for_tx and leave orphans.
-        self.peer_for_tx.insert(tx, peer_addr);
+        let prev = self.peer_for_tx.insert(tx, peer_addr);
+        match prev {
+            Some(prev_addr) if prev_addr == peer_addr => {
+                // Idempotent re-registration; don't duplicate in tx_per_peer's Vec.
+                return;
+            }
+            Some(prev_addr) => {
+                // Different peer: scrub the stale forward-index entry.
+                self.tx_per_peer.remove_if_mut(&prev_addr, |_, v| {
+                    v.retain(|otx| otx != &tx);
+                    v.is_empty()
+                });
+            }
+            None => {}
+        }
         self.tx_per_peer.entry(peer_addr).or_default().push(tx);
     }
 
@@ -249,5 +277,72 @@ mod tests {
         // Prune nonexistent peer returns empty
         let pruned = tracker.prune_transactions_from_peer(addr1);
         assert!(pruned.is_empty());
+    }
+
+    /// Regression for #4154: re-registering the same `(peer, tx)` pair
+    /// must be a no-op (no Vec duplication). The CONNECT ride-along
+    /// path (`Ring::initiate_connect` adds `(gw, tx)`, then
+    /// `handle_op_execution` re-adds the same pair when the request
+    /// flows through `send_to_and_collect_replies`) otherwise inflates
+    /// `active_connect_transaction_count` and throttles concurrent
+    /// CONNECT acquisitions.
+    #[test]
+    fn add_transaction_is_idempotent_for_same_pair() {
+        let tracker = LiveTransactionTracker::new();
+        let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+        let tx = Transaction::new::<ConnectMsg>();
+
+        tracker.add_transaction(addr, tx);
+        tracker.add_transaction(addr, tx);
+        tracker.add_transaction(addr, tx);
+
+        assert_eq!(tracker.active_transaction_count(), 1);
+        assert_eq!(tracker.active_connect_transaction_count(), 1);
+        assert_eq!(tracker.peer_for_tx.len(), 1);
+
+        // Single removal must clean both indices fully.
+        tracker.remove_finished_transaction(tx);
+        assert_eq!(tracker.active_transaction_count(), 0);
+        assert!(!tracker.has_live_connection(addr));
+        assert_eq!(tracker.peer_for_tx.len(), 0);
+    }
+
+    /// Regression for #4154: a relay that forwards a request downstream
+    /// then later sends a response back upstream re-registers the same
+    /// tx against a different peer. Before the fix, the old peer's
+    /// forward-index Vec retained the tx until that peer disconnected.
+    /// After the fix, the second registration scrubs the stale entry.
+    #[test]
+    fn add_transaction_rebinds_to_new_peer() {
+        let tracker = LiveTransactionTracker::new();
+        let downstream: SocketAddr = "127.0.0.1:9001".parse().unwrap();
+        let upstream: SocketAddr = "127.0.0.1:9002".parse().unwrap();
+        let tx = Transaction::new::<GetMsg>();
+
+        // Relay first forwards request to downstream.
+        tracker.add_transaction(downstream, tx);
+        assert!(tracker.has_live_connection(downstream));
+        assert!(!tracker.has_live_connection(upstream));
+
+        // Then forwards the response back to upstream — `tx` migrates.
+        tracker.add_transaction(upstream, tx);
+        assert!(
+            !tracker.has_live_connection(downstream),
+            "downstream's stale forward-index entry must be scrubbed"
+        );
+        assert!(tracker.has_live_connection(upstream));
+        assert_eq!(tracker.peer_for_tx.len(), 1);
+        assert_eq!(tracker.active_transaction_count(), 1);
+
+        // Pruning the (now-stale) downstream peer must NOT find `tx`.
+        let pruned = tracker.prune_transactions_from_peer(downstream);
+        assert!(
+            pruned.is_empty(),
+            "rebinding must leave the old peer with no orphan claim on tx"
+        );
+
+        // Upstream's prune still picks up tx as expected.
+        let pruned = tracker.prune_transactions_from_peer(upstream);
+        assert_eq!(pruned, vec![tx]);
     }
 }

--- a/crates/core/src/ring/live_tx.rs
+++ b/crates/core/src/ring/live_tx.rs
@@ -21,22 +21,29 @@ pub struct LiveTransactionTracker {
 impl LiveTransactionTracker {
     /// Register that transaction `tx` is in flight to `peer_addr`.
     ///
-    /// Idempotent and rebind-safe:
+    /// Single-writer-per-tx semantics: callers ARE expected to serialize
+    /// registrations for the same `tx` (typically a single driver task
+    /// owns each transaction). Under that contract:
     /// - Same `(peer_addr, tx)` re-registration is a no-op (no Vec duplication).
     /// - Re-registering `tx` to a different peer scrubs the previous
-    ///   peer's entry, so a tx that flows through multiple peers ends up
-    ///   tracked against exactly the most recent one. Pre-#4154 a CONNECT
-    ///   ride-along (`Ring::initiate_connect` + `handle_op_execution`)
-    ///   silently double-counted in `active_connect_transaction_count`;
-    ///   a relay re-sending response-side to its upstream after sending
-    ///   the request-side downstream left a stale entry on the
-    ///   downstream peer that only cleaned up on disconnect.
+    ///   peer's forward-index entry, so a tx that flows through multiple
+    ///   peers ends up tracked against exactly the most recent one.
+    ///   Pre-#4154 a CONNECT ride-along (`Ring::initiate_connect` +
+    ///   `handle_op_execution`) silently double-counted in
+    ///   `active_connect_transaction_count`; a relay re-sending
+    ///   response-side to its upstream after sending the request-side
+    ///   downstream left a stale entry on the downstream peer that only
+    ///   cleaned up on disconnect.
     ///
-    /// Concurrency note: the reverse-index insert happens first so a
-    /// racing `remove_finished_transaction` always sees a consistent
-    /// `(tx → peer)` mapping and cleans the matching forward-index
-    /// entry. The cross-peer scrub uses `remove_if_mut`'s atomic
-    /// retain-and-prune.
+    /// Concurrency caveat: the two DashMap operations (reverse-index
+    /// insert + forward-index push/scrub) are individually atomic but
+    /// NOT serialized as a pair. If a racing `remove_finished_transaction`
+    /// slips between them, an orphan forward-index entry can remain
+    /// until the peer disconnects — `prune_transactions_from_peer`
+    /// reaps it then. This matches the pre-#4154 fallback behavior,
+    /// not the wake-on-disconnect fast path. Hold single-writer
+    /// discipline or add per-tx serialization at the call site if the
+    /// race becomes problematic.
     pub fn add_transaction(&self, peer_addr: SocketAddr, tx: Transaction) {
         let prev = self.peer_for_tx.insert(tx, peer_addr);
         match prev {

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -3575,8 +3575,12 @@ pub(crate) enum GetEvent {
     /// An upstream peer received a ForwardingAck from a downstream relay.
     ///
     /// When received, `ack_received` is set to `true`, which prevents the GC task
-    /// from launching speculative retries. If the downstream chain then stalls,
-    /// the originator waits the full OPERATION_TTL with no recovery (#3570).
+    /// from launching speculative retries. If the downstream chain then stalls
+    /// (downstream peer never formally disconnects), the originator waits the full
+    /// OPERATION_TTL with no recovery (#3570). Formal disconnect of the immediate
+    /// downstream peer now wakes the parked driver sub-ms via
+    /// `handle_orphaned_transactions` (#4154); the no-recovery window remains for
+    /// silent stalls / slow-loris where no disconnect signal arrives.
     ForwardingAckReceived {
         id: Transaction,
         /// The peer that received the ACK (originator or intermediate relay).


### PR DESCRIPTION
## Problem

A GET op issued just before its downstream peer disconnects stalls for the full `OPERATION_TTL` (60 s) before retrying. The 2026-05-19 telemetry in #4154 captured the exact symptom: a user-visible 30 s HTTP timeout followed by a successful 18 s retry, with the original transaction completing **62 seconds** after issue and zero `get_request` telemetry events emitted along the way.

## Root cause

Two cooperating gaps in the disconnect-cancellation pipeline:

1. **`P2pBridge::handle_orphaned_transactions` was a logging-only stub.** It received every transaction associated with the pruned peer from `LiveTransactionTracker::prune_transactions_from_peer` and just logged the count. The doc-comment claimed "driver-owned cancellation," but no cancellation path existed — drivers parked in `OpCtx::send_and_await` were never told to give up.

2. **Forwards routed via `op_execution_sender` skipped `live_tx_tracker` registration.** `OpCtx::send_fire_and_forget` / `send_to_and_await` bypass `P2pBridge::send`, so the `(tx -> target_addr)` association `sending_transaction` normally records was never made. Even if (1) had been wired up, `prune_transactions_from_peer` would have returned empty for relayed GET / PUT / UPDATE / SUBSCRIBE ops.

The originator-loopback GET relay branch hits both: it fires the request to the downstream peer with `target_addr = Some(...)` and exits. The client driver's `send_and_await` waiter sits in `pending_op_results[client_tx]` waiting for a response that will never arrive (peer is gone) and is never woken.

## Approach

Wire the existing cancellation primitives end-to-end:

- **Register `(target_addr, *msg.id())` in `LiveTransactionTracker`** at `P2pConnManager::handle_op_execution` whenever the driver supplies an explicit target. Covers both `send_fire_and_forget` and `send_to_and_await` paths.
- **Make `P2pBridge::handle_orphaned_transactions` iterate orphans** and call `OpManager::try_release_pending_op_slot(tx)` — a new non-blocking helper that emits `NodeEvent::TransactionCompleted(tx)` via `try_send` (safe to call from the event loop).
- **Clean up `live_tx_tracker` in the `TransactionCompleted` event-loop arm**, so entries registered at `handle_op_execution` don't leak past op completion.

When the event loop processes `TransactionCompleted(tx)` it drops `pending_op_results[tx]`, closing the channel the driver is awaiting. `send_and_await` returns `Err(OpError::NotificationError)`; `drive_retry_loop` routes that to `advance()` and tries the next peer. Wake time goes from 60 s to sub-millisecond.

Why `try_send` rather than the existing `send().await` `release_pending_op_slot`: the orphan handler runs inside the event loop, and awaiting the same notification channel would risk deadlock. The non-blocking variant is best-effort — a momentarily-full channel falls back to the legacy `OPERATION_TTL` timeout, which is the pre-fix behavior. Mirrors the existing `notify_transaction_timeout` helper.

## Testing

Four new tests, all passing; the source-grep guard was verified to fail on regression by temporarily reverting `handle_orphaned_transactions` to a no-op stub.

- `try_release_pending_op_slot_emits_transaction_completed` — happy-path helper unit test.
- `try_release_pending_op_slot_handles_dropped_receiver` — robustness under shutdown races.
- `orphaned_transaction_wakes_parked_pending_op_results_waiter` — end-to-end pipeline: simulates the `registered-sender -> orphan-handler -> event-loop-drop -> driver-wake` sequence and asserts wake within 100 ms (vs. the pre-fix 60 s).
- `handle_orphaned_transactions_wakes_parked_drivers` — source-grep guard against the function reverting to logging-only.

Full `cargo test -p freenet --lib` is clean except for a single unrelated flaky timing test (`test_send_stream_without_bandwidth_limit`, 50 ms wall-clock threshold) which passes in isolation — filed separately as #4163.

## Why CI didn't catch this earlier

The pre-fix code path required a precise sequence: GET op forwarded just before peer disconnect, with the originator's loopback running on a node that lacked a replacement peer for the full `OPERATION_TTL`. Simulation tests with stable peer sets and no induced churn never hit it. The source-grep guard test prevents future refactors from silently re-stubbing the orphan handler; the end-to-end pipeline test now exercises the wake path directly.

Closes #4154

[AI-assisted - Claude]