### PR TITLE
fix: detect stale macOS service wrapper by content equality (#3967)

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -2814,9 +2814,27 @@ fn install_macos_service() -> Result<()> {
     fs::create_dir_all(&wrapper_dir).context("Failed to create wrapper directory")?;
     let wrapper_path = wrapper_dir.join("freenet-service-wrapper.sh");
     let wrapper_content = generate_wrapper_script(&exe_path);
-    fs::write(&wrapper_path, wrapper_content).context("Failed to write wrapper script")?;
+    fs::write(&wrapper_path, &wrapper_content).context("Failed to write wrapper script")?;
     fs::set_permissions(&wrapper_path, fs::Permissions::from_mode(0o755))
         .context("Failed to make wrapper script executable")?;
+
+    // Record the SHA-256 hash of the wrapper we just wrote so a later
+    // `freenet update` can distinguish "Freenet's wrapper" from "a
+    // hand-edited wrapper" before overwriting it (issue #3967). A
+    // failed sidecar write only weakens user-modification protection
+    // on the next update — it does not invalidate the wrapper we just
+    // wrote — so we warn and continue.
+    let wrapper_hash_path = wrapper_path.with_extension("sh.hash");
+    let wrapper_hash = super::update::wrapper_content_hash(&wrapper_content);
+    if let Err(e) = fs::write(&wrapper_hash_path, format!("{wrapper_hash}\n")) {
+        eprintln!(
+            "Warning: failed to write wrapper hash sidecar at {}: {}. \
+             User-modification detection on the next `freenet update` \
+             will fall back to treating the wrapper as ours.",
+            wrapper_hash_path.display(),
+            e
+        );
+    }
 
     let plist_content = generate_plist(&wrapper_path, &log_dir);
     let plist_path = launch_agents_dir.join("org.freenet.node.plist");

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -2818,12 +2818,10 @@ fn install_macos_service() -> Result<()> {
     fs::set_permissions(&wrapper_path, fs::Permissions::from_mode(0o755))
         .context("Failed to make wrapper script executable")?;
 
-    // Record the SHA-256 hash of the wrapper we just wrote so a later
-    // `freenet update` can distinguish "Freenet's wrapper" from "a
-    // hand-edited wrapper" before overwriting it (issue #3967). A
-    // failed sidecar write only weakens user-modification protection
-    // on the next update — it does not invalidate the wrapper we just
-    // wrote — so we warn and continue.
+    // Sidecar records the wrapper's SHA-256 so a later `freenet update`
+    // can distinguish "Freenet's wrapper" from a hand-edited one
+    // before overwriting (#3967). A failed sidecar write only weakens
+    // future user-modification protection — warn and continue.
     let wrapper_hash_path = wrapper_path.with_extension("sh.hash");
     let wrapper_hash = super::update::wrapper_content_hash(&wrapper_content);
     if let Err(e) = fs::write(&wrapper_hash_path, format!("{wrapper_hash}\n")) {

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -2819,16 +2819,14 @@ fn install_macos_service() -> Result<()> {
         .context("Failed to make wrapper script executable")?;
 
     // Sidecar records the wrapper's SHA-256 so a later `freenet update`
-    // can distinguish "Freenet's wrapper" from a hand-edited one
-    // before overwriting (#3967). A failed sidecar write only weakens
-    // future user-modification protection — warn and continue.
+    // can distinguish "Freenet's wrapper" from a hand-edited one before
+    // overwriting (#3967). A failed sidecar write only weakens future
+    // user-modification protection — warn and continue.
     let wrapper_hash_path = wrapper_path.with_extension("sh.hash");
     let wrapper_hash = super::update::wrapper_content_hash(&wrapper_content);
-    if let Err(e) = fs::write(&wrapper_hash_path, format!("{wrapper_hash}\n")) {
+    if let Err(e) = super::update::write_wrapper_hash_sidecar(&wrapper_hash_path, &wrapper_hash) {
         eprintln!(
-            "Warning: failed to write wrapper hash sidecar at {}: {}. \
-             User-modification detection on the next `freenet update` \
-             will fall back to treating the wrapper as ours.",
+            "Warning: failed to write wrapper hash sidecar at {}: {}.",
             wrapper_hash_path.display(),
             e
         );

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -1259,6 +1259,20 @@ pub(super) fn wrapper_needs_regen(current_template: &str, on_disk: &str) -> bool
     current_template != on_disk
 }
 
+/// Pure helper: validate a wrapper-sidecar hash string. SHA-256 hex is
+/// exactly 64 lowercase ASCII hex chars; anything else means the sidecar
+/// is truncated, corrupted, or was never a hash. Treating malformed
+/// as "no sidecar" (rather than as permanent UserModified) lets the
+/// host recover from a partial prior write — without this, a single
+/// interrupted update could lock the auto-update path forever.
+/// Code-first-reviewer flagged on PR #4286.
+#[allow(dead_code)]
+pub(super) fn is_valid_wrapper_hash(s: &str) -> bool {
+    s.len() == 64
+        && s.bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
 /// Pure helper: SHA-256 hex digest of `content`. Used to fingerprint the
 /// wrapper we last wrote so a later `freenet update` can distinguish
 /// "Freenet's previous wrapper" from "a user-edited wrapper" (#3967).
@@ -1275,6 +1289,95 @@ pub(super) fn wrapper_content_hash(content: &str) -> String {
             write!(s, "{b:02x}").expect("writing to String is infallible");
             s
         })
+}
+
+/// The decision the auto-update path takes for the wrapper script,
+/// derived purely from the current template, the on-disk wrapper, and
+/// the on-disk sidecar — no I/O. Extracting this lets non-macOS CI
+/// runners exercise the full decision matrix (skeptical-reviewer
+/// flagged on PR #4286 that the macOS-only end-to-end tests don't run
+/// in CI today).
+#[derive(Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(super) enum WrapperAction {
+    /// On-disk wrapper matches the current template byte-for-byte.
+    /// No rewrite needed. If `backfill_sidecar` is `Some`, the caller
+    /// should write that hash to the sidecar — covers the case where
+    /// the wrapper is up-to-date but the sidecar is missing or
+    /// malformed (self-heal so user-modification protection is in
+    /// force on the next update).
+    UpToDate { backfill_sidecar: Option<String> },
+    /// On-disk wrapper differs from the template and we have grounds
+    /// to overwrite it: no on-disk wrapper, or the sidecar shows the
+    /// wrapper is the one we wrote previously. The caller should
+    /// write `template` plus a sidecar containing `new_hash`.
+    WriteOurs { new_hash: String },
+    /// On-disk wrapper differs AND the sidecar records a different
+    /// hash, indicating the user (or another tool) edited it. The
+    /// caller should leave the wrapper alone and warn.
+    /// `on_disk_hash` is the hash of the current on-disk content,
+    /// provided so the warning message can include it.
+    UserModified { on_disk_hash: String },
+}
+
+/// Pure helper: decide what to do with the macOS launchd wrapper given
+/// the inputs the caller has gathered from disk. Cross-platform-compiled
+/// so every CI runner exercises this decision matrix — closes the gap
+/// the skeptical reviewer flagged on PR #4286 about the macOS-only E2E
+/// tests not running in CI.
+///
+/// - `current_template`: what `generate_wrapper_script(binary)` would
+///   produce now.
+/// - `on_disk_wrapper`: `Some(content)` if the wrapper exists and was
+///   read successfully (`None` if missing or unreadable).
+/// - `sidecar_raw`: `Some(raw)` if the sidecar exists and was read
+///   successfully (`None` if missing or unreadable). The raw bytes
+///   are trimmed and validated as a 64-char hex string by this
+///   helper, so the caller doesn't need to pre-process.
+#[allow(dead_code)]
+pub(super) fn decide_wrapper_action(
+    current_template: &str,
+    on_disk_wrapper: Option<&str>,
+    sidecar_raw: Option<&str>,
+) -> WrapperAction {
+    let stored_hash = sidecar_raw
+        .map(|s| s.trim())
+        .filter(|s| is_valid_wrapper_hash(s));
+    let template_hash = wrapper_content_hash(current_template);
+
+    let Some(on_disk) = on_disk_wrapper else {
+        return WrapperAction::WriteOurs {
+            new_hash: template_hash,
+        };
+    };
+    if !wrapper_needs_regen(current_template, on_disk) {
+        // Wrapper byte-matches template. Backfill the sidecar if it's
+        // missing or malformed, so a future hand-edit triggers the
+        // user-modification path instead of silently being clobbered.
+        let backfill_sidecar = match stored_hash {
+            Some(s) if s == template_hash => None,
+            _ => Some(template_hash),
+        };
+        return WrapperAction::UpToDate { backfill_sidecar };
+    }
+    let on_disk_hash = wrapper_content_hash(on_disk);
+    match stored_hash {
+        Some(s) if s != on_disk_hash => WrapperAction::UserModified { on_disk_hash },
+        _ => WrapperAction::WriteOurs {
+            new_hash: template_hash,
+        },
+    }
+}
+
+/// Write the wrapper hash sidecar in the canonical on-disk format
+/// (single line of 64 lowercase hex chars + trailing newline). Single
+/// source of truth so `install_macos_service` and
+/// `ensure_service_file_updated` cannot drift apart on the format
+/// — a divergence would loop-rewrite the wrapper on every update.
+/// Testing-reviewer flagged on PR #4286.
+#[allow(dead_code)]
+pub(super) fn write_wrapper_hash_sidecar(path: &Path, hash: &str) -> std::io::Result<()> {
+    fs::write(path, format!("{hash}\n"))
 }
 
 #[cfg(target_os = "macos")]
@@ -1294,40 +1397,21 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
     let wrapper_path = home_dir.join(".local/bin/freenet-service-wrapper.sh");
     let wrapper_hash_path = wrapper_path.with_extension("sh.hash");
 
-    // Equality-check against the current template (see
-    // `wrapper_needs_regen` docs re: issue #3967).
     let new_wrapper_content = generate_wrapper_script(binary_path);
 
-    // Tri-state so we can warn (and skip) when the user has
-    // hand-edited their wrapper rather than silently overwriting it.
-    enum WrapperPlan {
-        UpToDate,
-        WriteOurs,
-        UserModified(String), // hex hash of the on-disk file
-    }
-
-    let plan = if wrapper_path.exists() {
-        let on_disk = fs::read_to_string(&wrapper_path).context("Failed to read wrapper script")?;
-        if !wrapper_needs_regen(&new_wrapper_content, &on_disk) {
-            WrapperPlan::UpToDate
-        } else {
-            let on_disk_hash = wrapper_content_hash(&on_disk);
-            // Sidecar absent: pre-#3967 migration case, treat as ours.
-            // Sidecar matches on-disk hash: ours, safe to overwrite.
-            // Sidecar mismatches: user (or some tool) edited the
-            // wrapper since we wrote it — back off.
-            match fs::read_to_string(&wrapper_hash_path) {
-                Ok(stored) if stored.trim() != on_disk_hash => {
-                    WrapperPlan::UserModified(on_disk_hash)
-                }
-                _ => WrapperPlan::WriteOurs,
-            }
-        }
-    } else {
-        WrapperPlan::WriteOurs
-    };
-
-    let wrapper_needs_update = matches!(plan, WrapperPlan::WriteOurs);
+    // A non-UTF-8 wrapper on disk (very unusual for a shell script,
+    // but possible if corruption snuck in) is treated the same as a
+    // missing wrapper: we'll overwrite. Otherwise the whole update
+    // path would abort with a misleading "Failed to read wrapper
+    // script" error on an obviously-recoverable state.
+    // Skeptical-reviewer flagged on PR #4286.
+    let on_disk_wrapper = fs::read_to_string(&wrapper_path).ok();
+    let sidecar_raw = fs::read_to_string(&wrapper_hash_path).ok();
+    let action = decide_wrapper_action(
+        &new_wrapper_content,
+        on_disk_wrapper.as_deref(),
+        sidecar_raw.as_deref(),
+    );
 
     // Also force regeneration of the plist if it still points
     // StandardOutPath/StandardErrorPath at the unrotated freenet.log
@@ -1350,83 +1434,94 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
         }
     };
 
-    // Step 1: regenerate the wrapper FIRST. The plist's ProgramArguments
+    // Step 1: act on the wrapper FIRST. The plist's ProgramArguments
     // points at this wrapper path, so the wrapper must exist and be
-    // executable before we point launchd at it. If wrapper regen fails,
-    // we exit BEFORE rewriting the plist so the system stays in its
-    // previous-working state.
-    if let WrapperPlan::UserModified(on_disk_hash) = &plan {
-        if !quiet {
-            eprintln!(
-                "Warning: wrapper script at {} differs from the current Freenet \
-                 template AND from the hash recorded in {}, suggesting it has \
-                 been hand-edited. Leaving it alone. To accept the bundled \
-                 wrapper, delete the .sh.hash sidecar or reinstall via \
-                 `freenet service install`. (on-disk hash: {})",
-                wrapper_path.display(),
-                wrapper_hash_path.display(),
-                on_disk_hash,
-            );
-        }
-    }
-
-    if wrapper_needs_update {
-        if !quiet {
-            println!("Updating service wrapper to add auto-update support...");
-        }
-
-        // Ensure wrapper directory exists
-        let wrapper_dir = wrapper_path
-            .parent()
-            .context("Wrapper path has no parent directory")?;
-        fs::create_dir_all(wrapper_dir).context("Failed to create wrapper directory")?;
-
-        // Create backup of existing wrapper script if it exists
-        if wrapper_path.exists() {
-            let backup_path = wrapper_path.with_extension("sh.bak");
-            if let Err(e) = fs::copy(&wrapper_path, &backup_path) {
-                if !quiet {
-                    eprintln!(
-                        "Warning: Failed to backup wrapper script: {}. Continuing anyway.",
-                        e
-                    );
-                }
-            } else if !quiet {
-                println!("Backed up existing wrapper script to {:?}", backup_path);
-            }
-        }
-
-        fs::write(&wrapper_path, &new_wrapper_content).context("Failed to write wrapper script")?;
-
-        // Sidecar records the hash of what we just wrote so a later
-        // auto-update can detect a user-edited wrapper (#3967). A
-        // failed sidecar write only weakens future protection — it
-        // does NOT invalidate the wrapper we just wrote, so warn but
-        // continue.
-        let new_hash = wrapper_content_hash(&new_wrapper_content);
-        if let Err(e) = fs::write(&wrapper_hash_path, format!("{new_hash}\n")) {
+    // executable before we point launchd at it. If wrapper regen
+    // fails we exit BEFORE rewriting the plist so the system stays
+    // in its previous-working state.
+    match &action {
+        WrapperAction::UserModified { on_disk_hash } => {
             if !quiet {
                 eprintln!(
-                    "Warning: failed to write wrapper hash sidecar at {}: {}. \
-                     User-modification detection on the next `freenet update` \
-                     will fall back to treating the wrapper as ours.",
+                    "Warning: wrapper script at {} differs from the current Freenet \
+                     template AND from the hash recorded in {}, suggesting it has \
+                     been hand-edited. Leaving it alone. To accept the bundled \
+                     wrapper, delete the .sh.hash sidecar or reinstall via \
+                     `freenet service install`. (on-disk hash: {})",
+                    wrapper_path.display(),
                     wrapper_hash_path.display(),
-                    e
+                    on_disk_hash,
                 );
             }
         }
-
-        // Make executable
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&wrapper_path)?.permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&wrapper_path, perms)?;
+        WrapperAction::UpToDate {
+            backfill_sidecar: Some(h),
+        } => {
+            if let Err(e) = write_wrapper_hash_sidecar(&wrapper_hash_path, h) {
+                if !quiet {
+                    eprintln!(
+                        "Warning: failed to backfill wrapper hash sidecar at {}: {}.",
+                        wrapper_hash_path.display(),
+                        e
+                    );
+                }
+            }
         }
+        WrapperAction::UpToDate {
+            backfill_sidecar: None,
+        } => {}
+        WrapperAction::WriteOurs { new_hash } => {
+            if !quiet {
+                println!("Updating service wrapper to add auto-update support...");
+            }
+            let wrapper_dir = wrapper_path
+                .parent()
+                .context("Wrapper path has no parent directory")?;
+            fs::create_dir_all(wrapper_dir).context("Failed to create wrapper directory")?;
 
-        if !quiet {
-            println!("Service wrapper updated with auto-update hook.");
+            if wrapper_path.exists() {
+                let backup_path = wrapper_path.with_extension("sh.bak");
+                if let Err(e) = fs::copy(&wrapper_path, &backup_path) {
+                    if !quiet {
+                        eprintln!(
+                            "Warning: Failed to backup wrapper script: {}. Continuing anyway.",
+                            e
+                        );
+                    }
+                } else if !quiet {
+                    println!("Backed up existing wrapper script to {:?}", backup_path);
+                }
+            }
+
+            fs::write(&wrapper_path, &new_wrapper_content)
+                .context("Failed to write wrapper script")?;
+
+            // Failed sidecar write only weakens future user-mod
+            // protection; it does not invalidate the wrapper we
+            // just wrote, so warn but continue.
+            if let Err(e) = write_wrapper_hash_sidecar(&wrapper_hash_path, new_hash) {
+                if !quiet {
+                    eprintln!(
+                        "Warning: failed to write wrapper hash sidecar at {}: {}. \
+                         User-modification detection on the next `freenet update` \
+                         will fall back to treating the wrapper as ours.",
+                        wrapper_hash_path.display(),
+                        e
+                    );
+                }
+            }
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut perms = fs::metadata(&wrapper_path)?.permissions();
+                perms.set_mode(0o755);
+                fs::set_permissions(&wrapper_path, perms)?;
+            }
+
+            if !quiet {
+                println!("Service wrapper updated with auto-update hook.");
+            }
         }
     }
 
@@ -2068,6 +2163,191 @@ done
     }
 
     #[test]
+    fn is_valid_wrapper_hash_accepts_real_sha256_hex_only() {
+        // 64 lowercase hex chars: the actual SHA-256 shape.
+        let good = wrapper_content_hash("anything");
+        assert!(is_valid_wrapper_hash(&good));
+        assert!(is_valid_wrapper_hash(&"a".repeat(64)));
+        assert!(is_valid_wrapper_hash(&"0123456789abcdef".repeat(4)));
+
+        // Reject everything else — these are all "malformed sidecar"
+        // shapes that, before the carve-out, would have locked the
+        // host into permanent UserModified.
+        assert!(!is_valid_wrapper_hash(""), "empty");
+        assert!(!is_valid_wrapper_hash("not a hash"), "free text");
+        assert!(!is_valid_wrapper_hash(&"a".repeat(63)), "truncated");
+        assert!(!is_valid_wrapper_hash(&"a".repeat(65)), "too long");
+        assert!(
+            !is_valid_wrapper_hash(&"A".repeat(64)),
+            "uppercase rejected — wrapper_content_hash always emits lowercase"
+        );
+        assert!(
+            !is_valid_wrapper_hash(&"g".repeat(64)),
+            "non-hex char rejected"
+        );
+    }
+
+    // ---- decide_wrapper_action: pure decision matrix. ----
+    //
+    // Skeptical-reviewer flagged that the macOS-only end-to-end tests
+    // for `ensure_service_file_updated` don't run in CI (`ci.yml` has
+    // no macOS `cargo test` job). Extracting the decision logic into
+    // this pure helper closes that gap: every CI runner exercises the
+    // matrix below regardless of target OS, so a future regression on
+    // any branch is caught at PR time.
+
+    /// Build the "current" template + its hash for use in the
+    /// decision-matrix tests below. The exact content is irrelevant;
+    /// what matters is that on-disk wrappers we feed in differ from
+    /// it for the regen cases and match it for the up-to-date cases.
+    fn fixture_template() -> (String, String) {
+        let t = "#!/bin/bash\necho fixture\n".to_string();
+        let h = wrapper_content_hash(&t);
+        (t, h)
+    }
+
+    #[test]
+    fn decide_wrapper_action_no_wrapper_writes_ours() {
+        let (template, hash) = fixture_template();
+        assert_eq!(
+            decide_wrapper_action(&template, None, None),
+            WrapperAction::WriteOurs { new_hash: hash }
+        );
+    }
+
+    #[test]
+    fn decide_wrapper_action_stale_wrapper_no_sidecar_writes_ours_3967() {
+        // The migration shape for every pre-#3967 install: wrapper
+        // differs from current template (e.g. missing the pkill
+        // block) and no sidecar exists. Treat as ours so the host
+        // can recover.
+        let (template, hash) = fixture_template();
+        let stale = "#!/bin/bash\n# stale Jan 2026 wrapper\n";
+        assert_eq!(
+            decide_wrapper_action(&template, Some(stale), None),
+            WrapperAction::WriteOurs { new_hash: hash }
+        );
+    }
+
+    #[test]
+    fn decide_wrapper_action_stale_wrapper_matching_sidecar_writes_ours() {
+        // Sidecar present and matches the on-disk hash: it's ours,
+        // safe to overwrite (e.g. template drifted between releases).
+        let (template, template_hash) = fixture_template();
+        let stale = "#!/bin/bash\n# previous Freenet wrapper\n";
+        let stale_hash = wrapper_content_hash(stale);
+        assert_eq!(
+            decide_wrapper_action(&template, Some(stale), Some(&stale_hash)),
+            WrapperAction::WriteOurs {
+                new_hash: template_hash
+            }
+        );
+    }
+
+    #[test]
+    fn decide_wrapper_action_stale_wrapper_with_trailing_newline_sidecar() {
+        // Sidecar with `\n` (the canonical on-disk form) must trim
+        // and validate as ours. Pins the wire-format contract between
+        // `write_wrapper_hash_sidecar` and `decide_wrapper_action` —
+        // testing-reviewer flagged on PR #4286 that a future
+        // refactor dropping the trim would silently break.
+        let (template, template_hash) = fixture_template();
+        let stale = "#!/bin/bash\n# previous Freenet wrapper\n";
+        let sidecar_with_newline = format!("{}\n", wrapper_content_hash(stale));
+        assert_eq!(
+            decide_wrapper_action(&template, Some(stale), Some(&sidecar_with_newline)),
+            WrapperAction::WriteOurs {
+                new_hash: template_hash
+            },
+            "matching sidecar with trailing newline must validate the same as one without",
+        );
+    }
+
+    #[test]
+    fn decide_wrapper_action_user_modified_wrapper_is_preserved() {
+        let (template, _) = fixture_template();
+        let edited = "#!/bin/bash\n# user customized this\n";
+        let edited_hash = wrapper_content_hash(edited);
+        // Sidecar records what Freenet wrote previously (different
+        // from what's currently on disk → user edited it).
+        let prior_freenet_hash = wrapper_content_hash("#!/bin/bash\n# prior Freenet\n");
+        assert_eq!(
+            decide_wrapper_action(&template, Some(edited), Some(&prior_freenet_hash)),
+            WrapperAction::UserModified {
+                on_disk_hash: edited_hash
+            }
+        );
+    }
+
+    #[test]
+    fn decide_wrapper_action_malformed_sidecar_treated_as_missing_3967() {
+        // Truncated / corrupted sidecar must NOT lock the host into
+        // permanent UserModified — fall through to WriteOurs so the
+        // auto-update path can recover from a partial prior write.
+        let (template, hash) = fixture_template();
+        let stale = "#!/bin/bash\n# stale\n";
+        // Truncated hex (length 6 — not 64).
+        assert_eq!(
+            decide_wrapper_action(&template, Some(stale), Some("deadbe")),
+            WrapperAction::WriteOurs {
+                new_hash: hash.clone()
+            }
+        );
+        // Free text.
+        assert_eq!(
+            decide_wrapper_action(&template, Some(stale), Some("not a hash at all")),
+            WrapperAction::WriteOurs {
+                new_hash: hash.clone()
+            }
+        );
+        // Empty file.
+        assert_eq!(
+            decide_wrapper_action(&template, Some(stale), Some("")),
+            WrapperAction::WriteOurs { new_hash: hash }
+        );
+    }
+
+    #[test]
+    fn decide_wrapper_action_up_to_date_with_matching_sidecar_is_noop() {
+        let (template, template_hash) = fixture_template();
+        assert_eq!(
+            decide_wrapper_action(&template, Some(&template), Some(&template_hash)),
+            WrapperAction::UpToDate {
+                backfill_sidecar: None
+            }
+        );
+    }
+
+    #[test]
+    fn decide_wrapper_action_up_to_date_with_missing_sidecar_backfills() {
+        // Pre-#3967 install with a wrapper that happens to be
+        // byte-identical to today's template (rare but possible)
+        // — backfill the sidecar so future user-mod protection
+        // works. Code-first-reviewer flagged on PR #4286.
+        let (template, template_hash) = fixture_template();
+        assert_eq!(
+            decide_wrapper_action(&template, Some(&template), None),
+            WrapperAction::UpToDate {
+                backfill_sidecar: Some(template_hash)
+            }
+        );
+    }
+
+    #[test]
+    fn decide_wrapper_action_up_to_date_with_malformed_sidecar_backfills() {
+        // Same self-heal as the missing-sidecar case: a corrupted
+        // sidecar (truncated, free text, etc.) gets overwritten with
+        // a valid one when the wrapper is already up to date.
+        let (template, template_hash) = fixture_template();
+        assert_eq!(
+            decide_wrapper_action(&template, Some(&template), Some("garbage")),
+            WrapperAction::UpToDate {
+                backfill_sidecar: Some(template_hash)
+            }
+        );
+    }
+
+    #[test]
     fn wrapper_content_hash_is_stable_and_distinct() {
         let a = wrapper_content_hash("hello");
         let b = wrapper_content_hash("hello");
@@ -2109,16 +2389,35 @@ done
                 .lock()
                 .unwrap_or_else(|poison| poison.into_inner());
             let prior = std::env::var_os("HOME");
-            std::env::set_var("HOME", path);
+            // SAFETY: Rust 2024 marks `set_var`/`remove_var` unsafe
+            // because other threads could be reading the environment
+            // concurrently. The static `HOME_ENV_LOCK` mutex
+            // serializes ALL test code in this module that touches
+            // `HOME`, and nothing else in this crate's test binary
+            // reads `HOME` while a `ScopedHome` is alive. The
+            // serialization is local to the cargo-test process, which
+            // is what matters: cargo runs each binary in its own
+            // process, so HOME-touching tests in other binaries (the
+            // lib tests, integration tests, etc.) don't share state
+            // with this one.
+            unsafe {
+                std::env::set_var("HOME", path);
+            }
             Self { prior, _lock: lock }
         }
     }
     #[cfg(target_os = "macos")]
     impl Drop for ScopedHome {
         fn drop(&mut self) {
-            match self.prior.take() {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
+            // SAFETY: same lock-guarded reasoning as `ScopedHome::new`
+            // above; the `_lock` field keeps the mutex held until
+            // after this drop runs, so no sibling test sees a
+            // mid-restore HOME value.
+            unsafe {
+                match self.prior.take() {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
             }
         }
     }
@@ -2169,6 +2468,162 @@ done
             recorded.trim(),
             wrapper_content_hash(&new_content),
             "recorded sidecar hash must match the wrapper we just wrote"
+        );
+    }
+
+    /// Pin the install -> update no-op contract: when the wrapper is
+    /// byte-identical to the current template AND a matching sidecar
+    /// exists (the post-#3967 fresh-install shape), the next
+    /// `freenet update` must be a no-op. If either writer (`install`
+    /// in service.rs, the regen path here) ever changes the sidecar
+    /// format without the other matching, this test fails by
+    /// detecting the resulting regen loop. Testing reviewer flagged
+    /// this gap on PR #4286.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn ensure_service_file_updated_is_noop_after_fresh_install() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let fake_home = tmp.path();
+        let _home = ScopedHome::new(fake_home);
+
+        let launch_agents = fake_home.join("Library/LaunchAgents");
+        fs::create_dir_all(&launch_agents).unwrap();
+        fs::write(launch_agents.join("org.freenet.node.plist"), "<plist/>").unwrap();
+
+        let wrapper_dir = fake_home.join(".local/bin");
+        fs::create_dir_all(&wrapper_dir).unwrap();
+        let binary = wrapper_dir.join("freenet");
+
+        // Simulate what `install_macos_service` writes: wrapper text
+        // equal to what `generate_wrapper_script` produces now, plus
+        // a sidecar containing its SHA-256.
+        let wrapper = wrapper_dir.join("freenet-service-wrapper.sh");
+        let template = super::super::service::generate_wrapper_script(&binary);
+        fs::write(&wrapper, &template).unwrap();
+        let sidecar = wrapper.with_extension("sh.hash");
+        fs::write(&sidecar, format!("{}\n", wrapper_content_hash(&template))).unwrap();
+
+        // Snapshot mtimes so we can prove neither file was rewritten.
+        let wrapper_before = fs::metadata(&wrapper).unwrap().modified().unwrap();
+        let sidecar_before = fs::metadata(&sidecar).unwrap().modified().unwrap();
+
+        ensure_service_file_updated(&binary, /* quiet */ true).unwrap();
+
+        // Both files must still hold the same content AND have
+        // unchanged mtimes (no needless rewrite).
+        assert_eq!(fs::read_to_string(&wrapper).unwrap(), template);
+        assert_eq!(
+            fs::read_to_string(&sidecar).unwrap().trim(),
+            wrapper_content_hash(&template),
+        );
+        assert_eq!(
+            fs::metadata(&wrapper).unwrap().modified().unwrap(),
+            wrapper_before,
+            "wrapper must not be rewritten when already up to date \
+             — otherwise every `freenet update` loops on it"
+        );
+        assert_eq!(
+            fs::metadata(&sidecar).unwrap().modified().unwrap(),
+            sidecar_before,
+            "sidecar must not be rewritten when wrapper is already up to date"
+        );
+    }
+
+    /// Self-heal: if the wrapper is up-to-date but the sidecar is
+    /// missing (a prior wrapper write succeeded but the sidecar write
+    /// failed, or a pre-#3967 install that happened to land on the
+    /// current template), the next `freenet update` must backfill
+    /// the sidecar so the NEXT user-modification protection works.
+    /// Without this, the host stays in the "no sidecar = treat as
+    /// ours" migration state forever and a later hand-edit would be
+    /// silently clobbered on the next template change.
+    /// Code-first-reviewer flagged this on PR #4286.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn ensure_service_file_updated_backfills_missing_sidecar() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let fake_home = tmp.path();
+        let _home = ScopedHome::new(fake_home);
+
+        let launch_agents = fake_home.join("Library/LaunchAgents");
+        fs::create_dir_all(&launch_agents).unwrap();
+        fs::write(launch_agents.join("org.freenet.node.plist"), "<plist/>").unwrap();
+
+        let wrapper_dir = fake_home.join(".local/bin");
+        fs::create_dir_all(&wrapper_dir).unwrap();
+        let binary = wrapper_dir.join("freenet");
+
+        // Wrapper is up-to-date but no sidecar exists (the gap the
+        // self-heal closes).
+        let wrapper = wrapper_dir.join("freenet-service-wrapper.sh");
+        let template = super::super::service::generate_wrapper_script(&binary);
+        fs::write(&wrapper, &template).unwrap();
+        let sidecar = wrapper.with_extension("sh.hash");
+        assert!(!sidecar.exists(), "precondition: no sidecar");
+
+        ensure_service_file_updated(&binary, /* quiet */ true).unwrap();
+
+        // Wrapper unchanged.
+        assert_eq!(fs::read_to_string(&wrapper).unwrap(), template);
+        // Sidecar now present with the right hash.
+        assert_eq!(
+            fs::read_to_string(&sidecar).unwrap().trim(),
+            wrapper_content_hash(&template),
+            "sidecar must be backfilled when wrapper is up-to-date \
+             but sidecar was missing"
+        );
+    }
+
+    /// Malformed (truncated / corrupted) sidecar must NOT lock the
+    /// host into permanent `UserModified`: treating a non-64-hex
+    /// sidecar as "no sidecar" lets the auto-update path recover
+    /// after an interrupted prior write. The wrapper here is stale,
+    /// so the malformed sidecar should fall through to WriteOurs
+    /// rather than UserModified. Code-first-reviewer flagged this
+    /// on PR #4286.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn ensure_service_file_updated_treats_malformed_sidecar_as_missing() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let fake_home = tmp.path();
+        let _home = ScopedHome::new(fake_home);
+
+        let launch_agents = fake_home.join("Library/LaunchAgents");
+        fs::create_dir_all(&launch_agents).unwrap();
+        fs::write(launch_agents.join("org.freenet.node.plist"), "<plist/>").unwrap();
+
+        let wrapper_dir = fake_home.join(".local/bin");
+        fs::create_dir_all(&wrapper_dir).unwrap();
+        let wrapper = wrapper_dir.join("freenet-service-wrapper.sh");
+        let stale = "#!/bin/bash\n# stale Jan 2026 wrapper, no pkill block\n";
+        fs::write(&wrapper, stale).unwrap();
+        // Corrupted / truncated sidecar — what a partial prior write
+        // could leave behind.
+        fs::write(wrapper.with_extension("sh.hash"), "deadbe").unwrap();
+
+        let binary = wrapper_dir.join("freenet");
+        ensure_service_file_updated(&binary, /* quiet */ true).unwrap();
+
+        // Wrapper must have been rewritten — the malformed sidecar
+        // didn't latch the host into UserModified.
+        let new_content = fs::read_to_string(&wrapper).unwrap();
+        assert_ne!(new_content, stale, "stale wrapper must be replaced");
+        let expected = super::super::service::generate_wrapper_script(&binary);
+        assert_eq!(new_content, expected);
+        // Sidecar replaced with a real hash.
+        let recorded = fs::read_to_string(wrapper.with_extension("sh.hash")).unwrap();
+        assert!(
+            is_valid_wrapper_hash(recorded.trim()),
+            "sidecar must now hold a valid SHA-256, got {recorded:?}"
         );
     }
 

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -1241,44 +1241,27 @@ pub(super) fn launchd_plist_needs_regen(content: &str) -> bool {
         || content.contains("Library/Logs/freenet/freenet.error.log")
 }
 
-/// Pure helper: decide whether the macOS launchd wrapper script needs
-/// regeneration by comparing the on-disk content to what
-/// `generate_wrapper_script` would produce *now*. Returns `true` for any
-/// difference — template drift, binary path move, manual edit, etc.
+/// Pure helper: macOS launchd wrapper needs regen iff the on-disk
+/// content differs from what `generate_wrapper_script` produces now.
 ///
-/// This replaces the older marker-substring check (issue #3967), which
-/// looked for `EXIT_CODE=$?` + `freenet update` + absence of the legacy
-/// log path. That check passed for the Jan 2026 wrapper, which had the
-/// auto-update hook but lacked the later-added orphan-killing
+/// Replaces the older marker-substring check (issue #3967), which
+/// returned `false` for the Jan 2026 wrapper that had the auto-update
+/// markers but lacked the later-added orphan-killing
 /// `pkill -f -u "$(id -u)" "freenet network"` block on startup. Hosts
-/// installed before the pkill block was added kept hitting exit-43
-/// loops on every launchd restart because the staleness check believed
-/// they were already current. Comparing to the current template
-/// content is robust against any template change without needing
-/// pattern-specific markers.
-///
-/// User-modification protection (so this doesn't silently overwrite a
-/// hand-edited wrapper) is layered on at the caller via a sidecar
-/// `freenet-service-wrapper.sh.hash` file; see
-/// `ensure_service_file_updated`.
-///
-/// Cross-platform-compiled (no `#[cfg(target_os = "macos")]`) so
-/// non-macOS CI runners can exercise the predicate per code-style.md /
-/// deployment.md preference for pure decision helpers. The
-/// `#[allow(dead_code)]` suppresses the dead-code lint on non-macOS
-/// builds where the only non-test caller (`ensure_service_file_updated`)
-/// is cfg'd out.
+/// installed with that wrapper sat in exit-43 loops for weeks because
+/// the staleness check believed they were already current.
+/// User-modification protection is layered on at the caller via the
+/// `freenet-service-wrapper.sh.hash` sidecar (see
+/// `ensure_service_file_updated`). `dead_code` allow + cross-platform
+/// compile so non-macOS CI exercises the predicate.
 #[allow(dead_code)]
 pub(super) fn wrapper_needs_regen(current_template: &str, on_disk: &str) -> bool {
     current_template != on_disk
 }
 
-/// Pure helper: SHA-256 hex digest of arbitrary bytes. Used to fingerprint
-/// the wrapper template we last wrote so a later `freenet update` can
-/// distinguish "Freenet's previous wrapper" from "a user-edited wrapper".
-///
-/// Cross-platform-compiled (string ops only) so non-macOS CI runners can
-/// exercise the helper.
+/// Pure helper: SHA-256 hex digest of `content`. Used to fingerprint the
+/// wrapper we last wrote so a later `freenet update` can distinguish
+/// "Freenet's previous wrapper" from "a user-edited wrapper" (#3967).
 #[allow(dead_code)]
 pub(super) fn wrapper_content_hash(content: &str) -> String {
     use sha2::{Digest, Sha256};
@@ -1311,18 +1294,12 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
     let wrapper_path = home_dir.join(".local/bin/freenet-service-wrapper.sh");
     let wrapper_hash_path = wrapper_path.with_extension("sh.hash");
 
-    // Generate what the wrapper SHOULD be now. We compare the on-disk
-    // wrapper to this byte-for-byte instead of grepping for individual
-    // markers — the marker approach (issue #3967) silently failed for
-    // hosts running the Jan 2026 wrapper, which carried the
-    // auto-update markers but lacked the later-added pkill-on-startup
-    // orphan kill. Equality covers any template change without
-    // requiring per-feature marker plumbing.
+    // Equality-check against the current template (see
+    // `wrapper_needs_regen` docs re: issue #3967).
     let new_wrapper_content = generate_wrapper_script(binary_path);
 
-    // Tri-state decision so we can warn (and skip) when the user has
-    // hand-edited their wrapper — overwriting it would lose their
-    // changes silently.
+    // Tri-state so we can warn (and skip) when the user has
+    // hand-edited their wrapper rather than silently overwriting it.
     enum WrapperPlan {
         UpToDate,
         WriteOurs,
@@ -1335,13 +1312,10 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
             WrapperPlan::UpToDate
         } else {
             let on_disk_hash = wrapper_content_hash(&on_disk);
-            // If the sidecar hash file records the hash we wrote last
-            // time, we know the wrapper is ours and is safe to
-            // overwrite. If it records a different hash, the user (or
-            // some other tool) modified the wrapper since we wrote it
-            // — back off. If the sidecar is missing entirely, treat
-            // the wrapper as ours (this is the migration case for
-            // pre-#3967 installs that never recorded a hash).
+            // Sidecar absent: pre-#3967 migration case, treat as ours.
+            // Sidecar matches on-disk hash: ours, safe to overwrite.
+            // Sidecar mismatches: user (or some tool) edited the
+            // wrapper since we wrote it — back off.
             match fs::read_to_string(&wrapper_hash_path) {
                 Ok(stored) if stored.trim() != on_disk_hash => {
                     WrapperPlan::UserModified(on_disk_hash)
@@ -1422,15 +1396,13 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
             }
         }
 
-        // Write the new wrapper script (already generated above for the
-        // staleness check; reuse it).
         fs::write(&wrapper_path, &new_wrapper_content).context("Failed to write wrapper script")?;
 
-        // Record the hash of what we just wrote so a later auto-update
-        // can distinguish "Freenet's previous wrapper" from "a
-        // user-edited wrapper". A failure to write the sidecar only
-        // weakens future user-modification protection — it does NOT
-        // invalidate the wrapper we just wrote, so warn but continue.
+        // Sidecar records the hash of what we just wrote so a later
+        // auto-update can detect a user-edited wrapper (#3967). A
+        // failed sidecar write only weakens future protection — it
+        // does NOT invalidate the wrapper we just wrote, so warn but
+        // continue.
         let new_hash = wrapper_content_hash(&new_wrapper_content);
         if let Err(e) = fs::write(&wrapper_hash_path, format!("{new_hash}\n")) {
             if !quiet {
@@ -2014,27 +1986,15 @@ StandardError=journal
     }
 
     // ---- Issue #3967: wrapper-content-equality staleness detection. ----
-    //
-    // The Jan 2026 macOS wrapper carried the auto-update markers
-    // (`EXIT_CODE=$?` + `freenet update`) but lacked the later-added
-    // orphan-killing `pkill -f -u "$(id -u)" "freenet network"` block
-    // on startup. Hosts installed with that wrapper kept hitting
-    // exit-43 loops on every launchd restart because the old
-    // marker-substring staleness check believed they were already
-    // current. These tests pin the new comparison: ANY drift between
-    // the on-disk wrapper and what `generate_wrapper_script` produces
-    // now triggers a regen, regardless of which markers are present.
-    //
-    // The pure helpers (wrapper_needs_regen, wrapper_content_hash)
-    // are cross-platform-compiled, so these tests run on every CI
-    // platform per deployment.md's preference.
+    // Pin: ANY drift between the on-disk wrapper and what
+    // `generate_wrapper_script` produces now must trigger regen,
+    // regardless of which markers are present. See `wrapper_needs_regen`
+    // docs for the Jan-2026 incident this guards against.
 
     #[test]
     fn wrapper_with_auto_update_hook_but_no_pkill_block_needs_regen_3967() {
-        // Synthetic Jan 2026 wrapper: has the auto-update markers
-        // (EXIT_CODE=$?, `freenet update`) but no pkill-on-startup
-        // orphan-kill block. The old marker check returned false
-        // here, leaving hosts stuck.
+        // Jan 2026 shape: has auto-update markers but no pkill-on-startup
+        // block. The old marker check returned false here.
         let jan_2026_wrapper = r#"#!/bin/bash
 BACKOFF=10
 while true; do
@@ -2047,10 +2007,6 @@ while true; do
     sleep $BACKOFF
 done
 "#;
-        // Stand in for the current template — different content,
-        // notably the pkill-on-startup block. We don't need to
-        // call the macOS-only generator here; any non-equal string
-        // exercises the same code path.
         let current_template = r#"#!/bin/bash
 pkill -f -u "$(id -u)" "freenet network" 2>/dev/null || true
 BACKOFF=10
@@ -2067,9 +2023,7 @@ done
         assert!(
             wrapper_needs_regen(current_template, jan_2026_wrapper),
             "Jan 2026 wrapper missing the pkill-on-startup block must \
-             be detected as needing regen (#3967). The old \
-             marker-substring check returned false here, leaving \
-             hosts stuck in exit-43 loops for weeks."
+             be detected as needing regen (#3967)."
         );
     }
 
@@ -2085,15 +2039,8 @@ done
 
     #[test]
     fn wrapper_needs_regen_detects_single_char_drift() {
-        // Round-trip an arbitrary template change: even a one-byte
-        // difference (e.g. a new flag, an added comment, a bumped
-        // backoff constant) must trigger regen, since the whole
-        // point of equality-based detection is to be robust to ALL
-        // template edits, not just the ones we anticipated.
-        let template_a = "BACKOFF=10\n";
-        let template_b = "BACKOFF=11\n";
         assert!(
-            wrapper_needs_regen(template_a, template_b),
+            wrapper_needs_regen("BACKOFF=10\n", "BACKOFF=11\n"),
             "any drift between template and on-disk wrapper must \
              trigger regen (#3967)"
         );
@@ -2192,18 +2139,12 @@ done
         let fake_home = tmp.path();
         let _home = ScopedHome::new(fake_home);
 
-        // The macOS branch only acts when the user has actually
-        // installed the service (plist exists). Lay down a stub
-        // plist so the branch proceeds.
+        // The macOS branch only acts when the plist exists.
         let launch_agents = fake_home.join("Library/LaunchAgents");
         fs::create_dir_all(&launch_agents).unwrap();
-        let plist = launch_agents.join("org.freenet.node.plist");
-        fs::write(&plist, "<plist/>").unwrap();
+        fs::write(launch_agents.join("org.freenet.node.plist"), "<plist/>").unwrap();
 
-        // Stale Jan-2026-shape wrapper: carries the auto-update
-        // markers the old check looked for, but no pkill-on-startup
-        // block. No hash sidecar exists (the file landed here before
-        // #3967).
+        // Stale Jan-2026-shape wrapper with no sidecar (pre-#3967 install).
         let wrapper_dir = fake_home.join(".local/bin");
         fs::create_dir_all(&wrapper_dir).unwrap();
         let wrapper = wrapper_dir.join("freenet-service-wrapper.sh");
@@ -2216,22 +2157,12 @@ done
         ensure_service_file_updated(&binary, /* quiet */ true)
             .expect("ensure_service_file_updated should succeed");
 
-        // Wrapper must have been rewritten (no longer matches the
-        // stale stub).
         let new_content = fs::read_to_string(&wrapper).unwrap();
-        assert_ne!(
-            new_content, stale,
-            "stale Jan-2026 wrapper must be replaced by ensure_service_file_updated (#3967)"
-        );
-        // The rewritten wrapper must match what generate_wrapper_script
-        // produces now — the whole point of equality-based detection.
         let expected = super::super::service::generate_wrapper_script(&binary);
         assert_eq!(
             new_content, expected,
-            "rewritten wrapper must equal the current template byte-for-byte"
+            "stale Jan-2026 wrapper must be replaced byte-for-byte by the current template (#3967)"
         );
-        // Hash sidecar must be present and match the new wrapper, so
-        // a future hand-edit is correctly flagged as user-modified.
         let recorded = fs::read_to_string(&hash_sidecar)
             .expect("hash sidecar must be written after a successful regen");
         assert_eq!(
@@ -2264,8 +2195,8 @@ done
         let wrapper = wrapper_dir.join("freenet-service-wrapper.sh");
         let user_edited = "#!/bin/bash\n# I have customized this myself\necho user\n";
         fs::write(&wrapper, user_edited).unwrap();
-        // Record a sidecar with some OTHER hash — i.e. as if Freenet
-        // wrote a wrapper earlier and the user then edited it.
+        // Sidecar hash that doesn't match the on-disk file: simulates
+        // Freenet writing the wrapper, then the user editing it.
         let stale_hash = wrapper_content_hash("something-different");
         fs::write(wrapper.with_extension("sh.hash"), format!("{stale_hash}\n")).unwrap();
 

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -1241,6 +1241,59 @@ pub(super) fn launchd_plist_needs_regen(content: &str) -> bool {
         || content.contains("Library/Logs/freenet/freenet.error.log")
 }
 
+/// Pure helper: decide whether the macOS launchd wrapper script needs
+/// regeneration by comparing the on-disk content to what
+/// `generate_wrapper_script` would produce *now*. Returns `true` for any
+/// difference — template drift, binary path move, manual edit, etc.
+///
+/// This replaces the older marker-substring check (issue #3967), which
+/// looked for `EXIT_CODE=$?` + `freenet update` + absence of the legacy
+/// log path. That check passed for the Jan 2026 wrapper, which had the
+/// auto-update hook but lacked the later-added orphan-killing
+/// `pkill -f -u "$(id -u)" "freenet network"` block on startup. Hosts
+/// installed before the pkill block was added kept hitting exit-43
+/// loops on every launchd restart because the staleness check believed
+/// they were already current. Comparing to the current template
+/// content is robust against any template change without needing
+/// pattern-specific markers.
+///
+/// User-modification protection (so this doesn't silently overwrite a
+/// hand-edited wrapper) is layered on at the caller via a sidecar
+/// `freenet-service-wrapper.sh.hash` file; see
+/// `ensure_service_file_updated`.
+///
+/// Cross-platform-compiled (no `#[cfg(target_os = "macos")]`) so
+/// non-macOS CI runners can exercise the predicate per code-style.md /
+/// deployment.md preference for pure decision helpers. The
+/// `#[allow(dead_code)]` suppresses the dead-code lint on non-macOS
+/// builds where the only non-test caller (`ensure_service_file_updated`)
+/// is cfg'd out.
+#[allow(dead_code)]
+pub(super) fn wrapper_needs_regen(current_template: &str, on_disk: &str) -> bool {
+    current_template != on_disk
+}
+
+/// Pure helper: SHA-256 hex digest of arbitrary bytes. Used to fingerprint
+/// the wrapper template we last wrote so a later `freenet update` can
+/// distinguish "Freenet's previous wrapper" from "a user-edited wrapper".
+///
+/// Cross-platform-compiled (string ops only) so non-macOS CI runners can
+/// exercise the helper.
+#[allow(dead_code)]
+pub(super) fn wrapper_content_hash(content: &str) -> String {
+    use sha2::{Digest, Sha256};
+    use std::fmt::Write;
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    hasher
+        .finalize()
+        .iter()
+        .fold(String::with_capacity(64), |mut s, b| {
+            write!(s, "{b:02x}").expect("writing to String is infallible");
+            s
+        })
+}
+
 #[cfg(target_os = "macos")]
 fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
     let home_dir = match dirs::home_dir() {
@@ -1256,20 +1309,51 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
     }
 
     let wrapper_path = home_dir.join(".local/bin/freenet-service-wrapper.sh");
+    let wrapper_hash_path = wrapper_path.with_extension("sh.hash");
 
-    // Check if wrapper script exists and has the update logic
-    let wrapper_needs_update = if wrapper_path.exists() {
-        let content = fs::read_to_string(&wrapper_path).context("Failed to read wrapper script")?;
-        // Check for key auto-update markers
-        !content.contains("EXIT_CODE=$?")
-            || !content.contains("freenet update")
-            // Force regeneration if the wrapper still writes lifecycle messages
-            // to a fixed unrotated freenet.log (issue #4251). Newer wrappers
-            // route those messages through `logger -t freenet`.
-            || content.contains("$HOME/Library/Logs/freenet/freenet.log")
+    // Generate what the wrapper SHOULD be now. We compare the on-disk
+    // wrapper to this byte-for-byte instead of grepping for individual
+    // markers — the marker approach (issue #3967) silently failed for
+    // hosts running the Jan 2026 wrapper, which carried the
+    // auto-update markers but lacked the later-added pkill-on-startup
+    // orphan kill. Equality covers any template change without
+    // requiring per-feature marker plumbing.
+    let new_wrapper_content = generate_wrapper_script(binary_path);
+
+    // Tri-state decision so we can warn (and skip) when the user has
+    // hand-edited their wrapper — overwriting it would lose their
+    // changes silently.
+    enum WrapperPlan {
+        UpToDate,
+        WriteOurs,
+        UserModified(String), // hex hash of the on-disk file
+    }
+
+    let plan = if wrapper_path.exists() {
+        let on_disk = fs::read_to_string(&wrapper_path).context("Failed to read wrapper script")?;
+        if !wrapper_needs_regen(&new_wrapper_content, &on_disk) {
+            WrapperPlan::UpToDate
+        } else {
+            let on_disk_hash = wrapper_content_hash(&on_disk);
+            // If the sidecar hash file records the hash we wrote last
+            // time, we know the wrapper is ours and is safe to
+            // overwrite. If it records a different hash, the user (or
+            // some other tool) modified the wrapper since we wrote it
+            // — back off. If the sidecar is missing entirely, treat
+            // the wrapper as ours (this is the migration case for
+            // pre-#3967 installs that never recorded a hash).
+            match fs::read_to_string(&wrapper_hash_path) {
+                Ok(stored) if stored.trim() != on_disk_hash => {
+                    WrapperPlan::UserModified(on_disk_hash)
+                }
+                _ => WrapperPlan::WriteOurs,
+            }
+        }
     } else {
-        true
+        WrapperPlan::WriteOurs
     };
+
+    let wrapper_needs_update = matches!(plan, WrapperPlan::WriteOurs);
 
     // Also force regeneration of the plist if it still points
     // StandardOutPath/StandardErrorPath at the unrotated freenet.log
@@ -1297,6 +1381,21 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
     // executable before we point launchd at it. If wrapper regen fails,
     // we exit BEFORE rewriting the plist so the system stays in its
     // previous-working state.
+    if let WrapperPlan::UserModified(on_disk_hash) = &plan {
+        if !quiet {
+            eprintln!(
+                "Warning: wrapper script at {} differs from the current Freenet \
+                 template AND from the hash recorded in {}, suggesting it has \
+                 been hand-edited. Leaving it alone. To accept the bundled \
+                 wrapper, delete the .sh.hash sidecar or reinstall via \
+                 `freenet service install`. (on-disk hash: {})",
+                wrapper_path.display(),
+                wrapper_hash_path.display(),
+                on_disk_hash,
+            );
+        }
+    }
+
     if wrapper_needs_update {
         if !quiet {
             println!("Updating service wrapper to add auto-update support...");
@@ -1323,9 +1422,27 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
             }
         }
 
-        // Generate and write new wrapper script
-        let wrapper_content = generate_wrapper_script(binary_path);
-        fs::write(&wrapper_path, &wrapper_content).context("Failed to write wrapper script")?;
+        // Write the new wrapper script (already generated above for the
+        // staleness check; reuse it).
+        fs::write(&wrapper_path, &new_wrapper_content).context("Failed to write wrapper script")?;
+
+        // Record the hash of what we just wrote so a later auto-update
+        // can distinguish "Freenet's previous wrapper" from "a
+        // user-edited wrapper". A failure to write the sidecar only
+        // weakens future user-modification protection — it does NOT
+        // invalidate the wrapper we just wrote, so warn but continue.
+        let new_hash = wrapper_content_hash(&new_wrapper_content);
+        if let Err(e) = fs::write(&wrapper_hash_path, format!("{new_hash}\n")) {
+            if !quiet {
+                eprintln!(
+                    "Warning: failed to write wrapper hash sidecar at {}: {}. \
+                     User-modification detection on the next `freenet update` \
+                     will fall back to treating the wrapper as ours.",
+                    wrapper_hash_path.display(),
+                    e
+                );
+            }
+        }
 
         // Make executable
         #[cfg(unix)]
@@ -1893,6 +2010,273 @@ StandardError=journal
         assert!(
             !launchd_plist_needs_regen(current),
             "current /dev/null plist must NOT be flagged for regen"
+        );
+    }
+
+    // ---- Issue #3967: wrapper-content-equality staleness detection. ----
+    //
+    // The Jan 2026 macOS wrapper carried the auto-update markers
+    // (`EXIT_CODE=$?` + `freenet update`) but lacked the later-added
+    // orphan-killing `pkill -f -u "$(id -u)" "freenet network"` block
+    // on startup. Hosts installed with that wrapper kept hitting
+    // exit-43 loops on every launchd restart because the old
+    // marker-substring staleness check believed they were already
+    // current. These tests pin the new comparison: ANY drift between
+    // the on-disk wrapper and what `generate_wrapper_script` produces
+    // now triggers a regen, regardless of which markers are present.
+    //
+    // The pure helpers (wrapper_needs_regen, wrapper_content_hash)
+    // are cross-platform-compiled, so these tests run on every CI
+    // platform per deployment.md's preference.
+
+    #[test]
+    fn wrapper_with_auto_update_hook_but_no_pkill_block_needs_regen_3967() {
+        // Synthetic Jan 2026 wrapper: has the auto-update markers
+        // (EXIT_CODE=$?, `freenet update`) but no pkill-on-startup
+        // orphan-kill block. The old marker check returned false
+        // here, leaving hosts stuck.
+        let jan_2026_wrapper = r#"#!/bin/bash
+BACKOFF=10
+while true; do
+    /usr/local/bin/freenet network
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -eq 42 ]; then
+        /usr/local/bin/freenet update --quiet
+        continue
+    fi
+    sleep $BACKOFF
+done
+"#;
+        // Stand in for the current template — different content,
+        // notably the pkill-on-startup block. We don't need to
+        // call the macOS-only generator here; any non-equal string
+        // exercises the same code path.
+        let current_template = r#"#!/bin/bash
+pkill -f -u "$(id -u)" "freenet network" 2>/dev/null || true
+BACKOFF=10
+while true; do
+    /usr/local/bin/freenet network
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -eq 42 ]; then
+        /usr/local/bin/freenet update --quiet
+        continue
+    fi
+    sleep $BACKOFF
+done
+"#;
+        assert!(
+            wrapper_needs_regen(current_template, jan_2026_wrapper),
+            "Jan 2026 wrapper missing the pkill-on-startup block must \
+             be detected as needing regen (#3967). The old \
+             marker-substring check returned false here, leaving \
+             hosts stuck in exit-43 loops for weeks."
+        );
+    }
+
+    #[test]
+    fn wrapper_identical_to_template_does_not_need_regen() {
+        let template = "#!/bin/bash\necho hi\n";
+        assert!(
+            !wrapper_needs_regen(template, template),
+            "byte-identical wrapper must NOT be flagged for regen — \
+             otherwise every `freenet update` would loop rewriting it"
+        );
+    }
+
+    #[test]
+    fn wrapper_needs_regen_detects_single_char_drift() {
+        // Round-trip an arbitrary template change: even a one-byte
+        // difference (e.g. a new flag, an added comment, a bumped
+        // backoff constant) must trigger regen, since the whole
+        // point of equality-based detection is to be robust to ALL
+        // template edits, not just the ones we anticipated.
+        let template_a = "BACKOFF=10\n";
+        let template_b = "BACKOFF=11\n";
+        assert!(
+            wrapper_needs_regen(template_a, template_b),
+            "any drift between template and on-disk wrapper must \
+             trigger regen (#3967)"
+        );
+    }
+
+    /// Calls the real macOS wrapper generator with synthetic inputs
+    /// so a future edit to `generate_wrapper_script` that introduces
+    /// nondeterminism (timestamps, random IDs, environment-dependent
+    /// strings) is caught at test time — otherwise every auto-update
+    /// would loop rewriting an "always-stale" wrapper.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn freshly_generated_wrapper_does_not_trigger_regen_loop() {
+        use std::path::PathBuf;
+        let binary = PathBuf::from("/Users/test/.local/bin/freenet");
+        let a = super::super::service::generate_wrapper_script(&binary);
+        let b = super::super::service::generate_wrapper_script(&binary);
+        assert!(
+            !wrapper_needs_regen(&a, &b),
+            "two calls to generate_wrapper_script with the same \
+             binary path must produce identical output — \
+             otherwise every auto-update would loop rewriting the \
+             wrapper"
+        );
+    }
+
+    #[test]
+    fn wrapper_content_hash_is_stable_and_distinct() {
+        let a = wrapper_content_hash("hello");
+        let b = wrapper_content_hash("hello");
+        let c = wrapper_content_hash("hello\n"); // trailing newline differs
+        assert_eq!(a, b, "hash must be deterministic for the same input");
+        assert_ne!(
+            a, c,
+            "hash must distinguish inputs differing by a single byte — \
+             otherwise the user-modification sidecar can't tell a \
+             hand-edited wrapper from Freenet's"
+        );
+        assert_eq!(
+            a.len(),
+            64,
+            "SHA-256 hex digest must be exactly 64 chars; the wrapper \
+             sidecar's trim() comparison relies on a stable encoding"
+        );
+    }
+
+    /// Shared mutex for tests that mutate `HOME`. Cargo runs unit
+    /// tests in parallel, so HOME-touching tests must serialize on
+    /// this lock or they'd see each other's tempdirs and the assertions
+    /// would become flaky.
+    #[cfg(target_os = "macos")]
+    static HOME_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// RAII guard that restores the prior `HOME` on drop. Tests use it
+    /// to point `ensure_service_file_updated` at a tempdir without
+    /// leaking that override to sibling tests.
+    #[cfg(target_os = "macos")]
+    struct ScopedHome {
+        prior: Option<std::ffi::OsString>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+    #[cfg(target_os = "macos")]
+    impl ScopedHome {
+        fn new(path: &std::path::Path) -> Self {
+            let lock = HOME_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            let prior = std::env::var_os("HOME");
+            std::env::set_var("HOME", path);
+            Self { prior, _lock: lock }
+        }
+    }
+    #[cfg(target_os = "macos")]
+    impl Drop for ScopedHome {
+        fn drop(&mut self) {
+            match self.prior.take() {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    /// End-to-end regression for issue #3967: a host with a stale
+    /// pre-pkill wrapper but no hash sidecar (the migration shape for
+    /// every existing install before this PR landed) must have its
+    /// wrapper rewritten by `ensure_service_file_updated`, and a hash
+    /// sidecar must be left behind so the NEXT update has
+    /// user-modification protection.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn ensure_service_file_updated_rewrites_pre_pkill_wrapper_and_records_hash() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().expect("create tempdir");
+        let fake_home = tmp.path();
+        let _home = ScopedHome::new(fake_home);
+
+        // The macOS branch only acts when the user has actually
+        // installed the service (plist exists). Lay down a stub
+        // plist so the branch proceeds.
+        let launch_agents = fake_home.join("Library/LaunchAgents");
+        fs::create_dir_all(&launch_agents).unwrap();
+        let plist = launch_agents.join("org.freenet.node.plist");
+        fs::write(&plist, "<plist/>").unwrap();
+
+        // Stale Jan-2026-shape wrapper: carries the auto-update
+        // markers the old check looked for, but no pkill-on-startup
+        // block. No hash sidecar exists (the file landed here before
+        // #3967).
+        let wrapper_dir = fake_home.join(".local/bin");
+        fs::create_dir_all(&wrapper_dir).unwrap();
+        let wrapper = wrapper_dir.join("freenet-service-wrapper.sh");
+        let stale = "#!/bin/bash\n# EXIT_CODE=$?\n# freenet update\n# (no pkill block!)\n";
+        fs::write(&wrapper, stale).unwrap();
+        let hash_sidecar = wrapper.with_extension("sh.hash");
+        assert!(!hash_sidecar.exists(), "test precondition: no sidecar yet");
+
+        let binary = wrapper_dir.join("freenet");
+        ensure_service_file_updated(&binary, /* quiet */ true)
+            .expect("ensure_service_file_updated should succeed");
+
+        // Wrapper must have been rewritten (no longer matches the
+        // stale stub).
+        let new_content = fs::read_to_string(&wrapper).unwrap();
+        assert_ne!(
+            new_content, stale,
+            "stale Jan-2026 wrapper must be replaced by ensure_service_file_updated (#3967)"
+        );
+        // The rewritten wrapper must match what generate_wrapper_script
+        // produces now — the whole point of equality-based detection.
+        let expected = super::super::service::generate_wrapper_script(&binary);
+        assert_eq!(
+            new_content, expected,
+            "rewritten wrapper must equal the current template byte-for-byte"
+        );
+        // Hash sidecar must be present and match the new wrapper, so
+        // a future hand-edit is correctly flagged as user-modified.
+        let recorded = fs::read_to_string(&hash_sidecar)
+            .expect("hash sidecar must be written after a successful regen");
+        assert_eq!(
+            recorded.trim(),
+            wrapper_content_hash(&new_content),
+            "recorded sidecar hash must match the wrapper we just wrote"
+        );
+    }
+
+    /// User-modification protection: when the on-disk wrapper differs
+    /// from the current template AND the recorded sidecar hash
+    /// doesn't match the on-disk content, `ensure_service_file_updated`
+    /// must leave the wrapper alone (preserving the user's edits).
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn ensure_service_file_updated_preserves_user_modified_wrapper() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().expect("create tempdir");
+        let fake_home = tmp.path();
+        let _home = ScopedHome::new(fake_home);
+
+        let launch_agents = fake_home.join("Library/LaunchAgents");
+        fs::create_dir_all(&launch_agents).unwrap();
+        fs::write(launch_agents.join("org.freenet.node.plist"), "<plist/>").unwrap();
+
+        let wrapper_dir = fake_home.join(".local/bin");
+        fs::create_dir_all(&wrapper_dir).unwrap();
+        let wrapper = wrapper_dir.join("freenet-service-wrapper.sh");
+        let user_edited = "#!/bin/bash\n# I have customized this myself\necho user\n";
+        fs::write(&wrapper, user_edited).unwrap();
+        // Record a sidecar with some OTHER hash — i.e. as if Freenet
+        // wrote a wrapper earlier and the user then edited it.
+        let stale_hash = wrapper_content_hash("something-different");
+        fs::write(wrapper.with_extension("sh.hash"), format!("{stale_hash}\n")).unwrap();
+
+        let binary = wrapper_dir.join("freenet");
+        ensure_service_file_updated(&binary, /* quiet */ true)
+            .expect("ensure_service_file_updated should succeed even when skipping");
+
+        let still_on_disk = fs::read_to_string(&wrapper).unwrap();
+        assert_eq!(
+            still_on_disk, user_edited,
+            "user-modified wrapper must be preserved (sidecar hash mismatch)"
         );
     }
 


### PR DESCRIPTION
## Problem

`ensure_service_file_updated` (macOS branch) decided whether the
on-disk launchd wrapper was stale by grepping for a fixed set of
marker substrings (`EXIT_CODE=$?` + `freenet update` + absence of the
legacy log path). Any future template change whose markers weren't
part of the check was silently invisible — including the orphan-killing
`pkill -f -u "$(id -u)" "freenet network"` block added on startup
after the Jan 2026 wrapper.

Two independent production hosts hit this in two weeks: their Jan 16
wrappers passed the marker check on every `freenet update`, so they
never received the pkill block, and a `freenet network` orphan with
PPID=1 kept holding port 7509 across launchd restarts. Both nodes
silently served stale assets for ~19 days until a human noticed.

## Solution

Replace the marker grep with a byte-for-byte comparison against what
`generate_wrapper_script` produces now — any template drift, binary
path move, or hand-edit triggers a regen. To avoid silently overwriting
hand-edited wrappers, also write a `freenet-service-wrapper.sh.hash`
sidecar recording the SHA-256 of what we last wrote. A mismatch
between the sidecar and the on-disk hash blocks the rewrite with a
warning instead of clobbering the user's edits.

Both `freenet service install` (fresh installs) and
`ensure_service_file_updated` (auto-update path) write the sidecar
through a shared `write_wrapper_hash_sidecar` helper so the on-disk
format is single-source-of-truth.

**Migration:** pre-#3967 installs have no sidecar; that case is
treated as "ours" so the next auto-update fixes the wrapper and then
records the sidecar for future user-modification protection. The
existing `.sh.bak` backup is still written first, so a regen is
recoverable. Malformed (truncated/corrupted) sidecars are also
treated as "missing" rather than locking the host into permanent
UserModified.

**Self-heal:** if the wrapper is up-to-date but the sidecar is
missing or malformed (e.g. a prior sidecar write failed), the next
update backfills it. Without this self-heal, a host that lost its
sidecar would stay in the migration state forever and a future
hand-edit could be silently clobbered.

## Architecture

The decision logic is a cross-platform pure helper
`decide_wrapper_action(template, on_disk_wrapper?, sidecar?) ->
WrapperAction`. The macOS-only `ensure_service_file_updated` just
gathers the inputs and dispatches on the action. Every CI runner —
not just macOS — exercises the full decision matrix via the pure
helper tests below.

## Scope

This PR addresses **the deployment gap that caused the two production
incidents** (items 1 and 2 of issue #3967's checklist: re-template on
update; self-healing wrapper). The remaining acceptance criteria are
filed as follow-ups so they don't get lost:

- **#4287** — Linux systemd unit uses the same fragile marker pattern;
  apply the same equality + sidecar treatment.
- **#4288** — surface stuck-wrapper to the user after N consecutive
  failures (notification or homepage banner).
- **#4289** — homepage detects asset/runtime version mismatch and
  shows a warning.
- **#4290** — `freenet uninstall` should clean up the wrapper +
  sidecar + .bak files.

Per the global `finish-the-fix.md` rule: the user-visible symptom
(silent stale-asset serving for 19 days on macOS) goes away with
this PR alone, because the deployed wrapper finally gets the pkill
block. The other items are real but not load-bearing on the
reported symptom.

## Testing

**Cross-platform pure-helper tests** (run on every CI runner):

- `decide_wrapper_action_no_wrapper_writes_ours`
- `decide_wrapper_action_stale_wrapper_no_sidecar_writes_ours_3967` —
  Jan 2026 migration shape.
- `decide_wrapper_action_stale_wrapper_matching_sidecar_writes_ours`
- `decide_wrapper_action_stale_wrapper_with_trailing_newline_sidecar` —
  pins the `\n`-suffixed on-disk format.
- `decide_wrapper_action_user_modified_wrapper_is_preserved`
- `decide_wrapper_action_malformed_sidecar_treated_as_missing_3967`
- `decide_wrapper_action_up_to_date_with_matching_sidecar_is_noop` —
  install -> update no-op contract.
- `decide_wrapper_action_up_to_date_with_missing_sidecar_backfills` —
  self-heal.
- `decide_wrapper_action_up_to_date_with_malformed_sidecar_backfills`
- `wrapper_with_auto_update_hook_but_no_pkill_block_needs_regen_3967` —
  the original incident reproduced as a pin test.
- `wrapper_identical_to_template_does_not_need_regen` — no regen loop.
- `wrapper_needs_regen_detects_single_char_drift`
- `is_valid_wrapper_hash_accepts_real_sha256_hex_only` — sidecar
  validation: rejects empty, truncated, too-long, uppercase, non-hex.
- `wrapper_content_hash_is_stable_and_distinct`

**macOS-only end-to-end tests** (run when CI is on macOS; serve as
integration coverage):

- `freshly_generated_wrapper_does_not_trigger_regen_loop` — calls
  the real `generate_wrapper_script` and asserts determinism.
- `ensure_service_file_updated_rewrites_pre_pkill_wrapper_and_records_hash`
- `ensure_service_file_updated_is_noop_after_fresh_install`
- `ensure_service_file_updated_backfills_missing_sidecar`
- `ensure_service_file_updated_treats_malformed_sidecar_as_missing`
- `ensure_service_file_updated_preserves_user_modified_wrapper`

`cargo fmt`, `cargo clippy --all-targets -p freenet -- -D warnings`,
and `cargo test -p freenet` all clean locally (163 bin tests pass,
2743 lib tests pass).

## Why didn't CI catch this?

The old marker-based staleness check was a self-referential predicate:
a unit test asserting `contains("EXIT_CODE=$?")` doesn't verify
whether the on-disk artifact actually matches the current template.
The new equality-based check is naturally self-validating, and the
extraction of `decide_wrapper_action` into a pure helper means every
branch runs on every CI runner regardless of target OS.

Addresses #3967 (macOS item; see also #4287, #4288, #4289, #4290 for
the remaining acceptance criteria).

[AI-assisted - Claude]