### PR TITLE
refactor: avoid 200-cap allocation in GC delayed buffer

### DIFF
--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1097,7 +1097,7 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                     });
                 }
 
-                let old_missing = std::mem::replace(&mut delayed, Vec::with_capacity(200));
+                let old_missing = std::mem::take(&mut delayed);
                 for tx in old_missing {
                     if let Some(tx) = ops.completed.remove(&tx) {
                         if cfg!(feature = "trace-ot") {


### PR DESCRIPTION
## Problem

In `op_state_manager.rs::garbage_cleanup_task`, every GC tick allocates a fresh `Vec::with_capacity(200)` for the `delayed` buffer:

```rust
let old_missing = std::mem::replace(&mut delayed, Vec::with_capacity(200));
```

After the task-per-transaction refactor, this buffer is almost always empty:

- The first loop's `delayed.push(tx)` (line 1118) is unreachable — `still_waiting` is a const `false`.
- The only live repopulator is the `under_progress` branch (line ~1153), which fires only when an op exceeds its TTL but is still inside the 5× absolute cutoff. Rare path.

So we pay ~1.6KB of allocation every tick for a buffer that almost never receives a push.

## Solution

Use `std::mem::take`:

```rust
let old_missing = std::mem::take(&mut delayed);
```

- Common case (empty): zero allocation.
- Rare case (under_progress push): pays one small amortized `Vec` growth.

Same drain-and-reset semantics as before.

## Context

PR #4185 added a comment trying to explain the original construct's capacity-discard. This change removes the construct itself, so the explanation is no longer needed.

## Testing

- `cargo fmt`
- `cargo clippy -p freenet --lib -- -D warnings` — clean
- `cargo build -p freenet` — clean
- Behavior change: none. Only allocation pattern changes.