### PR TITLE
fix: refresh webapp cache on ?__sandbox=1 and subresource requests

### DIFF
--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -199,7 +199,7 @@ async fn web_home(
         .unwrap_or(false);
 
     if is_sandbox {
-        return serve_sandbox_response(key, api_version, None, &req_headers).await;
+        return serve_sandbox_response(key, api_version, None, &req_headers, rs).await;
     }
 
     // Shell page: generate auth token, serve iframe wrapper with CSP
@@ -269,7 +269,14 @@ async fn web_subpages(
     // For sandbox sub-page requests to HTML files, serve through the sandbox
     // content pipeline (with WebSocket shim + navigation interceptor injected).
     if is_sandbox && is_html_page(&last_path) {
-        return serve_sandbox_response(key, api_version, Some(&last_path), &req_headers).await;
+        return serve_sandbox_response(
+            key,
+            api_version,
+            Some(&last_path),
+            &req_headers,
+            request_sender,
+        )
+        .await;
     }
 
     // Top-level document loads of contract HTML sub-paths (pasted URLs,
@@ -440,6 +447,7 @@ async fn serve_sandbox_response(
     api_version: ApiVersion,
     sub_path: Option<&str>,
     req_headers: &axum::http::HeaderMap,
+    request_sender: HttpClientApiRequest,
 ) -> Result<axum::response::Response, WebSocketApiError> {
     // Block top-level navigation to sandbox URLs. Sec-Fetch-Dest: iframe is set
     // by the browser automatically and cannot be spoofed by scripts.
@@ -452,7 +460,7 @@ async fn serve_sandbox_response(
     }
 
     let contract_response =
-        path_handlers::serve_sandbox_content(key, api_version, sub_path).await?;
+        path_handlers::serve_sandbox_content(key, api_version, sub_path, request_sender).await?;
     let mut response = contract_response.into_response();
     add_sandbox_cors_headers(&mut response);
     // See `sandbox_csp_for_origin` for why we interpolate a concrete origin
@@ -945,7 +953,7 @@ mod tests {
         // top-level-document redirect inside `web_subpages`. Both
         // markers are unique to that function.
         let sandbox_idx = src
-            .find("serve_sandbox_response(key, api_version, Some(&last_path)")
+            .find("if is_sandbox && is_html_page(&last_path) {")
             .expect("sandbox short-circuit marker present in web_subpages");
         let redirect_idx = src
             .find("should_redirect_subpage_to_shell(is_sandbox")

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -165,8 +165,12 @@ async fn refresh_cache_if_due(
     // Slow path: refresh looks due. Serialize concurrent refreshers for this
     // contract so only the first issues a GET; the rest re-check below.
     let _guard = acquire_refresh_lock(&instance_id).await;
-    if cache_warm && cache_reconciled_recently(&instance_id) {
-        // A concurrent refresher completed while we waited for the lock.
+    // Re-check on the timer alone (not the pre-lock `cache_warm` snapshot): a
+    // concurrent refresher that completed while we waited recorded a fresh
+    // timer AND populated the cache via `ensure_contract_cached`, so a fresh
+    // timer means there is nothing left to do even if our snapshot saw the
+    // cache as cold.
+    if cache_reconciled_recently(&instance_id) {
         return Ok(());
     }
 

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -84,6 +84,37 @@ const CONTRACT_CACHE_REFRESH_TTL: Duration = Duration::from_secs(30);
 static CONTRACT_CACHE_REFRESH: LazyLock<DashMap<ContractInstanceId, Instant>> =
     LazyLock::new(DashMap::new);
 
+/// Per-contract lock serializing the *decision* to issue a staleness-refresh
+/// GET, so a fan-out of concurrent subresource requests after the TTL expiry
+/// issues at most one `ensure_contract_cached` GET per contract per window.
+///
+/// This is deliberately distinct from `CONTRACT_CACHE_LOCKS`: that lock guards
+/// the on-disk unpack and is re-taken inside `unpack_if_stale`. `tokio`'s mutex
+/// is not reentrant, so the refresh gate — which is held *across* the GET (and
+/// therefore across `unpack_if_stale`'s own lock acquisition) — must use its
+/// own mutex to avoid a self-deadlock.
+static CONTRACT_REFRESH_LOCKS: LazyLock<DashMap<ContractInstanceId, Arc<tokio::sync::Mutex<()>>>> =
+    LazyLock::new(DashMap::new);
+
+async fn acquire_refresh_lock(
+    instance_id: &ContractInstanceId,
+) -> tokio::sync::OwnedMutexGuard<()> {
+    let mutex = CONTRACT_REFRESH_LOCKS
+        .entry(*instance_id)
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone();
+    mutex.lock_owned().await
+}
+
+/// True if the contract was reconciled against the network within the last
+/// `CONTRACT_CACHE_REFRESH_TTL`. A missing timer reads as not-fresh.
+fn cache_reconciled_recently(instance_id: &ContractInstanceId) -> bool {
+    CONTRACT_CACHE_REFRESH
+        .get(instance_id)
+        .map(|last| last.elapsed() < CONTRACT_CACHE_REFRESH_TTL)
+        .unwrap_or(false)
+}
+
 /// Ensures the contract's webapp cache is populated and not stale before it is
 /// served from disk.
 ///
@@ -96,10 +127,28 @@ static CONTRACT_CACHE_REFRESH: LazyLock<DashMap<ContractInstanceId, Instant>> =
 /// the `?__sandbox=1` and subresource paths pick up a republished bundle
 /// without requiring a prior hit on the shell root. See #3977.
 ///
+/// # Concurrency
+///
+/// A typical page load fans out several concurrent subresource requests. To
+/// keep the "at most one network GET per contract per window" bound under that
+/// fan-out, the refresh decision uses double-checked locking against the
+/// dedicated per-contract `CONTRACT_REFRESH_LOCKS` mutex:
+///
+/// 1. A lock-free freshness check fast-paths the common warm-and-fresh case so
+///    steady-state requests never contend on the lock.
+/// 2. When a refresh looks due, the refresh lock is taken and the timer is
+///    re-checked. The first holder fetches and updates the timer; every
+///    follower that queued behind it observes the fresh timer and returns
+///    without issuing its own GET. Without this gate, a burst of requests
+///    arriving just after the TTL expiry would each fire a redundant GET.
+///
+/// The refresh lock is intentionally NOT `CONTRACT_CACHE_LOCKS`: the latter is
+/// re-acquired inside `unpack_if_stale`, and `tokio`'s mutex is not reentrant,
+/// so holding it across the GET would self-deadlock.
+///
 /// The refresh timer is only advanced on success, so a transient fetch failure
-/// does not suppress the next request's retry. `ensure_contract_cached` already
-/// serializes the actual unpack via `CONTRACT_CACHE_LOCKS` and skips the disk
-/// rewrite when the state hash is unchanged (`unpack_if_stale`).
+/// does not suppress the next request's retry. `ensure_contract_cached` skips
+/// the disk rewrite when the state hash is unchanged (`unpack_if_stale`).
 async fn refresh_cache_if_due(
     instance_id: ContractInstanceId,
     request_sender: &HttpClientApiRequest,
@@ -107,17 +156,18 @@ async fn refresh_cache_if_due(
     let hash_path = state_hash_path(&instance_id);
     let cache_warm = tokio::fs::try_exists(&hash_path).await.unwrap_or(false);
 
-    if cache_warm {
-        // Warm cache: only re-fetch if the TTL window has elapsed. Reading the
-        // timer (not removing it) keeps concurrent requests cheap — at most one
-        // will observe the window as expired and refresh.
-        let fresh = CONTRACT_CACHE_REFRESH
-            .get(&instance_id)
-            .map(|last| last.elapsed() < CONTRACT_CACHE_REFRESH_TTL)
-            .unwrap_or(false);
-        if fresh {
-            return Ok(());
-        }
+    // Fast path: a warm cache reconciled within the TTL needs no work and must
+    // not contend on the refresh lock.
+    if cache_warm && cache_reconciled_recently(&instance_id) {
+        return Ok(());
+    }
+
+    // Slow path: refresh looks due. Serialize concurrent refreshers for this
+    // contract so only the first issues a GET; the rest re-check below.
+    let _guard = acquire_refresh_lock(&instance_id).await;
+    if cache_warm && cache_reconciled_recently(&instance_id) {
+        // A concurrent refresher completed while we waited for the lock.
+        return Ok(());
     }
 
     ensure_contract_cached(instance_id, request_sender, None).await?;
@@ -1835,6 +1885,7 @@ mod tests {
             .await
             .ok();
         CONTRACT_CACHE_REFRESH.remove(instance_id);
+        CONTRACT_REFRESH_LOCKS.remove(instance_id);
     }
 
     /// Regression test for #3940. `variable_content` must trigger a network
@@ -2139,6 +2190,124 @@ mod tests {
         expect_fetch_pair(&mut rx, instance_id).await;
 
         handler.abort();
+        clear_cache(&instance_id).await;
+    }
+
+    /// Services one transient client connection's worth of
+    /// `ensure_contract_cached` traffic: replies to `NewConnection` with a
+    /// fresh client id, then answers the `Get` with a successful `GetResponse`
+    /// whose state hashes to the value already on disk. Because the on-disk
+    /// `{key}.hash` matches, `unpack_if_stale` returns early (no `WebApp`
+    /// unpack needed), so the refresh succeeds and records the timer.
+    ///
+    /// Both replies go on the `callbacks` sender from `NewConnection` — that is
+    /// the `response_recv` end `ensure_contract_cached` reads from.
+    async fn serve_one_get(
+        rx: &mut tokio::sync::mpsc::Receiver<ClientConnection>,
+        contract: &ContractContainer,
+        state: &WrappedState,
+    ) {
+        let msg = rx.recv().await.expect("leader must issue NewConnection");
+        let callbacks = match msg {
+            ClientConnection::NewConnection { callbacks, .. } => callbacks,
+            other => panic!("expected NewConnection, got: {other:?}"),
+        };
+        callbacks
+            .send(HostCallbackResult::NewId {
+                id: crate::client_events::ClientId::next(),
+            })
+            .expect("callback receiver live");
+        let get = rx.recv().await.expect("Get must follow NewConnection");
+        match get {
+            ClientConnection::Request { req, .. } => assert!(
+                matches!(
+                    req.as_ref(),
+                    ClientRequest::ContractOp(ContractRequest::Get { .. })
+                ),
+                "expected Get, got: {req:?}"
+            ),
+            other => panic!("expected Get request, got: {other:?}"),
+        }
+        callbacks
+            .send(HostCallbackResult::Result {
+                id: crate::client_events::ClientId::next(),
+                result: Ok(HostResponse::ContractResponse(
+                    ContractResponse::GetResponse {
+                        key: contract.key(),
+                        contract: Some(contract.clone()),
+                        state: state.clone(),
+                    },
+                )),
+            })
+            .expect("callback receiver live for GetResponse");
+        // Drain the trailing Disconnect the handler sends on the way out.
+        let _ = rx.recv().await;
+    }
+
+    /// Concurrency regression for the Codex review finding on #3977: a fan-out
+    /// of simultaneous requests on a warm-but-stale cache must issue exactly
+    /// ONE network GET per contract per window, not one per request.
+    ///
+    /// Runs the real `refresh_cache_if_due` end-to-end. The leader's GET is
+    /// answered with a `GetResponse` whose state hash matches the on-disk
+    /// `{key}.hash`, so `unpack_if_stale` returns early, the leader records the
+    /// refresh timer, and every follower that queued behind the refresh lock
+    /// re-checks, sees the fresh timer, and skips its own GET. The receiver
+    /// services exactly one `Get`, then asserts the channel closes with no
+    /// second `NewConnection`.
+    #[tokio::test]
+    async fn refresh_cache_if_due_coalesces_concurrent_refreshes() {
+        // Derive the instance id FROM a real contract so the GetResponse key
+        // matches and `unpack_if_stale` takes its matching-hash early return.
+        let contract = ContractContainer::Wasm(ContractWasmAPIVersion::V1(WrappedContract::new(
+            Arc::new(ContractCode::from(vec![1, 2, 3, 4])),
+            Parameters::from(vec![5, 6]),
+        )));
+        let instance_id = *contract.key().id();
+        let state = WrappedState::new(vec![9, 9, 9]);
+        clear_cache(&instance_id).await;
+
+        // Warm cache whose stored hash matches the state we'll return, so the
+        // refresh succeeds without an actual unpack. No fresh timer ⇒ due.
+        let cache_dir = contract_web_path(&instance_id);
+        tokio::fs::create_dir_all(&cache_dir).await.unwrap();
+        let matching_hash = hash_state(state.as_ref());
+        tokio::fs::write(state_hash_path(&instance_id), matching_hash.to_be_bytes())
+            .await
+            .unwrap();
+
+        // Shared channel so a single receiver observes every caller's traffic.
+        let (sender, mut rx) = request_channel();
+        let mut handlers = Vec::new();
+        for _ in 0..8 {
+            let sender = sender.clone();
+            handlers.push(tokio::spawn(async move {
+                refresh_cache_if_due(instance_id, &sender).await.map(|_| ())
+            }));
+        }
+        drop(sender); // channel closes once all 8 handlers finish.
+
+        // Service exactly one GET (the leader's). Every follower coalesces.
+        serve_one_get(&mut rx, &contract, &state).await;
+
+        // After the single served GET, no further NewConnection may appear:
+        // a second one would mean a follower issued a redundant GET.
+        let mut extra = 0;
+        while let Some(msg) = rx.recv().await {
+            if matches!(msg, ClientConnection::NewConnection { .. }) {
+                extra += 1;
+            }
+        }
+        assert_eq!(
+            extra, 0,
+            "concurrent refreshers must coalesce to a single GET; saw {extra} extra"
+        );
+
+        for h in handlers {
+            h.await
+                .expect("handler must not panic")
+                .expect("refresh must succeed");
+        }
         clear_cache(&instance_id).await;
     }
 

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -13,6 +13,7 @@
 use std::{
     path::{Path, PathBuf},
     sync::{Arc, LazyLock},
+    time::Duration,
 };
 
 use axum::response::{Html, IntoResponse};
@@ -21,6 +22,7 @@ use freenet_stdlib::{
     client_api::{ClientRequest, ContractRequest, ContractResponse, HostResponse},
     prelude::*,
 };
+use tokio::time::Instant;
 use tokio::{fs::File, io::AsyncReadExt, sync::mpsc};
 
 use crate::client_events::AuthToken;
@@ -56,6 +58,73 @@ async fn acquire_cache_lock(instance_id: &ContractInstanceId) -> tokio::sync::Ow
     mutex.lock_owned().await
 }
 
+/// How long a contract's extracted webapp cache is trusted before the next
+/// request reconciles it against current network state.
+///
+/// `serve_sandbox_content` (the `?__sandbox=1` iframe handler) and
+/// `variable_content` (subresource handler) both serve from the on-disk cache.
+/// Without a freshness check, a republished contract keeps serving the old
+/// bundle on these paths until the shell root (`/`) is hit again — only
+/// `contract_home` unconditionally re-fetches. See #3977.
+///
+/// A short TTL re-runs `ensure_contract_cached` periodically. The actual
+/// re-extraction still only happens when the state hash changed (see
+/// `unpack_if_stale`), so the cost of a same-state refresh is one network GET,
+/// not a disk rewrite. 30s keeps the publish-then-verify loop snappy while
+/// bounding the GET rate to at most one per contract per window.
+const CONTRACT_CACHE_REFRESH_TTL: Duration = Duration::from_secs(30);
+
+/// Last time each contract's cache was reconciled against the network via
+/// `ensure_contract_cached`. Used to gate the TTL refresh so the sandbox and
+/// subresource paths don't issue a network GET on every request.
+///
+/// Like `CONTRACT_CACHE_LOCKS`, entries are retained for the process lifetime;
+/// each is a single `Instant`, so the footprint is bounded by the number of
+/// distinct web contracts the node has served.
+static CONTRACT_CACHE_REFRESH: LazyLock<DashMap<ContractInstanceId, Instant>> =
+    LazyLock::new(DashMap::new);
+
+/// Ensures the contract's webapp cache is populated and not stale before it is
+/// served from disk.
+///
+/// Calls `ensure_contract_cached` when either:
+/// - the cache is cold (no `{key}.hash` file on disk), or
+/// - more than `CONTRACT_CACHE_REFRESH_TTL` has elapsed since the last
+///   reconciliation for this contract.
+///
+/// On a successful refresh the per-contract timer is reset. This is what makes
+/// the `?__sandbox=1` and subresource paths pick up a republished bundle
+/// without requiring a prior hit on the shell root. See #3977.
+///
+/// The refresh timer is only advanced on success, so a transient fetch failure
+/// does not suppress the next request's retry. `ensure_contract_cached` already
+/// serializes the actual unpack via `CONTRACT_CACHE_LOCKS` and skips the disk
+/// rewrite when the state hash is unchanged (`unpack_if_stale`).
+async fn refresh_cache_if_due(
+    instance_id: ContractInstanceId,
+    request_sender: &HttpClientApiRequest,
+) -> Result<(), WebSocketApiError> {
+    let hash_path = state_hash_path(&instance_id);
+    let cache_warm = tokio::fs::try_exists(&hash_path).await.unwrap_or(false);
+
+    if cache_warm {
+        // Warm cache: only re-fetch if the TTL window has elapsed. Reading the
+        // timer (not removing it) keeps concurrent requests cheap — at most one
+        // will observe the window as expired and refresh.
+        let fresh = CONTRACT_CACHE_REFRESH
+            .get(&instance_id)
+            .map(|last| last.elapsed() < CONTRACT_CACHE_REFRESH_TTL)
+            .unwrap_or(false);
+        if fresh {
+            return Ok(());
+        }
+    }
+
+    ensure_contract_cached(instance_id, request_sender, None).await?;
+    CONTRACT_CACHE_REFRESH.insert(instance_id, Instant::now());
+    Ok(())
+}
+
 #[instrument(level = "debug", skip(request_sender))]
 pub(super) async fn contract_home(
     key: String,
@@ -80,6 +149,10 @@ pub(super) async fn contract_home(
         Some((assigned_token.clone(), instance_id)),
     )
     .await?;
+    // Record the reconciliation so the iframe load that immediately follows
+    // (`?__sandbox=1`) and any subresource fetches reuse this fresh state
+    // instead of issuing their own redundant GET within the TTL window.
+    CONTRACT_CACHE_REFRESH.insert(instance_id, Instant::now());
 
     // Return the shell page instead of the contract HTML directly.
     // The shell page wraps the contract in a sandboxed iframe for
@@ -315,22 +388,16 @@ pub(super) async fn variable_content(
     let base_path = contract_web_path(&instance_id);
     debug!("variable_content: Base path resolved to: {:?}", base_path);
 
-    // Fetch + unpack the contract if its cache is cold. Without this, any
-    // request for a subresource (e.g. an <img src> pointing at this contract
-    // from a different webapp) would 404 because the cache is only populated
-    // by the shell-root handler (`contract_home`). See #3940.
-    //
-    // The hash file is written last by `unpack_if_stale`, so its presence is
-    // a reliable marker that a prior unpack completed successfully.
-    let hash_path = state_hash_path(&instance_id);
-    if tokio::fs::try_exists(&hash_path).await.unwrap_or(false) {
-        debug!("variable_content: Cache already populated, serving from disk");
-    } else {
-        debug!("variable_content: Cache miss, fetching contract before serving");
-        ensure_contract_cached(instance_id, &request_sender, None)
-            .await
-            .map_err(Box::new)?;
-    }
+    // Fetch + unpack the contract if its cache is cold OR stale. Without the
+    // cold-cache fetch, any subresource request (e.g. an <img src> pointing at
+    // this contract from a different webapp) would 404 because the cache is
+    // only populated by the shell-root handler (`contract_home`). See #3940.
+    // The TTL-gated staleness refresh additionally picks up a republished
+    // bundle on this path without requiring a prior hit on the shell root.
+    // See #3977.
+    refresh_cache_if_due(instance_id, &request_sender)
+        .await
+        .map_err(Box::new)?;
 
     // Parse the full request path URI to extract the relative path using the v1 helper.
     let req_uri =
@@ -491,11 +558,12 @@ fn shell_page(
 ///
 /// The `sub_path` parameter allows serving pages other than `index.html` for
 /// multi-page websites. When `None`, defaults to `index.html`.
-#[instrument(level = "debug")]
+#[instrument(level = "debug", skip(request_sender))]
 pub(super) async fn serve_sandbox_content(
     key: String,
     api_version: ApiVersion,
     sub_path: Option<&str>,
+    request_sender: HttpClientApiRequest,
 ) -> Result<impl IntoResponse, WebSocketApiError> {
     let page = sub_path.unwrap_or("index.html");
     debug!("serve_sandbox_content: serving iframe content for key: {key}, page: {page}");
@@ -503,6 +571,14 @@ pub(super) async fn serve_sandbox_content(
         ContractInstanceId::from_bytes(&key).map_err(|err| WebSocketApiError::InvalidParam {
             error_cause: format!("{err}"),
         })?;
+
+    // Reconcile the on-disk cache against current network state before serving.
+    // Previously this path only checked `path.exists()` and served whatever was
+    // already extracted, so a republished contract kept serving the old bundle
+    // here until the shell root (`/`) was hit again. The TTL gate bounds the
+    // network GET rate to at most one per contract per window. See #3977.
+    refresh_cache_if_due(instance_id, &request_sender).await?;
+
     let path = contract_web_path(&instance_id);
     if !path.exists() {
         return Err(WebSocketApiError::NodeError {
@@ -1747,6 +1823,10 @@ mod tests {
     /// and `state_hash_path` resolve to a shared process-global directory, so
     /// tests that exercise the cache must use unique keys AND scrub any stale
     /// filesystem residue from a prior run before asserting on behaviour.
+    ///
+    /// Also drops the in-memory `CONTRACT_CACHE_REFRESH` timer (process-global,
+    /// like the on-disk cache) so a stale timer from a prior run doesn't flip a
+    /// cold-cache assertion into a warm/fresh one.
     async fn clear_cache(instance_id: &ContractInstanceId) {
         tokio::fs::remove_file(state_hash_path(instance_id))
             .await
@@ -1754,6 +1834,7 @@ mod tests {
         tokio::fs::remove_dir_all(contract_web_path(instance_id))
             .await
             .ok();
+        CONTRACT_CACHE_REFRESH.remove(instance_id);
     }
 
     /// Regression test for #3940. `variable_content` must trigger a network
@@ -1839,11 +1920,11 @@ mod tests {
     }
 
     /// Companion to `variable_content_triggers_fetch_on_cache_miss`: when the
-    /// hash file is present (the signal that a prior unpack completed), the
-    /// handler must NOT issue a fetch. This pins the cache-hit fast path and
-    /// prevents a regression where every subpath request would re-fetch.
+    /// hash file is present AND the contract was reconciled within the refresh
+    /// TTL, the handler must NOT issue a fetch. This pins the cache-hit fast
+    /// path and prevents a regression where every subpath request re-fetches.
     #[tokio::test]
-    async fn variable_content_skips_fetch_when_cache_present() {
+    async fn variable_content_skips_fetch_when_cache_present_and_fresh() {
         let mut bytes = [0u8; 32];
         bytes[0] = 0x3a;
         bytes[1] = 0x41;
@@ -1860,6 +1941,8 @@ mod tests {
         tokio::fs::write(state_hash_path(&instance_id), 0u64.to_be_bytes())
             .await
             .unwrap();
+        // Mark the contract as just-reconciled so it falls inside the TTL window.
+        CONTRACT_CACHE_REFRESH.insert(instance_id, Instant::now());
 
         let (sender, mut rx) = request_channel();
         let result = variable_content(
@@ -1878,11 +1961,184 @@ mod tests {
         );
         assert!(
             rx.try_recv().is_err(),
-            "cache-hit path must not send any NewConnection/Get on the channel"
+            "fresh-cache path must not send any NewConnection/Get on the channel"
         );
 
         // Clean up last so a failed assertion above doesn't leave residue
         // that flips the next run's cold-cache check into warm-cache state.
+        clear_cache(&instance_id).await;
+    }
+
+    /// Drives `serve_sandbox_content` (or `variable_content`) to the point
+    /// where it has emitted its `NewConnection` + `Get` pair on the channel,
+    /// asserting the contract key on the `Get`, then aborts the in-flight
+    /// fetch. Returns once both messages have been observed.
+    ///
+    /// Replies to the `NewConnection` callback with a synthetic client id so
+    /// the handler progresses past its blocking `NewId` recv to the `Get`.
+    async fn expect_fetch_pair(
+        rx: &mut tokio::sync::mpsc::Receiver<ClientConnection>,
+        instance_id: ContractInstanceId,
+    ) {
+        let new_conn = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("handler must send NewConnection when a refresh is due")
+            .expect("channel must remain open for the duration of the send");
+        let callbacks = match new_conn {
+            ClientConnection::NewConnection { callbacks, .. } => callbacks,
+            other => panic!("first message must be NewConnection, got: {other:?}"),
+        };
+        callbacks
+            .send(HostCallbackResult::NewId {
+                id: crate::client_events::ClientId::next(),
+            })
+            .expect("callback receiver must be live while handler awaits NewId");
+
+        let get_req = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("handler must follow up with a Get request")
+            .expect("channel must remain open");
+        match get_req {
+            ClientConnection::Request { req, .. } => {
+                assert!(
+                    matches!(
+                        req.as_ref(),
+                        ClientRequest::ContractOp(ContractRequest::Get { key: k, .. })
+                            if *k == instance_id
+                    ),
+                    "second message must be Get({instance_id}), got: {req:?}"
+                );
+            }
+            other => panic!("expected ClientConnection::Request, got: {other:?}"),
+        }
+    }
+
+    /// Regression test for #3977. `serve_sandbox_content` (the `?__sandbox=1`
+    /// iframe handler) must reconcile the on-disk cache against current network
+    /// state, NOT serve blindly from disk.
+    ///
+    /// Before the fix, this handler only checked `path.exists()` and served the
+    /// already-extracted bundle, so a republished contract kept serving the old
+    /// bundle on the iframe path until the shell root (`/`) was hit again.
+    ///
+    /// Here the cache is warm (hash file + index.html on disk) but has never
+    /// been reconciled (`CONTRACT_CACHE_REFRESH` has no entry), so a refresh is
+    /// due and the handler must emit the `NewConnection` + `Get` fetch pair.
+    /// The pre-fix code sent nothing on the channel.
+    #[tokio::test]
+    async fn serve_sandbox_content_triggers_refresh_when_stale() {
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0x3a;
+        bytes[1] = 0x44;
+        let instance_id = ContractInstanceId::new(bytes);
+        let key = instance_id.to_string();
+        clear_cache(&instance_id).await;
+
+        // Warm but unreconciled cache: hash file present, but no refresh timer.
+        let cache_dir = contract_web_path(&instance_id);
+        tokio::fs::create_dir_all(&cache_dir).await.unwrap();
+        tokio::fs::write(cache_dir.join("index.html"), b"<html>old bundle</html>")
+            .await
+            .unwrap();
+        tokio::fs::write(state_hash_path(&instance_id), 0u64.to_be_bytes())
+            .await
+            .unwrap();
+
+        let (sender, mut rx) = request_channel();
+        let handler = {
+            let key = key.clone();
+            tokio::spawn(async move {
+                serve_sandbox_content(key.clone(), ApiVersion::V1, None, sender)
+                    .await
+                    .map(|_| ())
+            })
+        };
+
+        expect_fetch_pair(&mut rx, instance_id).await;
+
+        handler.abort();
+        clear_cache(&instance_id).await;
+    }
+
+    /// Companion to the above: once `serve_sandbox_content` has reconciled a
+    /// contract within the TTL window, a subsequent request must serve from
+    /// disk WITHOUT issuing another fetch. Pins the TTL fast path so the iframe
+    /// load doesn't do a network round-trip on every request.
+    #[tokio::test]
+    async fn serve_sandbox_content_skips_refresh_when_fresh() {
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0x3a;
+        bytes[1] = 0x45;
+        let instance_id = ContractInstanceId::new(bytes);
+        let key = instance_id.to_string();
+        clear_cache(&instance_id).await;
+
+        let cache_dir = contract_web_path(&instance_id);
+        tokio::fs::create_dir_all(&cache_dir).await.unwrap();
+        tokio::fs::write(cache_dir.join("index.html"), b"<html>fresh bundle</html>")
+            .await
+            .unwrap();
+        tokio::fs::write(state_hash_path(&instance_id), 0u64.to_be_bytes())
+            .await
+            .unwrap();
+        // Reconciled just now: inside the TTL window.
+        CONTRACT_CACHE_REFRESH.insert(instance_id, Instant::now());
+
+        let (sender, mut rx) = request_channel();
+        let result = serve_sandbox_content(key.clone(), ApiVersion::V1, None, sender).await;
+
+        let response = result.expect("fresh-cache sandbox request must succeed");
+        let body = response_body(response).await;
+        assert!(
+            body.contains("fresh bundle"),
+            "fresh-cache path must serve the primed index.html, got: {body}"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "fresh-cache sandbox path must not send any NewConnection/Get on the channel"
+        );
+
+        clear_cache(&instance_id).await;
+    }
+
+    /// `refresh_cache_if_due` must treat a refresh timer older than
+    /// `CONTRACT_CACHE_REFRESH_TTL` as stale and re-fetch, even when the
+    /// on-disk cache is warm. This is the path that picks up a mid-session
+    /// republish (#3977 impact 3) once the TTL window elapses.
+    ///
+    /// Uses paused time so the TTL boundary is crossed deterministically by
+    /// `advance()` rather than wall-clock subtraction — `Instant::now()` on a
+    /// freshly-booted host can be too close to the monotonic origin for a
+    /// `checked_sub(TTL)` to succeed, which would make the test flaky.
+    #[tokio::test(start_paused = true)]
+    async fn refresh_cache_if_due_refetches_after_ttl_expires() {
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0x3a;
+        bytes[1] = 0x46;
+        let instance_id = ContractInstanceId::new(bytes);
+        clear_cache(&instance_id).await;
+
+        // Warm cache, reconciled "now" (paused clock base).
+        let cache_dir = contract_web_path(&instance_id);
+        tokio::fs::create_dir_all(&cache_dir).await.unwrap();
+        tokio::fs::write(state_hash_path(&instance_id), 0u64.to_be_bytes())
+            .await
+            .unwrap();
+        CONTRACT_CACHE_REFRESH.insert(instance_id, Instant::now());
+
+        // Advance past the TTL so the timer reads as stale.
+        tokio::time::advance(CONTRACT_CACHE_REFRESH_TTL + Duration::from_secs(1)).await;
+
+        let (sender, mut rx) = request_channel();
+        let handler =
+            tokio::spawn(
+                async move { refresh_cache_if_due(instance_id, &sender).await.map(|_| ()) },
+            );
+
+        // A stale timer must trigger a fetch despite the warm on-disk cache.
+        expect_fetch_pair(&mut rx, instance_id).await;
+
+        handler.abort();
         clear_cache(&instance_id).await;
     }
 

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -2315,6 +2315,77 @@ mod tests {
         clear_cache(&instance_id).await;
     }
 
+    /// Regression for the failure-path invariant: when `ensure_contract_cached`
+    /// returns an error, `refresh_cache_if_due` must NOT record a fresh timer,
+    /// so the next request retries instead of being suppressed for the TTL.
+    ///
+    /// Drives a real refresh whose GET is answered with a `contract: None`
+    /// `GetResponse` (which `handle_get_response` maps to `MissingContract`),
+    /// then asserts the call returned `Err` AND no timer was inserted. This
+    /// pins the "timer advances only on success" property the
+    /// `CONTRACT_CACHE_REFRESH.insert` placement after the `?` relies on —
+    /// hoisting the insert before the GET would silently break retries.
+    #[tokio::test]
+    async fn refresh_cache_if_due_does_not_record_timer_on_fetch_failure() {
+        let contract = ContractContainer::Wasm(ContractWasmAPIVersion::V1(WrappedContract::new(
+            Arc::new(ContractCode::from(vec![7, 7, 7, 7])),
+            Parameters::from(vec![8, 8]),
+        )));
+        let instance_id = *contract.key().id();
+        clear_cache(&instance_id).await;
+
+        // Warm but unreconciled cache so a refresh is due (and no timer yet).
+        let cache_dir = contract_web_path(&instance_id);
+        tokio::fs::create_dir_all(&cache_dir).await.unwrap();
+        tokio::fs::write(state_hash_path(&instance_id), 0u64.to_be_bytes())
+            .await
+            .unwrap();
+
+        let (sender, mut rx) = request_channel();
+        let handler = tokio::spawn(async move { refresh_cache_if_due(instance_id, &sender).await });
+
+        // Service the GET with a contract: None GetResponse → MissingContract.
+        let msg = rx.recv().await.expect("must issue NewConnection");
+        let callbacks = match msg {
+            ClientConnection::NewConnection { callbacks, .. } => callbacks,
+            other => panic!("expected NewConnection, got: {other:?}"),
+        };
+        callbacks
+            .send(HostCallbackResult::NewId {
+                id: crate::client_events::ClientId::next(),
+            })
+            .expect("callback receiver live");
+        let _get = rx.recv().await.expect("Get must follow NewConnection");
+        callbacks
+            .send(HostCallbackResult::Result {
+                id: crate::client_events::ClientId::next(),
+                result: Ok(HostResponse::ContractResponse(
+                    ContractResponse::GetResponse {
+                        key: contract.key(),
+                        contract: None,
+                        state: WrappedState::new(Vec::new()),
+                    },
+                )),
+            })
+            .expect("callback receiver live for GetResponse");
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), handler)
+            .await
+            .expect("handler must finish promptly")
+            .expect("handler must not panic");
+        assert!(
+            result.is_err(),
+            "a None-contract GetResponse must surface as an error, got: {result:?}"
+        );
+        assert!(
+            !CONTRACT_CACHE_REFRESH.contains_key(&instance_id),
+            "a failed refresh must NOT record a timer, or the next request would \
+             be suppressed for the whole TTL instead of retrying"
+        );
+
+        clear_cache(&instance_id).await;
+    }
+
     /// Direct unit test for `handle_get_response`'s `MissingContract`
     /// branch. Refactoring `handle_get_response` introduced this seam as a
     /// pure-logic boundary; covering each arm here catches regressions


### PR DESCRIPTION
## Problem

After a contract is republished, the gateway's local `webapp_cache/` keeps
serving the old extracted bundle on the iframe-content path. `serve_sandbox_content`
(the `?__sandbox=1` handler) read files straight from disk, checking only
`path.exists()` — it never reconciled disk state against the network. Only
`contract_home` (the `/` shell-root handler) unconditionally re-fetches via
`ensure_contract_cached`, so the new bundle only appeared after a fresh hit on `/`.

`variable_content` (subresource handler) had the same one-shot weakness: it fetched
only when the `{key}.hash` file was missing (cold cache), never when the on-disk
cache was stale.

Impact (per #3977):
1. Publisher verification papercut — `publish` succeeds on the network, but
   `curl ?__sandbox=1` shows the OLD bundle until `/` is hit, making a good
   publish look like a failure.
2. Cross-contract / direct iframe sources (PWA service worker, mobile webview,
   cached outer shell) that bypass `contract_home` serve stale content indefinitely.
3. Mid-session network updates don't reach an open iframe until the outer page reloads.

## Approach

Add a TTL-gated `refresh_cache_if_due` helper that calls the existing
`ensure_contract_cached` when either:
- the cache is cold (no `{key}.hash` on disk), or
- more than `CONTRACT_CACHE_REFRESH_TTL` (30s) has elapsed since the last
  reconciliation for that contract (tracked in a process-global
  `DashMap<ContractInstanceId, Instant>`, mirroring the existing
  `CONTRACT_CACHE_LOCKS` pattern).

`serve_sandbox_content` and `variable_content` both route through it.
`contract_home` records the refresh timestamp after its own fetch, so the iframe
load that immediately follows reuses the fresh state instead of issuing a redundant
GET within the window.

This is the issue's option 1 (cheapest) with the recommended in-memory TTL gate so
iframe loads don't take a network round-trip on every request. The actual
re-extraction still only happens when the state hash changed (`unpack_if_stale`
re-reads the hash under a per-contract mutex), so a same-state refresh costs one
network GET, not a disk rewrite, and the TTL bounds the GET rate to at most one per
contract per window. The timer is advanced only on a successful refresh, so a
transient fetch failure doesn't suppress the next request's retry.

## Testing

New `#[test]`s in `path_handlers.rs` (verified to fail before the fix by neutering
`refresh_cache_if_due`, then pass after):
- `serve_sandbox_content_triggers_refresh_when_stale` — warm-but-unreconciled cache
  emits the `NewConnection`+`Get` fetch pair (the core bug: pre-fix sent nothing).
- `serve_sandbox_content_skips_refresh_when_fresh` — inside the TTL window, serves
  from disk with no network round-trip.
- `refresh_cache_if_due_refetches_after_ttl_expires` — uses paused time + `advance()`
  to deterministically cross the TTL boundary and confirm a re-fetch.
- Updated `variable_content_skips_fetch_when_cache_present_and_fresh` for the new
  TTL semantics; the existing `variable_content_triggers_fetch_on_cache_miss` and
  `web_subpages_sandbox_branch_runs_before_redirect_branch` pin test still pass.

`cargo fmt`, `cargo clippy -p freenet --locked -- -D warnings`, and the full
`server::path_handlers` + `server::client_api` test suites are green.

Closes #3977

[AI-assisted - Claude]