### PR TITLE
fix: serve shell for deep-link reload of contract subpaths (#3841)

### DIFF
--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -190,8 +190,6 @@ async fn web_home(
     api_version: ApiVersion,
     query_string: Option<String>,
 ) -> Result<axum::response::Response, WebSocketApiError> {
-    use headers::{Header, HeaderMapExt};
-
     // Check if this is the sandboxed iframe requesting its content
     let is_sandbox = query_string
         .as_ref()
@@ -201,6 +199,31 @@ async fn web_home(
     if is_sandbox {
         return serve_sandbox_response(key, api_version, None, &req_headers, rs).await;
     }
+
+    // Root document load: render the shell that wraps the contract root.
+    render_shell_response(key, &config, api_version, query_string, None, rs).await
+}
+
+/// Generates a shell page response: a fresh auth token + secure cookie,
+/// the contract fetched/unpacked into the cache, and the iframe wrapper
+/// with the shell CSP and anti-framing headers.
+///
+/// Shared by `web_home` (root document loads, `sub_path = None`) and the
+/// deep-link branch of `web_subpages` (`sub_path = Some(path)` so a
+/// reloaded/bookmarked sub-page URL renders the shell pointed at that
+/// page instead of 404ing or being flattened to the contract root — see
+/// freenet/freenet-core#3841). Both must issue the SAME credentials and
+/// headers; factoring it here keeps the deep-link path from drifting out
+/// of sync with the root path (e.g. forgetting the cookie or the CSP).
+async fn render_shell_response(
+    key: String,
+    config: &Config,
+    api_version: ApiVersion,
+    query_string: Option<String>,
+    sub_path: Option<&str>,
+    rs: HttpClientApiRequest,
+) -> Result<axum::response::Response, WebSocketApiError> {
+    use headers::{Header, HeaderMapExt};
 
     // Shell page: generate auth token, serve iframe wrapper with CSP
     let token = AuthToken::generate();
@@ -219,7 +242,8 @@ async fn web_home(
 
     let token_header = headers::Authorization::bearer(token.as_str()).unwrap();
     let contract_response =
-        path_handlers::contract_home(key, rs, token.clone(), api_version, query_string).await?;
+        path_handlers::contract_home(key, rs, token.clone(), api_version, query_string, sub_path)
+            .await?;
 
     let mut response = contract_response.into_response();
     response.headers_mut().typed_insert(token_header);
@@ -259,6 +283,7 @@ async fn web_subpages(
     api_version: ApiVersion,
     query_string: Option<String>,
     req_headers: axum::http::HeaderMap,
+    config: &Config,
     request_sender: HttpClientApiRequest,
 ) -> Result<axum::response::Response, WebSocketApiError> {
     let is_sandbox = query_string
@@ -280,29 +305,40 @@ async fn web_subpages(
     }
 
     // Top-level document loads of contract HTML sub-paths (pasted URLs,
-    // bookmarks, cross-contract link clicks) must be redirected to the
-    // shell root so `web_home` issues a fresh auth token and wraps the
-    // response in the sandbox iframe. Otherwise `variable_content` serves
-    // raw HTML with no `authToken` query parameter, breaking webapps that
-    // read credentials from `location.search` (freenet/river#208 follow-up:
-    // Delta links hit "Connection failed" on the destination).
+    // bookmarks, cross-contract link clicks, deep-link reloads) must be
+    // served the shell page — NOT the raw contract HTML — so the response
+    // carries a fresh auth token + cookie and wraps the contract in the
+    // sandbox iframe. Otherwise `variable_content` serves raw HTML with no
+    // `authToken`, breaking webapps that read credentials from
+    // `location.search` (freenet/river#208: Delta links hit "Connection
+    // failed" on the destination).
     //
-    // The browser preserves any URL fragment across a 303 redirect, which
-    // is sufficient for hash-routed webapps (e.g. Delta). Path-based
-    // multi-page apps still lose the sub-path — this redirect restores
-    // the baseline guarantee that top-level contract loads get a working
-    // shell. A fuller fix for path-based deep linking (#3841) would
-    // thread the sub-path into shell generation.
+    // The sub-path is threaded into shell generation so the iframe's
+    // `data-src` points at `/{prefix}/contract/web/{key}/{sub_path}?__sandbox=1`,
+    // landing the in-iframe webapp on the requested route instead of the
+    // contract root. This is the fuller fix for path-based deep-link reload
+    // (#3841): previously this branch issued a 303 redirect to the shell
+    // root, which preserved URL fragments (enough for hash-routed apps like
+    // Delta) but flattened path-routed deep links to `/`. Rendering the
+    // shell in place preserves the path AND avoids the extra round-trip.
     //
     // Clients without `Sec-Fetch-Dest` (curl, older browsers) intentionally
     // fall through to `variable_content` — matches pre-PR behaviour and
-    // avoids redirect loops for non-browser clients.
+    // avoids changing the response shape for non-browser clients.
     let fetch_dest = req_headers
         .get("sec-fetch-dest")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
-    if should_redirect_subpage_to_shell(is_sandbox, &last_path, fetch_dest) {
-        return redirect_to_shell_root(&key, api_version, query_string.as_deref());
+    if should_serve_shell_for_subpage(is_sandbox, &last_path, fetch_dest) {
+        return render_shell_response(
+            key,
+            config,
+            api_version,
+            query_string,
+            Some(&last_path),
+            request_sender,
+        )
+        .await;
     }
 
     let version_prefix = api_version.prefix();
@@ -408,16 +444,19 @@ fn is_sensitive_query_param(param: &str) -> bool {
 }
 
 /// Returns true if a contract sub-path request is a top-level HTML
-/// document load that must be redirected to the shell root.
+/// document load that must be served the shell page (with the sub-path
+/// threaded into the iframe), rather than raw contract HTML.
 ///
 /// Only top-level document loads (`Sec-Fetch-Dest: document`) of HTML
-/// sub-paths are ambiguous with pasted URLs and cross-contract link
-/// clicks; redirecting them to `web_home` guarantees a fresh auth token
-/// and sandbox wrapper. The browser preserves any URL fragment across
-/// the redirect, which is sufficient for hash-routed webapps (e.g. Delta).
-/// Sandbox iframe requests (`__sandbox=1`) already flow through the
-/// sandbox pipeline and are never redirected here.
-fn should_redirect_subpage_to_shell(is_sandbox: bool, last_path: &str, fetch_dest: &str) -> bool {
+/// sub-paths are ambiguous with pasted URLs, bookmarks, cross-contract
+/// link clicks, and deep-link reloads; serving them the shell guarantees
+/// a fresh auth token + cookie and the sandbox wrapper while preserving
+/// the requested path in the iframe's `data-src` (#3841). Sandbox iframe
+/// requests (`__sandbox=1`) already flow through the sandbox pipeline and
+/// are never handled here. Sub-resource fetches (`Sec-Fetch-Dest` =
+/// `script`/`style`/`image`/`empty`/...) and non-HTML asset paths fall
+/// through to `variable_content` so real assets still 404 normally.
+fn should_serve_shell_for_subpage(is_sandbox: bool, last_path: &str, fetch_dest: &str) -> bool {
     !is_sandbox && is_html_page(last_path) && fetch_dest == "document"
 }
 
@@ -690,19 +729,20 @@ mod tests {
     }
 
     /// Regression test for cross-contract link handling (Delta report,
-    /// freenet/river#208 follow-up). Top-level HTML sub-path loads must
-    /// redirect to the shell root so `web_home` issues a fresh auth token;
-    /// before the fix these loads served raw HTML with no `authToken`.
+    /// freenet/river#208 follow-up) and deep-link reload (#3841). Top-level
+    /// HTML sub-path document loads must be served the shell page so the
+    /// response carries a fresh auth token; before the original fix these
+    /// loads served raw HTML with no `authToken`.
     #[test]
-    fn subpage_redirects_top_level_html_document_load_to_shell() {
-        assert!(should_redirect_subpage_to_shell(false, "page2", "document"));
-        assert!(should_redirect_subpage_to_shell(
+    fn subpage_serves_shell_for_top_level_html_document_load() {
+        assert!(should_serve_shell_for_subpage(false, "page2", "document"));
+        assert!(should_serve_shell_for_subpage(
             false,
             "about/team",
             "document"
         ));
-        assert!(should_redirect_subpage_to_shell(false, "news/", "document"));
-        assert!(should_redirect_subpage_to_shell(
+        assert!(should_serve_shell_for_subpage(false, "news/", "document"));
+        assert!(should_serve_shell_for_subpage(
             false,
             "index.html",
             "document"
@@ -710,30 +750,32 @@ mod tests {
     }
 
     #[test]
-    fn subpage_does_not_redirect_sub_resource_fetches() {
+    fn subpage_does_not_serve_shell_for_sub_resource_fetches() {
         // Non-HTML assets must be served so the page can load resources.
+        // These still fall through to `variable_content`, so a genuinely
+        // missing asset 404s as before (the fix must not mask real 404s).
         for path in ["app.js", "style.css", "app.wasm", "logo.png"] {
             assert!(
-                !should_redirect_subpage_to_shell(false, path, "document"),
-                "{path} must not be redirected"
+                !should_serve_shell_for_subpage(false, path, "document"),
+                "{path} must not be served the shell"
             );
         }
         // Only top-level document loads are ambiguous with pasted URLs and
-        // cross-contract clicks; iframe/xhr/fetch must never be redirected.
+        // cross-contract clicks; iframe/xhr/fetch must never be intercepted.
         for dest in ["iframe", "empty", "script", "style", "image", ""] {
             assert!(
-                !should_redirect_subpage_to_shell(false, "page2", dest),
-                "Sec-Fetch-Dest={dest} must not be redirected"
+                !should_serve_shell_for_subpage(false, "page2", dest),
+                "Sec-Fetch-Dest={dest} must not be served the shell"
             );
         }
     }
 
     #[test]
-    fn subpage_does_not_redirect_sandbox_requests() {
+    fn subpage_does_not_serve_shell_for_sandbox_requests() {
         // Sandbox iframe requests flow through the sandbox content pipeline;
-        // redirecting would break multi-page navigation inside the sandbox.
-        assert!(!should_redirect_subpage_to_shell(true, "page2", "iframe"));
-        assert!(!should_redirect_subpage_to_shell(true, "page2", "document"));
+        // intercepting would break multi-page navigation inside the sandbox.
+        assert!(!should_serve_shell_for_subpage(true, "page2", "iframe"));
+        assert!(!should_serve_shell_for_subpage(true, "page2", "document"));
     }
 
     /// A valid contract key used across redirect tests. Constructed from
@@ -847,55 +889,73 @@ mod tests {
         ));
     }
 
-    /// End-to-end regression: call `web_subpages` with the exact input
-    /// shape the Delta cross-contract-link failure mode produces, and
-    /// assert the handler responds with the shell-root redirect, the
-    /// filtered query string, and the 303 status.
+    /// A minimal localhost `Config` for handler tests (controls only the
+    /// cookie Secure flag).
+    fn localhost_config() -> Config {
+        Config { localhost: true }
+    }
+
+    /// End-to-end regression for #3841: a top-level document load of an
+    /// HTML sub-path must be served the SHELL page (rendered in place with
+    /// the sub-path threaded into the iframe), NOT a raw redirect to the
+    /// contract root and NOT raw contract HTML. Routing into the shell is
+    /// observable on the client-connection channel: `render_shell_response`
+    /// → `contract_home` → `ensure_contract_cached` emits a `NewConnection`
+    /// before any response is produced, whereas the old behaviour returned a
+    /// synchronous 303 without touching the channel.
     ///
     /// Pins the wiring the predicate-only tests do not reach: the
-    /// `Sec-Fetch-Dest` header lookup, the interaction with the query
-    /// string from `RawQuery`, the redirect URL construction, and the
-    /// full status + `Location` response contract.
+    /// `Sec-Fetch-Dest` header lookup, the `RawQuery` interaction, and the
+    /// branch selection in `web_subpages`. The full shell HTML (iframe
+    /// `data-src` carrying the sub-path) is asserted at the `contract_home`
+    /// layer in path_handlers.rs, which can prime the webapp cache.
     #[tokio::test]
-    async fn web_subpages_redirects_top_level_document_load_to_shell() {
+    async fn web_subpages_serves_shell_for_top_level_document_load() {
         let key = valid_contract_key_b58();
 
         // Case 1: top-level HTML document load of an HTML sub-path
-        // (non-sandbox, matching a pasted cross-contract link). Must
-        // redirect to shell root, preserving `invite` and stripping
-        // the attacker-supplied `authToken`.
+        // (non-sandbox — a pasted/bookmarked/reloaded deep link). Must
+        // route into the shell-render path. We observe the `NewConnection`
+        // the render emits on the channel, then abort before delivering a
+        // GetResponse to keep the test bounded.
         let mut headers = axum::http::HeaderMap::new();
         headers.insert("sec-fetch-dest", "document".parse().unwrap());
-        let resp = web_subpages(
-            key.clone(),
-            "page2".to_string(),
-            ApiVersion::V1,
-            Some("authToken=attacker&invite=abc".to_string()),
-            headers,
-            dead_request_sender(),
-        )
-        .await
-        .expect("redirect response must be Ok");
-        assert_eq!(resp.status(), axum::http::StatusCode::SEE_OTHER);
-        let loc = resp
-            .headers()
-            .get(axum::http::header::LOCATION)
-            .expect("Location header must be set on the redirect")
-            .to_str()
-            .unwrap()
-            .to_string();
-        assert_eq!(loc, format!("/v1/contract/web/{key}/?invite=abc"));
+        let (tx, mut rx) = mpsc::channel(4);
+        let sender = HttpClientApiRequest::from_sender(tx);
+        let handler = {
+            let key = key.clone();
+            tokio::spawn(async move {
+                web_subpages(
+                    key,
+                    "page2".to_string(),
+                    ApiVersion::V1,
+                    Some("authToken=attacker&invite=abc".to_string()),
+                    headers,
+                    &localhost_config(),
+                    sender,
+                )
+                .await
+                .map(|_| ())
+            })
+        };
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("shell render must emit on the channel (not a synchronous redirect)")
+            .expect("channel must stay open for the send");
         assert!(
-            !loc.contains("authToken"),
-            "authToken must be stripped on the redirect hop"
+            matches!(msg, ClientConnection::NewConnection { .. }),
+            "top-level document load must route into the shell render path \
+             (NewConnection), not a 303 redirect; got: {msg:?}"
         );
+        handler.abort();
 
         // Case 1b: a sandbox sub-page request with `Sec-Fetch-Dest:
         // document` must still redirect to the shell root (via the
         // sandbox branch's existing top-level-load guard) rather than
-        // serving raw sandbox content in the top frame. Exercises the
-        // sandbox short-circuit that runs *before* the new redirect
-        // block, which is the path a pasted sandbox URL hits.
+        // serving raw sandbox content in the top frame. This guards the
+        // sandbox short-circuit that runs *before* the deep-link block,
+        // which is the path a pasted `?__sandbox=1` URL hits. Unchanged
+        // by #3841 — it is a security guard, not a deep-link.
         let mut headers = axum::http::HeaderMap::new();
         headers.insert("sec-fetch-dest", "document".parse().unwrap());
         let resp = web_subpages(
@@ -904,6 +964,7 @@ mod tests {
             ApiVersion::V1,
             Some("__sandbox=1".to_string()),
             headers,
+            &localhost_config(),
             dead_request_sender(),
         )
         .await
@@ -912,16 +973,17 @@ mod tests {
 
         // Case 2: missing Sec-Fetch-Dest (curl, older browsers) falls
         // through to variable_content — pre-PR behaviour preserved, no
-        // redirect loop for non-browser clients. With a dead request
-        // sender the cache-miss fetch fails fast with a closed-channel
-        // error (see `dead_request_sender` for why). We assert only
-        // that the response is NOT a shell-root redirect.
+        // change in response shape for non-browser clients. With a dead
+        // request sender the cache-miss fetch fails fast with a
+        // closed-channel error (see `dead_request_sender`). We assert
+        // only that the response is NOT a shell-root redirect.
         let res = web_subpages(
             key.clone(),
             "page2".to_string(),
             ApiVersion::V1,
             None,
             axum::http::HeaderMap::new(),
+            &localhost_config(),
             dead_request_sender(),
         )
         .await;
@@ -930,45 +992,45 @@ mod tests {
             Err(_) => {
                 // variable_content returned an error for the cache-miss
                 // fetch attempt — that's fine, the point is that we did
-                // not take the redirect branch.
+                // not take a redirect branch.
             }
         }
     }
 
     /// Regression test pinning the ordering inside `web_subpages`: a
     /// sandbox iframe request for an HTML sub-path MUST hit the sandbox
-    /// branch (line ~261), not the new top-level-document redirect,
-    /// even if a future reorder moves the redirect block earlier.
+    /// branch, not the top-level-document shell-render branch, even if a
+    /// future reorder moves the shell block earlier.
     ///
     /// We cannot exercise the full sandbox pipeline in a unit test
     /// (requires a real contract state in the cache), but we can
-    /// assert the predicate-level invariant — `should_redirect_subpage_to_shell`
+    /// assert the predicate-level invariant — `should_serve_shell_for_subpage`
     /// returns false for any sandbox request — and check the source
     /// ordering via byte-offset comparison so that a reorder is caught
     /// mechanically.
     #[test]
-    fn web_subpages_sandbox_branch_runs_before_redirect_branch() {
+    fn web_subpages_sandbox_branch_runs_before_shell_branch() {
         let src = include_str!("client_api.rs");
         // The sandbox short-circuit must appear before the
-        // top-level-document redirect inside `web_subpages`. Both
+        // top-level-document shell render inside `web_subpages`. Both
         // markers are unique to that function.
         let sandbox_idx = src
             .find("if is_sandbox && is_html_page(&last_path) {")
             .expect("sandbox short-circuit marker present in web_subpages");
-        let redirect_idx = src
-            .find("should_redirect_subpage_to_shell(is_sandbox")
-            .expect("subpage redirect marker present in web_subpages");
+        let shell_idx = src
+            .find("should_serve_shell_for_subpage(is_sandbox")
+            .expect("subpage shell-render marker present in web_subpages");
         assert!(
-            sandbox_idx < redirect_idx,
-            "sandbox branch must run before the top-level-document redirect: \
+            sandbox_idx < shell_idx,
+            "sandbox branch must run before the top-level-document shell render: \
              reordering would break sandbox iframe sub-page loads"
         );
 
         // Predicate-level invariant: sandbox requests are never
-        // redirected regardless of other inputs.
-        assert!(!should_redirect_subpage_to_shell(true, "page2", "document"));
-        assert!(!should_redirect_subpage_to_shell(true, "news/", "document"));
-        assert!(!should_redirect_subpage_to_shell(
+        // served the shell-render branch regardless of other inputs.
+        assert!(!should_serve_shell_for_subpage(true, "page2", "document"));
+        assert!(!should_serve_shell_for_subpage(true, "news/", "document"));
+        assert!(!should_serve_shell_for_subpage(
             true,
             "index.html",
             "iframe"

--- a/crates/core/src/server/client_api/v1.rs
+++ b/crates/core/src/server/client_api/v1.rs
@@ -38,9 +38,10 @@ async fn web_subpages_v1(
     Path((key, last_path)): Path<(String, String)>,
     axum::extract::RawQuery(query): axum::extract::RawQuery,
     headers: axum::http::HeaderMap,
+    axum::extract::State(config): axum::extract::State<Config>,
     Extension(rs): Extension<HttpClientApiRequest>,
 ) -> Result<axum::response::Response, WebSocketApiError> {
-    web_subpages(key, last_path, ApiVersion::V1, query, headers, rs).await
+    web_subpages(key, last_path, ApiVersion::V1, query, headers, &config, rs).await
 }
 
 /// Redirect `/v1/contract/web/{key}` (no trailing slash) to

--- a/crates/core/src/server/client_api/v2.rs
+++ b/crates/core/src/server/client_api/v2.rs
@@ -35,9 +35,10 @@ async fn web_subpages_v2(
     Path((key, last_path)): Path<(String, String)>,
     axum::extract::RawQuery(query): axum::extract::RawQuery,
     headers: axum::http::HeaderMap,
+    axum::extract::State(config): axum::extract::State<Config>,
     Extension(rs): Extension<HttpClientApiRequest>,
 ) -> Result<axum::response::Response, WebSocketApiError> {
-    web_subpages(key, last_path, ApiVersion::V2, query, headers, rs).await
+    web_subpages(key, last_path, ApiVersion::V2, query, headers, &config, rs).await
 }
 
 /// Redirect `/v2/contract/web/{key}` (no trailing slash) to

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -186,6 +186,7 @@ pub(super) async fn contract_home(
     assigned_token: AuthToken,
     api_version: ApiVersion,
     query_string: Option<String>,
+    sub_path: Option<&str>,
 ) -> Result<impl IntoResponse, WebSocketApiError> {
     let instance_id = ContractInstanceId::from_bytes(&key).map_err(|err| {
         debug!("contract_home: Failed to parse contract key: {}", err);
@@ -211,7 +212,7 @@ pub(super) async fn contract_home(
     // Return the shell page instead of the contract HTML directly.
     // The shell page wraps the contract in a sandboxed iframe for
     // origin isolation (GHSA-824h-7x5x-wfmf).
-    match shell_page(&assigned_token, &key, api_version, query_string) {
+    match shell_page(&assigned_token, &key, api_version, query_string, sub_path) {
         Ok(b) => Ok(b.into_response()),
         Err(err) => {
             tracing::error!("Failed to generate shell page: {err}");
@@ -526,6 +527,59 @@ fn html_escape_attr(s: &str) -> String {
     out
 }
 
+/// Validates a deep-link sub-path before it is interpolated into the
+/// shell iframe's `data-src` URL (#3841).
+///
+/// The sub-path comes from the request URL's path component (axum's
+/// `{*path}` wildcard), so a query string or fragment is normally split
+/// off before it reaches us. This guard rejects:
+///
+/// - Characters that would break out of the URL path component: `?`
+///   starts a query, `#` starts a fragment, `\` is treated as `/` by
+///   browsers, and whitespace/control chars (incl. CR/LF) could corrupt
+///   the attribute or — once HTML-unescaped by the browser — the
+///   surrounding markup.
+/// - A leading `/`, so the result stays relative to the contract web
+///   prefix rather than becoming an absolute path.
+/// - `.` / `..` path segments. This is the SECURITY-CRITICAL check:
+///   unlike `sandbox_content_body` (which canonicalizes the on-disk file
+///   against the contract cache dir), the dot-segments here would never
+///   reach that layer. The browser normalizes `..` in a URL *before*
+///   issuing the iframe request, so a `data-src` of
+///   `/v1/contract/web/KEY/../OTHER/?__sandbox=1` would be requested as
+///   `/v1/contract/web/OTHER/?__sandbox=1` — pointing the iframe at a
+///   *different contract* under the current shell's token/origin. We
+///   must therefore reject traversal segments here rather than relying
+///   on later file-path canonicalization (Codex review, #3841).
+fn sanitize_shell_sub_path(sub_path: &str) -> Result<String, WebSocketApiError> {
+    if sub_path.starts_with('/') {
+        return Err(WebSocketApiError::InvalidParam {
+            error_cause: "deep-link sub-path must be relative".to_string(),
+        });
+    }
+    if sub_path
+        .chars()
+        .any(|c| c.is_control() || c.is_whitespace() || matches!(c, '?' | '#' | '\\'))
+    {
+        return Err(WebSocketApiError::InvalidParam {
+            error_cause: "deep-link sub-path contains an illegal character".to_string(),
+        });
+    }
+    // Reject `.`/`..` segments. Split on `/` rather than using
+    // `std::path::Component` so that a trailing-slash directory form like
+    // `a/../` and an empty middle segment are both classified from the
+    // raw URL text (no OS-specific path semantics). A browser collapses
+    // these dot-segments client-side before requesting the iframe URL, so
+    // they would escape the contract prefix without ever reaching the
+    // on-disk canonicalization in `sandbox_content_body`.
+    if sub_path.split('/').any(|seg| seg == "." || seg == "..") {
+        return Err(WebSocketApiError::InvalidParam {
+            error_cause: "deep-link sub-path must not contain '.' or '..' segments".to_string(),
+        });
+    }
+    Ok(sub_path.to_string())
+}
+
 /// Generates the shell page HTML that wraps the contract in a sandboxed iframe.
 ///
 /// The shell page holds the auth token and proxies WebSocket connections via
@@ -535,9 +589,22 @@ fn shell_page(
     contract_key: &str,
     api_version: ApiVersion,
     query_string: Option<String>,
+    sub_path: Option<&str>,
 ) -> Result<impl IntoResponse, WebSocketApiError> {
     let version_prefix = api_version.prefix();
-    let base_path = format!("/{version_prefix}/contract/web/{contract_key}/");
+    // For a deep-link reload (#3841) the iframe must load the requested
+    // sub-page, not the contract root, so the in-iframe webapp starts on
+    // the right route. The sub-path is interpolated into the iframe's
+    // `data-src`; `sanitize_shell_sub_path` rejects anything that could
+    // break out of the URL's path component (`?`, `#`, control chars,
+    // CRLF), and the whole `data-src` is HTML-escaped below as a second
+    // layer of defence. Path traversal is additionally caught when the
+    // iframe later requests `?__sandbox=1` (see `sandbox_content_body`).
+    let sub_path = sub_path.map(sanitize_shell_sub_path).transpose()?;
+    let base_path = match sub_path.as_deref() {
+        Some(sp) => format!("/{version_prefix}/contract/web/{contract_key}/{sp}"),
+        None => format!("/{version_prefix}/contract/web/{contract_key}/"),
+    };
 
     // Build the iframe src URL: same path with __sandbox=1 plus any
     // original query params (e.g., ?invitation=...). `__sandbox` is the
@@ -2583,7 +2650,8 @@ mod tests {
         // Lock the token in so a future refactor does not regress the fix.
         let token = AuthToken::generate();
         let html =
-            response_body(shell_page(&token, "testkey123", ApiVersion::V1, None).unwrap()).await;
+            response_body(shell_page(&token, "testkey123", ApiVersion::V1, None, None).unwrap())
+                .await;
         assert!(
             html.contains("allow-downloads"),
             "iframe sandbox missing `allow-downloads` — user-initiated \
@@ -2596,7 +2664,8 @@ mod tests {
     async fn shell_page_contains_iframe_and_bridge() {
         let token = AuthToken::generate();
         let html =
-            response_body(shell_page(&token, "testkey123", ApiVersion::V1, None).unwrap()).await;
+            response_body(shell_page(&token, "testkey123", ApiVersion::V1, None, None).unwrap())
+                .await;
 
         // Shell page must contain sandboxed iframe
         assert!(
@@ -2670,7 +2739,8 @@ mod tests {
     async fn shell_page_permission_overlay_present_and_safe() {
         let token = AuthToken::generate();
         let html =
-            response_body(shell_page(&token, "testkey123", ApiVersion::V1, None).unwrap()).await;
+            response_body(shell_page(&token, "testkey123", ApiVersion::V1, None, None).unwrap())
+                .await;
 
         // Overlay root and accessibility attributes
         assert!(
@@ -2843,7 +2913,8 @@ mod tests {
     async fn shell_page_iframe_uses_data_src_for_deep_linking() {
         let token = AuthToken::generate();
         let html =
-            response_body(shell_page(&token, "testkey123", ApiVersion::V1, None).unwrap()).await;
+            response_body(shell_page(&token, "testkey123", ApiVersion::V1, None, None).unwrap())
+                .await;
 
         // The iframe must NOT have a src attribute (which would trigger an
         // immediate load before JS can append the hash fragment).
@@ -2865,7 +2936,8 @@ mod tests {
         let token = AuthToken::generate();
         let qs = Some("invitation=abc123&room=test".to_string());
         let html =
-            response_body(shell_page(&token, "testkey123", ApiVersion::V1, qs).unwrap()).await;
+            response_body(shell_page(&token, "testkey123", ApiVersion::V1, qs, None).unwrap())
+                .await;
 
         // Query params should be forwarded to iframe src
         assert!(
@@ -2881,6 +2953,165 @@ mod tests {
             html.contains("?__sandbox=1&"),
             "__sandbox=1 not first in iframe params"
         );
+    }
+
+    /// Regression test for #3841 (deep-link reload). When a sub-path is
+    /// threaded into shell generation, the iframe's `data-src` must point
+    /// at that sub-page (`/v1/contract/web/KEY/news/?__sandbox=1`) so the
+    /// in-iframe webapp starts on the requested route. Before the fix the
+    /// shell always pointed the iframe at the contract root, so reloading
+    /// a deep link silently dropped the user back at `/`.
+    #[tokio::test]
+    async fn shell_page_embeds_sub_path_in_iframe_data_src() {
+        let token = AuthToken::generate();
+
+        // Directory-style deep link.
+        let html = response_body(
+            shell_page(&token, "testkey123", ApiVersion::V1, None, Some("news/")).unwrap(),
+        )
+        .await;
+        assert!(
+            html.contains(r#"data-src="/v1/contract/web/testkey123/news/?__sandbox=1""#),
+            "iframe data-src must carry the sub-path; got: {html}"
+        );
+
+        // Nested extensionless deep link.
+        let html = response_body(
+            shell_page(
+                &token,
+                "testkey123",
+                ApiVersion::V1,
+                None,
+                Some("about/team"),
+            )
+            .unwrap(),
+        )
+        .await;
+        assert!(
+            html.contains(r#"data-src="/v1/contract/web/testkey123/about/team?__sandbox=1""#),
+            "iframe data-src must carry the nested sub-path; got: {html}"
+        );
+
+        // `None` sub-path keeps the iframe pointed at the contract root —
+        // pins that the new parameter does not change root-load behaviour.
+        let html =
+            response_body(shell_page(&token, "testkey123", ApiVersion::V1, None, None).unwrap())
+                .await;
+        assert!(
+            html.contains(r#"data-src="/v1/contract/web/testkey123/?__sandbox=1""#),
+            "root load must still point the iframe at the contract root; got: {html}"
+        );
+    }
+
+    /// The sub-path is interpolated into the iframe URL's path component,
+    /// so query/fragment delimiters, control characters, and `..`/`.`
+    /// traversal segments must be rejected before they can corrupt the
+    /// `data-src` URL (or, once the browser HTML-unescapes the attribute,
+    /// the surrounding markup) or — for `..` — be normalized by the
+    /// browser into a different contract's prefix.
+    #[test]
+    fn sanitize_shell_sub_path_accepts_safe_paths_and_rejects_dangerous() {
+        // Safe relative paths used by real multi-page webapps.
+        for ok in ["news/", "about/team", "page2", "index.html", "a/b/c/"] {
+            assert_eq!(
+                sanitize_shell_sub_path(ok).unwrap(),
+                ok,
+                "{ok} must be accepted unchanged"
+            );
+        }
+
+        // `..`/`.` segments MUST be rejected (Codex review, #3841): the
+        // browser collapses dot-segments in a URL *before* requesting the
+        // iframe, so `/v1/contract/web/KEY/../OTHER/` would be normalized
+        // to `/v1/contract/web/OTHER/` and load a different contract under
+        // the current shell's token. The later `sandbox_content_body`
+        // canonicalization never sees the un-normalized traversal, so this
+        // guard is the only layer that can stop it.
+        for traversal in ["..", "../other", "a/../b", "a/..", "a/./b", "."] {
+            assert!(
+                matches!(
+                    sanitize_shell_sub_path(traversal),
+                    Err(WebSocketApiError::InvalidParam { .. })
+                ),
+                "{traversal:?} (dot-segment) must be rejected"
+            );
+        }
+
+        // Dangerous inputs that would break out of the URL path component
+        // or inject into the attribute/markup must be rejected.
+        for bad in [
+            "/absolute",        // leading slash escapes the contract prefix
+            "news/?evil=1",     // `?` starts a query, corrupting __sandbox=1
+            "news/#frag",       // `#` starts a fragment
+            "a b",              // whitespace
+            "x\r\nInjected: y", // CRLF (header/markup injection surface)
+            "back\\slash",      // backslash (browsers may treat as `/`)
+            "tab\tafter",       // control char
+        ] {
+            assert!(
+                matches!(
+                    sanitize_shell_sub_path(bad),
+                    Err(WebSocketApiError::InvalidParam { .. })
+                ),
+                "{bad:?} must be rejected"
+            );
+        }
+    }
+
+    /// End-to-end regression for #3841: a deep-link reload routed through
+    /// `contract_home` (the path `web_subpages` takes for a top-level
+    /// document load of a sub-page) must fetch/cache the contract AND
+    /// produce a shell whose iframe loads the requested sub-page, not the
+    /// contract root. Drives the real `ensure_contract_cached` cycle via
+    /// `serve_one_get`, then inspects the rendered shell HTML.
+    #[tokio::test]
+    async fn contract_home_with_sub_path_renders_shell_for_that_page() {
+        let contract = ContractContainer::Wasm(ContractWasmAPIVersion::V1(WrappedContract::new(
+            Arc::new(ContractCode::from(vec![3, 1, 8, 4, 1])),
+            Parameters::from(vec![3, 8, 4, 1]),
+        )));
+        let instance_id = *contract.key().id();
+        let key = instance_id.to_string();
+        let state = WrappedState::new(vec![4, 2]);
+        clear_cache(&instance_id).await;
+
+        // Warm cache whose stored hash matches the state the served GET
+        // returns, so `unpack_if_stale` takes its matching-hash early
+        // return and the refresh succeeds without a real WebApp unpack.
+        let cache_dir = contract_web_path(&instance_id);
+        tokio::fs::create_dir_all(&cache_dir).await.unwrap();
+        let matching_hash = hash_state(state.as_ref());
+        tokio::fs::write(state_hash_path(&instance_id), matching_hash.to_be_bytes())
+            .await
+            .unwrap();
+
+        let (sender, mut rx) = request_channel();
+        let token = AuthToken::generate();
+        let handler = {
+            let key = key.clone();
+            tokio::spawn(async move {
+                contract_home(key, sender, token, ApiVersion::V1, None, Some("news/"))
+                    .await
+                    .map(|resp| resp.into_response())
+            })
+        };
+
+        // Service the fetch the shell render triggers.
+        serve_one_get(&mut rx, &contract, &state).await;
+
+        let resp = handler
+            .await
+            .expect("contract_home task must not panic")
+            .expect("contract_home must succeed once the GET is served");
+        let html = response_body(resp).await;
+        assert!(
+            html.contains(&format!(
+                r#"data-src="/v1/contract/web/{key}/news/?__sandbox=1""#
+            )),
+            "deep-link shell iframe must load the sub-page; got: {html}"
+        );
+
+        clear_cache(&instance_id).await;
     }
 
     #[tokio::test]
@@ -2977,7 +3208,8 @@ mod tests {
         let token = AuthToken::generate();
         let qs = Some("__sandbox_extra=evil&invitation=abc&__sandboxFoo=bar".to_string());
         let html =
-            response_body(shell_page(&token, "testkey123", ApiVersion::V1, qs).unwrap()).await;
+            response_body(shell_page(&token, "testkey123", ApiVersion::V1, qs, None).unwrap())
+                .await;
 
         // __sandbox-prefixed params must be stripped
         assert!(
@@ -3009,7 +3241,8 @@ mod tests {
         let token = AuthToken::generate();
         let qs = Some("authToken=attacker_value&invite=abc&authTokenExtra=x".to_string());
         let html =
-            response_body(shell_page(&token, "testkey123", ApiVersion::V1, qs).unwrap()).await;
+            response_body(shell_page(&token, "testkey123", ApiVersion::V1, qs, None).unwrap())
+                .await;
         assert!(
             !html.contains("attacker_value"),
             "attacker-supplied authToken value must not reach iframe src"
@@ -3036,7 +3269,8 @@ mod tests {
         let token = AuthToken::generate();
         let qs = Some("foo=\"><script>alert(1)</script>".to_string());
         let html =
-            response_body(shell_page(&token, "testkey123", ApiVersion::V1, qs).unwrap()).await;
+            response_body(shell_page(&token, "testkey123", ApiVersion::V1, qs, None).unwrap())
+                .await;
 
         // The double quote and angle brackets must be escaped
         assert!(


### PR DESCRIPTION
## Problem

After #3840, in-contract navigation pushes browser history entries, so the address bar reflects the current subpage (e.g. `/v1/contract/web/KEY/news/`). But **reloading** or **bookmarking** one of those URLs returned 404 — and, after the interim fix (commit `c74fcf1b`), a 303 redirect to the contract root. The redirect preserved URL *fragments* (enough for hash-routed apps like Delta) but **flattened path-routed deep links to `/`**, silently dropping the user at the root of any contract that uses path-based navigation. Deep links could not be shared or reloaded.

Closes #3841

## Approach

Thread an `Option<&str>` sub-path through `web_subpages` → `path_handlers::contract_home` → `shell_page`. When `web_subpages` receives a non-sandbox, top-level HTML **document** load of a sub-path, it now renders the shell **in place** (instead of redirecting) with the sub-path embedded in the iframe's `data-src`:

```
data-src="/v1/contract/web/{KEY}/{sub_path}?__sandbox=1"
```

so the in-iframe webapp starts on the requested route.

- The shell-rendering logic (fresh auth token + secure cookie + shell CSP + anti-framing headers) is factored out of `web_home` into a shared `render_shell_response` helper, so the deep-link path issues the **same** credentials/headers as the contract-root path and cannot drift out of sync.
- The sub-path is validated by `sanitize_shell_sub_path` before interpolation: rejects `?`, `#`, leading `/`, `\`, control/whitespace (incl. CR/LF), **and `.`/`..` traversal segments**. The `..` rejection is security-critical — the browser collapses dot-segments in a URL *before* requesting the iframe, so `.../KEY/../OTHER/` would otherwise normalize to `.../OTHER/` and load a *different contract* under the current shell's token (caught by the Codex review; the later on-disk canonicalization in `sandbox_content_body` never sees the un-normalized form).
- Sensitive query params (`__sandbox*`, `authToken*`) are still stripped by `shell_page`, preserving the protection the old redirect provided.
- Sub-resource fetches and non-HTML asset paths still fall through to `variable_content`, so **genuinely missing assets keep returning 404** — the SPA fallback only triggers for top-level HTML document loads.

`redirect_to_shell_root` / `build_canonical_shell_url` remain in use for the sandbox-URL top-level guard and the no-trailing-slash canonical redirect.

## Testing

New regression tests:
- `shell_page_embeds_sub_path_in_iframe_data_src` — iframe `data-src` carries the sub-path (directory + nested forms); root load unchanged. **Verified this FAILS without the fix and PASSES with it.**
- `contract_home_with_sub_path_renders_shell_for_that_page` — end-to-end through the real `ensure_contract_cached` GET cycle. **Also verified failing-without / passing-with.**
- `sanitize_shell_sub_path_accepts_safe_paths_and_rejects_dangerous` — accepts `news/`, `about/team`, etc.; rejects query/fragment/control chars and `.`/`..` segments.
- `web_subpages_serves_shell_for_top_level_document_load` — top-level document load routes into the shell-render path (observed via the `NewConnection` it emits) rather than a 303; the sandbox top-level guard still redirects; curl/no-`Sec-Fetch-Dest` fallthrough to `variable_content` unchanged.

Updated the existing predicate/ordering tests for the rename (`should_redirect_subpage_to_shell` → `should_serve_shell_for_subpage`).

`cargo test -p freenet` lib suite green (2896 passed); `cargo fmt` clean; `cargo clippy --locked -- -D warnings` clean.

## Review

External non-Claude review run: Codex (found the `..` traversal P1, fixed here) and Gemini 2.5 Flash on the fixed code (no material findings). Self-reviewed across code-first / skeptical / testing / big-picture lenses.

[AI-assisted - Claude]