### PR TITLE
fix(ci): bump cross-compile toolchain to 1.94.0 to match rust-toolchain.toml

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.94.0
           targets: x86_64-unknown-linux-musl
 
       - uses: Swatinem/rust-cache@v2
@@ -60,7 +60,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.94.0
           targets: aarch64-unknown-linux-musl
 
       - uses: Swatinem/rust-cache@v2
@@ -97,7 +97,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.94.0
 
       - uses: Swatinem/rust-cache@v2
 
@@ -142,7 +142,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.94.0
           targets: x86_64-apple-darwin
 
       - uses: Swatinem/rust-cache@v2
@@ -187,7 +187,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.94.0
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
## Problem

PR #4246 (hickory-resolver/sqlx CVE upgrade) bumped `rust-toolchain.toml` from 1.93.0 to 1.94.0 but didn't update the matching pins in `.github/workflows/cross-compile.yml`. cross-compile.yml only runs on push-to-main and tags (skipped on PRs to save CI cost), so the regression slipped through #4246's CI silently and first surfaced when the v0.2.64 tag-push triggered cross-compile — all five build jobs failed with:

```
error[E0463]: can't find crate for `std`
  = note: the `x86_64-apple-darwin` target may not be installed
```

`dtolnay/rust-toolchain` installed 1.93.0 with the target, but cargo activated 1.94.0 per `rust-toolchain.toml` and found no target for that toolchain.

## Fix

Bump all five `toolchain: 1.93.0` references in cross-compile.yml to `1.94.0` so the target install applies to the same toolchain cargo will use.

## Recovery

The v0.2.64 release is currently in DRAFT state with no binaries attached. After this lands, the v0.2.64 tag will be force-moved to the post-fix commit on main and re-pushed, which retriggers cross-compile (now with the toolchain fix). The freenet/fdev crate source code is byte-identical between the original v0.2.64 commit and the post-fix HEAD (the diff is workflow-only), so the binaries shipped will be functionally identical to what crates.io has at 0.2.64. The release update mechanism (\`freenet update\` via \`/releases/latest\` API + \`browser_download_url\`; gateway-update.yml via \`release.tag_name\`) doesn't reference the commit SHA the tag points to, so the re-tag is transparent to the cascade.

## Follow-up to prevent recurrence

Worth a tracking issue: cross-compile.yml's PR-skip means toolchain bumps to rust-toolchain.toml that break the cross-compile aren't caught until the next release. Options to consider in a follow-up:
- Add cross-compile.yml to PR triggers (CI cost increase but catches the class).
- Add a lightweight syntactic check that the workflow pin matches rust-toolchain.toml.
- Read the toolchain version dynamically from rust-toolchain.toml instead of pinning in the workflow.

[AI-assisted - Claude]