### PR TITLE
fix(subscribe): fetch contract body + announce hosted on originator subscribe

### DIFF
--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -391,24 +391,36 @@ pub(super) async fn fetch_contract_if_missing(
 ///    this, the peer registers as a subscriber but answers `NotFound`
 ///    on GETs that route through it because the contract body never
 ///    arrived.
-/// 5. **Announce that we host this contract to neighbors**, so they
-///    include us as a broadcast target for UPDATEs.
+/// 5. **Announce that we host this contract to neighbors**, *only when
+///    the body is locally present after step 4*. Announcing without a
+///    body would tell neighbors to forward UPDATEs to a peer that
+///    cannot validate or store them. If the body lands later via the
+///    sub-op GET's own cache path, `get/op_ctx_task.rs` calls
+///    `announce_contract_hosted` there — so the announce eventually
+///    fires either way.
 /// 6. Register the contract in our local interest manager (so inbound
 ///    `ChangeInterests` for this contract get processed) and broadcast
 ///    a `ChangeInterests` so connected peers learn we became interested.
-///    Gated on `!is_renewal` — renewals do not re-add the local-client
-///    entry (idempotent, but skipping the broadcast prevents a noisy
-///    spam every renewal cycle).
+///    Gated on `!is_renewal` — `add_local_client` is NOT idempotent
+///    (`ring::interest::Contract::add_client` increments
+///    `local_client_count` on every call); calling it on every renewal
+///    cycle (~2 minutes) would leak the gauge unboundedly.
 ///
-/// All side effects are idempotent for repeat subscribes / renewals.
+/// Latency note: because this function is awaited before the driver
+/// publishes `SubscribeResponse` to the client, a first-time subscribe
+/// to a contract we don't host can take up to `CONTRACT_WAIT_TIMEOUT_MS`
+/// (2 s) longer than the prior task-per-tx path took. This implements
+/// issue #4223's proposed approach point 2 ("do not emit
+/// subscribe_success to the client until fetch_contract_if_missing
+/// completes"); the latency is the cost of the client knowing the
+/// subscriber can actually serve a follow-up GET.
 ///
-/// The fetch step is best-effort: on timeout or sub-op failure the
-/// subscription is still finalized (lease installed, peer registered).
-/// The contract body can arrive later via UPDATE propagation, and a
-/// future GET through this peer would still return `NotFound` until
-/// then — but the alternative (failing the whole subscribe on a
-/// contract-fetch timeout) would leave the client without notifications
-/// it does want.
+/// See also: `crate::operations::complete_piggyback_subscription` —
+/// the GET-piggyback originator finalization path, which performs the
+/// same conceptual steps in a different order (it does NOT need the
+/// fetch step because the contract just arrived inside the GET
+/// response that carried the piggyback). Keep the two helpers in sync
+/// when adding new originator-side side effects.
 pub(super) async fn finalize_originator_subscribe(
     op_manager: &OpManager,
     key: ContractKey,
@@ -429,22 +441,45 @@ pub(super) async fn finalize_originator_subscribe(
     op_manager.ring.subscribe(key);
     op_manager.ring.complete_subscription_request(&key, true);
 
-    // Fetch the contract body if we don't have it locally. Best-effort:
-    // a timeout / sub-op failure does not abort finalization.
-    if let Err(err) = fetch_contract_if_missing(op_manager, *key.id()).await {
-        tracing::debug!(
-            contract = %key,
-            error = %err,
-            "subscribe: fetch_contract_if_missing failed; \
-             state will arrive via UPDATE if/when available"
-        );
-    }
+    // Fetch the contract body if we don't have it locally. The result
+    // gates the announce step: we only advertise hosting to neighbors
+    // when the body actually lands. On timeout (Ok(None)) or
+    // infrastructure failure (Err), the subscription is still finalized
+    // (lease installed, peer registered) — the contract may arrive
+    // later via UPDATE propagation or the sub-op GET completing past
+    // the 2 s wait window, at which point the GET driver's own
+    // `announce_contract_hosted` call fires.
+    let have_body = match fetch_contract_if_missing(op_manager, *key.id()).await {
+        Ok(Some(_)) => true,
+        Ok(None) => {
+            tracing::debug!(
+                contract = %key,
+                timeout_ms = CONTRACT_WAIT_TIMEOUT_MS,
+                "subscribe: contract body did not arrive within timeout; \
+                 deferring announce_contract_hosted — the sub-op GET will \
+                 announce when it caches, or UPDATE delivery will fill the gap"
+            );
+            false
+        }
+        Err(err) => {
+            // Infrastructure failure (notification channel closed,
+            // contract handler down). `warn` rather than `debug`
+            // because this signals broken local plumbing, not a
+            // routine cache miss.
+            tracing::warn!(
+                contract = %key,
+                error = %err,
+                "subscribe: fetch_contract_if_missing returned infra error; \
+                 deferring announce_contract_hosted — operator should \
+                 investigate (contract handler / notification channel)"
+            );
+            false
+        }
+    };
 
-    // Announce that we host this contract so neighbors include us as a
-    // broadcast target. Must come AFTER the fetch attempt — announcing
-    // before the body is present would tell neighbors to forward
-    // UPDATEs to a peer that cannot validate them.
-    super::announce_contract_hosted(op_manager, &key).await;
+    if have_body {
+        super::announce_contract_hosted(op_manager, &key).await;
+    }
 
     if !is_renewal {
         let became_interested = op_manager.interest_manager.add_local_client(&key);

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -340,6 +340,120 @@ async fn complete_local_subscription(
     Ok(())
 }
 
+/// Fetch the contract body locally if we do not already have it.
+///
+/// Fire-and-forget GET sub-op + bounded wait for the contract to land in
+/// local storage. Used by the originator finalization helper so that a
+/// peer that successfully subscribed to a contract it had never seen can
+/// answer subsequent GETs from local state rather than returning
+/// `get_not_found`. See issue #4223 — the v0.2.51+ task-per-tx SUBSCRIBE
+/// migration dropped this call, leaving subscribers with the lease
+/// installed but no contract body, so 37% of GETs that routed through a
+/// subscriber were returning NotFound.
+///
+/// Returns `Ok(Some(key))` if the contract is locally available after the
+/// fetch attempt (including the case where it was already present),
+/// `Ok(None)` if it could not be obtained within `CONTRACT_WAIT_TIMEOUT_MS`
+/// (the originator's subscribe still completes — the contract may arrive
+/// later via UPDATE), and `Err` only for local infrastructure failures
+/// (channel closed, etc.).
+pub(super) async fn fetch_contract_if_missing(
+    op_manager: &OpManager,
+    instance_id: ContractInstanceId,
+) -> Result<Option<ContractKey>, OpError> {
+    if let Some(key) = super::has_contract(op_manager, instance_id).await? {
+        return Ok(Some(key));
+    }
+
+    // Spawn the sub-op GET. We drop the receiver — we don't care about
+    // the structured `SubOpGetOutcome`, only the side effect of caching
+    // the contract locally. `wait_for_contract_with_timeout` (storage
+    // poll + wait_for_contract channel + timeout) detects arrival.
+    let (_tx, _rx) = super::get::op_ctx_task::start_sub_op_get(op_manager, instance_id, true);
+
+    wait_for_contract_with_timeout(op_manager, instance_id, CONTRACT_WAIT_TIMEOUT_MS).await
+}
+
+/// Finalize an originator-side subscribe success.
+///
+/// Called from the task-per-tx SUBSCRIBE driver
+/// (`op_ctx_task::drive_client_subscribe_inner`) after a `Subscribed`
+/// reply arrives. Performs every side-effect the originator needs so the
+/// subscription is fully usable end-to-end:
+///
+/// 1. Register the responding peer as our upstream interest (so
+///    `send_unsubscribe_upstream` can find it on client disconnect — #3874).
+/// 2. Install the lease in `active_subscriptions`
+///    (`op_manager.ring.subscribe`).
+/// 3. Clear pending backoff state for this contract
+///    (`op_manager.ring.complete_subscription_request(..., true)`).
+/// 4. **Fetch the contract body locally if missing** (#4223). Without
+///    this, the peer registers as a subscriber but answers `NotFound`
+///    on GETs that route through it because the contract body never
+///    arrived.
+/// 5. **Announce that we host this contract to neighbors**, so they
+///    include us as a broadcast target for UPDATEs.
+/// 6. Register the contract in our local interest manager (so inbound
+///    `ChangeInterests` for this contract get processed) and broadcast
+///    a `ChangeInterests` so connected peers learn we became interested.
+///    Gated on `!is_renewal` — renewals do not re-add the local-client
+///    entry (idempotent, but skipping the broadcast prevents a noisy
+///    spam every renewal cycle).
+///
+/// All side effects are idempotent for repeat subscribes / renewals.
+///
+/// The fetch step is best-effort: on timeout or sub-op failure the
+/// subscription is still finalized (lease installed, peer registered).
+/// The contract body can arrive later via UPDATE propagation, and a
+/// future GET through this peer would still return `NotFound` until
+/// then — but the alternative (failing the whole subscribe on a
+/// contract-fetch timeout) would leave the client without notifications
+/// it does want.
+pub(super) async fn finalize_originator_subscribe(
+    op_manager: &OpManager,
+    key: ContractKey,
+    upstream_addr: std::net::SocketAddr,
+    is_renewal: bool,
+) {
+    if let Some(pkl) = op_manager
+        .ring
+        .connection_manager
+        .get_peer_by_addr(upstream_addr)
+    {
+        let peer_key = crate::ring::interest::PeerKey::from(pkl.pub_key);
+        op_manager
+            .interest_manager
+            .register_peer_interest(&key, peer_key, None, true);
+    }
+
+    op_manager.ring.subscribe(key);
+    op_manager.ring.complete_subscription_request(&key, true);
+
+    // Fetch the contract body if we don't have it locally. Best-effort:
+    // a timeout / sub-op failure does not abort finalization.
+    if let Err(err) = fetch_contract_if_missing(op_manager, *key.id()).await {
+        tracing::debug!(
+            contract = %key,
+            error = %err,
+            "subscribe: fetch_contract_if_missing failed; \
+             state will arrive via UPDATE if/when available"
+        );
+    }
+
+    // Announce that we host this contract so neighbors include us as a
+    // broadcast target. Must come AFTER the fetch attempt — announcing
+    // before the body is present would tell neighbors to forward
+    // UPDATEs to a peer that cannot validate them.
+    super::announce_contract_hosted(op_manager, &key).await;
+
+    if !is_renewal {
+        let became_interested = op_manager.interest_manager.add_local_client(&key);
+        if became_interested {
+            super::broadcast_change_interests(op_manager, vec![key], vec![]).await;
+        }
+    }
+}
+
 /// Register a downstream subscriber for a contract.
 ///
 /// Resolves the requester's `PeerKey` from the pre-resolved public key (preferred,

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -396,8 +396,14 @@ pub(super) async fn fetch_contract_if_missing(
 ///    body would tell neighbors to forward UPDATEs to a peer that
 ///    cannot validate or store them. If the body lands later via the
 ///    sub-op GET's own cache path, `get/op_ctx_task.rs` calls
-///    `announce_contract_hosted` there — so the announce eventually
-///    fires either way.
+///    `announce_contract_hosted` there *on first-time cache* (gated
+///    on `is_new && put_persisted`). A niche case where the contract
+///    was previously hosted then evicted, the lease expires, and the
+///    re-subscribe fetch then times out, would not re-trigger the
+///    announce via that fallback — neighbors learn we host the
+///    contract again either through the next renewal cycle's
+///    finalization (if the body has arrived by then) or via UPDATE
+///    delivery + auto-fetch.
 /// 6. Register the contract in our local interest manager (so inbound
 ///    `ChangeInterests` for this contract get processed) and broadcast
 ///    a `ChangeInterests` so connected peers learn we became interested.

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -747,35 +747,22 @@ async fn drive_client_subscribe_inner(
                         .await;
                 }
                 op_manager.ring.routing_finished(route_event);
-                // Mirror the legacy Response-handler side effects from
-                // `subscribe.rs`'s `SubscribeMsg::Response` arm. The
-                // driver reply forwarding bypass in `node.rs` skips
-                // `handle_op_request` for terminal Responses, so without
-                // these calls the local interest manager and ring would
-                // never learn about the subscription, breaking
-                // ChangeInterests-driven update propagation. Both calls are
-                // idempotent for repeat subscribes.
-                //
-                // Register the responding peer as our upstream. Without
-                // this, `send_unsubscribe_upstream` cannot locate the peer
-                // on client disconnect and no Unsubscribe is emitted (#3874).
-                if let Some(pkl) = op_manager
-                    .ring
-                    .connection_manager
-                    .get_peer_by_addr(current_target_addr)
-                {
-                    let peer_key = crate::ring::interest::PeerKey::from(pkl.pub_key);
-                    op_manager
-                        .interest_manager
-                        .register_peer_interest(&key, peer_key, None, true);
-                }
-                op_manager.ring.subscribe(key);
-                op_manager.ring.complete_subscription_request(&key, true);
-                let became_interested = op_manager.interest_manager.add_local_client(&key);
-                if became_interested {
-                    crate::operations::broadcast_change_interests(op_manager, vec![key], vec![])
-                        .await;
-                }
+                // Run originator-side finalization. This is the single
+                // place that owns the post-Subscribed side effects:
+                // upstream-peer registration (#3874), lease install,
+                // backoff clear, contract-body fetch (#4223), neighbor
+                // announce, and local-interest bookkeeping. Keeping all
+                // of it inside `finalize_originator_subscribe` lets the
+                // executor-subscribe entry (`run_executor_subscribe`)
+                // and any future driver entry inherit the same shape
+                // by calling the same helper.
+                super::finalize_originator_subscribe(
+                    op_manager,
+                    key,
+                    current_target_addr,
+                    is_renewal,
+                )
+                .await;
                 return Ok(DriverOutcome::Publish(Ok(HostResponse::ContractResponse(
                     ContractResponse::SubscribeResponse {
                         key,

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -245,6 +245,31 @@ fn finalize_originator_subscribe_contains_all_required_side_effects() {
          forward UPDATEs to a peer that cannot validate them (Codex \
          HIGH finding on PR #4224)"
     );
+    // (5b) The announce MUST be conditionally gated on the fetch
+    // returning Ok(Some(_)) — ordering alone is not enough. Codex r2
+    // + skeptical r2 LOW: a future unconditional
+    // `announce_contract_hosted` after the fetch would still satisfy
+    // the ordering pin above. Anchor on a `have_body` binding +
+    // verify the announce call sits in the `if have_body { ... }`
+    // block (i.e. AFTER the `have_body` binding line).
+    let have_body_pos = body
+        .find("have_body")
+        .expect("finalize_originator_subscribe must bind `have_body` from the fetch match");
+    assert!(
+        body.contains("if have_body"),
+        "finalize_originator_subscribe MUST gate `announce_contract_hosted` \
+         on an `if have_body {{ ... }}` conditional — the gate is the \
+         Codex HIGH fix invariant, not just the ordering. Without it a \
+         future refactor could re-introduce the announce-without-body \
+         bug while keeping fetch < announce order."
+    );
+    assert!(
+        have_body_pos < announce_pos,
+        "the `have_body` binding MUST appear before the \
+         `announce_contract_hosted` call site so the announce is \
+         actually gated by the fetch result, not by some unrelated \
+         later binding of the same name"
+    );
     // (6) add_local_client gated on !is_renewal. Anchor on the API,
     // not the variable name.
     assert!(
@@ -289,7 +314,22 @@ fn drive_client_subscribe_inner_calls_finalize_helper_on_subscribed() {
         .find("ReplyClass::NotFound =>")
         .expect("end of Subscribed branch not found")
         + branch_start;
-    let branch = &SOURCE[branch_start..branch_end];
+    let raw_branch = &SOURCE[branch_start..branch_end];
+
+    // Strip line comments so doc / explanatory comments that mention
+    // the API names as negative context (e.g. "delegated to the
+    // helper which calls announce_contract_hosted") don't trip the
+    // negative substring pins. Mirrors the helper-side pin and the
+    // relay-side pin in op_ctx_task.rs.
+    let branch: String = raw_branch
+        .lines()
+        .map(|line| match line.find("//") {
+            Some(idx) => &line[..idx],
+            None => line,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let branch = branch.as_str();
 
     assert!(
         branch.contains("finalize_originator_subscribe"),

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -119,12 +119,19 @@ fn subscribe_dispatch_routes_unsubscribe_to_inbound_handler() {
 }
 
 /// Pin: `finalize_originator_subscribe` MUST call all six originator
-/// finalization side effects. The hand-inlined sequence at the task-per-tx
+/// finalization side effects, AND the fetch must come before the
+/// conditional announce. The hand-inlined sequence at the task-per-tx
 /// driver's `ReplyClass::Subscribed` branch previously omitted
 /// `fetch_contract_if_missing` and `announce_contract_hosted`, causing
 /// issue #4223 (subscribed peers returning `get_not_found` on the same
 /// contract). Each missing call has a documented production failure
 /// mode — if any is dropped, this test fails and points at the issue.
+///
+/// Assertion shape: substring-match on the API surface (e.g.
+/// `ring.subscribe(`) rather than on full call expressions with
+/// variable names (e.g. `ring.subscribe(key)`). A variable rename
+/// (`key` → `contract_key`) should not silently break the pin while
+/// still passing the bug class through.
 #[test]
 fn finalize_originator_subscribe_contains_all_required_side_effects() {
     const SOURCE: &str = include_str!("../subscribe.rs");
@@ -134,12 +141,51 @@ fn finalize_originator_subscribe_contains_all_required_side_effects() {
             "finalize_originator_subscribe not found in subscribe.rs — \
              rename or removal must trip this pin (issue #4223)",
         );
-    // Anchor end: scan to the next top-level `pub(` item declaration.
-    let body_after = &SOURCE[fn_start..];
-    let next_pub = body_after[1..]
-        .find("\npub(")
-        .expect("no subsequent pub item found after finalize_originator_subscribe");
-    let body = &body_after[..1 + next_pub];
+    // Anchor end: scan to the next top-level item declaration. Using
+    // `\n///` or `\nfn ` / `\nasync fn` / `\npub` would all work; the
+    // brace-counted approach is the most robust against helper
+    // insertions between this function and the next pub item. Count
+    // braces from the function body's opening `{` until they balance.
+    let body_open = SOURCE[fn_start..]
+        .find('{')
+        .expect("function body open brace not found")
+        + fn_start;
+    let mut depth = 0i32;
+    let mut body_end = body_open;
+    for (i, c) in SOURCE[body_open..].char_indices() {
+        match c {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    body_end = body_open + i + 1;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    assert!(
+        body_end > body_open,
+        "could not find balanced closing brace for \
+         finalize_originator_subscribe — body anchor is broken"
+    );
+    let raw_body = &SOURCE[fn_start..body_end];
+
+    // Strip line comments so doc strings and inline comments that
+    // mention the API names as context do not contaminate the
+    // substring + ordering scans. Mirrors the same pattern used by
+    // `relay_subscribe_does_not_install_lease_on_relayed_response` in
+    // `op_ctx_task.rs`.
+    let body: String = raw_body
+        .lines()
+        .map(|line| match line.find("//") {
+            Some(idx) => &line[..idx],
+            None => line,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let body = body.as_str();
 
     // (1) upstream-peer registration → enables `send_unsubscribe_upstream` (#3874).
     assert!(
@@ -148,19 +194,22 @@ fn finalize_originator_subscribe_contains_all_required_side_effects() {
          upstream interest — without it `send_unsubscribe_upstream` cannot \
          find the peer to notify on client disconnect (#3874)"
     );
-    // (2) install lease in active_subscriptions.
+    // (2) install lease in active_subscriptions. Anchor on the API,
+    // not the variable name, so renaming `key` does not break the pin.
     assert!(
-        body.contains("ring.subscribe(key)"),
-        "finalize_originator_subscribe must call `ring.subscribe` to install \
-         the lease in `active_subscriptions` — without it the contract is \
-         not picked up by `contracts_needing_renewal` and the subscription \
-         silently dies at TTL expiry (#3851)"
+        body.contains("ring.subscribe("),
+        "finalize_originator_subscribe must call `ring.subscribe(...)` to \
+         install the lease in `active_subscriptions` — without it the \
+         contract is not picked up by `contracts_needing_renewal` and the \
+         subscription silently dies at TTL expiry (#3851)"
     );
-    // (3) clear pending backoff state.
+    // (3) clear pending backoff state. Match on the API + success arg,
+    // independent of the contract-key variable name.
     assert!(
-        body.contains("complete_subscription_request(&key, true)"),
-        "finalize_originator_subscribe must call `complete_subscription_request` \
-         with success=true to clear the pending mark and reset backoff"
+        body.contains("complete_subscription_request(") && body.contains(", true)"),
+        "finalize_originator_subscribe must call \
+         `complete_subscription_request(..., true)` to clear the pending \
+         mark and reset backoff"
     );
     // (4) fetch contract body if missing → THIS is the core #4223 fix.
     assert!(
@@ -170,25 +219,47 @@ fn finalize_originator_subscribe_contains_all_required_side_effects() {
          subsequent GETs from local state instead of returning NotFound \
          (#4223 — 37% of GETs through subscriber peers were failing)"
     );
-    // (5) announce_contract_hosted → tells neighbors to include us in UPDATE broadcasts.
+    // (5) announce_contract_hosted → tells neighbors to include us in
+    // UPDATE broadcasts. Ordering: MUST come after the fetch attempt
+    // so it is gated on the body being locally present (Codex finding;
+    // pre-fetch announce would tell neighbors to forward UPDATEs we
+    // cannot validate).
     assert!(
         body.contains("announce_contract_hosted"),
         "finalize_originator_subscribe MUST call `announce_contract_hosted` \
-         so neighbors include us as an UPDATE broadcast target — without \
-         this, UPDATEs may not reach the subscriber even after the contract \
-         body is local (#3851)"
+         (gated on fetch success) so neighbors include us as an UPDATE \
+         broadcast target — without this, UPDATEs may not reach the \
+         subscriber even after the contract body is local (#3851)"
     );
-    // (6) add_local_client gated on !is_renewal.
+    let fetch_pos = body
+        .find("fetch_contract_if_missing")
+        .expect("fetch call site already asserted above");
+    let announce_pos = body
+        .find("announce_contract_hosted")
+        .expect("announce call site already asserted above");
     assert!(
-        body.contains("add_local_client(&key)"),
-        "finalize_originator_subscribe must call `add_local_client` so \
-         inbound ChangeInterests for this contract get processed"
+        fetch_pos < announce_pos,
+        "fetch_contract_if_missing must appear BEFORE \
+         announce_contract_hosted in finalize_originator_subscribe — \
+         announcing before the body is local would tell neighbors to \
+         forward UPDATEs to a peer that cannot validate them (Codex \
+         HIGH finding on PR #4224)"
+    );
+    // (6) add_local_client gated on !is_renewal. Anchor on the API,
+    // not the variable name.
+    assert!(
+        body.contains("add_local_client("),
+        "finalize_originator_subscribe must call `add_local_client(...)` \
+         so inbound ChangeInterests for this contract get processed"
     );
     assert!(
         body.contains("!is_renewal"),
         "finalize_originator_subscribe must gate `add_local_client` on \
-         `!is_renewal` — counter increments on every renewal cycle would \
-         leak the local_client_count gauge unboundedly"
+         `!is_renewal` — `add_client` is NOT idempotent \
+         (`ring::interest::Contract::add_client` increments \
+         `local_client_count` on every call), so an unconditional call \
+         on every ~2-minute renewal cycle would leak the gauge \
+         unboundedly"
     );
 }
 
@@ -199,6 +270,10 @@ fn finalize_originator_subscribe_contains_all_required_side_effects() {
 /// `fetch_contract_if_missing` and `announce_contract_hosted`. By
 /// pinning the call site to the helper, any future refactor that
 /// reverts to inlining will trip this test.
+///
+/// Negative-pin shape: matches on the API surface (`ring.subscribe(`)
+/// rather than full expressions, so a variable rename can't slip a
+/// re-inlined call past the guard.
 #[test]
 fn drive_client_subscribe_inner_calls_finalize_helper_on_subscribed() {
     const SOURCE: &str = include_str!("op_ctx_task.rs");
@@ -224,20 +299,28 @@ fn drive_client_subscribe_inner_calls_finalize_helper_on_subscribed() {
          helper as the single source of truth."
     );
 
-    // Negative pins: the inlined calls must NOT come back. If a future
-    // refactor re-inlines `ring.subscribe(key)` etc. directly into this
-    // branch instead of going through the helper, the helper might not
-    // be called at all and we'd silently regress.
+    // Negative pins: the inlined calls must NOT come back. Anchor on
+    // the API surface — `ring.subscribe(` rather than
+    // `op_manager.ring.subscribe(key)` — so a rename of either the
+    // receiver (e.g. `om.ring.subscribe(...)`) or the contract-key
+    // variable can't silently bypass the guard.
     assert!(
-        !branch.contains("op_manager.ring.subscribe(key)"),
-        "Subscribed branch must not call `ring.subscribe` directly — go \
+        !branch.contains("ring.subscribe("),
+        "Subscribed branch must not call `ring.subscribe(...)` directly — go \
          through `finalize_originator_subscribe` so the fetch + announce \
          steps stay grouped with the lease install"
     );
     assert!(
-        !branch.contains("op_manager.ring.complete_subscription_request"),
-        "Subscribed branch must not call `complete_subscription_request` \
+        !branch.contains("complete_subscription_request("),
+        "Subscribed branch must not call `complete_subscription_request(...)` \
          directly — go through `finalize_originator_subscribe`"
+    );
+    assert!(
+        !branch.contains("announce_contract_hosted"),
+        "Subscribed branch must not call `announce_contract_hosted` directly \
+         — the fetch-success gate lives inside `finalize_originator_subscribe`; \
+         inlining it would re-introduce the Codex HIGH finding on PR #4224 \
+         (announcing without the contract body)"
     );
 }
 

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -118,6 +118,129 @@ fn subscribe_dispatch_routes_unsubscribe_to_inbound_handler() {
     );
 }
 
+/// Pin: `finalize_originator_subscribe` MUST call all six originator
+/// finalization side effects. The hand-inlined sequence at the task-per-tx
+/// driver's `ReplyClass::Subscribed` branch previously omitted
+/// `fetch_contract_if_missing` and `announce_contract_hosted`, causing
+/// issue #4223 (subscribed peers returning `get_not_found` on the same
+/// contract). Each missing call has a documented production failure
+/// mode — if any is dropped, this test fails and points at the issue.
+#[test]
+fn finalize_originator_subscribe_contains_all_required_side_effects() {
+    const SOURCE: &str = include_str!("../subscribe.rs");
+    let fn_start = SOURCE
+        .find("pub(super) async fn finalize_originator_subscribe(")
+        .expect(
+            "finalize_originator_subscribe not found in subscribe.rs — \
+             rename or removal must trip this pin (issue #4223)",
+        );
+    // Anchor end: scan to the next top-level `pub(` item declaration.
+    let body_after = &SOURCE[fn_start..];
+    let next_pub = body_after[1..]
+        .find("\npub(")
+        .expect("no subsequent pub item found after finalize_originator_subscribe");
+    let body = &body_after[..1 + next_pub];
+
+    // (1) upstream-peer registration → enables `send_unsubscribe_upstream` (#3874).
+    assert!(
+        body.contains("register_peer_interest"),
+        "finalize_originator_subscribe must register the responding peer as \
+         upstream interest — without it `send_unsubscribe_upstream` cannot \
+         find the peer to notify on client disconnect (#3874)"
+    );
+    // (2) install lease in active_subscriptions.
+    assert!(
+        body.contains("ring.subscribe(key)"),
+        "finalize_originator_subscribe must call `ring.subscribe` to install \
+         the lease in `active_subscriptions` — without it the contract is \
+         not picked up by `contracts_needing_renewal` and the subscription \
+         silently dies at TTL expiry (#3851)"
+    );
+    // (3) clear pending backoff state.
+    assert!(
+        body.contains("complete_subscription_request(&key, true)"),
+        "finalize_originator_subscribe must call `complete_subscription_request` \
+         with success=true to clear the pending mark and reset backoff"
+    );
+    // (4) fetch contract body if missing → THIS is the core #4223 fix.
+    assert!(
+        body.contains("fetch_contract_if_missing"),
+        "finalize_originator_subscribe MUST call `fetch_contract_if_missing` \
+         so the originator has the contract body locally and can answer \
+         subsequent GETs from local state instead of returning NotFound \
+         (#4223 — 37% of GETs through subscriber peers were failing)"
+    );
+    // (5) announce_contract_hosted → tells neighbors to include us in UPDATE broadcasts.
+    assert!(
+        body.contains("announce_contract_hosted"),
+        "finalize_originator_subscribe MUST call `announce_contract_hosted` \
+         so neighbors include us as an UPDATE broadcast target — without \
+         this, UPDATEs may not reach the subscriber even after the contract \
+         body is local (#3851)"
+    );
+    // (6) add_local_client gated on !is_renewal.
+    assert!(
+        body.contains("add_local_client(&key)"),
+        "finalize_originator_subscribe must call `add_local_client` so \
+         inbound ChangeInterests for this contract get processed"
+    );
+    assert!(
+        body.contains("!is_renewal"),
+        "finalize_originator_subscribe must gate `add_local_client` on \
+         `!is_renewal` — counter increments on every renewal cycle would \
+         leak the local_client_count gauge unboundedly"
+    );
+}
+
+/// Pin: the task-per-tx subscribe driver's `ReplyClass::Subscribed`
+/// branch MUST delegate to `finalize_originator_subscribe`. Inlining
+/// the side effects directly at the branch is what caused issue #4223
+/// — the original inline sequence was missing
+/// `fetch_contract_if_missing` and `announce_contract_hosted`. By
+/// pinning the call site to the helper, any future refactor that
+/// reverts to inlining will trip this test.
+#[test]
+fn drive_client_subscribe_inner_calls_finalize_helper_on_subscribed() {
+    const SOURCE: &str = include_str!("op_ctx_task.rs");
+    let fn_start = SOURCE
+        .find("async fn drive_client_subscribe_inner(")
+        .expect("drive_client_subscribe_inner not found");
+    let branch_anchor = "ReplyClass::Subscribed { key } =>";
+    let branch_start = SOURCE[fn_start..]
+        .find(branch_anchor)
+        .expect("ReplyClass::Subscribed branch not found in drive_client_subscribe_inner")
+        + fn_start;
+    let branch_end = SOURCE[branch_start..]
+        .find("ReplyClass::NotFound =>")
+        .expect("end of Subscribed branch not found")
+        + branch_start;
+    let branch = &SOURCE[branch_start..branch_end];
+
+    assert!(
+        branch.contains("finalize_originator_subscribe"),
+        "Subscribed branch must delegate to `finalize_originator_subscribe` \
+         — inlining the side effects is what caused #4223 (missing \
+         fetch_contract_if_missing + announce_contract_hosted). Keep the \
+         helper as the single source of truth."
+    );
+
+    // Negative pins: the inlined calls must NOT come back. If a future
+    // refactor re-inlines `ring.subscribe(key)` etc. directly into this
+    // branch instead of going through the helper, the helper might not
+    // be called at all and we'd silently regress.
+    assert!(
+        !branch.contains("op_manager.ring.subscribe(key)"),
+        "Subscribed branch must not call `ring.subscribe` directly — go \
+         through `finalize_originator_subscribe` so the fetch + announce \
+         steps stay grouped with the lease install"
+    );
+    assert!(
+        !branch.contains("op_manager.ring.complete_subscription_request"),
+        "Subscribed branch must not call `complete_subscription_request` \
+         directly — go through `finalize_originator_subscribe`"
+    );
+}
+
 /// Pin: `SubscribeMsg::ForwardingAck` wire-format compatibility. The
 /// variant has no production reader, but a serde round-trip guards
 /// against bincode-discriminant shifts that would break cross-version


### PR DESCRIPTION
## Problem

Telemetry from the last 24h showed that on contracts with active
subscribers, **37 % of failing GETs reach one of the subscriber peers
and that subscriber still returns `get_not_found`** (#4223). The
subscriber is correctly registered as such but has never fetched the
contract body locally — so it answers truthfully that it has no state.

| Failure pattern on subscribed contracts | Count | % |
|---|---:|---:|
| **GET visited a subscriber, still got NF** | **63** | **37 %** |
| GET never visited any subscriber | 109 | 63 % |

Closes #4223, #3851 (#3851's proposed fix — extract a shared
`finalize_originator_subscribe` helper — is exactly what this PR
introduces).

## Approach

Root cause: the v0.2.51+ task-per-tx SUBSCRIBE migration moved the
`Subscribed`-reply finalization into `drive_client_subscribe_inner`
(`crates/core/src/operations/subscribe/op_ctx_task.rs`) but
hand-inlined only a subset of the originator-side side effects. The
inlined block called `ring.subscribe`, `complete_subscription_request`,
and `add_local_client`, but dropped:

- `fetch_contract_if_missing(...)` — fetch the contract body via a
  sub-op GET if we don't have it locally. Without this, a peer that
  successfully subscribed to a fresh contract holds the lease but has
  no body to serve subsequent GETs.
- `announce_contract_hosted(...)` — tell neighbors to include us as
  an UPDATE broadcast target. Without this, UPDATEs may not reach
  the subscriber even after the body lands.

### Fix

1. Extract `finalize_originator_subscribe(op_manager, key,
   upstream_addr, is_renewal)` in `subscribe.rs`. The helper performs
   every originator-side side effect (upstream-peer registration,
   lease install, backoff clear, contract-body fetch, neighbor
   announce, local-interest registration). This is exactly the
   shared helper proposed in #3851.
2. Restore `fetch_contract_if_missing(...)` as a `pub(super)` helper
   built on `start_sub_op_get` + `wait_for_contract_with_timeout`
   (resurrected from the pre-#4089 form).
3. Replace the inlined sequence in `drive_client_subscribe_inner`'s
   `ReplyClass::Subscribed` arm with a single call to the helper.
4. Gate `announce_contract_hosted` on the fetch returning
   `Ok(Some(_))` (Codex HIGH finding) — don't advertise hosting to
   neighbors when we don't actually have the body. If the body
   arrives later via the sub-op GET completing past the 2 s wait
   window, `get/op_ctx_task.rs` calls `announce_contract_hosted`
   itself; if it arrives via UPDATE, that path also re-announces.

### Behavior changes worth flagging

These are side fixes that come out of the helper extraction, not the
literal scope of "37 % of GETs return NotFound":

- **Renewal counter leak fix** (`add_local_client` gated on
  `!is_renewal`). The previous inline code called `add_local_client`
  unconditionally; `ring::interest::Contract::add_client` is NOT
  idempotent and increments `local_client_count` on every call, so
  every ~2-minute renewal cycle leaked the per-contract client
  counter. The helper restores the gate from
  `complete_local_subscription`. **Renewals now also call
  `fetch_contract_if_missing` and the announce-on-success path on
  every cycle** — both early-return / no-op when the body is already
  present, so steady-state cost is one local-storage check per
  renewal.
- **Client-visible latency on first subscribe**: because the fetch is
  awaited before the driver publishes `SubscribeResponse`, a
  first-time subscribe to a contract we don't host can take up to
  `CONTRACT_WAIT_TIMEOUT_MS` (2 s) longer than the prior task-per-tx
  path. This implements issue #4223 approach point 2 ("do not emit
  subscribe_success to the client until fetch_contract_if_missing
  completes"); the latency is the cost of the client knowing the
  subscriber can actually serve a follow-up GET.

### Cache GC angle

Issue #4223 approach point 3 (verify `active_subscriptions` exempts
contracts from cache GC) is **already handled** by
`sweep_expired_hosting` consulting `has_client_subscriptions` /
`has_downstream_subscribers` (`crates/core/src/ring/hosting.rs:825-828`).
No change needed there.

## Testing

Two source-scrape pin tests in
`crates/core/src/operations/subscribe/tests.rs`:

- `finalize_originator_subscribe_contains_all_required_side_effects` —
  verifies each of the six required calls is present in the helper
  AND that `fetch_contract_if_missing` appears before
  `announce_contract_hosted` (pins the Codex HIGH fix invariant).
  Pin shape: match on API surface (e.g. `ring.subscribe(`) not on
  full call expressions (e.g. `ring.subscribe(key)`) so renames
  don't silently bypass it. Body anchor: brace-balance walk + line
  comment stripping so intervening helpers / doc-string mentions
  don't contaminate the scan.
- `drive_client_subscribe_inner_calls_finalize_helper_on_subscribed` —
  verifies the driver delegates to the helper, and negative-pins
  `ring.subscribe(`, `complete_subscription_request(`, and
  `announce_contract_hosted` so a future refactor that re-inlines
  any of them trips the guard.

Test runs (post-review-feedback HEAD `57a9650c`):

- [x] `cargo test -p freenet --lib operations::subscribe` — 45 passed
- [x] `cargo test -p freenet --lib operations` — 314 / 315 passed
  (one pre-existing flake in
  `operations::connect::tests::relay_does_not_accept_after_forwarding_on_retry`
  that uses `Location::random()` / shared RNG; passes in isolation
  and on repeat runs; tracked as #3944, unrelated to subscribe)
- [x] `cargo clippy --locked -- -D warnings` clean
- [x] `cargo fmt` clean

Filed as follow-up: a deterministic simulation reproduction
(SeedContract on gateway only → Subscribe from another node →
assert subscriber's storage now contains the contract). The
testing-reviewer pointed at
`test_get_succeeds_despite_readiness_gating` as the model
infrastructure. Pin tests catch the structural regression class
that produced this bug; the simulation test would catch the
behavioral failure-mode if a future change preserves the helper
shape but breaks the fetch's effect.

## Bug-class entry

Added a new row to `~/code/freenet/.claude/rules/bug-prevention-patterns.md`
("Manually-inlined originator side effects after a task-per-tx
migration") so future task-per-tx migrations of GET / PUT / UPDATE
that grow their own originator-side finalization see this in
context with the #4009/#4010 counter mirror entry. Same bug class,
different surface.

[AI-assisted - Claude]