### PR TITLE
fix(contracts): make idempotency probe sound + TTL the broken-invariant flag

### DIFF
--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -148,11 +148,24 @@ State merging rules:
   - For `UpdateData::State` inputs, merge MUST be idempotent:
       update_state(update_state(S, State(X)), State(X)) == update_state(S, State(X))
     Enforced at runtime via the in-peer probe in
-    `Executor::maybe_probe_idempotency`. Violators get flagged in
-    `Ring::broken_invariants` and their outbound `BroadcastStateChange`
-    is suppressed locally; the flag is permanent for that contract
-    instance id and survives restart. See `ring::broken_invariants` and
-    issue #4251 / PR #4279.
+    `Executor::maybe_probe_idempotency`. The probe re-applies the update and
+    flags a violation when the re-applied state's byte MULTISET differs from
+    the original — i.e. the CONTENT changed (a counter/timestamp/signature
+    churned, an entry was added/removed), including the fixed-size byte-churn
+    shape of the #4251 incident. It does NOT flag a mere REORDERING of the
+    same bytes, because a correct contract with non-canonical serialization
+    (HashMap/HashSet iteration order) re-serializes the same logical state in
+    a different byte order (the #4295 false-positive case). Violators get
+    flagged in `Ring::broken_invariants` and their outbound
+    `BroadcastStateChange` is suppressed locally. The flag is TTL-bounded
+    (`BROKEN_INVARIANT_TTL`, swept by the Ring reaper) so a false positive
+    self-heals instead of bricking the contract forever; a genuine violation
+    is re-detected by the next sampled probe after expiry (probabilistic, so
+    a bounded periodic leak — see `ring::broken_invariants`). Residual
+    false-negative: a content change that coincidentally preserves the exact
+    byte multiset evades detection (far narrower than a size-only check). See
+    `ring::broken_invariants`, issue #4251 / PR #4279, and the #4295
+    soundness/TTL fix.
     Note: this invariant is NOT enforced for `UpdateData::Delta` inputs
     (CmRDT-style "increment by X" deltas legitimately violate it) or
     `UpdateData::RelatedState` (a cross-contract hint, not a CRDT op).

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -21,6 +21,47 @@ const RELATED_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 /// Sample selection uses `GlobalRng` (deterministic under a fixed seed
 /// for simulation tests). See `Executor::maybe_probe_idempotency`.
 const IDEMPOTENCY_PROBE_PROBABILITY: f64 = 1.0 / 32.0;
+
+/// Returns true if `a` and `b` contain the same multiset of bytes — i.e. one
+/// is a reordering of the other — and false if their byte content differs.
+///
+/// This is the discriminator the idempotency probe uses to tell benign
+/// serialization nondeterminism apart from a genuine non-idempotent merge:
+///
+/// - **Benign flutter** (the #4295 false-positive case): a correct contract
+///   with non-canonical serialization (`HashMap`/`HashSet` iteration order)
+///   re-serializes the SAME logical state in a different byte ORDER. Reordering
+///   permutes the serialized bytes but preserves their multiset, so this
+///   returns `true` → not flagged.
+/// - **Genuine non-idempotency** (the #4251/#4279 case the gate must catch):
+///   re-applying the update changes the state's CONTENT — a counter that churns
+///   in place, an embedded timestamp/signature regenerated each merge, an
+///   added/removed entry. Any content change alters the byte multiset (e.g. a
+///   464→465 counter flips digit bytes), so this returns `false` → flagged.
+///   Crucially this catches the *fixed-size* byte-different violator (the real
+///   #4251 incident was a constant-size ~464-byte state) that a size-only
+///   check would miss.
+///
+/// Residual false-negative: a content change that coincidentally preserves the
+/// exact byte multiset (e.g. swapping two equal bytes) evades detection. This
+/// is far narrower than the size-only heuristic's blind spot and far safer than
+/// byte-equality's false positives (which permanently suppressed propagation in
+/// #4295). O(n) in the state size; only runs on the sampled, byte-different
+/// probe path.
+fn byte_multiset_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut hist = [0i64; 256];
+    for &x in a {
+        hist[x as usize] += 1;
+    }
+    for &x in b {
+        hist[x as usize] -= 1;
+    }
+    hist.iter().all(|&c| c == 0)
+}
+
 use crate::node::OpManager;
 use crate::wasm_runtime::{
     BackendEngine, DEFAULT_MODULE_CACHE_CAPACITY, MAX_STATE_SIZE, RuntimeConfig, SharedModuleCache,
@@ -2136,7 +2177,11 @@ where
 
     /// Probe-sampled idempotency check. Re-runs `update_state` with the just-
     /// produced state as the current state and the same updates; flags the
-    /// contract as broken if the result differs.
+    /// contract as broken if the re-applied state's byte MULTISET differs from
+    /// the original (a genuine content change), but NOT if it is merely a
+    /// reordering of the same bytes (benign serialization nondeterminism such
+    /// as `HashMap` key order — the #4295 false-positive case). See
+    /// [`byte_multiset_eq`].
     ///
     /// Costs one extra WASM invocation per sampled merge. With the
     /// configured probability [`IDEMPOTENCY_PROBE_PROBABILITY`] (currently
@@ -2235,21 +2280,53 @@ where
         };
         let probe_state = WrappedState::new(probe_state.into_bytes());
 
-        if probe_state.as_ref() != post_merge_state.as_ref() {
-            if let Some(op_manager) = &self.op_manager {
-                tracing::warn!(
-                    contract = %key,
-                    post_merge_size = post_merge_state.size(),
-                    probe_size = probe_state.size(),
-                    event = "non_idempotent_merge_detected",
-                    "Contract violates update_state idempotency \
-                     (update_state(update_state(S, U), U) != update_state(S, U)). \
-                     Flagging contract; outbound BroadcastStateChange will be suppressed."
-                );
-                op_manager
-                    .ring
-                    .record_broken_invariant(*key, crate::ring::BrokenInvariant::NonIdempotent);
-            }
+        // Byte-identical re-application: definitively idempotent. Fast path
+        // for contracts with canonical serialization.
+        if probe_state.as_ref() == post_merge_state.as_ref() {
+            return;
+        }
+
+        // Bytes differ — but byte inequality alone does NOT prove a CRDT
+        // violation. A correct, logically-idempotent merge can still emit
+        // byte-different output for the SAME logical state when the contract's
+        // serialization is non-canonical (HashMap/HashSet iteration order):
+        // the re-serialized state is a REORDERING of the same bytes. Flagging
+        // on that byte flutter false-positives correct contracts and — because
+        // the broken-invariant flag gates ALL propagation — silently bricks
+        // them. That was the root cause of #4295: the ping contract's
+        // `HashMap`-backed state re-serialized in non-deterministic key order.
+        //
+        // Distinguish a benign reordering from a genuine content change by
+        // comparing the byte MULTISET (not the bytes, not just the size).
+        // Reordering preserves the multiset; a real non-idempotent merge
+        // changes content (a counter, timestamp, signature, added/removed
+        // entry), which changes the multiset — INCLUDING the fixed-size
+        // byte-churn shape of the #4251/#4279 production violator that a
+        // size-only check would miss.
+        if byte_multiset_eq(post_merge_state.as_ref(), probe_state.as_ref()) {
+            tracing::debug!(
+                contract = %key,
+                size = post_merge_state.size(),
+                event = "idempotency_probe_byte_flutter_ignored",
+                "Idempotency probe saw byte-different but same-multiset re-application \
+                 (serialization reordering); treating as benign, not a violation"
+            );
+            return;
+        }
+
+        if let Some(op_manager) = &self.op_manager {
+            tracing::warn!(
+                contract = %key,
+                post_merge_size = post_merge_state.size(),
+                probe_size = probe_state.size(),
+                event = "non_idempotent_merge_detected",
+                "Contract violates update_state idempotency: re-application changes \
+                 state content (different byte multiset, not a reordering). \
+                 Flagging contract; outbound BroadcastStateChange will be suppressed."
+            );
+            op_manager
+                .ring
+                .record_broken_invariant(*key, crate::ring::BrokenInvariant::NonIdempotent);
         }
     }
 
@@ -4980,6 +5057,63 @@ mod state_write_attribution_pin_tests {
              into store_state_sync would not compile, but a refactor \
              that moves state into an intermediate first could regress \
              this silently."
+        );
+    }
+}
+
+// NOTE: this module is placed at the END of the file on purpose. The
+// `production_gate_sites_consult_is_contract_broken` pin test in
+// `pool_tests/non_idempotent_detector_tests.rs` greps the production slice of
+// this file (everything before the FIRST `#[cfg(test)]`) for
+// `is_contract_broken`; a `#[cfg(test)]` placed above the gate sites would
+// truncate that slice and break the pin. Keep new test modules below all
+// production code.
+#[cfg(test)]
+mod idempotency_probe_convergence_tests {
+    use super::byte_multiset_eq;
+
+    /// Regression for #4295: the ping contract's `HashMap` state re-serialized
+    /// in a different key ORDER on re-merge — same bytes, permuted. That MUST
+    /// be treated as benign (same multiset), not flagged.
+    #[test]
+    fn reordered_bytes_are_benign_flutter() {
+        assert!(
+            byte_multiset_eq(b"{\"a\":1,\"b\":2}", b"{\"b\":2,\"a\":1}"),
+            "a key-order permutation has the same byte multiset and must not be flagged"
+        );
+        // Identical bytes are trivially benign.
+        assert!(byte_multiset_eq(b"same", b"same"));
+    }
+
+    /// Regression for the review finding: the #4251 production violator was a
+    /// FIXED-SIZE, byte-different non-idempotent merge (a ~464-byte state whose
+    /// counter prefix churns in place). A size-only check missed it; the
+    /// multiset check MUST flag it (different content => different multiset).
+    #[test]
+    fn fixed_size_content_change_is_flagged() {
+        // Same length, one byte of content differs (e.g. a counter 464 -> 465).
+        assert!(
+            !byte_multiset_eq(b"counter=464;payload", b"counter=465;payload"),
+            "a fixed-size content change must be detected as non-idempotent"
+        );
+        // Simulate the 464-byte fixed-size shape: equal length, differing bytes.
+        let mut s1 = vec![b'x'; 464];
+        let mut s2 = vec![b'x'; 464];
+        s1[0] = 0;
+        s2[0] = 1; // counter prefix churn at constant size
+        assert!(
+            !byte_multiset_eq(&s1, &s2),
+            "fixed-size (464-byte) counter churn must be flagged (the #4251 shape)"
+        );
+    }
+
+    /// A growing (accumulating) merge changes the length (and would also change
+    /// content); the length guard alone flags it. Non-convergent.
+    #[test]
+    fn growing_state_is_flagged() {
+        assert!(
+            !byte_multiset_eq(b"abc", b"abcd"),
+            "a state that grows on re-application is non-convergent"
         );
     }
 }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -280,7 +280,7 @@ impl Ring {
             router,
             connection_manager,
             hosting_manager: hosting::HostingManager::new(config.config.max_hosting_storage),
-            broken_invariants: BrokenInvariantsTracker::new(),
+            broken_invariants: BrokenInvariantsTracker::new(time_source.clone()),
             governance,
             update_rate_limiter: Arc::new(update_rate_limit::UpdateRateLimiter::new(
                 time_source.clone(),
@@ -726,6 +726,11 @@ impl Ring {
             // entry slipped through the reaper (e.g. mode flipped off
             // mid-window), cleanup catches it on the next tick.
             ring.contract_ban_list.cleanup();
+
+            // Sweep expired broken-invariant flags on the same cadence so a
+            // suppressed contract (especially a false-positive) recovers
+            // after BROKEN_INVARIANT_TTL instead of being bricked forever.
+            ring.broken_invariants.cleanup();
 
             // Network-norms summary at DEBUG — useful when debugging
             // calibration but too noisy for INFO on a healthy node.

--- a/crates/core/src/ring/broken_invariants.rs
+++ b/crates/core/src/ring/broken_invariants.rs
@@ -16,16 +16,67 @@
 //!
 //! Reads (via [`BrokenInvariantsTracker::is_broken`]) gate the broadcast-
 //! emission path so a flagged contract's state changes never leave the
-//! node. A "fixed" version of the same contract has a different code hash
-//! → different `ContractKey` → unaffected, so this flag is intentionally
-//! permanent for the given instance id.
+//! node.
+//!
+//! ## Why the flag is TTL-bounded, not permanent
+//!
+//! An earlier revision made the flag permanent on the theory that a "fixed"
+//! contract has a different code hash → different `ContractKey`, so an
+//! instance id flagged once is broken forever. That reasoning is sound for a
+//! *true* violation, but the probe is a sampled heuristic that can
+//! false-positive: it ultimately rests on a byte-level comparison, and a
+//! correct contract whose serialization is non-canonical (HashMap/HashSet
+//! iteration order, float formatting, embedded timestamps) can be flagged
+//! even though its merge is logically idempotent. A permanent, silent,
+//! cross-restart-persistent flag turns a single false positive into a
+//! contract that stops propagating *forever* with no recovery — exactly the
+//! failure mode behind issue #4295 (`test_ping_multi_node` froze because the
+//! ping contract's `HashMap`-backed state byte-fluttered on re-merge).
+//!
+//! So the flag now expires after [`BROKEN_INVARIANT_TTL`]. The consequences:
+//!
+//! - **False positive:** self-heals within one TTL window. Combined with the
+//!   probe's own soundness hardening (it no longer flags benign byte-flutter
+//!   — see `Executor::maybe_probe_idempotency`), false positives should be
+//!   rare *and* recoverable rather than permanent.
+//! - **True violation:** suppressed for a TTL, then re-detected and re-flagged
+//!   (which refreshes the window, so a continuously-merging violator stays
+//!   suppressed). Re-detection is probabilistic: after expiry the probe samples
+//!   at [`crate::contract::executor`]'s `IDEMPOTENCY_PROBE_PROBABILITY` (1/32),
+//!   so the contract leaks the merges that occur between expiry and the next
+//!   sampled probe — in expectation ~32 merges, with a longer tail under a high
+//!   merge rate. That is a deliberately accepted, bounded periodic leak, not the
+//!   permanent re-engaged storm of the pre-#4279 baseline. We accept it because
+//!   the opposite failure — a permanent flag that a *false* positive can trigger,
+//!   silently bricking a correct contract forever (#4295) — is worse, and we
+//!   bias toward false-positive recovery. (A genuinely non-idempotent contract
+//!   has never been observed in production; the only flag ever seen fire was the
+//!   #4295 false positive.) To shorten the leak, raise `BROKEN_INVARIANT_TTL`
+//!   (fewer expiry windows) rather than lowering it.
+//!
+//! This also satisfies the project rule that GC/suppression exemptions must
+//! be time-bounded (see `.claude/rules/ring.md` "Cleanup Exemptions Must Be
+//! Time-Bounded"). Expired entries are swept by [`BrokenInvariantsTracker::cleanup`],
+//! hooked into the same reaper tick as the UPDATE rate limiter.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use dashmap::DashMap;
 use freenet_stdlib::prelude::ContractInstanceId;
+use tokio::time::Instant;
 
 use crate::contract::storages::Storage;
+use crate::util::time_source::TimeSource;
+
+/// How long a broken-invariant flag suppresses a contract before it expires
+/// and the contract is given a fresh chance (re-detected by the next sampled
+/// probe if genuinely still broken).
+///
+/// Chosen to be long enough that a genuinely non-convergent contract leaks at
+/// most ≈one merge per window (negligible amplification) yet short enough that
+/// a false positive recovers promptly rather than bricking the contract.
+pub(crate) const BROKEN_INVARIANT_TTL: Duration = Duration::from_secs(300);
 
 /// The kind of CRDT invariant a contract was observed to violate. Currently
 /// only one variant; future work may add violations like non-commutativity
@@ -53,43 +104,75 @@ impl BrokenInvariant {
     }
 }
 
+/// An in-memory flag together with the instant it was (re-)recorded, so the
+/// flag can expire after [`BROKEN_INVARIANT_TTL`].
+#[derive(Debug, Clone, Copy)]
+struct FlagEntry {
+    kind: BrokenInvariant,
+    recorded_at: Instant,
+}
+
 /// Tracks per-contract broken-invariant flags with optional persistent backing.
 ///
 /// `set_storage` is called once during node startup, at which point the
 /// tracker reads any previously-persisted flags into the in-memory map.
 /// Until storage is wired, reads still work (empty map) and writes are
 /// in-memory only — this matches the pattern used by `HostingManager`.
-#[derive(Default)]
 pub(crate) struct BrokenInvariantsTracker {
-    flags: Arc<DashMap<ContractInstanceId, BrokenInvariant>>,
+    flags: Arc<DashMap<ContractInstanceId, FlagEntry>>,
     storage: std::sync::OnceLock<Storage>,
+    time_source: Arc<dyn TimeSource + Send + Sync>,
 }
 
 impl BrokenInvariantsTracker {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(time_source: Arc<dyn TimeSource + Send + Sync>) -> Self {
+        Self {
+            flags: Arc::new(DashMap::new()),
+            storage: std::sync::OnceLock::new(),
+            time_source,
+        }
     }
 
-    /// Returns true if `id` has any broken-invariant flag set.
+    /// Returns true if `id` currently has a non-expired broken-invariant flag.
+    ///
+    /// Pure read: expired entries are reported as not-broken here and are
+    /// physically reclaimed by the periodic [`BrokenInvariantsTracker::cleanup`]
+    /// sweep, so this stays cheap on the broadcast/commit hot path.
     pub fn is_broken(&self, id: &ContractInstanceId) -> bool {
-        self.flags.contains_key(id)
+        let now = self.time_source.now();
+        match self.flags.get(id) {
+            Some(entry) => now.saturating_duration_since(entry.recorded_at) < BROKEN_INVARIANT_TTL,
+            None => false,
+        }
     }
 
-    /// Returns the broken-invariant flag for `id`, if any. Used by tests
-    /// and future detectors that distinguish kinds; production callers
-    /// only need `is_broken`.
+    /// Returns the broken-invariant flag for `id`, if any and not expired.
+    /// Used by tests and future detectors that distinguish kinds; production
+    /// callers only need `is_broken`.
     #[cfg(test)]
     pub fn get(&self, id: &ContractInstanceId) -> Option<BrokenInvariant> {
-        self.flags.get(id).map(|r| *r.value())
+        let now = self.time_source.now();
+        self.flags.get(id).and_then(|entry| {
+            if now.saturating_duration_since(entry.recorded_at) < BROKEN_INVARIANT_TTL {
+                Some(entry.kind)
+            } else {
+                None
+            }
+        })
     }
 
-    /// Mark `id` as broken with `kind`. Idempotent — repeat calls are no-ops
-    /// once the in-memory entry exists. Persists best-effort to storage if
-    /// wired; persistence errors are logged but never block the in-memory
-    /// flag from taking effect (we'd rather suppress the storm than crash
-    /// on a database hiccup).
+    /// Mark `id` as broken with `kind`, stamping the current time. Re-recording
+    /// an already-flagged contract refreshes its expiry (so a contract the
+    /// probe keeps re-detecting stays suppressed). Persists best-effort to
+    /// storage if wired; persistence errors are logged but never block the
+    /// in-memory flag from taking effect (we'd rather suppress the storm than
+    /// crash on a database hiccup).
     pub fn record(&self, id: ContractInstanceId, kind: BrokenInvariant) {
-        let was_new = self.flags.insert(id, kind).is_none();
+        let recorded_at = self.time_source.now();
+        let was_new = self
+            .flags
+            .insert(id, FlagEntry { kind, recorded_at })
+            .is_none();
         if was_new {
             tracing::warn!(
                 contract = %id,
@@ -127,22 +210,9 @@ impl BrokenInvariantsTracker {
     /// the previous flag if any.
     #[allow(dead_code)] // wired in follow-up PR
     pub fn clear(&self, id: &ContractInstanceId) -> Option<BrokenInvariant> {
-        let previous = self.flags.remove(id).map(|(_, v)| v);
+        let previous = self.flags.remove(id).map(|(_, v)| v.kind);
         if previous.is_some() {
-            #[cfg(feature = "redb")]
-            if let Some(storage) = self.storage.get() {
-                if let Err(e) = storage.remove_broken_invariant(id) {
-                    // Best-effort: in-memory is cleared regardless, but
-                    // warn loudly because a stale on-disk row will
-                    // re-flag on next restart.
-                    tracing::warn!(
-                        contract = %id,
-                        error = %e,
-                        "Cleared in-memory broken-invariant flag, but persistence remove failed — \
-                         flag will be re-loaded on next restart"
-                    );
-                }
-            }
+            self.remove_from_storage(id);
             tracing::warn!(
                 contract = %id,
                 event = "broken_invariant_cleared",
@@ -152,10 +222,65 @@ impl BrokenInvariantsTracker {
         previous
     }
 
+    /// Sweep expired flags from the in-memory map (and best-effort from
+    /// storage). Hooked into the Ring reaper tick alongside the UPDATE rate
+    /// limiter's cleanup so expired suppressions are reclaimed promptly even
+    /// for contracts that are no longer being read on the hot path.
+    pub fn cleanup(&self) {
+        let now = self.time_source.now();
+        // Snapshot the currently-expired ids (read-only).
+        let candidates: Vec<ContractInstanceId> = self
+            .flags
+            .iter()
+            .filter(|e| {
+                now.saturating_duration_since(e.value().recorded_at) >= BROKEN_INVARIANT_TTL
+            })
+            .map(|e| *e.key())
+            .collect();
+        for id in candidates {
+            // Atomically re-check expiry under the shard guard and remove only
+            // if STILL expired. This closes a TOCTOU race: a concurrent
+            // `record()` (e.g. a probe re-detecting the same contract) may have
+            // refreshed `recorded_at` between the snapshot above and here — in
+            // which case `remove_if` keeps the fresh entry, and we must NOT
+            // purge its persisted row (a restart needs it to re-hydrate the
+            // active suppression). We only touch storage when we actually
+            // removed an expired entry.
+            let removed = self.flags.remove_if(&id, |_, entry| {
+                now.saturating_duration_since(entry.recorded_at) >= BROKEN_INVARIANT_TTL
+            });
+            if removed.is_some() {
+                self.remove_from_storage(&id);
+            }
+        }
+    }
+
+    /// Best-effort removal of a flag's persisted row. Shared by `clear` and
+    /// the expiry sweep so a stale row does not re-flag the contract on the
+    /// next restart.
+    fn remove_from_storage(&self, id: &ContractInstanceId) {
+        #[cfg(feature = "redb")]
+        if let Some(storage) = self.storage.get() {
+            if let Err(e) = storage.remove_broken_invariant(id) {
+                tracing::warn!(
+                    contract = %id,
+                    error = %e,
+                    "Failed to remove persisted broken-invariant flag (in-memory flag already cleared)"
+                );
+            }
+        }
+        #[cfg(not(feature = "redb"))]
+        let _ = id;
+    }
+
     /// Wire persistent storage. Called once at startup; idempotent on the
     /// `OnceLock` so callers cannot accidentally re-init with a different
     /// database. Hydrates the in-memory map from previously-persisted
     /// entries on first wiring.
+    ///
+    /// Loaded flags are stamped with the current time, so a node restart
+    /// gives each previously-flagged contract a fresh TTL window rather than
+    /// inheriting an unknown (and un-persisted) original timestamp.
     pub fn set_storage(&self, storage: Storage) {
         if self.storage.set(storage.clone()).is_err() {
             tracing::warn!("BrokenInvariantsTracker storage already set; ignoring re-init");
@@ -164,9 +289,10 @@ impl BrokenInvariantsTracker {
         #[cfg(feature = "redb")]
         match storage.load_all_broken_invariants() {
             Ok(entries) => {
+                let recorded_at = self.time_source.now();
                 for (id, byte) in entries {
                     if let Some(kind) = BrokenInvariant::from_byte(byte) {
-                        self.flags.insert(id, kind);
+                        self.flags.insert(id, FlagEntry { kind, recorded_at });
                     } else {
                         tracing::warn!(
                             contract = %id,
@@ -190,6 +316,7 @@ impl BrokenInvariantsTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::time_source::SharedMockTimeSource;
 
     fn fake_id(seed: u8) -> ContractInstanceId {
         let mut bytes = [0u8; 32];
@@ -197,9 +324,14 @@ mod tests {
         ContractInstanceId::new(bytes)
     }
 
+    fn mk_tracker() -> (BrokenInvariantsTracker, SharedMockTimeSource) {
+        let ts = SharedMockTimeSource::new();
+        (BrokenInvariantsTracker::new(Arc::new(ts.clone())), ts)
+    }
+
     #[test]
     fn record_then_query_returns_true() {
-        let t = BrokenInvariantsTracker::new();
+        let (t, _ts) = mk_tracker();
         let id = fake_id(1);
         assert!(!t.is_broken(&id));
         t.record(id, BrokenInvariant::NonIdempotent);
@@ -209,7 +341,7 @@ mod tests {
 
     #[test]
     fn record_is_idempotent() {
-        let t = BrokenInvariantsTracker::new();
+        let (t, _ts) = mk_tracker();
         let id = fake_id(2);
         t.record(id, BrokenInvariant::NonIdempotent);
         t.record(id, BrokenInvariant::NonIdempotent);
@@ -219,7 +351,7 @@ mod tests {
 
     #[test]
     fn unrelated_contracts_unaffected() {
-        let t = BrokenInvariantsTracker::new();
+        let (t, _ts) = mk_tracker();
         let broken = fake_id(3);
         let healthy = fake_id(4);
         t.record(broken, BrokenInvariant::NonIdempotent);
@@ -229,7 +361,7 @@ mod tests {
 
     #[test]
     fn clear_returns_previous_and_unsets() {
-        let t = BrokenInvariantsTracker::new();
+        let (t, _ts) = mk_tracker();
         let id = fake_id(5);
 
         // Clearing an absent entry returns None and is a no-op.
@@ -247,6 +379,69 @@ mod tests {
 
         // Second clear is also a no-op, returns None.
         assert_eq!(t.clear(&id), None);
+    }
+
+    /// Regression test for #4295: a flag MUST NOT brick a contract forever.
+    /// After `BROKEN_INVARIANT_TTL` elapses, the flag expires so a false
+    /// positive self-heals and the contract resumes propagating.
+    #[test]
+    fn flag_expires_after_ttl() {
+        let (t, ts) = mk_tracker();
+        let id = fake_id(6);
+        t.record(id, BrokenInvariant::NonIdempotent);
+        assert!(t.is_broken(&id), "freshly recorded flag is active");
+
+        // Just before the TTL boundary it is still active.
+        ts.advance_time(BROKEN_INVARIANT_TTL - Duration::from_secs(1));
+        assert!(t.is_broken(&id), "flag still active just before TTL");
+
+        // Past the TTL boundary it has expired.
+        ts.advance_time(Duration::from_secs(2));
+        assert!(
+            !t.is_broken(&id),
+            "flag must expire after TTL so a false positive self-heals"
+        );
+        assert_eq!(t.get(&id), None, "expired flag reports no kind");
+    }
+
+    /// `cleanup` physically reclaims expired entries from the in-memory map.
+    #[test]
+    fn cleanup_reclaims_expired_entries() {
+        let (t, ts) = mk_tracker();
+        let id = fake_id(7);
+        t.record(id, BrokenInvariant::NonIdempotent);
+        assert_eq!(t.flags.len(), 1);
+
+        // Before expiry, cleanup keeps it.
+        ts.advance_time(BROKEN_INVARIANT_TTL / 2);
+        t.cleanup();
+        assert_eq!(t.flags.len(), 1, "non-expired entry retained by cleanup");
+
+        // After expiry, cleanup removes it.
+        ts.advance_time(BROKEN_INVARIANT_TTL);
+        t.cleanup();
+        assert_eq!(t.flags.len(), 0, "expired entry reclaimed by cleanup");
+    }
+
+    /// Re-recording refreshes the expiry window so a contract the probe keeps
+    /// re-detecting stays suppressed instead of flapping every TTL.
+    #[test]
+    fn record_refreshes_ttl() {
+        let (t, ts) = mk_tracker();
+        let id = fake_id(8);
+        t.record(id, BrokenInvariant::NonIdempotent);
+
+        // Advance most of the way through the TTL, then re-record.
+        ts.advance_time(BROKEN_INVARIANT_TTL - Duration::from_secs(1));
+        t.record(id, BrokenInvariant::NonIdempotent);
+
+        // Advance past where the ORIGINAL stamp would have expired; the
+        // refreshed stamp keeps it active.
+        ts.advance_time(Duration::from_secs(2));
+        assert!(
+            t.is_broken(&id),
+            "re-recording must refresh the expiry window"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`test_ping_multi_node` flaked ~50% (#4295). Root cause (verified via logs):
the idempotency probe added in #4279 flags a contract `NonIdempotent` by
comparing the **raw serialized bytes** of `update_state(update_state(S,U),U)`
against `update_state(S,U)`. A correct, logically-idempotent contract whose
serialization is non-canonical — the ping contract's `Ping.from` is a
`HashMap` — re-serializes the SAME logical state in a different key ORDER on
re-merge. Observed in a failing run: `post_merge_size=374 probe_size=374`
(identical size, flagged anyway). The false positive calls
`record_broken_invariant(NonIdempotent)`, which had **no TTL** and permanently
suppressed both `commit_state_update` and `BroadcastStateChange` — so cross-node
propagation halted and interest-sync anti-entropy could not heal it (the
receiver's commit was suppressed too). Probabilistic firing (p=1/32 per State
merge) produced the ~50% rate.

## Approach

Byte inequality does not prove a CRDT violation — logical idempotency does not
imply byte-determinism. Two changes, both in core (general fix, no contract-key
change):

1. **Probe soundness** (`Executor::maybe_probe_idempotency`): re-apply the
   update once and compare the post-merge state to the re-applied state by
   **byte MULTISET** (`byte_multiset_eq`), not raw bytes and not size. A benign
   serialization reordering (HashMap/HashSet key order) permutes the bytes but
   preserves their multiset → not flagged (fixes #4295). Any genuine content
   change — a counter, timestamp, signature, added/removed entry — alters the
   multiset → flagged, **including the fixed-size byte-churn shape of the #4251
   production violator** (a ~464-byte state whose counter prefix churns in
   place) that a size-only check would miss. Residual false-negative: a content
   change that coincidentally preserves the exact byte multiset evades detection
   (far narrower than a size-only blind spot, far safer than byte-equality's
   false positives). Discriminator extracted to the pure `byte_multiset_eq`
   helper and unit-tested.

2. **TTL on the flag** (`BrokenInvariantsTracker`): the `NonIdempotent` flag now
   expires after `BROKEN_INVARIANT_TTL` (5 min), swept by the Ring reaper
   (mirroring the UPDATE rate limiter's `cleanup`, with an atomic `remove_if`
   re-check so a concurrently-refreshed flag's persisted row is not purged), so
   any residual false positive self-heals instead of bricking the contract
   forever. Satisfies the "cleanup exemptions must be time-bounded" rule.
   Re-recording refreshes the window so a genuine violation stays suppressed;
   after expiry a genuine violation is re-detected by the next sampled probe (a
   deliberately accepted, bounded periodic leak documented in the module — we
   bias toward false-positive recovery, the worse failure being the #4295
   permanent brick).

## Testing

- New unit tests: `byte_multiset_eq` (reordering benign; fixed-size 464-byte
  content churn flagged — the #4251 shape; growing state flagged); flag TTL
  expiry, cleanup reclamation, re-record refresh.
- End-to-end: `test_ping_multi_node` run repeatedly — **0 false flags**; the
  idempotency-probe convergence-freeze failure mode (the #4279-introduced
  regression) is eliminated.
- `cargo fmt` + `cargo clippy -p freenet --lib --tests --locked -- -D warnings` clean.

Updated `.claude/rules/contracts.md` (flag no longer "permanent"; describes the
multiset semantics).

## Scope / residual

Fixes the dominant, recently-introduced (#4279) cause of #4295 — the
idempotency-probe convergence freeze. Separate, **pre-existing** propagation
flakes remain in the same test (a >64KB contract GET landing state without
code/params; and lost-update non-convergence not healed within the window) —
the #3279 / #4064 / #4071 family, likely including the unimplemented
streaming-Found GET relay #3883. Those are deeper networking issues with their
own tracking and are intentionally **not** bundled here (per a deliberate
scope decision: bundling a high-risk, hard-to-verify networking change onto
this verified one was judged worse for regression risk). So this PR does not
fully close #4295; it removes the regression that took the test to ~50%, and
`test_ping_multi_node` may still flake (~10–20%) on the residuals until they
land.

Refs #4295. Residual tracked by #3279 / #4064 / #3883.

[AI-assisted - Claude]