### PR TITLE
fix: compute geiger per-member status from exit code

### DIFF
--- a/scripts/static-checks.sh
+++ b/scripts/static-checks.sh
@@ -166,8 +166,10 @@ run_geiger() {
   printf ']\n' >> "$OUT/geiger.raw"
   local t1; t1=$(date +%s)
 
+  local geiger_status
+  if [[ $rc -eq 0 ]]; then geiger_status="ok"; else geiger_status="exit_${rc}"; fi
   jq -n \
-    --arg status "ok" \
+    --arg status "$geiger_status" \
     --argjson rc  "$rc" \
     --argjson dur "$((t1-t0))" \
     --arg raw     "$OUT/geiger.raw" \


### PR DESCRIPTION
## Problem

The per-member geiger summary section in `scripts/static-checks.sh` hardcodes `--arg status "ok"` on line ~169 regardless of the actual exit code of the `cargo geiger` run. When a per-package geiger check fails (e.g., new unsafe trait implementations), the report JSON records `status: "ok"` and the failure is masked. Only the global geiger mode (lines ~60-68) correctly propagates the exit code.

## Solution

Compute `geiger_status` from `$rc` the same way `run_check` does:

```bash
local geiger_status
if [[ $rc -eq 0 ]]; then geiger_status="ok"; else geiger_status="exit_${rc}"; fi
```

Replace the hardcoded `--arg status "ok"` with `--arg status "$geiger_status"`.

## Testing

Manual verification: the global mode uses the same pattern (`run_check` at line ~68), so this change aligns the per-member mode with the already-working global mode. No functional test exists for the static-checks script yet (tracked separately in the CI integration work item).

## Fixes

Closes #4173.