### PR TITLE
fix(scripts): derive geiger status from exit code in per-member path

### DIFF
--- a/scripts/static-checks.sh
+++ b/scripts/static-checks.sh
@@ -166,8 +166,14 @@ run_geiger() {
   printf ']\n' >> "$OUT/geiger.raw"
   local t1; t1=$(date +%s)
 
+  # $rc is non-zero if ANY per-member run failed (set by `rc=$?` in the loop's
+  # else branch; the success branch never resets it). Derive `status` the same
+  # way run_check does so consumers checking only `status` don't see "ok" for
+  # a failed run.
+  local status; [[ $rc -eq 0 ]] && status=ok || status="exit_${rc}"
+
   jq -n \
-    --arg status "ok" \
+    --arg status "$status" \
     --argjson rc  "$rc" \
     --argjson dur "$((t1-t0))" \
     --arg raw     "$OUT/geiger.raw" \


### PR DESCRIPTION
## Problem

In `scripts/static-checks.sh`, the per-member geiger path (used when the
target is a virtual workspace manifest) hardcoded `--arg status "ok"` for
the final `geiger.summary.json` summary, even when one or more per-member
`cargo geiger` runs failed.

The exit code was captured correctly into `$rc` and into the JSON
`exit_code` field, but the `status` field was always `"ok"`. Any
downstream consumer checking only the `status` field (e.g. the
`status=...` summary line at the bottom of the script) would see success
for a failed run.

Flagged in the post-merge multi-model review of PR #4129 by Codex.

## Solution

Derive `status` from `$rc` immediately before the `jq -n` that writes
`geiger.summary.json`, using the exact same computation `run_check`
already uses elsewhere in the script:

```bash
local status; [[ $rc -eq 0 ]] && status=ok || status="exit_${rc}"
```

`$rc` already reflects whether *any* per-member run failed: the loop sets
`rc=$?` in its `else` (failure) branch, and the success branch never
resets it, so a single failed member leaves `$rc` non-zero through the
end of the loop.

## Testing

This bash script is not invoked by CI, so a full automated test is
overkill. Verified manually:

- `bash -n scripts/static-checks.sh` — passes, no syntax error.
- Simulated the per-member loop with one failing member (exit 7): the
  fixed code produces `status: "exit_7"` (previously `"ok"`), with
  `exit_code: 7` matching.
- All-pass case (`rc=0`): yields `status: ok` as expected.
- Attempted a full `./scripts/static-checks.sh` run; it spends >10 min
  in the earlier `cargo clippy` step on the full workspace and was
  terminated before reaching `run_geiger`. Additionally `cargo-geiger`
  is not installed on this machine, so the per-member path would take
  the `not_installed` early return anyway — the targeted simulation
  above is the meaningful verification of the changed code path.

Closes #4173

[AI-assisted - Claude]