### PR TITLE
fix(ops): downgrade queue-full WARN at relay driver wrappers (#4251)

### DIFF
--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -735,12 +735,22 @@ async fn run_relay_put<CB>(
     .await;
 
     if let Err(err) = &drive_result {
-        tracing::warn!(
-            tx = %incoming_tx,
-            error = %err,
-            phase = "relay_put_error",
-            "PUT relay: driver returned error"
-        );
+        if err.is_contract_queue_full() {
+            tracing::debug!(
+                tx = %incoming_tx,
+                error = %err,
+                phase = "relay_put_error",
+                event = "queue_full",
+                "PUT relay: driver returned error"
+            );
+        } else {
+            tracing::warn!(
+                tx = %incoming_tx,
+                error = %err,
+                phase = "relay_put_error",
+                "PUT relay: driver returned error"
+            );
+        }
     }
 
     // Originator-loopback error path: when the relay driver runs
@@ -1614,12 +1624,22 @@ async fn run_relay_put_streaming<CB>(
     )
     .await
     {
-        tracing::warn!(
-            tx = %incoming_tx,
-            error = %err,
-            phase = "relay_put_streaming_error",
-            "PUT streaming relay: driver returned error"
-        );
+        if err.is_contract_queue_full() {
+            tracing::debug!(
+                tx = %incoming_tx,
+                error = %err,
+                phase = "relay_put_streaming_error",
+                event = "queue_full",
+                "PUT streaming relay: driver returned error"
+            );
+        } else {
+            tracing::warn!(
+                tx = %incoming_tx,
+                error = %err,
+                phase = "relay_put_streaming_error",
+                "PUT streaming relay: driver returned error"
+            );
+        }
     }
 
     // Release per-tx pending_op_results slot (same rationale as slice A).

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -2062,6 +2062,51 @@ mod tests {
         Transaction::new::<PutMsg>()
     }
 
+    /// Issue #4251 follow-up: the PUT relay wrappers must mirror the UPDATE
+    /// wrappers' queue-full gating. Without it, a contract whose PUTs
+    /// saturate the per-contract queue would emit unbounded WARN spam
+    /// from `relay_put_error` / `relay_put_streaming_error` — the same
+    /// failure mode that filled `nova`'s error log with ~40 WARN/sec from
+    /// `relay_update_broadcast_error`. PUT volume is incidental today but
+    /// the regression risk is identical to UPDATE. Sibling pin test for
+    /// the UPDATE wrappers lives in `update/op_ctx_task.rs`.
+    #[test]
+    fn run_relay_put_wrappers_gate_queue_full_log_severity() {
+        let src = include_str!("op_ctx_task.rs");
+        for wrapper in [
+            "async fn run_relay_put<",
+            "async fn run_relay_put_streaming<",
+        ] {
+            let start = src
+                .find(wrapper)
+                .unwrap_or_else(|| panic!("{wrapper} not found"));
+            let after = &src[start + 1..];
+            let end = after
+                .find("\nasync fn ")
+                .or_else(|| after.find("\n#[cfg(test)]"))
+                .unwrap_or(after.len());
+            let body = &src[start..start + 1 + end];
+
+            assert!(
+                body.contains("is_contract_queue_full()"),
+                "{wrapper} must gate its WARN log on \
+                 err.is_contract_queue_full() — see issue #4251 and PR #4253"
+            );
+            assert!(
+                body.contains("event = \"queue_full\""),
+                "{wrapper} must tag the DEBUG branch with \
+                 event = \"queue_full\" so log filtering / telemetry can \
+                 distinguish queue-full backpressure from real failures"
+            );
+            assert!(
+                body.contains("tracing::debug!") && body.contains("tracing::warn!"),
+                "{wrapper} must keep BOTH a debug! (queue_full) and a warn! \
+                 (real failures) call — an inversion that maps queue_full to \
+                 warn would re-open the spam"
+            );
+        }
+    }
+
     #[test]
     fn classify_reply_response_is_stored() {
         let tx = dummy_tx();

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -2449,6 +2449,12 @@ mod tests {
                  event = \"queue_full\" so log filtering / telemetry can \
                  distinguish queue-full backpressure from real failures"
             );
+            assert!(
+                body.contains("tracing::debug!") && body.contains("tracing::warn!"),
+                "{wrapper} must keep BOTH a debug! (queue_full) and a warn! \
+                 (real failures) call — an inversion that maps queue_full to \
+                 warn would re-open the spam"
+            );
         }
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -708,13 +708,24 @@ async fn run_relay_request_update(
     )
     .await
     {
-        tracing::warn!(
-            tx = %incoming_tx,
-            %key,
-            error = %err,
-            phase = "relay_update_request_error",
-            "UPDATE relay: RequestUpdate driver returned error"
-        );
+        if err.is_contract_queue_full() {
+            tracing::debug!(
+                tx = %incoming_tx,
+                %key,
+                error = %err,
+                phase = "relay_update_request_error",
+                event = "queue_full",
+                "UPDATE relay: RequestUpdate driver returned error"
+            );
+        } else {
+            tracing::warn!(
+                tx = %incoming_tx,
+                %key,
+                error = %err,
+                phase = "relay_update_request_error",
+                "UPDATE relay: RequestUpdate driver returned error"
+            );
+        }
     }
 }
 
@@ -739,13 +750,24 @@ async fn run_relay_broadcast_to(
     )
     .await
     {
-        tracing::warn!(
-            tx = %incoming_tx,
-            %key,
-            error = %err,
-            phase = "relay_update_broadcast_error",
-            "UPDATE relay: BroadcastTo driver returned error"
-        );
+        if err.is_contract_queue_full() {
+            tracing::debug!(
+                tx = %incoming_tx,
+                %key,
+                error = %err,
+                phase = "relay_update_broadcast_error",
+                event = "queue_full",
+                "UPDATE relay: BroadcastTo driver returned error"
+            );
+        } else {
+            tracing::warn!(
+                tx = %incoming_tx,
+                %key,
+                error = %err,
+                phase = "relay_update_broadcast_error",
+                "UPDATE relay: BroadcastTo driver returned error"
+            );
+        }
     }
 }
 
@@ -1390,13 +1412,24 @@ async fn run_relay_request_update_streaming(
     )
     .await
     {
-        tracing::warn!(
-            tx = %incoming_tx,
-            %key,
-            error = %err,
-            phase = "relay_update_streaming_request_error",
-            "UPDATE relay (driver streaming): RequestUpdateStreaming driver returned error"
-        );
+        if err.is_contract_queue_full() {
+            tracing::debug!(
+                tx = %incoming_tx,
+                %key,
+                error = %err,
+                phase = "relay_update_streaming_request_error",
+                event = "queue_full",
+                "UPDATE relay (driver streaming): RequestUpdateStreaming driver returned error"
+            );
+        } else {
+            tracing::warn!(
+                tx = %incoming_tx,
+                %key,
+                error = %err,
+                phase = "relay_update_streaming_request_error",
+                "UPDATE relay (driver streaming): RequestUpdateStreaming driver returned error"
+            );
+        }
     }
 }
 
@@ -1421,13 +1454,24 @@ async fn run_relay_broadcast_to_streaming(
     )
     .await
     {
-        tracing::warn!(
-            tx = %incoming_tx,
-            %key,
-            error = %err,
-            phase = "relay_update_streaming_broadcast_error",
-            "UPDATE relay (driver streaming): BroadcastToStreaming driver returned error"
-        );
+        if err.is_contract_queue_full() {
+            tracing::debug!(
+                tx = %incoming_tx,
+                %key,
+                error = %err,
+                phase = "relay_update_streaming_broadcast_error",
+                event = "queue_full",
+                "UPDATE relay (driver streaming): BroadcastToStreaming driver returned error"
+            );
+        } else {
+            tracing::warn!(
+                tx = %incoming_tx,
+                %key,
+                error = %err,
+                phase = "relay_update_streaming_broadcast_error",
+                "UPDATE relay (driver streaming): BroadcastToStreaming driver returned error"
+            );
+        }
     }
 }
 
@@ -2363,6 +2407,49 @@ mod tests {
             "drive_relay_broadcast_to should still contain the auto-fetch \
              branch (gated on !queue_full)"
         );
+    }
+
+    /// Issue #4251 follow-up: the four `run_relay_*` driver wrappers each
+    /// log at WARN when the inner driver returns an error. PR #4253 gated
+    /// the amplification side effects (auto-fetch, ResyncRequest) on
+    /// `is_contract_queue_full()` inside the drivers, but left the WARN at
+    /// the wrapper boundary unconditional. On a hot contract (production
+    /// `4PjqN55KUCidW8vJvw5fhy5fe5maxXKNrWSyK33QjjVq` saturating its
+    /// per-contract queue) the broadcast wrapper alone emitted
+    /// ~40 WARNs/sec — 148k lines in a single hour on `nova`. Each wrapper
+    /// MUST drop queue-full to DEBUG with `event = "queue_full"` and keep
+    /// other errors at WARN. Regressing any of these re-opens the spam.
+    #[test]
+    fn run_relay_wrappers_gate_queue_full_log_severity() {
+        let src = include_str!("op_ctx_task.rs");
+        for wrapper in [
+            "async fn run_relay_request_update(",
+            "async fn run_relay_broadcast_to(",
+            "async fn run_relay_request_update_streaming(",
+            "async fn run_relay_broadcast_to_streaming(",
+        ] {
+            let start = src
+                .find(wrapper)
+                .unwrap_or_else(|| panic!("{wrapper} not found"));
+            let after = &src[start + 1..];
+            let end = after
+                .find("\nasync fn ")
+                .or_else(|| after.find("\n#[cfg(test)]"))
+                .unwrap_or(after.len());
+            let body = &src[start..start + 1 + end];
+
+            assert!(
+                body.contains("is_contract_queue_full()"),
+                "{wrapper} must gate its WARN log on \
+                 err.is_contract_queue_full() — see issue #4251 and PR #4253"
+            );
+            assert!(
+                body.contains("event = \"queue_full\""),
+                "{wrapper} must tag the DEBUG branch with \
+                 event = \"queue_full\" so log filtering / telemetry can \
+                 distinguish queue-full backpressure from real failures"
+            );
+        }
     }
 
     /// Pin: `BroadcastToStreaming` driver must classify failures via


### PR DESCRIPTION
## Problem

PR #4253 closed #4251 by gating the relay broadcast amplification (auto-fetch, ResyncRequest) on `is_contract_queue_full()` inside the inner `drive_relay_*` drivers, and downgraded the originator-path ERROR log to DEBUG. It missed one thing: the wrapper functions that *invoke* those drivers still log at WARN for any error the driver returns — including the typed queue-full marker the inner gating relies on.

Six wrapper sites are affected:

- `crates/core/src/operations/update/op_ctx_task.rs`
  - `run_relay_request_update` (`relay_update_request_error`)
  - `run_relay_broadcast_to` (`relay_update_broadcast_error`) ← **production spam source**
  - `run_relay_request_update_streaming` (`relay_update_streaming_request_error`)
  - `run_relay_broadcast_to_streaming` (`relay_update_streaming_broadcast_error`)
- `crates/core/src/operations/put/op_ctx_task.rs`
  - relay (`relay_put_error`)
  - relay streaming (`relay_put_streaming_error`)

## Production impact (today, before the fix)

Same contract `4PjqN55KUCidW8vJvw5fhy5fe5maxXKNrWSyK33QjjVq` from #4251. With v0.2.64 deployed (PR #4253 in place):

- **nova** (`freenet-gateway.service`, v0.2.64): 148,940 `relay_update_broadcast_error` WARNs in a single hour — 60% of all error log lines.  Error log volume `~8 MB/h baseline → 141 MB/h peak today`.
- **technic** (v0.2.64): 1,313 in the same hour, same pattern at lower volume.
- **vega**: 0 of these (different problem — router stuck `success_events=0`, tracked separately under #4239).

The amplification IS suppressed (no GET storm; the inner gating works). Only the log severity at the wrapper boundary regresses.

## Fix

At each of the six wrapper sites, mirror the existing pattern from `update/op_ctx_task.rs:402-419`:

```rust
if err.is_contract_queue_full() {
    tracing::debug!(..., event = "queue_full", "...");
} else {
    tracing::warn!(..., "...");
}
```

Pure log-severity change. No behavior change. Real WASM faults (OOG, traps, missing parameters, etc.) keep their WARN exactly as before — the predicate matches only the typed `ContractQueueFull` marker introduced by PR #4253.

## Testing

- New structural pin test `run_relay_wrappers_gate_queue_full_log_severity` asserts all four UPDATE wrappers contain both `is_contract_queue_full()` and `event = \"queue_full\"`. Future refactor that drops either fails CI.
- PUT wrappers covered by inspection — same code shape, production volume is 1-2 events/hr (negligible).
- `cargo test -p freenet --lib`: **2626 passed, 0 failed, 14 ignored.**
- `cargo clippy -p freenet --lib --tests -- -D warnings`: clean.
- `cargo fmt -p freenet`: no diff.

## Release plan

Cut a release as soon as this merges. Nova was restarted before this PR was opened (to drop the in-memory queue) and is currently re-accumulating the same WARN spam on v0.2.64 — release is the actual remediation.

## Out of scope (separate follow-up PR)

A per-callsite `tracing-subscriber` Layer that would have caught this even with the wrapper bug present. The existing global `RateLimiter` (1000 ev/sec, `crates/core/src/util/rate_limit_layer.rs`) sits above the observed ~40 ev/sec rate, so it never engaged. Will land separately.

Refs #4251 #4253

[AI-assisted - Claude]