### PR TITLE
feat(dashboard): surface UPDATE rate-limiter counters on status card

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -50,6 +50,17 @@ pub struct RingStatsSnapshot {
     pub peer_id: String,
     /// Base58-encoded full 32-byte X25519 public key.
     pub own_pub_key: String,
+    /// Total relayed UPDATEs accepted by the per-(sender, contract) rate
+    /// limiter since startup (see `ring::update_rate_limit`).
+    pub updates_accepted: u64,
+    /// Total relayed UPDATEs dropped because the per-(sender, contract)
+    /// rate exceeded the limit. A rising value means legitimate traffic
+    /// may be getting dropped — operators should watch this.
+    pub updates_rate_limited: u64,
+    /// Total relayed UPDATEs dropped because the limiter's tracking map
+    /// was at capacity (`MAX_TRACKED_PAIRS`). A non-zero value suggests
+    /// identity churn / admission pressure, distinct from per-pair rate.
+    pub updates_capacity_dropped: u64,
 }
 
 static GOVERNANCE_PROVIDER: parking_lot::RwLock<Option<GovernanceProvider>> =
@@ -1379,11 +1390,17 @@ mod tests {
             hosted_contracts: 7,
             peer_id: "abc".to_string(),
             own_pub_key: "test-key".to_string(),
+            updates_accepted: 1000,
+            updates_rate_limited: 13,
+            updates_capacity_dropped: 2,
         }));
         let snap = get_snapshot().unwrap();
         assert_eq!(snap.ring_stats.connection_count, 42);
         assert_eq!(snap.ring_stats.peer_id, "abc");
         assert_eq!(snap.ring_stats.own_pub_key, "test-key");
+        assert_eq!(snap.ring_stats.updates_accepted, 1000);
+        assert_eq!(snap.ring_stats.updates_rate_limited, 13);
+        assert_eq!(snap.ring_stats.updates_capacity_dropped, 2);
 
         // 3. Replace provider — must take effect immediately.
         set_ring_stats_provider(Arc::new(|| RingStatsSnapshot {
@@ -1391,6 +1408,7 @@ mod tests {
             hosted_contracts: 1,
             peer_id: "xyz".to_string(),
             own_pub_key: "new-key".to_string(),
+            ..Default::default()
         }));
         let snap = get_snapshot().unwrap();
         assert_eq!(snap.ring_stats.connection_count, 99);

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -162,11 +162,15 @@ impl NodeP2P {
                 let own_pub_key = bs58::encode(key_bytes).into_string(); // full 32-byte
                 (peer_id, own_pub_key)
             };
+            let rate_limiter = &ring_stats.update_rate_limiter;
             super::network_status::RingStatsSnapshot {
                 connection_count: ring_stats.connection_manager.connection_count() as u32,
                 hosted_contracts: ring_stats.hosting_contracts_count() as u32,
                 peer_id,
                 own_pub_key,
+                updates_accepted: rate_limiter.accepted_total(),
+                updates_rate_limited: rate_limiter.rejected_total(),
+                updates_capacity_dropped: rate_limiter.capacity_rejected_total(),
             }
         }));
 

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -308,17 +308,16 @@ impl UpdateRateLimiter {
         }
     }
 
-    /// Total accepted UPDATEs since creation. Used by the dashboard
-    /// snapshot (follow-up PR — surfaces "rate limit drops in last
-    /// hour" on the governance card).
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// Total accepted UPDATEs since creation. Surfaced on the node
+    /// status dashboard via `RingStatsSnapshot` ("UPDATEs relayed").
     pub fn accepted_total(&self) -> u64 {
         self.accepted_total.load(Ordering::Relaxed)
     }
 
-    /// Total rejected UPDATEs since creation. Used by the dashboard
-    /// snapshot (follow-up PR).
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// Total rejected UPDATEs since creation. Surfaced on the node
+    /// status dashboard via `RingStatsSnapshot` ("Rate-limited") — a
+    /// rising value is the operator's signal that the per-(sender,
+    /// contract) limiter may be dropping legitimate relayed traffic.
     pub fn rejected_total(&self) -> u64 {
         self.rejected_total.load(Ordering::Relaxed)
     }
@@ -326,9 +325,9 @@ impl UpdateRateLimiter {
     /// Total UPDATEs rejected because the tracking map was at capacity
     /// (a new `(sender, contract)` pair tried to register when the map
     /// already held [`MAX_TRACKED_PAIRS`] pairs). A non-zero value
-    /// suggests an attacker is churning identities — surface separately
-    /// from `rejected_total` on the dashboard for that reason.
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// suggests an attacker is churning identities — surfaced separately
+    /// from `rejected_total` on the dashboard ("Capacity-dropped") for
+    /// that reason.
     pub fn capacity_rejected_total(&self) -> u64 {
         self.capacity_rejected_total.load(Ordering::Relaxed)
     }

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -341,6 +341,38 @@ fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> St
         attempts = snap.connection_attempts,
     );
 
+    // UPDATE rate-limiter stats: only shown once the limiter has seen
+    // traffic, so idle nodes stay uncluttered. A non-zero "Rate-limited"
+    // or "Capacity-dropped" count is the operator's signal that the
+    // per-(sender, contract) UPDATE limiter is dropping relayed traffic.
+    let rate_limit_html = if snap.ring_stats.updates_accepted
+        + snap.ring_stats.updates_rate_limited
+        + snap.ring_stats.updates_capacity_dropped
+        > 0
+    {
+        format!(
+            r#"<div class="metrics-row">
+            <div class="metric-tile">
+                <span class="metric-value">{accepted}</span>
+                <span class="metric-label">UPDATEs relayed</span>
+            </div>
+            <div class="metric-tile">
+                <span class="metric-value">{rate_limited}</span>
+                <span class="metric-label">Rate-limited</span>
+            </div>
+            <div class="metric-tile">
+                <span class="metric-value">{capacity_dropped}</span>
+                <span class="metric-label">Capacity-dropped</span>
+            </div>
+        </div>"#,
+            accepted = snap.ring_stats.updates_accepted,
+            rate_limited = snap.ring_stats.updates_rate_limited,
+            capacity_dropped = snap.ring_stats.updates_capacity_dropped,
+        )
+    } else {
+        String::new()
+    };
+
     let spinner = if snap.open_connections == 0 {
         r#"<div class="spinner"></div>"#
     } else {
@@ -456,6 +488,7 @@ fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> St
             <h2>Connection Status</h2>
             {health_banner}
             {ring_stats_html}
+            {rate_limit_html}
             {external_addr_html}
             {spinner}
             {gateway_warning}
@@ -464,6 +497,7 @@ fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> St
         </div>"#,
         health_banner = health_banner,
         ring_stats_html = ring_stats_html,
+        rate_limit_html = rate_limit_html,
         external_addr_html = external_addr_html,
         spinner = spinner,
         gateway_warning = gateway_warning,
@@ -3996,6 +4030,52 @@ mod tests {
         assert!(
             html.contains("(normal)"),
             "should indicate failures are normal"
+        );
+    }
+
+    #[test]
+    fn rate_limit_stats_hidden_when_no_traffic() {
+        // A fresh node (no relayed UPDATEs yet) must not render the
+        // UPDATE rate-limiter row — keeps the idle dashboard uncluttered.
+        let snap = base_snapshot();
+        assert_eq!(snap.ring_stats.updates_accepted, 0);
+        let html = build_status_card(&Some(snap));
+        assert!(
+            !html.contains("Rate-limited"),
+            "rate-limit row should be hidden when the limiter has seen no traffic"
+        );
+    }
+
+    #[test]
+    fn rate_limit_stats_rendered_when_active() {
+        // Once the limiter has dropped traffic, the operator must see the
+        // accepted / rate-limited / capacity-dropped counts on the card.
+        let mut snap = base_snapshot();
+        snap.ring_stats.updates_accepted = 1234;
+        snap.ring_stats.updates_rate_limited = 56;
+        snap.ring_stats.updates_capacity_dropped = 7;
+        let html = build_status_card(&Some(snap));
+        assert!(html.contains("UPDATEs relayed"), "accepted label missing");
+        assert!(html.contains("1234</span>"), "accepted count missing");
+        assert!(html.contains("Rate-limited"), "rate-limited label missing");
+        assert!(html.contains("56</span>"), "rate-limited count missing");
+        assert!(
+            html.contains("Capacity-dropped"),
+            "capacity-dropped label missing"
+        );
+        assert!(html.contains("7</span>"), "capacity-dropped count missing");
+    }
+
+    #[test]
+    fn rate_limit_stats_shown_when_only_accepted() {
+        // Boundary: accepted>0 but zero drops should still render the row
+        // (operators want to see the limiter is active and healthy).
+        let mut snap = base_snapshot();
+        snap.ring_stats.updates_accepted = 10;
+        let html = build_status_card(&Some(snap));
+        assert!(
+            html.contains("UPDATEs relayed"),
+            "row should render once any UPDATE has been accepted"
         );
     }
 

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -4079,6 +4079,38 @@ mod tests {
     }
 
     #[test]
+    fn rate_limit_stats_shown_when_only_rate_limited() {
+        // Boundary: the row's most operator-critical trigger. Independently
+        // exercises the SECOND term of the OR guard so a `||`->`&&` change,
+        // a dropped term, or a field-name swap is caught. A node that has
+        // ONLY ever rate-limited (accepted/capacity both zero) must still
+        // surface the signal.
+        let mut snap = base_snapshot();
+        snap.ring_stats.updates_rate_limited = 1;
+        let html = build_status_card(&Some(snap));
+        assert!(
+            html.contains("Rate-limited"),
+            "row must render when the limiter has rate-limited traffic"
+        );
+        assert!(html.contains("1</span>"), "rate-limited count missing");
+    }
+
+    #[test]
+    fn rate_limit_stats_shown_when_only_capacity_dropped() {
+        // Boundary: independently exercises the THIRD term of the OR guard
+        // (capacity drops signal identity churn / admission pressure). A
+        // node that has ONLY ever capacity-dropped must still surface it.
+        let mut snap = base_snapshot();
+        snap.ring_stats.updates_capacity_dropped = 1;
+        let html = build_status_card(&Some(snap));
+        assert!(
+            html.contains("Capacity-dropped"),
+            "row must render when the limiter has capacity-dropped traffic"
+        );
+        assert!(html.contains("1</span>"), "capacity-dropped count missing");
+    }
+
+    #[test]
     fn failures_prominent_when_not_connected() {
         let mut snap = base_snapshot();
         snap.open_connections = 0;

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -345,10 +345,9 @@ fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> St
     // traffic, so idle nodes stay uncluttered. A non-zero "Rate-limited"
     // or "Capacity-dropped" count is the operator's signal that the
     // per-(sender, contract) UPDATE limiter is dropping relayed traffic.
-    let rate_limit_html = if snap.ring_stats.updates_accepted
-        + snap.ring_stats.updates_rate_limited
-        + snap.ring_stats.updates_capacity_dropped
-        > 0
+    let rate_limit_html = if snap.ring_stats.updates_accepted > 0
+        || snap.ring_stats.updates_rate_limited > 0
+        || snap.ring_stats.updates_capacity_dropped > 0
     {
         format!(
             r#"<div class="metrics-row">


### PR DESCRIPTION
## Problem

The per-`(sender, contract)` UPDATE rate limiter added in #4285 ("front-line defense against the May 21 incident pattern") silently drops relayed UPDATEs once a pair exceeds ~10/s, and drops new pairs when the tracking map hits `MAX_TRACKED_PAIRS`. The drop is `tracing::debug!`-only, so an operator has **no visible signal** that the limiter is active or that legitimate traffic might be getting dropped.

The accepted / rejected / capacity-rejected counters already exist on `UpdateRateLimiter` but were dead code (`#[cfg_attr(not(test), allow(dead_code))]`). #4285's own PR body reserved them "for the follow-up dashboard surface" — this is that follow-up.

## Approach

Surface the three existing counters on the node status dashboard, following the `RingStatsSnapshot` provider pattern from #4297:

- Extend `RingStatsSnapshot` with `updates_accepted` / `updates_rate_limited` / `updates_capacity_dropped` (`network_status.rs`).
- Read them off `Ring.update_rate_limiter` in the provider closure (`p2p_impl.rs`).
- Render three tiles — **UPDATEs relayed**, **Rate-limited**, **Capacity-dropped** — on the Connection Status card, shown only once the limiter has seen traffic so idle nodes stay uncluttered (`home_page.rs`).
- Drop the now-unnecessary `allow(dead_code)` attrs on the three accessors.

This is **observability only — no behavior change**. The limiter's thresholds and drop behavior are untouched; the change consistent with the design-doc principle that "the dashboard visualises what the system already does" (`docs/design/contract-hardening.md`, Phase 4.5).

## Testing

- `network_status::ring_stats_provider_round_trip` — extended to assert the three new counters round-trip through the provider.
- `home_page::rate_limit_stats_hidden_when_no_traffic` — idle node hides the row.
- `home_page::rate_limit_stats_rendered_when_active` — counts + labels appear.
- `home_page::rate_limit_stats_shown_when_only_accepted` — boundary: accepted>0, zero drops still renders.

`cargo fmt`, `cargo clippy -p freenet --lib -- -D warnings`, and the touched tests all pass.

## Context

Follow-up to #4285. Part of the release-readiness review ahead of v0.2.68 — adds operator visibility into the one governance feature that enforces (drops traffic) by default, per maintainer direction to ship the limiter as-is with a visible counter rather than re-tuning the threshold speculatively.

[AI-assisted - Claude]