### PR TITLE
refactor(delegate): avoid unnecessary Vec allocations in context handling

### DIFF
--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -373,7 +373,10 @@ impl Runtime {
                 }
 
                 OutboundDelegateMsg::ContextUpdated(new_context) => {
-                    *context = new_context.as_ref().to_vec();
+                    // Port #4242: reuse backing allocation instead of
+                    // unconditionally allocating a new Vec<u8>.
+                    context.clear();
+                    context.extend_from_slice(new_context.as_ref());
                 }
                 OutboundDelegateMsg::GetContractRequest(req) if !req.processed => {
                     tracing::debug!(
@@ -391,7 +394,8 @@ impl Runtime {
                     ..
                 }) => {
                     tracing::debug!("GetContractRequest processed");
-                    *context = ctx.as_ref().to_vec();
+                    context.clear();
+                    context.extend_from_slice(ctx.as_ref());
                 }
                 OutboundDelegateMsg::PutContractRequest(req) if !req.processed => {
                     tracing::debug!(
@@ -409,7 +413,8 @@ impl Runtime {
                     ..
                 }) => {
                     tracing::debug!("PutContractRequest processed");
-                    *context = ctx.as_ref().to_vec();
+                    context.clear();
+                    context.extend_from_slice(ctx.as_ref());
                 }
                 OutboundDelegateMsg::UpdateContractRequest(req) if !req.processed => {
                     tracing::debug!(
@@ -427,7 +432,8 @@ impl Runtime {
                     ..
                 }) => {
                     tracing::debug!("UpdateContractRequest processed");
-                    *context = ctx.as_ref().to_vec();
+                    context.clear();
+                    context.extend_from_slice(ctx.as_ref());
                 }
                 OutboundDelegateMsg::SubscribeContractRequest(req) if !req.processed => {
                     tracing::debug!(
@@ -445,7 +451,8 @@ impl Runtime {
                     ..
                 }) => {
                     tracing::debug!("SubscribeContractRequest processed");
-                    *context = ctx.as_ref().to_vec();
+                    context.clear();
+                    context.extend_from_slice(ctx.as_ref());
                 }
                 OutboundDelegateMsg::SendDelegateMessage(mut msg) if !msg.processed => {
                     tracing::debug!(
@@ -479,7 +486,8 @@ impl Runtime {
                     context: ctx, ..
                 }) => {
                     tracing::debug!("SendDelegateMessage processed");
-                    *context = ctx.as_ref().to_vec();
+                    context.clear();
+                    context.extend_from_slice(ctx.as_ref());
                 }
             }
         }
@@ -547,6 +555,12 @@ impl DelegateRuntimeInterface for Runtime {
                         processed,
                         ..
                     }) => {
+                        // Port #4242: context attached to ApplicationMessage
+                        // is read by delegates that need message-level context
+                        // (e.g. test-delegate-integration).  The clone here is
+                        // kept because the message must own its own copy; the
+                        // second copy (for exec_inbound_with_env) uses
+                        // `std::mem::take` to avoid a second allocation.
                         let app_msg = InboundDelegateMsg::ApplicationMessage(
                             ApplicationMessage::new(payload)
                                 .processed(processed)
@@ -558,7 +572,7 @@ impl DelegateRuntimeInterface for Runtime {
                             params,
                             origin,
                             &app_msg,
-                            context.clone(),
+                            std::mem::take(&mut context),
                             &running.handle,
                             instance_id,
                             api_version,
@@ -583,7 +597,7 @@ impl DelegateRuntimeInterface for Runtime {
                             params,
                             origin,
                             &InboundDelegateMsg::UserResponse(response),
-                            context.clone(),
+                            std::mem::take(&mut context),
                             &running.handle,
                             instance_id,
                             api_version,
@@ -608,7 +622,7 @@ impl DelegateRuntimeInterface for Runtime {
                             params,
                             origin,
                             &InboundDelegateMsg::GetContractResponse(response),
-                            context.clone(),
+                            std::mem::take(&mut context),
                             &running.handle,
                             instance_id,
                             api_version,
@@ -637,7 +651,7 @@ impl DelegateRuntimeInterface for Runtime {
                             params,
                             origin,
                             &msg,
-                            context.clone(),
+                            std::mem::take(&mut context),
                             &running.handle,
                             instance_id,
                             api_version,
@@ -667,7 +681,7 @@ impl DelegateRuntimeInterface for Runtime {
                             params,
                             origin,
                             &other,
-                            context.clone(),
+                            std::mem::take(&mut context),
                             &running.handle,
                             instance_id,
                             api_version,

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -373,7 +373,7 @@ impl Runtime {
                 }
 
                 OutboundDelegateMsg::ContextUpdated(new_context) => {
-                    // Port #4242: re-use buffer to avoid alloc churn.
+                    // avoid alloc churn — buffer reuse instead of to_vec
                     context.clear();
                     context.extend_from_slice(new_context.as_ref());
                 }
@@ -554,7 +554,7 @@ impl DelegateRuntimeInterface for Runtime {
                         processed,
                         ..
                     }) => {
-                        // Port #4242: clone kept — delegates read message context (e.g. test-delegate-integration).
+                        // clone kept — delegates read message-level context
                         let app_msg = InboundDelegateMsg::ApplicationMessage(
                             ApplicationMessage::new(payload)
                                 .processed(processed)

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -373,8 +373,7 @@ impl Runtime {
                 }
 
                 OutboundDelegateMsg::ContextUpdated(new_context) => {
-                    // Port #4242: reuse backing allocation instead of
-                    // unconditionally allocating a new Vec<u8>.
+                    // Port #4242: re-use buffer to avoid alloc churn.
                     context.clear();
                     context.extend_from_slice(new_context.as_ref());
                 }
@@ -555,12 +554,7 @@ impl DelegateRuntimeInterface for Runtime {
                         processed,
                         ..
                     }) => {
-                        // Port #4242: context attached to ApplicationMessage
-                        // is read by delegates that need message-level context
-                        // (e.g. test-delegate-integration).  The clone here is
-                        // kept because the message must own its own copy; the
-                        // second copy (for exec_inbound_with_env) uses
-                        // `std::mem::take` to avoid a second allocation.
+                        // Port #4242: clone kept — delegates read message context (e.g. test-delegate-integration).
                         let app_msg = InboundDelegateMsg::ApplicationMessage(
                             ApplicationMessage::new(payload)
                                 .processed(processed)


### PR DESCRIPTION
## Summary

Closes #4242 — two low-risk allocation reductions in the delegate runtime message loop.

## Changes

### 1. `to_vec()` → `clear()` + `extend_from_slice()` (6 sites)

`process_outbound` unconditionally allocated a new `Vec<u8>` on every
outbound message that carried context:

```rust
// Before
*context = ctx.as_ref().to_vec();

// After
context.clear();
context.extend_from_slice(ctx.as_ref());
```

Affected variants: `ContextUpdated`, `GetContractRequest`,
`PutContractRequest`, `UpdateContractRequest`,
`SubscribeContractRequest`, `SendDelegateMessage`.

### 2. `context.clone()` → `std::mem::take()` (5 sites)

`inbound_app_message` cloned the whole context `Vec<u8>` to pass to
`exec_inbound_with_env`, which immediately consumes it.  Replaced with
`std::mem::take(&mut context)` — O(1) pointer swap, same ownership
transfer.

The one remaining `context.clone()` is on
`ApplicationMessage::with_context()` — delegates like
`test-delegate-integration` read the message-level context, so the
message must own its own copy.

## Not included

- `Arc<Vec<u8>>` for the delegate context — premature without a
  real-world read-heavy delegate.  Would require changing signatures
  in `exec_inbound_with_env` and `DelegateCallEnv` plus clone-on-write
  in `native_api`.
- Clones in response constructors (`put_request.context.clone()` etc.)
  — outside the hot loop.

## Checklist

- [x] `cargo fmt` — clean
- [x] `cargo check -p freenet` — passes
- [x] No behavioural change — all call sites retain identical
  ownership semantics
