### PR TITLE
Add routing hop-count sweep benchmark

### DIFF
--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -94,6 +94,22 @@ mod messages {
             id: Transaction,
             instance_id: ContractInstanceId,
             result: GetMsgResult,
+            /// Forward-path hop count: how many hops the originating Request
+            /// traversed before reaching the node that produced this Response
+            /// (the storer for Found, or the HTL-exhausted relay for NotFound).
+            ///
+            /// Computed as `max_hops_to_live - htl_at_responder`. The relay
+            /// chain preserves this value as the Response bubbles back to the
+            /// originator — it does NOT increment on the return path. This
+            /// gives the whitepaper's "routing depth" metric (forward hops),
+            /// not round-trip.
+            ///
+            /// `#[serde(default)]` is set for source-level clarity. Bincode
+            /// does not honour serde defaults (positional encoding), so wire
+            /// compat with peers that lack this field is handled at the
+            /// handshake layer via `MIN_COMPATIBLE_VERSION`.
+            #[serde(default)]
+            hop_count: usize,
         },
 
         /// Streaming response for large contract data. Used when the response payload
@@ -264,6 +280,7 @@ mod tests {
                     contract: None,
                 },
             },
+            hop_count: 0,
         };
         let display = format!("{}", msg);
         assert!(
@@ -284,6 +301,7 @@ mod tests {
             id: tx,
             instance_id,
             result: GetMsgResult::NotFound,
+            hop_count: 0,
         };
         let display = format!("{}", msg);
         assert!(
@@ -345,6 +363,7 @@ mod tests {
                     contract: None,
                 },
             },
+            hop_count: 0,
         };
         let location_found = msg_found.requested_location();
         assert!(
@@ -362,6 +381,7 @@ mod tests {
             id: tx,
             instance_id,
             result: GetMsgResult::NotFound,
+            hop_count: 0,
         };
         let location_notfound = msg_notfound.requested_location();
         assert!(

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -2134,21 +2134,21 @@ async fn drive_relay_get_inner(
                         phase = "not_found",
                         "GET relay: all peers exhausted — sending NotFound upstream"
                     );
+                    // Exhaustion NotFound: this relay is reporting its own
+                    // exhaustion of downstream candidates. hop_count is its
+                    // forward depth (max_htl - htl).
+                    let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
                     if let Some(event) = crate::tracing::NetEventLog::get_not_found(
                         &incoming_tx,
                         &op_manager.ring,
                         instance_id,
-                        None,
+                        Some(hop_count),
                     ) {
                         op_manager
                             .ring
                             .register_events(either::Either::Left(event))
                             .await;
                     }
-                    // Exhaustion NotFound: this relay is reporting its own
-                    // exhaustion of downstream candidates. hop_count is its
-                    // forward depth (max_htl - htl).
-                    let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
                     relay_send_not_found(
                         op_manager,
                         incoming_tx,

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -320,6 +320,7 @@ async fn drive_client_get_inner(
                     key,
                     state,
                     contract,
+                    hop_count: _,
                 } => {
                     // InlineFound delivers state + optional contract in
                     // the same envelope as the Response header, so the
@@ -606,6 +607,11 @@ enum Terminal {
         key: ContractKey,
         state: WrappedState,
         contract: Option<ContractContainer>,
+        /// Forward-path hop count from the originating Request to the
+        /// storer, as carried on the wire Response. Preserved across the
+        /// relay bubble-up chain (relays do NOT increment on the return
+        /// path). Used by tracing to populate `GetSuccess.hop_count`.
+        hop_count: usize,
     },
     /// ResponseStreaming: the envelope references a stream_id whose
     /// bytes arrive separately via the orphan stream registry. The
@@ -643,11 +649,13 @@ fn classify(reply: NetMessage) -> AttemptOutcome<Terminal> {
                             contract,
                         },
                 },
+            hop_count,
             ..
         })) => AttemptOutcome::Terminal(Terminal::InlineFound {
             key,
             state,
             contract,
+            hop_count,
         }),
         NetMessage::V1(NetMessageV1::Get(GetMsg::Response {
             result: GetMsgResult::Found { value, .. },
@@ -1376,6 +1384,7 @@ async fn drive_sub_op_get(
                     key,
                     state,
                     contract,
+                    hop_count: _,
                 } => {
                     cache_contract_locally(
                         op_manager,
@@ -1700,7 +1709,15 @@ async fn drive_relay_get(
             );
             // On infrastructure error, send NotFound upstream so the upstream
             // doesn't time out waiting for us.
-            relay_send_not_found(op_manager, incoming_tx, instance_id, upstream_addr).await;
+            let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
+            relay_send_not_found(
+                op_manager,
+                incoming_tx,
+                instance_id,
+                upstream_addr,
+                hop_count,
+            )
+            .await;
             Err(err)
         }
     }
@@ -1821,16 +1838,24 @@ fn relay_advance_to_next_peer(
 }
 
 /// Build and send a `GetMsg::Response{NotFound}` to `upstream_addr`.
+///
+/// `hop_count` is the forward-path hop count to embed in the Response. For
+/// a relay that's producing the NotFound itself (HTL exhaustion or downstream
+/// exhaustion), this is `max_htl - incoming_htl`. For an originator-side
+/// originator-loopback NotFound from `start_client_get` after exhaustion,
+/// pass 0 (no remote hops traversed).
 async fn relay_send_not_found(
     op_manager: &OpManager,
     tx: Transaction,
     instance_id: ContractInstanceId,
     upstream_addr: SocketAddr,
+    hop_count: usize,
 ) {
     let msg = NetMessage::from(GetMsg::Response {
         id: tx,
         instance_id,
         result: GetMsgResult::NotFound,
+        hop_count,
     });
     let mut ctx = op_manager.op_ctx(tx);
     // Originator-loopback: when this driver runs on the originator's
@@ -1860,6 +1885,12 @@ async fn relay_send_not_found(
 
 /// Build and send a `GetMsg::Response{Found}` (inline, non-streaming) to
 /// `upstream_addr`.  Returns an error on serialization failure.
+///
+/// `hop_count` is the forward-path hop count to embed in the Response. For
+/// the storer's own initial Found, this is `max_htl - incoming_htl`. For a
+/// relay bubbling up a downstream Found, this is the downstream Response's
+/// `hop_count` (preserved through the bubble-up chain).
+#[allow(clippy::too_many_arguments)]
 async fn relay_send_found(
     op_manager: &OpManager,
     tx: Transaction,
@@ -1868,6 +1899,7 @@ async fn relay_send_found(
     key: ContractKey,
     state: WrappedState,
     contract: Option<ContractContainer>,
+    hop_count: usize,
 ) -> Result<(), OpError> {
     let msg = NetMessage::from(GetMsg::Response {
         id: tx,
@@ -1879,6 +1911,7 @@ async fn relay_send_found(
                 contract,
             },
         },
+        hop_count,
     });
     let mut ctx = op_manager.op_ctx(tx);
     // Originator-loopback: route via `send_local_loopback` to avoid
@@ -1931,7 +1964,18 @@ async fn drive_relay_get_inner(
                 .register_events(either::Either::Left(event))
                 .await;
         }
-        relay_send_not_found(op_manager, incoming_tx, instance_id, upstream_addr).await;
+        // HTL=0 path: the original Request reached us with htl already at 0,
+        // meaning the request traversed the full max_htl forward hops to get
+        // here. hop_count = max_htl - 0 = max_htl.
+        let hop_count = op_manager.ring.max_hops_to_live;
+        relay_send_not_found(
+            op_manager,
+            incoming_tx,
+            instance_id,
+            upstream_addr,
+            hop_count,
+        )
+        .await;
         return Ok(());
     }
 
@@ -2009,6 +2053,9 @@ async fn drive_relay_get_inner(
         // `local_client_access` flag — that's exclusively for the
         // client-originating node. Legacy mirror: `get.rs:2260-2262`
         // gates on `is_original_requester`.
+        // R4 (local cache hit): this relay IS the storer. hop_count =
+        // max_htl - htl_we_received.
+        let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
         let send_result = relay_send_found(
             op_manager,
             incoming_tx,
@@ -2017,6 +2064,7 @@ async fn drive_relay_get_inner(
             key,
             state.clone(),
             contract.clone(),
+            hop_count,
         )
         .await;
         cache_contract_locally(op_manager, key, state, contract, false).await;
@@ -2062,6 +2110,9 @@ async fn drive_relay_get_inner(
                     // runs after forwarding so LRU/TTL bookkeeping fires
                     // even when the forward errors. Relay path:
                     // `is_client_requester=false` on the cache call.
+                    // R10 (local fallback): this relay is acting as the
+                    // storer; same hop_count semantics as R4.
+                    let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
                     let send_result = relay_send_found(
                         op_manager,
                         incoming_tx,
@@ -2070,6 +2121,7 @@ async fn drive_relay_get_inner(
                         key,
                         state.clone(),
                         contract.clone(),
+                        hop_count,
                     )
                     .await;
                     cache_contract_locally(op_manager, key, state, contract, false).await;
@@ -2093,7 +2145,18 @@ async fn drive_relay_get_inner(
                             .register_events(either::Either::Left(event))
                             .await;
                     }
-                    relay_send_not_found(op_manager, incoming_tx, instance_id, upstream_addr).await;
+                    // Exhaustion NotFound: this relay is reporting its own
+                    // exhaustion of downstream candidates. hop_count is its
+                    // forward depth (max_htl - htl).
+                    let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
+                    relay_send_not_found(
+                        op_manager,
+                        incoming_tx,
+                        instance_id,
+                        upstream_addr,
+                        hop_count,
+                    )
+                    .await;
                 }
                 return Ok(());
             }
@@ -2253,6 +2316,7 @@ async fn drive_relay_get_inner(
                 key,
                 state,
                 contract,
+                hop_count: downstream_hop_count,
             }) => {
                 tracing::info!(
                     tx = %incoming_tx,
@@ -2285,6 +2349,9 @@ async fn drive_relay_get_inner(
                 // runs after forwarding so LRU/TTL and
                 // `announce_contract_hosted` semantics are preserved
                 // even on send error.
+                // Preserve the storer-side hop_count so the originator
+                // sees the *forward* depth from Request to storer, not
+                // the depth from Request to this relay.
                 let send_result = relay_send_found(
                     op_manager,
                     incoming_tx,
@@ -2293,6 +2360,7 @@ async fn drive_relay_get_inner(
                     key,
                     state.clone(),
                     contract.clone(),
+                    downstream_hop_count,
                 )
                 .await;
 
@@ -2410,6 +2478,7 @@ mod tests {
                     contract: None,
                 },
             },
+            hop_count: 0,
         }));
         assert!(matches!(
             classify(msg),
@@ -2425,6 +2494,7 @@ mod tests {
             id: tx,
             instance_id: *key.id(),
             result: GetMsgResult::NotFound,
+            hop_count: 0,
         }));
         assert!(matches!(classify(msg), AttemptOutcome::Retry));
     }
@@ -2509,6 +2579,7 @@ mod tests {
                     contract: None,
                 },
             },
+            hop_count: 0,
         }));
         assert!(matches!(classify(msg), AttemptOutcome::Unexpected));
     }

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -2929,6 +2929,22 @@ impl EventKind {
         }
     }
 
+    /// Returns the `hop_count` recorded in this event, if any.
+    ///
+    /// Currently populated for terminal GET events (`GetSuccess`, `GetNotFound`,
+    /// `GetFailure`). The value is the number of hops the GET request traversed
+    /// before reaching its terminal state. Returns `None` for non-terminal GET
+    /// events (e.g. `Request`) and for all non-GET events.
+    #[allow(clippy::wildcard_enum_match_arm)]
+    pub fn hop_count(&self) -> Option<usize> {
+        match self {
+            EventKind::Get(GetEvent::GetSuccess { hop_count, .. })
+            | EventKind::Get(GetEvent::GetNotFound { hop_count, .. })
+            | EventKind::Get(GetEvent::GetFailure { hop_count, .. }) => *hop_count,
+            _ => None,
+        }
+    }
+
     /// Returns the variant name of this event kind.
     pub fn variant_name(&self) -> &'static str {
         match self {

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -1302,19 +1302,18 @@ impl<'a> NetEventLog<'a> {
             NetMessageV1::Get(GetMsg::Response {
                 id,
                 result: GetMsgResult::Found { key, value },
+                hop_count,
                 ..
             }) if value.state.is_some() => {
                 let this_peer = op_manager.ring.connection_manager.own_location();
-                // Calculate hop_count from operation state: max_htl - current_hop
-                let hop_count = op_manager.get_current_hop(id).map(|current_hop| {
-                    op_manager.ring.max_hops_to_live.saturating_sub(current_hop)
-                });
+                // hop_count is carried on the wire Response: set by the storer
+                // (max_htl - htl_at_storer) and preserved by relays bubbling up.
                 EventKind::Get(GetEvent::GetSuccess {
                     id: *id,
                     requester: this_peer.clone(),
                     target: this_peer,
                     key: *key,
-                    hop_count,
+                    hop_count: Some(*hop_count),
                     elapsed_ms: id.elapsed().as_millis() as u64,
                     timestamp: chrono::Utc::now().timestamp() as u64,
                     state_hash: None, // Hash not available from message
@@ -1324,18 +1323,18 @@ impl<'a> NetEventLog<'a> {
                 id,
                 instance_id,
                 result: GetMsgResult::NotFound,
+                hop_count,
             }) => {
                 let this_peer = op_manager.ring.connection_manager.own_location();
-                // Calculate hop_count from operation state: max_htl - current_hop
-                let hop_count = op_manager.get_current_hop(id).map(|current_hop| {
-                    op_manager.ring.max_hops_to_live.saturating_sub(current_hop)
-                });
+                // hop_count is carried on the wire Response (same semantics
+                // as GetSuccess: forward-path depth from originator to the
+                // node that produced the NotFound).
                 EventKind::Get(GetEvent::GetNotFound {
                     id: *id,
                     requester: this_peer.clone(),
                     instance_id: *instance_id,
                     target: this_peer,
-                    hop_count,
+                    hop_count: Some(*hop_count),
                     elapsed_ms: id.elapsed().as_millis() as u64,
                     timestamp: chrono::Utc::now().timestamp() as u64,
                 })

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -9517,25 +9517,33 @@ async fn sim_network_regular_node_labels_start_at_gateway_count() {
 
 /// Sweep network size N and collect terminal-GET hop counts for each case.
 ///
-/// Uses `run_direct()` (paused-time single-thread runtime) for scale: turmoil's
-/// link bookkeeping is O(n²) in node count and becomes the bottleneck well
-/// before the simulation itself does.
+/// Workload: gateway 0 PUTs a known contract; every node then GETs that same
+/// contract. This is the `test_get_reliability_diagnostic` pattern — it gives
+/// a controlled, GET-success-heavy distribution rather than the random
+/// gen_event workload which produces almost only NotFound events.
 ///
-/// Per-case parameters are tuned to (a) yield enough completed GETs to give a
-/// meaningful distribution and (b) keep wall-clock time bounded. The HTL
-/// settings scale with N so that requests can plausibly traverse the network.
+/// Uses `run_controlled_simulation` (Turmoil-based) for deterministic
+/// scheduled operations. Turmoil link bookkeeping is O(n²), so N=200 takes
+/// disproportionately longer than smaller sizes — we cap the sweep at N=100
+/// to keep total wall time under ~15 minutes.
 #[test_log::test]
 #[ignore = "long-running hop-count sweep; run via `cargo test ... -- --ignored bench_hop_count_sweep`"]
 fn bench_hop_count_sweep() {
-    const SEED: u64 = 0x5EED_C0F1;
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
 
-    // (gateways, nodes, iters, max_contracts, duration_secs, sleep_secs,
-    //  min_conns, max_conns, ring_max_htl, rnd_if_htl_above)
-    let cases: [(usize, usize, usize, usize, u64, u64, usize, usize, usize, usize); 4] = [
-        (1, 20, 100, 5, 60, 3, 3, 15, 10, 7),
-        (2, 50, 200, 8, 120, 5, 3, 20, 12, 8),
-        (2, 100, 300, 10, 240, 8, 3, 25, 14, 10),
-        (3, 200, 500, 15, 480, 10, 3, 30, 16, 12),
+    const SEED_BASE: u64 = 0x5EED_C0F1;
+
+    // (gateways, nodes, ring_max_htl, rnd_if_htl_above, min_conns, max_conns,
+    //  sim_duration_secs, post_wait_secs)
+    //
+    // ring_max_htl scales loosely with log2(N). max_conns scales sublinearly to
+    // keep the topology connected without making every node a hub. Duration
+    // scales with N because the originator-loopback path through every node
+    // takes longer to drain on bigger networks.
+    let cases: [(usize, usize, usize, usize, usize, usize, u64, u64); 3] = [
+        (1, 20, 8, 5, 3, 10, 120, 30),
+        (2, 50, 10, 7, 4, 12, 240, 60),
+        (3, 100, 12, 8, 4, 14, 600, 120),
     ];
 
     #[derive(Default)]
@@ -9544,36 +9552,84 @@ fn bench_hop_count_sweep() {
         gw: usize,
         get_success: usize,
         get_not_found: usize,
-        get_failure: usize,
+        get_failure_or_timeout: usize,
         hops: Vec<usize>,
+        hops_success: Vec<usize>,
         hops_missing: usize,
         wall_secs: f64,
     }
 
     let mut all: Vec<CaseSummary> = Vec::new();
 
-    for (gw, n, iters, max_c, dur, sleep, min_c, max_c2, htl, rnd_above) in cases {
+    for (gw, n, htl, rnd_above, min_conns, max_conns, dur, post_wait) in cases {
         let case_start = std::time::Instant::now();
+        let network_name = "hop-sweep";
+        let case_seed = SEED_BASE ^ (n as u64);
+
         tracing::info!(
-            "=== sweep case: gateways={gw} nodes={n} iters={iters} max_contracts={max_c} \
-             duration={dur}s htl={htl}/{rnd_above} conns={min_c}..{max_c2} ==="
+            "=== sweep case: gateways={gw} nodes={n} htl={htl}/{rnd_above} \
+             conns={min_conns}..{max_conns} duration={dur}s post_wait={post_wait}s ==="
         );
 
-        let result = TestConfig::medium("hop-sweep", SEED ^ n as u64)
-            .with_gateways(gw)
-            .with_nodes(n)
-            .with_iterations(iters)
-            .with_max_contracts(max_c)
-            .with_duration(Duration::from_secs(dur))
-            .with_sleep(Duration::from_secs(sleep))
-            .with_connections(min_c, max_c2)
-            .with_htl(htl, rnd_above)
-            .run_direct()
-            .assert_ok();
+        GlobalTestMetrics::reset();
+        setup_deterministic_state(case_seed);
+        let rt = create_runtime();
+
+        let (sim, logs_handle) = rt.block_on(async {
+            let sim = SimNetwork::new(
+                network_name,
+                gw,
+                n,
+                htl,
+                rnd_above,
+                max_conns,
+                min_conns,
+                case_seed,
+            )
+            .await;
+            let logs_handle = sim.event_logs_handle();
+            (sim, logs_handle)
+        });
+
+        // PUT a known contract from gateway 0, then every node GETs it.
+        // Distinct contract bytes per case so trees can't poison each other.
+        let contract_seed_byte = (case_seed & 0xFF) as u8;
+        let contract = SimOperation::create_test_contract(contract_seed_byte);
+        let contract_id = *contract.key().id();
+
+        let mut operations = vec![ScheduledOperation::new(
+            NodeLabel::gateway(network_name, 0),
+            SimOperation::Put {
+                contract: contract.clone(),
+                state: vec![contract_seed_byte; 64],
+                subscribe: true,
+            },
+        )];
+
+        for i in 0..n {
+            operations.push(ScheduledOperation::new(
+                NodeLabel::node(network_name, i),
+                SimOperation::Get {
+                    contract_id,
+                    return_contract_code: true,
+                    subscribe: false,
+                },
+            ));
+        }
+
+        let result = sim.run_controlled_simulation(
+            case_seed,
+            operations,
+            Duration::from_secs(dur),
+            Duration::from_secs(post_wait),
+        );
+        if let Err(e) = &result.turmoil_result {
+            panic!("sweep case N={n} turmoil failed: {e:?}");
+        }
 
         let rt = create_runtime();
         let case = rt.block_on(async {
-            let logs = result.logs_handle.lock().await;
+            let logs = logs_handle.lock().await;
             let mut summary = CaseSummary {
                 n_total: n + gw,
                 gw,
@@ -9581,25 +9637,26 @@ fn bench_hop_count_sweep() {
             };
             for m in logs.iter() {
                 match m.kind.get_outcome() {
-                    Some(true) => summary.get_success += 1,
+                    Some(true) => {
+                        summary.get_success += 1;
+                        if let Some(h) = m.kind.hop_count() {
+                            summary.hops_success.push(h);
+                        }
+                    }
                     Some(false) => {
-                        // Cannot cheaply distinguish NotFound vs Failure without
-                        // adding another accessor; treat both as "non-success
-                        // terminal" and bucket via elapsed_ms heuristic for
-                        // visibility. Hop counts are pulled below.
                         if let Some(ms) = m.kind.get_elapsed_ms() {
                             if ms >= 55_000 {
-                                summary.get_failure += 1;
+                                summary.get_failure_or_timeout += 1;
                             } else {
                                 summary.get_not_found += 1;
                             }
                         } else {
-                            summary.get_failure += 1;
+                            summary.get_failure_or_timeout += 1;
                         }
                     }
                     None => {}
                 }
-                // Pull hop count from any terminal GET event.
+                // Pull hop count from any terminal GET event (success or not).
                 if m.kind.get_outcome().is_some() {
                     match m.kind.hop_count() {
                         Some(h) => summary.hops.push(h),
@@ -9612,14 +9669,15 @@ fn bench_hop_count_sweep() {
         let mut case = case;
         case.wall_secs = case_start.elapsed().as_secs_f64();
         tracing::info!(
-            "case N={} done in {:.1}s: success={}, not_found={}, failure={}, \
-             hop_samples={}, hop_missing={}",
+            "case N={} done in {:.1}s: success={}, not_found={}, fail/timeout={}, \
+             hop_samples={}, success_samples={}, hop_missing={}",
             case.n_total,
             case.wall_secs,
             case.get_success,
             case.get_not_found,
-            case.get_failure,
+            case.get_failure_or_timeout,
             case.hops.len(),
+            case.hops_success.len(),
             case.hops_missing,
         );
         all.push(case);
@@ -9633,52 +9691,60 @@ fn bench_hop_count_sweep() {
         sorted[idx]
     }
 
-    println!();
-    println!("=== HOP COUNT SWEEP ===");
-    println!(
-        "{:>5} {:>5} {:>5} {:>7} {:>8} {:>8} {:>6} {:>6} {:>6} {:>6} {:>8} {:>9}",
-        "N", "gw", "succ", "nfound", "fail", "samples", "mean", "median", "p95", "p99", "max",
-        "wall_s"
-    );
-    for case in &all {
-        let mut hops = case.hops.clone();
-        hops.sort_unstable();
-        if hops.is_empty() {
+    fn print_table(label: &str, all: &[CaseSummary], pick: impl Fn(&CaseSummary) -> &[usize]) {
+        println!();
+        println!("=== {label} ===");
+        println!(
+            "{:>5} {:>4} {:>5} {:>7} {:>6} {:>8} {:>6} {:>6} {:>4} {:>4} {:>4} {:>8}",
+            "N", "gw", "succ", "nfound", "fail", "samples", "mean", "median", "p95", "p99", "max",
+            "wall_s"
+        );
+        for case in all {
+            let mut hops: Vec<usize> = pick(case).to_vec();
+            hops.sort_unstable();
+            if hops.is_empty() {
+                println!(
+                    "{:>5} {:>4} {:>5} {:>7} {:>6} {:>8}     no data                   {:>8.1}",
+                    case.n_total,
+                    case.gw,
+                    case.get_success,
+                    case.get_not_found,
+                    case.get_failure_or_timeout,
+                    0,
+                    case.wall_secs,
+                );
+                continue;
+            }
+            let len = hops.len();
+            let mean = hops.iter().sum::<usize>() as f64 / len as f64;
+            let median = hops[len / 2];
+            let p95 = pct(&hops, 95);
+            let p99 = pct(&hops, 99);
+            let max = hops[len - 1];
             println!(
-                "{:>5} {:>5} {:>5} {:>7} {:>8} {:>8}    no hop data        wall_s={:.1}",
+                "{:>5} {:>4} {:>5} {:>7} {:>6} {:>8} {:>6.2} {:>6} {:>4} {:>4} {:>4} {:>8.1}",
                 case.n_total,
                 case.gw,
                 case.get_success,
                 case.get_not_found,
-                case.get_failure,
-                0,
+                case.get_failure_or_timeout,
+                len,
+                mean,
+                median,
+                p95,
+                p99,
+                max,
                 case.wall_secs,
             );
-            continue;
         }
-        let len = hops.len();
-        let mean = hops.iter().sum::<usize>() as f64 / len as f64;
-        let median = hops[len / 2];
-        let p95 = pct(&hops, 95);
-        let p99 = pct(&hops, 99);
-        let max = hops[len - 1];
-        println!(
-            "{:>5} {:>5} {:>5} {:>7} {:>8} {:>8} {:>6.2} {:>6} {:>6} {:>6} {:>6} {:>9.1}",
-            case.n_total,
-            case.gw,
-            case.get_success,
-            case.get_not_found,
-            case.get_failure,
-            len,
-            mean,
-            median,
-            p95,
-            p99,
-            max,
-            case.wall_secs,
-        );
+        println!("=== END {label} ===");
     }
-    println!("=== END HOP COUNT SWEEP ===");
+
+    // All terminal GET events (Success + NotFound) — broader sample.
+    print_table("HOP COUNT SWEEP (all terminal events)", &all, |c| &c.hops);
+    // GetSuccess-only — corresponds most closely to the whitepaper "routing
+    // depth to a contract that exists" claim.
+    print_table("HOP COUNT SWEEP (GetSuccess only)", &all, |c| &c.hops_success);
 
     // Soft check: we want at least one case with non-trivial hop data so a
     // future regression that loses hop_count propagation gets caught here.

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -9517,33 +9517,34 @@ async fn sim_network_regular_node_labels_start_at_gateway_count() {
 
 /// Sweep network size N and collect terminal-GET hop counts for each case.
 ///
-/// Workload: gateway 0 PUTs a known contract; every node then GETs that same
-/// contract. This is the `test_get_reliability_diagnostic` pattern — it gives
-/// a controlled, GET-success-heavy distribution rather than the random
-/// gen_event workload which produces almost only NotFound events.
-///
-/// Uses `run_controlled_simulation` (Turmoil-based) for deterministic
-/// scheduled operations. Turmoil link bookkeeping is O(n²), so N=200 takes
-/// disproportionately longer than smaller sizes — we cap the sweep at N=100
-/// to keep total wall time under ~15 minutes.
+/// Workload notes:
+/// - `run_direct()` with the random `gen_event` workload is used because the
+///   alternative `run_controlled_simulation` (Turmoil) was observed to have
+///   poor connection-formation at N >= 20 in this codebase — most peers
+///   never finished `connect` before operations were dispatched, so >95% of
+///   ops were rejected with "peer has not joined network yet" and the
+///   resulting hop-count sample was n<=10. The random workload tolerates
+///   the slow startup because operations keep firing during the
+///   stabilisation window.
+/// - The random workload produces mostly `GetNotFound` outcomes (random GETs
+///   target random pre-existing contracts; routing exhausts before finding
+///   them). Both `GetSuccess` and `GetNotFound` carry a valid forward-path
+///   `hop_count` — same routing metric, different terminal outcome — so the
+///   sweep tables report both together. The `GetSuccess`-only subtable
+///   captures the "GET on a contract that exists" subset most directly
+///   relevant to the whitepaper's claim, where samples permit.
 #[test_log::test]
 #[ignore = "long-running hop-count sweep; run via `cargo test ... -- --ignored bench_hop_count_sweep`"]
 fn bench_hop_count_sweep() {
-    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
+    const SEED: u64 = 0x5EED_C0F1;
 
-    const SEED_BASE: u64 = 0x5EED_C0F1;
-
-    // (gateways, nodes, ring_max_htl, rnd_if_htl_above, min_conns, max_conns,
-    //  sim_duration_secs, post_wait_secs)
-    //
-    // ring_max_htl scales loosely with log2(N). max_conns scales sublinearly to
-    // keep the topology connected without making every node a hub. Duration
-    // scales with N because the originator-loopback path through every node
-    // takes longer to drain on bigger networks.
-    let cases: [(usize, usize, usize, usize, usize, usize, u64, u64); 3] = [
-        (1, 20, 8, 5, 3, 10, 120, 30),
-        (2, 50, 10, 7, 4, 12, 240, 60),
-        (3, 100, 12, 8, 4, 14, 600, 120),
+    // (gateways, nodes, iters, max_contracts, duration_secs, sleep_secs,
+    //  min_conns, max_conns, ring_max_htl, rnd_if_htl_above)
+    let cases: [(usize, usize, usize, usize, u64, u64, usize, usize, usize, usize); 4] = [
+        (1, 20, 100, 5, 60, 3, 3, 15, 10, 7),
+        (2, 50, 200, 8, 120, 5, 3, 20, 12, 8),
+        (2, 100, 300, 10, 240, 8, 3, 25, 14, 10),
+        (3, 200, 500, 15, 480, 10, 3, 30, 16, 12),
     ];
 
     #[derive(Default)]
@@ -9561,75 +9562,28 @@ fn bench_hop_count_sweep() {
 
     let mut all: Vec<CaseSummary> = Vec::new();
 
-    for (gw, n, htl, rnd_above, min_conns, max_conns, dur, post_wait) in cases {
+    for (gw, n, iters, max_c, dur, sleep, min_c, max_c2, htl, rnd_above) in cases {
         let case_start = std::time::Instant::now();
-        let network_name = "hop-sweep";
-        let case_seed = SEED_BASE ^ (n as u64);
-
         tracing::info!(
-            "=== sweep case: gateways={gw} nodes={n} htl={htl}/{rnd_above} \
-             conns={min_conns}..{max_conns} duration={dur}s post_wait={post_wait}s ==="
+            "=== sweep case: gateways={gw} nodes={n} iters={iters} max_contracts={max_c} \
+             duration={dur}s htl={htl}/{rnd_above} conns={min_c}..{max_c2} ==="
         );
 
-        GlobalTestMetrics::reset();
-        setup_deterministic_state(case_seed);
-        let rt = create_runtime();
-
-        let (sim, logs_handle) = rt.block_on(async {
-            let sim = SimNetwork::new(
-                network_name,
-                gw,
-                n,
-                htl,
-                rnd_above,
-                max_conns,
-                min_conns,
-                case_seed,
-            )
-            .await;
-            let logs_handle = sim.event_logs_handle();
-            (sim, logs_handle)
-        });
-
-        // PUT a known contract from gateway 0, then every node GETs it.
-        // Distinct contract bytes per case so trees can't poison each other.
-        let contract_seed_byte = (case_seed & 0xFF) as u8;
-        let contract = SimOperation::create_test_contract(contract_seed_byte);
-        let contract_id = *contract.key().id();
-
-        let mut operations = vec![ScheduledOperation::new(
-            NodeLabel::gateway(network_name, 0),
-            SimOperation::Put {
-                contract: contract.clone(),
-                state: vec![contract_seed_byte; 64],
-                subscribe: true,
-            },
-        )];
-
-        for i in 0..n {
-            operations.push(ScheduledOperation::new(
-                NodeLabel::node(network_name, i),
-                SimOperation::Get {
-                    contract_id,
-                    return_contract_code: true,
-                    subscribe: false,
-                },
-            ));
-        }
-
-        let result = sim.run_controlled_simulation(
-            case_seed,
-            operations,
-            Duration::from_secs(dur),
-            Duration::from_secs(post_wait),
-        );
-        if let Err(e) = &result.turmoil_result {
-            panic!("sweep case N={n} turmoil failed: {e:?}");
-        }
+        let result = TestConfig::medium("hop-sweep", SEED ^ n as u64)
+            .with_gateways(gw)
+            .with_nodes(n)
+            .with_iterations(iters)
+            .with_max_contracts(max_c)
+            .with_duration(Duration::from_secs(dur))
+            .with_sleep(Duration::from_secs(sleep))
+            .with_connections(min_c, max_c2)
+            .with_htl(htl, rnd_above)
+            .run_direct()
+            .assert_ok();
 
         let rt = create_runtime();
         let case = rt.block_on(async {
-            let logs = logs_handle.lock().await;
+            let logs = result.logs_handle.lock().await;
             let mut summary = CaseSummary {
                 n_total: n + gw,
                 gw,

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -9501,3 +9501,191 @@ async fn sim_network_regular_node_labels_start_at_gateway_count() {
         GATEWAYS + NODES
     );
 }
+
+// =============================================================================
+// Routing Hop-Count Sweep
+//
+// Empirical evidence for the O(log n) routing claim. Sweeps network size N and
+// records the hop_count of completed GET operations. Prints summary statistics
+// per N so the resulting series can be fit / plotted offline (whitepaper).
+//
+// Marked `#[ignore]` — long-running, manually triggered. Invoke with:
+//   cargo test -p freenet --features "simulation_tests,testing" \
+//       --test simulation_integration bench_hop_count_sweep \
+//       -- --ignored --nocapture
+// =============================================================================
+
+/// Sweep network size N and collect terminal-GET hop counts for each case.
+///
+/// Uses `run_direct()` (paused-time single-thread runtime) for scale: turmoil's
+/// link bookkeeping is O(n²) in node count and becomes the bottleneck well
+/// before the simulation itself does.
+///
+/// Per-case parameters are tuned to (a) yield enough completed GETs to give a
+/// meaningful distribution and (b) keep wall-clock time bounded. The HTL
+/// settings scale with N so that requests can plausibly traverse the network.
+#[test_log::test]
+#[ignore = "long-running hop-count sweep; run via `cargo test ... -- --ignored bench_hop_count_sweep`"]
+fn bench_hop_count_sweep() {
+    const SEED: u64 = 0x5EED_C0F1;
+
+    // (gateways, nodes, iters, max_contracts, duration_secs, sleep_secs,
+    //  min_conns, max_conns, ring_max_htl, rnd_if_htl_above)
+    let cases: [(usize, usize, usize, usize, u64, u64, usize, usize, usize, usize); 4] = [
+        (1, 20, 100, 5, 60, 3, 3, 15, 10, 7),
+        (2, 50, 200, 8, 120, 5, 3, 20, 12, 8),
+        (2, 100, 300, 10, 240, 8, 3, 25, 14, 10),
+        (3, 200, 500, 15, 480, 10, 3, 30, 16, 12),
+    ];
+
+    #[derive(Default)]
+    struct CaseSummary {
+        n_total: usize,
+        gw: usize,
+        get_success: usize,
+        get_not_found: usize,
+        get_failure: usize,
+        hops: Vec<usize>,
+        hops_missing: usize,
+        wall_secs: f64,
+    }
+
+    let mut all: Vec<CaseSummary> = Vec::new();
+
+    for (gw, n, iters, max_c, dur, sleep, min_c, max_c2, htl, rnd_above) in cases {
+        let case_start = std::time::Instant::now();
+        tracing::info!(
+            "=== sweep case: gateways={gw} nodes={n} iters={iters} max_contracts={max_c} \
+             duration={dur}s htl={htl}/{rnd_above} conns={min_c}..{max_c2} ==="
+        );
+
+        let result = TestConfig::medium("hop-sweep", SEED ^ n as u64)
+            .with_gateways(gw)
+            .with_nodes(n)
+            .with_iterations(iters)
+            .with_max_contracts(max_c)
+            .with_duration(Duration::from_secs(dur))
+            .with_sleep(Duration::from_secs(sleep))
+            .with_connections(min_c, max_c2)
+            .with_htl(htl, rnd_above)
+            .run_direct()
+            .assert_ok();
+
+        let rt = create_runtime();
+        let case = rt.block_on(async {
+            let logs = result.logs_handle.lock().await;
+            let mut summary = CaseSummary {
+                n_total: n + gw,
+                gw,
+                ..CaseSummary::default()
+            };
+            for m in logs.iter() {
+                match m.kind.get_outcome() {
+                    Some(true) => summary.get_success += 1,
+                    Some(false) => {
+                        // Cannot cheaply distinguish NotFound vs Failure without
+                        // adding another accessor; treat both as "non-success
+                        // terminal" and bucket via elapsed_ms heuristic for
+                        // visibility. Hop counts are pulled below.
+                        if let Some(ms) = m.kind.get_elapsed_ms() {
+                            if ms >= 55_000 {
+                                summary.get_failure += 1;
+                            } else {
+                                summary.get_not_found += 1;
+                            }
+                        } else {
+                            summary.get_failure += 1;
+                        }
+                    }
+                    None => {}
+                }
+                // Pull hop count from any terminal GET event.
+                if m.kind.get_outcome().is_some() {
+                    match m.kind.hop_count() {
+                        Some(h) => summary.hops.push(h),
+                        None => summary.hops_missing += 1,
+                    }
+                }
+            }
+            summary
+        });
+        let mut case = case;
+        case.wall_secs = case_start.elapsed().as_secs_f64();
+        tracing::info!(
+            "case N={} done in {:.1}s: success={}, not_found={}, failure={}, \
+             hop_samples={}, hop_missing={}",
+            case.n_total,
+            case.wall_secs,
+            case.get_success,
+            case.get_not_found,
+            case.get_failure,
+            case.hops.len(),
+            case.hops_missing,
+        );
+        all.push(case);
+    }
+
+    fn pct(sorted: &[usize], p: usize) -> usize {
+        if sorted.is_empty() {
+            return 0;
+        }
+        let idx = ((sorted.len().saturating_sub(1)) * p) / 100;
+        sorted[idx]
+    }
+
+    println!();
+    println!("=== HOP COUNT SWEEP ===");
+    println!(
+        "{:>5} {:>5} {:>5} {:>7} {:>8} {:>8} {:>6} {:>6} {:>6} {:>6} {:>8} {:>9}",
+        "N", "gw", "succ", "nfound", "fail", "samples", "mean", "median", "p95", "p99", "max",
+        "wall_s"
+    );
+    for case in &all {
+        let mut hops = case.hops.clone();
+        hops.sort_unstable();
+        if hops.is_empty() {
+            println!(
+                "{:>5} {:>5} {:>5} {:>7} {:>8} {:>8}    no hop data        wall_s={:.1}",
+                case.n_total,
+                case.gw,
+                case.get_success,
+                case.get_not_found,
+                case.get_failure,
+                0,
+                case.wall_secs,
+            );
+            continue;
+        }
+        let len = hops.len();
+        let mean = hops.iter().sum::<usize>() as f64 / len as f64;
+        let median = hops[len / 2];
+        let p95 = pct(&hops, 95);
+        let p99 = pct(&hops, 99);
+        let max = hops[len - 1];
+        println!(
+            "{:>5} {:>5} {:>5} {:>7} {:>8} {:>8} {:>6.2} {:>6} {:>6} {:>6} {:>6} {:>9.1}",
+            case.n_total,
+            case.gw,
+            case.get_success,
+            case.get_not_found,
+            case.get_failure,
+            len,
+            mean,
+            median,
+            p95,
+            p99,
+            max,
+            case.wall_secs,
+        );
+    }
+    println!("=== END HOP COUNT SWEEP ===");
+
+    // Soft check: we want at least one case with non-trivial hop data so a
+    // future regression that loses hop_count propagation gets caught here.
+    let total_hops: usize = all.iter().map(|c| c.hops.len()).sum();
+    assert!(
+        total_hops > 0,
+        "sweep collected zero hop_count samples — either no GETs completed or hop_count is \
+         not being propagated to terminal GET events"
+    );
+}


### PR DESCRIPTION
## Summary

Routing hop-count sweep benchmark for use by the Freenet whitepaper §5.6 and as future scaling-study infrastructure. Adds an `EventKind::hop_count()` public accessor and a `bench_hop_count_sweep` ignored test that runs `run_direct()` at N ∈ {20, 50, 100, 200} and prints per-N path-length statistics.

## Status: parked

Empirical results at N up to ~200 are dominated by `GetNotFound` (random PUTs and random GETs barely overlap, so the routing depth being measured is *exhaustion* depth, not successful-path depth). Numbers are not in a publishable shape for the whitepaper's O(log n) claim.

The production telemetry fix that this PR depended on has been extracted to #4245 for clean merge on its own. This PR stays draft as future infrastructure: when someone has time to implement a properly warmed-up controlled workload (where every GET hits a contract that's already been PUT and the topology has converged before GETs start), the harness here is the right place to drop it.

## What's here

- `EventKind::hop_count()` public accessor (`crates/core/src/tracing.rs`)
- `bench_hop_count_sweep` test (`crates/core/tests/simulation_integration.rs`, `#[ignore]`)
- Wire-carried `hop_count` threading on `GetMsg::Response` — **same change as #4245** (will rebase after #4245 merges)

## How to run when revisited

```
cargo test -p freenet --features "simulation_tests,testing" \
  --test simulation_integration bench_hop_count_sweep -- --ignored --nocapture
```

[AI-assisted - Claude]