### PR TITLE
fix(dashboard): remove duplicate "ago" in governance "last evaluated" footer

### DIFF
--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -1001,6 +1001,14 @@ fn build_ring_svg(
     svg
 }
 
+/// Format the governance card's "last evaluated" footer from the number
+/// of seconds since the reaper last ticked. `format_ago` already appends
+/// " ago" (or returns "just now"), so the template must NOT add a second
+/// "ago" — doing so rendered "Last evaluated 18s ago ago".
+fn format_last_evaluated(secs: u64) -> String {
+    format!("Last evaluated {}", format_ago(secs))
+}
+
 /// Build the governance card. Reads `snap.governance` (sourced from
 /// `Ring::dashboard_governance_snapshot` → `GovernanceManager`). Every
 /// field rendered here came from the back-end's computation —
@@ -1030,7 +1038,7 @@ fn build_governance_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
             // moments ago so we can approximate "now" inline.
             let now = tokio::time::Instant::now();
             let secs = now.saturating_duration_since(at).as_secs();
-            format!("Last evaluated {} ago", format_ago(secs))
+            format_last_evaluated(secs)
         }
         None => "Reaper has not yet ticked".to_string(),
     };
@@ -3918,6 +3926,17 @@ mod tests {
         let snap = base_snapshot();
         let uri = build_favicon_data_uri(&Some(snap));
         assert!(uri.contains("%23fbbf24"), "expected amber color");
+    }
+
+    #[test]
+    fn last_evaluated_footer_has_single_ago() {
+        // Regression: format_ago already appends " ago", so the footer
+        // template must not add a second one. Previously rendered
+        // "Last evaluated 18s ago ago".
+        assert_eq!(format_last_evaluated(18), "Last evaluated 18s ago");
+        assert!(!format_last_evaluated(18).contains("ago ago"));
+        // Under 5s, format_ago returns "just now" (no "ago" suffix at all).
+        assert_eq!(format_last_evaluated(2), "Last evaluated just now");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The local node dashboard's governance card rendered the reaper footer as **"Last evaluated 18s ago ago"** — two "ago"s. `format_ago` already appends `" ago"` (or returns `"just now"`), but the footer template (`home_page.rs:1033`) added a second literal `" ago"`. The `<5s` case was also wrong: it read "Last evaluated just now ago".

## Solution

Extract the footer string into a small `format_last_evaluated` helper that defers entirely to `format_ago`, dropping the duplicate suffix. The other three `format_ago` call sites in this file embed the result directly into table cells without an extra "ago", so they were already correct and are unchanged.

## Testing

Added `last_evaluated_footer_has_single_ago` regression test asserting the footer renders `"Last evaluated 18s ago"` (not `"ago ago"`) and that the `<5s` case renders `"Last evaluated just now"`. Fails against the old template, passes with the fix. `cargo fmt`/`clippy`/test green.

Copy-only user-facing fix; no behavior change.

[AI-assisted - Claude]