### PR TITLE
fix(fdev): remove no-op --release flag and unconditional bail (#4088)

### DIFF
--- a/crates/fdev/src/commands.rs
+++ b/crates/fdev/src/commands.rs
@@ -57,9 +57,6 @@ pub(crate) struct PutDelegate {
 }
 
 pub async fn put(config: PutConfig, other: BaseConfig) -> anyhow::Result<()> {
-    if config.release {
-        anyhow::bail!("Cannot publish contracts in the network yet");
-    }
     let params = if let Some(params) = &config.parameters {
         let mut buf = vec![];
         File::open(params)?.read_to_end(&mut buf)?;
@@ -366,9 +363,6 @@ pub async fn get_contract_id(config: GetContractIdConfig) -> anyhow::Result<()> 
 }
 
 pub async fn update(config: UpdateConfig, other: BaseConfig) -> anyhow::Result<()> {
-    if config.release {
-        anyhow::bail!("Cannot publish contracts in the network yet");
-    }
     // Create ContractKey with placeholder code hash - the node will look up the actual key
     let instance_id = ContractInstanceId::try_from(config.key)?;
     let key = ContractKey::from_id_and_code(instance_id, CodeHash::new([0u8; 32]));

--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -151,9 +151,6 @@ pub struct UpdateConfig {
     /// contract's `update_state` only accepts full-state replacements.
     #[arg(long)]
     pub(crate) as_state: bool,
-    /// Whether this contract will be updated in the network or is just a dry run
-    /// to be executed in local mode only. By default puts are performed in local.
-    pub(crate) release: bool,
 }
 
 /// Publishes a new contract or delegate to the network.
@@ -169,10 +166,6 @@ pub struct PutConfig {
     /// with empty parameters.
     #[arg(long)]
     pub(crate) parameters: Option<PathBuf>,
-    /// Whether this contract will be released into the network or is just a dry run
-    /// to be executed in local mode only. By default puts are performed in local.
-    #[arg(long)]
-    pub(crate) release: bool,
     /// Type of put to perform.
     #[clap(subcommand)]
     pub(crate) package_type: PutType,
@@ -279,4 +272,61 @@ pub(crate) enum ContractKind {
     WebApp,
     /// An standard contract.
     Contract,
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser as _;
+
+    use super::Config;
+
+    /// Regression test for #4088: `fdev publish --release` used to bail
+    /// unconditionally with "Cannot publish contracts in the network yet".
+    /// After the fix the `--release` flag no longer exists on `publish`;
+    /// passing it should be a CLI parse error, not a silent rejection at
+    /// runtime.
+    #[test]
+    fn publish_does_not_accept_release_flag() {
+        let result = Config::try_parse_from([
+            "fdev",
+            "publish",
+            "--code",
+            "contract.wasm",
+            "--release", // must not exist
+            "contract",
+        ]);
+        let err_msg = result
+            .as_ref()
+            .map(|_| String::new())
+            .unwrap_or_else(|e| e.to_string());
+        assert!(
+            result.is_err(),
+            "fdev publish --release should be a parse error after #4088 removal, but parsed OK"
+        );
+        assert!(
+            err_msg.contains("--release") || err_msg.contains("release"),
+            "error message should mention the unknown flag, got: {err_msg}"
+        );
+    }
+
+    /// Regression test for #4088: `fdev execute update <KEY> <DELTA> <RELEASE>`
+    /// used to accept a positional `release: bool` argument that bailed
+    /// unconditionally when true. After the fix the positional arg is gone.
+    #[test]
+    fn execute_update_does_not_accept_positional_release_bool() {
+        // Passing "true" as a third positional arg should now be rejected
+        // because UpdateConfig only accepts key + delta.
+        let result = Config::try_parse_from([
+            "fdev",
+            "execute",
+            "update",
+            "SomeBase58ContractKey",
+            "/tmp/delta.bin",
+            "true", // was the `release: bool` positional; must not exist
+        ]);
+        assert!(
+            result.is_err(),
+            "fdev execute update with a third positional arg should fail after #4088 removal"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`fdev publish --release` and `fdev execute update <KEY> <DELTA> true` bailed unconditionally with:

```
Error: Cannot publish contracts in the network yet
```

The `--release` flag on `fdev publish` and the positional `RELEASE: bool` arg on `fdev execute update` had **no semantic effect** — both handlers rejected the call immediately rather than forwarding it. Network-vs-local behavior is determined entirely by which daemon the client connects to, not by any client-side flag. As a result, users following the docs (which pass `network` as the release string, which is not even a valid `bool`) or passing `--release` could never reach the network path.

## Solution

Remove the flag entirely — option 1 from the issue:

- **`PutConfig`**: drop `release: bool` field and its `#[arg(long)]` clap definition
- **`UpdateConfig`**: drop `release: bool` positional field  
- **`commands::put()`** and **`commands::update()`**: remove `if config.release { bail!(...) }` guards

Network vs. local behavior continues to be controlled by the daemon mode (`--mode` / `MODE` env var on the `BaseConfig`), which is correct and sufficient.

## Testing

Two regression tests added in `crates/fdev/src/config.rs`:

1. **`publish_does_not_accept_release_flag`** — verifies `fdev publish --release ...` is now a CLI parse error (unknown flag) rather than a runtime rejection.
2. **`execute_update_does_not_accept_positional_release_bool`** — verifies `fdev execute update KEY DELTA true` (the old positional bool) is rejected as an unexpected positional argument.

All 48 existing `fdev` tests continue to pass.

## Breaking change note

This is a CLI breaking change for anyone who passed `--release` to `fdev publish`, but since the flag **only ever produced an error**, the observable effect for existing users is that the command now *succeeds* instead of failing.

## Fixes

Fixes #4088