### PR TITLE
feat(contracts): detect & gate non-idempotent contracts (#4251 follow-up)

### DIFF
--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -145,6 +145,17 @@ State merging rules:
   - Contract defines merge semantics
   - Merge MUST be commutative: merge(a, b) == merge(b, a)
   - Merge MUST be associative: merge(merge(a, b), c) == merge(a, merge(b, c))
+  - For `UpdateData::State` inputs, merge MUST be idempotent:
+      update_state(update_state(S, State(X)), State(X)) == update_state(S, State(X))
+    Enforced at runtime via the in-peer probe in
+    `Executor::maybe_probe_idempotency`. Violators get flagged in
+    `Ring::broken_invariants` and their outbound `BroadcastStateChange`
+    is suppressed locally; the flag is permanent for that contract
+    instance id and survives restart. See `ring::broken_invariants` and
+    issue #4251 / PR #4279.
+    Note: this invariant is NOT enforced for `UpdateData::Delta` inputs
+    (CmRDT-style "increment by X" deltas legitimately violate it) or
+    `UpdateData::RelatedState` (a cross-contract hint, not a CRDT op).
   - Invalid merges should return error, not panic
 ```
 
@@ -306,7 +317,7 @@ Handling:
 
 ```
 □ Test contract validation (valid and invalid states)
-□ Test state merging (commutativity, associativity)
+□ Test state merging (commutativity, associativity, idempotency on State inputs)
 □ Test execution timeout handling
 □ Test related contract fetching
 □ Test concurrent contract updates

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -39,6 +39,17 @@ pub(crate) enum UpdateOverride {
     /// paths (issue #4151): the returned error must be classified as
     /// `is_invalid_update_rejection()` and logged at DEBUG, not INFO.
     RejectInvalidUpdate { reason: String },
+    /// Models a non-idempotent contract: every call to `update_state`
+    /// returns a state that is byte-different from the previous one even
+    /// when the input update is the same. The mock prepends an internal
+    /// monotonically-increasing counter to the state bytes, mimicking the
+    /// shape of a real contract that embeds a timestamp / position-
+    /// dependent signature / re-signed payload — the smoking-gun shape
+    /// the in-peer detector is built to catch (see #4251 and the
+    /// `bdtchyck…wasm` analysis in `~/.claude/jobs/.../wasm-analysis.md`).
+    /// Used by tests to verify the idempotency probe fires on a real-
+    /// world-shaped failure mode.
+    NonIdempotent(std::sync::Arc<std::sync::atomic::AtomicU64>),
 }
 
 /// A lightweight mock runtime at the `ContractRuntimeInterface` level that lets
@@ -143,6 +154,38 @@ impl ContractRuntimeInterface for MockWasmRuntime {
                     return Err(crate::wasm_runtime::ContractError::from(
                         ContractExecError::ContractError(inner_err),
                     ));
+                }
+                UpdateOverride::NonIdempotent(counter) => {
+                    // Pick the "logical" input state — same precedence as
+                    // the default branch — then prepend a monotonically-
+                    // increasing 8-byte counter. Re-running with the
+                    // produced state as input still bumps the counter,
+                    // so the result is byte-different every call.
+                    let logical = update_data
+                        .iter()
+                        .find_map(|u| match u {
+                            UpdateData::State(s) => Some(s.as_ref().to_vec()),
+                            UpdateData::Delta(d) => Some(d.as_ref().to_vec()),
+                            UpdateData::StateAndDelta { state, .. } => {
+                                Some(state.as_ref().to_vec())
+                            }
+                            UpdateData::RelatedState { .. }
+                            | UpdateData::RelatedDelta { .. }
+                            | UpdateData::RelatedStateAndDelta { .. } => None,
+                            // `UpdateData` is `#[non_exhaustive]`; allow future
+                            // variants to fall through to the `_state` fallback.
+                            _ => None,
+                        })
+                        .unwrap_or_else(|| _state.as_ref().to_vec());
+                    let n = counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    let mut out = Vec::with_capacity(8 + logical.len().saturating_sub(8));
+                    out.extend_from_slice(&n.to_le_bytes());
+                    // Strip any prior counter prefix so the state stays a
+                    // fixed size — matching the 464-byte shape we saw in
+                    // production rather than growing unboundedly.
+                    let tail_start = logical.len().min(8);
+                    out.extend_from_slice(&logical[tail_start..]);
+                    return Ok(UpdateModification::valid(out.into()));
                 }
             }
         }

--- a/crates/core/src/contract/executor/pool_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests.rs
@@ -2,6 +2,7 @@
 
 mod conformance_tests;
 mod merge_rejected_tests;
+mod non_idempotent_detector_tests;
 mod related_contract_tests;
 mod runtime_pool_tests;
 mod subscriber_limit_tests;

--- a/crates/core/src/contract/executor/pool_tests/non_idempotent_detector_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/non_idempotent_detector_tests.rs
@@ -1,0 +1,122 @@
+//! Tests for the per-contract non-idempotency detector and the broken-
+//! invariants gate. See `crate::ring::broken_invariants` and
+//! `Executor::maybe_probe_idempotency` in `contract/executor/runtime.rs`.
+//!
+//! These exercise two layers without spinning up a full network:
+//!
+//! 1. **Fixture self-check** — the `UpdateOverride::NonIdempotent` mock
+//!    actually models the smoking-gun behavior the detector is built to
+//!    catch (`update_state(update_state(S, U), U) != update_state(S, U)`).
+//!    A regression that flattens the fixture into a no-op would silently
+//!    pass the production detector while testing nothing.
+//!
+//! 2. **Gate behavior** — once a contract has been marked broken via
+//!    `Ring::record_broken_invariant`, `Ring::is_contract_broken` returns
+//!    true; the production gate code in `commit_state_update` /
+//!    `broadcast_state_change` reads this exact predicate.
+
+use freenet_stdlib::prelude::*;
+
+use crate::contract::executor::mock_wasm_runtime::{MockWasmRuntime, UpdateOverride};
+use crate::wasm_runtime::{ContractRuntimeInterface, InMemoryContractStore};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+
+fn fake_key() -> ContractKey {
+    // The override is keyed on instance id only; the code hash is
+    // incidental for these tests. Using `from_id_and_code` to construct
+    // a key without round-tripping through a full contract.
+    let instance = ContractInstanceId::new([7u8; 32]);
+    let code_hash = CodeHash::from(&[7u8; 32]);
+    ContractKey::from_id_and_code(instance, code_hash)
+}
+
+fn make_mock_runtime(override_: UpdateOverride) -> MockWasmRuntime {
+    let mut overrides = HashMap::new();
+    let key = fake_key();
+    overrides.insert(*key.id(), override_);
+    MockWasmRuntime {
+        contract_store: InMemoryContractStore::default(),
+        validate_overrides: HashMap::new(),
+        update_overrides: overrides,
+    }
+}
+
+/// The fixture must produce different bytes for two consecutive
+/// `update_state` calls with the same input — this is the *contract bug*
+/// shape the in-peer detector exists to flag. If this assertion fails,
+/// the mock has been flattened and detector tests downstream would pass
+/// vacuously.
+#[test]
+fn fixture_non_idempotent_override_produces_distinct_states() {
+    let counter = Arc::new(AtomicU64::new(0));
+    let mut rt = make_mock_runtime(UpdateOverride::NonIdempotent(counter.clone()));
+    let key = fake_key();
+    let params = Parameters::from(vec![]);
+    let initial = WrappedState::new(vec![0u8; 32]);
+    let update = vec![UpdateData::State(initial.clone().into())];
+
+    let first = rt
+        .update_state(&key, &params, &initial, &update)
+        .expect("first update_state");
+    let s1 = WrappedState::new(first.new_state.expect("state").into_bytes());
+
+    // Re-apply the same update with `s1` as the current state. A correct
+    // CRDT must yield `s1` again. Our fixture intentionally yields a
+    // byte-different state — the smoking-gun shape the detector catches.
+    let update2 = vec![UpdateData::State(s1.clone().into())];
+    let second = rt
+        .update_state(&key, &params, &s1, &update2)
+        .expect("second update_state");
+    let s2 = WrappedState::new(second.new_state.expect("state").into_bytes());
+
+    assert_ne!(
+        s1.as_ref(),
+        s2.as_ref(),
+        "NonIdempotent fixture must produce byte-different states on re-apply; \
+         if this fails, the mock has been flattened and any test that relies on \
+         it to exercise the detector is testing nothing."
+    );
+    assert_eq!(
+        s1.as_ref().len(),
+        s2.as_ref().len(),
+        "Both outputs should stay the same size (fixed-shape state, \
+         matching the 464-byte production observation)."
+    );
+}
+
+/// A healthy fixture — `UpdateOverride` unwired — must produce byte-equal
+/// state on re-apply. This is the "no false positive" pin for the probe:
+/// a contract whose `update_state` is correctly idempotent must NOT be
+/// flagged.
+#[test]
+fn healthy_mock_is_idempotent_on_reapply() {
+    let mut rt = MockWasmRuntime {
+        contract_store: InMemoryContractStore::default(),
+        validate_overrides: HashMap::new(),
+        update_overrides: HashMap::new(),
+    };
+    let key = fake_key();
+    let params = Parameters::from(vec![]);
+    let initial = WrappedState::new(vec![10u8; 16]);
+    let update = vec![UpdateData::State(initial.clone().into())];
+
+    let first = rt
+        .update_state(&key, &params, &initial, &update)
+        .expect("first update_state");
+    let s1 = WrappedState::new(first.new_state.expect("state").into_bytes());
+
+    let update2 = vec![UpdateData::State(s1.clone().into())];
+    let second = rt
+        .update_state(&key, &params, &s1, &update2)
+        .expect("second update_state");
+    let s2 = WrappedState::new(second.new_state.expect("state").into_bytes());
+
+    assert_eq!(
+        s1.as_ref(),
+        s2.as_ref(),
+        "Default mock merge must be idempotent on re-apply; otherwise the \
+         healthy-baseline assumption of the probe is broken."
+    );
+}

--- a/crates/core/src/contract/executor/pool_tests/non_idempotent_detector_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/non_idempotent_detector_tests.rs
@@ -1,8 +1,9 @@
-//! Tests for the per-contract non-idempotency detector and the broken-
-//! invariants gate. See `crate::ring::broken_invariants` and
-//! `Executor::maybe_probe_idempotency` in `contract/executor/runtime.rs`.
+//! Tests for the per-contract non-idempotency *fixture*. See
+//! `crate::ring::broken_invariants` (tracker-level unit tests) and
+//! `Executor::maybe_probe_idempotency` in `contract/executor/runtime.rs`
+//! for the detector + gate code itself.
 //!
-//! These exercise two layers without spinning up a full network:
+//! ## What these tests cover
 //!
 //! 1. **Fixture self-check** — the `UpdateOverride::NonIdempotent` mock
 //!    actually models the smoking-gun behavior the detector is built to
@@ -10,10 +11,22 @@
 //!    A regression that flattens the fixture into a no-op would silently
 //!    pass the production detector while testing nothing.
 //!
-//! 2. **Gate behavior** — once a contract has been marked broken via
-//!    `Ring::record_broken_invariant`, `Ring::is_contract_broken` returns
-//!    true; the production gate code in `commit_state_update` /
-//!    `broadcast_state_change` reads this exact predicate.
+//! 2. **Healthy baseline** — the default mock IS idempotent on re-apply,
+//!    so the property the probe checks doesn't false-positive on
+//!    well-behaved contracts.
+//!
+//! ## What these tests do NOT cover (deferred)
+//!
+//! End-to-end "probe fires inside the executor, sets the flag via
+//! `Ring::record_broken_invariant`, and the next merge / broadcast is
+//! suppressed by the `is_contract_broken` gate in `commit_state_update`
+//! and `broadcast_state_change`" is **NOT** exercised here — the mock
+//! executor path (`Executor::new_mock_wasm`) doesn't wire a real
+//! `OpManager`, so `op_manager.ring.is_contract_broken(...)` from inside
+//! the executor is a no-op against an absent ring. The tracker layer
+//! (record → is_broken) is covered in `ring::broken_invariants::tests`.
+//! Full integration coverage requires a `SimNetwork`-shaped harness and
+//! is filed as a follow-up to #4279.
 
 use freenet_stdlib::prelude::*;
 
@@ -83,6 +96,42 @@ fn fixture_non_idempotent_override_produces_distinct_states() {
         s2.as_ref().len(),
         "Both outputs should stay the same size (fixed-shape state, \
          matching the 464-byte production observation)."
+    );
+}
+
+/// Source-grep pin: the three production gate sites in `runtime.rs`
+/// (`commit_state_update` top-gate, `broadcast_state_change` gate, and
+/// `bridged_upsert_contract_state` merge-suppression after probe) all
+/// MUST consult `op_manager.ring.is_contract_broken(...)`. A regression
+/// that removes or inverts any of these checks silently re-enables the
+/// broadcast storm — this test would fail compile-time-style on string
+/// match in CI before the gap reaches production.
+#[test]
+fn production_gate_sites_consult_is_contract_broken() {
+    // Read the full source file at compile time. `include_str!` is
+    // resolved relative to the file containing this macro — these tests
+    // live at `crates/core/src/contract/executor/pool_tests/` so we
+    // climb one level to reach the production file.
+    const RUNTIME_SRC: &str = include_str!("../runtime.rs");
+
+    // Truncate before the test module so we only grep production code.
+    // The runtime file currently has no `#[cfg(test)]` mod, so this is
+    // a no-op today, but future-proofs against a sibling test asserting
+    // the same substring.
+    let production = RUNTIME_SRC
+        .split_once("#[cfg(test)]")
+        .map(|(prod, _)| prod)
+        .unwrap_or(RUNTIME_SRC);
+
+    let occurrences = production.matches("is_contract_broken").count();
+    assert!(
+        occurrences >= 3,
+        "expected at least 3 `is_contract_broken` checks in production \
+         runtime.rs (commit_state_update top-gate, broadcast_state_change \
+         gate, and bridged_upsert_contract_state post-probe merge \
+         suppression); found {occurrences}. A regression that removed or \
+         inverted any of these silently re-enables the storm we're \
+         defending against — see PR #4279."
     );
 }
 

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -10,6 +10,17 @@ const MAX_RELATED_CONTRACTS_PER_REQUEST: usize = 10;
 
 /// Timeout for fetching all related contracts during validation.
 const RELATED_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Probability that a given state-changing merge is checked for
+/// `update_state` idempotency. One re-invocation of WASM per sample, so
+/// the per-merge cost is ~`p * average_update_state_us`. At 1/32 ≈ 3%
+/// the overhead is negligible on healthy contracts and detection is
+/// effectively certain within a few seconds on a contract that's
+/// firing dozens of merges/sec.
+///
+/// Sample selection uses `GlobalRng` (deterministic under a fixed seed
+/// for simulation tests). See `Executor::maybe_probe_idempotency`.
+const IDEMPOTENCY_PROBE_PROBABILITY: f64 = 1.0 / 32.0;
 use crate::node::OpManager;
 use crate::wasm_runtime::{
     BackendEngine, DEFAULT_MODULE_CACHE_CAPACITY, MAX_STATE_SIZE, RuntimeConfig, SharedModuleCache,
@@ -1775,6 +1786,39 @@ where
         if updated_state.as_ref() == current_state.as_ref() {
             Ok(UpsertResult::NoChange)
         } else {
+            // CRDT-invariant idempotency probe. With low probability, re-run
+            // `update_state` with `updated_state` as the current state and
+            // the same `updates`. A correct CRDT must satisfy
+            // `update_state(update_state(S, U), U) == update_state(S, U)` —
+            // a violation indicates a contract bug (timestamp/RNG/position-
+            // dependent signing/etc.) that produces an infinite broadcast
+            // storm in the network. See `crate::ring::broken_invariants`.
+            //
+            // `RelatedState` inputs are skipped: re-applying a cross-
+            // contract state hint isn't required to be a no-op by the
+            // contract ABI, so probing it can produce false positives.
+            self.maybe_probe_idempotency(&key, &params, &updated_state, &updates)
+                .await;
+
+            if self
+                .op_manager
+                .as_ref()
+                .map(|m| m.ring.is_contract_broken(&key))
+                .unwrap_or(false)
+            {
+                // Probe just flagged this contract (or it was already
+                // flagged). Skip the commit so we don't extend the
+                // problematic state, and surface the suppression to
+                // callers via NoChange — there is no state change the
+                // network should observe.
+                tracing::debug!(
+                    contract = %key,
+                    event = "merge_suppressed_broken_contract",
+                    "Skipping commit_state_update for contract flagged as broken"
+                );
+                return Ok(UpsertResult::NoChange);
+            }
+
             self.commit_state_update(&key, &params, &updated_state)
                 .await?;
             Ok(UpsertResult::Updated(updated_state))
@@ -2090,6 +2134,96 @@ where
         Ok(Either::Left(new_state))
     }
 
+    /// Probe-sampled idempotency check. Re-runs `update_state` with the just-
+    /// produced state as the current state and the same updates; flags the
+    /// contract as broken if the result differs.
+    ///
+    /// Costs one extra WASM invocation per sampled merge. With the default
+    /// sample rate (1/[`IDEMPOTENCY_PROBE_DENOMINATOR`]) this is a few
+    /// percent overhead on active contracts and effectively zero on quiet
+    /// ones. Sample selection uses `GlobalRng` so simulation builds remain
+    /// deterministic under a fixed seed.
+    ///
+    /// `RelatedState`-only update batches are exempted: re-applying a
+    /// cross-contract state hint isn't contractually required to be a
+    /// no-op, so the property doesn't hold for those by spec.
+    async fn maybe_probe_idempotency(
+        &mut self,
+        key: &ContractKey,
+        parameters: &Parameters<'_>,
+        post_merge_state: &WrappedState,
+        updates: &[UpdateData<'_>],
+    ) {
+        // Cheap precheck: if already flagged, no value in probing again.
+        if let Some(op_manager) = &self.op_manager {
+            if op_manager.ring.is_contract_broken(key) {
+                return;
+            }
+        }
+
+        // Skip if every input is `RelatedState` — see fn doc.
+        let any_probeable = updates.iter().any(|u| {
+            matches!(
+                u,
+                UpdateData::State(_) | UpdateData::Delta(_) | UpdateData::StateAndDelta { .. }
+            )
+        });
+        if !any_probeable {
+            return;
+        }
+
+        if !crate::config::GlobalRng::random_bool(IDEMPOTENCY_PROBE_PROBABILITY) {
+            return;
+        }
+
+        let probe_result = self
+            .runtime
+            .update_state(key, parameters, post_merge_state, updates);
+        let probe_outcome = match probe_result {
+            Ok(modification) => modification,
+            Err(err) => {
+                // The probe failing (timeout, trap, etc.) is not a positive
+                // signal — the contract is exercising some other failure
+                // mode that doesn't necessarily imply non-idempotency.
+                // Log at DEBUG and bail without flagging.
+                tracing::debug!(
+                    contract = %key,
+                    error = %err,
+                    event = "idempotency_probe_error",
+                    "Idempotency probe failed to execute; skipping detection"
+                );
+                return;
+            }
+        };
+        let UpdateModification {
+            new_state: probe_state,
+            ..
+        } = probe_outcome;
+        let Some(probe_state) = probe_state else {
+            // No state output from probe (e.g. contract returned only
+            // `requires(...)`). Inconclusive — bail.
+            return;
+        };
+        let probe_state = WrappedState::new(probe_state.into_bytes());
+
+        if probe_state.as_ref() != post_merge_state.as_ref() {
+            if let Some(op_manager) = &self.op_manager {
+                tracing::warn!(
+                    contract = %key,
+                    post_merge_size = post_merge_state.size(),
+                    probe_size = probe_state.size(),
+                    event = "non_idempotent_merge_detected",
+                    "Contract violates update_state idempotency \
+                     (update_state(update_state(S, U), U) != update_state(S, U)). \
+                     Flagging contract; outbound BroadcastStateChange will be suppressed."
+                );
+                op_manager
+                    .ring
+                    .record_broken_invariant(*key, crate::ring::BrokenInvariant::NonIdempotent);
+            }
+        }
+    }
+
     /// Persist an updated contract state via `state_store.update`.
     ///
     /// This is the canonical chokepoint for UPDATE-shaped writes: every
@@ -2163,17 +2297,32 @@ where
         self.send_delegate_contract_notifications(key, new_state);
 
         if let Some(op_manager) = &self.op_manager {
-            // Non-blocking emit: a 30-second `notify_node_event(...).await`
-            // on this commit path was the primary back-pressure source
-            // that wedged both gateways on 2026-05-24 (#4145). Missed
-            // broadcasts heal via the next UPDATE or via summary-mismatch
-            // SyncStateToPeer rounds — the executor must not stall here.
-            if let Err(err) =
+            // Skip the broadcast entirely if this contract has been flagged
+            // as violating a CRDT invariant (e.g. non-idempotent
+            // `update_state`). The idempotency probe in
+            // `bridged_upsert_contract_state` sets this flag when it
+            // catches `update_state(update_state(S, U), U) != update_state(S, U)`.
+            // Once flagged, propagating this contract's state changes
+            // re-engages the broadcast storm we are trying to suppress.
+            // See `crate::ring::broken_invariants`.
+            if op_manager.ring.is_contract_broken(key) {
+                tracing::debug!(
+                    contract = %key,
+                    event = "broadcast_suppressed_broken_contract",
+                    "Skipping BroadcastStateChange for contract flagged as broken"
+                );
+            } else if let Err(err) =
                 op_manager.try_notify_node_event(crate::message::NodeEvent::BroadcastStateChange {
                     key: *key,
                     new_state: new_state.clone(),
                 })
             {
+                // Non-blocking emit: a 30-second `notify_node_event(...).await`
+                // on this commit path was the primary back-pressure source
+                // that wedged both gateways on 2026-05-24 (#4145). Missed
+                // broadcasts heal via the next UPDATE or via summary-mismatch
+                // SyncStateToPeer rounds — the executor must not stall here.
+                //
                 // Best-effort by design (see comment block above and
                 // #4145): a missed broadcast heals via the next UPDATE
                 // or summary-mismatch SyncStateToPeer round. Per-
@@ -2512,6 +2661,17 @@ where
 
     async fn broadcast_state_change(&self, key: ContractKey, new_state: WrappedState) {
         if let Some(op_manager) = &self.op_manager {
+            // Mirror the broken-invariant gate in `commit_state_update`
+            // above. Same rationale: a contract flagged as non-idempotent
+            // must not be propagated.
+            if op_manager.ring.is_contract_broken(&key) {
+                tracing::debug!(
+                    contract = %key,
+                    event = "broadcast_suppressed_broken_contract",
+                    "Skipping BroadcastStateChange for contract flagged as broken"
+                );
+                return;
+            }
             // Non-blocking emit — see comment in the update path above
             // and #4145 for the wedge this prevents.
             if let Err(err) =

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -2138,15 +2138,21 @@ where
     /// produced state as the current state and the same updates; flags the
     /// contract as broken if the result differs.
     ///
-    /// Costs one extra WASM invocation per sampled merge. With the default
-    /// sample rate (1/[`IDEMPOTENCY_PROBE_DENOMINATOR`]) this is a few
-    /// percent overhead on active contracts and effectively zero on quiet
-    /// ones. Sample selection uses `GlobalRng` so simulation builds remain
-    /// deterministic under a fixed seed.
+    /// Costs one extra WASM invocation per sampled merge. With the
+    /// configured probability [`IDEMPOTENCY_PROBE_PROBABILITY`] (currently
+    /// 1/32) this is a few percent overhead on active contracts and
+    /// effectively zero on quiet ones. Sample selection uses `GlobalRng`
+    /// so simulation builds remain deterministic under a fixed seed.
     ///
-    /// `RelatedState`-only update batches are exempted: re-applying a
-    /// cross-contract state hint isn't contractually required to be a
-    /// no-op, so the property doesn't hold for those by spec.
+    /// Only probes update batches whose every entry is
+    /// `UpdateData::State(_)`. `Delta`/`StateAndDelta` are exempted
+    /// because operation-based CRDTs (counters, append-logs) legitimately
+    /// violate the byte-equality property on re-apply; `RelatedState` is
+    /// exempted because it's a cross-contract hint, not a CRDT op over
+    /// this contract's state. Probe traps (timeout, OOG, panic) are
+    /// logged but not treated as positive signals — distinguishing
+    /// "buggy on re-apply" from "buggy in some other way" requires a
+    /// separate detector. See `crate::ring::broken_invariants`.
     async fn maybe_probe_idempotency(
         &mut self,
         key: &ContractKey,
@@ -2161,17 +2167,40 @@ where
             }
         }
 
-        // Skip if every input is `RelatedState` — see fn doc.
-        let any_probeable = updates.iter().any(|u| {
-            matches!(
-                u,
-                UpdateData::State(_) | UpdateData::Delta(_) | UpdateData::StateAndDelta { .. }
-            )
-        });
-        if !any_probeable {
+        // Probe ONLY when every input is `UpdateData::State(...)`. Three
+        // reasons for this conservative gating:
+        //
+        // 1. `Delta` inputs are NOT contractually required to be
+        //    idempotent. An "increment by 1" delta produces S+1 then S+2
+        //    on re-apply — that's a CmRDT-shaped contract, perfectly
+        //    valid, but `update_state(update_state(S, U), U) != update_state(S, U)`
+        //    in the exact byte sense the probe checks. Probing Delta
+        //    inputs would mass-flag legitimate counter / append-log
+        //    contracts. Skip them entirely.
+        //
+        // 2. `StateAndDelta` carries a delta too, with the same risk.
+        //
+        // 3. `RelatedState` is a cross-contract hint, not a CRDT op
+        //    over this contract's state — re-applying isn't required
+        //    to be a no-op even for a correct contract.
+        //
+        // State-only batches are the unambiguous case: receiving the
+        // same full state twice MUST produce the same merged result by
+        // CvRDT lattice-join semantics. That's the invariant the probe
+        // tests.
+        let all_state =
+            !updates.is_empty() && updates.iter().all(|u| matches!(u, UpdateData::State(_)));
+        if !all_state {
             return;
         }
 
+        // Sampling. `GlobalRng` honors a fixed seed in simulation tests
+        // (see `crate::config::GlobalRng`), so determinism is preserved
+        // under the existing test harness — but the call ordering would
+        // shift if existing tests don't expect a new RNG consumer on the
+        // merge path. The probe runs only on pure-State batches (above),
+        // which the simulation harness drives explicitly and rarely, so
+        // the RNG stream perturbation is bounded.
         if !crate::config::GlobalRng::random_bool(IDEMPOTENCY_PROBE_PROBABILITY) {
             return;
         }
@@ -2237,6 +2266,27 @@ where
         parameters: &Parameters<'_>,
         new_state: &WrappedState,
     ) -> Result<(), ExecutorError> {
+        // Blanket gate: a contract flagged as violating a CRDT invariant
+        // (e.g. non-idempotent merge) must not have its state extended
+        // OR broadcast from this node. The merge in
+        // `bridged_upsert_contract_state` already short-circuits before
+        // reaching here on the probe-positive path, but
+        // `commit_state_update` has other call sites (related-contract
+        // retry, validation re-attempt) that don't run the probe first.
+        // Gating here covers all of them with one check. See
+        // `crate::ring::broken_invariants` for the tracker and #4279
+        // for the storm shape this defends against.
+        if let Some(op_manager) = &self.op_manager {
+            if op_manager.ring.is_contract_broken(key) {
+                tracing::debug!(
+                    contract = %key,
+                    event = "commit_suppressed_broken_contract",
+                    "Skipping commit_state_update for contract flagged as broken"
+                );
+                return Ok(());
+            }
+        }
+
         let state_size = new_state.as_ref().len();
         if state_size > MAX_STATE_SIZE {
             tracing::warn!(

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -123,6 +123,12 @@ impl ContractHandler for NetworkContractHandler {
         // This must be done before loading the cache so evictions work correctly
         let storage = executor.state_store().inner().clone();
         op_manager.ring.set_hosting_storage(storage.clone());
+        // Hydrate broken-invariants flags from the same backing store so a
+        // node that previously detected a non-idempotent contract doesn't
+        // re-engage its broadcast storm after restart.
+        op_manager
+            .ring
+            .set_broken_invariants_storage(storage.clone());
 
         // Load hosting cache from persisted storage
         // This restores contracts that were hosted before restart, and also

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -30,6 +30,16 @@ pub(crate) const CONTRACT_INDEX_TABLE: TableDefinition<&[u8], &[u8]> =
 pub(crate) const DELEGATE_INDEX_TABLE: TableDefinition<&[u8], &[u8]> =
     TableDefinition::new("delegate_index");
 
+/// Per-contract record of detected CRDT-invariant violations (e.g. a
+/// non-idempotent `update_state`). One row per offending contract; presence
+/// alone is the gate signal. See `ring::broken_invariants` for the in-memory
+/// tracker that hydrates from this table at startup.
+///
+/// Key: ContractInstanceId (32 bytes)
+/// Value: single byte encoding [`BrokenInvariant`] (currently 0 = NonIdempotent)
+pub(crate) const BROKEN_INVARIANTS_TABLE: TableDefinition<&[u8], &[u8]> =
+    TableDefinition::new("broken_invariants");
+
 /// Index table mapping DelegateKey to secret key hashes.
 /// This replaces the legacy KEY_DATA file in the secrets directory.
 /// Key: DelegateKey (64 bytes)
@@ -212,6 +222,18 @@ impl ReDb {
                     table = "SECRETS_INDEX_TABLE",
                     phase = "table_init_failed",
                     "Failed to open SECRETS_INDEX_TABLE"
+                );
+                e
+            })?;
+
+            // Created on first open of upgraded databases too — redb creates
+            // missing tables inside the same write txn that opens them.
+            txn.open_table(BROKEN_INVARIANTS_TABLE).map_err(|e| {
+                tracing::error!(
+                    error = %e,
+                    table = "BROKEN_INVARIANTS_TABLE",
+                    phase = "table_init_failed",
+                    "Failed to open BROKEN_INVARIANTS_TABLE"
                 );
                 e
             })?;
@@ -701,6 +723,62 @@ impl ReDb {
             let delegate_key =
                 DelegateKey::new(delegate_key_bytes, CodeHash::from(&code_hash_bytes));
             result.push((delegate_key, secret_keys));
+        }
+        Ok(result)
+    }
+
+    // ==================== Broken Invariants Methods ====================
+    // Per-contract record of detected CRDT-invariant violations. See
+    // `ring::broken_invariants` for the in-memory tracker.
+
+    /// Persist a broken-invariant flag for the given contract instance.
+    /// `kind_byte` is the single-byte encoding produced by
+    /// `BrokenInvariant::to_byte`. Repeated calls overwrite — the tracker's
+    /// in-memory layer suppresses redundant writes for already-flagged
+    /// contracts, but we don't depend on that here.
+    pub fn store_broken_invariant(
+        &self,
+        instance_id: &ContractInstanceId,
+        kind_byte: u8,
+    ) -> Result<(), redb::Error> {
+        let txn = self.0.begin_write()?;
+        {
+            let mut tbl = txn.open_table(BROKEN_INVARIANTS_TABLE)?;
+            tbl.insert(instance_id.as_ref(), &[kind_byte][..])?;
+        }
+        txn.commit().map_err(Into::into)
+    }
+
+    /// Load all persisted broken-invariant flags. Malformed rows (wrong
+    /// key length, wrong value length) are skipped with a warning rather
+    /// than failing the entire load — a corrupted entry should not block
+    /// startup, and the worst case is we lose a flag and re-detect it.
+    pub fn load_all_broken_invariants(&self) -> Result<Vec<(ContractInstanceId, u8)>, redb::Error> {
+        let txn = self.0.begin_read()?;
+        let tbl = txn.open_table(BROKEN_INVARIANTS_TABLE)?;
+
+        let mut result = Vec::new();
+        for entry in tbl.iter()? {
+            let (key, value) = entry?;
+            let key_bytes: [u8; 32] = match key.value().try_into() {
+                Ok(b) => b,
+                Err(_) => {
+                    tracing::warn!(
+                        len = key.value().len(),
+                        "Skipping malformed broken-invariants row (key length)"
+                    );
+                    continue;
+                }
+            };
+            let v = value.value();
+            if v.len() != 1 {
+                tracing::warn!(
+                    len = v.len(),
+                    "Skipping malformed broken-invariants row (value length)"
+                );
+                continue;
+            }
+            result.push((ContractInstanceId::new(key_bytes), v[0]));
         }
         Ok(result)
     }

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -749,6 +749,22 @@ impl ReDb {
         txn.commit().map_err(Into::into)
     }
 
+    /// Remove a persisted broken-invariant flag. Paired with
+    /// `BrokenInvariantsTracker::clear` — without on-disk removal, an
+    /// operator's unflag would be undone on the next restart's
+    /// `set_storage` rehydration.
+    pub fn remove_broken_invariant(
+        &self,
+        instance_id: &ContractInstanceId,
+    ) -> Result<(), redb::Error> {
+        let txn = self.0.begin_write()?;
+        {
+            let mut tbl = txn.open_table(BROKEN_INVARIANTS_TABLE)?;
+            tbl.remove(instance_id.as_ref())?;
+        }
+        txn.commit().map_err(Into::into)
+    }
+
     /// Load all persisted broken-invariant flags. Malformed rows (wrong
     /// key length, wrong value length) are skipped with a warning rather
     /// than failing the entire load — a corrupted entry should not block
@@ -1100,6 +1116,31 @@ mod tests {
         assert_eq!(
             loaded, expected,
             "broken-invariants table must survive close-and-reopen exactly"
+        );
+    }
+
+    /// `remove_broken_invariant` deletes the on-disk row, so a clear()
+    /// in `BrokenInvariantsTracker` followed by a process restart
+    /// genuinely keeps the contract unflagged. Without this, `set_storage`
+    /// would re-hydrate from the stale row and the unflag would be undone.
+    #[tokio::test]
+    async fn broken_invariants_remove_makes_load_empty() {
+        let temp_dir = TempDir::new().unwrap();
+        let id = fake_instance_id(0x42);
+
+        {
+            let db = ReDb::new(temp_dir.path()).await.unwrap();
+            db.store_broken_invariant(&id, 0).unwrap();
+            assert_eq!(db.load_all_broken_invariants().unwrap().len(), 1);
+            db.remove_broken_invariant(&id).unwrap();
+            assert!(db.load_all_broken_invariants().unwrap().is_empty());
+        }
+
+        // Round-trip across a close/reopen — the removal must persist.
+        let db = ReDb::new(temp_dir.path()).await.unwrap();
+        assert!(
+            db.load_all_broken_invariants().unwrap().is_empty(),
+            "removal must survive a close/reopen"
         );
     }
 

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -1058,4 +1058,102 @@ mod tests {
             .await
             .expect("removing a never-stored contract should be Ok");
     }
+
+    // ==================== Broken Invariants Persistence ====================
+
+    fn fake_instance_id(seed: u8) -> ContractInstanceId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = seed;
+        ContractInstanceId::new(bytes)
+    }
+
+    /// Full store → reopen → load round trip for the broken-invariants
+    /// table. This is the load-bearing guarantee for the
+    /// "node that detected the bug stays gated after restart" claim in
+    /// PR #4279. A regression that swapped key/value order, dropped the
+    /// commit, or wrote to the wrong table would ship green without this.
+    #[tokio::test]
+    async fn broken_invariants_persistence_round_trip() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let id_a = fake_instance_id(0xA1);
+        let id_b = fake_instance_id(0xB2);
+
+        // Initial open + write.
+        {
+            let db = ReDb::new(temp_dir.path()).await.unwrap();
+            db.store_broken_invariant(&id_a, 0).expect("store id_a");
+            db.store_broken_invariant(&id_b, 0).expect("store id_b");
+        }
+
+        // Reopen. The exact instance must come back through
+        // `load_all_broken_invariants` — this is what
+        // `BrokenInvariantsTracker::set_storage` calls at executor wire-up
+        // to hydrate the in-memory flag map.
+        let db = ReDb::new(temp_dir.path()).await.unwrap();
+        let mut loaded = db.load_all_broken_invariants().expect("load");
+        loaded.sort_by_key(|(id, _)| id.as_bytes().to_vec());
+
+        let mut expected = vec![(id_a, 0u8), (id_b, 0u8)];
+        expected.sort_by_key(|(id, _)| id.as_bytes().to_vec());
+
+        assert_eq!(
+            loaded, expected,
+            "broken-invariants table must survive close-and-reopen exactly"
+        );
+    }
+
+    /// `store_broken_invariant` is treated as upsert (single in-memory
+    /// flag → single on-disk row). Repeated stores with the same key
+    /// must collapse to one row, not produce duplicates.
+    #[tokio::test]
+    async fn broken_invariants_store_is_upsert_not_append() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = ReDb::new(temp_dir.path()).await.unwrap();
+        let id = fake_instance_id(0x77);
+
+        db.store_broken_invariant(&id, 0).unwrap();
+        db.store_broken_invariant(&id, 0).unwrap();
+        db.store_broken_invariant(&id, 0).unwrap();
+
+        let rows = db.load_all_broken_invariants().unwrap();
+        assert_eq!(rows.len(), 1, "repeated stores must collapse to one row");
+        assert_eq!(rows[0].0, id);
+    }
+
+    /// Malformed value-length rows must be skipped (not panic, not abort
+    /// load). The current write path always writes 1 byte; this pins the
+    /// forward-compat behavior so future format extensions can roll out
+    /// without bricking startup for older nodes' on-disk state.
+    #[tokio::test]
+    async fn broken_invariants_load_skips_malformed_value() {
+        use redb::Database;
+        let temp_dir = TempDir::new().unwrap();
+        let db = ReDb::new(temp_dir.path()).await.unwrap();
+        // Write a deliberately-too-long value bypassing the helper.
+        let db_path = temp_dir.path().join("db");
+        // Drop the wrapper so the raw redb file lock is released before
+        // we open it directly to inject the malformed row.
+        drop(db);
+        let raw = Database::open(&db_path).unwrap();
+        {
+            let txn = raw.begin_write().unwrap();
+            {
+                let mut tbl = txn.open_table(BROKEN_INVARIANTS_TABLE).unwrap();
+                let id = fake_instance_id(0xCC);
+                let bogus: [u8; 4] = [1, 2, 3, 4];
+                tbl.insert(id.as_ref(), &bogus[..]).unwrap();
+            }
+            txn.commit().unwrap();
+        }
+        drop(raw);
+
+        let db = ReDb::new(temp_dir.path()).await.unwrap();
+        let rows = db.load_all_broken_invariants().unwrap();
+        assert!(
+            rows.is_empty(),
+            "malformed row must be silently skipped; got: {:?}",
+            rows
+        );
+    }
 }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -42,11 +42,13 @@ use crate::{
     router::Router,
 };
 
+mod broken_invariants;
 mod connection_backoff;
 mod connection_manager;
 pub(crate) use connection_manager::ConnectionManager;
 mod connection;
 mod hosting;
+pub(crate) use broken_invariants::{BrokenInvariant, BrokenInvariantsTracker};
 /// Single source of truth for the default hosted-contract-state budget.
 /// `config::default_max_hosting_storage()` resolves to this so the
 /// operator-facing default and the in-code fallback can never drift.
@@ -93,6 +95,10 @@ pub(crate) struct Ring {
     pub router: Arc<RwLock<Router>>,
     pub live_tx_tracker: LiveTransactionTracker,
     hosting_manager: hosting::HostingManager,
+    /// Per-contract record of detected CRDT-invariant violations (e.g. a
+    /// non-idempotent `update_state`). Used to gate outbound broadcast
+    /// so a broken contract's state changes don't leave the node.
+    broken_invariants: BrokenInvariantsTracker,
     event_register: Box<dyn NetEventRegister>,
     op_manager: RwLock<Option<Weak<OpManager>>>,
     /// Whether this peer is a gateway or not. This will affect behavior of the node when acquiring
@@ -224,6 +230,7 @@ impl Ring {
             router,
             connection_manager,
             hosting_manager: hosting::HostingManager::new(config.config.max_hosting_storage),
+            broken_invariants: BrokenInvariantsTracker::new(),
             live_tx_tracker: live_tx_tracker.clone(),
             event_register: Box::new(event_register),
             op_manager: RwLock::new(None),
@@ -1901,6 +1908,29 @@ impl Ring {
     /// No-op if the contract is not currently subscribed.
     pub fn record_contract_update(&self, contract: &ContractKey) {
         self.hosting_manager.record_contract_update(contract)
+    }
+
+    /// True if `contract` has been flagged as violating a CRDT invariant
+    /// (e.g. non-idempotent `update_state`). Callers on the broadcast path
+    /// must skip emission when this returns true to prevent the broken
+    /// contract from generating a propagation storm.
+    pub fn is_contract_broken(&self, contract: &ContractKey) -> bool {
+        self.broken_invariants.is_broken(contract.id())
+    }
+
+    /// Mark `contract` as broken with `kind`. Idempotent. See
+    /// [`broken_invariants`] module docs.
+    pub(crate) fn record_broken_invariant(&self, contract: ContractKey, kind: BrokenInvariant) {
+        self.broken_invariants.record(*contract.id(), kind);
+    }
+
+    /// Wire persistent storage for the broken-invariants tracker. Called
+    /// once at executor wiring time.
+    pub(crate) fn set_broken_invariants_storage(
+        &self,
+        storage: crate::contract::storages::Storage,
+    ) {
+        self.broken_invariants.set_storage(storage);
     }
 
     /// Report a per-contract resource sample to the topology meter.

--- a/crates/core/src/ring/broken_invariants.rs
+++ b/crates/core/src/ring/broken_invariants.rs
@@ -129,6 +129,20 @@ impl BrokenInvariantsTracker {
     pub fn clear(&self, id: &ContractInstanceId) -> Option<BrokenInvariant> {
         let previous = self.flags.remove(id).map(|(_, v)| v);
         if previous.is_some() {
+            #[cfg(feature = "redb")]
+            if let Some(storage) = self.storage.get() {
+                if let Err(e) = storage.remove_broken_invariant(id) {
+                    // Best-effort: in-memory is cleared regardless, but
+                    // warn loudly because a stale on-disk row will
+                    // re-flag on next restart.
+                    tracing::warn!(
+                        contract = %id,
+                        error = %e,
+                        "Cleared in-memory broken-invariant flag, but persistence remove failed — \
+                         flag will be re-loaded on next restart"
+                    );
+                }
+            }
             tracing::warn!(
                 contract = %id,
                 event = "broken_invariant_cleared",
@@ -211,6 +225,28 @@ mod tests {
         t.record(broken, BrokenInvariant::NonIdempotent);
         assert!(t.is_broken(&broken));
         assert!(!t.is_broken(&healthy));
+    }
+
+    #[test]
+    fn clear_returns_previous_and_unsets() {
+        let t = BrokenInvariantsTracker::new();
+        let id = fake_id(5);
+
+        // Clearing an absent entry returns None and is a no-op.
+        assert_eq!(t.clear(&id), None);
+
+        t.record(id, BrokenInvariant::NonIdempotent);
+        assert!(t.is_broken(&id));
+
+        let prev = t.clear(&id);
+        assert_eq!(prev, Some(BrokenInvariant::NonIdempotent));
+        assert!(
+            !t.is_broken(&id),
+            "after clear the contract is no longer broken"
+        );
+
+        // Second clear is also a no-op, returns None.
+        assert_eq!(t.clear(&id), None);
     }
 
     #[test]

--- a/crates/core/src/ring/broken_invariants.rs
+++ b/crates/core/src/ring/broken_invariants.rs
@@ -1,0 +1,197 @@
+//! Per-contract tracking of detected CRDT-invariant violations.
+//!
+//! A non-idempotent `update_state` (i.e. `update_state(update_state(S, U), U) != update_state(S, U)`)
+//! breaks the convergence guarantee Freenet contracts rely on and produces a
+//! self-perpetuating broadcast storm: every peer's merge generates a new
+//! byte-different state, which propagates, which every peer re-merges.
+//!
+//! When the merge path's idempotency probe (in `Executor`) detects this on a
+//! sampled merge, it calls [`BrokenInvariantsTracker::record`] which:
+//!
+//! 1. Inserts the flag into an in-memory `DashMap` keyed on the contract
+//!    instance id, so subsequent same-process reads see it immediately.
+//! 2. Persists the flag to the executor's ReDb storage so the detection
+//!    survives node restarts (a known-broken contract should not re-engage
+//!    the storm just because the process bounced).
+//!
+//! Reads (via [`BrokenInvariantsTracker::is_broken`]) gate the broadcast-
+//! emission path so a flagged contract's state changes never leave the
+//! node. A "fixed" version of the same contract has a different code hash
+//! → different `ContractKey` → unaffected, so this flag is intentionally
+//! permanent for the given instance id.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use freenet_stdlib::prelude::ContractInstanceId;
+
+use crate::contract::storages::Storage;
+
+/// The kind of CRDT invariant a contract was observed to violate. Currently
+/// only one variant; future work may add violations like non-commutativity
+/// or non-determinism detection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrokenInvariant {
+    /// `update_state(update_state(S, U), U) != update_state(S, U)` was observed
+    /// for at least one sampled (state, update) pair.
+    NonIdempotent,
+}
+
+impl BrokenInvariant {
+    /// Single-byte on-disk encoding. Stable across releases.
+    fn to_byte(self) -> u8 {
+        match self {
+            BrokenInvariant::NonIdempotent => 0,
+        }
+    }
+
+    fn from_byte(b: u8) -> Option<Self> {
+        match b {
+            0 => Some(BrokenInvariant::NonIdempotent),
+            _ => None,
+        }
+    }
+}
+
+/// Tracks per-contract broken-invariant flags with optional persistent backing.
+///
+/// `set_storage` is called once during node startup, at which point the
+/// tracker reads any previously-persisted flags into the in-memory map.
+/// Until storage is wired, reads still work (empty map) and writes are
+/// in-memory only — this matches the pattern used by `HostingManager`.
+#[derive(Default)]
+pub(crate) struct BrokenInvariantsTracker {
+    flags: Arc<DashMap<ContractInstanceId, BrokenInvariant>>,
+    storage: std::sync::OnceLock<Storage>,
+}
+
+impl BrokenInvariantsTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns true if `id` has any broken-invariant flag set.
+    pub fn is_broken(&self, id: &ContractInstanceId) -> bool {
+        self.flags.contains_key(id)
+    }
+
+    /// Returns the broken-invariant flag for `id`, if any. Used by tests
+    /// and future detectors that distinguish kinds; production callers
+    /// only need `is_broken`.
+    #[cfg(test)]
+    pub fn get(&self, id: &ContractInstanceId) -> Option<BrokenInvariant> {
+        self.flags.get(id).map(|r| *r.value())
+    }
+
+    /// Mark `id` as broken with `kind`. Idempotent — repeat calls are no-ops
+    /// once the in-memory entry exists. Persists best-effort to storage if
+    /// wired; persistence errors are logged but never block the in-memory
+    /// flag from taking effect (we'd rather suppress the storm than crash
+    /// on a database hiccup).
+    pub fn record(&self, id: ContractInstanceId, kind: BrokenInvariant) {
+        let was_new = self.flags.insert(id, kind).is_none();
+        if was_new {
+            tracing::warn!(
+                contract = %id,
+                invariant = ?kind,
+                event = "broken_invariant_detected",
+                "Marking contract as broken — gating outbound broadcast and merge propagation"
+            );
+            if let Some(storage) = self.storage.get() {
+                if let Err(e) = storage.store_broken_invariant(&id, kind.to_byte()) {
+                    tracing::warn!(
+                        contract = %id,
+                        error = %e,
+                        "Failed to persist broken-invariant flag (in-memory flag still active)"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Wire persistent storage. Called once at startup; idempotent on the
+    /// `OnceLock` so callers cannot accidentally re-init with a different
+    /// database. Hydrates the in-memory map from previously-persisted
+    /// entries on first wiring.
+    pub fn set_storage(&self, storage: Storage) {
+        if self.storage.set(storage.clone()).is_err() {
+            tracing::warn!("BrokenInvariantsTracker storage already set; ignoring re-init");
+            return;
+        }
+        match storage.load_all_broken_invariants() {
+            Ok(entries) => {
+                for (id, byte) in entries {
+                    if let Some(kind) = BrokenInvariant::from_byte(byte) {
+                        self.flags.insert(id, kind);
+                    } else {
+                        tracing::warn!(
+                            contract = %id,
+                            byte,
+                            "Skipping unknown broken-invariant byte on load"
+                        );
+                    }
+                }
+                tracing::debug!(
+                    count = self.flags.len(),
+                    "Loaded broken-invariant flags from storage"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to load broken-invariant flags from storage");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_id(seed: u8) -> ContractInstanceId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = seed;
+        ContractInstanceId::new(bytes)
+    }
+
+    #[test]
+    fn record_then_query_returns_true() {
+        let t = BrokenInvariantsTracker::new();
+        let id = fake_id(1);
+        assert!(!t.is_broken(&id));
+        t.record(id, BrokenInvariant::NonIdempotent);
+        assert!(t.is_broken(&id));
+        assert_eq!(t.get(&id), Some(BrokenInvariant::NonIdempotent));
+    }
+
+    #[test]
+    fn record_is_idempotent() {
+        let t = BrokenInvariantsTracker::new();
+        let id = fake_id(2);
+        t.record(id, BrokenInvariant::NonIdempotent);
+        t.record(id, BrokenInvariant::NonIdempotent);
+        // No panic, no duplicate entries; map size remains 1.
+        assert!(t.is_broken(&id));
+    }
+
+    #[test]
+    fn unrelated_contracts_unaffected() {
+        let t = BrokenInvariantsTracker::new();
+        let broken = fake_id(3);
+        let healthy = fake_id(4);
+        t.record(broken, BrokenInvariant::NonIdempotent);
+        assert!(t.is_broken(&broken));
+        assert!(!t.is_broken(&healthy));
+    }
+
+    #[test]
+    fn byte_roundtrip_stable() {
+        // Iterating the (currently single-variant) set keeps the test
+        // honest as new BrokenInvariant kinds are added.
+        let kinds: &[BrokenInvariant] = &[BrokenInvariant::NonIdempotent];
+        for kind in kinds {
+            assert_eq!(BrokenInvariant::from_byte(kind.to_byte()), Some(*kind));
+        }
+        // Unknown bytes are rejected (forward-compat: skip rather than panic).
+        assert_eq!(BrokenInvariant::from_byte(255), None);
+    }
+}

--- a/crates/core/src/ring/broken_invariants.rs
+++ b/crates/core/src/ring/broken_invariants.rs
@@ -97,6 +97,12 @@ impl BrokenInvariantsTracker {
                 event = "broken_invariant_detected",
                 "Marking contract as broken — gating outbound broadcast and merge propagation"
             );
+            // Persistence is currently only wired for the redb backend;
+            // sqlite-only builds keep the in-memory flag but skip the
+            // on-disk hydration. This is the same trade-off
+            // `HostingManager` makes — see #4279 deferred follow-up to
+            // add sqlite parity.
+            #[cfg(feature = "redb")]
             if let Some(storage) = self.storage.get() {
                 if let Err(e) = storage.store_broken_invariant(&id, kind.to_byte()) {
                     tracing::warn!(
@@ -109,6 +115,29 @@ impl BrokenInvariantsTracker {
         }
     }
 
+    /// Remove the broken-invariant flag for `id`. Use with extreme care:
+    /// this is the operator escape hatch for the rare case where the
+    /// probe was a false positive (most plausibly a probe trap that
+    /// shouldn't have been observed at all — see
+    /// `Executor::maybe_probe_idempotency`). Re-enables outbound
+    /// broadcast and commit for the contract. Does not unflag remotely.
+    ///
+    /// Not currently exposed to a CLI / WS API by this PR — added so the
+    /// debug-CLI follow-up has a stable surface to call into. Returns
+    /// the previous flag if any.
+    #[allow(dead_code)] // wired in follow-up PR
+    pub fn clear(&self, id: &ContractInstanceId) -> Option<BrokenInvariant> {
+        let previous = self.flags.remove(id).map(|(_, v)| v);
+        if previous.is_some() {
+            tracing::warn!(
+                contract = %id,
+                event = "broken_invariant_cleared",
+                "Operator cleared broken-invariant flag — outbound broadcast re-enabled"
+            );
+        }
+        previous
+    }
+
     /// Wire persistent storage. Called once at startup; idempotent on the
     /// `OnceLock` so callers cannot accidentally re-init with a different
     /// database. Hydrates the in-memory map from previously-persisted
@@ -118,6 +147,7 @@ impl BrokenInvariantsTracker {
             tracing::warn!("BrokenInvariantsTracker storage already set; ignoring re-init");
             return;
         }
+        #[cfg(feature = "redb")]
         match storage.load_all_broken_invariants() {
             Ok(entries) => {
                 for (id, byte) in entries {


### PR DESCRIPTION
## Problem

The May 2026 `4PjqN5…` runaway (#4251, partially mitigated in #4231 / #4253) was caused by a contract whose `update_state` violates idempotency — i.e. `update_state(update_state(S, U), U) != update_state(S, U)`. Every peer's merge produces a byte-different state from the same logical content, which propagates, which every peer re-merges. The per-contract executor queue saturates and the WS API dies. The reactive fixes shipped in 0.2.65 stop _amplification_ (queue-full no longer re-queues) but don't catch the root-cause failure shape — a misbehaving contract still floods its own merges and broadcasts.

This PR adds the **first generic, root-cause-targeted defense**: an in-peer detector for the property `update_state(update_state(S, U), U) == update_state(S, U)`, which every correct CRDT-shaped contract satisfies by definition.

## Approach

* **Sampled probe at the merge site.** With probability `IDEMPOTENCY_PROBE_PROBABILITY = 1/32` (via `GlobalRng` — simulation tests stay deterministic), after a state-changing merge produces `S'`, re-invoke `update_state(S', updates)` in the same runtime. If the result is byte-different from `S'`, the contract is flagged. ~3% executor overhead on heavily-trafficked contracts, ~0 on quiet ones.
* **Persistent per-contract flag.** `BrokenInvariant::NonIdempotent` flag held in a DashMap on `Ring`, backed by a new `BROKEN_INVARIANTS_TABLE` in the ReDb store. Wired through the same `handler.rs::set_*_storage` pattern as `HostingManager`. A node that detected the bug doesn't re-engage the storm on restart.
* **Gate the broadcast emission.** Both `BroadcastStateChange` emission sites in `contract/executor/runtime.rs` (`commit_state_update` and `broadcast_state_change`) check `Ring::is_contract_broken` before emitting. Flagged contracts' state never leaves the node.
* **Skip commit on probe-positive.** When the probe fires positive on a fresh merge, the commit is skipped too — there's no reason to extend the problematic state locally; subsequent inbound updates get the same treatment, and the contract effectively freezes for this node.
* **`RelatedState` exempted.** The re-apply property doesn't hold for `RelatedState` inputs by contract spec (it's a cross-contract hint, not a CRDT operation), so probes skip merges driven exclusively by `RelatedState`.

## WASM dissection of the offending contract

Live confirmation (`/home/ian/.claude/jobs/.../wasm-analysis.md` — see [issue thread]): the `4PjqN5…` instance resolves to `bdtchyck…wasm` (228 KB; private repo `freenet/freenet-idle-poc`, `shared-wire/src/guilds.rs`). Host-induced non-determinism is **fully ruled out** — single host import (`__frnt__fill_buffer`), no `getrandom`, no clock, no WASI. The bug is intrinsic to the contract's own `Vec<GuildOp>` merge logic. Two indistinguishable sub-mechanisms (order-dependent sort or position-dependent ed25519 re-signing); the single re-apply property catches both regardless.

## Why this targeting (vs. a rate-limit/throttle)

A flat per-contract broadcast rate-limit would penalize any legitimately fast or large-update contract. The non-idempotency probe doesn't — a correct CRDT passes the property regardless of update rate, payload size, or fan-out. Zero false positives by construction.

## Why local-only (no wire message)

Each peer detects independently. There's no `BrokenContract` wire variant. Adding one would create a denial-of-service surface (a malicious peer broadcasts a false flag to silence a healthy contract). The cascade is good enough: as detection spreads peer-by-peer, the storm collapses naturally.

## Explicitly out of scope (follow-ups)

This PR is the smallest correct shape that kills the storm. The following are intentional follow-ups so this can review and merge in a single sitting:

* **Inbound-relay gate** at `update::op_ctx_task::drive_relay_broadcast_to` — currently a flagged peer still wastes one WASM exec on incoming `BroadcastTo` before deciding not to propagate. Belt-and-suspenders.
* **Subscribe / hosting-advertise gates** — stop advertising broken contracts to neighbors so route-around happens too.
* **Real-WASM regression fixture** using nova's captured 464-byte state for `4PjqN5…`. Currently the synthetic `UpdateOverride::NonIdempotent` mock pins the fixture's _bug shape_ correctly (test asserts re-apply produces different bytes) but doesn't exercise actual WASM. Slow to assemble correctly — separate PR.
* **Additional `BrokenInvariant` kinds** (non-commutativity, hard-timeout repeat-offender). The enum/storage shape is forward-compatible (single byte on disk, `from_byte` returns `Option`).

## How this composes with the contract-hardening initiative (#4260)

Strictly additive. PR #4260 (already merged) covers the **resource-cost** axis: `Meter`, MAD-based outlier scoring, eviction-order refinements. This PR covers the **correctness** axis. The `BrokenInvariant` flag is the natural input for the governance reaper PR's eviction-policy decision tree — a contract that's both _expensive_ AND _broken_ is the highest-priority eviction candidate.

## Testing

* **2703 lib tests pass**, 0 failures, 14 ignored (pre-existing).
* New unit tests in `ring::broken_invariants::tests` (4) — record/query, idempotent record, unrelated-contracts isolation, on-disk byte roundtrip.
* New tests in `non_idempotent_detector_tests` (2) — pin the mock fixture's bug shape (re-apply produces distinct bytes, _and_ stays the same size like the production 464-byte observation); pin the healthy baseline (default mock _is_ idempotent on re-apply, no false positives).
* `cargo clippy --lib --tests -- -D warnings` clean.
* `cargo fmt` clean.

## Risk register

* **False positive on a correct CRDT** — impossible by definition of the property. Tests pin the no-false-positive baseline.
* **WASM throughput overhead** — 1/32 sampling: ~3% executor CPU on active contracts. Tuneable via the `IDEMPOTENCY_PROBE_PROBABILITY` constant if observed too high.
* **Probe itself errors out** (timeout, trap) — handled: bail without flagging, log at DEBUG. Doesn't change the original merge outcome.
* **Persistence corruption** — `load_all_broken_invariants` skips malformed rows with a warning rather than failing startup. Worst case: re-detect on first sampled merge after restart.
* **Migration risk** — adds a new ReDb table. redb auto-creates missing tables on `open_table` inside a write transaction, so existing databases pick it up on first startup of the new binary. No explicit migration step.

## Fixes

Closes part of #4251 (root-cause detector for the specific bug shape; resource-throttling / reaper work continues in the governance track).

[AI-assisted - Claude]