### PR TITLE
docs: document intentional capacity discard in op_state_manager drain

### DIFF
--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1097,6 +1097,8 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                     });
                 }
 
+                // Capacity discard is intentional — `old_missing` is a local that
+                // goes out of scope after this loop; the new Vec is allocated above.
                 let old_missing = std::mem::replace(&mut delayed, Vec::with_capacity(200));
                 for tx in old_missing {
                     if let Some(tx) = ops.completed.remove(&tx) {


### PR DESCRIPTION
## Problem

In `op_state_manager.rs`, the code iterates over a `Vec` that was just obtained via `mem::replace`. The original code used `.drain(..)` to clear the Vec while iterating, but since the Vec is a local variable that goes out of scope immediately after the loop, the `.drain(..)` was replaced with direct iteration (via `into_iter()`). The capacity discard from `into_iter()` vs `drain(..)` is intentional but undocumented — a future maintainer might not understand why `drain(..)` was removed.

## Solution

Add a comment explaining the intentional capacity discard:

```rust
// Capacity discard is intentional — `old_missing` is a local that
// goes out of scope after this loop; the new Vec is allocated above.
```

## Testing

Comment-only change — zero behavioural impact. Verified that the Vec is indeed `mem::replace`'d and immediately consumed.

## Fixes

Reviewer nit from iduartgomez on PR #4129.