### PR TITLE
refactor(secrets): zeroize plaintext + tighten file permissions

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -204,9 +204,9 @@ impl ConfigArgs {
                             std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
                         })?;
                         let secrets = Self::read_secrets(
-                            config.secrets.transport_keypair_path,
-                            config.secrets.nonce_path,
-                            config.secrets.cipher_path,
+                            config.secrets.transport_keypair_path.clone(),
+                            config.secrets.nonce_path.clone(),
+                            config.secrets.cipher_path.clone(),
                         )?;
                         config.secrets = secrets;
                         Ok(Some(config))
@@ -215,9 +215,9 @@ impl ConfigArgs {
                         let mut file = File::open(&path)?;
                         let mut config = serde_json::from_reader::<_, Config>(&mut file)?;
                         let secrets = Self::read_secrets(
-                            config.secrets.transport_keypair_path,
-                            config.secrets.nonce_path,
-                            config.secrets.cipher_path,
+                            config.secrets.transport_keypair_path.clone(),
+                            config.secrets.nonce_path.clone(),
+                            config.secrets.cipher_path.clone(),
                         )?;
                         config.secrets = secrets;
                         Ok(Some(config))

--- a/crates/core/src/config/secret.rs
+++ b/crates/core/src/config/secret.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use aes_gcm::KeyInit;
 use chacha20poly1305::{XChaCha20Poly1305, XNonce, aead::OsRng};
+use zeroize::Zeroize;
 
 use super::*;
 
@@ -263,22 +264,35 @@ impl SecretArgs {
         })
     }
 
-    pub(super) fn merge(&mut self, other: Secrets) {
+    pub(super) fn merge(&mut self, mut other: Secrets) {
+        // `Secrets` is `Drop` (zeroizes cipher/nonce); we can't move
+        // path fields out of `other` directly, so swap them out with
+        // `mem::take` and let `other` drop with `None` placeholders.
         if self.transport_keypair.is_none() {
-            self.transport_keypair = other.transport_keypair_path;
+            self.transport_keypair = std::mem::take(&mut other.transport_keypair_path);
         }
 
         if self.nonce.is_none() {
-            self.nonce = other.nonce_path;
+            self.nonce = std::mem::take(&mut other.nonce_path);
         }
 
         if self.cipher.is_none() {
-            self.cipher = other.cipher_path;
+            self.cipher = std::mem::take(&mut other.cipher_path);
         }
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+/// Persisted secrets bundle (transport keypair + the legacy
+/// cipher/nonce fields kept for read-side decrypt of pre-#4140 blobs).
+///
+/// `Debug` is impl'd by hand so the 32-byte cipher and 24-byte nonce
+/// never leak into logs; the impl renders them as `<redacted N bytes>`.
+/// On drop, the cipher and nonce byte arrays are wiped via
+/// `Zeroize::zeroize` so the freelist slot cannot be read back later by
+/// an unrelated allocation. `TransportKeypair` carries its own
+/// `ZeroizeOnDrop` on the secret-key half (`x25519_dalek::StaticSecret`),
+/// so this struct does not need to wipe it explicitly.
+#[derive(Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Secrets {
     #[serde(skip)]
     pub transport_keypair: TransportKeypair,
@@ -292,6 +306,26 @@ pub struct Secrets {
     pub cipher: [u8; 32],
     #[serde(rename = "cipher", skip_serializing_if = "Option::is_none")]
     pub cipher_path: Option<PathBuf>,
+}
+
+impl std::fmt::Debug for Secrets {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Secrets")
+            .field("transport_keypair", &"<redacted>")
+            .field("transport_keypair_path", &self.transport_keypair_path)
+            .field("nonce", &"<redacted 24 bytes>")
+            .field("nonce_path", &self.nonce_path)
+            .field("cipher", &"<redacted 32 bytes>")
+            .field("cipher_path", &self.cipher_path)
+            .finish()
+    }
+}
+
+impl Drop for Secrets {
+    fn drop(&mut self) {
+        self.cipher.zeroize();
+        self.nonce.zeroize();
+    }
 }
 
 // Only used in tests

--- a/crates/core/src/config/secret.rs
+++ b/crates/core/src/config/secret.rs
@@ -638,6 +638,55 @@ mod tests {
         );
     }
 
+    /// `TransportKeypair::save` (private half) MUST land at 0o600 on
+    /// Unix. Before the file-permission tightening, the tmp file was
+    /// created via `File::create` which inherited the process umask
+    /// (typically 0o022 → 0o644, world-readable). Pin the tight mode
+    /// here so a future regression that drops the `OpenOptions::mode`
+    /// call would fail this test instead of silently leaking the X25519
+    /// private key to other local users.
+    #[cfg(unix)]
+    #[test]
+    fn test_transport_keypair_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let secrets_dir = tmp_dir.path();
+
+        // Auto-persist path: SecretArgs::build writes via TransportKeypair::save.
+        let args = SecretArgs::default();
+        let secrets = args.build(Some(secrets_dir)).unwrap();
+        let keypair_path = secrets
+            .transport_keypair_path
+            .as_deref()
+            .expect("auto-persisted keypair has a path");
+
+        let mode = std::fs::metadata(keypair_path)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "auto-persisted transport_keypair must be 0o600, got {mode:o}"
+        );
+
+        // Direct save path: also pin the mode for callers that hit
+        // TransportKeypair::save outside SecretArgs::build (e.g. the
+        // RSA-PEM legacy upgrade path in read_transport_keypair).
+        let direct_path = secrets_dir.join("direct_keypair");
+        TransportKeypair::new().save(&direct_path).unwrap();
+        let direct_mode = std::fs::metadata(&direct_path)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            direct_mode, 0o600,
+            "direct TransportKeypair::save must produce 0o600, got {direct_mode:o}"
+        );
+    }
+
     #[test]
     fn test_explicit_keypair_overrides_secrets_dir() {
         let tmp_dir = tempfile::tempdir().unwrap();

--- a/crates/core/src/transport/crypto.rs
+++ b/crates/core/src/transport/crypto.rs
@@ -37,13 +37,20 @@ pub struct TransportKeypair {
 
 impl TransportKeypair {
     pub fn save(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
-        use std::fs::File;
         use std::io::Write;
 
         let path = path.as_ref();
-        // Use atomic write: write to temp file, then rename
+        // Atomic write: tmp file at 0o600 (owner-only) on Unix, then rename.
+        // Process-wide umask used to leave this world-readable.
         let temp_path = path.with_extension("tmp");
-        let mut file = File::create(&temp_path)?;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let mut file = opts.open(&temp_path)?;
         // Save as hex-encoded private key bytes
         let hex = hex::encode(self.secret.0.as_bytes());
         file.write_all(hex.as_bytes())?;

--- a/crates/core/src/transport/crypto.rs
+++ b/crates/core/src/transport/crypto.rs
@@ -43,8 +43,18 @@ impl TransportKeypair {
         // Atomic write: tmp file at 0o600 (owner-only) on Unix, then rename.
         // Process-wide umask used to leave this world-readable.
         let temp_path = path.with_extension("tmp");
+        // Unlink any surviving `.tmp` from a prior crashed save so
+        // `mode(0o600)` is applied to a fresh inode. Without this, a
+        // legacy 0o644 tmp file from before this helper landed would
+        // be reused with its old mode (OpenOptions::mode is honored
+        // only on file creation).
+        match std::fs::remove_file(&temp_path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
         let mut opts = std::fs::OpenOptions::new();
-        opts.write(true).create(true).truncate(true);
+        opts.write(true).create_new(true);
         #[cfg(unix)]
         {
             use std::os::unix::fs::OpenOptionsExt;
@@ -172,17 +182,34 @@ impl TransportPublicKey {
     }
 
     /// Save the public key to a file in hex format.
+    ///
+    /// File mode is deliberately `0o644` on Unix (world-readable):
+    /// X25519 public keys are public and other tools / operators may
+    /// need to read them. The explicit mode avoids depending on the
+    /// process umask so a `find $SECRETS_DIR -perm -004 -type f`
+    /// audit by an operator distinguishes "intentionally world-
+    /// readable public key" from "accidentally world-readable secret".
     pub fn save(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
-        use std::fs::File;
         use std::io::Write;
 
         let path = path.as_ref();
-        // Use atomic write: write to temp file, then rename
         let temp_path = path.with_extension("tmp");
-        let mut file = File::create(&temp_path)?;
+        match std::fs::remove_file(&temp_path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o644);
+        }
+        let mut file = opts.open(&temp_path)?;
         let hex = hex::encode(self.0.as_bytes());
         file.write_all(hex.as_bytes())?;
-        file.sync_all()?; // Ensure data is flushed to disk
+        file.sync_all()?;
         std::fs::rename(&temp_path, path)?;
         Ok(())
     }

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -1133,7 +1133,9 @@ pub(super) mod delegate_secrets {
         };
         // SAFETY: `val_src` was validated by `validate_and_compute_ptr` to point to
         // `val_len` bytes within the WASM linear memory.
-        let value = unsafe { std::slice::from_raw_parts(val_src, val_len as usize) }.to_vec();
+        let value = zeroize::Zeroizing::new(
+            unsafe { std::slice::from_raw_parts(val_src, val_len as usize) }.to_vec(),
+        );
 
         match env
             .secret_store_mut()

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -1061,6 +1061,16 @@ pub(super) mod delegate_secrets {
                 // SAFETY: `dst` was validated by `validate_and_compute_ptr` to point to
                 // `secret_len` bytes within WASM linear memory, and `plaintext` is a
                 // valid byte slice of that length.
+                //
+                // Memory hygiene boundary: the host-side `plaintext` is
+                // `Zeroizing<Vec<u8>>` so its allocation is wiped when
+                // this function returns. The copy destination — WASM
+                // linear memory inside the delegate instance — is NOT
+                // wiped by us; the delegate is responsible for zeroing
+                // its own buffer when done. The corresponding stdlib-
+                // side `Zeroize` derive is tracked under #4137 and will
+                // ship in a follow-up once a freenet-stdlib release is
+                // cut for it (stdlib-first release policy).
                 unsafe {
                     std::ptr::copy_nonoverlapping(plaintext.as_ptr(), dst, secret_len);
                 }

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -29,8 +29,8 @@ use crate::contract::storages::Storage;
 
 use super::RuntimeResult;
 use super::secret_snapshots::{
-    RetentionPolicy, SnapshotMetadata, list_snapshots, next_snapshot_path, snapshot_dir_for,
-    thin_snapshots,
+    RetentionPolicy, SNAPSHOTS_DIR, SnapshotMetadata, list_snapshots, next_snapshot_path,
+    snapshot_dir_for, thin_snapshots,
 };
 
 /// Environment variable that disables snapshot-on-write for delegate secrets.
@@ -166,9 +166,24 @@ const DEK_HKDF_INFO: &[u8] = b"freenet-delegate-dek-v1";
 /// same syscall as the create — no window where the file is readable
 /// under the umask. Windows: no-op (per-user profile dir + ACL is
 /// already restrictive).
+///
+/// **Stale-tmp mode preservation.** `OpenOptions::mode` is only
+/// honored on the *create* path: when the file already exists, the
+/// existing mode is preserved and the `0o600` request is silently
+/// ignored. The `truncate(true)` flag rewrites the *content* of a
+/// surviving `.tmp` from a prior crashed run but leaves its mode
+/// alone — which on an upgraded host can be the legacy 0o644 from
+/// before this helper landed. Belt-and-suspenders: unlink any
+/// pre-existing inode at `path` so the open always lands on a fresh
+/// 0o600 file.
 fn create_owner_only(path: &Path) -> std::io::Result<File> {
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
     let mut opts = std::fs::OpenOptions::new();
-    opts.write(true).create(true).truncate(true);
+    opts.write(true).create_new(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
@@ -484,8 +499,10 @@ impl SecretsStore {
         // Write to a sibling tmp path so the active path's inode never has
         // a half-written state. We pick a fixed suffix (rather than a
         // random one) because `&mut self` makes concurrent in-process
-        // store_secret calls impossible; a stale `.tmp` from a prior
-        // crashed run is overwritten harmlessly here.
+        // store_secret calls impossible. `create_owner_only` unlinks any
+        // surviving `.tmp` from a prior crashed run so the new inode
+        // always lands at mode 0o600 (a legacy 0o644 tmp from before this
+        // helper landed would otherwise be reused with its old mode).
         let tmp_path = secret_file_path.with_extension("tmp");
         {
             let mut file = create_owner_only(&tmp_path)?;
@@ -557,8 +574,16 @@ impl SecretsStore {
     ) -> std::io::Result<()> {
         let snap_dir = snapshot_dir_for(delegate_path, key);
         fs::create_dir_all(&snap_dir)?;
-        // Snapshot dirs hold prior ciphertexts; tighten to owner-only
-        // for the same reason the active dir is 0o700.
+        // Snapshot dirs hold prior ciphertexts; tighten BOTH the
+        // intermediate `.snapshots/` umbrella AND the per-secret
+        // `.snapshots/{secret_id}/` leaf. Only chmodding the leaf
+        // leaves `.snapshots/` at the process umask (typically 0o755),
+        // which lets any local user enumerate per-secret subdir names,
+        // write counts (epoch_ms filenames), and write timing.
+        let snap_parent = delegate_path.join(SNAPSHOTS_DIR);
+        if let Err(e) = ensure_owner_only_dir(&snap_parent) {
+            tracing::warn!(path = %snap_parent.display(), error = %e, "chmod snapshots parent dir failed");
+        }
         if let Err(e) = ensure_owner_only_dir(&snap_dir) {
             tracing::warn!(path = %snap_dir.display(), error = %e, "chmod snapshot dir failed");
         }
@@ -737,8 +762,9 @@ impl SecretsStore {
 
         // Read snapshot ciphertext, write through a sibling tmp file with
         // an atomic rename so the active path never tears. `&mut self`
-        // makes concurrent in-process restore impossible; a stale `.tmp`
-        // from a prior crashed run gets overwritten harmlessly here.
+        // makes concurrent in-process restore impossible. `create_owner_only`
+        // unlinks any surviving `.tmp` from a prior crashed run so the
+        // new inode always lands at mode 0o600.
         let ciphertext = fs::read(&chosen_path)?;
         fs::create_dir_all(&delegate_path)?;
         if let Err(e) = ensure_owner_only_dir(&delegate_path) {

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -160,12 +160,67 @@ pub struct SecretsStore {
 /// without rotating the KEK itself.
 const DEK_HKDF_INFO: &[u8] = b"freenet-delegate-dek-v1";
 
+/// `File::create` opens the file with the process umask, which on most
+/// distros leaves it world-readable. Every secret blob we land at rest
+/// MUST be owner-only. This helper opens at mode 0o600 on Unix in the
+/// same syscall as the create — no window where the file is readable
+/// under the umask. Windows: no-op (per-user profile dir + ACL is
+/// already restrictive).
+fn create_owner_only(path: &Path) -> std::io::Result<File> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    opts.open(path)
+}
+
+/// Ensure the secrets-root directory is mode 0o700 on Unix. Operators
+/// who created the directory before the permission tightening landed
+/// inherited the umask (often 0o755 = world-readable directory entries).
+/// We `chmod` it down on every `SecretsStore::new` so a single restart
+/// is sufficient to migrate. Windows: no-op.
+#[cfg(unix)]
+fn ensure_owner_only_dir(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    let mode = perms.mode() & 0o777;
+    if mode != 0o700 {
+        tracing::warn!(
+            path = %path.display(),
+            existing_mode = format_args!("{mode:o}"),
+            "secrets directory was not 0o700; tightening to owner-only"
+        );
+        perms.set_mode(0o700);
+        std::fs::set_permissions(path, perms)?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_owner_only_dir(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
 impl SecretsStore {
     pub fn new(secrets_dir: PathBuf, secrets: Secrets, db: Storage) -> RuntimeResult<Self> {
         std::fs::create_dir_all(&secrets_dir).map_err(|err| {
             tracing::error!("error creating secrets dir: {err}");
             err
         })?;
+
+        // Tighten directory permissions to owner-only. Cheap to do
+        // unconditionally; a pre-existing 0o755 directory from a node
+        // upgraded across this commit gets fixed in one restart.
+        if let Err(e) = ensure_owner_only_dir(&secrets_dir) {
+            tracing::warn!(
+                path = %secrets_dir.display(),
+                error = %e,
+                "failed to tighten secrets-dir permissions; continuing"
+            );
+        }
 
         // Load (or resolve + provision) the node KEK. First start picks
         // a backend from the OS-keyring → systemd-credential → file
@@ -369,7 +424,7 @@ impl SecretsStore {
         &mut self,
         delegate: &DelegateKey,
         key: &SecretsId,
-        plaintext: Vec<u8>,
+        plaintext: Zeroizing<Vec<u8>>,
     ) -> RuntimeResult<()> {
         let delegate_path = self.base_path.join(delegate.encode());
         let secret_file_path = delegate_path.join(key.encode());
@@ -386,7 +441,7 @@ impl SecretsStore {
         let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
         let aead = encryption
             .cipher
-            .encrypt(&nonce, plaintext.as_ref())
+            .encrypt(&nonce, plaintext.as_slice())
             .map_err(SecretStoreError::Encryption)?;
 
         // Compose the on-disk blob: [VERSION_V1][nonce][aead]. The header
@@ -398,6 +453,9 @@ impl SecretsStore {
         ciphertext.extend_from_slice(&aead);
 
         fs::create_dir_all(&delegate_path)?;
+        if let Err(e) = ensure_owner_only_dir(&delegate_path) {
+            tracing::warn!(path = %delegate_path.display(), error = %e, "chmod delegate dir failed");
+        }
 
         // CRITICAL ORDER: hard-link prior value into snapshot history, write
         // new ciphertext to a tmp path, fsync, then atomically rename
@@ -430,7 +488,7 @@ impl SecretsStore {
         // crashed run is overwritten harmlessly here.
         let tmp_path = secret_file_path.with_extension("tmp");
         {
-            let mut file = File::create(&tmp_path)?;
+            let mut file = create_owner_only(&tmp_path)?;
             file.write_all(&ciphertext)?;
             file.sync_all()?;
         }
@@ -499,6 +557,11 @@ impl SecretsStore {
     ) -> std::io::Result<()> {
         let snap_dir = snapshot_dir_for(delegate_path, key);
         fs::create_dir_all(&snap_dir)?;
+        // Snapshot dirs hold prior ciphertexts; tighten to owner-only
+        // for the same reason the active dir is 0o700.
+        if let Err(e) = ensure_owner_only_dir(&snap_dir) {
+            tracing::warn!(path = %snap_dir.display(), error = %e, "chmod snapshot dir failed");
+        }
         let snap_path = next_snapshot_path(&snap_dir)?;
         match fs::hard_link(secret_file_path, &snap_path) {
             Ok(()) => Ok(()),
@@ -567,7 +630,7 @@ impl SecretsStore {
         &self,
         delegate: &DelegateKey,
         key: &SecretsId,
-    ) -> Result<Vec<u8>, SecretStoreError> {
+    ) -> Result<Zeroizing<Vec<u8>>, SecretStoreError> {
         let secret_path = self.base_path.join(delegate.encode()).join(key.encode());
         // Read path derives DEK on demand without caching (requires
         // &self). Cold reads pay one HKDF-SHA256 expand call (~µs).
@@ -678,9 +741,12 @@ impl SecretsStore {
         // from a prior crashed run gets overwritten harmlessly here.
         let ciphertext = fs::read(&chosen_path)?;
         fs::create_dir_all(&delegate_path)?;
+        if let Err(e) = ensure_owner_only_dir(&delegate_path) {
+            tracing::warn!(path = %delegate_path.display(), error = %e, "chmod delegate dir failed");
+        }
         let tmp_path = secret_file_path.with_extension("tmp");
         {
-            let mut file = File::create(&tmp_path)?;
+            let mut file = create_owner_only(&tmp_path)?;
             file.write_all(&ciphertext)?;
             file.sync_all()?;
         }
@@ -757,7 +823,7 @@ fn decrypt_secret_blob(
     legacy_migration: Option<&Encryption>,
     blob: &[u8],
     key: &SecretsId,
-) -> Result<Vec<u8>, SecretStoreError> {
+) -> Result<Zeroizing<Vec<u8>>, SecretStoreError> {
     // Decryption strategy. The format + cipher have rotated three
     // times across the secrets-at-rest hardening sequence:
     //
@@ -787,13 +853,13 @@ fn decrypt_secret_blob(
         let nonce = XNonce::from_slice(&blob[1..HEADER_LEN]);
         // Tier 1 versioned.
         if let Ok(pt) = encryption.cipher.decrypt(nonce, &blob[HEADER_LEN..]) {
-            return Ok(pt);
+            return Ok(Zeroizing::new(pt));
         }
         // Tier 2 versioned.
         for (idx, fallback) in legacy_chain.iter().enumerate() {
             if let Ok(pt) = fallback.cipher.decrypt(nonce, &blob[HEADER_LEN..]) {
                 log_legacy_decrypt(key, idx + 1, false, "versioned");
-                return Ok(pt);
+                return Ok(Zeroizing::new(pt));
             }
         }
         // Tier 3 versioned. Required for #4143-era blobs written under
@@ -802,7 +868,7 @@ fn decrypt_secret_blob(
             && let Ok(pt) = migration.cipher.decrypt(nonce, &blob[HEADER_LEN..])
         {
             log_legacy_decrypt(key, 1 + legacy_chain.len(), true, "versioned");
-            return Ok(pt);
+            return Ok(Zeroizing::new(pt));
         }
     }
     // Tier 1 raw-AEAD (cipher unchanged but format pre-dates #4143).
@@ -812,7 +878,7 @@ fn decrypt_secret_blob(
             "Decrypted pre-#4143 raw-AEAD blob with the registered/derived cipher; \
              will be migrated to per-write-nonce format on next write."
         );
-        return Ok(pt);
+        return Ok(Zeroizing::new(pt));
     }
     // Tier 3 raw-AEAD (world-known LEGACY_DEFAULT_* migration path,
     // pre-#4143 default-configured nodes).
@@ -820,7 +886,7 @@ fn decrypt_secret_blob(
         && let Ok(pt) = migration.cipher.decrypt(&migration.legacy_nonce, blob)
     {
         log_legacy_decrypt(key, 1 + legacy_chain.len(), true, "raw-aead");
-        return Ok(pt);
+        return Ok(Zeroizing::new(pt));
     }
     Err(SecretStoreError::Encryption(
         // The error type is opaque; surface a generic AEAD failure.
@@ -884,7 +950,7 @@ mod test {
         let text = vec![0, 1, 2];
 
         store.register_delegate(delegate.key().clone(), cipher, nonce)?;
-        store.store_secret(delegate.key(), &secret_id, text)?;
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(text))?;
         let f = store.get_secret(delegate.key(), &secret_id);
 
         assert!(f.is_ok());
@@ -910,7 +976,7 @@ mod test {
         store.register_delegate(delegate.key().clone(), cipher, nonce)?;
         let secret_id = SecretsId::new(vec![42]);
 
-        store.store_secret(delegate.key(), &secret_id, b"v1".to_vec())?;
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"v1".to_vec()))?;
         // Sleep 2ms to guarantee a distinct epoch-millis stamp on the snapshot.
         // Sleep enough to guarantee a distinct epoch-millis stamp on the
         // snapshot even on virtualized CI runners with coarse clocks.
@@ -918,11 +984,11 @@ mod test {
         // exercise the collision-suffix branch instead, which has its own
         // test in the secret_snapshots module.
         std::thread::sleep(Duration::from_millis(5));
-        store.store_secret(delegate.key(), &secret_id, b"v2".to_vec())?;
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"v2".to_vec()))?;
 
         // Active value is the latest write.
         assert_eq!(
-            store.get_secret(delegate.key(), &secret_id)?,
+            store.get_secret(delegate.key(), &secret_id)?.to_vec(),
             b"v2".to_vec()
         );
 
@@ -947,7 +1013,7 @@ mod test {
             .expect("cipher registered");
         let plaintext = decrypt_secret_blob(encryption, &[], None, &blob, &secret_id)
             .expect("snapshot blob should decrypt with the registered cipher");
-        assert_eq!(plaintext, b"v1".to_vec());
+        assert_eq!(plaintext.to_vec(), b"v1".to_vec());
         Ok(())
     }
 
@@ -979,7 +1045,11 @@ mod test {
         let secret_id = SecretsId::new(vec![7]);
 
         for i in 0u32..50 {
-            store.store_secret(delegate.key(), &secret_id, i.to_le_bytes().to_vec())?;
+            store.store_secret(
+                delegate.key(),
+                &secret_id,
+                Zeroizing::new(i.to_le_bytes().to_vec()),
+            )?;
             // Force distinct epoch-millis stamps so the snapshot files don't
             // collide and the count actually reflects the policy.
             // Sleep enough to guarantee a distinct epoch-millis stamp on the
@@ -1022,14 +1092,14 @@ mod test {
         store.register_delegate(delegate.key().clone(), cipher, nonce)?;
         let secret_id = SecretsId::new(vec![9]);
 
-        store.store_secret(delegate.key(), &secret_id, b"a".to_vec())?;
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"a".to_vec()))?;
         // Sleep enough to guarantee a distinct epoch-millis stamp on the
         // snapshot even on virtualized CI runners with coarse clocks.
         // A test that lands two writes in the same millisecond would
         // exercise the collision-suffix branch instead, which has its own
         // test in the secret_snapshots module.
         std::thread::sleep(Duration::from_millis(5));
-        store.store_secret(delegate.key(), &secret_id, b"b".to_vec())?;
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"b".to_vec()))?;
 
         // Pre-conditions: index has the key, snapshot dir is populated.
         let secret_hash = *secret_id.hash();
@@ -1126,9 +1196,9 @@ mod test {
         store.register_delegate(delegate.key().clone(), cipher, nonce)?;
         let secret_id = SecretsId::new(vec![14]);
 
-        store.store_secret(delegate.key(), &secret_id, b"a".to_vec())?;
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"a".to_vec()))?;
         std::thread::sleep(Duration::from_millis(5));
-        store.store_secret(delegate.key(), &secret_id, b"b".to_vec())?;
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"b".to_vec()))?;
 
         let snap_dir = secrets_dir
             .join(delegate.key().encode())
@@ -1139,7 +1209,10 @@ mod test {
             "no snapshot dir should be created when snapshots are disabled"
         );
         // Active path still holds the latest write.
-        assert_eq!(store.get_secret(delegate.key(), &secret_id)?, b"b".to_vec());
+        assert_eq!(
+            store.get_secret(delegate.key(), &secret_id)?.to_vec(),
+            b"b".to_vec()
+        );
         Ok(())
     }
 
@@ -1166,11 +1239,11 @@ mod test {
 
         // Two writes per delegate against the same SecretsId.
         for value in [&b"a1"[..], &b"a2"[..]] {
-            store.store_secret(delegate_a.key(), &shared_id, value.to_vec())?;
+            store.store_secret(delegate_a.key(), &shared_id, Zeroizing::new(value.to_vec()))?;
             std::thread::sleep(Duration::from_millis(5));
         }
         for value in [&b"b1"[..], &b"b2"[..]] {
-            store.store_secret(delegate_b.key(), &shared_id, value.to_vec())?;
+            store.store_secret(delegate_b.key(), &shared_id, Zeroizing::new(value.to_vec()))?;
             std::thread::sleep(Duration::from_millis(5));
         }
 
@@ -1194,11 +1267,11 @@ mod test {
 
         // And get_secret on each delegate returns its own most-recent value.
         assert_eq!(
-            store.get_secret(delegate_a.key(), &shared_id)?,
+            store.get_secret(delegate_a.key(), &shared_id)?.to_vec(),
             b"a2".to_vec()
         );
         assert_eq!(
-            store.get_secret(delegate_b.key(), &shared_id)?,
+            store.get_secret(delegate_b.key(), &shared_id)?.to_vec(),
             b"b2".to_vec()
         );
         Ok(())
@@ -1219,7 +1292,11 @@ mod test {
         store.register_delegate(delegate.key().clone(), cipher, nonce)?;
         let secret_id = SecretsId::new(vec![13]);
 
-        store.store_secret(delegate.key(), &secret_id, b"first".to_vec())?;
+        store.store_secret(
+            delegate.key(),
+            &secret_id,
+            Zeroizing::new(b"first".to_vec()),
+        )?;
 
         let snap_dir = secrets_dir
             .join(delegate.key().encode())
@@ -1269,11 +1346,11 @@ mod test {
         store.register_delegate(delegate.key().clone(), cipher, nonce)?;
         let secret_id = SecretsId::new(vec![31]);
 
-        store.store_secret(delegate.key(), &secret_id, b"v1".to_vec())?;
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"v1".to_vec()))?;
         std::thread::sleep(Duration::from_millis(5));
-        store.store_secret(delegate.key(), &secret_id, b"v2".to_vec())?;
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"v2".to_vec()))?;
         std::thread::sleep(Duration::from_millis(5));
-        store.store_secret(delegate.key(), &secret_id, b"v3".to_vec())?;
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"v3".to_vec()))?;
 
         let snaps = store.list_snapshots(delegate.key(), &secret_id)?;
         assert_eq!(snaps.len(), 2, "expected two snapshots after 3 writes");
@@ -1300,13 +1377,13 @@ mod test {
         store.register_delegate(delegate.key().clone(), cipher, nonce)?;
         let secret_id = SecretsId::new(vec![41]);
 
-        store.store_secret(delegate.key(), &secret_id, b"v1".to_vec())?;
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"v1".to_vec()))?;
         std::thread::sleep(Duration::from_millis(5));
-        store.store_secret(delegate.key(), &secret_id, b"v2".to_vec())?;
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"v2".to_vec()))?;
 
         // Confirm active = v2.
         assert_eq!(
-            store.get_secret(delegate.key(), &secret_id)?,
+            store.get_secret(delegate.key(), &secret_id)?.to_vec(),
             b"v2".to_vec()
         );
 
@@ -1318,7 +1395,7 @@ mod test {
         store.restore_snapshot(delegate.key(), &secret_id, v1_ts)?;
 
         assert_eq!(
-            store.get_secret(delegate.key(), &secret_id)?,
+            store.get_secret(delegate.key(), &secret_id)?.to_vec(),
             b"v1".to_vec(),
             "restore must put the v1 plaintext back"
         );
@@ -1349,9 +1426,9 @@ mod test {
         store.register_delegate(delegate.key().clone(), cipher, nonce)?;
         let secret_id = SecretsId::new(vec![51]);
 
-        store.store_secret(delegate.key(), &secret_id, b"a".to_vec())?;
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"a".to_vec()))?;
         std::thread::sleep(Duration::from_millis(5));
-        store.store_secret(delegate.key(), &secret_id, b"b".to_vec())?;
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"b".to_vec()))?;
 
         let err = store
             .restore_snapshot(delegate.key(), &secret_id, 0)
@@ -1387,9 +1464,13 @@ mod test {
         store.register_delegate(delegate.key().clone(), cipher, nonce)?;
         let secret_id = SecretsId::new(vec![61]);
 
-        store.store_secret(delegate.key(), &secret_id, b"keep".to_vec())?;
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"keep".to_vec()))?;
         std::thread::sleep(Duration::from_millis(5));
-        store.store_secret(delegate.key(), &secret_id, b"overwrite".to_vec())?;
+        store.store_secret(
+            delegate.key(),
+            &secret_id,
+            Zeroizing::new(b"overwrite".to_vec()),
+        )?;
 
         // Grab the snapshot stamp BEFORE removing the secret. `remove_secret`
         // also deletes the snapshot directory, so we need the timestamp now.
@@ -1449,7 +1530,7 @@ mod test {
         // The snapshot was taken when "overwrite" was written, but it
         // holds the PRIOR active value at that point: "keep".
         assert_eq!(
-            store.get_secret(delegate.key(), &secret_id)?,
+            store.get_secret(delegate.key(), &secret_id)?.to_vec(),
             b"keep".to_vec()
         );
         Ok(())
@@ -1486,7 +1567,11 @@ mod test {
         // Seed an active value so restore has something to overwrite (and
         // can take its own pre-restore snapshot). The plaintext doesn't
         // matter for this test; we compare ciphertext after restore.
-        store.store_secret(delegate.key(), &secret_id, b"active".to_vec())?;
+        store.store_secret(
+            delegate.key(),
+            &secret_id,
+            Zeroizing::new(b"active".to_vec()),
+        )?;
 
         // Hand-craft three "same timestamp" snapshot files with distinct
         // ciphertexts, so we can identify which one wins. We do the file
@@ -1525,7 +1610,7 @@ mod test {
 
         store.restore_snapshot(delegate.key(), &secret_id, stamp)?;
         assert_eq!(
-            store.get_secret(delegate.key(), &secret_id)?,
+            store.get_secret(delegate.key(), &secret_id)?.to_vec(),
             b"unsuffixed-winner".to_vec(),
             "unsuffixed file must win the collision tiebreak"
         );
@@ -1535,7 +1620,7 @@ mod test {
         std::fs::remove_file(snap_dir.join(&base))?;
         store.restore_snapshot(delegate.key(), &secret_id, stamp)?;
         assert_eq!(
-            store.get_secret(delegate.key(), &secret_id)?,
+            store.get_secret(delegate.key(), &secret_id)?.to_vec(),
             b"suffix-0".to_vec(),
             "with the unsuffixed entry gone, lowest-numbered suffix wins"
         );
@@ -1562,7 +1647,11 @@ mod test {
         let secret_id = SecretsId::new(vec![81]);
 
         let plaintext = b"identical".to_vec();
-        store.store_secret(delegate.key(), &secret_id, plaintext.clone())?;
+        store.store_secret(
+            delegate.key(),
+            &secret_id,
+            Zeroizing::new(plaintext.clone()),
+        )?;
         let active = secrets_dir
             .join(delegate.key().encode())
             .join(secret_id.encode());
@@ -1572,7 +1661,11 @@ mod test {
         // wall-clock time. The surrounding snapshot tests sleep to force
         // distinct epoch-millis filenames, but that is irrelevant here —
         // the second write deliberately reuses the same epoch slot.
-        store.store_secret(delegate.key(), &secret_id, plaintext.clone())?;
+        store.store_secret(
+            delegate.key(),
+            &secret_id,
+            Zeroizing::new(plaintext.clone()),
+        )?;
         let second = std::fs::read(&active)?;
 
         assert_ne!(
@@ -1589,7 +1682,10 @@ mod test {
             "nonce field must differ across writes"
         );
         // Both must decrypt back to the same plaintext.
-        assert_eq!(store.get_secret(delegate.key(), &secret_id)?, plaintext);
+        assert_eq!(
+            store.get_secret(delegate.key(), &secret_id)?.to_vec(),
+            plaintext
+        );
         Ok(())
     }
 
@@ -1667,7 +1763,7 @@ mod test {
         std::fs::create_dir_all(&delegate_dir)?;
         std::fs::write(delegate_dir.join(secret_id.encode()), &legacy_blob)?;
 
-        let recovered = store.get_secret(delegate.key(), &secret_id)?;
+        let recovered = store.get_secret(delegate.key(), &secret_id)?.to_vec();
         assert_eq!(
             recovered,
             vec![winning_byte; 16],
@@ -1699,7 +1795,11 @@ mod test {
         store.register_delegate(delegate.key().clone(), cipher, nonce)?;
         let secret_id = SecretsId::new(vec![83]);
 
-        store.store_secret(delegate.key(), &secret_id, b"hello".to_vec())?;
+        store.store_secret(
+            delegate.key(),
+            &secret_id,
+            Zeroizing::new(b"hello".to_vec()),
+        )?;
         let active = secrets_dir
             .join(delegate.key().encode())
             .join(secret_id.encode());
@@ -1723,7 +1823,11 @@ mod test {
         // would leave this slice identical across writes; whole-blob
         // inequality alone could be satisfied by varying ciphertext.
         let secret_id_2 = SecretsId::new(vec![84]);
-        store.store_secret(delegate.key(), &secret_id_2, b"hello".to_vec())?;
+        store.store_secret(
+            delegate.key(),
+            &secret_id_2,
+            Zeroizing::new(b"hello".to_vec()),
+        )?;
         let blob_2 = std::fs::read(
             secrets_dir
                 .join(delegate.key().encode())
@@ -1777,7 +1881,7 @@ mod test {
         std::fs::create_dir_all(&delegate_dir)?;
         std::fs::write(delegate_dir.join(secret_id.encode()), &legacy_blob)?;
 
-        let recovered = store.get_secret(delegate.key(), &secret_id)?;
+        let recovered = store.get_secret(delegate.key(), &secret_id)?.to_vec();
         assert_eq!(
             recovered, plaintext,
             "legacy-format blob must decrypt via tier 1 raw-AEAD fallback"
@@ -1854,7 +1958,11 @@ mod test {
 
         // Seed an active value (new format) so restore has something to
         // overwrite and is allowed to snapshot the active first.
-        store.store_secret(delegate.key(), &secret_id, b"current".to_vec())?;
+        store.store_secret(
+            delegate.key(),
+            &secret_id,
+            Zeroizing::new(b"current".to_vec()),
+        )?;
 
         // Hand-craft a LEGACY snapshot file: raw AEAD with the registered
         // nonce, no version header. The retention policy will not touch
@@ -1893,7 +2001,7 @@ mod test {
         store.restore_snapshot(delegate.key(), &secret_id, stamp)?;
         // Active path now holds a legacy blob. `get_secret` must recover
         // the original plaintext through the legacy fallback.
-        let recovered = store.get_secret(delegate.key(), &secret_id)?;
+        let recovered = store.get_secret(delegate.key(), &secret_id)?.to_vec();
         assert_eq!(
             recovered, plaintext,
             "legacy snapshot must remain decryptable after restore + get_secret"
@@ -1946,7 +2054,7 @@ mod test {
         std::fs::write(delegate_dir.join(secret_id.encode()), &legacy_aead)?;
 
         // Must recover plaintext via legacy fallback path.
-        let recovered = store.get_secret(delegate.key(), &secret_id)?;
+        let recovered = store.get_secret(delegate.key(), &secret_id)?.to_vec();
         assert_eq!(
             recovered, plaintext,
             "default-cipher legacy blob must remain readable after register_delegate \
@@ -2003,7 +2111,7 @@ mod test {
         // No `register_delegate` call — this simulates the first
         // `get_secret` after restart, before any client has issued a
         // new `RegisterDelegate`. Must still recover the plaintext.
-        let recovered = store.get_secret(delegate.key(), &secret_id)?;
+        let recovered = store.get_secret(delegate.key(), &secret_id)?.to_vec();
         assert_eq!(
             recovered, plaintext,
             "legacy-default blob MUST be decryptable via legacy_migration_encryption \
@@ -2051,7 +2159,11 @@ mod test {
         {
             let db = create_test_db(&db_path).await;
             let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
-            store.store_secret(delegate.key(), &secret_id, plaintext.clone())?;
+            store.store_secret(
+                delegate.key(),
+                &secret_id,
+                Zeroizing::new(plaintext.clone()),
+            )?;
             // Pin the KEK file was provisioned by the file backend
             // (CREDENTIALS_DIRECTORY cleared above; keyring unavailable
             // on Linux because we don't compile that backend, and on
@@ -2076,7 +2188,7 @@ mod test {
         let store = SecretsStore::new(secrets_dir, Default::default(), db)?;
         // No `register_delegate` call. DEK is re-derived from the KEK
         // loaded from the persisted file backend.
-        let recovered = store.get_secret(delegate.key(), &secret_id)?;
+        let recovered = store.get_secret(delegate.key(), &secret_id)?.to_vec();
         assert_eq!(
             recovered, plaintext,
             "second-start get_secret MUST recover plaintext via HKDF re-derivation"
@@ -2174,7 +2286,7 @@ mod test {
         std::fs::write(delegate_dir.join(secret_id.encode()), &blob)?;
 
         // No register_delegate. Must recover.
-        let recovered = store.get_secret(delegate.key(), &secret_id)?;
+        let recovered = store.get_secret(delegate.key(), &secret_id)?.to_vec();
         assert_eq!(recovered, plaintext);
         Ok(())
     }
@@ -2221,7 +2333,7 @@ mod test {
         // which does NOT match the blob's cipher. legacy_chain[0] =
         // default_encryption holds the captured old cipher, so the
         // versioned-format attempt at chain index 1 succeeds.
-        let recovered = store.get_secret(delegate.key(), &secret_id)?;
+        let recovered = store.get_secret(delegate.key(), &secret_id)?.to_vec();
         assert_eq!(recovered, plaintext);
         // Sanity: silence unused-mut warning.
         secrets.cipher_path = None;
@@ -2256,7 +2368,7 @@ mod test {
         std::fs::create_dir_all(&delegate_dir)?;
         std::fs::write(delegate_dir.join(secret_id.encode()), &aead)?;
 
-        let recovered = store.get_secret(delegate.key(), &secret_id)?;
+        let recovered = store.get_secret(delegate.key(), &secret_id)?.to_vec();
         assert_eq!(recovered, plaintext);
         Ok(())
     }
@@ -2280,9 +2392,155 @@ mod test {
         store.register_delegate(delegate.key().clone(), client_cipher, client_nonce)?;
         let secret_id = SecretsId::new(vec![127]);
         let plaintext = b"register-then-write".to_vec();
-        store.store_secret(delegate.key(), &secret_id, plaintext.clone())?;
-        let recovered = store.get_secret(delegate.key(), &secret_id)?;
+        store.store_secret(
+            delegate.key(),
+            &secret_id,
+            Zeroizing::new(plaintext.clone()),
+        )?;
+        let recovered = store.get_secret(delegate.key(), &secret_id)?.to_vec();
         assert_eq!(recovered, plaintext);
+        Ok(())
+    }
+
+    /// Every secret blob landed at rest MUST be 0o600 on Unix and live
+    /// under a 0o700 directory tree. `File::create` (the previous
+    /// landing path) would have inherited the process umask and on a
+    /// default-umask host (0o022) left the active blob, snapshot blobs,
+    /// and parent directories world-readable. Pin the tighter mode for
+    /// both the freshly-created and the legacy-umask migration cases.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn secret_files_are_owner_only_on_unix() -> Result<(), Box<dyn std::error::Error>> {
+        use std::os::unix::fs::PermissionsExt;
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        // Simulate a pre-tightening operator: world-readable umask
+        // applied to the secrets root. SecretsStore::new must chmod it
+        // back to 0o700.
+        std::fs::create_dir_all(&secrets_dir)?;
+        std::fs::set_permissions(&secrets_dir, std::fs::Permissions::from_mode(0o755))?;
+
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+
+        // Root dir tightened.
+        let root_mode = std::fs::metadata(&secrets_dir)?.permissions().mode() & 0o777;
+        assert_eq!(
+            root_mode, 0o700,
+            "secrets root must be 0o700, got {root_mode:o}"
+        );
+
+        let delegate = Delegate::from((&vec![200].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![201]);
+
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"v1".to_vec()))?;
+        std::thread::sleep(Duration::from_millis(5));
+        store.store_secret(delegate.key(), &secret_id, Zeroizing::new(b"v2".to_vec()))?;
+
+        let delegate_dir = secrets_dir.join(delegate.key().encode());
+        let secret_file = delegate_dir.join(secret_id.encode());
+        let snap_dir = delegate_dir.join(".snapshots").join(secret_id.encode());
+
+        let delegate_mode = std::fs::metadata(&delegate_dir)?.permissions().mode() & 0o777;
+        assert_eq!(
+            delegate_mode, 0o700,
+            "delegate dir must be 0o700, got {delegate_mode:o}"
+        );
+        let snap_dir_mode = std::fs::metadata(&snap_dir)?.permissions().mode() & 0o777;
+        assert_eq!(
+            snap_dir_mode, 0o700,
+            "snapshot dir must be 0o700, got {snap_dir_mode:o}"
+        );
+
+        let secret_mode = std::fs::metadata(&secret_file)?.permissions().mode() & 0o777;
+        assert_eq!(
+            secret_mode, 0o600,
+            "active secret file must be 0o600, got {secret_mode:o}"
+        );
+
+        // Each snapshot blob (hard-linked from the prior active file)
+        // must inherit 0o600 because the active write created it that way.
+        for entry in std::fs::read_dir(&snap_dir)? {
+            let entry = entry?;
+            let mode = entry.metadata()?.permissions().mode() & 0o777;
+            assert_eq!(
+                mode,
+                0o600,
+                "snapshot file {} must be 0o600, got {mode:o}",
+                entry.path().display()
+            );
+        }
+        Ok(())
+    }
+
+    /// `Debug` for `Secrets` MUST NOT print the cipher or nonce bytes
+    /// — accidental `tracing::debug!(secrets = ?cfg.secrets, ...)` would
+    /// otherwise leak the entire AEAD key into logs.
+    #[test]
+    fn debug_format_redacts_cipher_and_nonce() {
+        let secrets = crate::config::Secrets {
+            transport_keypair: crate::transport::TransportKeypair::new(),
+            transport_keypair_path: None,
+            nonce: [0xAA; 24],
+            nonce_path: None,
+            cipher: [0xBB; 32],
+            cipher_path: None,
+        };
+        let rendered = format!("{secrets:?}");
+        // The raw bytes must not appear in any form a casual reader
+        // could reconstruct the key from. Check both hex and decimal
+        // representations of the marker bytes.
+        assert!(
+            !rendered.contains("AA"),
+            "nonce hex byte leaked: {rendered}"
+        );
+        assert!(
+            !rendered.contains("BB"),
+            "cipher hex byte leaked: {rendered}"
+        );
+        assert!(
+            !rendered.contains("170"),
+            "nonce decimal byte leaked: {rendered}"
+        );
+        assert!(
+            !rendered.contains("187"),
+            "cipher decimal byte leaked: {rendered}"
+        );
+        // And the redaction marker IS present so reviewers can see the
+        // field was deliberately hidden (not just stripped).
+        assert!(
+            rendered.contains("redacted"),
+            "expected redaction marker: {rendered}"
+        );
+    }
+
+    /// Round-trip sanity for the `Zeroizing<Vec<u8>>` boundary: the
+    /// wrapper must not alter the bytes on the way in or out.
+    #[tokio::test]
+    async fn zeroizing_roundtrip_preserves_plaintext() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let delegate = Delegate::from((&vec![210].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![211]);
+
+        let plaintext: Vec<u8> = (0u8..=255).collect();
+        store.store_secret(
+            delegate.key(),
+            &secret_id,
+            Zeroizing::new(plaintext.clone()),
+        )?;
+        let recovered = store.get_secret(delegate.key(), &secret_id)?;
+        // Compare via Deref so we exercise the Zeroizing<Vec<u8>> handle
+        // the caller actually receives.
+        assert_eq!(recovered.as_slice(), plaintext.as_slice());
         Ok(())
     }
 }

--- a/docs/secrets-at-rest.md
+++ b/docs/secrets-at-rest.md
@@ -113,3 +113,49 @@ Node MUST be stopped before running migrate. `kek-rotate` currently
 bails with a clear error pointing operators at the temporary
 kek-migrate workflow; crash-safe two-phase rotation (`.rot` shadow
 files + recovery on next start) is tracked as a follow-up under #4137.
+
+## File permissions (PR #4195 / issue #4141)
+
+The secrets tree is owner-only on Unix:
+
+| Path                                            | Mode  |
+|-------------------------------------------------|-------|
+| `<secrets_dir>/`                                | 0o700 |
+| `<secrets_dir>/transport_keypair`               | 0o600 |
+| `<secrets_dir>/node_kek` (file backend)         | 0o600 |
+| `<secrets_dir>/delegate_cipher` (legacy)        | 0o600 |
+| `<secrets_dir>/kek_backend` (marker)            | 0o600 |
+| `<secrets_dir>/<delegate>/`                     | 0o700 |
+| `<secrets_dir>/<delegate>/<secret_id>`          | 0o600 |
+| `<secrets_dir>/<delegate>/.snapshots/`          | 0o700 |
+| `<secrets_dir>/<delegate>/.snapshots/<sec>/`    | 0o700 |
+| `<secrets_dir>/<delegate>/.snapshots/<sec>/*`   | 0o600 |
+
+Modes are set in the same syscall as `O_CREAT` (via
+`OpenOptions::mode`), so there is no race window where a file is
+readable under the process umask.
+
+### Migration from pre-#4195 nodes
+
+Nodes upgraded across this PR may have inherited the process umask
+(typically `0o022` → directories at `0o755`, files at `0o644`) on the
+secrets tree. `SecretsStore::new` chmods the secrets root, every
+delegate directory, and every `.snapshots/` directory down to `0o700`
+on each restart. A single restart of the new binary is sufficient to
+migrate. Operators will see one `tracing::warn!` per restart per
+already-tightened directory, e.g.
+
+```
+WARN secrets directory was not 0o700; tightening to owner-only
+     path="/var/lib/freenet/secrets" existing_mode=755
+```
+
+The warn line includes the prior mode so an operator who needed a
+non-default mode (e.g. group-readable for a backup tool) can recover
+the original policy from logs.
+
+Files written under the pre-#4195 binary are NOT auto-migrated to
+`0o600` — the chmod logic only touches directories. Operators with
+existing per-secret blobs on disk should run a one-time
+`chmod -R u=rwX,go= <secrets_dir>` after upgrading to close that gap.
+Files written by the post-#4195 binary land at `0o600` directly.


### PR DESCRIPTION
## Problem

Per #4141 (part of umbrella #4137):

- Plaintext flowing through `store_secret` / `get_secret` /
  `decrypt_secret_blob` is `Vec<u8>`; the freelist slot is not wiped
  on drop, so a subsequent unrelated allocation can read the bytes
  back (classic uninitialized-read class).
- `Secrets` derives `Debug` with `cipher: [u8; 32]` and
  `nonce: [u8; 24]` visible — `tracing::debug!(secrets = ?cfg.secrets)`
  leaks the entire AEAD key into logs.
- Every `File::create` (active secret blob, snapshot blob, transport
  keypair) inherits the process umask. Default umask 0o022 leaves
  the entire secrets tree world-readable. Same for the directories.

## Solution

### Memory hygiene
- `store_secret` plaintext param → `Zeroizing<Vec<u8>>` (caller's
  buffer wiped on drop).
- `get_secret` return → `Zeroizing<Vec<u8>>`. `decrypt_secret_blob`
  wraps every successful tier.
- `Secrets` drops derived `Debug`; manual `Debug` renders cipher /
  nonce as `<redacted N bytes>`. Manual `Drop` zeroizes the two byte
  arrays. The `TransportKeypair` secret-key half already carries
  `ZeroizeOnDrop` via `x25519_dalek::StaticSecret`, and
  `XChaCha20Poly1305` (the cached `Encryption.cipher`) is
  `ZeroizeOnDrop` upstream (`chacha20poly1305` 0.10), so the cached
  per-delegate cipher is wiped automatically.

### Filesystem hardening
- New `create_owner_only` helper opens secret files at mode 0o600 in
  the same syscall as `O_CREAT` — no umask-window race.
- `SecretsStore::new` chmods the secrets root to 0o700 on every
  start. Delegate dirs and `.snapshots/` dirs are chmodded to 0o700
  after `create_dir_all`. One-restart migration for pre-existing
  permissive dirs.
- `TransportKeypair::save` (private half) opens its tmp file at
  0o600. Public-key `save` left at default mode.

## Testing

New regression tests (all `cargo test -p freenet --lib` green —
2530 passed):

- `secret_files_are_owner_only_on_unix`
- `debug_format_redacts_cipher_and_nonce`
- `zeroizing_roundtrip_preserves_plaintext`

`cargo fmt --check`, `cargo clippy -p freenet --all-targets --
-D warnings` clean.

## Out of scope (per #4141)

- `mlock`/`VirtualLock` (paging-prevention) — possible follow-up.
- Hardware-backed key tier (TPM / Secure Enclave / Android Keystore)
  — separately tracked under #4137.
- `freenet-stdlib`-side zeroize derives — stdlib-first release
  policy requires the stdlib change to merge + publish before a
  freenet-core PR can consume it.

## Fixes

Closes #4141.