### PR TITLE
feat(governance): phase 2 — per-(sender, contract) UPDATE rate limit (MVP)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
  "bytes 1.11.1",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -309,7 +309,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes 1.11.1",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "mime",
@@ -445,7 +445,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
  "hyper",
  "hyper-named-pipe",
@@ -948,27 +948,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008f1a8d1da5074ad858f398775a6d1989031892e46927df5ed18d3be1ed8717"
+checksum = "8c80cf55a351448317210f26c434be761bcb25e7b36116ec92f89540b73e2833"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd76237df1f4e26edb5ad7971d20280ed1e193331fd257f1b4e4dfefd88dda2"
+checksum = "07937ca8617b340162fe3a4716be885b5847e9b56d6c7a89abbe4d42340fdc91"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380f0bc43e535df6855bbee649efb00bde39c3f33434c47c8e10ac836d21bf47"
+checksum = "88217b08180882436d54c0133274885c590698ae854e352bede1cda041230800"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -976,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4811e3e4502de04257e90c0a93225b56d9b85e0f9ad10b81446b415511009610"
+checksum = "d5c3cf7ba29fa56e56040848e34835d4e45988b2760ef212413409af95ffd8c1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ffadb34d497f3e76fb3b4baf764c24ba8a51512976a1b77f78bdbf8f4aa687"
+checksum = "ebe1aac2efd4cba2047845fce38a68519935a30e20c8a6294ba7e2f448fe722d"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1001,7 +1001,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli 0.33.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "libm",
  "log",
  "pulley-interpreter",
@@ -1015,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4f6992eb6faf086ddc7deaaa5f279abfe7f5fd5ae5709bd38253450fc7b945"
+checksum = "0909eaf9d6f18f5bf802d50608cb4368ac340fbd03cc44f2888d1cfcc3faa64e"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1028,24 +1028,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e1b2aad7d055925a4ea9cdbfa9d1d987f9dfc8ad6b708be28f901ac620a298"
+checksum = "c95a8da8be283f49cda7d0ef228c94f10d791e517b27b0c7e282dadd2e79ce45"
 
 [[package]]
 name = "cranelift-control"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a355348325e0a63b65c00def3871597b9fcc79d25456397010d16d872b3772"
+checksum = "f5b19c81145146da1f7afda2e7f52111842fe6793512e740ad5cf3f5639e6212"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f4847d93ce2c80d2bff929aa1004dfb3ce2cf5d881f6ced54b8d654d967ba3"
+checksum = "4a55309b47e6633ab05821304206cb1e92952e845b1224985562bb7ac1e92323"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1055,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba24e5fe5242cc445e7892ef0a51a4351cf716e3a04ac7a3a05820d056c39818"
+checksum = "064d2d3533d9608f1cf44c8899cf2f7f33feb70300b0fb83e687b0d9e7b91147"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1067,15 +1067,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bc2035de85c4f04ba7bd57eb5bd3a8b775235bf28852dbf87105115cb8919a"
+checksum = "1ac4e0bc095b2dab2212d1e99d7a74b62afc1485db023f1c0cb34a68758f7bd1"
 
 [[package]]
 name = "cranelift-native"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea6630c16921ab087792750f239d0c0173411e80179ca7c0ce0710ce9e7646a"
+checksum = "09a40053f5cb925451dd1d57393d14ad3145c8e0786701c27b5415ebb9a3ba4f"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1084,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4bbad54fc28cc0da1f9a5d7f7f826ec8cafda3d503b401b2daaaa93c63ef0"
+checksum = "a3ceab9a53f7d362c89841fbaa8e63e44d47c40e91dc96ee6f777fca5d6b323b"
 
 [[package]]
 name = "crc"
@@ -1828,7 +1828,7 @@ dependencies = [
  "futures 0.3.32",
  "glob",
  "hex",
- "http 1.4.0",
+ "http 1.4.1",
  "prettytable-rs",
  "rand 0.9.4",
  "semver",
@@ -2741,7 +2741,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.1",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -2790,8 +2790,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2803,6 +2801,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2836,7 +2836,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes 1.11.1",
  "headers-core",
- "http 1.4.0",
+ "http 1.4.1",
  "httpdate",
  "mime",
  "sha1",
@@ -2848,7 +2848,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -3002,9 +3002,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes 1.11.1",
  "itoa",
@@ -3017,7 +3017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes 1.11.1",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -3028,7 +3028,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes 1.11.1",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "pin-project-lite",
 ]
@@ -3062,7 +3062,7 @@ dependencies = [
  "crossbeam-channel",
  "form_urlencoded",
  "futures 0.3.32",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -3111,7 +3111,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "httparse",
  "httpdate",
@@ -3143,7 +3143,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "hyper",
  "hyper-util",
  "rustls",
@@ -3176,7 +3176,7 @@ dependencies = [
  "bytes 1.11.1",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "hyper",
  "ipnet",
@@ -4555,7 +4555,7 @@ checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes 1.11.1",
- "http 1.4.0",
+ "http 1.4.1",
  "opentelemetry 0.32.0",
  "reqwest 0.13.3",
 ]
@@ -4585,7 +4585,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "opentelemetry 0.32.0",
  "opentelemetry-http 0.32.0",
  "opentelemetry-proto",
@@ -5155,9 +5155,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff0ead8b4616f81b3d3efd41ce41bcf9ea364a5d8df8be8a8a1f98b50104349"
+checksum = "e9204ad9435f2a6fe3bd13bba52389fb8488fa20ba497e35c5d2db638166019d"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -5167,9 +5167,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4389e5820b1b39810ac12a27aa665320cab3caa51913a79637c06f284cfe223"
+checksum = "53009b033747e0d79a76549a744da58e84c9da8076492c7e6d491fdc6cc41b95"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5523,7 +5523,7 @@ dependencies = [
  "bytes 1.11.1",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -5565,7 +5565,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -7096,7 +7096,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes 1.11.1",
  "h2",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -7161,7 +7161,7 @@ dependencies = [
  "bytes 1.11.1",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "http-range-header",
@@ -7340,7 +7340,7 @@ checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes 1.11.1",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -7359,7 +7359,7 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes 1.11.1",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -7645,9 +7645,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.246.2"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05a2b3bad87cc1ce45b63425ec09a854cc4cb369231c9fed1fee31538103efb"
+checksum = "96ba953e2b9b4b4b52a31cf4e3ee1c1374c872b6e012cf2138d1c37cba00bfd6"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -7655,8 +7655,8 @@ dependencies = [
  "log",
  "petgraph",
  "smallvec",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
  "wat",
 ]
 
@@ -7672,12 +7672,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.246.2"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.246.2",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -7729,12 +7729,12 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.246.2"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
 dependencies = [
  "bitflags 2.11.1",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "semver",
  "serde",
@@ -7753,20 +7753,20 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.246.2"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e41f7493ba994b8a779430a4c25ff550fd5a40d291693af43a6ef48688f00e3"
+checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.246.2",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4eccc0728f061979efa8ff4c962cff7041fead4baadb74973f01b9c47158a4"
+checksum = "d35aec1e932d00a7c941f816ad589e65ad8db948b9e971bf8ec655a1669f1f67"
 dependencies = [
  "addr2line 0.26.1",
  "async-trait",
@@ -7797,8 +7797,8 @@ dependencies = [
  "target-lexicon 0.13.5",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -7817,9 +7817,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e84dbe3208c1336a41546beb75927b3b37e2e4fce06653d214b407136fbe295"
+checksum = "d7da3dcce82a7e784121c19c8c9c5f69a743088264ff5212033e4a1f1b9dfaaf"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -7827,7 +7827,7 @@ dependencies = [
  "cranelift-bitset",
  "cranelift-entity",
  "gimli 0.33.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "log",
  "object 0.39.1",
@@ -7839,8 +7839,8 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "target-lexicon 0.13.5",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -7848,9 +7848,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910b8dcadc0888344b2dea5a087c836b58156d4f455c52b6dac0bdc776a9d029"
+checksum = "ef87f84d976e2f98a541eaf5837df0424e2039837fc20bd6cd4b4b5a322939c0"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -7868,9 +7868,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c223bd503db76df8d74d1fcca39e734d25f7a0c1dcaf1509b67f3855d1b0f803"
+checksum = "86991f201391afc1504e4fc363dc29b66f92af0287b4ac2efc3c0b0c19435eeb"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -7878,32 +7878,32 @@ dependencies = [
  "syn 2.0.117",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.246.2",
+ "wit-parser 0.248.0",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab123ad511483a1b918399789d0cc7dea7c5c6476743df73949007b5b225fc74"
+checksum = "47fda091250d7ab839ea51e4d98190b6eee37e9de4ab2462e8fe8465369c1986"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4364d345719bba7fc4c435992ea1cb0c118f1e90a88c6e6f22a7a4fc507700c6"
+checksum = "1bdae4b55b15a23d774b15f6e7cd90ae0d0aa17c47c12b4db098b3dd11ba9d58"
 dependencies = [
  "anyhow",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "libm",
  "serde",
 ]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a3bc28a172037c7864128bb208017a02bba659a59c27acacc048c09e25c1fc"
+checksum = "5773b36b87566239b020f1d01aa753a35626df85030485e40e36fc42a97acf4f"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -7919,7 +7919,7 @@ dependencies = [
  "smallvec",
  "target-lexicon 0.13.5",
  "thiserror 2.0.18",
- "wasmparser 0.246.2",
+ "wasmparser 0.248.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -7928,9 +7928,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c90a899a47d3da6e384e7b4cad61fdcb27535a395742b32440bdf9980ea83fa"
+checksum = "402cce4bba4c8c92a6fbaff39a6b23f8aa626d64b218ecf6dd3eeee8705cf096"
 dependencies = [
  "cc",
  "cfg-if",
@@ -7943,9 +7943,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f364747aa74c686b18925918e5cfd615a73c9613c7a31fc1cd86f42df12fbe"
+checksum = "8b426a5d0ec9c11a1a4525ed4e973b7caf40223b6d392588bb9f6468e4ae9d29"
 dependencies = [
  "cc",
  "object 0.39.1",
@@ -7955,9 +7955,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ba98c1492f530833e0d3cc17dbb0c3c57c9f1bb3b078ae44bb55a233e43eba"
+checksum = "8a312ba8bb77955dcd44294a223e7f124c3071ff966583d385d3f6a4639c62e3"
 dependencies = [
  "cfg-if",
  "libc",
@@ -7967,9 +7967,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b8f8a89e8f3660646f820c7d8310a67094156bb866e9d56f1b00892e011206"
+checksum = "4a62ad422ee3cbf1e87c2242dc0717a01c7a5878fbc3a68abc4b4d2fff3e85e1"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -7980,9 +7980,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a12754f1ffc4a3300d56d324c418b8b32cf029606618da22c7d076213882a3f"
+checksum = "2c660c5b091648cffdd84a34dc24ffcdb9d027f9048fe7bd5e01896adbd0935f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7991,16 +7991,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b06e4ed07adc579645e5c55c67b3138c49da2e468fad52d3db7b7a098ecc733"
+checksum = "d2aceb92b48b6e3a5cc2a05ab7a2dcb565eaf86fb870d04664b7f12cf9bba39a"
 dependencies = [
  "cranelift-codegen",
  "gimli 0.33.0",
  "log",
  "object 0.39.1",
  "target-lexicon 0.13.5",
- "wasmparser 0.246.2",
+ "wasmparser 0.248.0",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -8008,15 +8008,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f08787948e3c983799d616ef7dd57463253e9ca8bab6607eef8134f12353f70"
+checksum = "ce382df367ad2a2d48e139b191dbca3329f7232a43057dc9efc889dac54f1b0b"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
  "heck 0.5.0",
  "indexmap 2.14.0",
- "wit-parser 0.246.2",
+ "wit-parser 0.248.0",
 ]
 
 [[package]]
@@ -8229,9 +8229,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16496e92d2b232f9d195ae74f71a674aabae7b7fa722d39068836723d3b653c"
+checksum = "3128bd53313b132e8737d7d318edbc438bab1abe525ac037bbf9857839e717e2"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
@@ -8240,7 +8240,7 @@ dependencies = [
  "smallvec",
  "target-lexicon 0.13.5",
  "thiserror 2.0.18",
- "wasmparser 0.246.2",
+ "wasmparser 0.248.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
@@ -8784,12 +8784,12 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.246.2"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd979042b5ff288607ccf3b314145435453f20fc67173195f91062d2289b204d"
+checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
 dependencies = [
  "anyhow",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "id-arena",
  "indexmap 2.14.0",
  "log",
@@ -8798,7 +8798,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.246.2",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -8822,7 +8822,7 @@ dependencies = [
  "dpi",
  "dunce",
  "gtk",
- "http 1.4.0",
+ "http 1.4.1",
  "javascriptcore-rs",
  "jni 0.21.1",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ console-subscriber = "0.5.0"
 # stack-switching feature (undefined symbol wasmtime_continuation_start).
 # Disable default features and re-enable all defaults except stack-switching.
 # TODO: Re-enable default features once upstream fixes the linker regression.
-wasmtime = { version = "44", default-features = false, features = [
+wasmtime = { version = "45", default-features = false, features = [
     "anyhow", "async", "backtrace", "cache", "cranelift",
     "compile-time-builtins", "component-model", "component-model-async",
     "coredump", "debug", "debug-builtins", "demangle", "addr2line",

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1037,6 +1037,39 @@ where
             // mean an internal caller; there are none, so the else
             // branch logs and drops.
             if let Some(sender_addr) = source_addr {
+                // Phase 2 front-line rate limit. Apply UNIFORMLY across
+                // all four UPDATE wire variants so a flooder can't
+                // bypass by switching opcode (RequestUpdate /
+                // BroadcastTo / RequestUpdateStreaming /
+                // BroadcastToStreaming). The check happens BEFORE the
+                // dedup gate inside the relay drivers — that ordering
+                // is what made the previous PR-MVP iteration race-
+                // free per Codex review: rejected attempts never enter
+                // the dedup set, so a legitimate retry of the same
+                // tx is not silently dropped as a duplicate. See
+                // `crate::ring::update_rate_limit` for design.
+                let key = match op {
+                    update::UpdateMsg::RequestUpdate { key, .. }
+                    | update::UpdateMsg::BroadcastTo { key, .. }
+                    | update::UpdateMsg::RequestUpdateStreaming { key, .. }
+                    | update::UpdateMsg::BroadcastToStreaming { key, .. } => *key,
+                };
+                let rate_decision = op_manager
+                    .ring
+                    .update_rate_limiter
+                    .check_and_record(sender_addr, *key.id());
+                if !rate_decision.is_allowed() {
+                    tracing::debug!(
+                        tx = %op.id(),
+                        %key,
+                        %sender_addr,
+                        ?rate_decision,
+                        phase = "update_dispatch_rate_limited",
+                        "UPDATE dispatch: rejected by per-(sender, contract) rate limit"
+                    );
+                    return Ok(());
+                }
+
                 #[allow(clippy::wildcard_enum_match_arm)]
                 match op {
                     update::UpdateMsg::RequestUpdate {

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -564,6 +564,12 @@ pub(crate) async fn start_relay_request_update(
     #[cfg(any(test, feature = "testing"))]
     RELAY_UPDATE_DRIVER_CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
+    // Note: the Phase 2 per-(sender, contract) rate limit is applied
+    // UPSTREAM at the wire dispatch site in `node.rs` so the same
+    // gate covers all four UPDATE wire variants (RequestUpdate,
+    // BroadcastTo, RequestUpdateStreaming, BroadcastToStreaming)
+    // uniformly. Rejected messages never reach this driver.
+
     if !op_manager.active_relay_update_txs.insert(incoming_tx) {
         RELAY_UPDATE_DEDUP_REJECTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         tracing::debug!(
@@ -573,39 +579,6 @@ pub(crate) async fn start_relay_request_update(
             phase = "relay_update_dedup_reject",
             "UPDATE relay: duplicate RequestUpdate for in-flight tx, dropping"
         );
-        return Ok(());
-    }
-
-    // Phase 2 front-line rate limit. Catches sustained UPDATE floods
-    // from a single peer for a single contract at the receive
-    // boundary, in milliseconds — before the spawn cost, before
-    // contract handling, and well before the MAD-based governance
-    // reaper (which reacts in minutes). See
-    // `crate::ring::update_rate_limit` for design.
-    //
-    // Dedup-set membership is removed below so a real retry isn't
-    // permanently blocked by a single rejection.
-    let rate_decision = op_manager
-        .ring
-        .update_rate_limiter
-        .check_and_record(sender_addr, *key.id());
-    if !rate_decision.is_allowed() {
-        op_manager.active_relay_update_txs.remove(&incoming_tx);
-        if let crate::ring::update_rate_limit::RateLimitDecision::Rejected {
-            elapsed,
-            min_interval,
-        } = rate_decision
-        {
-            tracing::debug!(
-                tx = %incoming_tx,
-                %key,
-                %sender_addr,
-                elapsed_ms = elapsed.as_millis() as u64,
-                min_interval_ms = min_interval.as_millis() as u64,
-                phase = "relay_update_rate_limited",
-                "UPDATE relay: rejected by per-(sender, contract) rate limit"
-            );
-        }
         return Ok(());
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -576,6 +576,39 @@ pub(crate) async fn start_relay_request_update(
         return Ok(());
     }
 
+    // Phase 2 front-line rate limit. Catches sustained UPDATE floods
+    // from a single peer for a single contract at the receive
+    // boundary, in milliseconds — before the spawn cost, before
+    // contract handling, and well before the MAD-based governance
+    // reaper (which reacts in minutes). See
+    // `crate::ring::update_rate_limit` for design.
+    //
+    // Dedup-set membership is removed below so a real retry isn't
+    // permanently blocked by a single rejection.
+    let rate_decision = op_manager
+        .ring
+        .update_rate_limiter
+        .check_and_record(sender_addr, *key.id());
+    if !rate_decision.is_allowed() {
+        op_manager.active_relay_update_txs.remove(&incoming_tx);
+        if let crate::ring::update_rate_limit::RateLimitDecision::Rejected {
+            elapsed,
+            min_interval,
+        } = rate_decision
+        {
+            tracing::debug!(
+                tx = %incoming_tx,
+                %key,
+                %sender_addr,
+                elapsed_ms = elapsed.as_millis() as u64,
+                min_interval_ms = min_interval.as_millis() as u64,
+                phase = "relay_update_rate_limited",
+                "UPDATE relay: rejected by per-(sender, contract) rate limit"
+            );
+        }
+        return Ok(());
+    }
+
     tracing::debug!(
         tx = %incoming_tx,
         %key,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -61,6 +61,7 @@ pub(crate) mod peer_cache;
 mod peer_connection_backoff;
 mod peer_key_location;
 pub mod topology_registry;
+pub(crate) mod update_rate_limit;
 
 /// Whether to auto-subscribe to contracts on GET.
 /// When true, GET operations will automatically subscribe to the contract
@@ -128,6 +129,12 @@ pub(crate) struct Ring {
     /// already records. Mode defaults to `DryRun` per the staged-
     /// rollout plan.
     pub(crate) governance: Arc<crate::contract::governance::GovernanceManager>,
+    /// Front-line per-(sender, contract) UPDATE rate limit. Catches
+    /// flood patterns at the receive boundary in milliseconds, before
+    /// the slower MAD-based governance reaper can react. See
+    /// `crate::ring::update_rate_limit` and `docs/design/contract-hardening.md`
+    /// Phase 2.
+    pub(crate) update_rate_limiter: Arc<update_rate_limit::UpdateRateLimiter>,
     event_register: Box<dyn NetEventRegister>,
     op_manager: RwLock<Option<Weak<OpManager>>>,
     /// Whether this peer is a gateway or not. This will affect behavior of the node when acquiring
@@ -267,6 +274,9 @@ impl Ring {
             hosting_manager: hosting::HostingManager::new(config.config.max_hosting_storage),
             broken_invariants: BrokenInvariantsTracker::new(),
             governance,
+            update_rate_limiter: Arc::new(update_rate_limit::UpdateRateLimiter::new(
+                time_source.clone(),
+            )),
             live_tx_tracker: live_tx_tracker.clone(),
             event_register: Box::new(event_register),
             op_manager: RwLock::new(None),
@@ -693,6 +703,12 @@ impl Ring {
             last_tick = now;
 
             let result = ring.governance_tick(elapsed);
+
+            // Cycle the UPDATE rate limiter's idle-entry cleanup on
+            // the same cadence. Keeps the `(sender, contract)` map
+            // bounded; CLEANUP_AGE is 5 minutes so this drops entries
+            // for pairs that haven't tried an UPDATE since then.
+            ring.update_rate_limiter.cleanup();
 
             // Network-norms summary at DEBUG — useful when debugging
             // calibration but too noisy for INFO on a healthy node.

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -1,0 +1,433 @@
+//! Per-(peer, contract) UPDATE rate limiter — front-line defense against
+//! the May 21 incident pattern where one peer floods one contract with
+//! many UPDATE/s.
+//!
+//! ## What this does
+//!
+//! Maintains a `(sender_addr, contract_instance_id) → last_accepted_at`
+//! map. When a new UPDATE arrives, check the time since the last
+//! accepted UPDATE for the same pair. If under [`MIN_UPDATE_INTERVAL`],
+//! reject; otherwise stamp the new time and accept.
+//!
+//! ## What this is NOT
+//!
+//! - **Not the MAD outlier detector.** That's `crate::governance` and
+//!   `crate::contract::governance` — those react in *minutes* via the
+//!   reaper loop. This module reacts in *milliseconds* at the receive
+//!   boundary.
+//! - **Not a token-bucket smoothing layer.** Sustained bursts are
+//!   rejected outright, not queued. A flood pattern hits a flat ceiling.
+//! - **Not aware of intent.** A "renewing subscription that happened to
+//!   trigger an UPDATE" looks identical to "DOS flood at the same rate";
+//!   the rate is a flat statistical threshold, and we choose it
+//!   generously enough that legitimate traffic doesn't hit it.
+//!
+//! ## Default rate
+//!
+//! [`MIN_UPDATE_INTERVAL`] defaults to 100ms (≈10 UPDATEs/sec from a
+//! single peer for a single contract). Realistic human-driven contract
+//! updates (chat, settings change, post) are orders of magnitude slower
+//! than this. The 4PjqN5… incident was producing many UPDATEs per
+//! second sustained — well above this ceiling.
+//!
+//! ## Bounded growth
+//!
+//! The `last_accepted` DashMap is bounded by a periodic cleanup task
+//! that drops entries whose timestamp is older than [`CLEANUP_AGE`].
+//! Caller is responsible for invoking [`UpdateRateLimiter::cleanup`]
+//! periodically (the Ring's existing reaper loop is a natural place).
+//!
+//! ## Design doc reference
+//!
+//! `docs/design/contract-hardening.md` Phase 2: *"`TrackedBackoff<(PeerId,
+//! ContractInstanceId)>`. Apply at `SyncStateToPeer` emit + originator
+//! UPDATE entry. Reject with typed marker."*
+//!
+//! This MVP applies at INBOUND relay entry first (the highest-value
+//! protection point: blocks a flooding peer at the door). Originator
+//! and outbound-emit gates follow as separate PRs. The exponential
+//! repeat-offender backoff via `TrackedBackoff` is also a follow-up;
+//! the flat `MIN_UPDATE_INTERVAL` ceiling alone is sufficient for the
+//! May 21 incident pattern.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use dashmap::DashMap;
+use freenet_stdlib::prelude::ContractInstanceId;
+use tokio::time::Instant;
+
+use crate::util::time_source::TimeSource;
+
+/// Minimum interval between accepted UPDATEs for the same
+/// `(sender, contract)` pair. Default 100ms (≈10/s). UPDATEs arriving
+/// faster than this are dropped.
+///
+/// Calibration rationale: legitimate contract updates are
+/// human-cadence (seconds to minutes between writes). The 4PjqN5…
+/// May 21 incident was producing many UPDATEs/s sustained. 100ms is
+/// generous enough to never trigger on a real user while blocking the
+/// flood pattern instantly.
+pub(crate) const MIN_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
+
+/// How long an idle `(sender, contract)` entry stays in the map before
+/// being cleared by the periodic cleanup pass. Bounds memory while
+/// preserving the rate-limit signal across short-term retries.
+pub(crate) const CLEANUP_AGE: Duration = Duration::from_secs(5 * 60);
+
+/// Outcome of an UPDATE rate-limit check. Callers must treat
+/// `Rejected` as "drop this message at the receive boundary, do not
+/// spawn a relay driver."
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RateLimitDecision {
+    /// Allowed — proceed with normal UPDATE handling. The accepted
+    /// timestamp has been stamped.
+    Allowed,
+    /// Rejected — too soon after the previous accepted UPDATE from this
+    /// `(sender, contract)` pair. Carries the elapsed time vs the
+    /// configured minimum for diagnostic logging.
+    Rejected {
+        elapsed: Duration,
+        min_interval: Duration,
+    },
+}
+
+impl RateLimitDecision {
+    /// Convenience for the common branch shape `if !decision.is_allowed()`.
+    pub fn is_allowed(self) -> bool {
+        matches!(self, RateLimitDecision::Allowed)
+    }
+}
+
+/// Per-(sender_addr, contract_instance_id) UPDATE rate limiter.
+///
+/// All state lives in a single [`DashMap`] keyed by the pair. Each
+/// entry stores only the `Instant` of the most recent accepted UPDATE,
+/// so per-entry memory is tiny.
+pub(crate) struct UpdateRateLimiter {
+    last_accepted: DashMap<(SocketAddr, ContractInstanceId), Instant>,
+    min_interval: Duration,
+    time_source: Arc<dyn TimeSource + Send + Sync>,
+    /// Total accepted UPDATEs since limiter creation. Surfaced on the
+    /// dashboard so operators can see the limiter's signal-to-noise.
+    accepted_total: AtomicU64,
+    /// Total rejected UPDATEs since limiter creation.
+    rejected_total: AtomicU64,
+}
+
+impl UpdateRateLimiter {
+    pub fn new(time_source: Arc<dyn TimeSource + Send + Sync>) -> Self {
+        Self::with_min_interval(time_source, MIN_UPDATE_INTERVAL)
+    }
+
+    pub fn with_min_interval(
+        time_source: Arc<dyn TimeSource + Send + Sync>,
+        min_interval: Duration,
+    ) -> Self {
+        Self {
+            last_accepted: DashMap::new(),
+            min_interval,
+            time_source,
+            accepted_total: AtomicU64::new(0),
+            rejected_total: AtomicU64::new(0),
+        }
+    }
+
+    /// Check whether an UPDATE from `sender` for `contract` is allowed
+    /// right now. If allowed, the accepted timestamp is recorded
+    /// atomically; the caller can rely on this being the moment of
+    /// admission for downstream rate-tracking. If rejected, no state
+    /// change is made (so a barrage of rejected attempts doesn't itself
+    /// extend the rate-limit window — the existing `last_accepted`
+    /// timestamp stays put).
+    pub fn check_and_record(
+        &self,
+        sender: SocketAddr,
+        contract: ContractInstanceId,
+    ) -> RateLimitDecision {
+        let now = self.time_source.now();
+        let key = (sender, contract);
+
+        // Probe the existing timestamp without holding a guard across
+        // the conditional update — avoids holding the DashMap shard
+        // lock during the time-comparison + atomic-counter steps.
+        let existing = self.last_accepted.get(&key).map(|r| *r);
+
+        if let Some(last) = existing {
+            let elapsed = now.saturating_duration_since(last);
+            if elapsed < self.min_interval {
+                self.rejected_total.fetch_add(1, Ordering::Relaxed);
+                return RateLimitDecision::Rejected {
+                    elapsed,
+                    min_interval: self.min_interval,
+                };
+            }
+        }
+
+        // Allowed: stamp the new time. `insert` overwrites; if a
+        // concurrent caller stamped a different time between our probe
+        // and this insert, the later one wins, which is fine — the
+        // rate limit is per-pair and roughly idempotent under
+        // concurrent admission.
+        self.last_accepted.insert(key, now);
+        self.accepted_total.fetch_add(1, Ordering::Relaxed);
+        RateLimitDecision::Allowed
+    }
+
+    /// Drop entries whose timestamp is older than [`CLEANUP_AGE`].
+    /// Call periodically from a reaper loop to bound memory.
+    pub fn cleanup(&self) {
+        let now = self.time_source.now();
+        let cutoff = match now.checked_sub(CLEANUP_AGE) {
+            Some(t) => t,
+            None => return, // clock not advanced enough to bother
+        };
+        self.last_accepted.retain(|_, &mut last| last >= cutoff);
+    }
+
+    /// Total accepted UPDATEs since creation. Used by the dashboard
+    /// snapshot (follow-up PR — surfaces "rate limit drops in last
+    /// hour" on the governance card).
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn accepted_total(&self) -> u64 {
+        self.accepted_total.load(Ordering::Relaxed)
+    }
+
+    /// Total rejected UPDATEs since creation. Used by the dashboard
+    /// snapshot (follow-up PR).
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn rejected_total(&self) -> u64 {
+        self.rejected_total.load(Ordering::Relaxed)
+    }
+
+    /// Number of tracked `(sender, contract)` pairs. Used by tests and
+    /// the dashboard for size visibility.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn len(&self) -> usize {
+        self.last_accepted.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::time_source::SharedMockTimeSource;
+
+    fn mk_sender(byte: u8) -> SocketAddr {
+        SocketAddr::from(([10, 0, 0, byte], 30000 + byte as u16))
+    }
+
+    fn mk_contract(byte: u8) -> ContractInstanceId {
+        ContractInstanceId::new([byte; 32])
+    }
+
+    fn mk_limiter() -> (UpdateRateLimiter, SharedMockTimeSource) {
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::new(Arc::new(ts.clone()));
+        (limiter, ts)
+    }
+
+    // Local alias so test bodies can keep using `ts.advance(d)`
+    trait Advance {
+        fn advance(&self, d: Duration);
+    }
+    impl Advance for SharedMockTimeSource {
+        fn advance(&self, d: Duration) {
+            self.advance_time(d);
+        }
+    }
+
+    #[test]
+    fn first_update_for_pair_is_allowed() {
+        let (l, _ts) = mk_limiter();
+        let d = l.check_and_record(mk_sender(1), mk_contract(1));
+        assert_eq!(d, RateLimitDecision::Allowed);
+        assert_eq!(l.accepted_total(), 1);
+        assert_eq!(l.rejected_total(), 0);
+    }
+
+    #[test]
+    fn second_update_within_min_interval_is_rejected() {
+        let (l, ts) = mk_limiter();
+        assert!(
+            l.check_and_record(mk_sender(1), mk_contract(1))
+                .is_allowed()
+        );
+        // Only 10ms later — well under 100ms default.
+        ts.advance(Duration::from_millis(10));
+        let d = l.check_and_record(mk_sender(1), mk_contract(1));
+        assert!(
+            matches!(d, RateLimitDecision::Rejected { .. }),
+            "second UPDATE 10ms after first must be rejected, got {d:?}"
+        );
+        assert_eq!(l.accepted_total(), 1);
+        assert_eq!(l.rejected_total(), 1);
+    }
+
+    #[test]
+    fn update_after_min_interval_is_allowed() {
+        let (l, ts) = mk_limiter();
+        assert!(
+            l.check_and_record(mk_sender(1), mk_contract(1))
+                .is_allowed()
+        );
+        // 200ms later — past the 100ms default.
+        ts.advance(Duration::from_millis(200));
+        let d = l.check_and_record(mk_sender(1), mk_contract(1));
+        assert_eq!(d, RateLimitDecision::Allowed);
+        assert_eq!(l.accepted_total(), 2);
+        assert_eq!(l.rejected_total(), 0);
+    }
+
+    #[test]
+    fn different_senders_same_contract_independent() {
+        let (l, ts) = mk_limiter();
+        // Sender 1 accepts.
+        assert!(
+            l.check_and_record(mk_sender(1), mk_contract(1))
+                .is_allowed()
+        );
+        // Sender 2 immediately also accepts — different key.
+        ts.advance(Duration::from_millis(1));
+        assert!(
+            l.check_and_record(mk_sender(2), mk_contract(1))
+                .is_allowed()
+        );
+        // Sender 1 retry 1ms later still rejected.
+        let d = l.check_and_record(mk_sender(1), mk_contract(1));
+        assert!(matches!(d, RateLimitDecision::Rejected { .. }));
+    }
+
+    #[test]
+    fn same_sender_different_contracts_independent() {
+        let (l, _ts) = mk_limiter();
+        assert!(
+            l.check_and_record(mk_sender(1), mk_contract(1))
+                .is_allowed()
+        );
+        // Same sender, different contract — independent rate limit.
+        assert!(
+            l.check_and_record(mk_sender(1), mk_contract(2))
+                .is_allowed()
+        );
+        assert_eq!(l.accepted_total(), 2);
+    }
+
+    #[test]
+    fn rejected_attempts_do_not_extend_window() {
+        // If a flooding peer keeps trying every 10ms, we want the
+        // first attempt past the 100ms window to succeed — i.e. the
+        // rejected attempts MUST NOT push the last_accepted timestamp
+        // forward. Otherwise a sustained flood would lock the pair out
+        // indefinitely (the existing peer would never recover).
+        let (l, ts) = mk_limiter();
+        assert!(
+            l.check_and_record(mk_sender(1), mk_contract(1))
+                .is_allowed()
+        );
+        // 9 sub-100ms attempts, all rejected.
+        for _ in 0..9 {
+            ts.advance(Duration::from_millis(10));
+            assert!(
+                !l.check_and_record(mk_sender(1), mk_contract(1))
+                    .is_allowed()
+            );
+        }
+        // Now we're at 90ms — still rejected.
+        ts.advance(Duration::from_millis(5));
+        assert!(
+            !l.check_and_record(mk_sender(1), mk_contract(1))
+                .is_allowed()
+        );
+        // One more advance puts us past 100ms from the FIRST accept.
+        ts.advance(Duration::from_millis(10));
+        assert!(
+            l.check_and_record(mk_sender(1), mk_contract(1))
+                .is_allowed(),
+            "after 105ms+ from original accept, next attempt MUST be allowed — \
+             rejected attempts must not have moved the window forward"
+        );
+    }
+
+    #[test]
+    fn cleanup_removes_stale_entries() {
+        let (l, ts) = mk_limiter();
+        l.check_and_record(mk_sender(1), mk_contract(1));
+        l.check_and_record(mk_sender(2), mk_contract(2));
+        assert_eq!(l.len(), 2);
+
+        // Advance past CLEANUP_AGE.
+        ts.advance(CLEANUP_AGE + Duration::from_secs(1));
+        l.cleanup();
+        assert_eq!(l.len(), 0, "all stale entries must be cleared");
+    }
+
+    #[test]
+    fn cleanup_preserves_fresh_entries() {
+        let (l, ts) = mk_limiter();
+        l.check_and_record(mk_sender(1), mk_contract(1));
+        // Advance partway through the cleanup age.
+        ts.advance(CLEANUP_AGE / 2);
+        l.cleanup();
+        assert_eq!(l.len(), 1, "fresh entry must be preserved");
+    }
+
+    #[test]
+    fn counters_track_accepts_and_rejects() {
+        let (l, ts) = mk_limiter();
+        for i in 0..5 {
+            // Five accepts: stagger by min_interval.
+            ts.advance(MIN_UPDATE_INTERVAL + Duration::from_millis(1));
+            assert!(
+                l.check_and_record(mk_sender(1), mk_contract(1))
+                    .is_allowed(),
+                "iter {i}"
+            );
+        }
+        // Three rejects: hammer with no advance.
+        for _ in 0..3 {
+            assert!(
+                !l.check_and_record(mk_sender(1), mk_contract(1))
+                    .is_allowed()
+            );
+        }
+        assert_eq!(l.accepted_total(), 5);
+        assert_eq!(l.rejected_total(), 3);
+    }
+
+    /// Pin test exhibiting the May 21 incident pattern: a single sender
+    /// hammering a single contract at ~10 UPDATEs/s. With the limiter,
+    /// at most ~10/s are accepted (one per MIN_UPDATE_INTERVAL window);
+    /// the rest are dropped. The "real" 4PjqN5… incident was producing
+    /// far more than this, so the rejection rate is overwhelming.
+    #[test]
+    fn may21_flood_pattern_is_throttled() {
+        let (l, ts) = mk_limiter();
+        let sender = mk_sender(1);
+        let contract = mk_contract(1);
+
+        // Simulate 1 second of flooding at 1ms per attempt (1000
+        // attempts/s — 100× over the 10/s ceiling).
+        for _ in 0..1000 {
+            l.check_and_record(sender, contract);
+            ts.advance(Duration::from_millis(1));
+        }
+        // Expected admits: floor(1000ms / 100ms) + 1 (first one is
+        // unconditional) = ~11 admissions, ~989 rejections.
+        let accepted = l.accepted_total();
+        let rejected = l.rejected_total();
+        assert!(
+            (9..=12).contains(&accepted),
+            "expected ~10 admits over 1s of flooding, got {accepted}"
+        );
+        assert_eq!(accepted + rejected, 1000);
+        // The reject rate must be high — the flood is mostly dropped.
+        assert!(
+            rejected as f64 / 1000.0 > 0.95,
+            "expected >95% rejection rate, got {}",
+            rejected as f64 / 1000.0
+        );
+    }
+}

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -88,7 +88,7 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use dashmap::DashMap;
@@ -163,6 +163,21 @@ impl RateLimitDecision {
 /// so per-entry memory is tiny.
 pub(crate) struct UpdateRateLimiter {
     last_accepted: DashMap<(SocketAddr, ContractInstanceId), Instant>,
+    /// Authoritative size counter for capacity enforcement. Held
+    /// in sync with `last_accepted.len()` at every stable point
+    /// (incremented by successful new-pair inserts in
+    /// `check_and_record`; decremented by the count of dropped
+    /// entries in `cleanup`).
+    ///
+    /// Why not just use `last_accepted.len()`? Because `len()` walks
+    /// every shard, so it can't be called while holding any shard
+    /// guard (the previous probe-then-insert iteration deadlocked on
+    /// this). With this counter, the cap check is a single atomic
+    /// `fetch_add`, which strictly serializes — no overshoot from
+    /// concurrent inserts. Codex re-review of #4285 caught that the
+    /// `len()` precheck overshoots by `num_concurrent_callers`,
+    /// which can be hundreds.
+    size: AtomicUsize,
     min_interval: Duration,
     max_tracked_pairs: usize,
     time_source: Arc<dyn TimeSource + Send + Sync>,
@@ -190,6 +205,7 @@ impl UpdateRateLimiter {
     ) -> Self {
         Self {
             last_accepted: DashMap::new(),
+            size: AtomicUsize::new(0),
             min_interval,
             max_tracked_pairs,
             time_source,
@@ -202,17 +218,26 @@ impl UpdateRateLimiter {
     /// Check whether an UPDATE from `sender` for `contract` is allowed
     /// right now, and atomically stamp the accepted timestamp if so.
     ///
-    /// Implementation note: uses [`DashMap::entry`] so the per-shard
-    /// guard is held across the time-comparison + stamp. A previous
-    /// probe-then-insert version was non-atomic — Codex review of
-    /// PR #4285 caught that concurrent UPDATEs for the same pair
-    /// could all read the same old timestamp and all be admitted.
-    /// With the guard held, exactly one admitting caller wins per
-    /// `min_interval` window.
+    /// Two-property atomicity:
     ///
-    /// If rejected, no state change is made (so a barrage of rejected
-    /// attempts doesn't itself extend the rate-limit window — the
-    /// existing `last_accepted` timestamp stays put).
+    /// 1. **Same-pair compare-and-stamp** is atomic via
+    ///    [`DashMap::entry`] holding the per-shard guard across
+    ///    timestamp comparison and update. Exactly one caller per
+    ///    pair wins per `min_interval` window.
+    ///
+    /// 2. **Capacity enforcement** is strict via the [`Self::size`]
+    ///    atomic counter. New-pair insertion reserves a slot with
+    ///    `fetch_add` BEFORE inserting; if the post-increment value
+    ///    exceeds the cap, the reservation is returned via
+    ///    `fetch_sub` and the call returns `CapacityExceeded`.
+    ///    Concurrent distinct-key inserts strictly serialize through
+    ///    the counter — no overshoot.
+    ///
+    /// If rejected (either rate or capacity), no map mutation is
+    /// made. A barrage of rejected attempts doesn't extend the rate
+    /// window (the existing `last_accepted` timestamp is unchanged)
+    /// and doesn't grow memory (the reservation is rolled back on
+    /// CapacityExceeded).
     pub fn check_and_record(
         &self,
         sender: SocketAddr,
@@ -221,91 +246,66 @@ impl UpdateRateLimiter {
         let now = self.time_source.now();
         let key = (sender, contract);
 
-        // Two-phase check:
-        //   1. If the entry already exists, hold its shard guard
-        //      across the time-comparison + stamp (atomic per pair).
-        //   2. For new pairs we need to enforce MAX_TRACKED_PAIRS by
-        //      reading `DashMap::len()` — but `len()` walks every
-        //      shard, so we MUST NOT hold any shard guard when we
-        //      call it (otherwise it deadlocks on the shard we hold).
-        //      Check existence with a `contains_key` probe first; if
-        //      it's a new pair, check `len()` against the cap and
-        //      then call `insert`. `insert` is itself atomic per
-        //      shard, so the worst-case race is a transient ±N
-        //      overshoot of the cap (N = number of shards) — bounded
-        //      and harmless.
         use dashmap::mapref::entry::Entry;
-        if self.last_accepted.contains_key(&key) {
-            // Existing pair: hold the shard guard for the
-            // time-comparison + stamp.
-            match self.last_accepted.entry(key) {
-                Entry::Occupied(mut entry) => {
-                    let last = *entry.get();
-                    let elapsed = now.saturating_duration_since(last);
-                    if elapsed < self.min_interval {
-                        self.rejected_total.fetch_add(1, Ordering::Relaxed);
-                        return RateLimitDecision::Rejected {
-                            elapsed,
-                            min_interval: self.min_interval,
-                        };
-                    }
-                    *entry.get_mut() = now;
-                    self.accepted_total.fetch_add(1, Ordering::Relaxed);
-                    RateLimitDecision::Allowed
+        match self.last_accepted.entry(key) {
+            Entry::Occupied(mut entry) => {
+                // Existing pair: atomic compare-and-stamp under
+                // shard guard.
+                let last = *entry.get();
+                let elapsed = now.saturating_duration_since(last);
+                if elapsed < self.min_interval {
+                    self.rejected_total.fetch_add(1, Ordering::Relaxed);
+                    return RateLimitDecision::Rejected {
+                        elapsed,
+                        min_interval: self.min_interval,
+                    };
                 }
-                // Race: the entry was concurrently removed between
-                // the contains_key probe and the entry() call. Treat
-                // as a new pair, fall through.
-                Entry::Vacant(entry) => self.insert_new_pair(entry, now),
+                *entry.get_mut() = now;
+                self.accepted_total.fetch_add(1, Ordering::Relaxed);
+                RateLimitDecision::Allowed
             }
-        } else {
-            // New pair: check cap WITHOUT holding any shard guard.
-            if self.last_accepted.len() >= self.max_tracked_pairs {
-                self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
-                return RateLimitDecision::CapacityExceeded;
-            }
-            // Insert under the shard guard. If a concurrent insert
-            // beat us to the same key, treat as a normal admission
-            // (the other admit wins; we just bump our counter).
-            match self.last_accepted.entry(key) {
-                Entry::Vacant(entry) => self.insert_new_pair(entry, now),
-                Entry::Occupied(mut entry) => {
-                    let last = *entry.get();
-                    let elapsed = now.saturating_duration_since(last);
-                    if elapsed < self.min_interval {
-                        self.rejected_total.fetch_add(1, Ordering::Relaxed);
-                        return RateLimitDecision::Rejected {
-                            elapsed,
-                            min_interval: self.min_interval,
-                        };
-                    }
-                    *entry.get_mut() = now;
-                    self.accepted_total.fetch_add(1, Ordering::Relaxed);
-                    RateLimitDecision::Allowed
+            Entry::Vacant(entry) => {
+                // New pair: reserve a slot via the authoritative
+                // counter BEFORE inserting. `fetch_add` is the
+                // serialization point — concurrent new-key inserts
+                // strictly serialize, no overshoot beyond the cap.
+                let prev = self.size.fetch_add(1, Ordering::Relaxed);
+                if prev >= self.max_tracked_pairs {
+                    // Cap exceeded. Roll back the reservation.
+                    self.size.fetch_sub(1, Ordering::Relaxed);
+                    self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
+                    return RateLimitDecision::CapacityExceeded;
                 }
+                entry.insert(now);
+                self.accepted_total.fetch_add(1, Ordering::Relaxed);
+                RateLimitDecision::Allowed
             }
         }
     }
 
-    fn insert_new_pair(
-        &self,
-        entry: dashmap::mapref::entry::VacantEntry<'_, (SocketAddr, ContractInstanceId), Instant>,
-        now: Instant,
-    ) -> RateLimitDecision {
-        entry.insert(now);
-        self.accepted_total.fetch_add(1, Ordering::Relaxed);
-        RateLimitDecision::Allowed
-    }
-
     /// Drop entries whose timestamp is older than [`CLEANUP_AGE`].
     /// Call periodically from a reaper loop to bound memory.
+    ///
+    /// Decrements the [`Self::size`] counter by the number of
+    /// removed entries so the strict capacity enforcement remains
+    /// accurate as idle pairs roll off.
     pub fn cleanup(&self) {
         let now = self.time_source.now();
         let cutoff = match now.checked_sub(CLEANUP_AGE) {
             Some(t) => t,
             None => return, // clock not advanced enough to bother
         };
-        self.last_accepted.retain(|_, &mut last| last >= cutoff);
+        let mut removed = 0usize;
+        self.last_accepted.retain(|_, last| {
+            let keep = *last >= cutoff;
+            if !keep {
+                removed += 1;
+            }
+            keep
+        });
+        if removed > 0 {
+            self.size.fetch_sub(removed, Ordering::Relaxed);
+        }
     }
 
     /// Total accepted UPDATEs since creation. Used by the dashboard
@@ -679,10 +679,17 @@ mod tests {
             .find("NetMessageV1::Update(ref op) =>")
             .expect("could not locate UPDATE dispatch block in node.rs");
 
-        // Bound the search to a generous slice — the UPDATE block is
-        // well under 4KB.
-        let block_end = (block_start + 8192).min(NODE_SRC.len());
-        let block = &NODE_SRC[block_start..block_end];
+        // Bound the search to the END of the UPDATE arm — find the
+        // next `NetMessageV1::` arm that starts at the same match
+        // level. The UPDATE block must not "spill" into the next
+        // handler for our assertions (Codex re-review nit on #4285
+        // — the previous 8KB slice could include the next handler).
+        let tail = &NODE_SRC[block_start + 1..];
+        let block_len = tail
+            .find("\n        NetMessageV1::")
+            .or_else(|| tail.find("\n    NetMessageV1::"))
+            .unwrap_or(tail.len());
+        let block = &NODE_SRC[block_start..block_start + 1 + block_len];
 
         // (a) the gate is invoked.
         let rate_limit_pos = block
@@ -701,7 +708,8 @@ mod tests {
              messages don't pay the spawn cost"
         );
 
-        // (c) all four wire variants are matched in the dispatch.
+        // (c) all four wire variants are matched in the dispatch, and
+        //     each spawn site is also present.
         for variant in [
             "UpdateMsg::RequestUpdate {",
             "UpdateMsg::BroadcastTo {",
@@ -714,6 +722,126 @@ mod tests {
                  If a new UPDATE wire variant was added, gate it through \
                  the rate limiter and update this list. If a variant was \
                  removed, update this list."
+            );
+        }
+        // Spawn-site cross-check — the dispatch must invoke all four
+        // relay drivers. This pins the variants to actual driver
+        // calls (not just match arms), making the test less brittle
+        // to comment-only mentions of a variant name.
+        for spawn in [
+            "start_relay_request_update(",
+            "start_relay_broadcast_to(",
+            "start_relay_request_update_streaming(",
+            "start_relay_broadcast_to_streaming(",
+        ] {
+            let count = block.matches(spawn).count();
+            assert!(
+                count >= 1,
+                "UPDATE dispatch block does not invoke `{spawn}` — the \
+                 corresponding wire variant is not actually gated."
+            );
+        }
+    }
+
+    /// Strict-cap pin: under concurrent insertion of distinct keys
+    /// (no shared key), the total accepted count must NOT exceed the
+    /// cap regardless of how many threads race. Codex re-review of
+    /// PR #4285 caught that the previous `len()`-precheck pattern
+    /// could overshoot by up to `num_concurrent_callers` because
+    /// every racing caller saw `len < cap` at probe time. The fix
+    /// uses an `AtomicUsize::fetch_add` reservation, which strictly
+    /// serializes.
+    #[test]
+    fn concurrent_distinct_keys_do_not_overshoot_cap() {
+        use std::sync::{Arc as StdArc, Barrier};
+        use std::thread;
+
+        const CAP: usize = 8;
+        const THREADS: usize = 64; // 8× the cap to stress the race
+
+        let ts = SharedMockTimeSource::new();
+        let limiter = StdArc::new(UpdateRateLimiter::with_config(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            CAP,
+        ));
+        let barrier = StdArc::new(Barrier::new(THREADS));
+        let mut handles = Vec::with_capacity(THREADS);
+
+        for i in 0..THREADS {
+            let l = limiter.clone();
+            let b = barrier.clone();
+            handles.push(thread::spawn(move || {
+                b.wait();
+                // Each thread tries a DISTINCT key, so they all
+                // exercise the new-pair (Vacant) path concurrently.
+                l.check_and_record(mk_sender((i + 1) as u8), mk_contract((i + 1) as u8))
+            }));
+        }
+
+        let mut allowed = 0;
+        let mut cap_rejected = 0;
+        let mut rate_rejected = 0;
+        for h in handles {
+            match h.join().unwrap() {
+                RateLimitDecision::Allowed => allowed += 1,
+                RateLimitDecision::CapacityExceeded => cap_rejected += 1,
+                RateLimitDecision::Rejected { .. } => rate_rejected += 1,
+            }
+        }
+        // Critical invariant: the map size is EXACTLY the cap, not
+        // cap + overshoot.
+        assert_eq!(
+            limiter.len(),
+            CAP,
+            "strict cap: map size must equal CAP after a 64-thread \
+             concurrent flood of distinct keys, got {}",
+            limiter.len()
+        );
+        assert_eq!(
+            allowed, CAP,
+            "exactly CAP admissions allowed under flood, got {allowed}"
+        );
+        assert_eq!(cap_rejected, THREADS - CAP);
+        assert_eq!(rate_rejected, 0);
+        assert_eq!(limiter.capacity_rejected_total(), (THREADS - CAP) as u64);
+    }
+
+    /// Pin: cleanup decrements the `size` counter by the number of
+    /// dropped entries. After all entries roll off, the cap should
+    /// be fully available again — strict-cap accounting tracks the
+    /// map. Caught a related issue while refactoring the cap
+    /// implementation.
+    #[test]
+    fn cleanup_decrements_size_counter() {
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_config(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            4, // small cap
+        );
+        // Fill to cap.
+        for i in 0..4 {
+            assert_eq!(
+                limiter.check_and_record(mk_sender(i + 1), mk_contract(i + 1)),
+                RateLimitDecision::Allowed
+            );
+        }
+        // 5th is CapacityExceeded.
+        assert_eq!(
+            limiter.check_and_record(mk_sender(5), mk_contract(5)),
+            RateLimitDecision::CapacityExceeded
+        );
+        // Age out all entries.
+        ts.advance(CLEANUP_AGE + Duration::from_secs(1));
+        limiter.cleanup();
+        assert_eq!(limiter.len(), 0);
+        // Now we should be able to add 4 more without hitting the cap.
+        for i in 10..14 {
+            assert_eq!(
+                limiter.check_and_record(mk_sender(i), mk_contract(i)),
+                RateLimitDecision::Allowed,
+                "after cleanup, new pair (sender={i}) should be admitted"
             );
         }
     }

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -32,10 +32,36 @@
 //!
 //! ## Bounded growth
 //!
-//! The `last_accepted` DashMap is bounded by a periodic cleanup task
-//! that drops entries whose timestamp is older than [`CLEANUP_AGE`].
-//! Caller is responsible for invoking [`UpdateRateLimiter::cleanup`]
-//! periodically (the Ring's existing reaper loop is a natural place).
+//! Two layers:
+//!
+//! 1. **Hard cap on entry count** ([`MAX_TRACKED_PAIRS`]). When the
+//!    cap is hit, new entries are rejected — an attacker churning
+//!    distinct `(sender, contract)` pairs cannot grow the map past
+//!    this size. Critical because the address space is attacker-
+//!    chosen (32-byte contract id × any source address).
+//! 2. **Periodic TTL sweep** ([`UpdateRateLimiter::cleanup`]) drops
+//!    entries idle for longer than [`CLEANUP_AGE`]. Hooked into the
+//!    Ring's existing reaper tick.
+//!
+//! The cap alone is sufficient to bound memory; the TTL sweep
+//! reclaims space from genuinely-idle pairs so the cap isn't
+//! prematurely reached under normal traffic.
+//!
+//! ## Semantic note: `sender_addr` is the immediate upstream hop
+//!
+//! The key uses the SocketAddr of the peer that *sent us* the
+//! message — not the originator of the UPDATE transaction. This is
+//! deliberate: the limiter is a **receiver-side resource guard**.
+//! "How much of my CPU/memory am I willing to spend processing
+//! UPDATEs from a single immediate peer for a single contract?" is
+//! the question this answers. If A floods through B to reach us, B
+//! is who hits our limiter — and that's correct, because B is who
+//! is consuming our resources.
+//!
+//! Originator-level protection is a different layer (Phase 7 ban
+//! enforcement, where a banned originator's traffic is rejected
+//! even if relayed). The two layers compose; neither subsumes the
+//! other.
 //!
 //! ## Design doc reference
 //!
@@ -43,12 +69,22 @@
 //! ContractInstanceId)>`. Apply at `SyncStateToPeer` emit + originator
 //! UPDATE entry. Reject with typed marker."*
 //!
-//! This MVP applies at INBOUND relay entry first (the highest-value
-//! protection point: blocks a flooding peer at the door). Originator
-//! and outbound-emit gates follow as separate PRs. The exponential
-//! repeat-offender backoff via `TrackedBackoff` is also a follow-up;
-//! the flat `MIN_UPDATE_INTERVAL` ceiling alone is sufficient for the
-//! May 21 incident pattern.
+//! Divergences from the design doc, with rationale:
+//!
+//! - **Flat ceiling instead of `TrackedBackoff` exponential.** A flat
+//!   100ms ceiling catches the May 21 pattern; exponential repeat-
+//!   offender cooldown can land as a follow-up if observation shows
+//!   it's needed.
+//! - **Inbound relay receive-boundary, not `SyncStateToPeer` emit.**
+//!   The doc's wording targets outbound emit. We instead gate at
+//!   inbound receive (4 wire-variant sites: `RequestUpdate`,
+//!   `BroadcastTo`, `RequestUpdateStreaming`, `BroadcastToStreaming`).
+//!   Receive-side guards a peer's own resources directly; emit-side
+//!   guards against being an amplifier. Receive is the higher-value
+//!   first cut; emit is a follow-up.
+//! - **No typed wire-level error.** Rejected UPDATEs are dropped
+//!   silently. The sender's own retry / governance scoring will
+//!   detect the flood pattern from its end.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -77,13 +113,26 @@ pub(crate) const MIN_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
 /// preserving the rate-limit signal across short-term retries.
 pub(crate) const CLEANUP_AGE: Duration = Duration::from_secs(5 * 60);
 
-/// Outcome of an UPDATE rate-limit check. Callers must treat
-/// `Rejected` as "drop this message at the receive boundary, do not
-/// spawn a relay driver."
+/// Hard upper bound on the number of tracked `(sender, contract)`
+/// pairs. When the cap is reached, new pairs are rejected outright —
+/// this is the "no unbounded per-key collection for attacker-influenced
+/// keys" rule from `.claude/rules/code-style.md`. At 64 bytes/entry,
+/// 16 384 pairs ≈ 1 MB — tiny — but bounds the worst case where an
+/// attacker chooses fresh contract ids.
+///
+/// On reaching the cap: the per-shard guard's existing entries
+/// continue to track normally (so a legitimate peer who was already
+/// tracked keeps working); only NEW pairs hit the cap. Combined with
+/// the TTL sweep this gives smooth recovery as idle pairs roll off.
+pub(crate) const MAX_TRACKED_PAIRS: usize = 16_384;
+
+/// Outcome of an UPDATE rate-limit check. Callers must treat any
+/// non-`Allowed` variant as "drop this message at the receive
+/// boundary, do not spawn a relay driver."
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RateLimitDecision {
     /// Allowed — proceed with normal UPDATE handling. The accepted
-    /// timestamp has been stamped.
+    /// timestamp has been stamped atomically.
     Allowed,
     /// Rejected — too soon after the previous accepted UPDATE from this
     /// `(sender, contract)` pair. Carries the elapsed time vs the
@@ -92,6 +141,12 @@ pub(crate) enum RateLimitDecision {
         elapsed: Duration,
         min_interval: Duration,
     },
+    /// Rejected because the tracking map has hit
+    /// [`MAX_TRACKED_PAIRS`] and this is a new pair. Distinct from
+    /// `Rejected` so the dashboard can tell "throttling working as
+    /// intended" apart from "limiter overflowing" — the latter
+    /// suggests an attack pattern with churned identities.
+    CapacityExceeded,
 }
 
 impl RateLimitDecision {
@@ -109,39 +164,55 @@ impl RateLimitDecision {
 pub(crate) struct UpdateRateLimiter {
     last_accepted: DashMap<(SocketAddr, ContractInstanceId), Instant>,
     min_interval: Duration,
+    max_tracked_pairs: usize,
     time_source: Arc<dyn TimeSource + Send + Sync>,
     /// Total accepted UPDATEs since limiter creation. Surfaced on the
     /// dashboard so operators can see the limiter's signal-to-noise.
     accepted_total: AtomicU64,
-    /// Total rejected UPDATEs since limiter creation.
+    /// Total rejected UPDATEs since limiter creation (rate-limit hits).
     rejected_total: AtomicU64,
+    /// Total UPDATEs rejected because the tracking map was at capacity
+    /// when a new `(sender, contract)` pair tried to register. Surfaced
+    /// separately because a non-zero value suggests an attacker is
+    /// churning identities to exhaust the limiter's address space.
+    capacity_rejected_total: AtomicU64,
 }
 
 impl UpdateRateLimiter {
     pub fn new(time_source: Arc<dyn TimeSource + Send + Sync>) -> Self {
-        Self::with_min_interval(time_source, MIN_UPDATE_INTERVAL)
+        Self::with_config(time_source, MIN_UPDATE_INTERVAL, MAX_TRACKED_PAIRS)
     }
 
-    pub fn with_min_interval(
+    pub fn with_config(
         time_source: Arc<dyn TimeSource + Send + Sync>,
         min_interval: Duration,
+        max_tracked_pairs: usize,
     ) -> Self {
         Self {
             last_accepted: DashMap::new(),
             min_interval,
+            max_tracked_pairs,
             time_source,
             accepted_total: AtomicU64::new(0),
             rejected_total: AtomicU64::new(0),
+            capacity_rejected_total: AtomicU64::new(0),
         }
     }
 
     /// Check whether an UPDATE from `sender` for `contract` is allowed
-    /// right now. If allowed, the accepted timestamp is recorded
-    /// atomically; the caller can rely on this being the moment of
-    /// admission for downstream rate-tracking. If rejected, no state
-    /// change is made (so a barrage of rejected attempts doesn't itself
-    /// extend the rate-limit window — the existing `last_accepted`
-    /// timestamp stays put).
+    /// right now, and atomically stamp the accepted timestamp if so.
+    ///
+    /// Implementation note: uses [`DashMap::entry`] so the per-shard
+    /// guard is held across the time-comparison + stamp. A previous
+    /// probe-then-insert version was non-atomic — Codex review of
+    /// PR #4285 caught that concurrent UPDATEs for the same pair
+    /// could all read the same old timestamp and all be admitted.
+    /// With the guard held, exactly one admitting caller wins per
+    /// `min_interval` window.
+    ///
+    /// If rejected, no state change is made (so a barrage of rejected
+    /// attempts doesn't itself extend the rate-limit window — the
+    /// existing `last_accepted` timestamp stays put).
     pub fn check_and_record(
         &self,
         sender: SocketAddr,
@@ -150,28 +221,78 @@ impl UpdateRateLimiter {
         let now = self.time_source.now();
         let key = (sender, contract);
 
-        // Probe the existing timestamp without holding a guard across
-        // the conditional update — avoids holding the DashMap shard
-        // lock during the time-comparison + atomic-counter steps.
-        let existing = self.last_accepted.get(&key).map(|r| *r);
-
-        if let Some(last) = existing {
-            let elapsed = now.saturating_duration_since(last);
-            if elapsed < self.min_interval {
-                self.rejected_total.fetch_add(1, Ordering::Relaxed);
-                return RateLimitDecision::Rejected {
-                    elapsed,
-                    min_interval: self.min_interval,
-                };
+        // Two-phase check:
+        //   1. If the entry already exists, hold its shard guard
+        //      across the time-comparison + stamp (atomic per pair).
+        //   2. For new pairs we need to enforce MAX_TRACKED_PAIRS by
+        //      reading `DashMap::len()` — but `len()` walks every
+        //      shard, so we MUST NOT hold any shard guard when we
+        //      call it (otherwise it deadlocks on the shard we hold).
+        //      Check existence with a `contains_key` probe first; if
+        //      it's a new pair, check `len()` against the cap and
+        //      then call `insert`. `insert` is itself atomic per
+        //      shard, so the worst-case race is a transient ±N
+        //      overshoot of the cap (N = number of shards) — bounded
+        //      and harmless.
+        use dashmap::mapref::entry::Entry;
+        if self.last_accepted.contains_key(&key) {
+            // Existing pair: hold the shard guard for the
+            // time-comparison + stamp.
+            match self.last_accepted.entry(key) {
+                Entry::Occupied(mut entry) => {
+                    let last = *entry.get();
+                    let elapsed = now.saturating_duration_since(last);
+                    if elapsed < self.min_interval {
+                        self.rejected_total.fetch_add(1, Ordering::Relaxed);
+                        return RateLimitDecision::Rejected {
+                            elapsed,
+                            min_interval: self.min_interval,
+                        };
+                    }
+                    *entry.get_mut() = now;
+                    self.accepted_total.fetch_add(1, Ordering::Relaxed);
+                    RateLimitDecision::Allowed
+                }
+                // Race: the entry was concurrently removed between
+                // the contains_key probe and the entry() call. Treat
+                // as a new pair, fall through.
+                Entry::Vacant(entry) => self.insert_new_pair(entry, now),
+            }
+        } else {
+            // New pair: check cap WITHOUT holding any shard guard.
+            if self.last_accepted.len() >= self.max_tracked_pairs {
+                self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
+                return RateLimitDecision::CapacityExceeded;
+            }
+            // Insert under the shard guard. If a concurrent insert
+            // beat us to the same key, treat as a normal admission
+            // (the other admit wins; we just bump our counter).
+            match self.last_accepted.entry(key) {
+                Entry::Vacant(entry) => self.insert_new_pair(entry, now),
+                Entry::Occupied(mut entry) => {
+                    let last = *entry.get();
+                    let elapsed = now.saturating_duration_since(last);
+                    if elapsed < self.min_interval {
+                        self.rejected_total.fetch_add(1, Ordering::Relaxed);
+                        return RateLimitDecision::Rejected {
+                            elapsed,
+                            min_interval: self.min_interval,
+                        };
+                    }
+                    *entry.get_mut() = now;
+                    self.accepted_total.fetch_add(1, Ordering::Relaxed);
+                    RateLimitDecision::Allowed
+                }
             }
         }
+    }
 
-        // Allowed: stamp the new time. `insert` overwrites; if a
-        // concurrent caller stamped a different time between our probe
-        // and this insert, the later one wins, which is fine — the
-        // rate limit is per-pair and roughly idempotent under
-        // concurrent admission.
-        self.last_accepted.insert(key, now);
+    fn insert_new_pair(
+        &self,
+        entry: dashmap::mapref::entry::VacantEntry<'_, (SocketAddr, ContractInstanceId), Instant>,
+        now: Instant,
+    ) -> RateLimitDecision {
+        entry.insert(now);
         self.accepted_total.fetch_add(1, Ordering::Relaxed);
         RateLimitDecision::Allowed
     }
@@ -200,6 +321,16 @@ impl UpdateRateLimiter {
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn rejected_total(&self) -> u64 {
         self.rejected_total.load(Ordering::Relaxed)
+    }
+
+    /// Total UPDATEs rejected because the tracking map was at capacity
+    /// (a new `(sender, contract)` pair tried to register when the map
+    /// already held [`MAX_TRACKED_PAIRS`] pairs). A non-zero value
+    /// suggests an attacker is churning identities — surface separately
+    /// from `rejected_total` on the dashboard for that reason.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn capacity_rejected_total(&self) -> u64 {
+        self.capacity_rejected_total.load(Ordering::Relaxed)
     }
 
     /// Number of tracked `(sender, contract)` pairs. Used by tests and
@@ -429,5 +560,161 @@ mod tests {
             "expected >95% rejection rate, got {}",
             rejected as f64 / 1000.0
         );
+    }
+
+    /// Pin: hard cap on tracked pairs prevents an attacker churning
+    /// fresh contract identities from growing the map indefinitely.
+    /// Once `MAX_TRACKED_PAIRS` is reached, new pairs get
+    /// `CapacityExceeded`, never `Allowed`. Existing pairs keep
+    /// working — graceful degradation, not total denial.
+    #[test]
+    fn capacity_exceeded_when_cap_reached() {
+        // Small cap so the test is fast.
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_config(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            8, // tiny cap for test speed
+        );
+
+        // Fill the map with 8 distinct pairs — all should be Allowed.
+        for i in 0..8 {
+            let d = limiter.check_and_record(mk_sender(i + 1), mk_contract(i + 1));
+            assert_eq!(d, RateLimitDecision::Allowed, "pair {i} should be allowed");
+        }
+        assert_eq!(limiter.len(), 8);
+
+        // Pair #9 is a new key — must be CapacityExceeded.
+        let d = limiter.check_and_record(mk_sender(99), mk_contract(99));
+        assert_eq!(
+            d,
+            RateLimitDecision::CapacityExceeded,
+            "new pair past the cap must be CapacityExceeded"
+        );
+        assert_eq!(limiter.capacity_rejected_total(), 1);
+
+        // Pair #1 (already tracked) — should still work after
+        // the min_interval elapses. Existing pairs aren't punished
+        // by the cap.
+        ts.advance(MIN_UPDATE_INTERVAL + Duration::from_millis(1));
+        let d = limiter.check_and_record(mk_sender(1), mk_contract(1));
+        assert_eq!(
+            d,
+            RateLimitDecision::Allowed,
+            "existing pair must keep working at cap"
+        );
+
+        // After cleanup drops stale entries the cap recovers, but in
+        // this test no time has passed so they're still fresh.
+    }
+
+    /// Pin the atomicity of `check_and_record` under concurrent
+    /// callers. Without `DashMap::entry()` holding the shard guard
+    /// across the time-comparison + stamp, two threads racing the
+    /// same `(sender, contract)` pair could both decide `Allowed`,
+    /// both increment `accepted_total`, and both spawn relay work.
+    /// Codex review of PR #4285 caught this. The fixed implementation
+    /// must serialize exactly one Allowed per `min_interval` window
+    /// per pair.
+    #[test]
+    fn concurrent_check_and_record_admits_one_per_window() {
+        use std::sync::{Arc as StdArc, Barrier};
+        use std::thread;
+
+        let ts = SharedMockTimeSource::new();
+        let limiter = StdArc::new(UpdateRateLimiter::new(Arc::new(ts.clone())));
+        let sender = mk_sender(1);
+        let contract = mk_contract(1);
+
+        const THREADS: usize = 16;
+        let barrier = StdArc::new(Barrier::new(THREADS));
+        let mut handles = Vec::with_capacity(THREADS);
+
+        for _ in 0..THREADS {
+            let l = limiter.clone();
+            let b = barrier.clone();
+            handles.push(thread::spawn(move || {
+                b.wait();
+                l.check_and_record(sender, contract)
+            }));
+        }
+
+        let mut allowed = 0;
+        let mut rejected = 0;
+        for h in handles {
+            match h.join().unwrap() {
+                RateLimitDecision::Allowed => allowed += 1,
+                RateLimitDecision::Rejected { .. } => rejected += 1,
+                RateLimitDecision::CapacityExceeded => panic!("unexpected cap"),
+            }
+        }
+        assert_eq!(
+            allowed, 1,
+            "exactly ONE concurrent caller must be admitted per window; \
+             got {allowed} admits, {rejected} rejects"
+        );
+        assert_eq!(rejected, THREADS - 1);
+        assert_eq!(limiter.accepted_total(), 1);
+        assert_eq!(limiter.rejected_total(), (THREADS - 1) as u64);
+    }
+
+    /// Source-grep pin: the rate-limit gate at the UPDATE dispatch
+    /// site in `node.rs` must cover ALL four UPDATE wire variants
+    /// (`RequestUpdate`, `BroadcastTo`, `RequestUpdateStreaming`,
+    /// `BroadcastToStreaming`). Codex review of #4285 caught a
+    /// previous iteration that only gated `RequestUpdate`, letting
+    /// a flooder bypass by switching opcode.
+    ///
+    /// Strategy: scrape `node.rs` for the UPDATE dispatch block and
+    /// assert (a) the rate-limit call site appears, (b) it appears
+    /// BEFORE any `start_relay_*` spawn, and (c) the four wire-variant
+    /// names are mentioned in the same block (proving the dispatch
+    /// matches on all of them).
+    #[test]
+    fn update_dispatch_gates_all_four_wire_variants() {
+        const NODE_SRC: &str = include_str!("../node.rs");
+
+        // Find the UPDATE handler block.
+        let block_start = NODE_SRC
+            .find("NetMessageV1::Update(ref op) =>")
+            .expect("could not locate UPDATE dispatch block in node.rs");
+
+        // Bound the search to a generous slice — the UPDATE block is
+        // well under 4KB.
+        let block_end = (block_start + 8192).min(NODE_SRC.len());
+        let block = &NODE_SRC[block_start..block_end];
+
+        // (a) the gate is invoked.
+        let rate_limit_pos = block
+            .find("update_rate_limiter")
+            .expect("update_rate_limiter not invoked in UPDATE dispatch block");
+
+        // (b) the gate fires BEFORE the first relay spawn — otherwise
+        //     the spawn cost is paid even on rejection.
+        let first_spawn_pos = block
+            .find("start_relay_request_update(")
+            .expect("start_relay_request_update spawn not found in block");
+        assert!(
+            rate_limit_pos < first_spawn_pos,
+            "rate limit gate (offset {rate_limit_pos}) must appear BEFORE \
+             the first relay spawn (offset {first_spawn_pos}) so rejected \
+             messages don't pay the spawn cost"
+        );
+
+        // (c) all four wire variants are matched in the dispatch.
+        for variant in [
+            "UpdateMsg::RequestUpdate {",
+            "UpdateMsg::BroadcastTo {",
+            "UpdateMsg::RequestUpdateStreaming {",
+            "UpdateMsg::BroadcastToStreaming {",
+        ] {
+            assert!(
+                block.contains(variant),
+                "UPDATE dispatch block missing wire variant: `{variant}`. \
+                 If a new UPDATE wire variant was added, gate it through \
+                 the rate limiter and update this list. If a variant was \
+                 removed, update this list."
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Phase 2 of `docs/design/contract-hardening.md` — front-line defense against the May 21 incident pattern. Adds a per-`(sender_addr, contract_instance_id)` rate limit on inbound UPDATE relay traffic. Reacts at the receive boundary in milliseconds; complements the slower MAD-based governance reaper from #4270 (which reacts in minutes).

## What's in here

### `crates/core/src/ring/update_rate_limit.rs` (new, 10 unit tests)

`UpdateRateLimiter`:
- DashMap keyed by `(SocketAddr, ContractInstanceId)` → last accepted `Instant`.
- `check_and_record` rejects if elapsed since last accept is under `MIN_UPDATE_INTERVAL` (100ms default, ≈10 UPDATEs/s/pair).
- **Rejected attempts do NOT extend the window.** A flooding peer doesn't lock the pair out indefinitely; the legitimate peer recovers as soon as `MIN_UPDATE_INTERVAL` passes from the actual last accept (pinned by `rejected_attempts_do_not_extend_window` test).
- Counters for accepted vs rejected (reserved for the follow-up dashboard surface).
- Periodic `cleanup()` drops entries idle for >5 min — hooked into the existing `governance_reaper_loop` tick.

### Wiring

This MVP applies the gate at **inbound relay UPDATE entry** (`start_relay_request_update` in `crates/core/src/operations/update/op_ctx_task.rs`):

1. Existing dedup check passes.
2. **NEW: rate-limit check.** Rejected → dedup-set membership rolled back, return `Ok(())` without spawning the relay driver. Flooding traffic doesn't even get a tokio task.
3. Driver spawn proceeds as before.

## Design doc divergence (honest acknowledgement)

The design doc said `TrackedBackoff<(PeerId, ContractInstanceId)>` at `SyncStateToPeer` emit + originator UPDATE entry. This MVP diverges:
- **Flat ceiling instead of `TrackedBackoff` exponential.** Sufficient for the May 21 pattern. Repeat-offender exponential cooldown is a follow-up if observation shows it's needed.
- **Inbound site instead of originator + outbound emit.** Inbound is the highest-value protection point. Other sites land in follow-up PRs.
- **No typed wire-level error.** Rejected UPDATEs are dropped silently at the boundary. The sender's own retry / governance scoring will detect the flood from its end.

## Tests

10 unit tests including:
- `may21_flood_pattern_is_throttled` — pin test for the production incident pattern (1000 attempts/s for 1s → ~10 admits, >95% rejection rate).
- `rejected_attempts_do_not_extend_window` — pins the critical invariant that sustained rejections don't lock out a recovering peer.
- Independence tests for `(different sender, same contract)` and `(same sender, different contract)`.
- Cleanup behaviour.

Full lib: **2753 passed, 0 failed, 14 ignored.**
`cargo clippy --lib --tests -- -D warnings` clean.

## Follow-up work (separate PRs)

- Wire to `start_relay_broadcast_to`, `start_client_update`, streaming variants.
- Surface counters on the Contract Governance dashboard card.
- Decide whether `TrackedBackoff` exponential is needed based on real-attack observation.
- Move `MIN_UPDATE_INTERVAL` and `CLEANUP_AGE` to runtime config.

## Test plan

- [ ] CI green on HEAD SHA
- [ ] Multi-model review (full tier — touches a receive-boundary hot path)
- [ ] Optional: smoke test on technic — observe `rejected_total` over a few hours and confirm normal traffic doesn't trip the limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-assisted - Claude]