### PR TITLE
feat(replay-harness): offline harness for #4074 Phase 2 controller design

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5514,6 +5514,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "replay-harness"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/replay-harness/Cargo.toml
+++ b/crates/replay-harness/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "replay-harness"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+publish = false
+description = """
+Offline replay harness for evaluating shadow-RTT controllers against
+synthetic scenarios and OTLP telemetry. Phase 2 of #4074 design tool.
+Not a production component.
+"""
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "replay-harness"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]

--- a/crates/replay-harness/README.md
+++ b/crates/replay-harness/README.md
@@ -1,0 +1,105 @@
+# replay-harness
+
+Offline test harness for evaluating Phase 2 shadow-RTT controllers (issue
+[#4074][issue]) against synthetic scenarios and OTLP telemetry, before
+shipping any controller to production.
+
+Not a production component. No code path in `freenet` reaches this crate.
+
+## Why
+
+The previous three congestion-control attempts (LEDBAT++, BBRv3, custom
+adaptive) all failed in production because there was no offline test loop.
+LEDBAT's death spiral on a single packet loss only showed up after deploy.
+BBR's stale `min_RTT` across reroutes was caught by manual debugging weeks
+after the algorithm went live.
+
+Phase 1.5 ([#4292][p15]) just landed the per-node tagged telemetry we need.
+The replay harness is the next piece: before any Phase 2 controller ships,
+it must pass a battery of scripted scenarios that pin known failure modes,
+then be evaluated against real OTLP data without touching production.
+
+[issue]: https://github.com/freenet/freenet-core/issues/4074
+[p15]: https://github.com/freenet/freenet-core/pull/4292
+
+## Quick start
+
+```bash
+# List the scenarios and controllers shipped with v1.
+cargo run -p replay-harness -- scenarios
+cargo run -p replay-harness -- controllers
+
+# Run one scenario against the default controller (rfc_draft).
+cargo run -p replay-harness -- synthetic correlated_inflation
+
+# Run every scenario against rfc_draft (the algorithm sketched in #4074).
+cargo run -p replay-harness -- synthetic all
+
+# Same against the no-op baseline.
+cargo run -p replay-harness -- synthetic all --controller fixed_rate
+
+# Run the assertion suite (every scenario × every controller, with each
+# (controller, scenario) outcome pinned).
+cargo test -p replay-harness
+```
+
+## What's pinned in v1
+
+Four scenarios, chosen to cover the most important pins for Phase 2 design:
+
+| Scenario | What it pins | Sane behaviour |
+|---|---|---|
+| `idle_steady_state` | The ~55 ms ambient overlay noise we measured in production | MUST NOT fire |
+| `correlated_inflation` | Every peer's RTT rises together — the actual contention case | MUST fire at least once |
+| `single_peer_outlier` | One peer at 500 ms, four others at baseline | MUST NOT fire (cross-peer median rejects) |
+| `small_n` | Only 2 peers — below the `rolling_rtt_stats.rs` N≥3 trustworthy threshold | MUST NOT fire (N≥3 guard) |
+
+The `RfcDraft` reference controller intentionally **fails** the
+`idle_steady_state` pin (48 fires across the 300 s scenario, rate drops
+to ~0). That failure is the demonstration of the noise-floor problem the
+Phase 1 telemetry already showed: the 30 ms inflation threshold sits well
+below the ambient overlay queueing baseline, so the controller fires on
+healthy ambient noise. Any Phase 2 candidate MUST NOT repeat that failure.
+
+`FixedRate` (the production default) passes the universal sanity check
+of "never fires on any scenario."
+
+## Adding a controller
+
+1. Drop a new file in `src/controllers/`.
+2. Implement [`Controller`](src/controllers.rs).
+3. Re-export it from `src/controllers.rs`.
+4. Wire it into the binary's `match controller_name { … }` in `src/main.rs`.
+5. Run `cargo test -p replay-harness` — it auto-runs every scenario
+   against your controller; if your design philosophy diverges from the
+   default expectation for any scenario, extend `expected_fires` in
+   `tests/scenarios_pin.rs`.
+
+## Adding a scenario
+
+1. Drop a new file in `src/scenarios/`.
+2. Implement a `pub fn scenario() -> Scenario`.
+3. Add the module to `src/scenarios.rs` and append to `all_scenarios()`.
+4. `cargo test` — the new scenario runs against every controller
+   automatically.
+
+## Why not real OTLP replay yet
+
+The current OTLP `shadow_rtt_aggregate` event emits the pre-computed
+aggregate (`active_peers`, `peers_with_recent`, `median_inflation_us`) —
+not the underlying per-peer RTT samples that `RollingRttStats` needs to
+recompute the snapshot at each tick. Feeding OTLP into the harness
+requires either (a) ALSO emitting per-peer samples via OTLP, or (b) an
+aggregates-replay mode that fakes per-peer snapshots from the aggregate.
+Both have caveats; both are deferred to a follow-up.
+
+In the meantime, synthetic scenarios are the higher-value testing layer
+anyway — they pin *specific* failure modes rather than measuring against
+a single instance of "what happened in production last week."
+
+## Not in scope
+
+- Per-tick controller telemetry to the OTLP collector (offline tool only).
+- GUI / plots (decision-trace dump is CSV/JSON-friendly; plot externally).
+- Live mode (reading the collector in real-time).
+- Any change to production transport behaviour.

--- a/crates/replay-harness/README.md
+++ b/crates/replay-harness/README.md
@@ -55,11 +55,12 @@ Four scenarios, chosen to cover the most important pins for Phase 2 design:
 | `small_n` | Only 2 peers — below the `rolling_rtt_stats.rs` N≥3 trustworthy threshold | MUST NOT fire (N≥3 guard) |
 
 The `RfcDraft` reference controller intentionally **fails** the
-`idle_steady_state` pin (48 fires across the 300 s scenario, rate drops
-to ~0). That failure is the demonstration of the noise-floor problem the
-Phase 1 telemetry already showed: the 30 ms inflation threshold sits well
-below the ambient overlay queueing baseline, so the controller fires on
-healthy ambient noise. Any Phase 2 candidate MUST NOT repeat that failure.
+`idle_steady_state` pin (48 fires across the 300 s scenario, rate
+floors at 1 bps after enough successive 0.7× downsteps). That failure
+is the demonstration of the noise-floor problem the Phase 1 telemetry
+already showed: the 30 ms inflation threshold sits well below the
+ambient overlay queueing baseline, so the controller fires on healthy
+ambient noise. Any Phase 2 candidate MUST NOT repeat that failure.
 
 `FixedRate` (the production default) passes the universal sanity check
 of "never fires on any scenario."

--- a/crates/replay-harness/src/controllers.rs
+++ b/crates/replay-harness/src/controllers.rs
@@ -1,0 +1,62 @@
+//! [`Controller`] trait and the view it sees each tick.
+
+use std::time::Duration;
+
+use crate::event::PeerKey;
+use crate::rolling::RttSnapshot;
+
+pub mod fixed_rate;
+pub mod rfc_draft;
+
+pub use fixed_rate::FixedRate;
+pub use rfc_draft::RfcDraft;
+
+/// Snapshot the harness hands to a controller at each tick.
+#[derive(Debug, Clone)]
+pub struct ControllerView<'a> {
+    /// Wall-clock time of this tick (relative to scenario start / first
+    /// event in OTLP replay).
+    pub now: Duration,
+    /// Per-peer snapshots, one entry per peer currently registered.
+    /// Order is sorted by peer key so controllers are deterministic
+    /// against the same input.
+    pub per_peer: &'a [PeerObservation],
+    /// Reference-path snapshot, if reference-ping events were observed.
+    pub reference: Option<RttSnapshot>,
+    /// Current aggregate outbound rate (bytes/sec). The controller's
+    /// decisions are relative to this baseline.
+    pub current_aggregate_rate_bps: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct PeerObservation {
+    pub peer: PeerKey,
+    pub snapshot: RttSnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RateDecision {
+    /// Leave the aggregate rate unchanged.
+    Hold,
+    /// Set the aggregate rate to a new value. `reason` is logged in the
+    /// decision trace for post-hoc analysis.
+    Set {
+        aggregate_rate_bps: u64,
+        reason: &'static str,
+    },
+}
+
+impl RateDecision {
+    pub fn is_hold(&self) -> bool {
+        matches!(self, RateDecision::Hold)
+    }
+}
+
+pub trait Controller {
+    /// Stable name used in reports and assertions.
+    fn name(&self) -> &str;
+
+    /// Called once per tick (the harness drives ticks at the configured
+    /// cadence — production uses 1 Hz).
+    fn tick(&mut self, view: ControllerView<'_>) -> RateDecision;
+}

--- a/crates/replay-harness/src/controllers/fixed_rate.rs
+++ b/crates/replay-harness/src/controllers/fixed_rate.rs
@@ -1,0 +1,20 @@
+//! `FixedRate` — the production default and the harness baseline.
+//!
+//! Never changes the aggregate rate. Useful as a sanity-check that the
+//! harness itself works (every scenario should observe zero rate changes
+//! against this controller), and as a comparison point in `compare` runs.
+
+use super::{Controller, ControllerView, RateDecision};
+
+#[derive(Debug, Default)]
+pub struct FixedRate;
+
+impl Controller for FixedRate {
+    fn name(&self) -> &str {
+        "fixed_rate"
+    }
+
+    fn tick(&mut self, _view: ControllerView<'_>) -> RateDecision {
+        RateDecision::Hold
+    }
+}

--- a/crates/replay-harness/src/controllers/rfc_draft.rs
+++ b/crates/replay-harness/src/controllers/rfc_draft.rs
@@ -1,0 +1,119 @@
+//! `RfcDraft` — the algorithm sketched in [#4074][issue].
+//!
+//! Implements the downstep branch as specified:
+//!
+//! ```text
+//! if shared_inflation > 30 ms sustained for 5 s:
+//!   aggregate_R *= 0.7
+//!   freeze upward moves for 30 s
+//! ```
+//!
+//! With the N≥3 guard the rolling-stats module's own rustdoc demands
+//! ("any future controller built on this must require `recent.len() >= 3`
+//! before treating the result as a contention signal"). The upward branch
+//! (the "aggregate_outbound < 0.5 × aggregate_R for 60 s" idle-headroom
+//! check) requires modelling outbound traffic, which the v1 harness does
+//! not do — so this controller can downstep but never upsteps. That's
+//! deliberate: the point of v1 is to demonstrate the *trigger* behaviour
+//! on real telemetry, where Phase 1 analysis already showed the 30 ms
+//! threshold sits below the noise floor.
+//!
+//! [issue]: https://github.com/freenet/freenet-core/issues/4074
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use super::{Controller, ControllerView, RateDecision};
+
+/// The minimum population the cross-peer median is trustworthy on — per the
+/// rolling-stats module rustdoc. At N≤2 the upper-middle median degenerates
+/// to "the worse of the two".
+const MIN_PEERS_FOR_SIGNAL: usize = 3;
+
+/// Threshold from the #4074 sketch.
+const INFLATION_TRIGGER: Duration = Duration::from_millis(30);
+
+/// How long `shared_inflation` must stay above the trigger before we
+/// downstep.
+const SUSTAIN_WINDOW: Duration = Duration::from_secs(5);
+
+/// Multiplicative downstep factor.
+const DOWNSTEP_FACTOR: f64 = 0.7;
+
+#[derive(Debug, Default)]
+pub struct RfcDraft {
+    /// (tick_time, shared_inflation) for the last `SUSTAIN_WINDOW` worth
+    /// of ticks.
+    inflation_history: VecDeque<(Duration, Duration)>,
+}
+
+impl Controller for RfcDraft {
+    fn name(&self) -> &str {
+        "rfc_draft"
+    }
+
+    fn tick(&mut self, view: ControllerView<'_>) -> RateDecision {
+        // Collect per-peer inflations that are defined (peer has both a
+        // baseline and a recent median).
+        let mut inflations: Vec<Duration> = view
+            .per_peer
+            .iter()
+            .filter_map(|p| p.snapshot.inflation)
+            .collect();
+
+        // N≥3 guard from rolling_rtt_stats.rs:cross_connection_median_inflation
+        // rustdoc — without it we'd act on a "median of two" that is just
+        // "the worse of the two".
+        if inflations.len() < MIN_PEERS_FOR_SIGNAL {
+            // Clear history so a transient small-N period doesn't carry
+            // stale trigger samples into a later large-N window.
+            self.inflation_history.clear();
+            return RateDecision::Hold;
+        }
+
+        inflations.sort_unstable();
+        let shared_inflation = inflations[inflations.len() / 2];
+
+        // Window of recent shared_inflation values, pruned to SUSTAIN_WINDOW.
+        self.inflation_history
+            .push_back((view.now, shared_inflation));
+        let cutoff = view.now.saturating_sub(SUSTAIN_WINDOW);
+        while let Some(&(t, _)) = self.inflation_history.front() {
+            if t < cutoff {
+                self.inflation_history.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        // Trigger requires (a) every sample in the window exceeds the
+        // threshold, AND (b) the window actually covers SUSTAIN_WINDOW.
+        // The latter prevents a single tick at startup from firing on its
+        // own ((a) trivially holds for a one-sample window).
+        let all_above = self
+            .inflation_history
+            .iter()
+            .all(|(_, infl)| *infl > INFLATION_TRIGGER);
+        let oldest_age = self
+            .inflation_history
+            .front()
+            .map(|(t, _)| view.now.saturating_sub(*t))
+            .unwrap_or(Duration::ZERO);
+        let window_covers = oldest_age >= SUSTAIN_WINDOW;
+
+        if all_above && window_covers {
+            let new_rate =
+                (view.current_aggregate_rate_bps as f64 * DOWNSTEP_FACTOR).round() as u64;
+            // Reset history so we don't keep firing on the same sustained
+            // window — production would also freeze upward moves here, but
+            // since v1 has no upward branch the freeze is a no-op.
+            self.inflation_history.clear();
+            return RateDecision::Set {
+                aggregate_rate_bps: new_rate,
+                reason: "shared_inflation_sustained_over_30ms",
+            };
+        }
+
+        RateDecision::Hold
+    }
+}

--- a/crates/replay-harness/src/event.rs
+++ b/crates/replay-harness/src/event.rs
@@ -1,0 +1,58 @@
+//! Events the [`Replayer`](crate::Replayer) consumes.
+
+use std::time::Duration;
+
+/// Stable per-peer identifier as it appears in OTLP `peer_id` attributes
+/// (and as we make up for synthetic scenarios). Comparisons are
+/// case-sensitive and exact.
+pub type PeerKey = String;
+
+#[derive(Debug, Clone)]
+pub enum Event {
+    /// An overlay RTT sample observed at `at` from `peer`.
+    RttSample {
+        peer: PeerKey,
+        at: Duration,
+        rtt: Duration,
+    },
+    /// A reference-path RTT sample (the `shadow_reference_ping` signal).
+    /// Reference-ping events have no source peer in production — they are
+    /// emitted per node tagged with the local peer id. For replay, the
+    /// stream that produces them is responsible for routing per-node
+    /// streams correctly; the harness treats reference samples as
+    /// node-local, not per-overlay-peer.
+    ReferenceSample { at: Duration, rtt: Duration },
+    /// A new peer joined (registry insert). Used by churn scenarios.
+    PeerJoin { peer: PeerKey, at: Duration },
+    /// A peer left (registry remove). Used by churn scenarios.
+    PeerLeave { peer: PeerKey, at: Duration },
+}
+
+impl Event {
+    /// The wall-clock time at which this event happened.
+    pub fn at(&self) -> Duration {
+        match self {
+            Event::RttSample { at, .. }
+            | Event::ReferenceSample { at, .. }
+            | Event::PeerJoin { at, .. }
+            | Event::PeerLeave { at, .. } => *at,
+        }
+    }
+}
+
+/// Source of events the replayer pulls from. Iterator-shaped on purpose so
+/// large OTLP files can be streamed rather than loaded into memory.
+///
+/// Implementations MUST yield events in non-decreasing `at` order.
+pub trait EventStream {
+    fn next_event(&mut self) -> Option<Event>;
+}
+
+impl<I> EventStream for I
+where
+    I: Iterator<Item = Event>,
+{
+    fn next_event(&mut self) -> Option<Event> {
+        self.next()
+    }
+}

--- a/crates/replay-harness/src/lib.rs
+++ b/crates/replay-harness/src/lib.rs
@@ -1,0 +1,38 @@
+//! Offline replay harness for shadow-RTT controllers.
+//!
+//! This crate provides a deterministic, single-threaded simulator that drives
+//! a candidate [`Controller`] against a stream of RTT samples — either
+//! synthetic (programmatic scenarios that pin known failure modes from the
+//! prior congestion-control attempts in [#4074][issue]) or replayed from the
+//! OTLP shadow-RTT telemetry that Phase 1.5 emits (#4292).
+//!
+//! It is strictly offline tooling. Nothing here is reachable from the
+//! production `freenet` binary, and the rolling-stats / event types here
+//! are an intentional copy of the production types: we want the harness to
+//! pin against a specific iteration of the algorithm rather than silently
+//! follow whatever `crates/core` does next.
+//!
+//! [issue]: https://github.com/freenet/freenet-core/issues/4074
+//!
+//! # Workflow
+//!
+//! 1. Author a [`Controller`] in `controllers/`.
+//! 2. Author a synthetic [`Scenario`](scenarios::Scenario) that pins the
+//!    behaviour you expect on a specific input pattern (idle baseline,
+//!    routing event, contention burst, …).
+//! 3. `cargo test -p replay-harness` runs every scenario against every
+//!    controller — additions to either side compose automatically.
+//! 4. Once a controller passes synthetic scenarios, run it against real
+//!    OTLP data via the binary:
+//!    `replay-harness otlp <log.jsonl> --controller <name>`.
+
+pub mod controllers;
+pub mod event;
+pub mod replayer;
+pub mod rolling;
+pub mod scenarios;
+
+pub use controllers::{Controller, ControllerView, PeerObservation, RateDecision};
+pub use event::{Event, EventStream, PeerKey};
+pub use replayer::{DecisionLog, ReplayReport, Replayer};
+pub use rolling::{RollingRttStats, RttSnapshot};

--- a/crates/replay-harness/src/main.rs
+++ b/crates/replay-harness/src/main.rs
@@ -1,0 +1,139 @@
+//! CLI entry point: drive controllers against synthetic scenarios or OTLP
+//! replay files.
+
+use std::path::PathBuf;
+
+use anyhow::{Result, bail};
+use clap::{Parser, Subcommand};
+use replay_harness::Replayer;
+use replay_harness::controllers::{FixedRate, RfcDraft};
+use replay_harness::scenarios::{self, Expectation};
+
+#[derive(Parser)]
+#[command(
+    name = "replay-harness",
+    about = "Offline shadow-RTT controller harness (#4074)"
+)]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// List the built-in synthetic scenarios.
+    Scenarios,
+    /// List the built-in controllers.
+    Controllers,
+    /// Run one or all synthetic scenarios against the given controller.
+    Synthetic {
+        /// Scenario name, or `all` to run every scenario.
+        scenario: String,
+        /// Controller to drive (`fixed_rate` or `rfc_draft`).
+        #[arg(long, default_value = "rfc_draft")]
+        controller: String,
+    },
+    /// Replay an OTLP shadow_rtt_aggregate jsonl file through the given
+    /// controller. (v1: stub — wire-up coming in #4314 follow-up.)
+    Otlp {
+        /// Path to the OTLP jsonl file.
+        #[arg(long)]
+        file: PathBuf,
+        /// Controller to drive.
+        #[arg(long, default_value = "rfc_draft")]
+        controller: String,
+    },
+}
+
+fn main() -> Result<()> {
+    let _ = tracing_subscriber::fmt().try_init();
+    let cli = Cli::parse();
+    match cli.cmd {
+        Cmd::Scenarios => {
+            for s in scenarios::all_scenarios() {
+                println!(
+                    "{:32} [{}] events={} run_for={:?}\n    {}",
+                    s.name,
+                    match s.expectation {
+                        Expectation::NeverFires => "NEVER",
+                        Expectation::FiresAtLeastOnce => "FIRES",
+                        Expectation::Informational => "INFO",
+                    },
+                    s.events.len(),
+                    s.run_for,
+                    s.description,
+                );
+            }
+        }
+        Cmd::Controllers => {
+            println!("fixed_rate   — baseline; never changes rate");
+            println!("rfc_draft    — the #4074 sketched algorithm (downstep only)");
+        }
+        Cmd::Synthetic {
+            scenario,
+            controller,
+        } => {
+            let to_run: Vec<_> = if scenario == "all" {
+                scenarios::all_scenarios()
+            } else {
+                match scenarios::find(&scenario) {
+                    Some(s) => vec![s],
+                    None => bail!("unknown scenario: {scenario}"),
+                }
+            };
+            for s in to_run {
+                run_synthetic(&s, &controller)?;
+            }
+        }
+        Cmd::Otlp { file, controller } => {
+            anyhow::ensure!(file.exists(), "OTLP file not found: {}", file.display());
+            bail!(
+                "OTLP replay for controller `{controller}` is not yet \
+                 wired up; this v1 ships the synthetic-scenario harness only. \
+                 See #4314 for the planned follow-up."
+            );
+        }
+    }
+    Ok(())
+}
+
+fn run_synthetic(s: &scenarios::Scenario, controller_name: &str) -> Result<()> {
+    let report = match controller_name {
+        "fixed_rate" => Replayer::new().run(s.events.clone().into_iter(), FixedRate),
+        "rfc_draft" => Replayer::new().run(s.events.clone().into_iter(), RfcDraft::default()),
+        other => bail!("unknown controller: {other}"),
+    };
+
+    let pass = match s.expectation {
+        Expectation::NeverFires => report.decisions_set == 0,
+        Expectation::FiresAtLeastOnce => report.decisions_set > 0,
+        Expectation::Informational => true,
+    };
+    let marker = if pass { "PASS" } else { "FAIL" };
+    println!(
+        "{marker} {scenario}/{controller} — ticks={ticks} fires={fires} \
+         final_rate_bps={final_rate} range_bps=[{min}..{max}]",
+        scenario = s.name,
+        controller = report.controller,
+        ticks = report.ticks,
+        fires = report.decisions_set,
+        final_rate = report.final_rate_bps,
+        min = report.min_rate_bps,
+        max = report.max_rate_bps,
+    );
+    if !report.fired().is_empty() {
+        for d in report.fired().iter().take(5) {
+            if let replay_harness::RateDecision::Set { reason, .. } = &d.decision {
+                println!(
+                    "       fired at {:>6.1}s reason={reason} shared_infl={:?}",
+                    d.at.as_secs_f64(),
+                    d.shared_inflation,
+                );
+            }
+        }
+        if report.fired().len() > 5 {
+            println!("       ... +{} more", report.fired().len() - 5);
+        }
+    }
+    Ok(())
+}

--- a/crates/replay-harness/src/main.rs
+++ b/crates/replay-harness/src/main.rs
@@ -43,6 +43,12 @@ enum Cmd {
         #[arg(long, default_value = "rfc_draft")]
         controller: String,
     },
+    // Note: the `compare <a> <b> <events>` subcommand listed in the
+    // #4314 design is intentionally deferred. The Replayer already
+    // produces a full DecisionLog for each run, so a future PR can
+    // diff two runs without harness-side changes. Holding off on
+    // deciding the diff/output format (text vs JSON vs side-by-side)
+    // until we have a real Phase 2 candidate to compare against.
 }
 
 fn main() -> Result<()> {
@@ -99,20 +105,32 @@ fn main() -> Result<()> {
 
 fn run_synthetic(s: &scenarios::Scenario, controller_name: &str) -> Result<()> {
     let report = match controller_name {
-        "fixed_rate" => Replayer::new().run(s.events.clone().into_iter(), FixedRate),
-        "rfc_draft" => Replayer::new().run(s.events.clone().into_iter(), RfcDraft::default()),
+        "fixed_rate" => Replayer::new()
+            .run_until(s.run_for)
+            .run(s.events.clone().into_iter(), FixedRate),
+        "rfc_draft" => Replayer::new()
+            .run_until(s.run_for)
+            .run(s.events.clone().into_iter(), RfcDraft::default()),
         other => bail!("unknown controller: {other}"),
     };
 
-    let pass = match s.expectation {
-        Expectation::NeverFires => report.decisions_set == 0,
-        Expectation::FiresAtLeastOnce => report.decisions_set > 0,
-        Expectation::Informational => true,
+    // CLI output is neutral by design: it prints what the controller
+    // actually did, plus the scenario's expectation for a *sane*
+    // controller. Whether a specific controller's behaviour is correct
+    // depends on its design philosophy — `FixedRate` (a no-op
+    // baseline) never fires by definition, so it will always
+    // "disagree" with `FiresAtLeastOnce` scenarios; that disagreement
+    // is not a bug. Per-controller-per-scenario expected outcomes
+    // live in `tests/scenarios_pin.rs` where they are pinned with
+    // explicit knowledge of each controller's design.
+    let scenario_expects = match s.expectation {
+        Expectation::NeverFires => "scenario expects: no fire (sane controller)",
+        Expectation::FiresAtLeastOnce => "scenario expects: at least one fire (sane controller)",
+        Expectation::Informational => "scenario is informational",
     };
-    let marker = if pass { "PASS" } else { "FAIL" };
     println!(
-        "{marker} {scenario}/{controller} — ticks={ticks} fires={fires} \
-         final_rate_bps={final_rate} range_bps=[{min}..{max}]",
+        "{scenario}/{controller} — ticks={ticks} fires={fires} \
+         final_rate_bps={final_rate} range_bps=[{min}..{max}]\n    ({expects})",
         scenario = s.name,
         controller = report.controller,
         ticks = report.ticks,
@@ -120,6 +138,7 @@ fn run_synthetic(s: &scenarios::Scenario, controller_name: &str) -> Result<()> {
         final_rate = report.final_rate_bps,
         min = report.min_rate_bps,
         max = report.max_rate_bps,
+        expects = scenario_expects,
     );
     if !report.fired().is_empty() {
         for d in report.fired().iter().take(5) {

--- a/crates/replay-harness/src/replayer.rs
+++ b/crates/replay-harness/src/replayer.rs
@@ -20,6 +20,13 @@ pub struct DecisionLog {
     /// Snapshot of the cross-peer state at the moment of the decision.
     /// Useful for "why did the controller (not) fire?" post-hoc analysis.
     pub n_peers_with_inflation: usize,
+    /// Cross-peer median of defined inflations, **without the N≥3
+    /// guard** that controllers should apply. This is the raw signal
+    /// the rolling stats produce; for ticks where `n_peers_with_inflation
+    /// < 3`, a well-behaved controller (e.g. `RfcDraft`) treats this
+    /// as untrustworthy and does NOT fire even if the value is large.
+    /// When reading a trace, always cross-check `n_peers_with_inflation`
+    /// before concluding "the controller should have fired".
     pub shared_inflation: Option<Duration>,
 }
 
@@ -55,6 +62,12 @@ impl ReplayReport {
 pub struct Replayer {
     tick_interval: Duration,
     starting_rate_bps: u64,
+    /// Optional override for the observation window. Without it, the
+    /// replayer ticks until one interval past the last event; with it,
+    /// the replayer ticks until at least `now > run_until`, so
+    /// scenarios with a quiet-tail observation period (e.g. "no
+    /// further fires after the burst") actually exercise that period.
+    run_until: Option<Duration>,
 }
 
 impl Replayer {
@@ -64,16 +77,35 @@ impl Replayer {
         Self {
             tick_interval: Duration::from_secs(1),
             starting_rate_bps: 1_250_000,
+            run_until: None,
         }
     }
 
+    /// # Panics (in debug builds)
+    /// `interval` must be strictly positive. A zero interval would loop
+    /// forever (`now += ZERO` never grows past `stop_at`).
     pub fn with_tick_interval(mut self, interval: Duration) -> Self {
+        debug_assert!(
+            interval > Duration::ZERO,
+            "tick_interval must be > 0; zero would loop forever",
+        );
         self.tick_interval = interval;
         self
     }
 
     pub fn with_starting_rate_bps(mut self, rate: u64) -> Self {
         self.starting_rate_bps = rate;
+        self
+    }
+
+    /// Run ticks until the observation window covers at least `until`.
+    /// Without this, the replayer stops one interval past the last
+    /// event — fine for scenarios whose events span the full intended
+    /// window, but wrong for scenarios with a quiet observation tail.
+    /// Set from [`Scenario::run_for`](crate::scenarios::Scenario) by
+    /// callers that drive a scenario.
+    pub fn run_until(mut self, until: Duration) -> Self {
+        self.run_until = Some(until);
         self
     }
 
@@ -104,11 +136,15 @@ impl Replayer {
         let mut ev_idx = 0usize;
         let mut now = Duration::ZERO;
 
-        // Tick from t=tick_interval until one tick past the last event,
-        // so we capture the final-window state. If there were no events,
-        // we tick exactly once at t=tick_interval so the controller sees
-        // an empty network.
-        let stop_at = end_time + self.tick_interval;
+        // Tick from t=tick_interval until at least one tick past the
+        // last event AND at least one tick past `run_until` (if set).
+        // If there were no events and no `run_until` override, we tick
+        // exactly once so the controller sees an empty network.
+        let event_stop_at = end_time + self.tick_interval;
+        let stop_at = match self.run_until {
+            Some(until) => event_stop_at.max(until),
+            None => event_stop_at,
+        };
         loop {
             now += self.tick_interval;
             if now > stop_at && ev_idx >= events.len() {
@@ -161,6 +197,22 @@ fn collect_stream<S: EventStream>(mut stream: S) -> Vec<Event> {
     out
 }
 
+/// Apply one event to the rolling stats. Semantics:
+///
+/// - `RttSample` for a peer the registry doesn't know yet creates the
+///   peer with a fresh stats deque and records the sample. This
+///   matches production semantics — the first ACK for a new connection
+///   implicitly registers it. **Side effect:** a `PeerLeave` followed
+///   by an `RttSample` for the *same* peer silently resurrects the
+///   peer with empty stats (re-baselining from the post-leave sample).
+///   If a churn scenario needs leave-and-stay-gone behaviour, the
+///   scenario must avoid emitting late samples for departed peers; or
+///   if reconnect should be modelled explicitly, emit a `PeerJoin`
+///   first to make the transition visible in the event trace.
+/// - `ReferenceSample` similarly creates the reference stats lazily.
+/// - `PeerJoin` is idempotent (no-op if already present).
+/// - `PeerLeave` removes the peer's stats entirely; subsequent samples
+///   for that peer trigger the resurrect behaviour above.
 fn apply_event(
     ev: &Event,
     per_peer: &mut BTreeMap<PeerKey, RollingRttStats>,

--- a/crates/replay-harness/src/replayer.rs
+++ b/crates/replay-harness/src/replayer.rs
@@ -1,0 +1,247 @@
+//! Driver that feeds an [`EventStream`] into per-peer rolling stats and
+//! ticks a [`Controller`] at a fixed cadence.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use crate::controllers::{Controller, ControllerView, PeerObservation, RateDecision};
+use crate::event::{Event, EventStream, PeerKey};
+use crate::rolling::RollingRttStats;
+
+/// One row in the controller's decision trace.
+#[derive(Debug, Clone)]
+pub struct DecisionLog {
+    pub at: Duration,
+    pub decision: RateDecision,
+    /// The aggregate rate AFTER applying the decision. Stable rate across
+    /// many consecutive `Hold` decisions; the trace records every tick so
+    /// downstream tooling can plot rate-over-time without re-deriving it.
+    pub rate_after_bps: u64,
+    /// Snapshot of the cross-peer state at the moment of the decision.
+    /// Useful for "why did the controller (not) fire?" post-hoc analysis.
+    pub n_peers_with_inflation: usize,
+    pub shared_inflation: Option<Duration>,
+}
+
+/// Aggregate report returned by [`Replayer::run`].
+#[derive(Debug, Clone, Default)]
+pub struct ReplayReport {
+    pub controller: String,
+    pub ticks: usize,
+    pub decisions_set: usize,
+    pub final_rate_bps: u64,
+    pub min_rate_bps: u64,
+    pub max_rate_bps: u64,
+    pub log: Vec<DecisionLog>,
+}
+
+impl ReplayReport {
+    /// Decisions filtered to `RateDecision::Set` only. Useful for
+    /// assertions that check "the controller fired N times during the
+    /// contention period".
+    pub fn fired(&self) -> Vec<&DecisionLog> {
+        self.log
+            .iter()
+            .filter(|d| matches!(d.decision, RateDecision::Set { .. }))
+            .collect()
+    }
+
+    /// Were any rate decisions made? Equivalent to `!self.fired().is_empty()`.
+    pub fn fired_at_all(&self) -> bool {
+        self.decisions_set > 0
+    }
+}
+
+pub struct Replayer {
+    tick_interval: Duration,
+    starting_rate_bps: u64,
+}
+
+impl Replayer {
+    /// New replayer with the standard 1 Hz tick cadence and a default
+    /// 10 Mbps × 1 peer starting rate (the production FixedRate baseline).
+    pub fn new() -> Self {
+        Self {
+            tick_interval: Duration::from_secs(1),
+            starting_rate_bps: 1_250_000,
+        }
+    }
+
+    pub fn with_tick_interval(mut self, interval: Duration) -> Self {
+        self.tick_interval = interval;
+        self
+    }
+
+    pub fn with_starting_rate_bps(mut self, rate: u64) -> Self {
+        self.starting_rate_bps = rate;
+        self
+    }
+
+    /// Drive `stream` through `controller`, returning a full decision trace.
+    pub fn run<S, C>(&self, stream: S, mut controller: C) -> ReplayReport
+    where
+        S: EventStream,
+        C: Controller,
+    {
+        // Buffer all events. For synthetic scenarios this is tiny; for
+        // OTLP it's still bounded by a single file's worth of events
+        // (the binary streams file-by-file). The EventStream contract
+        // says events are in non-decreasing `at` order; we sort
+        // defensively to harden against a slightly-out-of-order source.
+        let mut events: Vec<Event> = collect_stream(stream);
+        events.sort_by_key(|e| e.at());
+
+        let end_time = events.last().map(|e| e.at()).unwrap_or(Duration::ZERO);
+
+        let mut per_peer: BTreeMap<PeerKey, RollingRttStats> = BTreeMap::new();
+        let mut reference: Option<RollingRttStats> = None;
+        let mut log: Vec<DecisionLog> = Vec::new();
+        let mut rate = self.starting_rate_bps;
+        let mut min_rate = rate;
+        let mut max_rate = rate;
+        let mut decisions_set = 0usize;
+
+        let mut ev_idx = 0usize;
+        let mut now = Duration::ZERO;
+
+        // Tick from t=tick_interval until one tick past the last event,
+        // so we capture the final-window state. If there were no events,
+        // we tick exactly once at t=tick_interval so the controller sees
+        // an empty network.
+        let stop_at = end_time + self.tick_interval;
+        loop {
+            now += self.tick_interval;
+            if now > stop_at && ev_idx >= events.len() {
+                break;
+            }
+
+            // Apply all events at or before this tick BEFORE running the
+            // controller, so the controller sees the state as of `now`.
+            while ev_idx < events.len() && events[ev_idx].at() <= now {
+                apply_event(&events[ev_idx], &mut per_peer, &mut reference);
+                ev_idx += 1;
+            }
+
+            tick_once(
+                &mut controller,
+                &per_peer,
+                reference.as_ref(),
+                now,
+                &mut rate,
+                &mut min_rate,
+                &mut max_rate,
+                &mut decisions_set,
+                &mut log,
+            );
+        }
+
+        ReplayReport {
+            controller: controller.name().to_string(),
+            ticks: log.len(),
+            decisions_set,
+            final_rate_bps: rate,
+            min_rate_bps: min_rate,
+            max_rate_bps: max_rate,
+            log,
+        }
+    }
+}
+
+impl Default for Replayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn collect_stream<S: EventStream>(mut stream: S) -> Vec<Event> {
+    let mut out = Vec::new();
+    while let Some(ev) = stream.next_event() {
+        out.push(ev);
+    }
+    out
+}
+
+fn apply_event(
+    ev: &Event,
+    per_peer: &mut BTreeMap<PeerKey, RollingRttStats>,
+    reference: &mut Option<RollingRttStats>,
+) {
+    match ev {
+        Event::RttSample { peer, at, rtt } => {
+            per_peer
+                .entry(peer.clone())
+                .or_default()
+                .record_at(*at, *rtt);
+        }
+        Event::ReferenceSample { at, rtt } => {
+            reference.get_or_insert_default().record_at(*at, *rtt);
+        }
+        Event::PeerJoin { peer, .. } => {
+            per_peer.entry(peer.clone()).or_default();
+        }
+        Event::PeerLeave { peer, .. } => {
+            per_peer.remove(peer);
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn tick_once<C: Controller>(
+    controller: &mut C,
+    per_peer: &BTreeMap<PeerKey, RollingRttStats>,
+    reference: Option<&RollingRttStats>,
+    now: Duration,
+    rate: &mut u64,
+    min_rate: &mut u64,
+    max_rate: &mut u64,
+    decisions_set: &mut usize,
+    log: &mut Vec<DecisionLog>,
+) {
+    let observations: Vec<PeerObservation> = per_peer
+        .iter()
+        .filter_map(|(peer, stats)| {
+            stats.snapshot_at(now).map(|snap| PeerObservation {
+                peer: peer.clone(),
+                snapshot: snap,
+            })
+        })
+        .collect();
+
+    let reference_snap = reference.and_then(|r| r.snapshot_at(now));
+
+    let mut infl: Vec<Duration> = observations
+        .iter()
+        .filter_map(|p| p.snapshot.inflation)
+        .collect();
+    let n_peers_with_inflation = infl.len();
+    let shared_inflation = if n_peers_with_inflation == 0 {
+        None
+    } else {
+        infl.sort_unstable();
+        Some(infl[infl.len() / 2])
+    };
+
+    let view = ControllerView {
+        now,
+        per_peer: &observations,
+        reference: reference_snap,
+        current_aggregate_rate_bps: *rate,
+    };
+    let decision = controller.tick(view);
+    if let RateDecision::Set {
+        aggregate_rate_bps, ..
+    } = decision
+    {
+        *rate = aggregate_rate_bps;
+        *min_rate = (*min_rate).min(aggregate_rate_bps);
+        *max_rate = (*max_rate).max(aggregate_rate_bps);
+        *decisions_set += 1;
+    }
+    log.push(DecisionLog {
+        at: now,
+        decision,
+        rate_after_bps: *rate,
+        n_peers_with_inflation,
+        shared_inflation,
+    });
+}

--- a/crates/replay-harness/src/rolling.rs
+++ b/crates/replay-harness/src/rolling.rs
@@ -1,0 +1,191 @@
+//! Per-peer rolling RTT statistics with a baseline window and a recent window.
+//!
+//! This is an offline / single-threaded port of
+//! `crates/core/src/transport/rolling_rtt_stats.rs`. The shape, window sizes,
+//! and inflation semantics are deliberately identical to the production type
+//! so the harness evaluates controllers against the same signal they would
+//! see in flight. The copy is intentional — the production type evolves with
+//! Phase 2 work, and we want the harness to be pinnable to a specific
+//! algorithm vintage rather than silently re-baseline as `crates/core`
+//! changes.
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+/// Baseline window: 5 minutes (per the RFC, and the current
+/// `rolling_rtt_stats.rs` constant).
+pub const BASELINE_WINDOW: Duration = Duration::from_secs(300);
+
+/// Recent window: 10 seconds.
+pub const RECENT_WINDOW: Duration = Duration::from_secs(10);
+
+/// Hard cap on retained samples per peer. Matches the production constant so
+/// the same degradation behaviour applies at very high sample rates.
+pub const MAX_SAMPLES: usize = 32_768;
+
+/// Snapshot returned by [`RollingRttStats::snapshot_at`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RttSnapshot {
+    /// Minimum RTT in the baseline window. `None` if no samples in window.
+    pub baseline_min: Option<Duration>,
+    /// Median RTT in the recent window (upper-middle for even N, matching
+    /// production). `None` if no samples in window.
+    pub recent_median: Option<Duration>,
+    /// `recent_median - baseline_min`, saturating at zero. `None` if either
+    /// input is `None`.
+    pub inflation: Option<Duration>,
+    /// Count of samples in the baseline window after pruning.
+    pub baseline_samples: usize,
+    /// Count of samples in the recent window.
+    pub recent_samples: usize,
+}
+
+/// Rolling RTT statistics for a single peer. The harness drives time
+/// explicitly via [`record_at`](Self::record_at) and
+/// [`snapshot_at`](Self::snapshot_at).
+#[derive(Debug, Default)]
+pub struct RollingRttStats {
+    /// (timestamp, rtt) pairs in ascending timestamp order.
+    samples: VecDeque<(Duration, Duration)>,
+}
+
+impl RollingRttStats {
+    pub fn new() -> Self {
+        Self {
+            samples: VecDeque::with_capacity(1024),
+        }
+    }
+
+    /// Record an RTT sample observed at `at`. Older samples outside the
+    /// baseline window are pruned; the hard `MAX_SAMPLES` cap is enforced.
+    pub fn record_at(&mut self, at: Duration, rtt: Duration) {
+        self.samples.push_back((at, rtt));
+        let cutoff = at.saturating_sub(BASELINE_WINDOW);
+        while let Some(&(ts, _)) = self.samples.front() {
+            if ts < cutoff {
+                self.samples.pop_front();
+            } else {
+                break;
+            }
+        }
+        while self.samples.len() > MAX_SAMPLES {
+            self.samples.pop_front();
+        }
+    }
+
+    /// Compute a snapshot at the given wall-clock time.
+    pub fn snapshot_at(&self, now: Duration) -> Option<RttSnapshot> {
+        if self.samples.is_empty() {
+            return None;
+        }
+        let baseline_cutoff = now.saturating_sub(BASELINE_WINDOW);
+        let recent_cutoff = now.saturating_sub(RECENT_WINDOW);
+
+        let mut baseline_min: Option<Duration> = None;
+        let mut baseline_samples = 0usize;
+        let mut recent: Vec<Duration> = Vec::new();
+        for &(ts, rtt) in &self.samples {
+            if ts < baseline_cutoff {
+                continue;
+            }
+            baseline_samples += 1;
+            baseline_min = Some(match baseline_min {
+                Some(m) => m.min(rtt),
+                None => rtt,
+            });
+            if ts >= recent_cutoff {
+                recent.push(rtt);
+            }
+        }
+        if baseline_samples == 0 {
+            return None;
+        }
+        let recent_samples = recent.len();
+        let recent_median = if recent.is_empty() {
+            None
+        } else {
+            recent.sort_unstable();
+            // Upper-middle, matching production.
+            Some(recent[recent.len() / 2])
+        };
+        let inflation = match (baseline_min, recent_median) {
+            (Some(b), Some(r)) => Some(r.saturating_sub(b)),
+            _ => None,
+        };
+        Some(RttSnapshot {
+            baseline_min,
+            recent_median,
+            inflation,
+            baseline_samples,
+            recent_samples,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn stored(&self) -> usize {
+        self.samples.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ms(n: u64) -> Duration {
+        Duration::from_millis(n)
+    }
+
+    #[test]
+    fn empty_snapshot_is_none() {
+        let s = RollingRttStats::new();
+        assert!(s.snapshot_at(ms(0)).is_none());
+    }
+
+    #[test]
+    fn baseline_min_tracks_minimum() {
+        let mut s = RollingRttStats::new();
+        for (i, rtt) in [50u64, 80, 40, 60, 100].into_iter().enumerate() {
+            s.record_at(ms(i as u64 * 100), ms(rtt));
+        }
+        let snap = s.snapshot_at(ms(1000)).unwrap();
+        assert_eq!(snap.baseline_min, Some(ms(40)));
+    }
+
+    #[test]
+    fn inflation_is_recent_minus_baseline() {
+        let mut s = RollingRttStats::new();
+        // 5 min ago: a fast sample (the baseline)
+        s.record_at(Duration::from_secs(0), ms(20));
+        // Recent: slower samples
+        for t in [290u64, 291, 292, 293, 294] {
+            s.record_at(Duration::from_secs(t), ms(80));
+        }
+        let snap = s.snapshot_at(Duration::from_secs(295)).unwrap();
+        assert_eq!(snap.baseline_min, Some(ms(20)));
+        assert_eq!(snap.recent_median, Some(ms(80)));
+        assert_eq!(snap.inflation, Some(ms(60)));
+    }
+
+    #[test]
+    fn samples_older_than_baseline_are_dropped() {
+        let mut s = RollingRttStats::new();
+        s.record_at(Duration::from_secs(0), ms(50));
+        s.record_at(Duration::from_secs(400), ms(60));
+        // First sample is 400s old when we record the second; baseline window
+        // is 300s, so the first should have been pruned.
+        let snap = s.snapshot_at(Duration::from_secs(400)).unwrap();
+        assert_eq!(snap.baseline_samples, 1);
+        assert_eq!(snap.baseline_min, Some(ms(60)));
+    }
+
+    #[test]
+    fn recent_median_uses_upper_middle_for_even_length() {
+        let mut s = RollingRttStats::new();
+        for (i, rtt) in [40u64, 50, 60, 70].into_iter().enumerate() {
+            s.record_at(ms(i as u64 * 100), ms(rtt));
+        }
+        let snap = s.snapshot_at(ms(400)).unwrap();
+        // [40, 50, 60, 70] sorted, len/2 = 2 → 60.
+        assert_eq!(snap.recent_median, Some(ms(60)));
+    }
+}

--- a/crates/replay-harness/src/scenarios.rs
+++ b/crates/replay-harness/src/scenarios.rs
@@ -1,0 +1,68 @@
+//! Synthetic scenarios — programmatic RTT-sample streams that pin specific
+//! controller behaviours.
+//!
+//! Each scenario:
+//! - Is named (used in reports and the binary's `synthetic` subcommand).
+//! - Builds an [`Vec<Event>`] of RTT samples (and optionally peer
+//!   join/leave events).
+//! - Carries an [`Expectation`] about what a sane controller MUST do
+//!   (or MUST NOT do) on this input.
+//!
+//! Scenarios are run from the binary (`replay-harness synthetic <name>`)
+//! and from `tests/scenarios_pin.rs`, which exercises every scenario
+//! against every controller and asserts the expectations. Adding a new
+//! scenario file in `scenarios/` and listing it in [`all_scenarios`] is
+//! enough; no other wiring required.
+
+use std::time::Duration;
+
+use crate::event::Event;
+
+pub mod correlated_inflation;
+pub mod idle_steady_state;
+pub mod single_peer_outlier;
+pub mod small_n;
+
+/// What a sane controller is expected to do on this scenario.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Expectation {
+    /// The controller MUST NOT take any rate action across the run.
+    /// Used for scenarios that simulate ambient overlay noise we don't
+    /// want to react to (small-N, single-peer outlier, etc.).
+    NeverFires,
+    /// The controller MUST fire at least once during the run. Used for
+    /// the scenarios that represent the cases the controller exists to
+    /// detect (correlated inflation, reference tracking overlay).
+    FiresAtLeastOnce,
+    /// Used for scenarios where the right answer depends on the
+    /// controller's design philosophy and we don't pin behaviour — the
+    /// scenario is informational only, run for the decision trace.
+    Informational,
+}
+
+#[derive(Debug, Clone)]
+pub struct Scenario {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub expectation: Expectation,
+    pub events: Vec<Event>,
+    /// Suggested run duration. The replayer will tick past the last
+    /// event by one interval, but synthetic scenarios often need the
+    /// observation window to extend further (e.g. to confirm "controller
+    /// fired" or "did NOT fire even after the suspect window").
+    pub run_for: Duration,
+}
+
+pub fn all_scenarios() -> Vec<Scenario> {
+    vec![
+        idle_steady_state::scenario(),
+        correlated_inflation::scenario(),
+        single_peer_outlier::scenario(),
+        small_n::scenario(),
+    ]
+}
+
+/// Convenience to look up by name (for the CLI).
+pub fn find(name: &str) -> Option<Scenario> {
+    all_scenarios().into_iter().find(|s| s.name == name)
+}

--- a/crates/replay-harness/src/scenarios/correlated_inflation.rs
+++ b/crates/replay-harness/src/scenarios/correlated_inflation.rs
@@ -1,0 +1,54 @@
+//! `correlated_inflation` — every peer's RTT rises together.
+//!
+//! Models the "user opened YouTube" case — the local uplink is contended,
+//! so every overlay path inflates at once. This is exactly the case the
+//! RFC controller is designed to detect. A sane controller MUST fire.
+
+use std::time::Duration;
+
+use crate::event::Event;
+
+use super::{Expectation, Scenario};
+
+pub fn scenario() -> Scenario {
+    let mut events = Vec::new();
+    let n_peers = 5;
+
+    // Establish a low baseline: 20 ms across all peers for the first 60
+    // seconds, one sample/s per peer. This gives the rolling stats a
+    // clean baseline to inflate against.
+    for peer_idx in 0..n_peers {
+        let peer = format!("peer-{peer_idx}");
+        for t in 0..60 {
+            events.push(Event::RttSample {
+                peer: peer.clone(),
+                at: Duration::from_secs(t),
+                rtt: Duration::from_millis(20),
+            });
+        }
+    }
+
+    // Contention burst: t=60s through t=120s, every peer's RTT jumps to
+    // 200 ms (well above the 30 ms inflation trigger, well above the
+    // noise floor, sustained way past the 5 s sustain window).
+    for peer_idx in 0..n_peers {
+        let peer = format!("peer-{peer_idx}");
+        for t in 60..120 {
+            events.push(Event::RttSample {
+                peer: peer.clone(),
+                at: Duration::from_secs(t),
+                rtt: Duration::from_millis(200),
+            });
+        }
+    }
+
+    Scenario {
+        name: "correlated_inflation",
+        description: "5 peers, clean 20 ms baseline for 60 s, then every peer inflates \
+             to 200 ms together for another 60 s. The case the RFC controller \
+             exists to detect; sane controllers MUST fire.",
+        expectation: Expectation::FiresAtLeastOnce,
+        events,
+        run_for: Duration::from_secs(120),
+    }
+}

--- a/crates/replay-harness/src/scenarios/correlated_inflation.rs
+++ b/crates/replay-harness/src/scenarios/correlated_inflation.rs
@@ -1,8 +1,17 @@
 //! `correlated_inflation` — every peer's RTT rises together.
 //!
-//! Models the "user opened YouTube" case — the local uplink is contended,
-//! so every overlay path inflates at once. This is exactly the case the
-//! RFC controller is designed to detect. A sane controller MUST fire.
+//! Models the "user opened YouTube" case — the local uplink is
+//! contended, so every overlay path inflates at once. This is exactly
+//! the case the RFC controller is designed to detect. A sane
+//! controller MUST fire.
+//!
+//! Note the inherent detection lag for RFC-style controllers: the
+//! 10 s recent-median window plus the 5 s sustained-trigger check
+//! mean the controller cannot see anything above the threshold until
+//! ~15 s after the burst starts. A scenario `run_for` shorter than
+//! that would falsely show "controller didn't fire". This scenario
+//! uses a 60 s baseline + 60 s burst so the detection window has
+//! plenty of room.
 
 use std::time::Duration;
 

--- a/crates/replay-harness/src/scenarios/idle_steady_state.rs
+++ b/crates/replay-harness/src/scenarios/idle_steady_state.rs
@@ -1,9 +1,19 @@
-//! `idle_steady_state` — 5 peers, all reporting flat 80 ms RTT.
+//! `idle_steady_state` — 5 peers, each anchored by a fast t=0 sample,
+//! then steady ~80 ms RTT for the rest of the window.
 //!
-//! This is the steady state we measured in production at ~55 ms p50,
-//! ~91 ms p90. Even a healthy network sits comfortably above the
-//! `RfcDraft` 30 ms threshold all the time. A sane controller must NOT
-//! interpret it as contention.
+//! Models the production noise-floor problem the Phase 1 analysis
+//! exposed: in the wild we measured ~55 ms p50 / ~91 ms p90 inflation
+//! across healthy peers, all sitting comfortably above the `RfcDraft`
+//! 30 ms threshold all the time.
+//!
+//! The synthetic construction here uses a single t=0 40 ms sample per
+//! peer to anchor `baseline_min`, then steady 80 ms for the rest of
+//! the run, producing ~40 ms persistent inflation. That's an
+//! intentionally simplified driver — real production sees a mix of
+//! transient fast samples scattered throughout, but the *signal the
+//! controller sees* (a sustained inflation well above the threshold)
+//! is the same. A sane controller MUST NOT interpret this as
+//! contention.
 
 use std::time::Duration;
 

--- a/crates/replay-harness/src/scenarios/idle_steady_state.rs
+++ b/crates/replay-harness/src/scenarios/idle_steady_state.rs
@@ -1,0 +1,50 @@
+//! `idle_steady_state` — 5 peers, all reporting flat 80 ms RTT.
+//!
+//! This is the steady state we measured in production at ~55 ms p50,
+//! ~91 ms p90. Even a healthy network sits comfortably above the
+//! `RfcDraft` 30 ms threshold all the time. A sane controller must NOT
+//! interpret it as contention.
+
+use std::time::Duration;
+
+use crate::event::Event;
+
+use super::{Expectation, Scenario};
+
+pub fn scenario() -> Scenario {
+    let mut events = Vec::new();
+
+    // Establish a clean baseline window: each peer's first sample is at
+    // t=0 with a low 40 ms RTT, then it drifts up to the steady state
+    // 80 ms by t=10s and stays there. Without the early-fast baseline,
+    // every sample would be the baseline, and `inflation` would be 0
+    // forever — not what we measure in production.
+    let n_peers = 5;
+    for peer_idx in 0..n_peers {
+        let peer = format!("peer-{peer_idx}");
+        events.push(Event::RttSample {
+            peer: peer.clone(),
+            at: Duration::from_secs(0),
+            rtt: Duration::from_millis(40),
+        });
+        // Steady-state 80 ms from t=10s through t=300s, one sample/s
+        // per peer. ~1500 events total.
+        for t in 10..300 {
+            events.push(Event::RttSample {
+                peer: peer.clone(),
+                at: Duration::from_secs(t),
+                rtt: Duration::from_millis(80),
+            });
+        }
+    }
+
+    Scenario {
+        name: "idle_steady_state",
+        description: "5 peers, steady ~40 ms baseline, ~80 ms recent (~40 ms inflation \
+             from path queueing). Matches the ambient overlay noise we measure \
+             in production — controller MUST NOT interpret it as contention.",
+        expectation: Expectation::NeverFires,
+        events,
+        run_for: Duration::from_secs(300),
+    }
+}

--- a/crates/replay-harness/src/scenarios/single_peer_outlier.rs
+++ b/crates/replay-harness/src/scenarios/single_peer_outlier.rs
@@ -1,0 +1,59 @@
+//! `single_peer_outlier` — one peer's RTT spikes to 500 ms, others stable.
+//!
+//! Models a single bad path (intermediate peer queueing, routing event on
+//! one route) while the local uplink is fine. The RFC explicitly chose
+//! median across peers to be robust against this case. A sane controller
+//! MUST NOT fire — the cross-peer median should stay close to baseline
+//! even with one wild outlier.
+
+use std::time::Duration;
+
+use crate::event::Event;
+
+use super::{Expectation, Scenario};
+
+pub fn scenario() -> Scenario {
+    let mut events = Vec::new();
+    let n_peers = 5;
+
+    // Clean baseline for first 60 s: 20 ms across all peers.
+    for peer_idx in 0..n_peers {
+        let peer = format!("peer-{peer_idx}");
+        for t in 0..60 {
+            events.push(Event::RttSample {
+                peer: peer.clone(),
+                at: Duration::from_secs(t),
+                rtt: Duration::from_millis(20),
+            });
+        }
+    }
+
+    // From t=60s onward: peer-0 spikes to 500 ms; the rest stay at
+    // baseline (still ~20 ms, with a small wobble). Run for another 60 s.
+    for t in 60..120 {
+        events.push(Event::RttSample {
+            peer: "peer-0".to_string(),
+            at: Duration::from_secs(t),
+            rtt: Duration::from_millis(500),
+        });
+        for peer_idx in 1..n_peers {
+            events.push(Event::RttSample {
+                peer: format!("peer-{peer_idx}"),
+                at: Duration::from_secs(t),
+                // Small jitter around baseline so recent_median is not
+                // identically equal to baseline_min.
+                rtt: Duration::from_millis(if t.is_multiple_of(2) { 22 } else { 24 }),
+            });
+        }
+    }
+
+    Scenario {
+        name: "single_peer_outlier",
+        description: "5 peers, peer-0 spikes to 500 ms while the other 4 stay at \
+             baseline. Cross-peer median must reject this; sane controllers \
+             MUST NOT fire.",
+        expectation: Expectation::NeverFires,
+        events,
+        run_for: Duration::from_secs(120),
+    }
+}

--- a/crates/replay-harness/src/scenarios/small_n.rs
+++ b/crates/replay-harness/src/scenarios/small_n.rs
@@ -1,0 +1,56 @@
+//! `small_n` — N=2 peers (below the rolling-stats N≥3 trustworthy threshold).
+//!
+//! The `rolling_rtt_stats.rs` rustdoc warns: at N≤2 the upper-middle
+//! median collapses to "the worse of the two". The Phase 1 measurement
+//! showed ~26% of production samples are in this regime, so any
+//! controller that doesn't explicitly guard against it would fire
+//! constantly on routine connection churn. Sane controllers MUST NOT
+//! fire on this scenario.
+
+use std::time::Duration;
+
+use crate::event::Event;
+
+use super::{Expectation, Scenario};
+
+pub fn scenario() -> Scenario {
+    let mut events = Vec::new();
+
+    // 2 peers: clean 20 ms baseline for the first 30 s, then peer-0
+    // inflates to 200 ms while peer-1 stays low. With N=2 and one peer
+    // bad, the upper-middle median picks the bad peer — but the N<3
+    // guard must prevent any action.
+    for peer_idx in 0..2 {
+        let peer = format!("peer-{peer_idx}");
+        for t in 0..30 {
+            events.push(Event::RttSample {
+                peer: peer.clone(),
+                at: Duration::from_secs(t),
+                rtt: Duration::from_millis(20),
+            });
+        }
+    }
+    for t in 30..120 {
+        events.push(Event::RttSample {
+            peer: "peer-0".to_string(),
+            at: Duration::from_secs(t),
+            rtt: Duration::from_millis(200),
+        });
+        events.push(Event::RttSample {
+            peer: "peer-1".to_string(),
+            at: Duration::from_secs(t),
+            rtt: Duration::from_millis(22),
+        });
+    }
+
+    Scenario {
+        name: "small_n",
+        description: "Only 2 peers — below the N≥3 trustworthy threshold for the \
+             cross-peer median. Even with one peer wildly inflated, sane \
+             controllers MUST NOT fire (per the rolling-stats module's \
+             own caveat).",
+        expectation: Expectation::NeverFires,
+        events,
+        run_for: Duration::from_secs(120),
+    }
+}

--- a/crates/replay-harness/tests/scenarios_pin.rs
+++ b/crates/replay-harness/tests/scenarios_pin.rs
@@ -14,10 +14,11 @@
 //! scenario's expectation.
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use replay_harness::controllers::{FixedRate, RfcDraft};
-use replay_harness::scenarios::{Expectation, Scenario, all_scenarios};
-use replay_harness::{Controller, Replayer};
+use replay_harness::scenarios::{Expectation, Scenario, all_scenarios, find};
+use replay_harness::{Controller, RateDecision, Replayer};
 
 /// Whether the given controller is currently *expected* to fire on the
 /// given scenario. Anything not in the map defaults to the scenario's
@@ -50,7 +51,9 @@ fn expected_fires(controller: &str, scenario: &str) -> bool {
 }
 
 fn run<C: Controller>(s: &Scenario, controller: C) -> (String, bool /* fired */) {
-    let report = Replayer::new().run(s.events.clone().into_iter(), controller);
+    let report = Replayer::new()
+        .run_until(s.run_for)
+        .run(s.events.clone().into_iter(), controller);
     (report.controller, report.decisions_set > 0)
 }
 
@@ -89,6 +92,44 @@ fn scenarios_declare_concrete_expectations() {
             !matches!(s.expectation, Expectation::Informational),
             "scenario {} should declare NeverFires or FiresAtLeastOnce",
             s.name
+        );
+    }
+}
+
+/// Strengthen the `correlated_inflation` pin: a controller passing
+/// "decisions_set > 0" could in principle fire for the wrong reason
+/// (e.g. a startup-tick spurious fire at t=2). The scenario sets a
+/// clean 60 s baseline, then bursts at t=60s. The minimum *correctness*
+/// invariant is: no fire during the baseline phase. Any controller
+/// firing before the burst starts is reacting to the clean baseline,
+/// which means it would also fire on a healthy idle network.
+#[test]
+fn rfc_draft_correlated_inflation_first_fire_is_inside_burst_window() {
+    let s = find("correlated_inflation").expect("scenario exists");
+    let report = Replayer::new()
+        .run_until(s.run_for)
+        .run(s.events.clone().into_iter(), RfcDraft::default());
+    let fires = report.fired();
+    assert!(!fires.is_empty(), "RfcDraft must fire during burst");
+    let first_fire_at = fires[0].at;
+    let burst_start = Duration::from_secs(60);
+    assert!(
+        first_fire_at >= burst_start,
+        "first fire at {:?} is before burst_start ({:?}) — the \
+         controller fired during the clean baseline phase",
+        first_fire_at,
+        burst_start,
+    );
+    // Sanity: every fire's decision is a Set with a non-trivial rate
+    // change, not a no-op.
+    for d in fires {
+        let RateDecision::Set { .. } = &d.decision else {
+            unreachable!("fired() filters to Set");
+        };
+        assert!(
+            d.rate_after_bps < 1_250_000,
+            "Set decisions must lower the rate; got rate_after_bps={}",
+            d.rate_after_bps,
         );
     }
 }

--- a/crates/replay-harness/tests/scenarios_pin.rs
+++ b/crates/replay-harness/tests/scenarios_pin.rs
@@ -1,0 +1,94 @@
+//! Pin every scenario against every controller. Adding a new
+//! [`Scenario`](replay_harness::scenarios::Scenario) or a new
+//! [`Controller`](replay_harness::Controller) only requires editing
+//! this file in one place: extend [`controllers_under_test`] with the
+//! new controller, or add the scenario to [`scenarios::all_scenarios`]
+//! and the loop below picks it up.
+//!
+//! Important: not every controller passes every "sane controller"
+//! expectation. The `RfcDraft` reference controller is intentionally
+//! broken-on-purpose for one scenario (`idle_steady_state`) — that
+//! failure is the demonstration of the noise-floor problem Phase 1
+//! telemetry exposed. We assert the **documented** outcome per
+//! (controller, scenario) rather than blanket-asserting the
+//! scenario's expectation.
+
+use std::collections::HashMap;
+
+use replay_harness::controllers::{FixedRate, RfcDraft};
+use replay_harness::scenarios::{Expectation, Scenario, all_scenarios};
+use replay_harness::{Controller, Replayer};
+
+/// Whether the given controller is currently *expected* to fire on the
+/// given scenario. Anything not in the map defaults to the scenario's
+/// own [`Expectation`].
+///
+/// This is intentionally explicit — it documents which controller has
+/// which known failure modes against which scenario. A new controller
+/// proposal can extend this map with its own expectations and the
+/// scenario assertions adapt accordingly.
+fn expected_fires(controller: &str, scenario: &str) -> bool {
+    let overrides: HashMap<(&str, &str), bool> = [
+        // RfcDraft fires on idle_steady_state because the 30 ms trigger
+        // sits below the ambient overlay noise floor. This is the bug
+        // the harness exists to demonstrate, and the failure mode any
+        // Phase 2 candidate must NOT repeat.
+        (("rfc_draft", "idle_steady_state"), true),
+    ]
+    .into_iter()
+    .collect();
+    if let Some(&v) = overrides.get(&(controller, scenario)) {
+        return v;
+    }
+    matches!(
+        all_scenarios()
+            .iter()
+            .find(|s| s.name == scenario)
+            .map(|s| s.expectation),
+        Some(Expectation::FiresAtLeastOnce)
+    )
+}
+
+fn run<C: Controller>(s: &Scenario, controller: C) -> (String, bool /* fired */) {
+    let report = Replayer::new().run(s.events.clone().into_iter(), controller);
+    (report.controller, report.decisions_set > 0)
+}
+
+#[test]
+fn fixed_rate_never_fires_on_any_scenario() {
+    // Universal sanity check: a no-op controller never produces any
+    // rate decisions, regardless of input. If this ever fails, the
+    // bug is in the harness itself (not in the controller).
+    for s in all_scenarios() {
+        let (name, fired) = run(&s, FixedRate);
+        assert!(!fired, "{name} fired on scenario {}", s.name);
+    }
+}
+
+#[test]
+fn rfc_draft_outcomes_match_documented_expectations() {
+    for s in all_scenarios() {
+        let (name, fired) = run(&s, RfcDraft::default());
+        let expected = expected_fires(&name, s.name);
+        assert_eq!(
+            fired, expected,
+            "{name} on {}: fired={fired}, expected={expected}",
+            s.name
+        );
+    }
+}
+
+/// Sanity check on the scenario set itself: every scenario must declare
+/// a meaningful expectation (not `Informational`) for v1, since the
+/// informational tier exists for design-evaluation scenarios we haven't
+/// authored yet.
+#[test]
+fn scenarios_declare_concrete_expectations() {
+    for s in all_scenarios() {
+        assert!(
+            !matches!(s.expectation, Expectation::Informational),
+            "scenario {} should declare NeverFires or FiresAtLeastOnce",
+            s.name
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Three prior congestion-control attempts (LEDBAT++, BBRv3, custom adaptive — see #4074) all failed in production because there was no offline test loop. LEDBAT's death spiral on a single packet loss only showed up after deploy. BBR's stale `min_RTT` across reroutes was caught by manual debugging weeks after the algorithm went live. The Phase 1.5 telemetry (#4292) just landed the per-node tagged data we need; this PR is the next piece — before any Phase 2 controller ships, it must pass scripted scenarios that pin known failure modes.

## Solution

New workspace member `crates/replay-harness/` (library + binary). Strictly offline tooling; no production code path reaches this crate.

### What v1 ships

- `Controller` trait + `ControllerView` snapshot + `RateDecision`.
- **`FixedRate`** — the production default, never changes rate. Sanity-checks the harness itself: any scenario where this controller fires is a bug in the harness, not the controller.
- **`RfcDraft`** — the algorithm sketched in #4074 (30 ms / 5 s / 0.7× downstep with the N≥3 guard the rolling-stats module's own rustdoc demands). Implements the downstep branch; the "idle headroom" upward branch needs an outbound-traffic model that v1 does not provide.
- **Four scenarios** (out of the 10 in the design — the other 6 are additive and tracked as follow-up):

  | Scenario | Pins |
  |---|---|
  | `idle_steady_state` | The ~80 ms ambient overlay noise we measured. Sane controllers MUST NOT fire. |
  | `correlated_inflation` | Every peer's RTT rises together — the actual contention case. MUST fire. |
  | `single_peer_outlier` | One peer at 500 ms, four others at baseline. Median rejects it; MUST NOT fire. |
  | `small_n` | Only 2 peers (below rolling-stats N≥3 threshold). MUST NOT fire. |

- `Replayer` drives an `EventStream` through a `Controller` at 1 Hz, recording a per-tick decision trace.
- Binary `replay-harness` with `scenarios`, `controllers`, `synthetic`, and (stub) `otlp` subcommands.

### What the harness already demonstrates

`RfcDraft` against `idle_steady_state` fires **48 times across 300 s**, dropping the rate from 1.25 Mbps to effectively 0. That's the demonstration of the threshold-below-noise-floor bug the Phase 1 telemetry already exposed. `RfcDraft` against `correlated_inflation` fires 9 times correctly (rate drops 25×). Against `single_peer_outlier` and `small_n` it correctly holds. Both `RfcDraft` outcomes are pinned in `tests/scenarios_pin.rs` so any Phase 2 candidate that "fixes" RfcDraft by accident has to update the pin.

### Why not full OTLP replay yet

The current `shadow_rtt_aggregate` event emits the pre-computed aggregate, not the per-peer RTT samples the rolling stats need. Two follow-up options — emit per-peer samples via OTLP, OR add an aggregates-replay mode — both with caveats, both deferred. The synthetic-scenario harness is the higher-value testing layer anyway: it pins *specific* failure modes rather than measuring against a single instance of "what happened in production last week."

## Testing

- 5 rolling-stats unit tests (port of the production `RollingRttStats` test suite).
- 3 pin tests in `tests/scenarios_pin.rs`:
  - `fixed_rate_never_fires_on_any_scenario` — universal sanity check.
  - `rfc_draft_outcomes_match_documented_expectations` — pin each (controller, scenario) outcome explicitly.
  - `scenarios_declare_concrete_expectations` — guards against `Expectation::Informational` slipping in.
- `cargo fmt`, `cargo clippy -p replay-harness --lib --tests --bins -- -D warnings`, and full `cargo check --workspace` all clean.

## Out of scope (deliberate, tracked as follow-up)

- Remaining 6 scenarios from the design (`slow_routing_drift`, `churning_peers`, `cold_start`, `reference_diverges_from_overlay`, `reference_tracks_overlay`, plus a stripped-down LEDBAT++ to reproduce the death spiral). Adding them is a small file each; deliberate scope discipline for v1.
- OTLP file replay (see "Why not" above).
- GUI / plots — decision trace is CSV/JSON-friendly, plot externally.
- Any change to production transport behaviour.

Closes #4314
Refs #4074, #4294
