### PR TITLE
fix: populate hop_count on terminal PUT and SUBSCRIBE events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.2.63"
+version = "0.2.64"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.2.63"
+version = "0.2.64"
 edition = "2024"
 rust-version = "1.85"
 publish = true
@@ -13,7 +13,7 @@ readme = "README.md"
 # Minimum compatible protocol version. Peers older than this are rejected.
 # Updated by scripts/release.sh during releases. The env var
 # FREENET_MIN_COMPATIBLE_VERSION overrides this at build time.
-min-compatible-version = "0.2.63"
+min-compatible-version = "0.2.64"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/freenet-{ target }.tar.gz"

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2551,6 +2551,7 @@ mod tests {
                 id: sub_tx,
                 instance_id,
                 result: SubscribeMsgResult::Subscribed { key },
+                hop_count: 0,
             };
 
             let taken = subscribe_branch_would_forward(&op, Some(&tx));
@@ -2627,6 +2628,7 @@ mod tests {
                 id: sub_tx,
                 instance_id,
                 result: SubscribeMsgResult::NotFound,
+                hop_count: 0,
             };
 
             let taken = subscribe_branch_would_forward(&op, None);
@@ -2726,7 +2728,11 @@ mod tests {
             let (tx, mut rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
             let put_tx = Transaction::new::<PutMsg>();
             let key = dummy_put_key(10, 11);
-            let op = PutMsg::Response { id: put_tx, key };
+            let op = PutMsg::Response {
+                id: put_tx,
+                key,
+                hop_count: 0,
+            };
 
             let taken = put_branch_would_forward(&op, Some(&tx));
             assert!(taken, "Response with callback → must be forwarded");
@@ -2744,6 +2750,7 @@ mod tests {
                 id: put_tx,
                 key,
                 continue_forwarding: false,
+                hop_count: 0,
             };
 
             let taken = put_branch_would_forward(&op, Some(&tx));
@@ -2803,7 +2810,11 @@ mod tests {
         async fn put_response_without_callback_falls_through() {
             let put_tx = Transaction::new::<PutMsg>();
             let key = dummy_put_key(16, 17);
-            let op = PutMsg::Response { id: put_tx, key };
+            let op = PutMsg::Response {
+                id: put_tx,
+                key,
+                hop_count: 0,
+            };
 
             let taken = put_branch_would_forward(&op, None);
             assert!(

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -608,20 +608,6 @@ impl OpManager {
         None
     }
 
-    /// Get the current hop count (remaining HTL) for an operation.
-    /// Always returns `None` — no live op reports a hop here.
-    ///
-    /// Currently called only by the PUT tracing path at
-    /// `crates/core/src/tracing.rs:1271`.  The corresponding GET path
-    /// was migrated to a wire-carried `hop_count` field on
-    /// `GetMsg::Response` in PR #4245 (this method returned `None` on
-    /// ~99% of GETs because op_manager had cleaned up the op by the
-    /// time the response was logged).  PUT / UPDATE / SUBSCRIBE are
-    /// expected to follow.
-    pub fn get_current_hop(&self, _id: &Transaction) -> Option<usize> {
-        None
-    }
-
     /// Emit a `NodeEvent::TransactionCompleted(tx)` to the event loop,
     /// triggering cleanup of any `pending_op_results` entry keyed by `tx`.
     ///

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -193,7 +193,30 @@ mod messages {
         },
         /// Response indicating the PUT completed. Routed hop-by-hop back to originator
         /// using each node's stored upstream_addr.
-        Response { id: Transaction, key: ContractKey },
+        Response {
+            id: Transaction,
+            key: ContractKey,
+            /// Forward-path hop count: how many hops the originating Request
+            /// traversed before reaching the node that produced this Response
+            /// (the final storer for `Response`, or the relay that finalised
+            /// locally because it had no next hop).
+            ///
+            /// Computed as `max_hops_to_live - htl_at_responder`. The relay
+            /// chain preserves this value as the Response bubbles back to the
+            /// originator — it does NOT increment on the return path. This
+            /// gives the whitepaper's "routing depth" metric (forward hops),
+            /// not round-trip.
+            ///
+            /// `#[serde(default)]` is set for source-level clarity. Bincode
+            /// does not honour serde defaults (positional encoding), so wire
+            /// compat with peers that lack this field is handled at the
+            /// handshake layer via `MIN_COMPATIBLE_VERSION`.
+            ///
+            /// Mirror of `GetMsg::Response.hop_count` (PR #4245); see also
+            /// `SubscribeMsg::Response.hop_count`.
+            #[serde(default)]
+            hop_count: usize,
+        },
 
         /// Streaming request to store a large contract. Used when payload exceeds
         /// streaming_threshold (default 64KB). The actual data is sent via a separate
@@ -224,6 +247,15 @@ mod messages {
             key: ContractKey,
             /// Whether the receiving node should continue forwarding to other peers
             continue_forwarding: bool,
+            /// Forward-path hop count — same semantics as
+            /// `PutMsg::Response.hop_count`. Carried for wire-format
+            /// symmetry: production code currently downgrades streaming
+            /// replies to non-streaming `Response` at the relay
+            /// (see `op_ctx_task::drive_relay_put` slice A note), but the
+            /// field is preserved here so any future streaming-passthrough
+            /// path can populate it without another wire bump.
+            #[serde(default)]
+            hop_count: usize,
         },
 
         /// Lightweight ACK sent by a relay peer back to its upstream when it forwards
@@ -274,7 +306,7 @@ mod messages {
                         htl
                     )
                 }
-                Self::Response { id, key } => {
+                Self::Response { id, key, .. } => {
                     write!(f, "PutResponse(id: {}, key: {})", id, key)
                 }
                 Self::RequestStreaming {
@@ -295,6 +327,7 @@ mod messages {
                     id,
                     key,
                     continue_forwarding,
+                    ..
                 } => {
                     write!(
                         f,
@@ -323,6 +356,7 @@ mod tests {
         let msg = PutMsg::Response {
             id: tx,
             key: make_contract_key(1),
+            hop_count: 0,
         };
         assert_eq!(*msg.id(), tx, "id() should return the transaction ID");
     }
@@ -333,6 +367,7 @@ mod tests {
         let msg = PutMsg::Response {
             id: tx,
             key: make_contract_key(1),
+            hop_count: 0,
         };
         let display = format!("{}", msg);
         assert!(
@@ -359,6 +394,66 @@ mod tests {
                 assert_eq!(contract_key, key);
             }
             other => panic!("Expected ForwardingAck, got {other}"),
+        }
+    }
+
+    /// Regression test: `PutMsg::Response.hop_count` and
+    /// `PutMsg::ResponseStreaming.hop_count` roundtrip through bincode.
+    ///
+    /// Before #4248 the PUT telemetry path computed `hop_count` at log time
+    /// via `op_manager.get_current_hop(id)`, which returned `None` once the
+    /// operation had been cleaned up — i.e., on the vast majority of
+    /// terminal PUT events.  The fix carries the value on the wire so the
+    /// originator has it when constructing `PutSuccess` log events.  This
+    /// test asserts that the new field survives round-trip serialisation
+    /// for both `Response` and `ResponseStreaming` variants — i.e., the
+    /// wire format actually carries it.
+    ///
+    /// bincode-positional caveat: any future positional change here will
+    /// break older binaries; see the `MIN_COMPATIBLE_VERSION` bump that
+    /// accompanies this PR.
+    #[test]
+    fn test_put_msg_response_hop_count_roundtrip() {
+        let key = make_contract_key(7);
+        let cases: &[(&str, usize)] = &[
+            ("zero", 0),
+            ("one", 1),
+            ("mid", 4),
+            ("htl", 10),
+            ("large", 64),
+        ];
+        for (label, hop_count) in cases.iter().copied() {
+            // Response variant
+            let response = PutMsg::Response {
+                id: Transaction::new::<PutMsg>(),
+                key,
+                hop_count,
+            };
+            let bytes = bincode::serialize(&response).expect(label);
+            let restored: PutMsg = bincode::deserialize(&bytes).expect(label);
+            match restored {
+                PutMsg::Response { hop_count: hc, .. } => {
+                    assert_eq!(hc, hop_count, "Response.hop_count must roundtrip ({label})")
+                }
+                _ => panic!("expected Response for {label}"),
+            }
+
+            // ResponseStreaming variant
+            let streaming = PutMsg::ResponseStreaming {
+                id: Transaction::new::<PutMsg>(),
+                key,
+                continue_forwarding: false,
+                hop_count,
+            };
+            let bytes = bincode::serialize(&streaming).expect(label);
+            let restored: PutMsg = bincode::deserialize(&bytes).expect(label);
+            match restored {
+                PutMsg::ResponseStreaming { hop_count: hc, .. } => assert_eq!(
+                    hc, hop_count,
+                    "ResponseStreaming.hop_count must roundtrip ({label})"
+                ),
+                _ => panic!("expected ResponseStreaming for {label}"),
+            }
         }
     }
 

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -218,7 +218,10 @@ async fn drive_client_put_inner(
     }
 
     impl RetryDriver for PutRetryDriver<'_> {
-        type Terminal = ContractKey;
+        // `(key, hop_count)`. `hop_count = None` for `LocalCompletion`
+        // (originator stored locally, no hops traversed); `Some(hop_count)`
+        // for `Stored` (wire-carried forward depth from the storer).
+        type Terminal = (ContractKey, Option<usize>);
 
         fn new_attempt_tx(&mut self) -> Transaction {
             Transaction::new::<PutMsg>()
@@ -244,11 +247,12 @@ async fn drive_client_put_inner(
             })
         }
 
-        fn classify(&mut self, reply: NetMessage) -> AttemptOutcome<ContractKey> {
+        fn classify(&mut self, reply: NetMessage) -> AttemptOutcome<Self::Terminal> {
             match classify_reply(&reply) {
-                ReplyClass::Stored { key } | ReplyClass::LocalCompletion { key } => {
-                    AttemptOutcome::Terminal(key)
+                ReplyClass::Stored { key, hop_count } => {
+                    AttemptOutcome::Terminal((key, Some(hop_count)))
                 }
+                ReplyClass::LocalCompletion { key } => AttemptOutcome::Terminal((key, None)),
                 ReplyClass::Unexpected => AttemptOutcome::Unexpected,
             }
         }
@@ -292,7 +296,7 @@ async fn drive_client_put_inner(
     let loop_result = drive_retry_loop(op_manager, client_tx, "put", &mut driver).await;
 
     match loop_result {
-        RetryLoopOutcome::Done(reply_key) => {
+        RetryLoopOutcome::Done((reply_key, wire_hop_count)) => {
             // Clean up the DashMap entry that process_message created.
             // Without this, the GC task finds a stale AwaitingResponse
             // entry and launches speculative retries on the completed op.
@@ -325,13 +329,22 @@ async fn drive_client_put_inner(
             );
 
             // Telemetry only — subscribe=false to avoid double-subscribe.
+            //
+            // `hop_count`: clamp the wire value to `ring.max_hops_to_live`
+            // for the same defence-in-depth reason `tracing.rs` clamps the
+            // implicit `PutSuccess` from `from_inbound_msg_v1` — a buggy or
+            // malicious peer must not be able to poison originator
+            // telemetry with `usize::MAX`. `None` is preserved for the
+            // `LocalCompletion` arm (no remote hops traversed).
+            let max_htl = op_manager.ring.max_hops_to_live;
+            let hop_count = wire_hop_count.map(|hc| hc.min(max_htl));
             super::finalize_put_at_originator(
                 op_manager,
                 client_tx,
                 reply_key,
                 PutFinalizationData {
                     sender: driver.current_target,
-                    hop_count: None,
+                    hop_count,
                     state_hash: None,
                     state_size: None,
                 },
@@ -368,13 +381,23 @@ async fn drive_client_put_inner(
 
 #[derive(Debug)]
 enum ReplyClass {
-    /// Remote peer accepted the PUT.
+    /// Remote peer accepted the PUT. `hop_count` is the forward-path
+    /// depth carried on the wire `PutMsg::Response`/`ResponseStreaming`.
+    /// Used by the originator's driver to populate
+    /// `PutFinalizationData.hop_count` so the explicit `PutSuccess`
+    /// event emitted from `finalize_put_at_originator` carries the
+    /// same value as the implicit one emitted from
+    /// `NetEventLog::from_inbound_msg_v1` — without this, the
+    /// originator's two `PutSuccess` events for the same tx would
+    /// disagree (one populated, one `None`).
     Stored {
         key: ContractKey,
+        hop_count: usize,
     },
     /// Local completion: process_message stored locally but found no
     /// next hop, so forward_pending_op_result_if_completed sent back
-    /// the original Request. The contract is stored at the originator.
+    /// the original Request. The contract is stored at the originator,
+    /// so no hops were traversed.
     LocalCompletion {
         key: ContractKey,
     },
@@ -383,9 +406,13 @@ enum ReplyClass {
 
 fn classify_reply(msg: &NetMessage) -> ReplyClass {
     match msg {
-        NetMessage::V1(NetMessageV1::Put(
-            PutMsg::Response { key, .. } | PutMsg::ResponseStreaming { key, .. },
-        )) => ReplyClass::Stored { key: *key },
+        NetMessage::V1(NetMessageV1::Put(PutMsg::Response { key, hop_count, .. }))
+        | NetMessage::V1(NetMessageV1::Put(PutMsg::ResponseStreaming { key, hop_count, .. })) => {
+            ReplyClass::Stored {
+                key: *key,
+                hop_count: *hop_count,
+            }
+        }
         // When process_message completes locally (no next hop), the
         // Request is echoed back via forward_pending_op_result_if_completed.
         NetMessage::V1(NetMessageV1::Put(PutMsg::Request {
@@ -2038,17 +2065,23 @@ mod tests {
                 key,
                 hop_count: hc,
             }));
-            assert!(
-                matches!(classify_reply(&msg), ReplyClass::Stored { .. }),
-                "Response with hop_count={hc} must classify as Stored"
-            );
-            // Destructure to assert the field is preserved on the
-            // message itself — the bubble-up reads it directly here.
-            match msg {
-                NetMessage::V1(NetMessageV1::Put(PutMsg::Response { hop_count: got, .. })) => {
-                    assert_eq!(got, hc, "Response.hop_count preserved ({hc})")
+            // Stored variant must extract the wire hop_count into the
+            // classifier output — the originator driver uses this to
+            // populate `PutFinalizationData.hop_count`. A regression that
+            // re-introduced `Stored { key }` without the field would
+            // silently revert PutSuccess from `finalize_put_at_originator`
+            // back to `None` (codex review of #4248).
+            match classify_reply(&msg) {
+                ReplyClass::Stored {
+                    key: got_key,
+                    hop_count: got_hc,
+                } => {
+                    assert_eq!(got_key, key, "Stored.key preserved");
+                    assert_eq!(got_hc, hc, "Stored.hop_count preserved ({hc})");
                 }
-                _ => unreachable!(),
+                other @ (ReplyClass::LocalCompletion { .. } | ReplyClass::Unexpected) => {
+                    panic!("expected Stored, got {other:?} for hc={hc}")
+                }
             }
 
             // ResponseStreaming variant
@@ -2058,18 +2091,70 @@ mod tests {
                 continue_forwarding: false,
                 hop_count: hc,
             }));
-            assert!(
-                matches!(classify_reply(&msg), ReplyClass::Stored { .. }),
-                "ResponseStreaming with hop_count={hc} must classify as Stored"
-            );
-            match msg {
-                NetMessage::V1(NetMessageV1::Put(PutMsg::ResponseStreaming {
-                    hop_count: got,
-                    ..
-                })) => assert_eq!(got, hc, "ResponseStreaming.hop_count preserved ({hc})"),
-                _ => unreachable!(),
+            match classify_reply(&msg) {
+                ReplyClass::Stored {
+                    key: got_key,
+                    hop_count: got_hc,
+                } => {
+                    assert_eq!(got_key, key, "ResponseStreaming Stored.key preserved");
+                    assert_eq!(
+                        got_hc, hc,
+                        "ResponseStreaming Stored.hop_count preserved ({hc})"
+                    );
+                }
+                other @ (ReplyClass::LocalCompletion { .. } | ReplyClass::Unexpected) => {
+                    panic!("expected Stored, got {other:?} for hc={hc}")
+                }
             }
         }
+    }
+
+    /// Regression pin: the client-PUT driver's `RetryLoopOutcome::Done`
+    /// branch MUST pass the wire-carried `hop_count` into
+    /// `PutFinalizationData` (clamped to `max_hops_to_live`). Without
+    /// this, the originator emits TWO `PutSuccess` events per tx: the
+    /// implicit one from `from_inbound_msg_v1` (populated) and the
+    /// explicit one from `finalize_put_at_originator` (`None`) — exactly
+    /// the inconsistency codex flagged on the first review pass of
+    /// #4248. Scrapes the source so a regression that re-introduces
+    /// `hop_count: None,` literal in the PutFinalizationData
+    /// construction trips immediately.
+    #[test]
+    fn finalize_put_at_originator_uses_wire_hop_count() {
+        const SOURCE: &str = include_str!("op_ctx_task.rs");
+        // Anchor: the `RetryLoopOutcome::Done` match arm in
+        // `start_client_put`. Scan forward to the next
+        // `finalize_put_at_originator(` call and verify the field shape.
+        let done_arm = SOURCE
+            .find("RetryLoopOutcome::Done((reply_key, wire_hop_count))")
+            .expect(
+                "RetryLoopOutcome::Done destructure not found — \
+                 if you've refactored to use named struct destructuring \
+                 update this anchor but keep the wire_hop_count threading",
+            );
+        let finalize_call = SOURCE[done_arm..]
+            .find("finalize_put_at_originator(")
+            .expect("no finalize_put_at_originator call in Done arm");
+        let region = &SOURCE[done_arm..done_arm + finalize_call + 500];
+        // The construction MUST NOT hard-code `hop_count: None,`. It must
+        // pass `hop_count` computed from `wire_hop_count`.
+        assert!(
+            !region.contains("hop_count: None,"),
+            "PutFinalizationData construction in start_client_put's \
+             Done arm must NOT hard-code hop_count: None — that emits a \
+             PutSuccess with hop_count=None alongside the populated one \
+             from from_inbound_msg_v1, defeating #4248"
+        );
+        assert!(
+            region.contains("hop_count,"),
+            "PutFinalizationData construction in start_client_put's \
+             Done arm must pass hop_count from the wire value"
+        );
+        assert!(
+            region.contains("wire_hop_count.map"),
+            "wire_hop_count must be mapped (e.g. clamp via .min(max_htl)) \
+             before being passed into PutFinalizationData"
+        );
     }
 
     #[test]
@@ -2259,17 +2344,18 @@ mod tests {
         // Verify that RetryLoopOutcome::Exhausted maps to a client-visible
         // OperationError, not a silent drop or infrastructure error.
         let cause = "PUT to contract failed after 3 attempts".to_string();
-        let outcome: DriverOutcome = match RetryLoopOutcome::<ContractKey>::Exhausted(cause) {
-            RetryLoopOutcome::Exhausted(cause) => {
-                DriverOutcome::Publish(Err(ErrorKind::OperationError {
-                    cause: cause.into(),
+        let outcome: DriverOutcome =
+            match RetryLoopOutcome::<(ContractKey, Option<usize>)>::Exhausted(cause) {
+                RetryLoopOutcome::Exhausted(cause) => {
+                    DriverOutcome::Publish(Err(ErrorKind::OperationError {
+                        cause: cause.into(),
+                    }
+                    .into()))
                 }
-                .into()))
-            }
-            RetryLoopOutcome::Done(_)
-            | RetryLoopOutcome::Unexpected
-            | RetryLoopOutcome::InfraError(_) => unreachable!(),
-        };
+                RetryLoopOutcome::Done(_)
+                | RetryLoopOutcome::Unexpected
+                | RetryLoopOutcome::InfraError(_) => unreachable!(),
+            };
         assert!(
             matches!(outcome, DriverOutcome::Publish(Err(_))),
             "Exhaustion must produce a client error, not be swallowed"

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -252,7 +252,13 @@ async fn drive_client_put_inner(
                 ReplyClass::Stored { key, hop_count } => {
                     AttemptOutcome::Terminal((key, Some(hop_count)))
                 }
-                ReplyClass::LocalCompletion { key } => AttemptOutcome::Terminal((key, None)),
+                // LocalCompletion = no remote hops traversed (originator
+                // is the storer). Forward depth is exactly 0 — emit it
+                // explicitly so local-only PUTs are distinguishable from
+                // "telemetry missing" in dashboards. Codex r2 review of
+                // #4248 flagged that mapping this to `None` leaked an
+                // unpopulated `PutSuccess` for a known-zero-depth path.
+                ReplyClass::LocalCompletion { key } => AttemptOutcome::Terminal((key, Some(0))),
                 ReplyClass::Unexpected => AttemptOutcome::Unexpected,
             }
         }

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -820,12 +820,15 @@ where
                         "PUT relay: next hop has no socket address"
                     );
                     // No next hop — act as final destination.
+                    // This node IS the storer; hop_count = max_htl - htl_we_received.
+                    let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
                     return relay_put_finalize_local(
                         op_manager,
                         incoming_tx,
                         key,
                         merged_value,
                         upstream_addr,
+                        hop_count,
                     )
                     .await;
                 }
@@ -840,12 +843,15 @@ where
                 phase = "relay_put_complete",
                 "PUT relay: no next hop, finalizing at this node"
             );
+            // Same arm as above: this node IS the storer.
+            let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
             return relay_put_finalize_local(
                 op_manager,
                 incoming_tx,
                 key,
                 merged_value,
                 upstream_addr,
+                hop_count,
             )
             .await;
         }
@@ -1127,7 +1133,11 @@ where
     // future routing decisions are informed by relay-observed outcomes,
     // not just events from ops this node originated.
     match reply {
-        NetMessage::V1(NetMessageV1::Put(PutMsg::Response { key: reply_key, .. })) => {
+        NetMessage::V1(NetMessageV1::Put(PutMsg::Response {
+            key: reply_key,
+            hop_count: downstream_hop_count,
+            ..
+        })) => {
             tracing::info!(
                 tx = %incoming_tx,
                 contract = %reply_key,
@@ -1141,9 +1151,23 @@ where
                 crate::router::RouteOutcome::SuccessUntimed,
                 crate::node::network_status::OpType::Put,
             );
-            relay_put_send_response(op_manager, incoming_tx, reply_key, upstream_addr).await
+            // Preserve the storer-side hop_count so the originator sees the
+            // *forward* depth from Request to storer, not the depth from
+            // Request to this relay. Mirrors GET relay bubble-up.
+            relay_put_send_response(
+                op_manager,
+                incoming_tx,
+                reply_key,
+                upstream_addr,
+                downstream_hop_count,
+            )
+            .await
         }
-        NetMessage::V1(NetMessageV1::Put(PutMsg::ResponseStreaming { key: reply_key, .. })) => {
+        NetMessage::V1(NetMessageV1::Put(PutMsg::ResponseStreaming {
+            key: reply_key,
+            hop_count: downstream_hop_count,
+            ..
+        })) => {
             // Streaming response arrived from downstream. Slice A does
             // not relay-forward streaming payloads, so log and
             // synthesize a non-streaming Response upstream. This
@@ -1164,7 +1188,15 @@ where
                 crate::router::RouteOutcome::SuccessUntimed,
                 crate::node::network_status::OpType::Put,
             );
-            relay_put_send_response(op_manager, incoming_tx, reply_key, upstream_addr).await
+            // Downgrade still preserves the storer-side forward depth.
+            relay_put_send_response(
+                op_manager,
+                incoming_tx,
+                reply_key,
+                upstream_addr,
+                downstream_hop_count,
+            )
+            .await
         }
         other => {
             // Unexpected reply variant: unclear whether it's a local
@@ -1278,12 +1310,18 @@ async fn relay_put_store_locally(
 
 /// Finalize at this node when there's no next hop. Emits `put_success`
 /// telemetry and sends `PutMsg::Response` upstream.
+///
+/// `hop_count` is the forward-path depth this relay finalised at — for the
+/// non-originator-as-storer arm this is `max_htl - htl_we_received`. Caller
+/// computes it from the inbound `htl` so this helper stays oblivious to
+/// ring state and is mechanically easy to audit.
 async fn relay_put_finalize_local(
     op_manager: &OpManager,
     incoming_tx: Transaction,
     key: ContractKey,
     merged_value: WrappedState,
     upstream_addr: SocketAddr,
+    hop_count: usize,
 ) -> Result<(), OpError> {
     // Telemetry: non-originator target peer — emit put_success for
     // convergence checking (mirrors put.rs:798-811 non-originator arm).
@@ -1295,18 +1333,24 @@ async fn relay_put_finalize_local(
         &op_manager.ring,
         key,
         own_location,
-        None,
+        Some(hop_count),
         hash,
         size,
     ) {
         op_manager.ring.register_events(Either::Left(event)).await;
     }
 
-    relay_put_send_response(op_manager, incoming_tx, key, upstream_addr).await
+    relay_put_send_response(op_manager, incoming_tx, key, upstream_addr, hop_count).await
 }
 
 /// Send `PutMsg::Response` upstream (fire-and-forget: upstream relay
 /// awaits via its own `send_to_and_await`, no reply expected).
+///
+/// `hop_count` is the forward-path depth to embed in the Response. For a
+/// relay that finalised locally (this node IS the storer), pass
+/// `max_htl - incoming_htl`. For a relay bubbling a downstream Response
+/// upstream, pass the downstream's `hop_count` verbatim — relays do NOT
+/// increment on the return path.
 ///
 /// Originator-loopback case (`upstream_addr == own_addr`): when
 /// the relay driver runs on the originator's own node, the
@@ -1319,10 +1363,12 @@ async fn relay_put_send_response(
     incoming_tx: Transaction,
     key: ContractKey,
     upstream_addr: SocketAddr,
+    hop_count: usize,
 ) -> Result<(), OpError> {
     let msg = NetMessage::from(PutMsg::Response {
         id: incoming_tx,
         key,
+        hop_count,
     });
     let mut ctx = op_manager.op_ctx(incoming_tx);
     let own_addr = op_manager.ring.connection_manager.get_own_addr();
@@ -1818,7 +1864,18 @@ where
                     );
                 }
                 op_manager.release_pending_op_slot(incoming_tx).await;
-                return relay_put_send_response(op_manager, incoming_tx, key, upstream_addr).await;
+                // Best-effort upstream reply after downstream failure: this
+                // node IS the storer (contract was put locally in step 6),
+                // so hop_count = max_htl - htl_we_received.
+                let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
+                return relay_put_send_response(
+                    op_manager,
+                    incoming_tx,
+                    key,
+                    upstream_addr,
+                    hop_count,
+                )
+                .await;
             }
             Err(_elapsed) => {
                 tracing::warn!(
@@ -1836,15 +1893,31 @@ where
                     );
                 }
                 op_manager.release_pending_op_slot(incoming_tx).await;
-                return relay_put_send_response(op_manager, incoming_tx, key, upstream_addr).await;
+                // Same as the channel-closed arm: this node stored locally
+                // in step 6 so we report our own forward depth.
+                let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
+                return relay_put_send_response(
+                    op_manager,
+                    incoming_tx,
+                    key,
+                    upstream_addr,
+                    hop_count,
+                )
+                .await;
             }
         };
         op_manager.release_pending_op_slot(incoming_tx).await;
 
         match reply {
-            NetMessage::V1(NetMessageV1::Put(PutMsg::Response { key: reply_key, .. }))
+            NetMessage::V1(NetMessageV1::Put(PutMsg::Response {
+                key: reply_key,
+                hop_count: downstream_hop_count,
+                ..
+            }))
             | NetMessage::V1(NetMessageV1::Put(PutMsg::ResponseStreaming {
-                key: reply_key, ..
+                key: reply_key,
+                hop_count: downstream_hop_count,
+                ..
             })) => {
                 tracing::info!(
                     tx = %incoming_tx,
@@ -1861,7 +1934,15 @@ where
                         crate::node::network_status::OpType::Put,
                     );
                 }
-                relay_put_send_response(op_manager, incoming_tx, reply_key, upstream_addr).await
+                // Preserve downstream storer's forward depth.
+                relay_put_send_response(
+                    op_manager,
+                    incoming_tx,
+                    reply_key,
+                    upstream_addr,
+                    downstream_hop_count,
+                )
+                .await
             }
             other => {
                 // Unexpected reply variant: unclear attribution. Skip the
@@ -1873,13 +1954,26 @@ where
                     reply_variant = ?std::mem::discriminant(&other),
                     "PUT streaming relay: unexpected reply variant"
                 );
-                relay_put_send_response(op_manager, incoming_tx, key, upstream_addr).await
+                // Same as the error arms: this node stored locally.
+                let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
+                relay_put_send_response(op_manager, incoming_tx, key, upstream_addr, hop_count)
+                    .await
             }
         }
     } else {
         // No next hop, streaming not appropriate, or register_waiter failed —
         // finalize locally and bubble Response upstream.
-        relay_put_finalize_local(op_manager, incoming_tx, key, merged_value, upstream_addr).await
+        // This node IS the storer; hop_count = max_htl - htl_we_received.
+        let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
+        relay_put_finalize_local(
+            op_manager,
+            incoming_tx,
+            key,
+            merged_value,
+            upstream_addr,
+            hop_count,
+        )
+        .await
     }
 }
 
@@ -1901,7 +1995,11 @@ mod tests {
     fn classify_reply_response_is_stored() {
         let tx = dummy_tx();
         let key = dummy_key();
-        let msg = NetMessage::V1(NetMessageV1::Put(PutMsg::Response { id: tx, key }));
+        let msg = NetMessage::V1(NetMessageV1::Put(PutMsg::Response {
+            id: tx,
+            key,
+            hop_count: 0,
+        }));
         assert!(matches!(classify_reply(&msg), ReplyClass::Stored { .. }));
     }
 
@@ -1913,8 +2011,65 @@ mod tests {
             id: tx,
             key,
             continue_forwarding: false,
+            hop_count: 0,
         }));
         assert!(matches!(classify_reply(&msg), ReplyClass::Stored { .. }));
+    }
+
+    /// Regression pin: `classify_reply` MUST extract the wire-carried
+    /// `hop_count` from `Response`/`ResponseStreaming` and propagate it
+    /// (via the bubble-up call site immediately following the classifier)
+    /// into the upstream Response unchanged.  Mirrors the GET classifier
+    /// pin `classify_response_found_preserves_hop_count`.  Since
+    /// `ReplyClass::Stored` itself doesn't carry the hop_count
+    /// (the bubble-up grabs the field directly from the matched message),
+    /// this test pins the classifier *and* the matcher contract by
+    /// destructuring the message and asserting the field survives
+    /// classification — that is, classify_reply doesn't conditionally
+    /// reject Stored on hop_count = 0 or any other value.
+    #[test]
+    fn classify_reply_preserves_hop_count_for_stored() {
+        for hc in [0_usize, 1, 4, 10, 64] {
+            let tx = dummy_tx();
+            let key = dummy_key();
+            // Response variant
+            let msg = NetMessage::V1(NetMessageV1::Put(PutMsg::Response {
+                id: tx,
+                key,
+                hop_count: hc,
+            }));
+            assert!(
+                matches!(classify_reply(&msg), ReplyClass::Stored { .. }),
+                "Response with hop_count={hc} must classify as Stored"
+            );
+            // Destructure to assert the field is preserved on the
+            // message itself — the bubble-up reads it directly here.
+            match msg {
+                NetMessage::V1(NetMessageV1::Put(PutMsg::Response { hop_count: got, .. })) => {
+                    assert_eq!(got, hc, "Response.hop_count preserved ({hc})")
+                }
+                _ => unreachable!(),
+            }
+
+            // ResponseStreaming variant
+            let msg = NetMessage::V1(NetMessageV1::Put(PutMsg::ResponseStreaming {
+                id: tx,
+                key,
+                continue_forwarding: false,
+                hop_count: hc,
+            }));
+            assert!(
+                matches!(classify_reply(&msg), ReplyClass::Stored { .. }),
+                "ResponseStreaming with hop_count={hc} must classify as Stored"
+            );
+            match msg {
+                NetMessage::V1(NetMessageV1::Put(PutMsg::ResponseStreaming {
+                    hop_count: got,
+                    ..
+                })) => assert_eq!(got, hc, "ResponseStreaming.hop_count preserved ({hc})"),
+                _ => unreachable!(),
+            }
+        }
     }
 
     #[test]
@@ -2873,10 +3028,11 @@ mod tests {
         let pos = b
             .find("downstream reply timed out")
             .expect("timeout arm not found");
-        // Window widened from 400 → 800 bytes to accommodate the
+        // Window widened from 400 → 800 → 1200 bytes to accommodate the
         // record_relay_route_event hook inserted between the timeout
-        // log and the bubble-Response call.
-        let arm = &b[pos..pos + 800.min(b.len() - pos)];
+        // log and the bubble-Response call, plus the multi-line
+        // hop_count computation + multi-line call site added in #4248.
+        let arm = &b[pos..pos + 1200.min(b.len() - pos)];
         assert!(
             arm.contains("relay_put_send_response"),
             "timeout arm must still call relay_put_send_response so the \

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -702,6 +702,26 @@ mod messages {
             id: Transaction,
             instance_id: ContractInstanceId,
             result: SubscribeMsgResult,
+            /// Forward-path hop count: how many hops the originating Request
+            /// traversed before reaching the node that produced this Response
+            /// (the hosting peer for `Subscribed`, or the relay that reported
+            /// exhaustion / no-candidates / forward-failure for `NotFound`).
+            ///
+            /// Computed as `max_hops_to_live - htl_at_responder`. The relay
+            /// chain preserves this value as the Response bubbles back to the
+            /// originator — it does NOT increment on the return path. For
+            /// `NotFound`, treat this as the depth at which exhaustion
+            /// occurred, not depth-to-the-contract.
+            ///
+            /// `#[serde(default)]` is set for source-level clarity. Bincode
+            /// does not honour serde defaults (positional encoding), so wire
+            /// compat with peers that lack this field is handled at the
+            /// handshake layer via `MIN_COMPATIBLE_VERSION`.
+            ///
+            /// Mirror of `GetMsg::Response.hop_count` (PR #4245); see also
+            /// `PutMsg::Response.hop_count`.
+            #[serde(default)]
+            hop_count: usize,
         },
         /// Explicit unsubscribe notification sent upstream for fast cleanup.
         /// Fire-and-forget: does not require a response or existing operation state.

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1132,10 +1132,17 @@ pub(crate) async fn start_relay_subscribe(
         // does not touch the winning driver's `pending_op_results`
         // slot (that slot is keyed on the attempt_tx the WINNER
         // forwarded downstream, not on `incoming_tx` at this node).
+        // Forward depth at this dedup-rejecting node = max_htl - htl.
+        // The winning in-flight driver will report its own (possibly
+        // deeper) hop_count to upstream — but for this rejected duplicate
+        // path the upstream sees this node's depth, which is correct from
+        // the duplicate's perspective.
+        let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
         let response = NetMessage::from(SubscribeMsg::Response {
             id: incoming_tx,
             instance_id,
             result: SubscribeMsgResult::NotFound,
+            hop_count,
         });
         let mut ctx = op_manager.op_ctx(incoming_tx);
         if let Err(err) = ctx.send_fire_and_forget(upstream_addr, response).await {
@@ -1322,12 +1329,16 @@ async fn drive_relay_subscribe(
             phase = "relay_subscribe_local_hit",
             "SUBSCRIBE relay: fulfilled locally, sending Response"
         );
+        // Local-hit storer arm: this node hosts the contract.
+        // hop_count = max_htl - htl_we_received.
+        let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
         return relay_subscribe_send_response(
             op_manager,
             incoming_tx,
             instance_id,
             SubscribeMsgResult::Subscribed { key },
             upstream_addr,
+            hop_count,
         )
         .await;
     }
@@ -1341,11 +1352,14 @@ async fn drive_relay_subscribe(
             phase = "relay_subscribe_not_found",
             "SUBSCRIBE relay: HTL exhausted"
         );
+        // HTL=0 path: the request traversed the full max_htl forward hops
+        // to reach us. hop_count = max_htl - 0 = max_htl.
+        let hop_count = op_manager.ring.max_hops_to_live;
         if let Some(event) = crate::tracing::NetEventLog::subscribe_not_found(
             &incoming_tx,
             &op_manager.ring,
             instance_id,
-            Some(op_manager.ring.max_hops_to_live),
+            Some(hop_count),
         ) {
             op_manager
                 .ring
@@ -1358,6 +1372,7 @@ async fn drive_relay_subscribe(
             instance_id,
             SubscribeMsgResult::NotFound,
             upstream_addr,
+            hop_count,
         )
         .await;
     }
@@ -1381,11 +1396,15 @@ async fn drive_relay_subscribe(
             phase = "relay_subscribe_not_found",
             "SUBSCRIBE relay: no closer peers to forward"
         );
+        // No-candidates exhaustion: this relay is reporting its own
+        // exhaustion of downstream candidates. hop_count = max_htl - htl
+        // (the forward depth of THIS relay).
+        let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
         if let Some(event) = crate::tracing::NetEventLog::subscribe_not_found(
             &incoming_tx,
             &op_manager.ring,
             instance_id,
-            None,
+            Some(hop_count),
         ) {
             op_manager
                 .ring
@@ -1398,6 +1417,7 @@ async fn drive_relay_subscribe(
             instance_id,
             SubscribeMsgResult::NotFound,
             upstream_addr,
+            hop_count,
         )
         .await;
     }
@@ -1412,12 +1432,15 @@ async fn drive_relay_subscribe(
                 target_pub_key = %next_hop.pub_key(),
                 "SUBSCRIBE relay: next hop has no socket address"
             );
+            // Forward-failure at THIS relay; same depth as no-candidates.
+            let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
             return relay_subscribe_send_response(
                 op_manager,
                 incoming_tx,
                 instance_id,
                 SubscribeMsgResult::NotFound,
                 upstream_addr,
+                hop_count,
             )
             .await;
         }
@@ -1483,12 +1506,15 @@ async fn drive_relay_subscribe(
                 crate::router::RouteOutcome::Failure,
                 crate::node::network_status::OpType::Subscribe,
             );
+            // Forward failure at THIS relay: report our own depth.
+            let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
             return relay_subscribe_send_response(
                 op_manager,
                 incoming_tx,
                 instance_id,
                 SubscribeMsgResult::NotFound,
                 upstream_addr,
+                hop_count,
             )
             .await;
         }
@@ -1507,12 +1533,15 @@ async fn drive_relay_subscribe(
                 crate::router::RouteOutcome::Failure,
                 crate::node::network_status::OpType::Subscribe,
             );
+            // Same as send-failure arm.
+            let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
             return relay_subscribe_send_response(
                 op_manager,
                 incoming_tx,
                 instance_id,
                 SubscribeMsgResult::NotFound,
                 upstream_addr,
+                hop_count,
             )
             .await;
         }
@@ -1523,9 +1552,16 @@ async fn drive_relay_subscribe(
     // Feed the relay's downstream-peer choice into the local Router so
     // future routing decisions are informed by relay-observed outcomes
     // (see operations.rs::record_relay_route_event).
-    let result = match reply {
+    //
+    // `bubble_hop_count` is the wire `hop_count` to forward upstream:
+    // - downstream Subscribed/NotFound: preserve the downstream's value
+    //   (relays do NOT increment on the return path);
+    // - unexpected variant: fall back to this relay's own depth
+    //   (`max_htl - htl`) — we know nothing about what produced `other`.
+    let (result, bubble_hop_count) = match reply {
         NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Response {
             result: SubscribeMsgResult::Subscribed { key },
+            hop_count: downstream_hop_count,
             ..
         })) => {
             // Relay-side Subscribed registration — mirror legacy
@@ -1558,10 +1594,11 @@ async fn drive_relay_subscribe(
                 crate::router::RouteOutcome::SuccessUntimed,
                 crate::node::network_status::OpType::Subscribe,
             );
-            SubscribeMsgResult::Subscribed { key }
+            (SubscribeMsgResult::Subscribed { key }, downstream_hop_count)
         }
         NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Response {
             result: SubscribeMsgResult::NotFound,
+            hop_count: downstream_hop_count,
             ..
         })) => {
             // Downstream peer correctly answered NotFound. The peer
@@ -1581,7 +1618,7 @@ async fn drive_relay_subscribe(
                 crate::router::RouteOutcome::SuccessUntimed,
                 crate::node::network_status::OpType::Subscribe,
             );
-            SubscribeMsgResult::NotFound
+            (SubscribeMsgResult::NotFound, downstream_hop_count)
         }
         other => {
             // Unexpected reply variant: unclear whether it's a local
@@ -1593,26 +1630,45 @@ async fn drive_relay_subscribe(
                 reply_variant = ?std::mem::discriminant(&other),
                 "SUBSCRIBE relay: unexpected reply variant; treating as NotFound"
             );
-            SubscribeMsgResult::NotFound
+            let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
+            (SubscribeMsgResult::NotFound, hop_count)
         }
     };
 
-    relay_subscribe_send_response(op_manager, incoming_tx, instance_id, result, upstream_addr).await
+    relay_subscribe_send_response(
+        op_manager,
+        incoming_tx,
+        instance_id,
+        result,
+        upstream_addr,
+        bubble_hop_count,
+    )
+    .await
 }
 
 /// Send `SubscribeMsg::Response` upstream (fire-and-forget: upstream
 /// relay awaits via its own `send_to_and_await`, no reply expected).
+///
+/// `hop_count` is the forward-path depth to embed in the Response. For a
+/// relay that fulfilled locally (this node hosts the contract), pass
+/// `max_htl - incoming_htl`. For an HTL-exhaustion / no-candidates /
+/// forward-failure relay, pass that same `max_htl - incoming_htl` (it's
+/// the depth at which this relay reported the failure). For a relay
+/// bubbling a downstream Response upstream, pass the downstream's
+/// `hop_count` verbatim — relays do NOT increment on the return path.
 async fn relay_subscribe_send_response(
     op_manager: &OpManager,
     incoming_tx: Transaction,
     instance_id: ContractInstanceId,
     result: SubscribeMsgResult,
     upstream_addr: std::net::SocketAddr,
+    hop_count: usize,
 ) -> Result<(), OpError> {
     let response = NetMessage::from(SubscribeMsg::Response {
         id: incoming_tx,
         instance_id,
         result,
+        hop_count,
     });
     let mut ctx = op_manager.op_ctx(incoming_tx);
     ctx.send_fire_and_forget(upstream_addr, response).await
@@ -1640,6 +1696,7 @@ mod tests {
             id: tx,
             instance_id: *key.id(),
             result: SubscribeMsgResult::Subscribed { key },
+            hop_count: 0,
         }));
         match classify_reply(&msg) {
             ReplyClass::Subscribed { key: got } => assert_eq!(got, key),
@@ -1657,8 +1714,72 @@ mod tests {
             id: tx,
             instance_id,
             result: SubscribeMsgResult::NotFound,
+            hop_count: 0,
         }));
         assert!(matches!(classify_reply(&msg), ReplyClass::NotFound));
+    }
+
+    /// Regression pin: the SUBSCRIBE bubble-up path MUST preserve the
+    /// wire-carried `hop_count` from the downstream Response unchanged.
+    /// A regression that synthesised 0 here (or dropped the field) would
+    /// silently collapse the storer's forward-path depth at every relay,
+    /// defeating the whole PR.  The bincode-roundtrip test in
+    /// `subscribe/tests.rs` catches the wire format only; this pin tests
+    /// that destructuring the message keeps the field intact and that the
+    /// classifier doesn't conditionally reject based on `hop_count`.
+    #[test]
+    fn classify_reply_preserves_hop_count_subscribed() {
+        use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([3u8; 32]),
+            CodeHash::new([4u8; 32]),
+        );
+        for hc in [0_usize, 1, 4, 10, 64] {
+            let tx = fresh_tx();
+            let msg = NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Response {
+                id: tx,
+                instance_id: *key.id(),
+                result: SubscribeMsgResult::Subscribed { key },
+                hop_count: hc,
+            }));
+            assert!(
+                matches!(classify_reply(&msg), ReplyClass::Subscribed { .. }),
+                "Subscribed with hop_count={hc} must still classify"
+            );
+            // Destructure the message to assert the field was preserved.
+            match msg {
+                NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Response {
+                    hop_count: got,
+                    ..
+                })) => assert_eq!(got, hc, "Subscribed hop_count preserved ({hc})"),
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    #[test]
+    fn classify_reply_preserves_hop_count_not_found() {
+        let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([4u8; 32]);
+        for hc in [0_usize, 1, 4, 10, 64] {
+            let tx = fresh_tx();
+            let msg = NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Response {
+                id: tx,
+                instance_id,
+                result: SubscribeMsgResult::NotFound,
+                hop_count: hc,
+            }));
+            assert!(
+                matches!(classify_reply(&msg), ReplyClass::NotFound),
+                "NotFound with hop_count={hc} must still classify"
+            );
+            match msg {
+                NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Response {
+                    hop_count: got,
+                    ..
+                })) => assert_eq!(got, hc, "NotFound hop_count preserved ({hc})"),
+                _ => unreachable!(),
+            }
+        }
     }
 
     #[test]

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -392,3 +392,75 @@ fn subscribe_forwarding_ack_serde_roundtrip() {
         }
     }
 }
+
+/// Regression test: `SubscribeMsg::Response.hop_count` roundtrips through
+/// bincode for both `Subscribed` and `NotFound` result variants.
+///
+/// Before #4248 the SUBSCRIBE telemetry path emitted `hop_count: None` at
+/// every terminal SUBSCRIBE event (`SubscribeSuccess`, `SubscribeNotFound`)
+/// because no value was being threaded through the wire.  The fix carries
+/// the field on `SubscribeMsg::Response` so the originator has it when
+/// constructing the log event.  This test asserts that the new field
+/// survives round-trip serialisation for both result variants — i.e., the
+/// wire format actually carries it.
+///
+/// bincode-positional caveat: any future positional change here will
+/// break older binaries; see the `MIN_COMPATIBLE_VERSION` bump that
+/// accompanies this PR.
+#[test]
+fn test_subscribe_msg_response_hop_count_roundtrip() {
+    use freenet_stdlib::prelude::{CodeHash, ContractKey};
+    let key =
+        ContractKey::from_id_and_code(ContractInstanceId::new([7u8; 32]), CodeHash::new([8u8; 32]));
+    let instance_id = *key.id();
+    let cases: &[(&str, usize)] = &[
+        ("zero", 0),
+        ("one", 1),
+        ("mid", 4),
+        ("htl", 10),
+        ("large", 64),
+    ];
+    for (label, hop_count) in cases.iter().copied() {
+        // Subscribed variant
+        let subscribed = SubscribeMsg::Response {
+            id: Transaction::new::<SubscribeMsg>(),
+            instance_id,
+            result: SubscribeMsgResult::Subscribed { key },
+            hop_count,
+        };
+        let bytes = bincode::serialize(&subscribed).expect(label);
+        let restored: SubscribeMsg = bincode::deserialize(&bytes).expect(label);
+        match restored {
+            SubscribeMsg::Response { hop_count: hc, .. } => assert_eq!(
+                hc, hop_count,
+                "Subscribed Response.hop_count must roundtrip ({label})"
+            ),
+            SubscribeMsg::Request { .. }
+            | SubscribeMsg::Unsubscribe { .. }
+            | SubscribeMsg::ForwardingAck { .. } => {
+                panic!("expected Response for {label}")
+            }
+        }
+
+        // NotFound variant
+        let notfound = SubscribeMsg::Response {
+            id: Transaction::new::<SubscribeMsg>(),
+            instance_id,
+            result: SubscribeMsgResult::NotFound,
+            hop_count,
+        };
+        let bytes = bincode::serialize(&notfound).expect(label);
+        let restored: SubscribeMsg = bincode::deserialize(&bytes).expect(label);
+        match restored {
+            SubscribeMsg::Response { hop_count: hc, .. } => assert_eq!(
+                hc, hop_count,
+                "NotFound Response.hop_count must roundtrip ({label})"
+            ),
+            SubscribeMsg::Request { .. }
+            | SubscribeMsg::Unsubscribe { .. }
+            | SubscribeMsg::ForwardingAck { .. } => {
+                panic!("expected Response for {label}")
+            }
+        }
+    }
+}

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -1115,7 +1115,7 @@ impl<'a> NetEventLog<'a> {
                     initiated_by: Some(peer_id.clone()), // We (the joiner) initiated
                 })
             }
-            NetMessage::V1(NetMessageV1::Put(PutMsg::Response { id, key })) => {
+            NetMessage::V1(NetMessageV1::Put(PutMsg::Response { id, key, .. })) => {
                 // Track outbound Put response for message routing visibility
                 let to = target_addr
                     .and_then(|addr| ring.connection_manager.get_peer_by_addr(addr))
@@ -1265,18 +1265,20 @@ impl<'a> NetEventLog<'a> {
                     timestamp: chrono::Utc::now().timestamp() as u64,
                 })
             }
-            NetMessageV1::Put(PutMsg::Response { id, key }) => {
+            NetMessageV1::Put(PutMsg::Response { id, key, hop_count }) => {
                 let this_peer = &op_manager.ring.connection_manager.own_location();
-                // Calculate hop_count from operation state: max_htl - current_htl
-                let hop_count = op_manager.get_current_hop(id).map(|current_htl| {
-                    op_manager.ring.max_hops_to_live.saturating_sub(current_htl)
-                });
+                // hop_count is carried on the wire Response: set by the storer
+                // (max_htl - htl_at_storer) and preserved by relays bubbling up.
+                // Clamp to ring.max_hops_to_live so a malicious or buggy peer
+                // sending hop_count = usize::MAX can't pollute telemetry.
+                // Mirrors the GET extraction logic (PR #4245).
+                let max_htl = op_manager.ring.max_hops_to_live;
                 EventKind::Put(PutEvent::PutSuccess {
                     id: *id,
                     requester: this_peer.clone(),
                     target: this_peer.clone(),
                     key: *key,
-                    hop_count,
+                    hop_count: Some((*hop_count).min(max_htl)),
                     elapsed_ms: id.elapsed().as_millis() as u64,
                     timestamp: chrono::Utc::now().timestamp() as u64,
                     state_hash: None, // Hash not available from message
@@ -1372,14 +1374,21 @@ impl<'a> NetEventLog<'a> {
             NetMessageV1::Subscribe(SubscribeMsg::Response {
                 id,
                 result: SubscribeMsgResult::Subscribed { key },
+                hop_count,
                 ..
             }) => {
                 let this_peer = op_manager.ring.connection_manager.own_location();
+                // hop_count is carried on the wire Response: set by the
+                // hosting peer (max_htl - htl_at_storer) and preserved by
+                // relays bubbling up.  Clamp to ring.max_hops_to_live so
+                // a malicious or buggy peer sending hop_count = usize::MAX
+                // can't pollute telemetry.  Mirrors GET (PR #4245).
+                let max_htl = op_manager.ring.max_hops_to_live;
                 EventKind::Subscribe(SubscribeEvent::SubscribeSuccess {
                     id: *id,
                     key: *key,
                     at: this_peer.clone(),
-                    hop_count: None, // TODO: Track hop count from operation state
+                    hop_count: Some((*hop_count).min(max_htl)),
                     elapsed_ms: id.elapsed().as_millis() as u64,
                     timestamp: chrono::Utc::now().timestamp() as u64,
                     requester: this_peer,
@@ -1389,14 +1398,28 @@ impl<'a> NetEventLog<'a> {
                 id,
                 instance_id,
                 result: SubscribeMsgResult::NotFound,
+                hop_count,
             }) => {
                 let this_peer = op_manager.ring.connection_manager.own_location();
+                // hop_count is carried on the wire Response (same semantics
+                // as SubscribeSuccess: forward-path depth from originator
+                // to the node that produced the response).
+                //
+                // Caveat for NotFound interpretation: the value is the
+                // forward depth of *the relay that produced the NotFound*
+                // (HTL exhaustion, no candidates, or downstream forward
+                // failure).  For analytics, treat NotFound hop_count as
+                // "exhaustion depth", not "depth to the hosting peer".
+                //
+                // Same clamp as SubscribeSuccess: bound by max_hops_to_live
+                // to guard against malicious or buggy peer values.
+                let max_htl = op_manager.ring.max_hops_to_live;
                 EventKind::Subscribe(SubscribeEvent::SubscribeNotFound {
                     id: *id,
                     requester: this_peer.clone(),
                     instance_id: *instance_id,
                     target: this_peer,
-                    hop_count: None, // TODO: Track hop count from operation state
+                    hop_count: Some((*hop_count).min(max_htl)),
                     elapsed_ms: id.elapsed().as_millis() as u64,
                     timestamp: chrono::Utc::now().timestamp() as u64,
                 })
@@ -2944,16 +2967,24 @@ impl EventKind {
 
     /// Returns the `hop_count` recorded in this event, if any.
     ///
-    /// Currently populated for terminal GET events (`GetSuccess`, `GetNotFound`,
-    /// `GetFailure`). The value is the number of hops the GET request traversed
-    /// before reaching its terminal state. Returns `None` for non-terminal GET
-    /// events (e.g. `Request`) and for all non-GET events.
+    /// Populated for terminal GET events (`GetSuccess`, `GetNotFound`,
+    /// `GetFailure`) since PR #4245, and for terminal PUT/SUBSCRIBE
+    /// events (`PutSuccess`, `SubscribeSuccess`, `SubscribeNotFound`)
+    /// since PR #4248.  The value is the number of forward hops the
+    /// originating request traversed before reaching its terminal state.
+    /// Returns `None` for non-terminal events (e.g. `Request`) and for
+    /// events that don't carry a hop_count field.
     #[allow(clippy::wildcard_enum_match_arm)]
     pub fn hop_count(&self) -> Option<usize> {
         match self {
             EventKind::Get(GetEvent::GetSuccess { hop_count, .. })
             | EventKind::Get(GetEvent::GetNotFound { hop_count, .. })
-            | EventKind::Get(GetEvent::GetFailure { hop_count, .. }) => *hop_count,
+            | EventKind::Get(GetEvent::GetFailure { hop_count, .. })
+            | EventKind::Put(PutEvent::PutSuccess { hop_count, .. })
+            | EventKind::Subscribe(SubscribeEvent::SubscribeSuccess { hop_count, .. })
+            | EventKind::Subscribe(SubscribeEvent::SubscribeNotFound { hop_count, .. }) => {
+                *hop_count
+            }
             _ => None,
         }
     }

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -14,12 +14,12 @@ readme = "README.md"
 # (v0.2.x), so we embed the matching freenet version literally — `v{ version }`
 # would expand to the fdev crate version and 404. release.yml rewrites the
 # `vX.Y.Z` segment whenever the freenet version is bumped (issue #3995).
-pkg-url = "{ repo }/releases/download/v0.2.63/fdev-{ target }.tar.gz"
+pkg-url = "{ repo }/releases/download/v0.2.64/fdev-{ target }.tar.gz"
 pkg-fmt = "tgz"
 bin-dir = "fdev"
 
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
-pkg-url = "{ repo }/releases/download/v0.2.63/fdev-{ target }.zip"
+pkg-url = "{ repo }/releases/download/v0.2.64/fdev-{ target }.zip"
 pkg-fmt = "zip"
 bin-dir = "fdev.exe"
 
@@ -56,7 +56,7 @@ ed25519-dalek = { version = "2", features = ["rand_core", "serde"] }
 hex = { workspace = true }
 
 # internal
-freenet = { path = "../core", version = "0.2.63", features = ["testing"] }
+freenet = { path = "../core", version = "0.2.64", features = ["testing"] }
 freenet-stdlib = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Mirrors the wire-format fix that PR #4245 applied to GET: threads `hop_count` through `PutMsg::Response`, `PutMsg::ResponseStreaming`, and `SubscribeMsg::Response` so the originator has a populated value when constructing `PutSuccess`, `SubscribeSuccess`, and `SubscribeNotFound` log events.

Before this change those terminal events called the `op_manager.get_current_hop(id)` stub, which always returned `None` because the op has been cleaned up by the time the response is logged. After this change the value is set at the storer / exhaustion-relay (`max_htl - htl`) and preserved verbatim by relays bubbling upstream (no return-path increment).

Closes #4248.

## Scope

**Single PR for PUT + SUBSCRIBE** so they share the version bump and review surface.

- PUT terminal events: `PutSuccess` (from `PutMsg::Response` and `PutMsg::ResponseStreaming`).
- SUBSCRIBE terminal events: `SubscribeSuccess` and `SubscribeNotFound` (from `SubscribeMsg::Response` with `Subscribed` / `NotFound` results).
- UPDATE is **out of scope** (see [issue #4248 first comment](https://github.com/freenet/freenet-core/issues/4248#issuecomment-4537092450)): no `Response` message, no `htl` on requests, fan-out rather than HTL routing — needs its own design discussion, not a mirror of the GET pattern.

## Wire-format changes

- Add positional `hop_count: usize` to `PutMsg::Response`, `PutMsg::ResponseStreaming`, and `SubscribeMsg::Response` (single variant with `Subscribed`/`NotFound` results).
- All storer / HTL-exhaustion / no-candidates / forward-failure / dedup-reject sites populate it as `max_htl - htl` (or `max_htl` on HTL=0 exhaustion).
- All relay bubble-up sites preserve the downstream's value verbatim (relays do NOT increment on the return path).
- `ResponseStreaming` is currently downgraded to non-streaming at the relay (slice A limitation), but the field is added for wire-format symmetry so any future streaming-passthrough path can populate it without another wire bump.

## Wire-format compatibility

Same approach as #4245: adds positional fields to bincode-serialized types. Bincode does not honour `#[serde(default)]` for positional encoding, so cross-version compatibility is gated by `MIN_COMPATIBLE_VERSION` at the handshake layer.

- Bumps `crates/core/Cargo.toml` `version` and `min-compatible-version` both `0.2.63` → `0.2.64`.
- Bumps `crates/fdev/Cargo.toml` freenet path dep + both binstall URLs (`v0.2.63` → `v0.2.64`). Enforced at PR time by `pkg_url_embeds_freenet_release_tag` (verified locally).

## Stub removal

Once PUT migrates, `op_state_manager::get_current_hop` has no remaining callers — it always returned `None` and was the root cause of the bug. This PR deletes the stub. Verified with `grep -rn 'get_current_hop' crates/core/src/`: only doc-comment references describing historical context remain.

## Tests

- `test_put_msg_response_hop_count_roundtrip` (new, `put.rs`) — asserts the new field roundtrips through bincode for `Response` and `ResponseStreaming` across values `{0, 1, 4, 10, 64}`.
- `test_subscribe_msg_response_hop_count_roundtrip` (new, `subscribe/tests.rs`) — same shape for `Subscribed` and `NotFound` results.
- `classify_reply_preserves_hop_count_for_stored` (new, `put/op_ctx_task.rs`) — pins that the PUT classifier + bubble-up matcher preserves the wire-carried value unchanged. Mirrors GET's `classify_response_found_preserves_hop_count`.
- `classify_reply_preserves_hop_count_subscribed` / `_not_found` (new, `subscribe/op_ctx_task.rs`) — same shape for SUBSCRIBE.
- Existing PUT/SUBSCRIBE/GET unit tests still pass (2603 lib tests, 16 binstall metadata tests).
- One pre-existing structural-pin test (`drive_relay_put_streaming_timeout_bubbles_response`) had its scan window widened from 800 → 1200 chars to accommodate the multi-line hop_count computation + call-site expansion.

## Defence-in-depth

- Tracing-layer extraction clamps peer-supplied `hop_count` to `op_manager.ring.max_hops_to_live` at all three new sites (`PutSuccess`, `SubscribeSuccess`, `SubscribeNotFound`). Matches GET's clamp from #4245.

## Test plan

- [x] `cargo build -p freenet --features testing --tests` clean
- [x] `cargo test -p freenet --features testing --lib` — 2603 passed, 14 ignored, 0 failed
- [x] `cargo test -p fdev --test binstall_metadata` — 16 passed
- [x] `cargo fmt --all`, `cargo clippy --tests` — no new warnings beyond the pre-existing one carried over from #4245
- [ ] Full multi-perspective review (wire-format = high-risk)
- [ ] CI green on the merge HEAD before auto-merge

## Review history

This PR will go through a Full multi-perspective review per the wire-format-high-risk rule. The pattern is mechanical mirror of #4245; expected review surface is the storer/relay/exhaustion threading correctness on the new ops (the GET review already established the abstract pattern).

[AI-assisted - Claude]