### PR TITLE
fix(ring): hold shard guard across index_contract_hash to prevent zombie entries

### DIFF
--- a/.claude/rules/ring.md
+++ b/.claude/rules/ring.md
@@ -154,6 +154,58 @@ CORRECT:
 - All `retain()` / sweep loops — verify exemption conditions have TTL or absolute age bounds
 - `ConnectionManager` fields — verify each map has a documented cleanup owner
 
+### Cross-DashMap Lock Discipline (`significant_drop_tightening` exception)
+
+```
+Some methods mutate a primary DashMap entry and then write to a SECOND
+DashMap that mirrors that state (a reverse index, a hash index, etc.).
+For those methods, the primary entry's shard guard MUST be held across
+the secondary write.
+
+This intentionally lifts the `significant_drop_tightening` clippy lint:
+the guard is load-bearing for atomicity against a concurrent remover,
+not for serializing unrelated callers. A blind `cargo clippy --fix` (or
+agent applying the lint) will silently re-introduce a race.
+
+WRONG (PR #4129 shape):
+  let became = {
+      let mut entry = self.primary.entry(key).or_default();
+      entry.add_reason()
+  };  // <-- guard dropped here
+  self.secondary_index.insert(key);  // <-- racy: a concurrent remover
+                                     //     can run `cleanup_if_no_reasons`
+                                     //     between the drop and the insert,
+                                     //     no-op-removing the not-yet-present
+                                     //     secondary entry, then this insert
+                                     //     leaks a zombie.
+
+CORRECT (PR #4171 shape):
+  let mut entry = self.primary.entry(key).or_default();
+  let became = entry.add_reason();
+  self.secondary_index.insert(key);  // <-- still under the primary guard
+  drop(entry);                       // explicit for documentation only
+  became
+```
+
+Concrete cases in this crate:
+- `InterestManager::{register_peer_interest, register_local_hosting,
+  add_local_client, add_downstream_subscriber, register_local_interest}`
+  hold `interested_peers` or `local_interests` across
+  `index_contract_hash` so a concurrent `remove_*` cannot run
+  `cleanup_contract_if_no_interest` → `unindex_contract_hash` in the
+  window between guard drop and indexing. See PR #4129 (introduced the
+  race) and PR #4171 (restored the discipline).
+
+Audit grep when adding a new method that touches multiple DashMaps:
+- Identify the primary map whose presence is the source of truth for
+  interest/membership.
+- Identify any secondary map that mirrors that state.
+- Confirm the primary guard is held across the secondary write.
+- Add an inline `// hold the X guard across Y to prevent the Z race`
+  comment so a future clippy pass leaves a footprint when it tries to
+  drop the guard.
+```
+
 ## Trigger-Action Rules
 
 ### BEFORE modifying ConnectionManager

--- a/.claude/rules/ring.md
+++ b/.claude/rules/ring.md
@@ -204,6 +204,17 @@ Audit grep when adding a new method that touches multiple DashMaps:
 - Add an inline `// hold the X guard across Y to prevent the Z race`
   comment so a future clippy pass leaves a footprint when it tries to
   drop the guard.
+
+CAVEAT — this rule only protects primary-origin removers (removers
+that take the primary map's guard first, then touch the secondary).
+A secondary-origin remover — one that starts from the secondary
+index and works back to the primary — is NOT protected by this
+discipline. Those need their own atomicity story: either share a
+lock order with the add path, batch the primary-side updates under a
+single guard, or use a reconciliation/two-phase remove protocol.
+Example of an unprotected secondary-origin remover that still has a
+bidirectional-consistency race even with the rule applied:
+`InterestManager::remove_all_peer_interests` (issue #4174).
 ```
 
 ## Trigger-Action Rules

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -1165,6 +1165,18 @@ mod tests {
         )
     }
 
+    /// Like `make_contract_key` but with a `u32` seed for tests that need
+    /// many distinct contracts.
+    fn make_unique_contract_key(seed: u32) -> ContractKey {
+        let s = seed.to_le_bytes();
+        let mut id = [0u8; 32];
+        id[0..4].copy_from_slice(&s);
+        let mut code = [0u8; 32];
+        code[0..4].copy_from_slice(&s);
+        code[4] = 0xAB;
+        ContractKey::from_id_and_code(ContractInstanceId::new(id), CodeHash::new(code))
+    }
+
     fn make_peer_key(_seed: u8) -> PeerKey {
         use crate::transport::TransportKeypair;
         let keypair = TransportKeypair::new();
@@ -2306,181 +2318,170 @@ mod tests {
         );
     }
 
-    /// Concurrent stress test for the PR #4129 add-then-index race in
+    /// Regression test for the PR #4129 add-then-index race in
     /// `InterestManager`.
     ///
     /// Before the fix, `add_local_client` / `register_local_hosting` /
-    /// `add_downstream_subscriber` / `register_peer_interest` released
-    /// the `local_interests` (or `interested_peers`) shard guard before
-    /// calling `index_contract_hash`. A concurrent `remove_*` for the
-    /// same contract could then acquire the guard, decrement the last
-    /// reason, run `cleanup_contract_if_no_interest` → `unindex_contract_hash`
+    /// `add_downstream_subscriber` / `register_peer_interest` /
+    /// `register_local_interest` released the `local_interests` (or
+    /// `interested_peers`) shard guard before calling
+    /// `index_contract_hash`. A concurrent `remove_*` for the same
+    /// contract could then acquire the guard, decrement the last reason,
+    /// run `cleanup_contract_if_no_interest` → `unindex_contract_hash`
     /// (a no-op because we haven't indexed yet), and the deferred index
-    /// would leak a zombie entry into `contract_hash_index` that
-    /// `cleanup_contract_if_no_interest` would never visit again.
-    /// `lookup_by_hash` and `get_all_interest_hashes` would then return
-    /// the stale entry forever.
+    /// would leak a zombie entry into `contract_hash_index`.
+    ///
+    /// Two properties make this race awkward to test:
+    ///
+    /// 1. The zombie only PERSISTS if the contract sees no further
+    ///    activity — a later add re-establishes backing interest, a
+    ///    later remove's cleanup unindexes it. A stress test that
+    ///    hammers one shared contract therefore continuously heals it.
+    /// 2. The racy window (`local_interests` guard drop → deferred
+    ///    `index_contract_hash`) is a handful of instructions wide.
+    ///
+    /// This test addresses both: each ROUND uses a fresh contract and
+    /// runs exactly ONE add racing exactly ONE remove. A barrier
+    /// releases the adder and remover simultaneously to maximize
+    /// overlap. Because there is only one add and one remove, nothing
+    /// can heal a zombie once created — it persists to the post-round
+    /// check, which reads the three maps directly and calls no
+    /// `remove_*` (which would trigger cleanup and heal it). Each of the
+    /// four fixed add/remove pairs is exercised round-robin.
     ///
     /// The fix holds the shard guard across `index_contract_hash`, so
-    /// the racy interleaving cannot occur. This test exercises all four
-    /// fixed add/remove pairs under contention and asserts the
-    /// `lookup_by_hash(C).is_empty()` invariant once interest is drained.
-    /// The fix makes this hold deterministically across every pair.
-    ///
-    /// The bug shape is also directly demonstrable via manual half-step
-    /// interleaving (see the PR description) but that demonstration is
-    /// not a useful CI guard because it bypasses the locking that the
-    /// fix introduces.
+    /// the racy interleaving cannot occur and no round produces a
+    /// zombie.
     #[test]
     fn test_concurrent_add_remove_preserves_hash_index_invariant() {
-        use std::sync::{Arc, Barrier};
+        use std::sync::{Arc, Barrier, Mutex};
         use std::thread;
 
         let (manager, _time) = make_manager();
         let manager = Arc::new(manager);
-        let contract = make_contract_key(7);
-        let peers: Vec<PeerKey> = (0..4).map(make_peer_key).collect();
 
-        let iters = 30_000;
+        let rounds: u32 = 120_000;
 
-        // 8 threads × 4 pairs of (adder, remover) ops on the same
-        // contract, plus shared peer keys for the peer-interest pair.
-        let pair_count = 4;
-        let start = Arc::new(Barrier::new(pair_count * 2));
-        let mut handles = Vec::with_capacity(pair_count * 2);
+        // Per-round spec shared with the two worker threads:
+        // (contract, which-pair, stop-sentinel).
+        let spec: Arc<Mutex<(ContractKey, u32, bool)>> =
+            Arc::new(Mutex::new((make_unique_contract_key(0), 0, false)));
+        // 3 parties: adder, remover, main.
+        let round_start = Arc::new(Barrier::new(3));
+        let round_end = Arc::new(Barrier::new(3));
 
-        // Pair 1: register_peer_interest ↔ remove_peer_interest
-        // (uses `interested_peers` + `peer_contracts` + `contract_hash_index`)
-        {
-            let m = Arc::clone(&manager);
-            let s = Arc::clone(&start);
-            let peer = peers[0].clone();
-            handles.push(thread::spawn(move || {
-                s.wait();
-                for _ in 0..iters {
-                    m.register_peer_interest(&contract, peer.clone(), None, false);
-                }
-            }));
-            let m = Arc::clone(&manager);
-            let s = Arc::clone(&start);
-            let peer = peers[0].clone();
-            handles.push(thread::spawn(move || {
-                s.wait();
-                for _ in 0..iters {
-                    m.remove_peer_interest(&contract, &peer);
-                }
-            }));
-        }
+        // Single shared peer key for the peer-interest pair. The remover
+        // drains by enumerating `interested_peers` so it needs no key.
+        let peer = make_peer_key(0);
 
-        // Pair 2: register_local_hosting ↔ unregister_local_hosting
-        {
-            let m = Arc::clone(&manager);
-            let s = Arc::clone(&start);
-            handles.push(thread::spawn(move || {
-                s.wait();
-                for _ in 0..iters {
-                    m.register_local_hosting(&contract);
+        let adder = {
+            let manager = Arc::clone(&manager);
+            let spec = Arc::clone(&spec);
+            let round_start = Arc::clone(&round_start);
+            let round_end = Arc::clone(&round_end);
+            let peer = peer.clone();
+            thread::spawn(move || {
+                loop {
+                    round_start.wait();
+                    let (contract, which, stop) = *spec.lock().unwrap();
+                    if stop {
+                        break;
+                    }
+                    match which {
+                        0 => {
+                            manager.register_peer_interest(&contract, peer.clone(), None, false);
+                        }
+                        1 => {
+                            manager.register_local_hosting(&contract);
+                        }
+                        2 => {
+                            manager.add_local_client(&contract);
+                        }
+                        _ => {
+                            manager.add_downstream_subscriber(&contract);
+                        }
+                    }
+                    round_end.wait();
                 }
-            }));
-            let m = Arc::clone(&manager);
-            let s = Arc::clone(&start);
-            handles.push(thread::spawn(move || {
-                s.wait();
-                for _ in 0..iters {
-                    m.unregister_local_hosting(&contract);
-                }
-            }));
-        }
+            })
+        };
 
-        // Pair 3: add_local_client ↔ remove_local_client
-        {
-            let m = Arc::clone(&manager);
-            let s = Arc::clone(&start);
-            handles.push(thread::spawn(move || {
-                s.wait();
-                for _ in 0..iters {
-                    m.add_local_client(&contract);
+        let remover = {
+            let manager = Arc::clone(&manager);
+            let spec = Arc::clone(&spec);
+            let round_start = Arc::clone(&round_start);
+            let round_end = Arc::clone(&round_end);
+            thread::spawn(move || {
+                loop {
+                    round_start.wait();
+                    let (contract, which, stop) = *spec.lock().unwrap();
+                    if stop {
+                        break;
+                    }
+                    match which {
+                        0 => {
+                            let peers: Vec<PeerKey> = manager
+                                .interested_peers
+                                .get(&contract)
+                                .map(|e| e.keys().cloned().collect())
+                                .unwrap_or_default();
+                            for p in peers {
+                                manager.remove_peer_interest(&contract, &p);
+                            }
+                        }
+                        1 => {
+                            manager.unregister_local_hosting(&contract);
+                        }
+                        2 => {
+                            manager.remove_local_client(&contract);
+                        }
+                        _ => {
+                            manager.remove_downstream_subscriber(&contract);
+                        }
+                    }
+                    round_end.wait();
                 }
-            }));
-            let m = Arc::clone(&manager);
-            let s = Arc::clone(&start);
-            handles.push(thread::spawn(move || {
-                s.wait();
-                for _ in 0..iters {
-                    m.remove_local_client(&contract);
-                }
-            }));
-        }
+            })
+        };
 
-        // Pair 4: add_downstream_subscriber ↔ remove_downstream_subscriber
-        {
-            let m = Arc::clone(&manager);
-            let s = Arc::clone(&start);
-            handles.push(thread::spawn(move || {
-                s.wait();
-                for _ in 0..iters {
-                    m.add_downstream_subscriber(&contract);
-                }
-            }));
-            let m = Arc::clone(&manager);
-            let s = Arc::clone(&start);
-            handles.push(thread::spawn(move || {
-                s.wait();
-                for _ in 0..iters {
-                    m.remove_downstream_subscriber(&contract);
-                }
-            }));
-        }
+        let mut zombies: Vec<(u32, u32)> = Vec::new();
+        for round in 0..rounds {
+            let contract = make_unique_contract_key(round);
+            let which = round % 4;
+            *spec.lock().unwrap() = (contract, which, false);
 
-        for h in handles {
-            h.join().unwrap();
-        }
+            round_start.wait(); // release adder + remover simultaneously
+            round_end.wait(); // both have completed their single op
 
-        // Drain residual peer + local interest before checking the invariant.
-        // Each `remove_*` decrements one counter (or clears one bool); call
-        // them in a tight loop until the `local_interests` entry is gone.
-        // Adders may have outrun removers during the parallel phase, leaving
-        // counts in the thousands — but each iteration decrements by 1 via
-        // saturating_sub, so total drain iterations are bounded by the
-        // worst-case adder count (one per thread per iter).
-        for peer in &peers {
-            while manager.get_peer_interest(&contract, peer).is_some() {
-                manager.remove_peer_interest(&contract, peer);
+            // Activity on `contract` has fully stopped — exactly one add
+            // and one remove ran, nothing can heal a zombie now. Check
+            // the shard-consistency invariant directly, calling no
+            // `remove_*` (which would trigger cleanup). A zombie =
+            // indexed in `contract_hash_index`, absent from BOTH
+            // `local_interests` and `interested_peers`.
+            let in_chi = !manager.lookup_by_hash(contract_hash(&contract)).is_empty();
+            let in_li = manager.local_interests.contains_key(&contract);
+            let in_ip = manager.interested_peers.contains_key(&contract);
+            if in_chi && !in_li && !in_ip {
+                zombies.push((round, which));
             }
         }
-        let mut drain_iters = 0usize;
-        while manager.local_interests.contains_key(&contract) {
-            manager.remove_local_client(&contract);
-            manager.remove_downstream_subscriber(&contract);
-            manager.unregister_local_hosting(&contract);
-            drain_iters += 1;
-            assert!(
-                drain_iters < iters * 4,
-                "drain did not converge after {drain_iters} iterations; \
-                 residual state: {:?}",
-                manager.local_interests.get(&contract).map(|e| (
-                    e.hosting,
-                    e.local_client_count,
-                    e.downstream_subscriber_count
-                ))
-            );
-        }
 
-        // Now both maps should be empty and the hash index must agree.
-        let leaked = manager.lookup_by_hash(contract_hash(&contract));
+        // Signal both workers to exit, then release them off round_start.
+        *spec.lock().unwrap() = (make_unique_contract_key(0), 0, true);
+        round_start.wait();
+        adder.join().unwrap();
+        remover.join().unwrap();
+
         assert!(
-            leaked.is_empty(),
-            "contract_hash_index has zombie entry after add/remove \
-             concurrency: {leaked:?}"
-        );
-        assert!(
-            manager.get_all_interest_hashes().is_empty(),
-            "get_all_interest_hashes leaks zombie: {:?}",
-            manager.get_all_interest_hashes()
-        );
-        assert!(
-            !manager.has_local_interest(&contract),
-            "has_local_interest still true after drain"
+            zombies.is_empty(),
+            "{} of {rounds} single-add/single-remove rounds leaked a \
+             zombie entry into contract_hash_index (no backing \
+             local_interests or interested_peers). This is the PR #4129 \
+             race that PR #4171 fixes. First offenders (round, pair): \
+             {:?}",
+            zombies.len(),
+            &zombies[..zombies.len().min(10)]
         );
     }
 }

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -634,9 +634,15 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     }
 
     /// Register local interest in a contract (for tracking our reasons).
+    ///
+    /// Currently unused inside the workspace but kept `pub` for external
+    /// consumers; same lock-across-index discipline as
+    /// [`Self::register_local_hosting`] applies so the method is not a
+    /// PR #4129–shaped race footgun.
     pub fn register_local_interest(&self, contract: &ContractKey) -> &Self {
-        self.local_interests.entry(*contract).or_default();
+        let entry = self.local_interests.entry(*contract).or_default();
         self.index_contract_hash(contract);
+        drop(entry);
         self
     }
 
@@ -2316,13 +2322,15 @@ mod tests {
     /// the stale entry forever.
     ///
     /// The fix holds the shard guard across `index_contract_hash`, so
-    /// the racy interleaving cannot occur. This test exercises the
-    /// production API under contention and asserts the
+    /// the racy interleaving cannot occur. This test exercises all four
+    /// fixed add/remove pairs under contention and asserts the
     /// `lookup_by_hash(C).is_empty()` invariant once interest is drained.
-    /// The fix makes this hold deterministically; the bug shape is also
-    /// directly demonstrable via manual half-step interleaving (see the
-    /// PR description) but that demonstration is not a useful CI guard
-    /// because it bypasses the locking that the fix introduces.
+    /// The fix makes this hold deterministically across every pair.
+    ///
+    /// The bug shape is also directly demonstrable via manual half-step
+    /// interleaving (see the PR description) but that demonstration is
+    /// not a useful CI guard because it bypasses the locking that the
+    /// fix introduces.
     #[test]
     fn test_concurrent_add_remove_preserves_hash_index_invariant() {
         use std::sync::{Arc, Barrier};
@@ -2331,14 +2339,61 @@ mod tests {
         let (manager, _time) = make_manager();
         let manager = Arc::new(manager);
         let contract = make_contract_key(7);
+        let peers: Vec<PeerKey> = (0..4).map(make_peer_key).collect();
 
-        let adders = 8;
-        let removers = 8;
-        let iters = 50_000;
-        let start = Arc::new(Barrier::new(adders + removers));
+        let iters = 30_000;
 
-        let mut handles = Vec::with_capacity(adders + removers);
-        for _ in 0..adders {
+        // 8 threads × 4 pairs of (adder, remover) ops on the same
+        // contract, plus shared peer keys for the peer-interest pair.
+        let pair_count = 4;
+        let start = Arc::new(Barrier::new(pair_count * 2));
+        let mut handles = Vec::with_capacity(pair_count * 2);
+
+        // Pair 1: register_peer_interest ↔ remove_peer_interest
+        // (uses `interested_peers` + `peer_contracts` + `contract_hash_index`)
+        {
+            let m = Arc::clone(&manager);
+            let s = Arc::clone(&start);
+            let peer = peers[0].clone();
+            handles.push(thread::spawn(move || {
+                s.wait();
+                for _ in 0..iters {
+                    m.register_peer_interest(&contract, peer.clone(), None, false);
+                }
+            }));
+            let m = Arc::clone(&manager);
+            let s = Arc::clone(&start);
+            let peer = peers[0].clone();
+            handles.push(thread::spawn(move || {
+                s.wait();
+                for _ in 0..iters {
+                    m.remove_peer_interest(&contract, &peer);
+                }
+            }));
+        }
+
+        // Pair 2: register_local_hosting ↔ unregister_local_hosting
+        {
+            let m = Arc::clone(&manager);
+            let s = Arc::clone(&start);
+            handles.push(thread::spawn(move || {
+                s.wait();
+                for _ in 0..iters {
+                    m.register_local_hosting(&contract);
+                }
+            }));
+            let m = Arc::clone(&manager);
+            let s = Arc::clone(&start);
+            handles.push(thread::spawn(move || {
+                s.wait();
+                for _ in 0..iters {
+                    m.unregister_local_hosting(&contract);
+                }
+            }));
+        }
+
+        // Pair 3: add_local_client ↔ remove_local_client
+        {
             let m = Arc::clone(&manager);
             let s = Arc::clone(&start);
             handles.push(thread::spawn(move || {
@@ -2347,8 +2402,6 @@ mod tests {
                     m.add_local_client(&contract);
                 }
             }));
-        }
-        for _ in 0..removers {
             let m = Arc::clone(&manager);
             let s = Arc::clone(&start);
             handles.push(thread::spawn(move || {
@@ -2358,15 +2411,62 @@ mod tests {
                 }
             }));
         }
+
+        // Pair 4: add_downstream_subscriber ↔ remove_downstream_subscriber
+        {
+            let m = Arc::clone(&manager);
+            let s = Arc::clone(&start);
+            handles.push(thread::spawn(move || {
+                s.wait();
+                for _ in 0..iters {
+                    m.add_downstream_subscriber(&contract);
+                }
+            }));
+            let m = Arc::clone(&manager);
+            let s = Arc::clone(&start);
+            handles.push(thread::spawn(move || {
+                s.wait();
+                for _ in 0..iters {
+                    m.remove_downstream_subscriber(&contract);
+                }
+            }));
+        }
+
         for h in handles {
             h.join().unwrap();
         }
 
-        // Drain residual interest before checking the invariant.
-        while manager.has_local_interest(&contract) {
+        // Drain residual peer + local interest before checking the invariant.
+        // Each `remove_*` decrements one counter (or clears one bool); call
+        // them in a tight loop until the `local_interests` entry is gone.
+        // Adders may have outrun removers during the parallel phase, leaving
+        // counts in the thousands — but each iteration decrements by 1 via
+        // saturating_sub, so total drain iterations are bounded by the
+        // worst-case adder count (one per thread per iter).
+        for peer in &peers {
+            while manager.get_peer_interest(&contract, peer).is_some() {
+                manager.remove_peer_interest(&contract, peer);
+            }
+        }
+        let mut drain_iters = 0usize;
+        while manager.local_interests.contains_key(&contract) {
             manager.remove_local_client(&contract);
+            manager.remove_downstream_subscriber(&contract);
+            manager.unregister_local_hosting(&contract);
+            drain_iters += 1;
+            assert!(
+                drain_iters < iters * 4,
+                "drain did not converge after {drain_iters} iterations; \
+                 residual state: {:?}",
+                manager.local_interests.get(&contract).map(|e| (
+                    e.hosting,
+                    e.local_client_count,
+                    e.downstream_subscriber_count
+                ))
+            );
         }
 
+        // Now both maps should be empty and the hash index must agree.
         let leaked = manager.lookup_by_hash(contract_hash(&contract));
         assert!(
             leaked.is_empty(),
@@ -2377,6 +2477,10 @@ mod tests {
             manager.get_all_interest_hashes().is_empty(),
             "get_all_interest_hashes leaks zombie: {:?}",
             manager.get_all_interest_hashes()
+        );
+        assert!(
+            !manager.has_local_interest(&contract),
+            "has_local_interest still true after drain"
         );
     }
 }

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -2346,8 +2346,19 @@ mod tests {
     /// overlap. Because there is only one add and one remove, nothing
     /// can heal a zombie once created — it persists to the post-round
     /// check, which reads the three maps directly and calls no
-    /// `remove_*` (which would trigger cleanup and heal it). Each of the
-    /// four fixed add/remove pairs is exercised round-robin.
+    /// `remove_*` (which would trigger cleanup and heal it).
+    ///
+    /// Each of the four real add/remove PAIRS is exercised round-robin:
+    /// `register_peer_interest`/`remove_peer_interest`,
+    /// `register_local_hosting`/`unregister_local_hosting`,
+    /// `add_local_client`/`remove_local_client`,
+    /// `add_downstream_subscriber`/`remove_downstream_subscriber`. The
+    /// fifth fixed site, `register_local_interest`, gets the same
+    /// lock-across-index discipline but is NOT raced here: it is dead
+    /// code (no workspace caller) with no symmetric remove operation, so
+    /// there is no natural pair to race it against. It is structurally
+    /// identical to the tested `register_local_hosting` and is guarded
+    /// by code review plus the `.claude/rules/ring.md` rule entry.
     ///
     /// The fix holds the shard guard across `index_contract_hash`, so
     /// the racy interleaving cannot occur and no round produces a
@@ -2459,7 +2470,12 @@ mod tests {
             // `remove_*` (which would trigger cleanup). A zombie =
             // indexed in `contract_hash_index`, absent from BOTH
             // `local_interests` and `interested_peers`.
-            let in_chi = !manager.lookup_by_hash(contract_hash(&contract)).is_empty();
+            // `lookup_by_hash` returns every contract sharing the 32-bit
+            // hash, so check membership of THIS contract specifically —
+            // `!is_empty()` would false-positive on a hash collision.
+            let in_chi = manager
+                .lookup_by_hash(contract_hash(&contract))
+                .contains(&contract);
             let in_li = manager.local_interests.contains_key(&contract);
             let in_ip = manager.interested_peers.contains_key(&contract);
             if in_chi && !in_li && !in_ip {

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -385,16 +385,16 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         is_upstream: bool,
     ) -> bool {
         let now = self.time_source.now();
-        // Release the `interested_peers` shard guard before touching
-        // `peer_contracts` and `index_contract_hash` — those acquire their
-        // own DashMap shards, so holding the first guard across them
-        // serializes unrelated callers (clippy: `significant_drop_tightening`).
-        let is_new = {
-            let mut entry = self.interested_peers.entry(*contract).or_default();
-            let is_new = !entry.contains_key(&peer);
-            entry.insert(peer.clone(), PeerInterest::new(summary, is_upstream, now));
-            is_new
-        };
+        // Hold the `interested_peers` shard guard across `peer_contracts`
+        // insertion and `index_contract_hash` to keep the three writes
+        // atomic against a concurrent `remove_peer_interest` (which would
+        // otherwise observe a fully-removed peer and unindex a contract
+        // we're about to re-index, leaving a zombie entry).
+        // This intentionally undoes the PR #4129 `significant_drop_tightening`
+        // change for these four sites — see PR notes.
+        let mut entry = self.interested_peers.entry(*contract).or_default();
+        let is_new = !entry.contains_key(&peer);
+        entry.insert(peer.clone(), PeerInterest::new(summary, is_upstream, now));
 
         // Maintain reverse index for O(1) peer disconnect cleanup
         self.peer_contracts
@@ -405,6 +405,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         // Also index by hash for fast lookup
         self.index_contract_hash(contract);
 
+        drop(entry);
         is_new
     }
 
@@ -642,16 +643,15 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// Register that we're hosting a contract locally.
     /// Returns true if this caused us to become interested (wasn't interested before).
     pub fn register_local_hosting(&self, contract: &ContractKey) -> bool {
-        // Drop the local_interests shard guard before index_contract_hash
-        // (which acquires a separate DashMap) so unrelated lookups don't
-        // serialize behind us (clippy: `significant_drop_tightening`).
-        let was_interested = {
-            let mut entry = self.local_interests.entry(*contract).or_default();
-            let was = entry.is_interested();
-            entry.hosting = true;
-            was
-        };
+        // Hold the `local_interests` shard guard across `index_contract_hash`
+        // so a concurrent `remove_local_client` / `unregister_local_hosting`
+        // for the last reason cannot run its cleanup (unindex no-op) before
+        // we index, leaving a zombie entry in `contract_hash_index`.
+        let mut entry = self.local_interests.entry(*contract).or_default();
+        let was_interested = entry.is_interested();
+        entry.hosting = true;
         self.index_contract_hash(contract);
+        drop(entry);
         !was_interested
     }
 
@@ -676,12 +676,14 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// Add a local client subscription.
     /// Returns true if this caused us to become interested.
     pub fn add_local_client(&self, contract: &ContractKey) -> bool {
-        // Same drop-before-index pattern as register_local_hosting.
-        let became_interested = {
-            let mut entry = self.local_interests.entry(*contract).or_default();
-            entry.add_client()
-        };
+        // Same lock-across-index discipline as `register_local_hosting`:
+        // hold the `local_interests` shard guard across
+        // `index_contract_hash` to prevent a concurrent
+        // `remove_local_client` from unindexing-before-we-index.
+        let mut entry = self.local_interests.entry(*contract).or_default();
+        let became_interested = entry.add_client();
         self.index_contract_hash(contract);
+        drop(entry);
         became_interested
     }
 
@@ -705,12 +707,11 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// Add a downstream subscriber.
     /// Returns true if this caused us to become interested.
     pub fn add_downstream_subscriber(&self, contract: &ContractKey) -> bool {
-        // Same drop-before-index pattern as register_local_hosting.
-        let became_interested = {
-            let mut entry = self.local_interests.entry(*contract).or_default();
-            entry.add_downstream()
-        };
+        // Same lock-across-index discipline as `register_local_hosting`.
+        let mut entry = self.local_interests.entry(*contract).or_default();
+        let became_interested = entry.add_downstream();
         self.index_contract_hash(contract);
+        drop(entry);
         became_interested
     }
 
@@ -2296,6 +2297,86 @@ mod tests {
             1,
             "Only 1 peer (B) should need syncing, not all {}",
             interested_peers.len()
+        );
+    }
+
+    /// Concurrent stress test for the PR #4129 add-then-index race in
+    /// `InterestManager`.
+    ///
+    /// Before the fix, `add_local_client` / `register_local_hosting` /
+    /// `add_downstream_subscriber` / `register_peer_interest` released
+    /// the `local_interests` (or `interested_peers`) shard guard before
+    /// calling `index_contract_hash`. A concurrent `remove_*` for the
+    /// same contract could then acquire the guard, decrement the last
+    /// reason, run `cleanup_contract_if_no_interest` → `unindex_contract_hash`
+    /// (a no-op because we haven't indexed yet), and the deferred index
+    /// would leak a zombie entry into `contract_hash_index` that
+    /// `cleanup_contract_if_no_interest` would never visit again.
+    /// `lookup_by_hash` and `get_all_interest_hashes` would then return
+    /// the stale entry forever.
+    ///
+    /// The fix holds the shard guard across `index_contract_hash`, so
+    /// the racy interleaving cannot occur. This test exercises the
+    /// production API under contention and asserts the
+    /// `lookup_by_hash(C).is_empty()` invariant once interest is drained.
+    /// The fix makes this hold deterministically; the bug shape is also
+    /// directly demonstrable via manual half-step interleaving (see the
+    /// PR description) but that demonstration is not a useful CI guard
+    /// because it bypasses the locking that the fix introduces.
+    #[test]
+    fn test_concurrent_add_remove_preserves_hash_index_invariant() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        let (manager, _time) = make_manager();
+        let manager = Arc::new(manager);
+        let contract = make_contract_key(7);
+
+        let adders = 8;
+        let removers = 8;
+        let iters = 50_000;
+        let start = Arc::new(Barrier::new(adders + removers));
+
+        let mut handles = Vec::with_capacity(adders + removers);
+        for _ in 0..adders {
+            let m = Arc::clone(&manager);
+            let s = Arc::clone(&start);
+            handles.push(thread::spawn(move || {
+                s.wait();
+                for _ in 0..iters {
+                    m.add_local_client(&contract);
+                }
+            }));
+        }
+        for _ in 0..removers {
+            let m = Arc::clone(&manager);
+            let s = Arc::clone(&start);
+            handles.push(thread::spawn(move || {
+                s.wait();
+                for _ in 0..iters {
+                    m.remove_local_client(&contract);
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // Drain residual interest before checking the invariant.
+        while manager.has_local_interest(&contract) {
+            manager.remove_local_client(&contract);
+        }
+
+        let leaked = manager.lookup_by_hash(contract_hash(&contract));
+        assert!(
+            leaked.is_empty(),
+            "contract_hash_index has zombie entry after add/remove \
+             concurrency: {leaked:?}"
+        );
+        assert!(
+            manager.get_all_interest_hashes().is_empty(),
+            "get_all_interest_hashes leaks zombie: {:?}",
+            manager.get_all_interest_hashes()
         );
     }
 }


### PR DESCRIPTION
## Problem

PR #4129 dropped the `local_interests` / `interested_peers` shard guard before calling `index_contract_hash` in four `InterestManager` methods (`register_peer_interest`, `register_local_hosting`, `add_local_client`, `add_downstream_subscriber`) as a `significant_drop_tightening` clippy cleanup. A fifth method (`register_local_interest`) had the same shape historically.

That opened a race against the corresponding `remove_*` methods:

1. **Adder** acquires the shard guard, mutates the entry (count → 1), drops the guard. Paused before calling `index_contract_hash`.
2. **Remover** acquires the now-released guard, decrements to 0, finds `lost_interest`, removes the map entry, calls `cleanup_contract_if_no_interest` → `unindex_contract_hash` — a no-op because we haven't indexed yet.
3. **Adder** resumes and runs `index_contract_hash`, inserting the contract into `contract_hash_index` with no backing interest.

Result: a zombie entry that `cleanup_contract_if_no_interest` will never revisit (it only fires on remove, and the contract has no interest left to remove). `lookup_by_hash` and `get_all_interest_hashes` return the stale entry forever, poisoning PUT propagation (`ring.rs:1586`, `ring.rs:1611`) and interest hash gossip.

This was found by a post-merge review of #4129. The race was triangulated by three independent reviewers (Claude `code-first-reviewer`, Claude `skeptical-reviewer`, Codex). I reproduced the bug shape deterministically by manually stepping through the half-state interleaving on the merged main, observing the predicted zombie entry in `contract_hash_index` (see the bug-trace section below).

## Approach

Hold the shard guard across `index_contract_hash` in all five affected sites. This restores the pre-#4129 invariant: the `local_interests` / `interested_peers` entry mutation and the corresponding `contract_hash_index` insertion are atomic against a concurrent `remove_*` for the same contract.

**Sites fixed (`crates/core/src/ring/interest.rs`):**
- `register_peer_interest` — holds `interested_peers[C]` across `peer_contracts[peer]` insertion AND `index_contract_hash`
- `register_local_hosting` — holds `local_interests[C]` across `index_contract_hash`
- `add_local_client` — same
- `add_downstream_subscriber` — same
- `register_local_interest` — same (currently unused inside the workspace but `pub`, flagged by Codex + skeptical-reviewer as a public-API footgun)

**Deadlock check:** nothing in the codebase acquires `contract_hash_index` then `local_interests` / `interested_peers` (verified by greping callers), and `peer_contracts` is only ever acquired after `interested_peers` in existing code paths — so the global lock order is preserved. `remove_all_peer_interests` acquires `peer_contracts` first then `interested_peers`, but it fully releases the `peer_contracts` guard before touching `interested_peers`, so no nested-hold deadlock. (`remove_all_peer_interests` has its own bidirectional-consistency bug — see #4174 — but that's pre-existing and out of scope here.)

**Trade-off:** this re-introduces the `significant_drop_tightening` clippy hits that #4129 was cleaning up. The lint is correct that holding the shard guard slightly increases contention on `index_contract_hash`, but correctness > contention. These five sites are the ones where the lock is load-bearing; the other lock-scope tightenings #4129 introduced elsewhere (in `connection_manager.rs`, `ring.rs`, `hosting.rs`) are unaffected.

**Rule update (`.claude/rules/ring.md`)**: added a "Cross-DashMap Lock Discipline" section documenting the pattern, with explicit cross-references to PRs #4129 / #4171, so a future clippy autofix (or agent applying the lint) leaves a footprint when it tries to drop a load-bearing guard.

## Bug trace

Reproduced deterministically on `8e24c63f` (the #4129 merge commit) by manually staging the racy half-state:

```rust
// Step 1: simulate the FIRST half of add_local_client(C) — entry
// inserted into local_interests with count=1, NOT yet indexed.
{
    let mut entry = manager.local_interests.entry(contract).or_default();
    entry.add_client();
}

// Step 2: concurrent thread runs the FULL remove_local_client cycle.
// Cleanup observes no local_interests entry, so unindex_contract_hash
// is a no-op.
assert!(manager.remove_local_client(&contract));
assert!(!manager.has_local_interest(&contract));

// Step 3: the SECOND half of add_local_client(C) — deferred index runs.
manager.index_contract_hash(&contract);

// FAILS: contract_hash_index has zombie entry: [ContractKey {...}]
assert!(manager.lookup_by_hash(contract_hash(&contract)).is_empty());
```

This test ran red on the merged-main code and produced the exact zombie entry predicted. With the fix applied, the production API cannot reach the racy interleaving (the lock holds the remove out), so this manual sequence is no longer constructible from real code paths.

## Testing

- **New concurrent regression test** `test_concurrent_add_remove_preserves_hash_index_invariant` in `ring/interest.rs`. The PR-#4129 zombie only *persists* when the contract sees no further activity (a later add re-establishes backing interest; a later remove's cleanup unindexes it), so a single-hammered-contract stress test self-heals and cannot observe the bug. Instead, the test runs **120 000 rounds, each on a fresh contract**: a 3-party barrier releases one adder and one remover simultaneously, they each do exactly **one** op, and the round is then checked directly (no `remove_*` calls, which would trigger cleanup and heal a zombie). With only one add and one remove, nothing can heal a zombie once created. Two long-lived worker threads loop over the rounds via the barrier to avoid per-round spawn overhead; all four add/remove pairs are exercised round-robin.
- **Sensitivity check**: with `add_downstream_subscriber`'s lock discipline reverted to the buggy PR-#4129 shape, the test fails **8/10** runs (1–5 leaked zombies per failing run). The earlier single-contract design caught it **0/10**. With the fix in place the test passes deterministically (~1.85s).
- **Existing test suite**: `cargo test -p freenet --lib --no-fail-fast` → **2512 passed, 0 failed, 14 ignored** (same as pre-fix baseline; no regressions). `cargo fmt --check` and `cargo clippy -p freenet --all-targets -- -D warnings`: clean.
- The deterministic bug-shape test from the bug-trace section above is not included in the PR — it bypasses the lock-discipline that the fix introduces, so it would always demonstrate the zombie shape regardless of fix, making it useless as a CI guard. It is documented here instead.

## Rule update

`.claude/rules/ring.md` gains a "Cross-DashMap Lock Discipline" section: it documents that the `significant_drop_tightening` clippy lint must be ignored when the dropped guard is load-bearing for atomicity against a concurrent remover, with `WRONG`/`CORRECT` examples and cross-references to #4129 / #4171. A caveat notes the discipline only protects *primary-origin* removers — *secondary-origin* removers (starting from the mirror index) still need their own atomicity story (see #4174).

## Follow-ups (filed as separate issues)

The same #4129 post-merge multi-model review surfaced three other findings out of scope here:

- **#4172** — `set_own_addr` TOCTOU between `own_addr` mutex and `network_status::set_external_address` (same PR-#4129 clippy-perf cleanup, different code path).
- **#4173** — `scripts/static-checks.sh:160-169` per-member geiger hardcodes `status="ok"` regardless of exit code (bug in the script PR #4129 added).
- **#4174** — `remove_all_peer_interests` bidirectional consistency race against `register_peer_interest` (pre-existing, surfaced while reviewing this PR by Codex).

[AI-assisted - Claude]
