### PR TITLE
fix: widen router candidate window to surface subscribers (#4222)

### DIFF
--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1470,6 +1470,7 @@ impl Ring {
         let mut candidates: Vec<PeerKeyLocation> = Vec::new();
         let mut not_ready_fallback: Vec<PeerKeyLocation> = Vec::new();
         let mut skipped_not_ready: usize = 0;
+        let mut skipped_transient: usize = 0;
 
         let connections = self.connection_manager.get_connections_by_location();
         // Sort keys for deterministic iteration order (HashMap iteration is non-deterministic)
@@ -1484,6 +1485,21 @@ impl Ring {
             for conn in sorted_conns {
                 if let Some(addr) = conn.location.socket_addr() {
                     if skip_list.has_element(addr) || !seen.insert(addr) {
+                        continue;
+                    }
+                    // Skip transient peers — these are short-TTL connections used for
+                    // CONNECT coordination, not stable routing targets. PUT/UPDATE
+                    // already exclude them via `ConnectionManager::routing_candidates`
+                    // (see connection_manager.rs:1578); previously GET/SUBSCRIBE
+                    // could route through them and waste hops on a forwarder that
+                    // was about to be dropped. Issue #4222 / #3570.
+                    if self.connection_manager.is_transient(addr) {
+                        tracing::debug!(
+                            %addr,
+                            target_location = %target_location.as_f64(),
+                            "k_closest: skipping transient peer"
+                        );
+                        skipped_transient += 1;
                         continue;
                     }
                     // Skip peers that haven't advertised readiness, but collect them
@@ -1548,6 +1564,7 @@ impl Ring {
             target_location = %target_location.as_f64(),
             candidates_found = selected.len(),
             skipped_not_ready,
+            skipped_transient,
             "k_closest_potentially_hosting result"
         );
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1534,6 +1534,22 @@ impl Ring {
             candidates = not_ready_fallback;
         }
 
+        // If the entire connection set was filtered out and transients carried
+        // weight in that filtering, warn the operator. There is no transient
+        // fallback by design — transient peers are short-TTL coordination slots
+        // and routing through them just wastes hops — but a sustained
+        // empty-candidate state means the local node has no viable routing
+        // options for this hop, which is operator-visible information that
+        // would otherwise only surface as an `EmptyRing` higher up.
+        if candidates.is_empty() && skipped_transient > 0 {
+            tracing::warn!(
+                skipped_transient,
+                target_location = %target_location.as_f64(),
+                "k_closest: no viable peers — all eligible connections were transient \
+                 (no fallback by design; routing will fail this hop)"
+            );
+        }
+
         // Sort candidates for deterministic input to select_k_best_peers
         candidates.sort();
 
@@ -2921,6 +2937,97 @@ fn deferred_swap_drops_to_execute(
 #[inline]
 fn classify_suspend_jump(boot_elapsed: Duration, mono_elapsed: Duration) -> Duration {
     boot_elapsed.saturating_sub(mono_elapsed)
+}
+
+#[cfg(test)]
+mod k_closest_source_tests {
+    //! Source-scrape pin tests for `Ring::k_closest_potentially_hosting`.
+    //!
+    //! Constructing a real `Ring` for behavioral tests requires significant
+    //! scaffolding (NodeConfig, EventLoopNotificationsSender, NetEventRegister,
+    //! BackgroundTaskMonitor) that does not currently exist in the test suite.
+    //! These tests instead scrape the production source to ensure load-bearing
+    //! filter invariants stay wired in — a future refactor that silently drops
+    //! the transient filter (issue #4222) or the readiness fallback should fail
+    //! CI rather than silently regress production routing behavior.
+    //!
+    //! Behavioral coverage exists transitively via the simulation_integration
+    //! tests; a dedicated integration test for the transient filter is filed
+    //! as a follow-up to the Ring test-scaffolding work.
+    fn production_source() -> &'static str {
+        const FULL: &str = include_str!("ring.rs");
+        // ring.rs has inline `#[cfg(test)]` annotations on individual const
+        // declarations inside `connection_maintenance` (lines ~1894–1940), so
+        // a plain `find("#[cfg(test)]")` would cut off the file mid-impl and
+        // miss the function we want to scrape. Anchor on the first *top-level*
+        // test module declaration instead.
+        let cutoff = FULL
+            .find("\n#[cfg(test)]\nmod ")
+            .expect("ring.rs must have a top-level #[cfg(test)] mod section");
+        &FULL[..cutoff]
+    }
+
+    fn extract_fn_body<'a>(source: &'a str, signature_prefix: &str) -> &'a str {
+        let start = source
+            .find(signature_prefix)
+            .unwrap_or_else(|| panic!("could not find {signature_prefix}"));
+        let brace = source[start..].find('{').expect("fn sig must have body");
+        let body_start = start + brace + 1;
+        let bytes = source.as_bytes();
+        let mut depth: i32 = 1;
+        let mut i = body_start;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &source[body_start..i];
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        panic!("unbalanced braces while extracting {signature_prefix}");
+    }
+
+    /// Issue #4222: `k_closest_potentially_hosting` must skip transient peers
+    /// so GET/SUBSCRIBE doesn't route through about-to-be-dropped connections.
+    /// The PUT/UPDATE path already filters them via `routing_candidates`; this
+    /// pin makes sure the GET path stays in sync.
+    #[test]
+    fn k_closest_potentially_hosting_filters_transient_peers() {
+        let src = production_source();
+        let body = extract_fn_body(src, "pub fn k_closest_potentially_hosting<K>(");
+        assert!(
+            body.contains("is_transient(addr)"),
+            "k_closest_potentially_hosting must call is_transient(addr) on each \
+             candidate connection. If the filter was deliberately removed, also \
+             update .claude/rules/ring.md (which documents the filter rule) and \
+             this test. Issue #4222 / #3570."
+        );
+        assert!(
+            body.contains("skipped_transient"),
+            "k_closest_potentially_hosting must surface a skipped_transient \
+             counter so operators can see when the filter is removing peers."
+        );
+    }
+
+    /// The existing readiness fallback must remain — without it, a node whose
+    /// peers haven't yet sent ReadyState would fail every GET with EmptyRing.
+    /// Pinning it here so a future refactor of the filter chain can't silently
+    /// drop the fallback.
+    #[test]
+    fn k_closest_potentially_hosting_preserves_not_ready_fallback() {
+        let src = production_source();
+        let body = extract_fn_body(src, "pub fn k_closest_potentially_hosting<K>(");
+        assert!(
+            body.contains("not_ready_fallback"),
+            "k_closest_potentially_hosting must keep the not-yet-ready peer \
+             fallback so cold-start nodes don't fail every GET with EmptyRing."
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -24,11 +24,21 @@ use util::{Mean, TransferSpeed};
 /// on subscribed contracts never visited any subscriber, because a small
 /// window misses uniformly-distributed subscribers most hops (issue #4222).
 ///
-/// 25 matches `ring::DEFAULT_MIN_CONNECTIONS`, so a node at its minimum
+/// 25 matches `ring::Ring::DEFAULT_MIN_CONNECTIONS`, so a node at its minimum
 /// connection count surfaces its entire routing table to the predictor. Larger
 /// tables still favor the closest 25; the predictor's distance penalty
 /// preserves small-world routing.
 const DEFAULT_CONSIDER_N_CLOSEST_PEERS: usize = 25;
+
+// Compile-time link between this default and `Ring::DEFAULT_MIN_CONNECTIONS`
+// so future changes to either constant fail the build instead of silently
+// diverging. If you intentionally want this window to differ from
+// `DEFAULT_MIN_CONNECTIONS`, drop this assertion and document why.
+const _: () = assert!(
+    DEFAULT_CONSIDER_N_CLOSEST_PEERS == crate::ring::Ring::DEFAULT_MIN_CONNECTIONS,
+    "DEFAULT_CONSIDER_N_CLOSEST_PEERS must match Ring::DEFAULT_MIN_CONNECTIONS — \
+     see comment above."
+);
 
 // ==================== Telemetry types ====================
 
@@ -1159,6 +1169,16 @@ mod tests {
         // matching production. Do NOT call `considering_n_closest_peers` here:
         // the test pins the SHIPPED default, not an ad-hoc test override.
         let router = Router::new(&[]);
+
+        // Pin the shipped window value explicitly. The statistical assertion
+        // below is calibrated against a window of 25 (~93% coverage); a silent
+        // drop to e.g. 18 would still produce ~85% coverage and pass the
+        // hypergeometric threshold by luck, hiding a regression. Fail loudly
+        // on any drift.
+        assert_eq!(
+            router.consider_n_closest_peers, 25,
+            "issue #4222 regression: expected DEFAULT_CONSIDER_N_CLOSEST_PEERS = 25"
+        );
 
         let mut covered = 0usize;
         for _ in 0..NUM_TRIALS {

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -13,6 +13,23 @@ use crate::ring::{Distance, Location, PeerKeyLocation};
 pub(crate) use isotonic_estimator::{EstimatorType, IsotonicEstimator, IsotonicEvent};
 use util::{Mean, TransferSpeed};
 
+/// Default size of the candidate window the prediction-based router considers.
+///
+/// The router truncates candidates to the N geographically closest peers
+/// BEFORE the isotonic estimator scores them, so any peer outside this window
+/// is invisible to routing for that hop. The historical value was 5, set when
+/// `min_connections` was tiny and the comment in the original PR (#903) said
+/// "Later we can experiment with increasing this limit." That experiment never
+/// happened. Production telemetry on 2026-05 then showed 63% of failing GETs
+/// on subscribed contracts never visited any subscriber, because a small
+/// window misses uniformly-distributed subscribers most hops (issue #4222).
+///
+/// 25 matches `ring::DEFAULT_MIN_CONNECTIONS`, so a node at its minimum
+/// connection count surfaces its entire routing table to the predictor. Larger
+/// tables still favor the closest 25; the predictor's distance penalty
+/// preserves small-world routing.
+const DEFAULT_CONSIDER_N_CLOSEST_PEERS: usize = 25;
+
 // ==================== Telemetry types ====================
 
 /// A snapshot of a single routing decision for telemetry.
@@ -352,7 +369,7 @@ impl Router {
                 EstimatorType::Negative,
             ),
             mean_transfer_size,
-            consider_n_closest_peers: 5,
+            consider_n_closest_peers: DEFAULT_CONSIDER_N_CLOSEST_PEERS,
             per_op_failure: per_op_failure
                 .into_iter()
                 .map(|(k, v)| (k, IsotonicEstimator::new(v, EstimatorType::Positive)))
@@ -1105,6 +1122,84 @@ mod tests {
                 .considering_n_closest_peers(CAP)
                 .select_closest_peers(&create_peers(NUM_PEERS), &Location::random())
                 .len()
+        );
+    }
+
+    /// Regression test for issue #4222.
+    ///
+    /// Production telemetry on 2026-05 showed that 63% of failing GETs on
+    /// subscribed contracts never visited any of the contract's subscribers
+    /// during routing. Hop chains terminated early at mean 3.9 hops out of
+    /// max htl 10. The root cause was the historical
+    /// `consider_n_closest_peers = 5` cap in `select_closest_peers`: it
+    /// truncates candidates to the N geographically closest peers BEFORE the
+    /// isotonic estimator ranks them, so subscribers outside the 5-window are
+    /// invisible to routing for that hop. With median 31 subscribers
+    /// distributed roughly uniformly across the keyspace, a 5-peer window
+    /// includes a subscriber on fewer than half of all target locations —
+    /// matching the observed failure rate.
+    ///
+    /// This test models the production regime — many uniformly-distributed
+    /// connected peers, a smaller fraction subscribed to the contract being
+    /// fetched — and asserts the router's window is wide enough that at
+    /// least one subscriber appears in the candidate set on the overwhelming
+    /// majority of target locations. With the historical default of 5, this
+    /// test fails (subscriber coverage ≈ 42%). With the corrected default of
+    /// 25, it passes (coverage > 90% — hypergeometric expected value 93.4%).
+    #[test]
+    fn select_closest_peers_includes_subscribers_4222() {
+        let _guard = crate::config::GlobalRng::seed_guard(0x4222_5AFE);
+
+        const NUM_CONNECTIONS: u32 = 100;
+        const NUM_SUBSCRIBERS: usize = 10;
+        const NUM_TRIALS: usize = 200;
+        const REQUIRED_COVERAGE: f64 = 0.85;
+
+        // Default-constructed router uses DEFAULT_CONSIDER_N_CLOSEST_PEERS,
+        // matching production. Do NOT call `considering_n_closest_peers` here:
+        // the test pins the SHIPPED default, not an ad-hoc test override.
+        let router = Router::new(&[]);
+
+        let mut covered = 0usize;
+        for _ in 0..NUM_TRIALS {
+            let peers = create_peers(NUM_CONNECTIONS);
+            // create_peers generates random locations, so taking the first N
+            // is effectively a uniform random sample of "subscribers".
+            // NOTE: peer identity is keyed on `peer_addr` rather than `pub_key`
+            // because the test helper shares a thread-local pub_key across all
+            // synthetic peers — keying on pub_key would trivially match every
+            // peer, hiding the structural window behavior we are asserting.
+            let subscriber_addrs: std::collections::HashSet<_> = peers
+                .iter()
+                .take(NUM_SUBSCRIBERS)
+                .filter_map(|p| p.socket_addr())
+                .collect();
+            let target = Location::random();
+
+            let window = router.select_closest_peers(&peers, &target);
+            if window.iter().any(|p| {
+                p.socket_addr()
+                    .is_some_and(|a| subscriber_addrs.contains(&a))
+            }) {
+                covered += 1;
+            }
+        }
+
+        let coverage = covered as f64 / NUM_TRIALS as f64;
+        assert!(
+            coverage > REQUIRED_COVERAGE,
+            "subscriber coverage {:.3} below required {:.2} — issue #4222 root cause \
+             may have regressed: the router's candidate window \
+             (consider_n_closest_peers = {}) is too small to reliably include \
+             subscribers when they are uniformly distributed across the keyspace \
+             ({}/{} trials covered with {} subscribers in {} peers)",
+            coverage,
+            REQUIRED_COVERAGE,
+            router.consider_n_closest_peers,
+            covered,
+            NUM_TRIALS,
+            NUM_SUBSCRIBERS,
+            NUM_CONNECTIONS,
         );
     }
 


### PR DESCRIPTION
## Problem

Production telemetry on 2026-05 showed that 63% of failing GETs on
subscribed contracts NEVER visited any of the contract's subscribers
during routing — even when the contract had a median of 31 subscribers
distributed across the keyspace.

| Failure pattern on subscribed contracts | Count |   % |
|---|---:|---:|
| GET visited a subscriber, still got NF | 63 | 37% |
| GET never visited any subscriber | **109** | **63%** |

Hop chains terminated at mean **3.9 hops** out of max htl **10** — the
operation was running out of routing options, not exhausting hops.

## Approach

The structural root cause is `consider_n_closest_peers = 5` in
`router.rs::select_closest_peers`. The router truncates candidates to
the N geographically closest peers BEFORE the isotonic estimator ranks
them, so any peer outside the 5-window is **invisible to routing for
that hop**. With subscribers distributed roughly uniformly across the
keyspace, the 5-window misses them on most hops — matching the observed
failure rate (hypergeometric: P(no subscriber in 5-window) ≈ 0.58 for
the production parameters; P(none in a 25-window) ≈ 0.07).

The historical 5 was conservative — the original PR ([#903]) said
*"Later we can experiment with increasing this limit"*. That experiment
never happened, even after `min_connections` grew to 25. This PR bumps
the default to **25** (matching `Ring::DEFAULT_MIN_CONNECTIONS`) so a
node at its minimum connection count surfaces its entire routing table
to the predictor. Larger tables still favor the closest 25; the
isotonic predictor's distance penalty preserves small-world routing.
A `const _: () = assert!(...)` ties the two literals so they can't
silently diverge.

Also adds a `is_transient` filter to `Ring::k_closest_potentially_hosting`
to align GET/SUBSCRIBE with the routing-candidate filtering that
PUT/UPDATE already does via `ConnectionManager::routing_candidates`.
This is a routing-quality cleanup adjacent to #3570 — it does **not**
fix either of #3570's documented root causes
(`ForwardingAck`-disables-retry; relay chain abandonment), so #3570
remains open.

### Caveat: bootstrap branch unaffected

`select_k_best_peers_with_telemetry` has a `!has_sufficient_routing_events()`
branch (`router.rs:688–732`) that does NOT call `select_closest_peers`
— it truncates directly to `k`. Nodes with `< MIN_EVENTS_FOR_PREDICTION
= 50` failure events (fresh starts, recently restarted, after a router
rebuild) do not benefit from this fix. Production telemetry was on
mature long-lived nodes, so the fix matches the documented failure
mode; widening the bootstrap branch is a separate decision.

### Hypothesis #3 (single-shot relay forwarding) — deferred to #4229

The investigation confirmed a third contributing cause:
`MAX_RELAY_RETRIES = 1` at `operations/get/op_ctx_task.rs:1797` means
a relay tries exactly ONE downstream peer per hop. If that peer
returns NF, the relay propagates NF upstream without trying
alternatives. The inline comment explains that the cap was set to 1
specifically to defuse a **3^HTL** relay-subtree amplification
observed during PR #3896 (16.9M task spawns in 95s during the
ci-fault-loss run). Even with `incoming_tx` reuse, raising the cap
allows each downstream peer to spawn its own retry subtree, restoring
the multiplicative compounding.

That fix needs its own amplification analysis and is tracked at
**#4229**.

## Testing

**Router-level regression test** (`router::tests::select_closest_peers_includes_subscribers_4222`):
Simulates 200 trials of 100 connected peers with 10 uniformly-distributed
subscribers, asserting subscriber-window coverage > 85% AND an explicit
`assert_eq!(consider_n_closest_peers, 25)` so future silent drops fail
loudly. The test:

- **FAILS** with the historical value of 5 (coverage ≈ 42% — matching
  the hypergeometric prediction `1 - C(90,5)/C(100,5)`)
- **PASSES** with 25 (coverage ≈ 93%)

Verified by temporarily reverting `DEFAULT_CONSIDER_N_CLOSEST_PEERS` to
5 and re-running.

**Source-scrape pin tests** (`ring::k_closest_source_tests`): Two pin
tests verify that the `is_transient` filter and the readiness fallback
stay wired into `k_closest_potentially_hosting` — a future refactor
that silently drops either fails CI. A full behavioral integration
test requires Ring test scaffolding (`NodeConfig`, etc.) that doesn't
exist today; that's a separate scaffolding task.

Full lib test suite: **2545 passed, 0 failed, 14 ignored**.
`cargo nextest run` on `test_turmoil_determinism_verification` (which
my change could plausibly affect since it's a routing change):
passes.

## Fixes

Closes #4222.

Related (not closed by this PR):
- #3570 — earlier GET routing/retry issue; transient filter is adjacent, not a direct fix.
- #4229 — follow-up to lift the `MAX_RELAY_RETRIES = 1` cap with proper amplification controls.

[AI-assisted - Claude]