### PR TITLE
fix(contract): stop queue-full saturation from amplifying network-wide

### DIFF
--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -31,7 +31,7 @@ pub(crate) use handler::{
     },
 };
 
-pub use executor::{Executor, ExecutorError, OperationMode};
+pub use executor::{ContractQueueFull, Executor, ExecutorError, OperationMode};
 pub use handler::reset_event_id_counter;
 
 use freenet_stdlib::client_api::DelegateRequest;
@@ -762,7 +762,13 @@ async fn send_queue_full_response(
         event = %rejected.event,
         "Rejected event due to per-contract queue capacity limit"
     );
-    let make_err = || ExecutorError::other(anyhow::anyhow!("contract queue full, try again later"));
+    // Use the typed `ContractQueueFull` marker so callers can distinguish
+    // queue saturation from real executor failures via
+    // `ExecutorError::is_contract_queue_full`. This is what suppresses the
+    // auto-fetch / ResyncRequest amplification in the UPDATE relay drivers
+    // (op_ctx_task.rs) when a single contract is saturating its own queue.
+    // See issue #4251.
+    let make_err = || ExecutorError::other(ContractQueueFull);
     let response = match &rejected.event {
         ContractHandlerEvent::PutQuery { .. } => ContractHandlerEvent::PutResponse {
             new_value: Err(make_err()),
@@ -1797,6 +1803,56 @@ mod tests {
                 assert!(delta.is_err(), "should be an error response");
             }
             other => panic!("expected GetDeltaResponse, got {other}"),
+        }
+    }
+
+    /// Issue #4251: the queue-full response MUST carry the typed
+    /// `ContractQueueFull` marker, not just an opaque anyhow error, so
+    /// callers can suppress amplification side effects (auto-fetch,
+    /// ResyncRequest, ERROR logs) via
+    /// `ExecutorError::is_contract_queue_full`. A regression here would
+    /// silently bring back the storm-on-saturation behavior.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn send_queue_full_response_carries_typed_queue_full_marker() {
+        let (send_halve, mut rcv_halve, _) = handler::contract_handler_channel();
+        let key = make_contract_key();
+
+        let (rejected, handle) = setup_rejected_event(
+            send_halve,
+            &mut rcv_halve,
+            ContractHandlerEvent::UpdateQuery {
+                key,
+                data: UpdateData::Delta(StateDelta::from(vec![1])),
+                related_contracts: RelatedContracts::default(),
+            },
+        )
+        .await;
+
+        send_queue_full_response(&mut rcv_halve, rejected).await;
+
+        let response = tokio::time::timeout(Duration::from_millis(200), handle)
+            .await
+            .expect("timeout")
+            .expect("task should complete")
+            .expect("should get response");
+
+        match response {
+            ContractHandlerEvent::UpdateResponse { new_value, .. } => {
+                let err = new_value.expect_err("UpdateResponse should carry an error");
+                assert!(
+                    err.is_contract_queue_full(),
+                    "queue-full response MUST be classified by is_contract_queue_full; \
+                     got err = {err:?}. If you removed this classification, you have also \
+                     re-enabled the auto-fetch / ResyncRequest amplification storm — see \
+                     issue #4251."
+                );
+                // The other predicates must NOT also match, otherwise the
+                // gating in op_ctx_task.rs becomes ambiguous.
+                assert!(!err.is_contract_exec_rejection());
+                assert!(!err.is_invalid_update_rejection());
+                assert!(!err.is_missing_contract_parameters());
+            }
+            other => panic!("expected UpdateResponse, got {other}"),
         }
     }
 

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -762,12 +762,8 @@ async fn send_queue_full_response(
         event = %rejected.event,
         "Rejected event due to per-contract queue capacity limit"
     );
-    // Use the typed `ContractQueueFull` marker so callers can distinguish
-    // queue saturation from real executor failures via
-    // `ExecutorError::is_contract_queue_full`. This is what suppresses the
-    // auto-fetch / ResyncRequest amplification in the UPDATE relay drivers
-    // (op_ctx_task.rs) when a single contract is saturating its own queue.
-    // See issue #4251.
+    // Typed `ContractQueueFull` marker powers `is_contract_queue_full` at
+    // every caller; the UPDATE relay drivers gate amplification on it. #4251.
     let make_err = || ExecutorError::other(ContractQueueFull);
     let response = match &rejected.event {
         ContractHandlerEvent::PutQuery { .. } => ContractHandlerEvent::PutResponse {
@@ -1846,11 +1842,9 @@ mod tests {
                      re-enabled the auto-fetch / ResyncRequest amplification storm — see \
                      issue #4251."
                 );
-                // The other predicates must NOT also match, otherwise the
-                // gating in op_ctx_task.rs becomes ambiguous.
-                assert!(!err.is_contract_exec_rejection());
-                assert!(!err.is_invalid_update_rejection());
-                assert!(!err.is_missing_contract_parameters());
+                // Disjointness from other predicates is covered by
+                // `test_contract_queue_full_disjoint_from_other_predicates`
+                // in executor.rs.
             }
             other => panic!("expected UpdateResponse, got {other}"),
         }

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -99,6 +99,28 @@ pub(crate) use init_tracker::{
 };
 pub(crate) use runtime::RuntimePool;
 
+/// Marker error returned by `send_queue_full_response` when the
+/// per-contract fair queue rejects an event because the contract's
+/// queue (or the global queue) has reached capacity.
+///
+/// Wrapping this in `ExecutorError::other(ContractQueueFull)` instead
+/// of an opaque `anyhow::anyhow!("contract queue full...")` lets
+/// callers distinguish queue saturation from real executor failures
+/// (OOG, traps, missing parameters, storage errors). Queue-full is a
+/// transient platform-level condition — not a contract-level fault —
+/// so callers should avoid amplification (auto-fetch, ResyncRequest)
+/// and ERROR-level logging on this path. See issue #4251.
+#[derive(Debug, Clone, Copy)]
+pub struct ContractQueueFull;
+
+impl std::fmt::Display for ContractQueueFull {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("contract queue full, try again later")
+    }
+}
+
+impl std::error::Error for ContractQueueFull {}
+
 #[derive(Debug)]
 pub struct ExecutorError {
     inner: Either<Box<RequestError>, anyhow::Error>,
@@ -268,6 +290,38 @@ impl ExecutorError {
                     if cause.starts_with("execution error: invalid contract update")
             ),
             Either::Right(_) => false,
+        }
+    }
+
+    /// Returns true if this error was produced by the per-contract fair
+    /// queue rejecting an event because the queue is at capacity (see
+    /// `send_queue_full_response` in `contract.rs` and `ContractQueueFull`
+    /// above).
+    ///
+    /// Queue-full is a transient platform-level backpressure signal — not
+    /// a contract-level fault, not a missing-contract condition, not a
+    /// WASM execution failure. Callers MUST use this predicate to suppress
+    /// amplification side effects that only make sense for real failures:
+    ///
+    /// - The UPDATE full-state relay path must NOT trigger
+    ///   `try_auto_fetch_contract` (the contract code is present; the
+    ///   queue is just busy).
+    /// - The UPDATE delta relay path must NOT emit `ResyncRequest`
+    ///   (asking the sender for full-state resends makes the storm
+    ///   worse).
+    /// - Originator-side error logging should drop from ERROR to DEBUG
+    ///   (a temporarily-saturated executor is not an operator-actionable
+    ///   alert; the volume on a hot contract can be enormous).
+    ///
+    /// Without this predicate, a single buggy / abusive / merely-popular
+    /// contract that saturates its own queue would induce the local peer
+    /// to fire auto-fetch GET storms and ResyncRequest broadcasts that
+    /// amplify the saturation onto every other peer subscribed to the
+    /// contract — see issue #4251.
+    pub fn is_contract_queue_full(&self) -> bool {
+        match &self.inner {
+            Either::Left(_) => false,
+            Either::Right(err) => err.downcast_ref::<ContractQueueFull>().is_some(),
         }
     }
 
@@ -958,6 +1012,80 @@ mod tests {
                 !err.is_fatal(),
                 "MaxComputeTimeExceeded must not be fatal - it would kill the entire contract handler"
             );
+        }
+
+        // ── ContractQueueFull predicate (issue #4251) ─────────────────────
+        //
+        // The queue-full marker must be cleanly distinguishable from every
+        // other error class so callers can suppress amplification side
+        // effects (auto-fetch, ResyncRequest, ERROR logs) specifically for
+        // this case without paying for them on real failures.
+
+        #[test]
+        fn test_contract_queue_full_true_for_marker_error() {
+            let err = ExecutorError::other(ContractQueueFull);
+            assert!(
+                err.is_contract_queue_full(),
+                "ContractQueueFull marker MUST be recognized by is_contract_queue_full"
+            );
+            // Display message preserved for human-readable surface (logs, etc.)
+            assert!(err.to_string().contains("contract queue full"));
+        }
+
+        #[test]
+        fn test_contract_queue_full_false_for_anyhow_string_lookalike() {
+            // Regression: an opaque anyhow error whose message happens to
+            // contain "contract queue full" must NOT satisfy the predicate.
+            // The predicate is typed (downcast), not string-matched, so a
+            // future caller that produces a similarly-worded error doesn't
+            // accidentally inherit queue-full semantics.
+            let err = ExecutorError::other(anyhow::anyhow!("contract queue full, try again later"));
+            assert!(
+                !err.is_contract_queue_full(),
+                "Anyhow string with matching prose must NOT satisfy the typed predicate"
+            );
+        }
+
+        #[test]
+        fn test_contract_queue_full_false_for_invalid_update() {
+            let key = test_fixtures::make_contract_key();
+            let err = ExecutorError::request(StdContractError::update_exec_error(
+                key,
+                "invalid contract update, reason: stale",
+            ));
+            assert!(
+                !err.is_contract_queue_full(),
+                "Benign WASM invalid-update rejection is not queue-full"
+            );
+        }
+
+        #[test]
+        fn test_contract_queue_full_false_for_missing_parameters() {
+            let key = test_fixtures::make_contract_key();
+            let err = ExecutorError::request(StdContractError::Update {
+                key,
+                cause: "missing contract parameters".into(),
+            });
+            assert!(
+                !err.is_contract_queue_full(),
+                "Missing contract parameters is not queue-full"
+            );
+        }
+
+        #[test]
+        fn test_contract_queue_full_disjoint_from_other_predicates() {
+            // Ensures the new predicate doesn't collide with the existing
+            // predicates' truth values for the queue-full case. This is the
+            // load-bearing property used in op_ctx_task.rs:1064/1107 to
+            // suppress amplification.
+            let err = ExecutorError::other(ContractQueueFull);
+            assert!(err.is_contract_queue_full());
+            assert!(!err.is_request());
+            assert!(!err.is_contract_exec_rejection());
+            assert!(!err.is_invalid_update_rejection());
+            assert!(!err.is_missing_contract_parameters());
+            assert!(!err.is_missing_delegate());
+            assert!(!err.is_fatal());
         }
     }
 

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -289,16 +289,22 @@ impl ExecutorError {
         }
     }
 
-    /// Returns true if this error is the typed `ContractQueueFull` marker
-    /// from `send_queue_full_response` (per-contract fair queue at capacity).
+    /// Returns true if this error is the typed `ContractQueueFull` marker.
+    ///
+    /// Produced by:
+    /// - `send_queue_full_response` (per-contract fair queue at capacity),
+    /// - the `InitCheckResult::QueueFull` arm in `executor/runtime.rs` (per-contract
+    ///   initialization queue at capacity).
     ///
     /// **Platform-resilience invariant**: queue-full is transient
     /// backpressure, not a contract-level fault, missing-contract condition,
-    /// or WASM failure. Callers MUST gate amplification side effects on this
-    /// predicate — auto-fetch GETs (the contract code is present), ResyncRequest
-    /// broadcasts (the merge never ran), and ERROR-level logging (volume on a
-    /// hot contract drowns real failures). Without it, a single saturated
-    /// contract induces a network-wide storm. See issue #4251.
+    /// or WASM failure. Callers in paths that have amplification side effects
+    /// (today: UPDATE relay's `try_auto_fetch_contract` and `ResyncRequest`)
+    /// MUST gate those branches on this predicate so a saturated contract
+    /// doesn't induce a network-wide storm. Paths without amplification
+    /// (today: PUT, GET, SUBSCRIBE) only need to gate **ERROR-level logging**
+    /// off this predicate, since on a hot contract the volume otherwise drowns
+    /// real failures. See issue #4251.
     pub fn is_contract_queue_full(&self) -> bool {
         match &self.inner {
             Either::Left(_) => false,

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -99,17 +99,13 @@ pub(crate) use init_tracker::{
 };
 pub(crate) use runtime::RuntimePool;
 
-/// Marker error returned by `send_queue_full_response` when the
-/// per-contract fair queue rejects an event because the contract's
-/// queue (or the global queue) has reached capacity.
+/// Typed marker for queue-full errors so callers can downcast and
+/// distinguish transient per-contract queue saturation from real
+/// executor failures (OOG, traps, missing parameters, storage errors).
 ///
-/// Wrapping this in `ExecutorError::other(ContractQueueFull)` instead
-/// of an opaque `anyhow::anyhow!("contract queue full...")` lets
-/// callers distinguish queue saturation from real executor failures
-/// (OOG, traps, missing parameters, storage errors). Queue-full is a
-/// transient platform-level condition — not a contract-level fault —
-/// so callers should avoid amplification (auto-fetch, ResyncRequest)
-/// and ERROR-level logging on this path. See issue #4251.
+/// Constructed by `send_queue_full_response`; recognized by
+/// `ExecutorError::is_contract_queue_full` (see that predicate for the
+/// platform-resilience invariant it enforces). Issue #4251.
 #[derive(Debug, Clone, Copy)]
 pub struct ContractQueueFull;
 
@@ -293,31 +289,16 @@ impl ExecutorError {
         }
     }
 
-    /// Returns true if this error was produced by the per-contract fair
-    /// queue rejecting an event because the queue is at capacity (see
-    /// `send_queue_full_response` in `contract.rs` and `ContractQueueFull`
-    /// above).
+    /// Returns true if this error is the typed `ContractQueueFull` marker
+    /// from `send_queue_full_response` (per-contract fair queue at capacity).
     ///
-    /// Queue-full is a transient platform-level backpressure signal — not
-    /// a contract-level fault, not a missing-contract condition, not a
-    /// WASM execution failure. Callers MUST use this predicate to suppress
-    /// amplification side effects that only make sense for real failures:
-    ///
-    /// - The UPDATE full-state relay path must NOT trigger
-    ///   `try_auto_fetch_contract` (the contract code is present; the
-    ///   queue is just busy).
-    /// - The UPDATE delta relay path must NOT emit `ResyncRequest`
-    ///   (asking the sender for full-state resends makes the storm
-    ///   worse).
-    /// - Originator-side error logging should drop from ERROR to DEBUG
-    ///   (a temporarily-saturated executor is not an operator-actionable
-    ///   alert; the volume on a hot contract can be enormous).
-    ///
-    /// Without this predicate, a single buggy / abusive / merely-popular
-    /// contract that saturates its own queue would induce the local peer
-    /// to fire auto-fetch GET storms and ResyncRequest broadcasts that
-    /// amplify the saturation onto every other peer subscribed to the
-    /// contract — see issue #4251.
+    /// **Platform-resilience invariant**: queue-full is transient
+    /// backpressure, not a contract-level fault, missing-contract condition,
+    /// or WASM failure. Callers MUST gate amplification side effects on this
+    /// predicate — auto-fetch GETs (the contract code is present), ResyncRequest
+    /// broadcasts (the merge never ran), and ERROR-level logging (volume on a
+    /// hot contract drowns real failures). Without it, a single saturated
+    /// contract induces a network-wide storm. See issue #4251.
     pub fn is_contract_queue_full(&self) -> bool {
         match &self.inner {
             Either::Left(_) => false,
@@ -1016,10 +997,8 @@ mod tests {
 
         // ── ContractQueueFull predicate (issue #4251) ─────────────────────
         //
-        // The queue-full marker must be cleanly distinguishable from every
-        // other error class so callers can suppress amplification side
-        // effects (auto-fetch, ResyncRequest, ERROR logs) specifically for
-        // this case without paying for them on real failures.
+        // The marker must be cleanly distinguishable from every other error
+        // class so amplification suppression fires only on queue-full.
 
         #[test]
         fn test_contract_queue_full_true_for_marker_error() {
@@ -1034,11 +1013,8 @@ mod tests {
 
         #[test]
         fn test_contract_queue_full_false_for_anyhow_string_lookalike() {
-            // Regression: an opaque anyhow error whose message happens to
-            // contain "contract queue full" must NOT satisfy the predicate.
-            // The predicate is typed (downcast), not string-matched, so a
-            // future caller that produces a similarly-worded error doesn't
-            // accidentally inherit queue-full semantics.
+            // Predicate is typed (downcast), not string-matched: a similarly-
+            // worded anyhow error must not inherit queue-full semantics.
             let err = ExecutorError::other(anyhow::anyhow!("contract queue full, try again later"));
             assert!(
                 !err.is_contract_queue_full(),
@@ -1074,10 +1050,8 @@ mod tests {
 
         #[test]
         fn test_contract_queue_full_disjoint_from_other_predicates() {
-            // Ensures the new predicate doesn't collide with the existing
-            // predicates' truth values for the queue-full case. This is the
-            // load-bearing property used in op_ctx_task.rs:1064/1107 to
-            // suppress amplification.
+            // Load-bearing property used by the gating in op_ctx_task.rs:
+            // the queue-full marker must trip its own predicate and no other.
             let err = ExecutorError::other(ContractQueueFull);
             assert!(err.is_contract_queue_full());
             assert!(!err.is_request());

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1044,10 +1044,15 @@ where
                     limit = MAX_QUEUED_OPS_PER_CONTRACT,
                     "Contract initialization queue full, rejecting operation"
                 );
-                return Err(ExecutorError::request(StdContractError::Update {
-                    key,
-                    cause: "contract initialization queue is full, try again later".into(),
-                }));
+                // Use the typed `ContractQueueFull` marker so the same
+                // amplification suppression and DEBUG log severity that
+                // the per-contract fair queue gets via
+                // `send_queue_full_response` also applies here. Without
+                // the typed marker, an init-queue-full looks like a
+                // generic StdContractError::Update to callers and
+                // re-enters the `try_auto_fetch_contract` /
+                // `ResyncRequest` paths. Issue #4251.
+                return Err(ExecutorError::other(super::ContractQueueFull));
             }
             InitCheckResult::Queued { queue_size } => {
                 tracing::info!(

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -142,12 +142,11 @@ impl OpError {
         matches!(self, Self::ExecutorError(e) if e.is_invalid_update_rejection())
     }
 
-    /// Returns true if the underlying error is the typed
-    /// `ContractQueueFull` marker (per-contract executor queue at capacity).
-    /// Callers MUST gate amplification side effects (auto-fetch,
-    /// ResyncRequest, ERROR logs) on this predicate so a saturated contract
-    /// queue doesn't induce network-wide storms. See
-    /// `ExecutorError::is_contract_queue_full` and issue #4251.
+    /// Returns true for the typed `ContractQueueFull` marker. Callers MUST
+    /// gate amplification side effects (auto-fetch, ResyncRequest, ERROR
+    /// logs) on this predicate so a saturated contract queue doesn't induce
+    /// network-wide storms. See `ExecutorError::is_contract_queue_full` and
+    /// issue #4251.
     pub fn is_contract_queue_full(&self) -> bool {
         matches!(self, Self::ExecutorError(e) if e.is_contract_queue_full())
     }

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -141,6 +141,16 @@ impl OpError {
     pub fn is_invalid_update_rejection(&self) -> bool {
         matches!(self, Self::ExecutorError(e) if e.is_invalid_update_rejection())
     }
+
+    /// Returns true if the underlying error is the typed
+    /// `ContractQueueFull` marker (per-contract executor queue at capacity).
+    /// Callers MUST gate amplification side effects (auto-fetch,
+    /// ResyncRequest, ERROR logs) on this predicate so a saturated contract
+    /// queue doesn't induce network-wide storms. See
+    /// `ExecutorError::is_contract_queue_full` and issue #4251.
+    pub fn is_contract_queue_full(&self) -> bool {
+        matches!(self, Self::ExecutorError(e) if e.is_contract_queue_full())
+    }
 }
 
 impl<T> From<SendError<T>> for OpError {

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -135,7 +135,19 @@ pub(super) async fn put_contract(
             new_value: Err(err),
             ..
         }) => {
-            tracing::error!(contract = %key, error = %err, phase = "error", "Failed to update contract value");
+            // Issue #4251: per-contract queue saturation logs at DEBUG, not
+            // ERROR — same rationale as the matching site in
+            // `update.rs::log_update_contract_failure`.
+            if err.is_contract_queue_full() {
+                tracing::debug!(
+                    contract = %key,
+                    error = %err,
+                    event = "queue_full",
+                    "PUT skipped: per-contract queue saturated"
+                );
+            } else {
+                tracing::error!(contract = %key, error = %err, phase = "error", "Failed to update contract value");
+            }
             Err(OpError::from(err))
         }
         Err(err) => Err(err.into()),

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1214,13 +1214,31 @@ async fn relay_put_store_locally(
     {
         Ok(result) => result,
         Err(err) => {
-            tracing::error!(
-                tx = %incoming_tx,
-                contract = %key,
-                error = %err,
-                htl,
-                "PUT relay: put_contract failed"
-            );
+            // Issue #4251: per-contract queue saturation is transient
+            // platform backpressure, not a real PUT failure. The PUT
+            // relay path doesn't trigger the auto-fetch / ResyncRequest
+            // amplification that UPDATE does (see PR for analysis), so
+            // we only have the log-spam half of the bug to fix here.
+            // Real PUT failures (validation, storage, missing
+            // parameters) keep the ERROR level.
+            if err.is_contract_queue_full() {
+                tracing::debug!(
+                    tx = %incoming_tx,
+                    contract = %key,
+                    error = %err,
+                    htl,
+                    event = "queue_full",
+                    "PUT relay: per-contract queue saturated"
+                );
+            } else {
+                tracing::error!(
+                    tx = %incoming_tx,
+                    contract = %key,
+                    error = %err,
+                    htl,
+                    "PUT relay: put_contract failed"
+                );
+            }
             if let Some(event) = NetEventLog::put_failure(
                 &incoming_tx,
                 &op_manager.ring,

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -340,11 +340,9 @@ fn log_update_contract_failure(key: &ContractKey, err: &ExecutorError) {
             "Update rejected by contract: incoming state invalid (likely stale rebroadcast), keeping local"
         );
     } else if err.is_contract_queue_full() {
-        // Issue #4251: per-contract queue saturation is transient
-        // platform backpressure, not an operator-actionable failure.
-        // On a hot contract this fires hundreds of times per second
-        // — keep the log at DEBUG so disks don't fill and so real
-        // failures stay visible at ERROR.
+        // Issue #4251: transient backpressure, not operator-actionable. A
+        // hot contract fires this hundreds of times/sec — DEBUG keeps real
+        // failures visible at ERROR.
         tracing::debug!(
             contract = %key,
             error = %err,
@@ -400,10 +398,8 @@ pub(crate) fn log_broadcast_to_streaming_failure(
             "BroadcastToStreaming merge rejected: incoming state invalid (likely stale rebroadcast), keeping local"
         );
     } else if err.is_contract_queue_full() {
-        // Issue #4251: queue-full is transient platform backpressure,
-        // not a contract failure. Keep the log at DEBUG so a hot
-        // contract doesn't drown operators in scary WARNs, and (via
-        // the return value below) skip the spurious auto-fetch GET.
+        // Issue #4251: transient backpressure. DEBUG (not WARN), and (via the
+        // return value) skip the spurious auto-fetch GET.
         tracing::debug!(
             tx = %tx,
             %key,
@@ -419,12 +415,10 @@ pub(crate) fn log_broadcast_to_streaming_failure(
             "BroadcastToStreaming update skipped: contract not ready locally"
         );
     }
-    // Trigger self-heal GET only when the contract is genuinely missing.
-    // Skip when the WASM merge ran and rejected the update (pre-#3914
-    // semantics) AND when the queue was simply saturated (#4251) — in
-    // both cases the contract code is present locally, and enqueuing a
-    // GET right back onto the saturated handler only amplifies the
-    // storm.
+    // Self-heal GET only when the contract is genuinely missing. Skip when
+    // the WASM merge ran (pre-#3914) or when the queue was saturated (#4251)
+    // — in both cases the contract code is present, and enqueuing a GET on
+    // a saturated handler only amplifies the storm.
     !err.is_contract_exec_rejection() && !err.is_contract_queue_full()
 }
 
@@ -981,9 +975,7 @@ mod tests {
         }
 
         fn queue_full_failure() -> ExecutorError {
-            // Mirrors what `send_queue_full_response` (contract.rs) produces
-            // when the per-contract fair queue rejects an event. The typed
-            // marker is what powers `ExecutorError::is_contract_queue_full`.
+            // Mirrors `send_queue_full_response` (contract.rs).
             ExecutorError::other(crate::contract::ContractQueueFull)
         }
 

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -339,6 +339,18 @@ fn log_update_contract_failure(key: &ContractKey, err: &ExecutorError) {
             event = "merge_rejected_invalid_update",
             "Update rejected by contract: incoming state invalid (likely stale rebroadcast), keeping local"
         );
+    } else if err.is_contract_queue_full() {
+        // Issue #4251: per-contract queue saturation is transient
+        // platform backpressure, not an operator-actionable failure.
+        // On a hot contract this fires hundreds of times per second
+        // — keep the log at DEBUG so disks don't fill and so real
+        // failures stay visible at ERROR.
+        tracing::debug!(
+            contract = %key,
+            error = %err,
+            event = "queue_full",
+            "Update skipped: per-contract queue saturated"
+        );
     } else {
         tracing::error!(
             contract = %key,
@@ -387,6 +399,18 @@ pub(crate) fn log_broadcast_to_streaming_failure(
             event = "merge_rejected_invalid_update",
             "BroadcastToStreaming merge rejected: incoming state invalid (likely stale rebroadcast), keeping local"
         );
+    } else if err.is_contract_queue_full() {
+        // Issue #4251: queue-full is transient platform backpressure,
+        // not a contract failure. Keep the log at DEBUG so a hot
+        // contract doesn't drown operators in scary WARNs, and (via
+        // the return value below) skip the spurious auto-fetch GET.
+        tracing::debug!(
+            tx = %tx,
+            %key,
+            error = %err,
+            event = "queue_full",
+            "BroadcastToStreaming update skipped: per-contract queue saturated"
+        );
     } else {
         tracing::warn!(
             tx = %tx,
@@ -395,10 +419,13 @@ pub(crate) fn log_broadcast_to_streaming_failure(
             "BroadcastToStreaming update skipped: contract not ready locally"
         );
     }
-    // Preserves the pre-#3914 auto-fetch behavior: skip the self-heal
-    // GET whenever the contract code is present (broader check than the
-    // log-severity decision above).
-    !err.is_contract_exec_rejection()
+    // Trigger self-heal GET only when the contract is genuinely missing.
+    // Skip when the WASM merge ran and rejected the update (pre-#3914
+    // semantics) AND when the queue was simply saturated (#4251) — in
+    // both cases the contract code is present locally, and enqueuing a
+    // GET right back onto the saturated handler only amplifies the
+    // storm.
+    !err.is_contract_exec_rejection() && !err.is_contract_queue_full()
 }
 
 /// Apply an update to a contract.
@@ -953,6 +980,13 @@ mod tests {
             req.into()
         }
 
+        fn queue_full_failure() -> ExecutorError {
+            // Mirrors what `send_queue_full_response` (contract.rs) produces
+            // when the per-contract fair queue rejects an event. The typed
+            // marker is what powers `ExecutorError::is_contract_queue_full`.
+            ExecutorError::other(crate::contract::ContractQueueFull)
+        }
+
         #[test]
         fn update_contract_failure_logs_info_for_invalid_update_rejection() {
             let logger = TestLogger::new().capture_logs().with_level("info").init();
@@ -1075,6 +1109,83 @@ mod tests {
             assert!(
                 logger.contains("contract not ready locally"),
                 "expected the WARN message text for real failure, got: {:?}",
+                logger.logs()
+            );
+        }
+
+        /// Issue #4251 regression: when the per-contract fair queue
+        /// rejects an event, `log_update_contract_failure` must classify
+        /// it as `is_contract_queue_full` and log at DEBUG (NOT ERROR).
+        /// A hot contract that saturates its own queue would otherwise
+        /// flood logs with ERROR-level "Failed to update contract value"
+        /// lines (~30% of all log volume on production gateways).
+        #[test]
+        fn update_contract_failure_logs_debug_for_queue_full() {
+            let logger = TestLogger::new().capture_logs().with_level("debug").init();
+
+            log_update_contract_failure(&make_contract_key(1), &queue_full_failure());
+
+            assert!(
+                logger.contains("queue_full"),
+                "queue-full must emit event=queue_full, got: {:?}",
+                logger.logs()
+            );
+            assert!(
+                !logger.logs().iter().any(|l| l.contains("ERROR")),
+                "queue-full must NOT log at ERROR (it's transient backpressure, not a fault), got: {:?}",
+                logger.logs()
+            );
+            assert!(
+                !logger
+                    .logs()
+                    .iter()
+                    .any(|l| l.contains("Failed to update contract value")),
+                "queue-full must NOT emit the legacy ERROR message, got: {:?}",
+                logger.logs()
+            );
+        }
+
+        /// Issue #4251 regression: the streaming branch's helper MUST
+        /// (1) log queue-full at DEBUG, NOT WARN — a buggy contract that
+        /// floods broadcasts must not also flood operator logs; and
+        /// (2) return `false` so the caller skips
+        /// `try_auto_fetch_contract` — enqueuing a GET right back onto
+        /// the saturated handler is the amplification path the typed
+        /// predicate exists to break.
+        #[test]
+        fn broadcast_to_streaming_failure_skips_auto_fetch_and_uses_debug_for_queue_full() {
+            let logger = TestLogger::new().capture_logs().with_level("debug").init();
+            let tx = Transaction::new::<UpdateMsg>();
+            let err: OpError = queue_full_failure().into();
+
+            let needs_auto_fetch =
+                log_broadcast_to_streaming_failure(&tx, &make_contract_key(3), &err);
+
+            assert!(
+                !needs_auto_fetch,
+                "queue-full MUST NOT trigger self-heal auto-fetch — enqueuing a GET \
+                 onto the saturated handler is exactly the amplification we're \
+                 trying to break (issue #4251)"
+            );
+            assert!(
+                logger.contains("queue_full"),
+                "queue-full must emit event=queue_full in the streaming branch, got: {:?}",
+                logger.logs()
+            );
+            assert!(
+                !logger.logs().iter().any(|l| l.contains("WARN")),
+                "queue-full must NOT log at WARN — a saturated contract would otherwise \
+                 fill operator dashboards with false-alarm WARNs, got: {:?}",
+                logger.logs()
+            );
+            assert!(
+                !logger
+                    .logs()
+                    .iter()
+                    .any(|l| l.contains("contract not ready locally")),
+                "the misleading 'contract not ready locally' message must not appear \
+                 for queue-full — the contract IS present, the queue is just busy, \
+                 got: {:?}",
                 logger.logs()
             );
         }

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -368,17 +368,20 @@ fn log_update_contract_failure(key: &ContractKey, err: &ExecutorError) {
 /// - Log severity uses `is_invalid_update_rejection` (narrow): only the
 ///   contract WASM's typed "invalid contract update" rejection counts as
 ///   benign. Out-of-gas, traps, timeouts stay at WARN even though the
-///   contract code is present.
+///   contract code is present. Issue #4251 adds a third level: queue-full
+///   logs at DEBUG (transient backpressure, not an operator-actionable
+///   fault).
 ///
-/// - Auto-fetch uses `is_contract_exec_rejection` (broad): any time the
-///   contract code DID execute (whether successfully rejecting a stale
-///   state or running out of gas), the code is present locally and a
-///   self-heal GET would be wasted. Auto-fetch only fires for failures
-///   where the contract is actually missing (e.g., missing parameters
-///   after restart, storage error).
+/// - Auto-fetch uses `is_contract_exec_rejection` (broad) AND
+///   `!is_contract_queue_full` (issue #4251): any time the contract code
+///   DID execute (whether successfully rejecting a stale state or running
+///   out of gas), OR the contract's queue is just saturated, the code is
+///   present locally and a self-heal GET would be wasted. Auto-fetch only
+///   fires for failures where the contract is actually missing (e.g.,
+///   missing parameters after restart, storage error).
 ///
 /// Returning `true` means "fetch missing contract code"; returning `false`
-/// means "contract is present, skip auto-fetch".
+/// means "contract is present (or queue saturated), skip auto-fetch".
 ///
 /// Note: this helper takes `&OpError` while `log_update_contract_failure`
 /// takes `&ExecutorError` because the two call sites have different error

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1061,17 +1061,10 @@ async fn drive_relay_broadcast_to(
                 });
             }
 
-            // Issue #4251: queue-full is a transient platform-level
-            // backpressure signal, not a contract-level failure. The
-            // delta-failed→ResyncRequest and full-state→auto-fetch
-            // branches below both treat the error as evidence that
-            // something is wrong with the contract or the local state;
-            // for queue-full neither is true (the contract code is
-            // present, the merge simply never got to run). Firing them
-            // anyway turns a single saturated contract into a network-
-            // wide storm — the sender resends full state on
-            // ResyncRequest, and auto-fetch enqueues a GET right back
-            // onto the same saturated queue. Skip both branches and
+            // Issue #4251: on queue-full the merge never ran, so neither
+            // amplification branch below is correct — ResyncRequest asks the
+            // sender to resend full state onto the same saturated queue, and
+            // auto-fetch enqueues a GET right back onto it. Skip both; still
             // surface the error to the caller for telemetry.
             let queue_full = err.is_contract_queue_full();
 
@@ -2333,28 +2326,16 @@ mod tests {
             .unwrap_or(after.len());
         let driver_src = &src[start..start + 1 + end];
 
-        // The gate must be computed once and applied to both amplification
-        // branches. We don't pin the exact variable name, but both branches
-        // must reference `is_contract_queue_full()` (directly or via the
-        // gate binding) so a refactor that drops the check from one branch
-        // fails this test.
+        // Gate must be present; both amplification call sites must still
+        // exist (suppressed on queue-full, not deleted). Runtime gating
+        // behavior is covered by the update.rs tests; this is a structural
+        // pin so a refactor that drops the check fails CI.
         assert!(
             driver_src.contains("is_contract_queue_full()"),
             "drive_relay_broadcast_to must call is_contract_queue_full() \
              to gate the ResyncRequest / auto-fetch amplification — see \
              issue #4251"
         );
-
-        // Both amplification call sites must still exist (we're suppressing
-        // them on queue-full, not deleting them) — and both must follow the
-        // gate. We assert co-occurrence of the textual markers; the
-        // suppression is enforced because the guards `if is_delta &&
-        // !queue_full` and `else if !is_delta && !err.is_contract_exec_rejection()
-        // && !queue_full` wrap them. If anyone re-introduces an
-        // unconditional ResyncRequest / auto-fetch branch, the
-        // `is_contract_queue_full()` reference would disappear from
-        // between the two and this test would still catch the regression
-        // via the dedicated runtime test below in update.rs.
         assert!(
             driver_src.contains("InterestMessage::ResyncRequest"),
             "drive_relay_broadcast_to should still contain the ResyncRequest \

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -392,13 +392,30 @@ async fn drive_client_update(
                         .into())));
                     }
 
-                    tracing::error!(
-                        tx = %client_tx,
-                        contract = %key,
-                        error = %err,
-                        phase = "error",
-                        "update: failed to apply update locally before forwarding"
-                    );
+                    // Issue #4251: per-contract queue saturation is
+                    // transient backpressure, not an operator-actionable
+                    // failure. On a hot contract this fires hundreds of
+                    // times per second; ERROR-level here drowns real
+                    // failures on the originator path. Real WASM faults
+                    // (OOG, traps, missing parameters) keep the ERROR
+                    // level.
+                    if err.is_contract_queue_full() {
+                        tracing::debug!(
+                            tx = %client_tx,
+                            contract = %key,
+                            error = %err,
+                            event = "queue_full",
+                            "update: per-contract queue saturated before forwarding"
+                        );
+                    } else {
+                        tracing::error!(
+                            tx = %client_tx,
+                            contract = %key,
+                            error = %err,
+                            phase = "error",
+                            "update: failed to apply update locally before forwarding"
+                        );
+                    }
                     return Err(err);
                 }
             };

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1061,7 +1061,21 @@ async fn drive_relay_broadcast_to(
                 });
             }
 
-            if is_delta {
+            // Issue #4251: queue-full is a transient platform-level
+            // backpressure signal, not a contract-level failure. The
+            // delta-failed→ResyncRequest and full-state→auto-fetch
+            // branches below both treat the error as evidence that
+            // something is wrong with the contract or the local state;
+            // for queue-full neither is true (the contract code is
+            // present, the merge simply never got to run). Firing them
+            // anyway turns a single saturated contract into a network-
+            // wide storm — the sender resends full state on
+            // ResyncRequest, and auto-fetch enqueues a GET right back
+            // onto the same saturated queue. Skip both branches and
+            // surface the error to the caller for telemetry.
+            let queue_full = err.is_contract_queue_full();
+
+            if is_delta && !queue_full {
                 // Delta application failed → send ResyncRequest. Mirrors
                 // update.rs:710-758.
                 tracing::warn!(
@@ -1104,10 +1118,18 @@ async fn drive_relay_broadcast_to(
                         "UPDATE relay: failed to send ResyncRequest"
                     );
                 }
-            } else if !err.is_contract_exec_rejection() {
+            } else if !is_delta && !err.is_contract_exec_rejection() && !queue_full {
                 // Full state failed and the merge function did NOT reject it
                 // (so contract code is missing). Trigger self-healing GET.
                 op_manager.try_auto_fetch_contract(&key, sender_addr);
+            } else if queue_full {
+                tracing::debug!(
+                    tx = %incoming_tx,
+                    contract = %key,
+                    sender = %sender_addr,
+                    event = "queue_full_amplification_suppressed",
+                    "UPDATE relay: per-contract queue saturated, suppressed ResyncRequest/auto-fetch to avoid amplification"
+                );
             }
             return Err(err);
         }
@@ -2288,6 +2310,60 @@ mod tests {
             dedup_pos < merge_pos,
             "broadcast_dedup_cache.check_and_insert MUST appear before \
              update_contract() in drive_relay_broadcast_to_streaming"
+        );
+    }
+
+    /// Issue #4251 regression pin: `drive_relay_broadcast_to` MUST
+    /// gate ResyncRequest emission AND `try_auto_fetch_contract` on
+    /// `!err.is_contract_queue_full()`. The two amplification branches
+    /// are what turn a single saturated contract into a network-wide
+    /// storm — ResyncRequest asks the sender for full state (bigger
+    /// payload onto the same full queue), and auto-fetch enqueues a
+    /// GET right back onto the saturated handler.
+    #[test]
+    fn broadcast_to_suppresses_amplification_on_queue_full() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn drive_relay_broadcast_to(")
+            .expect("drive_relay_broadcast_to not found");
+        let after = &src[start + 1..];
+        let end = after
+            .find("\nasync fn ")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .unwrap_or(after.len());
+        let driver_src = &src[start..start + 1 + end];
+
+        // The gate must be computed once and applied to both amplification
+        // branches. We don't pin the exact variable name, but both branches
+        // must reference `is_contract_queue_full()` (directly or via the
+        // gate binding) so a refactor that drops the check from one branch
+        // fails this test.
+        assert!(
+            driver_src.contains("is_contract_queue_full()"),
+            "drive_relay_broadcast_to must call is_contract_queue_full() \
+             to gate the ResyncRequest / auto-fetch amplification — see \
+             issue #4251"
+        );
+
+        // Both amplification call sites must still exist (we're suppressing
+        // them on queue-full, not deleting them) — and both must follow the
+        // gate. We assert co-occurrence of the textual markers; the
+        // suppression is enforced because the guards `if is_delta &&
+        // !queue_full` and `else if !is_delta && !err.is_contract_exec_rejection()
+        // && !queue_full` wrap them. If anyone re-introduces an
+        // unconditional ResyncRequest / auto-fetch branch, the
+        // `is_contract_queue_full()` reference would disappear from
+        // between the two and this test would still catch the regression
+        // via the dedicated runtime test below in update.rs.
+        assert!(
+            driver_src.contains("InterestMessage::ResyncRequest"),
+            "drive_relay_broadcast_to should still contain the ResyncRequest \
+             branch (gated on !queue_full)"
+        );
+        assert!(
+            driver_src.contains("try_auto_fetch_contract"),
+            "drive_relay_broadcast_to should still contain the auto-fetch \
+             branch (gated on !queue_full)"
         );
     }
 


### PR DESCRIPTION
## Problem

The per-contract executor fair queue (`MAX_QUEUED_PER_CONTRACT = 100` in `crates/core/src/contract/fair_queue.rs:32`) is doing its job — round-robin scheduling so one contract can't monopolize the WASM executor — but the rest of the codebase treats a queue-full rejection as a **real executor failure**. When a single contract saturates its own queue (production case: `4PjqN55KUCidW8vJvw5fhy5fe5maxXKNrWSyK33QjjVq`, 275k log mentions/hour on `nova` per issue #4251), the UPDATE relay drivers spuriously fire **two amplification paths**:

1. `try_auto_fetch_contract` (full-state branch, `update/op_ctx_task.rs:1107`, plus streaming branch via `log_broadcast_to_streaming_failure`). Reason: queue-full is mis-classified as "contract code missing locally" by `!is_contract_exec_rejection()`. The fetch enqueues a GET right back onto the saturated handler.
2. `InterestMessage::ResyncRequest` (delta branch, `update/op_ctx_task.rs:1064`). Asks the sender to resend **full** state — a bigger payload — onto the same queue that just rejected a delta.

The combination is the platform-harm vector: a buggy / abusive / merely-popular contract that saturates **its own** queue induces every subscribed peer to fire spurious GETs and request larger UPDATEs, turning a single-contract problem into a network-wide storm. Originator-side logging compounds: queue-full hits the `ERROR Failed to update contract value` path hundreds of times per second, drowning real failures.

## Approach

Foundation — typed error so the platform can recognize the condition without string-matching:

- New `contract::ContractQueueFull` marker (in `executor.rs`).
- `ExecutorError::is_contract_queue_full()` downcasts on it. Mirror up through `OpError::is_contract_queue_full()` for callers operating on the wider error type.
- `send_queue_full_response` now constructs `ExecutorError::other(ContractQueueFull)` instead of an opaque `anyhow::anyhow!("contract queue full...")`.

Suppression — gate the amplification on the typed predicate:

- `drive_relay_broadcast_to`: compute `queue_full = err.is_contract_queue_full()` once, gate both the delta→ResyncRequest branch and the full-state→auto-fetch branch on `!queue_full`. The relay still surfaces the error to its caller for telemetry; it just stops re-throwing work at the saturated handler.
- `log_broadcast_to_streaming_failure` (helper used by `drive_relay_broadcast_to_streaming`): returns `!err.is_contract_exec_rejection() && !err.is_contract_queue_full()`, so the streaming variant also skips auto-fetch on queue-full.

Log severity — queue-full is transient backpressure, not an operator-actionable failure:

- Originator and streaming paths both drop queue-full from ERROR / WARN to DEBUG with `event=queue_full`. Real WASM faults (OOG, traps, missing parameters) stay at ERROR/WARN unchanged.

## Testing

New regression tests (all pass locally):

- `executor::tests::executor_error_tests::test_contract_queue_full_*` — five tests pinning the predicate: recognises the typed marker, rejects an anyhow string lookalike (so an unrelated stringly-typed error can't accidentally inherit queue-full semantics), disjoint from every other predicate.
- `contract::tests::send_queue_full_response_carries_typed_queue_full_marker` — pins the typed marker at the channel boundary. Regression here silently re-enables the storm.
- `operations::update::tests::log_severity::update_contract_failure_logs_debug_for_queue_full` — originator log goes to DEBUG with `event=queue_full`, no `ERROR` and no `Failed to update contract value`.
- `operations::update::tests::log_severity::broadcast_to_streaming_failure_skips_auto_fetch_and_uses_debug_for_queue_full` — verifies both the log-level downgrade AND `log_broadcast_to_streaming_failure` returns `false` (auto-fetch skipped).
- `operations::update::op_ctx_task::tests::broadcast_to_suppresses_amplification_on_queue_full` — source-grep pin asserting `is_contract_queue_full()` appears in `drive_relay_broadcast_to` and both amplification branches still exist (gated, not deleted).

Pre-existing tests still pass — real failures (OOG, missing parameters, contract WASM rejections) keep their previous logging and trigger auto-fetch / ResyncRequest exactly as before.

Full lib test: `cargo test -p freenet --lib` → 2607 passed, 0 failed, 14 ignored.

## Contract identification correction

The issue body identifies `4PjqN5…` as the official River room. It isn't — the official River room is `7Z8Nf1Fx5WsGRfc1AzH23bQBXDhmQFt8FgAKGw9poWXN`. On `nova`'s last-hour log the official room has 249 mentions (with `BroadcastToStreaming` at ~160 KB payloads), while `4PjqN5…` has 275,632 mentions with no streaming (state < 64 KB). I posted the correction on the issue: https://github.com/freenet/freenet-core/issues/4251#issuecomment-4536621916. Identifying what `4PjqN5…` actually is remains a separate investigation; this fix is platform-resilience-against-any-such-contract, irrespective of which one is misbehaving.

## Out of scope (deliberately)

- WASM throughput vs. update-rate gap on `4PjqN5…`. Needs profiling and is contract-specific.
- `MAX_QUEUED_PER_CONTRACT` tuning. Bigger queues delay but don't break the saturation feedback loop.
- Log-volume reduction for `WARN Rejected event due to per-contract queue capacity limit` in `contract.rs:761`. Sibling PR already flagged in the issue.
- Per-(peer, contract) rate-limit on `SyncStateToPeer` emission. Investigated; the source-side emit is fire-and-forget non-blocking, so it's not the dominant pressure on the contract queue. Separate improvement.
- Bumping CI's pinned Rust toolchain from 1.93.0 to current stable (one new clippy lint trips locally on pre-existing code). Will follow up after this lands.

Closes #4251

[AI-assisted - Claude]