### PR TITLE
fix(connect): deflake relay_does_not_accept_after_forwarding_on_retry

### DIFF
--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -2756,10 +2756,29 @@ mod tests {
         let joiner = make_peer(5200);
         let next_hop = make_peer(6200);
 
+        // Pin the invariant the fix relies on: `desired_location` must be
+        // far enough from `self_loc` that the near-terminus probabilistic
+        // accept branch (line ~624: `d < NEAR_TERMINUS_DISTANCE`) is
+        // statically unreachable. Using `next_hop`'s location makes this
+        // deterministic — but only because `make_peer` derives location
+        // from the loopback port. If port choices, `Location::from_address`,
+        // or `NEAR_TERMINUS_DISTANCE` ever change such that the gap shrinks,
+        // fail loudly here rather than silently re-flake. See #3944.
+        let target_loc = next_hop.location().expect("test peer has location");
+        let self_to_target = self_loc
+            .location()
+            .expect("test peer has location")
+            .distance(target_loc)
+            .as_f64();
+        assert!(
+            self_to_target > NEAR_TERMINUS_DISTANCE,
+            "test invariant: self_loc must be > NEAR_TERMINUS_DISTANCE ({NEAR_TERMINUS_DISTANCE}) from desired_location, got {self_to_target}"
+        );
+
         let mut state = RelayState {
             upstream_addr: joiner.socket_addr().expect("test peer must have address"),
             request: ConnectRequest {
-                desired_location: Location::random(),
+                desired_location: target_loc,
                 joiner: joiner.clone(),
                 ttl: 3,
                 visited: VisitedPeers::default(),
@@ -2827,6 +2846,69 @@ mod tests {
         assert!(
             actions2.forward.is_none(),
             "second call should not forward again"
+        );
+    }
+
+    /// Regression for #3944: directly exercises the "already forwarded → don't
+    /// accept" guard at the terminus-acceptance check without going through the
+    /// forwarding path first. The companion test
+    /// `relay_does_not_accept_after_forwarding_on_retry` was previously flaky
+    /// because its first call exercised near-terminus probabilistic acceptance
+    /// (driven by `GlobalRng`) before `forwarded_to` was set, sometimes
+    /// triggering acceptance regardless of the post-forward guard.
+    ///
+    /// This test sets `forwarded_to` and `forwarded_at` in the initial
+    /// `RelayState` so the only path under test is the terminus-acceptance
+    /// gate, which is fully deterministic. It would have failed before the
+    /// fix at `is_terminus && !self.accepted_locally && self.forwarded_to.is_none()`
+    /// was introduced, and is unaffected by RNG state.
+    #[test]
+    fn relay_with_forwarded_state_rejects_acceptance_at_terminus() {
+        let self_loc = make_peer(4250);
+        let joiner = make_peer(5250);
+        let prior_next_hop = make_peer(6250);
+
+        let mut state = RelayState {
+            upstream_addr: joiner.socket_addr().expect("test peer must have address"),
+            request: ConnectRequest {
+                desired_location: prior_next_hop.location().expect("test peer has location"),
+                joiner: joiner.clone(),
+                ttl: 3,
+                visited: VisitedPeers::default(),
+                uphill_budget: DEFAULT_UPHILL_BUDGET,
+            },
+            // Simulate a prior forward that completed: the operation has
+            // already committed to a path and must not also accept locally.
+            forwarded_to: Some(prior_next_hop),
+            forwarded_at: Some(Instant::now()),
+            observed_sent: false,
+            accepted_locally: false,
+            response_forwarded: false,
+        };
+
+        // Terminus (next_hop=None) with should_accept=true — every condition
+        // that would normally green-light acceptance is in place EXCEPT the
+        // forwarded_to guard.
+        let ctx = TestRelayContext::new(self_loc).accept(true).next_hop(None);
+        let recency = HashMap::new();
+        let mut forward_attempts = HashMap::new();
+        let estimator = ConnectForwardEstimator::new();
+
+        let actions = state.handle_request(
+            &ctx,
+            &recency,
+            &mut forward_attempts,
+            &estimator,
+            Instant::now(),
+        );
+
+        assert!(
+            actions.accept.is_none(),
+            "relay must not accept once forwarded_to is set, even at terminus"
+        );
+        assert!(
+            actions.forward.is_none(),
+            "relay must not forward again when forwarded_to is already set"
         );
     }
 


### PR DESCRIPTION
## Problem

`operations::connect::tests::relay_does_not_accept_after_forwarding_on_retry` intermittently failed (~10% of full-suite runs) with `actions1.accept.is_none()` violated. Isolated execution always passed.

Root cause: the test used `Location::random()` for `desired_location`. Under parallel test execution (sharing `GlobalRng` state) it could land within `NEAR_TERMINUS_DISTANCE` (0.05) of `self_loc`, triggering near-terminus probabilistic acceptance (up to 0.6 probability scaling linearly with proximity) on the first `handle_request` call. The relay then accepted *while* forwarding, breaking the test's "should forward, not accept" assertion.

Same root cause and fix shape as commit 3ed7ae32 ("fix: fix two pre-existing flaky tests") which deflaked the analogous `relay_does_not_accept_when_not_at_terminus`.

## Approach

Two changes in `crates/core/src/operations/connect.rs`:

1. **Use `next_hop.location()` for `desired_location`.** `make_peer` derives location deterministically from the loopback port via `Location::from_address` — locations for ports 4200 and 6200 are 0.62 and 0.27, 0.36 apart on the ring, well outside the 0.05 near-terminus zone. The relay is guaranteed never to hit the probabilistic acceptance branch.

2. **Add a fully deterministic regression test** (`relay_with_forwarded_state_rejects_acceptance_at_terminus`) that directly exercises the "already-forwarded → don't accept" guard at the terminus-acceptance check (`is_terminus && !self.accepted_locally && self.forwarded_to.is_none()`). It initializes `forwarded_to` and `forwarded_at` in the initial state so no RNG-dependent path is exercised. This pins the actual invariant the original test was trying to verify and satisfies the CI fix-PR test requirement.

## Testing

- New test `relay_with_forwarded_state_rejects_acceptance_at_terminus`: passes.
- Full freenet unit-test suite: `cargo test -p freenet --lib` — 2626 passed, 14 ignored, 0 failed.
- `cargo clippy -p freenet --lib --tests -- -D warnings`: clean.
- Manually verified `make_peer(4200).location()` and `make_peer(6200).location()` are 0.356 apart on the ring (well > `NEAR_TERMINUS_DISTANCE = 0.05`).

## Fixes

Closes #3944

[AI-assisted - Claude]