### PR TITLE
fix: make network_status::init() overwrite the global in place

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -255,10 +255,12 @@ pub enum FailureReason {
 
 /// Initialize the global network status tracker.
 ///
-/// In production `init()` runs exactly once at node startup, so the first
-/// call always wins. If it is called again (the in-process test harness
-/// re-initializes the global between tests), the new status is written
-/// **in place** into the existing `RwLock` rather than dropped.
+/// In production `init()` runs exactly once, at node startup, on one of the
+/// two mutually-exclusive bring-up paths (`run_local_node` or `run_node`),
+/// so the first call installs the tracker. If it is called again — which in
+/// practice only happens in this module's own unit tests, each of which
+/// re-initializes the global with its own port/version — the new status is
+/// written **in place** into the existing `RwLock` rather than dropped.
 ///
 /// The previous implementation relied on `OnceLock::set`, which is
 /// first-write-wins: a second `init()` silently became a no-op. Because the
@@ -269,6 +271,11 @@ pub enum FailureReason {
 /// That made the test outcomes order-dependent: they passed in isolation but
 /// failed intermittently under parallel execution. Overwriting in place makes
 /// `init()` deterministically reset the tracker on every call.
+///
+/// This refreshes only the `NetworkStatus` value. The separately-registered
+/// providers (`SUBSCRIPTION_PROVIDER`, `GOVERNANCE_PROVIDER`,
+/// `RING_STATS_PROVIDER`, `ROUTER`) live in their own statics with their own
+/// replace-on-set semantics and are intentionally left untouched here.
 pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: String) {
     let status = NetworkStatus {
         gateway_failures: Vec::new(),
@@ -291,10 +298,15 @@ pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: St
                 *guard = status;
             }
         }
-        // First call: install the tracker. The race where two threads both
-        // observe `None` is benign — `set` makes exactly one win, and the
-        // loser's status is identical-shaped fresh state that a subsequent
-        // call would overwrite anyway.
+        // First call: install the tracker. A concurrent first-init race (two
+        // threads both observing `None`) cannot occur in production — `init()`
+        // is called exactly once, on a single linear startup path — and is
+        // serialized by `TEST_GLOBAL_STATE_LOCK` in tests. If it ever did
+        // occur, `set` picks exactly one winner and the loser's status (freshly
+        // built, with no accumulated failures/peers/stats) is dropped. That is
+        // the one window where the "every call overwrites" contract would not
+        // hold, but it is unreachable by construction, so we don't pay to
+        // recover the loser's value here.
         None => {
             #[allow(clippy::let_underscore_must_use)]
             let _ = NETWORK_STATUS.set(Arc::new(RwLock::new(status)));

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -254,6 +254,21 @@ pub enum FailureReason {
 }
 
 /// Initialize the global network status tracker.
+///
+/// In production `init()` runs exactly once at node startup, so the first
+/// call always wins. If it is called again (the in-process test harness
+/// re-initializes the global between tests), the new status is written
+/// **in place** into the existing `RwLock` rather than dropped.
+///
+/// The previous implementation relied on `OnceLock::set`, which is
+/// first-write-wins: a second `init()` silently became a no-op. Because the
+/// `OnceLock` outlives any single test (it is process-global and cannot be
+/// reset by the `TEST_GLOBAL_STATE_LOCK` the tests serialize on), every test
+/// running after the first `init()` inherited the first test's
+/// `NetworkStatus` — wrong version, leaked gateway failures, leaked op stats.
+/// That made the test outcomes order-dependent: they passed in isolation but
+/// failed intermittently under parallel execution. Overwriting in place makes
+/// `init()` deterministically reset the tracker on every call.
 pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: String) {
     let status = NetworkStatus {
         gateway_failures: Vec::new(),
@@ -268,9 +283,23 @@ pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: St
         op_stats: OperationStats::default(),
         nat_stats: NatStats::default(),
     };
-    // OnceLock::set returns Err if already initialized; this is expected on repeated calls
-    #[allow(clippy::let_underscore_must_use)]
-    let _ = NETWORK_STATUS.set(Arc::new(RwLock::new(status)));
+    match NETWORK_STATUS.get() {
+        // Already initialized: overwrite the existing tracker in place so
+        // repeated `init()` calls are idempotent-overwrite rather than no-ops.
+        Some(existing) => {
+            if let Ok(mut guard) = existing.write() {
+                *guard = status;
+            }
+        }
+        // First call: install the tracker. The race where two threads both
+        // observe `None` is benign — `set` makes exactly one win, and the
+        // loser's status is identical-shaped fresh state that a subsequent
+        // call would overwrite anyway.
+        None => {
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = NETWORK_STATUS.set(Arc::new(RwLock::new(status)));
+        }
+    }
 }
 
 /// Check if an address is a known gateway.
@@ -1368,6 +1397,52 @@ mod tests {
         assert_eq!(s.version, "0.1.0-test");
         assert_eq!(s.listening_port, 31337);
         assert_eq!(s.open_connections, 0);
+    }
+
+    /// Regression: a second `init()` must overwrite the global tracker in
+    /// place rather than no-op.
+    ///
+    /// The original implementation used `OnceLock::set` (first-write-wins),
+    /// so once any test initialized the process-global `NETWORK_STATUS`,
+    /// every later `init()` was silently dropped. The version/port/failures
+    /// from the first call leaked into every subsequent test, making the
+    /// whole module order-dependent and intermittently failing under
+    /// parallel execution. This test pins the fix deterministically: it
+    /// initializes twice, with a recorded failure between the calls, and
+    /// asserts the second call's values fully replace the first's.
+    #[test]
+    fn init_overwrites_existing_global() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+
+        // First initialization, then dirty the state so we can prove the
+        // second init() resets it (not just changes scalar fields).
+        init(40001, HashSet::new(), "first-version".to_string());
+        record_gateway_failure(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 31337),
+            FailureReason::Timeout,
+        );
+        let first = get_snapshot().unwrap();
+        assert_eq!(first.version, "first-version");
+        assert_eq!(first.listening_port, 40001);
+        assert_eq!(
+            first.failures.len(),
+            1,
+            "failure recorded against the first tracker"
+        );
+
+        // Second initialization with different values must take effect
+        // immediately and reset the accumulated state.
+        init(40002, HashSet::new(), "second-version".to_string());
+        let second = get_snapshot().unwrap();
+        assert_eq!(
+            second.version, "second-version",
+            "second init() version must win (first-write-wins would keep `first-version`)"
+        );
+        assert_eq!(second.listening_port, 40002);
+        assert!(
+            second.failures.is_empty(),
+            "second init() must reset accumulated gateway failures"
+        );
     }
 
     /// Registered RingStatsProvider must surface in `snap.ring_stats`,

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -2426,8 +2426,9 @@ mod tests {
         // test acquires below for its entire body.
         //
         // `network_status::set_external_address` is a no-op until `init()` has
-        // run. `init()` is idempotent (OnceLock — first caller wins), so this
-        // is safe even if another test already initialized the global.
+        // run. `init()` is idempotent-overwrite (installs the tracker on the
+        // first call, overwrites it in place on later calls), so this is safe
+        // even if another test already initialized the global.
         let _global = crate::node::network_status::TEST_GLOBAL_STATE_LOCK
             .lock()
             .expect("TEST_GLOBAL_STATE_LOCK poisoned by an earlier test panic");


### PR DESCRIPTION
## Problem

`crates/core/src/node/network_status.rs::tests` fail intermittently under
parallel test execution. The visible symptom on `init_populates_snapshot`
(and its sibling `ring_stats_provider_round_trip`):

```
assertion `left == right` failed
  left: "0.1.0"
 right: "0.1.0-test"
```

Root cause: `pub fn init(...)` did
`let _ = NETWORK_STATUS.set(Arc::new(RwLock::new(status)))` where
`NETWORK_STATUS` is a `OnceLock`. `OnceLock::set` is **first-write-wins**, so
once any test (e.g. `test_failure_snapshot_rendering`, which inits with
`"0.1.0"`) initialized the process-global, every later test's
`init(.., "0.1.0-test")` was silently a no-op. The `OnceLock` is
process-global and outlives every individual test — the `TEST_GLOBAL_STATE_LOCK`
the tests serialize on cannot reset it. So later tests inherited the first
test's `NetworkStatus`: wrong version, leaked gateway failures, leaked op
stats. The outcome was order-dependent — passes in isolation, fails when run
alongside sibling `network_status` tests. Once one assertion panicked while
holding the shared mutex, the poisoned mutex produced a cascade of further
failures in the same run.

Introduced with PR #4297 (cites #3507 / #4297).

## Solution

When `NETWORK_STATUS` is already set, write the fresh `NetworkStatus` into the
existing `RwLock` **in place** instead of dropping it. Only the first call
performs the `OnceLock::set`. This makes `init()` idempotent-overwrite.

Why this is safe in production: `init()` runs exactly once at node startup.
Both call sites — `node.rs` (local mode) and `p2p_impl.rs` (network mode) —
run once at bring-up, and only one of them executes per process. Neither
relies on first-write-wins. (Verified by grepping all `network_status::init(`
call sites.)

Alternatives considered: swapping `OnceLock` for a resettable primitive, or a
test-only reset helper. Overwrite-in-place is the smallest change that fixes
the determinism without altering the production contract (the global is still
installed exactly once; only its contents are refreshed) and without adding a
test-only code path to production.

## Testing

- Reproduced the flake: running the full module (`cargo test -p freenet --lib --
  node::network_status::tests`) repeatedly, ~1 in 5 runs failed with 4 tests
  red (one real state-leak assertion + 3 poisoned-mutex cascade panics).
  The isolated `--exact ...::init_populates_snapshot` always passed.
- Added `init_overwrites_existing_global`: a deterministic regression test that
  calls `init()` twice with different versions and a recorded failure between
  the calls, asserting the second call's version, port, and (reset) failures.
  Confirmed it **fails** against the old first-write-wins `init()`
  (`left: "first-version", right: "second-version"`) and **passes** with the fix.
- With the fix, ran the full `node::network_status::tests` module 8x and the
  combined `network_status` + `connection_manager` global-touching tests 5x —
  all green every run.
- `cargo fmt` and `cargo clippy -p freenet --lib -- -D warnings` clean.

[AI-assisted - Claude]