### PR TITLE
fix(get): restore relay GET response streaming (producer + forward)

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -35,7 +35,7 @@ for every inbound wire message. Pattern per op:
 
 1. **Reply bypass.** If a terminal reply variant arrives and a
    `pending_op_results` callback is registered, forward it via
-   `try_forward_task_per_tx_reply` and return. For GET/PUT/SUBSCRIBE
+   `try_forward_driver_reply` and return. For GET/PUT/SUBSCRIBE
    the gate is `Response | ResponseStreaming` only. CONNECT forwards
    all four non-`Request` variants (multi-reply fan-in).
 2. **Relay dispatch.** Spawn the matching `start_relay_*` driver.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -108,6 +108,8 @@ pub mod dev_tool {
     #[cfg(any(test, feature = "testing"))]
     pub use crate::operations::get::op_ctx_task::RELAY_DRIVER_CALL_COUNT as GET_RELAY_DRIVER_CALL_COUNT;
     #[cfg(any(test, feature = "testing"))]
+    pub use crate::operations::get::op_ctx_task::RELAY_GET_STREAMING_FORWARD_COUNT;
+    #[cfg(any(test, feature = "testing"))]
     pub use crate::operations::put::op_ctx_task::RELAY_PUT_DRIVER_CALL_COUNT;
     #[cfg(any(test, feature = "testing"))]
     pub use crate::operations::put::op_ctx_task::RELAY_PUT_STREAMING_DRIVER_CALL_COUNT;

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1040,6 +1040,7 @@ where
                     } => {
                         if let Err(err) = get::op_ctx_task::start_relay_get(
                             op_manager.clone(),
+                            conn_manager.clone(),
                             *id,
                             *instance_id,
                             *htl,

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -103,6 +103,18 @@ pub static RELAY_COMPLETED_TOTAL: std::sync::atomic::AtomicUsize =
 pub static RELAY_DEDUP_REJECTS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
+/// Test-only counter that increments every time the relay GET driver
+/// commits to forking + piping a streaming response to a REMOTE upstream
+/// (the `Terminal::Streaming` forward branch). Incremented after the
+/// loopback safety-net check and a successful `claim_or_wait`, before the
+/// header send. NOT incremented on the loopback branch or the
+/// `AlreadyClaimed` dedup branch. Used by `streaming_e2e` to prove a GET
+/// genuinely relayed through a streaming hop rather than falling back to
+/// store-and-forward. Mirrors `RELAY_PUT_STREAMING_DRIVER_CALL_COUNT`.
+#[cfg(any(test, feature = "testing"))]
+pub static RELAY_GET_STREAMING_FORWARD_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 /// Start a client-initiated GET, returning as soon as the task has been
 /// spawned (mirrors legacy `request_get` timing).
 ///
@@ -997,11 +1009,12 @@ async fn cache_contract_locally(
 /// originator for driver ops (`load_or_init` would return
 /// `OpNotPresent`).
 ///
-/// `peer_addr` is the sender's transport address — currently we
-/// use `driver.current_target.socket_addr()`, which is accurate for
-/// single-hop responses. Multi-hop (where a relay answers on behalf
-/// of a further peer) is not yet supported by the driver;
-/// see #3883.
+/// `peer_addr` is the sender's transport address — we use
+/// `driver.current_target.socket_addr()`. Multi-hop streamed GET IS now
+/// supported: relays fork+pipe the stream and re-key it with a fresh
+/// outbound `stream_id` per hop (#4307), so the originator always claims
+/// the stream keyed by its `current_target` (the immediate next hop),
+/// regardless of how many relays the response traversed. See #3883.
 async fn assemble_and_cache_stream(
     op_manager: &OpManager,
     peer_addr: std::net::SocketAddr,
@@ -1051,10 +1064,11 @@ async fn assemble_and_cache_stream(
         None
     };
 
-    // Streaming assembly is reachable only from the client-driver side (the
-    // relay driver does not claim streams — port plan §7). The originator
-    // IS the client requester, so the sticky `local_client_access` flag
-    // applies.
+    // This helper runs on the client-driver (originator) side. The relay
+    // driver also claims streams now (the `Terminal::Streaming` arm, #4307),
+    // but it uses its own inline assemble+cache with `local_client_access =
+    // false`; this path is the originator, which IS the client requester, so
+    // the sticky `local_client_access` flag applies here.
     cache_contract_locally(op_manager, payload.key, state, contract, true).await;
     Ok(())
 }
@@ -1492,13 +1506,11 @@ fn missing_state_cause(instance_id: &ContractInstanceId) -> String {
 // targeting the downstream peer, and the reply (Found / NotFound) is forwarded
 // to `upstream_addr` via a fire-and-forget `conn_manager.send`.
 //
-// Out of scope for this commit (§7 of the port plan):
-//   - ResponseStreaming relay forwarding (chunk pipe-through).
+// ResponseStreaming relay forwarding (chunk pipe-through) IS now implemented
+// in the `Terminal::Streaming` arm of `drive_relay_get_inner` (fork + pipe;
+// issue #4307). Still out of scope for the driver:
 //   - GC-spawned retries.
 //   - start_targeted_op (UPDATE-triggered auto-fetch).
-//
-// This entire section is dead code in commit 1 — node.rs dispatch is not
-// changed until commit 2.
 
 /// Start a relay (non-originator) GET driver.
 ///
@@ -1507,8 +1519,11 @@ fn missing_state_cause(instance_id: &ContractInstanceId) -> String {
 /// owns routing/forwarding/retry state in its task locals — no `GetOp`
 /// is stored in `OpManager.ops.get` for this transaction.
 ///
-/// Originator loop-back (`source_addr.is_none()`) continues to use the
-/// legacy `handle_op_request` → `process_message` path.
+/// Originator loop-back (`source_addr.is_none()`) is mapped by `node.rs`
+/// dispatch to `upstream_addr = own_addr` and driven by this same driver
+/// (the legacy `process_message` path is deleted); the loopback edge is
+/// handled by the safety-net branches that cache locally instead of
+/// piping/replying to self.
 ///
 /// # Scope (#3883)
 ///
@@ -1517,10 +1532,10 @@ fn missing_state_cause(instance_id: &ContractInstanceId) -> String {
 ///   interest gate), forward-or-respond decision.
 /// - `GetMsg::Response{NotFound}` retry to next alternative peer.
 /// - `GetMsg::Response{Found}` bubble-up to upstream.
+/// - `GetMsg::ResponseStreaming` relay forwarding (fork + pipe, #4307).
 /// - `ForwardingAck` send-before-forward.
 ///
-/// NOT migrated (stays on legacy path; see port plan §7):
-/// - Streaming-chunk relay forwarding (`ResponseStreaming` pass-through).
+/// NOT migrated (stays on legacy path):
 /// - GC-spawned retries.
 /// - `start_targeted_op` (UPDATE-triggered auto-fetch).
 #[allow(clippy::too_many_arguments)]
@@ -1991,6 +2006,21 @@ where
             total_size: payload_bytes.len() as u64,
             includes_contract,
         });
+        // Embed a serialized copy of the metadata header in fragment #1
+        // (fix #2757). On a lossy link the separately-sent fire-and-forget
+        // header can be lost while fragments arrive — without self-describing
+        // metadata the upstream waiter never matches the orphan stream and
+        // the GET times out. Mirrors the forward path's `embedded`.
+        let embedded = bincode::serialize(&header).ok().map(bytes::Bytes::from);
+        if embedded.is_none() {
+            tracing::warn!(
+                tx = %tx,
+                target = %upstream_addr,
+                %sid,
+                "GET relay: failed to serialize ResponseStreaming header for \
+                 fragment-#1 embedding; sending stream without embedded metadata"
+            );
+        }
         // Install nothing — the upstream already has its waiter (it sent
         // us the Request). Send the metadata header first, then push the
         // raw fragments. Ordering matches the PUT producer.
@@ -1998,7 +2028,12 @@ where
             .await
             .map_err(|_| OpError::NotificationError)?;
         conn_manager
-            .send_stream(upstream_addr, sid, bytes::Bytes::from(payload_bytes), None)
+            .send_stream(
+                upstream_addr,
+                sid,
+                bytes::Bytes::from(payload_bytes),
+                embedded,
+            )
             .await
             .map_err(|e| {
                 OpError::NotificationChannelError(format!("get relay send_stream failed: {e}"))
@@ -2535,7 +2570,13 @@ where
 
                 // ── Step 2: Loopback safety net. If upstream IS us
                 //    (originator-loopback edge — rare), assemble + cache
-                //    locally instead of piping to self.
+                //    locally instead of piping to self. This branch is
+                //    cache-only with NO wire Response: relay-loopback
+                //    initiators (GC-spawned retries / start_targeted_op
+                //    auto-fetch) only need the local cache populated — the
+                //    interactive client GET uses the separate
+                //    `drive_client_get_inner` driver, which owns its own
+                //    client delivery.
                 if Some(upstream_addr) == own_addr {
                     match handle.assemble().await {
                         Ok(bytes) => match bincode::deserialize::<GetStreamingPayload>(&bytes) {
@@ -2600,6 +2641,11 @@ where
                 // Serialize metadata for embedding in fragment #1 (fix #2757).
                 let embedded = bincode::serialize(&header_net).ok().map(bytes::Bytes::from);
 
+                // Committed to forking + piping to a remote upstream: count
+                // this streaming-forward hop (test-only; see counter doc).
+                #[cfg(any(test, feature = "testing"))]
+                RELAY_GET_STREAMING_FORWARD_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
                 // Send the metadata header BEFORE piping. The upstream
                 // already has its waiter installed (it sent us the Request),
                 // so a fire-and-forget header suffices.
@@ -2611,14 +2657,32 @@ where
 
                 // `pipe_stream` spawns a background task and returns
                 // promptly, so this does not block on the full transfer.
-                conn_manager
+                //
+                // Do NOT `?` this error: the `ResponseStreaming` header has
+                // already gone upstream (see send above), so the upstream is
+                // committed to assembling a stream. Propagating the error
+                // would bubble up to `drive_relay_get`, which sends a
+                // compensating `Response{NotFound}` to the SAME upstream — a
+                // contradictory double-signal that stalls the upstream ~60s
+                // on `claim_or_wait`. Instead, log and return cleanly so the
+                // upstream's claim simply times out without a NotFound. We do
+                // NOT fall through to the local-cache step: the held `handle`
+                // may be partial after a pipe failure.
+                if let Err(e) = conn_manager
                     .pipe_stream(upstream_addr, outbound_sid, forked, embedded)
                     .await
-                    .map_err(|e| {
-                        OpError::NotificationChannelError(format!(
-                            "get relay pipe_stream failed: {e}"
-                        ))
-                    })?;
+                {
+                    tracing::warn!(
+                        tx = %incoming_tx,
+                        %upstream_addr,
+                        %outbound_sid,
+                        error = %e,
+                        "GET relay: pipe_stream failed AFTER the ResponseStreaming \
+                         header already went upstream; letting the upstream's claim \
+                         time out cleanly rather than sending a contradictory NotFound"
+                    );
+                    return Ok(());
+                }
 
                 // ── Step 4: Record the relay route event for the downstream
                 //    peer that served the stream (it behaved correctly).

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1998,6 +1998,13 @@ where
             phase = "relay_streaming_forward",
             "GET relay: payload exceeds threshold, streaming response upstream"
         );
+        // NOTE: `hop_count` is intentionally NOT carried on the streaming
+        // wire path — the `ResponseStreaming` variant has no such field
+        // (unlike the inline `Response{Found}` below, which propagates
+        // `hop_count`). This matches the legacy streaming producer's
+        // limitation; transfer-rate routing observations on the originator
+        // come from `total_size` instead, so the lost hop depth does not
+        // degrade routing.
         let header = NetMessage::from(GetMsg::ResponseStreaming {
             id: tx,
             instance_id,
@@ -2547,6 +2554,9 @@ where
                 {
                     Ok(h) => h,
                     Err(OrphanStreamError::AlreadyClaimed) => {
+                        // Dedup, NOT a routing failure: another task already
+                        // owns this stream. Do NOT record a Failure route
+                        // event here — the downstream peer behaved correctly.
                         tracing::debug!(
                             tx = %incoming_tx,
                             %stream_id,
@@ -2561,6 +2571,22 @@ where
                             target = %peer,
                             error = %e,
                             "GET relay: orphan stream claim failed; advancing to next peer"
+                        );
+                        // The downstream advertised a `ResponseStreaming`
+                        // header but never delivered an assemblable stream
+                        // (timeout / claim error) — a genuine routing failure
+                        // for this peer. Train the router the same way the
+                        // transport-failure arms above do, so a peer that
+                        // stalls on stream delivery gets de-prioritised
+                        // instead of being re-selected. (AlreadyClaimed above
+                        // is deliberately NOT counted — that's dedup, not a
+                        // failure.)
+                        crate::operations::record_relay_route_event(
+                            op_manager,
+                            peer.clone(),
+                            crate::ring::Location::from(&instance_id),
+                            crate::router::RouteOutcome::Failure,
+                            crate::node::network_status::OpType::Get,
                         );
                         // Treat as a failed attempt — try another peer.
                         new_visited.mark_visited(peer_addr);
@@ -4135,14 +4161,87 @@ mod tests {
             .unwrap_or(tail.len());
         let arm = &tail[..clip];
         assert!(
-            arm.contains("StreamId::next_operations()"),
+            arm.contains("let outbound_sid = StreamId::next_operations()"),
             "Streaming arm must mint a fresh outbound stream id via \
-             `StreamId::next_operations()` per hop (#4307)."
+             `let outbound_sid = StreamId::next_operations()` per hop (#4307)."
         );
         assert!(
             arm.contains(".fork()"),
             "Streaming arm must `fork()` the inbound handle so it can pipe \
              AND assemble for local cache (#4307)."
+        );
+        // The fresh `outbound_sid` (NOT the inbound `stream_id`) must be the
+        // one re-keyed into the forwarded header AND piped. Without these the
+        // arm could mint `outbound_sid` yet still pipe/advertise the inbound
+        // id — exactly the re-keying bug this pin guards against.
+        assert!(
+            arm.contains("stream_id: outbound_sid"),
+            "Streaming arm must re-key the forwarded `ResponseStreaming` \
+             header with the FRESH `outbound_sid` (`stream_id: outbound_sid`), \
+             not the inbound `stream_id` (#4307)."
+        );
+        assert!(
+            arm.contains(".pipe_stream(upstream_addr, outbound_sid"),
+            "Streaming arm must pipe the forked handle under the FRESH \
+             `outbound_sid` (`pipe_stream(upstream_addr, outbound_sid, ..)`), \
+             not the inbound `stream_id` (#4307)."
+        );
+    }
+
+    /// Pin the deliberate non-`?` handling of a `pipe_stream` failure in the
+    /// relay `Terminal::Streaming` arm. Once the `ResponseStreaming` header
+    /// has gone upstream, the upstream is committed to assembling a stream;
+    /// propagating the pipe error would bubble to `drive_relay_get` and send
+    /// a compensating `Response{NotFound}` to that SAME upstream — a
+    /// contradictory double-signal that stalls it ~60s on `claim_or_wait`.
+    /// The arm therefore logs and `return Ok(())` instead. This invariant is
+    /// hard to exercise behaviourally (the mock bridge's `pipe_stream` can't
+    /// fail), so pin the SHAPE: a future refactor flipping `return Ok(())`
+    /// to `?`/`return Err(..)`/a NotFound send here would silently regress.
+    #[test]
+    fn relay_streaming_arm_pipe_failure_returns_ok_without_notfound() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
+        let arm_start = body
+            .find("AttemptOutcome::Terminal(Terminal::Streaming {")
+            .expect("Streaming arm must exist in relay driver");
+        let tail = &body[arm_start..];
+        let clip = tail[1..]
+            .find("AttemptOutcome::")
+            .map(|p| p + 1)
+            .unwrap_or(tail.len());
+        let arm = &tail[..clip];
+
+        // Isolate the `if let Err(e) = conn_manager.pipe_stream(..) { .. }`
+        // block: from the `pipe_stream` call to the end of the arm.
+        let pipe_pos = arm
+            .find(".pipe_stream(upstream_addr, outbound_sid")
+            .expect("Streaming arm must call pipe_stream on the forward path");
+        let pipe_tail = &arm[pipe_pos..];
+        // The error-handling block runs until Step 4 (route-event recording).
+        let block_end = pipe_tail
+            .find("record_relay_route_event")
+            .expect("route-event recording must follow the pipe on success");
+        let err_block = &pipe_tail[..block_end];
+
+        assert!(
+            err_block.contains("if let Err(e) = conn_manager")
+                || arm[..pipe_pos].contains("if let Err(e) = conn_manager"),
+            "pipe_stream must be guarded by an `if let Err(e) = ..` block, \
+             not `?`-propagated (the header already went upstream)."
+        );
+        assert!(
+            err_block.contains("return Ok(())"),
+            "On `pipe_stream` failure AFTER the header was sent upstream, the \
+             streaming arm MUST `return Ok(())` (let the upstream's claim time \
+             out cleanly), NOT propagate the error — a propagated error makes \
+             `drive_relay_get` send a contradictory `Response{{NotFound}}` to \
+             the same upstream and stalls it ~60s. #4307."
+        );
+        assert!(
+            !err_block.contains("relay_send_not_found"),
+            "The `pipe_stream`-failure block must NOT send a NotFound \
+             upstream — the upstream is already committed to a stream."
         );
     }
 
@@ -4749,6 +4848,10 @@ mod tests {
         for log_phrase in [
             "send_to_and_await failed; advancing to next peer",
             "attempt timed out; advancing to next peer",
+            // #4307: a downstream that advertised a ResponseStreaming header
+            // but never delivered an assemblable stream is also a routing
+            // failure for that peer — same training as the transport arms.
+            "orphan stream claim failed; advancing to next peer",
         ] {
             let pos = body.unwrap_or_default_pos(log_phrase);
             let after = &body[pos..pos + 1500.min(body.len() - pos)];

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -4245,6 +4245,63 @@ mod tests {
         );
     }
 
+    // ── R12b (SUPERSEDED): streaming-downstream WARN+continue guard ────────
+
+    /// SUPERSEDED by #4307: relay streaming-forward IS now implemented (the
+    /// `Terminal::Streaming` arm forks + pipes the stream upstream), so the
+    /// WARN+skip invariant this test pinned no longer holds. Kept as
+    /// historical documentation per `git-workflow.md` ("superseded by a
+    /// semantic change → add `#[ignore]`, keep as historical documentation").
+    /// The behaviour it used to assert is now inverted and pinned by
+    /// `relay_send_found_streams_large_payload_to_remote`,
+    /// `relay_streaming_arm_forwards_before_caching`,
+    /// `relay_streaming_arm_uses_fresh_outbound_stream_id`, and
+    /// `relay_streaming_arm_pipe_failure_returns_ok_without_notfound`. This
+    /// test references the pre-#4307 non-generic `drive_relay_get_inner`
+    /// signature and the old WARN+skip arm on purpose — it is a snapshot of
+    /// the prior contract, not a live guard, and is never executed.
+    #[test]
+    #[ignore = "superseded: relay streaming forwarding now implemented (#4307); kept as historical documentation per git-workflow.md"]
+    fn streaming_downstream_is_currently_warned_and_skipped() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let streaming_arm_start = body
+            .find("AttemptOutcome::Terminal(Terminal::Streaming { .. })")
+            .expect("Streaming arm must exist in relay driver");
+        let tail = &body[streaming_arm_start..];
+        // Bound at the next arm start.
+        let clip = tail[1..]
+            .find("AttemptOutcome::")
+            .map(|p| p + 1)
+            .unwrap_or(tail.len());
+        let arm = &tail[..clip];
+        assert!(
+            arm.contains("continue;"),
+            "Streaming arm must `continue;` to try the next peer — streaming \
+             relay forwarding is out of scope for #3883 (see port plan §7). \
+             A future PR will replace this with a proper chunk pipe-through."
+        );
+        assert!(
+            arm.contains("new_visited.mark_visited(peer_addr)"),
+            "Streaming arm must mark the streaming peer as visited so the \
+             retry loop doesn't re-select it next iteration."
+        );
+        assert!(
+            !arm.contains("relay_send_found"),
+            "Streaming arm must NOT call `relay_send_found` — doing so \
+             without the chunk payload would send a Found frame with \
+             `state: None` (Unexpected at the upstream classify). See R12b \
+             gap in port plan risk register."
+        );
+        assert!(
+            !arm.contains("orphan_stream_registry"),
+            "Streaming arm must NOT claim the stream via \
+             `orphan_stream_registry` — that's the migrated behavior for a \
+             follow-up PR. Doing it here without the upstream pipe would \
+             leak stream state."
+        );
+    }
+
     // ── R9: send_and_await Err/timeout outcomes advance to next peer ───────
 
     /// Both `Ok(Err(..))` (channel error / event loop gone) and

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -44,6 +44,7 @@ use crate::client_events::HostResult;
 use crate::config::{GlobalExecutor, OPERATION_TTL};
 use crate::contract::{ContractHandlerEvent, StoreResponse};
 use crate::message::{NetMessage, NetMessageV1, Transaction};
+use crate::node::NetworkBridge;
 use crate::node::OpManager;
 #[rustfmt::skip]
 use crate::operations::op_ctx::{
@@ -1523,8 +1524,9 @@ fn missing_state_cause(instance_id: &ContractInstanceId) -> String {
 /// - GC-spawned retries.
 /// - `start_targeted_op` (UPDATE-triggered auto-fetch).
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn start_relay_get(
+pub(crate) async fn start_relay_get<CB>(
     op_manager: Arc<OpManager>,
+    conn_manager: CB,
     incoming_tx: Transaction,
     instance_id: ContractInstanceId,
     htl: usize,
@@ -1532,7 +1534,10 @@ pub(crate) async fn start_relay_get(
     visited: VisitedPeers,
     fetch_contract: bool,
     subscribe: bool,
-) -> Result<(), OpError> {
+) -> Result<(), OpError>
+where
+    CB: NetworkBridge + Clone + Send + 'static,
+{
     // Test-only: count relay driver invocations so regression tests can
     // assert the dispatch gate in node.rs actually routed a fresh inbound
     // Request through the driver rather than the legacy
@@ -1570,6 +1575,7 @@ pub(crate) async fn start_relay_get(
 
     GlobalExecutor::spawn(run_relay_get(
         op_manager,
+        conn_manager,
         incoming_tx,
         instance_id,
         htl,
@@ -1602,8 +1608,9 @@ impl Drop for RelayInflightGuard {
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn run_relay_get(
+async fn run_relay_get<CB>(
     op_manager: Arc<OpManager>,
+    conn_manager: CB,
     incoming_tx: Transaction,
     instance_id: ContractInstanceId,
     htl: usize,
@@ -1611,7 +1618,9 @@ async fn run_relay_get(
     visited: VisitedPeers,
     fetch_contract: bool,
     subscribe: bool,
-) {
+) where
+    CB: NetworkBridge + Clone + Send + 'static,
+{
     RELAY_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     RELAY_SPAWNED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let _guard = RelayInflightGuard {
@@ -1621,6 +1630,7 @@ async fn run_relay_get(
 
     let drive_result = drive_relay_get(
         &op_manager,
+        &conn_manager,
         incoming_tx,
         instance_id,
         htl,
@@ -1676,8 +1686,9 @@ async fn run_relay_get(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn drive_relay_get(
+async fn drive_relay_get<CB>(
     op_manager: &Arc<OpManager>,
+    conn_manager: &CB,
     incoming_tx: Transaction,
     instance_id: ContractInstanceId,
     htl: usize,
@@ -1685,9 +1696,13 @@ async fn drive_relay_get(
     visited: VisitedPeers,
     fetch_contract: bool,
     subscribe: bool,
-) -> Result<(), OpError> {
+) -> Result<(), OpError>
+where
+    CB: NetworkBridge + Clone + Send + 'static,
+{
     match drive_relay_get_inner(
         op_manager,
+        conn_manager,
         incoming_tx,
         instance_id,
         htl,
@@ -1891,8 +1906,9 @@ async fn relay_send_not_found(
 /// relay bubbling up a downstream Found, this is the downstream Response's
 /// `hop_count` (preserved through the bubble-up chain).
 #[allow(clippy::too_many_arguments)]
-async fn relay_send_found(
+async fn relay_send_found<CB>(
     op_manager: &OpManager,
+    conn_manager: &CB,
     tx: Transaction,
     instance_id: ContractInstanceId,
     upstream_addr: SocketAddr,
@@ -1900,29 +1916,106 @@ async fn relay_send_found(
     state: WrappedState,
     contract: Option<ContractContainer>,
     hop_count: usize,
-) -> Result<(), OpError> {
-    let msg = NetMessage::from(GetMsg::Response {
-        id: tx,
-        instance_id,
-        result: GetMsgResult::Found {
-            key,
-            value: StoreResponse {
-                state: Some(state),
-                contract,
-            },
-        },
-        hop_count,
-    });
+) -> Result<(), OpError>
+where
+    CB: NetworkBridge + Clone + Send + 'static,
+{
     let mut ctx = op_manager.op_ctx(tx);
     // Originator-loopback: route via `send_local_loopback` to avoid
     // the wire-bound self-connection failure. See `relay_send_not_found`
-    // for the full rationale.
+    // for the full rationale. No streaming over loopback — there's no
+    // network benefit and it avoids loopback-stream complexity.
     let own_addr = op_manager.ring.connection_manager.get_own_addr();
     if Some(upstream_addr) == own_addr {
-        ctx.send_local_loopback(msg)
+        let msg = NetMessage::from(GetMsg::Response {
+            id: tx,
+            instance_id,
+            result: GetMsgResult::Found {
+                key,
+                value: StoreResponse {
+                    state: Some(state),
+                    contract,
+                },
+            },
+            hop_count,
+        });
+        return ctx
+            .send_local_loopback(msg)
             .await
-            .map_err(|_| OpError::NotificationError)
+            .map_err(|_| OpError::NotificationError);
+    }
+
+    // Remote upstream: stream large payloads instead of falling back to
+    // message-level store-and-forward. The legacy GET producer (#3586,
+    // removed by the task-per-tx migration) did exactly this; restoring
+    // it here closes #4307. Mirrors `drive_relay_put`'s streaming-upgrade
+    // producer branch (put/op_ctx_task.rs).
+    //
+    // Capture `includes_contract` BEFORE moving `contract` into the
+    // payload, since the wire header needs it but serialization consumes
+    // the contract.
+    let includes_contract = contract.is_some();
+    let payload = GetStreamingPayload {
+        key,
+        value: StoreResponse {
+            state: Some(state),
+            contract,
+        },
+    };
+    let payload_bytes = match bincode::serialize(&payload) {
+        Ok(b) => b,
+        Err(e) => {
+            return Err(OpError::NotificationChannelError(format!(
+                "Failed to serialize GET relay forward payload: {e}"
+            )));
+        }
+    };
+
+    if crate::operations::should_use_streaming(op_manager.streaming_threshold, payload_bytes.len())
+    {
+        let sid = StreamId::next_operations();
+        tracing::info!(
+            tx = %tx,
+            contract = %key,
+            target = %upstream_addr,
+            total_size = payload_bytes.len(),
+            %sid,
+            phase = "relay_streaming_forward",
+            "GET relay: payload exceeds threshold, streaming response upstream"
+        );
+        let header = NetMessage::from(GetMsg::ResponseStreaming {
+            id: tx,
+            instance_id,
+            stream_id: sid,
+            key,
+            total_size: payload_bytes.len() as u64,
+            includes_contract,
+        });
+        // Install nothing — the upstream already has its waiter (it sent
+        // us the Request). Send the metadata header first, then push the
+        // raw fragments. Ordering matches the PUT producer.
+        ctx.send_fire_and_forget(upstream_addr, header)
+            .await
+            .map_err(|_| OpError::NotificationError)?;
+        conn_manager
+            .send_stream(upstream_addr, sid, bytes::Bytes::from(payload_bytes), None)
+            .await
+            .map_err(|e| {
+                OpError::NotificationChannelError(format!("get relay send_stream failed: {e}"))
+            })?;
+        Ok(())
     } else {
+        // Below threshold: inline Response{Found} (legacy behavior).
+        let StoreResponse { state, contract } = payload.value;
+        let msg = NetMessage::from(GetMsg::Response {
+            id: tx,
+            instance_id,
+            result: GetMsgResult::Found {
+                key,
+                value: StoreResponse { state, contract },
+            },
+            hop_count,
+        });
         ctx.send_fire_and_forget(upstream_addr, msg)
             .await
             .map_err(|_| OpError::NotificationError)
@@ -1930,8 +2023,9 @@ async fn relay_send_found(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn drive_relay_get_inner(
+async fn drive_relay_get_inner<CB>(
     op_manager: &Arc<OpManager>,
+    conn_manager: &CB,
     incoming_tx: Transaction,
     instance_id: ContractInstanceId,
     htl: usize,
@@ -1939,7 +2033,10 @@ async fn drive_relay_get_inner(
     visited: VisitedPeers,
     fetch_contract: bool,
     subscribe: bool,
-) -> Result<(), OpError> {
+) -> Result<(), OpError>
+where
+    CB: NetworkBridge + Clone + Send + 'static,
+{
     let ring_max_htl = op_manager.ring.max_hops_to_live.max(1);
     let htl = htl.min(ring_max_htl);
 
@@ -2058,6 +2155,7 @@ async fn drive_relay_get_inner(
         let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
         let send_result = relay_send_found(
             op_manager,
+            conn_manager,
             incoming_tx,
             instance_id,
             upstream_addr,
@@ -2115,6 +2213,7 @@ async fn drive_relay_get_inner(
                     let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
                     let send_result = relay_send_found(
                         op_manager,
+                        conn_manager,
                         incoming_tx,
                         instance_id,
                         upstream_addr,
@@ -2354,6 +2453,7 @@ async fn drive_relay_get_inner(
                 // the depth from Request to this relay.
                 let send_result = relay_send_found(
                     op_manager,
+                    conn_manager,
                     incoming_tx,
                     instance_id,
                     upstream_addr,
@@ -2377,24 +2477,222 @@ async fn drive_relay_get_inner(
                 send_result?;
                 return Ok(());
             }
-            AttemptOutcome::Terminal(Terminal::Streaming { .. }) => {
-                // Streaming relay forwarding is out of scope for #3883 commit 1.
-                // The downstream peer answered correctly with a streaming
-                // response; the relay's inability to forward streams is a
-                // local implementation gap, not a peer-routing failure. Do
-                // NOT record a route event here — penalising the peer for
-                // a relay-side limitation would systematically de-prioritise
-                // peers that happen to host large contracts.
-                tracing::warn!(
+            AttemptOutcome::Terminal(Terminal::Streaming {
+                key,
+                stream_id,
+                includes_contract,
+                total_size,
+            }) => {
+                // Downstream answered with a streaming response. Restore the
+                // relay fork+pipe forward (reverted #3586 / port plan §7,
+                // issue #4307): claim the inbound stream, fork it, send the
+                // metadata header upstream, then pipe fragments onward. The
+                // relay caches a best-effort local copy from the held handle
+                // AFTER initiating the pipe. Mirrors
+                // `drive_relay_put_streaming`.
+                let own_addr = op_manager.ring.connection_manager.get_own_addr();
+
+                tracing::info!(
                     tx = %incoming_tx,
                     %instance_id,
+                    contract = %key,
                     target = %peer,
-                    "GET relay: downstream returned ResponseStreaming — \
-                     streaming relay forwarding not yet implemented (port plan §7); \
-                     trying next peer"
+                    %stream_id,
+                    total_size,
+                    phase = "relay_streaming_forward",
+                    "GET relay: downstream returned ResponseStreaming — forwarding stream upstream"
                 );
-                new_visited.mark_visited(peer_addr);
-                continue;
+
+                // ── Step 1: Claim the inbound stream (atomic dedup). The
+                //    DOWNSTREAM peer (`peer_addr`) is the responder.
+                let handle = match op_manager
+                    .orphan_stream_registry()
+                    .claim_or_wait(peer_addr, stream_id, STREAM_CLAIM_TIMEOUT)
+                    .await
+                {
+                    Ok(h) => h,
+                    Err(OrphanStreamError::AlreadyClaimed) => {
+                        tracing::debug!(
+                            tx = %incoming_tx,
+                            %stream_id,
+                            "GET relay: inbound stream already claimed (dedup), skipping"
+                        );
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            tx = %incoming_tx,
+                            %stream_id,
+                            target = %peer,
+                            error = %e,
+                            "GET relay: orphan stream claim failed; advancing to next peer"
+                        );
+                        // Treat as a failed attempt — try another peer.
+                        new_visited.mark_visited(peer_addr);
+                        continue;
+                    }
+                };
+
+                // ── Step 2: Loopback safety net. If upstream IS us
+                //    (originator-loopback edge — rare), assemble + cache
+                //    locally instead of piping to self.
+                if Some(upstream_addr) == own_addr {
+                    match handle.assemble().await {
+                        Ok(bytes) => match bincode::deserialize::<GetStreamingPayload>(&bytes) {
+                            Ok(payload) => {
+                                if let Some(state) = payload.value.state {
+                                    let contract = if includes_contract {
+                                        payload.value.contract
+                                    } else {
+                                        None
+                                    };
+                                    cache_contract_locally(
+                                        op_manager,
+                                        payload.key,
+                                        state,
+                                        contract,
+                                        false,
+                                    )
+                                    .await;
+                                } else {
+                                    tracing::warn!(
+                                        tx = %incoming_tx,
+                                        %stream_id,
+                                        "GET relay (loopback): streamed payload has no state"
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    tx = %incoming_tx,
+                                    %stream_id,
+                                    error = %e,
+                                    "GET relay (loopback): failed to deserialize streamed payload"
+                                );
+                            }
+                        },
+                        Err(e) => {
+                            tracing::warn!(
+                                tx = %incoming_tx,
+                                %stream_id,
+                                error = %e,
+                                "GET relay (loopback): stream assembly failed"
+                            );
+                        }
+                    }
+                    return Ok(());
+                }
+
+                // ── Step 3: Forward path (remote upstream). Fork, send
+                //    metadata header, pipe — BEFORE any local assemble/cache.
+                //    Re-key with a FRESH outbound stream_id per hop.
+                let outbound_sid = StreamId::next_operations();
+                let forked = handle.fork();
+                let header = GetMsg::ResponseStreaming {
+                    id: incoming_tx,
+                    instance_id,
+                    stream_id: outbound_sid,
+                    key,
+                    total_size,
+                    includes_contract,
+                };
+                let header_net = NetMessage::from(header);
+                // Serialize metadata for embedding in fragment #1 (fix #2757).
+                let embedded = bincode::serialize(&header_net).ok().map(bytes::Bytes::from);
+
+                // Send the metadata header BEFORE piping. The upstream
+                // already has its waiter installed (it sent us the Request),
+                // so a fire-and-forget header suffices.
+                op_manager
+                    .op_ctx(incoming_tx)
+                    .send_fire_and_forget(upstream_addr, header_net)
+                    .await
+                    .map_err(|_| OpError::NotificationError)?;
+
+                // `pipe_stream` spawns a background task and returns
+                // promptly, so this does not block on the full transfer.
+                conn_manager
+                    .pipe_stream(upstream_addr, outbound_sid, forked, embedded)
+                    .await
+                    .map_err(|e| {
+                        OpError::NotificationChannelError(format!(
+                            "get relay pipe_stream failed: {e}"
+                        ))
+                    })?;
+
+                // ── Step 4: Record the relay route event for the downstream
+                //    peer that served the stream (it behaved correctly).
+                crate::operations::record_relay_route_event(
+                    op_manager,
+                    peer.clone(),
+                    crate::ring::Location::from(&instance_id),
+                    crate::router::RouteOutcome::SuccessUntimed,
+                    crate::node::network_status::OpType::Get,
+                );
+
+                // ── Step 5: Subscriber-forwarding parity (subscribe only).
+                if subscribe {
+                    crate::operations::subscribe::register_downstream_subscriber(
+                        op_manager,
+                        &key,
+                        upstream_addr,
+                        None,
+                        None,
+                        &incoming_tx,
+                        " (relay, streamed GET response)",
+                    )
+                    .await;
+                }
+
+                // ── Step 6: Best-effort local cache (legacy parity — relays
+                //    cache forwarded payloads). `fork()` SHARES the buffer,
+                //    so the held `handle` can still assemble. On error, log
+                //    and continue — the pipe already succeeded.
+                match handle.assemble().await {
+                    Ok(bytes) => match bincode::deserialize::<GetStreamingPayload>(&bytes) {
+                        Ok(payload) => {
+                            if let Some(state) = payload.value.state {
+                                let contract = if includes_contract {
+                                    payload.value.contract
+                                } else {
+                                    None
+                                };
+                                cache_contract_locally(
+                                    op_manager,
+                                    payload.key,
+                                    state,
+                                    contract,
+                                    false,
+                                )
+                                .await;
+                            } else {
+                                tracing::warn!(
+                                    tx = %incoming_tx,
+                                    %stream_id,
+                                    "GET relay: streamed payload has no state; skipping local cache"
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                tx = %incoming_tx,
+                                %stream_id,
+                                error = %e,
+                                "GET relay: failed to deserialize streamed payload for local cache"
+                            );
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(
+                            tx = %incoming_tx,
+                            %stream_id,
+                            error = %e,
+                            "GET relay: stream assembly failed for local cache (pipe already sent)"
+                        );
+                    }
+                }
+
+                return Ok(());
             }
             AttemptOutcome::Terminal(Terminal::LocalCompletion) => {
                 // A relay driver should never receive a Request-echo because
@@ -3088,7 +3386,7 @@ mod tests {
     #[test]
     fn relay_driver_htl_zero_guard_precedes_retry_loop() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
         let htl_guard = body
             .find("if htl == 0")
             .expect("drive_relay_get_inner must have an `if htl == 0` guard");
@@ -3108,7 +3406,7 @@ mod tests {
     #[test]
     fn relay_driver_local_cache_check_precedes_retry_loop() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
         let local_check = body
             .find("check_local_with_interest_gate")
             .expect("drive_relay_get_inner must call check_local_with_interest_gate");
@@ -3156,7 +3454,7 @@ mod tests {
     #[test]
     fn relay_driver_forwards_upstream_before_caching_on_found_response() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
         // Find the InlineFound arm inside the loop.
         let found_arm = body
             .find("Terminal::InlineFound {")
@@ -3195,7 +3493,7 @@ mod tests {
     #[test]
     fn all_relay_callsites_forward_before_caching() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
 
         // For each relay-style block in the function, when both
         // `relay_send_found(` and `cache_contract_locally(` appear, the
@@ -3218,15 +3516,21 @@ mod tests {
         );
         assert_eq!(
             cache_positions.len(),
-            3,
-            "drive_relay_get_inner should have exactly three \
-             `cache_contract_locally(` callsites. Found {} — a refactor \
-             has changed the shape.",
+            5,
+            "drive_relay_get_inner should have exactly five \
+             `cache_contract_locally(` callsites (R4, R10, R12a, plus the \
+             two #4307 streaming-arm caches). Found {} — a refactor has \
+             changed the shape.",
             cache_positions.len(),
         );
-        // Pair them up positionally and verify each `send` comes before
-        // its corresponding `cache`. The two slices are sorted by
-        // position by construction.
+        // Pair the three `relay_send_found` callsites (R4, R10, R12a) with
+        // their corresponding inline-Found caches and verify each `send`
+        // comes before its `cache`. The streaming-arm caches (positions
+        // 4 and 5) forward via `pipe_stream` rather than `relay_send_found`
+        // and are covered by `relay_streaming_arm_forwards_before_caching`,
+        // so they are intentionally excluded from this positional pairing.
+        // The three sends all precede the streaming arm in source order, so
+        // zipping against the first three caches is correct.
         for (idx, (send_pos, cache_pos)) in send_positions
             .iter()
             .zip(cache_positions.iter())
@@ -3246,7 +3550,7 @@ mod tests {
     #[test]
     fn relay_driver_exhaustion_sends_not_found_upstream() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
         // Find the exhaustion branch (None arm of relay_advance_to_next_peer).
         assert!(
             body.contains("relay_send_not_found"),
@@ -3273,7 +3577,7 @@ mod tests {
     #[test]
     fn relay_driver_does_not_send_forwarding_ack() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
         assert!(
             !body.contains("relay_send_forwarding_ack"),
             "drive_relay_get_inner must NOT call relay_send_forwarding_ack \
@@ -3311,7 +3615,7 @@ mod tests {
     #[test]
     fn relay_driver_reuses_classify_function() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
         assert!(
             body.contains("classify(reply)"),
             "drive_relay_get_inner must call `classify(reply)` to classify \
@@ -3330,7 +3634,7 @@ mod tests {
     fn relay_entry_point_no_longer_annotated_dead_code_after_commit2() {
         let src = production_source();
         let fn_start = src
-            .find("pub(crate) async fn start_relay_get(")
+            .find("pub(crate) async fn start_relay_get<CB>(")
             .expect("start_relay_get must exist");
         // Look in the 500 chars before the fn signature for the attribute.
         let window_start = fn_start.saturating_sub(500);
@@ -3409,7 +3713,7 @@ mod tests {
     #[test]
     fn htl_zero_guard_emits_not_found_upstream_frame() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
         // Isolate the `if htl == 0 { ... }` block (before the retry loop).
         let guard_start = body.find("if htl == 0").expect("htl==0 guard must exist");
         let after_guard = &body[guard_start..];
@@ -3458,7 +3762,7 @@ mod tests {
     #[test]
     fn exhaustion_branches_on_local_fallback_presence() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
         // The None arm of the `match relay_advance_to_next_peer(...)` is the
         // exhaustion branch. It must contain both `local_fallback` disposition
         // AND both Found and NotFound sends.
@@ -3559,7 +3863,7 @@ mod tests {
     #[test]
     fn forwarded_request_decrements_htl_and_propagates_visited() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
         // The forwarded Request must be built with the decremented HTL.
         assert!(
             body.contains("let new_htl = htl.saturating_sub(1);"),
@@ -3605,7 +3909,7 @@ mod tests {
     #[test]
     fn visited_bloom_seeded_with_own_and_upstream_before_loop() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
         let loop_start = body.find("loop {").expect("retry loop must exist");
         let pre_loop = &body[..loop_start];
         assert!(
@@ -3633,7 +3937,7 @@ mod tests {
     #[test]
     fn drive_relay_get_sends_compensating_not_found_on_inner_err() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get(");
+        let body = extract_fn_body(src, "async fn drive_relay_get<CB>(");
         // Expected shape:
         //   match drive_relay_get_inner(...).await {
         //     Ok(()) => Ok(()),
@@ -3675,7 +3979,7 @@ mod tests {
     #[test]
     fn relay_send_found_maps_send_failure_to_op_error() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn relay_send_found(");
+        let body = extract_fn_body(src, "async fn relay_send_found<CB>(");
         assert!(
             body.contains("map_err(|_| OpError::NotificationError)"),
             "`relay_send_found` must map fire-and-forget send errors to \
@@ -3685,53 +3989,96 @@ mod tests {
         );
     }
 
-    // ── R12b: Streaming-downstream WARN+continue regression guard ──────────
+    // ── #4307: Relay streaming-forward regression guards ───────────────────
 
-    /// Relay streaming-forward migration is deferred to a follow-up PR
-    /// (port plan §7). Until then, a downstream `ResponseStreaming` reply
-    /// must be handled by the `Terminal::Streaming { .. }` arm with
-    /// `continue;` semantics — NOT piped through to the upstream. A
-    /// regression that either claims the stream (breaking phase-5 scope)
-    /// or panics (breaking availability when any downstream peer happens
-    /// to own a large contract) is caught here.
+    /// `relay_send_found` must stream large payloads to a remote upstream
+    /// instead of falling back to inline store-and-forward. Regression
+    /// guard for #4307 (the task-per-tx migration dropped this producer).
+    /// Mirrors PUT's producer pin.
     #[test]
-    fn streaming_downstream_is_currently_warned_and_skipped() {
+    fn relay_send_found_streams_large_payload_to_remote() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
-        let streaming_arm_start = body
-            .find("AttemptOutcome::Terminal(Terminal::Streaming { .. })")
+        let body = extract_fn_body(src, "async fn relay_send_found<CB>(");
+        assert!(
+            body.contains("should_use_streaming"),
+            "`relay_send_found` must gate the remote-upstream path on \
+             `should_use_streaming` so large payloads stream (#4307)."
+        );
+        assert!(
+            body.contains("ResponseStreaming"),
+            "`relay_send_found` must emit a `GetMsg::ResponseStreaming` \
+             metadata header on the streaming branch (#4307)."
+        );
+        assert!(
+            body.contains("conn_manager") && body.contains("send_stream"),
+            "`relay_send_found` must call `conn_manager.send_stream(..)` to \
+             push raw fragments on the streaming branch (#4307)."
+        );
+    }
+
+    /// The relay `Terminal::Streaming` arm must FORWARD (send the metadata
+    /// header + pipe fragments) BEFORE assembling/caching locally — the
+    /// #4155 forward-before-cache invariant applied to the streaming path.
+    #[test]
+    fn relay_streaming_arm_forwards_before_caching() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
+        let arm_start = body
+            .find("AttemptOutcome::Terminal(Terminal::Streaming {")
             .expect("Streaming arm must exist in relay driver");
-        let tail = &body[streaming_arm_start..];
-        // Bound at the next arm start.
+        let tail = &body[arm_start..];
+        let pipe = tail
+            .find("pipe_stream")
+            .expect("Streaming arm must call pipe_stream to forward upstream");
+        // The forward-path assemble/cache (best-effort local cache after
+        // the pipe) are the LAST occurrences in the arm. The loopback
+        // safety-net assemble/cache appear earlier but are inside a
+        // separate `return Ok(())` branch (upstream == own_addr), so we
+        // anchor on the final occurrences to verify the FORWARD path
+        // forwards before it caches.
+        let assemble = tail
+            .rfind(".assemble()")
+            .expect("Streaming arm must assemble for local cache");
+        let cache = tail
+            .rfind("cache_contract_locally")
+            .expect("Streaming arm must cache locally");
+        assert!(
+            pipe < assemble,
+            "Streaming arm forward path must `pipe_stream` BEFORE blocking \
+             on `handle.assemble()` (forward-before-cache, #4155/#4307)."
+        );
+        assert!(
+            pipe < cache,
+            "Streaming arm forward path must forward (pipe_stream) BEFORE \
+             `cache_contract_locally` (forward-before-cache, #4155/#4307)."
+        );
+    }
+
+    /// The relay `Terminal::Streaming` arm must re-key the outbound stream
+    /// with a FRESH `StreamId::next_operations()` and `fork()` the inbound
+    /// handle so it can both pipe and cache. Never reuse the inbound id.
+    #[test]
+    fn relay_streaming_arm_uses_fresh_outbound_stream_id() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
+        let arm_start = body
+            .find("AttemptOutcome::Terminal(Terminal::Streaming {")
+            .expect("Streaming arm must exist in relay driver");
+        let tail = &body[arm_start..];
         let clip = tail[1..]
             .find("AttemptOutcome::")
             .map(|p| p + 1)
             .unwrap_or(tail.len());
         let arm = &tail[..clip];
         assert!(
-            arm.contains("continue;"),
-            "Streaming arm must `continue;` to try the next peer — streaming \
-             relay forwarding is out of scope for #3883 (see port plan §7). \
-             A future PR will replace this with a proper chunk pipe-through."
+            arm.contains("StreamId::next_operations()"),
+            "Streaming arm must mint a fresh outbound stream id via \
+             `StreamId::next_operations()` per hop (#4307)."
         );
         assert!(
-            arm.contains("new_visited.mark_visited(peer_addr)"),
-            "Streaming arm must mark the streaming peer as visited so the \
-             retry loop doesn't re-select it next iteration."
-        );
-        assert!(
-            !arm.contains("relay_send_found"),
-            "Streaming arm must NOT call `relay_send_found` — doing so \
-             without the chunk payload would send a Found frame with \
-             `state: None` (Unexpected at the upstream classify). See R12b \
-             gap in port plan risk register."
-        );
-        assert!(
-            !arm.contains("orphan_stream_registry"),
-            "Streaming arm must NOT claim the stream via \
-             `orphan_stream_registry` — that's the migrated behavior for a \
-             follow-up PR. Doing it here without the upstream pipe would \
-             leak stream state."
+            arm.contains(".fork()"),
+            "Streaming arm must `fork()` the inbound handle so it can pipe \
+             AND assemble for local cache (#4307)."
         );
     }
 
@@ -3748,7 +4095,7 @@ mod tests {
     #[test]
     fn send_and_await_failure_arms_continue_to_next_peer() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
         // Match on the outer `round_trip` match arms.
         let round_trip = body
             .find("let reply = match round_trip {")
@@ -3847,13 +4194,13 @@ mod tests {
     fn run_relay_get_skips_release_in_originator_loopback() {
         let src = include_str!("../get/op_ctx_task.rs");
         let fn_start = src
-            .find("async fn run_relay_get(")
+            .find("async fn run_relay_get<CB>(")
             .expect("run_relay_get not found");
         // Bound the search window: `drive_relay_get` follows
         // `run_relay_get` in source order, gated by the
         // `clippy::too_many_arguments` attr.
         let fn_end = src[fn_start..]
-            .find("\n#[allow(clippy::too_many_arguments)]\nasync fn drive_relay_get(")
+            .find("\n#[allow(clippy::too_many_arguments)]\nasync fn drive_relay_get<CB>(")
             .expect("end-of-run_relay_get marker not found")
             + fn_start;
         let body = &src[fn_start..fn_end];
@@ -3892,7 +4239,7 @@ mod tests {
         let src = include_str!("../get/op_ctx_task.rs");
         for fn_name in [
             "async fn relay_send_not_found(",
-            "async fn relay_send_found(",
+            "async fn relay_send_found<CB>(",
         ] {
             let fn_start = src
                 .find(fn_name)
@@ -3932,11 +4279,11 @@ mod tests {
     fn drive_relay_get_loopback_uses_fire_and_forget() {
         let src = include_str!("../get/op_ctx_task.rs");
         let fn_start = src
-            .find("async fn drive_relay_get_inner(")
+            .find("async fn drive_relay_get_inner<CB>(")
             .expect("drive_relay_get_inner not found");
-        let fn_end = src[fn_start + "async fn drive_relay_get_inner(".len()..]
+        let fn_end = src[fn_start + "async fn drive_relay_get_inner<CB>(".len()..]
             .find("\nasync fn ")
-            .map(|idx| idx + fn_start + "async fn drive_relay_get_inner(".len())
+            .map(|idx| idx + fn_start + "async fn drive_relay_get_inner<CB>(".len())
             .unwrap_or(src.len());
         let body = &src[fn_start..fn_end];
         assert!(
@@ -4009,27 +4356,30 @@ mod tests {
         );
     }
 
-    /// All three relay-driver callsites must pass `false`.
+    /// All relay-driver cache callsites must pass `false`.
     /// Relay caches forwarded Found payloads but MUST NOT flag them as
-    /// client-accessed on the relay's own hosting cache. There are three
-    /// relay callsites in `drive_relay_get_inner`:
+    /// client-accessed on the relay's own hosting cache. There are five
+    /// relay cache callsites in `drive_relay_get_inner`:
     ///   1. Active-interest local Found (R4, immediate serve)
     ///   2. Exhaustion fallback (R10, stale local state)
     ///   3. Downstream Found bubble-up (R12a, forwarded payload)
+    ///   4. Streaming loopback safety-net (#4307, upstream == own_addr)
+    ///   5. Streaming forward best-effort cache (#4307, after pipe_stream)
     #[test]
     fn all_relay_callsites_pass_is_client_requester_false() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
         let callsites: Vec<usize> = body
             .match_indices("cache_contract_locally(")
             .map(|(i, _)| i)
             .collect();
         assert_eq!(
             callsites.len(),
-            3,
-            "drive_relay_get_inner should have exactly three \
+            5,
+            "drive_relay_get_inner should have exactly five \
              cache_contract_locally callsites (R4 immediate, R10 fallback, \
-             R12a bubble-up). Found {} — a refactor has changed the shape.",
+             R12a bubble-up, plus the two #4307 streaming-arm caches). \
+             Found {} — a refactor has changed the shape.",
             callsites.len(),
         );
         // Each callsite must terminate with `, false)` (the
@@ -4061,7 +4411,9 @@ mod tests {
             // The last argument must be `false`. Normalize whitespace.
             let normalized: String = call.chars().filter(|c| !c.is_whitespace()).collect();
             assert!(
-                normalized.ends_with("false,).await") || normalized.ends_with("false)"),
+                normalized.ends_with("false,).await")
+                    || normalized.ends_with("false)")
+                    || normalized.ends_with("false,)"),
                 "Relay callsite #{idx} of cache_contract_locally must pass \
                  `false` for is_client_requester (relay is not the client). \
                  Call text: {call}"
@@ -4163,7 +4515,7 @@ mod tests {
              tests to verify the dispatch gate routes through the relay driver."
         );
         // Increment must appear in the body of start_relay_get, under cfg.
-        let body = extract_fn_body(src, "pub(crate) async fn start_relay_get(");
+        let body = extract_fn_body(src, "pub(crate) async fn start_relay_get<CB>(");
         assert!(
             body.contains("RELAY_DRIVER_CALL_COUNT.fetch_add(1"),
             "`start_relay_get` must increment `RELAY_DRIVER_CALL_COUNT` at \
@@ -4324,7 +4676,7 @@ mod tests {
     #[test]
     fn drive_relay_get_inner_records_route_events_on_transport_failure() {
         let src = include_str!("op_ctx_task.rs");
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
 
         // The send_to_and_await error arm and the timeout arm must
         // record `Failure` for the chosen peer. Identify each by its

--- a/crates/core/tests/streaming_e2e.rs
+++ b/crates/core/tests/streaming_e2e.rs
@@ -598,9 +598,13 @@ fn test_streaming_multi_hop_forwarding() {
 /// 2. A different node GETs the contract, routing through intermediate relay nodes
 /// 3. The relay uses pipe_stream to forward the streaming GET response
 ///
-/// With 1 gateway + 4 nodes, the GET request from a non-storing node must relay
-/// through at least one intermediate node, exercising the pipe_stream forwarding
-/// path that the cwnd timeout protects.
+/// With a sparse topology (1 gateway + 6 nodes, max_connections = 3, below
+/// the node count) the GET request from node 5 cannot mesh directly with the
+/// storer and must relay through at least one intermediate node, exercising
+/// the pipe_stream forwarding path that the cwnd timeout protects. The
+/// `RELAY_GET_STREAMING_FORWARD_COUNT` assertion below proves a streaming
+/// relay hop genuinely fired (the sim is deterministic per-seed, so this is
+/// not flaky once the seed + topology are locked in).
 #[test]
 fn test_streaming_get_through_relay() {
     const SEED: u64 = 0xDE1A_0008_FACE_B00C;
@@ -613,7 +617,31 @@ fn test_streaming_get_through_relay() {
         .build()
         .unwrap();
 
-    let sim = rt.block_on(setup_streaming_network(NETWORK_NAME, 1, 4, SEED, THRESHOLD));
+    // Sparse topology: 1 gateway + 6 nodes, max_connections = 3 (below the
+    // node count) forces the getter (node 5) to relay rather than connect
+    // directly to the storer. `setup_streaming_network` hardcodes
+    // max_connections = 10, which meshes a network this small and yields a
+    // direct GET with no relay hop (counter stays 0), so build the
+    // SimNetwork inline here with the sparse cap.
+    GlobalRng::set_seed(SEED);
+    const BASE_EPOCH_MS: u64 = 1577836800000;
+    const RANGE_MS: u64 = 5 * 365 * 24 * 60 * 60 * 1000;
+    GlobalSimulationTime::set_time_ms(BASE_EPOCH_MS + (SEED % RANGE_MS));
+    let sim = rt.block_on(async {
+        let mut sim = SimNetwork::new(
+            NETWORK_NAME,
+            1, // gateways
+            6, // nodes
+            7, // ring_max_htl
+            3, // rnd_if_htl_above
+            3, // max_connections (sparse: < node count → forces a relay hop)
+            2, // min_connections
+            SEED,
+        )
+        .await;
+        sim.with_streaming_threshold(THRESHOLD);
+        sim
+    });
 
     let contract = SimOperation::create_test_contract(0xAB);
     let large_state = SimOperation::create_large_state(LARGE_STATE_SIZE, 0xAB);
@@ -630,9 +658,9 @@ fn test_streaming_get_through_relay() {
                 subscribe: false,
             },
         ),
-        // A different node GETs the contract — must relay through network
+        // Node 5 GETs the contract — must relay through network
         ScheduledOperation::new(
-            NodeLabel::node(NETWORK_NAME, 3),
+            NodeLabel::node(NETWORK_NAME, 5),
             SimOperation::Get {
                 contract_id,
                 return_contract_code: false,
@@ -640,6 +668,12 @@ fn test_streaming_get_through_relay() {
             },
         ),
     ];
+
+    // Snapshot the streaming relay GET forward counter so we can assert the
+    // relay genuinely forked+piped a streaming response through a hop (vs.
+    // satisfying the GET via store-and-forward without the streaming path).
+    let forward_calls_before = freenet::dev_tool::RELAY_GET_STREAMING_FORWARD_COUNT
+        .load(std::sync::atomic::Ordering::SeqCst);
 
     let result = sim.run_controlled_simulation(
         SEED,
@@ -654,19 +688,29 @@ fn test_streaming_get_through_relay() {
         result.turmoil_result.err()
     );
 
+    let forward_calls_after = freenet::dev_tool::RELAY_GET_STREAMING_FORWARD_COUNT
+        .load(std::sync::atomic::Ordering::SeqCst);
+    assert!(
+        forward_calls_after > forward_calls_before,
+        "Expected the relay GET streaming-forward path to run at least once \
+         during a 1MB relayed GET (before={forward_calls_before}, \
+         after={forward_calls_after}). Counter stuck → relay GET \
+         streaming-forward path did not run (fell back to store-and-forward)."
+    );
+
     // The GET-requesting node should have the contract state
-    let node3_label = NodeLabel::node(NETWORK_NAME, 3);
-    let node3_storage = result
+    let getter_label = NodeLabel::node(NETWORK_NAME, 5);
+    let getter_storage = result
         .node_storages
-        .get(&node3_label)
-        .expect("node 3 should have a storage handle");
-    let node3_state = node3_storage.get_stored_state(&contract_key);
+        .get(&getter_label)
+        .expect("node 5 should have a storage handle");
+    let getter_state = getter_storage.get_stored_state(&contract_key);
 
     assert!(
-        node3_state.is_some(),
-        "Node 3 should have 1MB contract state after streaming GET through relay"
+        getter_state.is_some(),
+        "Node 5 should have 1MB contract state after streaming GET through relay"
     );
-    let stored_bytes: Vec<u8> = node3_state.unwrap().as_ref().to_vec();
+    let stored_bytes: Vec<u8> = getter_state.unwrap().as_ref().to_vec();
     assert_eq!(
         stored_bytes, large_state,
         "Stored state bytes should match the original 1MB state after relay GET"


### PR DESCRIPTION
## Problem

The task-per-tx GET migration (#1454 Phase 5, commits `bc8ee9d0` / `9edade0c`) dropped GET response **streaming** entirely — both the producer and the relay-forward halves:

- `relay_send_found` always built an inline `GetMsg::Response{Found}` regardless of payload size (no `should_use_streaming` gate, no `send_stream`).
- The relay `Terminal::Streaming` arm logged "not yet implemented (port plan §7)" and skipped to the next peer.

Large GET payloads still load (they fall back to serial transport-level message fragmentation), but that is exactly the slow path streaming was introduced to replace. Per the original fix `f9fc0adc` ("relay GET response forwarding now uses streaming for large payloads", #3586): serial store-and-forward **adds 10–50s per hop for large contracts like the River UI at ~814 KB**. So multi-hop GET of large contracts regressed badly in latency. This restores the streaming fast path. Closes #4307 (follow-up to the now-closed #3883).

## Approach

Mirrors the proven PUT streaming relay (`start_relay_put` / `drive_relay_put_streaming`):

- **Thread `conn_manager: CB` (`NetworkBridge + Clone + Send + 'static`)** through `start_relay_get` → `run_relay_get` → `drive_relay_get` → `drive_relay_get_inner`, and update the `node.rs` GET dispatch site to pass it.
- **Producer (`relay_send_found`)**: for a remote upstream, serialize `GetStreamingPayload`; if it exceeds `streaming_threshold`, send a `GetMsg::ResponseStreaming` header (fire-and-forget — the upstream already has its waiter) then push fragments via `conn_manager.send_stream`. Loopback (`upstream == own_addr`) keeps the inline path (no network benefit). Below-threshold stays inline.
- **Relay forward (`Terminal::Streaming` arm)**: `claim_or_wait` the inbound stream from the downstream peer → `fork()` the handle → mint a **fresh** `outbound_sid` → send a re-keyed `ResponseStreaming` header upstream (with the serialized header embedded for fragment #1, #2757) → `conn_manager.pipe_stream` the forked handle — all **before** the best-effort local `cache_contract_locally` (forward-before-cache, #4155). Records a `SuccessUntimed` relay route event and registers the downstream subscriber when `subscribe`. A loopback safety net assembles+caches locally instead of piping to self.

## Testing

- `cargo test -p freenet --lib operations::get`: **72 passed, 0 failed**.
- Removed the now-false R12b pin (`streaming_downstream_is_currently_warned_and_skipped`) that asserted the absence of this behavior; added pins: producer streams large remote payloads, streaming arm forwards-before-caches, streaming arm uses a fresh outbound stream id.
- `cargo clippy -p freenet --lib --tests` (default features): clean.

## Notes / for reviewers

- **High-risk surface** (streaming/concurrency + wire protocol) — warrants Full multi-model review.
- `handle.fork()` shares the buffer, so the held handle still `assemble()`s for local caching while the fork pipes — same pattern as PUT.
- **Pre-existing, unrelated:** `cargo clippy -p freenet --all-features` fails to compile `tracing.rs` (opentelemetry `SpanBuilder` API drift) on base `main` too — not introduced here.
- cwnd-wait deadlock footgun (#3608) is handled by reusing the existing `pipe_stream` bridge path (same as PUT), not hand-rolled fragment sends.

[AI-assisted - Claude]
