### PR TITLE
fix: cut river-driven log spam and bound log-dir size (#4251)

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -2575,10 +2575,19 @@ SuccessExitStatus=42 43
 # Do NOT restart — the existing instance is healthy.
 RestartPreventExitStatus=43
 
-# Logging - write to files for systems without active user journald
-# (headless servers, systems without lingering enabled, etc.)
-StandardOutput=append:{log_dir}/freenet.log
-StandardError=append:{log_dir}/freenet.error.log
+# Logging
+# - The node's tracing layer writes its own size-capped, hourly-rotated
+#   logs to {log_dir}/freenet.YYYY-MM-DD-HH.log (LOG_RETENTION_HOURS +
+#   LOG_DIR_MAX_BYTES; see crates/core/src/tracing.rs).
+# - systemd's StandardOutput/StandardError previously appended to a fixed
+#   freenet.log / freenet.error.log that the time-based cleanup never
+#   pruned (mtime stayed fresh while the file was being written), so they
+#   grew without bound on long-running nodes (issue #4251).
+# - Routing both to the journal lets journald handle rotation, and panics
+#   or pre-tracing-init output remain queryable via
+#   `journalctl --user-unit freenet`.
+StandardOutput=journal
+StandardError=journal
 SyslogIdentifier=freenet
 
 # Resource limits to prevent runaway resource consumption
@@ -2640,9 +2649,19 @@ SuccessExitStatus=42 43
 # Do NOT restart — the existing instance is healthy.
 RestartPreventExitStatus=43
 
-# Logging - write to files for systems without active user journald
-StandardOutput=append:{log_dir}/freenet.log
-StandardError=append:{log_dir}/freenet.error.log
+# Logging
+# - The node's tracing layer writes its own size-capped, hourly-rotated
+#   logs to {log_dir}/freenet.YYYY-MM-DD-HH.log (LOG_RETENTION_HOURS +
+#   LOG_DIR_MAX_BYTES; see crates/core/src/tracing.rs).
+# - systemd's StandardOutput/StandardError previously appended to a fixed
+#   freenet.log / freenet.error.log that the time-based cleanup never
+#   pruned (mtime stayed fresh while the file was being written), so they
+#   grew without bound on long-running nodes (issue #4251).
+# - Routing both to the journal lets journald handle rotation, and panics
+#   or pre-tracing-init output remain queryable via
+#   `journalctl -u freenet`.
+StandardOutput=journal
+StandardError=journal
 SyslogIdentifier=freenet
 
 # Resource limits to prevent runaway resource consumption
@@ -2916,10 +2935,23 @@ fn generate_plist(wrapper_path: &Path, log_dir: &Path) -> String {
         <key>SuccessfulExit</key>
         <false/>
     </dict>
+    <!--
+        Logging
+        - The node's tracing layer writes its own size-capped, hourly-
+          rotated logs to {log_dir}/freenet.YYYY-MM-DD-HH.log
+          (LOG_RETENTION_HOURS + LOG_DIR_MAX_BYTES; see
+          crates/core/src/tracing.rs).
+        - launchd previously appended to fixed freenet.log / freenet.error.log
+          that the time-based cleanup never pruned, so they grew without
+          bound (issue #4251). macOS does not offer a journal target for
+          launchd, so the cleanest option is /dev/null — diagnostics
+          remain available via `freenet service report`, which collects
+          the rotated tracing logs.
+    -->
     <key>StandardOutPath</key>
-    <string>{log_dir}/freenet.log</string>
+    <string>/dev/null</string>
     <key>StandardErrorPath</key>
-    <string>{log_dir}/freenet.error.log</string>
+    <string>/dev/null</string>
     <key>SoftResourceLimits</key>
     <dict>
         <key>NumberOfFiles</key>
@@ -4054,9 +4086,16 @@ mod tests {
         // Verify it references the correct binary
         assert!(service_content.contains("/usr/local/bin/freenet network"));
 
-        // Verify log paths are set correctly (file-based logging for headless systems)
-        assert!(service_content.contains("/home/test/.local/state/freenet/freenet.log"));
-        assert!(service_content.contains("/home/test/.local/state/freenet/freenet.error.log"));
+        // Logging routes to journal so journald handles rotation. The tracing
+        // layer writes its own size-capped rolling files; routing systemd
+        // stdout/stderr to a fixed freenet.log / freenet.error.log caused
+        // unbounded growth (issue #4251 / log-spam fix).
+        assert!(service_content.contains("StandardOutput=journal"));
+        assert!(service_content.contains("StandardError=journal"));
+        assert!(
+            !service_content.contains("append:"),
+            "regression: must not append systemd output to fixed unrotated file (#4251)"
+        );
 
         // Verify resource limits are set
         assert!(service_content.contains("LimitNOFILE=65536"));
@@ -4125,6 +4164,14 @@ mod tests {
 
         // Verify exit code 43 prevents restart (another instance already running)
         assert!(service_content.contains("RestartPreventExitStatus=43"));
+
+        // Logging routes to journal (same reasoning as the user-unit test).
+        assert!(service_content.contains("StandardOutput=journal"));
+        assert!(service_content.contains("StandardError=journal"));
+        assert!(
+            !service_content.contains("append:"),
+            "regression: must not append systemd output to fixed unrotated file (#4251)"
+        );
     }
 
     #[test]
@@ -4200,9 +4247,19 @@ mod tests {
         // Verify it references the correct binary
         assert!(plist_content.contains("/usr/local/bin/freenet"));
 
-        // Verify log paths are set correctly
-        assert!(plist_content.contains("/Users/test/Library/Logs/freenet/freenet.log"));
-        assert!(plist_content.contains("/Users/test/Library/Logs/freenet/freenet.error.log"));
+        // Stdout/stderr are discarded; the tracing layer writes its own
+        // size-capped rolling logs and `freenet service report` collects
+        // them. Writing launchd output to a fixed freenet.log /
+        // freenet.error.log caused unbounded growth (issue #4251).
+        assert!(plist_content.contains("<string>/dev/null</string>"));
+        assert!(
+            !plist_content.contains("/Users/test/Library/Logs/freenet/freenet.log"),
+            "regression: launchd must not write stdout to a fixed unrotated log file (#4251)"
+        );
+        assert!(
+            !plist_content.contains("/Users/test/Library/Logs/freenet/freenet.error.log"),
+            "regression: launchd must not write stderr to a fixed unrotated log file (#4251)"
+        );
 
         // Verify resource limits are set
         assert!(plist_content.contains("<key>NumberOfFiles</key>"));

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -2849,14 +2849,24 @@ CONSECUTIVE_FAILURES=0
 PORT_CONFLICT_KILLS=0
 MAX_PORT_CONFLICT_KILLS=3  # Give up after this many kill attempts
 
-LOG="$HOME/Library/Logs/freenet/freenet.log"
+# Lifecycle messages route through `logger`, which writes to macOS unified
+# logging (auto-rotated, queryable via `log show --predicate 'process ==
+# "logger"' --info`). Previously these were appended to a fixed
+# ~/Library/Logs/freenet/freenet.log that the cleanup pass never touched
+# (its mtime stayed fresh while being written), so the file grew without
+# bound on long-running nodes (issue #4251). The transient
+# freenet.error.log.last scratch file below is overwritten on every launch
+# and so does not accumulate.
+log_event() {{
+    logger -t freenet "$1"
+}}
 
 # Kill any stale freenet network processes before starting.
 # This handles the case where a previous launch daemon restart left a child
 # process still holding the port (e.g. port 7509).
 # Scoped to the current user to avoid killing processes owned by other users.
 if pkill -f -u "$(id -u)" "freenet network" 2>/dev/null; then
-    echo "$(date): Killed stale freenet network process(es) on startup" >> "$LOG"
+    log_event "Killed stale freenet network process(es) on startup"
     sleep 2
 fi
 
@@ -2865,44 +2875,44 @@ while true; do
     EXIT_CODE=$?
 
     if [ $EXIT_CODE -eq 42 ]; then
-        echo "$(date): Update needed, running freenet update..." >> "$LOG"
+        log_event "Update needed, running freenet update..."
         if "{binary}" update --quiet; then
-            echo "$(date): Update successful, restarting..." >> "$LOG"
+            log_event "Update successful, restarting..."
             CONSECUTIVE_FAILURES=0
             PORT_CONFLICT_KILLS=0
             BACKOFF=10
             sleep 2
         else
             CONSECUTIVE_FAILURES=$((CONSECUTIVE_FAILURES + 1))
-            echo "$(date): Update failed (attempt $CONSECUTIVE_FAILURES), backing off $BACKOFF seconds..." >> "$LOG"
+            log_event "Update failed (attempt $CONSECUTIVE_FAILURES), backing off $BACKOFF seconds..."
             sleep $BACKOFF
             BACKOFF=$((BACKOFF * 2))
             [ $BACKOFF -gt $MAX_BACKOFF ] && BACKOFF=$MAX_BACKOFF
         fi
         continue
     elif [ $EXIT_CODE -eq 43 ]; then
-        echo "$(date): Another instance is already running, exiting cleanly" >> "$LOG"
+        log_event "Another instance is already running, exiting cleanly"
         exit 0
     elif [ $EXIT_CODE -eq 0 ]; then
-        echo "$(date): Normal shutdown" >> "$LOG"
+        log_event "Normal shutdown"
         exit 0
     else
         # Check if this looks like a port-already-in-use failure.
         if grep -q "already in use" "$HOME/Library/Logs/freenet/freenet.error.log.last" 2>/dev/null; then
             PORT_CONFLICT_KILLS=$((PORT_CONFLICT_KILLS + 1))
             if [ $PORT_CONFLICT_KILLS -le $MAX_PORT_CONFLICT_KILLS ]; then
-                echo "$(date): Port conflict detected (attempt $PORT_CONFLICT_KILLS/$MAX_PORT_CONFLICT_KILLS) — killing stale freenet process and retrying..." >> "$LOG"
+                log_event "Port conflict detected (attempt $PORT_CONFLICT_KILLS/$MAX_PORT_CONFLICT_KILLS) — killing stale freenet process and retrying..."
                 pkill -f -u "$(id -u)" "freenet network" 2>/dev/null || true
                 sleep 2
                 BACKOFF=10
                 continue
             else
-                echo "$(date): Port conflict persists after $MAX_PORT_CONFLICT_KILLS kill attempts. Manual intervention may be required ('pkill freenet'). Backing off..." >> "$LOG"
+                log_event "Port conflict persists after $MAX_PORT_CONFLICT_KILLS kill attempts. Manual intervention may be required ('pkill freenet'). Backing off..."
             fi
         fi
         CONSECUTIVE_FAILURES=$((CONSECUTIVE_FAILURES + 1))
         PORT_CONFLICT_KILLS=0
-        echo "$(date): Exited with code $EXIT_CODE, restarting after backoff..." >> "$LOG"
+        log_event "Exited with code $EXIT_CODE, restarting after backoff..."
         sleep $BACKOFF
         BACKOFF=$((BACKOFF * 2))
         [ $BACKOFF -gt $MAX_BACKOFF ] && BACKOFF=$MAX_BACKOFF
@@ -2914,7 +2924,7 @@ done
 }
 
 #[cfg(target_os = "macos")]
-fn generate_plist(wrapper_path: &Path, log_dir: &Path) -> String {
+pub(super) fn generate_plist(wrapper_path: &Path, log_dir: &Path) -> String {
     // Note: wrapper_path is the auto-update wrapper script, not the freenet binary directly.
     // The wrapper handles the loop: run freenet, check exit code, update if needed.
     format!(
@@ -4179,6 +4189,23 @@ mod tests {
     fn test_macos_wrapper_script_generation() {
         let binary_path = PathBuf::from("/usr/local/bin/freenet");
         let script = generate_wrapper_script(&binary_path);
+
+        // Regression for issue #4251: lifecycle messages MUST go through
+        // `logger -t freenet` (auto-rotated by macOS unified logging),
+        // not appended to a fixed ~/Library/Logs/freenet/freenet.log file
+        // that grows without bound.
+        assert!(
+            script.contains("logger -t freenet"),
+            "wrapper must route lifecycle messages through logger(1)"
+        );
+        assert!(
+            !script.contains("Library/Logs/freenet/freenet.log\""),
+            "regression: wrapper must NOT append to fixed unrotated freenet.log (#4251)"
+        );
+        assert!(
+            !script.contains(">> \"$LOG\""),
+            "regression: wrapper must not use the legacy LOG file variable (#4251)"
+        );
 
         // Regression for #3301: startup stale-process cleanup, scoped to current user
         assert!(

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -1113,7 +1113,10 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
 ///
 /// Cross-platform-compiled (no `#[cfg(target_os = "linux")]`) so non-Linux
 /// CI runners can exercise the predicate per code-style.md / deployment.md
-/// preference for pure decision helpers.
+/// preference for pure decision helpers. The `#[allow(dead_code)]`
+/// suppresses the dead-code lint on non-Linux builds where the only
+/// non-test caller (`update_service_file`) is cfg'd out.
+#[allow(dead_code)]
 pub(super) fn systemd_unit_needs_regen(content: &str) -> bool {
     let has_auto_update_markers = content.contains("ExecStopPost=")
         && content.contains("SuccessExitStatus=42")
@@ -1229,7 +1232,10 @@ fn update_service_file(
 ///
 /// Cross-platform-compiled (no `#[cfg(target_os = "macos")]`) so non-macOS
 /// CI runners can exercise the predicate per code-style.md / deployment.md
-/// preference for pure decision helpers.
+/// preference for pure decision helpers. The `#[allow(dead_code)]`
+/// suppresses the dead-code lint on non-macOS builds where the only
+/// non-test caller (`ensure_service_file_updated`) is cfg'd out.
+#[allow(dead_code)]
 pub(super) fn launchd_plist_needs_regen(content: &str) -> bool {
     content.contains("Library/Logs/freenet/freenet.log")
         || content.contains("Library/Logs/freenet/freenet.error.log")

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -1099,6 +1099,25 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
     Ok(())
 }
 
+/// Pure helper: decide whether a Linux systemd unit file needs to be
+/// regenerated. Returns true when EITHER the auto-update markers
+/// (`ExecStopPost=` + `SuccessExitStatus=42` + `RestartPreventExitStatus=43`)
+/// are missing, OR the legacy unrotated log target (`StandardOutput=append:`
+/// / `StandardError=append:` — issue #4251) is still present.
+///
+/// Extracted from `update_service_file` so the regen-trigger logic can be
+/// unit-tested without filesystem fixtures (per code-style.md's preference
+/// for pure decision helpers over inline platform-specific I/O).
+#[cfg(target_os = "linux")]
+pub(super) fn systemd_unit_needs_regen(content: &str) -> bool {
+    let has_auto_update_markers = content.contains("ExecStopPost=")
+        && content.contains("SuccessExitStatus=42")
+        && content.contains("RestartPreventExitStatus=43");
+    let has_legacy_log_target =
+        content.contains("StandardOutput=append:") || content.contains("StandardError=append:");
+    !has_auto_update_markers || has_legacy_log_target
+}
+
 /// Update a specific service file if it's missing the auto-update hook.
 #[cfg(target_os = "linux")]
 fn update_service_file(
@@ -1112,10 +1131,13 @@ fn update_service_file(
     // Check if the service file has all required directives.
     // RestartPreventExitStatus=43 prevents restart loops when another instance
     // is already running (added in 0.2.5).
-    if content.contains("ExecStopPost=")
-        && content.contains("SuccessExitStatus=42")
-        && content.contains("RestartPreventExitStatus=43")
-    {
+    //
+    // Also force regeneration when the legacy `StandardOutput=append:` or
+    // `StandardError=append:` directive is present (issue #4251). That target
+    // wrote stdout/stderr to a fixed freenet.log / freenet.error.log that was
+    // never rotated, growing without bound on long-running nodes. The current
+    // template routes both to the systemd journal.
+    if !systemd_unit_needs_regen(&content) {
         return Ok(()); // Already up to date
     }
 
@@ -1185,6 +1207,16 @@ fn update_service_file(
 }
 
 /// Check if the wrapper script needs updating (missing or outdated) and update if so.
+/// Pure helper: decide whether a launchd plist needs regeneration. Returns
+/// true when the plist still references the legacy unrotated log paths
+/// (`Library/Logs/freenet/freenet.log` / `freenet.error.log` — issue #4251).
+/// Newer plists send both standard streams to `/dev/null`.
+#[cfg(target_os = "macos")]
+pub(super) fn launchd_plist_needs_regen(content: &str) -> bool {
+    content.contains("Library/Logs/freenet/freenet.log")
+        || content.contains("Library/Logs/freenet/freenet.error.log")
+}
+
 #[cfg(target_os = "macos")]
 fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
     let home_dir = match dirs::home_dir() {
@@ -1202,15 +1234,52 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
     let wrapper_path = home_dir.join(".local/bin/freenet-service-wrapper.sh");
 
     // Check if wrapper script exists and has the update logic
-    let needs_update = if wrapper_path.exists() {
+    let wrapper_needs_update = if wrapper_path.exists() {
         let content = fs::read_to_string(&wrapper_path).context("Failed to read wrapper script")?;
         // Check for key auto-update markers
-        !content.contains("EXIT_CODE=$?") || !content.contains("freenet update")
+        !content.contains("EXIT_CODE=$?")
+            || !content.contains("freenet update")
+            // Force regeneration if the wrapper still writes lifecycle messages
+            // to a fixed unrotated freenet.log (issue #4251). Newer wrappers
+            // route those messages through `logger -t freenet`.
+            || content.contains("$HOME/Library/Logs/freenet/freenet.log")
     } else {
         true
     };
 
-    if !needs_update {
+    // Also force regeneration of the plist if it still points
+    // StandardOutPath/StandardErrorPath at the unrotated freenet.log /
+    // freenet.error.log paths (issue #4251). Newer plists send both to
+    // /dev/null; the tracing layer captures the same content into its
+    // own rotated files.
+    let plist_needs_update = {
+        let content = fs::read_to_string(&plist_path).context("Failed to read plist")?;
+        launchd_plist_needs_regen(&content)
+    };
+
+    if plist_needs_update {
+        if !quiet {
+            println!("Updating launchd plist to drop legacy log paths (issue #4251)...");
+        }
+        let log_dir = home_dir.join("Library/Logs/freenet");
+        let plist_content = super::service::generate_plist(&wrapper_path, &log_dir);
+        // Best-effort backup so a botched rewrite is recoverable.
+        let backup_path = plist_path.with_extension("plist.bak");
+        if let Err(e) = fs::copy(&plist_path, &backup_path) {
+            if !quiet {
+                eprintln!(
+                    "Warning: failed to back up plist: {}. Continuing anyway.",
+                    e
+                );
+            }
+        }
+        fs::write(&plist_path, plist_content).context("Failed to write updated plist")?;
+        if !quiet {
+            println!("launchd plist updated.");
+        }
+    }
+
+    if !wrapper_needs_update {
         return Ok(());
     }
 
@@ -1611,6 +1680,96 @@ fn spawn_detached_updater(script: &Path, current_app: &Path, staged_app: &Path) 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Regression tests for the issue #4251 auto-update migration logic:
+    // verify that existing units carrying the legacy unrotated log
+    // target are correctly detected as needing regen, AND that fresh
+    // units (current template) are NOT regenerated.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn systemd_unit_with_legacy_append_log_needs_regen() {
+        let legacy = r#"[Service]
+Type=simple
+ExecStart=/usr/local/bin/freenet network
+Restart=always
+ExecStopPost=-/bin/sh -c '...'
+SuccessExitStatus=42 43
+RestartPreventExitStatus=43
+StandardOutput=append:/home/u/.local/state/freenet/freenet.log
+StandardError=append:/home/u/.local/state/freenet/freenet.error.log
+"#;
+        assert!(
+            systemd_unit_needs_regen(legacy),
+            "legacy append:freenet.log unit must be detected as needing regen (#4251)"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn systemd_unit_with_journal_target_is_up_to_date() {
+        let current = r#"[Service]
+Type=simple
+ExecStart=/usr/local/bin/freenet network
+Restart=always
+ExecStopPost=-/bin/sh -c '...'
+SuccessExitStatus=42 43
+RestartPreventExitStatus=43
+StandardOutput=journal
+StandardError=journal
+"#;
+        assert!(
+            !systemd_unit_needs_regen(current),
+            "current journal-target unit must NOT be flagged for regen"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn systemd_unit_without_auto_update_markers_needs_regen() {
+        // Pre-auto-update unit (no exit-42 handling) — must regen even
+        // though it has no legacy log target.
+        let ancient = r#"[Service]
+Type=simple
+ExecStart=/usr/local/bin/freenet network
+Restart=always
+StandardOutput=journal
+StandardError=journal
+"#;
+        assert!(
+            systemd_unit_needs_regen(ancient),
+            "unit without ExecStopPost/SuccessExitStatus must regen"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn launchd_plist_with_legacy_log_paths_needs_regen() {
+        let legacy = r#"<plist version="1.0"><dict>
+    <key>StandardOutPath</key>
+    <string>/Users/u/Library/Logs/freenet/freenet.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/u/Library/Logs/freenet/freenet.error.log</string>
+</dict></plist>"#;
+        assert!(
+            launchd_plist_needs_regen(legacy),
+            "legacy plist must be detected as needing regen (#4251)"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn launchd_plist_with_dev_null_is_up_to_date() {
+        let current = r#"<plist version="1.0"><dict>
+    <key>StandardOutPath</key>
+    <string>/dev/null</string>
+    <key>StandardErrorPath</key>
+    <string>/dev/null</string>
+</dict></plist>"#;
+        assert!(
+            !launchd_plist_needs_regen(current),
+            "current /dev/null plist must NOT be flagged for regen"
+        );
+    }
 
     // Synthesize an ExitStatus with a specific numeric code. Uses the
     // Unix-specific `ExitStatusExt::from_raw` so this test module is

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -1105,16 +1105,23 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
 /// are missing, OR the legacy unrotated log target (`StandardOutput=append:`
 /// / `StandardError=append:` — issue #4251) is still present.
 ///
-/// Extracted from `update_service_file` so the regen-trigger logic can be
-/// unit-tested without filesystem fixtures (per code-style.md's preference
-/// for pure decision helpers over inline platform-specific I/O).
-#[cfg(target_os = "linux")]
+/// Filters out comment lines (those whose first non-whitespace character is
+/// `#`) so a unit annotated with the legacy directive in a comment doesn't
+/// trip a false-positive regen. Marker-presence check is whole-content
+/// because the markers we look for are uniquely-spelled and unlikely to
+/// appear in comments.
+///
+/// Cross-platform-compiled (no `#[cfg(target_os = "linux")]`) so non-Linux
+/// CI runners can exercise the predicate per code-style.md / deployment.md
+/// preference for pure decision helpers.
 pub(super) fn systemd_unit_needs_regen(content: &str) -> bool {
     let has_auto_update_markers = content.contains("ExecStopPost=")
         && content.contains("SuccessExitStatus=42")
         && content.contains("RestartPreventExitStatus=43");
-    let has_legacy_log_target =
-        content.contains("StandardOutput=append:") || content.contains("StandardError=append:");
+    let has_legacy_log_target = content
+        .lines()
+        .filter(|l| !l.trim_start().starts_with('#'))
+        .any(|l| l.contains("StandardOutput=append:") || l.contains("StandardError=append:"));
     !has_auto_update_markers || has_legacy_log_target
 }
 
@@ -1208,13 +1215,20 @@ fn update_service_file(
 
 /// Check if the wrapper script needs updating (missing or outdated) and update if so.
 /// Pure helper: decide whether a launchd plist needs regeneration. Returns
-/// true when the plist still references the legacy unrotated log paths
-/// (`Library/Logs/freenet/freenet.log` / `freenet.error.log` — issue #4251).
-/// Newer plists send both standard streams to `/dev/null`.
-#[cfg(target_os = "macos")]
+/// true when the plist still references the legacy unrotated log path
+/// (`Library/Logs/freenet/freenet.log` — issue #4251). Newer plists send
+/// both standard streams to `/dev/null`.
+///
+/// Single substring check: any plist that references
+/// `Library/Logs/freenet/freenet.error.log` necessarily contains
+/// `Library/Logs/freenet/freenet.log` as a substring of that path, so the
+/// one check covers both legacy fields.
+///
+/// Cross-platform-compiled (no `#[cfg(target_os = "macos")]`) so non-macOS
+/// CI runners can exercise the predicate per code-style.md / deployment.md
+/// preference for pure decision helpers.
 pub(super) fn launchd_plist_needs_regen(content: &str) -> bool {
     content.contains("Library/Logs/freenet/freenet.log")
-        || content.contains("Library/Logs/freenet/freenet.error.log")
 }
 
 #[cfg(target_os = "macos")]
@@ -1248,15 +1262,79 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
     };
 
     // Also force regeneration of the plist if it still points
-    // StandardOutPath/StandardErrorPath at the unrotated freenet.log /
-    // freenet.error.log paths (issue #4251). Newer plists send both to
-    // /dev/null; the tracing layer captures the same content into its
-    // own rotated files.
-    let plist_needs_update = {
-        let content = fs::read_to_string(&plist_path).context("Failed to read plist")?;
-        launchd_plist_needs_regen(&content)
+    // StandardOutPath/StandardErrorPath at the unrotated freenet.log
+    // paths (issue #4251). Read fails non-fatally: a transient FS
+    // error should not kill the whole auto-update path. If we cannot
+    // read the plist we conservatively skip the plist-regen step and
+    // log a warning; the wrapper-side update still gets a chance.
+    let plist_needs_update = match fs::read_to_string(&plist_path) {
+        Ok(content) => launchd_plist_needs_regen(&content),
+        Err(e) => {
+            if !quiet {
+                eprintln!(
+                    "Warning: failed to read launchd plist at {} for migration check: {}. \
+                     Skipping plist regen.",
+                    plist_path.display(),
+                    e
+                );
+            }
+            false
+        }
     };
 
+    // Step 1: regenerate the wrapper FIRST. The plist's ProgramArguments
+    // points at this wrapper path, so the wrapper must exist and be
+    // executable before we point launchd at it. If wrapper regen fails,
+    // we exit BEFORE rewriting the plist so the system stays in its
+    // previous-working state.
+    if wrapper_needs_update {
+        if !quiet {
+            println!("Updating service wrapper to add auto-update support...");
+        }
+
+        // Ensure wrapper directory exists
+        let wrapper_dir = wrapper_path
+            .parent()
+            .context("Wrapper path has no parent directory")?;
+        fs::create_dir_all(wrapper_dir).context("Failed to create wrapper directory")?;
+
+        // Create backup of existing wrapper script if it exists
+        if wrapper_path.exists() {
+            let backup_path = wrapper_path.with_extension("sh.bak");
+            if let Err(e) = fs::copy(&wrapper_path, &backup_path) {
+                if !quiet {
+                    eprintln!(
+                        "Warning: Failed to backup wrapper script: {}. Continuing anyway.",
+                        e
+                    );
+                }
+            } else if !quiet {
+                println!("Backed up existing wrapper script to {:?}", backup_path);
+            }
+        }
+
+        // Generate and write new wrapper script
+        let wrapper_content = generate_wrapper_script(binary_path);
+        fs::write(&wrapper_path, &wrapper_content).context("Failed to write wrapper script")?;
+
+        // Make executable
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&wrapper_path)?.permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&wrapper_path, perms)?;
+        }
+
+        if !quiet {
+            println!("Service wrapper updated with auto-update hook.");
+        }
+    }
+
+    // Step 2: regenerate the plist AFTER the wrapper is in place,
+    // then reload launchd so the new config takes effect immediately
+    // (rather than waiting for the next user logout / reboot — see
+    // issue #4251 re-review #1).
     if plist_needs_update {
         if !quiet {
             println!("Updating launchd plist to drop legacy log paths (issue #4251)...");
@@ -1274,58 +1352,90 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
             }
         }
         fs::write(&plist_path, plist_content).context("Failed to write updated plist")?;
+
+        // launchd caches the in-memory job from the plist contents at
+        // bootstrap time. Without bootout/bootstrap the new plist
+        // takes effect only on next login or reboot. Failures here are
+        // non-fatal: the next launchd-driven restart will still use
+        // the OLD config until reload, but the file is at least
+        // correct on disk.
+        reload_launchd_agent(&plist_path, quiet);
+
         if !quiet {
             println!("launchd plist updated.");
         }
     }
 
-    if !wrapper_needs_update {
-        return Ok(());
-    }
+    Ok(())
+}
 
-    if !quiet {
-        println!("Updating service wrapper to add auto-update support...");
-    }
+/// Reload the freenet launchd agent so the rewritten plist takes
+/// effect immediately. Uses the modern `bootout`/`bootstrap` interface
+/// scoped to the current user's GUI domain (`gui/<uid>`); falls back
+/// to the legacy `unload`/`load` pair on systems where `bootout`
+/// returns a non-zero status. Failures are surfaced as warnings, not
+/// errors — the rewritten plist is correct on disk regardless.
+#[cfg(target_os = "macos")]
+fn reload_launchd_agent(plist_path: &Path, quiet: bool) {
+    use std::process::Command;
 
-    // Ensure wrapper directory exists
-    let wrapper_dir = wrapper_path
-        .parent()
-        .context("Wrapper path has no parent directory")?;
-    fs::create_dir_all(wrapper_dir).context("Failed to create wrapper directory")?;
+    // SAFETY: getuid() is async-signal-safe and has no failure mode.
+    let uid = unsafe { libc::getuid() };
+    let domain = format!("gui/{uid}");
 
-    // Create backup of existing wrapper script if it exists
-    if wrapper_path.exists() {
-        let backup_path = wrapper_path.with_extension("sh.bak");
-        if let Err(e) = fs::copy(&wrapper_path, &backup_path) {
+    // bootout is idempotent: returns 0 if the service was loaded and
+    // is now unloaded, non-zero if it wasn't loaded. Either is fine.
+    let _ = Command::new("launchctl")
+        .args(["bootout", &domain])
+        .arg(plist_path)
+        .status();
+
+    let bootstrap_status = Command::new("launchctl")
+        .args(["bootstrap", &domain])
+        .arg(plist_path)
+        .status();
+
+    match bootstrap_status {
+        Ok(s) if s.success() => {
+            if !quiet {
+                println!("Reloaded launchd agent ({}).", domain);
+            }
+        }
+        Ok(s) => {
+            // bootstrap failed. Try the legacy unload/load fallback.
+            let _ = Command::new("launchctl")
+                .args(["unload", "-w"])
+                .arg(plist_path)
+                .status();
+            let load_status = Command::new("launchctl")
+                .args(["load", "-w"])
+                .arg(plist_path)
+                .status();
+            match load_status {
+                Ok(s) if s.success() => {
+                    if !quiet {
+                        println!("Reloaded launchd agent via legacy load/unload.");
+                    }
+                }
+                _ => {
+                    if !quiet {
+                        eprintln!(
+                            "Warning: launchctl bootstrap (status: {s}) and load fallback both \
+                             failed; new plist takes effect on next user login or reboot."
+                        );
+                    }
+                }
+            }
+        }
+        Err(e) => {
             if !quiet {
                 eprintln!(
-                    "Warning: Failed to backup wrapper script: {}. Continuing anyway.",
-                    e
+                    "Warning: failed to invoke launchctl bootstrap: {e}; new plist takes \
+                     effect on next user login or reboot."
                 );
             }
-        } else if !quiet {
-            println!("Backed up existing wrapper script to {:?}", backup_path);
         }
     }
-
-    // Generate and write new wrapper script
-    let wrapper_content = generate_wrapper_script(binary_path);
-    fs::write(&wrapper_path, &wrapper_content).context("Failed to write wrapper script")?;
-
-    // Make executable
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&wrapper_path)?.permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&wrapper_path, perms)?;
-    }
-
-    if !quiet {
-        println!("Service wrapper updated with auto-update hook.");
-    }
-
-    Ok(())
 }
 
 /// Migrate old-style Windows Task Scheduler entries to registry Run key,
@@ -1685,7 +1795,10 @@ mod tests {
     // verify that existing units carrying the legacy unrotated log
     // target are correctly detected as needing regen, AND that fresh
     // units (current template) are NOT regenerated.
-    #[cfg(target_os = "linux")]
+    //
+    // The helpers (systemd_unit_needs_regen, launchd_plist_needs_regen)
+    // are cross-platform-compiled (string ops only), so these tests run
+    // on every CI platform per deployment.md's preference.
     #[test]
     fn systemd_unit_with_legacy_append_log_needs_regen() {
         let legacy = r#"[Service]
@@ -1704,7 +1817,6 @@ StandardError=append:/home/u/.local/state/freenet/freenet.error.log
         );
     }
 
-    #[cfg(target_os = "linux")]
     #[test]
     fn systemd_unit_with_journal_target_is_up_to_date() {
         let current = r#"[Service]
@@ -1723,7 +1835,31 @@ StandardError=journal
         );
     }
 
-    #[cfg(target_os = "linux")]
+    #[test]
+    fn systemd_unit_with_commented_out_append_does_not_force_regen() {
+        // Regression for re-review M4: a unit that ALREADY migrated
+        // to `StandardOutput=journal` but kept a comment referencing
+        // the old directive must NOT be flagged as needing regen.
+        // Otherwise every auto-update would overwrite operator-edited
+        // units forever.
+        let migrated = r#"[Service]
+Type=simple
+ExecStart=/usr/local/bin/freenet network
+Restart=always
+ExecStopPost=-/bin/sh -c '...'
+SuccessExitStatus=42 43
+RestartPreventExitStatus=43
+# StandardOutput=append:/old/path (replaced with journal on 2026-05-25)
+# StandardError=append:/old/path  (replaced with journal on 2026-05-25)
+StandardOutput=journal
+StandardError=journal
+"#;
+        assert!(
+            !systemd_unit_needs_regen(migrated),
+            "commented-out legacy append directive must NOT force regen (#4251)"
+        );
+    }
+
     #[test]
     fn systemd_unit_without_auto_update_markers_needs_regen() {
         // Pre-auto-update unit (no exit-42 handling) — must regen even
@@ -1741,7 +1877,6 @@ StandardError=journal
         );
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
     fn launchd_plist_with_legacy_log_paths_needs_regen() {
         let legacy = r#"<plist version="1.0"><dict>
@@ -1756,7 +1891,6 @@ StandardError=journal
         );
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
     fn launchd_plist_with_dev_null_is_up_to_date() {
         let current = r#"<plist version="1.0"><dict>

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -1215,20 +1215,24 @@ fn update_service_file(
 
 /// Check if the wrapper script needs updating (missing or outdated) and update if so.
 /// Pure helper: decide whether a launchd plist needs regeneration. Returns
-/// true when the plist still references the legacy unrotated log path
-/// (`Library/Logs/freenet/freenet.log` — issue #4251). Newer plists send
-/// both standard streams to `/dev/null`.
+/// true when the plist still references either legacy unrotated log path
+/// (`Library/Logs/freenet/freenet.log` for StandardOutPath, or
+/// `Library/Logs/freenet/freenet.error.log` for StandardErrorPath — issue
+/// #4251). Newer plists send both standard streams to `/dev/null`.
 ///
-/// Single substring check: any plist that references
-/// `Library/Logs/freenet/freenet.error.log` necessarily contains
-/// `Library/Logs/freenet/freenet.log` as a substring of that path, so the
-/// one check covers both legacy fields.
+/// Both substrings are checked independently: the second is NOT a
+/// substring of the first (`.error.log` does not contain `.log` as a
+/// contiguous tail — the dot precedes `error`). A partially-migrated
+/// plist (stdout already `/dev/null` but stderr still legacy) must still
+/// be detected; round-3 review caught the regression from collapsing
+/// these into one check.
 ///
 /// Cross-platform-compiled (no `#[cfg(target_os = "macos")]`) so non-macOS
 /// CI runners can exercise the predicate per code-style.md / deployment.md
 /// preference for pure decision helpers.
 pub(super) fn launchd_plist_needs_regen(content: &str) -> bool {
     content.contains("Library/Logs/freenet/freenet.log")
+        || content.contains("Library/Logs/freenet/freenet.error.log")
 }
 
 #[cfg(target_os = "macos")]
@@ -1353,89 +1357,31 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
         }
         fs::write(&plist_path, plist_content).context("Failed to write updated plist")?;
 
-        // launchd caches the in-memory job from the plist contents at
-        // bootstrap time. Without bootout/bootstrap the new plist
-        // takes effect only on next login or reboot. Failures here are
-        // non-fatal: the next launchd-driven restart will still use
-        // the OLD config until reload, but the file is at least
-        // correct on disk.
-        reload_launchd_agent(&plist_path, quiet);
-
+        // No automatic launchctl reload: when auto-update is driven by
+        // the launchd-managed wrapper, `freenet update` runs as a child
+        // of the wrapper's job tree. Apple documents `launchctl bootout`
+        // as terminating the ENTIRE process tree of the agent — which
+        // would kill the in-flight `freenet update` mid-call before the
+        // subsequent `bootstrap` can run, silently failing in exactly
+        // the auto-update path this code exists to support. (Detached
+        // helpers race the bootout; `kickstart` does not re-read the
+        // plist.) The new plist therefore takes effect at the next
+        // user-driven reload or reboot. The wrapper-script rewrite
+        // (issue #4251) DOES take effect at the next wrapper iteration
+        // — that's where the dominant unbounded freenet.log growth was
+        // coming from. Once the OS reads the new plist, the smaller
+        // launchd-captured stdout/stderr also stops accumulating.
         if !quiet {
-            println!("launchd plist updated.");
+            println!(
+                "launchd plist updated. To apply immediately without rebooting, run:\n  \
+                 launchctl bootout gui/$(id -u) {plist}\n  \
+                 launchctl bootstrap gui/$(id -u) {plist}",
+                plist = plist_path.display()
+            );
         }
     }
 
     Ok(())
-}
-
-/// Reload the freenet launchd agent so the rewritten plist takes
-/// effect immediately. Uses the modern `bootout`/`bootstrap` interface
-/// scoped to the current user's GUI domain (`gui/<uid>`); falls back
-/// to the legacy `unload`/`load` pair on systems where `bootout`
-/// returns a non-zero status. Failures are surfaced as warnings, not
-/// errors — the rewritten plist is correct on disk regardless.
-#[cfg(target_os = "macos")]
-fn reload_launchd_agent(plist_path: &Path, quiet: bool) {
-    use std::process::Command;
-
-    // SAFETY: getuid() is async-signal-safe and has no failure mode.
-    let uid = unsafe { libc::getuid() };
-    let domain = format!("gui/{uid}");
-
-    // bootout is idempotent: returns 0 if the service was loaded and
-    // is now unloaded, non-zero if it wasn't loaded. Either is fine.
-    let _ = Command::new("launchctl")
-        .args(["bootout", &domain])
-        .arg(plist_path)
-        .status();
-
-    let bootstrap_status = Command::new("launchctl")
-        .args(["bootstrap", &domain])
-        .arg(plist_path)
-        .status();
-
-    match bootstrap_status {
-        Ok(s) if s.success() => {
-            if !quiet {
-                println!("Reloaded launchd agent ({}).", domain);
-            }
-        }
-        Ok(s) => {
-            // bootstrap failed. Try the legacy unload/load fallback.
-            let _ = Command::new("launchctl")
-                .args(["unload", "-w"])
-                .arg(plist_path)
-                .status();
-            let load_status = Command::new("launchctl")
-                .args(["load", "-w"])
-                .arg(plist_path)
-                .status();
-            match load_status {
-                Ok(s) if s.success() => {
-                    if !quiet {
-                        println!("Reloaded launchd agent via legacy load/unload.");
-                    }
-                }
-                _ => {
-                    if !quiet {
-                        eprintln!(
-                            "Warning: launchctl bootstrap (status: {s}) and load fallback both \
-                             failed; new plist takes effect on next user login or reboot."
-                        );
-                    }
-                }
-            }
-        }
-        Err(e) => {
-            if !quiet {
-                eprintln!(
-                    "Warning: failed to invoke launchctl bootstrap: {e}; new plist takes \
-                     effect on next user login or reboot."
-                );
-            }
-        }
-    }
 }
 
 /// Migrate old-style Windows Task Scheduler entries to registry Run key,
@@ -1888,6 +1834,45 @@ StandardError=journal
         assert!(
             launchd_plist_needs_regen(legacy),
             "legacy plist must be detected as needing regen (#4251)"
+        );
+    }
+
+    #[test]
+    fn launchd_plist_with_stderr_only_legacy_path_still_needs_regen() {
+        // Regression for round-3 review: a partially-migrated plist
+        // (stdout already /dev/null, stderr still pointing at the
+        // legacy freenet.error.log) must still be detected. The
+        // single-substring shortcut for `freenet.log` was wrong
+        // because `.error.log` does NOT contain `.log` as a
+        // contiguous substring (`.` precedes `error`).
+        let partial = r#"<plist version="1.0"><dict>
+    <key>StandardOutPath</key>
+    <string>/dev/null</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/u/Library/Logs/freenet/freenet.error.log</string>
+</dict></plist>"#;
+        assert!(
+            launchd_plist_needs_regen(partial),
+            "plist with legacy stderr-only path must still need regen (round-3 review)"
+        );
+    }
+
+    /// Round-3 review L2: assert the freshly-generated plist template
+    /// does NOT contain the legacy-path substrings, otherwise every
+    /// auto-update would loop rewriting it. Calls the real generator
+    /// with synthetic inputs so a future edit to `generate_plist` that
+    /// accidentally adds the legacy path is caught at test time.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn freshly_generated_plist_does_not_trigger_regen_loop() {
+        use std::path::PathBuf;
+        let wrapper = PathBuf::from("/Users/test/.local/bin/freenet-service-wrapper.sh");
+        let log_dir = PathBuf::from("/Users/test/Library/Logs/freenet");
+        let generated = super::super::service::generate_plist(&wrapper, &log_dir);
+        assert!(
+            !launchd_plist_needs_regen(&generated),
+            "freshly-generated plist must not match the legacy-path predicate \
+             — otherwise every auto-update would loop rewriting it.\n\nGenerated:\n{generated}"
         );
     }
 

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -752,7 +752,8 @@ fn track_pending_reclamation_if_evict<CH>(
 
 /// Send an error response to the event sender when the per-contract queue is full.
 ///
-/// Logs a warning and sends the appropriate error response variant for the rejected event.
+/// Logs at DEBUG (per-event backpressure is not user-actionable; see #4251)
+/// and sends the appropriate error response variant for the rejected event.
 /// For fire-and-forget events (delegates, disconnects), no response is sent.
 async fn send_queue_full_response(
     channel: &mut handler::ContractHandlerChannel<handler::ContractHandlerHalve>,

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1511,6 +1511,46 @@ mod tests {
     use crate::config::GlobalExecutor;
     use std::time::Duration;
 
+    /// Pin the rejection log site to DEBUG.
+    ///
+    /// Demoting `Rejected event due to per-contract queue capacity limit`
+    /// from WARN to DEBUG was the user-visible point of the #4251 fix —
+    /// at WARN it produced millions of lines/day on saturated contracts.
+    /// A future refactor that re-promotes it would silently restore that
+    /// regression. This is a source-level pin (per
+    /// `.claude/rules/bug-prevention-patterns.md`'s precedent for
+    /// regression-guard pins) rather than a tracing-subscriber capture,
+    /// because the level is the *only* thing being asserted and a string
+    /// scan over our own source is more robust than runtime-subscriber
+    /// state-machine plumbing.
+    #[test]
+    fn send_queue_full_response_logs_at_debug_not_warn_pin_test() {
+        // file!() returns a workspace-rooted path but tests run from
+        // CARGO_MANIFEST_DIR. Anchor explicitly.
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/contract.rs");
+        let source = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("must read own source at {}: {e}", path.display()));
+        let needle = "Rejected event due to per-contract queue capacity limit";
+        let idx = source
+            .find(needle)
+            .expect("rejection log message must still exist in source");
+        // Window the 200 bytes preceding the message: the `tracing::*!`
+        // macro that emits it lives within that window.
+        let start = idx.saturating_sub(200);
+        let window = &source[start..idx];
+        assert!(
+            window.contains("tracing::debug!"),
+            "Rejected-event log site must be at DEBUG. \
+             Re-promotion to WARN/INFO restores the issue #4251 log-volume regression.\n\
+             Source window:\n{window}"
+        );
+        assert!(
+            !window.contains("tracing::warn!") && !window.contains("tracing::info!"),
+            "Rejected-event log site must NOT be at WARN or INFO. \
+             Source window:\n{window}"
+        );
+    }
+
     fn make_contract_key() -> ContractKey {
         let code = ContractCode::from(vec![42u8; 32]);
         let params = Parameters::from(vec![7u8; 8]);

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -758,7 +758,12 @@ async fn send_queue_full_response(
     channel: &mut handler::ContractHandlerChannel<handler::ContractHandlerHalve>,
     rejected: Box<fair_queue::RejectedEvent>,
 ) {
-    tracing::warn!(
+    // Per-event backpressure is normal under sustained load on a hot contract
+    // and is not user-actionable. Logging at WARN once per rejection drowns
+    // node logs (millions of lines/day on a saturated contract). Aggregate
+    // backpressure visibility belongs in metrics, not per-event logs.
+    // See issue #4251 for the underlying queue-saturation tracking.
+    tracing::debug!(
         event = %rejected.event,
         "Rejected event due to per-contract queue capacity limit"
     );

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1786,16 +1786,18 @@ async fn handle_interest_sync_message(
                     );
                 }
                 Ok(other) => {
-                    // Use Display, not Debug, for `other`. Debug-formatting an
-                    // UpdateResponse expands the inner anyhow::Error and
-                    // prints a ~15-line backtrace per call. Under queue
-                    // saturation (issue #4251) this fires constantly and
-                    // dominates log volume. Display gives a one-line summary.
+                    // Display, not Debug, for `other` — `?other` Debug-prints
+                    // the full UpdateResponse, expands the inner
+                    // anyhow::Error, and emits a ~15-line backtrace per call
+                    // under queue saturation (issue #4251).
+                    // ContractHandlerEvent's hand-written Display
+                    // (`contract/handler.rs:706`) gives a single-line variant
+                    // summary without expanding nested anyhow chains.
                     tracing::debug!(
                         from = %source,
                         contract = %key,
                         event = "resync_failed",
-                        response_kind = std::any::type_name_of_val(&other),
+                        response = %other,
                         "Unexpected response to resync update"
                     );
                 }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2154,9 +2154,11 @@ mod tests {
 
     /// Source-level pins for the three log sites in this file that were
     /// demoted / format-fixed in PR #4252 for issue #4251. Each pin
-    /// asserts the macro family of the call site by scanning a 240-byte
+    /// asserts the macro family of the call site by scanning a 400-byte
     /// window before the anchor message. Same shape as the
     /// `bug-prevention-patterns.md` FreeConsole pins in `service.rs`.
+    /// Window widened from 240 to 400 in re-review #3 to absorb future
+    /// added structured fields without false-breaking the pin.
     fn assert_log_site_pin(needle: &str, must_contain: &[&str], must_not_contain: &[&str]) {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/node.rs");
         let source = std::fs::read_to_string(&path)
@@ -2164,7 +2166,7 @@ mod tests {
         let idx = source
             .find(needle)
             .unwrap_or_else(|| panic!("log message `{needle}` must still exist in source"));
-        let start = idx.saturating_sub(240);
+        let start = idx.saturating_sub(400);
         let window = &source[start..idx];
         for needle in must_contain {
             assert!(

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2208,6 +2208,19 @@ mod tests {
         );
     }
 
+    #[test]
+    fn failed_to_get_contract_summary_logs_at_debug_pin_test() {
+        // Demoted from WARN to DEBUG: this site fires repeatedly when
+        // the executor queue is saturated for a hot contract (#4251).
+        // The actionable signal is the queue saturation itself, not
+        // the per-summary failure. Caught by rule-review on PR #4252.
+        assert_log_site_pin(
+            "Failed to get contract summary",
+            &["tracing::debug!"],
+            &["tracing::warn!", "tracing::info!"],
+        );
+    }
+
     // Hostname resolution tests
     #[tokio::test]
     async fn test_hostname_resolution_localhost() {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2152,6 +2152,60 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
+    /// Source-level pins for the three log sites in this file that were
+    /// demoted / format-fixed in PR #4252 for issue #4251. Each pin
+    /// asserts the macro family of the call site by scanning a 240-byte
+    /// window before the anchor message. Same shape as the
+    /// `bug-prevention-patterns.md` FreeConsole pins in `service.rs`.
+    fn assert_log_site_pin(needle: &str, must_contain: &[&str], must_not_contain: &[&str]) {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/node.rs");
+        let source = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("must read own source at {}: {e}", path.display()));
+        let idx = source
+            .find(needle)
+            .unwrap_or_else(|| panic!("log message `{needle}` must still exist in source"));
+        let start = idx.saturating_sub(240);
+        let window = &source[start..idx];
+        for needle in must_contain {
+            assert!(
+                window.contains(needle),
+                "site `{needle}` must appear in the 240-byte window before message:\n{window}",
+                needle = needle
+            );
+        }
+        for forbidden in must_not_contain {
+            assert!(
+                !window.contains(forbidden),
+                "site must NOT contain `{forbidden}` (would restore an issue #4251 regression):\n{window}",
+                forbidden = forbidden
+            );
+        }
+    }
+
+    #[test]
+    fn summary_mismatch_in_interest_sync_logs_at_debug_pin_test() {
+        // Demoted from INFO to DEBUG to stop dominating peer logs on
+        // hot contracts. Per #4251 review (testing reviewer #1).
+        assert_log_site_pin(
+            "Summary mismatch in interest sync \u{2014} syncing state to stale peer",
+            &["tracing::debug!"],
+            &["tracing::info!", "tracing::warn!"],
+        );
+    }
+
+    #[test]
+    fn unexpected_resync_response_uses_display_not_debug_pin_test() {
+        // Switched from `response = ?other` (Debug-expanded UpdateResponse
+        // → anyhow chain → ~15-line backtrace per call) to `response =
+        // %other` (single-line Display via ContractHandlerEvent's
+        // hand-written impl). Per #4251 review (code-first + Codex).
+        assert_log_site_pin(
+            "Unexpected response to resync update",
+            &["tracing::debug!", "response = %other"],
+            &["response = ?other", "tracing::warn!", "tracing::info!"],
+        );
+    }
+
     // Hostname resolution tests
     #[tokio::test]
     async fn test_hostname_resolution_localhost() {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1546,7 +1546,10 @@ async fn handle_interest_sync_message(
                     );
                     continue;
                 };
-                tracing::info!(
+                // Fires per stale-peer detection during interest sync, which
+                // is dominant on hot contracts. Diagnostic-grade rather than
+                // user-actionable; keep accessible via RUST_LOG=…=debug.
+                tracing::debug!(
                     contract = %contract,
                     stale_peer = %source,
                     "Summary mismatch in interest sync — syncing state to stale peer"
@@ -1783,11 +1786,16 @@ async fn handle_interest_sync_message(
                     );
                 }
                 Ok(other) => {
-                    tracing::warn!(
+                    // Use Display, not Debug, for `other`. Debug-formatting an
+                    // UpdateResponse expands the inner anyhow::Error and
+                    // prints a ~15-line backtrace per call. Under queue
+                    // saturation (issue #4251) this fires constantly and
+                    // dominates log volume. Display gives a one-line summary.
+                    tracing::debug!(
                         from = %source,
                         contract = %key,
                         event = "resync_failed",
-                        response = ?other,
+                        response_kind = std::any::type_name_of_val(&other),
                         "Unexpected response to resync update"
                     );
                 }
@@ -1883,7 +1891,11 @@ async fn get_contract_summary(
         Ok(ContractHandlerEvent::GetSummaryResponse {
             summary: Err(e), ..
         }) => {
-            tracing::warn!(
+            // Fires repeatedly when the executor queue is saturated for a hot
+            // contract (issue #4251). Demoted to debug because the actionable
+            // signal is the queue saturation itself, not the per-summary
+            // failure.
+            tracing::debug!(
                 contract = %key,
                 error = %e,
                 "Failed to get contract summary"

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -2518,7 +2518,11 @@ mod tests {
                         "classifier must preserve hop_count={hc} unchanged"
                     );
                 }
-                _ => panic!("expected Terminal(InlineFound) for hop_count={hc}"),
+                AttemptOutcome::Terminal(_)
+                | AttemptOutcome::Retry
+                | AttemptOutcome::Unexpected => {
+                    panic!("expected Terminal(InlineFound) for hop_count={hc}");
+                }
             }
         }
     }

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -271,9 +271,11 @@ impl OpManager {
                 targets.insert(pkl);
             } else {
                 interest_resolve_failed += 1;
-                // Counter (interest_resolve_failed) is the actionable signal;
-                // per-peer-miss log fires hundreds of times/hour on hot
-                // contracts. The aggregate is logged once at INFO below.
+                // Counter (interest_resolve_failed) feeds the aggregate
+                // logged below — at INFO when targets were found,
+                // promoted to WARN when ALL targets failed to resolve
+                // (worst case, NO_TARGETS branch). Per-peer-miss DEBUG
+                // avoids the hundreds-per-hour spam on hot contracts.
                 tracing::debug!(
                     contract = %format!("{:.8}", key),
                     interest_peer = %peer_key.0,
@@ -304,12 +306,20 @@ impl OpManager {
                 "UPDATE_PROPAGATION"
             );
         } else {
-            tracing::debug!(
+            // NO_TARGETS is the worst-case outcome: every candidate
+            // target failed to resolve, so the UPDATE will not
+            // propagate at all. Keep this at WARN so operators see it
+            // at default log level even after the per-peer miss
+            // demotion above (issue #4251 review). When this fires on
+            // a hot contract, the per-event WARN volume is bounded by
+            // attempts-per-update, not by attempts-per-peer.
+            tracing::warn!(
                 contract = %format!("{:.8}", key),
                 peer_addr = %sender,
                 self_addr = ?self_addr.map(|a| format!("{:.8}", a)),
                 proximity_sources = proximity_found,
                 interest_sources = interest_found,
+                interest_resolve_failed,
                 phase = "warning",
                 "UPDATE_PROPAGATION: NO_TARGETS - update will not propagate further"
             );

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -271,7 +271,10 @@ impl OpManager {
                 targets.insert(pkl);
             } else {
                 interest_resolve_failed += 1;
-                tracing::warn!(
+                // Counter (interest_resolve_failed) is the actionable signal;
+                // per-peer-miss log fires hundreds of times/hour on hot
+                // contracts. The aggregate is logged once at INFO below.
+                tracing::debug!(
                     contract = %format!("{:.8}", key),
                     interest_peer = %peer_key.0,
                     is_local = is_local_update_initiator,

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -306,14 +306,16 @@ impl OpManager {
                 "UPDATE_PROPAGATION"
             );
         } else {
-            // NO_TARGETS is the worst-case outcome: every candidate
-            // target failed to resolve, so the UPDATE will not
-            // propagate at all. Keep this at WARN so operators see it
-            // at default log level even after the per-peer miss
-            // demotion above (issue #4251 review). When this fires on
-            // a hot contract, the per-event WARN volume is bounded by
-            // attempts-per-update, not by attempts-per-peer.
-            tracing::warn!(
+            // NO_TARGETS at DEBUG: this function is called up to 4
+            // times per BroadcastStateChange (initial + 3 retries) so
+            // per-attempt WARN amplifies 4x on stuck contracts. The
+            // operator-actionable signal is the outer streak-suppressed
+            // "no targets after 3 retries, giving up" WARN in
+            // p2p_protoc.rs (search for "BroadcastTo: no targets after");
+            // the per-attempt detail belongs in metrics/structured
+            // counters (interest_resolve_failed). Issue #4251 re-review
+            // M2.
+            tracing::debug!(
                 contract = %format!("{:.8}", key),
                 peer_addr = %sender,
                 self_addr = ?self_addr.map(|a| format!("{:.8}", a)),
@@ -911,6 +913,38 @@ mod messages {
 mod tests {
     use super::*;
     use crate::operations::test_utils::make_contract_key;
+
+    /// Source-level pin for the UPDATE_PROPAGATION NO_TARGETS log site.
+    /// Originally INFO; briefly promoted to WARN in PR #4252 commit 2;
+    /// then demoted back to DEBUG in commit 3 because
+    /// `get_broadcast_targets_update` is called up to 4 times per
+    /// `BroadcastStateChange` (initial + 3 retries) — per-attempt WARN
+    /// 4x amplifies on stuck contracts. The operator-actionable summary
+    /// lives in the outer streak-suppressed WARN at
+    /// `p2p_protoc.rs::BroadcastTo: no targets after …`. Per #4251
+    /// re-review M2 (skeptical).
+    #[test]
+    fn no_targets_propagation_logs_at_debug_pin_test() {
+        let path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/operations/update.rs");
+        let source = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("must read own source at {}: {e}", path.display()));
+        let needle = "UPDATE_PROPAGATION: NO_TARGETS - update will not propagate further";
+        let idx = source
+            .find(needle)
+            .expect("NO_TARGETS log message must still exist in source");
+        let start = idx.saturating_sub(400);
+        let window = &source[start..idx];
+        assert!(
+            window.contains("tracing::debug!"),
+            "NO_TARGETS log site must be DEBUG to avoid 4x amplification on retries. \
+             Re-promotion to WARN/INFO regresses #4251 review M2.\nWindow:\n{window}"
+        );
+        assert!(
+            !window.contains("tracing::warn!") && !window.contains("tracing::info!"),
+            "NO_TARGETS log site must NOT be WARN/INFO.\nWindow:\n{window}"
+        );
+    }
 
     /// Regression tests for issue #3914: misleading ERROR/WARN log noise from
     /// benign WASM rejections of stale broadcast UPDATEs. The contract correctly

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -3996,14 +3996,53 @@ pub mod tracer {
     /// At typical gateway log rates (~500KB/hour), 72 hours ≈ 36MB.
     const LOG_RETENTION_HOURS: usize = 72;
 
-    /// Hard upper bound on the total bytes the freenet log directory may
-    /// occupy. Acts as a backstop when log volume spikes above the steady-
-    /// state assumption baked into LOG_RETENTION_HOURS (e.g., a misbehaving
-    /// contract overflowing the executor queue at thousands of events per
-    /// second — see issue #4251). Enforced at startup after the time-based
-    /// pass: oldest files are removed first until the directory is under
-    /// the limit.
+    /// Startup-only backstop on the total bytes the freenet log directory
+    /// may occupy. When log volume spikes above the steady-state assumption
+    /// baked into `LOG_RETENTION_HOURS` (e.g., the executor-queue overflow
+    /// in issue #4251 producing thousands of events per second), the
+    /// time-based retention alone cannot bound disk usage within a single
+    /// session. This cap deletes oldest-first after the time pass to bring
+    /// the directory back under the limit on every restart.
+    ///
+    /// Caveat: enforcement runs only when the tracer initializes (i.e.,
+    /// node start). A long-uptime node under sustained runaway logging can
+    /// still exceed this cap until its next restart. Periodic enforcement
+    /// is a candidate follow-up.
     const LOG_DIR_MAX_BYTES: u64 = 1024 * 1024 * 1024; // 1 GiB
+
+    /// Match the rolling-appender naming convention used by
+    /// `RollingFileAppender::Rotation::HOURLY` for the `freenet` /
+    /// `freenet.error` prefixes:
+    ///
+    ///   freenet.YYYY-MM-DD-HH.log
+    ///   freenet.error.YYYY-MM-DD-HH.log
+    ///
+    /// Intentionally does NOT match:
+    /// - `freenet.log` / `freenet.error.log` — legacy systemd /launchd
+    ///   StandardOutput targets that the OS holds open; deleting them
+    ///   leaks an unlinked-but-open inode (Linux) or errors (Windows)
+    ///   and does not free disk space until restart.
+    /// - `freenet.error.log.last` — transient per-launch scratch file the
+    ///   macOS wrapper overwrites each iteration.
+    fn is_rotating_freenet_log(name: &str) -> bool {
+        // freenet.error.YYYY-MM-DD-HH.log → after stripping the prefix and
+        // suffix, the remainder must be the date-hour stem. We don't parse
+        // the stem strictly; cheap shape check: at least one '-' and all
+        // remaining characters in [0-9-].
+        let stem = if let Some(rest) = name.strip_prefix("freenet.error.") {
+            rest
+        } else if let Some(rest) = name.strip_prefix("freenet.") {
+            rest
+        } else {
+            return false;
+        };
+        let Some(date_part) = stem.strip_suffix(".log") else {
+            return false;
+        };
+        !date_part.is_empty()
+            && date_part.contains('-')
+            && date_part.chars().all(|c| c.is_ascii_digit() || c == '-')
+    }
 
     /// Guards for non-blocking file appenders - must be kept alive for the lifetime of the program
     static LOG_GUARDS: OnceLock<Vec<WorkerGuard>> = OnceLock::new();
@@ -4058,7 +4097,7 @@ pub mod tracer {
             let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
                 continue;
             };
-            if !name.starts_with("freenet") || !name.ends_with(".log") {
+            if !is_rotating_freenet_log(name) {
                 continue;
             }
 
@@ -4083,6 +4122,13 @@ pub mod tracer {
     /// Delete oldest log files until the total size of the supplied list is
     /// at or below `max_bytes`. Mutates the filesystem; the input vector
     /// is consumed. Parameterized for test isolation.
+    ///
+    /// The most-recently-modified file is preserved unconditionally even
+    /// when it alone exceeds `max_bytes`: it is the file currently being
+    /// written by `RollingFileAppender`. On Linux, removing it would leave
+    /// the appender writing to an unlinked inode (disk space not reclaimed
+    /// until the next rotation); on Windows, `remove_file` would simply
+    /// fail. Either way the live file should not be a cleanup target.
     fn enforce_log_dir_size_cap(
         mut files: Vec<(std::path::PathBuf, std::time::SystemTime, u64)>,
         max_bytes: u64,
@@ -4092,17 +4138,21 @@ pub mod tracer {
             return;
         }
 
-        // Oldest first.
+        // Oldest first; remove from this end and stop before the newest.
         files.sort_by_key(|(_, modified, _)| *modified);
+        let live = files.pop(); // newest mtime — never deleted
+        let live_size = live.as_ref().map(|(_, _, size)| *size).unwrap_or(0);
+        let mut non_live_remaining: u64 = files.iter().map(|(_, _, size)| *size).sum();
 
-        let mut remaining = total;
         for (path, _, size) in files {
-            if remaining <= max_bytes {
+            // Final on-disk size after additional deletions =
+            //   live_size + non_live_remaining (decreasing each loop).
+            if live_size.saturating_add(non_live_remaining) <= max_bytes {
                 break;
             }
             match std::fs::remove_file(&path) {
                 Ok(()) => {
-                    remaining = remaining.saturating_sub(size);
+                    non_live_remaining = non_live_remaining.saturating_sub(size);
                 }
                 Err(e) => {
                     eprintln!(
@@ -4493,6 +4543,91 @@ pub mod tracer {
             cleanup_old_logs(dir.path());
 
             assert!(other.exists(), "non-freenet files must not be touched");
+        }
+
+        /// The size cap must NEVER delete the most-recently-modified file
+        /// (the live file the rolling appender is currently writing to).
+        /// Removing it would leave the appender writing to an unlinked inode
+        /// on Linux, or fail on Windows. Regression for review findings on
+        /// issue #4251.
+        #[test]
+        fn size_cap_preserves_most_recently_modified_file() {
+            let dir = tempfile::tempdir().unwrap();
+            let now = SystemTime::now();
+
+            // Single oversized file — also the newest. Must NOT be deleted.
+            let live = dir.path().join("freenet.2026-05-25-18.log");
+            write_with_mtime(&live, 16 * 1024, now);
+
+            let files = vec![(live.clone(), now, 16 * 1024)];
+            enforce_log_dir_size_cap(files, 1024); // cap below file size
+
+            assert!(
+                live.exists(),
+                "live file must survive even when alone it exceeds the cap"
+            );
+        }
+
+        /// Even with the live file preserved, older files must be deleted
+        /// to bring the total down. Regression for the live-file fix
+        /// composing correctly with the eviction loop.
+        #[test]
+        fn size_cap_deletes_oldest_but_keeps_live() {
+            let dir = tempfile::tempdir().unwrap();
+            let now = SystemTime::now();
+
+            // Two oversized files: cap at 5 KiB, live=4 KiB, old=4 KiB,
+            // total 8 KiB → old gets deleted, live survives, final = 4 KiB.
+            let old = dir.path().join("freenet.2026-05-25-12.log");
+            let live = dir.path().join("freenet.2026-05-25-18.log");
+            write_with_mtime(&old, 4096, now - Duration::from_secs(3600));
+            write_with_mtime(&live, 4096, now);
+
+            let files = vec![
+                (old.clone(), now - Duration::from_secs(3600), 4096),
+                (live.clone(), now, 4096),
+            ];
+            enforce_log_dir_size_cap(files, 5120);
+
+            assert!(!old.exists(), "older file must be deleted");
+            assert!(live.exists(), "live file must survive");
+        }
+
+        /// `cleanup_old_logs` must NOT touch the legacy bare
+        /// `freenet.log` / `freenet.error.log` paths — systemd/launchd
+        /// hold them open and deletion leaks the inode (Linux) or fails
+        /// (Windows). Only the rolling-appender date-suffixed files are
+        /// eligible. Regression for review findings on issue #4251.
+        #[test]
+        fn cleanup_skips_legacy_bare_freenet_log_names() {
+            let dir = tempfile::tempdir().unwrap();
+            // Make these old so they'd be deleted by the time pass if it
+            // applied to them.
+            let bare = dir.path().join("freenet.log");
+            let bare_err = dir.path().join("freenet.error.log");
+            let scratch = dir.path().join("freenet.error.log.last");
+            for p in [&bare, &bare_err, &scratch] {
+                write_with_mtime(
+                    p,
+                    1024,
+                    SystemTime::now() - Duration::from_secs(30 * 24 * 3600),
+                );
+            }
+
+            cleanup_old_logs(dir.path());
+
+            assert!(
+                bare.exists(),
+                "legacy freenet.log must not be deleted (systemd-owned)"
+            );
+            assert!(
+                bare_err.exists(),
+                "legacy freenet.error.log must not be deleted (systemd-owned)"
+            );
+            assert!(
+                scratch.exists(),
+                "transient freenet.error.log.last must not be deleted (wrapper-owned)"
+            );
         }
     }
 }

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -3996,6 +3996,15 @@ pub mod tracer {
     /// At typical gateway log rates (~500KB/hour), 72 hours ≈ 36MB.
     const LOG_RETENTION_HOURS: usize = 72;
 
+    /// Hard upper bound on the total bytes the freenet log directory may
+    /// occupy. Acts as a backstop when log volume spikes above the steady-
+    /// state assumption baked into LOG_RETENTION_HOURS (e.g., a misbehaving
+    /// contract overflowing the executor queue at thousands of events per
+    /// second — see issue #4251). Enforced at startup after the time-based
+    /// pass: oldest files are removed first until the directory is under
+    /// the limit.
+    const LOG_DIR_MAX_BYTES: u64 = 1024 * 1024 * 1024; // 1 GiB
+
     /// Guards for non-blocking file appenders - must be kept alive for the lifetime of the program
     static LOG_GUARDS: OnceLock<Vec<WorkerGuard>> = OnceLock::new();
 
@@ -4024,7 +4033,12 @@ pub mod tracer {
     }
 
     /// Clean up old log files on startup.
-    /// Removes any log files older than LOG_RETENTION_HOURS, including legacy daily log files.
+    ///
+    /// First pass: remove files older than `LOG_RETENTION_HOURS`.
+    /// Second pass: if the total size of remaining `freenet*.log` files
+    /// still exceeds `LOG_DIR_MAX_BYTES`, delete oldest-first until under
+    /// the limit. The size cap is a backstop for runaway log rates that
+    /// the time-based retention alone can't bound.
     fn cleanup_old_logs(log_dir: &std::path::Path) {
         use std::time::{Duration, SystemTime};
 
@@ -4035,10 +4049,12 @@ pub mod tracer {
             return;
         };
 
+        // First pass: time-based deletion, collect survivors for the
+        // size-cap pass.
+        let mut survivors: Vec<(std::path::PathBuf, SystemTime, u64)> = Vec::new();
         for entry in entries.flatten() {
             let path = entry.path();
 
-            // Only process log files
             let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
                 continue;
             };
@@ -4046,14 +4062,54 @@ pub mod tracer {
                 continue;
             }
 
-            // Check file modification time
-            if let Ok(metadata) = path.metadata() {
-                if let Ok(modified) = metadata.modified() {
-                    if modified < cutoff {
-                        if let Err(e) = std::fs::remove_file(&path) {
-                            eprintln!("Failed to remove old log file {}: {}", path.display(), e);
-                        }
-                    }
+            let Ok(metadata) = path.metadata() else {
+                continue;
+            };
+            let Ok(modified) = metadata.modified() else {
+                continue;
+            };
+            if modified < cutoff {
+                if let Err(e) = std::fs::remove_file(&path) {
+                    eprintln!("Failed to remove old log file {}: {}", path.display(), e);
+                }
+                continue;
+            }
+            survivors.push((path, modified, metadata.len()));
+        }
+
+        enforce_log_dir_size_cap(survivors, LOG_DIR_MAX_BYTES);
+    }
+
+    /// Delete oldest log files until the total size of the supplied list is
+    /// at or below `max_bytes`. Mutates the filesystem; the input vector
+    /// is consumed. Parameterized for test isolation.
+    fn enforce_log_dir_size_cap(
+        mut files: Vec<(std::path::PathBuf, std::time::SystemTime, u64)>,
+        max_bytes: u64,
+    ) {
+        let total: u64 = files.iter().map(|(_, _, size)| *size).sum();
+        if total <= max_bytes {
+            return;
+        }
+
+        // Oldest first.
+        files.sort_by_key(|(_, modified, _)| *modified);
+
+        let mut remaining = total;
+        for (path, _, size) in files {
+            if remaining <= max_bytes {
+                break;
+            }
+            match std::fs::remove_file(&path) {
+                Ok(()) => {
+                    remaining = remaining.saturating_sub(size);
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Failed to enforce log dir size cap on {}: {}",
+                        path.display(),
+                        e
+                    );
                 }
             }
         }
@@ -4342,6 +4398,102 @@ pub mod tracer {
             tracing::subscriber::set_global_default(subscriber).expect("Error setting subscriber");
         }
         Ok(())
+    }
+
+    #[cfg(test)]
+    mod cleanup_tests {
+        use super::{cleanup_old_logs, enforce_log_dir_size_cap};
+        use std::fs;
+        use std::time::{Duration, SystemTime};
+
+        /// Writes `path` with `size` bytes and sets its mtime to `mtime`.
+        fn write_with_mtime(path: &std::path::Path, size: usize, mtime: SystemTime) {
+            fs::write(path, vec![b'.'; size]).unwrap();
+            let times = std::fs::FileTimes::new().set_modified(mtime);
+            let f = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+            f.set_times(times).unwrap();
+        }
+
+        /// Regression for issue #4251: when log volume blows past the
+        /// time-based retention's implicit assumption (~500 KB/h), the
+        /// size cap must delete oldest-first until the directory is
+        /// under the supplied limit.
+        #[test]
+        fn size_cap_deletes_oldest_first_until_under_limit() {
+            let dir = tempfile::tempdir().unwrap();
+            let now = SystemTime::now();
+
+            let oldest = dir.path().join("freenet.2026-05-25-12.log");
+            let middle = dir.path().join("freenet.2026-05-25-13.log");
+            let newest = dir.path().join("freenet.2026-05-25-14.log");
+
+            // 4 KiB each; total 12 KiB. Cap at 8 KiB → oldest must go.
+            write_with_mtime(&oldest, 4096, now - Duration::from_secs(3600));
+            write_with_mtime(&middle, 4096, now - Duration::from_secs(60));
+            write_with_mtime(&newest, 4096, now - Duration::from_secs(30));
+
+            let files = vec![
+                (oldest.clone(), now - Duration::from_secs(3600), 4096),
+                (middle.clone(), now - Duration::from_secs(60), 4096),
+                (newest.clone(), now - Duration::from_secs(30), 4096),
+            ];
+            enforce_log_dir_size_cap(files, 8192);
+
+            assert!(
+                !oldest.exists(),
+                "oldest file should be deleted by size cap"
+            );
+            assert!(middle.exists(), "middle file should survive");
+            assert!(newest.exists(), "newest file should survive");
+        }
+
+        /// Under-cap directories must not lose any files.
+        #[test]
+        fn size_cap_is_noop_when_under_limit() {
+            let dir = tempfile::tempdir().unwrap();
+            let now = SystemTime::now();
+            let small = dir.path().join("freenet.2026-05-25-15.log");
+            write_with_mtime(&small, 1024, now);
+
+            let files = vec![(small.clone(), now, 1024)];
+            enforce_log_dir_size_cap(files, 1024 * 1024 * 1024);
+
+            assert!(small.exists(), "file under cap must survive");
+        }
+
+        /// The time-based pass in `cleanup_old_logs` still removes files
+        /// older than the retention window, even when total size is under
+        /// the cap.
+        #[test]
+        fn time_pass_removes_files_older_than_retention() {
+            let dir = tempfile::tempdir().unwrap();
+            // 100 days old, 1 KiB — well under size cap but past time cap.
+            let ancient = dir.path().join("freenet.2026-02-14-00.log");
+            write_with_mtime(
+                &ancient,
+                1024,
+                SystemTime::now() - Duration::from_secs(100 * 24 * 3600),
+            );
+
+            cleanup_old_logs(dir.path());
+
+            assert!(
+                !ancient.exists(),
+                "ancient file must be removed by time pass"
+            );
+        }
+
+        /// Non-`freenet*` files in the same directory must be ignored.
+        #[test]
+        fn cleanup_ignores_non_freenet_files() {
+            let dir = tempfile::tempdir().unwrap();
+            let other = dir.path().join("other.log");
+            fs::write(&other, b"unrelated").unwrap();
+
+            cleanup_old_logs(dir.path());
+
+            assert!(other.exists(), "non-freenet files must not be touched");
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

The official River chat-room contract (`4PjqN55KUCidW8vJvw5fhy5fe5maxXKNrWSyK33QjjVq`) has been saturating the per-contract executor queue (`MAX_QUEUED_PER_CONTRACT = 100`) on every subscribed peer. Each rejection generates one `WARN` at the source, a `Failed to update contract value` `ERROR` upstream, and a ~15-line `anyhow` backtrace per resync failure (because `node.rs` was Debug-printing the full `UpdateResponse`, which expands the inner `anyhow::Error`).

Live measurement on monitored nodes (2026-05-25):

| Node | Volume | Top spam |
|---|---|---|
| nova gateway | ~10 GB/day | 30% per-contract queue rejection, 10% update-failed + backtrace |
| vega gateway | ~10 GB/day | 50% per-contract queue rejection, 37% summary-failed |
| technic peer | ~7 MB/h sustained | 27% INFO summary-mismatch, 24% queue rejection |

User reports (Ivvor, two independent nodes) traced to the same contract. Underlying queue saturation tracked separately in #4251; **this PR is the disk-fill symptom mitigation** so users stop losing their drives.

## Approach

Two commits. The first ships the log-volume / size-cap / service-file changes; the second addresses the multi-model review findings (notably the auto-update migration path).

**Commit 1 — symptom mitigation**

- Demote four highest-volume per-event logs to DEBUG (`contract.rs::send_queue_full_response`, `node.rs` "Summary mismatch" / "Failed to get contract summary", `operations/update.rs` "Interest manager peer not found").
- Stop Debug-printing `UpdateResponse` in `node.rs` "Unexpected response to resync update" — switched to `%other` (Display via `ContractHandlerEvent::Display`), kills the per-call ~15-line anyhow backtrace storm.
- Add a 1 GiB **startup-only** disk-size cap to `cleanup_old_logs`. Preserves the most-recently-modified file so it can't race-delete the live rolling-appender output. `enforce_log_dir_size_cap` extracted as a parameterized helper for testability.
- Restrict `cleanup_old_logs`'s file filter to the rolling-appender naming convention (`is_rotating_freenet_log`) so it no longer touches the legacy bare `freenet.log` / `freenet.error.log` files that systemd/launchd hold open.
- Switch systemd `StandardOutput`/`StandardError` to `journal` (Linux) and launchd `StandardOutPath`/`StandardErrorPath` to `/dev/null` (macOS). Tracing layer continues writing its own size-capped rotating files.
- Promote `update.rs::NO_TARGETS` else branch to WARN (with `interest_resolve_failed` counter) so the worst-case "UPDATE will not propagate" outcome stays visible at default level.

**Commit 2 — review-response fixes (Must Fix)**

- **Force unit/plist regen on auto-update when legacy log markers are present.** Both `update.rs::update_service_file` (Linux) and `update.rs::ensure_service_file_updated` (macOS) previously early-returned when the auto-update markers were present — which they are on every v0.2.x install — so existing gateway operators would never receive the new unit. Decision logic extracted as pure helpers `systemd_unit_needs_regen` and `launchd_plist_needs_regen` (per code-style.md preference for pure decision logic over inline platform I/O), each with unit tests for legacy-detection AND current-template no-op.
- **macOS wrapper script** switched from `echo … >> "$LOG"` (fixed unrotated `~/Library/Logs/freenet/freenet.log`) to `logger -t freenet` (auto-rotated by macOS unified logging, queryable via `log show --predicate 'process == "logger"' --info`).
- **Live-file preservation** in `enforce_log_dir_size_cap` and **legacy-bare-name exclusion** in `cleanup_old_logs` (described above) — both surfaced by skeptical review.

Existing users pick up the migration path automatically: on the next `freenet update` (exit-42) cycle, the unit/plist is detected as legacy and rewritten.

## Testing

New regression tests (all passing locally; fmt + clippy `-D warnings` clean):

| Test | Pins |
|------|------|
| `tracer::cleanup_tests::size_cap_deletes_oldest_first_until_under_limit` | size-cap eviction order |
| `tracer::cleanup_tests::size_cap_is_noop_when_under_limit` | no-op when under cap |
| `tracer::cleanup_tests::time_pass_removes_files_older_than_retention` | time-based pass still works |
| `tracer::cleanup_tests::cleanup_ignores_non_freenet_files` | prefix filter |
| `tracer::cleanup_tests::size_cap_preserves_most_recently_modified_file` | live-file preservation |
| `tracer::cleanup_tests::size_cap_deletes_oldest_but_keeps_live` | composition of eviction + live-preservation |
| `tracer::cleanup_tests::cleanup_skips_legacy_bare_freenet_log_names` | bare `freenet.log` is left alone |
| `contract::tests::send_queue_full_response_logs_at_debug_not_warn_pin_test` | source-level pin that the WARN→DEBUG demotion can't silently regress |
| `commands::service::tests::test_systemd_user_service_file_generation` | `StandardOutput=journal` + `!contains("append:")` regression guard |
| `commands::service::tests::test_systemd_system_service_file_generation` | same |
| `commands::service::tests::test_launchd_plist_generation` | `/dev/null` + `!contains` the fixed paths regression guard |
| `commands::service::tests::test_macos_wrapper_script_generation` | `logger -t freenet` + `!contains("Library/Logs/freenet/freenet.log")` |
| `commands::update::tests::systemd_unit_with_legacy_append_log_needs_regen` | legacy-marker detection |
| `commands::update::tests::systemd_unit_with_journal_target_is_up_to_date` | current-template no-op |
| `commands::update::tests::systemd_unit_without_auto_update_markers_needs_regen` | pre-auto-update unit detection |
| `commands::update::tests::launchd_plist_with_legacy_log_paths_needs_regen` | legacy plist detection |
| `commands::update::tests::launchd_plist_with_dev_null_is_up_to_date` | current plist no-op |

## Not in scope

- **Root cause of the queue saturation** — tracked separately in #4251; another agent is investigating.
- **Aggregated periodic INFO backpressure log** (e.g. "rejected N events for contract X in last Ms") — worthwhile follow-up to restore operator visibility lost by the per-event demotions, but out of scope for this disk-fill mitigation.
- **macOS pre-tracing-init panic visibility** — known trade-off of `/dev/null` on launchd; `freenet service report` still captures everything after tracing init.

## Fixes

Mitigates symptom of #4251.

[AI-assisted - Claude]