### PR TITLE
feat(secrets): freenet secrets snapshot-list / snapshot-restore CLI

### DIFF
--- a/crates/core/src/bin/commands/secrets_cmd.rs
+++ b/crates/core/src/bin/commands/secrets_cmd.rs
@@ -29,7 +29,7 @@ use chrono::{DateTime, Utc};
 use freenet::dev_tool::{
     KEK_SIZE, KekBackendKind, RestoreError, RetentionPolicy, build_backend_for, list_snapshots,
     load_from_backend, read_backend_marker, replace_backend_marker, restore_snapshot_file,
-    snapshot_dir_for_encoded, write_backend_marker,
+    snapshot_dir_for_encoded, thin_snapshots, write_backend_marker,
 };
 use sha2::{Digest, Sha256};
 use zeroize::Zeroizing;
@@ -626,17 +626,24 @@ async fn snapshot_restore(args: SnapshotRestoreArgs) -> Result<()> {
     // Byte-level restore via the shared core — the same code the node
     // runtime uses, so the durability discipline can't drift. The
     // reversibility snapshot is always enabled for the CLI (manual
-    // recovery should be undoable); default retention policy.
+    // recovery should be undoable).
     match restore_snapshot_file(
         &delegate_dir,
         &args.secret,
         args.timestamp_ms,
         args.suffix,
         true,
-        &RetentionPolicy::default(),
-        std::time::SystemTime::now(),
     ) {
         Ok(()) => {
+            // Bound the history (incl. the reversibility snapshot just
+            // added), matching the node runtime's default retention.
+            // Best-effort: the restore has already succeeded.
+            let snap_dir = snapshot_dir_for_encoded(&delegate_dir, &args.secret);
+            thin_snapshots(
+                &snap_dir,
+                &RetentionPolicy::default(),
+                std::time::SystemTime::now(),
+            );
             println!(
                 "Restored secret `{}` of delegate `{}` to snapshot {selector}.",
                 args.secret, args.delegate

--- a/crates/core/src/bin/commands/secrets_cmd.rs
+++ b/crates/core/src/bin/commands/secrets_cmd.rs
@@ -148,6 +148,13 @@ pub struct SnapshotRestoreArgs {
     /// `snapshot-list`).
     #[clap(long)]
     pub timestamp_ms: u64,
+    /// Collision suffix (the `suffix` column from `snapshot-list`), for
+    /// the rare case of multiple same-millisecond snapshots at one
+    /// timestamp. Omit to restore the unsuffixed snapshot at the
+    /// timestamp (the `-` row, and the only entry when there is no
+    /// collision); pass the number to target a specific collision row.
+    #[clap(long)]
+    pub suffix: Option<u32>,
     /// Skip the interactive confirmation prompt (for scripted use).
     #[clap(long)]
     pub yes: bool,
@@ -594,17 +601,23 @@ async fn snapshot_restore(args: SnapshotRestoreArgs) -> Result<()> {
         );
     }
 
+    // Human-readable selector for messages: "timestamp_ms=N" or
+    // "timestamp_ms=N suffix=K".
+    let selector = match args.suffix {
+        Some(s) => format!("timestamp_ms={} suffix={s}", args.timestamp_ms),
+        None => format!("timestamp_ms={}", args.timestamp_ms),
+    };
+
     if !args.yes {
         eprintln!(
             "About to restore secret `{}` of delegate `{}` to the snapshot at \
-             timestamp_ms={} in {}.\n\
+             {selector} in {}.\n\
              - The current value is snapshotted first, so this is reversible.\n\
              - The freenet node MUST be stopped (a running node may concurrently \
                write this secret).\n\
              Re-run with --yes to proceed.",
             args.secret,
             args.delegate,
-            args.timestamp_ms,
             args.secrets_dir.display()
         );
         bail!("aborted (no --yes)");
@@ -618,21 +631,22 @@ async fn snapshot_restore(args: SnapshotRestoreArgs) -> Result<()> {
         &delegate_dir,
         &args.secret,
         args.timestamp_ms,
+        args.suffix,
         true,
         &RetentionPolicy::default(),
         std::time::SystemTime::now(),
     ) {
         Ok(()) => {
             println!(
-                "Restored secret `{}` of delegate `{}` to snapshot timestamp_ms={}.",
-                args.secret, args.delegate, args.timestamp_ms
+                "Restored secret `{}` of delegate `{}` to snapshot {selector}.",
+                args.secret, args.delegate
             );
             Ok(())
         }
-        Err(RestoreError::NotFound(ts)) => bail!(
-            "no snapshot at timestamp_ms={ts} for secret `{}` of delegate `{}`. Run \
+        Err(RestoreError::NotFound(_)) => bail!(
+            "no snapshot at {selector} for secret `{}` of delegate `{}`. Run \
              `freenet secrets snapshot-list --secrets-dir {} --delegate {} --secret {}` to see \
-             available timestamps.",
+             available timestamps (and suffixes).",
             args.secret,
             args.delegate,
             args.secrets_dir.display(),
@@ -955,6 +969,7 @@ mod tests {
             delegate: delegate.to_string(),
             secret: secret.to_string(),
             timestamp_ms,
+            suffix: None,
             yes,
         }
     }
@@ -1122,6 +1137,46 @@ mod tests {
         assert!(
             res.is_err(),
             "--secret without --delegate must fail to parse"
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_restore_suffix_targets_collision_entry() {
+        // Same-millisecond collisions produce unsuffixed + `.0` + `.1`
+        // rows in `snapshot-list`; `--suffix` must be able to target each.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let secrets_dir = dir.path();
+        let snap_dir = secrets_dir.join("D").join(".snapshots").join("S");
+        std::fs::create_dir_all(&snap_dir).unwrap();
+        let base = format!("{:020}", 1000u64);
+        std::fs::write(snap_dir.join(&base), b"unsuffixed").unwrap();
+        std::fs::write(snap_dir.join(format!("{base}.0")), b"suffix-zero").unwrap();
+        std::fs::write(snap_dir.join(format!("{base}.1")), b"suffix-one").unwrap();
+        std::fs::create_dir_all(secrets_dir.join("D")).unwrap();
+        std::fs::write(secrets_dir.join("D").join("S"), b"current").unwrap();
+
+        // A non-existent suffix is rejected (not silently downgraded), and
+        // the error names the suffix. Run first so it can't see mutated state.
+        let mut args = restore_args(secrets_dir, "D", "S", 1000, true);
+        args.suffix = Some(9);
+        let err = snapshot_restore(args)
+            .await
+            .expect_err("missing suffix must error");
+        assert!(err.to_string().contains("suffix=9"));
+        assert_eq!(
+            std::fs::read(secrets_dir.join("D").join("S")).unwrap(),
+            b"current"
+        );
+
+        // Explicit suffix targets the exact collision row.
+        let mut args = restore_args(secrets_dir, "D", "S", 1000, true);
+        args.suffix = Some(1);
+        snapshot_restore(args)
+            .await
+            .expect("restore .1 must succeed");
+        assert_eq!(
+            std::fs::read(secrets_dir.join("D").join("S")).unwrap(),
+            b"suffix-one"
         );
     }
 }

--- a/crates/core/src/bin/commands/secrets_cmd.rs
+++ b/crates/core/src/bin/commands/secrets_cmd.rs
@@ -7,18 +7,29 @@
 //! - `kek-migrate --to <X>` — copy the KEK from the current backend to
 //!   target backend, update the marker, delete from the source
 //!   (operator-confirmable)
+//! - `snapshot-list` — inspect the per-secret snapshot history (the
+//!   on-write backups created since #4034). Metadata only; never prints
+//!   plaintext. Read-only, so safe with the node running, but a stopped
+//!   node gives a point-in-time-consistent view.
+//! - `snapshot-restore` — roll a delegate secret back to an earlier
+//!   snapshot. The current value is itself snapshotted first, so the
+//!   restore is reversible. The node MUST be stopped.
 //!
-//! All operations require the node process to be stopped (the on-disk
-//! secrets directory is exclusively owned during rotation/migration so
-//! a concurrent `freenet` write does not race the rewrite).
+//! The KEK operations require the node process to be stopped (the
+//! on-disk secrets directory is exclusively owned during rotation /
+//! migration so a concurrent `freenet` write does not race the rewrite);
+//! so does `snapshot-restore`, which writes the active secret file.
 
+use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, anyhow, bail};
 use chacha20poly1305::aead::{OsRng, rand_core::RngCore};
+use chrono::{DateTime, Utc};
 use freenet::dev_tool::{
-    KEK_SIZE, KekBackendKind, build_backend_for, load_from_backend, read_backend_marker,
-    replace_backend_marker, write_backend_marker,
+    KEK_SIZE, KekBackendKind, RestoreError, RetentionPolicy, build_backend_for, list_snapshots,
+    load_from_backend, read_backend_marker, replace_backend_marker, restore_snapshot_file,
+    snapshot_dir_for_encoded, write_backend_marker,
 };
 use sha2::{Digest, Sha256};
 use zeroize::Zeroizing;
@@ -30,12 +41,6 @@ pub struct SecretsCliConfig {
 }
 
 #[derive(clap::Subcommand, Clone, Debug)]
-#[allow(
-    clippy::enum_variant_names,
-    reason = "every variant manages the KEK and the `Kek` prefix matches the user-facing \
-              CLI verbs (`freenet secrets kek-status`, `freenet secrets kek-rotate`, \
-              `freenet secrets kek-migrate`)."
-)]
 pub enum SecretsCommand {
     /// Print the active KEK backend and the KEK fingerprint
     /// (`SHA-256(KEK)[..8]` in hex). Does NOT print the KEK itself.
@@ -54,6 +59,14 @@ pub enum SecretsCommand {
     /// Useful when migrating from `file` to `keyring` after installing
     /// a secret-storage daemon, or in reverse during disaster recovery.
     KekMigrate(KekMigrateArgs),
+    /// List the per-secret snapshot history (the on-write backups
+    /// created since #4034). Metadata only — never prints plaintext
+    /// secret values. Read-only.
+    SnapshotList(SnapshotListArgs),
+    /// Roll a delegate secret back to an earlier snapshot. The current
+    /// value is itself snapshotted first, so the restore is reversible.
+    /// The node MUST be stopped.
+    SnapshotRestore(SnapshotRestoreArgs),
 }
 
 #[derive(clap::Parser, Clone, Debug)]
@@ -103,12 +116,51 @@ pub struct KekMigrateArgs {
     pub yes: bool,
 }
 
+#[derive(clap::Parser, Clone, Debug)]
+pub struct SnapshotListArgs {
+    /// Path to the node's secrets directory (the parent of the
+    /// per-delegate secret subdirectories).
+    #[clap(long, value_parser)]
+    pub secrets_dir: PathBuf,
+    /// Restrict the listing to a single delegate, by its bs58-encoded
+    /// delegate key (as shown in the unfiltered listing).
+    #[clap(long)]
+    pub delegate: Option<String>,
+    /// Restrict the listing to a single secret, by its bs58-encoded id
+    /// (as shown in the per-delegate listing). Requires `--delegate`.
+    /// When set, every individual snapshot (timestamp + size) is printed
+    /// instead of just the per-secret count.
+    #[clap(long, requires = "delegate")]
+    pub secret: Option<String>,
+}
+
+#[derive(clap::Parser, Clone, Debug)]
+pub struct SnapshotRestoreArgs {
+    #[clap(long, value_parser)]
+    pub secrets_dir: PathBuf,
+    /// bs58-encoded delegate key (copy it from `snapshot-list`).
+    #[clap(long)]
+    pub delegate: String,
+    /// bs58-encoded secret id (copy it from `snapshot-list`).
+    #[clap(long)]
+    pub secret: String,
+    /// `timestamp_ms` of the snapshot to restore (copy it from
+    /// `snapshot-list`).
+    #[clap(long)]
+    pub timestamp_ms: u64,
+    /// Skip the interactive confirmation prompt (for scripted use).
+    #[clap(long)]
+    pub yes: bool,
+}
+
 pub async fn run(config: SecretsCliConfig) -> Result<()> {
     match config.command {
         SecretsCommand::KekStatus(args) => kek_status(args).await,
         SecretsCommand::KekInit(args) => kek_init(args).await,
         SecretsCommand::KekRotate(args) => kek_rotate(args).await,
         SecretsCommand::KekMigrate(args) => kek_migrate(args).await,
+        SecretsCommand::SnapshotList(args) => snapshot_list(args).await,
+        SecretsCommand::SnapshotRestore(args) => snapshot_restore(args).await,
     }
 }
 
@@ -365,6 +417,199 @@ async fn kek_migrate(args: KekMigrateArgs) -> Result<()> {
 
     println!("Migrated KEK from `{current}` to `{target}`.");
     Ok(())
+}
+
+/// Format an epoch-millis timestamp as an RFC3339 UTC string for
+/// display. Falls back to a raw annotation if the value is out of range
+/// (should never happen for a real snapshot filename).
+fn format_ts(timestamp_ms: u64) -> String {
+    DateTime::<Utc>::from_timestamp_millis(timestamp_ms as i64)
+        .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+        .unwrap_or_else(|| format!("{timestamp_ms}ms"))
+}
+
+/// Enumerate the immediate subdirectory names of `dir`, sorted. Used to
+/// walk delegate directories under the secrets root and per-secret
+/// snapshot directories under a delegate's `.snapshots/`.
+fn subdir_names(dir: &std::path::Path) -> Result<Vec<String>> {
+    let mut out = Vec::new();
+    for entry in fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))? {
+        let entry = entry?;
+        if entry.file_type().is_ok_and(|ft| ft.is_dir())
+            && let Some(name) = entry.file_name().to_str()
+        {
+            out.push(name.to_string());
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+async fn snapshot_list(args: SnapshotListArgs) -> Result<()> {
+    if !args.secrets_dir.exists() {
+        bail!("secrets dir {} does not exist", args.secrets_dir.display());
+    }
+
+    // Detailed single-secret view (`--delegate X --secret Y`): print
+    // every snapshot row.
+    if let Some(secret) = &args.secret {
+        // clap's `requires = "delegate"` guarantees this is Some.
+        let delegate = args
+            .delegate
+            .as_ref()
+            .expect("clap enforces --secret requires --delegate");
+        let delegate_dir = args.secrets_dir.join(delegate);
+        if !delegate_dir.is_dir() {
+            bail!(
+                "no delegate directory `{delegate}` under {}",
+                args.secrets_dir.display()
+            );
+        }
+        let snap_dir = snapshot_dir_for_encoded(&delegate_dir, secret);
+        let snaps = list_snapshots(&snap_dir)
+            .with_context(|| format!("failed to list snapshots in {}", snap_dir.display()))?;
+        println!("Delegate {delegate}");
+        println!("Secret   {secret}");
+        if snaps.is_empty() {
+            println!("  (no snapshot history)");
+            return Ok(());
+        }
+        println!(
+            "  {:>16}  {:<20}  {:>9}  suffix",
+            "timestamp_ms", "utc", "bytes"
+        );
+        for s in &snaps {
+            let suffix = s
+                .suffix
+                .map(|x| x.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            println!(
+                "  {:>16}  {:<20}  {:>9}  {suffix}",
+                s.timestamp_ms,
+                format_ts(s.timestamp_ms),
+                s.size_bytes,
+            );
+        }
+        println!("  {} snapshot(s)", snaps.len());
+        return Ok(());
+    }
+
+    // Summary view: one or all delegates, per-secret snapshot counts.
+    let delegates = match &args.delegate {
+        Some(d) => {
+            if !args.secrets_dir.join(d).is_dir() {
+                bail!(
+                    "no delegate directory `{d}` under {}",
+                    args.secrets_dir.display()
+                );
+            }
+            vec![d.clone()]
+        }
+        None => subdir_names(&args.secrets_dir)?,
+    };
+
+    if delegates.is_empty() {
+        println!(
+            "No delegate directories found under {}",
+            args.secrets_dir.display()
+        );
+        return Ok(());
+    }
+
+    println!("Secrets dir: {}", args.secrets_dir.display());
+    for delegate in &delegates {
+        let delegate_dir = args.secrets_dir.join(delegate);
+        let snapshots_root = delegate_dir.join(".snapshots");
+        println!("Delegate {delegate}");
+        let secrets = if snapshots_root.is_dir() {
+            subdir_names(&snapshots_root)?
+        } else {
+            Vec::new()
+        };
+        let mut any = false;
+        for secret in &secrets {
+            let snap_dir = snapshot_dir_for_encoded(&delegate_dir, secret);
+            let snaps = list_snapshots(&snap_dir).unwrap_or_default();
+            if snaps.is_empty() {
+                continue;
+            }
+            any = true;
+            let latest = snaps
+                .last()
+                .map(|s| format_ts(s.timestamp_ms))
+                .unwrap_or_default();
+            println!(
+                "  Secret {secret}: {} snapshot(s), latest {latest}",
+                snaps.len()
+            );
+        }
+        if !any {
+            println!("  (no snapshot history)");
+        }
+    }
+    Ok(())
+}
+
+async fn snapshot_restore(args: SnapshotRestoreArgs) -> Result<()> {
+    let delegate_dir = args.secrets_dir.join(&args.delegate);
+    let snap_dir = snapshot_dir_for_encoded(&delegate_dir, &args.secret);
+    if !snap_dir.is_dir() {
+        bail!(
+            "no snapshot history for secret `{}` of delegate `{}` under {} \
+             (run `freenet secrets snapshot-list` to see what's available)",
+            args.secret,
+            args.delegate,
+            args.secrets_dir.display()
+        );
+    }
+
+    if !args.yes {
+        eprintln!(
+            "About to restore secret `{}` of delegate `{}` to the snapshot at \
+             timestamp_ms={} in {}.\n\
+             - The current value is snapshotted first, so this is reversible.\n\
+             - The freenet node MUST be stopped (a running node may concurrently \
+               write this secret).\n\
+             Re-run with --yes to proceed.",
+            args.secret,
+            args.delegate,
+            args.timestamp_ms,
+            args.secrets_dir.display()
+        );
+        bail!("aborted (no --yes)");
+    }
+
+    // Byte-level restore via the shared core — the same code the node
+    // runtime uses, so the durability discipline can't drift. The
+    // reversibility snapshot is always enabled for the CLI (manual
+    // recovery should be undoable); default retention policy.
+    match restore_snapshot_file(
+        &delegate_dir,
+        &args.secret,
+        args.timestamp_ms,
+        true,
+        &RetentionPolicy::default(),
+        std::time::SystemTime::now(),
+    ) {
+        Ok(()) => {
+            println!(
+                "Restored secret `{}` of delegate `{}` to snapshot timestamp_ms={}.",
+                args.secret, args.delegate, args.timestamp_ms
+            );
+            Ok(())
+        }
+        Err(RestoreError::NotFound(ts)) => bail!(
+            "no snapshot at timestamp_ms={ts} for secret `{}` of delegate `{}`. Run \
+             `freenet secrets snapshot-list --secrets-dir {} --delegate {} --secret {}` to see \
+             available timestamps.",
+            args.secret,
+            args.delegate,
+            args.secrets_dir.display(),
+            args.delegate,
+            args.secret
+        ),
+        Err(RestoreError::Io(e)) => Err(anyhow::Error::new(e).context("snapshot restore failed")),
+    }
 }
 
 #[cfg(test)]
@@ -632,6 +877,162 @@ mod tests {
         assert_eq!(
             read_backend_marker(dir.path()).unwrap(),
             Some(KekBackendKind::File)
+        );
+    }
+
+    // ----- snapshot-list / snapshot-restore -----
+
+    /// Lay out `<secrets_dir>/<delegate>/<secret>` (active) and a single
+    /// `<delegate>/.snapshots/<secret>/<stamp:020>` snapshot.
+    fn seed_snapshot(
+        secrets_dir: &std::path::Path,
+        delegate: &str,
+        secret: &str,
+        active: &[u8],
+        stamp: u64,
+        snapshot: &[u8],
+    ) {
+        let delegate_dir = secrets_dir.join(delegate);
+        std::fs::create_dir_all(&delegate_dir).unwrap();
+        std::fs::write(delegate_dir.join(secret), active).unwrap();
+        let snap_dir = delegate_dir.join(".snapshots").join(secret);
+        std::fs::create_dir_all(&snap_dir).unwrap();
+        std::fs::write(snap_dir.join(format!("{stamp:020}")), snapshot).unwrap();
+    }
+
+    fn list_args(
+        dir: &std::path::Path,
+        delegate: Option<&str>,
+        secret: Option<&str>,
+    ) -> SnapshotListArgs {
+        SnapshotListArgs {
+            secrets_dir: dir.to_path_buf(),
+            delegate: delegate.map(str::to_string),
+            secret: secret.map(str::to_string),
+        }
+    }
+
+    fn restore_args(
+        dir: &std::path::Path,
+        delegate: &str,
+        secret: &str,
+        timestamp_ms: u64,
+        yes: bool,
+    ) -> SnapshotRestoreArgs {
+        SnapshotRestoreArgs {
+            secrets_dir: dir.to_path_buf(),
+            delegate: delegate.to_string(),
+            secret: secret.to_string(),
+            timestamp_ms,
+            yes,
+        }
+    }
+
+    #[tokio::test]
+    async fn snapshot_list_empty_dir_succeeds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        snapshot_list(list_args(dir.path(), None, None))
+            .await
+            .expect("list on empty dir must succeed");
+    }
+
+    #[tokio::test]
+    async fn snapshot_list_missing_dir_errors() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("nope");
+        let err = snapshot_list(list_args(&missing, None, None))
+            .await
+            .expect_err("missing secrets dir must error");
+        assert!(err.to_string().contains("does not exist"));
+    }
+
+    #[tokio::test]
+    async fn snapshot_list_summary_and_detail_views_succeed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        seed_snapshot(dir.path(), "delegateA", "secretX", b"cur", 7, b"old");
+        // Summary (all delegates) and single-delegate views.
+        snapshot_list(list_args(dir.path(), None, None))
+            .await
+            .expect("summary list ok");
+        snapshot_list(list_args(dir.path(), Some("delegateA"), None))
+            .await
+            .expect("single-delegate list ok");
+        // Detailed single-secret view.
+        snapshot_list(list_args(dir.path(), Some("delegateA"), Some("secretX")))
+            .await
+            .expect("detail list ok");
+    }
+
+    #[tokio::test]
+    async fn snapshot_list_unknown_delegate_errors() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = snapshot_list(list_args(dir.path(), Some("nope"), None))
+            .await
+            .expect_err("unknown delegate must error");
+        assert!(err.to_string().contains("no delegate directory"));
+    }
+
+    #[tokio::test]
+    async fn snapshot_restore_without_yes_aborts_and_preserves_active() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        seed_snapshot(dir.path(), "D", "S", b"current", 42, b"old");
+        let err = snapshot_restore(restore_args(dir.path(), "D", "S", 42, false))
+            .await
+            .expect_err("must abort without --yes");
+        assert!(err.to_string().contains("aborted"));
+        // Active value untouched.
+        assert_eq!(
+            std::fs::read(dir.path().join("D").join("S")).unwrap(),
+            b"current"
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_restore_unknown_secret_errors() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = snapshot_restore(restore_args(dir.path(), "D", "missing", 1, true))
+            .await
+            .expect_err("must error when no snapshot history");
+        assert!(err.to_string().contains("no snapshot history"));
+    }
+
+    #[tokio::test]
+    async fn snapshot_restore_round_trip_restores_prior_value() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Recent timestamp so the seeded snapshot survives the default
+        // retention's 2-year max_age cap during the restore's thin pass.
+        let stamp = (std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64)
+            - 60_000;
+        seed_snapshot(dir.path(), "D", "S", b"current", stamp, b"old-value");
+        snapshot_restore(restore_args(dir.path(), "D", "S", stamp, true))
+            .await
+            .expect("restore must succeed");
+        assert_eq!(
+            std::fs::read(dir.path().join("D").join("S")).unwrap(),
+            b"old-value"
+        );
+        // Reversible: the prior "current" value was snapshotted, so the
+        // history now has at least 2 entries.
+        let snap_dir = dir.path().join("D").join(".snapshots").join("S");
+        let count = std::fs::read_dir(&snap_dir).unwrap().count();
+        assert!(count >= 2, "expected reversibility snapshot, got {count}");
+    }
+
+    #[tokio::test]
+    async fn snapshot_restore_unknown_timestamp_errors() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        seed_snapshot(dir.path(), "D", "S", b"current", 100, b"old");
+        let err = snapshot_restore(restore_args(dir.path(), "D", "S", 999, true))
+            .await
+            .expect_err("must error on unknown timestamp");
+        assert!(err.to_string().contains("no snapshot at timestamp_ms=999"));
+        // Active untouched on the error path.
+        assert_eq!(
+            std::fs::read(dir.path().join("D").join("S")).unwrap(),
+            b"current"
         );
     }
 }

--- a/crates/core/src/bin/commands/secrets_cmd.rs
+++ b/crates/core/src/bin/commands/secrets_cmd.rs
@@ -428,6 +428,24 @@ fn format_ts(timestamp_ms: u64) -> String {
         .unwrap_or_else(|| format!("{timestamp_ms}ms"))
 }
 
+/// Reject an operator-supplied delegate/secret id that isn't a single,
+/// normal path component, so a fat-fingered or pasted `--delegate` /
+/// `--secret` (e.g. one containing `/`, `\`, or `..`) can't make the
+/// `--secrets-dir` join escape the secrets tree and clobber or disclose
+/// a file elsewhere. On-disk ids are bs58 (no separators, no dots), so
+/// this never rejects a value copied from `snapshot-list`.
+fn validate_component(label: &str, value: &str) -> Result<()> {
+    use std::path::Component;
+    let mut comps = std::path::Path::new(value).components();
+    match (comps.next(), comps.next()) {
+        (Some(Component::Normal(c)), None) if c == std::ffi::OsStr::new(value) => Ok(()),
+        _ => bail!(
+            "invalid {label} `{value}`: must be a single path component with no `/`, `\\`, or \
+             `..` — copy the exact value shown by `freenet secrets snapshot-list`"
+        ),
+    }
+}
+
 /// Enumerate the immediate subdirectory names of `dir`, sorted. Used to
 /// walk delegate directories under the secrets root and per-secret
 /// snapshot directories under a delegate's `.snapshots/`.
@@ -448,6 +466,12 @@ fn subdir_names(dir: &std::path::Path) -> Result<Vec<String>> {
 async fn snapshot_list(args: SnapshotListArgs) -> Result<()> {
     if !args.secrets_dir.exists() {
         bail!("secrets dir {} does not exist", args.secrets_dir.display());
+    }
+    if let Some(d) = &args.delegate {
+        validate_component("delegate", d)?;
+    }
+    if let Some(s) = &args.secret {
+        validate_component("secret", s)?;
     }
 
     // Detailed single-secret view (`--delegate X --secret Y`): print
@@ -529,7 +553,12 @@ async fn snapshot_list(args: SnapshotListArgs) -> Result<()> {
         let mut any = false;
         for secret in &secrets {
             let snap_dir = snapshot_dir_for_encoded(&delegate_dir, secret);
-            let snaps = list_snapshots(&snap_dir).unwrap_or_default();
+            // Propagate (don't swallow) a read/stat error: during the
+            // recovery scenario this tool exists for, silently rendering
+            // an unreadable snapshot dir as "no history" would mislead
+            // the operator. Matches the detail view's `?` handling.
+            let snaps = list_snapshots(&snap_dir)
+                .with_context(|| format!("failed to list snapshots in {}", snap_dir.display()))?;
             if snaps.is_empty() {
                 continue;
             }
@@ -551,6 +580,8 @@ async fn snapshot_list(args: SnapshotListArgs) -> Result<()> {
 }
 
 async fn snapshot_restore(args: SnapshotRestoreArgs) -> Result<()> {
+    validate_component("delegate", &args.delegate)?;
+    validate_component("secret", &args.secret)?;
     let delegate_dir = args.secrets_dir.join(&args.delegate);
     let snap_dir = snapshot_dir_for_encoded(&delegate_dir, &args.secret);
     if !snap_dir.is_dir() {
@@ -1033,6 +1064,64 @@ mod tests {
         assert_eq!(
             std::fs::read(dir.path().join("D").join("S")).unwrap(),
             b"current"
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_restore_rejects_path_traversal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = snapshot_restore(restore_args(dir.path(), "../../etc", "S", 1, true))
+            .await
+            .expect_err("traversal in --delegate must be rejected");
+        assert!(err.to_string().contains("invalid delegate"));
+        let err = snapshot_restore(restore_args(dir.path(), "D", "../../etc/passwd", 1, true))
+            .await
+            .expect_err("traversal in --secret must be rejected");
+        assert!(err.to_string().contains("invalid secret"));
+    }
+
+    #[tokio::test]
+    async fn snapshot_list_rejects_path_traversal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = snapshot_list(list_args(dir.path(), Some("../x"), None))
+            .await
+            .expect_err("traversal in --delegate must be rejected");
+        assert!(err.to_string().contains("invalid delegate"));
+        let err = snapshot_list(list_args(dir.path(), Some("D"), Some("a/b")))
+            .await
+            .expect_err("separator in --secret must be rejected");
+        assert!(err.to_string().contains("invalid secret"));
+    }
+
+    #[tokio::test]
+    async fn snapshot_list_detail_empty_history_succeeds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Delegate dir + active secret present, but no `.snapshots/` yet:
+        // the detail view's "(no snapshot history)" branch.
+        let delegate_dir = dir.path().join("D");
+        std::fs::create_dir_all(&delegate_dir).unwrap();
+        std::fs::write(delegate_dir.join("S"), b"v").unwrap();
+        snapshot_list(list_args(dir.path(), Some("D"), Some("S")))
+            .await
+            .expect("detail view with no history must succeed");
+    }
+
+    #[test]
+    fn snapshot_list_secret_requires_delegate_at_parse() {
+        use clap::Parser;
+        // `--secret` without `--delegate` must fail clap parsing — pins the
+        // `requires = "delegate"` invariant the `.expect()` in the detail
+        // view depends on.
+        let res = SnapshotListArgs::try_parse_from([
+            "snapshot-list",
+            "--secrets-dir",
+            "/tmp/x",
+            "--secret",
+            "y",
+        ]);
+        assert!(
+            res.is_err(),
+            "--secret without --delegate must fail to parse"
         );
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -139,7 +139,10 @@ pub mod dev_tool {
         register_topology_snapshot, set_current_network_name, validate_topology,
         validate_topology_from_snapshots,
     };
-    pub use wasm_runtime::secret_snapshots::SnapshotMetadata;
+    pub use wasm_runtime::secret_snapshots::{
+        RestoreError, RetentionPolicy, SnapshotMetadata, list_snapshots, restore_snapshot_file,
+        snapshot_dir_for_encoded,
+    };
     pub use wasm_runtime::{
         ContractStore, DelegateStore, MockStateStorage, Runtime, SecretStoreError, SecretsStore,
         StateStore,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -141,7 +141,7 @@ pub mod dev_tool {
     };
     pub use wasm_runtime::secret_snapshots::{
         RestoreError, RetentionPolicy, SnapshotMetadata, list_snapshots, restore_snapshot_file,
-        snapshot_dir_for_encoded,
+        snapshot_dir_for_encoded, thin_snapshots,
     };
     pub use wasm_runtime::{
         ContractStore, DelegateStore, MockStateStorage, Runtime, SecretStoreError, SecretsStore,

--- a/crates/core/src/wasm_runtime/secret_snapshots.rs
+++ b/crates/core/src/wasm_runtime/secret_snapshots.rs
@@ -1037,4 +1037,88 @@ mod tests {
             "missing active must not produce a snapshot"
         );
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn restore_snapshot_file_writes_owner_only() {
+        // The restore write path lands the active secret at 0o600 and the
+        // snapshot dirs at 0o700 — the crypto-at-rest regression class
+        // #4146 guarded for `store_secret`, here for the restore write.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let delegate_dir = dir.path().join("delegateA");
+        let secret = "secretX";
+        let snap_dir = snapshot_dir_for_encoded(&delegate_dir, secret);
+        let stamp = recent_ms();
+        write_snapshot(&snap_dir, stamp, b"old-value");
+        fs::create_dir_all(&delegate_dir).unwrap();
+        // Seed the active file owner-only, as `store_secret` always does
+        // in production, so the hard-linked reversibility snapshot is 0o600.
+        fs::write(delegate_dir.join(secret), b"current-value").unwrap();
+        fs::set_permissions(delegate_dir.join(secret), fs::Permissions::from_mode(0o600)).unwrap();
+
+        restore_snapshot_file(
+            &delegate_dir,
+            secret,
+            stamp,
+            true,
+            &RetentionPolicy::default(),
+            SystemTime::now(),
+        )
+        .expect("restore must succeed");
+
+        let mode = |p: &Path| fs::metadata(p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode(&delegate_dir.join(secret)),
+            0o600,
+            "restored active secret must be owner-only"
+        );
+        assert_eq!(
+            mode(&delegate_dir.join(SNAPSHOTS_DIR)),
+            0o700,
+            ".snapshots umbrella must be owner-only"
+        );
+        assert_eq!(
+            mode(&snap_dir),
+            0o700,
+            "per-secret snapshot dir must be owner-only"
+        );
+    }
+
+    #[test]
+    fn restore_snapshot_file_disabled_skips_reversibility_and_thin() {
+        // With `snapshots_enabled=false` the restore must still replace the
+        // active value, but skip BOTH the reversibility snapshot and the
+        // thin pass. Seed two ancient snapshots the default policy's 2-year
+        // max_age WOULD prune if thinning ran — their survival proves it
+        // didn't.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let delegate_dir = dir.path().join("delegateA");
+        let secret = "secretX";
+        let snap_dir = snapshot_dir_for_encoded(&delegate_dir, secret);
+        write_snapshot(&snap_dir, 1000, b"v1000");
+        write_snapshot(&snap_dir, 2000, b"v2000");
+        fs::create_dir_all(&delegate_dir).unwrap();
+        fs::write(delegate_dir.join(secret), b"current").unwrap();
+
+        let before = list_snapshots(&snap_dir).unwrap().len();
+        restore_snapshot_file(
+            &delegate_dir,
+            secret,
+            1000,
+            false,
+            &RetentionPolicy::default(),
+            SystemTime::now(),
+        )
+        .expect("restore must succeed");
+
+        assert_eq!(fs::read(delegate_dir.join(secret)).unwrap(), b"v1000");
+        let after = list_snapshots(&snap_dir).unwrap();
+        assert_eq!(
+            after.len(),
+            before,
+            "disabled restore must neither add a reversibility snapshot nor thin"
+        );
+        assert_eq!(after.len(), 2);
+    }
 }

--- a/crates/core/src/wasm_runtime/secret_snapshots.rs
+++ b/crates/core/src/wasm_runtime/secret_snapshots.rs
@@ -450,8 +450,15 @@ pub enum RestoreError {
 /// 1. snapshot the current active value first (so the restore is itself
 ///    reversible) when `snapshots_enabled`,
 /// 2. copy the chosen snapshot to a sibling `.tmp`, fsync, then
-///    atomically rename onto the active path,
-/// 3. thin the snapshot history per `retention`.
+///    atomically rename onto the active path.
+///
+/// History thinning is intentionally NOT done here — callers thin AFTER
+/// their own post-restore bookkeeping. The node runtime thins only after
+/// its ReDb index repair commits, so a failed repair cannot prune source
+/// history a retry would need; the CLI thins right after a successful
+/// restore. (Keeping thin out of the shared core is what makes the
+/// runtime path byte-for-byte order-preserving vs. the pre-extraction
+/// inline implementation.)
 ///
 /// `suffix` selects among same-millisecond collision entries (which
 /// [`list_snapshots`] / `snapshot-list` surface as the `suffix` column):
@@ -478,8 +485,6 @@ pub fn restore_snapshot_file(
     timestamp_ms: u64,
     suffix: Option<u32>,
     snapshots_enabled: bool,
-    retention: &RetentionPolicy,
-    now: SystemTime,
 ) -> Result<(), RestoreError> {
     let snap_dir = snapshot_dir_for_encoded(delegate_dir, secret_encoded);
     let secret_file_path = delegate_dir.join(secret_encoded);
@@ -539,12 +544,6 @@ pub fn restore_snapshot_file(
         return Err(err.into());
     }
 
-    // Best-effort thin: the reversibility snapshot above may have pushed
-    // the history one over the policy target. Self-correcting on the next
-    // write even if this pass fails.
-    if snapshots_enabled && snap_dir.exists() {
-        thin_snapshots(&snap_dir, retention, now);
-    }
     Ok(())
 }
 
@@ -912,16 +911,8 @@ mod tests {
         fs::create_dir_all(&delegate_dir).unwrap();
         fs::write(delegate_dir.join(secret), b"current-value").unwrap();
 
-        restore_snapshot_file(
-            &delegate_dir,
-            secret,
-            1000,
-            None,
-            true,
-            &RetentionPolicy::default(),
-            SystemTime::now(),
-        )
-        .expect("restore must succeed");
+        restore_snapshot_file(&delegate_dir, secret, 1000, None, true)
+            .expect("restore must succeed");
 
         assert_eq!(fs::read(delegate_dir.join(secret)).unwrap(), b"old-value");
     }
@@ -941,16 +932,8 @@ mod tests {
         fs::create_dir_all(&delegate_dir).unwrap();
         fs::write(delegate_dir.join(secret), b"current-value").unwrap();
 
-        restore_snapshot_file(
-            &delegate_dir,
-            secret,
-            stamp,
-            None,
-            true,
-            &RetentionPolicy::default(),
-            SystemTime::now(),
-        )
-        .expect("restore must succeed");
+        restore_snapshot_file(&delegate_dir, secret, stamp, None, true)
+            .expect("restore must succeed");
 
         let snaps = list_snapshots(&snap_dir).expect("list");
         assert!(
@@ -978,16 +961,8 @@ mod tests {
         fs::create_dir_all(&delegate_dir).unwrap();
         fs::write(delegate_dir.join(secret), b"current").unwrap();
 
-        let err = restore_snapshot_file(
-            &delegate_dir,
-            secret,
-            999,
-            None,
-            true,
-            &RetentionPolicy::default(),
-            SystemTime::now(),
-        )
-        .expect_err("unknown timestamp must error");
+        let err = restore_snapshot_file(&delegate_dir, secret, 999, None, true)
+            .expect_err("unknown timestamp must error");
         assert!(matches!(err, RestoreError::NotFound(999)));
         // Active value untouched on the error path.
         assert_eq!(fs::read(delegate_dir.join(secret)).unwrap(), b"current");
@@ -998,16 +973,8 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let delegate_dir = dir.path().join("delegateA");
         // Secret never had a snapshot directory at all.
-        let err = restore_snapshot_file(
-            &delegate_dir,
-            "neversnapshotted",
-            1,
-            None,
-            true,
-            &RetentionPolicy::default(),
-            SystemTime::now(),
-        )
-        .expect_err("missing history must error");
+        let err = restore_snapshot_file(&delegate_dir, "neversnapshotted", 1, None, true)
+            .expect_err("missing history must error");
         assert!(matches!(err, RestoreError::NotFound(1)));
     }
 
@@ -1030,16 +997,8 @@ mod tests {
 
         // snapshots_enabled=false isolates the disambiguation from the
         // reversibility snapshot.
-        restore_snapshot_file(
-            &delegate_dir,
-            secret,
-            50,
-            None,
-            false,
-            &RetentionPolicy::default(),
-            SystemTime::now(),
-        )
-        .expect("restore must succeed");
+        restore_snapshot_file(&delegate_dir, secret, 50, None, false)
+            .expect("restore must succeed");
         assert_eq!(fs::read(delegate_dir.join(secret)).unwrap(), b"unsuffixed");
     }
 
@@ -1064,30 +1023,14 @@ mod tests {
         fs::write(delegate_dir.join(secret), b"current").unwrap();
 
         // Explicit suffix targets the exact `.n` entry.
-        restore_snapshot_file(
-            &delegate_dir,
-            secret,
-            50,
-            Some(1),
-            false,
-            &RetentionPolicy::default(),
-            SystemTime::now(),
-        )
-        .expect("restore must succeed");
+        restore_snapshot_file(&delegate_dir, secret, 50, Some(1), false)
+            .expect("restore must succeed");
         assert_eq!(fs::read(delegate_dir.join(secret)).unwrap(), b"suffix-one");
 
         // A missing suffix is NotFound, never a silent fallback to the
         // unsuffixed entry (which would restore the wrong ciphertext).
-        let err = restore_snapshot_file(
-            &delegate_dir,
-            secret,
-            50,
-            Some(9),
-            false,
-            &RetentionPolicy::default(),
-            SystemTime::now(),
-        )
-        .expect_err("missing suffix must error");
+        let err = restore_snapshot_file(&delegate_dir, secret, 50, Some(9), false)
+            .expect_err("missing suffix must error");
         assert!(matches!(err, RestoreError::NotFound(50)));
         // Active unchanged by the failed lookup.
         assert_eq!(fs::read(delegate_dir.join(secret)).unwrap(), b"suffix-one");
@@ -1128,16 +1071,8 @@ mod tests {
         fs::write(delegate_dir.join(secret), b"current-value").unwrap();
         fs::set_permissions(delegate_dir.join(secret), fs::Permissions::from_mode(0o600)).unwrap();
 
-        restore_snapshot_file(
-            &delegate_dir,
-            secret,
-            stamp,
-            None,
-            true,
-            &RetentionPolicy::default(),
-            SystemTime::now(),
-        )
-        .expect("restore must succeed");
+        restore_snapshot_file(&delegate_dir, secret, stamp, None, true)
+            .expect("restore must succeed");
 
         let mode = |p: &Path| fs::metadata(p).unwrap().permissions().mode() & 0o777;
         assert_eq!(
@@ -1158,40 +1093,34 @@ mod tests {
     }
 
     #[test]
-    fn restore_snapshot_file_disabled_skips_reversibility_and_thin() {
-        // With `snapshots_enabled=false` the restore must still replace the
-        // active value, but skip BOTH the reversibility snapshot and the
-        // thin pass. Seed two ancient snapshots the default policy's 2-year
-        // max_age WOULD prune if thinning ran — their survival proves it
-        // didn't.
+    fn restore_snapshot_file_disabled_skips_reversibility_snapshot() {
+        // `snapshots_enabled=false` replaces the active value but skips the
+        // reversibility snapshot. (Thinning is no longer the core's job —
+        // it lives in the callers — so the only history change a restore
+        // makes here is the reversibility snapshot.)
         let dir = tempfile::tempdir().expect("tempdir");
         let delegate_dir = dir.path().join("delegateA");
         let secret = "secretX";
         let snap_dir = snapshot_dir_for_encoded(&delegate_dir, secret);
         write_snapshot(&snap_dir, 1000, b"v1000");
-        write_snapshot(&snap_dir, 2000, b"v2000");
         fs::create_dir_all(&delegate_dir).unwrap();
         fs::write(delegate_dir.join(secret), b"current").unwrap();
 
         let before = list_snapshots(&snap_dir).unwrap().len();
-        restore_snapshot_file(
-            &delegate_dir,
-            secret,
-            1000,
-            None,
-            false,
-            &RetentionPolicy::default(),
-            SystemTime::now(),
-        )
-        .expect("restore must succeed");
-
+        restore_snapshot_file(&delegate_dir, secret, 1000, None, false)
+            .expect("restore must succeed");
         assert_eq!(fs::read(delegate_dir.join(secret)).unwrap(), b"v1000");
-        let after = list_snapshots(&snap_dir).unwrap();
         assert_eq!(
-            after.len(),
+            list_snapshots(&snap_dir).unwrap().len(),
             before,
-            "disabled restore must neither add a reversibility snapshot nor thin"
+            "disabled restore must not add a reversibility snapshot"
         );
-        assert_eq!(after.len(), 2);
+
+        // Contrast: with `snapshots_enabled=true` the prior active value IS
+        // snapshotted, so the history grows by exactly one (no thinning here).
+        fs::write(delegate_dir.join(secret), b"current2").unwrap();
+        restore_snapshot_file(&delegate_dir, secret, 1000, None, true)
+            .expect("restore must succeed");
+        assert_eq!(list_snapshots(&snap_dir).unwrap().len(), before + 1);
     }
 }

--- a/crates/core/src/wasm_runtime/secret_snapshots.rs
+++ b/crates/core/src/wasm_runtime/secret_snapshots.rs
@@ -453,22 +453,30 @@ pub enum RestoreError {
 ///    atomically rename onto the active path,
 /// 3. thin the snapshot history per `retention`.
 ///
-/// If several snapshots share `timestamp_ms` (same-millisecond collision
-/// suffixes), the unsuffixed file wins, then the lowest-numbered suffix —
-/// matching `SecretsStore::restore_snapshot`.
+/// `suffix` selects among same-millisecond collision entries (which
+/// [`list_snapshots`] / `snapshot-list` surface as the `suffix` column):
+/// - `None` — the unsuffixed file wins, then the lowest-numbered suffix
+///   (the historical `SecretsStore::restore_snapshot` behavior; the
+///   common case, since a timestamp without collisions has exactly one
+///   entry).
+/// - `Some(n)` — restore exactly the `.n` collision entry, so an operator
+///   can target a specific row from the listing rather than silently
+///   getting the unsuffixed one.
 ///
-/// Shared by `SecretsStore::restore_snapshot` (node runtime; it adds the
-/// in-memory + ReDb index repair) and the `freenet secrets
-/// snapshot-restore` CLI (node stopped). Byte-level copy: the restored
-/// ciphertext stays decryptable by whatever cipher wrote it.
+/// Shared by `SecretsStore::restore_snapshot` (node runtime; passes
+/// `None` and adds the in-memory + ReDb index repair) and the `freenet
+/// secrets snapshot-restore` CLI (node stopped). Byte-level copy: the
+/// restored ciphertext stays decryptable by whatever cipher wrote it.
 ///
 /// # Errors
-/// - [`RestoreError::NotFound`] if no snapshot matches `timestamp_ms`.
+/// - [`RestoreError::NotFound`] if no snapshot matches `timestamp_ms`
+///   (and, when `suffix` is `Some(n)`, the `.n` entry).
 /// - [`RestoreError::Io`] for filesystem errors during the restore.
 pub fn restore_snapshot_file(
     delegate_dir: &Path,
     secret_encoded: &str,
     timestamp_ms: u64,
+    suffix: Option<u32>,
     snapshots_enabled: bool,
     retention: &RetentionPolicy,
     now: SystemTime,
@@ -476,17 +484,25 @@ pub fn restore_snapshot_file(
     let snap_dir = snapshot_dir_for_encoded(delegate_dir, secret_encoded);
     let secret_file_path = delegate_dir.join(secret_encoded);
 
-    // Disambiguation rule: unsuffixed file wins, then lowest-numbered
-    // suffix. `None` sorts before `Some(_)` via the (0, 0) key.
     let entries = list_snapshots(&snap_dir)?;
-    let chosen = entries
-        .iter()
-        .filter(|m| m.timestamp_ms == timestamp_ms)
-        .min_by_key(|m| match m.suffix {
-            None => (0u32, 0u32),
-            Some(s) => (1, s),
-        })
-        .ok_or(RestoreError::NotFound(timestamp_ms))?;
+    let chosen = match suffix {
+        // Explicit selector: the exact `.n` collision entry. A missing
+        // `.n` is NotFound (never a silent fallback to the unsuffixed
+        // file, which would restore the wrong ciphertext).
+        Some(want) => entries
+            .iter()
+            .find(|m| m.timestamp_ms == timestamp_ms && m.suffix == Some(want)),
+        // Default disambiguation: unsuffixed file wins, then lowest-
+        // numbered suffix. `None` sorts before `Some(_)` via the (0,0) key.
+        None => entries
+            .iter()
+            .filter(|m| m.timestamp_ms == timestamp_ms)
+            .min_by_key(|m| match m.suffix {
+                None => (0u32, 0u32),
+                Some(s) => (1, s),
+            }),
+    }
+    .ok_or(RestoreError::NotFound(timestamp_ms))?;
     let chosen_path = chosen.path.clone();
 
     // Snapshot the value currently at the active path so the restore is
@@ -900,6 +916,7 @@ mod tests {
             &delegate_dir,
             secret,
             1000,
+            None,
             true,
             &RetentionPolicy::default(),
             SystemTime::now(),
@@ -928,6 +945,7 @@ mod tests {
             &delegate_dir,
             secret,
             stamp,
+            None,
             true,
             &RetentionPolicy::default(),
             SystemTime::now(),
@@ -964,6 +982,7 @@ mod tests {
             &delegate_dir,
             secret,
             999,
+            None,
             true,
             &RetentionPolicy::default(),
             SystemTime::now(),
@@ -983,6 +1002,7 @@ mod tests {
             &delegate_dir,
             "neversnapshotted",
             1,
+            None,
             true,
             &RetentionPolicy::default(),
             SystemTime::now(),
@@ -1014,12 +1034,63 @@ mod tests {
             &delegate_dir,
             secret,
             50,
+            None,
             false,
             &RetentionPolicy::default(),
             SystemTime::now(),
         )
         .expect("restore must succeed");
         assert_eq!(fs::read(delegate_dir.join(secret)).unwrap(), b"unsuffixed");
+    }
+
+    #[test]
+    fn restore_snapshot_file_targets_explicit_suffix() {
+        // The listing exposes collision suffixes; restore must be able to
+        // target a specific one rather than silently picking unsuffixed.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let delegate_dir = dir.path().join("delegateA");
+        let secret = "secretX";
+        let snap_dir = snapshot_dir_for_encoded(&delegate_dir, secret);
+        fs::create_dir_all(&snap_dir).unwrap();
+        let base = format!(
+            "{stamp:0width$}",
+            stamp = 50u64,
+            width = SNAPSHOT_NAME_WIDTH
+        );
+        fs::write(snap_dir.join(&base), b"unsuffixed").unwrap();
+        fs::write(snap_dir.join(format!("{base}.0")), b"suffix-zero").unwrap();
+        fs::write(snap_dir.join(format!("{base}.1")), b"suffix-one").unwrap();
+        fs::create_dir_all(&delegate_dir).unwrap();
+        fs::write(delegate_dir.join(secret), b"current").unwrap();
+
+        // Explicit suffix targets the exact `.n` entry.
+        restore_snapshot_file(
+            &delegate_dir,
+            secret,
+            50,
+            Some(1),
+            false,
+            &RetentionPolicy::default(),
+            SystemTime::now(),
+        )
+        .expect("restore must succeed");
+        assert_eq!(fs::read(delegate_dir.join(secret)).unwrap(), b"suffix-one");
+
+        // A missing suffix is NotFound, never a silent fallback to the
+        // unsuffixed entry (which would restore the wrong ciphertext).
+        let err = restore_snapshot_file(
+            &delegate_dir,
+            secret,
+            50,
+            Some(9),
+            false,
+            &RetentionPolicy::default(),
+            SystemTime::now(),
+        )
+        .expect_err("missing suffix must error");
+        assert!(matches!(err, RestoreError::NotFound(50)));
+        // Active unchanged by the failed lookup.
+        assert_eq!(fs::read(delegate_dir.join(secret)).unwrap(), b"suffix-one");
     }
 
     #[test]
@@ -1061,6 +1132,7 @@ mod tests {
             &delegate_dir,
             secret,
             stamp,
+            None,
             true,
             &RetentionPolicy::default(),
             SystemTime::now(),
@@ -1106,6 +1178,7 @@ mod tests {
             &delegate_dir,
             secret,
             1000,
+            None,
             false,
             &RetentionPolicy::default(),
             SystemTime::now(),

--- a/crates/core/src/wasm_runtime/secret_snapshots.rs
+++ b/crates/core/src/wasm_runtime/secret_snapshots.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{BTreeSet, HashSet};
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 // Wall-clock SystemTime (not the project-wide TimeSource trait) is the
 // correct abstraction here: snapshot file names embed epoch_ms so retention
@@ -23,6 +24,11 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use freenet_stdlib::prelude::SecretsId;
+
+// The owner-only filesystem helpers live next door in `secrets_store`;
+// the snapshot restore path reuses them so the secret-blob and the
+// reversibility-snapshot writes share one perms discipline.
+use super::secrets_store::{create_owner_only, ensure_owner_only_dir};
 
 /// Subdirectory (relative to a delegate's secrets dir) holding the
 /// per-secret snapshot history. Leading dot keeps it visually separate from
@@ -184,11 +190,23 @@ impl RetentionPolicy {
     }
 }
 
+/// Path to the snapshot directory for a delegate secret, keyed on the
+/// secret's on-disk encoded id (bs58 of the secret hash).
+///
+/// This is the form the `freenet secrets` CLI and the filesystem-level
+/// [`restore_snapshot_file`] use: a [`SecretsId`] cannot be reconstructed
+/// from the on-disk directory name alone (the pre-image `key` bytes are
+/// not persisted, only their hash), so any tool that walks the secrets
+/// tree must work from the encoded id string.
+pub fn snapshot_dir_for_encoded(delegate_path: &Path, secret_encoded: &str) -> PathBuf {
+    delegate_path.join(SNAPSHOTS_DIR).join(secret_encoded)
+}
+
 /// Path to the snapshot directory for a particular `(delegate, secret_id)`
 /// pair. Snapshots are organized per secret so retention thinning of one
 /// busy key cannot affect another.
 pub fn snapshot_dir_for(delegate_path: &Path, key: &SecretsId) -> PathBuf {
-    delegate_path.join(SNAPSHOTS_DIR).join(key.encode())
+    snapshot_dir_for_encoded(delegate_path, &key.encode())
 }
 
 /// Pick the snapshot file path for a write happening "now". Uses the
@@ -361,6 +379,157 @@ pub(crate) fn parse_snapshot_name(path: &Path) -> Option<(u64, Option<u32>)> {
         None => None,
     };
     Some((stamp_part.parse().ok()?, suffix))
+}
+
+/// Capture the current active secret file as a snapshot so an overwrite
+/// (a `store_secret`, or a [`restore_snapshot_file`]) is reversible.
+///
+/// Hard-links the active inode into `.snapshots/{secret_encoded}/`
+/// (falling back to a copy on filesystems without hard links, e.g. FAT
+/// or some network mounts), after tightening both the `.snapshots/`
+/// umbrella and the per-secret leaf to owner-only. `active_path` must be
+/// the live secret file (`delegate_dir/{secret_encoded}`); a missing
+/// active file is a no-op (nothing to preserve).
+///
+/// The active file is never mutated here, so a crash mid-snapshot loses
+/// only the snapshot, never the live value. Best-effort by contract of
+/// its callers: they log and continue on error rather than failing the
+/// primary write/restore.
+pub fn snapshot_active_value(
+    delegate_dir: &Path,
+    secret_encoded: &str,
+    active_path: &Path,
+) -> std::io::Result<()> {
+    let snap_dir = snapshot_dir_for_encoded(delegate_dir, secret_encoded);
+    fs::create_dir_all(&snap_dir)?;
+    // Tighten BOTH the intermediate `.snapshots/` umbrella AND the
+    // per-secret leaf. Only chmodding the leaf leaves `.snapshots/` at
+    // the process umask (typically 0o755), which lets any local user
+    // enumerate per-secret subdir names, write counts (epoch_ms
+    // filenames), and write timing.
+    let snap_parent = delegate_dir.join(SNAPSHOTS_DIR);
+    if let Err(e) = ensure_owner_only_dir(&snap_parent) {
+        tracing::warn!(path = %snap_parent.display(), error = %e, "chmod snapshots parent dir failed");
+    }
+    if let Err(e) = ensure_owner_only_dir(&snap_dir) {
+        tracing::warn!(path = %snap_dir.display(), error = %e, "chmod snapshot dir failed");
+    }
+    let snap_path = next_snapshot_path(&snap_dir)?;
+    match fs::hard_link(active_path, &snap_path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(_) => {
+            // Hard-link unsupported (FAT, cross-device, etc.). Copy is
+            // slower but always works; the active file is not mutated
+            // here so the copy can't tear.
+            fs::copy(active_path, &snap_path).map(|_| ())
+        }
+    }
+}
+
+/// Error from the filesystem-level [`restore_snapshot_file`].
+#[derive(Debug, thiserror::Error)]
+pub enum RestoreError {
+    /// No snapshot in the directory matched the requested `timestamp_ms`.
+    #[error("no snapshot at timestamp_ms {0}")]
+    NotFound(u64),
+    /// Filesystem error during the find / copy / rename / fsync sequence.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+/// Restore the snapshot matching `timestamp_ms` onto the active secret
+/// path, purely at the filesystem level — no cipher, no ReDb index.
+///
+/// `delegate_dir` is `<secrets_dir>/<delegate_encoded>`; `secret_encoded`
+/// is the on-disk secret file name (bs58 of the secret hash). The active
+/// secret file is `delegate_dir/{secret_encoded}`; its snapshot history
+/// lives in `delegate_dir/.snapshots/{secret_encoded}/`.
+///
+/// Mirrors the durability discipline of `SecretsStore::store_secret`:
+/// 1. snapshot the current active value first (so the restore is itself
+///    reversible) when `snapshots_enabled`,
+/// 2. copy the chosen snapshot to a sibling `.tmp`, fsync, then
+///    atomically rename onto the active path,
+/// 3. thin the snapshot history per `retention`.
+///
+/// If several snapshots share `timestamp_ms` (same-millisecond collision
+/// suffixes), the unsuffixed file wins, then the lowest-numbered suffix —
+/// matching `SecretsStore::restore_snapshot`.
+///
+/// Shared by `SecretsStore::restore_snapshot` (node runtime; it adds the
+/// in-memory + ReDb index repair) and the `freenet secrets
+/// snapshot-restore` CLI (node stopped). Byte-level copy: the restored
+/// ciphertext stays decryptable by whatever cipher wrote it.
+///
+/// # Errors
+/// - [`RestoreError::NotFound`] if no snapshot matches `timestamp_ms`.
+/// - [`RestoreError::Io`] for filesystem errors during the restore.
+pub fn restore_snapshot_file(
+    delegate_dir: &Path,
+    secret_encoded: &str,
+    timestamp_ms: u64,
+    snapshots_enabled: bool,
+    retention: &RetentionPolicy,
+    now: SystemTime,
+) -> Result<(), RestoreError> {
+    let snap_dir = snapshot_dir_for_encoded(delegate_dir, secret_encoded);
+    let secret_file_path = delegate_dir.join(secret_encoded);
+
+    // Disambiguation rule: unsuffixed file wins, then lowest-numbered
+    // suffix. `None` sorts before `Some(_)` via the (0, 0) key.
+    let entries = list_snapshots(&snap_dir)?;
+    let chosen = entries
+        .iter()
+        .filter(|m| m.timestamp_ms == timestamp_ms)
+        .min_by_key(|m| match m.suffix {
+            None => (0u32, 0u32),
+            Some(s) => (1, s),
+        })
+        .ok_or(RestoreError::NotFound(timestamp_ms))?;
+    let chosen_path = chosen.path.clone();
+
+    // Snapshot the value currently at the active path so the restore is
+    // itself reversible. Best-effort: a failure here must not fail the
+    // restore (the primary operation), only forfeit reversibility.
+    if snapshots_enabled
+        && secret_file_path.exists()
+        && let Err(e) = snapshot_active_value(delegate_dir, secret_encoded, &secret_file_path)
+    {
+        tracing::warn!("failed to snapshot active value before restore for {secret_encoded}: {e}");
+    }
+
+    // Read snapshot ciphertext, write through a sibling tmp file with an
+    // atomic rename so the active path never tears. `create_owner_only`
+    // unlinks any surviving `.tmp` from a prior crashed run so the new
+    // inode always lands at mode 0o600.
+    let ciphertext = fs::read(&chosen_path)?;
+    fs::create_dir_all(delegate_dir)?;
+    if let Err(e) = ensure_owner_only_dir(delegate_dir) {
+        tracing::warn!(path = %delegate_dir.display(), error = %e, "chmod delegate dir failed");
+    }
+    let tmp_path = secret_file_path.with_extension("tmp");
+    {
+        let mut file = create_owner_only(&tmp_path)?;
+        file.write_all(&ciphertext)?;
+        file.sync_all()?;
+    }
+    if let Err(err) = fs::rename(&tmp_path, &secret_file_path) {
+        if let Err(rm_err) = fs::remove_file(&tmp_path) {
+            tracing::debug!(
+                "failed to clean up tmp file {tmp_path:?} after rename failure: {rm_err}"
+            );
+        }
+        return Err(err.into());
+    }
+
+    // Best-effort thin: the reversibility snapshot above may have pushed
+    // the history one over the policy target. Self-correcting on the next
+    // write even if this pass fails.
+    if snapshots_enabled && snap_dir.exists() {
+        thin_snapshots(&snap_dir, retention, now);
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -691,5 +860,181 @@ mod tests {
         let missing = dir.path().join("never-existed");
         let entries = list_snapshots(&missing).expect("missing dir is not an error");
         assert!(entries.is_empty());
+    }
+
+    fn write_snapshot(snap_dir: &Path, stamp: u64, body: &[u8]) {
+        fs::create_dir_all(snap_dir).unwrap();
+        fs::write(
+            snap_dir.join(format!("{stamp:0width$}", width = SNAPSHOT_NAME_WIDTH)),
+            body,
+        )
+        .unwrap();
+    }
+
+    /// A snapshot timestamp ~1 minute in the past: recent enough to
+    /// survive the default retention policy's 2-year `max_age` cap, so
+    /// tests that assert on post-restore snapshot counts aren't thrown
+    /// off by legitimate thinning of an ancient (epoch-zero) timestamp.
+    fn recent_ms() -> u64 {
+        (SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64)
+            - 60_000
+    }
+
+    #[test]
+    fn restore_snapshot_file_replaces_active_with_snapshot() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let delegate_dir = dir.path().join("delegateA");
+        let secret = "secretX";
+        write_snapshot(
+            &snapshot_dir_for_encoded(&delegate_dir, secret),
+            1000,
+            b"old-value",
+        );
+        fs::create_dir_all(&delegate_dir).unwrap();
+        fs::write(delegate_dir.join(secret), b"current-value").unwrap();
+
+        restore_snapshot_file(
+            &delegate_dir,
+            secret,
+            1000,
+            true,
+            &RetentionPolicy::default(),
+            SystemTime::now(),
+        )
+        .expect("restore must succeed");
+
+        assert_eq!(fs::read(delegate_dir.join(secret)).unwrap(), b"old-value");
+    }
+
+    #[test]
+    fn restore_snapshot_file_is_reversible() {
+        // Restoring must first snapshot the current active value, so the
+        // operation can itself be undone. After the restore the history
+        // contains both the original snapshot and the captured prior
+        // active value.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let delegate_dir = dir.path().join("delegateA");
+        let secret = "secretX";
+        let snap_dir = snapshot_dir_for_encoded(&delegate_dir, secret);
+        let stamp = recent_ms();
+        write_snapshot(&snap_dir, stamp, b"old-value");
+        fs::create_dir_all(&delegate_dir).unwrap();
+        fs::write(delegate_dir.join(secret), b"current-value").unwrap();
+
+        restore_snapshot_file(
+            &delegate_dir,
+            secret,
+            stamp,
+            true,
+            &RetentionPolicy::default(),
+            SystemTime::now(),
+        )
+        .expect("restore must succeed");
+
+        let snaps = list_snapshots(&snap_dir).expect("list");
+        assert!(
+            snaps.len() >= 2,
+            "reversibility snapshot missing; got {}",
+            snaps.len()
+        );
+        let bodies: Vec<Vec<u8>> = snaps.iter().map(|m| fs::read(&m.path).unwrap()).collect();
+        assert!(
+            bodies.iter().any(|b| b.as_slice() == b"current-value"),
+            "prior active value was not snapshotted"
+        );
+    }
+
+    #[test]
+    fn restore_snapshot_file_unknown_timestamp_is_not_found() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let delegate_dir = dir.path().join("delegateA");
+        let secret = "secretX";
+        write_snapshot(
+            &snapshot_dir_for_encoded(&delegate_dir, secret),
+            1000,
+            b"old",
+        );
+        fs::create_dir_all(&delegate_dir).unwrap();
+        fs::write(delegate_dir.join(secret), b"current").unwrap();
+
+        let err = restore_snapshot_file(
+            &delegate_dir,
+            secret,
+            999,
+            true,
+            &RetentionPolicy::default(),
+            SystemTime::now(),
+        )
+        .expect_err("unknown timestamp must error");
+        assert!(matches!(err, RestoreError::NotFound(999)));
+        // Active value untouched on the error path.
+        assert_eq!(fs::read(delegate_dir.join(secret)).unwrap(), b"current");
+    }
+
+    #[test]
+    fn restore_snapshot_file_missing_snapshot_dir_is_not_found() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let delegate_dir = dir.path().join("delegateA");
+        // Secret never had a snapshot directory at all.
+        let err = restore_snapshot_file(
+            &delegate_dir,
+            "neversnapshotted",
+            1,
+            true,
+            &RetentionPolicy::default(),
+            SystemTime::now(),
+        )
+        .expect_err("missing history must error");
+        assert!(matches!(err, RestoreError::NotFound(1)));
+    }
+
+    #[test]
+    fn restore_snapshot_file_prefers_unsuffixed_collision() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let delegate_dir = dir.path().join("delegateA");
+        let secret = "secretX";
+        let snap_dir = snapshot_dir_for_encoded(&delegate_dir, secret);
+        fs::create_dir_all(&snap_dir).unwrap();
+        let base = format!(
+            "{stamp:0width$}",
+            stamp = 50u64,
+            width = SNAPSHOT_NAME_WIDTH
+        );
+        fs::write(snap_dir.join(&base), b"unsuffixed").unwrap();
+        fs::write(snap_dir.join(format!("{base}.0")), b"suffix-zero").unwrap();
+        fs::create_dir_all(&delegate_dir).unwrap();
+        fs::write(delegate_dir.join(secret), b"current").unwrap();
+
+        // snapshots_enabled=false isolates the disambiguation from the
+        // reversibility snapshot.
+        restore_snapshot_file(
+            &delegate_dir,
+            secret,
+            50,
+            false,
+            &RetentionPolicy::default(),
+            SystemTime::now(),
+        )
+        .expect("restore must succeed");
+        assert_eq!(fs::read(delegate_dir.join(secret)).unwrap(), b"unsuffixed");
+    }
+
+    #[test]
+    fn snapshot_active_value_missing_active_is_noop() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let delegate_dir = dir.path().join("delegateA");
+        let secret = "secretX";
+        // Active file does not exist: snapshotting must not create a
+        // bogus entry.
+        snapshot_active_value(&delegate_dir, secret, &delegate_dir.join(secret))
+            .expect("missing active is not an error");
+        let snaps = list_snapshots(&snapshot_dir_for_encoded(&delegate_dir, secret)).expect("list");
+        assert!(
+            snaps.is_empty(),
+            "missing active must not produce a snapshot"
+        );
     }
 }

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -719,6 +719,9 @@ impl SecretsStore {
             &delegate_path,
             &key.encode(),
             timestamp_ms,
+            // The runtime API selects by timestamp only (unsuffixed-wins);
+            // explicit collision-suffix selection is a CLI affordance.
+            None,
             self.snapshots_enabled,
             &self.retention,
             SystemTime::now(),

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -675,15 +675,13 @@ impl SecretsStore {
     /// rename and the index update still leaves the active value
     /// readable on the next `get_secret`.
     ///
-    /// The find / reversibility-snapshot / atomic-write / history-thin
-    /// sequence is delegated to the shared [`restore_snapshot_file`] (so
-    /// the node runtime and the `freenet secrets snapshot-restore` CLI
-    /// can't drift); this wrapper adds only the index repair, the one
-    /// step that needs the typed `key` + ReDb. Note the thin therefore
-    /// runs inside the shared core, just before this index repair rather
-    /// than after it — harmless, since thinning only touches the
-    /// `.snapshots/` history while the index repair touches only ReDb /
-    /// the in-memory map.
+    /// The find / reversibility-snapshot / atomic-write sequence is
+    /// delegated to the shared [`restore_snapshot_file`] (so the node
+    /// runtime and the `freenet secrets snapshot-restore` CLI can't
+    /// drift); this wrapper then adds the index repair and the
+    /// best-effort history thin, in that order — matching the
+    /// pre-extraction inline implementation exactly, so a failed index
+    /// repair never prunes snapshot history a retry would need.
     ///
     /// If multiple snapshots share `timestamp_ms` (collision suffixes
     /// from same-millisecond writes), the unsuffixed file wins; absent
@@ -709,12 +707,14 @@ impl SecretsStore {
 
         // Byte-level restore: find the snapshot, reversibly snapshot the
         // current active value, atomic tmp+fsync+rename onto the active
-        // path, then thin. This durability discipline lives in exactly
-        // one place ([`restore_snapshot_file`]) so the node runtime and
-        // the `freenet secrets snapshot-restore` CLI cannot drift. The
-        // CLI cannot reconstruct a `SecretsId` from the on-disk name
-        // (the pre-image bytes are not persisted), so the shared core is
-        // keyed on the encoded secret id rather than the typed `key`.
+        // path. This durability discipline lives in exactly one place
+        // ([`restore_snapshot_file`]) so the node runtime and the
+        // `freenet secrets snapshot-restore` CLI cannot drift. The CLI
+        // cannot reconstruct a `SecretsId` from the on-disk name (the
+        // pre-image bytes are not persisted), so the shared core is keyed
+        // on the encoded secret id rather than the typed `key`. Thinning
+        // is deliberately NOT part of the core — we thin below, after the
+        // index repair, to preserve the pre-extraction order.
         match restore_snapshot_file(
             &delegate_path,
             &key.encode(),
@@ -723,8 +723,6 @@ impl SecretsStore {
             // explicit collision-suffix selection is a CLI affordance.
             None,
             self.snapshots_enabled,
-            &self.retention,
-            SystemTime::now(),
         ) {
             Ok(()) => {}
             Err(RestoreError::NotFound(timestamp_ms)) => {
@@ -757,6 +755,19 @@ impl SecretsStore {
                 })?;
             let secret_set: HashSet<SecretKey> = current_secrets.into_iter().collect();
             self.key_to_secret_part.insert(delegate.clone(), secret_set);
+        }
+
+        // Best-effort thin LAST — only after the index repair above has
+        // committed. Mirrors the pre-extraction order: a failed
+        // `store_secrets_index` early-returns above, so the snapshot
+        // history is left intact for a clean retry instead of having
+        // already pruned source snapshots. Thinning touches only
+        // `.snapshots/`; a failure here self-corrects on the next write.
+        if self.snapshots_enabled {
+            let snap_dir = snapshot_dir_for(&delegate_path, key);
+            if snap_dir.exists() {
+                thin_snapshots(&snap_dir, &self.retention, SystemTime::now());
+            }
         }
 
         Ok(())

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -675,6 +675,16 @@ impl SecretsStore {
     /// rename and the index update still leaves the active value
     /// readable on the next `get_secret`.
     ///
+    /// The find / reversibility-snapshot / atomic-write / history-thin
+    /// sequence is delegated to the shared [`restore_snapshot_file`] (so
+    /// the node runtime and the `freenet secrets snapshot-restore` CLI
+    /// can't drift); this wrapper adds only the index repair, the one
+    /// step that needs the typed `key` + ReDb. Note the thin therefore
+    /// runs inside the shared core, just before this index repair rather
+    /// than after it — harmless, since thinning only touches the
+    /// `.snapshots/` history while the index repair touches only ReDb /
+    /// the in-memory map.
+    ///
     /// If multiple snapshots share `timestamp_ms` (collision suffixes
     /// from same-millisecond writes), the unsuffixed file wins; absent
     /// that, the lowest-numbered suffix wins. To restore a specific

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -29,8 +29,8 @@ use crate::contract::storages::Storage;
 
 use super::RuntimeResult;
 use super::secret_snapshots::{
-    RetentionPolicy, SNAPSHOTS_DIR, SnapshotMetadata, list_snapshots, next_snapshot_path,
-    snapshot_dir_for, thin_snapshots,
+    RestoreError, RetentionPolicy, SnapshotMetadata, list_snapshots, restore_snapshot_file,
+    snapshot_active_value, snapshot_dir_for, thin_snapshots,
 };
 
 /// Environment variable that disables snapshot-on-write for delegate secrets.
@@ -176,7 +176,7 @@ const DEK_HKDF_INFO: &[u8] = b"freenet-delegate-dek-v1";
 /// before this helper landed. Belt-and-suspenders: unlink any
 /// pre-existing inode at `path` so the open always lands on a fresh
 /// 0o600 file.
-fn create_owner_only(path: &Path) -> std::io::Result<File> {
+pub(super) fn create_owner_only(path: &Path) -> std::io::Result<File> {
     match std::fs::remove_file(path) {
         Ok(()) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -198,7 +198,7 @@ fn create_owner_only(path: &Path) -> std::io::Result<File> {
 /// We `chmod` it down on every `SecretsStore::new` so a single restart
 /// is sufficient to migrate. Windows: no-op.
 #[cfg(unix)]
-fn ensure_owner_only_dir(path: &Path) -> std::io::Result<()> {
+pub(super) fn ensure_owner_only_dir(path: &Path) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
     let mut perms = std::fs::metadata(path)?.permissions();
     let mode = perms.mode() & 0o777;
@@ -215,7 +215,7 @@ fn ensure_owner_only_dir(path: &Path) -> std::io::Result<()> {
 }
 
 #[cfg(not(unix))]
-fn ensure_owner_only_dir(_path: &Path) -> std::io::Result<()> {
+pub(super) fn ensure_owner_only_dir(_path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
@@ -557,47 +557,20 @@ impl SecretsStore {
         Ok(())
     }
 
-    /// Capture the existing active secret file as a snapshot. Uses
-    /// hard-link so the active inode and snapshot inode coexist; the
-    /// subsequent `rename(tmp → active)` updates the active dir-entry to
-    /// a different inode without touching the snapshot.
-    ///
-    /// On filesystems that do not support hard links (FAT, some network
-    /// mounts), falls back to `fs::copy`. The active file is unchanged
-    /// either way, so callers that crash mid-snapshot just lose the
-    /// snapshot, never the live value.
+    /// Capture the existing active secret file as a snapshot so the
+    /// subsequent overwrite is reversible. Thin wrapper over the shared
+    /// [`snapshot_active_value`] (keyed on the encoded secret id), which
+    /// owns the hard-link/copy + owner-only-perms discipline reused by
+    /// both `store_secret` and the `freenet secrets snapshot-restore`
+    /// CLI. Keeping one implementation prevents the two paths from
+    /// drifting on a durability-critical operation.
     fn snapshot_prior_value(
         &self,
         delegate_path: &Path,
         key: &SecretsId,
         secret_file_path: &Path,
     ) -> std::io::Result<()> {
-        let snap_dir = snapshot_dir_for(delegate_path, key);
-        fs::create_dir_all(&snap_dir)?;
-        // Snapshot dirs hold prior ciphertexts; tighten BOTH the
-        // intermediate `.snapshots/` umbrella AND the per-secret
-        // `.snapshots/{secret_id}/` leaf. Only chmodding the leaf
-        // leaves `.snapshots/` at the process umask (typically 0o755),
-        // which lets any local user enumerate per-secret subdir names,
-        // write counts (epoch_ms filenames), and write timing.
-        let snap_parent = delegate_path.join(SNAPSHOTS_DIR);
-        if let Err(e) = ensure_owner_only_dir(&snap_parent) {
-            tracing::warn!(path = %snap_parent.display(), error = %e, "chmod snapshots parent dir failed");
-        }
-        if let Err(e) = ensure_owner_only_dir(&snap_dir) {
-            tracing::warn!(path = %snap_dir.display(), error = %e, "chmod snapshot dir failed");
-        }
-        let snap_path = next_snapshot_path(&snap_dir)?;
-        match fs::hard_link(secret_file_path, &snap_path) {
-            Ok(()) => Ok(()),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(_) => {
-                // Hard-link unsupported (FAT, cross-device, etc.). Copy
-                // is slower but always works. The active file is not
-                // mutated in this code path so the copy can't tear.
-                fs::copy(secret_file_path, &snap_path).map(|_| ())
-            }
-        }
+        snapshot_active_value(delegate_path, &key.encode(), secret_file_path)
     }
 
     pub fn remove_secret(
@@ -723,72 +696,39 @@ impl SecretsStore {
         timestamp_ms: u64,
     ) -> Result<(), SecretStoreError> {
         let delegate_path = self.base_path.join(delegate.encode());
-        let secret_file_path = delegate_path.join(key.encode());
-        let snap_dir = snapshot_dir_for(&delegate_path, key);
 
-        // Find the requested snapshot. Disambiguation rule: unsuffixed
-        // file wins, then lowest-numbered suffix. `list_snapshots`
-        // already sorts by (timestamp_ms, suffix.unwrap_or(0)), and
-        // `None` < `Some(_)` is encoded via that 0-default — fine because
-        // collision suffixes start at 0, so the unsuffixed entry sorts
-        // alongside `.0`; we explicitly prefer unsuffixed below.
-        let entries = list_snapshots(&snap_dir)?;
-        let chosen = entries
-            .iter()
-            .filter(|m| m.timestamp_ms == timestamp_ms)
-            .min_by_key(|m| match m.suffix {
-                None => (0u32, 0u32),
-                Some(s) => (1, s),
-            })
-            .ok_or_else(|| SecretStoreError::SnapshotNotFound {
-                key: key.clone(),
-                timestamp_ms,
-            })?;
-        let chosen_path = chosen.path.clone();
-        // Snapshot the value currently at the active path so the restore
-        // operation is itself reversible. Mirrors store_secret's
-        // best-effort logging — the primary operation (restore) must
-        // not fail just because we couldn't preserve the value being
-        // replaced.
-        if self.snapshots_enabled
-            && secret_file_path.exists()
-            && let Err(e) = self.snapshot_prior_value(&delegate_path, key, &secret_file_path)
-        {
-            tracing::warn!(
-                "failed to snapshot active value before restore for delegate {}: {e}",
-                delegate.encode()
-            );
-        }
-
-        // Read snapshot ciphertext, write through a sibling tmp file with
-        // an atomic rename so the active path never tears. `&mut self`
-        // makes concurrent in-process restore impossible. `create_owner_only`
-        // unlinks any surviving `.tmp` from a prior crashed run so the
-        // new inode always lands at mode 0o600.
-        let ciphertext = fs::read(&chosen_path)?;
-        fs::create_dir_all(&delegate_path)?;
-        if let Err(e) = ensure_owner_only_dir(&delegate_path) {
-            tracing::warn!(path = %delegate_path.display(), error = %e, "chmod delegate dir failed");
-        }
-        let tmp_path = secret_file_path.with_extension("tmp");
-        {
-            let mut file = create_owner_only(&tmp_path)?;
-            file.write_all(&ciphertext)?;
-            file.sync_all()?;
-        }
-        if let Err(err) = fs::rename(&tmp_path, &secret_file_path) {
-            if let Err(rm_err) = fs::remove_file(&tmp_path) {
-                tracing::debug!(
-                    "failed to clean up tmp file {tmp_path:?} after rename failure: {rm_err}"
-                );
+        // Byte-level restore: find the snapshot, reversibly snapshot the
+        // current active value, atomic tmp+fsync+rename onto the active
+        // path, then thin. This durability discipline lives in exactly
+        // one place ([`restore_snapshot_file`]) so the node runtime and
+        // the `freenet secrets snapshot-restore` CLI cannot drift. The
+        // CLI cannot reconstruct a `SecretsId` from the on-disk name
+        // (the pre-image bytes are not persisted), so the shared core is
+        // keyed on the encoded secret id rather than the typed `key`.
+        match restore_snapshot_file(
+            &delegate_path,
+            &key.encode(),
+            timestamp_ms,
+            self.snapshots_enabled,
+            &self.retention,
+            SystemTime::now(),
+        ) {
+            Ok(()) => {}
+            Err(RestoreError::NotFound(timestamp_ms)) => {
+                return Err(SecretStoreError::SnapshotNotFound {
+                    key: key.clone(),
+                    timestamp_ms,
+                });
             }
-            return Err(err.into());
+            Err(RestoreError::Io(e)) => return Err(e.into()),
         }
 
-        // Index update: only needed if the entry was previously removed
+        // Index repair: only needed if the entry was previously removed
         // (e.g. user called `remove_secret` then realized they wanted a
         // value back). In the common case the secret is already in the
-        // index and the write below is idempotent.
+        // index and the block below is a no-op. This is the only part of
+        // restore that needs the in-memory map + ReDb, so it stays here
+        // rather than in the shared filesystem core.
         let secret_key = *key.hash();
         let mut current_secrets: Vec<[u8; 32]> = self
             .key_to_secret_part
@@ -806,13 +746,6 @@ impl SecretsStore {
             self.key_to_secret_part.insert(delegate.clone(), secret_set);
         }
 
-        // Best-effort thin: we may have just doubled the snapshot count
-        // (active-value snapshot above). Failures here only mean we keep
-        // more snapshots than the policy targets, self-correcting on the
-        // next write.
-        if self.snapshots_enabled && snap_dir.exists() {
-            thin_snapshots(&snap_dir, &self.retention, SystemTime::now());
-        }
         Ok(())
     }
 }

--- a/docs/secrets-at-rest.md
+++ b/docs/secrets-at-rest.md
@@ -99,10 +99,13 @@ first write.
 ## `freenet secrets` CLI
 
 ```
-freenet secrets kek-status   --secrets-dir <path>
-freenet secrets kek-init     --secrets-dir <path> --backend {keyring|systemd|file} --yes
-freenet secrets kek-migrate  --secrets-dir <path> --to     {keyring|systemd|file} --yes
-freenet secrets kek-rotate   --secrets-dir <path> --yes   # NOT YET IMPLEMENTED (#4137)
+freenet secrets kek-status       --secrets-dir <path>
+freenet secrets kek-init          --secrets-dir <path> --backend {keyring|systemd|file} --yes
+freenet secrets kek-migrate       --secrets-dir <path> --to     {keyring|systemd|file} --yes
+freenet secrets kek-rotate        --secrets-dir <path> --yes   # NOT YET IMPLEMENTED (#4137)
+freenet secrets snapshot-list     --secrets-dir <path> [--delegate <key>] [--secret <id>]
+freenet secrets snapshot-restore  --secrets-dir <path> --delegate <key> --secret <id> \
+                                  --timestamp-ms <ms> --yes
 ```
 
 `kek-init` opts in to a specific backend BEFORE first start. It refuses
@@ -113,6 +116,31 @@ Node MUST be stopped before running migrate. `kek-rotate` currently
 bails with a clear error pointing operators at the temporary
 kek-migrate workflow; crash-safe two-phase rotation (`.rot` shadow
 files + recovery on next start) is tracked as a follow-up under #4137.
+
+### Snapshot inspect / restore (#4036)
+
+`snapshot-list` walks the secrets tree and reports the per-secret
+snapshot history created by the snapshot-on-write durability layer
+(#4034). With no filter it summarises every delegate; `--delegate`
+restricts to one; `--delegate X --secret Y` prints each individual
+snapshot's `timestamp_ms`, UTC time, and size. It is **metadata only**
+— it never decrypts or prints plaintext secret values (that would
+require the node KEK and expose secrets on the terminal), and it is
+read-only, so it is safe to run while the node is up (a stopped node
+just gives a point-in-time-consistent view).
+
+`snapshot-restore` rolls one secret back to the snapshot identified by
+`--timestamp-ms` (copy the value from `snapshot-list`). The current
+active value is snapshotted first, so the restore is itself reversible.
+Restore is a byte-level copy: the restored ciphertext stays decryptable
+by the same KEK-derived DEK that wrote it, so it only makes sense on the
+node that owns the secrets — snapshots are **not** portable across nodes
+(each node's DEK is HKDF-derived from its own KEK). The node MUST be
+stopped, because restore writes the active secret file and a running
+node may concurrently write the same secret. Both commands operate
+purely on the on-disk secrets tree (no ReDb / KEK access needed) and
+share the restore durability core (atomic tmp+fsync+rename) with the
+node runtime's `SecretsStore::restore_snapshot`.
 
 ## File permissions (PR #4195 / issue #4141)
 

--- a/docs/secrets-at-rest.md
+++ b/docs/secrets-at-rest.md
@@ -148,13 +148,13 @@ node runtime's `SecretsStore::restore_snapshot`. `--delegate` and
 `--secret` must be single path components (the bs58 ids printed by
 `snapshot-list`); values containing `/` or `..` are rejected.
 
-After a successful restore the shared core thins the history under the
-default retention policy, the same as a normal write. One consequence:
-if you restore from a snapshot older than the 2-year `max_age` cap, that
-very old source snapshot is pruned from `.snapshots/` afterward. The
-restore itself is unaffected (the value is already the active secret by
-then) and stays reversible — the prior active value is captured as a
-fresh snapshot before the overwrite.
+After a successful restore, `snapshot-restore` thins the history under
+the default retention policy, the same as a normal write. One
+consequence: if you restore from a snapshot older than the 2-year
+`max_age` cap, that very old source snapshot is pruned from
+`.snapshots/` afterward. The restore itself is unaffected (the value is
+already the active secret by then) and stays reversible — the prior
+active value is captured as a fresh snapshot before the overwrite.
 
 ## File permissions (PR #4195 / issue #4141)
 

--- a/docs/secrets-at-rest.md
+++ b/docs/secrets-at-rest.md
@@ -105,7 +105,7 @@ freenet secrets kek-migrate       --secrets-dir <path> --to     {keyring|systemd
 freenet secrets kek-rotate        --secrets-dir <path> --yes   # NOT YET IMPLEMENTED (#4137)
 freenet secrets snapshot-list     --secrets-dir <path> [--delegate <key>] [--secret <id>]
 freenet secrets snapshot-restore  --secrets-dir <path> --delegate <key> --secret <id> \
-                                  --timestamp-ms <ms> --yes
+                                  --timestamp-ms <ms> [--suffix <n>] --yes
 ```
 
 `kek-init` opts in to a specific backend BEFORE first start. It refuses
@@ -130,8 +130,12 @@ read-only, so it is safe to run while the node is up (a stopped node
 just gives a point-in-time-consistent view).
 
 `snapshot-restore` rolls one secret back to the snapshot identified by
-`--timestamp-ms` (copy the value from `snapshot-list`). The current
-active value is snapshotted first, so the restore is itself reversible.
+`--timestamp-ms` (copy the value from `snapshot-list`). If two writes
+landed in the same millisecond, `snapshot-list` shows multiple rows at
+that timestamp with a `suffix` (`-`, `0`, `1`, …); pass `--suffix <n>`
+to target the `.n` row (omit it to restore the unsuffixed `-` row, which
+is also the only entry when there is no collision). The current active
+value is snapshotted first, so the restore is itself reversible.
 Restore is a byte-level copy: the restored ciphertext stays decryptable
 by the same KEK-derived DEK that wrote it, so it only makes sense on the
 node that owns the secrets — snapshots are **not** portable across nodes

--- a/docs/secrets-at-rest.md
+++ b/docs/secrets-at-rest.md
@@ -140,7 +140,17 @@ stopped, because restore writes the active secret file and a running
 node may concurrently write the same secret. Both commands operate
 purely on the on-disk secrets tree (no ReDb / KEK access needed) and
 share the restore durability core (atomic tmp+fsync+rename) with the
-node runtime's `SecretsStore::restore_snapshot`.
+node runtime's `SecretsStore::restore_snapshot`. `--delegate` and
+`--secret` must be single path components (the bs58 ids printed by
+`snapshot-list`); values containing `/` or `..` are rejected.
+
+After a successful restore the shared core thins the history under the
+default retention policy, the same as a normal write. One consequence:
+if you restore from a snapshot older than the 2-year `max_age` cap, that
+very old source snapshot is pruned from `.snapshots/` afterward. The
+restore itself is unaffected (the value is already the active secret by
+then) and stays reversible — the prior active value is captured as a
+fresh snapshot before the overwrite.
 
 ## File permissions (PR #4195 / issue #4141)
 


### PR DESCRIPTION
## Problem

PR #4034 added per-secret snapshot-on-write history for delegate secrets, and #4107 added the `list_snapshots` / `restore_snapshot` runtime APIs — but there was **no operator-facing way to inspect or roll back those backups**. #4036 tracks the CLI half. Without it, an operator who wants to see what snapshots exist for a delegate secret, or recover a secret a buggy delegate corrupted, has to spelunk the on-disk `.snapshots/` tree by hand.

## Solution

Two new `freenet secrets` subcommands, co-located with the existing `kek-*` verbs (same `--secrets-dir`, node-stopped model):

```
freenet secrets snapshot-list     --secrets-dir <path> [--delegate <key>] [--secret <id>]
freenet secrets snapshot-restore  --secrets-dir <path> --delegate <key> --secret <id> \
                                  --timestamp-ms <ms> --yes
```

- **`snapshot-list`** walks the secrets tree and reports per-secret snapshot history (count + each snapshot's `timestamp_ms`, UTC time, size). **Metadata only — it never decrypts or prints plaintext** (that would need the node KEK and would expose secrets on the terminal). Read-only.
- **`snapshot-restore`** rolls a secret back to a chosen snapshot. The current active value is snapshotted first, so the restore is itself reversible. The node MUST be stopped (it writes the active secret file).

**Key design points**

- Both commands need **neither the ReDb index nor the node KEK**: listing reads filenames; restore is a byte-level copy (the restored ciphertext stays decryptable by whatever KEK-derived DEK wrote it). So the commands fit the existing `freenet secrets --secrets-dir`-only pattern.
- A `SecretsId` **cannot be reconstructed from the on-disk `bs58(hash)` directory name** — the pre-image `key` bytes aren't persisted, and stdlib has no `from_hash` constructor. The commands therefore operate on the encoded id strings (copied from `snapshot-list` output), which is also why the shared core is keyed on `secret_encoded: &str`.
- **Shared core (DRY on a durability-critical op):** the byte-level restore + reversible "snapshot the active value first" logic is extracted into `secret_snapshots::{restore_snapshot_file, snapshot_active_value}`. `SecretsStore::{restore_snapshot, snapshot_prior_value}` become thin wrappers (the in-memory/ReDb index-repair edge case stays in the runtime path). This guarantees the node runtime and the CLI cannot drift on the crash-safety-sensitive `tmp+fsync+rename` sequence. The two owner-only perms helpers in `secrets_store.rs` are made `pub(super)` so the sibling module reuses them.

Snapshots are **not portable across nodes** (each node's DEK is HKDF-derived from its own KEK, per #4146), so restore only makes sense on the node that owns the secrets — documented in `docs/secrets-at-rest.md`.

## Testing

- **6 new filesystem-core unit tests** (`secret_snapshots`): restore round-trip, reversibility (prior active value is snapshotted), unknown-timestamp → `NotFound`, missing snapshot dir → `NotFound`, unsuffixed-collision-wins disambiguation, and `snapshot_active_value` no-op on a missing active file.
- **9 new CLI tests** (`secrets_cmd`): list summary / single-delegate / detail / empty-dir / missing-dir / unknown-delegate; restore round-trip / without-`--yes` aborts (active preserved) / unknown-secret / unknown-timestamp.
- **All pre-existing `secret_snapshots` + `secrets_store` tests pass** (55 lib + 22 bin), confirming the `restore_snapshot` extraction is behavior-preserving.
- `cargo fmt` clean; `cargo clippy -p freenet --lib --bins -- -D warnings` clean.

Closes #4036

[AI-assisted - Claude]