### PR TITLE
test: drop nextest retries on test_ping_blocked_peers to stop masking flakes

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -22,6 +22,22 @@ slow-timeout = { period = "300s", terminate-after = 2 }
 filter = "package(freenet-ping-app)"
 slow-timeout = { period = "300s", terminate-after = 3 }
 
+# test_ping_blocked_peers is the canary for the CONNECT promotion-drop bug
+# class (#3838, fixed in #3893). The profile-wide retries = 2 masked a ~40%
+# per-run failure rate as ~6% effective during the flaky period, making an
+# "actively broken" test look "flaky but mostly passing". Run it with no
+# nextest retries so any re-emergence of that bug class surfaces on the first
+# run instead of being hidden (#3895).
+#
+# This does NOT reintroduce environmental flakiness: the only legitimately
+# transient failure mode (loopback port collisions with parallel tests) is
+# already handled inside the test itself by an in-process retry loop with
+# jitter (MAX_PORT_RETRY_ATTEMPTS in run_app_blocked_peers.rs), so it never
+# needed nextest-level retries to absorb port races.
+[[profile.ci.overrides]]
+filter = "test(test_ping_blocked_peers)"
+retries = 0
+
 [profile.nightly]
 # Nightly tests run longer by design; no retries since failures need investigation.
 retries = 0


### PR DESCRIPTION
## Problem

`test_ping_blocked_peers` runs under the nextest `ci` profile, which sets a
profile-wide `retries = 2`. That re-runs each failed run up to twice and reports
the test as passed if any attempt passes.

During the recent flaky period (investigated in #3893, the fix for #3838) the
test had a ~40% per-run failure rate. With `retries = 2` that surfaced as a ~6%
effective failure rate — so an actively-broken test looked "flaky but mostly
passing" rather than "broken." That is exactly the masking behavior
`.claude/rules/flaky-tests.md` warns against: "Flaky tests are broken tests —
investigate the root cause."

## Approach

Add a per-test `[[profile.ci.overrides]]` block pinning `retries = 0` for
`test(test_ping_blocked_peers)`, so any re-emergence of the CONNECT
promotion-drop bug class surfaces on the first run instead of being hidden by
retries.

Why `0` rather than `1`: the issue asks for "0 (or at most 1)," and #3893 fixed
the structural root cause (the type-level `AcceptOutcome` refactor) and ran the
test 5x locally green. If we are confident enough in the fix to keep the test,
we are confident enough to run it without retries.

This does **not** reintroduce environmental flakiness. The only legitimately
transient failure mode — loopback port collisions with parallel tests — is
already absorbed inside the test itself by an in-process retry loop with jitter
(`MAX_PORT_RETRY_ATTEMPTS` in `run_app_blocked_peers.rs`, which retries only on
`Address already in use` / os error 98 / os error 48). So this test never relied
on nextest-level retries to handle port races; dropping them removes only the
masking of genuine code-bug failures.

The earlier `package(freenet-ping-app)` override sets only `slow-timeout`, so it
does not conflict — this test keeps the 300s/terminate-after-3 timeout and gains
`retries = 0`.

## Testing

This is a CI-config-only change (`.config/nextest.toml`); there is no Rust code
to unit-test. Verified:

- `cargo fmt --check` clean (no Rust changes).
- The filter `test(test_ping_blocked_peers)` is unambiguous: exactly one
  `#[test]` function by that name exists; nothing else substring-matches it.
- The blocked-peers test runs serially in CI (`-j 1`, `--profile ci`) in the
  dedicated "Test blocked-peers (serial)" step, so the override applies there.

Closes #3895

[AI-assisted - Claude]