### PR TITLE
docs: tighten PR policy — feature PRs need an approved issue first

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -31,6 +31,22 @@ Does the body explain WHY, not WHAT?
 - `test:` – adding/updating tests
 - `build:` – build system or dependencies
 
+### BEFORE opening a PR — is this change in scope?
+
+```
+Is it a feature, new behavior, or API reshaping?
+  → YES: An approved issue MUST exist first. No issue + maintainer
+         sign-off → don't open the PR; it will be auto-closed.
+         See CONTRIBUTING.md.
+
+Is it a bug fix or non-overreaching perf improvement (no behavior change)?
+  → Accepted without prior discussion. Proceed.
+
+Does the PR bundle more than one logical change?
+  → NO single focus: split it. Scope creep (feature smuggled into a
+    "fix:", unrelated cleanup riding along) is grounds for closing.
+```
+
 ### WHEN creating a PR
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,21 @@
 
 @~/.claude/freenet-local.md
 
+## Contribution Scope (read before opening a PR)
+
+[CONTRIBUTING.md](CONTRIBUTING.md) is the authoritative policy. In short:
+
+- **Bug fixes** and **non-overreaching performance improvements** (no behavior
+  change) — accepted without prior discussion.
+- **Feature changes, new features, behavior changes, API reshaping** — require
+  an issue approved by a maintainer *before* writing code. Feature PRs without
+  an approved issue are auto-closed.
+- **One logical change per PR.** Don't smuggle a feature into a bug fix or let a
+  focused change accrete unrelated cleanup — that's scope creep and grounds for
+  closing the PR.
+
+When unsure which bucket a change is in, open an issue first.
+
 ## Behavioral Rules
 
 ### BEFORE modifying any file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,20 +2,35 @@
 
 We welcome contributions to Freenet! Here's what you need to know.
 
-## Before You Start
+## What Needs an Issue First
 
-- **Get agreement on an issue first.** For anything beyond trivial fixes, open or comment on an issue describing what you want to do and wait for a maintainer to confirm the approach before writing code. A maintainer saying "yes, a PR for this is welcome" is the green light.
-- **Read the codebase conventions.** See [AGENTS.md](AGENTS.md) for project structure, coding standards, and testing requirements.
-- **Ask questions.** If something is unclear, ask on the issue or in our [Matrix channel](https://matrix.to/#/#freenet:matrix.org) before writing code.
+Reviewer attention is the scarcest resource on this project, and code is now cheap to generate. To keep the review queue tractable, contributions fall into two buckets:
 
-## Review Capacity
+**Accepted without prior discussion:**
 
-Reviewer attention is the scarcest resource on this project, and code is now cheap to generate. To keep the review queue tractable we have to be explicit about what we can promise:
+- Bug fixes (that don't change intended behavior).
+- Performance improvements that aren't overreaching and don't change behavior.
+- Typo fixes, documentation corrections, and obvious one-line changes.
 
-- **Non-trivial PRs opened without prior agreement on an issue may be closed unreviewed.** This isn't personal — we simply can't commit to reviewing speculative work. Reopening is welcome after the issue discussion happens and a maintainer signs off on the approach.
-- **Trivial PRs are still welcome cold.** Typo fixes, obvious one-line bugfixes, documentation corrections, and similarly small changes don't need pre-agreement. Use your judgment; if in doubt, file an issue first.
+**Requires an approved issue first:**
+
+- **Any feature change or new feature.** Open an issue describing what you want to do and wait for a maintainer to confirm the approach *before* writing code. A maintainer explicitly saying "yes, a PR for this is welcome" is the green light — silence is not approval.
+- **Anything that changes behavior, adds scope, or reshapes an API**, even if it started life as a bug fix or a refactor.
+
+**Feature PRs opened without an approved issue will be auto-closed.** This isn't personal — we cannot commit to reviewing speculative feature work, and unsolicited feature PRs are now the dominant source of review load. Reopening is welcome once the issue discussion happens and a maintainer signs off on the approach.
+
+When in doubt about which bucket you're in, file an issue first. It costs you a round-trip; guessing wrong costs you the whole PR.
+
+### Scope discipline
+
+- **One logical change per PR.** Bundling a feature into a "bug fix," or letting a focused change accrete unrelated cleanup, is scope creep and a reason to close the PR pending an issue-level conversation — regardless of whether the extra change is good on its own merits.
 - **The submitter is responsible for the PR.** Whatever tools you used to produce it, you must understand the change well enough to defend the design choices, answer reviewer questions, and revise it. "I'm not sure, the AI wrote it" is grounds for closing the PR.
 - **Volume is a signal.** A burst of unrelated PRs from a new contributor will be treated as a single batch and likely closed pending an issue-level conversation about what you'd actually like to work on.
+
+## Before You Start
+
+- **Read the codebase conventions.** See [AGENTS.md](AGENTS.md) for project structure, coding standards, and testing requirements.
+- **Ask questions.** If something is unclear, ask on the issue or in our [Matrix channel](https://matrix.to/#/#freenet:matrix.org) before writing code.
 
 ## Quality Standards
 

--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@
   </a>
 </div>
 
-This is the freenet-core repository. To learn more about Freenet please visit our website 
+This is the freenet-core repository. To learn more about Freenet please visit our website
 at [freenet.org](https://freenet.org/).
 
 # Decentralize Everything
 
-Freenet is the internet as it should be—fully decentralized, designed to put you back in control. Imagine a global shared 
-computer where you can communicate and collaborate freely, without reliance on big tech. Freenet lets you regain your 
+Freenet is the internet as it should be—fully decentralized, designed to put you back in control. Imagine a global shared
+computer where you can communicate and collaborate freely, without reliance on big tech. Freenet lets you regain your
 digital independence.
 
-Freenet is a peer-to-peer network that transforms users’ computers into a resilient, distributed platform on which anyone 
-can build decentralized services. Every peer contributes to a fault-tolerant collective, ensuring services are always 
+Freenet is a peer-to-peer network that transforms users’ computers into a resilient, distributed platform on which anyone
+can build decentralized services. Every peer contributes to a fault-tolerant collective, ensuring services are always
 available and robust.
 
-Today’s web is a series of siloed services, but every system built on Freenet is fully interoperable by default. Freenet 
+Today’s web is a series of siloed services, but every system built on Freenet is fully interoperable by default. Freenet
 apps can be built with popular web frameworks, accessed through any browser just like the web.
 
 ## Build Instructions
@@ -52,3 +52,13 @@ Or for the fdev utility:
 ```bash
 $ cargo install --path crates/fdev
 ```
+
+## Contributing
+
+We welcome contributions, but **feature PRs opened without a prior approved
+issue will be auto-closed** — reviewer attention is our scarcest resource.
+Bug fixes and non-overreaching performance improvements are accepted without
+prior discussion; anything that adds or changes behavior needs an issue and a
+maintainer's sign-off first.
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.


### PR DESCRIPTION
## Problem

Reviewer attention is the project's scarcest resource, and AI now makes code cheap to generate. The result is a rising volume of unsolicited feature PRs — often with scope creep — that the team can't commit to reviewing. The existing CONTRIBUTING.md gestured at "get agreement first" but didn't draw a hard line or make the in/out-of-scope buckets explicit, and the policy wasn't surfaced from README or the agent-facing docs.

This follows a maintainer discussion (nachodg + ian) agreeing to tighten the language and be explicit about what is in vs out of scope.

## Solution

Draw an explicit two-bucket line in CONTRIBUTING.md:

- **Accepted without prior discussion:** bug fixes, non-overreaching performance improvements (no behavior change), typos/docs/obvious one-liners.
- **Requires an approved issue first:** any feature, new feature, behavior change, or API reshaping. **Feature PRs opened without an approved issue are auto-closed.** Silence is not approval.

Adds a **Scope discipline** section: one logical change per PR; smuggling a feature into a `fix:` or letting a focused change accrete unrelated cleanup is scope creep and grounds for closing — regardless of whether the extra change is good on its own.

Surfaces the policy from the entry points contributors and agents actually read:
- **README.md** — new Contributing section with the auto-close warning + link.
- **AGENTS.md** — Contribution Scope block at the top.
- **.claude/rules/git-workflow.md** — a "is this change in scope?" decision gate before the existing PR-creation rules.

## Testing

Docs-only. `cargo clippy` + merge-conflict + whitespace pre-commit hooks pass.

## Fixes

N/A — policy change per maintainer discussion.