### PR TITLE
docs: document DashMap serialization assumption in server.rs

### DIFF
--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -282,6 +282,8 @@ pub mod local_node {
                     // Drop the iter() guard before remove() to avoid holding a
                     // DashMap shard guard across a mutating call on the same map
                     // (clippy: `significant_drop_in_scrutinee`).
+                    // Safe: the outer caller serialises by `id`, so no concurrent
+                    // iter+remove on this shard is possible.
                     let rm_token = gw.origin_contracts.iter().find_map(|entry| {
                         let (k, origin) = entry.pair();
                         (origin.client_id == id).then(|| k.clone())


### PR DESCRIPTION
## Problem

At `server.rs:282`, the code splits a DashMap `iter()` guard drop from a subsequent `remove()` call on the same map. This was done as a `significant_drop_in_scrutinee` clippy cleanup in PR #4129. The split is safe because the outer caller serialises by `id`, but this assumption is non-obvious — a future reader or an automated clippy autofix could break the invariant by reintroducing a combined iter+remove under the same guard.

## Solution

Add a one-line comment documenting the safety invariant:

```rust
// Safe: the outer caller serialises by `id`, so no concurrent
// iter+remove on this shard is possible.
```

## Testing

Comment-only change — zero behavioural impact. Verified by reading the code at the call site to confirm the per-`id` serialisation assumption.

## Fixes

Reviewer nit from iduartgomez on PR #4129.