### PR TITLE
fix(release): sign River announcements with the owner key override

### DIFF
--- a/scripts/release-agent/announce-to-river.sh
+++ b/scripts/release-agent/announce-to-river.sh
@@ -96,19 +96,24 @@ wait_for_node() {
 # Post $MESSAGE to the room, signed by the room OWNER.
 #
 # The signing identity is load-bearing and the source of a long-standing
-# silent failure. riverctl's normal send path runs the chat-delegate sync,
-# which rewrites rooms.json's `signing_key_bytes` back to the locally-loaded
-# identity (on nova that's an unauthorized "bot" key, not the owner) right
-# before signing. If we sign with that identity, the room contract is valid
-# at the request layer but SILENTLY DROPS the delta on merge — riverctl still
+# silent failure. Without an explicit key, riverctl signs with whatever
+# identity rooms.json currently holds, and the chat-delegate sync can
+# silently rewrite that `signing_key_bytes` field to a non-owner key (on
+# nova it resolves to an unauthorized "bot" identity). riverctl documents
+# this exact hazard and provides `--signing-key-file` as the remedy (see its
+# `--help`: "signs at command time, without the UI's chat-delegate sync").
+# When the message is signed by a non-owner, the room contract is valid at
+# the request layer but SILENTLY DROPS the delta on merge — riverctl still
 # prints "Message sent successfully" and exits 0, yet the message never
 # converges into room state. Every release announcement before this fix was
 # lost exactly this way (v0.2.67 and v0.2.68 were both absent from the room).
 #
-# Pre-patching rooms.json (what this script used to do) does NOT work: the
-# delegate sync overwrites the patch in-process before signing. The fix is
-# riverctl's global `--signing-key-file` override, which is in-memory and
-# immune to the sync, so the delta is signed by the real owner and merges.
+# Pre-patching rooms.json's `signing_key_bytes` (what this script used to do)
+# is unreliable for the same reason — the sync can overwrite it before the
+# send signs. The fix is the global `--signing-key-file` override, which is
+# held in memory, never persisted, and is what riverctl returns from
+# resolve_signing_key, so the delta is deterministically signed by the real
+# owner and merges.
 #
 # `cargo run -p riverctl` from the source repo (not the installed binary) so
 # the embedded room_contract.wasm — and thus the derived contract key —

--- a/scripts/release-agent/announce-to-river.sh
+++ b/scripts/release-agent/announce-to-river.sh
@@ -93,6 +93,34 @@ wait_for_node() {
     return 1
 }
 
+# Post $MESSAGE to the room, signed by the room OWNER.
+#
+# The signing identity is load-bearing and the source of a long-standing
+# silent failure. riverctl's normal send path runs the chat-delegate sync,
+# which rewrites rooms.json's `signing_key_bytes` back to the locally-loaded
+# identity (on nova that's an unauthorized "bot" key, not the owner) right
+# before signing. If we sign with that identity, the room contract is valid
+# at the request layer but SILENTLY DROPS the delta on merge — riverctl still
+# prints "Message sent successfully" and exits 0, yet the message never
+# converges into room state. Every release announcement before this fix was
+# lost exactly this way (v0.2.67 and v0.2.68 were both absent from the room).
+#
+# Pre-patching rooms.json (what this script used to do) does NOT work: the
+# delegate sync overwrites the patch in-process before signing. The fix is
+# riverctl's global `--signing-key-file` override, which is in-memory and
+# immune to the sync, so the delta is signed by the real owner and merges.
+#
+# `cargo run -p riverctl` from the source repo (not the installed binary) so
+# the embedded room_contract.wasm — and thus the derived contract key —
+# matches the currently-deployed room.
+post_message() {
+    cd "$RIVER_DIR" || return 1
+    RIVER_SKIP_CONTRACT_CHECK=1 timeout 180 \
+        cargo run --quiet -p riverctl -- \
+            --signing-key-file "$SIGNING_KEY_FILE" \
+            message send "$ROOM_OWNER_VK" "$MESSAGE"
+}
+
 if [[ $# -ne 1 ]]; then
     usage
 fi
@@ -132,57 +160,11 @@ if ! wait_for_node; then
     exit 1
 fi
 
-# Ensure the room owner signing key in rooms.json matches the on-disk
-# key. This mirrors the equivalent block in scripts/release.sh — without
-# it, posting fails if the local rooms.json drifted.
-#
-# Failure modes are logged and abort (no `|| true` swallowing): if the
-# rooms.json schema drifted, posting with a stale key would be confusing
-# at best and identity-impersonation at worst. We'd rather fail loud.
-#
-# Writes are atomic (temp file + os.replace) so a crash mid-rewrite
-# can't leave rooms.json half-written for the human user.
-if ! python3 - <<PY; then
-import json, os, sys
-signing_key_file = "$SIGNING_KEY_FILE"
-rooms_file = "$ROOMS_JSON"
-room_vk = "$ROOM_OWNER_VK"
-try:
-    with open(signing_key_file, 'rb') as f:
-        key_bytes = list(f.read())
-    with open(rooms_file, 'r') as f:
-        data = json.load(f)
-    if room_vk not in data.get('rooms', {}):
-        # No-op if the room isn't in local storage — riverctl will
-        # itself fail with a clear error in that case.
-        sys.exit(0)
-    current_key = data['rooms'][room_vk].get('signing_key_bytes', [])
-    if current_key != key_bytes:
-        data['rooms'][room_vk]['signing_key_bytes'] = key_bytes
-        tmp = rooms_file + '.tmp'
-        with open(tmp, 'w') as f:
-            json.dump(data, f)
-        os.replace(tmp, rooms_file)
-        print("rooms.json signing key resynced", file=sys.stderr)
-except Exception as e:
-    print(f"rooms.json sync failed: {e}", file=sys.stderr)
-    sys.exit(1)
-PY
-    log "ERROR: rooms.json signing-key sync failed (see above)"
-    exit 1
-fi
-
 log "posting to River room $ROOM_OWNER_VK (msg ${#MESSAGE} bytes)"
 
-# Use `cargo run -p riverctl` from the source repo, NOT the installed
-# binary. The installed binary embeds room_contract.wasm at install
-# time, which can become stale when the contract WASM changes. The
-# repo version uses build.rs to copy the current WASM at build time.
-# RIVER_SKIP_CONTRACT_CHECK=1 bypasses the publish-time WASM staleness
-# check (only relevant when publishing riverctl, not when running it).
-cd "$RIVER_DIR"
-if RIVER_SKIP_CONTRACT_CHECK=1 timeout 180 \
-       cargo run --quiet -p riverctl -- message send "$ROOM_OWNER_VK" "$MESSAGE"; then
+# Sign as the owner via the in-memory --signing-key-file override (see
+# post_message above for why pre-patching rooms.json does not work).
+if post_message; then
     log "OK"
     exit 0
 else

--- a/scripts/release-agent/announce-to-river_test.sh
+++ b/scripts/release-agent/announce-to-river_test.sh
@@ -128,6 +128,39 @@ wait_for_node 2>/dev/null || rc=$?
 check "wait_for_node() fails when the node never returns" "$rc" "1"
 check "wait_for_node() honours NODE_WAIT_ATTEMPTS as the bound" "$CURL_CALLS" "3"
 
+# ── post_message() ───────────────────────────────────────────────────
+#
+# The signing-identity fix. post_message MUST hand riverctl the owner key
+# via the global `--signing-key-file` override, BEFORE the `message`
+# subcommand. Without it, riverctl's chat-delegate sync re-signs with the
+# locally-loaded (unauthorized) identity and the room contract silently
+# drops the delta on merge — the bug that lost the v0.2.67/v0.2.68
+# announcements while riverctl still exited 0. The function is extracted
+# verbatim, so dropping the override (or misplacing it after the
+# subcommand) fails these assertions.
+eval "$(awk '/^post_message\(\) \{/,/^}/' "$ANNOUNCE_SH")"
+
+RIVER_DIR="$TMP"
+SIGNING_KEY_FILE="$TMP/owner_key.bin"
+ROOM_OWNER_VK="OWNERVK111"
+MESSAGE="Freenet vX.Y.Z released"
+CARGO_ARGS_FILE="$TMP/cargo_args"
+
+# Stubs (inherited by the subshell that runs post_message): `timeout`
+# drops its duration and runs the rest; `cargo` records its argv joined.
+timeout() { shift; "$@"; }
+cargo() { echo "$*" > "$CARGO_ARGS_FILE"; }
+
+( post_message ) >/dev/null 2>&1 || true
+cargo_args="$(cat "$CARGO_ARGS_FILE" 2>/dev/null || true)"
+
+check "post_message signs with the owner key via --signing-key-file before the subcommand" \
+    "$(printf '%s' "$cargo_args" | grep -cF -- "--signing-key-file $SIGNING_KEY_FILE message send" || true)" "1"
+check "post_message sends to the owner VK" \
+    "$(printf '%s' "$cargo_args" | grep -cF -- "message send $ROOM_OWNER_VK" || true)" "1"
+check "post_message runs riverctl from source with the contract-check skip" \
+    "$(printf '%s' "$cargo_args" | grep -cF -- "run --quiet -p riverctl" || true)" "1"
+
 # ── result ───────────────────────────────────────────────────────────
 
 if (( FAILURES > 0 )); then

--- a/scripts/release-agent/announce-to-river_test.sh
+++ b/scripts/release-agent/announce-to-river_test.sh
@@ -132,12 +132,12 @@ check "wait_for_node() honours NODE_WAIT_ATTEMPTS as the bound" "$CURL_CALLS" "3
 #
 # The signing-identity fix. post_message MUST hand riverctl the owner key
 # via the global `--signing-key-file` override, BEFORE the `message`
-# subcommand. Without it, riverctl's chat-delegate sync re-signs with the
-# locally-loaded (unauthorized) identity and the room contract silently
-# drops the delta on merge — the bug that lost the v0.2.67/v0.2.68
-# announcements while riverctl still exited 0. The function is extracted
-# verbatim, so dropping the override (or misplacing it after the
-# subcommand) fails these assertions.
+# subcommand. Without it riverctl signs with the identity rooms.json holds
+# (on nova an unauthorized key the chat-delegate sync can rewrite in), and
+# the room contract silently drops the delta on merge — the bug that lost
+# the v0.2.67/v0.2.68 announcements while riverctl still exited 0. The
+# function is extracted verbatim, so dropping the override (or misplacing it
+# after the subcommand) fails these assertions.
 eval "$(awk '/^post_message\(\) \{/,/^}/' "$ANNOUNCE_SH")"
 
 RIVER_DIR="$TMP"
@@ -145,21 +145,26 @@ SIGNING_KEY_FILE="$TMP/owner_key.bin"
 ROOM_OWNER_VK="OWNERVK111"
 MESSAGE="Freenet vX.Y.Z released"
 CARGO_ARGS_FILE="$TMP/cargo_args"
+CARGO_SKIP_FILE="$TMP/cargo_skip"
 
-# Stubs (inherited by the subshell that runs post_message): `timeout`
-# drops its duration and runs the rest; `cargo` records its argv joined.
+# Stubs (inherited by the subshell that runs post_message): `timeout` drops
+# its duration and runs the rest; `cargo` records its argv joined plus the
+# RIVER_SKIP_CONTRACT_CHECK env it inherits from the command prefix.
 timeout() { shift; "$@"; }
-cargo() { echo "$*" > "$CARGO_ARGS_FILE"; }
+cargo() { echo "$*" > "$CARGO_ARGS_FILE"; echo "${RIVER_SKIP_CONTRACT_CHECK:-}" > "$CARGO_SKIP_FILE"; }
 
 ( post_message ) >/dev/null 2>&1 || true
 cargo_args="$(cat "$CARGO_ARGS_FILE" 2>/dev/null || true)"
+cargo_skip="$(cat "$CARGO_SKIP_FILE" 2>/dev/null || true)"
 
 check "post_message signs with the owner key via --signing-key-file before the subcommand" \
     "$(printf '%s' "$cargo_args" | grep -cF -- "--signing-key-file $SIGNING_KEY_FILE message send" || true)" "1"
 check "post_message sends to the owner VK" \
     "$(printf '%s' "$cargo_args" | grep -cF -- "message send $ROOM_OWNER_VK" || true)" "1"
-check "post_message runs riverctl from source with the contract-check skip" \
+check "post_message runs riverctl from the source repo" \
     "$(printf '%s' "$cargo_args" | grep -cF -- "run --quiet -p riverctl" || true)" "1"
+check "post_message sets RIVER_SKIP_CONTRACT_CHECK for the riverctl run" \
+    "$cargo_skip" "1"
 
 # ── result ───────────────────────────────────────────────────────────
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1434,34 +1434,10 @@ announce_to_river() {
         return 0
     fi
 
-    # Ensure Room Owner signing key is in rooms.json
-    # (riverctl uses local storage, not --signing-key for room members)
-    if [[ -f "$SIGNING_KEY_FILE" ]]; then
-        python3 -c "
-import json
-import sys
-
-signing_key_file = '$SIGNING_KEY_FILE'
-rooms_file = '$ROOMS_JSON'
-room_vk = '$ROOM_OWNER_VK'
-
-with open(signing_key_file, 'rb') as f:
-    key_bytes = list(f.read())
-
-with open(rooms_file, 'r') as f:
-    data = json.load(f)
-
-if room_vk not in data.get('rooms', {}):
-    print('Room not in local storage', file=sys.stderr)
-    sys.exit(1)
-
-# Update signing key if different
-current_key = data['rooms'][room_vk].get('signing_key_bytes', [])
-if current_key != key_bytes:
-    data['rooms'][room_vk]['signing_key_bytes'] = key_bytes
-    with open(rooms_file, 'w') as f:
-        json.dump(data, f)
-" 2>/dev/null || true
+    if [[ ! -f "$SIGNING_KEY_FILE" ]]; then
+        echo "  ⚠️  Room owner signing key not found at $SIGNING_KEY_FILE"
+        echo "     Skipping River announcement"
+        return 0
     fi
 
     # Simple announcement
@@ -1483,10 +1459,18 @@ if current_key != key_bytes:
     #
     # stderr is captured into a log instead of discarded so future failures are
     # diagnosable from the release log.
+    #
+    # --signing-key-file forces signing as the room owner. Without it riverctl
+    # signs with whatever identity rooms.json currently holds (the chat-delegate
+    # sync can silently rewrite that to a non-owner), and the room contract then
+    # drops the message on merge while riverctl still exits 0 — the silent
+    # failure that lost the v0.2.67/v0.2.68 announcements. The override is
+    # in-memory and never persisted, so it is immune to that drift. This mirrors
+    # the canonical announce-to-river.sh path used by the release-agent.
     local RIVER_DIR="$HOME/code/freenet/river/main"
     local RIVER_LOG="/tmp/release-$VERSION-river.log"
     if [[ -d "$RIVER_DIR" ]]; then
-        if (cd "$RIVER_DIR" && RIVER_SKIP_CONTRACT_CHECK=1 timeout 180 cargo run -p riverctl -- message send "$ROOM_OWNER_VK" "$announcement" >"$RIVER_LOG" 2>&1); then
+        if (cd "$RIVER_DIR" && RIVER_SKIP_CONTRACT_CHECK=1 timeout 180 cargo run -p riverctl -- --signing-key-file "$SIGNING_KEY_FILE" message send "$ROOM_OWNER_VK" "$announcement" >"$RIVER_LOG" 2>&1); then
             echo "✓"
             mark_completed "RIVER_ANNOUNCED"
         else
@@ -1495,11 +1479,11 @@ if current_key != key_bytes:
             echo "  ⚠️  Failed to send River announcement (non-critical, rc=$rc)"
             echo "     Last log lines from $RIVER_LOG:"
             tail -15 "$RIVER_LOG" 2>/dev/null | sed 's/^/       /'
-            echo "     Manual: cd $RIVER_DIR && RIVER_SKIP_CONTRACT_CHECK=1 cargo run -p riverctl -- message send $ROOM_OWNER_VK \"$announcement\""
+            echo "     Manual: cd $RIVER_DIR && RIVER_SKIP_CONTRACT_CHECK=1 cargo run -p riverctl -- --signing-key-file $SIGNING_KEY_FILE message send $ROOM_OWNER_VK \"$announcement\""
         fi
     else
         echo "⚠️  River repo not found at $RIVER_DIR"
-        echo "     Manual: cd <river-repo> && RIVER_SKIP_CONTRACT_CHECK=1 cargo run -p riverctl -- message send $ROOM_OWNER_VK \"$announcement\""
+        echo "     Manual: cd <river-repo> && RIVER_SKIP_CONTRACT_CHECK=1 cargo run -p riverctl -- --signing-key-file $SIGNING_KEY_FILE message send $ROOM_OWNER_VK \"$announcement\""
     fi
 }
 


### PR DESCRIPTION
## Problem

Release announcements to the Freenet Official River room have silently failed since at least v0.2.67. `riverctl message send` exits 0 ("Message sent successfully"), the release-agent logs "OK", and the workflow goes green — but the message **never converges into room state**. Both the v0.2.67 and v0.2.68 announcements were absent from the room (confirmed by reading the room back through nova's own node — not a propagation or technic-side issue, and not a contract-key mismatch).

Root cause is the **signing identity**. The script pre-patched `rooms.json`'s `signing_key_bytes` to the owner key, then ran `riverctl message send` with no explicit key. Without an explicit key, riverctl signs with whatever identity `rooms.json` holds — and the **chat-delegate sync can silently rewrite that field** to a non-owner ("bot") identity (on nova, `self_authorized_member: null`). riverctl's own `--help` documents this exact hazard and offers `--signing-key-file` as the remedy ("signs at command time, without the UI's chat-delegate sync"). When the delta is signed by a non-owner, the room contract is valid at the request layer but **silently drops it on merge** while riverctl still reports success.

## Solution

Sign via riverctl's global `--signing-key-file` override — an **in-memory** identity that is never persisted and is what `resolve_signing_key` returns, so it's immune to on-disk drift / the delegate-sync rewrite. The brittle `rooms.json` patch is removed. Applied in **both** announce paths:
- `scripts/release-agent/announce-to-river.sh` (the automated release-agent path) — send extracted into `post_message()`.
- `scripts/release.sh` (the manual fallback) — same override, same patch removal.

Verified live on nova: re-sending the v0.2.68 message with the owner-key override **merged into converged room state and persists** (`[13:55:30 - Room Owner]: Freenet v0.2.68 released: …`), so the v0.2.68 announcement is now out.

## Testing

`announce-to-river_test.sh` gains four assertions (eval-extracting the real `post_message`, same pattern as the existing `log`/`wait_for_node` tests): the riverctl invocation passes `--signing-key-file <owner-key> message send` in the correct order, sends to the owner VK, runs from the source repo, and sets `RIVER_SKIP_CONTRACT_CHECK`. Drop or misplace the override and they fail (verified by the reviewer reproducing the revert). Existing tests pass; `shellcheck` clean on both scripts (no new warnings in `release.sh`).

## Reviews

Codex (external) + an adversarial skeptical review — both verdict **safe to merge**, no correctness defects. Findings addressed: corrected the rationale prose (the mechanism is the chat-delegate sync rewriting `signing_key_bytes`, per riverctl's own docs — not riverctl "running" a sync), brought `release.sh` in line (finish-the-fix), and made the contract-check test assertion actually verify the env var.

## Follow-up note

riverctl reporting `rc=0`/"Message sent successfully" for a delta the contract later drops on merge is a real observability gap that masked this for multiple releases — worth surfacing the UpdateResponse, but out of scope here.

[AI-assisted - Claude]