### PR TITLE
fix(governance): default the cost/benefit detector to Off

### DIFF
--- a/crates/core/src/contract/governance.rs
+++ b/crates/core/src/contract/governance.rs
@@ -317,11 +317,13 @@ impl ContractScore {
     }
 }
 
-/// Operating mode for the governance system. Plan defaults to
-/// `DryRun` for one release after Phase 4 lands — operators see what
-/// would be evicted, dashboards reflect intended actions, but no
-/// contracts are actually evicted. After calibration, the operator
-/// (or release default) flips to `Enforce`.
+/// Operating mode for the governance system. Defaults to `Off`: the
+/// cost/benefit MAD detector proved miscalibrated in production DryRun
+/// (it false-flagged popular contracts, including the official River
+/// room — see [`GovernanceConfig::default`] and #4296), so it is
+/// disabled pending the demand-weighted, contention-only redesign.
+/// `DryRun` computes and surfaces `WouldEvict` / `Evicted` states
+/// without acting; `Enforce` additionally evicts/bans. Flip explicitly.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum GovernanceMode {
     /// Disabled. No state computation, no transitions.
@@ -414,7 +416,22 @@ pub(crate) struct GovernanceConfig {
 impl Default for GovernanceConfig {
     fn default() -> Self {
         Self {
-            mode: GovernanceMode::DryRun,
+            // Default OFF. The cost/benefit MAD detector is miscalibrated:
+            // in production DryRun on the gateways it flagged popular
+            // contracts (including the official River room) as WouldEvict
+            // — ~47% of active contracts on nova. Root cause: cost accrues
+            // on every hosted merge while benefit under-credits relay
+            // demand (FORWARDED_DEMAND_WEIGHT = 0.1), and the MAD detector
+            // has no absolute floor, so the busiest relay-hosted contract
+            // is definitionally the population's cost/benefit outlier. It
+            // is being replaced by demand-weighted, contention-only
+            // throttling (#4296); until that lands the detector stays Off
+            // so it cannot mislabel a contract on the dashboard or — under
+            // any future Enforce flip — evict a legitimate one. Off keeps
+            // the data model and Meter infrastructure in place but dormant;
+            // flip to DryRun/Enforce explicitly to exercise the detector.
+            // Reversible.
+            mode: GovernanceMode::Off,
             outlier: OutlierConfig::default(),
             ramp_up: Duration::from_secs(15 * 60), // 15 minutes
             decay_half_life: Duration::from_secs(60 * 60), // 1 hour
@@ -609,6 +626,15 @@ impl GovernanceManager {
     /// Meter wiring (subsequent commit) on every per-contract resource
     /// report. If the contract is new, creates a `Normal`-state score.
     pub(crate) fn ingest_cost(&self, key: ContractInstanceId, amount: f64) {
+        // When governance is Off the subsystem is fully dormant: cost is
+        // not accumulated, so the score map cannot grow. This matters
+        // because the reaper `tick` that would otherwise decay and prune
+        // the map is also a no-op under Off (see `tick`); without this
+        // gate, a default-Off node would accumulate one never-pruned
+        // score per contract it ever hosts. Keeps default-Off leak-free.
+        if matches!(self.config.mode, GovernanceMode::Off) {
+            return;
+        }
         if !amount.is_finite() || amount < 0.0 {
             return;
         }
@@ -1375,6 +1401,38 @@ mod tests {
         let result = mgr.tick(Duration::from_secs(1), &benefits(&[(k, 0.1)]));
         assert!(result.decisions.is_empty());
         assert_eq!(result.sample_size, 0);
+    }
+
+    /// Regression for the production false-positive (#4296): the DryRun
+    /// cost/benefit detector flagged popular contracts — including the
+    /// official River room, ~47% of active contracts on nova — as
+    /// `WouldEvict`. The detector is miscalibrated, so the default mode is
+    /// now `Off` until the demand-weighted redesign lands. Verify (1) the
+    /// default really is `Off`, and (2) `Off` is fully dormant: even the
+    /// abuser signature (large cost, zero live benefit) accumulates no
+    /// score and yields no decisions, so nothing can be mislabeled on the
+    /// dashboard or evicted under a future Enforce flip.
+    #[test]
+    fn default_governance_is_off_and_dormant() {
+        assert_eq!(
+            GovernanceConfig::default().mode,
+            GovernanceMode::Off,
+            "governance must default to Off until the detector is recalibrated (#4296)"
+        );
+
+        let ts = SharedTs::new();
+        let ts_dyn: Arc<dyn TimeSource + Send + Sync> = ts.clone();
+        let mgr = GovernanceManager::new(GovernanceConfig::default(), ts_dyn);
+        let k = mk_key(1);
+
+        // Abuser signature: large cost, never any beneficiaries.
+        mgr.ingest_cost(k, 1_000_000.0);
+        assert_eq!(mgr.len(), 0, "Off must not accumulate cost scores");
+
+        ts.advance(Duration::from_secs(60));
+        let result = mgr.tick(Duration::from_secs(1), &benefits(&[]));
+        assert!(result.decisions.is_empty(), "Off must produce no decisions");
+        assert!(mgr.score_snapshot(&k).is_none());
     }
 
     /// New abuser signature under the live-snapshot model: a contract

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -1058,10 +1058,17 @@ fn build_governance_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
     if g.contracts.is_empty() {
         let observed = g.observed_count;
         let needed = g.min_samples;
+        // When governance is Off (the default — see `GovernanceConfig`),
+        // no contract is ever scored, so the ramp-up / "scoring activates"
+        // copy below would be misleading on every default node. Render a
+        // disabled message instead.
+        let is_off = matches!(g.mode, network_status::GovernanceModeSnapshot::Off);
         // Tiny pluralization helper so the user-facing messages
         // don't read "1 contracts" — Codex review nit.
         let plural = |n: usize| if n == 1 { "contract" } else { "contracts" };
-        let progress_msg = if needed == 0 {
+        let progress_msg = if is_off {
+            "Governance is off: contracts are not scored, and nothing is evicted.".to_string()
+        } else if needed == 0 {
             "Governance manager is not yet wired.".to_string()
         } else if observed == 0 {
             format!(
@@ -1091,7 +1098,12 @@ fn build_governance_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
                 n_word = plural(observed),
             )
         };
-        let verdict_main = if observed >= needed {
+        let verdict_main = if is_off {
+            r#"<div class="verdict-num">—</div>
+                   <div class="verdict-headline">Governance off</div>
+                   <div class="verdict-detail">Contracts are not scored or evicted.</div>"#
+                .to_string()
+        } else if observed >= needed {
             format!(
                 r#"<div class="verdict-num">✓</div>
                    <div class="verdict-headline">{observed} contracts within normal range</div>
@@ -5350,6 +5362,37 @@ mod tests {
         assert!(
             html.contains("once 1 more contract accumulates"),
             "with remaining=1 message must use singular 'contract accumulates' — got:\n{html}"
+        );
+    }
+
+    #[test]
+    fn governance_card_empty_state_off_mode_is_disabled() {
+        // Regression (#4338 review): with the default mode now Off, the
+        // empty state must NOT claim "scoring activates after N contracts"
+        // — scoring never activates while Off, so that copy is misleading
+        // on every default node. It must say governance is off instead.
+        let mut snap = base_snapshot();
+        snap.governance = GovernanceSnapshot {
+            mode: GovernanceModeSnapshot::Off,
+            contracts: Vec::new(),
+            norms: NetworkNorms::default(),
+            observed_count: 0,
+            min_samples: 30,
+            last_tick_at: None,
+            state_by_id: std::collections::HashMap::new(),
+        };
+        let html = build_governance_card(&Some(snap));
+        assert!(
+            html.contains("Governance is off"),
+            "Off empty state must say governance is off — got:\n{html}"
+        );
+        assert!(
+            !html.contains("Scoring activates"),
+            "Off empty state must NOT claim scoring will activate — got:\n{html}"
+        );
+        assert!(
+            html.contains(r#"g-mode g-mode-off">off<"#),
+            "Off empty state must show the off mode pill — got:\n{html}"
         );
     }
 


### PR DESCRIPTION
## Problem

The contract-governance cost/benefit MAD detector false-flags popular contracts. In production DryRun on the gateways it labelled **~47% of active contracts** (88/189 on nova) as `WouldEvict`, including the **official River room contract**, and a third-party user reported their node showing the River chat contract as "would evict".

Root cause (confirmed on v0.2.68, across nova/vega/technic):
- **Cost** accrues on every hosted merge, including relayed UPDATEs the node didn't originate (`commit_state_write` → `StateBytesWritten` → `ingest_cost`).
- **Benefit** under-credits relay demand: `FORWARDED_DEMAND_WEIGHT = 0.1` vs `LOCAL_DEMAND_WEIGHT = 1.0`. On a gateway a popular room is almost all relay demand, so its live benefit is a fraction of a point while update cost is large.
- **MAD has no absolute-reasonableness floor**: `capacity_ceiling_log` caps the *threshold* (more aggressive), it does not protect a busy-but-legitimate contract. So the busiest relay-hosted contract is *by construction* the population's cost/benefit outlier — popularity itself trips the detector.

The earlier #4309 "live beneficiary stock" fix removed the decay artifact but left this structural issue intact, so the false-positive survived it. The detector's own regression test (`popular_contract_with_subscribers_not_evicted`) only models the sustained-high-subscriber *host*, not the relay-only-demand replica that flaps in production.

## Solution

The detector is being replaced by demand-weighted, contention-only throttling (#4296). Until that lands, **default the governance mode to `Off`** so the miscalibrated detector cannot mislabel a contract on the dashboard or — under any future `Enforce` flip — evict a legitimate one.

- `GovernanceConfig::default().mode` → `Off` (was `DryRun`), with a comment recording the why.
- `ingest_cost` is gated on `Off` so the subsystem is **fully dormant**. Without this, a default-`Off` node would accumulate one never-pruned score per contract it ever hosts, because the reaper `tick` that decays/prunes the map is itself a no-op under `Off`. This keeps default-`Off` leak-free.
- The data model, dashboard rendering (`Off` is already a handled snapshot variant), and `Meter` infrastructure all stay in place. Flip to `DryRun`/`Enforce` explicitly to exercise the detector.

This is **reversible** and changes **no enforcement behavior today** (production was `DryRun`, which never evicts). It only stops the dashboard mislabelling and removes the foot-gun ahead of the redesign.

## Testing

- New regression test `default_governance_is_off_and_dormant`: asserts the default mode is `Off`, and that `Off` is dormant — the abuser signature (large cost, zero benefit) accumulates no score (`len() == 0`) and produces no decisions. Fails without this change (default was `DryRun`, and `ingest_cost` would create a score).
- The detector's own logic tests are unchanged and still pass under explicit `DryRun`/`Enforce` (e.g. `zero_beneficiary_contract_with_cost_is_flagged`), confirming only the *default* changed, not the detector.
- `cargo test -p freenet --lib governance`: 60 passed, 0 failed.
- `cargo clippy --locked -- -D warnings`: clean. `cargo fmt`: clean.

Refs #4296

[AI-assisted - Claude]
