### PR TITLE
fix: bound contract storage disk usage — hosting-cache eviction now reclaims disk

### DIFF
--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -110,10 +110,11 @@ Pattern (logic in native_api.rs):
 USE: StateStore trait
 Backends: redb (default), sqlite
 
-Operations:
-  - get_state(key) → Option<State>
-  - put_state(key, state) → Result
-  - delete_state(key) → Result
+Operations (StateStore methods):
+  - get(key) → WrappedState
+  - store(key, state, params) → Result
+  - update(key, state) → Result
+  - delete(key) → Result
 
 MUST:
   - Handle missing state gracefully (new contract)

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -63,6 +63,11 @@ const DEFAULT_TRANSIENT_BUDGET: usize = 2048;
 const DEFAULT_TRANSIENT_TTL_SECS: u64 = 30;
 const DEFAULT_EVENT_LOOP_CHANNEL_CAPACITY: usize = 2048;
 
+/// Default operator-facing budget for hosted contract storage (1 GiB).
+/// Must stay consistent with `ring::hosting::cache::DEFAULT_HOSTING_BUDGET_BYTES`,
+/// which is the in-code fallback used by tests.
+const DEFAULT_MAX_HOSTING_STORAGE: u64 = 1024 * 1024 * 1024; // 1 GiB
+
 const QUALIFIER: &str = "";
 const ORGANIZATION: &str = "The Freenet Project Inc";
 const APPLICATION: &str = "Freenet";
@@ -102,6 +107,12 @@ pub struct ConfigArgs {
     /// Default: 2x CPU cores, clamped to 4-32.
     #[arg(long, env = "MAX_BLOCKING_THREADS")]
     pub max_blocking_threads: Option<usize>,
+
+    /// Maximum disk space in bytes for hosted contract storage. Once exceeded,
+    /// contracts are evicted oldest-first (LRU) and their on-disk state
+    /// reclaimed. Default: 1 GiB.
+    #[arg(long, env = "MAX_HOSTING_STORAGE")]
+    pub max_hosting_storage: Option<u64>,
 
     #[command(flatten)]
     pub telemetry: TelemetryArgs,
@@ -150,6 +161,7 @@ impl Default for ConfigArgs {
             id: None,
             version: false,
             max_blocking_threads: None,
+            max_hosting_storage: None,
             telemetry: Default::default(),
         }
     }
@@ -354,6 +366,8 @@ impl ConfigArgs {
                 self.network_api.bbr_startup_rate = cfg.network_api.bbr_startup_rate;
             }
             self.log_level.get_or_insert(cfg.log_level);
+            self.max_hosting_storage
+                .get_or_insert(cfg.max_hosting_storage);
             self.config_paths.merge(cfg.config_paths.as_ref().clone());
             // Merge telemetry config - CLI args override file config
             // Note: enabled defaults to true via clap, so we only override
@@ -695,6 +709,9 @@ impl ConfigArgs {
             max_blocking_threads: self
                 .max_blocking_threads
                 .unwrap_or_else(default_max_blocking_threads),
+            max_hosting_storage: self
+                .max_hosting_storage
+                .unwrap_or(DEFAULT_MAX_HOSTING_STORAGE),
             telemetry: TelemetryConfig {
                 enabled: self.telemetry.enabled,
                 endpoint: self
@@ -801,6 +818,14 @@ pub struct Config {
     /// Maximum number of threads for blocking operations (WASM execution, etc.).
     #[serde(default = "default_max_blocking_threads")]
     pub max_blocking_threads: usize,
+    /// Maximum disk space in bytes for hosted contract storage. Once exceeded,
+    /// contracts are evicted oldest-first (LRU) and their on-disk state
+    /// reclaimed.
+    #[serde(
+        default = "default_max_hosting_storage",
+        rename = "max-hosting-storage"
+    )]
+    pub max_hosting_storage: u64,
     /// Telemetry configuration
     #[serde(flatten)]
     pub telemetry: TelemetryConfig,
@@ -811,6 +836,11 @@ fn default_max_blocking_threads() -> usize {
     std::thread::available_parallelism()
         .map(|n| (n.get() * 2).clamp(4, 32))
         .unwrap_or(8)
+}
+
+/// Default operator-facing budget for hosted contract storage (1 GiB).
+fn default_max_hosting_storage() -> u64 {
+    DEFAULT_MAX_HOSTING_STORAGE
 }
 
 impl Config {
@@ -2702,6 +2732,50 @@ mod tests {
         let cfg = args.build().await.unwrap();
         let serialized = toml::to_string(&cfg).unwrap();
         let _: Config = toml::from_str(&serialized).unwrap();
+    }
+
+    #[tokio::test]
+    async fn max_hosting_storage_defaults_to_one_gib() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let args = ConfigArgs {
+            mode: Some(OperationMode::Local),
+            config_paths: ConfigPathsArgs {
+                config_dir: Some(temp_dir.path().to_path_buf()),
+                data_dir: Some(temp_dir.path().to_path_buf()),
+                log_dir: Some(temp_dir.path().to_path_buf()),
+            },
+            ..Default::default()
+        };
+        let cfg = args.build().await.unwrap();
+        assert_eq!(
+            cfg.max_hosting_storage, DEFAULT_MAX_HOSTING_STORAGE,
+            "default max_hosting_storage should resolve to 1 GiB"
+        );
+        assert_eq!(DEFAULT_MAX_HOSTING_STORAGE, 1024 * 1024 * 1024);
+    }
+
+    #[tokio::test]
+    async fn max_hosting_storage_explicit_value_round_trips() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let custom = 256 * 1024 * 1024_u64;
+        let args = ConfigArgs {
+            mode: Some(OperationMode::Local),
+            config_paths: ConfigPathsArgs {
+                config_dir: Some(temp_dir.path().to_path_buf()),
+                data_dir: Some(temp_dir.path().to_path_buf()),
+                log_dir: Some(temp_dir.path().to_path_buf()),
+            },
+            max_hosting_storage: Some(custom),
+            ..Default::default()
+        };
+        let cfg = args.build().await.unwrap();
+        assert_eq!(cfg.max_hosting_storage, custom);
+
+        // Round-trips through TOML serialization.
+        let serialized = toml::to_string(&cfg).unwrap();
+        assert!(serialized.contains("max-hosting-storage"));
+        let deserialized: Config = toml::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.max_hosting_storage, custom);
     }
 
     /// Build a minimal local-mode ConfigArgs with the given CIDR list and

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -63,11 +63,6 @@ const DEFAULT_TRANSIENT_BUDGET: usize = 2048;
 const DEFAULT_TRANSIENT_TTL_SECS: u64 = 30;
 const DEFAULT_EVENT_LOOP_CHANNEL_CAPACITY: usize = 2048;
 
-/// Default operator-facing budget for hosted contract storage (1 GiB).
-/// Must stay consistent with `ring::hosting::cache::DEFAULT_HOSTING_BUDGET_BYTES`,
-/// which is the in-code fallback used by tests.
-const DEFAULT_MAX_HOSTING_STORAGE: u64 = 1024 * 1024 * 1024; // 1 GiB
-
 const QUALIFIER: &str = "";
 const ORGANIZATION: &str = "The Freenet Project Inc";
 const APPLICATION: &str = "Freenet";
@@ -108,9 +103,11 @@ pub struct ConfigArgs {
     #[arg(long, env = "MAX_BLOCKING_THREADS")]
     pub max_blocking_threads: Option<usize>,
 
-    /// Maximum disk space in bytes for hosted contract storage. Once exceeded,
-    /// contracts are evicted oldest-first (LRU) and their on-disk state
-    /// reclaimed. Default: 1 GiB.
+    /// Budget in bytes for hosted contract *state*. Once exceeded, contracts
+    /// are evicted (least-valuable-first) and their on-disk state reclaimed.
+    /// This bounds tracked contract state only — WASM code blobs and ReDb/
+    /// SQLite database overhead are additional and not counted against it.
+    /// Default: 1 GiB.
     #[arg(long, env = "MAX_HOSTING_STORAGE")]
     pub max_hosting_storage: Option<u64>,
 
@@ -711,7 +708,7 @@ impl ConfigArgs {
                 .unwrap_or_else(default_max_blocking_threads),
             max_hosting_storage: self
                 .max_hosting_storage
-                .unwrap_or(DEFAULT_MAX_HOSTING_STORAGE),
+                .unwrap_or(crate::ring::DEFAULT_HOSTING_BUDGET_BYTES),
             telemetry: TelemetryConfig {
                 enabled: self.telemetry.enabled,
                 endpoint: self
@@ -818,9 +815,10 @@ pub struct Config {
     /// Maximum number of threads for blocking operations (WASM execution, etc.).
     #[serde(default = "default_max_blocking_threads")]
     pub max_blocking_threads: usize,
-    /// Maximum disk space in bytes for hosted contract storage. Once exceeded,
-    /// contracts are evicted oldest-first (LRU) and their on-disk state
-    /// reclaimed.
+    /// Budget in bytes for hosted contract *state*. Once exceeded, contracts
+    /// are evicted (least-valuable-first) and their on-disk state reclaimed.
+    /// This bounds tracked contract state only — WASM code blobs and ReDb/
+    /// SQLite database overhead are additional and not counted against it.
     #[serde(
         default = "default_max_hosting_storage",
         rename = "max-hosting-storage"
@@ -838,9 +836,14 @@ fn default_max_blocking_threads() -> usize {
         .unwrap_or(8)
 }
 
-/// Default operator-facing budget for hosted contract storage (1 GiB).
+/// Default operator-facing budget for hosted contract state (1 GiB).
+///
+/// Resolves to [`crate::ring::DEFAULT_HOSTING_BUDGET_BYTES`], which is
+/// the single source of truth for this value — the in-code fallback used by the
+/// hosting cache and its tests. This indirection keeps the operator-facing
+/// default and the in-code default from ever drifting apart.
 fn default_max_hosting_storage() -> u64 {
-    DEFAULT_MAX_HOSTING_STORAGE
+    crate::ring::DEFAULT_HOSTING_BUDGET_BYTES
 }
 
 impl Config {
@@ -2748,10 +2751,16 @@ mod tests {
         };
         let cfg = args.build().await.unwrap();
         assert_eq!(
-            cfg.max_hosting_storage, DEFAULT_MAX_HOSTING_STORAGE,
-            "default max_hosting_storage should resolve to 1 GiB"
+            cfg.max_hosting_storage,
+            crate::ring::DEFAULT_HOSTING_BUDGET_BYTES,
+            "default max_hosting_storage should resolve to the hosting cache's \
+             single-source-of-truth default budget"
         );
-        assert_eq!(DEFAULT_MAX_HOSTING_STORAGE, 1024 * 1024 * 1024);
+        assert_eq!(
+            crate::ring::DEFAULT_HOSTING_BUDGET_BYTES,
+            1024 * 1024 * 1024,
+            "default hosting budget should be 1 GiB"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1412,13 +1412,24 @@ where
             contract_handler.executor().remove_client(client_id);
             contract_handler.channel().drop_waiting_response(id);
         }
-        ContractHandlerEvent::EvictContract { key } => {
+        ContractHandlerEvent::EvictContract {
+            key,
+            expected_generation,
+        } => {
             // Reclaim the contract's on-disk storage after it was evicted
             // from the hosting cache. Routed here (not inline-fast-pathed in
             // the drain loop) so it goes through the fair queue and is
             // serialized per-contract with any other in-flight ops on the
             // same key. Fire-and-forget: no response is sent.
-            match contract_handler.executor().remove_contract(&key).await {
+            //
+            // `expected_generation` is consulted by
+            // `RuntimePool::remove_contract` to skip deletion if the
+            // contract's state was rewritten since eviction (re-host race).
+            match contract_handler
+                .executor()
+                .remove_contract(&key, expected_generation)
+                .await
+            {
                 Ok(()) => {
                     tracing::info!(contract = %key, "Reclaimed on-disk storage for evicted contract");
                 }

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -776,7 +776,8 @@ async fn send_queue_full_response(
         | ContractHandlerEvent::QuerySubscriptionsResponse
         | ContractHandlerEvent::GetSummaryResponse { .. }
         | ContractHandlerEvent::GetDeltaResponse { .. }
-        | ContractHandlerEvent::ClientDisconnect { .. } => {
+        | ContractHandlerEvent::ClientDisconnect { .. }
+        | ContractHandlerEvent::EvictContract { .. } => {
             channel.drop_waiting_response(rejected.id);
             return;
         }
@@ -1409,6 +1410,26 @@ where
         }
         ContractHandlerEvent::ClientDisconnect { client_id } => {
             contract_handler.executor().remove_client(client_id);
+            contract_handler.channel().drop_waiting_response(id);
+        }
+        ContractHandlerEvent::EvictContract { key } => {
+            // Reclaim the contract's on-disk storage after it was evicted
+            // from the hosting cache. Routed here (not inline-fast-pathed in
+            // the drain loop) so it goes through the fair queue and is
+            // serialized per-contract with any other in-flight ops on the
+            // same key. Fire-and-forget: no response is sent.
+            match contract_handler.executor().remove_contract(&key).await {
+                Ok(()) => {
+                    tracing::info!(contract = %key, "Reclaimed on-disk storage for evicted contract");
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        contract = %key,
+                        error = %error,
+                        "Failed to reclaim on-disk storage for evicted contract"
+                    );
+                }
+            }
             contract_handler.channel().drop_waiting_response(id);
         }
         ContractHandlerEvent::DelegateResponse(_)

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -682,6 +682,7 @@ where
                         continue;
                     }
                     if let Err(rejected) = fair_queue.try_push(id, event) {
+                        track_pending_reclamation_if_evict(&mut contract_handler, &rejected);
                         send_queue_full_response(contract_handler.channel(), rejected).await;
                     }
                 }
@@ -714,6 +715,7 @@ where
             result = contract_handler.channel().recv_from_sender() => {
                 let (id, event) = result?;
                 if let Err(rejected) = fair_queue.try_push(id, event) {
+                    track_pending_reclamation_if_evict(&mut contract_handler, &rejected);
                     send_queue_full_response(contract_handler.channel(), rejected).await;
                 }
             }
@@ -721,6 +723,30 @@ where
                 handle_delegate_notification(&mut contract_handler, notification, &prompter).await;
             }
         }
+    }
+}
+
+/// When the fair queue rejects an `EvictContract` event (queue-full),
+/// the hosting-cache entry is already gone — no later sweep would
+/// re-emit on its own. Record the key in the pending-reclamation retry
+/// queue so the periodic sweep retries via `reclaim_evicted_contract`.
+///
+/// This closes disk-leak edge case #1 in PR #4212 review round 7
+/// (other variants are no-ops here — they have their own error paths).
+fn track_pending_reclamation_if_evict<CH>(
+    contract_handler: &mut CH,
+    rejected: &fair_queue::RejectedEvent,
+) where
+    CH: ContractHandler + Send + 'static,
+{
+    if let ContractHandlerEvent::EvictContract {
+        key,
+        expected_generation,
+    } = &rejected.event
+    {
+        contract_handler
+            .executor()
+            .track_pending_reclamation(*key, *expected_generation);
     }
 }
 

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -455,6 +455,15 @@ pub(crate) trait ContractExecutor: Send + 'static {
         async { Ok(()) }
     }
 
+    /// Record that an `EvictContract` event was dropped before it could
+    /// complete (queue-full rejection in `contract_handling`), so the
+    /// periodic sweep can retry it via `reclaim_evicted_contract`.
+    ///
+    /// Default implementation is a no-op (for mock executors with no
+    /// `Ring` to record into). The real implementation on `RuntimePool`
+    /// forwards to `op_manager.ring.pending_reclamation_add`.
+    fn track_pending_reclamation(&self, _key: ContractKey, _expected_generation: u64) {}
+
     /// Compute the state summary for a contract using the contract's summarize_state method.
     fn summarize_contract_state(
         &mut self,

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -438,11 +438,19 @@ pub(crate) trait ContractExecutor: Send + 'static {
     /// the WASM code blob) after the contract was evicted from the hosting
     /// cache. Best-effort and idempotent: a double eviction is a no-op.
     ///
+    /// `expected_generation` is the state-write generation captured
+    /// atomically with the eviction decision. Implementations that wire
+    /// through to a real `Ring`/`HostingManager` re-read the current
+    /// generation and skip reclamation if it has advanced (closing the
+    /// EvictContract re-host race). Implementations without a `Ring` may
+    /// ignore the argument.
+    ///
     /// Default implementation is a no-op (for mock executors that keep state
     /// in memory and have no on-disk storage to reclaim).
     fn remove_contract(
         &mut self,
         _key: &ContractKey,
+        _expected_generation: u64,
     ) -> impl Future<Output = Result<(), ExecutorError>> + Send {
         async { Ok(()) }
     }

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -434,6 +434,19 @@ pub(crate) trait ContractExecutor: Send + 'static {
     /// Default implementation is a no-op (for mock executors that don't track subscriptions).
     fn remove_client(&self, _client_id: ClientId) {}
 
+    /// Reclaim a contract's on-disk storage (persisted state + parameters and
+    /// the WASM code blob) after the contract was evicted from the hosting
+    /// cache. Best-effort and idempotent: a double eviction is a no-op.
+    ///
+    /// Default implementation is a no-op (for mock executors that keep state
+    /// in memory and have no on-disk storage to reclaim).
+    fn remove_contract(
+        &mut self,
+        _key: &ContractKey,
+    ) -> impl Future<Output = Result<(), ExecutorError>> + Send {
+        async { Ok(()) }
+    }
+
     /// Compute the state summary for a contract using the contract's summarize_state method.
     fn summarize_contract_state(
         &mut self,

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -603,18 +603,40 @@ impl ContractExecutor for RuntimePool {
         let current_generation = self.op_manager.ring.state_generation(key);
         if current_generation != expected_generation {
             // A state write (PUT/UPDATE) occurred between eviction and
-            // now. The contract has been re-hosted by the write path;
-            // a later genuine eviction will emit a fresh
-            // `EvictContract` with the current generation. We do NOT
-            // add a pending entry — the write path will naturally
-            // re-host and re-evict if appropriate.
+            // now. Two sub-cases matter for whether we keep the
+            // pending-reclamation entry:
             //
-            // Clear any stale pending entry for the same reason: the
-            // write path's re-host+re-evict cycle owns subsequent
-            // reclamation, so leaving an entry behind only produces
-            // spurious sweep retries that all bail at the
-            // generation-mismatch check.
-            self.op_manager.ring.pending_reclamation_remove(key);
+            // (a) The contract IS in the hosting cache: PUT's write
+            //     path re-hosts via `host_contract`, so the cache
+            //     itself now owns subsequent eviction. A later genuine
+            //     eviction will emit a fresh `EvictContract` with the
+            //     up-to-date generation. Clear the pending entry —
+            //     leaving it would let the sweep keep emitting
+            //     `EvictContract` events that all bail at the
+            //     `is_hosting_contract` check above.
+            //
+            // (b) The contract is NOT in the hosting cache: UPDATE
+            //     bumps `state_generation` without calling
+            //     `host_contract`, so a subscriber-only contract that
+            //     was evicted and then UPDATEd reaches this branch
+            //     with an advanced generation but no cache entry.
+            //     Clearing pending here would permanently leak the
+            //     on-disk storage once the subscriber later expires
+            //     (there is no cache entry left to emit another
+            //     `EvictContract`). Upsert the pending entry with the
+            //     current generation so the periodic sweep retries
+            //     with a fresh `EvictContract{key, current_generation}`;
+            //     if no further writes happen the next pass will reach
+            //     the reclaim step, and if more writes happen this
+            //     upsert repeats until the generation stabilises.
+            //     See PR #4212 review round 8.
+            if self.op_manager.ring.is_hosting_contract(key) {
+                self.op_manager.ring.pending_reclamation_remove(key);
+            } else {
+                self.op_manager
+                    .ring
+                    .pending_reclamation_add(*key, current_generation);
+            }
             tracing::debug!(
                 contract = %key,
                 expected_generation,
@@ -635,19 +657,41 @@ impl ContractExecutor for RuntimePool {
         self.return_checked(executor, "remove_contract").await;
         self.track_contract_return(key);
 
-        // On successful disk reclamation, forget the generation entry so
-        // the state_generation map does not grow unbounded. We only forget
-        // on success: leaving the entry behind on partial failures is safe
-        // (the next access will refresh it; the generation is monotonic).
-        if result.is_ok() {
-            self.op_manager.ring.forget_state_generation(key);
-            // A successful retry from the pending-reclamation queue
-            // must clear the queue entry too. No-op when the key was
-            // not previously pending (the common case — most evictions
-            // succeed on the first attempt).
-            self.op_manager.ring.pending_reclamation_remove(key);
+        // Translate the `ReclaimOutcome` into pending-reclamation management:
+        //   - Full   → forget state_generation + clear pending (existing behavior).
+        //   - Partial → keep pending and keep state_generation; the next sweep
+        //               retries the half that failed. Avoids leaking the
+        //               unreclaimed half forever when a transient DB/FS error
+        //               struck only one of the two delete steps. See PR #4212
+        //               review round 8.
+        //   - Err    → both halves failed; log and keep pending for retry.
+        match &result {
+            Ok(ReclaimOutcome::Full) => {
+                self.op_manager.ring.forget_state_generation(key);
+                // A successful retry from the pending-reclamation queue
+                // must clear the queue entry too. No-op when the key was
+                // not previously pending (the common case — most evictions
+                // succeed on the first attempt).
+                self.op_manager.ring.pending_reclamation_remove(key);
+            }
+            Ok(ReclaimOutcome::Partial) => {
+                // Leave both pending-reclamation and state_generation in
+                // place: the entry will be retried by the periodic sweep
+                // (or by a fresh `EvictContract` if the cache re-emits
+                // one) until the remaining half is reclaimable.
+                tracing::debug!(
+                    contract = %key,
+                    "partial reclaim — retaining pending-reclamation entry for retry"
+                );
+            }
+            Err(_) => {
+                // Both halves failed; keep pending so the sweep retries.
+                // (The error is logged inside `reclaim_contract_storage`.)
+            }
         }
-        result
+        // Drop the outcome detail at the trait boundary: callers expect
+        // `Result<(), ExecutorError>` and cannot act on Full vs Partial.
+        result.map(|_| ())
     }
 
     async fn upsert_contract_state(
@@ -2750,10 +2794,14 @@ impl ContractExecutor for Executor<Runtime> {
         _expected_generation: u64,
     ) -> Result<(), ExecutorError> {
         // The inner Executor does not own a Ring (and so cannot consult
-        // the state-write generation directly). Race detection lives at
-        // the `RuntimePool::remove_contract` layer; the inner impl just
-        // performs the disk reclamation.
-        self.reclaim_contract_storage(key).await
+        // the state-write generation directly). Race detection and
+        // partial-failure retry both live at the
+        // `RuntimePool::remove_contract` layer; the inner impl just
+        // performs the disk reclamation. Trait-level callers that go
+        // through this method (i.e. not via `RuntimePool`) cannot make
+        // a Full/Partial distinction anyway, so collapse to
+        // `Result<(), _>` — `Partial` is reported as `Ok` here.
+        self.reclaim_contract_storage(key).await.map(|_| ())
     }
 }
 
@@ -3583,55 +3631,87 @@ impl Executor<Runtime> {
     /// still attempted so a partial reclaim is achieved rather than none. The
     /// method is idempotent — both `StateStore::delete` and
     /// `ContractStore::remove_contract` tolerate already-missing entries — so a
-    /// double eviction is harmless. Returns `Ok(())` whenever either step
-    /// succeeds (or both were already clean); only a failure of *both* steps is
-    /// surfaced as an error, since this is fire-and-forget maintenance.
+    /// double eviction is harmless.
     ///
-    /// Note that `Ok(())` does NOT mean the contract is fully consistent: a
-    /// partial failure (state deleted but code kept, or vice versa) leaves the
-    /// contract half-present on disk until a subsequent access re-fetches it.
-    /// Callers must not treat `Ok` as "fully reclaimed" or "fully consistent".
+    /// Return value:
+    ///   - `Ok(ReclaimOutcome::Full)` — both halves are absent at end (either
+    ///     both deleted in this call, or one was already missing and the other
+    ///     was deleted, or both were already missing).
+    ///   - `Ok(ReclaimOutcome::Partial)` — exactly one half failed with a real
+    ///     error while the other succeeded. The caller MUST retain the
+    ///     pending-reclamation entry so a future sweep retries the remaining
+    ///     work. Closes the disk-leak edge case where a transient DB/FS
+    ///     error in one half leaves the other half permanently leaked. See
+    ///     PR #4212 review round 8.
+    ///   - `Err` — BOTH halves failed; surfaced so the caller can log/retry.
     ///
     /// This is the inherent implementation; the `ContractExecutor::remove_contract`
-    /// trait method delegates to it.
-    async fn reclaim_contract_storage(&mut self, key: &ContractKey) -> Result<(), ExecutorError> {
-        let state_deleted = match self.state_store.delete(key).await {
-            Ok(()) => true,
+    /// trait method delegates to it and translates the outcome into
+    /// pending-reclamation management.
+    async fn reclaim_contract_storage(
+        &mut self,
+        key: &ContractKey,
+    ) -> Result<ReclaimOutcome, ExecutorError> {
+        let state_result = match self.state_store.delete(key).await {
+            Ok(()) => Ok(()),
             Err(e) => {
                 tracing::warn!(
                     contract = %key,
                     error = %e,
                     "failed to delete persisted state while reclaiming evicted contract"
                 );
-                false
+                Err(())
             }
         };
-        let code_deleted = match self.runtime.contract_store.remove_contract(key) {
-            Ok(()) => true,
+        let code_result = match self.runtime.contract_store.remove_contract(key) {
+            Ok(()) => Ok(()),
             Err(e) => {
                 tracing::warn!(
                     contract = %key,
                     error = %e,
                     "failed to delete WASM code while reclaiming evicted contract"
                 );
-                false
+                Err(())
             }
         };
 
-        if !state_deleted && !code_deleted {
+        let state_ok = state_result.is_ok();
+        let code_ok = code_result.is_ok();
+        if !state_ok && !code_ok {
             return Err(ExecutorError::other(anyhow::anyhow!(
                 "failed to reclaim any on-disk storage for contract {key}"
             )));
         }
 
+        let outcome = if state_ok && code_ok {
+            ReclaimOutcome::Full
+        } else {
+            ReclaimOutcome::Partial
+        };
         tracing::info!(
             contract = %key,
-            state_deleted,
-            code_deleted,
+            state_deleted = state_ok,
+            code_deleted = code_ok,
+            ?outcome,
             "reclaimed on-disk storage for evicted contract"
         );
-        Ok(())
+        Ok(outcome)
     }
+}
+
+/// Outcome of [`Executor::reclaim_contract_storage`].
+///
+/// The split exists so the caller (`RuntimePool::remove_contract`) can decide
+/// whether to clear the pending-reclamation entry (on `Full`) or leave it for
+/// a future retry (on `Partial`). See PR #4212 review round 8.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReclaimOutcome {
+    /// Both state and code are absent at end of the reclaim call.
+    Full,
+    /// Exactly one half failed with a real error; the other succeeded (or was
+    /// already absent). The pending-reclamation entry should be retained so a
+    /// future sweep retries the remaining work.
+    Partial,
 }
 
 impl Executor<Runtime> {
@@ -4240,6 +4320,7 @@ mod remove_contract_tests {
         WrappedContract, WrappedState,
     };
 
+    use super::ReclaimOutcome;
     use crate::contract::executor::Executor;
     use crate::contract::storages::Storage;
     use crate::wasm_runtime::{
@@ -4336,10 +4417,15 @@ mod remove_contract_tests {
         );
 
         // Evict.
-        executor
+        let outcome = executor
             .reclaim_contract_storage(&key)
             .await
             .expect("reclaim must succeed");
+        assert_eq!(
+            outcome,
+            ReclaimOutcome::Full,
+            "fresh-evict path with both halves present must be Full"
+        );
 
         // Post-conditions: state gone, .wasm gone.
         match executor.state_store.get(&key).await {
@@ -4372,15 +4458,29 @@ mod remove_contract_tests {
             .await
             .expect("store contract state");
 
-        executor
+        let first = executor
             .reclaim_contract_storage(&key)
             .await
             .expect("first reclaim must succeed");
-        // Second reclaim: state and .wasm are already gone — must still be Ok.
-        executor
+        assert_eq!(
+            first,
+            ReclaimOutcome::Full,
+            "first reclaim with both halves present must be Full"
+        );
+        // Second reclaim: state and .wasm are already gone — both
+        // backends treat missing entries as a successful no-op, so the
+        // outcome stays Full (not Partial). This pins down the
+        // "idempotent double-evict" invariant after the Full/Partial
+        // refactor.
+        let second = executor
             .reclaim_contract_storage(&key)
             .await
             .expect("second reclaim must be a no-op, not an error");
+        assert_eq!(
+            second,
+            ReclaimOutcome::Full,
+            "double-evict must report Full (both backends treat missing as ok)"
+        );
         assert!(
             !wasm_path(&contracts_dir, &key).exists(),
             "WASM blob must remain absent after double eviction"
@@ -4394,9 +4494,66 @@ mod remove_contract_tests {
     async fn remove_contract_unknown_contract_is_noop() {
         let (mut executor, _contracts_dir, _temp) = build_disk_executor("unknown").await;
         let (_container, key) = make_contract(0x55, 0x66);
-        executor
+        let outcome = executor
             .reclaim_contract_storage(&key)
             .await
             .expect("reclaiming an unknown contract must be Ok");
+        assert_eq!(
+            outcome,
+            ReclaimOutcome::Full,
+            "unknown-contract path is treated as already-clean, hence Full"
+        );
+    }
+
+    /// `ReclaimOutcome` discrimination compiles and the `Full` vs `Partial`
+    /// shape works in trivial cases.
+    ///
+    /// Full coverage:
+    ///   - state present + code present → Full (covered above in
+    ///     `remove_contract_reclaims_state_and_wasm_from_disk`).
+    ///   - both absent → Full (covered above in
+    ///     `remove_contract_is_idempotent_on_double_eviction` and
+    ///     `remove_contract_unknown_contract_is_noop`).
+    ///   - state present + code already gone → still Full (because
+    ///     `ContractStore::remove_contract` treats a missing blob as
+    ///     `Ok(())`, and the state half deletes cleanly).
+    ///
+    /// Partial coverage: a real `Partial` outcome would require fault
+    /// injection at the `StateStore::delete` or
+    /// `ContractStore::remove_contract` level (e.g. a poisoned redb
+    /// transaction or a permissions error on the contracts dir). The
+    /// current backends do not surface a "failed but not for missing"
+    /// error mode that's safe to provoke from a unit test without
+    /// reaching into private state — so genuine `Partial` is exercised
+    /// only via the manager-layer logic (`RuntimePool::remove_contract`
+    /// retains the pending entry on `Partial` and forgets it on
+    /// `Full`). A `#[freenet_test]` follow-up could simulate a backend
+    /// fault, but that's out of scope here.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reclaim_outcome_state_present_code_absent_is_full() {
+        let (mut executor, _contracts_dir, _temp) = build_disk_executor("partial-state-only").await;
+        let (container, key) = make_contract(0x77, 0x88);
+        let params = container.params();
+        let state = WrappedState::new(b"state without code".to_vec());
+
+        // Skip storing the contract code; only persist state. The
+        // contract store's `remove_contract` for an absent key is
+        // `Ok(())`, so the outcome should still be Full.
+        executor
+            .state_store
+            .store(key, state, params)
+            .await
+            .expect("store contract state");
+
+        let outcome = executor
+            .reclaim_contract_storage(&key)
+            .await
+            .expect("reclaim must succeed even when code half is already absent");
+        assert_eq!(
+            outcome,
+            ReclaimOutcome::Full,
+            "state-only present + code-already-gone counts as Full because \
+             both halves are absent at end"
+        );
     }
 }

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1140,9 +1140,17 @@ where
                             // generation counter so a racing `EvictContract`
                             // captured before this store sees a stale
                             // generation at deletion time and skips
-                            // reclamation. See `RuntimePool::remove_contract`.
+                            // reclamation. Then refresh the hosting-cache
+                            // snapshot so subsequent evictions of this
+                            // already-hosted contract carry the new
+                            // generation rather than the stale snapshot
+                            // captured at first `record_access` — without
+                            // the refresh, every UPDATE leaks on eviction.
+                            // See `RuntimePool::remove_contract` and
+                            // `HostingCache::refresh_entry_generation`.
                             if let Some(op_manager) = &self.op_manager {
-                                op_manager.ring.bump_state_generation(&key);
+                                let new_gen = op_manager.ring.bump_state_generation(&key);
+                                op_manager.ring.refresh_cache_generation(&key, new_gen);
                             }
 
                             let completion_now = now_nanos();
@@ -1997,8 +2005,14 @@ where
             .map_err(ExecutorError::other)?;
         // State-write chokepoint (UPDATE): see `commit_state_update` docs
         // and `RuntimePool::remove_contract` for the race this bump closes.
+        // Refresh the hosting-cache snapshot in lock-step so an UPDATE to
+        // an already-hosted contract doesn't leave the cached generation
+        // stuck at its first-`record_access` value — that mismatch would
+        // make later evictions silently skip reclamation. See
+        // `HostingCache::refresh_entry_generation`.
         if let Some(op_manager) = &self.op_manager {
-            op_manager.ring.bump_state_generation(key);
+            let new_gen = op_manager.ring.bump_state_generation(key);
+            op_manager.ring.refresh_cache_generation(key, new_gen);
         }
 
         tracing::info!(
@@ -2697,6 +2711,17 @@ impl Executor<Runtime> {
         let mut rt = Runtime::build(contract_store, delegate_store, secret_store, false).unwrap();
         // Enable V2 delegate contract access by providing the state store DB
         rt.set_state_store_db(state_store.storage());
+        // V2 delegate state writes bypass the executor's
+        // `state_store.{store,update}` chokepoints, so install a callback that
+        // mirrors the bump+refresh those chokepoints perform. Without this,
+        // V2 delegate PUT/UPDATE leaves the EvictContract re-host race open.
+        if let Some(op_manager_ref) = &op_manager {
+            let op_manager_clone = op_manager_ref.clone();
+            rt.set_state_write_callback(Arc::new(move |key: &ContractKey| {
+                let new_gen = op_manager_clone.ring.bump_state_generation(key);
+                op_manager_clone.ring.refresh_cache_generation(key, new_gen);
+            }));
+        }
         Executor::new(
             state_store,
             move || {
@@ -2753,6 +2778,17 @@ impl Executor<Runtime> {
         )
         .unwrap();
         rt.set_state_store_db(db);
+        // V2 delegate state writes bypass the executor chokepoints — install
+        // the bump+refresh callback so the EvictContract re-host race is
+        // closed for that path too. See `from_config` and
+        // `Runtime::set_state_write_callback`.
+        if let Some(op_manager_ref) = &op_manager {
+            let op_manager_clone = op_manager_ref.clone();
+            rt.set_state_write_callback(Arc::new(move |key: &ContractKey| {
+                let new_gen = op_manager_clone.ring.bump_state_generation(key);
+                op_manager_clone.ring.refresh_cache_generation(key, new_gen);
+            }));
+        }
         Executor::new(
             shared_state_store,
             || Ok(()),
@@ -3148,8 +3184,12 @@ impl Executor<Runtime> {
                 .map_err(ExecutorError::other)?;
             // State-write chokepoint: see `commit_state_update` doc comment
             // and `RuntimePool::remove_contract` for the race this bump closes.
+            // Refresh the hosting-cache snapshot so already-hosted contracts
+            // don't leak on eviction after this re-PUT — see
+            // `HostingCache::refresh_entry_generation`.
             if let Some(op_manager) = &self.op_manager {
-                op_manager.ring.bump_state_generation(&key);
+                let new_gen = op_manager.ring.bump_state_generation(&key);
+                op_manager.ring.refresh_cache_generation(&key, new_gen);
             }
 
             self.send_update_notification(&key, &params, &new_state)
@@ -3456,8 +3496,12 @@ impl Executor<Runtime> {
         // State-write chokepoint (verify_and_store PUT): see
         // `commit_state_update` doc comment and
         // `RuntimePool::remove_contract` for the race this bump closes.
+        // Refresh the hosting-cache snapshot so already-hosted contracts
+        // don't leak on eviction after this re-PUT — see
+        // `HostingCache::refresh_entry_generation`.
         if let Some(op_manager) = &self.op_manager {
-            op_manager.ring.bump_state_generation(&key);
+            let new_gen = op_manager.ring.bump_state_generation(&key);
+            op_manager.ring.refresh_cache_generation(&key, new_gen);
         }
 
         Ok(())

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -487,6 +487,17 @@ impl RuntimePool {
 }
 
 impl ContractExecutor for RuntimePool {
+    /// Forward the pending-reclamation registration to the ring's retry
+    /// queue. See `Ring::pending_reclamation_add` and the
+    /// `pending_reclamation` field docs on `HostingManager`. Called by
+    /// the `contract_handling` event loop when a fair-queue rejection
+    /// drops an `EvictContract` event before it can complete.
+    fn track_pending_reclamation(&self, key: ContractKey, expected_generation: u64) {
+        self.op_manager
+            .ring
+            .pending_reclamation_add(key, expected_generation);
+    }
+
     fn lookup_key(&self, instance_id: &ContractInstanceId) -> Option<ContractKey> {
         // Try to find the key in any available executor
         self.runtimes.iter().flatten().find_map(|executor| {
@@ -544,18 +555,66 @@ impl ContractExecutor for RuntimePool {
         //    path (i.e. before the PUT response returns), so a write that
         //    raced ahead of this handler will have already advanced it
         //    past `expected_generation`.
-        if self.op_manager.ring.is_hosting_contract(key)
-            || self.op_manager.ring.contract_in_use(key)
-        {
+        if self.op_manager.ring.is_hosting_contract(key) {
+            // The hosting cache itself re-added the contract — a later
+            // genuine eviction will emit a fresh `EvictContract`, so we
+            // do NOT need a pending-reclamation entry. Adding one here
+            // would race the cache and risk a spurious retry against a
+            // contract that is still hosted.
+            //
+            // If a pending entry already exists (e.g. an earlier
+            // `contract_in_use` skip queued the key, then a later write
+            // re-hosted it via the cache), clear it: the cache is now
+            // responsible for emitting a fresh `EvictContract` if and
+            // when the contract is evicted again. Leaving the stale
+            // pending entry behind would let the sweep keep emitting
+            // `EvictContract` events that hit `is_hosting_contract` and
+            // bail without progress.
+            self.op_manager.ring.pending_reclamation_remove(key);
             tracing::debug!(
                 contract = %key,
-                "Skipping eviction reclamation — contract was re-hosted or re-subscribed \
-                 since it was evicted"
+                "Skipping eviction reclamation — contract was re-hosted \
+                 (hosting cache contains it) since it was evicted"
+            );
+            return Ok(());
+        }
+        if self.op_manager.ring.contract_in_use(key) {
+            // A subscriber (client or downstream peer) appeared in the
+            // window between eviction and this handler running. The
+            // hosting-cache entry is already gone, so when that
+            // subscriber later expires/disconnects no cache entry will
+            // remain to emit another `EvictContract`. Stash the key in
+            // the pending-reclamation queue so the periodic sweep
+            // retries once `contract_in_use` becomes false.
+            //
+            // Disk-leak edge case #2 in PR #4212 review round 7 — see
+            // `HostingManager::pending_reclamation` docs.
+            self.op_manager
+                .ring
+                .pending_reclamation_add(*key, expected_generation);
+            tracing::debug!(
+                contract = %key,
+                "Skipping eviction reclamation — contract is in use \
+                 (client subscription or downstream subscriber); queued \
+                 for retry by the periodic sweep"
             );
             return Ok(());
         }
         let current_generation = self.op_manager.ring.state_generation(key);
         if current_generation != expected_generation {
+            // A state write (PUT/UPDATE) occurred between eviction and
+            // now. The contract has been re-hosted by the write path;
+            // a later genuine eviction will emit a fresh
+            // `EvictContract` with the current generation. We do NOT
+            // add a pending entry — the write path will naturally
+            // re-host and re-evict if appropriate.
+            //
+            // Clear any stale pending entry for the same reason: the
+            // write path's re-host+re-evict cycle owns subsequent
+            // reclamation, so leaving an entry behind only produces
+            // spurious sweep retries that all bail at the
+            // generation-mismatch check.
+            self.op_manager.ring.pending_reclamation_remove(key);
             tracing::debug!(
                 contract = %key,
                 expected_generation,
@@ -582,6 +641,11 @@ impl ContractExecutor for RuntimePool {
         // (the next access will refresh it; the generation is monotonic).
         if result.is_ok() {
             self.op_manager.ring.forget_state_generation(key);
+            // A successful retry from the pending-reclamation queue
+            // must clear the queue entry too. No-op when the key was
+            // not previously pending (the common case — most evictions
+            // succeed on the first attempt).
+            self.op_manager.ring.pending_reclamation_remove(key);
         }
         result
     }

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -675,18 +675,32 @@ impl ContractExecutor for RuntimePool {
                 self.op_manager.ring.pending_reclamation_remove(key);
             }
             Ok(ReclaimOutcome::Partial) => {
-                // Leave both pending-reclamation and state_generation in
-                // place: the entry will be retried by the periodic sweep
-                // (or by a fresh `EvictContract` if the cache re-emits
-                // one) until the remaining half is reclaimable.
+                // Upsert pending-reclamation so the periodic sweep retries
+                // the unreclaimed half. On the first EvictContract attempt
+                // there is NO prior pending entry, so "retaining" alone
+                // would leave the failed half permanently leaked — we must
+                // affirmatively insert. The current state_generation is
+                // captured so the deletion-time guard matches on retry
+                // unless new writes have happened in the meantime.
+                let current_gen = self.op_manager.ring.state_generation(key);
+                self.op_manager
+                    .ring
+                    .pending_reclamation_add(*key, current_gen);
                 tracing::debug!(
                     contract = %key,
-                    "partial reclaim — retaining pending-reclamation entry for retry"
+                    "partial reclaim — queued for retry via pending_reclamation"
                 );
             }
             Err(_) => {
-                // Both halves failed; keep pending so the sweep retries.
-                // (The error is logged inside `reclaim_contract_storage`.)
+                // Both halves failed. Same logic as Partial: on a first
+                // attempt there is no prior pending entry, so we must
+                // affirmatively insert one so the periodic sweep retries
+                // both halves. (The error itself is logged inside
+                // `reclaim_contract_storage`.)
+                let current_gen = self.op_manager.ring.state_generation(key);
+                self.op_manager
+                    .ring
+                    .pending_reclamation_add(*key, current_gen);
             }
         }
         // Drop the outcome detail at the trait boundary: callers expect

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -511,7 +511,11 @@ impl ContractExecutor for RuntimePool {
         result
     }
 
-    async fn remove_contract(&mut self, key: &ContractKey) -> Result<(), ExecutorError> {
+    async fn remove_contract(
+        &mut self,
+        key: &ContractKey,
+        expected_generation: u64,
+    ) -> Result<(), ExecutorError> {
         // Re-check at deletion time. `EvictContract` is fire-and-forget and
         // fair-queued, so an arbitrary amount of time can pass between the
         // hosting cache evicting the contract and this event being processed.
@@ -522,6 +526,24 @@ impl ContractExecutor for RuntimePool {
         // out here closes that re-host / re-subscribe TOCTOU window — the
         // hosting cache will issue a fresh `EvictContract` if the contract is
         // genuinely evicted again later.
+        //
+        // Three guards, in order:
+        // 1. `is_hosting_contract` — the hosting cache itself re-added the
+        //    contract (a GET refreshed it).
+        // 2. `contract_in_use` — client / downstream / network subscription
+        //    re-registered interest in this contract.
+        // 3. `state_generation != expected_generation` — a state write
+        //    occurred between eviction and now. This is the load-bearing
+        //    check: `EvictContract{X}` and `PutQuery{X}` are serialized in
+        //    the per-key fair queue, but the driver-side `host_contract(X)`
+        //    that re-marks X as hosted runs on the driver task AFTER
+        //    `PutQuery{X}.await` returns — so the `is_hosting_contract`
+        //    re-check above can still see a freshly-PUT contract as "not
+        //    hosting" and delete its state. The state-write generation
+        //    is bumped under the executor in the contract-handler call
+        //    path (i.e. before the PUT response returns), so a write that
+        //    raced ahead of this handler will have already advanced it
+        //    past `expected_generation`.
         if self.op_manager.ring.is_hosting_contract(key)
             || self.op_manager.ring.contract_in_use(key)
         {
@@ -529,6 +551,16 @@ impl ContractExecutor for RuntimePool {
                 contract = %key,
                 "Skipping eviction reclamation — contract was re-hosted or re-subscribed \
                  since it was evicted"
+            );
+            return Ok(());
+        }
+        let current_generation = self.op_manager.ring.state_generation(key);
+        if current_generation != expected_generation {
+            tracing::debug!(
+                contract = %key,
+                expected_generation,
+                current_generation,
+                "Skipping eviction reclamation — contract was written since eviction"
             );
             return Ok(());
         }
@@ -543,6 +575,14 @@ impl ContractExecutor for RuntimePool {
         let result = executor.reclaim_contract_storage(key).await;
         self.return_checked(executor, "remove_contract").await;
         self.track_contract_return(key);
+
+        // On successful disk reclamation, forget the generation entry so
+        // the state_generation map does not grow unbounded. We only forget
+        // on success: leaving the entry behind on partial failures is safe
+        // (the next access will refresh it; the generation is monotonic).
+        if result.is_ok() {
+            self.op_manager.ring.forget_state_generation(key);
+        }
         result
     }
 
@@ -1096,6 +1136,14 @@ where
                                 .store(key, state_to_store, params.clone())
                                 .await
                                 .map_err(ExecutorError::other)?;
+                            // State-write chokepoint: bump the per-contract
+                            // generation counter so a racing `EvictContract`
+                            // captured before this store sees a stale
+                            // generation at deletion time and skips
+                            // reclamation. See `RuntimePool::remove_contract`.
+                            if let Some(op_manager) = &self.op_manager {
+                                op_manager.ring.bump_state_generation(&key);
+                            }
 
                             let completion_now = now_nanos();
                             if let Some(completion_info) = self
@@ -1913,6 +1961,13 @@ where
         Ok(Either::Left(new_state))
     }
 
+    /// Persist an updated contract state via `state_store.update`.
+    ///
+    /// This is the canonical chokepoint for UPDATE-shaped writes: every
+    /// in-place state update funnels through here. Bumping the per-contract
+    /// state-write generation immediately after the store succeeds is what
+    /// closes the EvictContract re-host race for UPDATE — see
+    /// `RuntimePool::remove_contract`.
     async fn commit_state_update(
         &mut self,
         key: &ContractKey,
@@ -1940,6 +1995,11 @@ where
             .update(key, new_state.clone())
             .await
             .map_err(ExecutorError::other)?;
+        // State-write chokepoint (UPDATE): see `commit_state_update` docs
+        // and `RuntimePool::remove_contract` for the race this bump closes.
+        if let Some(op_manager) = &self.op_manager {
+            op_manager.ring.bump_state_generation(key);
+        }
 
         tracing::info!(
             contract = %key,
@@ -2606,7 +2666,15 @@ impl ContractExecutor for Executor<Runtime> {
             .await
     }
 
-    async fn remove_contract(&mut self, key: &ContractKey) -> Result<(), ExecutorError> {
+    async fn remove_contract(
+        &mut self,
+        key: &ContractKey,
+        _expected_generation: u64,
+    ) -> Result<(), ExecutorError> {
+        // The inner Executor does not own a Ring (and so cannot consult
+        // the state-write generation directly). Race detection lives at
+        // the `RuntimePool::remove_contract` layer; the inner impl just
+        // performs the disk reclamation.
         self.reclaim_contract_storage(key).await
     }
 }
@@ -3078,6 +3146,11 @@ impl Executor<Runtime> {
                 .update(&key, new_state.clone())
                 .await
                 .map_err(ExecutorError::other)?;
+            // State-write chokepoint: see `commit_state_update` doc comment
+            // and `RuntimePool::remove_contract` for the race this bump closes.
+            if let Some(op_manager) = &self.op_manager {
+                op_manager.ring.bump_state_generation(&key);
+            }
 
             self.send_update_notification(&key, &params, &new_state)
                 .await
@@ -3380,6 +3453,12 @@ impl Executor<Runtime> {
                 );
                 ExecutorError::other(e)
             })?;
+        // State-write chokepoint (verify_and_store PUT): see
+        // `commit_state_update` doc comment and
+        // `RuntimePool::remove_contract` for the race this bump closes.
+        if let Some(op_manager) = &self.op_manager {
+            op_manager.ring.bump_state_generation(&key);
+        }
 
         Ok(())
     }
@@ -4036,12 +4115,13 @@ mod remove_contract_tests {
     //! evicting a contract actually frees its on-disk state and WASM code,
     //! so the hosting budget is a real disk bound.
     //!
-    //! Note: the `RuntimePool::remove_contract` re-host / re-subscribe
-    //! TOCTOU guard (which consults `op_manager.ring`) is not unit-tested
-    //! here because constructing a `RuntimePool` requires a fully-built
-    //! `OpManager` (config, `NetEventRegister`, ring, etc.), which is too
-    //! heavy for a focused unit test. The `Ring::is_hosting_contract` /
-    //! `Ring::contract_in_use` predicates the guard relies on are covered
+    //! Note: the `RuntimePool::remove_contract` re-host / re-subscribe /
+    //! generation-mismatch TOCTOU guards (which consult `op_manager.ring`)
+    //! are not unit-tested here because constructing a `RuntimePool`
+    //! requires a fully-built `OpManager` (config, `NetEventRegister`,
+    //! ring, etc.), which is too heavy for a focused unit test. The
+    //! `Ring::is_hosting_contract` / `Ring::contract_in_use` /
+    //! `Ring::state_generation` predicates the guards rely on are covered
     //! directly in `ring/hosting.rs`. End-to-end coverage of the guarded
     //! eviction path is a deferred `#[freenet_test]` follow-up.
 

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -512,6 +512,27 @@ impl ContractExecutor for RuntimePool {
     }
 
     async fn remove_contract(&mut self, key: &ContractKey) -> Result<(), ExecutorError> {
+        // Re-check at deletion time. `EvictContract` is fire-and-forget and
+        // fair-queued, so an arbitrary amount of time can pass between the
+        // hosting cache evicting the contract and this event being processed.
+        // In that window a GET/PUT can re-store the contract (re-hosting it) or
+        // a subscription can re-register interest. Reclaiming the on-disk
+        // storage then would either leave the contract in-cache-but-not-on-disk
+        // or delete the state of a contract that is once again wanted. Bailing
+        // out here closes that re-host / re-subscribe TOCTOU window — the
+        // hosting cache will issue a fresh `EvictContract` if the contract is
+        // genuinely evicted again later.
+        if self.op_manager.ring.is_hosting_contract(key)
+            || self.op_manager.ring.contract_in_use(key)
+        {
+            tracing::debug!(
+                contract = %key,
+                "Skipping eviction reclamation — contract was re-hosted or re-subscribed \
+                 since it was evicted"
+            );
+            return Ok(());
+        }
+
         // Mirror the pop-an-executor pattern from `fetch_contract`: the
         // checked-out executor owns the `ContractStore` whose on-disk `.wasm`
         // blob must be removed, while the `StateStore` is shared across the
@@ -3379,6 +3400,11 @@ impl Executor<Runtime> {
     /// succeeds (or both were already clean); only a failure of *both* steps is
     /// surfaced as an error, since this is fire-and-forget maintenance.
     ///
+    /// Note that `Ok(())` does NOT mean the contract is fully consistent: a
+    /// partial failure (state deleted but code kept, or vice versa) leaves the
+    /// contract half-present on disk until a subsequent access re-fetches it.
+    /// Callers must not treat `Ok` as "fully reclaimed" or "fully consistent".
+    ///
     /// This is the inherent implementation; the `ContractExecutor::remove_contract`
     /// trait method delegates to it.
     async fn reclaim_contract_storage(&mut self, key: &ContractKey) -> Result<(), ExecutorError> {
@@ -4009,6 +4035,15 @@ mod remove_contract_tests {
     //! path wired to hosting-cache eviction. The core proof here is that
     //! evicting a contract actually frees its on-disk state and WASM code,
     //! so the hosting budget is a real disk bound.
+    //!
+    //! Note: the `RuntimePool::remove_contract` re-host / re-subscribe
+    //! TOCTOU guard (which consults `op_manager.ring`) is not unit-tested
+    //! here because constructing a `RuntimePool` requires a fully-built
+    //! `OpManager` (config, `NetEventRegister`, ring, etc.), which is too
+    //! heavy for a focused unit test. The `Ring::is_hosting_contract` /
+    //! `Ring::contract_in_use` predicates the guard relies on are covered
+    //! directly in `ring/hosting.rs`. End-to-end coverage of the guarded
+    //! eviction path is a deferred `#[freenet_test]` follow-up.
 
     use std::sync::Arc;
 

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -511,6 +511,20 @@ impl ContractExecutor for RuntimePool {
         result
     }
 
+    async fn remove_contract(&mut self, key: &ContractKey) -> Result<(), ExecutorError> {
+        // Mirror the pop-an-executor pattern from `fetch_contract`: the
+        // checked-out executor owns the `ContractStore` whose on-disk `.wasm`
+        // blob must be removed, while the `StateStore` is shared across the
+        // pool. Delegating to `Executor::reclaim_contract_storage` keeps the
+        // best-effort, idempotent reclaim logic in one place.
+        self.track_contract_checkout(key);
+        let mut executor = self.pop_executor().await;
+        let result = executor.reclaim_contract_storage(key).await;
+        self.return_checked(executor, "remove_contract").await;
+        self.track_contract_return(key);
+        result
+    }
+
     async fn upsert_contract_state(
         &mut self,
         key: ContractKey,
@@ -2570,6 +2584,10 @@ impl ContractExecutor for Executor<Runtime> {
         self.bridged_get_contract_state_delta(key, their_summary)
             .await
     }
+
+    async fn remove_contract(&mut self, key: &ContractKey) -> Result<(), ExecutorError> {
+        self.reclaim_contract_storage(key).await
+    }
 }
 
 impl Executor<Runtime> {
@@ -3344,6 +3362,63 @@ impl Executor<Runtime> {
 
         Ok(())
     }
+
+    /// Reclaim a contract's on-disk storage after it was evicted from the
+    /// hosting cache.
+    ///
+    /// Deletes (1) the persisted state and parameters from the `StateStore`
+    /// and (2) the WASM code blob from the `ContractStore`. The contract-store
+    /// removal is code-hash refcount-safe: the shared `.wasm` blob is only
+    /// deleted once no other contract instance references the same code.
+    ///
+    /// Both steps are best-effort and independent: if one fails, the other is
+    /// still attempted so a partial reclaim is achieved rather than none. The
+    /// method is idempotent — both `StateStore::delete` and
+    /// `ContractStore::remove_contract` tolerate already-missing entries — so a
+    /// double eviction is harmless. Returns `Ok(())` whenever either step
+    /// succeeds (or both were already clean); only a failure of *both* steps is
+    /// surfaced as an error, since this is fire-and-forget maintenance.
+    ///
+    /// This is the inherent implementation; the `ContractExecutor::remove_contract`
+    /// trait method delegates to it.
+    async fn reclaim_contract_storage(&mut self, key: &ContractKey) -> Result<(), ExecutorError> {
+        let state_deleted = match self.state_store.delete(key).await {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::warn!(
+                    contract = %key,
+                    error = %e,
+                    "failed to delete persisted state while reclaiming evicted contract"
+                );
+                false
+            }
+        };
+        let code_deleted = match self.runtime.contract_store.remove_contract(key) {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::warn!(
+                    contract = %key,
+                    error = %e,
+                    "failed to delete WASM code while reclaiming evicted contract"
+                );
+                false
+            }
+        };
+
+        if !state_deleted && !code_deleted {
+            return Err(ExecutorError::other(anyhow::anyhow!(
+                "failed to reclaim any on-disk storage for contract {key}"
+            )));
+        }
+
+        tracing::info!(
+            contract = %key,
+            state_deleted,
+            code_deleted,
+            "reclaimed on-disk storage for evicted contract"
+        );
+        Ok(())
+    }
 }
 
 impl Executor<Runtime> {
@@ -3925,5 +4000,180 @@ mod executor_pin_tests {
             "UPDATE-side inline related fetch must call \
              futures::future::join_all (#4077)"
         );
+    }
+}
+
+#[cfg(test)]
+mod remove_contract_tests {
+    //! Tests for `Executor::reclaim_contract_storage` — the disk-reclamation
+    //! path wired to hosting-cache eviction. The core proof here is that
+    //! evicting a contract actually frees its on-disk state and WASM code,
+    //! so the hosting budget is a real disk bound.
+
+    use std::sync::Arc;
+
+    use freenet_stdlib::prelude::{
+        ContractCode, ContractContainer, ContractKey, ContractWasmAPIVersion, Parameters,
+        WrappedContract, WrappedState,
+    };
+
+    use crate::contract::executor::Executor;
+    use crate::contract::storages::Storage;
+    use crate::wasm_runtime::{
+        ContractStore, DelegateStore, Runtime, SecretsStore, StateStore, StateStoreError,
+    };
+
+    /// Build a disk-backed `Executor<Runtime>` and return it alongside the
+    /// `contracts_dir` (so the test can probe the `.wasm` file directly) and
+    /// the `TempDir` (kept alive for the test's duration).
+    async fn build_disk_executor(
+        seed: &str,
+    ) -> (Executor<Runtime>, std::path::PathBuf, tempfile::TempDir) {
+        let temp_dir = crate::util::tests::get_temp_dir();
+        let db = Storage::new(temp_dir.path())
+            .await
+            .expect("create storage db");
+        let contracts_dir = temp_dir.path().join(format!("contracts-{seed}"));
+        let contract_store = ContractStore::new(contracts_dir.clone(), 10_000, db.clone())
+            .expect("create contract store");
+        let delegate_store =
+            DelegateStore::new(temp_dir.path().join("delegate"), 10_000, db.clone())
+                .expect("create delegate store");
+        let secrets_store = SecretsStore::new(
+            temp_dir.path().join("secrets"),
+            Default::default(),
+            db.clone(),
+        )
+        .expect("create secrets store");
+        let state_store = StateStore::new(db, 10_000_000).expect("create state store");
+        let runtime = Runtime::build(contract_store, delegate_store, secrets_store, false)
+            .expect("build runtime");
+        let executor = Executor::new(
+            state_store,
+            || Ok(()),
+            crate::contract::executor::OperationMode::Local,
+            runtime,
+            None,
+        )
+        .await
+        .expect("create executor");
+        (executor, contracts_dir, temp_dir)
+    }
+
+    /// Construct a synthetic contract container. The bytes are never executed
+    /// (`reclaim_contract_storage` only deletes files / DB rows), so a fake
+    /// blob is sufficient and far faster than compiling real WASM.
+    fn make_contract(code_seed: u8, param_seed: u8) -> (ContractContainer, ContractKey) {
+        let code = ContractCode::from(vec![code_seed; 64]);
+        let params = Parameters::from(vec![param_seed; 8]);
+        let key = ContractKey::from_params_and_code(&params, &code);
+        let wrapped = WrappedContract::new(Arc::new(code), params);
+        let container = ContractContainer::Wasm(ContractWasmAPIVersion::V1(wrapped));
+        (container, key)
+    }
+
+    fn wasm_path(contracts_dir: &std::path::Path, key: &ContractKey) -> std::path::PathBuf {
+        contracts_dir
+            .join(key.code_hash().encode())
+            .with_extension("wasm")
+    }
+
+    /// Core regression test: storing a contract makes its state retrievable
+    /// and its `.wasm` blob present on disk; `remove_contract` reclaims both.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remove_contract_reclaims_state_and_wasm_from_disk() {
+        let (mut executor, contracts_dir, _temp) = build_disk_executor("reclaim").await;
+        let (container, key) = make_contract(0x11, 0x22);
+        let params = container.params();
+        let state = WrappedState::new(b"hosted state payload".to_vec());
+
+        // Store the WASM blob and the persisted state.
+        executor
+            .runtime
+            .contract_store
+            .store_contract(container)
+            .expect("store contract code");
+        executor
+            .state_store
+            .store(key, state.clone(), params)
+            .await
+            .expect("store contract state");
+
+        // Pre-conditions: state retrievable and the .wasm file exists.
+        let fetched = executor
+            .state_store
+            .get(&key)
+            .await
+            .expect("state retrievable before eviction");
+        assert_eq!(fetched, state, "stored state must round-trip");
+        let blob = wasm_path(&contracts_dir, &key);
+        assert!(
+            blob.exists(),
+            "WASM blob must exist on disk before eviction: {blob:?}"
+        );
+
+        // Evict.
+        executor
+            .reclaim_contract_storage(&key)
+            .await
+            .expect("reclaim must succeed");
+
+        // Post-conditions: state gone, .wasm gone.
+        match executor.state_store.get(&key).await {
+            Err(StateStoreError::MissingContract(missing)) => assert_eq!(missing, key),
+            other => panic!("expected MissingContract after eviction, got {other:?}"),
+        }
+        assert!(
+            !blob.exists(),
+            "WASM blob must be deleted from disk after eviction: {blob:?}"
+        );
+    }
+
+    /// Double eviction is idempotent: a second `remove_contract` on an
+    /// already-reclaimed contract is a harmless no-op, not an error.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remove_contract_is_idempotent_on_double_eviction() {
+        let (mut executor, contracts_dir, _temp) = build_disk_executor("idempotent").await;
+        let (container, key) = make_contract(0x33, 0x44);
+        let params = container.params();
+        let state = WrappedState::new(b"payload".to_vec());
+
+        executor
+            .runtime
+            .contract_store
+            .store_contract(container)
+            .expect("store contract code");
+        executor
+            .state_store
+            .store(key, state, params)
+            .await
+            .expect("store contract state");
+
+        executor
+            .reclaim_contract_storage(&key)
+            .await
+            .expect("first reclaim must succeed");
+        // Second reclaim: state and .wasm are already gone — must still be Ok.
+        executor
+            .reclaim_contract_storage(&key)
+            .await
+            .expect("second reclaim must be a no-op, not an error");
+        assert!(
+            !wasm_path(&contracts_dir, &key).exists(),
+            "WASM blob must remain absent after double eviction"
+        );
+    }
+
+    /// Reclaiming a never-stored contract is also a harmless no-op: both the
+    /// state-store delete and the contract-store removal tolerate a fully
+    /// absent contract.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remove_contract_unknown_contract_is_noop() {
+        let (mut executor, _contracts_dir, _temp) = build_disk_executor("unknown").await;
+        let (_container, key) = make_contract(0x55, 0x66);
+        executor
+            .reclaim_contract_storage(&key)
+            .await
+            .expect("reclaiming an unknown contract must be Ok");
     }
 }

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -216,7 +216,11 @@ fn extract_contract_id(event: &ContractHandlerEvent) -> Option<ContractInstanceI
         ContractHandlerEvent::PutQuery { key, .. }
         | ContractHandlerEvent::UpdateQuery { key, .. }
         | ContractHandlerEvent::GetSummaryQuery { key, .. }
-        | ContractHandlerEvent::GetDeltaQuery { key, .. } => Some(*key.id()),
+        | ContractHandlerEvent::GetDeltaQuery { key, .. }
+        // EvictContract is routed to its contract's per-key queue so disk
+        // reclamation is serialized with any other in-flight ops on that
+        // key (e.g. a concurrent GET/PUT touching the same contract).
+        | ContractHandlerEvent::EvictContract { key, .. } => Some(*key.id()),
         ContractHandlerEvent::GetQuery { instance_id, .. }
         | ContractHandlerEvent::RegisterSubscriberListener {
             key: instance_id, ..
@@ -739,6 +743,12 @@ mod tests {
                     summary: None,
                     subscriber_listener: mpsc::channel(64).0,
                 },
+            ),
+            // EvictContract must route to the contract's per-key queue so
+            // disk reclamation is serialized with other ops on that key.
+            (
+                "EvictContract",
+                ContractHandlerEvent::EvictContract { key },
             ),
         ];
 

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -746,7 +746,13 @@ mod tests {
             ),
             // EvictContract must route to the contract's per-key queue so
             // disk reclamation is serialized with other ops on that key.
-            ("EvictContract", ContractHandlerEvent::EvictContract { key }),
+            (
+                "EvictContract",
+                ContractHandlerEvent::EvictContract {
+                    key,
+                    expected_generation: 0,
+                },
+            ),
         ];
 
         for (name, event) in &contract_events {

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -746,10 +746,7 @@ mod tests {
             ),
             // EvictContract must route to the contract's per-key queue so
             // disk reclamation is serialized with other ops on that key.
-            (
-                "EvictContract",
-                ContractHandlerEvent::EvictContract { key },
-            ),
+            ("EvictContract", ContractHandlerEvent::EvictContract { key }),
         ];
 
         for (name, event) in &contract_events {

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -685,6 +685,11 @@ pub(crate) enum ContractHandlerEvent {
     ClientDisconnect {
         client_id: ClientId,
     },
+    /// Reclaim a contract's on-disk storage (state + WASM code) after it was
+    /// evicted from the hosting cache. Fire-and-forget: no response is sent.
+    EvictContract {
+        key: ContractKey,
+    },
 }
 
 impl std::fmt::Display for ContractHandlerEvent {
@@ -795,6 +800,9 @@ impl std::fmt::Display for ContractHandlerEvent {
             },
             ContractHandlerEvent::ClientDisconnect { client_id } => {
                 write!(f, "client disconnect {{ {client_id} }}")
+            }
+            ContractHandlerEvent::EvictContract { key } => {
+                write!(f, "evict contract {{ {key} }}")
             }
         }
     }

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -687,8 +687,19 @@ pub(crate) enum ContractHandlerEvent {
     },
     /// Reclaim a contract's on-disk storage (state + WASM code) after it was
     /// evicted from the hosting cache. Fire-and-forget: no response is sent.
+    ///
+    /// `expected_generation` is the state-write generation captured
+    /// atomically when the contract was evicted (see
+    /// `HostingCache::record_access` / `sweep_expired`). The eviction
+    /// handler in `RuntimePool::remove_contract` re-reads the current
+    /// generation and skips disk reclamation if it has advanced — that
+    /// means a state write (PUT/UPDATE) occurred between eviction and
+    /// this handler running, and the contract has been re-hosted with
+    /// fresh state we must not delete. This closes the re-host TOCTOU
+    /// window described on `RuntimePool::remove_contract`.
     EvictContract {
         key: ContractKey,
+        expected_generation: u64,
     },
 }
 
@@ -801,8 +812,14 @@ impl std::fmt::Display for ContractHandlerEvent {
             ContractHandlerEvent::ClientDisconnect { client_id } => {
                 write!(f, "client disconnect {{ {client_id} }}")
             }
-            ContractHandlerEvent::EvictContract { key } => {
-                write!(f, "evict contract {{ {key} }}")
+            ContractHandlerEvent::EvictContract {
+                key,
+                expected_generation,
+            } => {
+                write!(
+                    f,
+                    "evict contract {{ {key}, expected_generation: {expected_generation} }}"
+                )
             }
         }
     }

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -788,6 +788,26 @@ impl StateStorage for ReDb {
             None => Ok(None),
         }
     }
+
+    async fn remove(&self, key: &ContractKey) -> Result<(), Self::Error> {
+        // Delete from all three per-key tables in a single write transaction
+        // so the removal is atomic. `redb`'s `Table::remove` does not error
+        // when the key is absent, so this is naturally idempotent.
+        let txn = self.0.begin_write()?;
+        {
+            let mut tbl = txn.open_table(STATE_TABLE)?;
+            tbl.remove(key.as_bytes())?;
+        }
+        {
+            let mut tbl = txn.open_table(CONTRACT_PARAMS_TABLE)?;
+            tbl.remove(key.as_bytes())?;
+        }
+        {
+            let mut tbl = txn.open_table(HOSTING_METADATA_TABLE)?;
+            tbl.remove(key.as_bytes())?;
+        }
+        txn.commit().map_err(Into::into)
+    }
 }
 
 #[cfg(test)]
@@ -919,5 +939,45 @@ mod tests {
     fn test_hosting_metadata_too_short() {
         assert!(HostingMetadata::from_bytes(&[0u8; 48]).is_none());
         assert!(HostingMetadata::from_bytes(&[]).is_none());
+    }
+
+    fn make_test_key() -> ContractKey {
+        let code = ContractCode::from(vec![1, 2, 3, 4]);
+        let params = Parameters::from(vec![5, 6, 7, 8]);
+        ContractKey::from_params_and_code(&params, &code)
+    }
+
+    /// `remove` deletes both the state and the params for a contract.
+    #[tokio::test]
+    async fn test_remove_deletes_state_and_params() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = ReDb::new(temp_dir.path()).await.unwrap();
+
+        let key = make_test_key();
+        let state = WrappedState::new(vec![1, 2, 3]);
+        let params = Parameters::from(vec![10, 20, 30]);
+
+        // Store state + params and confirm they are present.
+        db.store(key, state.clone()).await.unwrap();
+        db.store_params(key, params.clone()).await.unwrap();
+        assert_eq!(db.get(&key).await.unwrap(), Some(state));
+        assert_eq!(db.get_params(&key).await.unwrap(), Some(params));
+
+        // Remove and confirm both are gone.
+        db.remove(&key).await.unwrap();
+        assert_eq!(db.get(&key).await.unwrap(), None);
+        assert_eq!(db.get_params(&key).await.unwrap(), None);
+    }
+
+    /// `remove` on a contract that was never stored is a no-op (idempotent).
+    #[tokio::test]
+    async fn test_remove_never_stored_is_idempotent() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = ReDb::new(temp_dir.path()).await.unwrap();
+
+        let key = make_test_key();
+        db.remove(&key)
+            .await
+            .expect("removing a never-stored contract should be Ok");
     }
 }

--- a/crates/core/src/contract/storages/sqlite.rs
+++ b/crates/core/src/contract/storages/sqlite.rs
@@ -313,6 +313,21 @@ impl StateStorage for Pool {
             Err(_) => Err(SqlDbError::ContractNotFound),
         }
     }
+
+    async fn remove(&self, key: &ContractKey) -> Result<(), Self::Error> {
+        // State and params share the `states` row; `hosting_metadata` is a
+        // separate table. A `DELETE` of an absent row is a no-op, so this is
+        // idempotent.
+        sqlx::query("DELETE FROM states WHERE contract = ?")
+            .bind(key.as_bytes())
+            .execute(&self.0)
+            .await?;
+        sqlx::query("DELETE FROM hosting_metadata WHERE contract = ?")
+            .bind(key.as_bytes())
+            .execute(&self.0)
+            .await?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/core/src/contract/storages/sqlite.rs
+++ b/crates/core/src/contract/storages/sqlite.rs
@@ -330,6 +330,61 @@ impl StateStorage for Pool {
     }
 }
 
+#[cfg(all(test, feature = "sqlite"))]
+mod tests {
+    //! Tests for the SQLite `StateStorage::remove` implementation — mirrors
+    //! redb's `test_remove_deletes_state_and_params` so eviction-driven disk
+    //! reclamation is covered on both storage backends.
+
+    use super::*;
+
+    fn make_test_key() -> ContractKey {
+        let code = ContractCode::from(vec![1, 2, 3, 4]);
+        let params = Parameters::from(vec![5, 6, 7, 8]);
+        ContractKey::from_params_and_code(&params, &code)
+    }
+
+    /// `remove` deletes both the state and the params for a contract.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_remove_deletes_state_and_params() {
+        // `Pool::new(None)` uses an in-memory database; `block_in_place` inside
+        // it requires the multi-thread runtime flavor.
+        let pool = Pool::new(None).await.expect("create in-memory sqlite pool");
+
+        let key = make_test_key();
+        let state = WrappedState::new(vec![1, 2, 3]);
+        let params = Parameters::from(vec![10, 20, 30]);
+
+        // Store state + params and confirm they are present.
+        pool.store(key, state.clone()).await.unwrap();
+        pool.store_params(key, params.clone()).await.unwrap();
+        assert_eq!(pool.get(&key).await.unwrap(), Some(state));
+        assert_eq!(pool.get_params(&key).await.unwrap(), Some(params));
+
+        // Remove and confirm both are gone.
+        pool.remove(&key).await.unwrap();
+        assert_eq!(pool.get(&key).await.unwrap(), None);
+        assert_eq!(pool.get_params(&key).await.unwrap(), None);
+    }
+
+    /// `remove` on a contract that was never stored is a no-op (idempotent):
+    /// a `DELETE` of an absent row affects zero rows and must not error.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_remove_never_stored_is_idempotent() {
+        let pool = Pool::new(None).await.expect("create in-memory sqlite pool");
+
+        let key = make_test_key();
+        pool.remove(&key)
+            .await
+            .expect("removing a never-stored contract should be Ok");
+
+        // A second remove is equally harmless.
+        pool.remove(&key)
+            .await
+            .expect("double remove should remain Ok");
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum SqlDbError {
     #[error("Contract not found")]

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -557,6 +557,15 @@ impl OpManager {
             .await
     }
 
+    /// Fire-and-forget notification to the contract handler. Used for
+    /// maintenance events (e.g. EvictContract) where no response is needed
+    /// and the caller must not block.
+    pub fn notify_contract_handler_fire_and_forget(&self, ev: ContractHandlerEvent) {
+        if let Err(e) = self.ch_outbound.send_to_handler_fire_and_forget(ev) {
+            tracing::warn!(error = %e, "failed to send fire-and-forget event to contract handler");
+        }
+    }
+
     /// Peek at the next hop address for an outbound initial request.
     ///
     /// Always returns `None` — every op now runs on a driver

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -200,8 +200,17 @@ pub(crate) fn reclaim_evicted_contract(
         tracing::debug!(
             contract = %key,
             "Skipping disk reclamation for evicted contract — still in use \
-             (client subscription or downstream subscriber)"
+             (client subscription or downstream subscriber); queued for retry"
         );
+        // Queue for retry by the periodic sweep: the hosting-cache entry is
+        // already gone (we are processing its `evicted` tuple), so when the
+        // subscriber later expires nothing else would emit another
+        // EvictContract for this key — without this, the disk state/code
+        // would leak permanently. Mirrors the symmetric in-use skip in
+        // RuntimePool::remove_contract.
+        op_manager
+            .ring
+            .pending_reclamation_add(key, expected_generation);
         return;
     }
     op_manager.notify_contract_handler_fire_and_forget(

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -173,6 +173,28 @@ pub(crate) async fn announce_contract_hosted(op_manager: &OpManager, key: &Contr
     }
 }
 
+/// Reclaim the on-disk storage of a contract that was evicted from the
+/// hosting cache. Skips contracts that are still in use — an active client
+/// subscription or a downstream peer subscriber means something still
+/// depends on us hosting it, so its state/code must NOT be deleted.
+///
+/// Fire-and-forget: emits an `EvictContract` event to the contract handler,
+/// which routes it through the fair queue (serialized per-contract with other
+/// ops on the same key) and reclaims disk in `handle_contract_event`.
+pub(crate) fn reclaim_evicted_contract(op_manager: &OpManager, key: ContractKey) {
+    if op_manager.ring.contract_in_use(&key) {
+        tracing::debug!(
+            contract = %key,
+            "Skipping disk reclamation for evicted contract — still in use \
+             (client subscription or downstream subscriber)"
+        );
+        return;
+    }
+    op_manager.notify_contract_handler_fire_and_forget(
+        crate::contract::ContractHandlerEvent::EvictContract { key },
+    );
+}
+
 /// Complete subscription at the originator node via GET piggyback.
 ///
 /// The subscription tree was built by relay nodes during GET response propagation.
@@ -349,7 +371,8 @@ pub(crate) async fn has_contract(
         | crate::contract::ContractHandlerEvent::GetSummaryResponse { .. }
         | crate::contract::ContractHandlerEvent::GetDeltaQuery { .. }
         | crate::contract::ContractHandlerEvent::GetDeltaResponse { .. }
-        | crate::contract::ContractHandlerEvent::ClientDisconnect { .. } => Ok(None),
+        | crate::contract::ContractHandlerEvent::ClientDisconnect { .. }
+        | crate::contract::ContractHandlerEvent::EvictContract { .. } => Ok(None),
     }
 }
 

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -175,9 +175,10 @@ pub(crate) async fn announce_contract_hosted(op_manager: &OpManager, key: &Contr
 
 /// Reclaim the on-disk storage of a contract that was evicted from the
 /// hosting cache. Skips contracts that are still in use — an active client
-/// subscription, a downstream peer subscriber, or an active upstream
-/// network subscription means something still depends on us hosting it,
-/// so its state/code must NOT be deleted.
+/// subscription or a downstream peer subscriber means something still
+/// depends on us hosting it, so its state/code must NOT be deleted. See
+/// `HostingManager::contract_in_use` for why an active upstream network
+/// subscription alone is NOT included in the gate.
 ///
 /// `expected_generation` is the state-write generation captured atomically
 /// with the eviction decision (see `HostingCache::record_access` /
@@ -199,7 +200,7 @@ pub(crate) fn reclaim_evicted_contract(
         tracing::debug!(
             contract = %key,
             "Skipping disk reclamation for evicted contract — still in use \
-             (client subscription, downstream subscriber, or network subscription)"
+             (client subscription or downstream subscriber)"
         );
         return;
     }

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -175,23 +175,39 @@ pub(crate) async fn announce_contract_hosted(op_manager: &OpManager, key: &Contr
 
 /// Reclaim the on-disk storage of a contract that was evicted from the
 /// hosting cache. Skips contracts that are still in use — an active client
-/// subscription or a downstream peer subscriber means something still
-/// depends on us hosting it, so its state/code must NOT be deleted.
+/// subscription, a downstream peer subscriber, or an active upstream
+/// network subscription means something still depends on us hosting it,
+/// so its state/code must NOT be deleted.
+///
+/// `expected_generation` is the state-write generation captured atomically
+/// with the eviction decision (see `HostingCache::record_access` /
+/// `sweep_expired`). It is carried through `EvictContract` so the
+/// deletion-time guard in `RuntimePool::remove_contract` can detect a
+/// state write (PUT/UPDATE) that re-hosted the contract between eviction
+/// and this handler running — that case must skip disk reclamation
+/// because the freshly written state would otherwise be deleted.
 ///
 /// Fire-and-forget: emits an `EvictContract` event to the contract handler,
 /// which routes it through the fair queue (serialized per-contract with other
 /// ops on the same key) and reclaims disk in `handle_contract_event`.
-pub(crate) fn reclaim_evicted_contract(op_manager: &OpManager, key: ContractKey) {
+pub(crate) fn reclaim_evicted_contract(
+    op_manager: &OpManager,
+    key: ContractKey,
+    expected_generation: u64,
+) {
     if op_manager.ring.contract_in_use(&key) {
         tracing::debug!(
             contract = %key,
             "Skipping disk reclamation for evicted contract — still in use \
-             (client subscription or downstream subscriber)"
+             (client subscription, downstream subscriber, or network subscription)"
         );
         return;
     }
     op_manager.notify_contract_handler_fire_and_forget(
-        crate::contract::ContractHandlerEvent::EvictContract { key },
+        crate::contract::ContractHandlerEvent::EvictContract {
+            key,
+            expected_generation,
+        },
     );
 }
 

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -947,7 +947,7 @@ async fn cache_contract_locally(
     }
 
     let mut removed_contracts = Vec::new();
-    for evicted_key in &access_result.evicted {
+    for (evicted_key, expected_generation) in &access_result.evicted {
         if op_manager
             .interest_manager
             .unregister_local_hosting(evicted_key)
@@ -955,8 +955,9 @@ async fn cache_contract_locally(
             removed_contracts.push(*evicted_key);
         }
         // Reclaim on-disk storage for the evicted contract so the hosting
-        // budget is a real disk bound (subscription-gated inside the helper).
-        crate::operations::reclaim_evicted_contract(op_manager, *evicted_key);
+        // budget is a real disk bound (subscription- and generation-gated
+        // inside the helper).
+        crate::operations::reclaim_evicted_contract(op_manager, *evicted_key, *expected_generation);
     }
 
     // (4) Newly-hosted announcement gates on BOTH first-time access

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -954,6 +954,9 @@ async fn cache_contract_locally(
         {
             removed_contracts.push(*evicted_key);
         }
+        // Reclaim on-disk storage for the evicted contract so the hosting
+        // budget is a real disk bound (subscription-gated inside the helper).
+        crate::operations::reclaim_evicted_contract(op_manager, *evicted_key);
     }
 
     // (4) Newly-hosted announcement gates on BOTH first-time access

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1243,7 +1243,7 @@ async fn relay_put_store_locally(
         crate::operations::announce_contract_hosted(op_manager, &key).await;
 
         let mut removed_contracts = Vec::new();
-        for evicted_key in evicted {
+        for (evicted_key, expected_generation) in evicted {
             if op_manager
                 .interest_manager
                 .unregister_local_hosting(&evicted_key)
@@ -1251,8 +1251,13 @@ async fn relay_put_store_locally(
                 removed_contracts.push(evicted_key);
             }
             // Reclaim on-disk storage for the evicted contract so the hosting
-            // budget is a real disk bound (subscription-gated inside the helper).
-            crate::operations::reclaim_evicted_contract(op_manager, evicted_key);
+            // budget is a real disk bound (subscription- and generation-gated
+            // inside the helper).
+            crate::operations::reclaim_evicted_contract(
+                op_manager,
+                evicted_key,
+                expected_generation,
+            );
         }
 
         let became_interested = op_manager.interest_manager.register_local_hosting(&key);

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1250,6 +1250,9 @@ async fn relay_put_store_locally(
             {
                 removed_contracts.push(evicted_key);
             }
+            // Reclaim on-disk storage for the evicted contract so the hosting
+            // budget is a real disk bound (subscription-gated inside the helper).
+            crate::operations::reclaim_evicted_contract(op_manager, evicted_key);
         }
 
         let became_interested = op_manager.interest_manager.register_local_hosting(&key);

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -526,7 +526,8 @@ pub(crate) async fn update_contract(
                             | ContractHandlerEvent::GetSummaryResponse { .. }
                             | ContractHandlerEvent::GetDeltaQuery { .. }
                             | ContractHandlerEvent::GetDeltaResponse { .. }
-                            | ContractHandlerEvent::ClientDisconnect { .. } => None,
+                            | ContractHandlerEvent::ClientDisconnect { .. }
+                            | ContractHandlerEvent::EvictContract { .. } => None,
                         });
 
                     match fetched_state {

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1178,6 +1178,14 @@ impl Ring {
                 "GET subscription cache sweep found expired entries"
             );
 
+            // Reclaim on-disk storage for the expired contracts so the hosting
+            // budget is a real disk bound. The sweep task only holds an
+            // `Arc<Ring>`; reach the `OpManager` the same way
+            // `recover_orphaned_subscriptions` does, via the weak back-reference.
+            // `reclaim_evicted_contract` re-checks the subscription gate per
+            // key before emitting the eviction event.
+            let op_manager = ring.upgrade_op_manager();
+
             // Clean up local subscription state for each expired contract.
             // Note: contracts with client subscriptions are protected from eviction
             // by the should_retain predicate in sweep_expired_hosting().
@@ -1187,6 +1195,9 @@ impl Ring {
                     %key,
                     "Cleaned up expired hosting subscription from local state"
                 );
+                if let Some(op_manager) = &op_manager {
+                    crate::operations::reclaim_evicted_contract(op_manager, key);
+                }
             }
         }
     }
@@ -1638,6 +1649,15 @@ impl Ring {
 
     pub fn has_downstream_subscribers(&self, contract: &ContractKey) -> bool {
         self.hosting_manager.has_downstream_subscribers(contract)
+    }
+
+    /// Whether something still depends on this node hosting `contract` (a live
+    /// local client subscription or a downstream peer subscriber).
+    ///
+    /// Used to gate hosting-cache eviction reclamation: a contract that is in
+    /// use must not have its on-disk state/code deleted.
+    pub(crate) fn contract_in_use(&self, contract: &ContractKey) -> bool {
+        self.hosting_manager.contract_in_use(contract)
     }
 
     pub fn expire_stale_downstream_subscribers(&self) -> Vec<(ContractKey, usize)> {

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1203,14 +1203,22 @@ impl Ring {
             // Clean up local subscription state for each expired contract.
             // Note: contracts with client subscriptions are protected from eviction
             // by the should_retain predicate in sweep_expired_hosting().
-            for key in expired {
+            // The `expected_generation` snapshot is captured atomically with
+            // the eviction decision in `HostingCache::record_access` /
+            // `sweep_expired`; it is re-checked at deletion time by
+            // `RuntimePool::remove_contract` to close the re-host race.
+            for (key, expected_generation) in expired {
                 ring.unsubscribe(&key);
                 tracing::info!(
                     %key,
                     "Cleaned up expired hosting subscription from local state"
                 );
                 if let Some(op_manager) = &op_manager {
-                    crate::operations::reclaim_evicted_contract(op_manager, key);
+                    crate::operations::reclaim_evicted_contract(
+                        op_manager,
+                        key,
+                        expected_generation,
+                    );
                 }
             }
         }
@@ -1665,13 +1673,36 @@ impl Ring {
         self.hosting_manager.has_downstream_subscribers(contract)
     }
 
-    /// Whether something still depends on this node hosting `contract` (a live
-    /// local client subscription or a downstream peer subscriber).
+    /// Whether something still depends on this node hosting `contract` — i.e.
+    /// it has a live local client subscription, a downstream peer subscriber,
+    /// or an active upstream network subscription.
     ///
     /// Used to gate hosting-cache eviction reclamation: a contract that is in
     /// use must not have its on-disk state/code deleted.
     pub(crate) fn contract_in_use(&self, contract: &ContractKey) -> bool {
         self.hosting_manager.contract_in_use(contract)
+    }
+
+    /// Atomically bump the state-write generation for `contract`.
+    ///
+    /// Called from the executor's state-write chokepoints
+    /// (`state_store.store` / `state_store.update`). Pairs with the
+    /// generation captured in `HostedContract.write_generation` at
+    /// eviction time to close the EvictContract re-host race — see
+    /// `HostingManager::state_generation` for full rationale.
+    pub(crate) fn bump_state_generation(&self, contract: &ContractKey) -> u64 {
+        self.hosting_manager.bump_state_generation(contract)
+    }
+
+    /// Read the current state-write generation for `contract` (0 if never written).
+    pub(crate) fn state_generation(&self, contract: &ContractKey) -> u64 {
+        self.hosting_manager.state_generation(contract)
+    }
+
+    /// Forget the state-write generation entry for `contract` after a
+    /// successful disk reclamation. Keeps the generation map bounded.
+    pub(crate) fn forget_state_generation(&self, contract: &ContractKey) {
+        self.hosting_manager.forget_state_generation(contract)
     }
 
     pub fn expire_stale_downstream_subscribers(&self) -> Vec<(ContractKey, usize)> {
@@ -1804,18 +1835,22 @@ impl Ring {
 
     /// Sweep for expired entries in the hosting cache.
     ///
-    /// Returns contracts evicted from this cache. Contracts with client
-    /// subscriptions are protected from eviction.
-    pub fn sweep_expired_hosting(&self) -> Vec<ContractKey> {
+    /// Returns `(ContractKey, write_generation)` pairs for contracts
+    /// evicted from this cache. Contracts with client subscriptions
+    /// (or downstream/network subscribers) are protected from eviction.
+    /// The generation snapshot is carried through `EvictContract` so the
+    /// deletion-time guard can detect a re-host race.
+    pub fn sweep_expired_hosting(&self) -> Vec<(ContractKey, u64)> {
         self.hosting_manager.sweep_expired_hosting()
     }
 
     // ==================== Legacy GET Auto-Subscription (delegating to hosting cache) ====================
     /// Sweep for expired entries (delegated to hosting cache).
     ///
-    /// Returns contracts evicted from the cache. Contracts with client
-    /// subscriptions are protected from eviction.
-    pub fn sweep_expired_get_subscriptions(&self) -> Vec<ContractKey> {
+    /// Returns `(ContractKey, write_generation)` pairs for contracts
+    /// evicted from the cache. Contracts with client subscriptions are
+    /// protected from eviction.
+    pub fn sweep_expired_get_subscriptions(&self) -> Vec<(ContractKey, u64)> {
         // Delegate to hosting cache
         self.sweep_expired_hosting()
     }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1173,14 +1173,17 @@ impl Ring {
             // Sweep expired entries from GET subscription cache
             let expired = ring.sweep_expired_get_subscriptions();
 
-            if expired.is_empty() {
-                continue;
+            // Do NOT early-continue when `expired` is empty: pending
+            // reclamation retries below must run every cycle, otherwise
+            // entries queued by the in-use / queue-full skip points stay
+            // leaked indefinitely whenever the cache is under budget
+            // (the common case). See Codex r10 P2.
+            if !expired.is_empty() {
+                tracing::debug!(
+                    expired_count = expired.len(),
+                    "GET subscription cache sweep found expired entries"
+                );
             }
-
-            tracing::debug!(
-                expired_count = expired.len(),
-                "GET subscription cache sweep found expired entries"
-            );
 
             // Reclaim on-disk storage for the expired contracts so the hosting
             // budget is a real disk bound. The sweep task only holds an

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -219,7 +219,7 @@ impl Ring {
             max_hops_to_live,
             router,
             connection_manager,
-            hosting_manager: hosting::HostingManager::new(),
+            hosting_manager: hosting::HostingManager::new(config.config.max_hosting_storage),
             live_tx_tracker: live_tx_tracker.clone(),
             event_register: Box::new(event_register),
             op_manager: RwLock::new(None),

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -47,11 +47,11 @@ mod connection_manager;
 pub(crate) use connection_manager::ConnectionManager;
 mod connection;
 mod hosting;
-pub use hosting::{AccessType, RecordAccessResult};
 /// Single source of truth for the default hosted-contract-state budget.
 /// `config::default_max_hosting_storage()` resolves to this so the
 /// operator-facing default and the in-code fallback can never drift.
 pub(crate) use hosting::DEFAULT_HOSTING_BUDGET_BYTES;
+pub use hosting::{AccessType, RecordAccessResult};
 pub mod interest;
 mod live_tx;
 mod location;

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1705,6 +1705,15 @@ impl Ring {
         self.hosting_manager.forget_state_generation(contract)
     }
 
+    /// Refresh the hosting-cache snapshot of `contract`'s state-write
+    /// generation to `new_gen`. Paired with `bump_state_generation` at
+    /// every state-write chokepoint — see
+    /// `HostingManager::refresh_cache_generation`.
+    pub(crate) fn refresh_cache_generation(&self, contract: &ContractKey, new_gen: u64) {
+        self.hosting_manager
+            .refresh_cache_generation(contract, new_gen)
+    }
+
     pub fn expire_stale_downstream_subscribers(&self) -> Vec<(ContractKey, usize)> {
         self.hosting_manager.expire_stale_downstream_subscribers()
     }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -48,6 +48,10 @@ pub(crate) use connection_manager::ConnectionManager;
 mod connection;
 mod hosting;
 pub use hosting::{AccessType, RecordAccessResult};
+/// Single source of truth for the default hosted-contract-state budget.
+/// `config::default_max_hosting_storage()` resolves to this so the
+/// operator-facing default and the in-code fallback can never drift.
+pub(crate) use hosting::DEFAULT_HOSTING_BUDGET_BYTES;
 pub mod interest;
 mod live_tx;
 mod location;
@@ -1185,6 +1189,16 @@ impl Ring {
             // `reclaim_evicted_contract` re-checks the subscription gate per
             // key before emitting the eviction event.
             let op_manager = ring.upgrade_op_manager();
+            if op_manager.is_none() {
+                // The weak back-reference is dropped only during node shutdown;
+                // surface the skipped reclamation so an unexpected `None` (and
+                // the resulting on-disk leak for this cycle) is observable.
+                tracing::debug!(
+                    expired_count = expired.len(),
+                    "OpManager unavailable during GET subscription sweep — \
+                     on-disk reclamation skipped for the expired contracts this cycle"
+                );
+            }
 
             // Clean up local subscription state for each expired contract.
             // Note: contracts with client subscriptions are protected from eviction

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1673,12 +1673,14 @@ impl Ring {
         self.hosting_manager.has_downstream_subscribers(contract)
     }
 
-    /// Whether something still depends on this node hosting `contract` — i.e.
-    /// it has a live local client subscription, a downstream peer subscriber,
-    /// or an active upstream network subscription.
+    /// Whether something still depends on this node hosting `contract` — a
+    /// live local client subscription or a downstream peer subscriber.
     ///
     /// Used to gate hosting-cache eviction reclamation: a contract that is in
-    /// use must not have its on-disk state/code deleted.
+    /// use must not have its on-disk state/code deleted. See
+    /// `HostingManager::contract_in_use` for why an active upstream network
+    /// subscription alone does NOT make the contract in-use (the renewal
+    /// machinery would refresh the lease unboundedly).
     pub(crate) fn contract_in_use(&self, contract: &ContractKey) -> bool {
         self.hosting_manager.contract_in_use(contract)
     }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1221,6 +1221,34 @@ impl Ring {
                     );
                 }
             }
+
+            // Retry pending reclamations queued by the two skip points
+            // (fair-queue rejection of `EvictContract` and the
+            // `contract_in_use` skip in `RuntimePool::remove_contract`).
+            // The snapshot iterates without holding the DashMap shard
+            // guards. Each retry routes through
+            // `reclaim_evicted_contract`, which re-checks
+            // `contract_in_use` — entries that are still in use stay in
+            // the queue (no event emitted) and will be retried next
+            // cycle. Successful reclamations clear their pending entry
+            // in `RuntimePool::remove_contract`.
+            if let Some(op_manager) = &op_manager {
+                let pending = ring.pending_reclamation_snapshot();
+                if !pending.is_empty() {
+                    tracing::debug!(
+                        pending_count = pending.len(),
+                        "Retrying pending reclamations from previous skipped \
+                         `EvictContract` events"
+                    );
+                    for (key, expected_generation) in pending {
+                        crate::operations::reclaim_evicted_contract(
+                            op_manager,
+                            key,
+                            expected_generation,
+                        );
+                    }
+                }
+            }
         }
     }
 
@@ -1714,6 +1742,31 @@ impl Ring {
     pub(crate) fn refresh_cache_generation(&self, contract: &ContractKey, new_gen: u64) {
         self.hosting_manager
             .refresh_cache_generation(contract, new_gen)
+    }
+
+    /// Add `contract` to the pending-reclamation retry queue with the
+    /// captured `expected_generation`. Called from the two skip points
+    /// that drop an `EvictContract` event before it can complete (fair
+    /// queue rejection, `contract_in_use` skip in `RuntimePool::remove_contract`).
+    /// See `HostingManager::pending_reclamation_add` for the queue's
+    /// invariants and how the periodic sweep retries entries.
+    pub(crate) fn pending_reclamation_add(&self, contract: ContractKey, expected_generation: u64) {
+        self.hosting_manager
+            .pending_reclamation_add(contract, expected_generation)
+    }
+
+    /// Remove `contract` from the pending-reclamation retry queue after
+    /// a successful disk reclamation. See
+    /// `HostingManager::pending_reclamation_remove`.
+    pub(crate) fn pending_reclamation_remove(&self, contract: &ContractKey) {
+        self.hosting_manager.pending_reclamation_remove(contract)
+    }
+
+    /// Snapshot the pending-reclamation queue for the periodic sweep
+    /// to iterate without holding any DashMap shard guard. See
+    /// `HostingManager::pending_reclamation_snapshot`.
+    pub(crate) fn pending_reclamation_snapshot(&self) -> Vec<(ContractKey, u64)> {
+        self.hosting_manager.pending_reclamation_snapshot()
     }
 
     pub fn expire_stale_downstream_subscribers(&self) -> Vec<(ContractKey, usize)> {

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -194,14 +194,14 @@ pub(crate) struct HostingManager {
 }
 
 impl HostingManager {
-    pub fn new() -> Self {
+    pub fn new(budget_bytes: u64) -> Self {
         let backoff_config =
             ExponentialBackoff::new(INITIAL_SUBSCRIPTION_BACKOFF, MAX_SUBSCRIPTION_BACKOFF);
         Self {
             active_subscriptions: DashMap::new(),
             client_subscriptions: DashMap::new(),
             hosting_cache: RwLock::new(HostingCache::new(
-                DEFAULT_HOSTING_BUDGET_BYTES,
+                budget_bytes,
                 DEFAULT_MIN_TTL,
                 InstantTimeSrc::new(),
             )),
@@ -732,6 +732,12 @@ impl HostingManager {
     /// Get the number of contracts in the hosting cache.
     pub fn hosting_contracts_count(&self) -> usize {
         self.hosting_cache.read().len()
+    }
+
+    /// Get the configured byte-budget of the hosting cache.
+    #[cfg(test)]
+    pub(crate) fn hosting_budget_bytes(&self) -> u64 {
+        self.hosting_cache.read().budget_bytes()
     }
 
     /// Check if we should continue hosting a contract.
@@ -1419,7 +1425,7 @@ impl HostingManager {
 
 impl Default for HostingManager {
     fn default() -> Self {
-        Self::new()
+        Self::new(DEFAULT_HOSTING_BUDGET_BYTES)
     }
 }
 
@@ -1441,7 +1447,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_subscribe_creates_new_subscription() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
 
         let result = manager.subscribe(contract);
@@ -1451,8 +1457,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_new_uses_configured_budget() {
+        let custom_budget = 256 * 1024 * 1024_u64;
+        let manager = HostingManager::new(custom_budget);
+        assert_eq!(
+            manager.hosting_budget_bytes(),
+            custom_budget,
+            "HostingManager::new should pass the budget through to the cache"
+        );
+
+        // The default constructor still uses the in-code default.
+        let default_manager = HostingManager::default();
+        assert_eq!(
+            default_manager.hosting_budget_bytes(),
+            DEFAULT_HOSTING_BUDGET_BYTES
+        );
+    }
+
+    #[tokio::test]
     async fn test_subscribe_renews_existing() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
 
         let first = manager.subscribe(contract);
@@ -1465,7 +1489,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_unsubscribe_removes_subscription() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
 
         manager.subscribe(contract);
@@ -1477,7 +1501,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_renew_subscription() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
 
         // Renew non-existent subscription fails
@@ -1490,7 +1514,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_subscribed_contracts() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let c1 = make_contract_key(1);
         let c2 = make_contract_key(2);
         let c3 = make_contract_key(3);
@@ -1513,7 +1537,7 @@ mod tests {
     /// after the SUBSCRIBE migration (PR #3806 → #3981).
     #[tokio::test]
     async fn dashboard_snapshot_reflects_active_subscriptions() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let c1 = make_contract_key(1);
         let c2 = make_contract_key(2);
 
@@ -1559,7 +1583,7 @@ mod tests {
     /// entries) must break by contract-key bytes.
     #[tokio::test]
     async fn dashboard_snapshot_sort_is_deterministic_on_ties() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         // Three contracts with distinct, ordered key-byte prefixes
         // (`make_contract_key(seed)` writes `[seed; 32]` into the
         // ContractInstanceId, so seeds 0x10/0x40/0xF0 sort low/mid/high).
@@ -1605,7 +1629,7 @@ mod tests {
     /// to ~0 every renewal interval (2 min) for every River user.
     #[tokio::test]
     async fn dashboard_snapshot_preserves_subscribed_since_across_renewals() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let c = make_contract_key(1);
 
         let read_lease = || {
@@ -1633,7 +1657,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_active_subscription_count() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
 
         assert_eq!(manager.active_subscription_count(), 0);
 
@@ -1647,7 +1671,7 @@ mod tests {
 
     #[test]
     fn test_client_subscription_basic() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let instance_id = ContractInstanceId::new([1; 32]);
         let client_id = crate::client_events::ClientId::next();
 
@@ -1662,7 +1686,7 @@ mod tests {
 
     #[test]
     fn test_client_subscription_multiple_clients() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let instance_id = ContractInstanceId::new([1; 32]);
         let client1 = crate::client_events::ClientId::next();
         let client2 = crate::client_events::ClientId::next();
@@ -1682,7 +1706,7 @@ mod tests {
 
     #[test]
     fn test_hosting_cache_basic() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let key = make_contract_key(1);
 
         assert!(!manager.is_hosting_contract(&key));
@@ -1696,7 +1720,7 @@ mod tests {
 
     #[test]
     fn test_subscription_backoff() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
 
         // Initially can request
@@ -1717,7 +1741,7 @@ mod tests {
 
     #[test]
     fn test_should_host() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
 
         // Not hosting initially
@@ -1732,7 +1756,7 @@ mod tests {
     /// renewal list. Including them caused subscription storms (#3763 incident).
     #[test]
     fn test_hosted_contract_not_in_renewal_after_restart() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(42);
         manager.record_contract_access(contract, 1000, AccessType::Get);
         assert!(manager.is_hosting_contract(&contract));
@@ -1746,7 +1770,7 @@ mod tests {
     /// a contract is only in the hosting LRU cache (no active subscription).
     #[test]
     fn test_is_receiving_updates_excludes_hosting_cache_only() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
 
         // Not receiving updates initially
@@ -1768,7 +1792,7 @@ mod tests {
     /// Regression test for #3340: is_receiving_updates with client subscriptions.
     #[test]
     fn test_is_receiving_updates_with_client_subscription() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
         let client_id = crate::client_events::ClientId::next();
 
@@ -1780,7 +1804,7 @@ mod tests {
 
     #[test]
     fn test_contracts_needing_renewal_excludes_hosted_only() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
 
         // Add to hosting cache (simulating GET operation)
@@ -1822,7 +1846,7 @@ mod tests {
     /// is that such a relay does not get recruited into the renewal cycle.
     #[test]
     fn test_relay_downstream_only_not_in_renewal() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(77);
         let downstream = make_peer_key(42);
 
@@ -1869,7 +1893,7 @@ mod tests {
     #[ignore]
     #[test]
     fn test_hosted_contract_renewed_despite_no_interest() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(42);
         manager.record_contract_access(contract, 1000, AccessType::Get);
         assert!(manager.is_hosting_contract(&contract));
@@ -1887,7 +1911,7 @@ mod tests {
     #[ignore]
     #[test]
     fn test_startup_revalidation_includes_hosted_contracts() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
         manager.record_contract_access(contract, 1000, AccessType::Get);
         // Before #3546: during startup window, this would be in renewal list
@@ -1903,7 +1927,7 @@ mod tests {
     #[ignore]
     #[test]
     fn test_startup_revalidation_skips_already_subscribed() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
         manager.record_contract_access(contract, 1000, AccessType::Get);
         manager.subscribe(contract);
@@ -1918,7 +1942,7 @@ mod tests {
     #[ignore]
     #[test]
     fn test_startup_revalidation_window_expires() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
         manager.record_contract_access(contract, 1000, AccessType::Get);
         let needs_renewal = manager.contracts_needing_renewal();
@@ -1932,7 +1956,7 @@ mod tests {
     #[ignore]
     #[test]
     fn test_startup_revalidation_multiple_contracts() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract_a = make_contract_key(1);
         let contract_b = make_contract_key(2);
         let contract_c = make_contract_key(3);
@@ -1965,7 +1989,7 @@ mod tests {
     /// prevents subscription storms by processing at most 10 per cycle.
     #[test]
     fn test_hosted_contracts_not_renewed_at_scale() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
 
         // Simulate 200 relay-cached contracts loaded from disk
         for i in 0..200u8 {
@@ -2051,7 +2075,7 @@ mod tests {
     /// tracked (simulates "contract not found" early return in the Unsubscribe handler).
     #[test]
     fn test_should_unsubscribe_upstream_unknown_contract() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let unknown_contract = make_contract_key(99);
 
         // Contract never added to any tracking structure
@@ -2065,7 +2089,7 @@ mod tests {
 
     #[test]
     fn test_should_unsubscribe_upstream() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
         let peer = make_peer_key(10);
         let client_id = crate::client_events::ClientId::next();
@@ -2098,7 +2122,7 @@ mod tests {
     /// should propagate the unsubscribe to A.
     #[test]
     fn test_chain_propagation_single_downstream() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(10);
         let downstream_c = make_peer_key(30);
 
@@ -2120,7 +2144,7 @@ mod tests {
     /// B should NOT propagate upstream because A remains as a downstream subscriber.
     #[test]
     fn test_no_propagation_with_remaining_downstream() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(10);
         let downstream_a = make_peer_key(10);
         let downstream_c = make_peer_key(30);
@@ -2144,7 +2168,7 @@ mod tests {
     /// Node should NOT propagate upstream because a local WebSocket client is subscribed.
     #[test]
     fn test_no_propagation_with_local_client() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(10);
         let downstream_peer = make_peer_key(10);
         let client_id = crate::client_events::ClientId::next();
@@ -2169,7 +2193,7 @@ mod tests {
     /// is correct.
     #[test]
     fn test_client_disconnect_triggers_unsubscribe_decision() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(10);
         let client_id = crate::client_events::ClientId::next();
 
@@ -2200,7 +2224,7 @@ mod tests {
     /// no remaining interest should trigger the unsubscribe decision.
     #[test]
     fn test_client_disconnect_partial_unsubscribe() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract_a = make_contract_key(10);
         let contract_b = make_contract_key(20);
         let client_id = crate::client_events::ClientId::next();
@@ -2236,7 +2260,7 @@ mod tests {
     /// Uses manual timestamp manipulation via DashMap to simulate time passing.
     #[test]
     fn test_expire_downstream_triggers_unsubscribe_decision() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(10);
         let peer = make_peer_key(10);
 
@@ -2276,7 +2300,7 @@ mod tests {
     /// Should NOT trigger unsubscribe.
     #[test]
     fn test_partial_downstream_expiry_no_unsubscribe() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(10);
         let stale_peer = make_peer_key(10);
         let fresh_peer = make_peer_key(20);
@@ -2319,7 +2343,7 @@ mod tests {
     /// triggers upstream unsubscribe propagation.
     #[test]
     fn test_unsubscribe_handler_contract_found_peer_resolved() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let interest = make_interest_manager();
         let contract = make_contract_key(1);
         let peer = make_peer_key(10);
@@ -2338,7 +2362,7 @@ mod tests {
     /// Removing an unknown peer is a noop; existing entries remain intact.
     #[test]
     fn test_unsubscribe_handler_unknown_peer_is_noop() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(2);
         let known_peer = make_peer_key(20);
         let unknown_peer = make_peer_key(99);
@@ -2353,7 +2377,7 @@ mod tests {
     /// Removing from an untracked contract is a noop; other contracts unaffected.
     #[test]
     fn test_unsubscribe_handler_unknown_contract_is_noop() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let known_contract = make_contract_key(3);
         let unknown_contract = make_contract_key(99);
         let peer = make_peer_key(30);
@@ -2369,7 +2393,7 @@ mod tests {
     /// independent of `InterestManager` state.
     #[test]
     fn test_unsubscribe_dual_tracking_authority() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let interest = make_interest_manager();
         let contract = make_contract_key(4);
         let peer = make_peer_key(40);
@@ -2469,7 +2493,7 @@ mod tests {
 
     #[test]
     fn test_downstream_subscriber_limit_enforced() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(50);
 
         // Use a small limit for testing to avoid issues with peer key generation.
@@ -2525,7 +2549,7 @@ mod tests {
 
     #[test]
     fn test_downstream_subscriber_existing_peer_can_renew_at_limit() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(51);
 
         // Fill up to the limit
@@ -2557,7 +2581,7 @@ mod tests {
     /// count of expired peers so the interest manager can be decremented.
     #[test]
     fn test_expire_returns_expired_count_for_interest_sync() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let interest = make_interest_manager();
         let contract = make_contract_key(90);
         let peer_a = make_peer_key(90);
@@ -2606,7 +2630,7 @@ mod tests {
     /// renewal, but relay-cached contracts should NOT.
     #[test]
     fn test_local_client_access_enables_renewal() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let local_contract = make_contract_key(1);
         let relay_contract = make_contract_key(2);
 
@@ -2633,7 +2657,7 @@ mod tests {
     /// Regression test for #3763/#3765 (the subscription storm incident).
     #[test]
     fn test_relay_cached_contracts_not_renewed_at_scale() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
 
         // Simulate 200 relay-cached contracts (no local_client_access)
         for i in 0..200u8 {
@@ -2662,7 +2686,7 @@ mod tests {
     /// double-counted in the renewal list.
     #[test]
     fn test_local_client_access_with_active_subscription_no_duplicate() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
 
         manager.record_contract_access(contract, 1000, AccessType::Get);
@@ -2681,7 +2705,7 @@ mod tests {
     /// Marking and querying unknown contracts should be no-ops (no panic).
     #[test]
     fn test_local_client_access_unknown_contract() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
 
         assert!(!manager.has_local_client_access(&contract));
@@ -2693,7 +2717,7 @@ mod tests {
     /// persist even after the contract's access type changes.
     #[test]
     fn test_local_client_access_sticky_across_access_type_changes() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
 
         manager.record_contract_access(contract, 1000, AccessType::Get);
@@ -2712,7 +2736,7 @@ mod tests {
     /// should appear in contracts_needing_renewal().
     #[test]
     fn test_local_client_access_survives_restart_via_load() {
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
 
         // Simulate loading from disk with local_client_access=true
         {
@@ -2750,7 +2774,7 @@ mod tests {
     #[test]
     fn test_eviction_clears_local_client_access() {
         // Small budget to force eviction
-        let manager = HostingManager::new();
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         // Override with a tiny cache
         {
             let mut cache = manager.hosting_cache.write();

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -649,20 +649,30 @@ impl HostingManager {
             .is_some_and(|peers| !peers.is_empty())
     }
 
-    /// Whether something still depends on this node hosting `contract` — i.e.
-    /// it has a live local client subscription, a downstream peer subscriber,
-    /// or an active upstream network subscription. Used to gate hosting-cache
-    /// eviction reclamation: a contract that is in use must NOT have its
-    /// on-disk state/code deleted.
+    /// Whether something still depends on this node hosting `contract` — a
+    /// live local client subscription or a downstream peer subscriber. Used
+    /// to gate hosting-cache eviction reclamation: a contract that is in
+    /// use must NOT have its on-disk state/code deleted.
     ///
-    /// The network-subscription term (`is_subscribed`) matters because a node
-    /// can hold an active upstream subscription for a contract with no local
-    /// client and no downstream subscriber — it still expects UPDATEs, so its
-    /// disk state must be retained.
+    /// **Why `is_subscribed` (this node's own upstream subscription) is NOT
+    /// included.** It would seem natural to also exempt contracts the node
+    /// is actively subscribed to. The problem is `contracts_needing_renewal`
+    /// section 1 renews ANY soon-to-expire active subscription
+    /// unconditionally, with no gate on local interest. So an
+    /// `is_subscribed`-only exemption is effectively unbounded — the renewal
+    /// machinery would keep extending the lease forever, blocking
+    /// reclamation indefinitely. That would violate the cleanup-exemption
+    /// rule in `AGENTS.md` (exemptions must be time-bounded). Local-client
+    /// subscriptions and downstream subscribers ARE both time-bounded:
+    /// client subscriptions expire on disconnect; downstream subscribers
+    /// expire via `expire_stale_downstream_subscribers` after
+    /// `SUBSCRIPTION_LEASE_DURATION` without renewal.
+    ///
+    /// The narrow case "subscribed but no local interest" should be handled
+    /// by tearing down the orphaned upstream subscription, not by carrying
+    /// an unbounded GC exemption here.
     pub fn contract_in_use(&self, contract: &ContractKey) -> bool {
-        self.has_client_subscriptions(contract.id())
-            || self.has_downstream_subscribers(contract)
-            || self.is_subscribed(contract)
+        self.has_client_subscriptions(contract.id()) || self.has_downstream_subscribers(contract)
     }
 
     /// Remove downstream subscribers whose leases have expired.
@@ -2554,38 +2564,37 @@ mod tests {
         );
     }
 
-    /// A contract with ONLY an active upstream network subscription (no local
-    /// client, no downstream subscriber) IS in use — this node still expects
-    /// UPDATEs, so its on-disk state must not be reclaimed.
+    /// A contract with ONLY an active upstream network subscription (no
+    /// local client, no downstream subscriber) is NOT in use for
+    /// reclamation purposes. Documented in `contract_in_use`'s rustdoc:
+    /// `contracts_needing_renewal` renews active subscriptions
+    /// unconditionally, so including `is_subscribed` here would be an
+    /// effectively unbounded GC exemption (AGENTS.md cleanup-exemption
+    /// rule). Local-client subscriptions and downstream-peer subscribers
+    /// are both time-bounded and remain in the predicate.
     #[test]
-    fn test_contract_in_use_true_with_network_subscription_only() {
+    fn test_contract_in_use_excludes_network_subscription_only() {
         let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(4);
 
-        // No client subscription, no downstream subscriber yet.
         assert!(!manager.has_client_subscriptions(contract.id()));
         assert!(!manager.has_downstream_subscribers(&contract));
-        assert!(
-            !manager.contract_in_use(&contract),
-            "with no subscriptions of any kind the contract is not in use"
-        );
+        assert!(!manager.contract_in_use(&contract));
 
-        // Establish an active upstream network subscription only.
+        // Establishing an upstream network subscription alone must NOT
+        // make the contract appear in-use, because the renewal machinery
+        // would keep extending the lease forever.
         manager.subscribe(contract);
         assert!(manager.is_subscribed(&contract));
         assert!(
-            manager.contract_in_use(&contract),
-            "a contract with an active network subscription must be in use \
-             even with no local client or downstream subscriber"
+            !manager.contract_in_use(&contract),
+            "an active upstream network subscription alone must NOT block \
+             reclamation (the renewal machinery would keep it alive \
+             unboundedly — see contract_in_use rustdoc)"
         );
 
-        // Once the network subscription is dropped, it becomes reclaimable.
         manager.unsubscribe(&contract);
-        assert!(
-            !manager.contract_in_use(&contract),
-            "contract must become reclaimable once its network subscription \
-             is removed"
-        );
+        assert!(!manager.contract_in_use(&contract));
     }
 
     /// Generation flow through `HostingManager`: bumping the state
@@ -2775,9 +2784,12 @@ mod tests {
         );
     }
 
-    /// `record_contract_access` must not evict an in-use (subscribed)
-    /// contract when the cache is over budget; once the subscription is
-    /// removed the contract becomes evictable.
+    /// `record_contract_access` must not evict an in-use contract when the
+    /// cache is over budget; once the in-use signal is removed the contract
+    /// becomes evictable. The in-use signal here is a local client
+    /// subscription — the time-bounded form `contract_in_use` actually
+    /// checks (see its rustdoc for why an upstream network subscription
+    /// alone is excluded).
     #[test]
     fn test_record_contract_access_skips_in_use_contract() {
         let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
@@ -2796,8 +2808,9 @@ mod tests {
         let filler = make_contract_key(2);
         let trigger = make_contract_key(3);
 
-        // `in_use` is the oldest LRU entry but has an active subscription.
-        manager.subscribe(in_use);
+        // `in_use` is the oldest LRU entry but has a local client subscription.
+        let client = crate::client_events::ClientId::next();
+        manager.add_client_subscription(in_use.id(), client);
         assert!(manager.contract_in_use(&in_use));
 
         manager.record_contract_access(in_use, 100, AccessType::Get);
@@ -2810,14 +2823,14 @@ mod tests {
         assert_eq!(
             result.evicted,
             vec![(filler, 0)],
-            "in-use subscribed contract must be skipped; the unprotected \
-             contract must be evicted instead"
+            "in-use (client-subscribed) contract must be skipped; the \
+             unprotected contract must be evicted instead"
         );
         assert!(manager.is_hosting_contract(&in_use));
         assert!(!manager.is_hosting_contract(&filler));
 
-        // Drop the subscription: `in_use` is now evictable.
-        manager.unsubscribe(&in_use);
+        // Drop the client subscription: `in_use` is now evictable.
+        manager.remove_client_subscription(in_use.id(), client);
         assert!(!manager.contract_in_use(&in_use));
 
         let result = manager.record_contract_access(filler, 100, AccessType::Get);

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -574,6 +574,14 @@ impl HostingManager {
             .is_some_and(|peers| !peers.is_empty())
     }
 
+    /// Whether something still depends on this node hosting `contract` — i.e.
+    /// it has a live local client subscription or a downstream peer
+    /// subscriber. Used to gate hosting-cache eviction reclamation: a
+    /// contract that is in use must NOT have its on-disk state/code deleted.
+    pub fn contract_in_use(&self, contract: &ContractKey) -> bool {
+        self.has_client_subscriptions(contract.id()) || self.has_downstream_subscribers(contract)
+    }
+
     /// Remove downstream subscribers whose leases have expired.
     /// Returns each affected contract paired with the number of expired peers.
     pub fn expire_stale_downstream_subscribers(&self) -> Vec<(ContractKey, usize)> {
@@ -2372,6 +2380,68 @@ mod tests {
         assert!(!manager.remove_downstream_subscriber(&contract, &unknown_peer));
         assert!(manager.has_downstream_subscribers(&contract));
         assert!(!manager.should_unsubscribe_upstream(&contract));
+    }
+
+    // ----------------------------------------------------------------------
+    // contract_in_use — the eviction-reclamation gate.
+    //
+    // `operations::reclaim_evicted_contract` MUST NOT emit an EvictContract
+    // event (which would delete the contract's state/code from disk) for a
+    // contract that is still in use. `contract_in_use` is that gate.
+    // ----------------------------------------------------------------------
+
+    /// A freshly-evicted contract with no client or downstream subscribers is
+    /// NOT in use — reclamation may proceed.
+    #[test]
+    fn test_contract_in_use_false_when_no_subscribers() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let contract = make_contract_key(1);
+        assert!(
+            !manager.contract_in_use(&contract),
+            "a contract with no subscribers must not be considered in use"
+        );
+    }
+
+    /// A contract with a live client subscription IS in use — the gate must
+    /// keep its on-disk storage.
+    #[test]
+    fn test_contract_in_use_true_with_client_subscription() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let contract = make_contract_key(2);
+        let client = crate::client_events::ClientId::next();
+
+        manager.add_client_subscription(contract.id(), client);
+        assert!(
+            manager.contract_in_use(&contract),
+            "a contract with a client subscription must be considered in use"
+        );
+
+        // After the last client unsubscribes, the contract is reclaimable.
+        manager.remove_client_subscription(contract.id(), client);
+        assert!(
+            !manager.contract_in_use(&contract),
+            "contract must become reclaimable once its last client unsubscribes"
+        );
+    }
+
+    /// A contract with a downstream peer subscriber IS in use.
+    #[test]
+    fn test_contract_in_use_true_with_downstream_subscriber() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let contract = make_contract_key(3);
+        let peer = make_peer_key(7);
+
+        manager.add_downstream_subscriber(&contract, peer.clone());
+        assert!(
+            manager.contract_in_use(&contract),
+            "a contract with a downstream subscriber must be considered in use"
+        );
+
+        manager.remove_downstream_subscriber(&contract, &peer);
+        assert!(
+            !manager.contract_in_use(&contract),
+            "contract must become reclaimable once its last downstream subscriber leaves"
+        );
     }
 
     /// Removing from an untracked contract is a noop; other contracts unaffected.

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -195,6 +195,24 @@ pub(crate) struct HostingManager {
     storage: RwLock<Option<crate::contract::storages::Storage>>,
     #[cfg(all(feature = "sqlite", not(feature = "redb")))]
     storage: RwLock<Option<crate::contract::storages::Storage>>,
+
+    /// Monotonic per-contract state-write generation counter.
+    ///
+    /// Bumped at every persistent state write in the executor
+    /// (`state_store.store` / `state_store.update`). Captured atomically
+    /// when an `EvictContract` is enqueued (`HostedContract.write_generation`,
+    /// recorded under the hosting-cache write lock) and re-checked at
+    /// deletion time in `RuntimePool::remove_contract`. If the captured
+    /// generation no longer matches the current value, a state write
+    /// occurred between eviction and deletion (e.g. a PUT/UPDATE
+    /// re-hosted the contract) and the disk reclamation must be skipped
+    /// — the freshly-PUT state would otherwise be deleted.
+    ///
+    /// See `RuntimePool::remove_contract` and `EvictContract` for the
+    /// race this token closes (the driver-side `host_contract` re-mark
+    /// of a freshly-PUT contract runs after `PutQuery.await` returns,
+    /// so the existing `is_hosting_contract` check is not sufficient).
+    state_generation: DashMap<ContractKey, u64>,
 }
 
 impl HostingManager {
@@ -217,7 +235,46 @@ impl HostingManager {
                 MAX_SUBSCRIPTION_BACKOFF_ENTRIES,
             )),
             storage: RwLock::new(None),
+            state_generation: DashMap::new(),
         }
+    }
+
+    // =========================================================================
+    // State-Write Generation Token
+    // =========================================================================
+
+    /// Atomically increment the state-write generation for `key` and return
+    /// the new value. Called by the executor after every successful state
+    /// write (`state_store.store` / `state_store.update`) — see the chokepoint
+    /// comment in `Executor::commit_state_update` and the per-call-site
+    /// callouts in `contract/executor/runtime.rs`.
+    pub(crate) fn bump_state_generation(&self, key: &ContractKey) -> u64 {
+        use dashmap::mapref::entry::Entry;
+        match self.state_generation.entry(*key) {
+            Entry::Occupied(mut e) => {
+                let next = e.get().saturating_add(1);
+                *e.get_mut() = next;
+                next
+            }
+            Entry::Vacant(e) => {
+                e.insert(1);
+                1
+            }
+        }
+    }
+
+    /// Read the current state-write generation for `key` (0 if never written).
+    pub(crate) fn state_generation(&self, key: &ContractKey) -> u64 {
+        self.state_generation
+            .get(key)
+            .map(|v| *v.value())
+            .unwrap_or(0)
+    }
+
+    /// Remove the generation entry for `key`. Called after a successful disk
+    /// reclamation so the map does not grow unbounded.
+    pub(crate) fn forget_state_generation(&self, key: &ContractKey) {
+        self.state_generation.remove(key);
     }
 
     /// Set the storage reference for persisting hosting metadata.
@@ -649,7 +706,9 @@ impl HostingManager {
     ///
     /// Returns a `RecordAccessResult` containing:
     /// - `is_new`: Whether this contract was newly added (vs. refreshed existing)
-    /// - `evicted`: Contracts that were evicted to make room
+    /// - `evicted`: `(ContractKey, write_generation)` pairs for contracts
+    ///   evicted to make room — the generation snapshot is carried through
+    ///   `EvictContract` and re-checked at deletion time.
     ///
     /// Automatically persists hosting metadata for the accessed contract and
     /// removes persisted metadata for evicted contracts.
@@ -664,10 +723,20 @@ impl HostingManager {
         // `hosting_cache` — so calling it from inside the `hosting_cache`
         // write guard does not re-enter that lock. `sweep_expired_hosting`
         // uses this same pattern.
+        //
+        // Read the current state-write generation BEFORE taking the
+        // hosting-cache write lock to avoid nested lock order against the
+        // `state_generation` DashMap shards. The generation is monotonic so
+        // a value read here is a valid lower bound; if a write races and
+        // bumps it after this read, the cached entry will simply be
+        // refreshed by the subsequent `record_contract_access` from that
+        // write path.
+        let current_generation = self.state_generation(&key);
         let result = self.hosting_cache.write().record_access(
             key,
             size_bytes,
             access_type,
+            current_generation,
             |k: &ContractKey| self.contract_in_use(k),
         );
 
@@ -713,7 +782,7 @@ impl HostingManager {
             }
 
             // Clean up persisted metadata for evicted contracts
-            for evicted_key in &result.evicted {
+            for (evicted_key, _generation) in &result.evicted {
                 #[cfg(feature = "redb")]
                 {
                     if let Err(e) = storage.remove_hosting_metadata(evicted_key) {
@@ -857,7 +926,12 @@ impl HostingManager {
     /// removed by `expire_stale_downstream_subscribers()` (called periodically)
     /// after `SUBSCRIPTION_LEASE_DURATION` without renewal.
     /// Automatically removes persisted metadata for expired contracts.
-    pub fn sweep_expired_hosting(&self) -> Vec<ContractKey> {
+    ///
+    /// Returns `(ContractKey, write_generation)` pairs — the generation
+    /// captured atomically under the hosting-cache write lock travels with
+    /// the `EvictContract` event so the deletion-time guard can detect a
+    /// re-host race.
+    pub fn sweep_expired_hosting(&self) -> Vec<(ContractKey, u64)> {
         let expired = self
             .hosting_cache
             .write()
@@ -866,7 +940,7 @@ impl HostingManager {
         // Clean up persisted metadata for expired contracts
         if !expired.is_empty() {
             if let Some(storage) = self.storage.read().as_ref() {
-                for expired_key in &expired {
+                for (expired_key, _generation) in &expired {
                     #[cfg(feature = "redb")]
                     {
                         if let Err(e) = storage.remove_hosting_metadata(expired_key) {
@@ -2500,6 +2574,103 @@ mod tests {
         );
     }
 
+    /// Generation flow through `HostingManager`: bumping the state
+    /// generation BEFORE `record_contract_access` makes the captured
+    /// generation match; subsequently bumping the generation simulates
+    /// a write that raced ahead of an `EvictContract`, and the captured
+    /// snapshot on the evicted entry is now stale (less than current).
+    ///
+    /// This is the load-bearing flow the `RuntimePool::remove_contract`
+    /// generation-mismatch guard relies on. PR #4212 review round C.
+    #[test]
+    fn test_record_contract_access_captures_then_diverges_from_current_generation() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        // Tiny cache, zero TTL: any insert past the first immediately
+        // evicts the previous entry.
+        {
+            let mut cache = manager.hosting_cache.write();
+            *cache = cache::HostingCache::new(
+                100,
+                std::time::Duration::ZERO,
+                crate::util::time_source::InstantTimeSrc::new(),
+            );
+        }
+
+        let key = make_contract_key(1);
+        let trigger = make_contract_key(2);
+
+        // Simulate three state writes before the hosting record.
+        assert_eq!(manager.bump_state_generation(&key), 1);
+        assert_eq!(manager.bump_state_generation(&key), 2);
+        assert_eq!(manager.bump_state_generation(&key), 3);
+        assert_eq!(manager.state_generation(&key), 3);
+
+        // Recording the access captures the current generation (3).
+        manager.record_contract_access(key, 100, AccessType::Get);
+
+        // Simulate a state write that races ahead of `EvictContract`.
+        let new_generation = manager.bump_state_generation(&key);
+        assert_eq!(new_generation, 4);
+
+        // Now evict the entry by inserting `trigger`; the captured
+        // generation on the evicted tuple must be the snapshot taken at
+        // `record_contract_access` time (3), NOT the current value (4).
+        // `RuntimePool::remove_contract` will compare this captured
+        // value (3) against the current `state_generation` (4) and
+        // SKIP the on-disk reclamation, closing the re-host race.
+        let result = manager.record_contract_access(trigger, 100, AccessType::Get);
+        assert_eq!(
+            result.evicted,
+            vec![(key, 3)],
+            "evicted tuple must carry the generation captured atomically \
+             when the entry was inserted, NOT the current generation"
+        );
+        assert_eq!(
+            manager.state_generation(&key),
+            4,
+            "current generation must reflect the most recent write"
+        );
+        assert_ne!(
+            result.evicted[0].1,
+            manager.state_generation(&key),
+            "the mismatch between captured and current is exactly what \
+             `RuntimePool::remove_contract` keys off to skip reclamation"
+        );
+    }
+
+    /// `bump_state_generation` is monotonic and starts at 1 on first
+    /// bump (`state_generation` returns 0 for never-seen contracts).
+    /// `forget_state_generation` returns the entry to the absent state
+    /// so the next bump restarts at 1.
+    #[test]
+    fn test_state_generation_lifecycle() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let key = make_contract_key(42);
+
+        assert_eq!(
+            manager.state_generation(&key),
+            0,
+            "never-seen contract reads as generation 0"
+        );
+
+        assert_eq!(manager.bump_state_generation(&key), 1);
+        assert_eq!(manager.bump_state_generation(&key), 2);
+        assert_eq!(manager.bump_state_generation(&key), 3);
+        assert_eq!(manager.state_generation(&key), 3);
+
+        manager.forget_state_generation(&key);
+        assert_eq!(
+            manager.state_generation(&key),
+            0,
+            "after forget, generation reads as 0 again"
+        );
+        assert_eq!(
+            manager.bump_state_generation(&key),
+            1,
+            "after forget, next bump restarts at 1"
+        );
+    }
+
     /// `record_contract_access` must not evict an in-use (subscribed)
     /// contract when the cache is over budget; once the subscription is
     /// removed the contract becomes evictable.
@@ -2534,7 +2705,7 @@ mod tests {
         let result = manager.record_contract_access(trigger, 100, AccessType::Get);
         assert_eq!(
             result.evicted,
-            vec![filler],
+            vec![(filler, 0)],
             "in-use subscribed contract must be skipped; the unprotected \
              contract must be evicted instead"
         );
@@ -2547,7 +2718,7 @@ mod tests {
 
         let result = manager.record_contract_access(filler, 100, AccessType::Get);
         assert!(
-            result.evicted.contains(&in_use),
+            result.evicted.iter().any(|(k, _)| *k == in_use),
             "once the subscription is removed the contract must become \
              evictable when the cache is over budget"
         );
@@ -2608,8 +2779,8 @@ mod tests {
         let protected = make_contract_key(1);
         let unprotected = make_contract_key(2);
 
-        cache.record_access(protected, 100, AccessType::Get, |_| false);
-        cache.record_access(unprotected, 100, AccessType::Get, |_| false);
+        cache.record_access(protected, 100, AccessType::Get, 0, |_| false);
+        cache.record_access(unprotected, 100, AccessType::Get, 0, |_| false);
         assert_eq!(cache.current_bytes(), 200); // over budget
 
         // Advance past TTL
@@ -2620,11 +2791,11 @@ mod tests {
         let evicted = cache.sweep_expired(|k| *k == protected);
 
         assert!(
-            !evicted.contains(&protected),
+            !evicted.iter().any(|(k, _)| *k == protected),
             "Contract with downstream subscribers must not be evicted"
         );
         assert!(
-            evicted.contains(&unprotected),
+            evicted.iter().any(|(k, _)| *k == unprotected),
             "Unprotected contract should be evicted when over budget + past TTL"
         );
         assert!(cache.contains(&protected));
@@ -2645,7 +2816,7 @@ mod tests {
         let mut cache = HostingCache::new(80, min_ttl, time.clone());
 
         let contract = make_contract_key(100);
-        cache.record_access(contract, 100, AccessType::Get, |_| false);
+        cache.record_access(contract, 100, AccessType::Get, 0, |_| false);
         assert!(cache.contains(&contract));
 
         // Under TTL: should not be evicted even though over budget
@@ -2661,7 +2832,7 @@ mod tests {
         // Now should be evicted (over budget + past TTL + no retain predicate)
         let evicted = cache.sweep_expired(|_| false);
         assert!(
-            evicted.contains(&contract),
+            evicted.iter().any(|(k, _)| *k == contract),
             "Contract past TTL with no subscribers should be evicted"
         );
         assert!(!cache.contains(&contract));

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -213,6 +213,39 @@ pub(crate) struct HostingManager {
     /// of a freshly-PUT contract runs after `PutQuery.await` returns,
     /// so the existing `is_hosting_contract` check is not sufficient).
     state_generation: DashMap<ContractKey, u64>,
+
+    /// Retry queue for contracts whose `EvictContract` could not be
+    /// completed at the original eviction time. Maps contract key →
+    /// `expected_generation` captured when the original `EvictContract`
+    /// event was emitted.
+    ///
+    /// Two skip points add entries here (both close narrow disk-leak
+    /// edge cases — see PR #4212 review round 7):
+    ///
+    /// 1. **Queue-full drop**: when the per-contract fair queue rejects
+    ///    an `EvictContract` event (queue-full), the hosting-cache
+    ///    entry is already gone so no later sweep would re-emit. The
+    ///    pending entry lets the periodic sweep retry.
+    /// 2. **In-use-then-subscriber-expires**: when
+    ///    `RuntimePool::remove_contract` skips reclamation because
+    ///    `contract_in_use` is true (a subscriber appeared between
+    ///    eviction and processing), the contract is gone from the
+    ///    hosting cache. When that subscriber later expires no cache
+    ///    entry remains to emit another eviction — the pending entry
+    ///    lets the periodic sweep retry once `contract_in_use`
+    ///    becomes false.
+    ///
+    /// Entries are removed by `pending_reclamation_remove` after a
+    /// successful disk reclamation. The map is monotonically draining
+    /// under steady load — bounded by the contracts the node has ever
+    /// stored. The pending entries are a *retry queue* for
+    /// reclamation, NOT a *block* on reclamation, so they do not
+    /// constitute an unbounded cleanup exemption (AGENTS.md cleanup
+    /// rule): the on-disk state stays until the retry succeeds.
+    ///
+    /// Behind an `Arc` so the periodic sweep snapshot can iterate
+    /// without re-entering the `HostingManager` borrow.
+    pending_reclamation: std::sync::Arc<DashMap<ContractKey, u64>>,
 }
 
 impl HostingManager {
@@ -236,6 +269,7 @@ impl HostingManager {
             )),
             storage: RwLock::new(None),
             state_generation: DashMap::new(),
+            pending_reclamation: std::sync::Arc::new(DashMap::new()),
         }
     }
 
@@ -295,6 +329,47 @@ impl HostingManager {
     /// Must be called after executor creation.
     pub fn set_storage(&self, storage: crate::contract::storages::Storage) {
         *self.storage.write() = Some(storage);
+    }
+
+    // =========================================================================
+    // Pending Reclamation Retry Queue
+    // =========================================================================
+
+    /// Add `key` to the pending-reclamation retry queue, recording the
+    /// `expected_generation` captured at the original `EvictContract`
+    /// emission time. If `key` is already present, replaces the entry —
+    /// the most recent attempt's generation is the relevant one for the
+    /// retry, and over-writing avoids unbounded growth from repeated
+    /// add calls on the same key.
+    ///
+    /// See `pending_reclamation` field docs for the two skip points
+    /// that feed this queue.
+    pub(crate) fn pending_reclamation_add(&self, key: ContractKey, expected_generation: u64) {
+        self.pending_reclamation.insert(key, expected_generation);
+    }
+
+    /// Remove `key` from the pending-reclamation queue. Called after a
+    /// successful disk reclamation so the queue drains under steady
+    /// load.
+    pub(crate) fn pending_reclamation_remove(&self, key: &ContractKey) {
+        self.pending_reclamation.remove(key);
+    }
+
+    /// Snapshot every pending reclamation entry as an owned vector so
+    /// the periodic sweep can iterate without holding any DashMap
+    /// shard guard.
+    pub(crate) fn pending_reclamation_snapshot(&self) -> Vec<(ContractKey, u64)> {
+        self.pending_reclamation
+            .iter()
+            .map(|entry| (*entry.key(), *entry.value()))
+            .collect()
+    }
+
+    /// Number of contracts currently in the pending-reclamation queue
+    /// (used in tests and diagnostics).
+    #[cfg(test)]
+    pub(crate) fn pending_reclamation_len(&self) -> usize {
+        self.pending_reclamation.len()
     }
 
     // =========================================================================
@@ -3281,5 +3356,133 @@ mod tests {
         // After local client re-accesses, flag is restored
         manager.mark_local_client_access(&contract_a);
         assert!(manager.has_local_client_access(&contract_a));
+    }
+
+    // =========================================================================
+    // Pending Reclamation Retry Queue (PR #4212 review round 7)
+    //
+    // The queue catches two narrow disk-leak edge cases — fair-queue
+    // rejection of `EvictContract`, and the `contract_in_use` skip in
+    // `RuntimePool::remove_contract` — where an `EvictContract` event
+    // is dropped before reclamation runs but the hosting-cache entry is
+    // already gone. The queue is drained by the periodic sweep, which
+    // re-emits `EvictContract` via `reclaim_evicted_contract`.
+    //
+    // End-to-end coverage of the periodic sweep retry path (which
+    // requires a wired `OpManager`) is intentionally deferred —
+    // constructing a `RuntimePool` is too heavy for a unit test (see
+    // the note on `remove_contract_tests` in
+    // `contract/executor/runtime.rs`). These tests cover the manager-
+    // level API the sweep relies on.
+    // =========================================================================
+
+    /// Basic API: add → snapshot reflects the entry; remove → snapshot
+    /// becomes empty. The snapshot returns owned tuples (no lock held
+    /// across iteration), which is the property the periodic sweep
+    /// relies on.
+    #[test]
+    fn test_pending_reclamation_add_remove_snapshot() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let key_a = make_contract_key(1);
+        let key_b = make_contract_key(2);
+
+        assert_eq!(manager.pending_reclamation_len(), 0);
+        assert!(manager.pending_reclamation_snapshot().is_empty());
+
+        manager.pending_reclamation_add(key_a, 7);
+        manager.pending_reclamation_add(key_b, 13);
+        assert_eq!(manager.pending_reclamation_len(), 2);
+
+        let mut snapshot = manager.pending_reclamation_snapshot();
+        snapshot.sort_by(|a, b| a.0.id().as_bytes().cmp(b.0.id().as_bytes()));
+        assert_eq!(snapshot, vec![(key_a, 7), (key_b, 13)]);
+
+        // Re-adding the same key replaces the generation. This matters
+        // for the queue-full skip point: if multiple eviction events
+        // for the same key race the queue, the most recent generation
+        // is the relevant one for the retry.
+        manager.pending_reclamation_add(key_a, 99);
+        let snapshot = manager.pending_reclamation_snapshot();
+        let gen_a = snapshot
+            .iter()
+            .find(|(k, _)| *k == key_a)
+            .map(|(_, g)| *g)
+            .expect("key_a still present");
+        assert_eq!(gen_a, 99, "re-add must replace the generation");
+
+        manager.pending_reclamation_remove(&key_a);
+        assert_eq!(manager.pending_reclamation_len(), 1);
+        let remaining = manager.pending_reclamation_snapshot();
+        assert_eq!(remaining, vec![(key_b, 13)]);
+
+        manager.pending_reclamation_remove(&key_b);
+        assert_eq!(manager.pending_reclamation_len(), 0);
+
+        // Removing a key that is not present is a no-op (matters because
+        // the success path in `RuntimePool::remove_contract` calls
+        // `pending_reclamation_remove` unconditionally — the queue must
+        // tolerate non-pending keys).
+        manager.pending_reclamation_remove(&key_a);
+        assert_eq!(manager.pending_reclamation_len(), 0);
+    }
+
+    /// Simulate the `contract_in_use` skip path: an EvictContract event
+    /// could not complete because a subscriber appeared between
+    /// eviction and processing. The pending entry survives subsequent
+    /// snapshots so the periodic sweep can keep retrying; once the
+    /// subscriber expires the snapshot still contains the entry and a
+    /// successful retry would call `pending_reclamation_remove` to
+    /// clear it.
+    ///
+    /// This is the manager-level invariant; end-to-end coverage of the
+    /// sweep loop calling `reclaim_evicted_contract` for each entry
+    /// (which requires a wired `OpManager`) is deferred — see the
+    /// module-level test note.
+    #[test]
+    fn test_pending_reclamation_survives_in_use_skip_and_retries() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let contract = make_contract_key(42);
+        let client = crate::client_events::ClientId::next();
+        let captured_generation = 5u64;
+
+        // Step 1: a client subscription means `contract_in_use` is true.
+        // In production this is the state `RuntimePool::remove_contract`
+        // observes when it hits the in-use skip and adds the key to the
+        // pending queue.
+        manager.add_client_subscription(contract.id(), client);
+        assert!(manager.contract_in_use(&contract));
+        manager.pending_reclamation_add(contract, captured_generation);
+        assert_eq!(manager.pending_reclamation_len(), 1);
+
+        // Step 2: the periodic sweep snapshots the queue. The entry is
+        // returned with its captured generation intact, and the queue
+        // state is unchanged (the sweep does not consume entries —
+        // `reclaim_evicted_contract`'s `contract_in_use` gate filters
+        // them, and successful retries call `pending_reclamation_remove`
+        // explicitly).
+        let snapshot = manager.pending_reclamation_snapshot();
+        assert_eq!(snapshot, vec![(contract, captured_generation)]);
+        assert_eq!(
+            manager.pending_reclamation_len(),
+            1,
+            "snapshot must NOT drain the queue — entries stay until \
+             explicit removal so the sweep can keep retrying until \
+             `contract_in_use` becomes false"
+        );
+
+        // Step 3: subscriber leaves; `contract_in_use` becomes false.
+        // The next sweep would route this through
+        // `reclaim_evicted_contract`, which (with the gate now open)
+        // emits a fresh `EvictContract`. On successful reclamation,
+        // `RuntimePool::remove_contract` calls
+        // `pending_reclamation_remove`. We model the successful retry
+        // here by calling `pending_reclamation_remove` directly.
+        manager.remove_client_subscription(contract.id(), client);
+        assert!(!manager.contract_in_use(&contract));
+        // The sweep would re-snapshot at this point and route through
+        // reclaim_evicted_contract — model the successful path.
+        manager.pending_reclamation_remove(&contract);
+        assert_eq!(manager.pending_reclamation_len(), 0);
+        assert!(manager.pending_reclamation_snapshot().is_empty());
     }
 }

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -3485,4 +3485,87 @@ mod tests {
         assert_eq!(manager.pending_reclamation_len(), 0);
         assert!(manager.pending_reclamation_snapshot().is_empty());
     }
+
+    /// Generation-mismatch + not-in-cache → keep pending and update its
+    /// captured generation to the current one. Models the
+    /// `RuntimePool::remove_contract` branch added in PR #4212 review
+    /// round 8: an evicted-then-in-use-then-UPDATEd contract must keep
+    /// its retry entry, otherwise the on-disk storage leaks once the
+    /// subscriber later expires (UPDATE does not call `host_contract`,
+    /// so the cache cannot emit another `EvictContract`).
+    #[test]
+    fn test_pending_reclamation_kept_on_generation_mismatch_when_not_hosted() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let contract = make_contract_key(0xA1);
+
+        // Initial state: contract has been written 5 times (gen=5), was
+        // evicted with `expected_generation=5`, and queued for retry
+        // because a subscriber was still attached at the time.
+        for _ in 0..5 {
+            manager.bump_state_generation(&contract);
+        }
+        let captured_generation = manager.state_generation(&contract);
+        assert_eq!(captured_generation, 5);
+        manager.pending_reclamation_add(contract, captured_generation);
+
+        // Simulate UPDATEs while the contract is still evicted (not in
+        // cache): `state_generation` advances past the captured value.
+        // UPDATE does not call `host_contract`, so the cache stays
+        // empty.
+        manager.bump_state_generation(&contract);
+        manager.bump_state_generation(&contract);
+        manager.bump_state_generation(&contract);
+        let current_generation = manager.state_generation(&contract);
+        assert_eq!(current_generation, captured_generation + 3);
+
+        // Precondition: the contract is NOT in the hosting cache.
+        assert!(!manager.is_hosting_contract(&contract));
+
+        // The `RuntimePool::remove_contract` generation-mismatch +
+        // not-hosted branch upserts the pending entry to the current
+        // generation. Model that here via `pending_reclamation_add`.
+        manager.pending_reclamation_add(contract, current_generation);
+
+        let snapshot = manager.pending_reclamation_snapshot();
+        assert_eq!(
+            snapshot,
+            vec![(contract, current_generation)],
+            "pending entry must survive the generation mismatch AND its \
+             expected_generation must advance to the current generation"
+        );
+    }
+
+    /// Generation-mismatch + IS-in-cache → clear pending. Models the
+    /// other half of the new branch: when the contract is back in the
+    /// hosting cache (a PUT re-hosted it), the cache owns subsequent
+    /// re-eviction and a stale pending entry would only produce
+    /// spurious sweep retries.
+    #[test]
+    fn test_pending_reclamation_cleared_on_generation_mismatch_when_hosted() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let contract = make_contract_key(0xA2);
+
+        // Queue a stale pending entry.
+        let captured_generation = 7u64;
+        manager.pending_reclamation_add(contract, captured_generation);
+        assert_eq!(manager.pending_reclamation_len(), 1);
+
+        // Simulate a PUT that re-hosted: bump generation AND add to
+        // the hosting cache (record_contract_access ≈ what
+        // `host_contract` does in production).
+        manager.bump_state_generation(&contract);
+        manager.record_contract_access(contract, 128, AccessType::Put);
+        assert!(manager.is_hosting_contract(&contract));
+
+        // The `RuntimePool::remove_contract` generation-mismatch +
+        // is-hosting branch removes the pending entry. Model that here.
+        manager.pending_reclamation_remove(&contract);
+        assert_eq!(
+            manager.pending_reclamation_len(),
+            0,
+            "pending entry must be cleared once the cache owns the contract \
+             again — leaving it would let the sweep emit `EvictContract` \
+             events that all bail at the `is_hosting_contract` check"
+        );
+    }
 }

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -33,8 +33,12 @@ mod cache;
 
 use crate::util::backoff::{ExponentialBackoff, TrackedBackoff};
 use crate::util::time_source::{InstantTimeSrc, TimeSource};
+/// Re-exported as the single source of truth for the default hosting storage
+/// budget. `config::default_max_hosting_storage()` resolves to this constant so
+/// the operator-facing default and the in-code fallback can never drift.
+pub(crate) use cache::DEFAULT_HOSTING_BUDGET_BYTES;
 pub use cache::{AccessType, RecordAccessResult};
-use cache::{DEFAULT_HOSTING_BUDGET_BYTES, DEFAULT_MIN_TTL, HostingCache};
+use cache::{DEFAULT_MIN_TTL, HostingCache};
 use dashmap::{DashMap, DashSet};
 use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
 use parking_lot::RwLock;

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -277,6 +277,20 @@ impl HostingManager {
         self.state_generation.remove(key);
     }
 
+    /// Update the hosting-cache snapshot of `key`'s state-write generation
+    /// to `new_gen`. Paired with `bump_state_generation` at every state-write
+    /// chokepoint (executor PUT/UPDATE and V2 delegate PUT/UPDATE) so a
+    /// later eviction's snapshot reflects the current generation and the
+    /// deletion-time guard in `RuntimePool::remove_contract` does not
+    /// permanently skip reclamation after an UPDATE-then-evict. No-op when
+    /// the entry is not currently cached. See
+    /// `HostingCache::refresh_entry_generation`.
+    pub(crate) fn refresh_cache_generation(&self, key: &ContractKey, new_gen: u64) {
+        self.hosting_cache
+            .write()
+            .refresh_entry_generation(key, new_gen);
+    }
+
     /// Set the storage reference for persisting hosting metadata.
     /// Must be called after executor creation.
     pub fn set_storage(&self, storage: crate::contract::storages::Storage) {
@@ -2635,6 +2649,96 @@ mod tests {
             manager.state_generation(&key),
             "the mismatch between captured and current is exactly what \
              `RuntimePool::remove_contract` keys off to skip reclamation"
+        );
+    }
+
+    /// Without `refresh_cache_generation`, a hosted contract that receives
+    /// a subsequent state write (UPDATE or re-PUT) has its `state_generation`
+    /// advance while the cached `write_generation` snapshot stays at the
+    /// `record_contract_access`-time value. Later, when this contract is
+    /// evicted (LRU pressure, expiry sweep, etc.), the `EvictContract` event
+    /// carries the stale snapshot. The deletion-time guard in
+    /// `RuntimePool::remove_contract` compares the snapshot against the
+    /// current generation and — seeing a mismatch — skips reclamation.
+    /// Result: every UPDATE-then-evict leaks the on-disk state and code blob.
+    ///
+    /// The fix is to call `refresh_cache_generation` paired with every
+    /// `bump_state_generation` so the snapshot tracks the counter. This
+    /// test asserts the refresh updates the snapshot, so the
+    /// subsequently-evicted entry carries the current generation rather
+    /// than the stale one.
+    ///
+    /// Regression test for PR #4212 review round D (skeptical r3 #2).
+    #[test]
+    fn test_record_access_refresh_updates_write_generation() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        // Tiny cache, zero TTL so the next insert evicts immediately.
+        {
+            let mut cache = manager.hosting_cache.write();
+            *cache = cache::HostingCache::new(
+                100,
+                std::time::Duration::ZERO,
+                crate::util::time_source::InstantTimeSrc::new(),
+            );
+        }
+
+        let key = make_contract_key(1);
+        let trigger = make_contract_key(2);
+
+        // Initial write + hosting record: snapshot captures generation 1.
+        let new_gen = manager.bump_state_generation(&key);
+        assert_eq!(new_gen, 1);
+        manager.refresh_cache_generation(&key, new_gen);
+        manager.record_contract_access(key, 100, AccessType::Get);
+
+        // Simulate an UPDATE that bumps the counter to 2 AND refreshes
+        // the cached snapshot — this is the bump+refresh pair installed
+        // at every state-write chokepoint.
+        let new_gen = manager.bump_state_generation(&key);
+        assert_eq!(new_gen, 2);
+        manager.refresh_cache_generation(&key, new_gen);
+
+        // Now force eviction. With the refresh, the evicted tuple should
+        // carry the post-UPDATE generation (2). Without the refresh, it
+        // would carry the stale snapshot (1), and `RuntimePool::remove_contract`
+        // would see a mismatch against the current generation (2) and
+        // SKIP reclamation — leaking the on-disk state forever.
+        let result = manager.record_contract_access(trigger, 100, AccessType::Get);
+        assert_eq!(
+            result.evicted,
+            vec![(key, 2)],
+            "evicted tuple must carry the refreshed generation (post-UPDATE), \
+             not the stale snapshot from initial record_contract_access"
+        );
+        assert_eq!(
+            result.evicted[0].1,
+            manager.state_generation(&key),
+            "with bump+refresh in lock-step, the evicted snapshot matches \
+             the current generation — deletion-time guard would proceed \
+             with reclamation rather than skipping it"
+        );
+    }
+
+    /// `refresh_cache_generation` is a no-op when the entry is not in the
+    /// cache: if the contract was evicted between bump and refresh, the
+    /// `EvictContract` already carried the pre-bump snapshot and the
+    /// deletion-time guard will skip on that narrower mismatch. The
+    /// no-op behavior is intentional — see the comment on
+    /// `HostingCache::refresh_entry_generation`.
+    #[test]
+    fn test_refresh_cache_generation_is_noop_when_entry_absent() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let key = make_contract_key(99);
+
+        // The contract is not in the hosting cache. The bump+refresh
+        // pair runs from a state-write chokepoint, but the entry was
+        // already evicted in a prior eviction wave. The refresh must
+        // simply do nothing — not panic, not insert.
+        let new_gen = manager.bump_state_generation(&key);
+        manager.refresh_cache_generation(&key, new_gen);
+        assert!(
+            !manager.hosting_cache.read().contains(&key),
+            "refresh must not insert a phantom entry for an absent contract"
         );
     }
 

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -575,11 +575,19 @@ impl HostingManager {
     }
 
     /// Whether something still depends on this node hosting `contract` — i.e.
-    /// it has a live local client subscription or a downstream peer
-    /// subscriber. Used to gate hosting-cache eviction reclamation: a
-    /// contract that is in use must NOT have its on-disk state/code deleted.
+    /// it has a live local client subscription, a downstream peer subscriber,
+    /// or an active upstream network subscription. Used to gate hosting-cache
+    /// eviction reclamation: a contract that is in use must NOT have its
+    /// on-disk state/code deleted.
+    ///
+    /// The network-subscription term (`is_subscribed`) matters because a node
+    /// can hold an active upstream subscription for a contract with no local
+    /// client and no downstream subscriber — it still expects UPDATEs, so its
+    /// disk state must be retained.
     pub fn contract_in_use(&self, contract: &ContractKey) -> bool {
-        self.has_client_subscriptions(contract.id()) || self.has_downstream_subscribers(contract)
+        self.has_client_subscriptions(contract.id())
+            || self.has_downstream_subscribers(contract)
+            || self.is_subscribed(contract)
     }
 
     /// Remove downstream subscribers whose leases have expired.
@@ -647,10 +655,17 @@ impl HostingManager {
         size_bytes: u64,
         access_type: AccessType,
     ) -> RecordAccessResult {
-        let result = self
-            .hosting_cache
-            .write()
-            .record_access(key, size_bytes, access_type);
+        // `contract_in_use` reads only the client_subscriptions /
+        // downstream_subscribers / active_subscriptions DashMaps — never
+        // `hosting_cache` — so calling it from inside the `hosting_cache`
+        // write guard does not re-enter that lock. `sweep_expired_hosting`
+        // uses this same pattern.
+        let result = self.hosting_cache.write().record_access(
+            key,
+            size_bytes,
+            access_type,
+            |k: &ContractKey| self.contract_in_use(k),
+        );
 
         // Persist hosting metadata for the accessed contract
         if let Some(storage) = self.storage.read().as_ref() {
@@ -830,16 +845,19 @@ impl HostingManager {
 
     /// Sweep for expired entries in the hosting cache.
     ///
-    /// Contracts are protected from eviction if they have client subscriptions
-    /// OR downstream subscribers (other peers relying on us for updates).
+    /// Contracts are protected from eviction while `contract_in_use` returns
+    /// true — i.e. they have client subscriptions, downstream subscribers, or
+    /// an active upstream network subscription. This is the same predicate
+    /// used by `record_contract_access`, so all eviction paths agree.
     /// The downstream subscriber exemption is time-bounded: stale entries are
     /// removed by `expire_stale_downstream_subscribers()` (called periodically)
     /// after `SUBSCRIPTION_LEASE_DURATION` without renewal.
     /// Automatically removes persisted metadata for expired contracts.
     pub fn sweep_expired_hosting(&self) -> Vec<ContractKey> {
-        let expired = self.hosting_cache.write().sweep_expired(|key| {
-            self.has_client_subscriptions(key.id()) || self.has_downstream_subscribers(key)
-        });
+        let expired = self
+            .hosting_cache
+            .write()
+            .sweep_expired(|key| self.contract_in_use(key));
 
         // Clean up persisted metadata for expired contracts
         if !expired.is_empty() {
@@ -2444,6 +2462,94 @@ mod tests {
         );
     }
 
+    /// A contract with ONLY an active upstream network subscription (no local
+    /// client, no downstream subscriber) IS in use — this node still expects
+    /// UPDATEs, so its on-disk state must not be reclaimed.
+    #[test]
+    fn test_contract_in_use_true_with_network_subscription_only() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let contract = make_contract_key(4);
+
+        // No client subscription, no downstream subscriber yet.
+        assert!(!manager.has_client_subscriptions(contract.id()));
+        assert!(!manager.has_downstream_subscribers(&contract));
+        assert!(
+            !manager.contract_in_use(&contract),
+            "with no subscriptions of any kind the contract is not in use"
+        );
+
+        // Establish an active upstream network subscription only.
+        manager.subscribe(contract);
+        assert!(manager.is_subscribed(&contract));
+        assert!(
+            manager.contract_in_use(&contract),
+            "a contract with an active network subscription must be in use \
+             even with no local client or downstream subscriber"
+        );
+
+        // Once the network subscription is dropped, it becomes reclaimable.
+        manager.unsubscribe(&contract);
+        assert!(
+            !manager.contract_in_use(&contract),
+            "contract must become reclaimable once its network subscription \
+             is removed"
+        );
+    }
+
+    /// `record_contract_access` must not evict an in-use (subscribed)
+    /// contract when the cache is over budget; once the subscription is
+    /// removed the contract becomes evictable.
+    #[test]
+    fn test_record_contract_access_skips_in_use_contract() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        // Override with a tiny cache and ZERO TTL so every entry is instantly
+        // eviction-eligible — `contract_in_use` is then the only protection.
+        {
+            let mut cache = manager.hosting_cache.write();
+            *cache = cache::HostingCache::new(
+                200, // room for ~2 contracts at 100 bytes
+                std::time::Duration::ZERO,
+                crate::util::time_source::InstantTimeSrc::new(),
+            );
+        }
+
+        let in_use = make_contract_key(1);
+        let filler = make_contract_key(2);
+        let trigger = make_contract_key(3);
+
+        // `in_use` is the oldest LRU entry but has an active subscription.
+        manager.subscribe(in_use);
+        assert!(manager.contract_in_use(&in_use));
+
+        manager.record_contract_access(in_use, 100, AccessType::Get);
+        manager.record_contract_access(filler, 100, AccessType::Get);
+
+        // Inserting `trigger` puts the cache over budget. A naive LRU would
+        // evict `in_use` (oldest) — `contract_in_use` must protect it, so
+        // `filler` is evicted instead.
+        let result = manager.record_contract_access(trigger, 100, AccessType::Get);
+        assert_eq!(
+            result.evicted,
+            vec![filler],
+            "in-use subscribed contract must be skipped; the unprotected \
+             contract must be evicted instead"
+        );
+        assert!(manager.is_hosting_contract(&in_use));
+        assert!(!manager.is_hosting_contract(&filler));
+
+        // Drop the subscription: `in_use` is now evictable.
+        manager.unsubscribe(&in_use);
+        assert!(!manager.contract_in_use(&in_use));
+
+        let result = manager.record_contract_access(filler, 100, AccessType::Get);
+        assert!(
+            result.evicted.contains(&in_use),
+            "once the subscription is removed the contract must become \
+             evictable when the cache is over budget"
+        );
+        assert!(!manager.is_hosting_contract(&in_use));
+    }
+
     /// Removing from an untracked contract is a noop; other contracts unaffected.
     #[test]
     fn test_unsubscribe_handler_unknown_contract_is_noop() {
@@ -2498,8 +2604,8 @@ mod tests {
         let protected = make_contract_key(1);
         let unprotected = make_contract_key(2);
 
-        cache.record_access(protected, 100, AccessType::Get);
-        cache.record_access(unprotected, 100, AccessType::Get);
+        cache.record_access(protected, 100, AccessType::Get, |_| false);
+        cache.record_access(unprotected, 100, AccessType::Get, |_| false);
         assert_eq!(cache.current_bytes(), 200); // over budget
 
         // Advance past TTL
@@ -2535,7 +2641,7 @@ mod tests {
         let mut cache = HostingCache::new(80, min_ttl, time.clone());
 
         let contract = make_contract_key(100);
-        cache.record_access(contract, 100, AccessType::Get);
+        cache.record_access(contract, 100, AccessType::Get, |_| false);
         assert!(cache.contains(&contract));
 
         // Under TTL: should not be evicted even though over budget

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -18,8 +18,10 @@ use tokio::time::Instant;
 
 use crate::util::time_source::TimeSource;
 
-/// Default hosting cache budget: 100MB
-pub const DEFAULT_HOSTING_BUDGET_BYTES: u64 = 100 * 1024 * 1024;
+/// Default hosting storage budget (1 GiB). The operator-facing default lives in
+/// `config.rs` as `DEFAULT_MAX_HOSTING_STORAGE`; keep the two consistent. This
+/// constant is the in-code default used by tests and as a fallback.
+pub const DEFAULT_HOSTING_BUDGET_BYTES: u64 = 1024 * 1024 * 1024;
 
 /// Multiplier for TTL relative to subscription renewal interval.
 /// Gives this many renewal attempts before eviction if renewals keep failing.

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -118,6 +118,52 @@ impl<T: TimeSource> HostingCache<T> {
         }
     }
 
+    /// Evict past-TTL, non-retained contracts while the cache is over budget.
+    ///
+    /// Walks `lru_order` front-first (oldest first). An entry is evicted when
+    /// it is past `min_ttl` since its last access AND `should_retain(key)` is
+    /// `false`. Eviction stops as soon as `current_bytes <= budget_bytes`.
+    /// Entries that are retained (in use) or still within `min_ttl` are kept
+    /// even if that leaves the cache over budget.
+    ///
+    /// Uses a `retain()`-style walk so the LRU ordering of surviving entries
+    /// is preserved. Returns the evicted keys.
+    fn evict_over_budget<F>(&mut self, should_retain: &F) -> Vec<ContractKey>
+    where
+        F: Fn(&ContractKey) -> bool,
+    {
+        if self.current_bytes <= self.budget_bytes {
+            return Vec::new();
+        }
+
+        let now = self.time_source.now();
+        let mut evicted = Vec::new();
+
+        self.lru_order.retain(|key| {
+            if self.current_bytes <= self.budget_bytes {
+                return true; // back under budget, stop evicting
+            }
+            if let Some(entry) = self.contracts.get(key) {
+                let age = now.saturating_duration_since(entry.last_accessed);
+                if age >= self.min_ttl && !should_retain(key) {
+                    let size = entry.size_bytes;
+                    self.contracts.remove(key);
+                    self.current_bytes = self.current_bytes.saturating_sub(size);
+                    evicted.push(*key);
+                    false
+                } else {
+                    // Retained (in use) or still within TTL — keep it even
+                    // if that leaves the cache over budget.
+                    true
+                }
+            } else {
+                false // orphaned LRU entry
+            }
+        });
+
+        evicted
+    }
+
     /// Record an access to a contract, adding or refreshing it in the cache.
     ///
     /// If the contract is already cached, this refreshes its LRU position and timestamp.
@@ -127,15 +173,27 @@ impl<T: TimeSource> HostingCache<T> {
     /// - `is_new`: Whether this contract was newly added (vs. refreshed existing)
     /// - `evicted`: Contracts that were evicted to make room (if any)
     ///
-    /// Eviction respects TTL: contracts won't be evicted until min_ttl has passed.
-    pub fn record_access(
+    /// Eviction respects TTL: contracts won't be evicted until min_ttl has
+    /// passed. It also honors `should_retain`: a contract for which
+    /// `should_retain(key)` returns `true` (e.g. one with an active client
+    /// subscription, downstream subscriber, or network subscription) is
+    /// never evicted, even past TTL. Evicting an in-use contract would
+    /// orphan its on-disk state — the caller skips disk reclamation for it,
+    /// but the contract is then gone from the cache and never revisited.
+    ///
+    /// The newly-inserted contract is age-0, so it can never be evicted by
+    /// the same `record_access` call.
+    pub fn record_access<F>(
         &mut self,
         key: ContractKey,
         size_bytes: u64,
         access_type: AccessType,
-    ) -> RecordAccessResult {
+        should_retain: F,
+    ) -> RecordAccessResult
+    where
+        F: Fn(&ContractKey) -> bool,
+    {
         let now = self.time_source.now();
-        let mut evicted = Vec::new();
 
         if let Some(existing) = self.contracts.get_mut(&key) {
             // Already cached - update size if changed and refresh position
@@ -156,38 +214,12 @@ impl<T: TimeSource> HostingCache<T> {
 
             RecordAccessResult {
                 is_new: false,
-                evicted,
+                evicted: Vec::new(),
             }
         } else {
-            // Not cached - need to add it
-            // First, evict until we have room (respecting TTL)
-            while self.current_bytes + size_bytes > self.budget_bytes && !self.lru_order.is_empty()
-            {
-                if let Some(oldest_key) = self.lru_order.front().cloned() {
-                    if let Some(oldest) = self.contracts.get(&oldest_key) {
-                        let age = now.saturating_duration_since(oldest.last_accessed);
-                        if age >= self.min_ttl {
-                            // Entry is past TTL, safe to evict
-                            if let Some(removed) = self.contracts.remove(&oldest_key) {
-                                self.current_bytes =
-                                    self.current_bytes.saturating_sub(removed.size_bytes);
-                                self.lru_order.pop_front();
-                                evicted.push(oldest_key);
-                            }
-                        } else {
-                            // Oldest entry still within TTL - allow exceeding budget
-                            break;
-                        }
-                    } else {
-                        // Entry in LRU but not in map - clean up
-                        self.lru_order.pop_front();
-                    }
-                } else {
-                    break;
-                }
-            }
-
-            // Add the new contract
+            // Not cached - insert the new entry first, then evict over-budget
+            // entries. The new entry is age-0 so the eviction walk's
+            // past-TTL check guarantees it is never evicted by this call.
             let contract = HostedContract {
                 size_bytes,
                 last_accessed: now,
@@ -198,6 +230,8 @@ impl<T: TimeSource> HostingCache<T> {
             self.contracts.insert(key, contract);
             self.lru_order.push_back(key);
             self.current_bytes = self.current_bytes.saturating_add(size_bytes);
+
+            let evicted = self.evict_over_budget(&should_retain);
 
             RecordAccessResult {
                 is_new: true,
@@ -311,39 +345,10 @@ impl<T: TimeSource> HostingCache<T> {
     where
         F: Fn(&ContractKey) -> bool,
     {
-        if self.current_bytes <= self.budget_bytes {
-            // Under budget — nothing to evict. Contracts live indefinitely
-            // while we have space. TTL only determines eviction eligibility
-            // when we need to free space.
-            return Vec::new();
-        }
-
-        let now = self.time_source.now();
-        let mut evicted = Vec::new();
-
-        // Over budget: evict past-TTL contracts (oldest first via LRU order)
-        // until we're back under budget.
-        self.lru_order.retain(|key| {
-            if self.current_bytes <= self.budget_bytes {
-                return true; // back under budget, stop evicting
-            }
-            if let Some(entry) = self.contracts.get(key) {
-                let age = now.saturating_duration_since(entry.last_accessed);
-                if age >= self.min_ttl && !should_retain(key) {
-                    let size = entry.size_bytes;
-                    self.contracts.remove(key);
-                    self.current_bytes = self.current_bytes.saturating_sub(size);
-                    evicted.push(*key);
-                    false
-                } else {
-                    true
-                }
-            } else {
-                false // orphaned LRU entry
-            }
-        });
-
-        evicted
+        // Over-budget eviction logic is shared with `record_access` via
+        // `evict_over_budget`: it returns early when under budget, then
+        // evicts past-TTL, non-retained entries oldest-first.
+        self.evict_over_budget(&should_retain)
     }
 
     /// Load a contract entry from persisted data during startup.
@@ -446,7 +451,7 @@ mod tests {
         let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
         let key = make_key(1);
 
-        let result = cache.record_access(key, 100, AccessType::Get);
+        let result = cache.record_access(key, 100, AccessType::Get, |_| false);
 
         assert!(result.is_new);
         assert!(result.evicted.is_empty());
@@ -465,12 +470,12 @@ mod tests {
         let key = make_key(1);
 
         // First access
-        cache.record_access(key, 100, AccessType::Get);
+        cache.record_access(key, 100, AccessType::Get, |_| false);
         let first_access = cache.get(&key).unwrap().last_accessed;
 
         // Advance time and access again
         time.advance_time(Duration::from_secs(10));
-        cache.record_access(key, 100, AccessType::Put);
+        cache.record_access(key, 100, AccessType::Put, |_| false);
 
         // Should still be one contract, but updated
         assert_eq!(cache.len(), 1);
@@ -490,15 +495,15 @@ mod tests {
         let key3 = make_key(3);
 
         // Add two entries
-        cache.record_access(key1, 100, AccessType::Get);
-        cache.record_access(key2, 100, AccessType::Get);
+        cache.record_access(key1, 100, AccessType::Get, |_| false);
+        cache.record_access(key2, 100, AccessType::Get, |_| false);
         assert_eq!(cache.current_bytes(), 200);
 
         // Advance time by 30 seconds (under TTL)
         time.advance_time(Duration::from_secs(30));
 
         // Add third entry - should NOT evict because all entries under TTL
-        let result = cache.record_access(key3, 100, AccessType::Get);
+        let result = cache.record_access(key3, 100, AccessType::Get, |_| false);
         assert!(
             result.evicted.is_empty(),
             "Should not evict entries under TTL"
@@ -522,14 +527,14 @@ mod tests {
         let key3 = make_key(3);
 
         // Add two entries
-        cache.record_access(key1, 100, AccessType::Get);
-        cache.record_access(key2, 100, AccessType::Get);
+        cache.record_access(key1, 100, AccessType::Get, |_| false);
+        cache.record_access(key2, 100, AccessType::Get, |_| false);
 
         // Advance time past TTL
         time.advance_time(Duration::from_secs(61));
 
         // Add third entry - should evict key1 (oldest)
-        let result = cache.record_access(key3, 100, AccessType::Get);
+        let result = cache.record_access(key3, 100, AccessType::Get, |_| false);
         assert!(result.is_new);
         assert_eq!(result.evicted, vec![key1]);
         assert_eq!(cache.len(), 2);
@@ -546,11 +551,11 @@ mod tests {
         let key3 = make_key(3);
 
         // Add two contracts
-        cache.record_access(key1, 100, AccessType::Get);
-        cache.record_access(key2, 100, AccessType::Get);
+        cache.record_access(key1, 100, AccessType::Get, |_| false);
+        cache.record_access(key2, 100, AccessType::Get, |_| false);
 
         // Access key1 again - should move it to back of LRU
-        cache.record_access(key1, 100, AccessType::Subscribe);
+        cache.record_access(key1, 100, AccessType::Subscribe, |_| false);
 
         // LRU order should now be [key2, key1]
         let order = cache.keys_lru_order();
@@ -558,7 +563,7 @@ mod tests {
 
         // Advance past TTL and add key3 - should evict key2 (now oldest)
         time.advance_time(Duration::from_secs(61));
-        let result = cache.record_access(key3, 100, AccessType::Get);
+        let result = cache.record_access(key3, 100, AccessType::Get, |_| false);
 
         assert_eq!(result.evicted, vec![key2]);
         assert!(cache.contains(&key1));
@@ -574,8 +579,8 @@ mod tests {
         let key3 = make_key(3);
 
         // Add two entries
-        cache.record_access(key1, 100, AccessType::Get);
-        cache.record_access(key2, 100, AccessType::Get);
+        cache.record_access(key1, 100, AccessType::Get, |_| false);
+        cache.record_access(key2, 100, AccessType::Get, |_| false);
 
         // Advance time by 50 seconds
         time.advance_time(Duration::from_secs(50));
@@ -587,7 +592,7 @@ mod tests {
         time.advance_time(Duration::from_secs(15));
 
         // Add key3 - should evict key2 (past TTL), NOT key1 (recently touched)
-        let result = cache.record_access(key3, 100, AccessType::Get);
+        let result = cache.record_access(key3, 100, AccessType::Get, |_| false);
 
         assert_eq!(
             result.evicted,
@@ -611,16 +616,16 @@ mod tests {
         let large = make_key(4);
 
         // Add three small contracts
-        cache.record_access(small1, 100, AccessType::Get);
-        cache.record_access(small2, 100, AccessType::Get);
-        cache.record_access(small3, 100, AccessType::Get);
+        cache.record_access(small1, 100, AccessType::Get, |_| false);
+        cache.record_access(small2, 100, AccessType::Get, |_| false);
+        cache.record_access(small3, 100, AccessType::Get, |_| false);
         assert_eq!(cache.current_bytes(), 300);
 
         // Advance past TTL
         time.advance_time(Duration::from_secs(61));
 
         // Add one large contract - should evict two small ones
-        let result = cache.record_access(large, 200, AccessType::Put);
+        let result = cache.record_access(large, 200, AccessType::Put, |_| false);
 
         assert_eq!(result.evicted.len(), 2);
         assert_eq!(result.evicted[0], small1); // Oldest first
@@ -639,9 +644,9 @@ mod tests {
         let key3 = make_key(3);
 
         // Add three entries (exceeds budget)
-        cache.record_access(key1, 100, AccessType::Get);
-        cache.record_access(key2, 100, AccessType::Get);
-        cache.record_access(key3, 100, AccessType::Get);
+        cache.record_access(key1, 100, AccessType::Get, |_| false);
+        cache.record_access(key2, 100, AccessType::Get, |_| false);
+        cache.record_access(key3, 100, AccessType::Get, |_| false);
         assert_eq!(cache.len(), 3);
         assert_eq!(cache.current_bytes(), 300);
 
@@ -667,9 +672,9 @@ mod tests {
         let key3 = make_key(3);
 
         // Add three entries (exceeds budget)
-        cache.record_access(key1, 100, AccessType::Get);
-        cache.record_access(key2, 100, AccessType::Get);
-        cache.record_access(key3, 100, AccessType::Get);
+        cache.record_access(key1, 100, AccessType::Get, |_| false);
+        cache.record_access(key2, 100, AccessType::Get, |_| false);
+        cache.record_access(key3, 100, AccessType::Get, |_| false);
 
         // Advance past TTL
         time.advance_time(Duration::from_secs(61));
@@ -683,6 +688,63 @@ mod tests {
         assert!(!cache.contains(&key2));
         assert!(cache.contains(&key3));
         assert_eq!(cache.current_bytes(), 200);
+    }
+
+    /// `record_access` must honor `should_retain`: an over-budget, past-TTL
+    /// entry whose `should_retain` returns true is NOT evicted; an
+    /// unretained past-TTL entry IS evicted.
+    #[test]
+    fn test_record_access_respects_should_retain() {
+        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let retained = make_key(1);
+        let evictable = make_key(2);
+        let trigger = make_key(3);
+
+        // Fill the cache: `retained` (oldest) then `evictable`.
+        cache.record_access(retained, 100, AccessType::Get, |_| false);
+        cache.record_access(evictable, 100, AccessType::Get, |_| false);
+        assert_eq!(cache.current_bytes(), 200);
+
+        // Advance past TTL so both existing entries are eviction-eligible.
+        time.advance_time(Duration::from_secs(61));
+
+        // Insert a third entry, over budget. `retained` is the oldest, so a
+        // naive LRU eviction would drop it first — but `should_retain`
+        // protects it, so `evictable` (next oldest) must be evicted instead.
+        let result = cache.record_access(trigger, 100, AccessType::Get, |k| *k == retained);
+
+        assert_eq!(
+            result.evicted,
+            vec![evictable],
+            "in-use (retained) contract must be skipped; the unretained \
+             past-TTL contract must be evicted instead"
+        );
+        assert!(
+            cache.contains(&retained),
+            "retained contract must survive even past TTL and over budget"
+        );
+        assert!(!cache.contains(&evictable));
+        assert!(cache.contains(&trigger));
+    }
+
+    /// The contract inserted by `record_access` is age-0, so it is never
+    /// evicted by the same call even when the insert pushes over budget.
+    #[test]
+    fn test_record_access_never_evicts_the_new_entry() {
+        let (mut cache, time) = make_cache(100, Duration::from_secs(60));
+        let first = make_key(1);
+        let second = make_key(2);
+
+        cache.record_access(first, 100, AccessType::Get, |_| false);
+        time.advance_time(Duration::from_secs(61));
+
+        // Inserting `second` puts the cache over budget; `first` is past TTL
+        // and unretained so it is evicted, but the just-inserted `second`
+        // (age 0) must survive.
+        let result = cache.record_access(second, 100, AccessType::Get, |_| false);
+        assert_eq!(result.evicted, vec![first]);
+        assert!(cache.contains(&second));
+        assert!(!cache.contains(&first));
     }
 
     #[test]
@@ -704,13 +766,13 @@ mod tests {
         let key = make_key(1);
 
         // Test each access type is recorded correctly
-        cache.record_access(key, 100, AccessType::Get);
+        cache.record_access(key, 100, AccessType::Get, |_| false);
         assert_eq!(cache.get(&key).unwrap().access_type, AccessType::Get);
 
-        cache.record_access(key, 100, AccessType::Put);
+        cache.record_access(key, 100, AccessType::Put, |_| false);
         assert_eq!(cache.get(&key).unwrap().access_type, AccessType::Put);
 
-        cache.record_access(key, 100, AccessType::Subscribe);
+        cache.record_access(key, 100, AccessType::Subscribe, |_| false);
         assert_eq!(cache.get(&key).unwrap().access_type, AccessType::Subscribe);
     }
 
@@ -720,17 +782,17 @@ mod tests {
         let key = make_key(1);
 
         // Add contract with initial size
-        cache.record_access(key, 100, AccessType::Get);
+        cache.record_access(key, 100, AccessType::Get, |_| false);
         assert_eq!(cache.current_bytes(), 100);
         assert_eq!(cache.get(&key).unwrap().size_bytes, 100);
 
         // Contract state grows
-        cache.record_access(key, 200, AccessType::Put);
+        cache.record_access(key, 200, AccessType::Put, |_| false);
         assert_eq!(cache.current_bytes(), 200);
         assert_eq!(cache.get(&key).unwrap().size_bytes, 200);
 
         // Contract state shrinks
-        cache.record_access(key, 150, AccessType::Put);
+        cache.record_access(key, 150, AccessType::Put, |_| false);
         assert_eq!(cache.current_bytes(), 150);
         assert_eq!(cache.get(&key).unwrap().size_bytes, 150);
     }
@@ -746,9 +808,9 @@ mod tests {
         let key2 = make_key(2);
         let key3 = make_key(3);
 
-        cache.record_access(key1, 100, AccessType::Get);
-        cache.record_access(key2, 100, AccessType::Put);
-        cache.record_access(key3, 100, AccessType::Subscribe);
+        cache.record_access(key1, 100, AccessType::Get, |_| false);
+        cache.record_access(key2, 100, AccessType::Put, |_| false);
+        cache.record_access(key3, 100, AccessType::Subscribe, |_| false);
 
         let keys: Vec<ContractKey> = cache.iter().collect();
         assert_eq!(keys.len(), 3);
@@ -766,7 +828,7 @@ mod tests {
         let (mut cache, time) = make_cache(10000, Duration::from_secs(60));
         let key = make_key(1);
 
-        cache.record_access(key, 100, AccessType::Get);
+        cache.record_access(key, 100, AccessType::Get, |_| false);
         cache.mark_local_client_access(&key);
 
         // Immediately after marking: recent access is true

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -325,6 +325,31 @@ impl<T: TimeSource> HostingCache<T> {
         }
     }
 
+    /// Update the cached `write_generation` snapshot for `key` to `new_gen`.
+    ///
+    /// Called paired with `HostingManager::bump_state_generation` from
+    /// every state-write chokepoint (executor PUT/UPDATE and V2 delegate
+    /// PUT/UPDATE). Without this refresh, an UPDATE (or re-PUT) to an
+    /// already-hosted contract would leave the cached snapshot stuck at
+    /// its `record_access`-time value while the `state_generation` counter
+    /// kept advancing; a later eviction would carry the stale snapshot,
+    /// the deletion-time generation guard in
+    /// `RuntimePool::remove_contract` would see a mismatch, and disk
+    /// reclamation would be permanently skipped — leaking the on-disk
+    /// state and code blob.
+    ///
+    /// No-op when `key` is not in the cache: if the contract has been
+    /// evicted between the bump and this refresh, the `EvictContract`
+    /// already carried the pre-bump snapshot and the deletion-time guard
+    /// will skip on the mismatch. That residual leak is narrower than
+    /// the "permanent leak on every UPDATE" failure mode this method
+    /// closes — see the call-site comment in `runtime.rs`.
+    pub fn refresh_entry_generation(&mut self, key: &ContractKey, new_gen: u64) {
+        if let Some(existing) = self.contracts.get_mut(key) {
+            existing.write_generation = new_gen;
+        }
+    }
+
     /// Check if a contract is in the cache.
     pub fn contains(&self, key: &ContractKey) -> bool {
         self.contracts.contains_key(key)

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -62,8 +62,12 @@ pub enum AccessType {
 pub struct RecordAccessResult {
     /// Whether this contract was newly added (vs. refreshed existing)
     pub is_new: bool,
-    /// Contracts that were evicted to make room
-    pub evicted: Vec<ContractKey>,
+    /// Contracts that were evicted to make room, paired with the
+    /// state-write generation captured atomically under the hosting
+    /// cache's write lock. Carried through `EvictContract` so the
+    /// deletion-time guard in `RuntimePool::remove_contract` can detect
+    /// a re-host that occurred between eviction and disk reclamation.
+    pub evicted: Vec<(ContractKey, u64)>,
 }
 
 /// Metadata about a hosted contract.
@@ -82,6 +86,13 @@ pub struct HostedContract {
     /// contracts not accessed locally within SUBSCRIPTION_LEASE_DURATION stop
     /// being renewed (AGENTS.md cleanup exemption rule). None = never locally accessed.
     pub local_client_last_access: Option<Instant>,
+    /// State-write generation observed when this entry was inserted or
+    /// refreshed. Captured atomically under the hosting cache's write
+    /// lock — passed in by `HostingManager::record_contract_access` from
+    /// `Ring::state_generation`. Carried through `EvictContract` and
+    /// re-checked at deletion time to close the re-host race. See
+    /// `RecordAccessResult.evicted` and `RuntimePool::remove_contract`.
+    pub write_generation: u64,
 }
 
 /// Unified hosting cache that combines byte-budget LRU with TTL protection.
@@ -136,7 +147,7 @@ impl<T: TimeSource> HostingCache<T> {
     ///
     /// Uses a `retain()`-style walk so the LRU ordering of surviving entries
     /// is preserved. Returns the evicted keys.
-    fn evict_over_budget<F>(&mut self, should_retain: &F) -> Vec<ContractKey>
+    fn evict_over_budget<F>(&mut self, should_retain: &F) -> Vec<(ContractKey, u64)>
     where
         F: Fn(&ContractKey) -> bool,
     {
@@ -155,9 +166,14 @@ impl<T: TimeSource> HostingCache<T> {
                 let age = now.saturating_duration_since(entry.last_accessed);
                 if age >= self.min_ttl && !should_retain(key) {
                     let size = entry.size_bytes;
+                    // Capture the generation atomically under the cache's
+                    // write lock so the `EvictContract` deletion-time
+                    // guard can detect a re-host that races with this
+                    // eviction. See `RuntimePool::remove_contract`.
+                    let generation = entry.write_generation;
                     self.contracts.remove(key);
                     self.current_bytes = self.current_bytes.saturating_sub(size);
-                    evicted.push(*key);
+                    evicted.push((*key, generation));
                     false
                 } else {
                     // Retained (in use) or still within TTL — keep it even
@@ -179,23 +195,33 @@ impl<T: TimeSource> HostingCache<T> {
     ///
     /// Returns a `RecordAccessResult` containing:
     /// - `is_new`: Whether this contract was newly added (vs. refreshed existing)
-    /// - `evicted`: Contracts that were evicted to make room (if any)
+    /// - `evicted`: `(ContractKey, write_generation)` pairs for contracts
+    ///   evicted to make room. The generation is captured atomically under
+    ///   the cache's write lock so the `EvictContract` deletion-time guard
+    ///   can detect a re-host that occurred after this call returned.
     ///
-    /// Eviction respects TTL: contracts won't be evicted until min_ttl has
-    /// passed. It also honors `should_retain`: a contract for which
-    /// `should_retain(key)` returns `true` (e.g. one with an active client
-    /// subscription, downstream subscriber, or network subscription) is
-    /// never evicted, even past TTL. Evicting an in-use contract would
-    /// orphan its on-disk state — the caller skips disk reclamation for it,
-    /// but the contract is then gone from the cache and never revisited.
+    /// Eviction respects TTL: age-0 entries are not eligible for eviction
+    /// while `min_ttl > 0` (the production default — i.e. the new entry
+    /// just inserted by this call cannot be evicted by the same call).
+    /// It also honors `should_retain`: a contract for which `should_retain(key)` returns
+    /// `true` (e.g. one with an active client subscription, downstream
+    /// subscriber, or network subscription) is never evicted, even past
+    /// TTL. Evicting an in-use contract would orphan its on-disk state —
+    /// the caller skips disk reclamation for it, but the contract is then
+    /// gone from the cache and never revisited.
     ///
-    /// The newly-inserted contract is age-0, so it can never be evicted by
-    /// the same `record_access` call.
+    /// `write_generation` is the current state-write generation for this
+    /// contract (from `HostingManager::state_generation`). It is stored on
+    /// the freshly-inserted/refreshed `HostedContract` so that when this
+    /// entry is later evicted, its `write_generation` snapshot travels
+    /// with the `EvictContract` event and is compared against the
+    /// then-current generation at deletion time.
     pub fn record_access<F>(
         &mut self,
         key: ContractKey,
         size_bytes: u64,
         access_type: AccessType,
+        write_generation: u64,
         should_retain: F,
     ) -> RecordAccessResult
     where
@@ -215,6 +241,10 @@ impl<T: TimeSource> HostingCache<T> {
             }
             existing.last_accessed = now;
             existing.access_type = access_type;
+            // Refresh the generation snapshot: a re-access is a fresh
+            // "I'm hosting this state" assertion, so its captured generation
+            // should track the current state-write generation.
+            existing.write_generation = write_generation;
 
             // Move to back of LRU (most recently used)
             self.lru_order.retain(|k| k != &key);
@@ -234,6 +264,7 @@ impl<T: TimeSource> HostingCache<T> {
                 access_type,
                 local_client_access: false,
                 local_client_last_access: None,
+                write_generation,
             };
             self.contracts.insert(key, contract);
             self.lru_order.push_back(key);
@@ -348,8 +379,10 @@ impl<T: TimeSource> HostingCache<T> {
     /// downstream subscribers).
     ///
     /// Uses `retain()` to preserve LRU ordering for non-evicted entries.
-    /// Returns contracts evicted from this cache.
-    pub fn sweep_expired<F>(&mut self, should_retain: F) -> Vec<ContractKey>
+    /// Returns `(ContractKey, write_generation)` pairs for evicted contracts;
+    /// the generation snapshot is carried through `EvictContract` so the
+    /// deletion-time guard can detect a re-host race.
+    pub fn sweep_expired<F>(&mut self, should_retain: F) -> Vec<(ContractKey, u64)>
     where
         F: Fn(&ContractKey) -> bool,
     {
@@ -397,6 +430,11 @@ impl<T: TimeSource> HostingCache<T> {
             access_type,
             local_client_access,
             local_client_last_access,
+            // Generation 0 = "no observed writes since restart". The
+            // executor will bump on the next state write, so a re-PUT
+            // after restart will cleanly close the race window against
+            // any concurrent eviction.
+            write_generation: 0,
         };
 
         self.contracts.insert(key, contract);
@@ -459,7 +497,7 @@ mod tests {
         let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
         let key = make_key(1);
 
-        let result = cache.record_access(key, 100, AccessType::Get, |_| false);
+        let result = cache.record_access(key, 100, AccessType::Get, 0, |_| false);
 
         assert!(result.is_new);
         assert!(result.evicted.is_empty());
@@ -478,12 +516,12 @@ mod tests {
         let key = make_key(1);
 
         // First access
-        cache.record_access(key, 100, AccessType::Get, |_| false);
+        cache.record_access(key, 100, AccessType::Get, 0, |_| false);
         let first_access = cache.get(&key).unwrap().last_accessed;
 
         // Advance time and access again
         time.advance_time(Duration::from_secs(10));
-        cache.record_access(key, 100, AccessType::Put, |_| false);
+        cache.record_access(key, 100, AccessType::Put, 0, |_| false);
 
         // Should still be one contract, but updated
         assert_eq!(cache.len(), 1);
@@ -503,15 +541,15 @@ mod tests {
         let key3 = make_key(3);
 
         // Add two entries
-        cache.record_access(key1, 100, AccessType::Get, |_| false);
-        cache.record_access(key2, 100, AccessType::Get, |_| false);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| false);
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| false);
         assert_eq!(cache.current_bytes(), 200);
 
         // Advance time by 30 seconds (under TTL)
         time.advance_time(Duration::from_secs(30));
 
         // Add third entry - should NOT evict because all entries under TTL
-        let result = cache.record_access(key3, 100, AccessType::Get, |_| false);
+        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| false);
         assert!(
             result.evicted.is_empty(),
             "Should not evict entries under TTL"
@@ -535,16 +573,16 @@ mod tests {
         let key3 = make_key(3);
 
         // Add two entries
-        cache.record_access(key1, 100, AccessType::Get, |_| false);
-        cache.record_access(key2, 100, AccessType::Get, |_| false);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| false);
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| false);
 
         // Advance time past TTL
         time.advance_time(Duration::from_secs(61));
 
         // Add third entry - should evict key1 (oldest)
-        let result = cache.record_access(key3, 100, AccessType::Get, |_| false);
+        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| false);
         assert!(result.is_new);
-        assert_eq!(result.evicted, vec![key1]);
+        assert_eq!(result.evicted, vec![(key1, 0)]);
         assert_eq!(cache.len(), 2);
         assert!(!cache.contains(&key1));
         assert!(cache.contains(&key2));
@@ -559,11 +597,11 @@ mod tests {
         let key3 = make_key(3);
 
         // Add two contracts
-        cache.record_access(key1, 100, AccessType::Get, |_| false);
-        cache.record_access(key2, 100, AccessType::Get, |_| false);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| false);
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| false);
 
         // Access key1 again - should move it to back of LRU
-        cache.record_access(key1, 100, AccessType::Subscribe, |_| false);
+        cache.record_access(key1, 100, AccessType::Subscribe, 0, |_| false);
 
         // LRU order should now be [key2, key1]
         let order = cache.keys_lru_order();
@@ -571,9 +609,9 @@ mod tests {
 
         // Advance past TTL and add key3 - should evict key2 (now oldest)
         time.advance_time(Duration::from_secs(61));
-        let result = cache.record_access(key3, 100, AccessType::Get, |_| false);
+        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| false);
 
-        assert_eq!(result.evicted, vec![key2]);
+        assert_eq!(result.evicted, vec![(key2, 0)]);
         assert!(cache.contains(&key1));
         assert!(!cache.contains(&key2));
         assert!(cache.contains(&key3));
@@ -587,8 +625,8 @@ mod tests {
         let key3 = make_key(3);
 
         // Add two entries
-        cache.record_access(key1, 100, AccessType::Get, |_| false);
-        cache.record_access(key2, 100, AccessType::Get, |_| false);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| false);
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| false);
 
         // Advance time by 50 seconds
         time.advance_time(Duration::from_secs(50));
@@ -600,11 +638,11 @@ mod tests {
         time.advance_time(Duration::from_secs(15));
 
         // Add key3 - should evict key2 (past TTL), NOT key1 (recently touched)
-        let result = cache.record_access(key3, 100, AccessType::Get, |_| false);
+        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| false);
 
         assert_eq!(
             result.evicted,
-            vec![key2],
+            vec![(key2, 0)],
             "Should evict key2 which is past TTL"
         );
         assert!(
@@ -624,20 +662,20 @@ mod tests {
         let large = make_key(4);
 
         // Add three small contracts
-        cache.record_access(small1, 100, AccessType::Get, |_| false);
-        cache.record_access(small2, 100, AccessType::Get, |_| false);
-        cache.record_access(small3, 100, AccessType::Get, |_| false);
+        cache.record_access(small1, 100, AccessType::Get, 0, |_| false);
+        cache.record_access(small2, 100, AccessType::Get, 0, |_| false);
+        cache.record_access(small3, 100, AccessType::Get, 0, |_| false);
         assert_eq!(cache.current_bytes(), 300);
 
         // Advance past TTL
         time.advance_time(Duration::from_secs(61));
 
         // Add one large contract - should evict two small ones
-        let result = cache.record_access(large, 200, AccessType::Put, |_| false);
+        let result = cache.record_access(large, 200, AccessType::Put, 0, |_| false);
 
         assert_eq!(result.evicted.len(), 2);
-        assert_eq!(result.evicted[0], small1); // Oldest first
-        assert_eq!(result.evicted[1], small2);
+        assert_eq!(result.evicted[0], (small1, 0)); // Oldest first
+        assert_eq!(result.evicted[1], (small2, 0));
         assert!(!cache.contains(&small1));
         assert!(!cache.contains(&small2));
         assert!(cache.contains(&small3));
@@ -652,9 +690,9 @@ mod tests {
         let key3 = make_key(3);
 
         // Add three entries (exceeds budget)
-        cache.record_access(key1, 100, AccessType::Get, |_| false);
-        cache.record_access(key2, 100, AccessType::Get, |_| false);
-        cache.record_access(key3, 100, AccessType::Get, |_| false);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| false);
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| false);
+        cache.record_access(key3, 100, AccessType::Get, 0, |_| false);
         assert_eq!(cache.len(), 3);
         assert_eq!(cache.current_bytes(), 300);
 
@@ -668,7 +706,7 @@ mod tests {
 
         // Sweep should evict oldest entry to get back under budget
         let evicted = cache.sweep_expired(|_| false);
-        assert_eq!(evicted, vec![key1]);
+        assert_eq!(evicted, vec![(key1, 0)]);
         assert_eq!(cache.current_bytes(), 200);
     }
 
@@ -680,9 +718,9 @@ mod tests {
         let key3 = make_key(3);
 
         // Add three entries (exceeds budget)
-        cache.record_access(key1, 100, AccessType::Get, |_| false);
-        cache.record_access(key2, 100, AccessType::Get, |_| false);
-        cache.record_access(key3, 100, AccessType::Get, |_| false);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| false);
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| false);
+        cache.record_access(key3, 100, AccessType::Get, 0, |_| false);
 
         // Advance past TTL
         time.advance_time(Duration::from_secs(61));
@@ -691,7 +729,7 @@ mod tests {
         let evicted = cache.sweep_expired(|k| *k == key1);
 
         // key1 should be retained, key2 evicted to get under budget
-        assert_eq!(evicted, vec![key2]);
+        assert_eq!(evicted, vec![(key2, 0)]);
         assert!(cache.contains(&key1));
         assert!(!cache.contains(&key2));
         assert!(cache.contains(&key3));
@@ -709,8 +747,8 @@ mod tests {
         let trigger = make_key(3);
 
         // Fill the cache: `retained` (oldest) then `evictable`.
-        cache.record_access(retained, 100, AccessType::Get, |_| false);
-        cache.record_access(evictable, 100, AccessType::Get, |_| false);
+        cache.record_access(retained, 100, AccessType::Get, 0, |_| false);
+        cache.record_access(evictable, 100, AccessType::Get, 0, |_| false);
         assert_eq!(cache.current_bytes(), 200);
 
         // Advance past TTL so both existing entries are eviction-eligible.
@@ -719,11 +757,11 @@ mod tests {
         // Insert a third entry, over budget. `retained` is the oldest, so a
         // naive LRU eviction would drop it first — but `should_retain`
         // protects it, so `evictable` (next oldest) must be evicted instead.
-        let result = cache.record_access(trigger, 100, AccessType::Get, |k| *k == retained);
+        let result = cache.record_access(trigger, 100, AccessType::Get, 0, |k| *k == retained);
 
         assert_eq!(
             result.evicted,
-            vec![evictable],
+            vec![(evictable, 0)],
             "in-use (retained) contract must be skipped; the unretained \
              past-TTL contract must be evicted instead"
         );
@@ -735,22 +773,23 @@ mod tests {
         assert!(cache.contains(&trigger));
     }
 
-    /// The contract inserted by `record_access` is age-0, so it is never
-    /// evicted by the same call even when the insert pushes over budget.
+    /// The contract inserted by `record_access` is age-0, so while
+    /// `min_ttl > 0` (the production default) it is never evicted by the
+    /// same call even when the insert pushes over budget.
     #[test]
     fn test_record_access_never_evicts_the_new_entry() {
         let (mut cache, time) = make_cache(100, Duration::from_secs(60));
         let first = make_key(1);
         let second = make_key(2);
 
-        cache.record_access(first, 100, AccessType::Get, |_| false);
+        cache.record_access(first, 100, AccessType::Get, 0, |_| false);
         time.advance_time(Duration::from_secs(61));
 
         // Inserting `second` puts the cache over budget; `first` is past TTL
         // and unretained so it is evicted, but the just-inserted `second`
         // (age 0) must survive.
-        let result = cache.record_access(second, 100, AccessType::Get, |_| false);
-        assert_eq!(result.evicted, vec![first]);
+        let result = cache.record_access(second, 100, AccessType::Get, 0, |_| false);
+        assert_eq!(result.evicted, vec![(first, 0)]);
         assert!(cache.contains(&second));
         assert!(!cache.contains(&first));
     }
@@ -774,13 +813,13 @@ mod tests {
         let key = make_key(1);
 
         // Test each access type is recorded correctly
-        cache.record_access(key, 100, AccessType::Get, |_| false);
+        cache.record_access(key, 100, AccessType::Get, 0, |_| false);
         assert_eq!(cache.get(&key).unwrap().access_type, AccessType::Get);
 
-        cache.record_access(key, 100, AccessType::Put, |_| false);
+        cache.record_access(key, 100, AccessType::Put, 0, |_| false);
         assert_eq!(cache.get(&key).unwrap().access_type, AccessType::Put);
 
-        cache.record_access(key, 100, AccessType::Subscribe, |_| false);
+        cache.record_access(key, 100, AccessType::Subscribe, 0, |_| false);
         assert_eq!(cache.get(&key).unwrap().access_type, AccessType::Subscribe);
     }
 
@@ -790,17 +829,17 @@ mod tests {
         let key = make_key(1);
 
         // Add contract with initial size
-        cache.record_access(key, 100, AccessType::Get, |_| false);
+        cache.record_access(key, 100, AccessType::Get, 0, |_| false);
         assert_eq!(cache.current_bytes(), 100);
         assert_eq!(cache.get(&key).unwrap().size_bytes, 100);
 
         // Contract state grows
-        cache.record_access(key, 200, AccessType::Put, |_| false);
+        cache.record_access(key, 200, AccessType::Put, 0, |_| false);
         assert_eq!(cache.current_bytes(), 200);
         assert_eq!(cache.get(&key).unwrap().size_bytes, 200);
 
         // Contract state shrinks
-        cache.record_access(key, 150, AccessType::Put, |_| false);
+        cache.record_access(key, 150, AccessType::Put, 0, |_| false);
         assert_eq!(cache.current_bytes(), 150);
         assert_eq!(cache.get(&key).unwrap().size_bytes, 150);
     }
@@ -816,15 +855,93 @@ mod tests {
         let key2 = make_key(2);
         let key3 = make_key(3);
 
-        cache.record_access(key1, 100, AccessType::Get, |_| false);
-        cache.record_access(key2, 100, AccessType::Put, |_| false);
-        cache.record_access(key3, 100, AccessType::Subscribe, |_| false);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| false);
+        cache.record_access(key2, 100, AccessType::Put, 0, |_| false);
+        cache.record_access(key3, 100, AccessType::Subscribe, 0, |_| false);
 
         let keys: Vec<ContractKey> = cache.iter().collect();
         assert_eq!(keys.len(), 3);
         assert!(keys.contains(&key1));
         assert!(keys.contains(&key2));
         assert!(keys.contains(&key3));
+    }
+
+    /// `record_access` MUST capture the supplied `write_generation` on
+    /// the inserted entry AND surface it on the `RecordAccessResult.evicted`
+    /// tuple when that entry is later evicted by a subsequent
+    /// `record_access`. This is the load-bearing flow for the
+    /// EvictContract re-host race fix — `RuntimePool::remove_contract`
+    /// compares this captured generation against the then-current
+    /// generation to decide whether a write raced ahead of the eviction.
+    /// Regression test for PR #4212 review round C.
+    #[test]
+    fn test_record_access_carries_write_generation_through_eviction() {
+        let (mut cache, time) = make_cache(100, Duration::from_secs(60));
+        let evicted_key = make_key(1);
+        let trigger_key = make_key(2);
+
+        // Insert `evicted_key` with a specific captured generation.
+        let captured_generation: u64 = 0xABCD_EF42;
+        let first = cache.record_access(
+            evicted_key,
+            100,
+            AccessType::Get,
+            captured_generation,
+            |_| false,
+        );
+        assert!(first.evicted.is_empty(), "first insert evicts nothing");
+        assert_eq!(
+            cache
+                .get(&evicted_key)
+                .expect("just inserted")
+                .write_generation,
+            captured_generation,
+            "captured generation must be stored on the HostedContract entry"
+        );
+
+        // Advance past TTL and trigger an over-budget insert; this must
+        // evict `evicted_key` and emit the captured generation alongside
+        // it on the result tuple.
+        time.advance_time(Duration::from_secs(61));
+        let result = cache.record_access(
+            trigger_key,
+            100,
+            AccessType::Get,
+            999, // trigger's own generation is irrelevant to the eviction
+            |_| false,
+        );
+        assert_eq!(
+            result.evicted,
+            vec![(evicted_key, captured_generation)],
+            "evicted tuple must carry the generation captured atomically \
+             when the evicted entry was inserted"
+        );
+    }
+
+    /// Re-accessing an existing entry refreshes its captured generation.
+    ///
+    /// Rationale: a re-access (GET/PUT/SUBSCRIBE) is a fresh "I'm
+    /// hosting this state" assertion. If a state write bumped the
+    /// generation between the original insert and the refresh, the
+    /// refresh must adopt the new generation so a later eviction
+    /// captures the correct generation snapshot.
+    #[test]
+    fn test_record_access_refresh_updates_write_generation() {
+        let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
+        let key = make_key(7);
+
+        cache.record_access(key, 100, AccessType::Get, 1, |_| false);
+        assert_eq!(cache.get(&key).unwrap().write_generation, 1);
+
+        // Refresh with a higher generation (simulates a state write that
+        // bumped the generation between the original insert and a later
+        // GET/PUT/SUBSCRIBE re-access).
+        cache.record_access(key, 100, AccessType::Put, 5, |_| false);
+        assert_eq!(
+            cache.get(&key).unwrap().write_generation,
+            5,
+            "re-access must refresh the captured generation snapshot"
+        );
     }
 
     /// Age gate: has_recent_local_client_access returns false after the
@@ -836,7 +953,7 @@ mod tests {
         let (mut cache, time) = make_cache(10000, Duration::from_secs(60));
         let key = make_key(1);
 
-        cache.record_access(key, 100, AccessType::Get, |_| false);
+        cache.record_access(key, 100, AccessType::Get, 0, |_| false);
         cache.mark_local_client_access(&key);
 
         // Immediately after marking: recent access is true

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -18,9 +18,15 @@ use tokio::time::Instant;
 
 use crate::util::time_source::TimeSource;
 
-/// Default hosting storage budget (1 GiB). The operator-facing default lives in
-/// `config.rs` as `DEFAULT_MAX_HOSTING_STORAGE`; keep the two consistent. This
-/// constant is the in-code default used by tests and as a fallback.
+/// Default hosting storage budget (1 GiB).
+///
+/// This is the single source of truth for the default budget: the operator-
+/// facing `config::default_max_hosting_storage()` resolves to it (re-exported
+/// via `ring::hosting::DEFAULT_HOSTING_BUDGET_BYTES`).
+///
+/// The budget tracks hosted contract **state** bytes only. WASM code blobs and
+/// ReDb/SQLite database overhead are additional and not counted against it, so
+/// this is not a hard bound on total on-disk usage.
 pub const DEFAULT_HOSTING_BUDGET_BYTES: u64 = 1024 * 1024 * 1024;
 
 /// Multiplier for TTL relative to subscription renewal interval.
@@ -82,7 +88,9 @@ pub struct HostedContract {
 ///
 /// This cache maintains contracts that this peer is "hosting" - keeping available
 /// for the network. The cache has:
-/// - Byte budget: Large contracts consume more budget
+/// - Byte budget: Large contracts consume more budget. The budget is measured
+///   in tracked contract **state** bytes only; WASM code blobs and database
+///   overhead are not counted against it.
 /// - TTL protection: Contracts can't be evicted until min_ttl has passed
 /// - LRU ordering: Oldest contracts evicted first when over budget
 ///

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -249,7 +249,9 @@ impl ContractStore {
                 // blob is unreferenced. A leaked blob is recoverable disk
                 // space; deleting a still-referenced shared blob corrupts
                 // every surviving contract using that code. Fail safe:
-                // keep the blob.
+                // keep the blob — and return an error so the caller knows
+                // the code half was NOT fully reclaimed and will requeue
+                // for retry rather than clearing the pending entry.
                 tracing::warn!(
                     code_hash = %contract_hash,
                     error = %e,
@@ -257,7 +259,11 @@ impl ContractStore {
                      contract; keeping the .wasm blob to avoid corrupting \
                      contracts that may still reference this code"
                 );
-                return Ok(());
+                return Err(anyhow::anyhow!(
+                    "kept WASM blob for {contract_hash}: shared contract \
+                     index read failed: {e}"
+                )
+                .into());
             }
         };
         if !code_still_referenced {

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -138,15 +138,24 @@ impl ContractStore {
             ContractContainer::Wasm(_) | _ => unimplemented!(),
         };
         let code_hash = key.code_hash();
-        if self.contract_cache.get(code_hash).is_some() {
-            // WASM code is cached, but we still need to ensure this instance_id is indexed.
-            // Different ContractInstanceIds with the same code need their own mapping.
-            // See issue #2380.
+        let key_path = code_hash.encode();
+        let key_path = self.contracts_dir.join(key_path).with_extension("wasm");
+        if self.contract_cache.get(code_hash).is_some() && key_path.exists() {
+            // WASM code is cached AND the blob is still on disk: fast path. We
+            // still need to ensure this instance_id is indexed (different
+            // ContractInstanceIds with the same code each need their own
+            // mapping — see issue #2380).
+            //
+            // We MUST also verify the blob is on disk: this `contract_cache` is
+            // per-`ContractStore` (per pool executor), and a `remove_contract`
+            // on a sibling executor can delete the shared blob without
+            // invalidating our cache. Falling through to the disk-write branch
+            // below restores the blob in that case so the new instance is
+            // durably stored. See issue #4218 for the underlying per-executor
+            // map divergence and Codex's round-4 finding.
             self.ensure_key_indexed(&key)?;
             return Ok(());
         }
-        let key_path = code_hash.encode();
-        let key_path = self.contracts_dir.join(key_path).with_extension("wasm");
         if let Ok((code, _ver)) = ContractCode::load_versioned_from_path(&key_path) {
             // WASM file exists on disk. Add to cache AND ensure the index is updated.
             // See issue #2344 for why this is critical after crash recovery.
@@ -910,6 +919,73 @@ mod test {
         store
             .remove_contract(&key)
             .expect("remove_contract must be Ok when the WASM file is already gone");
+
+        Ok(())
+    }
+
+    /// Regression test for Codex's round-4 finding: the `contract_cache` is
+    /// per-`ContractStore` (one per pool executor), but the `.wasm` blob on
+    /// disk is shared. A sibling executor's `remove_contract` can delete the
+    /// blob without invalidating this store's cache. A subsequent
+    /// `store_contract` for a new instance with the same code hash must NOT
+    /// take the cache-hit fast path silently — it must verify the blob still
+    /// exists on disk and re-write it if not. Otherwise the new instance is
+    /// indexed but blobless until the cache evicts and a fetch fails.
+    #[tokio::test]
+    async fn test_store_contract_rewrites_blob_when_cache_hit_but_disk_missing()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let contract_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(contract_dir.path())?;
+        let db = create_test_db(contract_dir.path()).await;
+        let mut store = ContractStore::new(contract_dir.path().into(), 10_000, db)?;
+
+        let shared_code = vec![9, 9, 9, 9];
+
+        // Store instance X1: caches the code AND writes the blob.
+        let x1 = WrappedContract::new(
+            Arc::new(ContractCode::from(shared_code.clone())),
+            [1, 1].as_ref().into(),
+        );
+        let x1_code_hash = *x1.key().code_hash();
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(x1)))?;
+
+        let wasm_path = contract_dir
+            .path()
+            .join(x1_code_hash.encode())
+            .with_extension("wasm");
+        assert!(wasm_path.exists(), "blob must exist after first store");
+
+        // Simulate a sibling executor's `remove_contract` deleting the shared
+        // blob WITHOUT invalidating this store's `contract_cache`.
+        std::fs::remove_file(&wasm_path)?;
+        assert!(!wasm_path.exists());
+        assert!(
+            store.contract_cache.get(&x1_code_hash).is_some(),
+            "this store's cache still has the code (sibling did not invalidate it)"
+        );
+
+        // Store a NEW instance X2 with the SAME code hash. Pre-fix, the
+        // cache-hit fast path returned Ok without re-writing the blob,
+        // leaving X2 indexed but blobless. Post-fix, the disk-existence
+        // check forces a re-write.
+        let x2 = WrappedContract::new(
+            Arc::new(ContractCode::from(shared_code)),
+            [2, 2].as_ref().into(),
+        );
+        let x2_key = *x2.key();
+        let params: Parameters = [2, 2].as_ref().into();
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(x2)))?;
+
+        assert!(
+            wasm_path.exists(),
+            "blob must be re-written after store_contract for a new instance \
+             whose shared code was in cache but missing from disk"
+        );
+        // And the new instance is fetchable end-to-end.
+        assert!(
+            store.fetch_contract(&x2_key, &params).is_some(),
+            "new instance must be fetchable after rewrite"
+        );
 
         Ok(())
     }

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -173,28 +173,49 @@ impl ContractStore {
         Ok(self.contracts_dir.join(key_path).with_extension("wasm"))
     }
 
+    /// Remove a contract instance from the store.
+    ///
+    /// Removes this instance's index entries (ReDb + in-memory) and any
+    /// delegate subscriptions unconditionally. The on-disk `.wasm` blob and
+    /// the code cache entry are keyed by `code_hash`, which is shared across
+    /// every `ContractInstanceId` using the same code, so they are removed
+    /// only once no remaining instance references that code hash. File
+    /// removal is idempotent — an already-missing `.wasm` is not an error.
     pub fn remove_contract(&mut self, key: &ContractKey) -> RuntimeResult<()> {
         let contract_hash = *key.code_hash();
 
-        // Invalidate cache to prevent serving "ghost" contracts. See issue #3487.
-        self.contract_cache.invalidate(&contract_hash);
-
-        // Remove from ReDb index
+        // Remove this instance's index entries first.
         self.db
             .remove_contract_index(key.id())
             .map_err(|e| anyhow::anyhow!("Failed to remove contract index: {e}"))?;
-
-        // Remove from in-memory index
         self.key_to_code_part.remove(key.id());
 
-        // Clean up any delegate subscriptions for this contract
+        // Clean up any delegate subscriptions for this contract instance.
         super::DELEGATE_SUBSCRIPTIONS.remove(key.id());
 
-        let key_path = self
-            .contracts_dir
-            .join(contract_hash.encode())
-            .with_extension("wasm");
-        std::fs::remove_file(key_path)?;
+        // The WASM blob on disk is keyed by code hash and shared by every
+        // contract instance with the same code (e.g. all River rooms share
+        // one room-contract WASM — see issue #2380). Only delete the blob
+        // and its cache entry once no remaining instance references this
+        // code hash, otherwise the surviving instances break on cache miss.
+        let code_still_referenced = self
+            .key_to_code_part
+            .iter()
+            .any(|entry| entry.value() == &contract_hash);
+        if !code_still_referenced {
+            // Invalidate the code cache so a removed contract is never served
+            // as a "ghost" (issue #3487).
+            self.contract_cache.invalidate(&contract_hash);
+            let key_path = self
+                .contracts_dir
+                .join(contract_hash.encode())
+                .with_extension("wasm");
+            match std::fs::remove_file(&key_path) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
         Ok(())
     }
 
@@ -630,6 +651,139 @@ mod test {
             store.fetch_contract(&key, &params).is_none(),
             "Removed contract must not be served from cache (ghost contract)"
         );
+
+        Ok(())
+    }
+
+    /// Regression test for the latent shared-WASM deletion bug: removing one
+    /// contract instance must NOT delete the `.wasm` blob while another
+    /// instance still references the same code hash.
+    ///
+    /// Multiple `ContractInstanceId`s can share one code hash (e.g. every
+    /// River chat room shares one room-contract WASM — see issue #2380).
+    /// The on-disk blob is keyed by code hash, so an unconditional delete
+    /// would break the surviving instances after a cache miss / restart.
+    #[tokio::test]
+    async fn test_remove_contract_keeps_shared_wasm() -> Result<(), Box<dyn std::error::Error>> {
+        let contract_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(contract_dir.path())?;
+        let db = create_test_db(contract_dir.path()).await;
+        let mut store = ContractStore::new(contract_dir.path().into(), 10_000, db)?;
+
+        // Two instances: SAME code, DIFFERENT params -> same code_hash,
+        // different ContractInstanceIds.
+        let shared_code = vec![1, 2, 3, 4, 5];
+        let params1 = Parameters::from(vec![1, 1, 1]);
+        let params2 = Parameters::from(vec![2, 2, 2]);
+        let contract1 = WrappedContract::new(
+            Arc::new(ContractCode::from(shared_code.clone())),
+            params1.clone(),
+        );
+        let contract2 = WrappedContract::new(
+            Arc::new(ContractCode::from(shared_code.clone())),
+            params2.clone(),
+        );
+        let key1 = *contract1.key();
+        let key2 = *contract2.key();
+
+        // Both instances share one code hash.
+        assert_eq!(key1.code_hash(), key2.code_hash());
+
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            contract1,
+        )))?;
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            contract2,
+        )))?;
+
+        let wasm_path = contract_dir
+            .path()
+            .join(key1.code_hash().encode())
+            .with_extension("wasm");
+        assert!(wasm_path.exists(), "WASM file should exist after store");
+
+        // Remove the first instance — the shared WASM must survive because
+        // the second instance still references the code hash.
+        store.remove_contract(&key1)?;
+        assert!(
+            wasm_path.exists(),
+            "Shared WASM file must NOT be deleted while another instance references it"
+        );
+
+        // The second instance must still be fetchable.
+        assert!(
+            store.fetch_contract(&key2, &params2).is_some(),
+            "Surviving instance must still be fetchable after the other is removed"
+        );
+
+        Ok(())
+    }
+
+    /// Removing the last instance referencing a code hash must delete the
+    /// `.wasm` blob from disk to reclaim space.
+    #[tokio::test]
+    async fn test_remove_contract_deletes_last_instance_wasm()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let contract_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(contract_dir.path())?;
+        let db = create_test_db(contract_dir.path()).await;
+        let mut store = ContractStore::new(contract_dir.path().into(), 10_000, db)?;
+
+        let contract = WrappedContract::new(
+            Arc::new(ContractCode::from(vec![9, 8, 7, 6])),
+            [4, 2].as_ref().into(),
+        );
+        let key = *contract.key();
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            contract,
+        )))?;
+
+        let wasm_path = contract_dir
+            .path()
+            .join(key.code_hash().encode())
+            .with_extension("wasm");
+        assert!(wasm_path.exists(), "WASM file should exist after store");
+
+        // Removing the only instance must delete the blob.
+        store.remove_contract(&key)?;
+        assert!(
+            !wasm_path.exists(),
+            "WASM file must be deleted when the last instance is removed"
+        );
+
+        Ok(())
+    }
+
+    /// `remove_contract` must tolerate an already-missing `.wasm` file
+    /// (idempotent file removal).
+    #[tokio::test]
+    async fn test_remove_contract_idempotent_when_file_missing()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let contract_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(contract_dir.path())?;
+        let db = create_test_db(contract_dir.path()).await;
+        let mut store = ContractStore::new(contract_dir.path().into(), 10_000, db)?;
+
+        let contract = WrappedContract::new(
+            Arc::new(ContractCode::from(vec![3, 3, 3])),
+            [7, 7].as_ref().into(),
+        );
+        let key = *contract.key();
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            contract,
+        )))?;
+
+        // Manually delete the WASM file out from under the store.
+        let wasm_path = contract_dir
+            .path()
+            .join(key.code_hash().encode())
+            .with_extension("wasm");
+        std::fs::remove_file(&wasm_path)?;
+
+        // remove_contract must still succeed despite the missing file.
+        store
+            .remove_contract(&key)
+            .expect("remove_contract must be Ok when the WASM file is already gone");
 
         Ok(())
     }

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -80,6 +80,20 @@ impl ContractStore {
 
     /// Returns a copy of the contract bytes if available, none otherwise.
     // todo: instead return Result<Option<_>, _> to handle IO errors upstream
+    //
+    // Known limitation: `key_to_code_part` is a per-`ContractStore` index
+    // (a fresh `Arc<DashMap>` per `ContractStore::new`), so when the
+    // executor pool holds multiple `ContractStore` instances each carries
+    // its own copy of the index. A contract stored via executor A may
+    // therefore be reported as "missing" by `fetch_contract` on executor
+    // B even though both share the same on-disk `.wasm` and the same
+    // process-wide `contract_cache`. The cache-hit fast path below
+    // masks this for shared-code reads when the code hash happens to be
+    // warm in the cache, which is the only reason cross-executor
+    // fetches currently work in production. This divergence is tracked
+    // as #4218; a proper fix would either share the index across
+    // pool members or rebuild it from the on-disk state at startup
+    // per executor.
     pub fn fetch_contract(
         &self,
         key: &ContractKey,

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -181,10 +181,24 @@ impl ContractStore {
     /// every `ContractInstanceId` using the same code, so they are removed
     /// only once no remaining instance references that code hash. File
     /// removal is idempotent — an already-missing `.wasm` is not an error.
+    ///
+    /// The "still referenced?" decision is made against the **shared,
+    /// persistent ReDb `contract_index`**, not the per-`ContractStore`
+    /// in-memory `key_to_code_part` map. Each runtime-pool executor owns a
+    /// *separate* `ContractStore` with its own `key_to_code_part` built
+    /// fresh in [`ContractStore::new`], so an instance stored via a
+    /// different pool executor is invisible to an in-memory scan. Deciding
+    /// from the in-memory map would wrongly delete a `.wasm` blob still
+    /// referenced by an instance owned by another executor — corrupting
+    /// every surviving contract that shares the code (e.g. every River
+    /// room shares one room-contract WASM, see issue #2380). The ReDb
+    /// index is the single shared source of truth across all executors.
     pub fn remove_contract(&mut self, key: &ContractKey) -> RuntimeResult<()> {
         let contract_hash = *key.code_hash();
 
-        // Remove this instance's index entries first.
+        // Remove this instance's index entries first. The ReDb removal must
+        // happen before the `load_all_contract_index()` scan below so this
+        // instance's own entry is not counted as a remaining reference.
         self.db
             .remove_contract_index(key.id())
             .map_err(|e| anyhow::anyhow!("Failed to remove contract index: {e}"))?;
@@ -198,10 +212,29 @@ impl ContractStore {
         // one room-contract WASM — see issue #2380). Only delete the blob
         // and its cache entry once no remaining instance references this
         // code hash, otherwise the surviving instances break on cache miss.
-        let code_still_referenced = self
-            .key_to_code_part
-            .iter()
-            .any(|entry| entry.value() == &contract_hash);
+        //
+        // Decide from the shared persistent index, NOT the per-executor
+        // in-memory map (see the doc comment above for why).
+        let code_still_referenced = match self.db.load_all_contract_index() {
+            Ok(entries) => entries
+                .iter()
+                .any(|(_, code_hash)| code_hash == &contract_hash),
+            Err(e) => {
+                // If we cannot read the shared index we cannot prove the
+                // blob is unreferenced. A leaked blob is recoverable disk
+                // space; deleting a still-referenced shared blob corrupts
+                // every surviving contract using that code. Fail safe:
+                // keep the blob.
+                tracing::warn!(
+                    code_hash = %contract_hash,
+                    error = %e,
+                    "Could not load shared contract index while removing a \
+                     contract; keeping the .wasm blob to avoid corrupting \
+                     contracts that may still reference this code"
+                );
+                return Ok(());
+            }
+        };
         if !code_still_referenced {
             // Invalidate the code cache so a removed contract is never served
             // as a "ghost" (issue #3487).
@@ -714,6 +747,83 @@ mod test {
         assert!(
             store.fetch_contract(&key2, &params2).is_some(),
             "Surviving instance must still be fetchable after the other is removed"
+        );
+
+        Ok(())
+    }
+
+    /// Regression test for the cross-executor shared-WASM deletion bug.
+    ///
+    /// Each runtime-pool executor owns a SEPARATE `ContractStore` with its
+    /// own in-memory `key_to_code_part` map, but they all share one ReDb
+    /// `contract_index`. If `remove_contract` decided "is this code still
+    /// referenced?" from its own in-memory map, an instance stored via a
+    /// different executor would be invisible — and removing the locally
+    /// known instance would wrongly delete the shared `.wasm` blob,
+    /// corrupting the instance owned by the other executor.
+    ///
+    /// This test reproduces that: two `ContractStore`s sharing ONE `db`,
+    /// each storing a different instance of the SAME code. Removing one
+    /// instance via store A must NOT delete the blob, and the instance
+    /// stored via store B must remain fetchable.
+    #[tokio::test]
+    async fn test_remove_contract_keeps_shared_wasm_across_executors()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let contract_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(contract_dir.path())?;
+        let db = create_test_db(contract_dir.path()).await;
+
+        // Two separate ContractStores (simulating two runtime-pool
+        // executors) sharing ONE db / ReDb contract_index.
+        let mut store_a = ContractStore::new(contract_dir.path().into(), 10_000, db.clone())?;
+        let mut store_b = ContractStore::new(contract_dir.path().into(), 10_000, db)?;
+
+        // Same code, different params -> same code_hash, different
+        // ContractInstanceIds.
+        let shared_code = vec![10, 20, 30, 40, 50];
+        let params1 = Parameters::from(vec![1, 1, 1]);
+        let params2 = Parameters::from(vec![2, 2, 2]);
+        let contract1 = WrappedContract::new(
+            Arc::new(ContractCode::from(shared_code.clone())),
+            params1.clone(),
+        );
+        let contract2 = WrappedContract::new(
+            Arc::new(ContractCode::from(shared_code.clone())),
+            params2.clone(),
+        );
+        let key1 = *contract1.key();
+        let key2 = *contract2.key();
+        assert_eq!(key1.code_hash(), key2.code_hash());
+
+        // Instance X1 stored via executor A, instance X2 via executor B.
+        store_a.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            contract1,
+        )))?;
+        store_b.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            contract2,
+        )))?;
+
+        let wasm_path = contract_dir
+            .path()
+            .join(key1.code_hash().encode())
+            .with_extension("wasm");
+        assert!(wasm_path.exists(), "WASM file should exist after store");
+
+        // Remove X1 via store A. Store A's in-memory map never saw X2, so
+        // the OLD code would delete the shared blob here.
+        store_a.remove_contract(&key1)?;
+
+        assert!(
+            wasm_path.exists(),
+            "Shared WASM file must NOT be deleted while another executor's \
+             ContractStore still references the code hash"
+        );
+
+        // X2, owned by executor B, must still be fetchable.
+        assert!(
+            store_b.fetch_contract(&key2, &params2).is_some(),
+            "Instance stored via another executor must survive removal of a \
+             different instance sharing the same code"
         );
 
         Ok(())

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -85,19 +85,6 @@ impl ContractStore {
         key: &ContractKey,
         params: &Parameters<'_>,
     ) -> Option<ContractContainer> {
-        // Invariant: a contract instance is fetchable iff it is indexed in
-        // `key_to_code_part`. The code-hash cache below is keyed by `code_hash`
-        // and is shared across every `ContractInstanceId` using the same
-        // code, so a removed instance whose sibling still references the
-        // same code would otherwise be served as a "ghost" via the cache
-        // hit. Checking the index first makes this impossible: after
-        // `remove_contract` of one of two shared-code instances, the
-        // removed instance is no longer fetchable here even though the
-        // shared `code_hash` is still cached for the surviving instance.
-        // See `test_fetch_contract_returns_none_for_removed_shared_code_instance`.
-        if !self.key_to_code_part.contains_key(key.id()) {
-            return None;
-        }
         let code_hash = key.code_hash();
         if let Some(data) = self.contract_cache.get(code_hash) {
             return Some(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
@@ -909,96 +896,6 @@ mod test {
         store
             .remove_contract(&key)
             .expect("remove_contract must be Ok when the WASM file is already gone");
-
-        Ok(())
-    }
-
-    /// `fetch_contract` must not serve a "ghost" of a removed instance via
-    /// the shared code-hash cache. Two instances share one code hash; the
-    /// first instance is removed. The second instance must remain
-    /// fetchable (it is still indexed), and the removed instance must NOT
-    /// be fetchable even though `code_hash` is still in the in-memory
-    /// `contract_cache` thanks to the surviving sibling.
-    ///
-    /// Regression test for the Codex P2 finding in PR #4212 review round C.
-    /// The cache-hit fast path used to return `Some` based purely on
-    /// `code_hash`, which meant a `remove_contract`'d instance was served
-    /// as if still present after the refcount-safe shared-WASM fix in
-    /// PR #4212. The added `key_to_code_part.contains_key` guard at the
-    /// top of `fetch_contract` makes "fetchable iff indexed" the
-    /// invariant.
-    #[tokio::test]
-    async fn test_fetch_contract_returns_none_for_removed_shared_code_instance()
-    -> Result<(), Box<dyn std::error::Error>> {
-        let contract_dir = crate::util::tests::get_temp_dir();
-        std::fs::create_dir_all(contract_dir.path())?;
-        let db = create_test_db(contract_dir.path()).await;
-        let mut store = ContractStore::new(contract_dir.path().into(), 10_000, db)?;
-
-        // Two instances sharing one code hash, distinguished by params.
-        let shared_code = vec![0xAB, 0xCD, 0xEF];
-        let params_removed = Parameters::from(vec![1, 1, 1]);
-        let params_survivor = Parameters::from(vec![2, 2, 2]);
-        let contract_removed = WrappedContract::new(
-            Arc::new(ContractCode::from(shared_code.clone())),
-            params_removed.clone(),
-        );
-        let contract_survivor = WrappedContract::new(
-            Arc::new(ContractCode::from(shared_code.clone())),
-            params_survivor.clone(),
-        );
-        let key_removed = *contract_removed.key();
-        let key_survivor = *contract_survivor.key();
-        assert_eq!(key_removed.code_hash(), key_survivor.code_hash());
-        assert_ne!(key_removed.id(), key_survivor.id());
-
-        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
-            contract_removed,
-        )))?;
-        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
-            contract_survivor,
-        )))?;
-
-        // Both fetchable initially.
-        assert!(
-            store
-                .fetch_contract(&key_removed, &params_removed)
-                .is_some(),
-            "Pre-condition: removed-instance must be fetchable before removal"
-        );
-        assert!(
-            store
-                .fetch_contract(&key_survivor, &params_survivor)
-                .is_some(),
-            "Pre-condition: surviving instance must be fetchable"
-        );
-
-        // Remove one instance. The shared `.wasm` blob stays because the
-        // other instance still references the code hash — and crucially,
-        // the code-hash cache entry stays too (it is keyed by code hash).
-        store.remove_contract(&key_removed)?;
-
-        // The removed instance must NOT be fetchable, even though the
-        // code-hash cache still has its bytes (kept warm by the sibling).
-        // Without the index-first guard at the top of fetch_contract this
-        // would erroneously return Some via the cache-hit fast path.
-        assert!(
-            store
-                .fetch_contract(&key_removed, &params_removed)
-                .is_none(),
-            "Removed instance must NOT be served via shared code-hash \
-             cache hit — `fetch_contract` must check `key_to_code_part` \
-             before the cache lookup"
-        );
-
-        // The surviving instance must still be fully fetchable.
-        assert!(
-            store
-                .fetch_contract(&key_survivor, &params_survivor)
-                .is_some(),
-            "Surviving instance must still be fetchable after a sibling \
-             with shared code is removed"
-        );
 
         Ok(())
     }

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -18,8 +18,10 @@ pub struct ContractStore {
     /// ReDb storage for persistent index
     db: Storage,
 }
-// TODO: add functionality to delete old contracts which have not been used for a while
-//       to keep the total space used under a configured threshold
+// Eviction-driven reclamation of unused contracts now exists: the hosting
+// cache evicts least-valuable contracts past its budget and the resulting
+// `EvictContract` event drives `Executor::reclaim_contract_storage`, which
+// calls `ContractStore::remove_contract` to delete the on-disk `.wasm` blob.
 
 impl ContractStore {
     /// # Arguments

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -85,6 +85,19 @@ impl ContractStore {
         key: &ContractKey,
         params: &Parameters<'_>,
     ) -> Option<ContractContainer> {
+        // Invariant: a contract instance is fetchable iff it is indexed in
+        // `key_to_code_part`. The code-hash cache below is keyed by `code_hash`
+        // and is shared across every `ContractInstanceId` using the same
+        // code, so a removed instance whose sibling still references the
+        // same code would otherwise be served as a "ghost" via the cache
+        // hit. Checking the index first makes this impossible: after
+        // `remove_contract` of one of two shared-code instances, the
+        // removed instance is no longer fetchable here even though the
+        // shared `code_hash` is still cached for the surviving instance.
+        // See `test_fetch_contract_returns_none_for_removed_shared_code_instance`.
+        if !self.key_to_code_part.contains_key(key.id()) {
+            return None;
+        }
         let code_hash = key.code_hash();
         if let Some(data) = self.contract_cache.get(code_hash) {
             return Some(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
@@ -896,6 +909,96 @@ mod test {
         store
             .remove_contract(&key)
             .expect("remove_contract must be Ok when the WASM file is already gone");
+
+        Ok(())
+    }
+
+    /// `fetch_contract` must not serve a "ghost" of a removed instance via
+    /// the shared code-hash cache. Two instances share one code hash; the
+    /// first instance is removed. The second instance must remain
+    /// fetchable (it is still indexed), and the removed instance must NOT
+    /// be fetchable even though `code_hash` is still in the in-memory
+    /// `contract_cache` thanks to the surviving sibling.
+    ///
+    /// Regression test for the Codex P2 finding in PR #4212 review round C.
+    /// The cache-hit fast path used to return `Some` based purely on
+    /// `code_hash`, which meant a `remove_contract`'d instance was served
+    /// as if still present after the refcount-safe shared-WASM fix in
+    /// PR #4212. The added `key_to_code_part.contains_key` guard at the
+    /// top of `fetch_contract` makes "fetchable iff indexed" the
+    /// invariant.
+    #[tokio::test]
+    async fn test_fetch_contract_returns_none_for_removed_shared_code_instance()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let contract_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(contract_dir.path())?;
+        let db = create_test_db(contract_dir.path()).await;
+        let mut store = ContractStore::new(contract_dir.path().into(), 10_000, db)?;
+
+        // Two instances sharing one code hash, distinguished by params.
+        let shared_code = vec![0xAB, 0xCD, 0xEF];
+        let params_removed = Parameters::from(vec![1, 1, 1]);
+        let params_survivor = Parameters::from(vec![2, 2, 2]);
+        let contract_removed = WrappedContract::new(
+            Arc::new(ContractCode::from(shared_code.clone())),
+            params_removed.clone(),
+        );
+        let contract_survivor = WrappedContract::new(
+            Arc::new(ContractCode::from(shared_code.clone())),
+            params_survivor.clone(),
+        );
+        let key_removed = *contract_removed.key();
+        let key_survivor = *contract_survivor.key();
+        assert_eq!(key_removed.code_hash(), key_survivor.code_hash());
+        assert_ne!(key_removed.id(), key_survivor.id());
+
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            contract_removed,
+        )))?;
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            contract_survivor,
+        )))?;
+
+        // Both fetchable initially.
+        assert!(
+            store
+                .fetch_contract(&key_removed, &params_removed)
+                .is_some(),
+            "Pre-condition: removed-instance must be fetchable before removal"
+        );
+        assert!(
+            store
+                .fetch_contract(&key_survivor, &params_survivor)
+                .is_some(),
+            "Pre-condition: surviving instance must be fetchable"
+        );
+
+        // Remove one instance. The shared `.wasm` blob stays because the
+        // other instance still references the code hash — and crucially,
+        // the code-hash cache entry stays too (it is keyed by code hash).
+        store.remove_contract(&key_removed)?;
+
+        // The removed instance must NOT be fetchable, even though the
+        // code-hash cache still has its bytes (kept warm by the sibling).
+        // Without the index-first guard at the top of fetch_contract this
+        // would erroneously return Some via the cache-hit fast path.
+        assert!(
+            store
+                .fetch_contract(&key_removed, &params_removed)
+                .is_none(),
+            "Removed instance must NOT be served via shared code-hash \
+             cache hit — `fetch_contract` must check `key_to_code_part` \
+             before the cache lookup"
+        );
+
+        // The surviving instance must still be fully fetchable.
+        assert!(
+            store
+                .fetch_contract(&key_survivor, &params_survivor)
+                .is_some(),
+            "Surviving instance must still be fetchable after a sibling \
+             with shared code is removed"
+        );
 
         Ok(())
     }

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -129,6 +129,7 @@ impl Runtime {
                 &mut self.secret_store,
                 &self.contract_store,
                 self.state_store_db.clone(),
+                self.state_write_callback.clone(),
                 delegate_key.clone(),
                 &mut self.delegate_store,
                 0, // creation_depth: always 0 for top-level calls

--- a/crates/core/src/wasm_runtime/delegate_api.rs
+++ b/crates/core/src/wasm_runtime/delegate_api.rs
@@ -390,9 +390,36 @@ mod tests {
                     &mut self.secret_store,
                     &self.contract_store,
                     Some(self.db.clone()),
+                    None,
                     delegate_key,
                     &mut self.delegate_store,
                     depth,
+                    vec![],
+                )
+            }
+        }
+
+        /// Create a DelegateCallEnv wired to an arbitrary state-write callback.
+        ///
+        /// # Safety
+        /// Caller must ensure the returned env does not outlive `self`.
+        unsafe fn make_env_with_callback(
+            &mut self,
+            cb: super::super::runtime::StateWriteCallback,
+        ) -> DelegateCallEnv {
+            let delegate_key = DelegateKey::new([0u8; 32], CodeHash::new([0u8; 32]));
+            // SAFETY: The caller guarantees the returned env does not outlive `self`,
+            // which keeps the borrowed `secret_store` and `contract_store` alive.
+            unsafe {
+                DelegateCallEnv::new(
+                    vec![],
+                    &mut self.secret_store,
+                    &self.contract_store,
+                    Some(self.db.clone()),
+                    Some(cb),
+                    delegate_key,
+                    &mut self.delegate_store,
+                    0,
                     vec![],
                 )
             }
@@ -415,6 +442,7 @@ mod tests {
                     &mut self.secret_store,
                     &self.contract_store,
                     Some(self.db.clone()),
+                    None,
                     delegate_key,
                     &mut self.delegate_store,
                     0,
@@ -507,6 +535,7 @@ mod tests {
                 &mut env_holder.secret_store,
                 &env_holder.contract_store,
                 None, // No state store
+                None,
                 delegate_key,
                 &mut env_holder.delegate_store,
                 0,
@@ -587,6 +616,7 @@ mod tests {
                 &mut env_holder.secret_store,
                 &env_holder.contract_store,
                 None,
+                None,
                 delegate_key,
                 &mut env_holder.delegate_store,
                 0,
@@ -612,6 +642,7 @@ mod tests {
                 vec![],
                 &mut env_holder.secret_store,
                 &env_holder.contract_store,
+                None,
                 None,
                 delegate_key,
                 &mut env_holder.delegate_store,
@@ -674,6 +705,108 @@ mod tests {
 
         let state = env.get_contract_state_sync(&contract_id).unwrap();
         assert_eq!(state, Some(vec![40, 50, 60]));
+    }
+
+    /// V2 delegate PUT must fire the `state_write_callback` (which the
+    /// executor wires to `bump_state_generation` + `refresh_cache_generation`)
+    /// AFTER a successful write. Without this hook the V2 delegate write
+    /// path bypasses the executor's `state_store.store` chokepoint and the
+    /// per-contract generation counter never advances on V2 delegate writes,
+    /// leaving the EvictContract re-host race open.
+    ///
+    /// Regression test for PR #4212 review round D (skeptical r3 #1).
+    #[tokio::test]
+    async fn test_env_put_contract_state_fires_write_callback() {
+        let mut env_holder = TestEnv::new().await;
+        let contract_id = env_holder.store_contract(120, &[1, 2, 3]).await;
+
+        let observed = std::sync::Arc::new(std::sync::Mutex::new(Vec::<ContractKey>::new()));
+        let observed_for_cb = observed.clone();
+        let cb: super::super::runtime::StateWriteCallback =
+            std::sync::Arc::new(move |k: &ContractKey| {
+                observed_for_cb.lock().unwrap().push(*k);
+            });
+
+        // SAFETY: `env_holder` is alive for the duration of this test.
+        let env = unsafe { env_holder.make_env_with_callback(cb) };
+        env.put_contract_state_sync(&contract_id, vec![4, 5, 6])
+            .expect("V2 PUT should succeed");
+
+        let calls = observed.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "callback must fire exactly once per successful V2 PUT"
+        );
+        assert_eq!(
+            calls[0].id(),
+            &contract_id,
+            "callback must receive the written contract key"
+        );
+    }
+
+    /// V2 delegate UPDATE must also fire `state_write_callback` after a
+    /// successful update. Mirrors `test_env_put_contract_state_fires_write_callback`
+    /// for the UPDATE path — same race rationale.
+    #[tokio::test]
+    async fn test_env_update_contract_state_fires_write_callback() {
+        let mut env_holder = TestEnv::new().await;
+        let contract_id = env_holder.store_contract(121, &[10, 20, 30]).await;
+
+        let observed = std::sync::Arc::new(std::sync::Mutex::new(Vec::<ContractKey>::new()));
+        let observed_for_cb = observed.clone();
+        let cb: super::super::runtime::StateWriteCallback =
+            std::sync::Arc::new(move |k: &ContractKey| {
+                observed_for_cb.lock().unwrap().push(*k);
+            });
+
+        // SAFETY: `env_holder` is alive for the duration of this test.
+        let env = unsafe { env_holder.make_env_with_callback(cb) };
+        env.update_contract_state_sync(&contract_id, vec![40, 50, 60])
+            .expect("V2 UPDATE should succeed");
+
+        let calls = observed.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "callback must fire exactly once per successful V2 UPDATE"
+        );
+        assert_eq!(
+            calls[0].id(),
+            &contract_id,
+            "callback must receive the updated contract key"
+        );
+    }
+
+    /// A failed V2 delegate UPDATE (no existing state) must NOT fire the
+    /// callback — the write didn't happen, so no generation bump is owed.
+    #[tokio::test]
+    async fn test_env_update_contract_state_failure_does_not_fire_callback() {
+        let mut env_holder = TestEnv::new().await;
+        // Register contract code but do NOT store any state — UPDATE will fail.
+        let code = ContractCode::from(vec![122, 123, 124]);
+        let params = Parameters::from(vec![132, 133]);
+        let key = ContractKey::from_params_and_code(&params, &code);
+        let contract_id = *key.id();
+        env_holder.contract_store.ensure_key_indexed(&key).unwrap();
+
+        let observed = std::sync::Arc::new(std::sync::Mutex::new(Vec::<ContractKey>::new()));
+        let observed_for_cb = observed.clone();
+        let cb: super::super::runtime::StateWriteCallback =
+            std::sync::Arc::new(move |k: &ContractKey| {
+                observed_for_cb.lock().unwrap().push(*k);
+            });
+
+        // SAFETY: `env_holder` is alive for the duration of this test.
+        let env = unsafe { env_holder.make_env_with_callback(cb) };
+        let result = env.update_contract_state_sync(&contract_id, vec![1, 2, 3]);
+        assert!(matches!(result, Err(DelegateEnvError::NoExistingState)));
+
+        let calls = observed.lock().unwrap();
+        assert!(
+            calls.is_empty(),
+            "callback must NOT fire when the V2 UPDATE returns NoExistingState"
+        );
     }
 
     /// V2 delegate UPDATE fails when there's no existing state.

--- a/crates/core/src/wasm_runtime/mock_state_storage.rs
+++ b/crates/core/src/wasm_runtime/mock_state_storage.rs
@@ -285,6 +285,14 @@ impl StateStorage for MockStateStorage {
 
         Ok(inner.params.get(key).cloned())
     }
+
+    async fn remove(&self, key: &ContractKey) -> Result<(), Self::Error> {
+        let mut inner = self.inner.lock().unwrap();
+        // HashMap::remove on an absent key is fine, so this is idempotent.
+        inner.states.remove(key);
+        inner.params.remove(key);
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -277,6 +277,15 @@ pub(super) struct DelegateCallEnv {
     /// contract state synchronously via host functions. ReDb is Arc<Database>
     /// internally, so cloning is cheap.
     state_store_db: Option<Storage>,
+    /// Optional callback invoked AFTER a successful V2 delegate state write
+    /// (`put_contract_state_sync` / `update_contract_state_sync`). Closes the
+    /// EvictContract re-host race for the V2 delegate write path by bumping
+    /// the per-contract generation token and refreshing the hosting-cache
+    /// snapshot — the V2 path bypasses the executor `state_store.{store,update}`
+    /// chokepoints where the four executor-side bump+refresh sites live, so
+    /// without this hook the V2 path leaves the race open. See
+    /// `super::runtime::StateWriteCallback`.
+    state_write_callback: Option<super::runtime::StateWriteCallback>,
     /// Interior-mutable pointer to the runtime's DelegateStore. Valid only during
     /// synchronous `process()` call. Used for creating child delegates.
     delegate_store: std::cell::UnsafeCell<*mut DelegateStore>,
@@ -344,6 +353,7 @@ impl DelegateCallEnv {
         secret_store: &mut SecretsStore,
         contract_store: &ContractStore,
         state_store_db: Option<Storage>,
+        state_write_callback: Option<super::runtime::StateWriteCallback>,
         delegate_key: DelegateKey,
         delegate_store: &mut DelegateStore,
         creation_depth: u32,
@@ -355,6 +365,7 @@ impl DelegateCallEnv {
             delegate_key,
             contract_store: contract_store as *const ContractStore,
             state_store_db,
+            state_write_callback,
             delegate_store: std::cell::UnsafeCell::new(delegate_store as *mut DelegateStore),
             creation_depth,
             creations_this_call: std::cell::Cell::new(0),
@@ -570,7 +581,20 @@ impl DelegateCallEnv {
             &contract_key,
             freenet_stdlib::prelude::WrappedState::new(state),
         )
-        .map_err(|e| DelegateEnvError::StorageError(e.to_string()))
+        .map_err(|e| DelegateEnvError::StorageError(e.to_string()))?;
+
+        // V2 delegate write chokepoint: this path bypasses the executor's
+        // `state_store.store` call site where the per-contract generation
+        // counter is bumped and the hosting-cache snapshot refreshed. The
+        // callback (when wired) closes the EvictContract re-host race for
+        // V2 delegate writes by mirroring those two steps. Failure here is
+        // best-effort — the write has already committed and we don't want
+        // to roll it back over a counter bump.
+        if let Some(cb) = &self.state_write_callback {
+            cb(&contract_key);
+        }
+
+        Ok(())
     }
 
     /// Update contract state by instance ID.
@@ -593,7 +617,16 @@ impl DelegateCallEnv {
             &contract_key,
             freenet_stdlib::prelude::WrappedState::new(state),
         ) {
-            Ok(true) => Ok(()),
+            Ok(true) => {
+                // V2 delegate write chokepoint: mirror the executor's
+                // `state_store.update` bump+refresh so the EvictContract
+                // re-host race is also closed for V2 delegate UPDATEs.
+                // See `put_contract_state_sync` for the rationale.
+                if let Some(cb) = &self.state_write_callback {
+                    cb(&contract_key);
+                }
+                Ok(())
+            }
             Ok(false) => Err(DelegateEnvError::NoExistingState),
             Err(e) => Err(DelegateEnvError::StorageError(e.to_string())),
         }

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -186,6 +186,25 @@ impl Default for RuntimeConfig {
     }
 }
 
+/// Callback invoked after a successful state write from a V2 delegate host
+/// function (`put_contract_state_sync` or `update_contract_state_sync`).
+///
+/// V2 delegate writes go through `db.store_state_sync` / `db.update_state_sync`
+/// directly and bypass the executor's `state_store.{store,update}` chokepoints
+/// where the four `bump_state_generation` + `refresh_cache_generation` sites
+/// live. Without this callback the per-contract generation counter never
+/// advances on a V2 delegate write, leaving the EvictContract re-host race
+/// open for that path. The wiring lives outside `wasm_runtime/` (Ring lives
+/// in `crates/core/src/ring.rs`) so the callback is plumbed via a trait
+/// object owned by `Runtime` to keep `wasm_runtime` independent of the ring.
+///
+/// The closure SHOULD bump the per-contract generation and refresh the
+/// hosting-cache snapshot for the given key — see
+/// `RuntimePool::contract_state_write_callback` for the production wiring
+/// and `HostingCache::refresh_entry_generation` for the rationale.
+pub type StateWriteCallback =
+    Arc<dyn Fn(&freenet_stdlib::prelude::ContractKey) + Send + Sync + 'static>;
+
 pub struct Runtime {
     /// The WASM engine backend (wasmtime).
     pub(super) engine: Engine,
@@ -206,6 +225,12 @@ pub struct Runtime {
 
     /// Optional state storage backend for V2 delegate contract access.
     pub(crate) state_store_db: Option<crate::contract::storages::Storage>,
+
+    /// Optional callback invoked after a successful V2 delegate state write,
+    /// used to bump the per-contract generation token and refresh the
+    /// hosting-cache snapshot from the V2 path (which bypasses the executor
+    /// chokepoints). See `StateWriteCallback`.
+    pub(crate) state_write_callback: Option<StateWriteCallback>,
 }
 
 impl Runtime {
@@ -222,6 +247,14 @@ impl Runtime {
     /// Set the state storage backend for V2 delegate contract access.
     pub fn set_state_store_db(&mut self, db: crate::contract::storages::Storage) {
         self.state_store_db = Some(db);
+    }
+
+    /// Install a callback invoked after each successful V2 delegate state
+    /// write. See `StateWriteCallback`. Without this, V2 PUT/UPDATE bypass
+    /// the executor's bump+refresh chokepoints and the EvictContract
+    /// re-host race stays open for V2 delegate writes.
+    pub fn set_state_write_callback(&mut self, cb: StateWriteCallback) {
+        self.state_write_callback = Some(cb);
     }
 
     pub fn build_with_config(
@@ -247,6 +280,7 @@ impl Runtime {
             delegate_modules: Arc::new(Mutex::new(LruCache::new(cache_capacity))),
             delegate_contexts: super::native_api::new_delegate_context_cache(),
             state_store_db: None,
+            state_write_callback: None,
         })
     }
 
@@ -304,6 +338,7 @@ impl Runtime {
             delegate_modules,
             delegate_contexts,
             state_store_db: None,
+            state_write_callback: None,
         })
     }
 

--- a/crates/core/src/wasm_runtime/state_store.rs
+++ b/crates/core/src/wasm_runtime/state_store.rs
@@ -68,6 +68,9 @@ pub trait StateStorage {
         &'a self,
         key: &'a ContractKey,
     ) -> impl Future<Output = Result<Option<Parameters<'static>>, Self::Error>> + Send + 'a;
+    /// Remove all persisted data for a contract (state and parameters).
+    /// Idempotent: removing a contract that is not stored is not an error.
+    fn remove(&self, key: &ContractKey) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
 /// StateStore wraps a persistent storage backend with an optional in-memory cache.
@@ -227,6 +230,17 @@ where
         }
         let r = self.store.get(key).await.map_err(Into::into)?;
         r.ok_or_else(|| StateStoreError::MissingContract(*key))
+    }
+
+    /// Delete a contract's persisted state and parameters and drop it from
+    /// the in-memory cache. Used to reclaim disk space when a contract is
+    /// evicted from the hosting cache. Idempotent.
+    pub async fn delete(&self, key: &ContractKey) -> Result<(), StateStoreError> {
+        if let Some(cache) = &self.state_mem_cache {
+            cache.invalidate(key);
+        }
+        self.store.remove(key).await.map_err(Into::into)?;
+        Ok(())
     }
 
     pub async fn get_params<'a>(
@@ -895,5 +909,54 @@ mod tests {
             retrieved, original_state,
             "Cache should serve last persisted state after failed update"
         );
+    }
+
+    // ============ delete() Tests ============
+
+    /// After store() then delete(), the contract's state and params must be gone.
+    #[tokio::test]
+    async fn test_state_store_delete_removes_state_and_params() {
+        let mock_storage = MockStateStorage::new();
+        let mut store = StateStore::new(mock_storage, 10_000).unwrap();
+
+        let key = make_test_key();
+        let state = make_test_state(&[1, 2, 3]);
+        let params = Parameters::from(vec![10, 20, 30]);
+
+        // Store state and params, confirm they are present
+        store
+            .store(key, state.clone(), params.clone())
+            .await
+            .unwrap();
+        assert_eq!(store.get(&key).await.unwrap(), state);
+        assert_eq!(store.get_params(&key).await.unwrap(), Some(params));
+
+        // Delete the contract
+        store.delete(&key).await.unwrap();
+
+        // State should no longer be retrievable
+        let get_result = store.get(&key).await;
+        assert!(
+            matches!(get_result, Err(StateStoreError::MissingContract(_))),
+            "Expected MissingContract after delete, got {get_result:?}"
+        );
+
+        // Params should be gone too
+        assert_eq!(store.get_params(&key).await.unwrap(), None);
+    }
+
+    /// delete() on a contract that was never stored is a no-op (idempotent).
+    #[tokio::test]
+    async fn test_state_store_delete_never_stored_is_idempotent() {
+        let mock_storage = MockStateStorage::new();
+        let store = StateStore::new(mock_storage, 10_000).unwrap();
+
+        let key = make_test_key();
+
+        // Deleting a contract that was never stored must succeed
+        store
+            .delete(&key)
+            .await
+            .expect("delete of a never-stored contract should be Ok");
     }
 }


### PR DESCRIPTION
## Problem

Freenet nodes had **no limit on disk space used for contract storage**. Contract WASM code (`contracts/`) and contract state (`db/`) accumulated permanently — every contract whose data ever passed through a node stayed on disk forever.

The `HostingCache` already has a byte budget and LRU eviction, but eviction was a **metadata-only** operation: when a contract was evicted, the node dropped the in-memory tracking entry and the ReDb `hosting_metadata` row, but **never deleted the contract's state or WASM code from disk**. `ContractStore` even carried a standing TODO acknowledging that disk-bounded eviction was unimplemented.

Net effect: the hosting budget bounded the *in-memory hosted set* but not actual disk usage, which grew without bound.

A second, latent bug found along the way: `ContractStore::remove_contract` deleted the on-disk `.wasm` blob unconditionally. The blob is keyed by code hash and shared across contract instances (every River room shares one room-contract WASM), so removing one instance could break the others on a cache miss / after restart.

## Approach

Make hosting-cache eviction actually reclaim disk, and make the budget operator-configurable.

1. **Storage delete APIs.** Added `StateStorage::remove` (ReDb, SQLite, mock backends) and `StateStore::delete` — deletes persisted state + params and invalidates the moka cache. Made `ContractStore::remove_contract` code-hash refcount-safe: the shared `.wasm` blob is deleted only when no remaining contract instance references that code hash, decided from the **persistent ReDb `contract_index`** (the source of truth shared across all pool executors — a per-executor in-memory index would miss siblings stored via a different executor). File removal is idempotent.

2. **Configurable budget.** New `max-hosting-storage` config option (CLI / env / TOML), default **1 GiB**. Threaded into `HostingCache`.

3. **Eviction → reclamation wiring.** New fire-and-forget `ContractHandlerEvent::EvictContract`, an executor `reclaim_contract_storage` path, and a `reclaim_evicted_contract` helper wired into all three eviction sites (GET cache, PUT cache, periodic hosting sweep). `EvictContract` is routed through the fair queue per-contract.

**In-use contracts are never deleted.** A contract with an active client subscription, downstream peer subscriber, or upstream network subscription (`contract_in_use`) is exempt from eviction-driven deletion. This exemption is applied in three places so it is airtight: `HostingCache::record_access` and `sweep_expired` will not *evict* an in-use contract from the cache at all (so it is never orphaned on disk); `reclaim_evicted_contract` re-checks the gate before emitting an event; and `RuntimePool::remove_contract` re-checks once more at deletion time, skipping the delete if the contract was re-hosted or re-subscribed in the window since eviction.

**State-write generation token.** Re-subscription and re-hosting checks alone are insufficient against a tighter race: a contract can be re-PUT or UPDATEd in the window between eviction and the executor processing the EvictContract event. To close that, every state write bumps a per-contract monotonic counter (`HostingManager::bump_state_generation`), the current value is captured atomically in `HostedContract.write_generation` at hosting-cache record/refresh time, the snapshot is carried through `EvictContract`, and the deletion-time guard in `RuntimePool::remove_contract` re-reads the current generation and skips reclamation on any mismatch. The bump+refresh pair runs from FOUR executor chokepoints (`commit_state_update` PUT/UPDATE, the store-initial-state path, and `verify_and_store`) AND from the V2 delegate write path (`put_contract_state_sync` / `update_contract_state_sync`) via a callback installed on `Runtime` so the V2 path is also covered. The `is_hosting_contract` / `contract_in_use` re-checks at deletion time remain as defense in depth.

## Scope of the bound

The budget tracks **contract state bytes** — the dominant consumer. WASM code blobs and database (ReDb/SQLite) overhead are reclaimed on eviction but not counted toward the budget, so total on-disk use can modestly exceed the configured value. Eviction reclamation is also best-effort (fire-and-forget): under sustained load an eviction event can be dropped and retried on the next cycle. The budget is therefore a soft target on tracked state, not a hard ceiling on every byte.

## Operator note

The enforced default rises from a previously-hardcoded 100 MiB to 1 GiB **and** eviction now actually deletes disk. A node upgrading with more than `max-hosting-storage` of cached contract state will, on first run, evict and delete down to the budget — contracts it is not actively using will be shed and re-fetched from the network on next access. Contracts the node has a subscription to are retained.

## Testing

New unit tests covering:
- **Storage layer** — `StateStorage::remove` (ReDb + SQLite); `StateStore::delete` idempotency; refcount-safe `ContractStore::remove_contract`, including `test_remove_contract_keeps_shared_wasm_across_executors` (two `ContractStore`s sharing one DB — proves the cross-executor case).
- **Hosting cache** — `record_access` honors the retain predicate (in-use contracts not evicted); `contract_in_use` (client / downstream / network subscription, reclaimable once all leave).
- **State-write generation token** — `test_record_access_carries_write_generation_through_eviction`, `test_record_contract_access_captures_then_diverges_from_current_generation`, `test_state_generation_lifecycle`, `test_record_access_refresh_updates_write_generation`, `test_refresh_cache_generation_is_noop_when_entry_absent`.
- **V2 delegate write path** — `test_env_put_contract_state_fires_write_callback`, `test_env_update_contract_state_fires_write_callback`, `test_env_update_contract_state_failure_does_not_fire_callback`.
- **Config** — `max-hosting-storage` default + explicit-value round-trip.
- **Executor** — `remove_contract` reclaims state + WASM from disk; idempotent double-eviction.

Full `cargo test -p freenet --lib`: passing. `cargo clippy --lib --tests` (incl. `--features sqlite`): clean.

Three rounds of multi-perspective + external-model review found and fixed:
- **Round 1** — four deterministic data-loss bugs (refcount-check race, eviction/deletion TOCTOU, orphaned disk leak for in-use contracts, stale TODO).
- **Round 2** — the eviction/re-host TOCTOU (closed via the state-write generation token described above).
- **Round 3** — the V2 delegate write path bypassing the executor's bump+refresh chokepoints, and a permanent disk leak introduced by the round-2 fix on the UPDATE-then-evict case (the cache snapshot never refreshed after the first `record_access`, so every UPDATE-then-evict leaked).

Each round's review was re-run on the result.

Follow-ups (filed, not blocking):
- #4216 — concurrent store/remove on a shared code hash can delete a freshly-written WASM blob (pre-existing).
- #4217 — end-to-end `#[freenet_test]` driving the cache over budget.
- #4218 — pool executors have divergent per-instance `ContractStore::key_to_code_part` maps. The original "ghost" cache-hit symptom mentioned in earlier rounds is rooted in this pre-existing per-executor map divergence; the index-membership guard added during review round 3 to mask it was reverted in this PR because it regressed cross-executor fetches, and the divergence is now documented at the top of `fetch_contract`.

[AI-assisted - Claude]
