### PR TITLE
fix: make River release announcement survive the gateway-restart race

### DIFF
--- a/scripts/release-agent/announce-to-river.sh
+++ b/scripts/release-agent/announce-to-river.sh
@@ -26,14 +26,20 @@ ROOM_OWNER_VK="${ROOM_OWNER_VK:-4uNUKFzZQCnzo4K2ecZ16cMsYEEfoaRS35z6exEsbvm4}"
 SIGNING_KEY_FILE="${SIGNING_KEY_FILE:-$HOME/.config/freenet-river-official/room_owner_signing_key.bin}"
 ROOMS_JSON="${ROOMS_JSON:-$HOME/.local/share/river/rooms.json}"
 FREENET_NODE_URL="${FREENET_NODE_URL:-http://127.0.0.1:7509/}"
-LOG_FILE="${LOG_FILE:-/var/log/freenet-release-agent-river.log}"
+# Optional persistent log file. Empty by default — the release-agent already
+# captures this script's stderr to journald, and the old /var/log default
+# was not writable by the announce user, so every log() call emitted a
+# spurious "Permission denied" line (issue #4208).
+LOG_FILE="${LOG_FILE:-}"
 
 log() {
     local timestamp
     timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
     echo "[$timestamp] $*" >&2
-    # Best-effort persistent log; non-fatal if not writable.
-    echo "[$timestamp] $*" >> "$LOG_FILE" 2>/dev/null || true
+    # Optional best-effort persistent log; non-fatal if not writable.
+    if [[ -n "$LOG_FILE" ]]; then
+        echo "[$timestamp] $*" >> "$LOG_FILE" 2>/dev/null || true
+    fi
 }
 
 usage() {
@@ -76,9 +82,31 @@ if [[ ! -f "$ROOMS_JSON" ]]; then
     exit 1
 fi
 
-# Check that the Freenet node is reachable. riverctl will hang otherwise.
-if ! curl -s --max-time 3 "$FREENET_NODE_URL" >/dev/null 2>&1; then
-    log "ERROR: Freenet node not reachable at $FREENET_NODE_URL"
+# Wait for the Freenet node to be reachable (riverctl hangs otherwise).
+#
+# A release announcement runs concurrently with the gateway update that
+# restarts the local node, so a single probe routinely races that restart
+# window and the announce fails (issue #4208). Retry for several minutes —
+# the node is only briefly down.
+#
+# The sleep also keeps this script alive past the release-agent's 1-second
+# early-exit probe: the agent treats a sub-1s exit as a failure (HTTP 500)
+# but returns 202 for a script still running, then reaps it in the
+# background. Retrying here therefore lets the announce complete once the
+# node is back instead of dying inside that probe window.
+node_ready=false
+for attempt in $(seq 1 60); do
+    if curl -s --max-time 3 "$FREENET_NODE_URL" >/dev/null 2>&1; then
+        node_ready=true
+        break
+    fi
+    if [[ "$attempt" -eq 1 ]]; then
+        log "Freenet node not reachable at $FREENET_NODE_URL yet — waiting (it is restarted by the concurrent gateway update)"
+    fi
+    sleep 5
+done
+if [[ "$node_ready" != true ]]; then
+    log "ERROR: Freenet node still not reachable at $FREENET_NODE_URL after retries"
     exit 1
 fi
 

--- a/scripts/release-agent/announce-to-river.sh
+++ b/scripts/release-agent/announce-to-river.sh
@@ -31,6 +31,13 @@ FREENET_NODE_URL="${FREENET_NODE_URL:-http://127.0.0.1:7509/}"
 # was not writable by the announce user, so every log() call emitted a
 # spurious "Permission denied" line (issue #4208).
 LOG_FILE="${LOG_FILE:-}"
+# Node-reachability polling budget. A release announcement runs concurrently
+# with the gateway update that restarts the local node, so it must wait that
+# restart out (issue #4208). ATTEMPTS * INTERVAL is the wall-clock budget —
+# default ~5 min, comfortably over the ~90s gateway down-window observed on
+# the v0.2.61 release. Overridable (e.g. INTERVAL=0 in tests).
+NODE_WAIT_ATTEMPTS="${NODE_WAIT_ATTEMPTS:-60}"
+NODE_WAIT_INTERVAL="${NODE_WAIT_INTERVAL:-5}"
 
 log() {
     local timestamp
@@ -49,6 +56,41 @@ Usage: $0 <message>
 Posts <message> to the Freenet Official River room.
 EOF
     exit 1
+}
+
+# Poll FREENET_NODE_URL until it responds, or NODE_WAIT_ATTEMPTS is reached.
+# Returns 0 once reachable, 1 if it never became reachable.
+#
+# A release announcement runs concurrently with the gateway update that
+# restarts the local node (down ~90s), so a single probe routinely races
+# that window (issue #4208) — hence the polling.
+#
+# The polling also keeps this script alive past the release-agent's
+# 1-second early-exit probe: the agent treats a sub-1s exit as a failure
+# (HTTP 500) but returns 202 for a still-running script and reaps it in the
+# background. So a node that is merely restarting still yields a completed
+# announcement. The flip side: a node that stays down for the whole budget
+# fails only in this script's journald log, not visibly to the release
+# workflow (which already received its 202). A prolonged gateway outage on
+# release day is independently visible, so that trade-off is acceptable;
+# surfacing late failures to the workflow would need a release-agent change.
+wait_for_node() {
+    local attempt
+    for ((attempt = 1; attempt <= NODE_WAIT_ATTEMPTS; attempt++)); do
+        if curl -s --max-time 3 "$FREENET_NODE_URL" >/dev/null 2>&1; then
+            return 0
+        fi
+        if [[ "$attempt" -eq 1 ]]; then
+            log "Freenet node not reachable at $FREENET_NODE_URL yet — waiting (it is restarted by the concurrent gateway update)"
+        elif (( attempt % 12 == 0 )); then
+            log "still waiting for Freenet node ($attempt/$NODE_WAIT_ATTEMPTS)"
+        fi
+        # No sleep after the final attempt — nothing follows it.
+        if (( attempt < NODE_WAIT_ATTEMPTS )); then
+            sleep "$NODE_WAIT_INTERVAL"
+        fi
+    done
+    return 1
 }
 
 if [[ $# -ne 1 ]]; then
@@ -82,31 +124,11 @@ if [[ ! -f "$ROOMS_JSON" ]]; then
     exit 1
 fi
 
-# Wait for the Freenet node to be reachable (riverctl hangs otherwise).
-#
-# A release announcement runs concurrently with the gateway update that
-# restarts the local node, so a single probe routinely races that restart
-# window and the announce fails (issue #4208). Retry for several minutes —
-# the node is only briefly down.
-#
-# The sleep also keeps this script alive past the release-agent's 1-second
-# early-exit probe: the agent treats a sub-1s exit as a failure (HTTP 500)
-# but returns 202 for a script still running, then reaps it in the
-# background. Retrying here therefore lets the announce complete once the
-# node is back instead of dying inside that probe window.
-node_ready=false
-for attempt in $(seq 1 60); do
-    if curl -s --max-time 3 "$FREENET_NODE_URL" >/dev/null 2>&1; then
-        node_ready=true
-        break
-    fi
-    if [[ "$attempt" -eq 1 ]]; then
-        log "Freenet node not reachable at $FREENET_NODE_URL yet — waiting (it is restarted by the concurrent gateway update)"
-    fi
-    sleep 5
-done
-if [[ "$node_ready" != true ]]; then
-    log "ERROR: Freenet node still not reachable at $FREENET_NODE_URL after retries"
+# Wait for the local Freenet node before invoking riverctl (it hangs
+# otherwise). See wait_for_node() above for why this polls rather than
+# probing once.
+if ! wait_for_node; then
+    log "ERROR: Freenet node still not reachable at $FREENET_NODE_URL after $NODE_WAIT_ATTEMPTS attempts"
     exit 1
 fi
 

--- a/scripts/release-agent/announce-to-river_test.sh
+++ b/scripts/release-agent/announce-to-river_test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# ^ FREENET_NODE_URL / NODE_WAIT_* / LOG_FILE are read by the functions
+#   extracted from announce-to-river.sh via `eval`; shellcheck cannot see
+#   into the eval and would otherwise flag them all as unused.
+#
+# Regression test for announce-to-river.sh (issue #4208).
+#
+# Covers the two functions the #4208 fix touches:
+#   - wait_for_node(): the bounded node-reachability poll that lets the
+#     announce survive the gateway restarting the local node mid-release,
+#     instead of failing on a single probe that races the restart window.
+#   - log(): now writes a persistent log file only when LOG_FILE is set
+#     (the old unconditional /var/log default emitted "Permission denied"
+#     on every call because the announce user cannot write there).
+#
+# Both functions are extracted verbatim from announce-to-river.sh and
+# eval'd here, so the test exercises the real implementation and cannot
+# drift from it. curl is stubbed and NODE_WAIT_INTERVAL=0 keeps it instant.
+#
+# Run manually with: bash scripts/release-agent/announce-to-river_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ANNOUNCE_SH="$SCRIPT_DIR/announce-to-river.sh"
+
+if [[ ! -f "$ANNOUNCE_SH" ]]; then
+    echo "FAIL: $ANNOUNCE_SH not found" >&2
+    exit 1
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Pull the two functions verbatim so the test runs the real code, not a
+# copy that could drift. Mirrors scripts/release_state_restore_test.sh.
+eval "$(awk '/^log\(\) \{/,/^}/' "$ANNOUNCE_SH")"
+eval "$(awk '/^wait_for_node\(\) \{/,/^}/' "$ANNOUNCE_SH")"
+
+FAILURES=0
+check() {
+    # check <description> <actual> <expected>
+    if [[ "$2" == "$3" ]]; then
+        echo "ok   - $1"
+    else
+        echo "FAIL - $1 (got '$2', expected '$3')" >&2
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# ── log() ────────────────────────────────────────────────────────────
+
+# Empty LOG_FILE (the new default): nothing is written to disk, and the
+# call still succeeds.
+LOG_FILE=""
+log "hello" 2>/dev/null
+check "log() with empty LOG_FILE writes no file" \
+    "$(find "$TMP" -type f | wc -l)" "0"
+
+# LOG_FILE set: each call is appended.
+LOG_FILE="$TMP/river.log"
+log "first" 2>/dev/null
+log "second" 2>/dev/null
+check "log() appends every call to a set LOG_FILE" \
+    "$(grep -c . "$LOG_FILE")" "2"
+check "log() writes the message text" \
+    "$(grep -c 'second' "$LOG_FILE")" "1"
+
+# Unwritable LOG_FILE: log() is best-effort and must not abort the caller.
+LOG_FILE="$TMP/no-such-dir/river.log"
+rc=0
+log "ignored" 2>/dev/null || rc=$?
+check "log() survives an unwritable LOG_FILE" "$rc" "0"
+
+# ── wait_for_node() ──────────────────────────────────────────────────
+
+FREENET_NODE_URL="http://stub/"
+NODE_WAIT_INTERVAL=0
+LOG_FILE=""
+
+# curl stub: fails for the first CURL_FAIL_COUNT calls, then succeeds.
+CURL_CALLS=0
+CURL_FAIL_COUNT=0
+curl() {
+    CURL_CALLS=$((CURL_CALLS + 1))
+    (( CURL_CALLS > CURL_FAIL_COUNT ))
+}
+
+# Node already up: succeeds on the first probe.
+NODE_WAIT_ATTEMPTS=60
+CURL_CALLS=0
+CURL_FAIL_COUNT=0
+rc=0
+wait_for_node 2>/dev/null || rc=$?
+check "wait_for_node() succeeds when the node is already up" "$rc" "0"
+check "wait_for_node() probes once when the node is up" "$CURL_CALLS" "1"
+
+# Node down then up: the poll bridges the restart window (issue #4208).
+NODE_WAIT_ATTEMPTS=60
+CURL_CALLS=0
+CURL_FAIL_COUNT=3
+rc=0
+wait_for_node 2>/dev/null || rc=$?
+check "wait_for_node() succeeds once the node returns" "$rc" "0"
+check "wait_for_node() keeps probing across the down-window" "$CURL_CALLS" "4"
+
+# Node never returns: the poll gives up after NODE_WAIT_ATTEMPTS.
+NODE_WAIT_ATTEMPTS=3
+CURL_CALLS=0
+CURL_FAIL_COUNT=9999
+rc=0
+wait_for_node 2>/dev/null || rc=$?
+check "wait_for_node() fails when the node never returns" "$rc" "1"
+check "wait_for_node() honours NODE_WAIT_ATTEMPTS as the bound" "$CURL_CALLS" "3"
+
+# ── result ───────────────────────────────────────────────────────────
+
+if (( FAILURES > 0 )); then
+    echo "$FAILURES announce-to-river.sh test(s) failed" >&2
+    exit 1
+fi
+echo "All announce-to-river.sh tests passed."

--- a/scripts/release-agent/announce-to-river_test.sh
+++ b/scripts/release-agent/announce-to-river_test.sh
@@ -49,14 +49,28 @@ check() {
     fi
 }
 
+# ── LOG_FILE default ─────────────────────────────────────────────────
+
+# The #4208 logging fix: with nothing in the environment, LOG_FILE must
+# default to empty — the old default was an unwritable /var/log path.
+# The default-assignment line is extracted and eval'd verbatim, so
+# reverting it to a /var/log path fails this assertion.
+unset LOG_FILE
+eval "$(grep -E '^LOG_FILE=' "$ANNOUNCE_SH")"
+check "LOG_FILE defaults to empty when unset" "$LOG_FILE" ""
+
 # ── log() ────────────────────────────────────────────────────────────
 
-# Empty LOG_FILE (the new default): nothing is written to disk, and the
-# call still succeeds.
+# Empty LOG_FILE: log() must skip the file write entirely. The pre-fix
+# code wrote unconditionally; with no file configured that write fails
+# and bash prints a redirection diagnostic — the exact "Permission
+# denied" spam issue #4208 reports. Assert log()'s stderr carries only
+# the intended message line, no such diagnostic. (Removing the
+# `[[ -n "$LOG_FILE" ]]` guard makes this assertion fail.)
 LOG_FILE=""
-log "hello" 2>/dev/null
-check "log() with empty LOG_FILE writes no file" \
-    "$(find "$TMP" -type f | wc -l)" "0"
+log_stderr=$(log "hello" 2>&1)
+check "log() with empty LOG_FILE emits no redirection error" \
+    "$(printf '%s\n' "$log_stderr" | grep -cE 'No such file|Permission denied|ambiguous redirect' || true)" "0"
 
 # LOG_FILE set: each call is appended.
 LOG_FILE="$TMP/river.log"


### PR DESCRIPTION
## Problem

The `release-announce.yml` workflow's **"Post to River"** step failed on the last two releases — **v0.2.60** and **v0.2.61** — both with `nova /announce/river returned HTTP 500`. The Matrix announcement is unaffected. Tracked in #4208.

Root cause, confirmed from nova's journals:

- `release.published` fires `gateway-update.yml` and `release-announce.yml` **concurrently**. The gateway update restarts the local Freenet node — on the v0.2.61 release nova's `freenet-gateway.service` was down from 13:04:16 to 13:05:47.
- `announce-to-river.sh` probed the node with a single `curl --max-time 3 http://127.0.0.1:7509/` and no retry. The River announce ran at 13:04:28, inside that window, so the probe failed and the script `exit 1`'d.
- Because the script failed *fast* (sub-second), it exited inside the release-agent's 1-second early-exit probe — which the agent reports to the GitHub Actions caller as **HTTP 500**.

A second, cosmetic problem: `LOG_FILE` defaulted to `/var/log/freenet-release-agent-river.log`, which the announce user cannot write (`install.sh` deliberately keeps logs in journald). Every `log()` call emitted a spurious `Permission denied` line.

## Solution

- **Poll for node reachability** (`wait_for_node()`) instead of a single probe. The node is *expected* to bounce during a release, so waiting for it is the correct behaviour. The poll's `sleep` also keeps the script alive past the release-agent's 1-second early-exit probe, so the agent returns `202` and the announcement completes in the background once the node is up — instead of dying inside that window and surfacing as HTTP 500.
- **Default `LOG_FILE` to empty** and only append to a file when one is explicitly configured. The release-agent already captures the script's stderr to journald.

The probe is a named function with overridable parameters (`NODE_WAIT_ATTEMPTS`, `NODE_WAIT_INTERVAL`; ~5 min budget by default) — both so the budget is explicit and so the function is unit-testable.

### Trade-offs (consciously accepted)

- **Prolonged outage is reported only in journald.** Because the poll keeps the script alive past the agent's 1s probe, the agent returns `202` and the workflow goes green regardless of the eventual outcome. If the node stays down for the whole budget, the failure is logged on nova but not surfaced to the release workflow. This is inherent to the agent's fire-and-forget-after-1s design; a prolonged gateway outage on release day is independently visible. Surfacing late failures to the workflow would be a release-agent change — see the follow-up issue.
- **Duplicate-announce window.** The agent's rate limit (1/60s) is shorter than the poll budget, so a *manual* workflow re-run during the poll could spawn a second announce. The "Post to River" step does not auto-retry, so this requires deliberate operator action; the worst case is a duplicate chat line. Also noted in the follow-up issue.

## Testing

- Added **`scripts/release-agent/announce-to-river_test.sh`** — a regression test following the existing `scripts/release_state_restore_test.sh` awk-extract-and-`eval` pattern. It extracts `log()` and `wait_for_node()` verbatim and asserts: empty/­set/­unwritable `LOG_FILE` behaviour; node-up, node-down-then-up, and node-never-returns polling outcomes (10 assertions). `shellcheck`-clean; runs in <1s with `NODE_WAIT_INTERVAL=0`.
- `bash -n` + `shellcheck 0.9.0` clean on both files.
- Diagnosis verified end-to-end on nova: confirmed the gateway down-window from the `freenet-gateway.service` journal vs. the announce timestamp, and confirmed the announce succeeds when run with the node up.
- Carries the `test-exempt` label only because the Rule Lint CI check counts **Rust** `#[test]` attributes; the regression test here is a shell test, which that check does not recognise. There is no shell-test runner wired into CI yet — see the follow-up issue.

## Fixes

Closes #4208

[AI-assisted - Claude]
