### PR TITLE
feat(observability): add INFO log for DelegateRequest dispatch (#4152)

### DIFF
--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1512,6 +1512,58 @@ async fn process_open_request(
                     "Received delegate operation from client"
                 );
                 let delegate_key = req.key().clone();
+                // Derive a short discriminant tag for the INFO log before `req` is moved.
+                let msg_type = match &req {
+                    freenet_stdlib::client_api::DelegateRequest::ApplicationMessages {
+                        inbound,
+                        ..
+                    } => {
+                        // Include the count of inbound message variants for observability.
+                        // Each variant name is a short discriminant so operators can tell
+                        // ApplicationMessage (from app) apart from GetContractResponse etc.
+                        let tags: Vec<&str> = inbound
+                            .iter()
+                            .map(|m| match m {
+                                InboundDelegateMsg::ApplicationMessage(_) => "ApplicationMessage",
+                                InboundDelegateMsg::UserResponse(_) => "UserResponse",
+                                InboundDelegateMsg::GetContractResponse(_) => "GetContractResponse",
+                                InboundDelegateMsg::PutContractResponse(_) => "PutContractResponse",
+                                InboundDelegateMsg::UpdateContractResponse(_) => {
+                                    "UpdateContractResponse"
+                                }
+                                InboundDelegateMsg::SubscribeContractResponse(_) => {
+                                    "SubscribeContractResponse"
+                                }
+                                InboundDelegateMsg::ContractNotification(_) => {
+                                    "ContractNotification"
+                                }
+                                InboundDelegateMsg::DelegateMessage(_) => "DelegateMessage",
+                                _ => "Unknown",
+                            })
+                            .collect();
+                        // Format as "ApplicationMessages[ApplicationMessage,DelegateMessage]"
+                        // when there are inbound messages, or bare "ApplicationMessages" when empty.
+                        if tags.is_empty() {
+                            "ApplicationMessages".to_string()
+                        } else {
+                            format!("ApplicationMessages[{}]", tags.join(","))
+                        }
+                    }
+                    freenet_stdlib::client_api::DelegateRequest::RegisterDelegate { .. } => {
+                        "RegisterDelegate".to_string()
+                    }
+                    freenet_stdlib::client_api::DelegateRequest::UnregisterDelegate(_) => {
+                        "UnregisterDelegate".to_string()
+                    }
+                    _ => "Unknown".to_string(),
+                };
+                tracing::info!(
+                    delegate = %delegate_key,
+                    msg_type = %msg_type,
+                    request_id = %request_id,
+                    outcome = "queued",
+                    "DelegateRequest dispatch"
+                );
                 let origin_contract = request.origin_contract;
 
                 let res = match op_manager
@@ -1521,7 +1573,16 @@ async fn process_open_request(
                     })
                     .await
                 {
-                    Ok(ContractHandlerEvent::DelegateResponse(res)) => res,
+                    Ok(ContractHandlerEvent::DelegateResponse(res)) => {
+                        tracing::info!(
+                            delegate = %delegate_key,
+                            msg_type = %msg_type,
+                            request_id = %request_id,
+                            outcome = "executed",
+                            "DelegateRequest dispatch"
+                        );
+                        res
+                    }
                     Err(err) => {
                         tracing::error!(
                             client_id = %client_id,

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1512,58 +1512,72 @@ async fn process_open_request(
                     "Received delegate operation from client"
                 );
                 let delegate_key = req.key().clone();
-                // Derive a short discriminant tag for the INFO log before `req` is moved.
-                let msg_type = match &req {
-                    freenet_stdlib::client_api::DelegateRequest::ApplicationMessages {
-                        inbound,
-                        ..
-                    } => {
-                        // Include the count of inbound message variants for observability.
-                        // Each variant name is a short discriminant so operators can tell
-                        // ApplicationMessage (from app) apart from GetContractResponse etc.
-                        let tags: Vec<&str> = inbound
-                            .iter()
-                            .map(|m| match m {
-                                InboundDelegateMsg::ApplicationMessage(_) => "ApplicationMessage",
-                                InboundDelegateMsg::UserResponse(_) => "UserResponse",
-                                InboundDelegateMsg::GetContractResponse(_) => "GetContractResponse",
-                                InboundDelegateMsg::PutContractResponse(_) => "PutContractResponse",
-                                InboundDelegateMsg::UpdateContractResponse(_) => {
-                                    "UpdateContractResponse"
-                                }
-                                InboundDelegateMsg::SubscribeContractResponse(_) => {
-                                    "SubscribeContractResponse"
-                                }
-                                InboundDelegateMsg::ContractNotification(_) => {
-                                    "ContractNotification"
-                                }
-                                InboundDelegateMsg::DelegateMessage(_) => "DelegateMessage",
-                                _ => "Unknown",
-                            })
-                            .collect();
-                        // Format as "ApplicationMessages[ApplicationMessage,DelegateMessage]"
-                        // when there are inbound messages, or bare "ApplicationMessages" when empty.
-                        if tags.is_empty() {
-                            "ApplicationMessages".to_string()
-                        } else {
-                            format!("ApplicationMessages[{}]", tags.join(","))
+                // Derive a short discriminant tag for the INFO logs, but only when INFO is
+                // enabled — the Vec<&str> collect + format! would otherwise allocate on every
+                // delegate dispatch even when the log line is suppressed.
+                let msg_type: Option<String> = if tracing::enabled!(tracing::Level::INFO) {
+                    Some(match &req {
+                        freenet_stdlib::client_api::DelegateRequest::ApplicationMessages {
+                            inbound,
+                            ..
+                        } => {
+                            // Include the count of inbound message variants for observability.
+                            // Each variant name is a short discriminant so operators can tell
+                            // ApplicationMessage (from app) apart from GetContractResponse etc.
+                            let tags: Vec<&str> = inbound
+                                .iter()
+                                .map(|m| match m {
+                                    InboundDelegateMsg::ApplicationMessage(_) => {
+                                        "ApplicationMessage"
+                                    }
+                                    InboundDelegateMsg::UserResponse(_) => "UserResponse",
+                                    InboundDelegateMsg::GetContractResponse(_) => {
+                                        "GetContractResponse"
+                                    }
+                                    InboundDelegateMsg::PutContractResponse(_) => {
+                                        "PutContractResponse"
+                                    }
+                                    InboundDelegateMsg::UpdateContractResponse(_) => {
+                                        "UpdateContractResponse"
+                                    }
+                                    InboundDelegateMsg::SubscribeContractResponse(_) => {
+                                        "SubscribeContractResponse"
+                                    }
+                                    InboundDelegateMsg::ContractNotification(_) => {
+                                        "ContractNotification"
+                                    }
+                                    InboundDelegateMsg::DelegateMessage(_) => "DelegateMessage",
+                                    _ => "Unknown",
+                                })
+                                .collect();
+                            // Format as "ApplicationMessages[ApplicationMessage,DelegateMessage]"
+                            // when there are inbound messages, or bare "ApplicationMessages" when empty.
+                            if tags.is_empty() {
+                                "ApplicationMessages".to_string()
+                            } else {
+                                format!("ApplicationMessages[{}]", tags.join(","))
+                            }
                         }
-                    }
-                    freenet_stdlib::client_api::DelegateRequest::RegisterDelegate { .. } => {
-                        "RegisterDelegate".to_string()
-                    }
-                    freenet_stdlib::client_api::DelegateRequest::UnregisterDelegate(_) => {
-                        "UnregisterDelegate".to_string()
-                    }
-                    _ => "Unknown".to_string(),
+                        freenet_stdlib::client_api::DelegateRequest::RegisterDelegate {
+                            ..
+                        } => "RegisterDelegate".to_string(),
+                        freenet_stdlib::client_api::DelegateRequest::UnregisterDelegate(_) => {
+                            "UnregisterDelegate".to_string()
+                        }
+                        _ => "Unknown".to_string(),
+                    })
+                } else {
+                    None
                 };
-                tracing::info!(
-                    delegate = %delegate_key,
-                    msg_type = %msg_type,
-                    request_id = %request_id,
-                    outcome = "queued",
-                    "DelegateRequest dispatch"
-                );
+                if let Some(ref mt) = msg_type {
+                    tracing::info!(
+                        delegate = %delegate_key,
+                        msg_type = %mt,
+                        request_id = %request_id,
+                        outcome = "queued",
+                        "DelegateRequest dispatch"
+                    );
+                }
                 let origin_contract = request.origin_contract;
 
                 let res = match op_manager
@@ -1574,13 +1588,15 @@ async fn process_open_request(
                     .await
                 {
                     Ok(ContractHandlerEvent::DelegateResponse(res)) => {
-                        tracing::info!(
-                            delegate = %delegate_key,
-                            msg_type = %msg_type,
-                            request_id = %request_id,
-                            outcome = "executed",
-                            "DelegateRequest dispatch"
-                        );
+                        if let Some(ref mt) = msg_type {
+                            tracing::info!(
+                                delegate = %delegate_key,
+                                msg_type = %mt,
+                                request_id = %request_id,
+                                outcome = "executed",
+                                "DelegateRequest dispatch"
+                            );
+                        }
                         res
                     }
                     Err(err) => {


### PR DESCRIPTION
## Problem

Delegate operations are completely invisible at INFO log level. The existing `debug!` line (`"Received delegate operation from client"`) is suppressed in production deployments running at INFO. Operators running a Freenet node today have no way to tell from logs whether a `DelegateRequest::ApplicationMessages` was even dispatched, let alone whether it executed — whereas contract-side operations already emit an INFO line (`"Created new operation"`) via `request_router.rs`.

This gap makes delegate-related debugging in production require toggling DEBUG, which is noisy and not always viable.

## Solution

Add two symmetric `tracing::info!` lines in the `ClientRequest::DelegateOp` arm of `process_client_request` in `client_events.rs`:

- **outcome=queued** — emitted before `notify_contract_handler`, captures:
  - `delegate` — the delegate key
  - `msg_type` — a short discriminant string encoding the `DelegateRequest` variant and, for `ApplicationMessages`, the list of `InboundDelegateMsg` variant names it carries (e.g. `ApplicationMessages[ApplicationMessage]` vs `ApplicationMessages[GetContractResponse,DelegateMessage]`)
  - `request_id` — the client request correlation ID

- **outcome=executed** — emitted after the handler returns `DelegateResponse` successfully, confirming the delegate was invoked rather than rejected before reaching the runtime.

The `msg_type` field uses exhaustive matching over all known `InboundDelegateMsg` variants (with a wildcard arm to satisfy `#[non_exhaustive]`) so operators can distinguish app-sourced messages from contract responses or inter-delegate relays at a glance, without enabling DEBUG.

The existing error-path `tracing::error!` lines are unchanged.

## Testing

- `cargo fmt && cargo clippy -p freenet -- -D warnings` — clean
- `cargo build -p freenet` — clean
- `cargo test -p freenet --lib` — 2526 passed, 14 ignored; the 1 failure (`udp_socket_failed_send_does_not_record_metrics`) is a pre-existing flaky test that passes in isolation and is unrelated to this change

No regression test is added: this is a pure observability addition with no semantic behaviour change, and there is no `tracing-test` harness in scope for this module.

## Notes

The adjacent observation in #4152 about delegate module cache miss on cold boot is a separate concern and is **not** addressed here.

## Fixes

Closes #4152