### PR TITLE
build: configure cargo-deny to allow multiple crate versions

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,9 @@
+# cargo-deny configuration for freenet-core.
+# See: https://embarkstudios.github.io/cargo-deny/
+
+[bans]
+# Allow multiple versions — most duplicates are semver-incompatible
+# versions pulled in by different dependency ecosystems (e.g., wasmtime
+# vs reqwest, rustls 0.21 vs 0.23). These cannot be unified without
+# upstream changes. Tracked in #4177.
+multiple-versions = "allow"


### PR DESCRIPTION

## Problem
cargo-deny reports 55 duplicate crate versions across the workspace.
These are not bugs — they are unavoidable semver-incompatible forks
in the dependency tree (e.g., wasmtime pins time 0.3.7 while
reqwest uses time 0.3.36, rustls 0.21 vs 0.23 via webpki-roots vs
soketto). There is no single version that satisfies all consumers.

## Solution
Add deny.toml with multiple-versions = "allow" to explicitly permit
duplicates. Tracked in #4177 for future reduction effort.

## Testing
cargo deny check bans passes cleanly (0 errors, 0 warnings).

## Fixes
Closes #4177