### PR TITLE
fix: downgrade same-version merge-rejected log + short-circuit WASM call (#4151)

### DIFF
--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -34,6 +34,11 @@ pub(crate) enum UpdateOverride {
     /// whether RelatedState entries are already populated. Drives the
     /// depth-limit branch in `bridged_upsert_contract_state`.
     AlwaysRequiresRelated(Vec<ContractInstanceId>),
+    /// Always return `ContractError::InvalidUpdateWithInfo` with the given
+    /// reason string. Used to test same-version / idempotent-push rejection
+    /// paths (issue #4151): the returned error must be classified as
+    /// `is_invalid_update_rejection()` and logged at DEBUG, not INFO.
+    RejectInvalidUpdate { reason: String },
 }
 
 /// A lightweight mock runtime at the `ContractRuntimeInterface` level that lets
@@ -126,6 +131,18 @@ impl ContractRuntimeInterface for MockWasmRuntime {
                         .collect();
                     return Ok(UpdateModification::requires(related)
                         .map_err(|e| anyhow::anyhow!("{e}"))?);
+                }
+                UpdateOverride::RejectInvalidUpdate { reason } => {
+                    // Simulate the WASM contract returning InvalidUpdateWithInfo
+                    // (e.g., "New state version X must be higher than current version X").
+                    // This produces an error that `ExecutorError::is_invalid_update_rejection()`
+                    // must classify as a benign idempotent-push rejection.
+                    use crate::wasm_runtime::ContractExecError;
+                    use freenet_stdlib::prelude::ContractError as StdlibContractError;
+                    let inner_err = StdlibContractError::InvalidUpdateWithInfo { reason };
+                    return Err(crate::wasm_runtime::ContractError::from(
+                        ContractExecError::ContractError(inner_err),
+                    ));
                 }
             }
         }

--- a/crates/core/src/contract/executor/pool_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for the contract executor module.
 
 mod conformance_tests;
+mod merge_rejected_tests;
 mod related_contract_tests;
 mod runtime_pool_tests;
 mod subscriber_limit_tests;

--- a/crates/core/src/contract/executor/pool_tests/merge_rejected_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/merge_rejected_tests.rs
@@ -1,0 +1,198 @@
+//! Regression tests for issue #4151 — same-version merge-rejected spam.
+//!
+//! When `update_state` WASM returns `InvalidUpdateWithInfo` for an idempotent
+//! re-push (incoming version == current version), the `merge_rejected_valid_local`
+//! event MUST:
+//!   1. Be classified as `is_invalid_update_rejection()` = true (the predicate
+//!      that gates log severity).
+//!   2. NOT fire at INFO level (this is tested indirectly via the predicate).
+//!
+//! Additionally, when the incoming state bytes are byte-identical to the stored
+//! state, the short-circuit MUST return `UpsertResult::NoChange` without invoking
+//! the WASM `update_state` function at all (verified by a spy-counted override).
+
+use either::Either;
+use freenet_stdlib::prelude::*;
+use std::sync::Arc;
+
+use crate::contract::executor::mock_wasm_runtime::{MockWasmRuntime, UpdateOverride};
+use crate::contract::executor::{ContractExecutor, Executor, UpsertResult};
+use crate::wasm_runtime::MockStateStorage;
+
+/// Create a MockWasmRuntime executor.
+async fn create_executor() -> Executor<MockWasmRuntime, MockStateStorage> {
+    let storage = MockStateStorage::new();
+    Executor::new_mock_wasm("merge_rejected_test", storage, None, None)
+        .await
+        .expect("create MockWasmRuntime executor")
+}
+
+/// Create a contract with the given code bytes and empty params.
+fn make_contract(code_bytes: &[u8]) -> ContractContainer {
+    let code = ContractCode::from(code_bytes.to_vec());
+    let params = Parameters::from(vec![]);
+    ContractContainer::Wasm(ContractWasmAPIVersion::V1(WrappedContract::new(
+        Arc::new(code),
+        params,
+    )))
+}
+
+// =========================================================================
+// Test: same-version rejection error is classified as is_invalid_update_rejection
+// =========================================================================
+
+/// Regression test for #4151.
+///
+/// When the contract WASM's `update_state` returns `InvalidUpdateWithInfo`
+/// (e.g. "New state version X must be higher than current version X"), the
+/// resulting `ExecutorError` MUST satisfy `is_invalid_update_rejection()`.
+/// The production code uses this predicate to decide whether to log at DEBUG
+/// (benign idempotent push) or INFO (unexpected merge failure).
+#[tokio::test(flavor = "current_thread")]
+async fn test_same_version_rejection_is_classified_as_invalid_update() {
+    let mut executor = create_executor().await;
+
+    // PUT the contract with initial state.
+    let contract = make_contract(b"same_version_test");
+    let key = contract.key();
+    let initial_state = WrappedState::new(vec![1, 2, 3, 4]);
+
+    executor
+        .upsert_contract_state(
+            key,
+            Either::Left(initial_state.clone()),
+            RelatedContracts::default(),
+            Some(contract),
+        )
+        .await
+        .expect("initial PUT should succeed");
+
+    // Wire the same-version rejection override so update_state returns
+    // InvalidUpdateWithInfo (exactly what website-contract emits when
+    // new_version <= current_version).
+    let version_rejection_reason =
+        "New state version 100 must be higher than current version 100".to_string();
+    executor.runtime.update_overrides.insert(
+        *key.id(),
+        UpdateOverride::RejectInvalidUpdate {
+            reason: version_rejection_reason.clone(),
+        },
+    );
+
+    // Attempt to update with a different state (different bytes so the
+    // byte-equality short-circuit does NOT fire — we want the WASM path).
+    let different_state = WrappedState::new(vec![5, 6, 7, 8]);
+    let err = executor
+        .upsert_contract_state(
+            key,
+            Either::Left(different_state),
+            RelatedContracts::default(),
+            None,
+        )
+        .await
+        .expect_err("same-version update should fail");
+
+    // The error MUST be recognized as a benign invalid-update rejection.
+    // This is the predicate the production code uses to downgrade the log
+    // level from INFO to DEBUG (issue #4151).
+    assert!(
+        err.is_invalid_update_rejection(),
+        "same-version WASM rejection must satisfy is_invalid_update_rejection(); \
+         got: {err:?}"
+    );
+
+    // It must also satisfy the broader is_contract_exec_rejection predicate
+    // (auto-fetch gate).
+    assert!(
+        err.is_contract_exec_rejection(),
+        "same-version rejection must also satisfy is_contract_exec_rejection()"
+    );
+}
+
+// =========================================================================
+// Test: byte-identical state update short-circuits without calling WASM
+// =========================================================================
+
+/// Regression test for #4151 (short-circuit).
+///
+/// When the incoming state bytes are identical to the stored state bytes,
+/// `upsert_contract_state` MUST return `UpsertResult::NoChange` immediately
+/// without invoking `update_state` in the WASM contract.  This avoids a
+/// pointless WASM round-trip — and, critically, suppresses the spurious
+/// `merge_rejected_valid_local` INFO log that fires when the contract's
+/// version-gating logic rejects an idempotent re-push.
+///
+/// We verify the short-circuit by wiring a `RejectInvalidUpdate` override:
+/// if `update_state` were called, the executor would return `Err`; if the
+/// short-circuit fires, we get `Ok(UpsertResult::NoChange)`.
+#[tokio::test(flavor = "current_thread")]
+async fn test_identical_state_short_circuits_before_wasm_update() {
+    let mut executor = create_executor().await;
+
+    // PUT the contract with initial state.
+    let contract = make_contract(b"short_circuit_test");
+    let key = contract.key();
+    let initial_state = WrappedState::new(vec![10, 20, 30, 40]);
+
+    executor
+        .upsert_contract_state(
+            key,
+            Either::Left(initial_state.clone()),
+            RelatedContracts::default(),
+            Some(contract),
+        )
+        .await
+        .expect("initial PUT should succeed");
+
+    // Wire the rejection override so that if update_state is called it errors.
+    // The short-circuit must prevent this from being reached.
+    executor.runtime.update_overrides.insert(
+        *key.id(),
+        UpdateOverride::RejectInvalidUpdate {
+            reason: "short-circuit spy: update_state must NOT be called for identical state"
+                .to_string(),
+        },
+    );
+
+    // Attempt to update with the SAME state bytes.
+    let result = executor
+        .upsert_contract_state(
+            key,
+            Either::Left(initial_state.clone()),
+            RelatedContracts::default(),
+            None,
+        )
+        .await
+        .expect("identical-state upsert must succeed (short-circuit, not WASM error)");
+
+    assert!(
+        matches!(result, UpsertResult::NoChange),
+        "byte-identical state update must return NoChange (short-circuit), got: {result:?}"
+    );
+}
+
+// =========================================================================
+// Test: ExecutorError predicate for the inline error message format
+// =========================================================================
+
+/// Unit test for the `is_invalid_update_rejection` predicate matching the
+/// exact string that `website-contract` emits for same-version pushes.
+///
+/// This is a plain unit test (no executor needed) that guards against
+/// string-format drift between the predicate and the contract's error message.
+#[test]
+fn test_is_invalid_update_rejection_matches_website_contract_format() {
+    use crate::contract::executor::ExecutorError;
+    use freenet_stdlib::client_api::ContractError as StdContractError;
+
+    let key = crate::contract::executor::test_fixtures::make_contract_key();
+    // Exact string format from website-contract/src/lib.rs:179
+    let cause_string = "invalid contract update, reason: \
+                        New state version 100 must be higher than current version 100";
+    let err = ExecutorError::request(StdContractError::update_exec_error(key, cause_string));
+
+    assert!(
+        err.is_invalid_update_rejection(),
+        "predicate must match website-contract's same-version error format"
+    );
+}

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1267,6 +1267,24 @@ where
             });
         }
 
+        // Short-circuit: if the incoming state is byte-identical to the stored
+        // state, there is nothing to merge and no WASM call is needed.  This
+        // is the dominant case for idempotent re-broadcasts (a peer re-pushes
+        // the state it already received) and avoids the spurious
+        // `merge_rejected_valid_local` INFO log that was firing every time the
+        // dedup cache missed an already-current state.  See issue #4151.
+        if let Some(ref full_incoming) = incoming_full_state {
+            if full_incoming.as_ref() == current_state.as_ref() {
+                tracing::debug!(
+                    contract = %key,
+                    state_size = current_state.size(),
+                    event = "merge_skipped_identical",
+                    "Incoming state is byte-identical to stored state — skipping WASM update_state"
+                );
+                return Ok(UpsertResult::NoChange);
+            }
+        }
+
         let mut recovery_performed = false;
         let updated_state = match self
             .attempt_state_update(&params, &current_state, &key, &updates)
@@ -1445,15 +1463,34 @@ where
 
                 // Local state is valid — the merge failure is legitimate, not corruption.
                 if local_valid {
-                    tracing::info!(
-                        contract = %key,
-                        error = %merge_err,
-                        local_state_size = current_state.size(),
-                        incoming_state_size = valid_incoming.size(),
-                        event = "merge_rejected_valid_local",
-                        "Merge rejected incoming state but local state is valid - \
-                         not replacing (incoming state may be stale)"
-                    );
+                    // Downgrade to DEBUG for idempotent re-pushes where the contract's
+                    // merge function correctly rejected the incoming state because its
+                    // version is not newer (e.g. "New state version X must be higher
+                    // than current version X"). These fire on every re-broadcast that
+                    // misses the dedup cache and are not operator-actionable. Any other
+                    // merge failure (OOG, WASM trap, etc.) keeps the INFO level because
+                    // it may indicate a real problem. See issue #4151.
+                    if merge_err.is_invalid_update_rejection() {
+                        tracing::debug!(
+                            contract = %key,
+                            error = %merge_err,
+                            local_state_size = current_state.size(),
+                            incoming_state_size = valid_incoming.size(),
+                            event = "merge_rejected_valid_local",
+                            "Merge rejected incoming state (idempotent re-push, \
+                             incoming version not newer) - not replacing"
+                        );
+                    } else {
+                        tracing::info!(
+                            contract = %key,
+                            error = %merge_err,
+                            local_state_size = current_state.size(),
+                            incoming_state_size = valid_incoming.size(),
+                            event = "merge_rejected_valid_local",
+                            "Merge rejected incoming state but local state is valid - \
+                             not replacing (incoming state may be stale)"
+                        );
+                    }
                     return Err(merge_err);
                 }
 


### PR DESCRIPTION
## Problem

In high-traffic gateways running the website-contract (or any version-gated contract), the `merge_rejected_valid_local` INFO log fires on **every idempotent re-broadcast** that misses the dedup cache. The message `"Merge rejected ... New state version X must be higher than current version X"` is emitted at INFO level even though it is not operator-actionable — it just means a peer re-pushed a state the node already has at the same or newer version.

At busy gateways this produces hundreds of spammy INFO lines per minute, drowning out real problems. Closes #4151.

## Solution

Two complementary fixes in `crates/core/src/contract/executor/runtime.rs`:

### 1. Downgrade log level for idempotent rejections

At the `merge_rejected_valid_local` site (post-WASM path), check `merge_err.is_invalid_update_rejection()` — the predicate introduced in #3914 that identifies typed `ContractError::InvalidUpdate{,WithInfo}` rejections from WASM. If true: emit `tracing::debug!` (not `tracing::info!`). The structured `event="merge_rejected_valid_local"` field is preserved for grep/dashboard queries.

Other merge failures (OOG, WASM traps, internal runtime errors) keep INFO level — they may indicate real problems operators need to see.

### 2. Short-circuit byte-identical state updates

Before calling `attempt_state_update` (which invokes the WASM `update_state` function), compare the incoming full-state bytes to the stored state bytes. If they are identical, return `UpsertResult::NoChange` immediately — no WASM round-trip needed.

This covers the dominant spammy case: a peer re-broadcasts the exact state bytes the node already holds. For the minority case where incoming/current versions are equal but bytes differ, the WASM call still runs, and the resulting rejection is now logged at DEBUG.

A true pre-WASM version comparison is not feasible at the executor layer: state is opaque bytes at this level, and version semantics are defined per-contract inside WASM.

## Testing

Three regression tests added in `crates/core/src/contract/executor/pool_tests/merge_rejected_tests.rs`:

| Test | What it verifies |
|------|-----------------|
| `test_same_version_rejection_is_classified_as_invalid_update` | A `RejectInvalidUpdate` mock override produces an `ExecutorError` where `is_invalid_update_rejection()` = true. This is the predicate used to decide log severity. |
| `test_identical_state_short_circuits_before_wasm_update` | Byte-identical upsert returns `NoChange` without calling `update_state` (spy: the `RejectInvalidUpdate` override would `Err` if WASM were called). |
| `test_is_invalid_update_rejection_matches_website_contract_format` | Unit test that guards against format drift between the `is_invalid_update_rejection` string prefix and the website-contract error message. |

```
cargo test -p freenet --lib -- merge_rejected
running 3 tests
test ... ok
test ... ok
test ... ok
test result: ok. 3 passed
```

Also: `cargo fmt && cargo clippy -p freenet -- -D warnings` — clean.

## Fixes

Fixes #4151