### PR TITLE
test(ring): deterministic set_own_addr global-state test

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -373,6 +373,25 @@ pub(crate) fn external_address() -> Option<SocketAddr> {
         .and_then(|status| status.read().ok().and_then(|s| s.external_address))
 }
 
+/// Process-wide serialization lock for tests that read or write the shared
+/// `NETWORK_STATUS` global (directly, or indirectly via `set_external_address`
+/// / `set_own_addr` / `try_set_own_addr`).
+///
+/// `NETWORK_STATUS` is process-global. Under `cargo test` (the project's
+/// documented pre-commit command — see AGENTS.md) the whole lib-test binary
+/// runs in ONE process with tests executing concurrently, so any two tests
+/// touching this global race each other. CI's `cargo nextest` happens to mask
+/// the race by giving every test its own process, but `cargo test` does not.
+///
+/// Every test in this crate that touches `NETWORK_STATUS` MUST acquire this
+/// lock for its whole body, so the writes/reads are serialized under both
+/// `cargo test` and `cargo nextest`. This lives at crate scope (not inside a
+/// `mod tests`) precisely so tests in *other* modules — notably the
+/// `set_own_addr` TOCTOU regression test in `connection_manager.rs` — can
+/// share the exact same lock.
+#[cfg(test)]
+pub(crate) static TEST_GLOBAL_STATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 // --- Snapshot types for rendering ---
 
 /// Snapshot of the current network status for rendering.
@@ -699,11 +718,16 @@ pub(crate) fn format_ago(secs: u64) -> String {
 mod tests {
     use super::*;
     use std::net::{IpAddr, Ipv4Addr};
-    use std::sync::Mutex;
 
     /// Tests that touch the shared NETWORK_STATUS global must hold this lock
     /// to prevent interleaving with other tests running in parallel.
-    static TEST_MUTEX: Mutex<()> = Mutex::new(());
+    ///
+    /// This is the crate-wide [`TEST_GLOBAL_STATE_LOCK`] — shared with the
+    /// `set_own_addr` TOCTOU regression test in `connection_manager.rs`, which
+    /// also mutates this global. A poisoned lock here would mean some test
+    /// panicked while holding it; `.lock()` would then return `Err`, which is
+    /// itself a useful signal, so the `.unwrap()` is intentional.
+    use super::TEST_GLOBAL_STATE_LOCK as TEST_MUTEX;
 
     #[test]
     fn test_classify_version_mismatch() {

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -2348,6 +2348,15 @@ mod tests {
 
     #[test]
     fn test_try_set_own_addr_when_unset() {
+        // `try_set_own_addr` on an unset `own_addr` calls
+        // `network_status::set_external_address`, writing the process-global
+        // `NETWORK_STATUS`. Hold the crate-wide lock so this does not race
+        // `test_set_own_addr_atomic_with_network_status` or the
+        // `node::network_status` tests under `cargo test` (one process, all
+        // tests concurrent). See `TEST_GLOBAL_STATE_LOCK` rustdoc.
+        let _global = crate::node::network_status::TEST_GLOBAL_STATE_LOCK
+            .lock()
+            .expect("TEST_GLOBAL_STATE_LOCK poisoned by an earlier test panic");
         let cm = make_connection_manager(None, 1, 10, false);
 
         let addr = make_addr(8000);
@@ -2358,6 +2367,10 @@ mod tests {
 
     #[test]
     fn test_try_set_own_addr_when_already_set() {
+        // No `TEST_GLOBAL_STATE_LOCK` needed: `own_addr` starts `Some`, so
+        // `try_set_own_addr` takes the early-return branch and never calls
+        // `network_status::set_external_address` — this test does not touch
+        // the process-global `NETWORK_STATUS`.
         let original_addr = make_addr(8000);
         let cm = make_connection_manager(Some(original_addr), 1, 10, false);
 
@@ -2400,22 +2413,25 @@ mod tests {
     fn test_set_own_addr_atomic_with_network_status() {
         use std::sync::{Arc as StdArc, Barrier};
 
-        // GLOBAL-STATE CONTRACT: this test asserts on the process-global
-        // `network_status::external_address`, so it must remain the ONLY
-        // test that concurrently writes that global. That holds today:
-        // `set_external_address` has exactly one production caller
-        // (`set_own_addr`), and integration tests that spin up nodes run in
-        // separate test binaries (separate processes — each gets its own
-        // `NETWORK_STATUS`). Within this lib-test binary no other test calls
-        // `set_own_addr` / `set_external_address`. If a future lib-test does,
-        // it must serialize against this one (e.g. share a test mutex) or
-        // this `assert_eq!` can flake. (Reviewers: Claude testing/skeptical +
-        // Gemini all flagged this latent coupling — documented, not a current
-        // bug.)
+        // GLOBAL-STATE CONTRACT: this test reads and writes the process-global
+        // `network_status::external_address` (via `set_own_addr`). Under
+        // `cargo test` — the project's documented pre-commit command (see
+        // AGENTS.md) — the whole lib-test binary runs in ONE process with
+        // tests executing concurrently, so any other test touching that
+        // global races this one's `assert_eq!`. (CI's `cargo nextest` masks
+        // the race with per-process isolation; `cargo test` does not.)
+        //
+        // `connection_manager`'s `test_try_set_own_addr_*` tests and every
+        // test in `node::network_status` also touch this global. They are all
+        // serialized by the crate-wide `TEST_GLOBAL_STATE_LOCK`, which this
+        // test acquires below for its entire body.
         //
         // `network_status::set_external_address` is a no-op until `init()` has
         // run. `init()` is idempotent (OnceLock — first caller wins), so this
         // is safe even if another test already initialized the global.
+        let _global = crate::node::network_status::TEST_GLOBAL_STATE_LOCK
+            .lock()
+            .expect("TEST_GLOBAL_STATE_LOCK poisoned by an earlier test panic");
         crate::node::network_status::init(0, HashSet::new(), "test".to_string());
 
         // Use a single ConnectionManager across all rounds: the bug is a
@@ -2425,6 +2441,13 @@ mod tests {
         const ROUNDS: u32 = 4_000;
         const THREADS: u16 = 8;
 
+        // Collect the first divergence (if any) instead of asserting inside
+        // the loop. Panicking while `_global` is held would poison
+        // `TEST_GLOBAL_STATE_LOCK` and cascade `PoisonError`s into every
+        // other test that shares it; instead we record the failure, drop the
+        // guard, then assert. The check itself is unchanged — exact equality
+        // of the two mirrors after all writers for the round have joined.
+        let mut divergence: Option<String> = None;
         for round in 0..ROUNDS {
             let barrier = StdArc::new(Barrier::new(THREADS as usize));
             let mut handles = Vec::with_capacity(THREADS as usize);
@@ -2449,16 +2472,27 @@ mod tests {
             // whichever writer won the race.
             let own = cm.get_own_addr();
             let external = crate::node::network_status::external_address();
-            assert!(
-                own.is_some(),
-                "round {round}: own_addr should be set after concurrent writes"
-            );
-            assert_eq!(
-                own, external,
-                "round {round}: own_addr ({own:?}) and \
-                 network_status::external_address ({external:?}) diverged — \
-                 set_own_addr is not atomic (#4172)"
-            );
+            if own.is_none() {
+                divergence = Some(format!(
+                    "round {round}: own_addr unset after concurrent writes"
+                ));
+                break;
+            }
+            if own != external {
+                divergence = Some(format!(
+                    "round {round}: own_addr ({own:?}) and \
+                     network_status::external_address ({external:?}) diverged — \
+                     set_own_addr is not atomic (#4172)"
+                ));
+                break;
+            }
+        }
+
+        // Release the shared global-state lock before asserting so a failure
+        // does not poison it for other tests.
+        drop(_global);
+        if let Some(msg) = divergence {
+            panic!("{msg}");
         }
     }
 


### PR DESCRIPTION
## Problem

The #4172 regression test `test_set_own_addr_atomic_with_network_status`
(added by PR #4200, now in `main`) asserts a per-`ConnectionManager`
`own_addr` value against the **process-global**
`network_status::external_address`.

Under `cargo test` — the project's documented pre-commit command (see
`AGENTS.md`) — the entire lib-test binary runs in a single process with
tests executing concurrently. Other tests in that binary also write the
same global, so the assertion races them intermittently. CI stayed green
only because CI uses `cargo nextest`, which runs each test in its own
process. By the project's own definition this is a flaky/broken test.

Reproduced locally: `cargo test -p freenet --lib -- ring::connection_manager node::network_status`
fails intermittently. When the assertion lost the race it panicked,
poisoning shared state, and the cascade surfaced as `PoisonError` in
**seven** unrelated `node::network_status` tests.

The test's old "GLOBAL-STATE CONTRACT" comment claimed no other lib-test
wrote the global — that claim was **false**:

- `test_try_set_own_addr_when_unset` writes it via `try_set_own_addr`.
- The `node::network_status` tests already shared a module-private
  `TEST_MUTEX` that the regression test could not see.

## Solution

Test-only change. **The production `set_own_addr` lock scope (the #4172
fix) is unchanged**, and `network_status.rs` production code is unchanged.

- Promote the test serialization lock to a crate-wide
  `pub(crate) static TEST_GLOBAL_STATE_LOCK` in `network_status.rs`,
  next to the existing `#[cfg(test)]` `external_address()` accessor.
- `network_status`'s `mod tests` now aliases that shared lock instead of
  its own private `TEST_MUTEX`.
- The regression test and `test_try_set_own_addr_when_unset` acquire the
  same lock, serializing every test that touches the global under both
  `cargo test` and `cargo nextest`.
- The regression test collects the first divergence into a local and
  drops the lock guard **before** asserting, so an assertion failure
  reports the bug without poisoning the shared lock for other tests.
- The stale "GLOBAL-STATE CONTRACT" comment is rewritten to describe the
  real coupling.

`serial_test` was deliberately **not** re-added (it was removed as an
unused dep in PR #4181); a plain `std::sync::Mutex<()>` guard achieves
the same serialization without the dependency.

## Testing

- Bug-detection power preserved: with the #4172 lock scope temporarily
  reverted, the regression test still diverges reliably (round 260,
  `:22080` vs `:22084`), then restored.
- 5 consecutive clean runs of
  `cargo test -p freenet --lib -- ring::connection_manager node::network_status`
  (117 passed each run).
- Full `cargo test -p freenet --lib` green (2553 passed, 0 failed).
- `cargo clippy -p freenet --lib -- -D warnings` clean.
- `cargo fmt` applied.

Refs #4200, #4172.

[AI-assisted - Claude]