### PR TITLE
fix(transport): sample RTT from ping/pong keep-alive cycle

### DIFF
--- a/crates/core/src/transport/metrics.rs
+++ b/crates/core/src/transport/metrics.rs
@@ -255,7 +255,13 @@ impl TransportMetrics {
     }
 
     /// Record an RTT sample in microseconds.
-    fn record_rtt_sample(&self, rtt_us: u64) {
+    ///
+    /// Called both from [`Self::record_transfer_completed`] (LEDBAT
+    /// `base_delay` at stream completion) and from the ping/pong keep-alive
+    /// cycle in `peer_connection.rs` (round-trip of a keep-alive Ping). The
+    /// keep-alive path is what keeps RTT statistics populated for quiet,
+    /// long-lived connections that rarely complete a stream transfer (#4000).
+    pub(crate) fn record_rtt_sample(&self, rtt_us: u64) {
         self.rtt_sum_us
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
                 Some(v.saturating_add(rtt_us))
@@ -288,6 +294,16 @@ impl TransportMetrics {
     /// without interfering with the periodic telemetry snapshots.
     pub fn cumulative_bytes_sent(&self) -> u64 {
         self.cumulative_bytes_sent.load(Ordering::Relaxed)
+    }
+
+    /// Number of RTT samples accumulated in the current snapshot window.
+    ///
+    /// Reset to 0 by `take_snapshot`. Exposed so tests can assert that a
+    /// code path (e.g. the ping/pong keep-alive cycle) actually recorded a
+    /// sample without consuming the snapshot.
+    #[cfg(test)]
+    pub(crate) fn rtt_sample_count(&self) -> u32 {
+        self.rtt_samples.load(Ordering::Relaxed)
     }
 
     /// Record a completed inbound stream transfer.

--- a/crates/core/src/transport/metrics.rs
+++ b/crates/core/src/transport/metrics.rs
@@ -526,10 +526,18 @@ impl TransportMetrics {
             self.cwnd_sum.store(0, Ordering::Relaxed);
             self.cwnd_samples.store(0, Ordering::Relaxed);
             self.slowdowns_triggered.store(0, Ordering::Relaxed);
-            self.min_rtt_us.store(u64::MAX, Ordering::Relaxed);
-            self.max_rtt_us.store(0, Ordering::Relaxed);
-            self.rtt_sum_us.store(0, Ordering::Relaxed);
-            // `rtt_samples` was already swapped to 0 above.
+            // Deliberately DO NOT reset the RTT accumulators (`rtt_sum_us`,
+            // `min_rtt_us`, `max_rtt_us`) here. `rtt_samples` was already
+            // swapped to 0; if a concurrent `record_rtt_sample` lands between
+            // that swap and this point, it bumps `rtt_sum_us`/min/max *and*
+            // `rtt_samples` (back to 1). Zeroing the accumulators here would
+            // then leave a nonzero sample count paired with a zeroed
+            // sum/min/max, so the next snapshot would emit a bogus
+            // avg/min/max = 0. Since these accumulators are only ever advanced
+            // alongside a sample, they are already at their identity values
+            // (0 / u64::MAX / 0) in the genuine no-activity case, making the
+            // stores redundant anyway. Leaving them keeps the count and the
+            // accumulators mutually consistent under concurrency.
             return None;
         }
 

--- a/crates/core/src/transport/metrics.rs
+++ b/crates/core/src/transport/metrics.rs
@@ -506,9 +506,16 @@ impl TransportMetrics {
         // Read and reset counters
         let transfers_completed = self.transfers_completed.swap(0, Ordering::Relaxed);
         let transfers_failed = self.transfers_failed.swap(0, Ordering::Relaxed);
+        // RTT samples count as activity in their own right: quiet connections
+        // that only exchange keep-alive ping/pong traffic record RTT samples
+        // but complete no transfers (#4000). Gating snapshot emission solely
+        // on transfers would discard (and reset) those samples here, so the
+        // telemetry worker would never see RTT data for a quiet node — the
+        // exact under-counting this is meant to fix.
+        let rtt_samples = self.rtt_samples.swap(0, Ordering::Relaxed);
 
         // No activity = no snapshot
-        if transfers_completed == 0 && transfers_failed == 0 {
+        if transfers_completed == 0 && transfers_failed == 0 && rtt_samples == 0 {
             // Still reset other counters to prevent stale data
             self.bytes_sent.store(0, Ordering::Relaxed);
             self.bytes_received.store(0, Ordering::Relaxed);
@@ -522,7 +529,7 @@ impl TransportMetrics {
             self.min_rtt_us.store(u64::MAX, Ordering::Relaxed);
             self.max_rtt_us.store(0, Ordering::Relaxed);
             self.rtt_sum_us.store(0, Ordering::Relaxed);
-            self.rtt_samples.store(0, Ordering::Relaxed);
+            // `rtt_samples` was already swapped to 0 above.
             return None;
         }
 
@@ -538,7 +545,6 @@ impl TransportMetrics {
         let min_rtt_us = self.min_rtt_us.swap(u64::MAX, Ordering::Relaxed);
         let max_rtt_us = self.max_rtt_us.swap(0, Ordering::Relaxed);
         let rtt_sum_us = self.rtt_sum_us.swap(0, Ordering::Relaxed);
-        let rtt_samples = self.rtt_samples.swap(0, Ordering::Relaxed);
 
         // Compute averages
         let avg_cwnd_bytes = if cwnd_samples > 0 {
@@ -775,6 +781,33 @@ mod tests {
         assert_eq!(snapshot.bytes_sent, 1024);
         assert_eq!(snapshot.peak_cwnd_bytes, 50000);
         assert_eq!(snapshot.slowdowns_triggered, 1);
+    }
+
+    /// Regression test for #4000: a quiet connection that records RTT samples
+    /// from the ping/pong keep-alive cycle but completes no transfers must
+    /// still produce a telemetry snapshot. Without counting RTT samples as
+    /// activity, `take_snapshot` would early-return `None` and reset the RTT
+    /// counters, silently discarding exactly the quiet-connection RTT data the
+    /// keep-alive sampling path is meant to surface.
+    #[test]
+    fn test_snapshot_emitted_for_rtt_only_activity() {
+        let metrics = TransportMetrics::new();
+
+        // No transfers — only a keep-alive RTT sample, as a quiet connection
+        // would produce.
+        metrics.record_rtt_sample(42_000);
+
+        let snapshot = metrics
+            .take_snapshot()
+            .expect("RTT-only activity must still produce a snapshot");
+        assert_eq!(snapshot.transfers_completed, 0);
+        assert_eq!(snapshot.transfers_failed, 0);
+        assert_eq!(snapshot.avg_rtt_us, 42_000);
+        assert_eq!(snapshot.min_rtt_us, 42_000);
+        assert_eq!(snapshot.max_rtt_us, 42_000);
+
+        // Counters reset: a subsequent snapshot with no new activity is None.
+        assert!(metrics.take_snapshot().is_none());
     }
 
     #[test]

--- a/crates/core/src/transport/metrics.rs
+++ b/crates/core/src/transport/metrics.rs
@@ -508,15 +508,29 @@ impl TransportMetrics {
         let transfers_failed = self.transfers_failed.swap(0, Ordering::Relaxed);
         // RTT samples count as activity in their own right: quiet connections
         // that only exchange keep-alive ping/pong traffic record RTT samples
-        // but complete no transfers (#4000). Gating snapshot emission solely
-        // on transfers would discard (and reset) those samples here, so the
-        // telemetry worker would never see RTT data for a quiet node — the
-        // exact under-counting this is meant to fix.
-        let rtt_samples = self.rtt_samples.swap(0, Ordering::Relaxed);
+        // but complete no transfers (#4000). Gating snapshot emission solely on
+        // transfers would discard those samples, so the telemetry worker would
+        // never see RTT data for a quiet node — the exact under-counting this is
+        // meant to fix.
+        //
+        // The activity check `load`s the count (peek, no reset) instead of
+        // swapping it, so the count is consumed in exactly one place — grouped
+        // with the RTT accumulator swaps below. Resetting the count up here
+        // separately would create a window where a concurrent
+        // `record_rtt_sample` has its sum/min/max consumed by this snapshot
+        // while its count carries into the next, producing a bogus
+        // avg/min/max = 0 next tick.
+        let rtt_samples_pending = self.rtt_samples.load(Ordering::Relaxed);
 
         // No activity = no snapshot
-        if transfers_completed == 0 && transfers_failed == 0 && rtt_samples == 0 {
-            // Still reset other counters to prevent stale data
+        if transfers_completed == 0 && transfers_failed == 0 && rtt_samples_pending == 0 {
+            // Still reset other counters to prevent stale data. The RTT
+            // accumulators (`rtt_samples`, `rtt_sum_us`, `min_rtt_us`,
+            // `max_rtt_us`) are deliberately left untouched: they are only ever
+            // advanced together by `record_rtt_sample`, so in the genuine
+            // no-activity case they already hold their identity values, and
+            // leaving them keeps the count and accumulators mutually consistent
+            // if a sample lands concurrently with this reset.
             self.bytes_sent.store(0, Ordering::Relaxed);
             self.bytes_received.store(0, Ordering::Relaxed);
             self.total_transfer_time_ms.store(0, Ordering::Relaxed);
@@ -526,18 +540,6 @@ impl TransportMetrics {
             self.cwnd_sum.store(0, Ordering::Relaxed);
             self.cwnd_samples.store(0, Ordering::Relaxed);
             self.slowdowns_triggered.store(0, Ordering::Relaxed);
-            // Deliberately DO NOT reset the RTT accumulators (`rtt_sum_us`,
-            // `min_rtt_us`, `max_rtt_us`) here. `rtt_samples` was already
-            // swapped to 0; if a concurrent `record_rtt_sample` lands between
-            // that swap and this point, it bumps `rtt_sum_us`/min/max *and*
-            // `rtt_samples` (back to 1). Zeroing the accumulators here would
-            // then leave a nonzero sample count paired with a zeroed
-            // sum/min/max, so the next snapshot would emit a bogus
-            // avg/min/max = 0. Since these accumulators are only ever advanced
-            // alongside a sample, they are already at their identity values
-            // (0 / u64::MAX / 0) in the genuine no-activity case, making the
-            // stores redundant anyway. Leaving them keeps the count and the
-            // accumulators mutually consistent under concurrency.
             return None;
         }
 
@@ -550,9 +552,14 @@ impl TransportMetrics {
         let cwnd_sum = self.cwnd_sum.swap(0, Ordering::Relaxed);
         let cwnd_samples = self.cwnd_samples.swap(0, Ordering::Relaxed);
         let slowdowns_triggered = self.slowdowns_triggered.swap(0, Ordering::Relaxed);
+        // Swap the RTT accumulators and the sample count together so the count
+        // is consumed in lockstep with the sum/min/max it summarizes. Order
+        // mirrors `record_rtt_sample` (sum, then count) to minimize the chance
+        // of a concurrent sample being split across two snapshots.
+        let rtt_sum_us = self.rtt_sum_us.swap(0, Ordering::Relaxed);
+        let rtt_samples = self.rtt_samples.swap(0, Ordering::Relaxed);
         let min_rtt_us = self.min_rtt_us.swap(u64::MAX, Ordering::Relaxed);
         let max_rtt_us = self.max_rtt_us.swap(0, Ordering::Relaxed);
-        let rtt_sum_us = self.rtt_sum_us.swap(0, Ordering::Relaxed);
 
         // Compute averages
         let avg_cwnd_bytes = if cwnd_samples > 0 {

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -972,16 +972,42 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                                 pong_sequence = sequence,
                                 "Received Pong, confirming bidirectional liveness"
                             );
-                            // Remove the corresponding ping from pending set
-                            let mut pending = self.pending_pings.write();
-                            if pending.remove(sequence).is_some() {
-                                tracing::trace!(
-                                    target: "freenet_core::transport::keepalive_received",
-                                    remote = ?self.remote_conn.remote_addr,
-                                    pong_sequence = sequence,
-                                    remaining_pending = pending.len(),
-                                    "Removed acknowledged ping from pending set"
-                                );
+                            // Remove the corresponding ping from pending set and,
+                            // if found, sample the round-trip time. The keep-alive
+                            // cycle runs on every connection regardless of stream
+                            // traffic, so this keeps RTT statistics populated for
+                            // quiet, long-lived connections that rarely (or never)
+                            // complete a stream transfer (#4000). Without it,
+                            // RTT was only sampled at stream completion and quiet
+                            // connections contributed zero samples.
+                            let removed_send_nanos = {
+                                let mut pending = self.pending_pings.write();
+                                let removed = pending.remove(sequence);
+                                if removed.is_some() {
+                                    tracing::trace!(
+                                        target: "freenet_core::transport::keepalive_received",
+                                        remote = ?self.remote_conn.remote_addr,
+                                        pong_sequence = sequence,
+                                        remaining_pending = pending.len(),
+                                        "Removed acknowledged ping from pending set"
+                                    );
+                                }
+                                removed
+                            };
+                            if let Some(send_nanos) = removed_send_nanos {
+                                // The ping timestamp was recorded with this same
+                                // `time_source` (the keep-alive task clones it), so
+                                // the subtraction is over one monotonic clock.
+                                // `saturating_sub` is defensive against any skew
+                                // yielding a 0 sample rather than underflowing.
+                                let rtt_nanos = self
+                                    .time_source
+                                    .now_nanos()
+                                    .saturating_sub(send_nanos);
+                                let rtt_us = rtt_nanos / 1_000;
+                                if rtt_us > 0 {
+                                    super::TRANSPORT_METRICS.record_rtt_sample(rtt_us);
+                                }
                             }
                         }
                         SymmetricMessagePayload::AckConnection { .. } | SymmetricMessagePayload::ShortMessage { .. } | SymmetricMessagePayload::StreamFragment { .. } => {}
@@ -3029,6 +3055,136 @@ mod tests {
         );
 
         // Cleanup so the singleton doesn't leak our address into other tests.
+        crate::transport::TRANSPORT_METRICS.remove_peer(remote_addr);
+    }
+
+    /// Regression test for #4000: a Pong received for a pending keep-alive
+    /// Ping must record an RTT sample, so quiet connections that never
+    /// complete a stream transfer still contribute to the RTT statistics.
+    ///
+    /// Before the fix, the Pong handler removed the matching ping timestamp
+    /// from `pending_pings` and discarded it — `record_rtt_sample` was only
+    /// reachable from `record_transfer_completed` (stream completion), so a
+    /// connection exchanging only keep-alive traffic recorded zero RTT
+    /// samples. This test seeds a pending ping, advances the (mock) clock,
+    /// feeds an encrypted Pong, and asserts the global RTT sample counter
+    /// moved by at least one.
+    #[tokio::test]
+    async fn pong_records_rtt_sample_from_keepalive_cycle() {
+        use crate::transport::crypto::TransportKeypair;
+        use crate::transport::packet_data::PacketData;
+        use crate::transport::symmetric_message::SymmetricMessagePayload;
+        use crate::util::time_source::SharedMockTimeSource;
+        use bytes::Bytes;
+
+        let time_source = SharedMockTimeSource::new();
+        let (inbound_tx, inbound_rx) = mpsc::channel(16);
+        let remote_addr = SocketAddr::new(Ipv4Addr::new(10, 99, 99, 2).into(), 50002);
+
+        let mut key = [0u8; 16];
+        crate::config::GlobalRng::fill_bytes(&mut key);
+        let cipher = Aes128Gcm::new(&key.into());
+        let keypair = TransportKeypair::new();
+
+        let sent_tracker = Arc::new(parking_lot::Mutex::new(
+            SentPacketTracker::new_with_time_source(time_source.clone()),
+        ));
+        let congestion_controller =
+            crate::transport::congestion_control::CongestionControlConfig::default()
+                .build_arc_with_time_source(time_source.clone());
+        let token_bucket = Arc::new(TokenBucket::new_with_time_source(
+            10_000,
+            10_000_000,
+            time_source.clone(),
+        ));
+        let socket = Arc::new(TestSocket::new(
+            mpsc::channel::<(SocketAddr, Arc<[u8]>)>(16).0,
+        ));
+
+        let rolling_rtt_stats = crate::transport::rolling_rtt_stats::RollingRttStatsHandle::new(
+            remote_addr,
+            time_source.clone(),
+        );
+        let remote_conn = RemoteConnection {
+            outbound_symmetric_key: cipher.clone(),
+            remote_addr,
+            sent_tracker,
+            last_packet_id: Arc::new(AtomicU32::new(0)),
+            inbound_packet_recv: inbound_rx,
+            inbound_symmetric_key: cipher.clone(),
+            inbound_symmetric_key_bytes: key,
+            my_address: None,
+            transport_secret_key: keypair.secret,
+            congestion_controller,
+            token_bucket,
+            socket,
+            global_bandwidth: None,
+            rolling_rtt_stats,
+            time_source: time_source.clone(),
+        };
+
+        // Build the encrypted Pong (sequence 7) and a trailing ShortMessage.
+        // The Pong handler does not make `recv()` return (it produces no
+        // message), so the ShortMessage gives the loop a value to yield once
+        // the Pong has been processed.
+        let pong_seq = 7u64;
+        let pong = SymmetricMessage::serialize_msg_to_packet_data(
+            1,
+            SymmetricMessagePayload::Pong { sequence: pong_seq },
+            &cipher,
+            vec![],
+        )
+        .expect("encrypt pong");
+        let pong_packet =
+            PacketData::<crate::transport::packet_data::UnknownEncryption>::from_buf(pong.data());
+
+        let short = SymmetricMessage::serialize_msg_to_packet_data(
+            2,
+            SymmetricMessagePayload::ShortMessage {
+                payload: Bytes::from_static(b"done"),
+            },
+            &cipher,
+            vec![],
+        )
+        .expect("encrypt short");
+        let short_packet =
+            PacketData::<crate::transport::packet_data::UnknownEncryption>::from_buf(short.data());
+
+        let mut conn = PeerConnection::new(remote_conn);
+
+        // Advance past zero before seeding so the ping's send timestamp is
+        // strictly positive. The recv loop's stale-ping cleanup retains only
+        // pings with `sent_at_nanos > now_nanos - idle_timeout`; at small mock
+        // times that threshold saturates to 0, so a ping stamped at exactly 0
+        // would be pruned before the Pong arrives. Stamp at 10 ms, then
+        // advance another 50 ms so the round-trip is a deterministic 50 ms.
+        time_source.advance_time(Duration::from_millis(10));
+        let send_nanos = time_source.now_nanos();
+        conn.pending_pings.write().insert(pong_seq, send_nanos);
+        time_source.advance_time(Duration::from_millis(50));
+
+        let samples_before = crate::transport::TRANSPORT_METRICS.rtt_sample_count();
+
+        inbound_tx.send(pong_packet).await.expect("send pong");
+        inbound_tx.send(short_packet).await.expect("send short");
+
+        let _msg = conn.recv().await.expect("recv");
+
+        let samples_after = crate::transport::TRANSPORT_METRICS.rtt_sample_count();
+        assert!(
+            samples_after >= samples_before + 1,
+            "Pong for a pending ping must record at least one RTT sample \
+             (before={samples_before}, after={samples_after}). \
+             The keep-alive RTT path (#4000) is not wired up."
+        );
+
+        // The matching ping must have been consumed so it isn't sampled twice
+        // or treated as still-unanswered by the keep-alive backoff.
+        assert!(
+            !conn.pending_pings.read().contains_key(&pong_seq),
+            "Pong must remove the matching pending ping"
+        );
+
         crate::transport::TRANSPORT_METRICS.remove_peer(remote_addr);
     }
 


### PR DESCRIPTION
## Problem

`TransportMetrics::record_rtt_sample` was only reachable from `record_transfer_completed`, which fires on stream-transfer completion. Connections that exchange only keep-alive / control / small-contract traffic for hours never complete a stream transfer, so they contributed **zero RTT samples**. The dashboard / telemetry RTT statistics (`min_rtt_us`, `max_rtt_us`, `avg_rtt_us`) under-represented quiet connections.

This is the same class of undercounting as the per-peer SENT/RECV bug fixed in #3996: a metric that should reflect ongoing connection health was tied to a low-frequency event.

## Approach

The ping/pong keep-alive cycle already records each Ping's send timestamp in `pending_pings` (`sequence -> nanos`). The Pong handler already removed the matching entry on receipt but **discarded** the timestamp. The fix captures it, computes the round-trip against the same `time_source`, and records an RTT sample. The keep-alive cycle runs on every connection regardless of stream traffic, so RTT statistics now stay populated for quiet, long-lived connections.

- `record_rtt_sample` widened from private to `pub(crate)` so the connection layer can call it (it was already the shared sink used by the stream-completion path).
- The `rtt_us > 0` guard mirrors the existing stream-completion path.
- The `pending_pings` write lock is released before recording the sample.
- No new attack surface: a Pong only yields a sample if it matches a sequence **we** pinged (we control `pending_pings`); unsolicited/replayed Pongs find no entry and record nothing.

This is observation-only and does not feed congestion control — the shadow-RTT system in #4074 remains the path for that.

## Testing

New regression test `pong_records_rtt_sample_from_keepalive_cycle` drives an encrypted Pong through the real `recv()` path after seeding a pending ping, then asserts the global RTT sample counter advances and the matching ping is consumed.

- Verified it **FAILS** without the fix (`record_rtt_sample` disabled → zero samples) and **PASSES** with it.
- Full transport lib suite: 607 passed, 0 failed.
- `cargo clippy --locked -- -D warnings` clean.

Closes #4000

[AI-assisted - Claude]