### PR TITLE
feat(governance): phase 7 — repeat-offender ban TTL with wire-boundary drop

### DIFF
--- a/crates/core/src/contract/governance.rs
+++ b/crates/core/src/contract/governance.rs
@@ -88,8 +88,8 @@ impl GovernanceState {
     }
 
     /// Whether this state actively blocks new operations on the
-    /// contract (PUT / UPDATE / SUBSCRIBE rejected at the receive
-    /// boundary). Only `Banned` does this.
+    /// contract (PUT / GET / UPDATE / SUBSCRIBE Request variants
+    /// rejected at the receive boundary). Only `Banned` does this.
     pub(crate) fn blocks_operations(self) -> bool {
         matches!(self, GovernanceState::Banned)
     }
@@ -1355,6 +1355,100 @@ mod tests {
         assert_eq!(lifted.from, GovernanceState::Banned);
         assert_eq!(lifted.to, GovernanceState::Normal);
         assert!(matches!(lifted.reason, TransitionReason::BanLifted));
+    }
+
+    /// End-to-end regression test for the May 21 incident pattern.
+    /// Drives a contract through evict → recover → re-feed → Banned
+    /// using `GovernanceManager`, then runs the decisions through
+    /// `Ring::apply_ban_decisions` and asserts the contract lands on
+    /// a fresh `ContractBanList`. Then advances past `ban_ttl` and
+    /// verifies BanLifted removes it.
+    ///
+    /// Why this lives here: the state-machine setup (mk_mgr_shared,
+    /// the honest distribution, the evicted_ttl + ban_ttl
+    /// advancements) is heavy and mirrors the existing
+    /// `ban_ttl_expires_back_to_normal` test. Keeping the e2e test
+    /// next to its setup helpers avoids cross-module test plumbing.
+    #[test]
+    fn governance_to_ban_list_end_to_end() {
+        use crate::ring::Ring;
+        use crate::ring::contract_ban_list::ContractBanList;
+
+        let (mgr, ts) = mk_mgr_shared(GovernanceMode::Enforce);
+        let ts_dyn: Arc<dyn TimeSource + Send + Sync> = ts.clone();
+        let bl = ContractBanList::new(ts_dyn);
+
+        for i in 0..30 {
+            let jitter = (i as f64 - 15.0) * 0.01;
+            mgr.ingest_cost(mk_key(i), 0.1 + jitter * 0.05);
+            mgr.ingest_demand(mk_key(i), 1.0 + jitter);
+        }
+        let abuser = mk_key(99);
+        mgr.ingest_cost(abuser, 100.0);
+        mgr.ingest_demand(abuser, 1.0);
+        ts.advance(Duration::from_secs(2));
+
+        // Tick 1: first eviction.
+        let r1 = mgr.tick(Duration::from_millis(100));
+        Ring::apply_ban_decisions(&bl, &r1.decisions, ts.now() + mgr.ban_ttl());
+        assert!(
+            !bl.is_banned(&abuser),
+            "first eviction is not a ban — abuser must not yet be on the list"
+        );
+
+        // Recover.
+        ts.advance(Duration::from_secs(15 * 60 + 1));
+        for i in 0..30 {
+            let jitter = (i as f64 - 15.0) * 0.01;
+            mgr.ingest_cost(mk_key(i), 0.1 + jitter * 0.05);
+            mgr.ingest_demand(mk_key(i), 1.0 + jitter);
+        }
+        let r2 = mgr.tick(Duration::from_millis(100));
+        Ring::apply_ban_decisions(&bl, &r2.decisions, ts.now() + mgr.ban_ttl());
+        assert!(
+            !bl.is_banned(&abuser),
+            "recovery does not ban — abuser must still be off the list"
+        );
+
+        // Re-feed → Banned (recently_evicted in ban_window).
+        mgr.ingest_cost(abuser, 100.0);
+        mgr.ingest_cost(abuser, 100.0);
+        mgr.ingest_demand(abuser, 1.0);
+        ts.advance(Duration::from_secs(1));
+        let r3 = mgr.tick(Duration::from_millis(100));
+        let triggered = r3
+            .decisions
+            .iter()
+            .find(|d| d.key == abuser && matches!(d.reason, TransitionReason::BanTriggered))
+            .expect("second eviction within ban_window must emit BanTriggered");
+        assert!(
+            triggered.actionable,
+            "Enforce-mode BanTriggered must be actionable"
+        );
+        Ring::apply_ban_decisions(&bl, &r3.decisions, ts.now() + mgr.ban_ttl());
+        assert!(
+            bl.is_banned(&abuser),
+            "after BanTriggered the abuser must land on the ban list — \
+             this is the wire-boundary enforcement signal for Phase 7"
+        );
+
+        // BanLifted after ban_ttl.
+        ts.advance(Duration::from_secs(60 * 60 + 1));
+        let r4 = mgr.tick(Duration::from_millis(100));
+        let lifted = r4
+            .decisions
+            .iter()
+            .find(|d| d.key == abuser && matches!(d.reason, TransitionReason::BanLifted))
+            .expect("after ban_ttl, BanLifted must fire");
+        assert!(
+            lifted.actionable,
+            "Enforce-mode BanLifted must be actionable"
+        );
+        Ring::apply_ban_decisions(&bl, &r4.decisions, ts.now() + mgr.ban_ttl());
+        assert!(
+            !bl.is_banned(&abuser),
+            "after BanLifted the abuser must be removed from the ban list"
+        );
     }
 
     #[test]

--- a/crates/core/src/contract/governance.rs
+++ b/crates/core/src/contract/governance.rs
@@ -470,6 +470,15 @@ impl GovernanceManager {
         self.config.outlier.min_samples
     }
 
+    /// How long a `Banned` state persists before `BanLifted` fires.
+    /// Surfaced for the Phase 7 ban-list wiring: when the reaper
+    /// emits a `BanTriggered` decision, the receive-boundary ban
+    /// entry is given `now + ban_ttl()` as its expiry so the two
+    /// timers converge.
+    pub(crate) fn ban_ttl(&self) -> Duration {
+        self.config.ban_ttl
+    }
+
     /// Read the latest network-norms snapshot, if any tick has run.
     /// Used by the dashboard snapshot builder.
     pub(crate) fn latest_norms(&self) -> Option<NetworkNormsCache> {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -858,6 +858,27 @@ where
                 return Ok(());
             }
 
+            // Phase 7 ban-list gate (inbound REQUEST variants only).
+            // Responses to our OWN outbound requests pass through
+            // above; here we drop new PUTs for banned contracts so
+            // the contract can't get re-hosted while banned.
+            let banned_key = match op {
+                put::PutMsg::Request { contract, .. } => Some(contract.key()),
+                put::PutMsg::RequestStreaming { contract_key, .. } => Some(*contract_key),
+                _ => None,
+            };
+            if let Some(key) = banned_key {
+                if op_manager.ring.contract_ban_list.is_banned(key.id()) {
+                    tracing::debug!(
+                        tx = %op.id(),
+                        %key,
+                        phase = "put_banned_drop",
+                        "PUT dispatch: dropping request for banned contract"
+                    );
+                    return Ok(());
+                }
+            }
+
             // Relay PUT dispatch. `start_relay_put` handles
             // non-streaming Request (with upgrade-on-forward to
             // streaming when payload > threshold);
@@ -971,6 +992,21 @@ where
                 return Ok(());
             }
 
+            // Phase 7 ban-list gate (inbound REQUEST only). Responses
+            // pass through above. We refuse to serve state for a
+            // banned contract.
+            if let get::GetMsg::Request { instance_id, .. } = op {
+                if op_manager.ring.contract_ban_list.is_banned(instance_id) {
+                    tracing::debug!(
+                        tx = %op.id(),
+                        %instance_id,
+                        phase = "get_banned_drop",
+                        "GET dispatch: dropping request for banned contract"
+                    );
+                    return Ok(());
+                }
+            }
+
             // Relay GET dispatch. Originator loopback
             // (`source_addr=None`) is mapped to
             // `upstream_addr=own_addr` so the same `start_relay_get`
@@ -1054,6 +1090,22 @@ where
                     | update::UpdateMsg::RequestUpdateStreaming { key, .. }
                     | update::UpdateMsg::BroadcastToStreaming { key, .. } => *key,
                 };
+
+                // Phase 7 ban-list gate. Runs BEFORE the rate limiter
+                // so a banned contract's traffic doesn't even count
+                // against the per-(sender, contract) window — keeps
+                // the rate limiter's signal-to-noise high.
+                if op_manager.ring.contract_ban_list.is_banned(key.id()) {
+                    tracing::debug!(
+                        tx = %op.id(),
+                        %key,
+                        %sender_addr,
+                        phase = "update_dispatch_banned_drop",
+                        "UPDATE dispatch: dropping request for banned contract"
+                    );
+                    return Ok(());
+                }
+
                 let rate_decision = op_manager
                     .ring
                     .update_rate_limiter
@@ -1215,6 +1267,21 @@ where
                         visited,
                         is_renewal,
                     } => {
+                        // Phase 7 ban-list gate. Drop SUBSCRIBE for
+                        // banned contracts before reaching the driver
+                        // so we don't register interest in something
+                        // we have already decided to reject.
+                        if op_manager.ring.contract_ban_list.is_banned(instance_id) {
+                            tracing::debug!(
+                                tx = %id,
+                                %instance_id,
+                                %upstream_addr,
+                                phase = "subscribe_dispatch_banned_drop",
+                                "SUBSCRIBE dispatch: dropping request for banned contract"
+                            );
+                            return Ok(());
+                        }
+
                         if let Err(err) = subscribe::op_ctx_task::start_relay_subscribe(
                             op_manager.clone(),
                             *id,

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -862,6 +862,7 @@ where
             // Responses to our OWN outbound requests pass through
             // above; here we drop new PUTs for banned contracts so
             // the contract can't get re-hosted while banned.
+            #[allow(clippy::wildcard_enum_match_arm)]
             let banned_key = match op {
                 put::PutMsg::Request { contract, .. } => Some(contract.key()),
                 put::PutMsg::RequestStreaming { contract_key, .. } => Some(*contract_key),
@@ -1382,6 +1383,20 @@ where
             // Only sync contracts we're actively interested in (receiving updates
             // or have downstream subscribers) — skip cached-only contracts.
             for instance_id in result.overlapping_contracts {
+                // Phase 7 egress gate. If we've banned the contract,
+                // don't proactively push its state to a sibling peer
+                // via the overlap-sync path — that would undermine
+                // the wire-boundary drop the ban list is supposed to
+                // provide.
+                if op_manager.ring.contract_ban_list.is_banned(&instance_id) {
+                    tracing::debug!(
+                        %instance_id,
+                        peer = %source_pub_key,
+                        phase = "neighbor_hosting_banned_skip",
+                        "skipping proximity sync for banned contract"
+                    );
+                    continue;
+                }
                 if let Some((key, state)) =
                     get_contract_state_by_id(&op_manager, &instance_id).await
                 {
@@ -1643,6 +1658,20 @@ async fn handle_interest_sync_message(
             // out to ALL subscribers (~28 peers), causing O(peers^2) traffic when
             // many peers reported mismatches within the same heartbeat cycle.
             for contract in stale_contracts {
+                // Phase 7 egress gate. Don't repair a stale peer's
+                // summary mismatch by pushing state for a contract
+                // we have banned — same rationale as the inbound
+                // wire-boundary drop, applied to the proactive heal
+                // path.
+                if op_manager.ring.contract_ban_list.is_banned(contract.id()) {
+                    tracing::debug!(
+                        %contract,
+                        stale_peer = %source,
+                        phase = "interest_sync_banned_skip",
+                        "skipping summary-mismatch sync for banned contract"
+                    );
+                    continue;
+                }
                 let Some(state) = get_contract_state(op_manager, &contract).await else {
                     tracing::trace!(
                         contract = %contract,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -45,6 +45,7 @@ use crate::{
 mod broken_invariants;
 mod connection_backoff;
 mod connection_manager;
+mod contract_ban_list;
 pub(crate) use connection_manager::ConnectionManager;
 mod connection;
 mod hosting;
@@ -135,6 +136,13 @@ pub(crate) struct Ring {
     /// `crate::ring::update_rate_limit` and `docs/design/contract-hardening.md`
     /// Phase 2.
     pub(crate) update_rate_limiter: Arc<update_rate_limit::UpdateRateLimiter>,
+    /// Per-contract ban list. Populated by the governance reaper on
+    /// `BanTriggered` / `BanLifted` transitions; consulted at the
+    /// inbound dispatch site to drop wire requests for banned
+    /// contracts. Phase 7 of the contract-hardening plan
+    /// (`docs/design/contract-hardening.md`) and the auto-detection
+    /// half of issue #4274 (operator-CLI blocklist).
+    pub(crate) contract_ban_list: Arc<contract_ban_list::ContractBanList>,
     event_register: Box<dyn NetEventRegister>,
     op_manager: RwLock<Option<Weak<OpManager>>>,
     /// Whether this peer is a gateway or not. This will affect behavior of the node when acquiring
@@ -275,6 +283,9 @@ impl Ring {
             broken_invariants: BrokenInvariantsTracker::new(),
             governance,
             update_rate_limiter: Arc::new(update_rate_limit::UpdateRateLimiter::new(
+                time_source.clone(),
+            )),
+            contract_ban_list: Arc::new(contract_ban_list::ContractBanList::new(
                 time_source.clone(),
             )),
             live_tx_tracker: live_tx_tracker.clone(),
@@ -710,6 +721,12 @@ impl Ring {
             // for pairs that haven't tried an UPDATE since then.
             ring.update_rate_limiter.cleanup();
 
+            // Phase 7 ban-list maintenance. Defense-in-depth — the
+            // BanLifted decisions below explicitly unban, but if any
+            // entry slipped through the reaper (e.g. mode flipped off
+            // mid-window), cleanup catches it on the next tick.
+            ring.contract_ban_list.cleanup();
+
             // Network-norms summary at DEBUG — useful when debugging
             // calibration but too noisy for INFO on a healthy node.
             tracing::debug!(
@@ -720,6 +737,16 @@ impl Ring {
                 capacity_ceiling_binding = result.capacity_ceiling_binding,
                 skip_reason = ?result.skip_reason,
                 "governance reaper tick",
+            );
+
+            // Phase 7 enforcement wiring: BanTriggered → ban list;
+            // BanLifted → unban. Done AFTER the cleanup() so a
+            // stale-cleanup race can't briefly remove an entry that
+            // a fresh BanTriggered is about to add this tick.
+            Self::apply_ban_decisions(
+                &ring.contract_ban_list,
+                &result.decisions,
+                ring.time_source.now() + ring.governance.ban_ttl(),
             );
 
             // Decisions at INFO — these are the dashboard-relevant
@@ -734,6 +761,34 @@ impl Ring {
                     actionable = decision.actionable,
                     "governance state transition",
                 );
+            }
+        }
+    }
+
+    /// Translate a batch of governance decisions into ban-list
+    /// mutations. Pulled out of the reaper loop so the wiring is
+    /// directly testable: a missing or reversed branch here would
+    /// silently break Phase 7 enforcement even with the
+    /// `GovernanceManager` emitting correct transitions.
+    fn apply_ban_decisions(
+        ban_list: &contract_ban_list::ContractBanList,
+        decisions: &[crate::contract::governance::ReaperDecision],
+        ban_expiry: tokio::time::Instant,
+    ) {
+        use crate::contract::governance::TransitionReason;
+        for decision in decisions {
+            match decision.reason {
+                TransitionReason::BanTriggered => {
+                    ban_list.ban(
+                        decision.key,
+                        ban_expiry,
+                        contract_ban_list::BanReason::AutoMad,
+                    );
+                }
+                TransitionReason::BanLifted => {
+                    ban_list.unban(&decision.key);
+                }
+                _ => {}
             }
         }
     }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -45,7 +45,7 @@ use crate::{
 mod broken_invariants;
 mod connection_backoff;
 mod connection_manager;
-mod contract_ban_list;
+pub(crate) mod contract_ban_list;
 pub(crate) use connection_manager::ConnectionManager;
 mod connection;
 mod hosting;
@@ -741,8 +741,11 @@ impl Ring {
 
             // Phase 7 enforcement wiring: BanTriggered → ban list;
             // BanLifted → unban. Done AFTER the cleanup() so a
-            // stale-cleanup race can't briefly remove an entry that
-            // a fresh BanTriggered is about to add this tick.
+            // freshly-added entry (with expiry = now + ban_ttl) is
+            // not immediately swept by the same tick's cleanup. The
+            // two calls are sequential in this task — no concurrent
+            // race — the ordering is purely to defend the
+            // not-quite-expired-yet invariant.
             Self::apply_ban_decisions(
                 &ring.contract_ban_list,
                 &result.decisions,
@@ -770,13 +773,24 @@ impl Ring {
     /// directly testable: a missing or reversed branch here would
     /// silently break Phase 7 enforcement even with the
     /// `GovernanceManager` emitting correct transitions.
-    fn apply_ban_decisions(
+    ///
+    /// **`actionable` filter:** non-actionable decisions (DryRun
+    /// mode) are skipped. Today the `GovernanceManager` only emits
+    /// `BanTriggered` in Enforce mode so this is a defense-in-depth
+    /// guard — but a future "shadow" mode that wants to surface
+    /// would-have-banned transitions in the dashboard must not
+    /// silently begin enforcing them through this wiring.
+    pub(crate) fn apply_ban_decisions(
         ban_list: &contract_ban_list::ContractBanList,
         decisions: &[crate::contract::governance::ReaperDecision],
         ban_expiry: tokio::time::Instant,
     ) {
         use crate::contract::governance::TransitionReason;
         for decision in decisions {
+            if !decision.actionable {
+                continue;
+            }
+            #[allow(clippy::wildcard_enum_match_arm)]
             match decision.reason {
                 TransitionReason::BanTriggered => {
                     ban_list.ban(

--- a/crates/core/src/ring/contract_ban_list.rs
+++ b/crates/core/src/ring/contract_ban_list.rs
@@ -1,0 +1,415 @@
+//! Per-contract ban list — Phase 7 of the contract-hardening plan.
+//!
+//! When `GovernanceManager` transitions a contract into the `Banned`
+//! state (repeat offender — re-flagged within the ban_window after a
+//! prior eviction), the contract id is pushed into this list along
+//! with a TTL. While in the list, all inbound wire-protocol REQUEST
+//! messages for that contract are dropped at the receive boundary.
+//!
+//! ## What this rejects
+//!
+//! - `PutMsg::Request` / `PutMsg::RequestStreaming` — refuse to store.
+//! - `GetMsg::Request` / `GetMsg::RequestStreaming` — refuse to serve.
+//! - `UpdateMsg::*` — refuse to apply or fan out.
+//! - `SubscribeMsg::Request` — refuse to register interest.
+//!
+//! ## What this does NOT reject
+//!
+//! - **Responses to our own outbound requests.** If we sent a request
+//!   before the ban kicked in, allowing the reply completes that
+//!   transaction cleanly. The next request we make for the contract
+//!   would be self-blocked at the egress (Phase 7 follow-up); for now
+//!   we focus on the receive side.
+//! - **Peer-level messages** (ConnectMsg, etc.) — those are the peer
+//!   layer's concern, not the contract layer.
+//!
+//! ## Two ways entries get added
+//!
+//! 1. **Automatic** (this PR): `GovernanceManager` transitions a
+//!    contract into `Banned`. The reaper loop sees the decision and
+//!    pushes the id to this list with the configured `ban_ttl`. When
+//!    the matching `BanLifted` transition fires, the entry is removed.
+//!
+//! 2. **Operator CLI** (issue #4274, follow-up): operator runs
+//!    `freenet contract ban <key>` or sets a config flag. Hooks into
+//!    the same list via [`ContractBanList::ban`].
+//!
+//! ## Cleanup
+//!
+//! The `Banned` state has its own TTL (`ban_ttl`, default 1 hour) and
+//! `GovernanceManager` emits a `BanLifted` decision when the TTL
+//! expires. That decision drives [`ContractBanList::unban`]. So the
+//! list shouldn't accumulate stale entries under normal operation.
+//!
+//! As a defense-in-depth, [`ContractBanList::cleanup`] sweeps any
+//! entries whose `expires_at` has passed but for some reason weren't
+//! removed by an explicit `unban` — e.g. if the GovernanceManager
+//! state was reset without flushing the list.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use freenet_stdlib::prelude::ContractInstanceId;
+use tokio::time::Instant;
+
+use crate::util::time_source::TimeSource;
+
+/// Why a contract was added to the ban list. Surface on the dashboard
+/// so operators can distinguish automatic (governance-driven) bans
+/// from manual (operator-CLI) bans.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BanReason {
+    /// Auto-flipped by `GovernanceManager` after `BanTriggered`
+    /// (repeat-eviction within the ban_window).
+    AutoMad,
+    /// Operator-driven via the CLI / config flag (#4274). Reserved
+    /// for the follow-up PR that wires the operator-facing surface.
+    #[allow(dead_code)]
+    Operator,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BanEntry {
+    /// Wall-clock-equivalent moment when this ban automatically
+    /// lifts. Computed at insertion time as `now + ban_ttl`; the
+    /// `GovernanceManager` does the same arithmetic when it emits the
+    /// matching `BanLifted` decision, so the two converge.
+    expires_at: Instant,
+    reason: BanReason,
+}
+
+/// Per-(contract instance) ban list. Read by the wire-message
+/// dispatch site to drop inbound requests; written by the governance
+/// reaper loop on `BanTriggered` / `BanLifted` transitions.
+pub(crate) struct ContractBanList {
+    entries: DashMap<ContractInstanceId, BanEntry>,
+    time_source: Arc<dyn TimeSource + Send + Sync>,
+}
+
+impl ContractBanList {
+    pub fn new(time_source: Arc<dyn TimeSource + Send + Sync>) -> Self {
+        Self {
+            entries: DashMap::new(),
+            time_source,
+        }
+    }
+
+    /// Fast-path predicate used at every inbound wire dispatch arm
+    /// carrying a `ContractKey`. Returns true if the contract is
+    /// banned right now — caller drops the message.
+    ///
+    /// The expiry check here is a safety net: under normal operation
+    /// the explicit `unban()` call from the reaper's `BanLifted`
+    /// decision removes the entry before we ever look at the
+    /// timestamp. But if the reaper hasn't ticked since the TTL
+    /// elapsed (e.g. just after a long-paused interval in a
+    /// simulation), this returns false anyway and the entry will be
+    /// cleared on the next `cleanup()`.
+    pub fn is_banned(&self, contract: &ContractInstanceId) -> bool {
+        match self.entries.get(contract) {
+            None => false,
+            Some(entry) => {
+                let now = self.time_source.now();
+                now < entry.expires_at
+            }
+        }
+    }
+
+    /// Add a contract to the ban list with the given expiry instant
+    /// and reason. Idempotent: re-banning extends the expiry to
+    /// whichever value is later (the new one — typically the reaper
+    /// is calling this because a fresh `BanTriggered` just fired).
+    pub fn ban(&self, contract: ContractInstanceId, expires_at: Instant, reason: BanReason) {
+        use dashmap::mapref::entry::Entry;
+        match self.entries.entry(contract) {
+            Entry::Occupied(mut e) => {
+                let cur = e.get_mut();
+                // Keep whichever expiry is later — re-bans should
+                // never shorten an existing ban window.
+                if expires_at > cur.expires_at {
+                    cur.expires_at = expires_at;
+                }
+                // Reason: operator wins over auto, since explicit
+                // operator action should not be overwritten by a
+                // later auto-flip.
+                if matches!(reason, BanReason::Operator) {
+                    cur.reason = BanReason::Operator;
+                }
+            }
+            Entry::Vacant(e) => {
+                e.insert(BanEntry { expires_at, reason });
+            }
+        }
+    }
+
+    /// Remove a contract from the ban list, regardless of expiry.
+    /// Called from the reaper loop when a `BanLifted` decision fires.
+    pub fn unban(&self, contract: &ContractInstanceId) {
+        self.entries.remove(contract);
+    }
+
+    /// Drop entries whose `expires_at` has passed. Called periodically
+    /// from the governance reaper tick as a defense-in-depth in case
+    /// an explicit `unban` was skipped (process restart, race during
+    /// configuration reload, etc).
+    pub fn cleanup(&self) {
+        let now = self.time_source.now();
+        self.entries.retain(|_, entry| entry.expires_at > now);
+    }
+
+    /// Number of currently-banned contracts. Used by tests and the
+    /// dashboard's governance card for "N contracts on ban list."
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract::governance::{GovernanceState, ReaperDecision, TransitionReason};
+    use crate::ring::Ring;
+    use crate::util::time_source::SharedMockTimeSource;
+    use std::time::Duration;
+
+    fn mk_contract(byte: u8) -> ContractInstanceId {
+        ContractInstanceId::new([byte; 32])
+    }
+
+    fn mk_decision(
+        contract: ContractInstanceId,
+        reason: TransitionReason,
+        at: Instant,
+    ) -> ReaperDecision {
+        // The from/to states aren't load-bearing for the
+        // `apply_ban_decisions` wiring — only `reason` is — but
+        // populate them with a plausible pair so the value reads
+        // naturally in test failure output.
+        let (from, to) = match reason {
+            TransitionReason::BanTriggered => (GovernanceState::Evicted, GovernanceState::Banned),
+            TransitionReason::BanLifted => (GovernanceState::Banned, GovernanceState::Normal),
+            _ => (GovernanceState::Normal, GovernanceState::Normal),
+        };
+        ReaperDecision {
+            key: contract,
+            from,
+            to,
+            reason,
+            at,
+            actionable: true,
+        }
+    }
+
+    fn mk_ban_list() -> (ContractBanList, SharedMockTimeSource) {
+        let ts = SharedMockTimeSource::new();
+        let bl = ContractBanList::new(Arc::new(ts.clone()));
+        (bl, ts)
+    }
+
+    #[test]
+    fn unbanned_contract_returns_false() {
+        let (bl, _ts) = mk_ban_list();
+        assert!(!bl.is_banned(&mk_contract(1)));
+    }
+
+    #[test]
+    fn banned_contract_returns_true_until_expiry() {
+        let (bl, ts) = mk_ban_list();
+        let contract = mk_contract(1);
+        let now = ts.now();
+        bl.ban(contract, now + Duration::from_secs(60), BanReason::AutoMad);
+        assert!(bl.is_banned(&contract));
+        // Just before expiry.
+        ts.advance_time(Duration::from_secs(59));
+        assert!(bl.is_banned(&contract));
+        // At expiry — boundary check uses `<` so equal-time is NOT
+        // banned (the contract has done its time).
+        ts.advance_time(Duration::from_secs(1));
+        assert!(!bl.is_banned(&contract));
+    }
+
+    #[test]
+    fn unban_removes_entry_immediately() {
+        let (bl, ts) = mk_ban_list();
+        let contract = mk_contract(1);
+        bl.ban(
+            contract,
+            ts.now() + Duration::from_secs(60),
+            BanReason::AutoMad,
+        );
+        assert!(bl.is_banned(&contract));
+        bl.unban(&contract);
+        assert!(!bl.is_banned(&contract));
+        assert_eq!(bl.len(), 0);
+    }
+
+    #[test]
+    fn rebanning_extends_window_not_shortens() {
+        let (bl, ts) = mk_ban_list();
+        let contract = mk_contract(1);
+        let start = ts.now();
+        bl.ban(
+            contract,
+            start + Duration::from_secs(120),
+            BanReason::AutoMad,
+        );
+        // Re-ban with an EARLIER expiry — must not shorten.
+        bl.ban(
+            contract,
+            start + Duration::from_secs(30),
+            BanReason::AutoMad,
+        );
+        ts.advance_time(Duration::from_secs(60));
+        assert!(
+            bl.is_banned(&contract),
+            "re-banning with earlier expiry must not shorten the existing ban"
+        );
+    }
+
+    #[test]
+    fn rebanning_with_later_expiry_extends() {
+        let (bl, ts) = mk_ban_list();
+        let contract = mk_contract(1);
+        let start = ts.now();
+        bl.ban(
+            contract,
+            start + Duration::from_secs(60),
+            BanReason::AutoMad,
+        );
+        bl.ban(
+            contract,
+            start + Duration::from_secs(120),
+            BanReason::AutoMad,
+        );
+        ts.advance_time(Duration::from_secs(90));
+        assert!(
+            bl.is_banned(&contract),
+            "extended ban window must keep contract banned past original expiry"
+        );
+    }
+
+    #[test]
+    fn operator_reason_wins_over_auto() {
+        let (bl, ts) = mk_ban_list();
+        let contract = mk_contract(1);
+        let now = ts.now();
+        bl.ban(contract, now + Duration::from_secs(60), BanReason::AutoMad);
+        bl.ban(contract, now + Duration::from_secs(60), BanReason::Operator);
+        // We don't expose `reason` publicly yet (Phase 7 follow-up
+        // surfaces it on the dashboard), but the invariant matters:
+        // operator action shouldn't be overwritten by a later auto
+        // flip. Test via a fresh override.
+        bl.ban(contract, now + Duration::from_secs(60), BanReason::AutoMad);
+        assert!(bl.is_banned(&contract));
+        // Direct inspect via internal field for test.
+        let entry = bl.entries.get(&contract).unwrap();
+        assert_eq!(entry.reason, BanReason::Operator);
+    }
+
+    #[test]
+    fn cleanup_drops_expired_entries() {
+        let (bl, ts) = mk_ban_list();
+        bl.ban(
+            mk_contract(1),
+            ts.now() + Duration::from_secs(10),
+            BanReason::AutoMad,
+        );
+        bl.ban(
+            mk_contract(2),
+            ts.now() + Duration::from_secs(60),
+            BanReason::AutoMad,
+        );
+        assert_eq!(bl.len(), 2);
+        ts.advance_time(Duration::from_secs(20));
+        bl.cleanup();
+        assert_eq!(
+            bl.len(),
+            1,
+            "cleanup must drop contract 1 (expired) but keep contract 2 (fresh)"
+        );
+    }
+
+    #[test]
+    fn distinct_contracts_independent() {
+        let (bl, ts) = mk_ban_list();
+        bl.ban(
+            mk_contract(1),
+            ts.now() + Duration::from_secs(60),
+            BanReason::AutoMad,
+        );
+        assert!(bl.is_banned(&mk_contract(1)));
+        assert!(!bl.is_banned(&mk_contract(2)));
+        assert_eq!(bl.len(), 1);
+    }
+
+    // Wiring tests — `Ring::apply_ban_decisions` is the bridge between
+    // governance decisions and the ban list. Even with the unit tests
+    // above passing, a missing or reversed match arm in the wiring
+    // would silently break Phase 7. These tests pin the contract.
+
+    #[test]
+    fn ban_decision_adds_to_list() {
+        let (bl, ts) = mk_ban_list();
+        let contract = mk_contract(7);
+        let now = ts.now();
+        let decisions = vec![mk_decision(contract, TransitionReason::BanTriggered, now)];
+        Ring::apply_ban_decisions(&bl, &decisions, now + Duration::from_secs(60));
+        assert!(
+            bl.is_banned(&contract),
+            "BanTriggered decision must add the contract to the ban list"
+        );
+    }
+
+    #[test]
+    fn lifted_decision_removes_from_list() {
+        let (bl, ts) = mk_ban_list();
+        let contract = mk_contract(7);
+        bl.ban(
+            contract,
+            ts.now() + Duration::from_secs(60),
+            BanReason::AutoMad,
+        );
+        let decisions = vec![mk_decision(contract, TransitionReason::BanLifted, ts.now())];
+        Ring::apply_ban_decisions(&bl, &decisions, ts.now() + Duration::from_secs(60));
+        assert!(
+            !bl.is_banned(&contract),
+            "BanLifted decision must remove the contract from the ban list"
+        );
+    }
+
+    #[test]
+    fn unrelated_decisions_do_not_touch_ban_list() {
+        let (bl, ts) = mk_ban_list();
+        let contract = mk_contract(7);
+        // Non-ban transitions (Evicted, etc.) should be no-ops here —
+        // they're handled elsewhere (eviction queue, dashboard).
+        let decisions = vec![mk_decision(contract, TransitionReason::Evicted, ts.now())];
+        Ring::apply_ban_decisions(&bl, &decisions, ts.now() + Duration::from_secs(60));
+        assert!(
+            !bl.is_banned(&contract),
+            "non-ban transition reasons must not affect the ban list"
+        );
+        assert_eq!(bl.len(), 0);
+    }
+
+    #[test]
+    fn batch_mixed_decisions_apply_in_order() {
+        let (bl, ts) = mk_ban_list();
+        let a = mk_contract(1);
+        let b = mk_contract(2);
+        let c = mk_contract(3);
+        // Pre-ban `b` so a BanLifted in the same batch can clear it.
+        bl.ban(b, ts.now() + Duration::from_secs(60), BanReason::AutoMad);
+        let now = ts.now();
+        let decisions = vec![
+            mk_decision(a, TransitionReason::BanTriggered, now),
+            mk_decision(b, TransitionReason::BanLifted, now),
+            mk_decision(c, TransitionReason::BanTriggered, now),
+        ];
+        Ring::apply_ban_decisions(&bl, &decisions, now + Duration::from_secs(60));
+        assert!(bl.is_banned(&a), "contract A must be newly banned");
+        assert!(!bl.is_banned(&b), "contract B must be unbanned");
+        assert!(bl.is_banned(&c), "contract C must be newly banned");
+    }
+}

--- a/crates/core/src/ring/contract_ban_list.rs
+++ b/crates/core/src/ring/contract_ban_list.rs
@@ -9,9 +9,12 @@
 //! ## What this rejects
 //!
 //! - `PutMsg::Request` / `PutMsg::RequestStreaming` — refuse to store.
-//! - `GetMsg::Request` / `GetMsg::RequestStreaming` — refuse to serve.
-//! - `UpdateMsg::*` — refuse to apply or fan out.
+//! - `GetMsg::Request` — refuse to serve. (No `RequestStreaming`
+//!   variant exists for GET; only responses stream.)
+//! - `UpdateMsg::*` Request / Broadcast variants — refuse to apply or
+//!   fan out.
 //! - `SubscribeMsg::Request` — refuse to register interest.
+//!   `Unsubscribe` deliberately passes through so cleanup proceeds.
 //!
 //! ## What this does NOT reject
 //!
@@ -22,6 +25,11 @@
 //!   we focus on the receive side.
 //! - **Peer-level messages** (ConnectMsg, etc.) — those are the peer
 //!   layer's concern, not the contract layer.
+//! - **Proactive state egress for already-hosted contracts**
+//!   (`NeighborHosting` overlap sync, `InterestSync::Summaries` stale
+//!   repair). These paths are also gated (see node.rs) but the gates
+//!   live at the egress sites, not here. See issue tracking egress
+//!   self-blocking for the full design.
 //!
 //! ## Two ways entries get added
 //!
@@ -186,6 +194,7 @@ mod tests {
         // `apply_ban_decisions` wiring — only `reason` is — but
         // populate them with a plausible pair so the value reads
         // naturally in test failure output.
+        #[allow(clippy::wildcard_enum_match_arm)]
         let (from, to) = match reason {
             TransitionReason::BanTriggered => (GovernanceState::Evicted, GovernanceState::Banned),
             TransitionReason::BanLifted => (GovernanceState::Banned, GovernanceState::Normal),
@@ -394,6 +403,38 @@ mod tests {
     }
 
     #[test]
+    fn non_actionable_decision_is_skipped() {
+        // DryRun-mode safety: even if a BanTriggered somehow reaches
+        // the wiring with `actionable: false` (a future Shadow mode,
+        // a misconfigured GovernanceManager), it must not enter the
+        // ban list. Otherwise DryRun silently enforces.
+        let (bl, ts) = mk_ban_list();
+        let contract = mk_contract(9);
+        let mut decision = mk_decision(contract, TransitionReason::BanTriggered, ts.now());
+        decision.actionable = false;
+        Ring::apply_ban_decisions(&bl, &[decision], ts.now() + Duration::from_secs(60));
+        assert!(
+            !bl.is_banned(&contract),
+            "non-actionable BanTriggered must not land on the ban list"
+        );
+
+        // And the same for BanLifted — a non-actionable lift must
+        // not silently delete an enforcement-mode ban.
+        bl.ban(
+            contract,
+            ts.now() + Duration::from_secs(60),
+            BanReason::AutoMad,
+        );
+        let mut decision = mk_decision(contract, TransitionReason::BanLifted, ts.now());
+        decision.actionable = false;
+        Ring::apply_ban_decisions(&bl, &[decision], ts.now() + Duration::from_secs(60));
+        assert!(
+            bl.is_banned(&contract),
+            "non-actionable BanLifted must not remove an existing ban"
+        );
+    }
+
+    #[test]
     fn batch_mixed_decisions_apply_in_order() {
         let (bl, ts) = mk_ban_list();
         let a = mk_contract(1);
@@ -412,4 +453,189 @@ mod tests {
         assert!(!bl.is_banned(&b), "contract B must be unbanned");
         assert!(bl.is_banned(&c), "contract C must be newly banned");
     }
+
+    // Source-grep pin tests for the wire-boundary and egress gates in
+    // node.rs. The gates themselves are one-liner `is_banned(...)`
+    // checks — a refactor of `process_message` that drops or
+    // reorders one would silently disable enforcement and pass every
+    // other test in the suite. Mirrors the pattern from Phase 2's
+    // `update_dispatch_gates_all_four_wire_variants` test in
+    // `update_rate_limit.rs`. If you're here because a test below
+    // failed: the message tells you which gate moved or disappeared
+    // — re-establish the check before re-running the suite.
+
+    /// Returns the slice of `node.rs` covering one `NetMessageV1::X`
+    /// arm. Bounds the slice at the next `NetMessageV1::` arm so an
+    /// assertion can't accidentally match the next handler.
+    fn dispatch_block<'a>(src: &'a str, arm_header: &str) -> &'a str {
+        let start = src
+            .find(arm_header)
+            .unwrap_or_else(|| panic!("could not locate `{arm_header}` in node.rs"));
+        let tail = &src[start + 1..];
+        let len = tail
+            .find("\n        NetMessageV1::")
+            .or_else(|| tail.find("\n    NetMessageV1::"))
+            .unwrap_or(tail.len());
+        &src[start..start + 1 + len]
+    }
+
+    #[test]
+    fn put_dispatch_gates_banned_contracts() {
+        const NODE_SRC: &str = include_str!("../node.rs");
+        let block = dispatch_block(NODE_SRC, "NetMessageV1::Put(ref op) =>");
+        let gate_pos = block
+            .find("contract_ban_list.is_banned")
+            .expect("PUT dispatch is missing the ban-list gate");
+        let spawn_pos = block
+            .find("start_relay_put")
+            .expect("PUT dispatch is missing start_relay_put");
+        assert!(
+            gate_pos < spawn_pos,
+            "PUT ban-list gate (offset {gate_pos}) must run BEFORE \
+             start_relay_put (offset {spawn_pos}) so banned requests \
+             don't pay the spawn cost"
+        );
+        // Both inbound request variants must be matched so a flooder
+        // can't bypass by switching to streaming (mirrors the Phase 2
+        // four-variant pin).
+        for variant in ["PutMsg::Request {", "PutMsg::RequestStreaming {"] {
+            assert!(
+                block.contains(variant),
+                "PUT dispatch block is missing wire variant `{variant}`"
+            );
+        }
+    }
+
+    #[test]
+    fn get_dispatch_gates_banned_contracts() {
+        const NODE_SRC: &str = include_str!("../node.rs");
+        let block = dispatch_block(NODE_SRC, "NetMessageV1::Get(ref op) =>");
+        let gate_pos = block
+            .find("contract_ban_list.is_banned")
+            .expect("GET dispatch is missing the ban-list gate");
+        let spawn_pos = block
+            .find("start_relay_get")
+            .expect("GET dispatch is missing start_relay_get");
+        assert!(
+            gate_pos < spawn_pos,
+            "GET ban-list gate (offset {gate_pos}) must run BEFORE \
+             start_relay_get (offset {spawn_pos})"
+        );
+        assert!(
+            block.contains("GetMsg::Request {"),
+            "GET dispatch block is missing wire variant `GetMsg::Request {{`"
+        );
+    }
+
+    #[test]
+    fn update_dispatch_gates_banned_contracts() {
+        const NODE_SRC: &str = include_str!("../node.rs");
+        let block = dispatch_block(NODE_SRC, "NetMessageV1::Update(ref op) =>");
+        let gate_pos = block
+            .find("contract_ban_list.is_banned")
+            .expect("UPDATE dispatch is missing the ban-list gate");
+        let rate_limit_pos = block
+            .find("update_rate_limiter")
+            .expect("UPDATE dispatch is missing the rate limiter");
+        assert!(
+            gate_pos < rate_limit_pos,
+            "UPDATE ban-list gate (offset {gate_pos}) must run BEFORE \
+             the rate limiter (offset {rate_limit_pos}) so banned \
+             traffic doesn't consume the rate-limit budget"
+        );
+        // All four UPDATE wire variants must remain matched; if a new
+        // one is added it must be gated through both the ban list
+        // and the rate limiter.
+        for variant in [
+            "UpdateMsg::RequestUpdate {",
+            "UpdateMsg::BroadcastTo {",
+            "UpdateMsg::RequestUpdateStreaming {",
+            "UpdateMsg::BroadcastToStreaming {",
+        ] {
+            assert!(
+                block.contains(variant),
+                "UPDATE dispatch block is missing wire variant `{variant}`"
+            );
+        }
+    }
+
+    #[test]
+    fn subscribe_dispatch_gates_banned_contracts() {
+        const NODE_SRC: &str = include_str!("../node.rs");
+        let block = dispatch_block(NODE_SRC, "NetMessageV1::Subscribe(ref op) =>");
+        let gate_pos = block
+            .find("contract_ban_list.is_banned")
+            .expect("SUBSCRIBE dispatch is missing the ban-list gate");
+        // Match the call site (`(`-terminated) — `start_relay_subscribe`
+        // appears in a doc comment too, and `block.find()` returns the
+        // first match.
+        let driver_pos = block
+            .find("start_relay_subscribe(")
+            .expect("SUBSCRIBE dispatch is missing start_relay_subscribe call");
+        assert!(
+            gate_pos < driver_pos,
+            "SUBSCRIBE ban-list gate (offset {gate_pos}) must run \
+             BEFORE start_relay_subscribe call (offset {driver_pos})"
+        );
+        // Gate must match Request (block registration); Unsubscribe
+        // deliberately passes through so cleanup proceeds.
+        assert!(
+            block.contains("SubscribeMsg::Request {"),
+            "SUBSCRIBE dispatch block is missing `SubscribeMsg::Request {{`"
+        );
+    }
+
+    #[test]
+    fn neighbor_hosting_gates_banned_egress() {
+        const NODE_SRC: &str = include_str!("../node.rs");
+        let block = dispatch_block(NODE_SRC, "NetMessageV1::NeighborHosting");
+        let gate_pos = block.find("contract_ban_list.is_banned").expect(
+            "NeighborHosting overlap-sync block is missing the ban-list egress gate — \
+             banned contracts would continue to be pushed to sibling peers",
+        );
+        let emit_pos = block
+            .find("NodeEvent::SyncStateToPeer")
+            .expect("NeighborHosting block is missing SyncStateToPeer emit");
+        assert!(
+            gate_pos < emit_pos,
+            "NeighborHosting ban-list gate (offset {gate_pos}) must \
+             precede SyncStateToPeer emit (offset {emit_pos})"
+        );
+    }
+
+    #[test]
+    fn interest_sync_summaries_gates_banned_egress() {
+        // The stale-summary repair loop lives inside
+        // `handle_interest_sync_message` (the helper that the
+        // NetMessageV1::InterestSync arm delegates to), not in
+        // `process_message` itself. Search the whole file scoped to
+        // the `for contract in stale_contracts` loop.
+        const NODE_SRC: &str = include_str!("../node.rs");
+        let stale_loop = NODE_SRC
+            .find("for contract in stale_contracts")
+            .expect("node.rs is missing the stale_contracts loop");
+        // Bound the search to the loop body — the loop ends when
+        // indentation returns to the loop's level. A loose heuristic:
+        // take 2_000 bytes after the loop header (the body is short).
+        let scan = &NODE_SRC[stale_loop..stale_loop.saturating_add(2_000).min(NODE_SRC.len())];
+        let gate_pos = scan.find("contract_ban_list.is_banned").expect(
+            "stale-summary repair loop is missing the ban-list egress gate — \
+             banned contracts would continue to be pushed to peers that report \
+             stale summaries (defeats the Phase 7 wire-boundary drop)",
+        );
+        let emit_pos = scan
+            .find("NodeEvent::SyncStateToPeer")
+            .expect("stale-summary loop is missing SyncStateToPeer emit");
+        assert!(
+            gate_pos < emit_pos,
+            "InterestSync ban-list gate (offset {gate_pos}) must \
+             precede SyncStateToPeer emit (offset {emit_pos})"
+        );
+    }
+
+    // End-to-end regression test (May 21 incident pattern) lives in
+    // `contract/governance.rs` next to the BanTriggered/BanLifted
+    // unit tests, where the test helpers for the state-machine setup
+    // (mk_mgr_shared, etc.) already exist. See
+    // `governance_to_ban_list_end_to_end` in that module.
 }


### PR DESCRIPTION
## Problem

After Phase 4 (`GovernanceManager` state machine with `Normal → Borderline → WouldEvict → Evicted → Banned`), the `Banned` state had no enforcement: a contract could be flagged, evicted, re-flagged, and transitioned into `Banned` — and nothing on the wire would change. Repeat offenders could continue to send PUT/GET/UPDATE/SUBSCRIBE traffic and burn resources.

## Approach

Add a per-node `ContractBanList` keyed by `ContractInstanceId`, populated by the governance reaper loop on `TransitionReason::BanTriggered` and drained on `BanLifted`. The wire-boundary dispatch site in `node.rs` consults the list and drops inbound REQUEST messages for banned contracts:

- `PutMsg::Request` / `PutMsg::RequestStreaming`
- `GetMsg::Request`
- `UpdateMsg::*` (all 4 wire variants — gate runs before the Phase 2 rate limiter so banned traffic doesn't consume the rate-limit budget)
- `SubscribeMsg::Request`

**What is NOT blocked:** responses to our own outbound requests — letting them through lets in-flight transactions complete cleanly. Future Phase 7 follow-up may add egress self-blocking.

**Wiring:** `Ring::apply_ban_decisions` extracted from `governance_reaper_loop` so the bridge between `ReaperDecision` and `ContractBanList` mutations is directly testable. The reaper calls it once per tick after `ContractBanList::cleanup()` (defense-in-depth against stale entries from a config reload).

## Testing

- **8 unit tests** on `ContractBanList`: ban/unban, expiry boundary (`<` not `<=`), re-ban with later vs earlier expiry (must not shorten), operator reason wins over auto, cleanup drops only expired, distinct contracts independent.
- **4 wiring tests** on `Ring::apply_ban_decisions`: BanTriggered adds, BanLifted removes, unrelated transitions are no-ops, mixed batch applies in order.
- Full lib build clean, clippy clean (\`-D warnings\`), all 28 \`contract::governance\` tests still pass.

End-to-end simulation test (inject May 21 pattern → assert rate-limit → MAD → eviction → ban chain) deferred to a follow-up.

Closes part of #4296 (Phase 7 checkbox).

[AI-assisted - Claude]