### PR TITLE
feat(replay-harness): add 6 scenarios + LEDBAT++ death-spiral controller

### DIFF
--- a/crates/replay-harness/README.md
+++ b/crates/replay-harness/README.md
@@ -81,8 +81,8 @@ deliberately disagree (see below), and those disagreements are pinned per
 - **`ledbat`** (a stripped-down LEDBAT++) exists to reproduce the **death
   spiral** that got LEDBAT++ abandoned in production. It reacts to the *worst*
   single connection's queueing delay, so on `single_packet_loss` one peer's
-  transient spike drives a deep multiplicative cut (down to ~12% of the
-  starting rate) followed by slow additive recovery — while `RfcDraft`'s
+  transient spike drives a deep multiplicative cut (down to a few percent of
+  the starting rate) followed by slow additive recovery — while `RfcDraft`'s
   cross-peer median rejects the same outlier and never moves. The asymmetric
   drop/recover trajectory is pinned in `tests/scenarios_pin.rs`.
 

--- a/crates/replay-harness/README.md
+++ b/crates/replay-harness/README.md
@@ -43,9 +43,12 @@ cargo run -p replay-harness -- synthetic all --controller fixed_rate
 cargo test -p replay-harness
 ```
 
-## What's pinned in v1
+## What's pinned
 
-Four scenarios, chosen to cover the most important pins for Phase 2 design:
+Ten scenarios covering the failure modes Phase 2 design has to clear. "Sane
+behaviour" is what a *correct* controller must do; some current controllers
+deliberately disagree (see below), and those disagreements are pinned per
+`(controller, scenario)` in `tests/scenarios_pin.rs`.
 
 | Scenario | What it pins | Sane behaviour |
 |---|---|---|
@@ -53,17 +56,35 @@ Four scenarios, chosen to cover the most important pins for Phase 2 design:
 | `correlated_inflation` | Every peer's RTT rises together — the actual contention case | MUST fire at least once |
 | `single_peer_outlier` | One peer at 500 ms, four others at baseline | MUST NOT fire (cross-peer median rejects) |
 | `small_n` | Only 2 peers — below the `rolling_rtt_stats.rs` N≥3 trustworthy threshold | MUST NOT fire (N≥3 guard) |
+| `single_packet_loss` | A transient 10× spike on one peer | MUST NOT fire (transient single-connection outlier) |
+| `slow_routing_drift` | Baseline drifts up 5 ms/min for 30 min (a real path change) | MUST NOT fire (5-min baseline tracks the drift) |
+| `churning_peers` | Peers join/leave every 30 s with healthy RTTs | MUST NOT fire (churn alone is not a signal) |
+| `cold_start` | New peers on a slow path, no baseline history | MUST NOT fire (high RTT ≠ rising RTT; no panic) |
+| `reference_diverges_from_overlay` | Overlay inflates, reference path stays flat | MUST NOT fire (overlay queueing, not uplink contention) |
+| `reference_tracks_overlay` | Overlay and reference inflate together | MUST fire (shared cause is the local uplink) |
 
-The `RfcDraft` reference controller intentionally **fails** the
-`idle_steady_state` pin (48 fires across the 300 s scenario, rate
-floors at 1 bps after enough successive 0.7× downsteps). That failure
-is the demonstration of the noise-floor problem the Phase 1 telemetry
-already showed: the 30 ms inflation threshold sits well below the
-ambient overlay queueing baseline, so the controller fires on healthy
-ambient noise. Any Phase 2 candidate MUST NOT repeat that failure.
+### Controllers, and their documented failures
 
-`FixedRate` (the production default) passes the universal sanity check
-of "never fires on any scenario."
+- **`FixedRate`** (production default) passes the universal sanity check of
+  "never fires on any scenario."
+- **`RfcDraft`** (the algorithm sketched in #4074) intentionally **fails** two
+  pins, and those failures are the point:
+  - `idle_steady_state` — fires 48 times across 300 s. The 30 ms inflation
+    threshold sits below the ambient overlay noise floor Phase 1 telemetry
+    measured, so it reacts to healthy noise.
+  - `reference_diverges_from_overlay` — fires because it is reference-blind. It
+    cannot distinguish overlay queueing from uplink contention, which is the
+    entire reason the Phase 1.5 reference-ping signal (#4292) exists. It gets
+    `reference_tracks_overlay` "right" only by luck (it fires on both). A
+    reference-aware Phase 2 controller must fire on `tracks` and hold on
+    `diverges`.
+- **`ledbat`** (a stripped-down LEDBAT++) exists to reproduce the **death
+  spiral** that got LEDBAT++ abandoned in production. It reacts to the *worst*
+  single connection's queueing delay, so on `single_packet_loss` one peer's
+  transient spike drives a deep multiplicative cut (down to ~12% of the
+  starting rate) followed by slow additive recovery — while `RfcDraft`'s
+  cross-peer median rejects the same outlier and never moves. The asymmetric
+  drop/recover trajectory is pinned in `tests/scenarios_pin.rs`.
 
 ## Adding a controller
 

--- a/crates/replay-harness/src/controllers.rs
+++ b/crates/replay-harness/src/controllers.rs
@@ -1,14 +1,16 @@
 //! [`Controller`] trait and the view it sees each tick.
 
+pub mod fixed_rate;
+pub mod ledbat;
+pub mod rfc_draft;
+
 use std::time::Duration;
 
 use crate::event::PeerKey;
 use crate::rolling::RttSnapshot;
 
-pub mod fixed_rate;
-pub mod rfc_draft;
-
 pub use fixed_rate::FixedRate;
+pub use ledbat::LedbatPlusPlus;
 pub use rfc_draft::RfcDraft;
 
 /// Snapshot the harness hands to a controller at each tick.

--- a/crates/replay-harness/src/controllers/ledbat.rs
+++ b/crates/replay-harness/src/controllers/ledbat.rs
@@ -77,7 +77,14 @@ impl Controller for LedbatPlusPlus {
             // No defined inflation anywhere yet (cold network): nothing to act on.
             None => RateDecision::Hold,
             Some(queue_delay) if queue_delay > TARGET => {
-                let new = ((rate as f64 * MD_FACTOR).round() as u64).max(FLOOR_BPS);
+                // Multiplicative decrease, floored. The trailing `.min(rate)`
+                // keeps a "decrease" from ever raising the rate: if the
+                // configured starting rate is already below FLOOR_BPS, the
+                // `.max(FLOOR_BPS)` would otherwise clamp *upward* and emit an
+                // increase mislabelled as a cut.
+                let new = ((rate as f64 * MD_FACTOR).round() as u64)
+                    .max(FLOOR_BPS)
+                    .min(rate);
                 decide(rate, new, "ledbat_md_on_queue_delay")
             }
             Some(_) => {

--- a/crates/replay-harness/src/controllers/ledbat.rs
+++ b/crates/replay-harness/src/controllers/ledbat.rs
@@ -1,0 +1,102 @@
+//! `LedbatPlusPlus` — a stripped-down LEDBAT++ to reproduce the death spiral.
+//!
+//! This controller exists to *fail* in a specific, historically-real way, so
+//! the harness can pin that failure mode as a regression any Phase 2 candidate
+//! must not repeat. LEDBAT++ was one of the three congestion-control schemes
+//! abandoned in production (see [#4074][issue]); its core problem is that it is
+//! a **per-connection** controller, so a transient excursion on a *single*
+//! path (a reroute, one lost packet's retransmit) reads as congestion and
+//! drives the whole rate down with a multiplicative decrease that then takes a
+//! long time to additively recover.
+//!
+//! The harness models that single-connection sensitivity by reacting to the
+//! **worst** (max) per-peer queueing delay rather than the cross-peer median
+//! that [`RfcDraft`](super::rfc_draft::RfcDraft) uses. That one line is the
+//! whole difference between the controller that death-spirals and the one that
+//! doesn't: on `single_packet_loss` a single peer's transient spike sends this
+//! controller into a deep cut + slow recovery, while RfcDraft's cross-peer
+//! median rejects the same outlier and holds.
+//!
+//! It is deliberately *stripped down* — real LEDBAT++ filters per-packet RTT,
+//! runs slow-start, and has a richer gain schedule. We keep only what is needed
+//! to reproduce the asymmetric drop/recover dynamic on the harness's 1 Hz,
+//! median-filtered snapshot signal.
+//!
+//! [issue]: https://github.com/freenet/freenet-core/issues/4074
+
+use std::time::Duration;
+
+use super::{Controller, ControllerView, RateDecision};
+
+/// Target queueing delay. Above this, LEDBAT++ treats the path as congested
+/// and multiplicatively decreases. Classic LEDBAT targets 100 ms; LEDBAT++
+/// lowered it to 60 ms to yield more aggressively.
+const TARGET: Duration = Duration::from_millis(60);
+
+/// Multiplicative-decrease factor applied on every congested tick. Compounding
+/// this across a sustained over-target window is what turns a single transient
+/// spike into a deep cut.
+const MD_FACTOR: f64 = 0.7;
+
+/// Hard floor so a long death spiral can't divide the rate to zero (which would
+/// make the recovery ratio meaningless). Not a real LEDBAT parameter — purely a
+/// harness guard.
+const FLOOR_BPS: u64 = 10_000;
+
+#[derive(Debug, Default)]
+pub struct LedbatPlusPlus {
+    /// The rate observed on the first tick, used as the additive-increase
+    /// ceiling so the controller recovers toward (but never above) its
+    /// starting point. Captured rather than hard-coded so it tracks whatever
+    /// starting rate the [`Replayer`](crate::Replayer) was configured with.
+    ceiling: Option<u64>,
+}
+
+impl Controller for LedbatPlusPlus {
+    fn name(&self) -> &str {
+        "ledbat"
+    }
+
+    fn tick(&mut self, view: ControllerView<'_>) -> RateDecision {
+        let ceiling = *self.ceiling.get_or_insert(view.current_aggregate_rate_bps);
+        // Additive increase of 1% of the ceiling per tick. The asymmetry
+        // between this slow linear recovery and the compounding multiplicative
+        // cut below is precisely the death-spiral dynamic.
+        let ai_step = (ceiling / 100).max(1);
+
+        // Per-connection congestion view: react to the single worst path, not a
+        // cross-peer aggregate. This is the modelled flaw.
+        let worst = view
+            .per_peer
+            .iter()
+            .filter_map(|p| p.snapshot.inflation)
+            .max();
+
+        let rate = view.current_aggregate_rate_bps;
+        match worst {
+            // No defined inflation anywhere yet (cold network): nothing to act on.
+            None => RateDecision::Hold,
+            Some(queue_delay) if queue_delay > TARGET => {
+                let new = ((rate as f64 * MD_FACTOR).round() as u64).max(FLOOR_BPS);
+                decide(rate, new, "ledbat_md_on_queue_delay")
+            }
+            Some(_) => {
+                let new = rate.saturating_add(ai_step).min(ceiling);
+                decide(rate, new, "ledbat_ai_below_target")
+            }
+        }
+    }
+}
+
+/// Emit a `Set` only when the rate actually changes, so a controller sitting at
+/// the ceiling (or the floor) records `Hold` rather than a stream of no-op sets.
+fn decide(old: u64, new: u64, reason: &'static str) -> RateDecision {
+    if new == old {
+        RateDecision::Hold
+    } else {
+        RateDecision::Set {
+            aggregate_rate_bps: new,
+            reason,
+        }
+    }
+}

--- a/crates/replay-harness/src/main.rs
+++ b/crates/replay-harness/src/main.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use anyhow::{Result, bail};
 use clap::{Parser, Subcommand};
 use replay_harness::Replayer;
-use replay_harness::controllers::{FixedRate, RfcDraft};
+use replay_harness::controllers::{FixedRate, LedbatPlusPlus, RfcDraft};
 use replay_harness::scenarios::{self, Expectation};
 
 #[derive(Parser)]
@@ -74,6 +74,7 @@ fn main() -> Result<()> {
         Cmd::Controllers => {
             println!("fixed_rate   — baseline; never changes rate");
             println!("rfc_draft    — the #4074 sketched algorithm (downstep only)");
+            println!("ledbat       — stripped-down LEDBAT++; reproduces the death spiral");
         }
         Cmd::Synthetic {
             scenario,
@@ -111,6 +112,9 @@ fn run_synthetic(s: &scenarios::Scenario, controller_name: &str) -> Result<()> {
         "rfc_draft" => Replayer::new()
             .run_until(s.run_for)
             .run(s.events.clone().into_iter(), RfcDraft::default()),
+        "ledbat" => Replayer::new()
+            .run_until(s.run_for)
+            .run(s.events.clone().into_iter(), LedbatPlusPlus::default()),
         other => bail!("unknown controller: {other}"),
     };
 

--- a/crates/replay-harness/src/scenarios.rs
+++ b/crates/replay-harness/src/scenarios.rs
@@ -14,14 +14,20 @@
 //! scenario file in `scenarios/` and listing it in [`all_scenarios`] is
 //! enough; no other wiring required.
 
+pub mod churning_peers;
+pub mod cold_start;
+pub mod correlated_inflation;
+pub mod idle_steady_state;
+pub mod reference_diverges_from_overlay;
+pub mod reference_tracks_overlay;
+pub mod single_packet_loss;
+pub mod single_peer_outlier;
+pub mod slow_routing_drift;
+pub mod small_n;
+
 use std::time::Duration;
 
 use crate::event::Event;
-
-pub mod correlated_inflation;
-pub mod idle_steady_state;
-pub mod single_peer_outlier;
-pub mod small_n;
 
 /// What a sane controller is expected to do on this scenario.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -59,6 +65,12 @@ pub fn all_scenarios() -> Vec<Scenario> {
         correlated_inflation::scenario(),
         single_peer_outlier::scenario(),
         small_n::scenario(),
+        single_packet_loss::scenario(),
+        slow_routing_drift::scenario(),
+        churning_peers::scenario(),
+        cold_start::scenario(),
+        reference_diverges_from_overlay::scenario(),
+        reference_tracks_overlay::scenario(),
     ]
 }
 

--- a/crates/replay-harness/src/scenarios/churning_peers.rs
+++ b/crates/replay-harness/src/scenarios/churning_peers.rs
@@ -1,0 +1,75 @@
+//! `churning_peers` — peers join and leave every 30 s; RTTs stay healthy.
+//!
+//! Pins the requirement that connection churn alone produces no rate action.
+//! A stable core of peers holds a flat, healthy RTT throughout; on top of that,
+//! a rotating transient peer joins, sends healthy samples for 30 s, then leaves,
+//! repeatedly. Membership turns over constantly but nothing about the RTT
+//! signal says "contention".
+//!
+//! A sane controller MUST NOT fire: the join/leave bookkeeping (and the
+//! cold-start of each freshly-joined peer) must not be mistaken for a
+//! congestion signal. This guards against a controller that, e.g., treats a
+//! newly-joined peer's sparse baseline as inflation.
+
+use std::time::Duration;
+
+use crate::event::Event;
+
+use super::{Expectation, Scenario};
+
+pub fn scenario() -> Scenario {
+    let mut events = Vec::new();
+    let healthy_ms = 40;
+    let duration_secs = 300u64;
+    let churn_period = 30u64;
+
+    // Stable core: three peers present the whole time at a flat healthy RTT.
+    for peer_idx in 0..3 {
+        let peer = format!("core-{peer_idx}");
+        for t in 0..duration_secs {
+            events.push(Event::RttSample {
+                peer: peer.clone(),
+                at: Duration::from_secs(t),
+                rtt: Duration::from_millis(healthy_ms),
+            });
+        }
+    }
+
+    // Rotating transient peer: a new one joins each 30 s window, sends healthy
+    // samples while present, then leaves. Explicit join/leave events make the
+    // churn visible in the trace; we stop sampling a peer once it leaves so it
+    // is not silently resurrected (see `replayer::apply_event` docs).
+    let mut window = 0u64;
+    while window * churn_period < duration_secs {
+        let start = window * churn_period;
+        let end = (start + churn_period).min(duration_secs);
+        let peer = format!("transient-{window}");
+        events.push(Event::PeerJoin {
+            peer: peer.clone(),
+            at: Duration::from_secs(start),
+        });
+        for t in start..end {
+            events.push(Event::RttSample {
+                peer: peer.clone(),
+                at: Duration::from_secs(t),
+                rtt: Duration::from_millis(healthy_ms),
+            });
+        }
+        events.push(Event::PeerLeave {
+            peer: peer.clone(),
+            at: Duration::from_secs(end),
+        });
+        window += 1;
+    }
+
+    Scenario {
+        name: "churning_peers",
+        description: "Three stable core peers at a flat 40 ms RTT, plus a transient peer \
+             that joins/leaves every 30 s (with explicit join/leave events) while sending \
+             healthy samples. Membership churns constantly but the RTT signal is clean; a \
+             sane controller MUST NOT fire on churn alone.",
+        expectation: Expectation::NeverFires,
+        events,
+        run_for: Duration::from_secs(duration_secs),
+    }
+}

--- a/crates/replay-harness/src/scenarios/cold_start.rs
+++ b/crates/replay-harness/src/scenarios/cold_start.rs
@@ -1,0 +1,52 @@
+//! `cold_start` — brand-new peers on a slow path, no baseline history.
+//!
+//! Pins the cold-start requirement: a peer that appears with no baseline must
+//! not be mistaken for contention, and the controller must not panic on the
+//! partial state. Three peers come online at t=0 on a genuinely slow path
+//! (a flat 200 ms RTT from their very first sample). Because each peer's
+//! `baseline_min` is established from those same high samples, the *inflation*
+//! (recent_median − baseline_min) is ~0 throughout: high absolute RTT is not
+//! the same as RTT inflation.
+//!
+//! A sane controller MUST NOT fire: there is no baseline to inflate against, so
+//! there is no contention signal — only a slow link. This guards against a
+//! controller that confuses "high RTT" with "rising RTT", and against any
+//! panic on snapshots taken before a full baseline window exists.
+
+use std::time::Duration;
+
+use crate::event::Event;
+
+use super::{Expectation, Scenario};
+
+pub fn scenario() -> Scenario {
+    let mut events = Vec::new();
+    let n_peers = 3;
+    let slow_path_ms = 200; // high absolute RTT, but flat — no inflation
+
+    for peer_idx in 0..n_peers {
+        let peer = format!("cold-{peer_idx}");
+        // Peers appear at t=0 with no prior history and immediately report a
+        // high, flat RTT. Run only 90 s — well short of the 5-minute baseline
+        // window — so the snapshot is always taken on a partially-filled
+        // baseline, which is exactly the cold-start state we want to exercise.
+        for t in 0..90u64 {
+            events.push(Event::RttSample {
+                peer: peer.clone(),
+                at: Duration::from_secs(t),
+                rtt: Duration::from_millis(slow_path_ms),
+            });
+        }
+    }
+
+    Scenario {
+        name: "cold_start",
+        description: "3 peers appear at t=0 on a slow path (flat 200 ms) with no baseline \
+             history; the run is shorter than the baseline window so every snapshot is \
+             cold. Inflation stays ~0 because high RTT is not rising RTT — a sane \
+             controller MUST hold (and must not panic on the partial state).",
+        expectation: Expectation::NeverFires,
+        events,
+        run_for: Duration::from_secs(90),
+    }
+}

--- a/crates/replay-harness/src/scenarios/reference_diverges_from_overlay.rs
+++ b/crates/replay-harness/src/scenarios/reference_diverges_from_overlay.rs
@@ -1,0 +1,66 @@
+//! `reference_diverges_from_overlay` — overlay inflates, reference stays flat.
+//!
+//! This is the scenario that motivates the Phase 1.5 reference-ping signal
+//! (#4292). Every overlay path inflates together (looks exactly like
+//! `correlated_inflation`), but the parallel reference path to a fixed external
+//! target stays flat. That combination means the inflation is *overlay*
+//! queueing (intermediate-hop buckets), NOT contention on the local uplink —
+//! backing off our own send rate would not help, so a sane controller MUST NOT
+//! fire.
+//!
+//! Telling this apart from real contention is impossible without the reference
+//! signal, which is the whole reason it was added. So:
+//! - The scenario's *sane-controller* expectation is `NeverFires`.
+//! - [`RfcDraft`](crate::controllers::RfcDraft) is reference-blind — it only
+//!   looks at cross-peer overlay inflation — so it fires here, **incorrectly**.
+//!   That known limitation is pinned in `tests/scenarios_pin.rs` (exactly as
+//!   the `idle_steady_state` noise-floor failure is pinned), and it is the
+//!   regression a reference-aware Phase 2 controller must fix: same overlay
+//!   input as `reference_tracks_overlay`, opposite correct action, and the
+//!   reference signal is the only thing that distinguishes them.
+
+use std::time::Duration;
+
+use crate::event::Event;
+
+use super::{Expectation, Scenario};
+
+pub fn scenario() -> Scenario {
+    let mut events = Vec::new();
+    let n_peers = 5;
+
+    // Overlay: clean 20 ms baseline for 60 s, then every peer inflates to
+    // 200 ms together for 60 s — identical to `correlated_inflation`.
+    for peer_idx in 0..n_peers {
+        let peer = format!("peer-{peer_idx}");
+        for t in 0..120u64 {
+            let rtt = if t < 60 { 20 } else { 200 };
+            events.push(Event::RttSample {
+                peer: peer.clone(),
+                at: Duration::from_secs(t),
+                rtt: Duration::from_millis(rtt),
+            });
+        }
+    }
+
+    // Reference path: flat 20 ms the entire time. The uplink is NOT contended;
+    // the overlay inflation is intermediate-hop queueing.
+    for t in 0..120u64 {
+        events.push(Event::ReferenceSample {
+            at: Duration::from_secs(t),
+            rtt: Duration::from_millis(20),
+        });
+    }
+
+    Scenario {
+        name: "reference_diverges_from_overlay",
+        description: "Overlay inflates 20→200 ms across all peers while the reference path \
+             stays flat at 20 ms. Flat reference means overlay (intermediate-hop) queueing, \
+             not local uplink contention, so a sane controller MUST NOT fire. A \
+             reference-blind controller (RfcDraft) cannot tell this from real contention \
+             and fires incorrectly.",
+        expectation: Expectation::NeverFires,
+        events,
+        run_for: Duration::from_secs(120),
+    }
+}

--- a/crates/replay-harness/src/scenarios/reference_tracks_overlay.rs
+++ b/crates/replay-harness/src/scenarios/reference_tracks_overlay.rs
@@ -1,0 +1,61 @@
+//! `reference_tracks_overlay` — overlay and reference inflate together.
+//!
+//! The companion to `reference_diverges_from_overlay`, with an identical
+//! overlay signal but the *opposite* correct action. Here the parallel
+//! reference path to a fixed external target inflates in lockstep with the
+//! overlay: when even a contention-free external path slows down at the same
+//! time as every overlay path, the shared cause is the *local uplink* being
+//! contended (the user started a big upload). That is exactly the case the
+//! controller exists to catch, so a sane controller MUST fire.
+//!
+//! Run against `reference_diverges_from_overlay`, this is the pair that shows
+//! the reference signal is load-bearing: same overlay inflation, but a
+//! reference-aware controller should fire here and hold there. RfcDraft fires
+//! on both (it ignores the reference), so it gets this one right by luck and
+//! the diverging one wrong — see that scenario's note.
+
+use std::time::Duration;
+
+use crate::event::Event;
+
+use super::{Expectation, Scenario};
+
+pub fn scenario() -> Scenario {
+    let mut events = Vec::new();
+    let n_peers = 5;
+
+    // Overlay: clean 20 ms baseline for 60 s, then inflate to 200 ms together.
+    for peer_idx in 0..n_peers {
+        let peer = format!("peer-{peer_idx}");
+        for t in 0..120u64 {
+            let rtt = if t < 60 { 20 } else { 200 };
+            events.push(Event::RttSample {
+                peer: peer.clone(),
+                at: Duration::from_secs(t),
+                rtt: Duration::from_millis(rtt),
+            });
+        }
+    }
+
+    // Reference path: tracks the overlay — flat 20 ms, then inflates to 200 ms
+    // at the same moment. A contention-free external path slowing down too
+    // means the shared bottleneck is the local uplink.
+    for t in 0..120u64 {
+        let rtt = if t < 60 { 20 } else { 200 };
+        events.push(Event::ReferenceSample {
+            at: Duration::from_secs(t),
+            rtt: Duration::from_millis(rtt),
+        });
+    }
+
+    Scenario {
+        name: "reference_tracks_overlay",
+        description: "Overlay inflates 20→200 ms across all peers AND the reference path \
+             inflates in lockstep. A contention-free external path slowing at the same \
+             time points at the local uplink being contended — the case the controller \
+             exists to catch — so a sane controller MUST fire.",
+        expectation: Expectation::FiresAtLeastOnce,
+        events,
+        run_for: Duration::from_secs(120),
+    }
+}

--- a/crates/replay-harness/src/scenarios/single_packet_loss.rs
+++ b/crates/replay-harness/src/scenarios/single_packet_loss.rs
@@ -1,0 +1,67 @@
+//! `single_packet_loss` — one peer's RTT spikes transiently, then returns.
+//!
+//! Pins the LEDBAT++ death spiral. The original failure (see [#4074][issue])
+//! was that a single packet loss / reroute on one connection drove a
+//! multiplicative decrease that took 5–10 minutes to recover on high-RTT
+//! paths. The harness has no loss event and its per-peer snapshot is a 10 s
+//! median (which correctly filters a literal single sample), so we model the
+//! event as a short RTT excursion on *one* peer: long enough to move that
+//! peer's own recent median, but confined to a single connection.
+//!
+//! Two controllers must disagree here, and that disagreement is the whole
+//! point:
+//! - [`RfcDraft`](crate::controllers::RfcDraft) takes the cross-peer median,
+//!   so one elevated peer among four is rejected — it MUST NOT fire.
+//! - [`LedbatPlusPlus`](crate::controllers::ledbat::LedbatPlusPlus) reacts to
+//!   the worst single connection, so it cuts hard on the spike and then
+//!   recovers slowly — the death spiral, pinned in `tests/scenarios_pin.rs`.
+//!
+//! The scenario's *sane-controller* expectation is therefore `NeverFires`
+//! (a robust controller ignores a single-connection transient); LEDBAT's
+//! contrary behaviour is asserted explicitly as a documented failure mode.
+//!
+//! [issue]: https://github.com/freenet/freenet-core/issues/4074
+
+use std::time::Duration;
+
+use crate::event::Event;
+
+use super::{Expectation, Scenario};
+
+pub fn scenario() -> Scenario {
+    let mut events = Vec::new();
+    let n_peers = 4;
+    let baseline_ms = 30;
+    let spike_ms = 300; // 10× the baseline
+    let spike_start = 60;
+    let spike_end = 66; // ~6 s: enough to dominate peer-0's 10 s recent median
+
+    for peer_idx in 0..n_peers {
+        let peer = format!("peer-{peer_idx}");
+        for t in 0..180u64 {
+            // peer-0 takes a transient 10× spike during the spike window;
+            // every other peer stays flat at the baseline the whole time.
+            let rtt = if peer_idx == 0 && (spike_start..spike_end).contains(&t) {
+                spike_ms
+            } else {
+                baseline_ms
+            };
+            events.push(Event::RttSample {
+                peer: peer.clone(),
+                at: Duration::from_secs(t),
+                rtt: Duration::from_millis(rtt),
+            });
+        }
+    }
+
+    Scenario {
+        name: "single_packet_loss",
+        description: "4 peers at a flat 30 ms baseline; one peer takes a transient 10× \
+             (300 ms) excursion for ~6 s, then returns. A cross-peer-median controller \
+             rejects the single-connection outlier and MUST NOT fire; a per-connection \
+             controller (LEDBAT++) cuts hard and recovers slowly — the death spiral.",
+        expectation: Expectation::NeverFires,
+        events,
+        run_for: Duration::from_secs(240),
+    }
+}

--- a/crates/replay-harness/src/scenarios/single_packet_loss.rs
+++ b/crates/replay-harness/src/scenarios/single_packet_loss.rs
@@ -34,7 +34,13 @@ pub fn scenario() -> Scenario {
     let baseline_ms = 30;
     let spike_ms = 300; // 10× the baseline
     let spike_start = 60;
-    let spike_end = 66; // ~6 s: enough to dominate peer-0's 10 s recent median
+    // The spike must last long enough to tip peer-0's 10 s recent-median
+    // window. At 1 Hz that window holds 11 samples and the upper-middle median
+    // only flips to the spike value once >=6 of them are spike samples, so ~6 s
+    // is the bare minimum that reproduces the death spiral at all. Use 10 s for
+    // headroom — do NOT reduce below ~7 s or the median stops tipping and the
+    // `ledbat_single_packet_loss_death_spiral` pin silently stops reproducing.
+    let spike_end = 70;
 
     for peer_idx in 0..n_peers {
         let peer = format!("peer-{peer_idx}");
@@ -57,7 +63,7 @@ pub fn scenario() -> Scenario {
     Scenario {
         name: "single_packet_loss",
         description: "4 peers at a flat 30 ms baseline; one peer takes a transient 10× \
-             (300 ms) excursion for ~6 s, then returns. A cross-peer-median controller \
+             (300 ms) excursion for ~10 s, then returns. A cross-peer-median controller \
              rejects the single-connection outlier and MUST NOT fire; a per-connection \
              controller (LEDBAT++) cuts hard and recovers slowly — the death spiral.",
         expectation: Expectation::NeverFires,

--- a/crates/replay-harness/src/scenarios/slow_routing_drift.rs
+++ b/crates/replay-harness/src/scenarios/slow_routing_drift.rs
@@ -1,0 +1,50 @@
+//! `slow_routing_drift` — the baseline genuinely drifts upward over 30 min.
+//!
+//! Pins the "min over 5 min" baseline tracking a *real* path change rather than
+//! mistaking it for contention. Every peer's RTT rises by 5 ms/min for 30
+//! minutes (a legitimate routing change, not local uplink contention). Because
+//! the baseline window is 5 minutes, `baseline_min` always sits ~5 min behind
+//! the current median, so the inflation the controller sees plateaus at
+//! ~5 ms/min × 5 min = ~25 ms — just under the 30 ms trigger.
+//!
+//! A sane controller MUST NOT fire: slow, sustained drift shared by all peers
+//! is the path moving, and the 5-minute baseline is supposed to follow it. If
+//! a future controller shortens the baseline window enough that the drift
+//! outruns it, this scenario flips to firing and the regression is visible.
+
+use std::time::Duration;
+
+use crate::event::Event;
+
+use super::{Expectation, Scenario};
+
+pub fn scenario() -> Scenario {
+    let mut events = Vec::new();
+    let n_peers = 5;
+    let base_ms = 80.0;
+    let drift_ms_per_min = 5.0;
+    let duration_secs = 30 * 60; // 30 minutes
+
+    for peer_idx in 0..n_peers {
+        let peer = format!("peer-{peer_idx}");
+        for t in 0..duration_secs {
+            let rtt = base_ms + drift_ms_per_min * (t as f64 / 60.0);
+            events.push(Event::RttSample {
+                peer: peer.clone(),
+                at: Duration::from_secs(t),
+                rtt: Duration::from_millis(rtt.round() as u64),
+            });
+        }
+    }
+
+    Scenario {
+        name: "slow_routing_drift",
+        description: "5 peers whose baseline RTT drifts up 5 ms/min for 30 min (a real \
+             path change, not contention). The 5-minute baseline_min trails the median, \
+             so observed inflation plateaus near 25 ms — below the 30 ms trigger. A sane \
+             controller MUST NOT fire on legitimate slow drift.",
+        expectation: Expectation::NeverFires,
+        events,
+        run_for: Duration::from_secs(duration_secs),
+    }
+}

--- a/crates/replay-harness/tests/scenarios_pin.rs
+++ b/crates/replay-harness/tests/scenarios_pin.rs
@@ -16,7 +16,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use replay_harness::controllers::{FixedRate, RfcDraft};
+use replay_harness::controllers::{FixedRate, LedbatPlusPlus, RfcDraft};
 use replay_harness::scenarios::{Expectation, Scenario, all_scenarios, find};
 use replay_harness::{Controller, RateDecision, Replayer};
 
@@ -35,6 +35,14 @@ fn expected_fires(controller: &str, scenario: &str) -> bool {
         // the harness exists to demonstrate, and the failure mode any
         // Phase 2 candidate must NOT repeat.
         (("rfc_draft", "idle_steady_state"), true),
+        // RfcDraft fires on reference_diverges_from_overlay because it is
+        // reference-blind: it sees correlated overlay inflation and cannot
+        // tell overlay queueing from local uplink contention. The flat
+        // reference path (which says "do NOT fire") is exactly the signal
+        // it ignores. Pinned as the documented limitation a reference-aware
+        // Phase 2 controller must fix — same overlay input as
+        // reference_tracks_overlay, opposite correct action.
+        (("rfc_draft", "reference_diverges_from_overlay"), true),
     ]
     .into_iter()
     .collect();
@@ -132,4 +140,75 @@ fn rfc_draft_correlated_inflation_first_fire_is_inside_burst_window() {
             d.rate_after_bps,
         );
     }
+}
+
+/// The LEDBAT++ death spiral, pinned. `single_packet_loss` is a transient
+/// spike on a *single* peer. LEDBAT++ reacts to the worst connection, so it
+/// cuts the aggregate rate hard and then recovers slowly; RfcDraft takes the
+/// cross-peer median, rejects the outlier, and never moves the rate. The
+/// contrast on identical input is the whole point of the scenario.
+#[test]
+fn ledbat_single_packet_loss_death_spiral() {
+    let s = find("single_packet_loss").expect("scenario exists");
+
+    // Derive the starting rate from a no-op FixedRate run rather than
+    // hard-coding the Replayer default, so this test doesn't pin a magic number.
+    let starting = Replayer::new()
+        .run_until(s.run_for)
+        .run(s.events.clone().into_iter(), FixedRate)
+        .final_rate_bps;
+
+    let ledbat = Replayer::new()
+        .run_until(s.run_for)
+        .run(s.events.clone().into_iter(), LedbatPlusPlus::default());
+
+    // 1. A deep multiplicative cut actually happened.
+    assert!(
+        ledbat.min_rate_bps <= starting / 2,
+        "LEDBAT++ should cut hard on the spike; min_rate_bps={} (> half of {starting})",
+        ledbat.min_rate_bps,
+    );
+    // 2. Additive increase is capped at the starting rate — it never overshoots.
+    assert!(
+        ledbat.max_rate_bps <= starting,
+        "max_rate_bps={} exceeded starting rate {starting}",
+        ledbat.max_rate_bps,
+    );
+
+    // 3. The defining asymmetry: the cut is fast, the recovery is slow. Measure
+    // ticks from the last pre-drop tick to the trough, vs ticks from the trough
+    // back up to within 90% of the starting rate.
+    let rates: Vec<u64> = ledbat.log.iter().map(|d| d.rate_after_bps).collect();
+    let trough = *rates.iter().min().expect("non-empty trace");
+    let trough_idx = rates
+        .iter()
+        .position(|&r| r == trough)
+        .expect("trough is in the trace");
+    let drop_start = rates[..trough_idx]
+        .iter()
+        .rposition(|&r| r >= starting)
+        .unwrap_or(0);
+    let drop_ticks = trough_idx - drop_start;
+    let recover_to = (starting as f64 * 0.9) as u64;
+    let recover_ticks = rates[trough_idx..]
+        .iter()
+        .position(|&r| r >= recover_to)
+        .expect("LEDBAT++ should recover toward the ceiling within the run");
+    assert!(
+        recover_ticks > drop_ticks * 3,
+        "death-spiral asymmetry not demonstrated: drop took {drop_ticks} ticks, \
+         recovery took {recover_ticks} ticks",
+    );
+
+    // 4. Contrast: RfcDraft's cross-peer median rejects the single-peer outlier,
+    // so it never changes the rate on the same input.
+    let rfc = Replayer::new()
+        .run_until(s.run_for)
+        .run(s.events.clone().into_iter(), RfcDraft::default());
+    assert_eq!(
+        rfc.decisions_set, 0,
+        "RfcDraft must hold on single_packet_loss (cross-peer median rejects the outlier)",
+    );
+    assert_eq!(rfc.min_rate_bps, starting);
+    assert_eq!(rfc.max_rate_bps, starting);
 }

--- a/crates/replay-harness/tests/scenarios_pin.rs
+++ b/crates/replay-harness/tests/scenarios_pin.rs
@@ -43,6 +43,19 @@ fn expected_fires(controller: &str, scenario: &str) -> bool {
         // Phase 2 controller must fix — same overlay input as
         // reference_tracks_overlay, opposite correct action.
         (("rfc_draft", "reference_diverges_from_overlay"), true),
+        // LedbatPlusPlus is per-connection: it reacts to the single worst
+        // connection's queueing delay with no cross-peer median and no N>=3
+        // guard. So it false-positives on exactly the scenarios that isolate
+        // one bad/inflated connection — the flaw #4074 identifies. For all
+        // four the sane expectation is NeverFires; LEDBAT firing is the
+        // documented failure mode:
+        //   - single_peer_outlier / small_n: reacts to one outlier / tiny N
+        //   - single_packet_loss: the death spiral (also pinned in detail below)
+        //   - reference_diverges_from_overlay: reference-blind, same as RfcDraft
+        (("ledbat", "single_peer_outlier"), true),
+        (("ledbat", "small_n"), true),
+        (("ledbat", "single_packet_loss"), true),
+        (("ledbat", "reference_diverges_from_overlay"), true),
     ]
     .into_iter()
     .collect();
@@ -80,6 +93,23 @@ fn fixed_rate_never_fires_on_any_scenario() {
 fn rfc_draft_outcomes_match_documented_expectations() {
     for s in all_scenarios() {
         let (name, fired) = run(&s, RfcDraft::default());
+        let expected = expected_fires(&name, s.name);
+        assert_eq!(
+            fired, expected,
+            "{name} on {}: fired={fired}, expected={expected}",
+            s.name
+        );
+    }
+}
+
+#[test]
+fn ledbat_outcomes_match_documented_expectations() {
+    // Pin LedbatPlusPlus across the whole scenario matrix, not just the
+    // dedicated death-spiral test, so its per-connection false-positives
+    // (documented via the `ledbat` overrides in `expected_fires`) cannot
+    // silently change when scenarios or the controller are edited.
+    for s in all_scenarios() {
+        let (name, fired) = run(&s, LedbatPlusPlus::default());
         let expected = expected_fires(&name, s.name);
         assert_eq!(
             fired, expected,


### PR DESCRIPTION
## Problem

#4314 set up the offline replay harness for #4074 Phase 2 controller design, but PR #4315 deliberately shipped only a v1 increment: 4 of the 10 designed scenarios, and the `FixedRate` + `RfcDraft` controllers. The remaining 6 scenarios and the stripped-down LEDBAT++ "death spiral" controller were tracked as follow-up. This PR adds them, so every Phase 2 candidate has the full battery of failure-mode pins to clear.

## Solution

**Six new scenarios** (`src/scenarios/`), each pinning a known #4074 failure mode:

| Scenario | Pins | Sane behaviour |
|---|---|---|
| `single_packet_loss` | Transient 10× spike on one peer | MUST NOT fire |
| `slow_routing_drift` | Baseline drifts 5 ms/min for 30 min (real path change) | MUST NOT fire |
| `churning_peers` | Peers join/leave every 30 s, healthy RTTs | MUST NOT fire |
| `cold_start` | New peers on a slow path, no baseline | MUST NOT fire (no panic) |
| `reference_diverges_from_overlay` | Overlay inflates, reference flat | MUST NOT fire |
| `reference_tracks_overlay` | Overlay and reference inflate together | MUST fire |

**One new controller** (`src/controllers/ledbat.rs`): a stripped-down LEDBAT++ that reproduces the death spiral which got LEDBAT++ abandoned in production. The key insight, and the whole reason it spirals: it reacts to the **worst single connection's** queueing delay, not the cross-peer median. On `single_packet_loss`, one peer's transient spike drives a deep multiplicative cut (down to ~12% of the starting rate) followed by slow additive recovery — while `RfcDraft`'s cross-peer median rejects the same outlier and never moves. That contrast on identical input is the demonstration.

`reference_diverges_from_overlay` is the other interesting pin: `RfcDraft` is reference-blind, so it fires on it (wrongly) — exactly as it fires on `reference_tracks_overlay` (rightly). Same overlay input, opposite correct action, and only the Phase 1.5 reference signal (#4292) distinguishes them. This pins `RfcDraft`'s limitation as the regression a reference-aware Phase 2 controller must fix, the same way the existing `idle_steady_state` pin documents its noise-floor failure.

No production code is touched — this is entirely additive offline tooling under `crates/replay-harness/`.

## Testing

- `tests/scenarios_pin.rs`: the existing per-`(controller, scenario)` sweep now covers all 10 scenarios. `FixedRate` never fires on any; `RfcDraft`'s outcomes (including the two documented failures) are pinned via `expected_fires`.
- New `ledbat_single_packet_loss_death_spiral` test asserts the trajectory: a deep cut (`min_rate ≤ half` the start), additive increase capped at the ceiling, the drop/recover **asymmetry** (recovery takes >3× the ticks the drop did), and the contrast that `RfcDraft` holds flat on the same input.
- `cargo fmt`, `cargo clippy -p replay-harness --lib --tests --bins -- -D warnings`, and `cargo test -p replay-harness` all clean.

## Still open on #4314 (not this PR)

- OTLP file replay (the `otlp` subcommand is still a stub) — now feasible against the durable shadow-telemetry archive.
- `RfcDraft`'s upward "idle headroom" branch (needs an outbound-traffic model).

Refs #4314, #4074

[AI-assisted - Claude]
