### PR TITLE
fix: add missing license fields to release-agent and topology-sim

### DIFF
--- a/crates/release-agent/Cargo.toml
+++ b/crates/release-agent/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = "1.85"
 publish = false
 description = "HTTP agent that lets the freenet-core release pipeline trigger gateway updates"
 repository = "https://github.com/freenet/freenet-core"
+license = "MIT OR Apache-2.0"
 
 [[bin]]
 name = "freenet-release-agent"

--- a/crates/topology-sim/Cargo.toml
+++ b/crates/topology-sim/Cargo.toml
@@ -3,6 +3,7 @@ name = "topology-sim"
 version = "0.1.0"
 edition = "2024"
 publish = false
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 rand = { workspace = true }


### PR DESCRIPTION

## Problem

Two crates in the workspace are missing the `license` field in their `Cargo.toml`:

- `crates/release-agent/Cargo.toml` — has `description`, `repository`, `edition`, `rust-version`, but no `license`
- `crates/topology-sim/Cargo.toml` — has `edition`, `publish`, but no `license`

The rest of the workspace uses either `license = "MIT OR Apache-2.0"` or `license-file = "../../LICENSE.md"`. Missing license metadata causes `cargo deny check` to flag these crates and creates ambiguity for downstream consumers about licensing terms.

## Solution

Add `license = "MIT OR Apache-2.0"` to both Cargo.toml files, matching the explicit dual-license used by other workspace crates.

## Testing

Verified with `grep -r '^license' crates/*/Cargo.toml` that all crates now have a license declaration. `cargo check --workspace` passes cleanly.

## Fixes

Closes #4178.