### PR TITLE
docs(dashboard): add Freenet Mail to node home page links

### DIFF
--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -79,6 +79,10 @@ fn homepage_html() -> String {
                     <p class="note">You'll need an <a href="https://freenet.org/quickstart#invite-form" target="_blank" rel="noopener noreferrer">invite</a> to join the "Freenet Official" room.</p>
                 </li>
                 <li>
+                    <a href="/v1/contract/web/122f6AR7PyF8d8mhczuNQM4xrLtBf5t8g2iB7PEVT7KC/">Freenet Mail</a>
+                    <p class="note">Decentralized email built on Freenet. <a href="https://github.com/freenet/mail" target="_blank" rel="noopener noreferrer">Source</a>.</p>
+                </li>
+                <li>
                     <a href="/v1/contract/web/EqJ5YpEEV3XLqEvKWLQHFhGAac2qXzSUoE6k2zbdnXBr/">Delta</a>
                     <p class="note">A website builder for Freenet.</p>
                 </li>


### PR DESCRIPTION
## Problem

The Mail app was released (https://github.com/freenet/mail) but the
node's localhost dashboard at `http://127.0.0.1:<port>/` ("Freenet
Links") does not list it. Users who visit the dashboard see River,
Delta, Ghostkey Vault, and freenet.org but have no entry point for
Mail unless they already know the contract ID.

## Solution

Add a Mail entry pointing at the published facade contract
`122f6AR7PyF8d8mhczuNQM4xrLtBf5t8g2iB7PEVT7KC` (from
`freenet-email/published-contract/facade-id.txt`). The facade is the
stable redirector — its ID does not rotate when the underlying webapp
contract changes, so this link survives Mail releases.

## Testing

- `cargo check -p freenet` passes.
- HTML is a static string in `home_page.rs`; rendered list now contains
  five entries instead of four.

## Fixes

N/A — pure docs/dashboard surface change.