### PR TITLE
fix(clippy): allow wildcard match arms in delegate test assertions

### DIFF
--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -1604,10 +1604,16 @@ mod test {
                 ApplicationMessage::new(payload),
             )],
         )?;
+        // Wildcard satisfies #[non_exhaustive] on OutboundDelegateMsg so
+        // future stdlib variants don't break this test at compile time.
+        #[allow(clippy::wildcard_enum_match_arm)]
         let response: OutboundAppMessage = match &outbound[0] {
             OutboundDelegateMsg::ApplicationMessage(m) => bincode::deserialize(&m.payload)?,
             other => panic!("Expected ApplicationMessage, got {other:?}"),
         };
+        // Wildcard satisfies #[non_exhaustive] on OutboundAppMessage so
+        // future stdlib variants don't break this test at compile time.
+        #[allow(clippy::wildcard_enum_match_arm)]
         match response {
             OutboundAppMessage::ContextData(data) => {
                 assert!(


### PR DESCRIPTION
## Problem

`crates/core/src/wasm_runtime/delegate.rs` has two `other =>` wildcard match arms in `#[cfg(test)]` code that trip `clippy::wildcard_enum_match_arm` (enabled crate-wide via `crates/core/Cargo.toml` `[lints]`):

- `other => panic!("Expected ApplicationMessage, got {other:?}")` matching on `OutboundDelegateMsg`
- `other => panic!("Expected ContextData, got {other:?}")` matching on `OutboundAppMessage`

`cargo clippy --all-targets -- -D warnings` (or `--tests`) fails with 2 errors. CI's Clippy job runs `cargo clippy --locked -- -D warnings` without `--all-targets`/`--tests`, so it only lints lib+bins and never sees these test-code arms — that's why main's CI is green despite this. The arms started failing after the freenet-stdlib 0.8.0 bump added enum variants.

## Solution

Add `#[allow(clippy::wildcard_enum_match_arm)]` to each of the two enclosing `match` expressions, with a comment explaining the wildcard exists to satisfy the `#[non_exhaustive]` enums. The wildcard-with-panic is intentional in these test assertions — each test only cares about one specific variant, and the wildcard keeps the tests compiling against future stdlib variants.

This matches the existing pattern already used in the same file at `delegate.rs:542`, `:4180`, and `:4188`.

The change is deliberately minimal: just the two `#[allow]` attributes. A possible future follow-up is to add `--all-targets` to the CI Clippy invocation in `.github/workflows/ci.yml` so test-code lints are caught — that is intentionally **not** done here since it has broader blast radius (it could surface other test-code lint failures across the workspace).

## Testing

`cargo clippy -p freenet --all-targets -- -D warnings` now passes with zero errors (it failed with 2 errors before the change). `cargo fmt` clean.

Closes #4197

[AI-assisted - Claude]