### PR TITLE
fix(node): downgrade try_send Full WARN to DEBUG (#4238)

### DIFF
--- a/crates/core/src/contract/executor/mock_runtime.rs
+++ b/crates/core/src/contract/executor/mock_runtime.rs
@@ -260,7 +260,11 @@ where
                 key,
                 new_state: state.clone(),
             }) {
-                tracing::warn!(
+                // Best-effort by design (mirrors the production
+                // executor; see runtime.rs for the #4145 / #4238
+                // rationale). Per-occurrence WARN here would re-
+                // introduce the spam at the caller layer.
+                tracing::debug!(
                     contract = %key,
                     error = %err,
                     "MockRuntime: Failed to broadcast state change (best-effort)"

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -2183,7 +2183,16 @@ where
                     new_state: new_state.clone(),
                 })
             {
-                tracing::warn!(
+                // Best-effort by design (see comment block above and
+                // #4145): a missed broadcast heals via the next UPDATE
+                // or summary-mismatch SyncStateToPeer round. Per-
+                // occurrence WARN here flooded gateways under fan-out
+                // at the same rate as the helper-internal log it
+                // mirrored (#4238). The rate-limited `notify_node_event:
+                // Notification channel full for too long` ERROR in
+                // op_state_manager.rs is the sustained-back-pressure
+                // alert operators should grep for.
+                tracing::debug!(
                     contract = %key,
                     error = %err,
                     "Failed to broadcast state change to network peers (best-effort)"
@@ -2520,7 +2529,11 @@ where
                     new_state,
                 })
             {
-                tracing::warn!(
+                // Best-effort by design — see #4145 and the sibling
+                // commit path above. Per-occurrence WARN here re-
+                // introduced the #4238 spam at the caller layer even
+                // after the helper-internal downgrade.
+                tracing::debug!(
                     contract = %key,
                     error = %err,
                     "Failed to broadcast state change to network peers (best-effort)"

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1307,7 +1307,11 @@ where
                         new_state: state,
                         target: source,
                     }) {
-                        tracing::warn!(
+                        // Best-effort by design (see comment above);
+                        // log at debug to keep the caller layer in
+                        // step with the helper-internal downgrade
+                        // (#4238).
+                        tracing::debug!(
                             contract = %instance_id,
                             error = %e,
                             "Failed to emit SyncStateToPeer for proximity sync (best-effort)"
@@ -1564,7 +1568,10 @@ async fn handle_interest_sync_message(
                     new_state: state,
                     target: source,
                 }) {
-                    tracing::warn!(
+                    // Best-effort by design (see comment above); log
+                    // at debug to keep the caller layer in step with
+                    // the helper-internal downgrade (#4238).
+                    tracing::debug!(
                         contract = %contract,
                         error = %e,
                         "Failed to emit SyncStateToPeer for stale peer correction (best-effort)"

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1018,7 +1018,14 @@ fn notify_transaction_timeout(
     {
         Ok(()) => true,
         Err(mpsc::error::TrySendError::Full(_)) => {
-            tracing::warn!(
+            // Benign back-pressure on the same event-loop notification
+            // channel as the two `try_*` helpers above: the GC sweep
+            // already removed the tx from the ops maps; this
+            // notification only lets the event loop clean up its
+            // `tx_to_client` map, so dropping it is tolerated. Per-
+            // occurrence WARN here would re-introduce the #4238 spam
+            // class during sustained back-pressure.
+            tracing::debug!(
                 tx = %tx,
                 "Notification channel full, skipping timeout notification for event loop"
             );
@@ -2004,6 +2011,73 @@ mod tests {
 
         assert!(
             logger.contains("try_notify_node_event: event-loop notification channel closed"),
+            "Closed arm must still emit WARN; captured: {:?}",
+            logger.logs()
+        );
+    }
+
+    #[tokio::test]
+    async fn notify_transaction_timeout_full_does_not_emit_warn() {
+        // #4238 sibling pin: `notify_transaction_timeout` writes to
+        // the same event-loop notification channel as the two
+        // `try_*` helpers and is called once per timed-out tx by the
+        // GC sweep. Pre-fix it emitted WARN on every Full event;
+        // post-fix it must be DEBUG so a WARN-level subscriber sees
+        // nothing under sustained back-pressure.
+        let logger = crate::test_utils::TestLogger::new()
+            .with_level("warn")
+            .capture_logs()
+            .init();
+
+        let (_receiver, notifier) = event_loop_notification_channel();
+
+        let filler_tx = Transaction::ttl_transaction();
+        let mut pre_filled = 0usize;
+        loop {
+            match notifier
+                .notifications_sender()
+                .try_send(Either::Right(NodeEvent::TransactionCompleted(filler_tx)))
+            {
+                Ok(()) => pre_filled += 1,
+                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => break,
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                    panic!("channel unexpectedly closed while pre-filling")
+                }
+            }
+            if pre_filled > 4096 {
+                panic!("channel did not backpressure after 4096 entries");
+            }
+        }
+
+        let tx = Transaction::ttl_transaction();
+        let delivered = super::notify_transaction_timeout(&notifier, tx);
+        assert!(!delivered, "helper must return false on a full channel");
+
+        assert!(
+            !logger.contains("Notification channel full, skipping timeout notification"),
+            "notify_transaction_timeout Full arm must not emit WARN \
+             (would re-introduce #4238 spam from the GC-sweep path); \
+             captured: {:?}",
+            logger.logs()
+        );
+    }
+
+    #[tokio::test]
+    async fn notify_transaction_timeout_closed_still_emits_warn() {
+        let logger = crate::test_utils::TestLogger::new()
+            .with_level("warn")
+            .capture_logs()
+            .init();
+
+        let (receiver, notifier) = event_loop_notification_channel();
+        drop(receiver);
+
+        let tx = Transaction::ttl_transaction();
+        let delivered = super::notify_transaction_timeout(&notifier, tx);
+        assert!(!delivered, "helper must return false on a closed channel");
+
+        assert!(
+            logger.contains("Notification channel closed, receiver likely dropped"),
             "Closed arm must still emit WARN; captured: {:?}",
             logger.logs()
         );

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -879,7 +879,14 @@ fn try_release_pending_op_slot_on(
     match notifications_sender.try_send(Either::Right(NodeEvent::TransactionCompleted(tx))) {
         Ok(()) => true,
         Err(mpsc::error::TrySendError::Full(_)) => {
-            tracing::warn!(
+            // Benign back-pressure: the driver parks on its
+            // OPERATION_TTL fallback and the 60s sweep reclaims the
+            // slot. Per-occurrence WARN here flooded production
+            // gateways at 30K+/hr (#4238); the rate-limited
+            // `release_pending_op_slot: notification channel full for
+            // too long` error in `release_pending_op_slot_on` is the
+            // signal operators should grep for.
+            tracing::debug!(
                 %tx,
                 "try_release_pending_op_slot: notification channel full; \
                  driver will wait for OPERATION_TTL timeout"
@@ -945,10 +952,12 @@ async fn notify_node_event_on(
 ///
 /// Extracted from [`OpManager::try_notify_node_event`] so the try-send
 /// path is testable in isolation without building a full `OpManager`.
-/// On `Full` or `Closed` the event is dropped, a warn-level log is
-/// emitted, and the function returns `Err(OpError::NotificationError)`.
-/// Best-effort by design — see the OpManager method doc for the wedge
-/// (#4145) this prevents.
+/// On `Full` the event is dropped at debug level (benign back-pressure
+/// under fan-out — was flooding gateways at 30K+/hr, see #4238); on
+/// `Closed` it is dropped at warn level (receiver torn down). Either
+/// arm returns `Err(OpError::NotificationError)`. Best-effort by
+/// design — see the OpManager method doc for the wedge (#4145) this
+/// prevents.
 ///
 /// `channel_pending` and `channel_remaining` are passed by the caller
 /// purely for log enrichment; they are read at the call site to avoid
@@ -964,7 +973,14 @@ fn try_notify_node_event_on(
     match notifications_sender.try_send(Either::Right(msg)) {
         Ok(()) => Ok(()),
         Err(mpsc::error::TrySendError::Full(_)) => {
-            tracing::warn!(
+            // Benign back-pressure under sustained fan-out (best-
+            // effort broadcast emission). Each occurrence isn't
+            // actionable — the aggregate is, and the rate-limited
+            // `notify_node_event: Notification channel full for too
+            // long` error above is the alert operators should care
+            // about. Per-occurrence WARN here flooded production
+            // gateways post-HN-spike (#4238).
+            tracing::debug!(
                 channel_pending,
                 channel_remaining,
                 "try_notify_node_event: event-loop notification channel full; \
@@ -1823,6 +1839,170 @@ mod tests {
         assert!(
             result.is_err(),
             "helper must return Err once receiver is dropped"
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // Log-level regression tests for #4238.
+    //
+    // Production gateways were emitting tens of thousands of WARNs
+    // per hour ("notification channel full") under normal back-
+    // pressure post-HN-spike: 8–14 MB/hour of log noise that buried
+    // genuinely-actionable signals like the rate-limited "channel
+    // full for too long" error. The fix downgrades the per-occurrence
+    // Full arm to DEBUG on both try-send helpers while keeping the
+    // Closed arm at WARN (closed-channel is abnormal: receiver was
+    // torn down, e.g. shutdown races).
+    //
+    // These tests pin the level split by initializing a captured
+    // subscriber filtered at WARN: with the fix, a Full event emits
+    // nothing (DEBUG is below the filter); without the fix, a WARN
+    // entry would appear. Closed must still emit WARN either way.
+    // ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn try_release_pending_op_slot_full_does_not_emit_warn() {
+        // #4238 regression pin: per-occurrence Full must NOT emit a
+        // WARN. Pre-fix this fired 30K+/hr on nova; post-fix the
+        // helper logs at DEBUG and a WARN-level subscriber sees
+        // nothing.
+        let logger = crate::test_utils::TestLogger::new()
+            .with_level("warn")
+            .capture_logs()
+            .init();
+
+        let (_receiver, notifier) = event_loop_notification_channel();
+
+        // Saturate the channel so the helper hits the Full arm.
+        let filler_tx = Transaction::ttl_transaction();
+        let mut pre_filled = 0usize;
+        loop {
+            match notifier
+                .notifications_sender()
+                .try_send(Either::Right(NodeEvent::TransactionCompleted(filler_tx)))
+            {
+                Ok(()) => pre_filled += 1,
+                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => break,
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                    panic!("channel unexpectedly closed while pre-filling")
+                }
+            }
+            if pre_filled > 4096 {
+                panic!("channel did not backpressure after 4096 entries");
+            }
+        }
+
+        let tx = Transaction::ttl_transaction();
+        let delivered = super::try_release_pending_op_slot_on(notifier.notifications_sender(), tx);
+        assert!(!delivered, "helper must return false on a full channel");
+
+        assert!(
+            !logger.contains("try_release_pending_op_slot: notification channel full"),
+            "Full arm must not emit WARN (would re-spam gateways at 30K+/hr — #4238); \
+             captured: {:?}",
+            logger.logs()
+        );
+    }
+
+    #[tokio::test]
+    async fn try_release_pending_op_slot_closed_still_emits_warn() {
+        // #4238 inverse: the Closed arm is genuinely abnormal
+        // (receiver torn down) and MUST stay at WARN even after the
+        // Full-arm downgrade.
+        let logger = crate::test_utils::TestLogger::new()
+            .with_level("warn")
+            .capture_logs()
+            .init();
+
+        let (receiver, notifier) = event_loop_notification_channel();
+        drop(receiver);
+
+        let tx = Transaction::ttl_transaction();
+        let delivered = super::try_release_pending_op_slot_on(notifier.notifications_sender(), tx);
+        assert!(!delivered, "helper must return false on a closed channel");
+
+        assert!(
+            logger.contains("try_release_pending_op_slot: notification channel closed"),
+            "Closed arm must still emit WARN — receiver-dropped is not benign back-pressure; \
+             captured: {:?}",
+            logger.logs()
+        );
+    }
+
+    #[tokio::test]
+    async fn try_notify_node_event_full_does_not_emit_warn() {
+        // #4238 regression pin for the sibling helper introduced by
+        // #4231. Same shape as the release-pending variant above —
+        // best-effort broadcast emission must not spam WARN on every
+        // back-pressure drop.
+        let logger = crate::test_utils::TestLogger::new()
+            .with_level("warn")
+            .capture_logs()
+            .init();
+
+        let (_receiver, notifier) = event_loop_notification_channel();
+
+        let filler_tx = Transaction::ttl_transaction();
+        let mut pre_filled = 0usize;
+        loop {
+            match notifier
+                .notifications_sender()
+                .try_send(Either::Right(NodeEvent::TransactionCompleted(filler_tx)))
+            {
+                Ok(()) => pre_filled += 1,
+                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => break,
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                    panic!("channel unexpectedly closed while pre-filling")
+                }
+            }
+            if pre_filled > 4096 {
+                panic!("channel did not backpressure after 4096 entries");
+            }
+        }
+
+        let tx = Transaction::ttl_transaction();
+        let result = super::try_notify_node_event_on(
+            notifier.notifications_sender(),
+            pre_filled,
+            0,
+            NodeEvent::TransactionCompleted(tx),
+        );
+        assert!(result.is_err(), "helper must return Err on a full channel");
+
+        assert!(
+            !logger.contains("try_notify_node_event: event-loop notification channel full"),
+            "Full arm must not emit WARN (would re-introduce #4238 spam under fan-out); \
+             captured: {:?}",
+            logger.logs()
+        );
+    }
+
+    #[tokio::test]
+    async fn try_notify_node_event_closed_still_emits_warn() {
+        let logger = crate::test_utils::TestLogger::new()
+            .with_level("warn")
+            .capture_logs()
+            .init();
+
+        let (receiver, notifier) = event_loop_notification_channel();
+        drop(receiver);
+
+        let tx = Transaction::ttl_transaction();
+        let result = super::try_notify_node_event_on(
+            notifier.notifications_sender(),
+            0,
+            0,
+            NodeEvent::TransactionCompleted(tx),
+        );
+        assert!(
+            result.is_err(),
+            "helper must return Err once receiver is dropped"
+        );
+
+        assert!(
+            logger.contains("try_notify_node_event: event-loop notification channel closed"),
+            "Closed arm must still emit WARN; captured: {:?}",
+            logger.logs()
         );
     }
 

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -870,8 +870,11 @@ async fn release_pending_op_slot_on(
 ///
 /// Extracted from [`OpManager::try_release_pending_op_slot`] so it can be
 /// exercised in unit tests without building a full `OpManager`. Best-effort:
-/// a momentarily-full or closed channel produces a warning and the parked
-/// driver falls back to its `OPERATION_TTL` timeout (#4154).
+/// a momentarily-full channel produces a debug-level log (benign back-
+/// pressure under load — was flooding gateways at 30K+/hr, see #4238); a
+/// closed channel produces a warn-level log (receiver torn down). Either
+/// arm leaves the parked driver to fall back to its `OPERATION_TTL`
+/// timeout (#4154).
 fn try_release_pending_op_slot_on(
     notifications_sender: &mpsc::Sender<Either<NetMessage, NodeEvent>>,
     tx: Transaction,

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -349,7 +349,9 @@ pub(crate) async fn broadcast_change_interests(
             removed: removed_hashes,
         })
     {
-        tracing::warn!(
+        // Best-effort by design — log at debug to keep the caller
+        // layer in step with the helper-internal downgrade (#4238).
+        tracing::debug!(
             error = %err,
             "Failed to broadcast ChangeInterests (best-effort)"
         );


### PR DESCRIPTION
## Problem

Production gateways on v0.2.62 (and v0.2.61 before that) were emitting tens of thousands of WARN entries per hour from two `try_send` helpers in `op_state_manager.rs`:

```
WARN freenet::node::op_state_manager: try_release_pending_op_slot: notification channel full; driver will wait for OPERATION_TTL timeout
```

Observed rates post-HN-spike (2026-05-24):
- nova: 34K/hr current, 56K/hr peak at 18:00 UTC
- vega: 20K/hr current

At ~250 bytes per entry that's 8–14 MB/hour, with `freenet.error.YYYY-MM-DD-HH.log` reaching 19 MB in a single hour. Over a day this is ~200 MB just for these two WARN sites. The flood buried genuinely actionable signals — most notably the rate-limited `release_pending_op_slot: notification channel full for too long` error that fires when the event loop is *actually* stuck.

## Approach

Each `try_send` Full event corresponds to benign back-pressure: the parked driver retries via its OPERATION_TTL fallback, and the 60s sweep reclaims the slot if the notification doesn't land. The drop is the correct behavior — only the per-occurrence WARN is wrong. The aggregate matters; the individual occurrence does not.

Downgrade the per-occurrence log to `debug!` on both helpers (`try_release_pending_op_slot_on` and `try_notify_node_event_on`), keeping the `Closed` arms at `warn!`. Closed-channel means the receiver was torn down (shutdown race or similar), which is genuinely abnormal and should remain a visible signal.

The companion error-level signal (`release_pending_op_slot: notification channel full for too long`) in `release_pending_op_slot_on` is what operators should grep for now — it's rate-limited by design and only fires when back-pressure is sustained.

## Testing

Added four `#[tokio::test]` regression pins in `crates/core/src/node/op_state_manager.rs`:

- `try_release_pending_op_slot_full_does_not_emit_warn` — saturates the channel, calls the helper, asserts no WARN line containing `"notification channel full"` was captured at a WARN-level subscriber.
- `try_release_pending_op_slot_closed_still_emits_warn` — drops the receiver, calls the helper, asserts the `"notification channel closed"` WARN line is present.
- `try_notify_node_event_full_does_not_emit_warn` — same shape for the sibling helper from #4231.
- `try_notify_node_event_closed_still_emits_warn` — inverse for the sibling helper.

All four use `crate::test_utils::TestLogger` with `with_level("warn").capture_logs()`, so the captured buffer only contains entries the WARN-level subscriber actually saw. Pre-fix, the Full assertions would fail because the WARN line would be visible in captured logs.

Local run: all 19 tests in `node::op_state_manager::tests` pass; `cargo clippy --lib --tests -- -D warnings` clean.

## Notes for reviewers

- Not a #4231 regression — the WARN spam existed pre-#4231 and was actually firing at a higher rate on v0.2.61 (56K/hr) than v0.2.62 (34K/hr in the same window). #4231 reduced the rate by removing the 30s blocking await that held the channel saturated longer. The issue was filed because #4231's post-release monitoring made the existing spam visible.
- Kept `Closed` arms at WARN intentionally — closed channel is rare and indicates the receiver was torn down (shutdown race). That signal is worth preserving even with the Full downgrade.
- Updated the `try_notify_node_event_on` rustdoc that previously said "On `Full` or `Closed` ... a warn-level log is emitted" — it now correctly describes the per-arm level split.

Closes #4238

[AI-assisted - Claude]