### PR TITLE
feat(governance): governance manager + dashboard renderer (Phase 4 + 4.5)

### DIFF
--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -9,6 +9,7 @@ use freenet_stdlib::prelude::*;
 
 mod executor;
 mod fair_queue;
+pub(crate) mod governance;
 mod handler;
 pub mod storages;
 pub(crate) mod user_input;

--- a/crates/core/src/contract/governance.rs
+++ b/crates/core/src/contract/governance.rs
@@ -171,8 +171,11 @@ pub(crate) struct ContractScore {
     /// check to know "did we evict this contract within the window?"
     pub last_transition: Instant,
     /// State history, capped at `MAX_TRANSITIONS_PER_CONTRACT`. Always
-    /// preserves the `FirstSeen` entry as the head; older transitions
-    /// in the middle are dropped if the cap is exceeded.
+    /// preserves the `FirstSeen` entry as the head[0]; once the cap is
+    /// reached, each new entry drops the OLDEST non-FirstSeen entry
+    /// (i.e. `history[1]`) — a sliding window of the most recent
+    /// `MAX_TRANSITIONS_PER_CONTRACT - 1` transitions plus the
+    /// permanent FirstSeen anchor.
     pub history: Vec<StateTransition>,
 }
 
@@ -310,8 +313,20 @@ pub(crate) struct GovernanceConfig {
     /// half-life = sample-history sticks around longer = state more
     /// stable but slower to recover.
     pub decay_half_life: Duration,
-    /// Window within which a re-eviction transitions to Banned (Phase 7).
+    /// Window measured from a contract's original `Evicted` transition
+    /// during which a SECOND eviction escalates to `Banned`. Must be
+    /// strictly greater than [`evicted_ttl`] so there is a window
+    /// between recovery and `ban_window` expiry where a re-eviction
+    /// can fire (otherwise the contract recovers to Normal and the
+    /// `recently_evicted` check immediately falls outside the window).
     pub ban_window: Duration,
+    /// How long an `Evicted` contract stays Evicted before the TTL
+    /// sweep transitions it back to `Normal` (via
+    /// [`TransitionReason::Recovered`]). Should be shorter than
+    /// [`ban_window`] so a contract that gets re-flagged shortly after
+    /// recovery has its first eviction still within the ban window —
+    /// that is the "repeat offender" path that triggers `Banned`.
+    pub evicted_ttl: Duration,
     /// How long Banned status persists before transitioning back to
     /// Normal automatically.
     pub ban_ttl: Duration,
@@ -332,8 +347,11 @@ impl Default for GovernanceConfig {
             outlier: OutlierConfig::default(),
             ramp_up: Duration::from_secs(15 * 60), // 15 minutes
             decay_half_life: Duration::from_secs(60 * 60), // 1 hour
+            // ban_window > evicted_ttl is required for the
+            // repeat-offender path to fire. See field docs.
             ban_window: Duration::from_secs(60 * 60), // 1 hour
-            ban_ttl: Duration::from_secs(60 * 60), // 1 hour
+            evicted_ttl: Duration::from_secs(15 * 60), // 15 minutes
+            ban_ttl: Duration::from_secs(60 * 60),    // 1 hour
             borderline_mad_units: 3.0,
             capacity_ceiling_log: 4.0, // log10 ceiling = 10000× typical
         }
@@ -451,9 +469,28 @@ impl GovernanceManager {
 
     /// Iterate per-contract scores. Yields cloned snapshots so the
     /// caller doesn't need to hold the DashMap shard guards.
+    ///
+    /// Note: at 10k+ contracts this clones the entire state set per
+    /// call. Use [`iter_flagged_scores`] from the dashboard hot path
+    /// when only flagged contracts are needed.
     pub(crate) fn iter_scores(&self) -> Vec<(ContractInstanceId, ContractScore)> {
         self.scores
             .iter()
+            .map(|e| (*e.key(), e.value().clone()))
+            .collect()
+    }
+
+    /// Iterate per-contract scores, returning ONLY flagged entries
+    /// (Borderline / WouldEvict / Evicted / Banned). The dashboard
+    /// Contract Governance card hides Normal contracts at render
+    /// time; using this filter avoids cloning thousands of entries
+    /// per refresh on a busy node with mostly-healthy contracts.
+    /// Code-first reviewer of #4270 raised the clone-the-world cost
+    /// as a major concern at 10k+ contracts.
+    pub(crate) fn iter_flagged_scores(&self) -> Vec<(ContractInstanceId, ContractScore)> {
+        self.scores
+            .iter()
+            .filter(|e| e.value().state.is_flagged())
             .map(|e| (*e.key(), e.value().clone()))
             .collect()
     }
@@ -553,7 +590,7 @@ impl GovernanceManager {
                 }
                 GovernanceState::Evicted => {
                     let elapsed = now.saturating_duration_since(entry.last_transition);
-                    if elapsed >= self.config.ban_window {
+                    if elapsed >= self.config.evicted_ttl {
                         evicted_lifted.push(*entry.key());
                     }
                 }
@@ -575,10 +612,29 @@ impl GovernanceManager {
                 if age < self.config.ramp_up {
                     return None;
                 }
-                // Banned contracts are excluded from the distribution
-                // computation — we don't want a banned contract's
-                // extreme ratio dragging the threshold.
-                if entry.state == GovernanceState::Banned {
+                // Banned AND Evicted contracts are excluded from the
+                // distribution computation:
+                // - Banned: their extreme ratio would drag the threshold.
+                // - Evicted: same retained score keeps getting reprocessed
+                //   tick-after-tick; without this filter the second tick
+                //   sees `flagged.contains(key)` AND `recently_evicted ==
+                //   true`, escalating Evicted → Banned just because the
+                //   meter still carries the pre-eviction cost. That is
+                //   not "repeat offender", it is double-counting the
+                //   same eviction event. Codex reviewer of #4270 caught
+                //   this blocker. With Evicted excluded, the existing
+                //   stickiness rule in the main loop suffices: Evicted
+                //   stays Evicted until either:
+                //   (a) the `evicted_lifted` TTL sweep recovers it after
+                //       `ban_window`, OR
+                //   (b) a NEW eviction event fires after the contract
+                //       has recovered to Normal AND been re-evicted —
+                //       which is the real "repeat offender" path that
+                //       should trigger Banned.
+                if matches!(
+                    entry.state,
+                    GovernanceState::Banned | GovernanceState::Evicted
+                ) {
                     return None;
                 }
                 entry.log_ratio().map(|r| (*entry.key(), r))
@@ -608,10 +664,21 @@ impl GovernanceManager {
         // distinguish "elevated" from "normal"; falling back to
         // median-only would flag every contract slightly above
         // median, which is wrong.
+        // Scale MAD by `MAD_GAUSSIAN_CONSISTENCY` (≈1.4826) so
+        // `borderline_mad_units` is interpretable as standard
+        // deviations under a normal honest population — matching the
+        // semantics of the eviction threshold computed by
+        // `detect_outliers`, which uses scaled MAD too. Without this
+        // scaling, `borderline_mad_units = 3.0` would correspond to
+        // ~2.0σ, not the "+3 standard deviations" the
+        // `GovernanceState::Borderline` docstring claims. Codex
+        // reviewer of #4270 caught this inconsistency.
         let borderline_cutoff = match (outlier_result.median_log_ratio, outlier_result.mad) {
-            (Some(m), Some(mad)) if mad > f64::EPSILON => {
-                Some(m + self.config.borderline_mad_units * mad)
-            }
+            (Some(m), Some(mad)) if mad > f64::EPSILON => Some(
+                m + self.config.borderline_mad_units
+                    * crate::governance::MAD_GAUSSIAN_CONSISTENCY
+                    * mad,
+            ),
             _ => None,
         };
 
@@ -682,17 +749,34 @@ impl GovernanceManager {
                 (_, GovernanceState::Normal) => TransitionReason::Recovered,
             };
             entry.record_transition(now, next, reason);
+            // `actionable` means "the executor wiring should emit an
+            // `EvictContract` event for this decision" — true only for
+            // transitions INTO an actively-enforced state (Evicted or
+            // Banned). Borderline/WouldEvict/Normal transitions are
+            // observation-only regardless of mode. Codex reviewer of
+            // #4270 caught that the previous `actionable = mode.evicts()`
+            // marked every transition in Enforce mode (including
+            // Recovered and BorderlineEntered) as actionable, which
+            // violates the field's documented contract.
+            let actionable_decision =
+                actionable && matches!(next, GovernanceState::Evicted | GovernanceState::Banned);
             decisions.push(ReaperDecision {
                 key: *key,
                 from,
                 to: next,
                 reason,
                 at: now,
-                actionable,
+                actionable: actionable_decision,
             });
         }
 
         // 5. Process ban TTLs that expired during the decay walk.
+        //
+        // `actionable` mirrors the per-mode semantics: a ban lifted in
+        // DryRun was never actionable to begin with, so its lift
+        // isn't either. Skeptical-reviewer caught the earlier
+        // hardcoded `true` here would let a future actor act on a
+        // DryRun-lifted "ban" that never enforced.
         for key in ban_lifted {
             if let Some(mut entry) = self.scores.get_mut(&key) {
                 if entry.state == GovernanceState::Banned {
@@ -708,19 +792,36 @@ impl GovernanceManager {
                         to: GovernanceState::Normal,
                         reason: TransitionReason::BanLifted,
                         at: now,
-                        actionable: true,
+                        actionable,
                     });
                 }
             }
         }
 
         // 5b. Process evicted-window expiries the same way. A contract
-        // that has been Evicted for at least `ban_window` without a
-        // re-eviction is allowed to return to Normal. The
-        // `TransitionReason::Recovered` reason is reused — the dashboard
-        // can distinguish "actively-recovered (decay-driven)" from
-        // "recovered after eviction-window" via the `from` field.
+        // that has been Evicted for at least `evicted_ttl` AND is not
+        // currently being re-flagged is allowed to return to Normal.
+        //
+        // The currently-flagged filter is critical: without it, a
+        // contract whose `evicted_ttl` just elapsed AND is still
+        // actively abusive (still produces flagging samples) would get
+        // a free Recovered transition this tick — short-circuiting
+        // through `next == from` in the main loop, then unconditionally
+        // recovered here. Net effect: an abuser cycles "Evicted →
+        // Recovered → Normal → Evicted" indefinitely without ever
+        // triggering Banned. Skeptical-reviewer caught this as a
+        // high-severity bug. Filter against `flagged` so recovery
+        // only fires for contracts whose behavior has actually
+        // calmed down.
         for key in evicted_lifted {
+            if flagged.contains(&key) {
+                // Still actively flagged — let the main transition
+                // loop's `recently_evicted` check escalate on the
+                // next tick (or, if `ban_window` has also elapsed
+                // and the abuser keeps flagging, the next tick after
+                // recovery will start the Evicted clock fresh).
+                continue;
+            }
             if let Some(mut entry) = self.scores.get_mut(&key) {
                 if entry.state == GovernanceState::Evicted {
                     let from = entry.state;
@@ -735,7 +836,7 @@ impl GovernanceManager {
                         to: GovernanceState::Normal,
                         reason: TransitionReason::Recovered,
                         at: now,
-                        actionable: true,
+                        actionable,
                     });
                 }
             }
@@ -1132,12 +1233,20 @@ mod tests {
 
     #[test]
     fn second_eviction_within_ban_window_triggers_ban() {
+        // Real repeat-offender path post-#4270 review:
+        //   1. Contract gets Evicted at T=0.
+        //   2. evicted_ttl elapses (default 15min); the contract is
+        //      not currently flagged → TTL sweep recovers to Normal.
+        //   3. Fresh cost arrives → contract is flagged again.
+        //   4. Main loop's recently_evicted check finds the original
+        //      Evicted within ban_window (default 1h) → Banned.
+        //
+        // The earlier version of this test re-fed the SAME tick after
+        // eviction. Codex reviewer caught that this double-counted the
+        // same eviction event; the fix excludes Evicted contracts from
+        // the distribution so the next-tick re-feed path is unreachable.
         let (mgr, ts) = mk_mgr_shared(GovernanceMode::Enforce);
-        // Healthy population.
         for i in 0..30 {
-            // Tiny jitter so MAD doesn't collapse to zero; keeps the
-            // population recognisably honest but gives the detector
-            // a real distribution to work with.
             let jitter = (i as f64 - 15.0) * 0.01;
             mgr.ingest_cost(mk_key(i), 0.1 + jitter * 0.05);
             mgr.ingest_demand(mk_key(i), 1.0 + jitter);
@@ -1146,34 +1255,53 @@ mod tests {
         mgr.ingest_cost(abuser, 100.0);
         mgr.ingest_demand(abuser, 1.0);
         ts.advance(Duration::from_secs(2));
-        // First eviction.
-        let result1 = mgr.tick(Duration::from_millis(100));
+
+        // Tick 1: first eviction.
+        let r1 = mgr.tick(Duration::from_millis(100));
         assert_eq!(
-            result1
-                .decisions
-                .iter()
-                .find(|d| d.key == abuser)
-                .unwrap()
-                .to,
+            r1.decisions.iter().find(|d| d.key == abuser).unwrap().to,
             GovernanceState::Evicted
         );
-        // Re-feed abuser's cost (simulating re-PUT + UPDATE storm).
+
+        // Advance past evicted_ttl (15min default). Re-establish the
+        // honest distribution so MAD stays well-defined during recovery.
+        ts.advance(Duration::from_secs(15 * 60 + 1));
+        for i in 0..30 {
+            let jitter = (i as f64 - 15.0) * 0.01;
+            mgr.ingest_cost(mk_key(i), 0.1 + jitter * 0.05);
+            mgr.ingest_demand(mk_key(i), 1.0 + jitter);
+        }
+        let recovery = mgr.tick(Duration::from_millis(100));
+        let recovered = recovery
+            .decisions
+            .iter()
+            .find(|d| d.key == abuser)
+            .expect("evicted_lifted sweep must recover the abuser");
+        assert_eq!(recovered.from, GovernanceState::Evicted);
+        assert_eq!(recovered.to, GovernanceState::Normal);
+        assert!(matches!(recovered.reason, TransitionReason::Recovered));
+
+        // Re-feed abuser. The original Evicted transition is still
+        // within ban_window (we advanced 15min+1s, well under 1h).
         mgr.ingest_cost(abuser, 100.0);
+        mgr.ingest_cost(abuser, 100.0);
+        mgr.ingest_demand(abuser, 1.0);
         ts.advance(Duration::from_secs(1));
-        // Second eviction within the ban_window — should escalate to Banned.
-        let result2 = mgr.tick(Duration::from_millis(100));
-        let second = result2.decisions.iter().find(|d| d.key == abuser).unwrap();
+
+        // Tick 3: recently_evicted check fires → Banned, not Evicted.
+        let r2 = mgr.tick(Duration::from_millis(100));
+        let second = r2.decisions.iter().find(|d| d.key == abuser).unwrap();
         assert_eq!(second.to, GovernanceState::Banned);
         assert!(matches!(second.reason, TransitionReason::BanTriggered));
     }
 
     #[test]
     fn ban_ttl_expires_back_to_normal() {
+        // After the Banned state's ban_ttl elapses, BanLifted fires.
+        // Setup mirrors `second_eviction_within_ban_window_triggers_ban`:
+        // evict → recover → re-feed → Banned, then advance past ban_ttl.
         let (mgr, ts) = mk_mgr_shared(GovernanceMode::Enforce);
         for i in 0..30 {
-            // Tiny jitter so MAD doesn't collapse to zero; keeps the
-            // population recognisably honest but gives the detector
-            // a real distribution to work with.
             let jitter = (i as f64 - 15.0) * 0.01;
             mgr.ingest_cost(mk_key(i), 0.1 + jitter * 0.05);
             mgr.ingest_demand(mk_key(i), 1.0 + jitter);
@@ -1182,13 +1310,27 @@ mod tests {
         mgr.ingest_cost(abuser, 100.0);
         mgr.ingest_demand(abuser, 1.0);
         ts.advance(Duration::from_secs(2));
-        // First eviction.
+
+        // Tick 1: Evicted.
         mgr.tick(Duration::from_millis(100));
-        // Re-feed + second tick → Banned.
+
+        // Advance past evicted_ttl + re-establish honest distribution.
+        ts.advance(Duration::from_secs(15 * 60 + 1));
+        for i in 0..30 {
+            let jitter = (i as f64 - 15.0) * 0.01;
+            mgr.ingest_cost(mk_key(i), 0.1 + jitter * 0.05);
+            mgr.ingest_demand(mk_key(i), 1.0 + jitter);
+        }
+        mgr.tick(Duration::from_millis(100)); // → Normal via Recovered.
+
+        // Re-feed → Banned (recently_evicted in window).
         mgr.ingest_cost(abuser, 100.0);
+        mgr.ingest_cost(abuser, 100.0);
+        mgr.ingest_demand(abuser, 1.0);
         ts.advance(Duration::from_secs(1));
         mgr.tick(Duration::from_millis(100));
-        // Now advance past ban_ttl.
+
+        // Now advance past ban_ttl (1h default).
         ts.advance(Duration::from_secs(60 * 60 + 1));
         let result = mgr.tick(Duration::from_millis(100));
         let lifted = result.decisions.iter().find(|d| d.key == abuser).unwrap();
@@ -1198,43 +1340,58 @@ mod tests {
     }
 
     #[test]
-    fn borderline_state_for_three_mad_outside_threshold() {
-        // Build a tight distribution where one contract sits between
-        // +3·MAD and +5·MAD — the borderline zone.
+    fn borderline_state_for_contract_above_borderline_below_threshold() {
+        // Construct a distribution where the test contract MUST land
+        // in Borderline — specifically, between `+borderline_mad_units
+        // × 1.4826 × MAD` (the borderline cutoff) and `k × 1.4826 ×
+        // MAD` (the eviction threshold). With default config
+        // (borderline_mad_units=3, k=5), that's roughly 4.4σ–7.4σ.
+        //
+        // Codex reviewer of #4270 flagged that the previous version of
+        // this test (a) over-permitted WouldEvict, and (b) silently
+        // passed when no decision was logged. Both fixed here:
+        //   - The assertion is unconditional (no `if let Some`).
+        //   - It pins `Borderline` specifically, not the union.
         let (mgr, ts) = mk_mgr_shared(GovernanceMode::DryRun);
-        // Tighten the trim so all 30 honest contracts dominate the MAD.
-        // Set 30 contracts at exactly cost=0.1, benefit=1.0
-        // (log-ratio = -1, MAD then comes from the inserted outlier).
-        // Use slight jitter so MAD isn't zero.
+        // 30 honest contracts with enough spread to give MAD a
+        // meaningful magnitude. cost=0.1 ± slight jitter → log-ratio ≈ -1.
         for i in 0..30 {
-            let jitter = (i as f64 - 15.0) * 0.001;
-            mgr.ingest_cost(mk_key(i), 0.1 + jitter);
+            let jitter = (i as f64 - 15.0) * 0.02;
+            mgr.ingest_cost(mk_key(i), 0.1 + jitter * 0.05);
             mgr.ingest_demand(mk_key(i), 1.0);
         }
-        // A "borderline" contract: cost ratio = 1.0 (log = 0), which
-        // is +1 above the median of -1. With small MAD this is multiple
-        // MAD-units away — should land in Borderline, not WouldEvict.
+        // Borderline test contract: cost ratio designed to land at
+        // ~5σ above median, which is between the borderline cutoff
+        // (≈4.4σ) and the eviction threshold (≈7.4σ). Calibrated
+        // empirically against the test fixture's MAD.
         let borderline = mk_key(99);
-        mgr.ingest_cost(borderline, 1.0);
+        mgr.ingest_cost(borderline, 0.15);
         mgr.ingest_demand(borderline, 1.0);
         ts.advance(Duration::from_secs(2));
         let result = mgr.tick(Duration::from_millis(100));
-        let decision = result.decisions.iter().find(|d| d.key == borderline);
-        if let Some(d) = decision {
-            // Either WouldEvict (if it crossed threshold due to tight MAD)
-            // or Borderline (between +3·MAD and threshold). Both are
-            // valid outcomes of this synthesized distribution; the
-            // critical invariant is that something flagged this
-            // contract.
-            assert!(
-                matches!(
-                    d.to,
-                    GovernanceState::WouldEvict | GovernanceState::Borderline
-                ),
-                "expected borderline/wouldevict, got {:?}",
-                d.to
-            );
-        }
+        let decision = result
+            .decisions
+            .iter()
+            .find(|d| d.key == borderline)
+            .unwrap_or_else(|| {
+                panic!(
+                    "borderline contract MUST produce a decision, got: {:?}",
+                    result.decisions
+                )
+            });
+        assert_eq!(
+            decision.to,
+            GovernanceState::Borderline,
+            "expected Borderline (not WouldEvict / Normal); got {:?}. \
+             If this drifts to WouldEvict, the test fixture's MAD has \
+             tightened beyond the test's design and the cost value \
+             needs recalibration.",
+            decision.to
+        );
+        assert!(matches!(
+            decision.reason,
+            TransitionReason::BorderlineEntered
+        ));
     }
 
     #[test]

--- a/crates/core/src/contract/governance.rs
+++ b/crates/core/src/contract/governance.rs
@@ -36,13 +36,18 @@
 //!   state transitions actually evict.
 //!
 //! Wiring (read costs from `Meter`, read demand from `HostingManager`,
-//! drive the reaper tick, emit `EvictContract` events) lands in
-//! subsequent commits. The data model is committed first so each
-//! subsequent commit is small enough to review independently.
+//! emit `EvictContract` events) lands in subsequent commits.
 
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
+use dashmap::DashMap;
+use freenet_stdlib::prelude::ContractKey;
 use tokio::time::Instant;
+
+use crate::governance::{OutlierConfig, OutlierResult, SkipReason, detect_outliers};
+use crate::util::time_source::TimeSource;
 
 /// The five states a contract can be in under per-contract governance.
 ///
@@ -289,6 +294,341 @@ impl GovernanceMode {
     }
 }
 
+/// Tunable parameters for the governance manager. Defaults reflect
+/// the design doc; tests can override.
+#[derive(Clone, Debug)]
+pub(crate) struct GovernanceConfig {
+    /// Operating mode.
+    pub mode: GovernanceMode,
+    /// MAD detector config (k, min_samples, trim_fraction).
+    pub outlier: OutlierConfig,
+    /// How long after first-seen a contract is exempt from flagging.
+    /// New contracts haven't accumulated enough demand for the ratio
+    /// to be meaningful; flagging them would punish growth.
+    pub ramp_up: Duration,
+    /// Half-life of the cost/benefit decay applied per tick. Larger
+    /// half-life = sample-history sticks around longer = state more
+    /// stable but slower to recover.
+    pub decay_half_life: Duration,
+    /// Window within which a re-eviction transitions to Banned (Phase 7).
+    pub ban_window: Duration,
+    /// How long Banned status persists before transitioning back to
+    /// Normal automatically.
+    pub ban_ttl: Duration,
+    /// `+3·MAD` borderline threshold expressed in MAD-units from the
+    /// median. Below the eviction threshold but above this enters
+    /// Borderline.
+    pub borderline_mad_units: f64,
+    /// Capacity ceiling for the MAD detector in log-space. If the
+    /// threshold would exceed this, it's clamped. Sourced from
+    /// hardware capacity; placeholder value here.
+    pub capacity_ceiling_log: f64,
+}
+
+impl Default for GovernanceConfig {
+    fn default() -> Self {
+        Self {
+            mode: GovernanceMode::DryRun,
+            outlier: OutlierConfig::default(),
+            ramp_up: Duration::from_secs(15 * 60), // 15 minutes
+            decay_half_life: Duration::from_secs(60 * 60), // 1 hour
+            ban_window: Duration::from_secs(60 * 60), // 1 hour
+            ban_ttl: Duration::from_secs(60 * 60), // 1 hour
+            borderline_mad_units: 3.0,
+            capacity_ceiling_log: 4.0, // log10 ceiling = 10000× typical
+        }
+    }
+}
+
+/// One decision emitted by the reaper tick. The caller (executor wiring)
+/// reads these and decides what to do — in `Enforce` mode emit an
+/// `EvictContract` event; in `DryRun` mode just log. The decision is
+/// always recorded in the contract's `history`, regardless of mode.
+#[derive(Clone, Debug)]
+pub(crate) struct ReaperDecision {
+    pub key: ContractKey,
+    pub from: GovernanceState,
+    pub to: GovernanceState,
+    pub reason: TransitionReason,
+    pub at: Instant,
+    /// `true` if the system should actually act on this transition.
+    /// `false` in `DryRun` (or in `Off`, though `Off` never produces
+    /// decisions). Lets the caller treat dry-run logging uniformly
+    /// without re-checking the mode.
+    pub actionable: bool,
+}
+
+/// Summary of a single reaper tick. The dashboard reads this for the
+/// network-norms panel (median, MAD, threshold, sample size).
+#[derive(Clone, Debug)]
+pub(crate) struct ReaperTickResult {
+    /// Decisions to act on this tick.
+    pub decisions: Vec<ReaperDecision>,
+    /// Median log-ratio across the population, or None if the
+    /// detector skipped (insufficient sample / mad collapsed / etc).
+    pub median_log_ratio: Option<f64>,
+    /// MAD value.
+    pub mad: Option<f64>,
+    /// Threshold = median + k·MAD, clamped by capacity ceiling.
+    pub threshold: Option<f64>,
+    /// True if the threshold was clamped at the capacity ceiling
+    /// (surface in dashboard as a warning).
+    pub capacity_ceiling_binding: bool,
+    /// Number of contracts that produced a usable log-ratio. Less
+    /// than total population if some had no demand yet.
+    pub sample_size: usize,
+    /// Why the detector skipped, when applicable.
+    pub skip_reason: Option<SkipReason>,
+}
+
+/// Per-contract governance scoring + reaper tick.
+///
+/// **Authoritative for what the dashboard shows.** Every per-contract
+/// state and every network-level statistic in the dashboard is read
+/// from this manager (or from data it commands). No fields exist on
+/// the dashboard that aren't computed here.
+pub(crate) struct GovernanceManager<T: TimeSource> {
+    /// Per-contract scoring state. `DashMap` chosen per code-style
+    /// rule: fine-grained shard locking lets the meter + the reaper
+    /// tick + the receive-boundary check all read/write
+    /// independently without serializing on a global lock.
+    scores: DashMap<ContractKey, ContractScore>,
+    /// Configuration; cloned cheaply when the reaper tick reads its
+    /// fields.
+    config: GovernanceConfig,
+    /// Time source — every timestamp goes through this for DST.
+    time_source: Arc<T>,
+}
+
+impl<T: TimeSource> GovernanceManager<T> {
+    pub(crate) fn new(config: GovernanceConfig, time_source: Arc<T>) -> Self {
+        Self {
+            scores: DashMap::new(),
+            config,
+            time_source,
+        }
+    }
+
+    /// Add a cost sample to a contract's `cost_used`. Called from the
+    /// Meter wiring (subsequent commit) on every per-contract resource
+    /// report. If the contract is new, creates a `Normal`-state score.
+    pub(crate) fn ingest_cost(&self, key: ContractKey, amount: f64) {
+        if !amount.is_finite() || amount < 0.0 {
+            return;
+        }
+        let now = self.time_source.now();
+        let mut entry = self
+            .scores
+            .entry(key)
+            .or_insert_with(|| ContractScore::new(now));
+        entry.cost_used += amount;
+    }
+
+    /// Add a demand event to a contract's `benefit_score`. Called
+    /// from the HostingManager wiring (subsequent commit) on every
+    /// observed local/forwarded GET / SUBSCRIBE / client-attach.
+    /// Weight comes from the caller (local vs forwarded weighting
+    /// applied at the call site).
+    pub(crate) fn ingest_demand(&self, key: ContractKey, weight: f64) {
+        if !weight.is_finite() || weight <= 0.0 {
+            return;
+        }
+        let now = self.time_source.now();
+        let mut entry = self
+            .scores
+            .entry(key)
+            .or_insert_with(|| ContractScore::new(now));
+        entry.benefit_score += weight;
+    }
+
+    /// Look up the current score for a contract, for dashboard reads.
+    /// Returns a cloned snapshot; the dashboard doesn't need (and
+    /// shouldn't have) write access.
+    pub(crate) fn score_snapshot(&self, key: &ContractKey) -> Option<ContractScore> {
+        self.scores.get(key).map(|s| s.clone())
+    }
+
+    /// Total number of contracts being tracked.
+    pub(crate) fn len(&self) -> usize {
+        self.scores.len()
+    }
+
+    /// Run one reaper tick. Applies decay, runs the MAD detector
+    /// across all contracts past the ramp-up window, drives state
+    /// transitions, and returns the result for the caller to act on.
+    ///
+    /// `tick_interval` is the time since the previous tick; used for
+    /// decay. If this is the first tick, pass any reasonable value
+    /// (e.g. the same value `decay_half_life` is configured with);
+    /// decay applied once at startup is a no-op anyway because all
+    /// scores are zero.
+    pub(crate) fn tick(&self, tick_interval: Duration) -> ReaperTickResult {
+        if matches!(self.config.mode, GovernanceMode::Off) {
+            return ReaperTickResult {
+                decisions: Vec::new(),
+                median_log_ratio: None,
+                mad: None,
+                threshold: None,
+                capacity_ceiling_binding: false,
+                sample_size: 0,
+                skip_reason: None,
+            };
+        }
+
+        let now = self.time_source.now();
+
+        // 1. Apply decay to every score AND check for ban-TTL expiry.
+        // Banned → Normal transition is unconditional after `ban_ttl`
+        // passes since the BanTriggered transition (recorded in
+        // `last_transition`).
+        let mut ban_lifted: Vec<ContractKey> = Vec::new();
+        for mut entry in self.scores.iter_mut() {
+            entry.decay(tick_interval, self.config.decay_half_life);
+            if entry.state == GovernanceState::Banned {
+                let elapsed = now.saturating_duration_since(entry.last_transition);
+                if elapsed >= self.config.ban_ttl {
+                    ban_lifted.push(*entry.key());
+                }
+            }
+        }
+
+        // 2. Collect the log-ratio sample. Contracts inside the ramp-up
+        //    window are excluded — a new contract whose benefit hasn't
+        //    accumulated yet would skew the distribution and might be
+        //    flagged for being new rather than for being abusive.
+        let actionable_samples: HashMap<ContractKey, f64> = self
+            .scores
+            .iter()
+            .filter_map(|entry| {
+                let age = now.saturating_duration_since(entry.first_seen);
+                if age < self.config.ramp_up {
+                    return None;
+                }
+                // Banned contracts are excluded from the distribution
+                // computation — we don't want a banned contract's
+                // extreme ratio dragging the threshold.
+                if entry.state == GovernanceState::Banned {
+                    return None;
+                }
+                entry.log_ratio().map(|r| (*entry.key(), r))
+            })
+            .collect();
+
+        // 3. Run MAD detection on the sample.
+        let outlier_result: OutlierResult<ContractKey> = detect_outliers(
+            &actionable_samples,
+            |&r| Some(r),
+            &self.config.outlier,
+            self.config.capacity_ceiling_log,
+        );
+
+        // 4. Drive state transitions. For each contract in the sample,
+        //    decide its new state based on where its log-ratio falls:
+        //    - Above threshold → WouldEvict (or Evicted in Enforce)
+        //    - Above median + N·MAD (borderline) → Borderline
+        //    - Otherwise → Normal (or stay where it is if recently
+        //      transitioned and recovering)
+        let mut decisions: Vec<ReaperDecision> = Vec::new();
+        let flagged: std::collections::HashSet<ContractKey> =
+            outlier_result.flagged.iter().cloned().collect();
+        let actionable = self.config.mode.evicts();
+        // Borderline cutoff is only meaningful when MAD is non-zero.
+        // A collapsed MAD means the population is too homogeneous to
+        // distinguish "elevated" from "normal"; falling back to
+        // median-only would flag every contract slightly above
+        // median, which is wrong.
+        let borderline_cutoff = match (outlier_result.median_log_ratio, outlier_result.mad) {
+            (Some(m), Some(mad)) if mad > f64::EPSILON => {
+                Some(m + self.config.borderline_mad_units * mad)
+            }
+            _ => None,
+        };
+
+        for (key, log_ratio) in actionable_samples.iter() {
+            let Some(mut entry) = self.scores.get_mut(key) else {
+                continue;
+            };
+            let from = entry.state;
+            let next = if flagged.contains(key) {
+                // Past threshold. In Enforce we'd move to Evicted; in
+                // DryRun we mark WouldEvict so the dashboard reflects
+                // "the system would act on this." Repeat-eviction
+                // ban (Phase 7) escalates Evicted → Banned only if
+                // a previous eviction happened within the ban window.
+                if actionable {
+                    let recently_evicted = entry.history.iter().rev().any(|t| {
+                        matches!(t.reason, TransitionReason::Evicted)
+                            && now.saturating_duration_since(t.at) <= self.config.ban_window
+                    });
+                    if recently_evicted {
+                        GovernanceState::Banned
+                    } else {
+                        GovernanceState::Evicted
+                    }
+                } else {
+                    GovernanceState::WouldEvict
+                }
+            } else if borderline_cutoff.is_some_and(|c| *log_ratio >= c) {
+                GovernanceState::Borderline
+            } else {
+                GovernanceState::Normal
+            };
+
+            if next == from {
+                continue;
+            }
+            let reason = match (from, next) {
+                (_, GovernanceState::Borderline) => TransitionReason::BorderlineEntered,
+                (_, GovernanceState::WouldEvict) => TransitionReason::ThresholdCrossed,
+                (_, GovernanceState::Evicted) => TransitionReason::Evicted,
+                (_, GovernanceState::Banned) => TransitionReason::BanTriggered,
+                (_, GovernanceState::Normal) => TransitionReason::Recovered,
+            };
+            entry.record_transition(now, next, reason);
+            decisions.push(ReaperDecision {
+                key: *key,
+                from,
+                to: next,
+                reason,
+                at: now,
+                actionable,
+            });
+        }
+
+        // 5. Process ban TTLs that expired during the decay walk.
+        for key in ban_lifted {
+            if let Some(mut entry) = self.scores.get_mut(&key) {
+                if entry.state == GovernanceState::Banned {
+                    let from = entry.state;
+                    entry.record_transition(
+                        now,
+                        GovernanceState::Normal,
+                        TransitionReason::BanLifted,
+                    );
+                    decisions.push(ReaperDecision {
+                        key,
+                        from,
+                        to: GovernanceState::Normal,
+                        reason: TransitionReason::BanLifted,
+                        at: now,
+                        actionable: true,
+                    });
+                }
+            }
+        }
+
+        ReaperTickResult {
+            decisions,
+            median_log_ratio: outlier_result.median_log_ratio,
+            mad: outlier_result.mad,
+            threshold: outlier_result.threshold,
+            capacity_ceiling_binding: outlier_result.capacity_ceiling_binding,
+            sample_size: outlier_result.sample_size,
+            skip_reason: outlier_result.skip_reason,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -457,5 +797,330 @@ mod tests {
         assert!(!GovernanceMode::Off.evicts());
         assert!(!GovernanceMode::DryRun.evicts());
         assert!(GovernanceMode::Enforce.evicts());
+    }
+
+    // ============================================================
+    // GovernanceManager tests
+    // ============================================================
+
+    use crate::util::time_source::MockTimeSource;
+    use freenet_stdlib::prelude::{CodeHash, ContractInstanceId};
+
+    fn mk_key(seed: u8) -> ContractKey {
+        ContractKey::from_id_and_code(
+            ContractInstanceId::new([seed; 32]),
+            CodeHash::new([seed.wrapping_add(1); 32]),
+        )
+    }
+
+    /// Mutex-wrapping the time source for tests where we need to
+    /// advance time after construction. Wraps `MockTimeSource` in a
+    /// type that implements `TimeSource` by locking and reading.
+    #[derive(Debug)]
+    struct SharedTs(std::sync::Mutex<MockTimeSource>);
+    impl SharedTs {
+        fn new() -> Arc<Self> {
+            Arc::new(Self(std::sync::Mutex::new(MockTimeSource::new(
+                Instant::now(),
+            ))))
+        }
+        fn advance(&self, d: Duration) {
+            self.0.lock().unwrap().advance_time(d);
+        }
+    }
+    impl TimeSource for SharedTs {
+        fn now(&self) -> Instant {
+            self.0.lock().unwrap().now()
+        }
+    }
+
+    fn mk_mgr_shared(mode: GovernanceMode) -> (GovernanceManager<SharedTs>, Arc<SharedTs>) {
+        let ts = SharedTs::new();
+        let outlier = OutlierConfig {
+            min_samples: 5,
+            trim_fraction: 0.0,
+            ..Default::default()
+        };
+        let config = GovernanceConfig {
+            mode,
+            outlier,
+            ramp_up: Duration::from_secs(1),
+            ..Default::default()
+        };
+        let mgr = GovernanceManager::new(config, ts.clone());
+        (mgr, ts)
+    }
+
+    #[test]
+    fn new_manager_is_empty() {
+        let (mgr, _ts) = mk_mgr_shared(GovernanceMode::DryRun);
+        assert_eq!(mgr.len(), 0);
+    }
+
+    #[test]
+    fn ingest_cost_creates_score_on_first_observation() {
+        let (mgr, _ts) = mk_mgr_shared(GovernanceMode::DryRun);
+        let k = mk_key(1);
+        mgr.ingest_cost(k, 10.0);
+        assert_eq!(mgr.len(), 1);
+        let s = mgr.score_snapshot(&k).unwrap();
+        assert_eq!(s.cost_used, 10.0);
+        assert_eq!(s.benefit_score, 0.0);
+        assert_eq!(s.state, GovernanceState::Normal);
+        // FirstSeen is recorded.
+        assert_eq!(s.history.len(), 1);
+    }
+
+    #[test]
+    fn ingest_demand_creates_score_on_first_observation() {
+        let (mgr, _ts) = mk_mgr_shared(GovernanceMode::DryRun);
+        let k = mk_key(1);
+        mgr.ingest_demand(k, 1.5);
+        let s = mgr.score_snapshot(&k).unwrap();
+        assert_eq!(s.benefit_score, 1.5);
+        assert_eq!(s.cost_used, 0.0);
+    }
+
+    #[test]
+    fn ingest_rejects_non_finite_or_negative_amounts() {
+        let (mgr, _ts) = mk_mgr_shared(GovernanceMode::DryRun);
+        let k = mk_key(1);
+        mgr.ingest_cost(k, -5.0); // negative ignored
+        mgr.ingest_cost(k, f64::NAN);
+        mgr.ingest_cost(k, f64::INFINITY);
+        mgr.ingest_demand(k, 0.0); // zero ignored (no demand)
+        mgr.ingest_demand(k, -1.0);
+        // No score created from invalid inputs.
+        assert_eq!(mgr.len(), 0);
+    }
+
+    #[test]
+    fn off_mode_tick_produces_no_decisions() {
+        let (mgr, ts) = mk_mgr_shared(GovernanceMode::Off);
+        let k = mk_key(1);
+        mgr.ingest_cost(k, 1000.0);
+        mgr.ingest_demand(k, 0.1);
+        ts.advance(Duration::from_secs(60));
+        let result = mgr.tick(Duration::from_secs(1));
+        assert!(result.decisions.is_empty());
+        assert_eq!(result.sample_size, 0);
+    }
+
+    #[test]
+    fn ramp_up_excludes_new_contracts_from_detection() {
+        let (mgr, _ts) = mk_mgr_shared(GovernanceMode::DryRun);
+        // Synthesize a clearly-abusive contract immediately on creation.
+        for i in 0..10 {
+            mgr.ingest_cost(mk_key(i), 1.0);
+            mgr.ingest_demand(mk_key(i), 1.0);
+        }
+        let abuser = mk_key(99);
+        mgr.ingest_cost(abuser, 100_000.0);
+        mgr.ingest_demand(abuser, 0.1);
+        // Tick immediately — all contracts are inside ramp-up.
+        let result = mgr.tick(Duration::from_secs(1));
+        assert!(result.decisions.is_empty());
+        // The detector saw zero usable samples because everything was
+        // ramp-up gated.
+        assert_eq!(result.sample_size, 0);
+    }
+
+    #[test]
+    fn detects_outlier_after_ramp_up() {
+        let (mgr, ts) = mk_mgr_shared(GovernanceMode::DryRun);
+        // Bulk: 30 honest contracts clustered around log-ratio = -1.
+        for i in 0..30 {
+            // Tiny jitter so MAD doesn't collapse to zero; keeps the
+            // population recognisably honest but gives the detector
+            // a real distribution to work with.
+            let jitter = (i as f64 - 15.0) * 0.01;
+            mgr.ingest_cost(mk_key(i), 0.1 + jitter * 0.05);
+            mgr.ingest_demand(mk_key(i), 1.0 + jitter);
+        }
+        // One abuser with cost ratio = 100 (log10 = 2).
+        let abuser = mk_key(99);
+        mgr.ingest_cost(abuser, 100.0);
+        mgr.ingest_demand(abuser, 1.0);
+
+        // Past ramp-up window so all contracts are eligible.
+        ts.advance(Duration::from_secs(2));
+        let result = mgr.tick(Duration::from_millis(100));
+        // Sample includes everything (31 total).
+        assert_eq!(result.sample_size, 31);
+        // The abuser should be flagged.
+        let flagged_keys: Vec<_> = result.decisions.iter().map(|d| d.key).collect();
+        assert!(flagged_keys.contains(&abuser));
+        // Honest contracts shouldn't be flagged.
+        assert!(!flagged_keys.contains(&mk_key(0)));
+    }
+
+    #[test]
+    fn dry_run_marks_would_evict_not_evicted() {
+        let (mgr, ts) = mk_mgr_shared(GovernanceMode::DryRun);
+        for i in 0..30 {
+            // Tiny jitter so MAD doesn't collapse to zero; keeps the
+            // population recognisably honest but gives the detector
+            // a real distribution to work with.
+            let jitter = (i as f64 - 15.0) * 0.01;
+            mgr.ingest_cost(mk_key(i), 0.1 + jitter * 0.05);
+            mgr.ingest_demand(mk_key(i), 1.0 + jitter);
+        }
+        let abuser = mk_key(99);
+        mgr.ingest_cost(abuser, 100.0);
+        mgr.ingest_demand(abuser, 1.0);
+        ts.advance(Duration::from_secs(2));
+        let result = mgr.tick(Duration::from_millis(100));
+        let abuser_decision = result.decisions.iter().find(|d| d.key == abuser).unwrap();
+        assert_eq!(abuser_decision.to, GovernanceState::WouldEvict);
+        // Dry-run: not actionable.
+        assert!(!abuser_decision.actionable);
+    }
+
+    #[test]
+    fn enforce_marks_evicted_first_time() {
+        let (mgr, ts) = mk_mgr_shared(GovernanceMode::Enforce);
+        for i in 0..30 {
+            // Tiny jitter so MAD doesn't collapse to zero; keeps the
+            // population recognisably honest but gives the detector
+            // a real distribution to work with.
+            let jitter = (i as f64 - 15.0) * 0.01;
+            mgr.ingest_cost(mk_key(i), 0.1 + jitter * 0.05);
+            mgr.ingest_demand(mk_key(i), 1.0 + jitter);
+        }
+        let abuser = mk_key(99);
+        mgr.ingest_cost(abuser, 100.0);
+        mgr.ingest_demand(abuser, 1.0);
+        ts.advance(Duration::from_secs(2));
+        let result = mgr.tick(Duration::from_millis(100));
+        let abuser_decision = result.decisions.iter().find(|d| d.key == abuser).unwrap();
+        assert_eq!(abuser_decision.to, GovernanceState::Evicted);
+        assert!(abuser_decision.actionable);
+    }
+
+    #[test]
+    fn second_eviction_within_ban_window_triggers_ban() {
+        let (mgr, ts) = mk_mgr_shared(GovernanceMode::Enforce);
+        // Healthy population.
+        for i in 0..30 {
+            // Tiny jitter so MAD doesn't collapse to zero; keeps the
+            // population recognisably honest but gives the detector
+            // a real distribution to work with.
+            let jitter = (i as f64 - 15.0) * 0.01;
+            mgr.ingest_cost(mk_key(i), 0.1 + jitter * 0.05);
+            mgr.ingest_demand(mk_key(i), 1.0 + jitter);
+        }
+        let abuser = mk_key(99);
+        mgr.ingest_cost(abuser, 100.0);
+        mgr.ingest_demand(abuser, 1.0);
+        ts.advance(Duration::from_secs(2));
+        // First eviction.
+        let result1 = mgr.tick(Duration::from_millis(100));
+        assert_eq!(
+            result1
+                .decisions
+                .iter()
+                .find(|d| d.key == abuser)
+                .unwrap()
+                .to,
+            GovernanceState::Evicted
+        );
+        // Re-feed abuser's cost (simulating re-PUT + UPDATE storm).
+        mgr.ingest_cost(abuser, 100.0);
+        ts.advance(Duration::from_secs(1));
+        // Second eviction within the ban_window — should escalate to Banned.
+        let result2 = mgr.tick(Duration::from_millis(100));
+        let second = result2.decisions.iter().find(|d| d.key == abuser).unwrap();
+        assert_eq!(second.to, GovernanceState::Banned);
+        assert!(matches!(second.reason, TransitionReason::BanTriggered));
+    }
+
+    #[test]
+    fn ban_ttl_expires_back_to_normal() {
+        let (mgr, ts) = mk_mgr_shared(GovernanceMode::Enforce);
+        for i in 0..30 {
+            // Tiny jitter so MAD doesn't collapse to zero; keeps the
+            // population recognisably honest but gives the detector
+            // a real distribution to work with.
+            let jitter = (i as f64 - 15.0) * 0.01;
+            mgr.ingest_cost(mk_key(i), 0.1 + jitter * 0.05);
+            mgr.ingest_demand(mk_key(i), 1.0 + jitter);
+        }
+        let abuser = mk_key(99);
+        mgr.ingest_cost(abuser, 100.0);
+        mgr.ingest_demand(abuser, 1.0);
+        ts.advance(Duration::from_secs(2));
+        // First eviction.
+        mgr.tick(Duration::from_millis(100));
+        // Re-feed + second tick → Banned.
+        mgr.ingest_cost(abuser, 100.0);
+        ts.advance(Duration::from_secs(1));
+        mgr.tick(Duration::from_millis(100));
+        // Now advance past ban_ttl.
+        ts.advance(Duration::from_secs(60 * 60 + 1));
+        let result = mgr.tick(Duration::from_millis(100));
+        let lifted = result.decisions.iter().find(|d| d.key == abuser).unwrap();
+        assert_eq!(lifted.from, GovernanceState::Banned);
+        assert_eq!(lifted.to, GovernanceState::Normal);
+        assert!(matches!(lifted.reason, TransitionReason::BanLifted));
+    }
+
+    #[test]
+    fn borderline_state_for_three_mad_outside_threshold() {
+        // Build a tight distribution where one contract sits between
+        // +3·MAD and +5·MAD — the borderline zone.
+        let (mgr, ts) = mk_mgr_shared(GovernanceMode::DryRun);
+        // Tighten the trim so all 30 honest contracts dominate the MAD.
+        // Set 30 contracts at exactly cost=0.1, benefit=1.0
+        // (log-ratio = -1, MAD then comes from the inserted outlier).
+        // Use slight jitter so MAD isn't zero.
+        for i in 0..30 {
+            let jitter = (i as f64 - 15.0) * 0.001;
+            mgr.ingest_cost(mk_key(i), 0.1 + jitter);
+            mgr.ingest_demand(mk_key(i), 1.0);
+        }
+        // A "borderline" contract: cost ratio = 1.0 (log = 0), which
+        // is +1 above the median of -1. With small MAD this is multiple
+        // MAD-units away — should land in Borderline, not WouldEvict.
+        let borderline = mk_key(99);
+        mgr.ingest_cost(borderline, 1.0);
+        mgr.ingest_demand(borderline, 1.0);
+        ts.advance(Duration::from_secs(2));
+        let result = mgr.tick(Duration::from_millis(100));
+        let decision = result.decisions.iter().find(|d| d.key == borderline);
+        if let Some(d) = decision {
+            // Either WouldEvict (if it crossed threshold due to tight MAD)
+            // or Borderline (between +3·MAD and threshold). Both are
+            // valid outcomes of this synthesized distribution; the
+            // critical invariant is that something flagged this
+            // contract.
+            assert!(
+                matches!(
+                    d.to,
+                    GovernanceState::WouldEvict | GovernanceState::Borderline
+                ),
+                "expected borderline/wouldevict, got {:?}",
+                d.to
+            );
+        }
+    }
+
+    #[test]
+    fn snapshot_returns_clone() {
+        let (mgr, _ts) = mk_mgr_shared(GovernanceMode::DryRun);
+        let k = mk_key(1);
+        mgr.ingest_cost(k, 10.0);
+        let s1 = mgr.score_snapshot(&k).unwrap();
+        // Modify the manager's score after snapshot — snapshot
+        // should be unaffected (it's a clone).
+        mgr.ingest_cost(k, 5.0);
+        let s2 = mgr.score_snapshot(&k).unwrap();
+        assert_eq!(s1.cost_used, 10.0);
+        assert_eq!(s2.cost_used, 15.0);
+    }
+
+    #[test]
+    fn missing_key_returns_none() {
+        let (mgr, _ts) = mk_mgr_shared(GovernanceMode::DryRun);
+        assert!(mgr.score_snapshot(&mk_key(42)).is_none());
     }
 }

--- a/crates/core/src/contract/governance.rs
+++ b/crates/core/src/contract/governance.rs
@@ -1,0 +1,461 @@
+// Consumers (the meter-driven reaper tick, the executor's contract-
+// receive boundary, the dashboard's snapshot endpoint) land in
+// subsequent commits. This commit ships the data model and state-
+// transition logic in isolation so each piece is reviewable
+// independently.
+#![allow(dead_code)]
+
+//! Per-contract governance scoring and state machine.
+//!
+//! Consumes the shared MAD-based outlier detector in `crate::governance`
+//! and turns it into per-contract decisions (Normal / Borderline /
+//! WouldEvict / Evicted / Banned). Reads cost data from the per-contract
+//! attribution wired into the `Meter` in PR #1 and demand data from
+//! `HostingManager`'s existing subscription tracking.
+//!
+//! ## Authoritative principle
+//!
+//! See `docs/design/contract-hardening.md` — "Design principle:
+//! dashboard reflects back-end, not the other way around." This module
+//! is the back-end. Every state, transition, and number that appears
+//! on the dashboard must originate from data this module computes
+//! from real meter samples and real subscription events. The dashboard
+//! does not invent fields; this module does not invent state.
+//!
+//! ## What's here in this commit
+//!
+//! Data model and state-machine logic, no I/O wiring yet:
+//!
+//! * [`GovernanceState`] — the five lifecycle states a contract can be
+//!   in under this node's view.
+//! * [`ContractScore`] — running cost/benefit aggregates per contract,
+//!   plus the contract's current state and transition history.
+//! * [`StateTransition`] / [`TransitionReason`] — the entries that
+//!   feed the dashboard's Decision History panel.
+//! * [`GovernanceMode`] — off / dry-run / enforce, gating whether
+//!   state transitions actually evict.
+//!
+//! Wiring (read costs from `Meter`, read demand from `HostingManager`,
+//! drive the reaper tick, emit `EvictContract` events) lands in
+//! subsequent commits. The data model is committed first so each
+//! subsequent commit is small enough to review independently.
+
+use std::time::Duration;
+
+use tokio::time::Instant;
+
+/// The five states a contract can be in under per-contract governance.
+///
+/// Transitions are driven by the reaper tick comparing each contract's
+/// log(cost/benefit) ratio against the MAD-derived threshold from the
+/// network distribution.
+///
+/// **No operator-initiated state.** None of these states represent an
+/// operator marking a contract; every transition is automatic and
+/// based on observed cost/benefit. The dashboard surfaces these
+/// states; it does not invoke them.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+pub(crate) enum GovernanceState {
+    /// Within network norms. The default state for any healthy contract.
+    Normal,
+    /// Cost/benefit ratio has crossed +3 standard deviations from
+    /// typical but is below the eviction threshold. Watching; no
+    /// action yet.
+    Borderline,
+    /// Cost/benefit ratio has crossed the eviction threshold. In
+    /// dry-run mode this is logged but no eviction occurs; in enforce
+    /// mode the reaper acts.
+    WouldEvict,
+    /// Actively evicted by this node. Disk reclamation done;
+    /// `SubscribeMsg::Cancelled` sent to downstream peers (Phase 5).
+    Evicted,
+    /// Re-evicted within the ban TTL window (Phase 7). This node
+    /// refuses to host or process this contract for the remainder
+    /// of the ban window.
+    Banned,
+}
+
+impl GovernanceState {
+    /// Whether this state is "flagged" — anything that would show up
+    /// in the dashboard's verdict block as worth surfacing.
+    pub(crate) fn is_flagged(self) -> bool {
+        !matches!(self, GovernanceState::Normal)
+    }
+
+    /// Whether this state actively blocks new operations on the
+    /// contract (PUT / UPDATE / SUBSCRIBE rejected at the receive
+    /// boundary). Only `Banned` does this.
+    pub(crate) fn blocks_operations(self) -> bool {
+        matches!(self, GovernanceState::Banned)
+    }
+}
+
+/// Why a contract transitioned between states. Surfaces as the human-
+/// readable string in the dashboard's Decision History panel — the
+/// translation happens at render time, not here. This enum stays
+/// expressive and code-shaped; the dashboard chooses operator-facing
+/// language.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum TransitionReason {
+    /// Contract first observed on this node. Score initialised; no
+    /// demand or cost yet recorded.
+    FirstSeen,
+    /// Cost/benefit ratio crossed into the borderline zone
+    /// (median + 3·MAD ≤ log-ratio < threshold).
+    BorderlineEntered,
+    /// Cost/benefit ratio crossed the eviction threshold.
+    ThresholdCrossed,
+    /// Reaper actioned the eviction. In dry-run this transition is
+    /// recorded but the contract isn't actually evicted.
+    Evicted,
+    /// Re-evicted within the ban TTL window — Phase 7's repeat-
+    /// offender mechanism.
+    BanTriggered,
+    /// Score decayed below the borderline threshold. Contract
+    /// returned to Normal.
+    Recovered,
+    /// Ban TTL expired. Contract returns to Normal and may be
+    /// re-accepted (or re-flagged) based on subsequent activity.
+    BanLifted,
+}
+
+/// A recorded state transition. The dashboard's Decision History
+/// panel iterates the contract's transition list and renders each as
+/// a row.
+///
+/// Bounded length is enforced at insertion (see [`ContractScore::record_transition`])
+/// so this never grows without bound on a long-lived contract.
+#[derive(Clone, Debug)]
+pub(crate) struct StateTransition {
+    pub at: Instant,
+    pub from: GovernanceState,
+    pub to: GovernanceState,
+    pub reason: TransitionReason,
+}
+
+/// Maximum number of transitions retained per contract. Older entries
+/// are dropped; the head of `history` always holds `FirstSeen` so the
+/// dashboard can show "first observed at" without unbounded growth.
+pub(crate) const MAX_TRANSITIONS_PER_CONTRACT: usize = 32;
+
+/// Per-contract running aggregate. The dashboard's per-contract row
+/// reads from this; the reaper compares `cost_used / benefit_score`
+/// against the network's MAD-derived threshold to drive transitions.
+///
+/// Both `cost_used` and `benefit_score` decay over a rolling window
+/// (handled by [`ContractScore::decay`] called from the reaper tick).
+/// Without decay, a once-flagged contract would stay flagged forever
+/// even if its activity calmed down.
+#[derive(Clone, Debug)]
+pub(crate) struct ContractScore {
+    /// Sum of weighted resource samples attributed to this contract.
+    /// Sourced from `Meter` entries keyed on
+    /// `AttributionSource::Contract(_)`.
+    pub cost_used: f64,
+    /// Sum of weighted demand events. Local subscriptions weigh more
+    /// than forwarded (Sybil resistance — see design doc).
+    pub benefit_score: f64,
+    /// Current state.
+    pub state: GovernanceState,
+    /// Wall-clock-equivalent (via `TimeSource`) of first observation.
+    /// Used to gate the ramp-up window — a brand-new contract isn't
+    /// eligible for flagging while it's still accumulating its first
+    /// few demand signals.
+    pub first_seen: Instant,
+    /// When the last state transition happened. Used by the ban-TTL
+    /// check to know "did we evict this contract within the window?"
+    pub last_transition: Instant,
+    /// State history, capped at `MAX_TRANSITIONS_PER_CONTRACT`. Always
+    /// preserves the `FirstSeen` entry as the head; older transitions
+    /// in the middle are dropped if the cap is exceeded.
+    pub history: Vec<StateTransition>,
+}
+
+impl ContractScore {
+    /// Create a new score in the `Normal` state and record the
+    /// `FirstSeen` transition. Cost and benefit start at zero.
+    pub(crate) fn new(now: Instant) -> Self {
+        let first = StateTransition {
+            at: now,
+            from: GovernanceState::Normal,
+            to: GovernanceState::Normal,
+            reason: TransitionReason::FirstSeen,
+        };
+        Self {
+            cost_used: 0.0,
+            benefit_score: 0.0,
+            state: GovernanceState::Normal,
+            first_seen: now,
+            last_transition: now,
+            history: vec![first],
+        }
+    }
+
+    /// Compute the log10(cost/benefit) ratio used by the MAD detector.
+    /// Returns `None` if benefit_score is too small to produce a
+    /// stable ratio (avoids division-by-near-zero pulling the
+    /// distribution toward infinity for new contracts).
+    pub(crate) fn log_ratio(&self) -> Option<f64> {
+        if self.benefit_score <= f64::EPSILON {
+            return None;
+        }
+        let ratio = self.cost_used / self.benefit_score;
+        if ratio <= 0.0 {
+            return None;
+        }
+        Some(ratio.log10())
+    }
+
+    /// Record a state transition into the history, capped at
+    /// `MAX_TRANSITIONS_PER_CONTRACT`. Always preserves the
+    /// `FirstSeen` entry — if the cap is exceeded, drops the
+    /// second-oldest entry instead.
+    pub(crate) fn record_transition(
+        &mut self,
+        now: Instant,
+        to: GovernanceState,
+        reason: TransitionReason,
+    ) {
+        let from = self.state;
+        if from == to {
+            // No-op transitions (same state, just a re-check) don't
+            // pollute history. The reaper tick may call us with the
+            // same state on every pass for a healthy contract.
+            return;
+        }
+        let transition = StateTransition {
+            at: now,
+            from,
+            to,
+            reason,
+        };
+        self.state = to;
+        self.last_transition = now;
+
+        if self.history.len() < MAX_TRANSITIONS_PER_CONTRACT {
+            self.history.push(transition);
+            return;
+        }
+        // Cap exceeded: keep FirstSeen at index 0, drop the next-
+        // oldest entry, append the new one.
+        if self.history.len() >= 2 {
+            self.history.remove(1);
+        }
+        self.history.push(transition);
+    }
+
+    /// Apply exponential decay to cost and benefit. Called once per
+    /// reaper tick. `half_life` is the duration over which a sample
+    /// loses half its weight; with `tick_interval` smaller than
+    /// `half_life` the decay per tick is gentle.
+    ///
+    /// Cost decays the same way benefit does, so a contract that goes
+    /// quiet has its ratio held constant by symmetric decay — the
+    /// state stays where the algorithm last placed it until new
+    /// samples arrive.
+    pub(crate) fn decay(&mut self, tick_interval: Duration, half_life: Duration) {
+        if tick_interval.is_zero() || half_life.is_zero() {
+            return;
+        }
+        let factor = 0.5f64.powf(tick_interval.as_secs_f64() / half_life.as_secs_f64());
+        self.cost_used *= factor;
+        self.benefit_score *= factor;
+    }
+}
+
+/// Operating mode for the governance system. Plan defaults to
+/// `DryRun` for one release after Phase 4 lands — operators see what
+/// would be evicted, dashboards reflect intended actions, but no
+/// contracts are actually evicted. After calibration, the operator
+/// (or release default) flips to `Enforce`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum GovernanceMode {
+    /// Disabled. No state computation, no transitions.
+    Off,
+    /// Compute state and record transitions, but do not evict. The
+    /// dashboard shows `WouldEvict` / `Evicted` states reflecting
+    /// what the system would do under `Enforce`.
+    DryRun,
+    /// Compute state, record transitions, and act — `Evicted` /
+    /// `Banned` cause real eviction and real refusal.
+    Enforce,
+}
+
+impl GovernanceMode {
+    /// Whether this mode actually evicts contracts. Both `Off` and
+    /// `DryRun` answer false.
+    pub(crate) fn evicts(self) -> bool {
+        matches!(self, GovernanceMode::Enforce)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn instant_t(offset_ms: u64) -> Instant {
+        // Tests use `Instant::now() + offset`; the offset is
+        // monotonic and the comparisons in this module only ever
+        // look at relative ordering, so the absolute time doesn't
+        // matter for the assertions here.
+        Instant::now() + Duration::from_millis(offset_ms)
+    }
+
+    #[test]
+    fn new_score_starts_normal_with_first_seen_history() {
+        let now = instant_t(0);
+        let s = ContractScore::new(now);
+        assert_eq!(s.state, GovernanceState::Normal);
+        assert_eq!(s.cost_used, 0.0);
+        assert_eq!(s.benefit_score, 0.0);
+        assert_eq!(s.history.len(), 1);
+        assert!(matches!(s.history[0].reason, TransitionReason::FirstSeen));
+        assert_eq!(s.first_seen, now);
+        assert_eq!(s.last_transition, now);
+    }
+
+    #[test]
+    fn log_ratio_none_when_no_benefit() {
+        let mut s = ContractScore::new(instant_t(0));
+        // No benefit yet → undefined ratio.
+        assert_eq!(s.log_ratio(), None);
+        s.cost_used = 5.0;
+        // Cost without benefit is still undefined — a brand-new
+        // contract has no demand baseline yet.
+        assert_eq!(s.log_ratio(), None);
+    }
+
+    #[test]
+    fn log_ratio_none_when_cost_zero() {
+        let mut s = ContractScore::new(instant_t(0));
+        s.benefit_score = 10.0;
+        // No cost → ratio is 0, log(0) is undefined.
+        assert_eq!(s.log_ratio(), None);
+    }
+
+    #[test]
+    fn log_ratio_computes_log10_of_cost_over_benefit() {
+        let mut s = ContractScore::new(instant_t(0));
+        s.cost_used = 10.0;
+        s.benefit_score = 1.0;
+        // log10(10) = 1
+        assert!((s.log_ratio().unwrap() - 1.0).abs() < 1e-9);
+
+        s.cost_used = 0.1;
+        s.benefit_score = 10.0;
+        // log10(0.01) = -2
+        assert!((s.log_ratio().unwrap() - (-2.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn record_transition_updates_state_and_history() {
+        let mut s = ContractScore::new(instant_t(0));
+        s.record_transition(
+            instant_t(100),
+            GovernanceState::Borderline,
+            TransitionReason::BorderlineEntered,
+        );
+        assert_eq!(s.state, GovernanceState::Borderline);
+        assert_eq!(s.history.len(), 2);
+        let last = s.history.last().unwrap();
+        assert_eq!(last.from, GovernanceState::Normal);
+        assert_eq!(last.to, GovernanceState::Borderline);
+        assert!(matches!(last.reason, TransitionReason::BorderlineEntered));
+    }
+
+    #[test]
+    fn record_transition_skips_no_op_same_state() {
+        let mut s = ContractScore::new(instant_t(0));
+        s.record_transition(
+            instant_t(100),
+            GovernanceState::Borderline,
+            TransitionReason::BorderlineEntered,
+        );
+        let initial_len = s.history.len();
+        // Re-asserting the same state is a no-op — the reaper tick
+        // will call this every cycle, history must not bloat.
+        s.record_transition(
+            instant_t(200),
+            GovernanceState::Borderline,
+            TransitionReason::BorderlineEntered,
+        );
+        assert_eq!(s.history.len(), initial_len);
+    }
+
+    #[test]
+    fn history_capped_preserves_first_seen() {
+        let mut s = ContractScore::new(instant_t(0));
+        // Force the history to exceed the cap by alternating
+        // transitions.
+        let mut state_toggle = false;
+        for i in 1..(MAX_TRANSITIONS_PER_CONTRACT + 10) {
+            state_toggle = !state_toggle;
+            let to = if state_toggle {
+                GovernanceState::Borderline
+            } else {
+                GovernanceState::Normal
+            };
+            let reason = if state_toggle {
+                TransitionReason::BorderlineEntered
+            } else {
+                TransitionReason::Recovered
+            };
+            s.record_transition(instant_t(i as u64 * 100), to, reason);
+        }
+        // FirstSeen is preserved as the head — that's load-bearing
+        // for the dashboard's "first observed at" display.
+        assert!(matches!(s.history[0].reason, TransitionReason::FirstSeen));
+        assert_eq!(s.history.len(), MAX_TRANSITIONS_PER_CONTRACT);
+    }
+
+    #[test]
+    fn decay_reduces_cost_and_benefit_symmetrically() {
+        let mut s = ContractScore::new(instant_t(0));
+        s.cost_used = 100.0;
+        s.benefit_score = 10.0;
+        let initial_ratio = s.cost_used / s.benefit_score;
+        s.decay(Duration::from_secs(60), Duration::from_secs(60));
+        // After one half-life, both should be half. Ratio is invariant
+        // — a contract that goes quiet doesn't drift through states.
+        assert!((s.cost_used - 50.0).abs() < 1e-9);
+        assert!((s.benefit_score - 5.0).abs() < 1e-9);
+        let new_ratio = s.cost_used / s.benefit_score;
+        assert!((new_ratio - initial_ratio).abs() < 1e-9);
+    }
+
+    #[test]
+    fn decay_zero_intervals_no_op() {
+        let mut s = ContractScore::new(instant_t(0));
+        s.cost_used = 100.0;
+        s.benefit_score = 10.0;
+        s.decay(Duration::ZERO, Duration::from_secs(60));
+        assert_eq!(s.cost_used, 100.0);
+        s.decay(Duration::from_secs(60), Duration::ZERO);
+        assert_eq!(s.cost_used, 100.0);
+    }
+
+    #[test]
+    fn governance_state_predicates() {
+        assert!(!GovernanceState::Normal.is_flagged());
+        assert!(GovernanceState::Borderline.is_flagged());
+        assert!(GovernanceState::WouldEvict.is_flagged());
+        assert!(GovernanceState::Evicted.is_flagged());
+        assert!(GovernanceState::Banned.is_flagged());
+
+        // Only Banned blocks new operations — Evicted contracts can
+        // be re-PUT immediately (and might trigger a re-eviction,
+        // which is Phase 7's ban-TTL trigger).
+        assert!(!GovernanceState::Normal.blocks_operations());
+        assert!(!GovernanceState::Borderline.blocks_operations());
+        assert!(!GovernanceState::WouldEvict.blocks_operations());
+        assert!(!GovernanceState::Evicted.blocks_operations());
+        assert!(GovernanceState::Banned.blocks_operations());
+    }
+
+    #[test]
+    fn governance_mode_evicts_only_in_enforce() {
+        assert!(!GovernanceMode::Off.evicts());
+        assert!(!GovernanceMode::DryRun.evicts());
+        assert!(GovernanceMode::Enforce.evicts());
+    }
+}

--- a/crates/core/src/contract/governance.rs
+++ b/crates/core/src/contract/governance.rs
@@ -43,7 +43,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dashmap::DashMap;
-use freenet_stdlib::prelude::ContractKey;
+use freenet_stdlib::prelude::ContractInstanceId;
 use tokio::time::Instant;
 
 use crate::governance::{OutlierConfig, OutlierResult, SkipReason, detect_outliers};
@@ -346,7 +346,7 @@ impl Default for GovernanceConfig {
 /// always recorded in the contract's `history`, regardless of mode.
 #[derive(Clone, Debug)]
 pub(crate) struct ReaperDecision {
-    pub key: ContractKey,
+    pub key: ContractInstanceId,
     pub from: GovernanceState,
     pub to: GovernanceState,
     pub reason: TransitionReason,
@@ -392,7 +392,7 @@ pub(crate) struct GovernanceManager<T: TimeSource> {
     /// rule: fine-grained shard locking lets the meter + the reaper
     /// tick + the receive-boundary check all read/write
     /// independently without serializing on a global lock.
-    scores: DashMap<ContractKey, ContractScore>,
+    scores: DashMap<ContractInstanceId, ContractScore>,
     /// Configuration; cloned cheaply when the reaper tick reads its
     /// fields.
     config: GovernanceConfig,
@@ -412,7 +412,7 @@ impl<T: TimeSource> GovernanceManager<T> {
     /// Add a cost sample to a contract's `cost_used`. Called from the
     /// Meter wiring (subsequent commit) on every per-contract resource
     /// report. If the contract is new, creates a `Normal`-state score.
-    pub(crate) fn ingest_cost(&self, key: ContractKey, amount: f64) {
+    pub(crate) fn ingest_cost(&self, key: ContractInstanceId, amount: f64) {
         if !amount.is_finite() || amount < 0.0 {
             return;
         }
@@ -429,7 +429,7 @@ impl<T: TimeSource> GovernanceManager<T> {
     /// observed local/forwarded GET / SUBSCRIBE / client-attach.
     /// Weight comes from the caller (local vs forwarded weighting
     /// applied at the call site).
-    pub(crate) fn ingest_demand(&self, key: ContractKey, weight: f64) {
+    pub(crate) fn ingest_demand(&self, key: ContractInstanceId, weight: f64) {
         if !weight.is_finite() || weight <= 0.0 {
             return;
         }
@@ -444,7 +444,7 @@ impl<T: TimeSource> GovernanceManager<T> {
     /// Look up the current score for a contract, for dashboard reads.
     /// Returns a cloned snapshot; the dashboard doesn't need (and
     /// shouldn't have) write access.
-    pub(crate) fn score_snapshot(&self, key: &ContractKey) -> Option<ContractScore> {
+    pub(crate) fn score_snapshot(&self, key: &ContractInstanceId) -> Option<ContractScore> {
         self.scores.get(key).map(|s| s.clone())
     }
 
@@ -481,7 +481,7 @@ impl<T: TimeSource> GovernanceManager<T> {
         // Banned → Normal transition is unconditional after `ban_ttl`
         // passes since the BanTriggered transition (recorded in
         // `last_transition`).
-        let mut ban_lifted: Vec<ContractKey> = Vec::new();
+        let mut ban_lifted: Vec<ContractInstanceId> = Vec::new();
         for mut entry in self.scores.iter_mut() {
             entry.decay(tick_interval, self.config.decay_half_life);
             if entry.state == GovernanceState::Banned {
@@ -496,7 +496,7 @@ impl<T: TimeSource> GovernanceManager<T> {
         //    window are excluded — a new contract whose benefit hasn't
         //    accumulated yet would skew the distribution and might be
         //    flagged for being new rather than for being abusive.
-        let actionable_samples: HashMap<ContractKey, f64> = self
+        let actionable_samples: HashMap<ContractInstanceId, f64> = self
             .scores
             .iter()
             .filter_map(|entry| {
@@ -515,7 +515,7 @@ impl<T: TimeSource> GovernanceManager<T> {
             .collect();
 
         // 3. Run MAD detection on the sample.
-        let outlier_result: OutlierResult<ContractKey> = detect_outliers(
+        let outlier_result: OutlierResult<ContractInstanceId> = detect_outliers(
             &actionable_samples,
             |&r| Some(r),
             &self.config.outlier,
@@ -529,7 +529,7 @@ impl<T: TimeSource> GovernanceManager<T> {
         //    - Otherwise → Normal (or stay where it is if recently
         //      transitioned and recovering)
         let mut decisions: Vec<ReaperDecision> = Vec::new();
-        let flagged: std::collections::HashSet<ContractKey> =
+        let flagged: std::collections::HashSet<ContractInstanceId> =
             outlier_result.flagged.iter().cloned().collect();
         let actionable = self.config.mode.evicts();
         // Borderline cutoff is only meaningful when MAD is non-zero.
@@ -804,13 +804,10 @@ mod tests {
     // ============================================================
 
     use crate::util::time_source::MockTimeSource;
-    use freenet_stdlib::prelude::{CodeHash, ContractInstanceId};
+    use freenet_stdlib::prelude::ContractInstanceId;
 
-    fn mk_key(seed: u8) -> ContractKey {
-        ContractKey::from_id_and_code(
-            ContractInstanceId::new([seed; 32]),
-            CodeHash::new([seed.wrapping_add(1); 32]),
-        )
+    fn mk_key(seed: u8) -> ContractInstanceId {
+        ContractInstanceId::new([seed; 32])
     }
 
     /// Mutex-wrapping the time source for tests where we need to

--- a/crates/core/src/contract/governance.rs
+++ b/crates/core/src/contract/governance.rs
@@ -387,7 +387,12 @@ pub(crate) struct ReaperTickResult {
 /// state and every network-level statistic in the dashboard is read
 /// from this manager (or from data it commands). No fields exist on
 /// the dashboard that aren't computed here.
-pub(crate) struct GovernanceManager<T: TimeSource> {
+///
+/// The time source is a trait object so the manager slots into `Ring`
+/// without generic bound propagation through every consumer. Tests
+/// wrap a `MockTimeSource` in `Arc<dyn TimeSource + Send + Sync>` and
+/// pass it through unchanged.
+pub(crate) struct GovernanceManager {
     /// Per-contract scoring state. `DashMap` chosen per code-style
     /// rule: fine-grained shard locking lets the meter + the reaper
     /// tick + the receive-boundary check all read/write
@@ -397,11 +402,14 @@ pub(crate) struct GovernanceManager<T: TimeSource> {
     /// fields.
     config: GovernanceConfig,
     /// Time source — every timestamp goes through this for DST.
-    time_source: Arc<T>,
+    time_source: Arc<dyn TimeSource + Send + Sync>,
 }
 
-impl<T: TimeSource> GovernanceManager<T> {
-    pub(crate) fn new(config: GovernanceConfig, time_source: Arc<T>) -> Self {
+impl GovernanceManager {
+    pub(crate) fn new(
+        config: GovernanceConfig,
+        time_source: Arc<dyn TimeSource + Send + Sync>,
+    ) -> Self {
         Self {
             scores: DashMap::new(),
             config,
@@ -831,7 +839,7 @@ mod tests {
         }
     }
 
-    fn mk_mgr_shared(mode: GovernanceMode) -> (GovernanceManager<SharedTs>, Arc<SharedTs>) {
+    fn mk_mgr_shared(mode: GovernanceMode) -> (GovernanceManager, Arc<SharedTs>) {
         let ts = SharedTs::new();
         let outlier = OutlierConfig {
             min_samples: 5,
@@ -844,7 +852,8 @@ mod tests {
             ramp_up: Duration::from_secs(1),
             ..Default::default()
         };
-        let mgr = GovernanceManager::new(config, ts.clone());
+        let ts_dyn: Arc<dyn TimeSource + Send + Sync> = ts.clone();
+        let mgr = GovernanceManager::new(config, ts_dyn);
         (mgr, ts)
     }
 

--- a/crates/core/src/contract/governance.rs
+++ b/crates/core/src/contract/governance.rs
@@ -403,6 +403,26 @@ pub(crate) struct GovernanceManager {
     config: GovernanceConfig,
     /// Time source — every timestamp goes through this for DST.
     time_source: Arc<dyn TimeSource + Send + Sync>,
+    /// Most recent reaper-tick stats (median / MAD / threshold /
+    /// sample size / skip reason). Stored so the dashboard snapshot
+    /// builder can read network-norms without re-running detection.
+    /// `parking_lot::RwLock` for cheap reads — the snapshot builder
+    /// hits this every dashboard refresh.
+    latest_tick: parking_lot::RwLock<Option<NetworkNormsCache>>,
+}
+
+/// Internal cache of the network-norms portion of a `ReaperTickResult`.
+/// Excludes the per-decision list (those are logged at tick time;
+/// the dashboard reads transitions from each contract's `history`).
+#[derive(Clone, Debug)]
+pub(crate) struct NetworkNormsCache {
+    pub median_log_ratio: Option<f64>,
+    pub mad: Option<f64>,
+    pub threshold: Option<f64>,
+    pub capacity_ceiling_binding: bool,
+    pub sample_size: usize,
+    pub skip_reason: Option<SkipReason>,
+    pub at: Instant,
 }
 
 impl GovernanceManager {
@@ -414,7 +434,28 @@ impl GovernanceManager {
             scores: DashMap::new(),
             config,
             time_source,
+            latest_tick: parking_lot::RwLock::new(None),
         }
+    }
+
+    /// Operating mode, for the dashboard snapshot.
+    pub(crate) fn mode(&self) -> GovernanceMode {
+        self.config.mode
+    }
+
+    /// Read the latest network-norms snapshot, if any tick has run.
+    /// Used by the dashboard snapshot builder.
+    pub(crate) fn latest_norms(&self) -> Option<NetworkNormsCache> {
+        self.latest_tick.read().clone()
+    }
+
+    /// Iterate per-contract scores. Yields cloned snapshots so the
+    /// caller doesn't need to hold the DashMap shard guards.
+    pub(crate) fn iter_scores(&self) -> Vec<(ContractInstanceId, ContractScore)> {
+        self.scores
+            .iter()
+            .map(|e| (*e.key(), e.value().clone()))
+            .collect()
     }
 
     /// Add a cost sample to a contract's `cost_used`. Called from the
@@ -624,6 +665,17 @@ impl GovernanceManager {
                 }
             }
         }
+
+        // Cache the network-norms for the dashboard snapshot builder.
+        *self.latest_tick.write() = Some(NetworkNormsCache {
+            median_log_ratio: outlier_result.median_log_ratio,
+            mad: outlier_result.mad,
+            threshold: outlier_result.threshold,
+            capacity_ceiling_binding: outlier_result.capacity_ceiling_binding,
+            sample_size: outlier_result.sample_size,
+            skip_reason: outlier_result.skip_reason,
+            at: now,
+        });
 
         ReaperTickResult {
             decisions,

--- a/crates/core/src/contract/governance.rs
+++ b/crates/core/src/contract/governance.rs
@@ -526,18 +526,40 @@ impl GovernanceManager {
 
         let now = self.time_source.now();
 
-        // 1. Apply decay to every score AND check for ban-TTL expiry.
+        // 1. Apply decay to every score AND check for ban-TTL expiry
+        //    + evicted-window expiry.
+        //
         // Banned → Normal transition is unconditional after `ban_ttl`
         // passes since the BanTriggered transition (recorded in
         // `last_transition`).
+        //
+        // Evicted → Normal works on the same shape but with the
+        // `ban_window` TTL — once that window has elapsed without
+        // re-eviction, the contract is allowed to recover (skeptical
+        // reviewer flagged that without an explicit TTL sweep, Evicted
+        // could either flap back to Normal via decay-driven score
+        // recovery — see the stickiness rule in the transition loop —
+        // OR stay Evicted forever, neither of which we want).
         let mut ban_lifted: Vec<ContractInstanceId> = Vec::new();
+        let mut evicted_lifted: Vec<ContractInstanceId> = Vec::new();
         for mut entry in self.scores.iter_mut() {
             entry.decay(tick_interval, self.config.decay_half_life);
-            if entry.state == GovernanceState::Banned {
-                let elapsed = now.saturating_duration_since(entry.last_transition);
-                if elapsed >= self.config.ban_ttl {
-                    ban_lifted.push(*entry.key());
+            match entry.state {
+                GovernanceState::Banned => {
+                    let elapsed = now.saturating_duration_since(entry.last_transition);
+                    if elapsed >= self.config.ban_ttl {
+                        ban_lifted.push(*entry.key());
+                    }
                 }
+                GovernanceState::Evicted => {
+                    let elapsed = now.saturating_duration_since(entry.last_transition);
+                    if elapsed >= self.config.ban_window {
+                        evicted_lifted.push(*entry.key());
+                    }
+                }
+                GovernanceState::Normal
+                | GovernanceState::Borderline
+                | GovernanceState::WouldEvict => {}
             }
         }
 
@@ -593,6 +615,26 @@ impl GovernanceManager {
             _ => None,
         };
 
+        // Stickiness + MAD-collapse rules (skeptical-reviewer
+        // findings on #4270):
+        //
+        // - Once a contract is Evicted (Enforce mode), it stays
+        //   Evicted for the duration of the ban_window. Decay-driven
+        //   score recovery is NOT enough to undo an eviction — the
+        //   on-disk state is gone, and shrinking `cost_used` only
+        //   tells us "the cost signal faded", not "the contract is
+        //   fine now". Recovery happens via the explicit TTL sweep
+        //   in `evicted_lifted` below the main loop, the same shape
+        //   already used for Banned → Normal.
+        //
+        // - When MAD collapses (the population is too homogeneous
+        //   to compute `borderline_cutoff`), a previously-Borderline
+        //   contract MUST NOT auto-recover to Normal. Doing so logs
+        //   a spurious `Recovered` transition each time MAD
+        //   collapses and a fresh `BorderlineEntered` each time it
+        //   recomputes — pure flap. Skip the transition for that
+        //   tick and let the next tick re-evaluate.
+        let mad_collapsed = borderline_cutoff.is_none();
         for (key, log_ratio) in actionable_samples.iter() {
             let Some(mut entry) = self.scores.get_mut(key) else {
                 continue;
@@ -617,6 +659,12 @@ impl GovernanceManager {
                 } else {
                     GovernanceState::WouldEvict
                 }
+            } else if from == GovernanceState::Evicted {
+                // Evicted is sticky — see comment above the loop.
+                continue;
+            } else if mad_collapsed {
+                // No reliable signal — see comment above the loop.
+                continue;
             } else if borderline_cutoff.is_some_and(|c| *log_ratio >= c) {
                 GovernanceState::Borderline
             } else {
@@ -659,6 +707,33 @@ impl GovernanceManager {
                         from,
                         to: GovernanceState::Normal,
                         reason: TransitionReason::BanLifted,
+                        at: now,
+                        actionable: true,
+                    });
+                }
+            }
+        }
+
+        // 5b. Process evicted-window expiries the same way. A contract
+        // that has been Evicted for at least `ban_window` without a
+        // re-eviction is allowed to return to Normal. The
+        // `TransitionReason::Recovered` reason is reused — the dashboard
+        // can distinguish "actively-recovered (decay-driven)" from
+        // "recovered after eviction-window" via the `from` field.
+        for key in evicted_lifted {
+            if let Some(mut entry) = self.scores.get_mut(&key) {
+                if entry.state == GovernanceState::Evicted {
+                    let from = entry.state;
+                    entry.record_transition(
+                        now,
+                        GovernanceState::Normal,
+                        TransitionReason::Recovered,
+                    );
+                    decisions.push(ReaperDecision {
+                        key,
+                        from,
+                        to: GovernanceState::Normal,
+                        reason: TransitionReason::Recovered,
                         at: now,
                         actionable: true,
                     });
@@ -1180,5 +1255,190 @@ mod tests {
     fn missing_key_returns_none() {
         let (mgr, _ts) = mk_mgr_shared(GovernanceMode::DryRun);
         assert!(mgr.score_snapshot(&mk_key(42)).is_none());
+    }
+
+    /// Stickiness pin: once Evicted, a contract MUST NOT transition
+    /// back to Normal via decay-driven score recovery in the main loop.
+    /// It can only recover via the explicit ban_window TTL sweep.
+    ///
+    /// Skeptical reviewer of PR #4270 flagged this as the
+    /// Normal → Evicted → Normal flapping bug: an evicted contract is
+    /// still in `scores` and still receives demand events, so decay
+    /// shrinks `cost_used` faster than `benefit_score` builds, and the
+    /// ratio falls below threshold → "Recovered" transition is logged
+    /// while the on-disk state is already gone. Confusing at best,
+    /// state-machine vs data-plane divergence at worst.
+    #[test]
+    fn evicted_is_sticky_to_decay_driven_recovery() {
+        let (mgr, ts) = mk_mgr_shared(GovernanceMode::Enforce);
+        // Build an honest distribution + one abuser.
+        for i in 0..30 {
+            let jitter = (i as f64 - 15.0) * 0.01;
+            mgr.ingest_cost(mk_key(i), 0.1 + jitter * 0.05);
+            mgr.ingest_demand(mk_key(i), 1.0 + jitter);
+        }
+        let abuser = mk_key(99);
+        mgr.ingest_cost(abuser, 100.0);
+        mgr.ingest_demand(abuser, 1.0);
+        ts.advance(Duration::from_secs(2));
+
+        // First tick → abuser Evicted.
+        let r1 = mgr.tick(Duration::from_millis(100));
+        let evicted_decision = r1.decisions.iter().find(|d| d.key == abuser).unwrap();
+        assert_eq!(evicted_decision.to, GovernanceState::Evicted);
+
+        // Now flip the abuser's signal to "low cost, high benefit" —
+        // dragging its log-ratio FAR below threshold and below
+        // borderline_cutoff too. Without the stickiness rule, the next
+        // tick would log a `Recovered` transition (Evicted → Normal)
+        // even though the on-disk state is already gone.
+        for _ in 0..20 {
+            mgr.ingest_demand(abuser, 1.0);
+        }
+        // Re-feed honest contracts so the distribution still has a
+        // sensible MAD.
+        for i in 0..30 {
+            let jitter = (i as f64 - 15.0) * 0.01;
+            mgr.ingest_cost(mk_key(i), 0.1 + jitter * 0.05);
+            mgr.ingest_demand(mk_key(i), 1.0);
+        }
+        ts.advance(Duration::from_secs(60));
+        let r2 = mgr.tick(Duration::from_millis(100));
+
+        // Critical assertion: NO `Recovered` (or any `Normal`) transition
+        // logged for the abuser. It's allowed to escalate to Banned
+        // (repeat-eviction inside ban_window — also a valid transition
+        // out of Evicted) but never recover via decay.
+        assert!(
+            !r2.decisions
+                .iter()
+                .any(|d| d.key == abuser && d.to == GovernanceState::Normal),
+            "Evicted contract must NOT auto-recover to Normal via decay — \
+             found decision: {:?}",
+            r2.decisions
+                .iter()
+                .filter(|d| d.key == abuser)
+                .collect::<Vec<_>>(),
+        );
+
+        // Snapshot confirms the abuser is still Evicted or escalated to
+        // Banned — anything BUT Normal.
+        let snap_state = mgr.score_snapshot(&abuser).unwrap().state;
+        assert!(
+            matches!(
+                snap_state,
+                GovernanceState::Evicted | GovernanceState::Banned
+            ),
+            "abuser snapshot must still report Evicted/Banned, got {:?}",
+            snap_state
+        );
+    }
+
+    /// After the ban_window has elapsed, an Evicted contract IS allowed
+    /// to return to Normal via the explicit TTL sweep (the same shape
+    /// already used for Banned → Normal). This pins that the TTL recovery
+    /// path actually fires.
+    #[test]
+    fn evicted_lifts_back_to_normal_after_ban_window() {
+        let (mgr, ts) = mk_mgr_shared(GovernanceMode::Enforce);
+        for i in 0..30 {
+            let jitter = (i as f64 - 15.0) * 0.01;
+            mgr.ingest_cost(mk_key(i), 0.1 + jitter * 0.05);
+            mgr.ingest_demand(mk_key(i), 1.0 + jitter);
+        }
+        let abuser = mk_key(99);
+        mgr.ingest_cost(abuser, 100.0);
+        mgr.ingest_demand(abuser, 1.0);
+        ts.advance(Duration::from_secs(2));
+
+        // First tick → Evicted.
+        let r1 = mgr.tick(Duration::from_millis(100));
+        assert!(
+            r1.decisions
+                .iter()
+                .any(|d| d.key == abuser && d.to == GovernanceState::Evicted)
+        );
+
+        // Advance past ban_window without re-eviction.
+        ts.advance(Duration::from_secs(60 * 60 + 1));
+        let r = mgr.tick(Duration::from_millis(100));
+        let lift = r.decisions.iter().find(|d| d.key == abuser).unwrap();
+        assert_eq!(lift.from, GovernanceState::Evicted);
+        assert_eq!(lift.to, GovernanceState::Normal);
+        assert!(matches!(lift.reason, TransitionReason::Recovered));
+    }
+
+    /// MAD-collapse pin: when MAD collapses (the population is too
+    /// homogeneous to compute a borderline cutoff), a previously-
+    /// Borderline contract MUST NOT auto-recover to Normal. Doing so
+    /// would log a spurious `Recovered` transition each time MAD
+    /// collapses and a fresh `BorderlineEntered` each time it recomputes.
+    ///
+    /// Skeptical reviewer of PR #4270 flagged this as a dashboard
+    /// flapping risk: a homogeneous tick spuriously "recovers" every
+    /// Borderline contract, then the next tick with two outliers
+    /// flips them back to Borderline.
+    #[test]
+    fn mad_collapse_does_not_recover_borderline_to_normal() {
+        let (mgr, ts) = mk_mgr_shared(GovernanceMode::DryRun);
+        // Step 1: build a distribution with one Borderline contract.
+        for i in 0..30 {
+            let jitter = (i as f64 - 15.0) * 0.001;
+            mgr.ingest_cost(mk_key(i), 0.1 + jitter);
+            mgr.ingest_demand(mk_key(i), 1.0);
+        }
+        let borderline = mk_key(99);
+        mgr.ingest_cost(borderline, 1.0);
+        mgr.ingest_demand(borderline, 1.0);
+        ts.advance(Duration::from_secs(2));
+        let _r1 = mgr.tick(Duration::from_millis(100));
+        // The borderline contract may have ended Borderline or
+        // WouldEvict — both flagged states. Confirm via the snapshot.
+        let after_first_tick = mgr.score_snapshot(&borderline).unwrap().state;
+        // Borderline or flagged is what we want — anything but Normal.
+        assert_ne!(
+            after_first_tick,
+            GovernanceState::Normal,
+            "test fixture must flag the contract on first tick; got {:?}",
+            after_first_tick
+        );
+
+        // Step 2: replace the honest population with identical values
+        // (MAD collapse). Re-feeding identical cost/benefit doesn't
+        // immediately replace the running averages but moves them
+        // toward homogeneity. Skip this — instead, simulate MAD
+        // collapse by NOT advancing time and feeding everyone the
+        // same value to drag the average to zero spread.
+        for i in 0..30 {
+            // Heavy injection to dominate the running average.
+            for _ in 0..100 {
+                mgr.ingest_cost(mk_key(i), 0.1);
+                mgr.ingest_demand(mk_key(i), 1.0);
+            }
+        }
+        ts.advance(Duration::from_secs(60));
+        let r2 = mgr.tick(Duration::from_millis(100));
+
+        // The critical assertion: even if MAD collapsed and the
+        // borderline contract's score sample is no longer extracted
+        // (or extracts but can't be classified), there is NO
+        // `Recovered` transition logged. The state stays whatever it
+        // was after r1.
+        assert!(
+            !r2.decisions
+                .iter()
+                .any(|d| d.key == borderline && d.to == GovernanceState::Normal),
+            "MAD-collapse must NOT recover Borderline to Normal — found: {:?}",
+            r2.decisions
+                .iter()
+                .filter(|d| d.key == borderline)
+                .collect::<Vec<_>>()
+        );
+        // Snapshot confirms state unchanged.
+        assert_eq!(
+            mgr.score_snapshot(&borderline).unwrap().state,
+            after_first_tick,
+            "borderline contract state must persist through MAD-collapse tick"
+        );
     }
 }

--- a/crates/core/src/governance.rs
+++ b/crates/core/src/governance.rs
@@ -55,7 +55,7 @@ use std::hash::Hash;
 /// `k × 0.6745 × σ`, so k=5 would correspond to ~3.37σ (≈ 1-in-1500),
 /// not the 1-in-a-million the design doc claims. See
 /// <https://en.wikipedia.org/wiki/Median_absolute_deviation#Relation_to_standard_deviation>.
-const MAD_GAUSSIAN_CONSISTENCY: f64 = 1.4826;
+pub(crate) const MAD_GAUSSIAN_CONSISTENCY: f64 = 1.4826;
 
 /// Configuration for the outlier detector. Defaults match the
 /// design-doc values: k=5 (1-in-a-million false-positive rate under

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -24,6 +24,34 @@ static ROUTER: OnceLock<Arc<parking_lot::RwLock<Router>>> = OnceLock::new();
 pub type SubscriptionProvider =
     Arc<dyn Fn() -> Vec<SubscribedContractSnapshot> + Send + Sync + 'static>;
 
+/// Provider for the per-contract governance snapshot. Same pattern as
+/// `SubscriptionProvider`: registered at node startup, replaceable for
+/// multi-node test harnesses, used by `get_snapshot` to build the
+/// dashboard payload from real back-end data.
+///
+/// In production this closure captures `Arc<Ring>` and reads from
+/// `ring.governance` — the GovernanceManager populated by the
+/// meter-driven cost reporters and the HostingManager-driven demand
+/// reporters.
+pub type GovernanceProvider = Arc<dyn Fn() -> GovernanceSnapshot + Send + Sync + 'static>;
+
+static GOVERNANCE_PROVIDER: parking_lot::RwLock<Option<GovernanceProvider>> =
+    parking_lot::RwLock::new(None);
+
+/// Register the dashboard's governance data source. Replaces any
+/// previously-registered provider.
+pub fn set_governance_provider(provider: GovernanceProvider) {
+    *GOVERNANCE_PROVIDER.write() = Some(provider);
+}
+
+/// Clear the governance provider. Used by tests once they're added
+/// for the dashboard renderer (Phase 4.5).
+#[cfg(test)]
+#[allow(dead_code)] // consumed by Phase 4.5 dashboard tests
+pub(crate) fn clear_governance_provider() {
+    *GOVERNANCE_PROVIDER.write() = None;
+}
+
 /// Replaceable storage for the subscription provider. Wrapped in a
 /// `RwLock<Option<…>>` rather than `OnceLock` so multi-node in-process
 /// harnesses can re-wire the dashboard to the live node — and so a
@@ -417,6 +445,119 @@ pub struct NetworkStatusSnapshot {
     pub bytes_downloaded: u64,
     /// Overall node health level for the "everything looks good" indicator.
     pub health: HealthLevel,
+    /// Per-contract governance state (Phase 4). The dashboard's
+    /// verdict block, contracts table, ring inner-ring, and
+    /// distribution histogram all read from this. Empty when the
+    /// governance manager has no contracts yet (cold start).
+    ///
+    /// `#[allow(dead_code)]` is on the inner types — see
+    /// `GovernanceSnapshot` — and that flows through; CI lint
+    /// strictness on `-D warnings` flags the outer field anyway, so
+    /// we silence it here too with the same justification.
+    #[allow(dead_code)] // consumed by the dashboard renderer (Phase 4.5)
+    pub governance: GovernanceSnapshot,
+}
+
+/// Snapshot of the governance system's state, mirrored from
+/// `crate::contract::governance::GovernanceManager`. Public-facing
+/// mirror so the manager's `pub(crate)` types stay internal.
+///
+/// Fields are consumed by the dashboard renderer in `home_page.rs`
+/// (Phase 4.5, landing in a subsequent commit). The `#[allow]` lives
+/// here so the snapshot can be built and tested independently of the
+/// renderer landing.
+#[allow(dead_code)] // consumed by the dashboard renderer (Phase 4.5)
+#[derive(Default)]
+pub struct GovernanceSnapshot {
+    /// Off / DryRun / Enforce — visible on the dashboard as the
+    /// "mode" pill.
+    pub mode: GovernanceModeSnapshot,
+    /// One entry per contract the manager is currently tracking.
+    pub contracts: Vec<ContractGovernanceEntry>,
+    /// Network-level statistics from the last reaper tick. Drives
+    /// the median / MAD / threshold / sample-size mini-tiles.
+    pub norms: NetworkNorms,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GovernanceModeSnapshot {
+    Off,
+    #[default]
+    DryRun,
+    Enforce,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GovernanceStateSnapshot {
+    Normal,
+    Borderline,
+    WouldEvict,
+    Evicted,
+    Banned,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GovernanceTransitionReasonSnapshot {
+    FirstSeen,
+    BorderlineEntered,
+    ThresholdCrossed,
+    Evicted,
+    BanTriggered,
+    Recovered,
+    BanLifted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GovernanceSkipReasonSnapshot {
+    InsufficientSamples,
+    MadCollapsed,
+    NoExtractableRatios,
+}
+
+#[allow(dead_code)] // consumed by the dashboard renderer (Phase 4.5)
+#[derive(Debug, Clone)]
+pub struct ContractGovernanceEntry {
+    /// `key.id().to_string()` — same string the dashboard's
+    /// contracts-table renders.
+    pub instance_id: String,
+    /// Short-form key (first ~10 chars) for the dashboard's compact
+    /// labels on the ring.
+    pub instance_id_short: String,
+    pub state: GovernanceStateSnapshot,
+    pub cost_used: f64,
+    pub benefit_score: f64,
+    /// log10(cost/benefit). None when benefit_score is too small to
+    /// produce a stable ratio.
+    pub log_ratio: Option<f64>,
+    /// Age in seconds since first observation.
+    pub age_secs: u64,
+    /// Seconds since the last state transition.
+    pub last_transition_secs_ago: u64,
+    /// State history (bounded). Newest last.
+    pub history: Vec<GovernanceTransitionEntry>,
+}
+
+#[allow(dead_code)] // consumed by the dashboard renderer (Phase 4.5)
+#[derive(Debug, Clone)]
+pub struct GovernanceTransitionEntry {
+    /// Seconds ago this transition happened.
+    pub secs_ago: u64,
+    pub from: GovernanceStateSnapshot,
+    pub to: GovernanceStateSnapshot,
+    pub reason: GovernanceTransitionReasonSnapshot,
+}
+
+#[allow(dead_code)] // consumed by the dashboard renderer (Phase 4.5)
+#[derive(Default, Debug, Clone)]
+pub struct NetworkNorms {
+    pub median_log_ratio: Option<f64>,
+    pub mad: Option<f64>,
+    pub threshold: Option<f64>,
+    pub sample_size: usize,
+    /// True if the threshold was clamped at the capacity ceiling
+    /// instead of being driven by the MAD-derived value.
+    pub capacity_ceiling_binding: bool,
+    pub skip_reason: Option<GovernanceSkipReasonSnapshot>,
 }
 
 /// Overall health verdict for the node, synthesized from multiple signals.
@@ -646,6 +787,11 @@ pub fn get_snapshot() -> Option<NetworkStatusSnapshot> {
         bytes_uploaded,
         bytes_downloaded,
         health,
+        governance: GOVERNANCE_PROVIDER
+            .read()
+            .as_ref()
+            .map(|provider| provider())
+            .unwrap_or_default(),
     })
 }
 

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -139,8 +139,15 @@ impl NodeP2P {
         // ring state so the panel doesn't drift the way the legacy
         // `record_subscription` mirror did.
         let ring = self.op_manager.ring.clone();
-        super::network_status::set_subscription_provider(std::sync::Arc::new(move || {
-            ring.dashboard_subscription_snapshot()
+        super::network_status::set_subscription_provider(std::sync::Arc::new({
+            let ring = ring.clone();
+            move || ring.dashboard_subscription_snapshot()
+        }));
+        // Same pattern for the per-contract governance snapshot —
+        // dashboard reads live state from the GovernanceManager
+        // populated by the meter and HostingManager wiring.
+        super::network_status::set_governance_provider(std::sync::Arc::new(move || {
+            ring.dashboard_governance_snapshot()
         }));
 
         // Emit peer startup event

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2089,9 +2089,12 @@ impl Ring {
             gov::TransitionReason::BanLifted => ns::GovernanceTransitionReasonSnapshot::BanLifted,
         };
 
+        // Only iterate flagged contracts for the dashboard mirror —
+        // the renderer hides Normal anyway. Avoids cloning thousands of
+        // entries per refresh on a busy node. See `iter_flagged_scores`.
         let contracts: Vec<ns::ContractGovernanceEntry> = self
             .governance
-            .iter_scores()
+            .iter_flagged_scores()
             .into_iter()
             .map(|(id, score)| {
                 let instance_id = id.to_string();
@@ -2238,23 +2241,13 @@ impl Ring {
         self.governance.ingest_cost(contract_id, amount * weight);
     }
 
-    /// Record a demand event for a contract. Called from
-    /// subscription-registration sites in `HostingManager` so the
-    /// governance manager's `benefit_score` for the contract reflects
-    /// who's actually asking for it.
-    ///
-    /// `weight` is the caller's chance to differentiate local-client
-    /// subscriptions from forwarded-peer ones (Sybil resistance). A
-    /// reasonable default per the design doc: 1.0 for local,
-    /// 0.1 for forwarded.
-    #[allow(dead_code)] // wired by HostingManager-side reporters in subsequent commit
-    pub(crate) fn ingest_contract_demand(
-        &self,
-        contract_id: freenet_stdlib::prelude::ContractInstanceId,
-        weight: f64,
-    ) {
-        self.governance.ingest_demand(contract_id, weight);
-    }
+    // Note: there is intentionally no standalone `ingest_contract_demand`
+    // method here. Demand is ingested through `add_client_subscription` /
+    // `add_downstream_subscriber` (the two production registration sites)
+    // and gated on `is_new_for_client` / `AddSubscriberOutcome::NewAdd`
+    // there. Adding a bare entry point would let a future caller bypass
+    // the Sybil-resistance gate — that exact concern was flagged by
+    // skeptical-reviewer of #4270 as a latent foot-gun.
 
     /// Run one governance reaper tick. Caller (the periodic
     /// `governance_reaper_loop` task) is expected to feed

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -83,6 +83,13 @@ const LOCAL_DEMAND_WEIGHT: f64 = 1.0;
 /// local user.
 const FORWARDED_DEMAND_WEIGHT: f64 = 0.1;
 
+/// Interval between governance reaper ticks. Each tick applies
+/// decay and runs MAD-based outlier detection across the population.
+/// One minute balances responsiveness (a sustained-cost contract is
+/// flagged within a minute or two of crossing the threshold) against
+/// CPU overhead (MAD over the entire contract set every tick).
+const GOVERNANCE_TICK_INTERVAL: Duration = Duration::from_secs(60);
+
 use connection_backoff::ConnectionBackoff;
 pub use connection_backoff::ConnectionFailureReason;
 pub(crate) use peer_connection_backoff::PeerConnectionBackoff;
@@ -371,6 +378,19 @@ impl Ring {
             GlobalExecutor::spawn(Self::interest_heartbeat(ring.clone())),
         );
 
+        // Spawn periodic governance reaper tick.
+        // Computes per-contract state from accumulated cost/benefit
+        // samples and logs `ReaperDecision`s. Mode defaults to DryRun
+        // per the staged-rollout plan, so this task only ever logs —
+        // no eviction actions until the operator (or release default)
+        // flips to Enforce. The dashboard reads `governance.score_snapshot`
+        // independently of the tick; the tick is only the engine that
+        // updates state.
+        task_monitor.register(
+            "governance_reaper",
+            GlobalExecutor::spawn(Self::governance_reaper_loop(ring.clone())),
+        );
+
         Ok(ring)
     }
 
@@ -623,6 +643,72 @@ impl Ring {
     /// This prevents the death spiral where interest entries expire because no
     /// broadcasts are flowing, which in turn prevents broadcasts from ever
     /// flowing again. By periodically re-sending the full interest set, we
+    /// Periodic governance reaper loop. Ticks every
+    /// `GOVERNANCE_TICK_INTERVAL` and:
+    ///
+    ///   1. Calls `governance.tick(interval)` to apply decay and
+    ///      run the MAD detector over the per-contract distribution.
+    ///   2. Logs each `ReaperDecision` at INFO level with the from→to
+    ///      state and reason. In `DryRun` mode (the default) this is
+    ///      the only effect; in `Enforce` mode the caller would also
+    ///      emit `EvictContract` events here. Enforce-mode wiring
+    ///      lands in a subsequent commit.
+    ///   3. Logs the network-norms summary (median, MAD, threshold,
+    ///      sample size) at DEBUG so a busy node doesn't spam INFO.
+    ///
+    /// **Cancellation safety:** the loop's only `.await` points are
+    /// `tokio::time::sleep` / `interval.tick()`. No channel sends, no
+    /// long-running operations — the design-doc rule that "the
+    /// dashboard reflects the back-end" is respected here too: the
+    /// reaper writes governance state; readers consume it
+    /// asynchronously.
+    async fn governance_reaper_loop(ring: Arc<Self>) {
+        // Random initial delay so a fleet-wide restart doesn't have
+        // every node ticking in lockstep. 30-90 second offset; the
+        // tick itself runs every minute below.
+        let initial_delay = Duration::from_secs(GlobalRng::random_range(30u64..=90u64));
+        tokio::time::sleep(initial_delay).await;
+
+        let mut interval = tokio::time::interval(GOVERNANCE_TICK_INTERVAL);
+        interval.tick().await; // Skip first immediate tick.
+        let mut last_tick = ring.time_source.now();
+
+        loop {
+            interval.tick().await;
+            let now = ring.time_source.now();
+            let elapsed = now.saturating_duration_since(last_tick);
+            last_tick = now;
+
+            let result = ring.governance_tick(elapsed);
+
+            // Network-norms summary at DEBUG — useful when debugging
+            // calibration but too noisy for INFO on a healthy node.
+            tracing::debug!(
+                median = ?result.median_log_ratio,
+                mad = ?result.mad,
+                threshold = ?result.threshold,
+                sample_size = result.sample_size,
+                capacity_ceiling_binding = result.capacity_ceiling_binding,
+                skip_reason = ?result.skip_reason,
+                "governance reaper tick",
+            );
+
+            // Decisions at INFO — these are the dashboard-relevant
+            // events. Empty in healthy state, surfaces every
+            // transition during incidents.
+            for decision in result.decisions {
+                tracing::info!(
+                    contract = %decision.key,
+                    from = ?decision.from,
+                    to = ?decision.to,
+                    reason = ?decision.reason,
+                    actionable = decision.actionable,
+                    "governance state transition",
+                );
+            }
+        }
+    }
+
     /// keep entries alive on the remote side.
     ///
     /// Sends are spread evenly across the interval to avoid bursts.
@@ -2050,13 +2136,12 @@ impl Ring {
         self.governance.ingest_demand(contract_id, weight);
     }
 
-    /// Run one governance reaper tick. Caller (a periodic task in
-    /// `connection_maintenance` or similar) is expected to feed
+    /// Run one governance reaper tick. Caller (the periodic
+    /// `governance_reaper_loop` task) is expected to feed
     /// `tick_interval` = wall-time since the previous tick for decay.
     /// Returns the `ReaperTickResult` for the caller to act on (emit
     /// `EvictContract` events for actionable decisions, log dry-run
     /// decisions, surface stats on the dashboard).
-    #[allow(dead_code)] // periodic driver task lands in subsequent commit
     pub(crate) fn governance_tick(
         &self,
         tick_interval: Duration,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -99,6 +99,12 @@ pub(crate) struct Ring {
     /// non-idempotent `update_state`). Used to gate outbound broadcast
     /// so a broken contract's state changes don't leave the node.
     broken_invariants: BrokenInvariantsTracker,
+    /// Per-contract governance scoring + reaper. Routes every
+    /// per-contract resource report through `ingest_cost` so the
+    /// governance state for a contract reflects what the meter
+    /// already records. Mode defaults to `DryRun` per the staged-
+    /// rollout plan.
+    pub(crate) governance: Arc<crate::contract::governance::GovernanceManager>,
     event_register: Box<dyn NetEventRegister>,
     op_manager: RwLock<Option<Weak<OpManager>>>,
     /// Whether this peer is a gateway or not. This will affect behavior of the node when acquiring
@@ -225,19 +231,26 @@ impl Ring {
         } else {
             Some(config.config.data_dir())
         };
+        let time_source: Arc<dyn crate::util::time_source::TimeSource + Send + Sync> =
+            Arc::new(InstantTimeSrc::new());
+        let governance = Arc::new(crate::contract::governance::GovernanceManager::new(
+            crate::contract::governance::GovernanceConfig::default(),
+            time_source.clone(),
+        ));
         let ring = Ring {
             max_hops_to_live,
             router,
             connection_manager,
             hosting_manager: hosting::HostingManager::new(config.config.max_hosting_storage),
             broken_invariants: BrokenInvariantsTracker::new(),
+            governance,
             live_tx_tracker: live_tx_tracker.clone(),
             event_register: Box::new(event_register),
             op_manager: RwLock::new(None),
             is_gateway,
             connection_backoff: Arc::new(Mutex::new(ConnectionBackoff::new())),
             contract_connect_backoff: Mutex::new(HashMap::new()),
-            time_source: Arc::new(InstantTimeSrc::new()),
+            time_source,
             peer_cache_dir,
         };
 
@@ -1968,8 +1981,71 @@ impl Ring {
             amount,
             now,
         );
+        drop(topo);
+        // Also feed the governance manager — the meter stores rates
+        // for telemetry/the dashboard's bandwidth view, while the
+        // governance manager aggregates these samples into the
+        // cost/benefit ratio that drives state. Both ingest in
+        // parallel from this one entry point so there's no risk of
+        // them diverging (governance reading from a stale meter
+        // snapshot, etc).
+        //
+        // Per-resource weight: identity (1.0) for now. Future tuning
+        // could weight CPU-µs and fanout-cost higher than
+        // state-bytes, but until we have live data to calibrate
+        // against, unit weights match what the design doc proposed
+        // as a starting point.
+        let weight = resource_weight(resource);
+        self.governance.ingest_cost(contract_id, amount * weight);
     }
 
+    /// Record a demand event for a contract. Called from
+    /// subscription-registration sites in `HostingManager` so the
+    /// governance manager's `benefit_score` for the contract reflects
+    /// who's actually asking for it.
+    ///
+    /// `weight` is the caller's chance to differentiate local-client
+    /// subscriptions from forwarded-peer ones (Sybil resistance). A
+    /// reasonable default per the design doc: 1.0 for local,
+    /// 0.1 for forwarded.
+    #[allow(dead_code)] // wired by HostingManager-side reporters in subsequent commit
+    pub(crate) fn ingest_contract_demand(
+        &self,
+        contract_id: freenet_stdlib::prelude::ContractInstanceId,
+        weight: f64,
+    ) {
+        self.governance.ingest_demand(contract_id, weight);
+    }
+
+    /// Run one governance reaper tick. Caller (a periodic task in
+    /// `connection_maintenance` or similar) is expected to feed
+    /// `tick_interval` = wall-time since the previous tick for decay.
+    /// Returns the `ReaperTickResult` for the caller to act on (emit
+    /// `EvictContract` events for actionable decisions, log dry-run
+    /// decisions, surface stats on the dashboard).
+    #[allow(dead_code)] // periodic driver task lands in subsequent commit
+    pub(crate) fn governance_tick(
+        &self,
+        tick_interval: Duration,
+    ) -> crate::contract::governance::ReaperTickResult {
+        self.governance.tick(tick_interval)
+    }
+}
+
+/// Per-resource weight for cost aggregation. Defaults to 1.0 for all
+/// dimensions so total cost = simple sum of meter samples. Hooks here
+/// for future tuning if any one dimension proves to dominate the
+/// signal-to-noise ratio.
+fn resource_weight(resource: crate::topology::meter::ResourceType) -> f64 {
+    use crate::topology::meter::ResourceType::*;
+    match resource {
+        InboundBandwidthBytes | OutboundBandwidthBytes => 1.0,
+        ExecCpuMicros | ExecFuelUnits => 1.0,
+        StateBytesWritten | BroadcastFanoutCost => 1.0,
+    }
+}
+
+impl Ring {
     // ==================== Subscription Retry Spam Prevention ====================
 
     /// Check if a subscription request can be made for a contract.

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1840,18 +1840,27 @@ impl Ring {
     // ==================== Downstream Subscriber Tracking ====================
 
     pub fn add_downstream_subscriber(&self, contract: &ContractKey, peer: PeerKey) -> bool {
-        let added = self
+        let outcome = self
             .hosting_manager
             .add_downstream_subscriber(contract, peer);
-        if added {
-            // Downstream peer subscription = demand signal for this
-            // contract. Forwarded weight (per design doc Sybil
-            // resistance): 0.1, since peer identities are
-            // attacker-rotatable.
+        // Sybil resistance: count demand on NewAdd only. A peer that
+        // keeps renewing its subscription every few minutes would
+        // otherwise pad `benefit_score` by FORWARDED_DEMAND_WEIGHT
+        // per renewal — equivalent to N distinct subscribers from a
+        // single rotating peer over an hour. Renewals must NOT
+        // register as fresh demand. Forwarded weight (0.1, per the
+        // design doc) reflects that peer identities are
+        // attacker-rotatable. See `AddSubscriberOutcome`.
+        if matches!(outcome, crate::ring::hosting::AddSubscriberOutcome::NewAdd) {
             self.governance
                 .ingest_demand(*contract.id(), FORWARDED_DEMAND_WEIGHT);
         }
-        added
+        // Caller-facing bool preserved for backward compat: Rejected
+        // → false; NewAdd or Renewal → true (the peer is tracked).
+        !matches!(
+            outcome,
+            crate::ring::hosting::AddSubscriberOutcome::Rejected
+        )
     }
 
     #[allow(dead_code)] // Only used in tests
@@ -1990,8 +1999,13 @@ impl Ring {
         // Local client subscription = strong demand signal. Full
         // weight: this is our own user telling us they care about
         // this contract, harder to fake than a peer-side signal.
-        self.governance
-            .ingest_demand(*instance_id, LOCAL_DEMAND_WEIGHT);
+        // Gated on `is_new_for_client` so an idempotent re-subscribe
+        // call (same client + same contract) doesn't pad demand —
+        // see `AddClientSubscriptionResult::is_new_for_client`.
+        if result.is_new_for_client {
+            self.governance
+                .ingest_demand(*instance_id, LOCAL_DEMAND_WEIGHT);
+        }
         result
     }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -67,6 +67,22 @@ pub mod topology_registry;
 /// to receive updates. This is controlled by hosting cache eviction.
 pub const AUTO_SUBSCRIBE_ON_GET: bool = true;
 
+/// Governance demand weight for a local-client subscription. Strong
+/// signal: a real user on this node opted in. Hard to fake without
+/// running an actual freenet client locally.
+///
+/// Sourced from the design doc — see "Sybil weighting falls out
+/// naturally" in `docs/design/contract-hardening.md`.
+const LOCAL_DEMAND_WEIGHT: f64 = 1.0;
+
+/// Governance demand weight for a downstream peer's subscription.
+/// Weaker signal because peer identity is attacker-rotatable —
+/// without an identity layer, a single attacker can spin up many
+/// peers and each "subscribes." We weight forwarded demand at 0.1
+/// so an attacker would need 10 peers to fake the demand of one
+/// local user.
+const FORWARDED_DEMAND_WEIGHT: f64 = 0.1;
+
 use connection_backoff::ConnectionBackoff;
 pub use connection_backoff::ConnectionFailureReason;
 pub(crate) use peer_connection_backoff::PeerConnectionBackoff;
@@ -1738,8 +1754,18 @@ impl Ring {
     // ==================== Downstream Subscriber Tracking ====================
 
     pub fn add_downstream_subscriber(&self, contract: &ContractKey, peer: PeerKey) -> bool {
-        self.hosting_manager
-            .add_downstream_subscriber(contract, peer)
+        let added = self
+            .hosting_manager
+            .add_downstream_subscriber(contract, peer);
+        if added {
+            // Downstream peer subscription = demand signal for this
+            // contract. Forwarded weight (per design doc Sybil
+            // resistance): 0.1, since peer identities are
+            // attacker-rotatable.
+            self.governance
+                .ingest_demand(*contract.id(), FORWARDED_DEMAND_WEIGHT);
+        }
+        added
     }
 
     #[allow(dead_code)] // Only used in tests
@@ -1872,8 +1898,15 @@ impl Ring {
         instance_id: &ContractInstanceId,
         client_id: crate::client_events::ClientId,
     ) -> AddClientSubscriptionResult {
-        self.hosting_manager
-            .add_client_subscription(instance_id, client_id)
+        let result = self
+            .hosting_manager
+            .add_client_subscription(instance_id, client_id);
+        // Local client subscription = strong demand signal. Full
+        // weight: this is our own user telling us they care about
+        // this contract, harder to fake than a peer-side signal.
+        self.governance
+            .ingest_demand(*instance_id, LOCAL_DEMAND_WEIGHT);
+        result
     }
 
     /// Remove a client from all its subscriptions (used when client disconnects).

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -663,10 +663,23 @@ impl Ring {
     /// reaper writes governance state; readers consume it
     /// asynchronously.
     async fn governance_reaper_loop(ring: Arc<Self>) {
-        // Random initial delay so a fleet-wide restart doesn't have
-        // every node ticking in lockstep. 30-90 second offset; the
-        // tick itself runs every minute below.
-        let initial_delay = Duration::from_secs(GlobalRng::random_range(30u64..=90u64));
+        // Initial delay so a fleet-wide restart doesn't have every node
+        // ticking in lockstep. Derived from the node's own ring location
+        // (already random + node-distinct) rather than from `GlobalRng`,
+        // because consuming from `GlobalRng` at startup shifts the
+        // deterministic seed state and breaks simulation tests whose
+        // routing/topology decisions are RNG-driven (the
+        // `test_get_routing_coverage_low_htl` regression was caught by
+        // CI on PR #4270). 30-90 second offset; the tick itself runs
+        // every minute below.
+        let own_loc = ring
+            .connection_manager
+            .own_location()
+            .location()
+            .map(|l| l.as_f64())
+            .unwrap_or(0.5);
+        let initial_delay_secs = 30 + ((own_loc * 60.0) as u64);
+        let initial_delay = Duration::from_secs(initial_delay_secs);
         tokio::time::sleep(initial_delay).await;
 
         let mut interval = tokio::time::interval(GOVERNANCE_TICK_INTERVAL);

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2036,6 +2036,112 @@ impl Ring {
         self.hosting_manager.dashboard_subscription_snapshot()
     }
 
+    /// Snapshot of per-contract governance state for the local-peer
+    /// dashboard. Reads directly from the canonical `GovernanceManager`
+    /// state — no mirror, no cache, no derived recomputation. If a
+    /// state appears here it's because the manager computed it from
+    /// real meter samples and real subscription events.
+    pub fn dashboard_governance_snapshot(&self) -> crate::node::network_status::GovernanceSnapshot {
+        use crate::contract::governance as gov;
+        use crate::node::network_status as ns;
+
+        let now = self.time_source.now();
+        let mode = match self.governance.mode() {
+            gov::GovernanceMode::Off => ns::GovernanceModeSnapshot::Off,
+            gov::GovernanceMode::DryRun => ns::GovernanceModeSnapshot::DryRun,
+            gov::GovernanceMode::Enforce => ns::GovernanceModeSnapshot::Enforce,
+        };
+
+        let map_state = |s: gov::GovernanceState| match s {
+            gov::GovernanceState::Normal => ns::GovernanceStateSnapshot::Normal,
+            gov::GovernanceState::Borderline => ns::GovernanceStateSnapshot::Borderline,
+            gov::GovernanceState::WouldEvict => ns::GovernanceStateSnapshot::WouldEvict,
+            gov::GovernanceState::Evicted => ns::GovernanceStateSnapshot::Evicted,
+            gov::GovernanceState::Banned => ns::GovernanceStateSnapshot::Banned,
+        };
+        let map_reason = |r: gov::TransitionReason| match r {
+            gov::TransitionReason::FirstSeen => ns::GovernanceTransitionReasonSnapshot::FirstSeen,
+            gov::TransitionReason::BorderlineEntered => {
+                ns::GovernanceTransitionReasonSnapshot::BorderlineEntered
+            }
+            gov::TransitionReason::ThresholdCrossed => {
+                ns::GovernanceTransitionReasonSnapshot::ThresholdCrossed
+            }
+            gov::TransitionReason::Evicted => ns::GovernanceTransitionReasonSnapshot::Evicted,
+            gov::TransitionReason::BanTriggered => {
+                ns::GovernanceTransitionReasonSnapshot::BanTriggered
+            }
+            gov::TransitionReason::Recovered => ns::GovernanceTransitionReasonSnapshot::Recovered,
+            gov::TransitionReason::BanLifted => ns::GovernanceTransitionReasonSnapshot::BanLifted,
+        };
+
+        let contracts: Vec<ns::ContractGovernanceEntry> = self
+            .governance
+            .iter_scores()
+            .into_iter()
+            .map(|(id, score)| {
+                let instance_id = id.to_string();
+                let instance_id_short = if instance_id.chars().count() > 12 {
+                    let trunc: String = instance_id.chars().take(12).collect();
+                    format!("{trunc}...")
+                } else {
+                    instance_id.clone()
+                };
+                let history = score
+                    .history
+                    .iter()
+                    .map(|t| ns::GovernanceTransitionEntry {
+                        secs_ago: now.saturating_duration_since(t.at).as_secs(),
+                        from: map_state(t.from),
+                        to: map_state(t.to),
+                        reason: map_reason(t.reason),
+                    })
+                    .collect();
+                ns::ContractGovernanceEntry {
+                    instance_id,
+                    instance_id_short,
+                    state: map_state(score.state),
+                    cost_used: score.cost_used,
+                    benefit_score: score.benefit_score,
+                    log_ratio: score.log_ratio(),
+                    age_secs: now.saturating_duration_since(score.first_seen).as_secs(),
+                    last_transition_secs_ago: now
+                        .saturating_duration_since(score.last_transition)
+                        .as_secs(),
+                    history,
+                }
+            })
+            .collect();
+
+        let norms = match self.governance.latest_norms() {
+            Some(n) => ns::NetworkNorms {
+                median_log_ratio: n.median_log_ratio,
+                mad: n.mad,
+                threshold: n.threshold,
+                sample_size: n.sample_size,
+                capacity_ceiling_binding: n.capacity_ceiling_binding,
+                skip_reason: n.skip_reason.map(|r| match r {
+                    crate::governance::SkipReason::InsufficientSamples => {
+                        ns::GovernanceSkipReasonSnapshot::InsufficientSamples
+                    }
+                    crate::governance::SkipReason::MadCollapsed => {
+                        ns::GovernanceSkipReasonSnapshot::MadCollapsed
+                    }
+                    crate::governance::SkipReason::NoExtractableRatios => {
+                        ns::GovernanceSkipReasonSnapshot::NoExtractableRatios
+                    }
+                }),
+            },
+            None => ns::NetworkNorms::default(),
+        };
+
+        ns::GovernanceSnapshot {
+            mode,
+            contracts,
+            norms,
+        }
+    }
+
     /// Record that a state update was observed for `contract`.
     /// No-op if the contract is not currently subscribed.
     pub fn record_contract_update(&self, contract: &ContractKey) {

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -93,6 +93,42 @@ const MAX_DOWNSTREAM_SUBSCRIBERS_PER_CONTRACT: usize = 512;
 pub struct AddClientSubscriptionResult {
     /// Whether this was the first client for this contract.
     pub is_first_client: bool,
+    /// Whether this specific `(contract, client_id)` pair was newly
+    /// added (vs. an idempotent repeat call for an already-tracked
+    /// client). Used by the governance scoring layer to gate the
+    /// `ingest_demand` call — without this distinction a client that
+    /// re-subscribes repeatedly would pad the contract's
+    /// `benefit_score` indefinitely. See
+    /// `Ring::add_client_subscription` for the caller-side gating.
+    pub is_new_for_client: bool,
+}
+
+/// Outcome of an `add_downstream_subscriber` call. The variant
+/// distinguishes "the peer was newly added" from "the peer was already
+/// tracked and this call refreshed its lease timestamp" so the
+/// governance scoring layer can gate `ingest_demand` on new-add only.
+/// See `HostingManager::add_downstream_subscriber` for the rationale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddSubscriberOutcome {
+    /// Peer is now tracked for this contract; was not before.
+    /// Governance treats this as fresh demand evidence.
+    NewAdd,
+    /// Peer was already tracked; this call refreshed the lease
+    /// timestamp. Governance must NOT count this as fresh demand.
+    Renewal,
+    /// Per-contract subscriber cap reached; this is a new peer that
+    /// was rejected. Equivalent to the old `false` return.
+    Rejected,
+}
+
+impl AddSubscriberOutcome {
+    /// True when the peer is now tracked (either newly added or
+    /// renewed). Preserves the pre-Sybil-fix `bool` semantics for
+    /// callers that only care "was the registration accepted".
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn was_accepted(self) -> bool {
+        matches!(self, Self::NewAdd | Self::Renewal)
+    }
 }
 
 /// Result of removing all subscriptions for a disconnected client.
@@ -576,14 +612,23 @@ impl HostingManager {
     ) -> AddClientSubscriptionResult {
         let mut entry = self.client_subscriptions.entry(*instance_id).or_default();
         let is_first_client = entry.is_empty();
-        entry.insert(client_id);
+        // HashSet::insert returns true if the value was newly added.
+        // Capture this so the governance scoring layer can gate
+        // `ingest_demand` to new-adds only — otherwise a client that
+        // repeatedly re-subscribes for the same contract would pad
+        // demand by `LOCAL_DEMAND_WEIGHT × N` per N calls.
+        let is_new_for_client = entry.insert(client_id);
         debug!(
             contract = %instance_id,
             %client_id,
             is_first_client,
+            is_new_for_client,
             "add_client_subscription: registered"
         );
-        AddClientSubscriptionResult { is_first_client }
+        AddClientSubscriptionResult {
+            is_first_client,
+            is_new_for_client,
+        }
     }
 
     /// Remove a client subscription.
@@ -676,20 +721,36 @@ impl HostingManager {
     // =========================================================================
 
     /// Record that a downstream peer is subscribed to a contract we host.
-    /// Returns false if the downstream subscriber limit for this contract has been reached
-    /// and the peer is not already tracked (existing peers can always renew).
-    pub fn add_downstream_subscriber(&self, contract: &ContractKey, peer: PeerKey) -> bool {
+    ///
+    /// Returns `AddSubscriberOutcome` so callers can distinguish a
+    /// genuine NewAdd (counts as fresh demand for governance scoring)
+    /// from a Renewal (lease-extension only — must NOT count as fresh
+    /// demand, otherwise a peer churning subscriptions every 2 minutes
+    /// would pad a contract's `benefit_score` by `0.1 × 30 = 3.0` per
+    /// hour, the Sybil-resistance equivalent of 30 distinct subscribers
+    /// for a single rotating peer). See `Ring::add_downstream_subscriber`
+    /// for the caller-side gating.
+    pub fn add_downstream_subscriber(
+        &self,
+        contract: &ContractKey,
+        peer: PeerKey,
+    ) -> AddSubscriberOutcome {
         let mut entry = self.downstream_subscribers.entry(*contract).or_default();
-        if !entry.contains_key(&peer) && entry.len() >= MAX_DOWNSTREAM_SUBSCRIBERS_PER_CONTRACT {
+        let is_new = !entry.contains_key(&peer);
+        if is_new && entry.len() >= MAX_DOWNSTREAM_SUBSCRIBERS_PER_CONTRACT {
             tracing::warn!(
                 contract = %contract,
                 limit = MAX_DOWNSTREAM_SUBSCRIBERS_PER_CONTRACT,
                 "Downstream subscriber limit reached, rejecting peer"
             );
-            return false;
+            return AddSubscriberOutcome::Rejected;
         }
         entry.insert(peer, self.time_source.now());
-        true
+        if is_new {
+            AddSubscriberOutcome::NewAdd
+        } else {
+            AddSubscriberOutcome::Renewal
+        }
     }
 
     /// Renew a downstream peer's subscription lease.
@@ -2097,7 +2158,11 @@ mod tests {
         // contract, but we have not called `subscribe()` on our own behalf
         // (we're just forwarding Updates for someone else) and we have no
         // local client expressing interest.
-        assert!(manager.add_downstream_subscriber(&contract, downstream.clone()));
+        assert!(
+            manager
+                .add_downstream_subscriber(&contract, downstream.clone())
+                .was_accepted()
+        );
 
         // Invariant 1: we did not install a self-subscription lease.
         assert!(
@@ -3095,7 +3160,9 @@ mod tests {
                 bytes
             }));
             peers.push(peer.clone());
-            let result = manager.add_downstream_subscriber(&contract, peer);
+            let result = manager
+                .add_downstream_subscriber(&contract, peer)
+                .was_accepted();
             assert!(
                 result,
                 "Downstream subscriber {i} should succeed within limit (count before: {i})"
@@ -3123,10 +3190,50 @@ mod tests {
             .unwrap_or(false);
         assert!(is_new, "Extra peer should not already be in the set");
 
-        let rejected = !manager.add_downstream_subscriber(&contract, extra_peer);
+        let outcome = manager.add_downstream_subscriber(&contract, extra_peer);
+        assert_eq!(
+            outcome,
+            AddSubscriberOutcome::Rejected,
+            "Downstream subscriber beyond limit should return Rejected (count was {actual_count})"
+        );
         assert!(
-            rejected,
-            "Downstream subscriber beyond limit should be rejected (count was {actual_count})"
+            !outcome.was_accepted(),
+            "Rejected must NOT count as accepted"
+        );
+    }
+
+    /// Sybil-resistance pin: `add_downstream_subscriber` MUST distinguish
+    /// a genuine new add from a renewal so the governance scoring layer
+    /// can gate `ingest_demand` on new-add only. Without this distinction,
+    /// a peer renewing every 2 minutes would pad benefit_score by
+    /// `FORWARDED_DEMAND_WEIGHT × 30 = 3.0 per hour` — the equivalent of
+    /// 30 distinct subscribers from one rotating peer.
+    #[test]
+    fn add_downstream_subscriber_distinguishes_new_add_from_renewal() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let contract = make_contract_key(1);
+        let peer = make_peer_key(2);
+
+        // First call: NewAdd.
+        assert_eq!(
+            manager.add_downstream_subscriber(&contract, peer.clone()),
+            AddSubscriberOutcome::NewAdd,
+            "first registration of a peer must be NewAdd"
+        );
+
+        // Second call with the same peer: Renewal, not NewAdd.
+        assert_eq!(
+            manager.add_downstream_subscriber(&contract, peer.clone()),
+            AddSubscriberOutcome::Renewal,
+            "repeated registration of the same peer must be Renewal — \
+             otherwise the governance demand-ingest gate is bypassed and \
+             a churning peer pads benefit_score indefinitely"
+        );
+
+        // Third call also Renewal — no escalation back to NewAdd.
+        assert_eq!(
+            manager.add_downstream_subscriber(&contract, peer),
+            AddSubscriberOutcome::Renewal,
         );
     }
 
@@ -3149,11 +3256,16 @@ mod tests {
             manager.add_downstream_subscriber(&contract, peer);
         }
 
-        // Existing peer can still renew (re-insert updates the timestamp)
-        assert!(
-            manager.add_downstream_subscriber(&contract, first_peer),
-            "Existing peer should be able to renew at limit"
+        // Existing peer can still renew (re-insert updates the timestamp).
+        // Post-Sybil-fix: this returns Renewal, not NewAdd — pin both
+        // facts so a regression flips the demand-ingest gate the wrong way.
+        let outcome = manager.add_downstream_subscriber(&contract, first_peer);
+        assert_eq!(
+            outcome,
+            AddSubscriberOutcome::Renewal,
+            "Existing peer at limit should return Renewal (not NewAdd or Rejected)"
         );
+        assert!(outcome.was_accepted(), "Renewal must count as accepted");
     }
 
     // =========================================================================

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2803,6 +2803,7 @@ mod tests {
             bytes_uploaded: 0,
             bytes_downloaded: 0,
             health: HealthLevel::Connecting,
+            governance: Default::default(),
         }
     }
 

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -473,7 +473,7 @@ fn build_peers_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> Str
         );
     }
 
-    let ring_svg = build_ring_svg(snap.own_location, &snap.peers);
+    let ring_svg = build_ring_svg(snap.own_location, &snap.peers, Some(&snap.governance));
 
     let mut rows = String::new();
     for p in &snap.peers {
@@ -526,66 +526,201 @@ fn build_peers_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> Str
     )
 }
 
-/// Build an SVG ring visualization showing this node and connected peers.
-/// Locations are 0.0–1.0, mapped to angles around a circle.
-fn build_ring_svg(own_location: Option<f64>, peers: &[network_status::PeerSnapshot]) -> String {
-    // Only render if we have location data for at least one peer
+/// Build an SVG ring visualization. Two concentric rings:
+///
+/// - **Outer ring**: peers we're connected to, placed by their
+///   ring-location (Kleinberg topology position).
+/// - **Inner ring**: contracts the governance manager is tracking,
+///   placed by a deterministic hash of the instance id. Colored by
+///   governance state.
+///
+/// Lines (Bezier curves through the interior) go YOU → peer (outer)
+/// and YOU → contract (inner). All curves originate from or terminate
+/// at YOU — a node only sees its own traffic, so anything else would
+/// be fabricated.
+///
+/// Falls back to outer-ring-only rendering when no governance
+/// snapshot is supplied (e.g. tests that pre-date the upgrade).
+fn build_ring_svg(
+    own_location: Option<f64>,
+    peers: &[network_status::PeerSnapshot],
+    governance: Option<&network_status::GovernanceSnapshot>,
+) -> String {
+    // Render when there's *something* to show. The historical guard
+    // (at least one peer with a location) still applies.
     let has_any_location = own_location.is_some() || peers.iter().any(|p| p.location.is_some());
     if !has_any_location {
         return String::new();
     }
 
-    let cx: f64 = 120.0;
-    let cy: f64 = 120.0;
-    let r: f64 = 95.0;
-    let size = 240;
+    // Larger viewBox than the original 240×240 so the inner ring +
+    // labels have room. Use a viewBox-only sizing (no fixed width)
+    // so the SVG scales with the card.
+    let size: f64 = 480.0;
+    let cx: f64 = size / 2.0;
+    let cy: f64 = size / 2.0;
+    let r_outer: f64 = 195.0;
+    let r_inner: f64 = 120.0;
 
     let mut svg = format!(
-        "<div class=\"ring-wrap\"><svg viewBox=\"0 0 {size} {size}\" width=\"{size}\" height=\"{size}\" class=\"ring-svg\">"
+        "<div class=\"ring-wrap\"><svg viewBox=\"0 0 {size:.0} {size:.0}\" class=\"ring-svg\" preserveAspectRatio=\"xMidYMid meet\">"
     );
 
-    // Ring circle
+    // === Background rings ===
     write!(
         svg,
-        "<circle cx=\"{cx}\" cy=\"{cy}\" r=\"{r}\" fill=\"none\" stroke=\"#e0e0e0\" stroke-width=\"2\"/>"
+        "<circle cx=\"{cx}\" cy=\"{cy}\" r=\"{r_outer}\" fill=\"none\" stroke=\"#363c4a\" stroke-width=\"1\"/>"
+    )
+    .ok();
+    write!(
+        svg,
+        "<circle cx=\"{cx}\" cy=\"{cy}\" r=\"{r_inner}\" fill=\"none\" stroke=\"#363c4a\" stroke-width=\"1\"/>"
     )
     .ok();
 
-    // Helper: location (0.0-1.0) to (x, y) on the ring.
+    // Helper: location (0.0..1.0) → (x, y) on a ring of given radius.
     // 0.0 is at the top, increasing clockwise.
-    let loc_to_xy = |loc: f64| -> (f64, f64) {
+    let loc_to_xy = |loc: f64, r: f64| -> (f64, f64) {
         let angle = loc * std::f64::consts::TAU - std::f64::consts::FRAC_PI_2;
         (cx + r * angle.cos(), cy + r * angle.sin())
     };
 
-    // Draw connection lines from own location to each peer
-    if let Some(own_loc) = own_location {
-        let (ox, oy) = loc_to_xy(own_loc);
+    // Curved chord path generator. Quadratic Bezier from (x1,y1) to
+    // (x2,y2) with the control point pulled toward the SVG centre.
+    // `bend_base` is the maximum bend for antipodal points; chord
+    // length scales bend so short hops look flat and long hops arc
+    // through the interior. Matches the nova.locut.us:3133 ring
+    // routing visualization.
+    let curve_path = |x1: f64, y1: f64, x2: f64, y2: f64, bend_base: f64| -> String {
+        let dx = x2 - x1;
+        let dy = y2 - y1;
+        let chord = (dx * dx + dy * dy).sqrt();
+        let ratio = (chord / (2.0 * r_outer)).min(1.0);
+        let bend = bend_base * ratio;
+        let mx = (x1 + x2) / 2.0;
+        let my = (y1 + y2) / 2.0;
+        let pcx = cx + (mx - cx) * (1.0 - bend);
+        let pcy = cy + (my - cy) * (1.0 - bend);
+        format!("M {x1:.1},{y1:.1} Q {pcx:.1},{pcy:.1} {x2:.1},{y2:.1}")
+    };
+
+    // === Ring labels at top ===
+    write!(
+        svg,
+        "<text x=\"{cx}\" y=\"{y:.1}\" text-anchor=\"middle\" fill=\"#6b7280\" font-family=\"monospace\" font-size=\"9\" letter-spacing=\"0.18em\">PEERS</text>",
+        y = cy - r_outer - 8.0,
+    )
+    .ok();
+    write!(
+        svg,
+        "<text x=\"{cx}\" y=\"{y:.1}\" text-anchor=\"middle\" fill=\"#6b7280\" font-family=\"monospace\" font-size=\"9\" letter-spacing=\"0.18em\">CONTRACTS</text>",
+        y = cy - r_inner - 8.0,
+    )
+    .ok();
+
+    let own_xy = own_location.map(|loc| loc_to_xy(loc, r_outer));
+
+    // === Connection curves: YOU → peers ===
+    // Only drawn if we know our own location; otherwise we can't
+    // anchor them. Bezier through the interior so the path looks
+    // like a routing arc, not a chord.
+    if let Some((ox, oy)) = own_xy {
         for p in peers {
             if let Some(ploc) = p.location {
-                let (px, py) = loc_to_xy(ploc);
-                let stroke = if p.is_gateway { "#fbbf24" } else { "#007FFF" };
+                let (px, py) = loc_to_xy(ploc, r_outer);
+                let stroke = if p.is_gateway { "#ffb610" } else { "#66d9ff" };
+                let path = curve_path(ox, oy, px, py, 0.55);
                 write!(
                     svg,
-                    "<line x1=\"{ox:.1}\" y1=\"{oy:.1}\" x2=\"{px:.1}\" y2=\"{py:.1}\" stroke=\"{stroke}\" stroke-width=\"1\" opacity=\"0.4\"/>"
+                    "<path d=\"{path}\" fill=\"none\" stroke=\"{stroke}\" stroke-width=\"1\" stroke-opacity=\"0.35\"/>"
                 )
                 .ok();
             }
         }
     }
 
-    // Peer dots — each wrapped in an <a> link to its detail page so the
-    // SVG ring stays in sync with the table rows below it.
+    // === Contract dots (and YOU → flagged-contract curves) ===
+    if let Some(gov) = governance {
+        // Deterministic hash → ring location for placing contracts.
+        // The instance id is a 32-byte content hash; we fold the
+        // string form to a u64 and modulo onto [0, 1). Position is
+        // stable across refreshes (same id → same dot location).
+        let hash_to_loc = |s: &str| -> f64 {
+            use std::collections::hash_map::DefaultHasher;
+            use std::hash::{Hash, Hasher};
+            let mut h = DefaultHasher::new();
+            s.hash(&mut h);
+            (h.finish() % 10_000) as f64 / 10_000.0
+        };
+        for c in &gov.contracts {
+            let loc = hash_to_loc(&c.instance_id);
+            let (kx, ky) = loc_to_xy(loc, r_inner);
+            let (fill, glow) = match c.state {
+                network_status::GovernanceStateSnapshot::Normal => ("#43c178", false),
+                network_status::GovernanceStateSnapshot::Borderline => ("#ffb610", false),
+                network_status::GovernanceStateSnapshot::WouldEvict => ("#ff8a3d", true),
+                network_status::GovernanceStateSnapshot::Evicted => ("#ff667a", true),
+                network_status::GovernanceStateSnapshot::Banned => ("#d33682", true),
+            };
+            // Flagged contracts get a curve from YOU into the inner
+            // ring + a small label of the short instance id. Normal
+            // ones get a dot only — they'd otherwise overwhelm the
+            // visual with curves.
+            let is_flagged = !matches!(c.state, network_status::GovernanceStateSnapshot::Normal);
+            if is_flagged {
+                if let Some((ox, oy)) = own_xy {
+                    let path = curve_path(ox, oy, kx, ky, 0.6);
+                    write!(
+                        svg,
+                        "<path d=\"{path}\" fill=\"none\" stroke=\"{fill}\" stroke-width=\"1.4\" stroke-opacity=\"0.7\"/>"
+                    )
+                    .ok();
+                }
+            }
+            // Use a more distinctive shape for flagged (rect) than
+            // normal (smaller, dimmer dot) so glance-scanning the
+            // ring surfaces flagged contracts first.
+            let size_px = if is_flagged { 6.0 } else { 3.0 };
+            let opacity = if is_flagged { "1.0" } else { "0.55" };
+            let glow_attr = if glow {
+                "filter=\"drop-shadow(0 0 3px currentColor)\""
+            } else {
+                ""
+            };
+            write!(
+                svg,
+                "<rect x=\"{x:.1}\" y=\"{y:.1}\" width=\"{size_px:.1}\" height=\"{size_px:.1}\" fill=\"{fill}\" fill-opacity=\"{opacity}\" {glow_attr}><title>{title}</title></rect>",
+                x = kx - size_px / 2.0,
+                y = ky - size_px / 2.0,
+                title = html_escape(&format!("{} ({:?})", c.instance_id_short, c.state)),
+            )
+            .ok();
+            // Short label next to flagged contracts so the ring view
+            // matches the table without clicking.
+            if is_flagged {
+                let label_loc_r = r_inner - 12.0;
+                let (lx, ly) = loc_to_xy(loc, label_loc_r);
+                write!(
+                    svg,
+                    "<text x=\"{lx:.1}\" y=\"{ly:.1}\" text-anchor=\"middle\" dominant-baseline=\"middle\" fill=\"{fill}\" font-family=\"monospace\" font-size=\"9\" font-weight=\"500\">{label}</text>",
+                    label = html_escape(&c.instance_id_short),
+                )
+                .ok();
+            }
+        }
+    }
+
+    // === Peer dots on the outer ring ===
     for p in peers {
         if let Some(loc) = p.location {
-            let (px, py) = loc_to_xy(loc);
-            let fill = if p.is_gateway { "#fbbf24" } else { "#007FFF" };
+            let (px, py) = loc_to_xy(loc, r_outer);
+            let fill = if p.is_gateway { "#ffb610" } else { "#66d9ff" };
             let kind = if p.is_gateway { "Gateway" } else { "Peer" };
             let addr = p.address.to_string();
             let title = format!("{kind} {addr} (loc {loc:.4})");
             write!(
                 svg,
-                "<a href=\"/peer/{href}\" class=\"ring-peer-link\"><title>{title}</title><circle cx=\"{px:.1}\" cy=\"{py:.1}\" r=\"5\" fill=\"{fill}\"/></a>",
+                "<a href=\"/peer/{href}\" class=\"ring-peer-link\"><title>{title}</title><circle cx=\"{px:.1}\" cy=\"{py:.1}\" r=\"4\" fill=\"{fill}\"/></a>",
                 href = html_escape(&addr),
                 title = html_escape(&title),
             )
@@ -593,25 +728,28 @@ fn build_ring_svg(own_location: Option<f64>, peers: &[network_status::PeerSnapsh
         }
     }
 
-    // Own location (drawn last so it's on top). Not a link — there is no
-    // detail page for the local node.
+    // === YOU marker — drawn last so it sits above everything ===
     if let Some(own_loc) = own_location {
-        let (ox, oy) = loc_to_xy(own_loc);
+        let (ox, oy) = loc_to_xy(own_loc, r_outer);
         write!(
             svg,
-            "<g class=\"ring-self\"><title>You (loc {own_loc:.4})</title><circle cx=\"{ox:.1}\" cy=\"{oy:.1}\" r=\"7\" fill=\"#34d399\" stroke=\"#fff\" stroke-width=\"2\"/></g>"
+            "<g class=\"ring-self\"><title>You (loc {own_loc:.4})</title><circle cx=\"{ox:.1}\" cy=\"{oy:.1}\" r=\"6\" fill=\"#43c178\" stroke=\"#ebecf0\" stroke-width=\"1.5\"/><text x=\"{lx:.1}\" y=\"{ly:.1}\" text-anchor=\"middle\" fill=\"#43c178\" font-family=\"monospace\" font-size=\"9\" font-weight=\"500\" letter-spacing=\"0.05em\">YOU</text></g>",
+            lx = ox,
+            ly = oy + 18.0,
         )
         .ok();
     }
 
     svg.push_str("</svg>");
 
-    // Legend
+    // Legend below the ring.
     svg.push_str(concat!(
         "<div class=\"ring-legend\">",
         "<span class=\"ring-key\"><span class=\"ring-dot ring-dot-self\"></span> You</span>",
         "<span class=\"ring-key\"><span class=\"ring-dot ring-dot-peer\"></span> Peer</span>",
         "<span class=\"ring-key\"><span class=\"ring-dot ring-dot-gw\"></span> Gateway</span>",
+        "<span class=\"ring-key\"><span class=\"ring-dot ring-dot-contract-normal\"></span> Hosted</span>",
+        "<span class=\"ring-key\"><span class=\"ring-dot ring-dot-contract-flagged\"></span> Flagged</span>",
         "</div></div>",
     ));
 
@@ -1412,9 +1550,11 @@ p:last-child { margin-bottom: 0; }
     border-radius: 50%;
     display: inline-block;
 }
-.ring-dot-self { background: #34d399; }
-.ring-dot-peer { background: var(--accent-primary); }
-.ring-dot-gw { background: #fbbf24; }
+.ring-dot-self { background: #43c178; }
+.ring-dot-peer { background: #66d9ff; }
+.ring-dot-gw { background: #ffb610; }
+.ring-dot-contract-normal { background: #43c178; opacity: 0.55; }
+.ring-dot-contract-flagged { background: #ff667a; }
 .theme-btn {
     background: none;
     border: 1px solid var(--border-color);
@@ -3648,7 +3788,7 @@ mod tests {
     #[test]
     fn ring_svg_dots_link_to_peer_pages() {
         let peers = vec![sample_peer("127.0.0.1:31337", 0.25)];
-        let svg = build_ring_svg(Some(0.5), &peers);
+        let svg = build_ring_svg(Some(0.5), &peers, None);
         assert!(
             svg.contains("<a href=\"/peer/127.0.0.1:31337\""),
             "ring peer dot must be wrapped in a link to /peer/{{addr}}, got: {svg}"
@@ -3752,7 +3892,7 @@ mod tests {
         // The local node has no /peer/{addr} page, so the self circle
         // must NOT be wrapped in an <a>, but it should still expose a
         // <title> for parity with the peer dots.
-        let svg = build_ring_svg(Some(0.42), &[]);
+        let svg = build_ring_svg(Some(0.42), &[], None);
         assert!(svg.contains("<svg"), "ring SVG should still render");
         assert!(
             !svg.contains("<a "),
@@ -3784,7 +3924,7 @@ mod tests {
             bytes_received: 0,
         };
         let peer = sample_peer("10.0.0.2:31338", 0.90);
-        let svg = build_ring_svg(Some(0.5), &[gw, peer]);
+        let svg = build_ring_svg(Some(0.5), &[gw, peer], None);
         assert!(
             svg.contains("<title>Gateway 10.0.0.1:31337"),
             "gateway dot title must say 'Gateway', got: {svg}"
@@ -3813,8 +3953,8 @@ mod tests {
             bytes_sent: 0,
             bytes_received: 0,
         };
-        assert!(build_ring_svg(None, &[no_loc_peer]).is_empty());
-        assert!(build_ring_svg(None, &[]).is_empty());
+        assert!(build_ring_svg(None, &[no_loc_peer], None).is_empty());
+        assert!(build_ring_svg(None, &[], None).is_empty());
     }
 
     // ── Sort attribute coverage for both tables ─────────────────────────────

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -32,6 +32,7 @@ fn homepage_html() -> String {
 
     let status_card = build_status_card(&snap);
     let peers_card = build_peers_card(&snap);
+    let governance_card = build_governance_card(&snap);
     let contracts_card = build_contracts_card(&snap);
     let ops_card = build_ops_card(&snap);
     let transfer_card = build_transfer_card(&snap);
@@ -68,6 +69,7 @@ fn homepage_html() -> String {
         {status_card}
         {peers_card}
         {transfer_card}
+        {governance_card}
         {contracts_card}
         {ops_card}
 
@@ -107,6 +109,7 @@ fn homepage_html() -> String {
         status_card = status_card,
         peers_card = peers_card,
         transfer_card = transfer_card,
+        governance_card = governance_card,
         contracts_card = contracts_card,
         ops_card = ops_card,
     )
@@ -613,6 +616,216 @@ fn build_ring_svg(own_location: Option<f64>, peers: &[network_status::PeerSnapsh
     ));
 
     svg
+}
+
+/// Build the governance card. Reads `snap.governance` (sourced from
+/// `Ring::dashboard_governance_snapshot` → `GovernanceManager`). Every
+/// field rendered here came from the back-end's computation —
+/// nothing is invented at render time.
+///
+/// Layout follows the prototype: verdict block on the left (big
+/// number + headline), mini-strip with network-norms on the right,
+/// then the per-contract table below. The histogram and ring inner-
+/// ring renderings are deliberately separate commits — this commit
+/// proves the data path end-to-end with the simplest visualisations.
+fn build_governance_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> String {
+    let Some(snap) = snap else {
+        return String::new();
+    };
+    let g = &snap.governance;
+
+    // Empty state: no contracts tracked yet (cold start, or this
+    // build doesn't have the governance manager enabled). Per the
+    // design principle — show nothing rather than show fabricated
+    // data. The "history strip" pattern from the prototype lives
+    // here as a single compact line so the absence reads as
+    // working-correctly rather than missing-panel.
+    if g.contracts.is_empty() {
+        return r#"<div class="card">
+            <h2>Contract Governance</h2>
+            <p class="empty">Not enough contracts observed yet. Governance scoring activates once this node has seen at least 30 contracts and they have had time to accumulate cost/benefit signals.</p>
+        </div>"#.to_string();
+    }
+
+    // Verdict counts. Mirror state-snapshot enum → string.
+    let mut counts = [0u32; 5];
+    for c in &g.contracts {
+        let idx = match c.state {
+            network_status::GovernanceStateSnapshot::Normal => 0,
+            network_status::GovernanceStateSnapshot::Borderline => 1,
+            network_status::GovernanceStateSnapshot::WouldEvict => 2,
+            network_status::GovernanceStateSnapshot::Evicted => 3,
+            network_status::GovernanceStateSnapshot::Banned => 4,
+        };
+        counts[idx] = counts[idx].saturating_add(1);
+    }
+    let borderline = counts[1];
+    let would_evict = counts[2];
+    let evicted = counts[3];
+    let banned = counts[4];
+    let flagged = borderline + would_evict + evicted + banned;
+    let total = g.contracts.len();
+
+    let verdict_class = if flagged == 0 {
+        "verdict-ok"
+    } else {
+        "verdict-alert"
+    };
+    let verdict_main = if flagged == 0 {
+        format!(
+            r#"<div class="verdict-num">✓</div>
+               <div class="verdict-headline">All {total} contracts within normal range</div>"#,
+        )
+    } else {
+        let mut detail_parts: Vec<String> = Vec::new();
+        if would_evict > 0 {
+            detail_parts.push(format!(
+                r#"<span class="sw sw-wouldevict"></span>{would_evict} would be evicted"#
+            ));
+        }
+        if borderline > 0 {
+            detail_parts.push(format!(
+                r#"<span class="sw sw-borderline"></span>{borderline} borderline"#
+            ));
+        }
+        if evicted > 0 {
+            detail_parts.push(format!(
+                r#"<span class="sw sw-evicted"></span>{evicted} evicted"#
+            ));
+        }
+        if banned > 0 {
+            detail_parts.push(format!(
+                r#"<span class="sw sw-banned"></span>{banned} banned"#
+            ));
+        }
+        format!(
+            r#"<div class="verdict-num">{flagged}</div>
+               <div class="verdict-headline">contracts flagged on this node</div>
+               <div class="verdict-detail">{detail}</div>"#,
+            detail = detail_parts.join(" &nbsp;·&nbsp; "),
+        )
+    };
+
+    // Network-norms mini-strip — sourced from the last reaper-tick
+    // result. Empty if no tick has run yet (cold start; sample size
+    // didn't reach min_samples; MAD collapsed).
+    let median_txt = g
+        .norms
+        .median_log_ratio
+        .map(|v| format!("{:.2}", v))
+        .unwrap_or_else(|| "—".to_string());
+    let mad_txt = g
+        .norms
+        .mad
+        .map(|v| format!("{:.2}", v))
+        .unwrap_or_else(|| "—".to_string());
+    let threshold_txt = g
+        .norms
+        .threshold
+        .map(|v| format!("{:.2}", v))
+        .unwrap_or_else(|| "—".to_string());
+    let sample_size_txt = g.norms.sample_size.to_string();
+    let mode_txt = match g.mode {
+        network_status::GovernanceModeSnapshot::Off => "off",
+        network_status::GovernanceModeSnapshot::DryRun => "dry-run",
+        network_status::GovernanceModeSnapshot::Enforce => "enforce",
+    };
+
+    // Per-contract table — flagged-only by default; an "all" link
+    // could come later. Honest principle: this table reflects the
+    // governance manager's `iter_scores()`, nothing else.
+    let mut rows = String::new();
+    let mut shown_count = 0;
+    // Sort: most-flagged first (Banned > Evicted > WouldEvict >
+    // Borderline > Normal), then by highest log-ratio descending so
+    // the worst offenders sit at the top.
+    let mut sorted: Vec<&network_status::ContractGovernanceEntry> = g.contracts.iter().collect();
+    sorted.sort_by(|a, b| {
+        let rank = |s: network_status::GovernanceStateSnapshot| match s {
+            network_status::GovernanceStateSnapshot::Banned => 0,
+            network_status::GovernanceStateSnapshot::Evicted => 1,
+            network_status::GovernanceStateSnapshot::WouldEvict => 2,
+            network_status::GovernanceStateSnapshot::Borderline => 3,
+            network_status::GovernanceStateSnapshot::Normal => 4,
+        };
+        rank(a.state).cmp(&rank(b.state)).then_with(|| {
+            b.log_ratio
+                .partial_cmp(&a.log_ratio)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+    });
+    for c in sorted.iter() {
+        // Default: only show flagged contracts. An "all" toggle could
+        // come later; for now keeping the table digestible.
+        if matches!(c.state, network_status::GovernanceStateSnapshot::Normal) {
+            continue;
+        }
+        shown_count += 1;
+        let state_label = match c.state {
+            network_status::GovernanceStateSnapshot::Normal => "normal",
+            network_status::GovernanceStateSnapshot::Borderline => "borderline",
+            network_status::GovernanceStateSnapshot::WouldEvict => "would evict",
+            network_status::GovernanceStateSnapshot::Evicted => "evicted",
+            network_status::GovernanceStateSnapshot::Banned => "banned",
+        };
+        let state_class = match c.state {
+            network_status::GovernanceStateSnapshot::Normal => "g-normal",
+            network_status::GovernanceStateSnapshot::Borderline => "g-borderline",
+            network_status::GovernanceStateSnapshot::WouldEvict => "g-wouldevict",
+            network_status::GovernanceStateSnapshot::Evicted => "g-evicted",
+            network_status::GovernanceStateSnapshot::Banned => "g-banned",
+        };
+        let log_ratio_txt = c
+            .log_ratio
+            .map(|v| format!("{:+.2}", v))
+            .unwrap_or_else(|| "—".to_string());
+        let age = format_ago(c.age_secs);
+        rows.push_str(&format!(
+            r#"<tr><td title="{full}"><code>{short}</code></td><td><span class="g-badge {state_class}">{state_label}</span></td><td class="right">{log_ratio}</td><td class="right">{cost:.2}</td><td class="right">{benefit:.2}</td><td class="right">{age}</td></tr>"#,
+            full = html_escape(&c.instance_id),
+            short = html_escape(&c.instance_id_short),
+            state_class = state_class,
+            state_label = state_label,
+            log_ratio = log_ratio_txt,
+            cost = c.cost_used,
+            benefit = c.benefit_score,
+            age = age,
+        ));
+    }
+    if shown_count == 0 {
+        rows = r#"<tr><td colspan="6" class="empty" style="padding: 0.5rem 0.9rem">All contracts within normal range.</td></tr>"#.to_string();
+    }
+
+    format!(
+        r##"<div class="card">
+            <div class="card-header"><h2>Contract Governance</h2><span class="g-mode g-mode-{mode}">{mode}</span></div>
+            <div class="g-verdict-row">
+                <div class="g-verdict {verdict_class}">{verdict_main}</div>
+                <div class="g-norms">
+                    <div class="g-norm"><div class="g-norm-label">Tracked</div><div class="g-norm-value">{total}</div></div>
+                    <div class="g-norm"><div class="g-norm-label">Sample size</div><div class="g-norm-value">{sample_size}</div></div>
+                    <div class="g-norm"><div class="g-norm-label">Median log-ratio</div><div class="g-norm-value">{median}</div></div>
+                    <div class="g-norm"><div class="g-norm-label">MAD spread</div><div class="g-norm-value">{mad}</div></div>
+                    <div class="g-norm"><div class="g-norm-label">Eviction threshold</div><div class="g-norm-value">{threshold}</div></div>
+                </div>
+            </div>
+            <div class="table-wrap">
+                <table>
+                    <thead><tr><th>Contract</th><th>State</th><th class="right">log-ratio</th><th class="right">Cost</th><th class="right">Benefit</th><th class="right">Age</th></tr></thead>
+                    <tbody>{rows}</tbody>
+                </table>
+            </div>
+        </div>"##,
+        mode = mode_txt,
+        verdict_class = verdict_class,
+        verdict_main = verdict_main,
+        total = total,
+        sample_size = sample_size_txt,
+        median = median_txt,
+        mad = mad_txt,
+        threshold = threshold_txt,
+        rows = rows,
+    )
 }
 
 fn build_contracts_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> String {
@@ -1312,6 +1525,128 @@ table.sortable thead th.sort-desc::after { content: "▼"; opacity: 1; color: va
     from { opacity: 0; transform: translateY(8px); }
     to   { opacity: 1; transform: translateY(0); }
 }
+
+/* ── Governance card (Phase 4.5) ───────────────────────────────────── */
+.g-mode {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 3px;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    margin-left: auto;
+}
+.g-mode-dry-run {
+    background: rgba(255, 182, 16, 0.15);
+    color: #ffb610;
+    border: 1px solid rgba(255, 182, 16, 0.35);
+}
+.g-mode-enforce {
+    background: rgba(255, 102, 122, 0.15);
+    color: #ff667a;
+    border: 1px solid rgba(255, 102, 122, 0.35);
+}
+.g-mode-off {
+    background: rgba(148, 163, 184, 0.15);
+    color: var(--text-secondary);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.g-verdict-row {
+    display: grid;
+    grid-template-columns: minmax(280px, 0.85fr) 2fr;
+    gap: 0.75rem;
+    margin: 0.5rem 0 0.75rem;
+}
+.g-verdict {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-left: 3px solid #ff8a3d;
+    border-radius: 6px;
+    padding: 0.85rem 1rem 0.85rem 1.1rem;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+    column-gap: 1rem;
+    align-items: center;
+}
+.verdict-ok { border-left-color: #43c178; }
+.verdict-alert { border-left-color: #ff8a3d; }
+.g-verdict .verdict-num {
+    grid-row: 1 / 3;
+    font-family: var(--font-mono);
+    font-size: 3.2rem;
+    font-weight: 500;
+    line-height: 0.95;
+    color: #ff8a3d;
+    letter-spacing: -0.04em;
+}
+.verdict-ok .verdict-num { color: #43c178; }
+.g-verdict .verdict-headline {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+.g-verdict .verdict-detail {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    margin-top: 0.15rem;
+}
+.g-verdict .sw {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    margin-right: 0.3rem;
+    vertical-align: 0.07rem;
+}
+.sw-borderline { background: #ffb610; }
+.sw-wouldevict { background: #ff8a3d; }
+.sw-evicted    { background: #ff667a; }
+.sw-banned     { background: #d33682; }
+
+.g-norms {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 0.5rem;
+}
+.g-norm {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    padding: 0.55rem 0.75rem;
+}
+.g-norm-label {
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+}
+.g-norm-value {
+    font-family: var(--font-mono);
+    font-size: 1rem;
+    font-weight: 500;
+    margin-top: 0.1rem;
+    color: var(--text-primary);
+}
+
+.g-badge {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    padding: 0.1rem 0.45rem;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    font-weight: 500;
+}
+.g-normal     { background: rgba(67,193,120,0.16);  color: #43c178; }
+.g-borderline { background: rgba(255,182,16,0.16);  color: #ffb610; }
+.g-wouldevict { background: rgba(255,138,61,0.18);  color: #ff8a3d; }
+.g-evicted    { background: rgba(255,102,122,0.18); color: #ff667a; }
+.g-banned     { background: rgba(211,54,130,0.18);  color: #d33682; }
 "##;
 
 /// Inline JavaScript for the dark/light mode toggle.
@@ -3671,5 +4006,116 @@ mod tests {
             JS.contains("localStorage") && JS.contains("freenet-update-check"),
             "JS must persist the update check in localStorage under the freenet-update-check key"
         );
+    }
+
+    // ─── Governance card (Phase 4.5) ───────────────────────────────
+
+    use crate::node::network_status::{
+        ContractGovernanceEntry, GovernanceModeSnapshot, GovernanceSnapshot,
+        GovernanceStateSnapshot, NetworkNorms,
+    };
+
+    fn mk_entry(state: GovernanceStateSnapshot, instance_id: &str) -> ContractGovernanceEntry {
+        ContractGovernanceEntry {
+            instance_id: instance_id.to_string(),
+            instance_id_short: instance_id.chars().take(12).collect::<String>(),
+            state,
+            cost_used: 12.5,
+            benefit_score: 1.0,
+            log_ratio: Some(1.1),
+            age_secs: 3600,
+            last_transition_secs_ago: 60,
+            history: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn governance_card_empty_state_when_no_contracts() {
+        let snap = base_snapshot();
+        let html = build_governance_card(&Some(snap));
+        assert!(
+            html.contains("Not enough contracts observed yet"),
+            "empty state should explain why governance has nothing to show — got:\n{html}"
+        );
+        assert!(
+            !html.contains("verdict-alert"),
+            "empty state must not render the alert verdict block"
+        );
+    }
+
+    #[test]
+    fn governance_card_verdict_ok_when_all_normal() {
+        let mut snap = base_snapshot();
+        snap.governance = GovernanceSnapshot {
+            mode: GovernanceModeSnapshot::DryRun,
+            contracts: (0..5)
+                .map(|i| mk_entry(GovernanceStateSnapshot::Normal, &format!("aaa{i}")))
+                .collect(),
+            norms: NetworkNorms::default(),
+        };
+        let html = build_governance_card(&Some(snap));
+        assert!(
+            html.contains("verdict-ok"),
+            "5 normal contracts should produce verdict-ok styling — got:\n{html}"
+        );
+        assert!(
+            html.contains("All 5 contracts within normal range"),
+            "verdict should name the total — got:\n{html}"
+        );
+    }
+
+    #[test]
+    fn governance_card_verdict_alert_with_breakdown_when_flagged() {
+        let mut snap = base_snapshot();
+        snap.governance = GovernanceSnapshot {
+            mode: GovernanceModeSnapshot::DryRun,
+            contracts: vec![
+                mk_entry(GovernanceStateSnapshot::WouldEvict, "abuser1"),
+                mk_entry(GovernanceStateSnapshot::Borderline, "warn1"),
+                mk_entry(GovernanceStateSnapshot::Borderline, "warn2"),
+                mk_entry(GovernanceStateSnapshot::Normal, "ok1"),
+            ],
+            norms: NetworkNorms::default(),
+        };
+        let html = build_governance_card(&Some(snap));
+        assert!(html.contains("verdict-alert"));
+        // Total flagged = 1 + 2 = 3
+        assert!(
+            html.contains(">3<"),
+            "verdict number should be the flagged count — got:\n{html}"
+        );
+        assert!(html.contains("1 would be evicted"));
+        assert!(html.contains("2 borderline"));
+        // Table renders the flagged ones, not the normal one.
+        assert!(html.contains("abuser1"));
+        assert!(html.contains("warn1"));
+        assert!(!html.contains(r#"<code>ok1</code>"#));
+    }
+
+    #[test]
+    fn governance_card_mode_pill_reflects_snapshot_mode() {
+        for (mode, label) in [
+            (GovernanceModeSnapshot::Off, "off"),
+            (GovernanceModeSnapshot::DryRun, "dry-run"),
+            (GovernanceModeSnapshot::Enforce, "enforce"),
+        ] {
+            let mut snap = base_snapshot();
+            snap.governance = GovernanceSnapshot {
+                mode,
+                contracts: vec![mk_entry(GovernanceStateSnapshot::Normal, "ok")],
+                norms: NetworkNorms::default(),
+            };
+            let html = build_governance_card(&Some(snap));
+            assert!(
+                html.contains(&format!(r#"g-mode g-mode-{label}">{label}<"#)),
+                "mode pill should reflect {label} — got:\n{html}"
+            );
+        }
+    }
+
+    #[test]
+    fn governance_card_omits_when_snap_is_none() {
+        let html = build_governance_card(&None);
+        assert!(html.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Builds on **#4260** (now merged). Implements **Phase 4 (Shared governance module — dry-run mode)** and the **first two slices of Phase 4.5 (dashboard renderer)** from `docs/design/contract-hardening.md`.

The motivation is the incident PRs that landed on 2026-05-21: contract `4PjqN5KUCidW8vJvw5fhy5fe5maxXKNrWSyK33QjjVq` exhibited a runaway UPDATE pattern and we want to bound the blast radius of misbehaving contracts.

## What's in here

### `crates/core/src/contract/governance.rs` (new, 28 unit tests)

`GovernanceManager` — the per-node, in-memory scorer. Keyed by `ContractInstanceId`. Backed by `DashMap` for fine-grained shard locking. Drives a 5-state machine per contract:

```
Normal → Borderline → WouldEvict → Evicted → Banned
```

- **Cost ingest** (`ingest_cost`): every `MeterEvent` the executor reports against a contract.
- **Demand ingest** (`ingest_demand`): every subscription delta. Sybil-resistant weighting: `LOCAL = 1.0`, `FORWARDED = 0.1`, **gated on new-add only** (renewals don't pad).
- **Symmetric exponential decay** (1-hour half-life).
- **MAD-based outlier detection** (5% top-trim, 1.4826 sigma-scaling, k=5 default).
- **Mode gate**: `Off / DryRun (default) / Enforce`. The dashboard surfaces the mode prominently.
- **Ramp-up window**: a contract is excluded from flagging for its first 15 minutes.
- **Ban TTL + Evicted window**: re-eviction inside the window triggers `Banned`; both states are sticky and only recover via explicit TTL sweeps (not decay-driven recovery).
- **Reaper loop** (60 s tick) drives the transitions. Channel-safety audited.

### Ring integration

- `Ring::governance: Arc<GovernanceManager>` field.
- `report_contract_resource_usage` now also calls `governance.ingest_cost`.
- `add_client_subscription` / `add_downstream_subscriber` call `ingest_demand` with local/forwarded weights, ONLY on new-add (not renewal) — see `AddSubscriberOutcome::NewAdd`.
- `Ring::dashboard_governance_snapshot()` translates internal types to the public `GovernanceSnapshot` mirror.

### Dashboard data path (`NetworkStatusSnapshot.governance`)

- Provider pattern registered at startup in `p2p_impl.rs`.
- Public mirror types: `GovernanceSnapshot`, `GovernanceModeSnapshot`, `GovernanceStateSnapshot`, `GovernanceTransitionReasonSnapshot`, `GovernanceSkipReasonSnapshot`, `ContractGovernanceEntry`, `GovernanceTransitionEntry`, `NetworkNorms`.

### Dashboard renderer (`server/home_page.rs`)

Two slices:

1. **`build_governance_card`** — Contract Governance card between Transfer and Subscribed-Contracts.
2. **Ring inner-ring + curved chords** — `build_ring_svg` extended from 240×240 outer-only to 480×480 two-ring with quadratic Bezier curves through the interior.

## Multi-model review status

Initial review on the round-1 commit found these issues which are all addressed:

| Severity | Finding | Status |
|---|---|---|
| Major | Sybil: `add_downstream_subscriber` returns `true` on renewal — `ingest_demand` fires every renewal, padding `benefit_score` indefinitely | Fixed in 3c6eac51 (now returns `AddSubscriberOutcome::{NewAdd, Renewal, Rejected}`; ingest gated on `NewAdd`). Same shape for client subscriptions via new `is_new_for_client` field. |
| Major | State machine: Evicted can transition back to Normal via decay-driven score recovery — flap risk while the on-disk state is gone | Fixed in d48c75d0 (Evicted is sticky in the main transition loop; explicit TTL sweep mirrors the existing `BanLifted` shape). |
| Major | State machine: MAD-collapse spuriously transitions Borderline → Normal | Fixed in d48c75d0 (skip transitions when `borderline_cutoff = None`). |
| Minor | Reaper loop initial sleep is uninterruptible | Filed as follow-up #4278 — requires plumbing a shutdown signal, cross-cutting refactor across 3+ loops. |

A second multi-model review on the post-fix HEAD will run after this PR moves out of draft.

## Mode default

Ships as **`DryRun`**. Operators see the verdict + "would evict" badges with no eviction actions taken. Stage to `Enforce` after observing on real workloads.

## Tests

- 28 new unit tests in `contract/governance.rs` (including the 3 new state-machine pin tests).
- New `add_downstream_subscriber_distinguishes_new_add_from_renewal` test in `ring/hosting.rs`.
- 5 new tests in `server/home_page.rs` (governance card).
- **Full lib pass: 2731 tests, 0 failures.**
- `cargo clippy --lib --tests -- -D warnings` clean.

## What's NOT in here (deliberate follow-ups)

- Phase 2: per-(peer, contract) UPDATE rate limit.
- Phase 5: `SubscribeMsg::Cancelled` wire variant.
- Phase 7: ban TTL enforcement at the receive boundary (turns "Banned" from a dashboard label into a real rejection).
- Phase 4.5 remaining slices: cost-ratio distribution histogram, per-contract drill-down.
- Issues #4276 (split topology meter), #4277 (migrate ring.rs `Instant::now()` to TimeSource), #4278 (shutdown plumbing).

## Test plan

- [ ] CI green on the head SHA before any rebase/merge
- [ ] Multi-model review (full tier)
- [ ] Visual check on a dev node (smoke test on technic discussed with maintainer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-assisted - Claude]