### PR TITLE
fix: stop Windows installer self-destruct from blanket taskkill

### DIFF
--- a/.claude/rules/bug-prevention-patterns.md
+++ b/.claude/rules/bug-prevention-patterns.md
@@ -53,6 +53,7 @@ Source-level regression pins live in:
 
 - `commands::tray::tests::open_log_file_spawn_must_null_all_three_standard_handles`
 - `commands::service::tests::spawn_update_command_must_null_all_three_standard_handles`
+- `commands::service::tests::taskkill_pid_must_null_all_three_standard_handles`
 
 A future revert of any of these null-stdio calls fails CI with a
 specific, issue-numbered error message rather than shipping the

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -3196,21 +3196,11 @@ pub fn stop_and_remove_service(_system: bool) -> Result<bool> {
 
     let had_registry = run_key.delete_value("Freenet").is_ok();
 
-    // Kill any running freenet processes (wrapper + child), excluding ourselves
-    let our_pid = std::process::id().to_string();
-    drop(
-        std::process::Command::new("taskkill")
-            .args([
-                "/f",
-                "/im",
-                "freenet.exe",
-                "/fi",
-                &format!("PID ne {}", our_pid),
-            ])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status(),
-    );
+    // Kill the running Freenet service processes (wrapper + node child).
+    // Targets only the service's own processes by command line so an
+    // unrelated freenet.exe — e.g. the GUI installer — is never killed
+    // (issue #4205).
+    kill_freenet_service_processes();
 
     // Also clean up any legacy scheduled task from older installs
     let had_task = std::process::Command::new("schtasks")
@@ -3311,32 +3301,127 @@ fn start_service(system: bool) -> Result<()> {
     Ok(())
 }
 
+/// Strip the leading executable path from a Windows process command line,
+/// returning just the argument portion (everything after the program name).
+///
+/// The program path is normally quoted — both Rust's `Command` and the
+/// registry `Run` key quote it — in which case it can be stripped exactly.
+/// For an unquoted path we fall back to splitting on the first whitespace;
+/// that is only ambiguous for unquoted paths containing spaces, which
+/// Windows avoids for the processes Freenet itself spawns.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn command_line_args(cmdline: &str) -> &str {
+    let trimmed = cmdline.trim_start();
+    if let Some(after_open_quote) = trimmed.strip_prefix('"') {
+        after_open_quote
+            .find('"')
+            .map_or("", |close| after_open_quote[close + 1..].trim_start())
+    } else {
+        trimmed
+            .find(char::is_whitespace)
+            .map_or("", |space| trimmed[space..].trim_start())
+    }
+}
+
+/// Decide whether a `freenet.exe` process — identified by its full command
+/// line — belongs to the running Freenet service: the `service run-wrapper`
+/// wrapper or its `network` node child.
+///
+/// This must return `false` for every other `freenet.exe` invocation. In
+/// particular the Windows GUI installer is launched with no subcommand, so a
+/// blanket `taskkill /im freenet.exe` during its install-time stop step used
+/// to terminate the installer itself (issue #4205). Targeting only the
+/// wrapper/node by command line avoids that.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn is_freenet_service_process(cmdline: &str) -> bool {
+    command_line_args(cmdline)
+        .split_whitespace()
+        .any(|token| token == "run-wrapper" || token == "network")
+}
+
+/// Parse the `<pid>\t<command line>` lines produced by the PowerShell process
+/// listing in [`list_freenet_processes`] into `(pid, command_line)` pairs.
+/// Lines that do not begin with a numeric PID are ignored.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn parse_freenet_process_listing(stdout: &str) -> Vec<(u32, String)> {
+    stdout
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim_end_matches('\r');
+            let (pid, cmdline) = line.split_once('\t').unwrap_or((line, ""));
+            Some((pid.trim().parse::<u32>().ok()?, cmdline.to_string()))
+        })
+        .collect()
+}
+
+/// Enumerate `freenet.exe` processes and their command lines via PowerShell.
+///
+/// Uses `Get-CimInstance` rather than `wmic`, which is deprecated and no
+/// longer installed by default on recent Windows releases. Returns `None` if
+/// the process listing could not be obtained.
+#[cfg(target_os = "windows")]
+fn list_freenet_processes() -> Option<Vec<(u32, String)>> {
+    let output = std::process::Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "Get-CimInstance Win32_Process -Filter \"Name='freenet.exe'\" | \
+             ForEach-Object { \"$($_.ProcessId)`t$($_.CommandLine)\" }",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(parse_freenet_process_listing(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
+}
+
+/// Stop the running Freenet service — the `service run-wrapper` wrapper and
+/// the `network` node child — and return the number of processes terminated.
+///
+/// Unlike a blanket `taskkill /im freenet.exe`, this targets only the
+/// service's own processes (identified by command line), so it never kills an
+/// unrelated `freenet.exe` that merely shares the image name: the GUI
+/// installer (issue #4205), a concurrent `freenet` CLI command, or the caller
+/// itself. The current process is always excluded.
+#[cfg(target_os = "windows")]
+pub(crate) fn kill_freenet_service_processes() -> usize {
+    let our_pid = std::process::id();
+    let Some(processes) = list_freenet_processes() else {
+        return 0;
+    };
+    let mut killed = 0;
+    for (pid, cmdline) in processes {
+        if pid == our_pid || !is_freenet_service_process(&cmdline) {
+            continue;
+        }
+        let terminated = std::process::Command::new("taskkill")
+            .args(["/f", "/pid", &pid.to_string()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false);
+        if terminated {
+            killed += 1;
+        }
+    }
+    killed
+}
+
 #[cfg(target_os = "windows")]
 fn stop_service(system: bool) -> Result<()> {
     check_no_system_flag_windows(system)?;
 
-    // Kill freenet processes, excluding the current one (which IS freenet.exe)
-    let our_pid = std::process::id().to_string();
-    let status = std::process::Command::new("taskkill")
-        .args([
-            "/f",
-            "/im",
-            "freenet.exe",
-            "/fi",
-            &format!("PID ne {}", our_pid),
-        ])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .context("Failed to stop Freenet")?;
-
-    if status.success() {
+    if kill_freenet_service_processes() > 0 {
         println!("Freenet stopped.");
+        Ok(())
     } else {
-        anyhow::bail!("Failed to stop Freenet. It may not be running.");
+        anyhow::bail!("Failed to stop Freenet. It may not be running.")
     }
-
-    Ok(())
 }
 
 #[cfg(target_os = "windows")]
@@ -3491,6 +3576,91 @@ fn service_logs(_error_only: bool) -> Result<()> {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn command_line_args_strips_quoted_executable_path() {
+        assert_eq!(
+            command_line_args("\"C:\\Program Files\\Freenet\\freenet.exe\" service run-wrapper"),
+            "service run-wrapper"
+        );
+        // Quoted path, no arguments — the GUI installer launched by Explorer.
+        assert_eq!(
+            command_line_args("\"C:\\Users\\me\\Downloads\\freenet.exe\""),
+            ""
+        );
+    }
+
+    #[test]
+    fn command_line_args_strips_unquoted_executable_path() {
+        assert_eq!(command_line_args("C:\\bin\\freenet.exe network"), "network");
+        assert_eq!(command_line_args("freenet.exe"), "");
+    }
+
+    #[test]
+    fn is_freenet_service_process_matches_wrapper_and_node() {
+        assert!(is_freenet_service_process(
+            "\"C:\\Users\\me\\AppData\\Local\\Freenet\\bin\\freenet.exe\" service run-wrapper"
+        ));
+        assert!(is_freenet_service_process(
+            "\"C:\\Users\\me\\AppData\\Local\\Freenet\\bin\\freenet.exe\" network"
+        ));
+    }
+
+    /// Regression test for issue #4205: the Windows GUI installer is launched
+    /// with no subcommand, so it must never be classified as a service
+    /// process — otherwise the install-time `service stop` step kills the
+    /// installer itself before anything is installed.
+    #[test]
+    fn is_freenet_service_process_spares_installer_and_other_commands() {
+        // GUI installer: double-clicked freenet.exe, no arguments.
+        assert!(!is_freenet_service_process(
+            "\"C:\\Users\\me\\Downloads\\freenet.exe\""
+        ));
+        // The `service stop` child process that triggers the kill.
+        assert!(!is_freenet_service_process(
+            "\"C:\\Users\\me\\Downloads\\freenet.exe\" service stop"
+        ));
+        // A concurrent self-update must not be killed.
+        assert!(!is_freenet_service_process(
+            "\"C:\\Program Files\\Freenet\\freenet.exe\" update"
+        ));
+        // An install path that merely contains the word "network" — the
+        // quoted exe path is stripped, so this must not match.
+        assert!(!is_freenet_service_process(
+            "\"C:\\Users\\me\\My Network Tools\\freenet.exe\""
+        ));
+    }
+
+    #[test]
+    fn parse_freenet_process_listing_extracts_pid_and_command_line() {
+        let stdout = "1234\t\"C:\\bin\\freenet.exe\" service run-wrapper\r\n\
+                      5678\t\"C:\\bin\\freenet.exe\" network\r\n\
+                      9012\t\"C:\\Users\\me\\Downloads\\freenet.exe\"\r\n";
+        assert_eq!(
+            parse_freenet_process_listing(stdout),
+            vec![
+                (
+                    1234u32,
+                    "\"C:\\bin\\freenet.exe\" service run-wrapper".to_string()
+                ),
+                (5678u32, "\"C:\\bin\\freenet.exe\" network".to_string()),
+                (
+                    9012u32,
+                    "\"C:\\Users\\me\\Downloads\\freenet.exe\"".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_freenet_process_listing_skips_blank_and_malformed_lines() {
+        // A process whose CommandLine could not be read prints just its PID;
+        // blank lines and non-numeric lines must be ignored.
+        assert_eq!(
+            parse_freenet_process_listing("4242\t\r\n\r\nnot-a-pid\tsomething\r\n"),
+            vec![(4242u32, String::new())]
+        );
+    }
 
     /// Flock-level regression test for the dup-tray bug observed in
     /// phase-1 smoke test 2026-04-22. Uses a dedicated path inside a

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -1101,8 +1101,9 @@ fn run_wrapper(version: &str) -> Result<()> {
     //   - `spawn_new_wrapper`                      (this file)
     //   - `open_log_file` notepad/open/xdg-open    (tray.rs)
     //   - `taskkill_pid` (nulls all three) and `list_freenet_processes`
-    //     (`.output()` — pipes, no stdin inherit), reached via the
-    //     post-update restart in `update.rs` -> `kill_freenet_service_processes`
+    //     (`.output()` — fresh pipes, no stdin inherit), reached directly via
+    //     `kill_stale_freenet_processes` (called below) and via
+    //     `kill_freenet_service_processes` (the `update.rs` restart path)
     // Add any new child spawn in this module with null stdio by default.
     // See #3933 / #3934 and `.claude/rules/bug-prevention-patterns.md`
     // at the repo root for the rule + audit grep.
@@ -3354,6 +3355,11 @@ fn parse_freenet_process_listing(stdout: &str) -> Vec<(u32, String)> {
 /// longer installed by default on recent Windows releases. Returns `None` if
 /// the process listing could not be obtained.
 ///
+/// A process whose `CommandLine` cannot be read (owned by another user) is
+/// listed with an empty command line and so is never classified as a service
+/// process. The wrapper, node, and installer all run as the same user, so
+/// this never hides one of our own processes.
+///
 /// `.output()` captures stdout/stderr through fresh pipes and does not inherit
 /// stdin, so this spawn is safe even after `FreeConsole()` (see the spawn-site
 /// audit note on `run_wrapper`).
@@ -3422,19 +3428,31 @@ fn kill_freenet_processes_matching(kind: FreenetServiceProcess) -> usize {
 /// installer (issue #4205), a concurrent `freenet` CLI command, or the caller
 /// itself.
 ///
-/// Wrappers are killed before nodes, and the node set is re-enumerated once
-/// the wrappers are gone: a live wrapper's run loop respawns the `network`
-/// child the instant it exits, so a node killed while a wrapper is still alive
-/// could be replaced by one missing from the original listing.
+/// Wrappers are killed first, then nodes are killed in a short re-enumerating
+/// loop. A live wrapper's run loop respawns the `network` child the instant it
+/// exits, and `taskkill /f` only *requests* termination (`TerminateProcess` is
+/// asynchronous), so a wrapper can briefly outlive the wrapper pass and spawn
+/// a node the first node pass never saw. The loop re-enumerates until a pass
+/// finds no nodes — by then every wrapper has fully exited — bounded so an
+/// unkillable process cannot hang the caller.
 ///
 /// Returns `0` when nothing was running — but also when the process listing
 /// could not be obtained or every `taskkill` failed; callers treat `0`
 /// uniformly as "nothing was stopped".
 #[cfg(target_os = "windows")]
 pub(crate) fn kill_freenet_service_processes() -> usize {
-    let wrappers = kill_freenet_processes_matching(FreenetServiceProcess::Wrapper);
-    // Re-enumerate: with every wrapper gone, no new node child can be spawned.
-    wrappers + kill_freenet_processes_matching(FreenetServiceProcess::Node)
+    let mut killed = kill_freenet_processes_matching(FreenetServiceProcess::Wrapper);
+    for _ in 0..3 {
+        let nodes = kill_freenet_processes_matching(FreenetServiceProcess::Node);
+        killed += nodes;
+        if nodes == 0 {
+            break;
+        }
+        // Give a still-dying wrapper time to finish so a node it respawns is
+        // visible to the next enumeration.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+    killed
 }
 
 #[cfg(target_os = "windows")]
@@ -3619,6 +3637,15 @@ mod tests {
     fn command_line_args_strips_unquoted_executable_path() {
         assert_eq!(command_line_args("C:\\bin\\freenet.exe network"), "network");
         assert_eq!(command_line_args("freenet.exe"), "");
+    }
+
+    #[test]
+    fn command_line_args_handles_degenerate_input() {
+        // Empty and whitespace-only input.
+        assert_eq!(command_line_args(""), "");
+        assert_eq!(command_line_args("   "), "");
+        // A leading quote with no closing quote — must not panic, yields "".
+        assert_eq!(command_line_args("\"C:\\bin\\freenet.exe network"), "");
     }
 
     #[test]
@@ -4904,6 +4931,42 @@ mod tests {
                  autostart fires a silent spawn failure with os error 6 \
                  (#3933 / #3934). The fix pattern matches the network-child \
                  spawn in run_wrapper_loop.",
+                pattern
+            );
+        }
+    }
+
+    /// Source-level regression pin for the `FreeConsole()` rule, mirroring
+    /// `spawn_update_command_must_null_all_three_standard_handles`.
+    ///
+    /// `taskkill_pid` spawns a child via `Command::status()`, which inherits
+    /// the parent's standard handles unless they are explicitly nulled. It is
+    /// reachable from `kill_stale_freenet_processes` (run by the wrapper right
+    /// after `FreeConsole()`) and from the auto-update restart path. If a
+    /// future refactor drops the `.stdin/.stdout/.stderr(Stdio::null())`
+    /// lines, this fails loudly instead of shipping a silent os-error-6 spawn
+    /// failure to Windows.
+    #[test]
+    fn taskkill_pid_must_null_all_three_standard_handles() {
+        let src = include_str!("service.rs");
+        let (_, after_fn_start) = src
+            .split_once("fn taskkill_pid(")
+            .expect("taskkill_pid definition not found");
+        let (body, _) = after_fn_start
+            .split_once("\nfn ")
+            .expect("could not locate end of taskkill_pid");
+        let code_only: String = body
+            .lines()
+            .map(|line| line.split_once("//").map(|(c, _)| c).unwrap_or(line))
+            .collect::<Vec<_>>()
+            .join("\n");
+        for handle in ["stdin", "stdout", "stderr"] {
+            let pattern = format!(".{handle}(std::process::Stdio::null())");
+            assert!(
+                code_only.contains(&pattern),
+                "taskkill_pid must call `{}` — without it, the `taskkill` \
+                 spawn fails with os error 6 after the wrapper's \
+                 FreeConsole() (#3933 / #3934).",
                 pattern
             );
         }

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -3403,8 +3403,7 @@ pub(crate) fn kill_freenet_service_processes() -> usize {
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
-            .map(|status| status.success())
-            .unwrap_or(false);
+            .is_ok_and(|status| status.success());
         if terminated {
             killed += 1;
         }

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -1100,6 +1100,9 @@ fn run_wrapper(version: &str) -> Result<()> {
     //   - network child in `run_wrapper_loop`      (this file, ~line 1452)
     //   - `spawn_new_wrapper`                      (this file)
     //   - `open_log_file` notepad/open/xdg-open    (tray.rs)
+    //   - `taskkill_pid` (nulls all three) and `list_freenet_processes`
+    //     (`.output()` — pipes, no stdin inherit), reached via the
+    //     post-update restart in `update.rs` -> `kill_freenet_service_processes`
     // Add any new child spawn in this module with null stdio by default.
     // See #3933 / #3934 and `.claude/rules/bug-prevention-patterns.md`
     // at the repo root for the rule + audit grep.
@@ -2012,44 +2015,17 @@ fn kill_stale_freenet_processes(log_dir: &Path) {
 
     #[cfg(target_os = "windows")]
     {
-        // Use WMIC to find freenet.exe processes with "network" in the command line,
-        // then kill them by PID. This avoids killing the wrapper itself or other
-        // freenet subcommands (update, service, etc.).
-        let output = std::process::Command::new("wmic")
-            .args([
-                "process",
-                "where",
-                "name='freenet.exe' and commandline like '%network%'",
-                "get",
-                "processid",
-                "/format:list",
-            ])
-            .output();
-        if let Ok(output) = output {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let mut killed = false;
-            for line in stdout.lines() {
-                if let Some(pid_str) = line.strip_prefix("ProcessId=") {
-                    let pid = pid_str.trim();
-                    if !pid.is_empty() {
-                        drop(
-                            std::process::Command::new("taskkill")
-                                .args(["/F", "/PID", pid])
-                                .stdout(std::process::Stdio::null())
-                                .stderr(std::process::Stdio::null())
-                                .status(),
-                        );
-                        killed = true;
-                    }
-                }
-            }
-            if killed {
-                log_wrapper_event(
-                    log_dir,
-                    "Killed stale freenet network process(es) on startup",
-                );
-                std::thread::sleep(std::time::Duration::from_secs(2));
-            }
+        // Reap orphaned `network` node children left by a previous wrapper
+        // instance. Only nodes are targeted — never a wrapper or another
+        // `freenet` subcommand. Shares the PowerShell-based enumeration used
+        // by `kill_freenet_service_processes`; `wmic` (used here previously)
+        // is deprecated and absent by default on recent Windows releases.
+        if kill_freenet_processes_matching(FreenetServiceProcess::Node) > 0 {
+            log_wrapper_event(
+                log_dir,
+                "Killed stale freenet network process(es) on startup",
+            );
+            std::thread::sleep(std::time::Duration::from_secs(2));
         }
     }
 }
@@ -3323,24 +3299,42 @@ fn command_line_args(cmdline: &str) -> &str {
     }
 }
 
-/// Decide whether a `freenet.exe` process — identified by its full command
-/// line — belongs to the running Freenet service: the `service run-wrapper`
-/// wrapper or its `network` node child.
-///
-/// This must return `false` for every other `freenet.exe` invocation. In
-/// particular the Windows GUI installer is launched with no subcommand, so a
-/// blanket `taskkill /im freenet.exe` during its install-time stop step used
-/// to terminate the installer itself (issue #4205). Targeting only the
-/// wrapper/node by command line avoids that.
+/// Which Freenet service process a `freenet.exe` command line represents.
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
-fn is_freenet_service_process(cmdline: &str) -> bool {
-    command_line_args(cmdline)
-        .split_whitespace()
-        .any(|token| token == "run-wrapper" || token == "network")
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FreenetServiceProcess {
+    /// The `service run-wrapper` supervisor (also the Windows tray process).
+    Wrapper,
+    /// The `network` node child the wrapper supervises.
+    Node,
+}
+
+/// Classify a `freenet.exe` process from its full command line.
+///
+/// Matching is by the **subcommand prefix** — the first argument token after
+/// the executable path — not by scanning every token. A blanket token scan
+/// would misfire on a command line where `network` or `run-wrapper` appears
+/// as an option value or path component rather than the subcommand, e.g.
+/// `freenet local --config-dir network`.
+///
+/// Returns `None` for every other `freenet.exe` invocation, which must never
+/// be killed: the GUI installer (launched with no subcommand — issue #4205),
+/// `service stop`, `update`, or any directly-run `freenet` CLI command. Note
+/// that a node started manually via the top-level `freenet network`
+/// subcommand IS classified as `Node` — `service stop` is meant to stop a
+/// running node regardless of how it was launched.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn classify_freenet_process(cmdline: &str) -> Option<FreenetServiceProcess> {
+    let mut args = command_line_args(cmdline).split_whitespace();
+    match args.next()? {
+        "network" => Some(FreenetServiceProcess::Node),
+        "service" if args.next() == Some("run-wrapper") => Some(FreenetServiceProcess::Wrapper),
+        _ => None,
+    }
 }
 
 /// Parse the `<pid>\t<command line>` lines produced by the PowerShell process
-/// listing in [`list_freenet_processes`] into `(pid, command_line)` pairs.
+/// listing in `list_freenet_processes` into `(pid, command_line)` pairs.
 /// Lines that do not begin with a numeric PID are ignored.
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 fn parse_freenet_process_listing(stdout: &str) -> Vec<(u32, String)> {
@@ -3359,6 +3353,10 @@ fn parse_freenet_process_listing(stdout: &str) -> Vec<(u32, String)> {
 /// Uses `Get-CimInstance` rather than `wmic`, which is deprecated and no
 /// longer installed by default on recent Windows releases. Returns `None` if
 /// the process listing could not be obtained.
+///
+/// `.output()` captures stdout/stderr through fresh pipes and does not inherit
+/// stdin, so this spawn is safe even after `FreeConsole()` (see the spawn-site
+/// audit note on `run_wrapper`).
 #[cfg(target_os = "windows")]
 fn list_freenet_processes() -> Option<Vec<(u32, String)>> {
     let output = std::process::Command::new("powershell")
@@ -3379,36 +3377,64 @@ fn list_freenet_processes() -> Option<Vec<(u32, String)>> {
     )))
 }
 
-/// Stop the running Freenet service — the `service run-wrapper` wrapper and
-/// the `network` node child — and return the number of processes terminated.
+/// Force-terminate a process by PID via `taskkill`. Returns whether `taskkill`
+/// reported success.
 ///
-/// Unlike a blanket `taskkill /im freenet.exe`, this targets only the
-/// service's own processes (identified by command line), so it never kills an
-/// unrelated `freenet.exe` that merely shares the image name: the GUI
-/// installer (issue #4205), a concurrent `freenet` CLI command, or the caller
-/// itself. The current process is always excluded.
+/// All three standard handles are nulled so the spawn succeeds even when the
+/// caller has detached from its console via `FreeConsole()` — the auto-update
+/// restart path reaches here from the wrapper. See
+/// `.claude/rules/bug-prevention-patterns.md`.
 #[cfg(target_os = "windows")]
-pub(crate) fn kill_freenet_service_processes() -> usize {
+fn taskkill_pid(pid: u32) -> bool {
+    std::process::Command::new("taskkill")
+        .args(["/f", "/pid", &pid.to_string()])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+/// Enumerate `freenet.exe` processes and `taskkill` every one classified as
+/// `kind`, excluding the current process. Returns the number terminated.
+#[cfg(target_os = "windows")]
+fn kill_freenet_processes_matching(kind: FreenetServiceProcess) -> usize {
     let our_pid = std::process::id();
     let Some(processes) = list_freenet_processes() else {
         return 0;
     };
     let mut killed = 0;
     for (pid, cmdline) in processes {
-        if pid == our_pid || !is_freenet_service_process(&cmdline) {
-            continue;
-        }
-        let terminated = std::process::Command::new("taskkill")
-            .args(["/f", "/pid", &pid.to_string()])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .is_ok_and(|status| status.success());
-        if terminated {
+        if pid != our_pid && classify_freenet_process(&cmdline) == Some(kind) && taskkill_pid(pid) {
             killed += 1;
         }
     }
     killed
+}
+
+/// Stop the running Freenet service — the `service run-wrapper` supervisor and
+/// the `network` node child it manages — and return the number of processes
+/// terminated.
+///
+/// Unlike a blanket `taskkill /im freenet.exe`, this targets only the
+/// service's own processes (classified by command line), so it never kills an
+/// unrelated `freenet.exe` that merely shares the image name: the GUI
+/// installer (issue #4205), a concurrent `freenet` CLI command, or the caller
+/// itself.
+///
+/// Wrappers are killed before nodes, and the node set is re-enumerated once
+/// the wrappers are gone: a live wrapper's run loop respawns the `network`
+/// child the instant it exits, so a node killed while a wrapper is still alive
+/// could be replaced by one missing from the original listing.
+///
+/// Returns `0` when nothing was running — but also when the process listing
+/// could not be obtained or every `taskkill` failed; callers treat `0`
+/// uniformly as "nothing was stopped".
+#[cfg(target_os = "windows")]
+pub(crate) fn kill_freenet_service_processes() -> usize {
+    let wrappers = kill_freenet_processes_matching(FreenetServiceProcess::Wrapper);
+    // Re-enumerate: with every wrapper gone, no new node child can be spawned.
+    wrappers + kill_freenet_processes_matching(FreenetServiceProcess::Node)
 }
 
 #[cfg(target_os = "windows")]
@@ -3596,13 +3622,19 @@ mod tests {
     }
 
     #[test]
-    fn is_freenet_service_process_matches_wrapper_and_node() {
-        assert!(is_freenet_service_process(
-            "\"C:\\Users\\me\\AppData\\Local\\Freenet\\bin\\freenet.exe\" service run-wrapper"
-        ));
-        assert!(is_freenet_service_process(
-            "\"C:\\Users\\me\\AppData\\Local\\Freenet\\bin\\freenet.exe\" network"
-        ));
+    fn classify_freenet_process_identifies_wrapper_and_node() {
+        assert_eq!(
+            classify_freenet_process(
+                "\"C:\\Users\\me\\AppData\\Local\\Freenet\\bin\\freenet.exe\" service run-wrapper"
+            ),
+            Some(FreenetServiceProcess::Wrapper)
+        );
+        assert_eq!(
+            classify_freenet_process(
+                "\"C:\\Users\\me\\AppData\\Local\\Freenet\\bin\\freenet.exe\" network"
+            ),
+            Some(FreenetServiceProcess::Node)
+        );
     }
 
     /// Regression test for issue #4205: the Windows GUI installer is launched
@@ -3610,24 +3642,50 @@ mod tests {
     /// process — otherwise the install-time `service stop` step kills the
     /// installer itself before anything is installed.
     #[test]
-    fn is_freenet_service_process_spares_installer_and_other_commands() {
+    fn classify_freenet_process_spares_installer_and_other_commands() {
         // GUI installer: double-clicked freenet.exe, no arguments.
-        assert!(!is_freenet_service_process(
-            "\"C:\\Users\\me\\Downloads\\freenet.exe\""
-        ));
+        assert_eq!(
+            classify_freenet_process("\"C:\\Users\\me\\Downloads\\freenet.exe\""),
+            None
+        );
         // The `service stop` child process that triggers the kill.
-        assert!(!is_freenet_service_process(
-            "\"C:\\Users\\me\\Downloads\\freenet.exe\" service stop"
-        ));
+        assert_eq!(
+            classify_freenet_process("\"C:\\Users\\me\\Downloads\\freenet.exe\" service stop"),
+            None
+        );
         // A concurrent self-update must not be killed.
-        assert!(!is_freenet_service_process(
-            "\"C:\\Program Files\\Freenet\\freenet.exe\" update"
-        ));
+        assert_eq!(
+            classify_freenet_process("\"C:\\Program Files\\Freenet\\freenet.exe\" update"),
+            None
+        );
         // An install path that merely contains the word "network" — the
         // quoted exe path is stripped, so this must not match.
-        assert!(!is_freenet_service_process(
-            "\"C:\\Users\\me\\My Network Tools\\freenet.exe\""
-        ));
+        assert_eq!(
+            classify_freenet_process("\"C:\\Users\\me\\My Network Tools\\freenet.exe\""),
+            None
+        );
+    }
+
+    /// `network` / `run-wrapper` must only match as the subcommand (the first
+    /// argument token), never as an option value or later argument —
+    /// otherwise an unrelated `freenet` CLI invocation would be killed.
+    #[test]
+    fn classify_freenet_process_matches_subcommand_prefix_only() {
+        // `network` appearing as an option value, not the subcommand.
+        assert_eq!(
+            classify_freenet_process("\"C:\\bin\\freenet.exe\" local --config-dir network"),
+            None
+        );
+        // `run-wrapper` only counts immediately after the `service` subcommand.
+        assert_eq!(
+            classify_freenet_process("\"C:\\bin\\freenet.exe\" service stop run-wrapper"),
+            None
+        );
+        // The real node spawn has `network` as the first token.
+        assert_eq!(
+            classify_freenet_process("\"C:\\bin\\freenet.exe\" network"),
+            Some(FreenetServiceProcess::Node)
+        );
     }
 
     #[test]

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -2018,9 +2018,13 @@ fn kill_stale_freenet_processes(log_dir: &Path) {
     {
         // Reap orphaned `network` node children left by a previous wrapper
         // instance. Only nodes are targeted — never a wrapper or another
-        // `freenet` subcommand. Shares the PowerShell-based enumeration used
-        // by `kill_freenet_service_processes`; `wmic` (used here previously)
-        // is deprecated and absent by default on recent Windows releases.
+        // `freenet` subcommand. A single pass suffices here (unlike the loop
+        // in `kill_freenet_service_processes`): this runs at wrapper startup
+        // and on the port-conflict retry, when the only live wrapper is this
+        // process, so no other wrapper exists to respawn a reaped node.
+        // Shares the PowerShell-based enumeration used by
+        // `kill_freenet_service_processes`; `wmic` (used here previously) is
+        // deprecated and absent by default on recent Windows releases.
         if kill_freenet_processes_matching(FreenetServiceProcess::Node) > 0 {
             log_wrapper_event(
                 log_dir,
@@ -3419,8 +3423,7 @@ fn kill_freenet_processes_matching(kind: FreenetServiceProcess) -> usize {
 }
 
 /// Stop the running Freenet service — the `service run-wrapper` supervisor and
-/// the `network` node child it manages — and return the number of processes
-/// terminated.
+/// the `network` node child it manages.
 ///
 /// Unlike a blanket `taskkill /im freenet.exe`, this targets only the
 /// service's own processes (classified by command line), so it never kills an
@@ -3428,17 +3431,26 @@ fn kill_freenet_processes_matching(kind: FreenetServiceProcess) -> usize {
 /// installer (issue #4205), a concurrent `freenet` CLI command, or the caller
 /// itself.
 ///
-/// Wrappers are killed first, then nodes are killed in a short re-enumerating
-/// loop. A live wrapper's run loop respawns the `network` child the instant it
-/// exits, and `taskkill /f` only *requests* termination (`TerminateProcess` is
-/// asynchronous), so a wrapper can briefly outlive the wrapper pass and spawn
-/// a node the first node pass never saw. The loop re-enumerates until a pass
-/// finds no nodes — by then every wrapper has fully exited — bounded so an
-/// unkillable process cannot hang the caller.
+/// Wrappers are killed first, then nodes in a short re-enumerating loop. Only
+/// a live wrapper spawns `network` children, and `taskkill /f` merely
+/// *requests* termination (`TerminateProcess` is asynchronous), so a wrapper
+/// can briefly outlive the wrapper pass — long enough to spawn a node the
+/// first node enumeration missed. Each loop pass re-enumerates; once no
+/// wrapper this sweep terminated is still alive, the node set is stable. The
+/// loop stops as soon as a pass kills nothing — everything is gone, or the
+/// remainder is unkillable and retrying will not help — and is bounded to 3
+/// passes (200ms apart, comfortably over normal `TerminateProcess` latency)
+/// so an unkillable process cannot hang the caller.
 ///
-/// Returns `0` when nothing was running — but also when the process listing
-/// could not be obtained or every `taskkill` failed; callers treat `0`
-/// uniformly as "nothing was stopped".
+/// Known limitation: a wrapper mid-self-update can `spawn_new_wrapper` inside
+/// its own async-termination window; that successor is not re-enumerated and
+/// may survive. This matches the previous blanket `taskkill`'s exposure and
+/// requires a self-update to coincide with a stop to the millisecond.
+///
+/// Returns the count of successful `taskkill` requests — which counts a node
+/// re-killed across passes more than once, so callers only test `> 0`. A `0`
+/// result means nothing was running, the process listing was unavailable, or
+/// every `taskkill` failed; callers treat all three as "nothing was stopped".
 #[cfg(target_os = "windows")]
 pub(crate) fn kill_freenet_service_processes() -> usize {
     let mut killed = kill_freenet_processes_matching(FreenetServiceProcess::Wrapper);

--- a/crates/core/src/bin/commands/setup_wizard/installer.rs
+++ b/crates/core/src/bin/commands/setup_wizard/installer.rs
@@ -44,17 +44,18 @@ pub fn run_install(progress: impl Fn(InstallProgress) + Send) -> Result<()> {
 
     let installed_exe = install_dir.join("freenet.exe");
 
-    // Step 1: Stop existing service if running
+    // Step 1: Stop existing service if running.
+    //
+    // Stop it in-process rather than shelling out to the already-installed
+    // `freenet.exe service stop`. Older installed versions implement that
+    // subcommand as a blanket `taskkill /im freenet.exe`, which also matches
+    // this GUI installer (it is likewise named `freenet.exe`) and kills it
+    // mid-install — issue #4205. Running the stop here uses this binary's
+    // command-line-targeted logic and excludes the current process, so it is
+    // unaffected by whatever version is already installed.
     progress(InstallProgress::StoppingExisting);
     if installed_exe.exists() {
-        // Try to stop gracefully — ignore errors (may not be running)
-        drop(
-            std::process::Command::new(&installed_exe)
-                .args(["service", "stop"])
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status(),
-        );
+        crate::commands::service::kill_freenet_service_processes();
         std::thread::sleep(std::time::Duration::from_secs(2));
     }
 

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -473,21 +473,11 @@ impl UpdateCommand {
             {
                 if is_windows_wrapper_running() {
                     println!("Restarting Freenet service...");
-                    // Kill old wrapper + child processes (excluding ourselves),
-                    // then start a new wrapper with the updated binary.
-                    let our_pid = std::process::id().to_string();
-                    Command::new("taskkill")
-                        .args([
-                            "/f",
-                            "/im",
-                            "freenet.exe",
-                            "/fi",
-                            &format!("PID ne {}", our_pid),
-                        ])
-                        .stdout(std::process::Stdio::null())
-                        .stderr(std::process::Stdio::null())
-                        .status()
-                        .ok();
+                    // Kill the old wrapper + node child, then start a new
+                    // wrapper with the updated binary. Targets only the
+                    // service's own processes by command line so an unrelated
+                    // freenet.exe is never killed (issue #4205).
+                    super::service::kill_freenet_service_processes();
                     // Brief pause to ensure the old process is fully stopped
                     std::thread::sleep(std::time::Duration::from_secs(2));
                     let status = Command::new(&current_exe)


### PR DESCRIPTION
## Problem

The Windows GUI installer is itself named `freenet.exe`. When the user
presses **Install**, the installer's first step runs `service stop` on the
already-installed binary, which executed:

```
taskkill /f /im freenet.exe /fi "PID ne <stop-command-pid>"
```

`taskkill /im freenet.exe` matches **every** process with that image name —
so it killed the GUI installer too. It excluded only the short-lived
`service stop` child, not the parent installer. The installer window
silently disappeared shortly after Install was pressed, before anything was
copied (#4205). Renaming the downloaded binary to `freenet-installer.exe`
worked around it, confirming the diagnosis.

The same blanket `taskkill /im freenet.exe` pattern also lived in
`stop_and_remove_service` (uninstall) and the post-update restart in
`update.rs` — both could kill an unrelated `freenet.exe`.

## Solution

Replace the blanket image-name kill with **command-line-targeted**
selection. `freenet.exe` processes are enumerated via PowerShell
`Get-CimInstance` and classified by their **subcommand prefix** (the first
argument token): `service run-wrapper` → the wrapper, `network` → the node
child. Only those two are terminated, by PID; every other `freenet.exe`
(the GUI installer, a concurrent CLI command, the caller itself) is left
alone. Killing is split into a wrapper pass then a re-enumerated node pass,
so a node the wrapper respawns mid-sweep is not missed.

All three blanket-taskkill sites — `stop_service`, `stop_and_remove_service`,
and the `update.rs` post-update restart — now route through one shared
helper, `kill_freenet_service_processes()`.

The installer additionally stopped the service by shelling out to the
**already-installed** binary — so a buggy *old* version's `service stop`
would still self-destruct the installer during an upgrade. The installer
now runs the stop **in-process**, using this binary's fixed logic
regardless of which version is installed.

`kill_stale_freenet_processes` (the wrapper-startup orphan reaper) is
migrated off `wmic` onto the same PowerShell helper: `wmic` is deprecated
and absent by default on Windows 11 24H2 / Server 2025, where it was
silently no-opping. After this PR there is no `wmic` dependency left in the
file.

The kill decision is extracted into pure, cross-platform functions
(`command_line_args`, `classify_freenet_process`,
`parse_freenet_process_listing`) so it can be unit-tested on the Linux CI
matrix — the rest of this Windows-only code is otherwise only
compile-checked by the `windows_check` job.

### Behavior note

`freenet service stop` now stops only the wrapper/node. A node a developer
started manually via the top-level `freenet network` subcommand is still
classified as a node and stopped (intended — `service stop` should stop a
running node however it was launched); a foreground node from the
"run without installing" path (plain `freenet.exe`, no subcommand) is no
longer killed by `service stop`, which is the correct narrowing.

## Testing

- 7 pure-function unit tests in `service.rs`, including
  `classify_freenet_process_spares_installer_and_other_commands` (the
  #4205 regression — the installer command line must classify as `None`)
  and `classify_freenet_process_matches_subcommand_prefix_only` (a token
  like `network` appearing as an option value must not match).
- `cargo fmt`, `cargo clippy --locked -p freenet`, and the tests all pass
  on Linux.
- Windows-gated code could not be compiled locally (no MSVC C toolchain for
  cross-compilation); CI's `windows_check` job covers compilation on a real
  Windows runner. The PowerShell/`taskkill` invocations themselves are not
  exercised by CI and warrant a manual Windows smoke-test before relying on
  them.

## Fixes

Closes #4205

[AI-assisted - Claude]
