### PR TITLE
fix: make event loop notification channel capacity configurable (#4145)

### DIFF
--- a/apps/freenet-ping/app/tests/common/mod.rs
+++ b/apps/freenet-ping/app/tests/common/mod.rs
@@ -172,6 +172,7 @@ pub async fn base_node_test_config_with_rng<R: Rng>(
             max_connections: None,
             bandwidth_limit: None,
             blocked_addresses,
+            event_loop_channel_capacity: None,
             transient_budget: None,
             // Use a longer TTL for tests (120s) to prevent connections from expiring
             // during test operations. The default 30s can cause flaky failures when

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -56,6 +56,7 @@ static ASYNC_RT: LazyLock<Option<Runtime>> = LazyLock::new(GlobalExecutor::initi
 
 const DEFAULT_TRANSIENT_BUDGET: usize = 2048;
 const DEFAULT_TRANSIENT_TTL_SECS: u64 = 30;
+const DEFAULT_EVENT_LOOP_CHANNEL_CAPACITY: usize = 2048;
 
 const QUALIFIER: &str = "";
 const ORGANIZATION: &str = "The Freenet Project Inc";
@@ -120,6 +121,7 @@ impl Default for ConfigArgs {
                 total_bandwidth_limit: None,
                 min_bandwidth_per_connection: None,
                 blocked_addresses: None,
+                event_loop_channel_capacity: None,
                 transient_budget: Some(DEFAULT_TRANSIENT_BUDGET),
                 transient_ttl_secs: Some(DEFAULT_TRANSIENT_TTL_SECS),
                 min_connections: None,
@@ -603,6 +605,10 @@ impl ConfigArgs {
                     .network_api
                     .blocked_addresses
                     .map(|addrs| addrs.into_iter().collect()),
+                event_loop_channel_capacity: self
+                    .network_api
+                    .event_loop_channel_capacity
+                    .unwrap_or_else(default_event_loop_channel_capacity),
                 transient_budget: self
                     .network_api
                     .transient_budget
@@ -904,6 +910,16 @@ pub struct NetworkArgs {
     #[arg(long, num_args = 0..)]
     pub blocked_addresses: Option<Vec<SocketAddr>>,
 
+    /// Capacity for the event loop notification and op execution channels.
+    /// Default: 2048. Increase under sustained multi-client load to reduce
+    /// channel saturation and associated context-switch spikes.
+    #[arg(long, env = "EVENT_LOOP_CHANNEL_CAPACITY")]
+    #[serde(
+        rename = "event-loop-channel-capacity",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub event_loop_channel_capacity: Option<usize>,
+
     /// Maximum number of concurrent transient connections accepted by a gateway.
     #[arg(long, env = "TRANSIENT_BUDGET")]
     #[serde(rename = "transient-budget", skip_serializing_if = "Option::is_none")]
@@ -1127,6 +1143,12 @@ pub struct NetworkApiConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blocked_addresses: Option<HashSet<SocketAddr>>,
 
+    /// Capacity for the event loop notification and op execution channels.
+    /// Default: 2048. Increase under sustained multi-client load to reduce
+    /// channel saturation and associated context-switch spikes.
+    #[serde(default = "default_event_loop_channel_capacity")]
+    pub event_loop_channel_capacity: usize,
+
     /// Maximum number of concurrent transient connections accepted by a gateway.
     #[serde(default = "default_transient_budget", rename = "transient-budget")]
     pub transient_budget: usize,
@@ -1229,6 +1251,10 @@ use port_allocation::find_available_port;
 
 pub fn default_network_api_port() -> u16 {
     find_available_port().unwrap_or(31337) // Fallback to 31337 if we can't find a random port
+}
+
+pub(crate) fn default_event_loop_channel_capacity() -> usize {
+    DEFAULT_EVENT_LOOP_CHANNEL_CAPACITY
 }
 
 fn default_transient_budget() -> usize {

--- a/crates/core/src/node/network_bridge.rs
+++ b/crates/core/src/node/network_bridge.rs
@@ -429,6 +429,48 @@ mod tests {
         }
         assert_eq!(received, 2, "Should receive both messages");
     }
+
+    /// Test that event_loop_notification_channel_with_capacity creates channels
+    /// with the specified capacity and that the capacity is respected.
+    #[tokio::test]
+    async fn test_channel_with_custom_capacity() {
+        let custom_capacity: usize = 5;
+        let (notification_channel, notification_tx) =
+            event_loop_notification_channel_with_capacity(custom_capacity);
+        let mut rx = notification_channel.notifications_receiver;
+
+        // Fill up to capacity without draining
+        for i in 0..custom_capacity {
+            let test_event = crate::message::NodeEvent::Disconnect {
+                cause: Some(format!("msg-{i}").into()),
+            };
+            notification_tx
+                .notifications_sender()
+                .send(Either::Right(test_event))
+                .await
+                .expect("Should not block within channel capacity");
+        }
+
+        // Verify we can drain all messages
+        let mut count = 0;
+        while count < custom_capacity {
+            match timeout(Duration::from_millis(50), rx.recv()).await {
+                Ok(Some(_)) => count += 1,
+                Ok(None) => panic!("Channel closed unexpectedly"),
+                Err(_) => panic!(
+                    "Timeout draining message {}/{} — channel may have over-accepted",
+                    count + 1,
+                    custom_capacity
+                ),
+            }
+        }
+
+        assert_eq!(
+            count, custom_capacity,
+            "Should receive exactly {} messages (channel capacity)",
+            custom_capacity
+        );
+    }
 }
 
 // ConnectionError tests

--- a/crates/core/src/node/network_bridge.rs
+++ b/crates/core/src/node/network_bridge.rs
@@ -151,21 +151,32 @@ pub fn reset_channel_id_counter() {
     CHANNEL_ID_COUNTER.with(|c| c.set(idx * CHANNEL_ID_BLOCK));
 }
 
-/// Channel capacity for event loop notification and op execution channels.
-const EVENT_LOOP_CHANNEL_CAPACITY: usize = 2048;
+/// Default channel capacity for event loop notification and op execution channels.
+const DEFAULT_EVENT_LOOP_CHANNEL_CAPACITY: usize = 2048;
 
+/// Create an event loop notification channel pair with the default capacity.
 pub(crate) fn event_loop_notification_channel()
 -> (EventLoopNotificationsReceiver, EventLoopNotificationsSender) {
+    event_loop_notification_channel_with_capacity(DEFAULT_EVENT_LOOP_CHANNEL_CAPACITY)
+}
+
+/// Create an event loop notification channel pair with a specific capacity.
+///
+/// Use [`event_loop_notification_channel`] for the default capacity (2048).
+pub(crate) fn event_loop_notification_channel_with_capacity(
+    capacity: usize,
+) -> (EventLoopNotificationsReceiver, EventLoopNotificationsSender) {
     let _channel_id = CHANNEL_ID_COUNTER.with(|c| {
         let v = c.get();
         c.set(v + 1);
         v
     });
-    let (notification_tx, notification_rx) = mpsc::channel(EVENT_LOOP_CHANNEL_CAPACITY);
-    let (op_execution_tx, op_execution_rx) = mpsc::channel(EVENT_LOOP_CHANNEL_CAPACITY);
+    let (notification_tx, notification_rx) = mpsc::channel(capacity);
+    let (op_execution_tx, op_execution_rx) = mpsc::channel(capacity);
 
     tracing::info!(
         channel_id = _channel_id,
+        capacity,
         "Created event loop notification channel pair"
     );
 

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -7,8 +7,8 @@ use tracing::Instrument;
 use super::{
     NetEventRegister, PeerId,
     network_bridge::{
-        EventLoopNotificationsReceiver,
-        event_loop_notification_channel_with_capacity, p2p_protoc::P2pConnManager,
+        EventLoopNotificationsReceiver, event_loop_notification_channel_with_capacity,
+        p2p_protoc::P2pConnManager,
     },
 };
 use crate::{

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -7,7 +7,8 @@ use tracing::Instrument;
 use super::{
     NetEventRegister, PeerId,
     network_bridge::{
-        EventLoopNotificationsReceiver, event_loop_notification_channel, p2p_protoc::P2pConnManager,
+        EventLoopNotificationsReceiver,
+        event_loop_notification_channel_with_capacity, p2p_protoc::P2pConnManager,
     },
 };
 use crate::{
@@ -309,7 +310,9 @@ impl NodeP2P {
         CH: ContractHandler + Send + 'static,
         ER: NetEventRegister + Clone,
     {
-        let (notification_channel, notification_tx) = event_loop_notification_channel();
+        let channel_capacity = config.config.network_api.event_loop_channel_capacity;
+        let (notification_channel, notification_tx) =
+            event_loop_notification_channel_with_capacity(channel_capacity);
         let (mut ch_outbound, ch_inbound, wait_for_event) = contract::contract_handler_channel();
         let (client_responses, cli_response_sender) = contract::client_responses_channel();
 


### PR DESCRIPTION
## Problem
EVENT_LOOP_CHANNEL_CAPACITY was hard-coded at 2048 with no way for
operators or deployers to tune it. Under sustained multi-client load
the fixed capacity can cause channel saturation and context-switch
spikes.

## Solution
- NetworkArgs::event_loop_channel_capacity (Option<usize>, CLI/env)
- NetworkApiConfig::event_loop_channel_capacity (usize, serde default)
- event_loop_notification_channel_with_capacity(capacity) for prod path
- event_loop_notification_channel() wrapper (default capacity) for tests
- Capacity value is logged at channel creation time

## Testing
- cargo check --workspace passes
- Existing tests continue to use the default 2048 via the no-arg wrapper

## Fixes
Closes #4145