### PR TITLE
feat(home_page): dashboard polish — empty-state skeleton, Gov column, hosted-on-ring

### DIFF
--- a/crates/core/src/contract/governance.rs
+++ b/crates/core/src/contract/governance.rs
@@ -461,6 +461,15 @@ impl GovernanceManager {
         self.config.mode
     }
 
+    /// MAD detector's `min_samples` threshold — the number of
+    /// contracts needed for outlier scoring to activate. Surfaced
+    /// on the dashboard so the empty-state message can read
+    /// "Observed N / min_samples contracts needed" without
+    /// hard-coding the threshold at the render site.
+    pub(crate) fn outlier_min_samples(&self) -> usize {
+        self.config.outlier.min_samples
+    }
+
     /// Read the latest network-norms snapshot, if any tick has run.
     /// Used by the dashboard snapshot builder.
     pub(crate) fn latest_norms(&self) -> Option<NetworkNormsCache> {

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -620,6 +620,15 @@ pub struct PeerSnapshot {
 pub struct ContractSnapshot {
     pub key_short: String,
     pub key_full: String,
+    /// `ContractKey.id().to_string()` — the 32-byte content hash
+    /// portion of the key. Distinct from `key_full` which carries
+    /// the full ContractKey encoding (instance id + parameters /
+    /// code-hash bookkeeping). Surfaced so the dashboard can
+    /// cross-reference this contract against
+    /// `GovernanceSnapshot.state_by_id`, which is keyed by
+    /// `ContractInstanceId::to_string()`. Codex review of
+    /// dashboard-polish PR caught the id/key string mismatch.
+    pub instance_id: String,
     pub subscribed_secs: u64,
     pub last_updated_secs: Option<u64>,
 }
@@ -743,6 +752,7 @@ pub fn get_snapshot() -> Option<NetworkStatusSnapshot> {
                 .into_iter()
                 .map(|c| {
                     let key_full = c.key.to_string();
+                    let instance_id = c.key.id().to_string();
                     // Use char boundary for safe truncation (contract keys
                     // are base58/ASCII, but be defensive against future
                     // encoding changes).
@@ -755,6 +765,7 @@ pub fn get_snapshot() -> Option<NetworkStatusSnapshot> {
                     ContractSnapshot {
                         key_short,
                         key_full,
+                        instance_id,
                         subscribed_secs: c.subscribed_secs,
                         last_updated_secs: c.last_updated_secs,
                     }

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -472,11 +472,35 @@ pub struct GovernanceSnapshot {
     /// Off / DryRun / Enforce — visible on the dashboard as the
     /// "mode" pill.
     pub mode: GovernanceModeSnapshot,
-    /// One entry per contract the manager is currently tracking.
+    /// One entry per contract the manager is currently tracking
+    /// AND flagged (Borderline / WouldEvict / Evicted / Banned).
+    /// Normal contracts are excluded to keep the snapshot cheap on
+    /// large nodes — see `Ring::iter_flagged_scores`.
     pub contracts: Vec<ContractGovernanceEntry>,
+    /// Total count of contracts the manager is scoring (including
+    /// Normal). Surfaces on the dashboard as "Observed N / 30
+    /// contracts needed for scoring" — gives operators a progress
+    /// signal during the ramp-up window where the existing
+    /// `contracts` list is empty.
+    pub observed_count: usize,
+    /// `min_samples` from the outlier detector config — the
+    /// threshold at which the MAD distribution becomes reliable.
+    /// Surfaced so the dashboard can render "Observed N / `M`"
+    /// without hard-coding 30.
+    pub min_samples: usize,
     /// Network-level statistics from the last reaper tick. Drives
     /// the median / MAD / threshold / sample-size mini-tiles.
     pub norms: NetworkNorms,
+    /// When the reaper tick last ran. Surfaces as "Last evaluated
+    /// Ns ago" on the dashboard so operators can tell if the
+    /// scoring engine is alive even when there are no decisions
+    /// to log. None when the reaper has not run yet.
+    pub last_tick_at: Option<tokio::time::Instant>,
+    /// Map from `ContractInstanceId.to_string()` → governance
+    /// state. Lets the Subscribed Contracts table cross-reference
+    /// each row to its current governance state without iterating
+    /// the `contracts` list per row.
+    pub state_by_id: std::collections::HashMap<String, GovernanceStateSnapshot>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2165,10 +2165,28 @@ impl Ring {
             None => ns::NetworkNorms::default(),
         };
 
+        // state_by_id: map ContractInstanceId → state for the
+        // Subscribed Contracts table's Gov column cross-reference.
+        // Walking iter_flagged_scores() once for the `contracts`
+        // list above gave us the flagged set; for unflagged
+        // contracts the absence from this map means "Normal".
+        let state_by_id: std::collections::HashMap<String, ns::GovernanceStateSnapshot> = contracts
+            .iter()
+            .map(|c| (c.instance_id.clone(), c.state))
+            .collect();
+
+        let observed_count = self.governance.len();
+        let min_samples = self.governance.outlier_min_samples();
+        let last_tick_at = self.governance.latest_norms().map(|n| n.at);
+
         ns::GovernanceSnapshot {
             mode,
             contracts,
+            observed_count,
+            min_samples,
             norms,
+            last_tick_at,
+            state_by_id,
         }
     }
 

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -473,7 +473,12 @@ fn build_peers_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> Str
         );
     }
 
-    let ring_svg = build_ring_svg(snap.own_location, &snap.peers, Some(&snap.governance));
+    let ring_svg = build_ring_svg(
+        snap.own_location,
+        &snap.peers,
+        Some(&snap.governance),
+        &snap.contracts,
+    );
 
     let mut rows = String::new();
     for p in &snap.peers {
@@ -545,6 +550,7 @@ fn build_ring_svg(
     own_location: Option<f64>,
     peers: &[network_status::PeerSnapshot],
     governance: Option<&network_status::GovernanceSnapshot>,
+    hosted_contracts: &[network_status::ContractSnapshot],
 ) -> String {
     // Render when there's *something* to show. The historical guard
     // (at least one peer with a location) still applies.
@@ -639,19 +645,56 @@ fn build_ring_svg(
         }
     }
 
+    // Deterministic hash → ring location for placing contracts.
+    // The instance id is a 32-byte content hash; we fold the
+    // string form to a u64 and modulo onto [0, 1). Position is
+    // stable across refreshes (same id → same dot location).
+    let hash_to_loc = |s: &str| -> f64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut h = DefaultHasher::new();
+        s.hash(&mut h);
+        (h.finish() % 10_000) as f64 / 10_000.0
+    };
+
+    // === Hosted contracts on the inner ring (faint dots) ===
+    //
+    // Before drawing flagged-contract markers, draw ALL hosted
+    // contracts as faint dim dots so the inner ring isn't visually
+    // empty in healthy state. Hosted-contract data comes from the
+    // Subscribed Contracts list (different source from governance,
+    // which only carries flagged entries). A contract that's also
+    // flagged will get a brighter overlay drawn on top below.
+    //
+    // This addresses the "inner ring looks broken" finding from the
+    // UI feedback doc — operators saw the CONTRACTS wordmark with
+    // no dots beneath it and assumed the renderer was unfinished.
+    let governance_ids: std::collections::HashSet<&str> = governance
+        .map(|g| g.contracts.iter().map(|c| c.instance_id.as_str()).collect())
+        .unwrap_or_default();
+    for c in hosted_contracts {
+        // Skip contracts that are flagged — they get a more visible
+        // marker in the flagged-rendering loop below. Drawing them
+        // here would just be overlapped.
+        if governance_ids.contains(c.key_full.as_str()) {
+            continue;
+        }
+        let loc = hash_to_loc(&c.key_full);
+        let (kx, ky) = loc_to_xy(loc, r_inner);
+        // Dim teal dot — same brand color as YOU but smaller and
+        // translucent so flagged dots stand out by contrast.
+        write!(
+            svg,
+            "<circle cx=\"{x:.1}\" cy=\"{y:.1}\" r=\"2.5\" fill=\"#43c178\" fill-opacity=\"0.45\"><title>{title}</title></circle>",
+            x = kx,
+            y = ky,
+            title = html_escape(&format!("{} (hosted)", &c.key_short)),
+        )
+        .ok();
+    }
+
     // === Contract dots (and YOU → flagged-contract curves) ===
     if let Some(gov) = governance {
-        // Deterministic hash → ring location for placing contracts.
-        // The instance id is a 32-byte content hash; we fold the
-        // string form to a u64 and modulo onto [0, 1). Position is
-        // stable across refreshes (same id → same dot location).
-        let hash_to_loc = |s: &str| -> f64 {
-            use std::collections::hash_map::DefaultHasher;
-            use std::hash::{Hash, Hasher};
-            let mut h = DefaultHasher::new();
-            s.hash(&mut h);
-            (h.finish() % 10_000) as f64 / 10_000.0
-        };
         for c in &gov.contracts {
             let loc = hash_to_loc(&c.instance_id);
             let (kx, ky) = loc_to_xy(loc, r_inner);
@@ -772,17 +815,119 @@ fn build_governance_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
     };
     let g = &snap.governance;
 
-    // Empty state: no contracts tracked yet (cold start, or this
-    // build doesn't have the governance manager enabled). Per the
-    // design principle — show nothing rather than show fabricated
-    // data. The "history strip" pattern from the prototype lives
-    // here as a single compact line so the absence reads as
-    // working-correctly rather than missing-panel.
+    let mode_txt = match g.mode {
+        network_status::GovernanceModeSnapshot::Off => "off",
+        network_status::GovernanceModeSnapshot::DryRun => "dry-run",
+        network_status::GovernanceModeSnapshot::Enforce => "enforce",
+    };
+
+    let last_tick_footer = match g.last_tick_at {
+        Some(at) => {
+            // Compute "Ns ago" using TOKIO instant arithmetic via
+            // a wall-clock comparison. The snapshot was built
+            // moments ago so we can approximate "now" inline.
+            let now = tokio::time::Instant::now();
+            let secs = now.saturating_duration_since(at).as_secs();
+            format!("Last evaluated {} ago", format_ago(secs))
+        }
+        None => "Reaper has not yet ticked".to_string(),
+    };
+
+    // Empty state: no FLAGGED contracts. Render the structural
+    // skeleton (mode pill, 5-tile mini-strip with em-dashes if data
+    // is unavailable, observed/required progress) rather than just a
+    // paragraph — teaches operators what data will appear and what
+    // mode is active. The previous empty state hid this and made
+    // an operator think the dashboard was half-implemented.
     if g.contracts.is_empty() {
-        return r#"<div class="card">
-            <h2>Contract Governance</h2>
-            <p class="empty">Not enough contracts observed yet. Governance scoring activates once this node has seen at least 30 contracts and they have had time to accumulate cost/benefit signals.</p>
-        </div>"#.to_string();
+        let observed = g.observed_count;
+        let needed = g.min_samples;
+        let progress_msg = if needed == 0 {
+            "Governance manager is not yet wired.".to_string()
+        } else if observed == 0 {
+            format!(
+                "No contracts observed yet. Scoring activates after {needed} contracts \
+                 have accumulated cost/benefit signals."
+            )
+        } else if observed < needed {
+            format!(
+                "Observed {observed} / {needed} contracts needed for statistical scoring. \
+                 Scoring activates once {needed_remaining} more contracts accumulate \
+                 cost/benefit signals.",
+                needed_remaining = needed - observed,
+            )
+        } else {
+            // Enough samples observed but none flagged — that's the
+            // healthy steady state.
+            format!(
+                "All {observed} tracked contracts within normal range. \
+                 (Scored against the network's own observed distribution.)"
+            )
+        };
+        let verdict_main = if observed >= needed {
+            format!(
+                r#"<div class="verdict-num">✓</div>
+                   <div class="verdict-headline">{observed} contracts within normal range</div>
+                   <div class="verdict-detail">No flags raised.</div>"#
+            )
+        } else {
+            format!(
+                r#"<div class="verdict-num">{observed}<span class="verdict-num-denom">/{needed}</span></div>
+                   <div class="verdict-headline">contracts observed</div>
+                   <div class="verdict-detail">Scoring activates at {needed}.</div>"#
+            )
+        };
+
+        // 5-tile skeleton — render even with no data, using em-dashes
+        // for missing values. This shows operators what fields will
+        // populate as the reaper ticks.
+        let median_txt = g
+            .norms
+            .median_log_ratio
+            .map(|v| format!("{:.2}", v))
+            .unwrap_or_else(|| "—".to_string());
+        let mad_txt = g
+            .norms
+            .mad
+            .map(|v| format!("{:.2}", v))
+            .unwrap_or_else(|| "—".to_string());
+        let threshold_txt = g
+            .norms
+            .threshold
+            .map(|v| format!("{:.2}", v))
+            .unwrap_or_else(|| "—".to_string());
+        let sample_size_txt = if g.norms.sample_size == 0 {
+            "—".to_string()
+        } else {
+            g.norms.sample_size.to_string()
+        };
+
+        return format!(
+            r##"<div class="card">
+                <div class="card-header"><h2>Contract Governance</h2><span class="g-mode g-mode-{mode}">{mode}</span></div>
+                <div class="g-verdict-row">
+                    <div class="g-verdict verdict-ok">{verdict_main}</div>
+                    <div class="g-norms">
+                        <div class="g-norm"><div class="g-norm-label">Tracked</div><div class="g-norm-value">{observed}</div></div>
+                        <div class="g-norm"><div class="g-norm-label">Sample size</div><div class="g-norm-value">{sample_size}</div></div>
+                        <div class="g-norm"><div class="g-norm-label">Median log-ratio</div><div class="g-norm-value">{median}</div></div>
+                        <div class="g-norm"><div class="g-norm-label">MAD spread</div><div class="g-norm-value">{mad}</div></div>
+                        <div class="g-norm"><div class="g-norm-label">Eviction threshold</div><div class="g-norm-value">{threshold}</div></div>
+                    </div>
+                </div>
+                <p class="empty" style="margin: 0.6rem 0.9rem 0.2rem; font-size: 0.9rem;">{progress}</p>
+                <p class="empty" style="margin: 0 0.9rem 0.6rem; font-size: 0.78rem; color: var(--text-muted, #888);">{tick_footer}</p>
+            </div>"##,
+            mode = mode_txt,
+            verdict_main = verdict_main,
+            observed = observed,
+            sample_size = sample_size_txt,
+            median = median_txt,
+            mad = mad_txt,
+            threshold = threshold_txt,
+            progress = progress_msg,
+            tick_footer = last_tick_footer,
+        );
     }
 
     // Verdict counts. Mirror state-snapshot enum → string.
@@ -863,11 +1008,9 @@ fn build_governance_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
         .map(|v| format!("{:.2}", v))
         .unwrap_or_else(|| "—".to_string());
     let sample_size_txt = g.norms.sample_size.to_string();
-    let mode_txt = match g.mode {
-        network_status::GovernanceModeSnapshot::Off => "off",
-        network_status::GovernanceModeSnapshot::DryRun => "dry-run",
-        network_status::GovernanceModeSnapshot::Enforce => "enforce",
-    };
+    // `mode_txt` and `last_tick_footer` are in scope from the top
+    // of this function (defined once, reused in both empty and
+    // populated branches).
 
     // Per-contract table — flagged-only by default; an "all" link
     // could come later. Honest principle: this table reflects the
@@ -934,13 +1077,14 @@ fn build_governance_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
         rows = r#"<tr><td colspan="6" class="empty" style="padding: 0.5rem 0.9rem">All contracts within normal range.</td></tr>"#.to_string();
     }
 
+    let tracked_total = g.observed_count.max(total);
     format!(
         r##"<div class="card">
             <div class="card-header"><h2>Contract Governance</h2><span class="g-mode g-mode-{mode}">{mode}</span></div>
             <div class="g-verdict-row">
                 <div class="g-verdict {verdict_class}">{verdict_main}</div>
                 <div class="g-norms">
-                    <div class="g-norm"><div class="g-norm-label">Tracked</div><div class="g-norm-value">{total}</div></div>
+                    <div class="g-norm"><div class="g-norm-label">Tracked</div><div class="g-norm-value">{tracked_total}</div></div>
                     <div class="g-norm"><div class="g-norm-label">Sample size</div><div class="g-norm-value">{sample_size}</div></div>
                     <div class="g-norm"><div class="g-norm-label">Median log-ratio</div><div class="g-norm-value">{median}</div></div>
                     <div class="g-norm"><div class="g-norm-label">MAD spread</div><div class="g-norm-value">{mad}</div></div>
@@ -953,11 +1097,13 @@ fn build_governance_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
                     <tbody>{rows}</tbody>
                 </table>
             </div>
+            <p class="empty" style="margin: 0.4rem 0.9rem 0.6rem; font-size: 0.78rem; color: var(--text-muted, #888);">{tick_footer}</p>
         </div>"##,
         mode = mode_txt,
         verdict_class = verdict_class,
         verdict_main = verdict_main,
-        total = total,
+        tracked_total = tracked_total,
+        tick_footer = last_tick_footer,
         sample_size = sample_size_txt,
         median = median_txt,
         mad = mad_txt,
@@ -981,20 +1127,40 @@ fn build_contracts_card(snap: &Option<network_status::NetworkStatusSnapshot>) ->
         return String::new();
     }
 
+    let state_by_id = &snap.governance.state_by_id;
     let mut rows = String::new();
     for c in &snap.contracts {
         let last_update = c
             .last_updated_secs
             .map(format_ago)
             .unwrap_or_else(|| "—".to_string());
-        // last_updated_secs absent → never updated. Sort it as the
-        // largest possible "ago", so it lands at the bottom in ascending
-        // order (i.e. "never" is treated as the oldest activity).
         let last_update_sort = c.last_updated_secs.unwrap_or(u64::MAX);
+        // Governance state cell. A contract may appear in the
+        // Subscribed Contracts table without being flagged by
+        // governance — in that case the state isn't in `state_by_id`
+        // (the snapshot only carries flagged contracts) and we
+        // render it as "ok". Absence from the table specifically
+        // means "not flagged"; we trust the back-end's `iter_flagged_
+        // scores` filter.
+        let (gov_class, gov_label, gov_sort) = match state_by_id.get(&c.key_full) {
+            None => ("gov-ok", "ok", 0u8),
+            Some(network_status::GovernanceStateSnapshot::Normal) => ("gov-ok", "ok", 0),
+            Some(network_status::GovernanceStateSnapshot::Borderline) => {
+                ("gov-borderline", "borderline", 1)
+            }
+            Some(network_status::GovernanceStateSnapshot::WouldEvict) => {
+                ("gov-wouldevict", "would evict", 2)
+            }
+            Some(network_status::GovernanceStateSnapshot::Evicted) => ("gov-evicted", "evicted", 3),
+            Some(network_status::GovernanceStateSnapshot::Banned) => ("gov-banned", "banned", 4),
+        };
         rows.push_str(&format!(
-            r#"<tr><td title="{full}" data-sort="{full}"><code>{short}</code><button type="button" class="copy-key" data-copy="{full}" title="Copy contract key" aria-label="Copy contract key">⧉</button></td><td data-sort="{sub_secs}">{subscribed}</td><td data-sort="{last_sort}">{last_update}</td></tr>"#,
+            r#"<tr><td title="{full}" data-sort="{full}"><code>{short}</code><button type="button" class="copy-key" data-copy="{full}" title="Copy contract key" aria-label="Copy contract key">⧉</button></td><td data-sort="{gov_sort}"><span class="gov-pill {gov_class}">{gov_label}</span></td><td data-sort="{sub_secs}">{subscribed}</td><td data-sort="{last_sort}">{last_update}</td></tr>"#,
             full = html_escape(&c.key_full),
             short = html_escape(&c.key_short),
+            gov_sort = gov_sort,
+            gov_class = gov_class,
+            gov_label = gov_label,
             sub_secs = c.subscribed_secs,
             subscribed = format_ago(c.subscribed_secs),
             last_sort = last_update_sort,
@@ -1007,7 +1173,7 @@ fn build_contracts_card(snap: &Option<network_status::NetworkStatusSnapshot>) ->
             <h2>Subscribed Contracts</h2>
             <div class="table-wrap">
                 <table class="sortable" data-table-id="contracts">
-                    <thead><tr><th data-sort-type="text">Contract</th><th data-sort-type="num">Subscribed</th><th data-sort-type="num">Last Update</th></tr></thead>
+                    <thead><tr><th data-sort-type="text">Contract</th><th data-sort-type="num">Gov</th><th data-sort-type="num">Subscribed</th><th data-sort-type="num">Last Update</th></tr></thead>
                     <tbody>{rows}</tbody>
                 </table>
             </div>
@@ -1787,6 +1953,37 @@ table.sortable thead th.sort-desc::after { content: "▼"; opacity: 1; color: va
 .g-wouldevict { background: rgba(255,138,61,0.18);  color: #ff8a3d; }
 .g-evicted    { background: rgba(255,102,122,0.18); color: #ff667a; }
 .g-banned     { background: rgba(211,54,130,0.18);  color: #d33682; }
+
+/* Compact governance-state pill rendered inline in the Subscribed
+ * Contracts table's Gov column. Smaller than the `.g-badge` used in
+ * the main Contract Governance table so it doesn't dominate the
+ * row, while still being a single visual cue scanning down the
+ * column. */
+.gov-pill {
+    display: inline-block;
+    padding: 0.1rem 0.45rem;
+    font-size: 0.72rem;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 500;
+    line-height: 1.2;
+}
+.gov-ok         { background: rgba(67,193,120,0.12);  color: #6b8a76; }
+.gov-borderline { background: rgba(255,182,16,0.18);  color: #ffb610; }
+.gov-wouldevict { background: rgba(255,138,61,0.20);  color: #ff8a3d; }
+.gov-evicted    { background: rgba(255,102,122,0.22); color: #ff667a; }
+.gov-banned     { background: rgba(211,54,130,0.22);  color: #d33682; }
+
+/* Denominator in the empty-state verdict ("3/30"). Smaller than the
+ * numerator so the eye reads the count first and the threshold
+ * second. */
+.verdict-num-denom {
+    font-size: 0.55em;
+    color: var(--text-muted, #888);
+    margin-left: 0.1em;
+    vertical-align: middle;
+}
 "##;
 
 /// Inline JavaScript for the dark/light mode toggle.
@@ -3788,7 +3985,7 @@ mod tests {
     #[test]
     fn ring_svg_dots_link_to_peer_pages() {
         let peers = vec![sample_peer("127.0.0.1:31337", 0.25)];
-        let svg = build_ring_svg(Some(0.5), &peers, None);
+        let svg = build_ring_svg(Some(0.5), &peers, None, &[]);
         assert!(
             svg.contains("<a href=\"/peer/127.0.0.1:31337\""),
             "ring peer dot must be wrapped in a link to /peer/{{addr}}, got: {svg}"
@@ -3892,7 +4089,7 @@ mod tests {
         // The local node has no /peer/{addr} page, so the self circle
         // must NOT be wrapped in an <a>, but it should still expose a
         // <title> for parity with the peer dots.
-        let svg = build_ring_svg(Some(0.42), &[], None);
+        let svg = build_ring_svg(Some(0.42), &[], None, &[]);
         assert!(svg.contains("<svg"), "ring SVG should still render");
         assert!(
             !svg.contains("<a "),
@@ -3924,7 +4121,7 @@ mod tests {
             bytes_received: 0,
         };
         let peer = sample_peer("10.0.0.2:31338", 0.90);
-        let svg = build_ring_svg(Some(0.5), &[gw, peer], None);
+        let svg = build_ring_svg(Some(0.5), &[gw, peer], None, &[]);
         assert!(
             svg.contains("<title>Gateway 10.0.0.1:31337"),
             "gateway dot title must say 'Gateway', got: {svg}"
@@ -3953,8 +4150,8 @@ mod tests {
             bytes_sent: 0,
             bytes_received: 0,
         };
-        assert!(build_ring_svg(None, &[no_loc_peer], None).is_empty());
-        assert!(build_ring_svg(None, &[], None).is_empty());
+        assert!(build_ring_svg(None, &[no_loc_peer], None, &[]).is_empty());
+        assert!(build_ring_svg(None, &[], None, &[]).is_empty());
     }
 
     // ── Sort attribute coverage for both tables ─────────────────────────────
@@ -4171,15 +4368,77 @@ mod tests {
 
     #[test]
     fn governance_card_empty_state_when_no_contracts() {
+        // Empty state = "no FLAGGED contracts." Post-polish slice 2 the
+        // card still renders structural skeleton (mode pill, 5-tile
+        // mini-strip with em-dashes, observed/needed progress) so an
+        // operator can see what fields will appear once data arrives.
+        // Pin: the skeleton tiles + mode pill are visible.
         let snap = base_snapshot();
         let html = build_governance_card(&Some(snap));
         assert!(
-            html.contains("Not enough contracts observed yet"),
-            "empty state should explain why governance has nothing to show — got:\n{html}"
+            html.contains(r#"g-mode g-mode-dry-run">dry-run<"#),
+            "empty state must show the mode pill — got:\n{html}"
+        );
+        assert!(
+            html.contains("Eviction threshold"),
+            "empty state must render the 5-tile skeleton — got:\n{html}"
+        );
+        assert!(
+            html.contains("—"),
+            "empty state should use em-dashes for missing tile values"
         );
         assert!(
             !html.contains("verdict-alert"),
             "empty state must not render the alert verdict block"
+        );
+    }
+
+    #[test]
+    fn governance_card_empty_state_shows_observed_progress() {
+        // Pin: the empty state surfaces "N / min_samples" so the
+        // operator can see progress toward statistical scoring.
+        let mut snap = base_snapshot();
+        snap.governance = GovernanceSnapshot {
+            mode: GovernanceModeSnapshot::DryRun,
+            contracts: Vec::new(), // none flagged
+            norms: NetworkNorms::default(),
+            observed_count: 12,
+            min_samples: 30,
+            last_tick_at: None,
+            state_by_id: std::collections::HashMap::new(),
+        };
+        let html = build_governance_card(&Some(snap));
+        assert!(
+            html.contains("12") && html.contains("30"),
+            "empty state should surface observed_count and min_samples — got:\n{html}"
+        );
+        assert!(
+            html.contains("18"),
+            "empty state should mention the remaining count (30-12=18) — got:\n{html}"
+        );
+    }
+
+    #[test]
+    fn governance_card_empty_state_healthy_when_enough_samples() {
+        // Pin: once observed_count >= min_samples but nothing is
+        // flagged, the empty state should read "all N within normal
+        // range" — the healthy-steady-state message — not the
+        // ramp-up-progress one.
+        let mut snap = base_snapshot();
+        snap.governance = GovernanceSnapshot {
+            mode: GovernanceModeSnapshot::DryRun,
+            contracts: Vec::new(),
+            norms: NetworkNorms::default(),
+            observed_count: 50,
+            min_samples: 30,
+            last_tick_at: None,
+            state_by_id: std::collections::HashMap::new(),
+        };
+        let html = build_governance_card(&Some(snap));
+        assert!(
+            html.contains("All 50 tracked contracts within normal range")
+                || html.contains("50 contracts within normal range"),
+            "healthy-steady-state empty card should declare 'normal range' — got:\n{html}"
         );
     }
 
@@ -4192,6 +4451,10 @@ mod tests {
                 .map(|i| mk_entry(GovernanceStateSnapshot::Normal, &format!("aaa{i}")))
                 .collect(),
             norms: NetworkNorms::default(),
+            observed_count: 0,
+            min_samples: 30,
+            last_tick_at: None,
+            state_by_id: std::collections::HashMap::new(),
         };
         let html = build_governance_card(&Some(snap));
         assert!(
@@ -4216,6 +4479,10 @@ mod tests {
                 mk_entry(GovernanceStateSnapshot::Normal, "ok1"),
             ],
             norms: NetworkNorms::default(),
+            observed_count: 0,
+            min_samples: 30,
+            last_tick_at: None,
+            state_by_id: std::collections::HashMap::new(),
         };
         let html = build_governance_card(&Some(snap));
         assert!(html.contains("verdict-alert"));
@@ -4244,6 +4511,10 @@ mod tests {
                 mode,
                 contracts: vec![mk_entry(GovernanceStateSnapshot::Normal, "ok")],
                 norms: NetworkNorms::default(),
+                observed_count: 0,
+                min_samples: 30,
+                last_tick_at: None,
+                state_by_id: std::collections::HashMap::new(),
             };
             let html = build_governance_card(&Some(snap));
             assert!(

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -4172,6 +4172,106 @@ mod tests {
         assert!(build_ring_svg(None, &[], None, &[]).is_empty());
     }
 
+    /// Pin: build_ring_svg renders hosted contracts as faint dim
+    /// teal dots on the inner ring (non-flagged ones). Without this
+    /// the inner ring was visually empty in healthy state and made
+    /// the renderer look unfinished.
+    ///
+    /// Rule-review of #4298 caught that the new `hosted_contracts`
+    /// rendering loop was untested — every test site passed `&[]`.
+    /// This test exercises the happy path (at least one dot
+    /// rendered) and the skip-flagged path (a contract present in
+    /// BOTH hosted and flagged sets gets the flagged marker only,
+    /// not a duplicate hosted dot).
+    #[test]
+    fn ring_svg_renders_hosted_contracts_on_inner_ring() {
+        use crate::node::network_status::{
+            ContractGovernanceEntry, ContractSnapshot, GovernanceSnapshot, GovernanceStateSnapshot,
+            NetworkNorms,
+        };
+
+        let hosted = vec![
+            ContractSnapshot {
+                key_short: "HOST1...".to_string(),
+                key_full: "HOST1_with_params".to_string(),
+                instance_id: "HOST1".to_string(),
+                subscribed_secs: 60,
+                last_updated_secs: Some(5),
+            },
+            ContractSnapshot {
+                key_short: "HOST2...".to_string(),
+                key_full: "HOST2_with_params".to_string(),
+                instance_id: "HOST2".to_string(),
+                subscribed_secs: 60,
+                last_updated_secs: Some(5),
+            },
+            // This one is ALSO flagged — should be skipped in the
+            // hosted dim-dot loop to avoid a duplicate marker.
+            ContractSnapshot {
+                key_short: "FLAG1...".to_string(),
+                key_full: "FLAG1_with_params".to_string(),
+                instance_id: "FLAG1".to_string(),
+                subscribed_secs: 60,
+                last_updated_secs: Some(5),
+            },
+        ];
+
+        let governance = GovernanceSnapshot {
+            mode: crate::node::network_status::GovernanceModeSnapshot::DryRun,
+            contracts: vec![ContractGovernanceEntry {
+                instance_id: "FLAG1".to_string(),
+                instance_id_short: "FLAG1".to_string(),
+                state: GovernanceStateSnapshot::WouldEvict,
+                cost_used: 1.0,
+                benefit_score: 1.0,
+                log_ratio: Some(0.0),
+                age_secs: 100,
+                last_transition_secs_ago: 1,
+                history: Vec::new(),
+            }],
+            observed_count: 3,
+            min_samples: 30,
+            norms: NetworkNorms::default(),
+            last_tick_at: None,
+            state_by_id: std::collections::HashMap::new(),
+        };
+
+        let svg = build_ring_svg(Some(0.5), &[], Some(&governance), &hosted);
+
+        // The faint hosted-contract dot uses the brand teal at 0.45
+        // opacity. Pin both attributes so a future refactor that
+        // changes the style triggers the test, AND count the dots so
+        // we know flagged-skipping worked.
+        let hosted_dot_count = svg
+            .matches("fill=\"#43c178\" fill-opacity=\"0.45\"")
+            .count();
+        assert_eq!(
+            hosted_dot_count, 2,
+            "expected exactly 2 hosted-contract dim dots (HOST1, HOST2). \
+             FLAG1 should be skipped because it's already in the flagged set. \
+             Got {hosted_dot_count} hosted dots in SVG:\n{svg}"
+        );
+
+        // FLAG1 must still appear, just via the brighter flagged-
+        // dot rendering (the WouldEvict color, with glow).
+        assert!(
+            svg.contains("#ff8a3d"),
+            "FLAG1 should render with its WouldEvict color regardless of being in hosted set"
+        );
+    }
+
+    /// Pin: when the hosted-contracts slice is empty, the inner ring
+    /// emits no hosted-dot circles. Sanity check that the
+    /// `&[] → no rendering` path still works as before.
+    #[test]
+    fn ring_svg_no_hosted_contracts_means_no_dim_dots() {
+        let svg = build_ring_svg(Some(0.5), &[], None, &[]);
+        assert!(
+            !svg.contains("fill-opacity=\"0.45\""),
+            "empty hosted slice must produce no dim-dot fill-opacity attribute, got:\n{svg}"
+        );
+    }
+
     // ── Sort attribute coverage for both tables ─────────────────────────────
 
     #[test]

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -676,10 +676,14 @@ fn build_ring_svg(
         // Skip contracts that are flagged — they get a more visible
         // marker in the flagged-rendering loop below. Drawing them
         // here would just be overlapped.
-        if governance_ids.contains(c.key_full.as_str()) {
+        if governance_ids.contains(c.instance_id.as_str()) {
             continue;
         }
-        let loc = hash_to_loc(&c.key_full);
+        // Hash on the instance_id so the hosted-dot position matches
+        // the same contract's flagged-dot position (which also hashes
+        // on instance_id) — Codex review caught the previous
+        // key_full vs instance_id mismatch.
+        let loc = hash_to_loc(&c.instance_id);
         let (kx, ky) = loc_to_xy(loc, r_inner);
         // Dim teal dot — same brand color as YOU but smaller and
         // translucent so flagged dots stand out by contrast.
@@ -842,26 +846,37 @@ fn build_governance_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
     if g.contracts.is_empty() {
         let observed = g.observed_count;
         let needed = g.min_samples;
+        // Tiny pluralization helper so the user-facing messages
+        // don't read "1 contracts" — Codex review nit.
+        let plural = |n: usize| if n == 1 { "contract" } else { "contracts" };
         let progress_msg = if needed == 0 {
             "Governance manager is not yet wired.".to_string()
         } else if observed == 0 {
             format!(
-                "No contracts observed yet. Scoring activates after {needed} contracts \
-                 have accumulated cost/benefit signals."
+                "No contracts observed yet. Scoring activates after {needed} {n_word} \
+                 have accumulated cost/benefit signals.",
+                n_word = plural(needed),
             )
         } else if observed < needed {
+            let remaining = needed - observed;
+            let verb = if remaining == 1 {
+                "accumulates"
+            } else {
+                "accumulate"
+            };
             format!(
-                "Observed {observed} / {needed} contracts needed for statistical scoring. \
-                 Scoring activates once {needed_remaining} more contracts accumulate \
-                 cost/benefit signals.",
-                needed_remaining = needed - observed,
+                "Observed {observed} / {needed} {n_word} needed for statistical scoring. \
+                 Scoring activates once {remaining} more {r_word} {verb} cost/benefit signals.",
+                n_word = plural(needed),
+                r_word = plural(remaining),
             )
         } else {
             // Enough samples observed but none flagged — that's the
             // healthy steady state.
             format!(
-                "All {observed} tracked contracts within normal range. \
-                 (Scored against the network's own observed distribution.)"
+                "All {observed} tracked {n_word} within normal range. \
+                 (Scored against the network's own observed distribution.)",
+                n_word = plural(observed),
             )
         };
         let verdict_main = if observed >= needed {
@@ -1142,7 +1157,7 @@ fn build_contracts_card(snap: &Option<network_status::NetworkStatusSnapshot>) ->
         // render it as "ok". Absence from the table specifically
         // means "not flagged"; we trust the back-end's `iter_flagged_
         // scores` filter.
-        let (gov_class, gov_label, gov_sort) = match state_by_id.get(&c.key_full) {
+        let (gov_class, gov_label, gov_sort) = match state_by_id.get(&c.instance_id) {
             None => ("gov-ok", "ok", 0u8),
             Some(network_status::GovernanceStateSnapshot::Normal) => ("gov-ok", "ok", 0),
             Some(network_status::GovernanceStateSnapshot::Borderline) => {
@@ -3719,12 +3734,14 @@ mod tests {
             ContractSnapshot {
                 key_short: "ABC1...".to_string(),
                 key_full: "ABC123".to_string(),
+                instance_id: "ABC123".to_string(),
                 subscribed_secs: 100,
                 last_updated_secs: Some(5),
             },
             ContractSnapshot {
                 key_short: "DEF4...".to_string(),
                 key_full: "DEF456".to_string(),
+                instance_id: "DEF456".to_string(),
                 subscribed_secs: 50,
                 last_updated_secs: None,
             },
@@ -4029,6 +4046,7 @@ mod tests {
         snap.contracts = vec![ContractSnapshot {
             key_short: "ABC1...".to_string(),
             key_full: "ABC123XYZ".to_string(),
+            instance_id: "ABC123XYZ".to_string(),
             subscribed_secs: 100,
             last_updated_secs: Some(5),
         }];
@@ -4194,6 +4212,7 @@ mod tests {
         snap.contracts = vec![ContractSnapshot {
             key_short: "DEAD...".to_string(),
             key_full: "DEADBEEF".to_string(),
+            instance_id: "DEADBEEF".to_string(),
             subscribed_secs: 60,
             last_updated_secs: Some(2),
         }];
@@ -4231,12 +4250,14 @@ mod tests {
             ContractSnapshot {
                 key_short: "FRESH..".to_string(),
                 key_full: "FRESH".to_string(),
+                instance_id: "FRESH".to_string(),
                 subscribed_secs: 1,
                 last_updated_secs: Some(1),
             },
             ContractSnapshot {
                 key_short: "NEVER..".to_string(),
                 key_full: "NEVER".to_string(),
+                instance_id: "NEVER".to_string(),
                 subscribed_secs: 1,
                 last_updated_secs: None,
             },
@@ -4395,8 +4416,9 @@ mod tests {
 
     #[test]
     fn governance_card_empty_state_shows_observed_progress() {
-        // Pin: the empty state surfaces "N / min_samples" so the
-        // operator can see progress toward statistical scoring.
+        // Pin: the empty state surfaces "N / min_samples" + the
+        // remaining count, using the exact phrases the user sees —
+        // not just digit substrings (Codex review nit).
         let mut snap = base_snapshot();
         snap.governance = GovernanceSnapshot {
             mode: GovernanceModeSnapshot::DryRun,
@@ -4409,12 +4431,33 @@ mod tests {
         };
         let html = build_governance_card(&Some(snap));
         assert!(
-            html.contains("12") && html.contains("30"),
-            "empty state should surface observed_count and min_samples — got:\n{html}"
+            html.contains("Observed 12 / 30 contracts needed"),
+            "empty state should pin the 'Observed X / Y contracts needed' phrase — got:\n{html}"
         );
         assert!(
-            html.contains("18"),
-            "empty state should mention the remaining count (30-12=18) — got:\n{html}"
+            html.contains("once 18 more contracts accumulate"),
+            "empty state should name the remaining count by name — got:\n{html}"
+        );
+    }
+
+    #[test]
+    fn governance_card_empty_state_pluralizes_singular_count() {
+        // Pin: when remaining == 1, the message uses "1 more contract"
+        // not "1 more contracts". Codex review nit on pluralization.
+        let mut snap = base_snapshot();
+        snap.governance = GovernanceSnapshot {
+            mode: GovernanceModeSnapshot::DryRun,
+            contracts: Vec::new(),
+            norms: NetworkNorms::default(),
+            observed_count: 29,
+            min_samples: 30,
+            last_tick_at: None,
+            state_by_id: std::collections::HashMap::new(),
+        };
+        let html = build_governance_card(&Some(snap));
+        assert!(
+            html.contains("once 1 more contract accumulates"),
+            "with remaining=1 message must use singular 'contract accumulates' — got:\n{html}"
         );
     }
 

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -4271,6 +4271,46 @@ mod tests {
         );
     }
 
+    /// Regression test for the ContractKey/ContractInstanceId
+    /// id-vs-key string mismatch that Codex review of #4298 caught:
+    /// `GovernanceSnapshot.state_by_id` is keyed by
+    /// `ContractInstanceId::to_string()` (the 32-byte content hash),
+    /// while `ContractSnapshot.key_full` is the full `ContractKey`
+    /// encoding (including parameters / code-hash bookkeeping). The
+    /// two strings are NOT equal, so a lookup keyed on `key_full`
+    /// would silently miss every flagged contract.
+    ///
+    /// Pin: with a contract whose `instance_id` differs from
+    /// `key_full` and whose state in `state_by_id` is Banned, the
+    /// rendered row MUST show "banned" (not "ok"). Pre-fix the
+    /// assertion would have failed because the lookup never found
+    /// the entry.
+    #[test]
+    fn contracts_table_gov_column_uses_instance_id_not_key_full() {
+        use crate::node::network_status::{ContractSnapshot, GovernanceStateSnapshot};
+        let mut snap = base_snapshot();
+        snap.open_connections = 1;
+        // The critical part: instance_id ≠ key_full. In production
+        // key_full includes the params / code hash so this is the
+        // common case, not an edge.
+        snap.contracts = vec![ContractSnapshot {
+            key_short: "FOO1234...".to_string(),
+            key_full: "FOO1234WITH_PARAMS_AND_CODE_HASH".to_string(),
+            instance_id: "FOO1234".to_string(),
+            subscribed_secs: 60,
+            last_updated_secs: Some(10),
+        }];
+        snap.governance
+            .state_by_id
+            .insert("FOO1234".to_string(), GovernanceStateSnapshot::Banned);
+        let html = build_contracts_card(&Some(snap));
+        assert!(
+            html.contains(r#"<span class="gov-pill gov-banned">banned</span>"#),
+            "Gov column lookup must use `instance_id` (not `key_full`) so \
+             state_by_id keys match — got:\n{html}"
+        );
+    }
+
     // ── Header / version badge guarantees ───────────────────────────────────
 
     /// Helper for header-element tests: pull a specific HTML element line


### PR DESCRIPTION
## Summary

Phase 4.5 slice 2 of contract-hardening. Addresses the top 3 items from the UI feedback review post-#4270 (`~/code/tmp/governance-dashboard-feedback-2026-05-27.md`):

1. **Empty-state skeleton + mode pill + progress message + last-tick footer** — the empty governance card now teaches operators what fields will appear and shows ramp-up progress (`12/30 contracts observed`) instead of a single confusing paragraph.
2. **Inner ring shows ALL hosted contracts** — no longer only flagged ones. The CONTRACTS ring was visually empty on healthy nodes despite 16+ hosted contracts being listed below; faint dim teal dots now render every hosted contract.
3. **Gov column on Subscribed Contracts table** — compact governance-state pill per row, sourced from a new `state_by_id` field, sortable by severity.

## Why now (and what's deferred)

User feedback on the live dashboard at http://technic.locut.us:7509/ flagged that the card "feels half-finished." These three changes are small + high-value for the "is this thing working?" comprehension test — they make the dashboard usable for evaluating whether the resource-usage detection mechanism actually works, which is the broader project goal (#4296).

Slice 3 (per-contract drill-down, distribution histogram, decision history timeline) is deliberately separate — bigger work, needs an inline charting solution.

## Data path

New fields on `GovernanceSnapshot`:
- `observed_count: usize` — total scored contracts
- `min_samples: usize` — from outlier config, drives the "N/30" message
- `last_tick_at: Option<Instant>` — for the "Last evaluated Ns ago" footer
- `state_by_id: HashMap<String, GovernanceStateSnapshot>` — Subscribed Contracts cross-reference

`Ring::dashboard_governance_snapshot` populates all four. `state_by_id` is built from the existing flagged-only contracts list (no extra DashMap walk), so a row absent from the map is implicitly Normal/ok.

## Tests

3 new tests, all 51 original home_page tests still pass:

- `governance_card_empty_state_when_no_contracts` — updated to pin mode pill visible, 5-tile skeleton rendered with em-dashes.
- `governance_card_empty_state_shows_observed_progress` — pins `12 / 30 (18 remaining)` ramp-up message.
- `governance_card_empty_state_healthy_when_enough_samples` — pins steady-state message when observed ≥ min_samples and nothing flagged.

Full lib: **2745 passed, 0 failed.**
`cargo clippy --lib --tests -- -D warnings` clean.

## Test plan

- [ ] CI green on HEAD
- [ ] Multi-model review (light tier — pure read-side dashboard work, no behavior change)
- [ ] Visual check on technic — render the new empty-state, verify the 5-tile skeleton with em-dashes, mode pill ("dry-run"), observed/needed progress message, and Gov column on Subscribed Contracts

## Tracking

Tracked under #4296 (Phase 4.5 slice 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-assisted - Claude]