### PR TITLE
fix(ring): restore connection convergence in nightly sim tests (#4348)

### DIFF
--- a/.claude/rules/ring.md
+++ b/.claude/rules/ring.md
@@ -93,7 +93,17 @@ CORRECT:
 WHY: Backing off a target for a local problem prevents connecting to it
 later when local conditions improve (e.g., more connections acquired).
 
-See: ring.rs connection_maintenance, issue #3414
+COROLLARY (under-min backoff escape, #4348):
+  A node still BELOW min_connections must IGNORE per-target-location
+  backoff entirely and keep probing. Its under-connection is by definition
+  a local capacity problem, so a `Rejected`-stamped 30s→600s location
+  backoff would trap a poorly-positioned node permanently below min.
+  connection_maintenance gates this via should_respect_location_backoff()
+  (honor backoff only at/above min). Storm safety is preserved by the
+  adaptive fast-tick backoff + max_concurrent cap, not by location backoff.
+
+See: ring.rs connection_maintenance + should_respect_location_backoff,
+issues #3414, #4348
 ```
 
 ### Routing Decisions

--- a/crates/core/src/operations/connect/op_ctx_task.rs
+++ b/crates/core/src/operations/connect/op_ctx_task.rs
@@ -136,6 +136,16 @@ pub(crate) async fn start_client_connect(
     desired_location: Location,
     overall_timeout: Option<std::time::Duration>,
 ) -> Result<(), OpError> {
+    // Count this CONNECT toward the connection_maintenance acquisition throttle.
+    // `start_client_connect` is the single entry for every *self-initiated*
+    // (originator) CONNECT — ring acquisition (`Ring::acquire_new`), gateway
+    // joins (`join_ring_request`), and version probes (`gateway_version_probe`)
+    // all route through here — so registering once here keeps the throttle's
+    // storm-safety cap honest across all of them. Relayed CONNECTs go through
+    // `start_relay_connect` and are deliberately NOT counted (#4348). Registered
+    // before the first send below so it precedes any reply or completion.
+    op_manager.ring.live_tx_tracker.register_acquisition(tx);
+
     // Snapshot whether the joiner knows its own external address before
     // contacting the gateway. Mirrors legacy `JoinerState`'s
     // `started_without_address` field at connect.rs:1162. Used at the

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -3021,8 +3021,17 @@ impl Ring {
             // node's own in-flight acquisitions, NOT CONNECTs it is relaying for
             // others (#4348).
             let mut active_count = live_tx_tracker.active_acquisition_transaction_count();
+            // Honor target-location backoff only once we've reached
+            // min_connections. A node still below min MUST keep probing even
+            // recently-rejected ring regions: its under-connection is a local
+            // capacity problem, not the target's fault, and the 30s→600s
+            // location backoff stamped on a `Rejected` would otherwise trap a
+            // poorly-positioned node permanently below min — the straggler tail
+            // in #4348. This mirrors the zero-connection re-bootstrap escape
+            // above, extended to the whole under-min regime.
+            let respect_backoff = current_conn_count >= self.connection_manager.min_connections;
             while let Some(ideal_location) = pending_conn_adds.pop_first() {
-                if self.is_in_connection_backoff(ideal_location) {
+                if respect_backoff && self.is_in_connection_backoff(ideal_location) {
                     tracing::debug!(
                         target_location = %ideal_location,
                         "Skipping connection attempt - target in backoff"

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -3448,14 +3448,10 @@ impl Ring {
 
         // Register tx with the live transaction tracker BEFORE spawning the
         // driver. Otherwise the driver's first Response could land on the
-        // bypass before the registration completes, breaking the
-        // acquisition gauge that connection_maintenance uses to throttle
-        // concurrent acquisitions.
+        // bypass before the registration completes. (The acquisition-throttle
+        // registration is done inside `start_client_connect`, shared by every
+        // self-initiated CONNECT — ring acquisition, gateway join, and probe.)
         live_tx_tracker.add_transaction(gateway_addr, tx);
-        // Mark this as a self-initiated acquisition so it (and only it, not
-        // relayed CONNECTs) counts toward the maintenance concurrency throttle
-        // (#4348).
-        live_tx_tracker.register_acquisition(tx);
 
         let op_manager_spawn = op_manager.clone();
         let gateway = query_target;

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -3017,8 +3017,10 @@ impl Ring {
             );
 
             // Drain pending connections, initiating multiple attempts per tick
-            // (up to max_concurrent) for faster mesh formation.
-            let mut active_count = live_tx_tracker.active_connect_transaction_count();
+            // (up to max_concurrent) for faster mesh formation. Counts only this
+            // node's own in-flight acquisitions, NOT CONNECTs it is relaying for
+            // others (#4348).
+            let mut active_count = live_tx_tracker.active_acquisition_transaction_count();
             while let Some(ideal_location) = pending_conn_adds.pop_first() {
                 if self.is_in_connection_backoff(ideal_location) {
                     tracing::debug!(
@@ -3441,9 +3443,13 @@ impl Ring {
         // Register tx with the live transaction tracker BEFORE spawning the
         // driver. Otherwise the driver's first Response could land on the
         // bypass before the registration completes, breaking the
-        // active_connect_transaction_count gauge that connection_maintenance
-        // uses to throttle concurrent acquisitions.
+        // acquisition gauge that connection_maintenance uses to throttle
+        // concurrent acquisitions.
         live_tx_tracker.add_transaction(gateway_addr, tx);
+        // Mark this as a self-initiated acquisition so it (and only it, not
+        // relayed CONNECTs) counts toward the maintenance concurrency throttle
+        // (#4348).
+        live_tx_tracker.register_acquisition(tx);
 
         let op_manager_spawn = op_manager.clone();
         let gateway = query_target;

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -3021,15 +3021,12 @@ impl Ring {
             // node's own in-flight acquisitions, NOT CONNECTs it is relaying for
             // others (#4348).
             let mut active_count = live_tx_tracker.active_acquisition_transaction_count();
-            // Honor target-location backoff only once we've reached
-            // min_connections. A node still below min MUST keep probing even
-            // recently-rejected ring regions: its under-connection is a local
-            // capacity problem, not the target's fault, and the 30s→600s
-            // location backoff stamped on a `Rejected` would otherwise trap a
-            // poorly-positioned node permanently below min — the straggler tail
-            // in #4348. This mirrors the zero-connection re-bootstrap escape
-            // above, extended to the whole under-min regime.
-            let respect_backoff = current_conn_count >= self.connection_manager.min_connections;
+            // Under-min nodes bypass per-target backoff to escape the straggler
+            // trap (#4348); see `should_respect_location_backoff`.
+            let respect_backoff = should_respect_location_backoff(
+                current_conn_count,
+                self.connection_manager.min_connections,
+            );
             while let Some(ideal_location) = pending_conn_adds.pop_first() {
                 if respect_backoff && self.is_in_connection_backoff(ideal_location) {
                     tracing::debug!(
@@ -3553,6 +3550,28 @@ fn calculate_max_concurrent_connections(
     (BASE + deficit / CONNECTIONS_PER_EXTRA_SLOT).min(bootstrap_cap)
 }
 
+/// Whether `connection_maintenance` should honor per-target-location connection
+/// backoff for a node with `current_connections` open connections.
+///
+/// Backoff is honored only once the node has reached `min_connections`. A node
+/// still below min MUST keep probing even recently-rejected ring regions: its
+/// under-connection is a local capacity problem, not the target's fault (cf. the
+/// ring.md "Backoff Target Must Match Failure Cause" rule), and the 30s→600s
+/// location backoff stamped on a `Rejected` would otherwise trap a poorly
+/// positioned node permanently below min — the straggler tail in #4348. This
+/// mirrors the zero-connection re-bootstrap escape, extended to the whole
+/// under-min regime; at/above min, steady-state backoff is unchanged.
+///
+/// Storm safety: bypassing location backoff below min does NOT let a stuck node
+/// hammer indefinitely. The maintenance loop's adaptive fast-tick backoff still
+/// stretches the retry cadence toward the steady ~60s `CHECK_TICK` after
+/// consecutive no-progress ticks (connection count not changing), per-tick
+/// attempts remain bounded by [`calculate_max_concurrent_connections`], and the
+/// separate gateway re-bootstrap backoff (`gateway_backoff`) is untouched.
+fn should_respect_location_backoff(current_connections: usize, min_connections: usize) -> bool {
+    current_connections >= min_connections
+}
+
 fn calculate_allowed_connection_additions(
     current_connections: usize,
     pending_connections: usize,
@@ -3938,6 +3957,29 @@ mod max_concurrent_connections_tests {
     fn high_min_connections_scales_cap() {
         // deficit=50, 3 + 50/3 = 19, cap = 50/2 = 25 → 19
         assert_eq!(calculate_max_concurrent_connections(0, 50), 19);
+    }
+}
+
+#[cfg(test)]
+mod respect_location_backoff_tests {
+    use super::should_respect_location_backoff;
+
+    /// Regression guard for the under-min backoff escape (#4348): a node below
+    /// min_connections must bypass per-target location backoff so it cannot be
+    /// trapped below min by a stamped `Rejected` backoff; at/above min, backoff
+    /// is respected as before. Pins the inequality direction and boundary.
+    #[test]
+    fn below_min_bypasses_backoff() {
+        assert!(!should_respect_location_backoff(0, 10));
+        assert!(!should_respect_location_backoff(7, 10));
+        assert!(!should_respect_location_backoff(9, 10));
+    }
+
+    #[test]
+    fn at_or_above_min_respects_backoff() {
+        assert!(should_respect_location_backoff(10, 10)); // exactly min
+        assert!(should_respect_location_backoff(11, 10));
+        assert!(should_respect_location_backoff(20, 10));
     }
 }
 

--- a/crates/core/src/ring/live_tx.rs
+++ b/crates/core/src/ring/live_tx.rs
@@ -29,7 +29,12 @@ pub struct LiveTransactionTracker {
     /// only `BASE = 3`, so a few relayed CONNECTs would stall the node's own
     /// growth flat just above `min_connections` (#4348). Entries are removed in
     /// lockstep with `remove_finished_transaction` / `prune_transactions_from_peer`,
-    /// inheriting their 60s-TTL release backstop, so this set cannot leak.
+    /// so this set's lifecycle is identical to (and cannot leak any worse than)
+    /// the existing `tx_per_peer` accounting. The backstop against a stuck entry
+    /// is the acquisition driver's own 60s `OPERATION_TTL`: `start_client_connect`
+    /// exits on `should_exit_for_ttl` and calls `release_pending_op_slot`, which
+    /// fires `TransactionCompleted` → `remove_finished_transaction`; peer
+    /// disconnect clears it via `prune_transactions_from_peer`.
     acquisition_txs: Arc<DashSet<Transaction>>,
 }
 

--- a/crates/core/src/ring/live_tx.rs
+++ b/crates/core/src/ring/live_tx.rs
@@ -1,5 +1,5 @@
-use crate::message::{Transaction, TransactionType};
-use dashmap::DashMap;
+use crate::message::Transaction;
+use dashmap::{DashMap, DashSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -16,6 +16,21 @@ pub struct LiveTransactionTracker {
     /// Reverse index: Transaction -> SocketAddr for O(1) lookup during removal.
     /// Without this, remove_finished_transaction would need to iterate all peers.
     peer_for_tx: Arc<DashMap<Transaction, SocketAddr>>,
+    /// CONNECT transactions this node *initiated itself* via `Ring::acquire_new`
+    /// (i.e. genuine connection-acquisition attempts), as opposed to CONNECTs it
+    /// is merely relaying for other peers.
+    ///
+    /// `connection_maintenance` throttles concurrent acquisition attempts on
+    /// this count. It must NOT include relayed CONNECTs: a relay holds a
+    /// `tx_per_peer` entry for each CONNECT it forwards (registered in
+    /// `p2p_protoc`) until the op completes or hits the 60s TTL, so counting
+    /// those would let a relay-heavy node's own acquisition budget be consumed
+    /// by other peers' traffic — once at/above `min_connections` the budget is
+    /// only `BASE = 3`, so a few relayed CONNECTs would stall the node's own
+    /// growth flat just above `min_connections` (#4348). Entries are removed in
+    /// lockstep with `remove_finished_transaction` / `prune_transactions_from_peer`,
+    /// inheriting their 60s-TTL release backstop, so this set cannot leak.
+    acquisition_txs: Arc<DashSet<Transaction>>,
 }
 
 impl LiveTransactionTracker {
@@ -40,6 +55,10 @@ impl LiveTransactionTracker {
     }
 
     pub fn remove_finished_transaction(&self, tx: Transaction) {
+        // Clear the acquisition gauge in lockstep with the live-tx removal so a
+        // completed acquisition frees its maintenance-throttle slot. No-op for
+        // relayed CONNECTs (never registered as acquisitions).
+        self.acquisition_txs.remove(&tx);
         // O(1) lookup using reverse index instead of O(n) full-map iteration
         if let Some((_, peer_addr)) = self.peer_for_tx.remove(&tx) {
             self.tx_per_peer.remove_if_mut(&peer_addr, |_, v| {
@@ -49,10 +68,18 @@ impl LiveTransactionTracker {
         }
     }
 
+    /// Mark `tx` as a self-initiated connection-acquisition attempt so it counts
+    /// toward the `connection_maintenance` concurrency throttle. Call this only
+    /// from `Ring::acquire_new`; relayed CONNECTs must NOT be registered here.
+    pub(crate) fn register_acquisition(&self, tx: Transaction) {
+        self.acquisition_txs.insert(tx);
+    }
+
     pub(crate) fn new() -> Self {
         Self {
             tx_per_peer: Arc::new(DashMap::default()),
             peer_for_tx: Arc::new(DashMap::default()),
+            acquisition_txs: Arc::new(DashSet::default()),
         }
     }
 
@@ -65,6 +92,7 @@ impl LiveTransactionTracker {
         if let Some((_, txs)) = self.tx_per_peer.remove(&peer_addr) {
             for tx in &txs {
                 self.peer_for_tx.remove(tx);
+                self.acquisition_txs.remove(tx);
             }
             txs
         } else {
@@ -89,19 +117,16 @@ impl LiveTransactionTracker {
             .sum()
     }
 
-    /// Returns the number of active Connect transactions across all peers.
-    /// Used to limit concurrent connection acquisition attempts.
-    pub(crate) fn active_connect_transaction_count(&self) -> usize {
-        self.tx_per_peer
-            .iter()
-            .map(|entry| {
-                entry
-                    .value()
-                    .iter()
-                    .filter(|tx| tx.transaction_type() == TransactionType::Connect)
-                    .count()
-            })
-            .sum()
+    /// Returns the number of in-flight connection-acquisition attempts this node
+    /// initiated itself (via `Ring::acquire_new`). `connection_maintenance` uses
+    /// this to throttle concurrent acquisitions.
+    ///
+    /// This deliberately excludes CONNECTs the node is relaying for other peers
+    /// (those are tracked in `tx_per_peer` for cancellation/`has_live_connection`
+    /// but never registered as acquisitions), so relay load cannot consume the
+    /// node's own acquisition budget — see the `acquisition_txs` field (#4348).
+    pub(crate) fn active_acquisition_transaction_count(&self) -> usize {
+        self.acquisition_txs.len()
     }
 }
 
@@ -163,39 +188,81 @@ mod tests {
     }
 
     #[test]
-    fn active_connect_transaction_count_filters_by_type() {
+    fn acquisition_count_empty() {
         let tracker = LiveTransactionTracker::new();
-        let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
-
-        // Add mixed transaction types
-        tracker.add_transaction(addr, Transaction::new::<ConnectMsg>());
-        tracker.add_transaction(addr, Transaction::new::<GetMsg>());
-        tracker.add_transaction(addr, Transaction::new::<PutMsg>());
-        tracker.add_transaction(addr, Transaction::new::<ConnectMsg>());
-
-        // Total count should be 4
-        assert_eq!(tracker.active_transaction_count(), 4);
-        // Connect count should only be 2
-        assert_eq!(tracker.active_connect_transaction_count(), 2);
+        assert_eq!(tracker.active_acquisition_transaction_count(), 0);
     }
 
+    /// Regression test for the residual half of #4348: the
+    /// `connection_maintenance` acquisition throttle must count ONLY CONNECTs
+    /// this node initiated itself, not CONNECTs it is relaying for other peers.
+    /// Relayed CONNECTs land in `tx_per_peer` (via `add_transaction`) and are
+    /// held until the op completes or hits the 60s TTL; counting them let a
+    /// relay-heavy node's own acquisition budget (only `BASE = 3` once at/above
+    /// `min_connections`) be consumed by other peers' traffic, stalling its
+    /// growth flat just above `min_connections`.
     #[test]
-    fn active_connect_transaction_count_empty() {
+    fn acquisition_count_excludes_relayed_connects() {
         let tracker = LiveTransactionTracker::new();
-        assert_eq!(tracker.active_connect_transaction_count(), 0);
+        let peer1: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+        let peer2: SocketAddr = "127.0.0.1:8081".parse().unwrap();
+
+        // Three CONNECTs this node is merely relaying for others.
+        tracker.add_transaction(peer1, Transaction::new::<ConnectMsg>());
+        tracker.add_transaction(peer1, Transaction::new::<ConnectMsg>());
+        tracker.add_transaction(peer2, Transaction::new::<ConnectMsg>());
+
+        // None of them are this node's own acquisition attempts.
+        assert_eq!(
+            tracker.active_acquisition_transaction_count(),
+            0,
+            "relayed CONNECTs must not consume the acquisition throttle budget"
+        );
+
+        // One CONNECT this node initiated itself via acquire_new.
+        let own = Transaction::new::<ConnectMsg>();
+        tracker.add_transaction(peer1, own);
+        tracker.register_acquisition(own);
+        assert_eq!(tracker.active_acquisition_transaction_count(), 1);
     }
 
+    /// A self-initiated CONNECT rebound across hops (acquire_new registers once,
+    /// then the tx is forwarded to successive peers via `add_transaction`) is
+    /// still a single in-flight acquisition.
     #[test]
-    fn active_connect_transaction_count_no_connects() {
+    fn acquisition_count_unaffected_by_cross_peer_rebind() {
         let tracker = LiveTransactionTracker::new();
-        let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+        let addr1: SocketAddr = "127.0.0.1:9001".parse().unwrap();
+        let addr2: SocketAddr = "127.0.0.1:9002".parse().unwrap();
+        let tx = Transaction::new::<ConnectMsg>();
 
-        // Add only non-connect transactions
-        tracker.add_transaction(addr, Transaction::new::<GetMsg>());
-        tracker.add_transaction(addr, Transaction::new::<PutMsg>());
+        tracker.register_acquisition(tx);
+        tracker.add_transaction(addr1, tx);
+        tracker.add_transaction(addr2, tx); // rebind to a second hop
 
-        assert_eq!(tracker.active_transaction_count(), 2);
-        assert_eq!(tracker.active_connect_transaction_count(), 0);
+        assert_eq!(tracker.active_acquisition_transaction_count(), 1);
+    }
+
+    /// Completing an acquisition frees its throttle slot, and a peer disconnect
+    /// (prune) does too — so the gauge cannot leak and pin acquisition at the cap.
+    #[test]
+    fn acquisition_count_drains_on_completion_and_prune() {
+        let tracker = LiveTransactionTracker::new();
+        let addr: SocketAddr = "127.0.0.1:9001".parse().unwrap();
+
+        let done = Transaction::new::<ConnectMsg>();
+        tracker.add_transaction(addr, done);
+        tracker.register_acquisition(done);
+        let pruned = Transaction::new::<ConnectMsg>();
+        tracker.add_transaction(addr, pruned);
+        tracker.register_acquisition(pruned);
+        assert_eq!(tracker.active_acquisition_transaction_count(), 2);
+
+        tracker.remove_finished_transaction(done);
+        assert_eq!(tracker.active_acquisition_transaction_count(), 1);
+
+        tracker.prune_transactions_from_peer(addr);
+        assert_eq!(tracker.active_acquisition_transaction_count(), 0);
     }
 
     #[test]

--- a/crates/core/src/ring/live_tx.rs
+++ b/crates/core/src/ring/live_tx.rs
@@ -329,8 +329,9 @@ mod tests {
         assert!(pruned.is_empty());
     }
 
-    /// Pins the load-bearing invariant for `Ring::connection_maintenance`
-    /// (`crates/core/src/ring.rs:2360-2365`): once a `tx` has been
+    /// Pins the load-bearing invariant for `Ring::connection_maintenance`'s
+    /// `has_live_connection` neighbor filter (`crates/core/src/ring.rs:3110`):
+    /// once a `tx` has been
     /// registered against a peer, `has_live_connection(that_peer)` must
     /// remain `true` until the tx is explicitly cleared, even after the
     /// same `tx` is re-registered against another peer.

--- a/crates/core/src/ring/live_tx.rs
+++ b/crates/core/src/ring/live_tx.rs
@@ -96,8 +96,25 @@ impl LiveTransactionTracker {
         // Remove all transactions for this peer from the reverse index
         if let Some((_, txs)) = self.tx_per_peer.remove(&peer_addr) {
             for tx in &txs {
-                self.peer_for_tx.remove(tx);
-                self.acquisition_txs.remove(tx);
+                // A tx that was cross-peer *rebound* to a different, still-live
+                // peer (see `add_transaction`) leaves a stale entry on the
+                // earlier peer. Pruning that earlier peer must NOT clear the
+                // reverse index or the acquisition gauge, or
+                // `active_acquisition_transaction_count` would undercount and
+                // let `connection_maintenance` exceed `max_concurrent` during
+                // churn (#4348 review). Only clear when this peer is still the
+                // tx's current owner (or the tx has no current owner). The
+                // `.map(...)` copies the addr and drops the Ref before
+                // `remove`, avoiding a same-shard self-deadlock.
+                let owned_here = self
+                    .peer_for_tx
+                    .get(tx)
+                    .map(|e| *e.value())
+                    .is_none_or(|owner| owner == peer_addr);
+                if owned_here {
+                    self.peer_for_tx.remove(tx);
+                    self.acquisition_txs.remove(tx);
+                }
             }
             txs
         } else {
@@ -267,6 +284,37 @@ mod tests {
         assert_eq!(tracker.active_acquisition_transaction_count(), 1);
 
         tracker.prune_transactions_from_peer(addr);
+        assert_eq!(tracker.active_acquisition_transaction_count(), 0);
+    }
+
+    /// Pruning the *stale* earlier peer of a cross-peer-rebound acquisition tx
+    /// must NOT drop it from the gauge — it's still in flight on the newer peer.
+    /// Otherwise `active_acquisition_transaction_count` undercounts and the
+    /// maintenance throttle can exceed max_concurrent during churn (#4348 review).
+    #[test]
+    fn acquisition_count_survives_prune_of_rebound_stale_peer() {
+        let tracker = LiveTransactionTracker::new();
+        let old_peer: SocketAddr = "127.0.0.1:9001".parse().unwrap();
+        let new_peer: SocketAddr = "127.0.0.1:9002".parse().unwrap();
+        let tx = Transaction::new::<ConnectMsg>();
+
+        tracker.register_acquisition(tx);
+        tracker.add_transaction(old_peer, tx);
+        tracker.add_transaction(new_peer, tx); // rebind; old_peer entry now stale
+        assert_eq!(tracker.active_acquisition_transaction_count(), 1);
+
+        // old_peer disconnects — its stale entry is pruned, but the tx is live
+        // on new_peer, so the acquisition gauge must stay at 1.
+        tracker.prune_transactions_from_peer(old_peer);
+        assert_eq!(
+            tracker.active_acquisition_transaction_count(),
+            1,
+            "rebound acquisition must survive prune of its stale old peer"
+        );
+        assert!(tracker.has_live_connection(new_peer));
+
+        // Completion finally drains it.
+        tracker.remove_finished_transaction(tx);
         assert_eq!(tracker.active_acquisition_transaction_count(), 0);
     }
 

--- a/crates/core/src/ring/live_tx.rs
+++ b/crates/core/src/ring/live_tx.rs
@@ -27,14 +27,16 @@ pub struct LiveTransactionTracker {
     /// those would let a relay-heavy node's own acquisition budget be consumed
     /// by other peers' traffic — once at/above `min_connections` the budget is
     /// only `BASE = 3`, so a few relayed CONNECTs would stall the node's own
-    /// growth flat just above `min_connections` (#4348). Entries are removed in
-    /// lockstep with `remove_finished_transaction` / `prune_transactions_from_peer`,
-    /// so this set's lifecycle is identical to (and cannot leak any worse than)
-    /// the existing `tx_per_peer` accounting. The backstop against a stuck entry
-    /// is the acquisition driver's own 60s `OPERATION_TTL`: `start_client_connect`
-    /// exits on `should_exit_for_ttl` and calls `release_pending_op_slot`, which
-    /// fires `TransactionCompleted` → `remove_finished_transaction`; peer
-    /// disconnect clears it via `prune_transactions_from_peer`.
+    /// growth flat just above `min_connections` (#4348). An entry is cleared
+    /// only by `remove_finished_transaction` (NOT by `prune_transactions_from_peer`):
+    /// an acquisition stays "in flight" across peer churn until its driver
+    /// actually finishes. The acquisition driver always reaches
+    /// `remove_finished_transaction` — on completion, on an orphan wake
+    /// (`handle_orphaned_transactions` after a peer disconnect), or via the
+    /// driver's 60s `OPERATION_TTL` exit (`should_exit_for_ttl` →
+    /// `release_pending_op_slot` → `TransactionCompleted`) — so the set cannot
+    /// leak, and tying cleanup to completion alone keeps the gauge race-free
+    /// under concurrent rebinds.
     acquisition_txs: Arc<DashSet<Transaction>>,
 }
 
@@ -93,28 +95,22 @@ impl LiveTransactionTracker {
     /// Returns the list of transactions that were associated with this peer,
     /// allowing callers to handle them appropriately (e.g., retry via alternate routes).
     pub(crate) fn prune_transactions_from_peer(&self, peer_addr: SocketAddr) -> Vec<Transaction> {
-        // Remove all transactions for this peer from the reverse index
+        // Remove all transactions for this peer from the reverse index.
+        //
+        // NOTE: this deliberately does NOT touch `acquisition_txs`. A pruned
+        // peer means a disconnect, not acquisition completion — the orphaned
+        // acquisition's driver is woken (`handle_orphaned_transactions`) and
+        // retries or fails, and either way reaches `remove_finished_transaction`
+        // (or the 60s TTL backstop), which clears the gauge. Removing here would
+        // (a) undercount a tx that was rebound to a still-live peer, and
+        // (b) race a concurrent `add_transaction` rebind between the owner check
+        // and the remove. Leaving acquisition cleanup solely to
+        // `remove_finished_transaction` is race-free and, during the brief
+        // orphan window, errs toward over-counting — the safe direction for a
+        // concurrency throttle (#4348 review).
         if let Some((_, txs)) = self.tx_per_peer.remove(&peer_addr) {
             for tx in &txs {
-                // A tx that was cross-peer *rebound* to a different, still-live
-                // peer (see `add_transaction`) leaves a stale entry on the
-                // earlier peer. Pruning that earlier peer must NOT clear the
-                // reverse index or the acquisition gauge, or
-                // `active_acquisition_transaction_count` would undercount and
-                // let `connection_maintenance` exceed `max_concurrent` during
-                // churn (#4348 review). Only clear when this peer is still the
-                // tx's current owner (or the tx has no current owner). The
-                // `.map(...)` copies the addr and drops the Ref before
-                // `remove`, avoiding a same-shard self-deadlock.
-                let owned_here = self
-                    .peer_for_tx
-                    .get(tx)
-                    .map(|e| *e.value())
-                    .is_none_or(|owner| owner == peer_addr);
-                if owned_here {
-                    self.peer_for_tx.remove(tx);
-                    self.acquisition_txs.remove(tx);
-                }
+                self.peer_for_tx.remove(tx);
             }
             txs
         } else {
@@ -265,34 +261,38 @@ mod tests {
         assert_eq!(tracker.active_acquisition_transaction_count(), 1);
     }
 
-    /// Completing an acquisition frees its throttle slot, and a peer disconnect
-    /// (prune) does too — so the gauge cannot leak and pin acquisition at the cap.
+    /// The acquisition gauge drains on transaction completion (and only then),
+    /// so a completed acquisition frees its throttle slot and the set cannot
+    /// leak and pin acquisition at the cap.
     #[test]
-    fn acquisition_count_drains_on_completion_and_prune() {
+    fn acquisition_count_drains_on_completion() {
         let tracker = LiveTransactionTracker::new();
         let addr: SocketAddr = "127.0.0.1:9001".parse().unwrap();
 
-        let done = Transaction::new::<ConnectMsg>();
-        tracker.add_transaction(addr, done);
-        tracker.register_acquisition(done);
-        let pruned = Transaction::new::<ConnectMsg>();
-        tracker.add_transaction(addr, pruned);
-        tracker.register_acquisition(pruned);
+        let first = Transaction::new::<ConnectMsg>();
+        tracker.add_transaction(addr, first);
+        tracker.register_acquisition(first);
+        let second = Transaction::new::<ConnectMsg>();
+        tracker.add_transaction(addr, second);
+        tracker.register_acquisition(second);
         assert_eq!(tracker.active_acquisition_transaction_count(), 2);
 
-        tracker.remove_finished_transaction(done);
+        tracker.remove_finished_transaction(first);
         assert_eq!(tracker.active_acquisition_transaction_count(), 1);
 
-        tracker.prune_transactions_from_peer(addr);
+        tracker.remove_finished_transaction(second);
         assert_eq!(tracker.active_acquisition_transaction_count(), 0);
     }
 
-    /// Pruning the *stale* earlier peer of a cross-peer-rebound acquisition tx
-    /// must NOT drop it from the gauge — it's still in flight on the newer peer.
-    /// Otherwise `active_acquisition_transaction_count` undercounts and the
-    /// maintenance throttle can exceed max_concurrent during churn (#4348 review).
+    /// Pruning a peer (a disconnect, NOT completion) must NOT drain the
+    /// acquisition gauge: the orphaned acquisition is still in flight (its
+    /// driver retries or fails and reaches `remove_finished_transaction`). This
+    /// holds even for a tx cross-peer-rebound to a still-live peer, where a
+    /// remove-on-prune would undercount and let the maintenance throttle exceed
+    /// max_concurrent during churn (#4348 review). The gauge clears only on
+    /// completion.
     #[test]
-    fn acquisition_count_survives_prune_of_rebound_stale_peer() {
+    fn acquisition_count_unaffected_by_prune() {
         let tracker = LiveTransactionTracker::new();
         let old_peer: SocketAddr = "127.0.0.1:9001".parse().unwrap();
         let new_peer: SocketAddr = "127.0.0.1:9002".parse().unwrap();
@@ -303,13 +303,13 @@ mod tests {
         tracker.add_transaction(new_peer, tx); // rebind; old_peer entry now stale
         assert_eq!(tracker.active_acquisition_transaction_count(), 1);
 
-        // old_peer disconnects — its stale entry is pruned, but the tx is live
-        // on new_peer, so the acquisition gauge must stay at 1.
+        // old_peer disconnects — its stale entry is pruned, but the tx is still
+        // in flight (live on new_peer), so the acquisition gauge must stay at 1.
         tracker.prune_transactions_from_peer(old_peer);
         assert_eq!(
             tracker.active_acquisition_transaction_count(),
             1,
-            "rebound acquisition must survive prune of its stale old peer"
+            "prune must not drain an in-flight acquisition"
         );
         assert!(tracker.has_live_connection(new_peer));
 

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -7425,15 +7425,22 @@ fn test_get_routing_coverage_low_htl() {
     use std::sync::atomic::Ordering;
 
     use freenet::dev_tool::{
-        GET_RELAY_DRIVER_CALL_COUNT, NodeLabel, RELAY_GET_ROUTE_EVENT_COUNT,
-        RELAY_PUT_DRIVER_CALL_COUNT, RELAY_PUT_ROUTE_EVENT_COUNT,
-        RELAY_SUBSCRIBE_DRIVER_CALL_COUNT, RELAY_SUBSCRIBE_ROUTE_EVENT_COUNT, ScheduledOperation,
-        SimOperation, register_crdt_contract,
+        GET_RELAY_DRIVER_CALL_COUNT, NodeLabel, RELAY_PUT_DRIVER_CALL_COUNT,
+        RELAY_SUBSCRIBE_DRIVER_CALL_COUNT, ScheduledOperation, SimOperation,
+        register_crdt_contract,
     };
 
-    // Seed updated: per-peer acceptor reliability scoring replaces binary
-    // exclusion (PR #3659), changing the CONNECT routing code path and
-    // Turmoil scheduling. Previous seed: 0xC0DE_B0CA_0032 (PR #3621).
+    // NOTE: the relay-hop *route-event* assertions (RELAY_*_ROUTE_EVENT_COUNT)
+    // that used to live here were moved to `test_relay_route_events_multihop`.
+    // They require a SPARSE topology where a GET/PUT actually forwards a
+    // downstream response, but this test deliberately keeps the mesh well
+    // connected (max_connections=7) so the GET-coverage assertion (#3431)
+    // holds. Once the #4348 convergence fix let nodes reliably reach
+    // min_connections, a 15-node/max=7 net converged dense enough that ops
+    // resolved in 0-1 hops and the route-event counters stayed at 0 — a
+    // topology-coupling that the dedicated sparse test now owns. This test
+    // keeps the relay *driver-call* assertions (which fire even when a relay
+    // resolves locally) plus the coverage assertion.
     const SEED: u64 = 0xC0DE_B0CA_0032;
     const NETWORK_NAME: &str = "get-routing-coverage";
 
@@ -7449,19 +7456,6 @@ fn test_get_routing_coverage_low_htl() {
     let relay_baseline = GET_RELAY_DRIVER_CALL_COUNT.load(Ordering::SeqCst);
     let relay_put_baseline = RELAY_PUT_DRIVER_CALL_COUNT.load(Ordering::SeqCst);
     let relay_subscribe_baseline = RELAY_SUBSCRIBE_DRIVER_CALL_COUNT.load(Ordering::SeqCst);
-
-    // Baselines for the relay-hop routing-event counters. Each fires when
-    // a relay forwards a downstream peer's response and feeds the result
-    // into the local Router via record_relay_route_event. Without these
-    // hooks the per-peer dashboard panels stay empty and the failure-
-    // probability model is trained only on originator-side events.
-    // The same workload that exercises the relay drivers above must
-    // also exercise these counters — drivers running without route-event
-    // emission would silently regress router quality.
-    let relay_get_route_event_baseline = RELAY_GET_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
-    let relay_put_route_event_baseline = RELAY_PUT_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
-    let relay_subscribe_route_event_baseline =
-        RELAY_SUBSCRIBE_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
 
     let rt = create_runtime();
 
@@ -7619,49 +7613,14 @@ fn test_get_routing_coverage_low_htl() {
          Baseline: {relay_subscribe_baseline}, after: {relay_subscribe_after}."
     );
 
-    // Relay-hop routing-event counters: every relay that forwards a
-    // downstream response should feed the local Router. Drivers running
-    // without route-event emission means the per-peer dashboard panels
-    // stay empty and the failure-probability model is undertrained on
-    // relay-heavy nodes (the bug this work fixes).
-    let relay_get_route_event_after = RELAY_GET_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
-    let relay_get_route_event_delta =
-        relay_get_route_event_after.saturating_sub(relay_get_route_event_baseline);
-    assert!(
-        relay_get_route_event_delta > 0,
-        "RELAY_GET_ROUTE_EVENT_COUNT did not advance — at least one \
-         relay-forwarded GET should have produced a routing event for \
-         the local Router. {num_nodes}-node / HTL=3 workload with 15 \
-         GETs must traverse at least one relay hop. \
-         Baseline: {relay_get_route_event_baseline}, after: {relay_get_route_event_after}."
-    );
-
-    let relay_put_route_event_after = RELAY_PUT_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
-    let relay_put_route_event_delta =
-        relay_put_route_event_after.saturating_sub(relay_put_route_event_baseline);
-    assert!(
-        relay_put_route_event_delta > 0,
-        "RELAY_PUT_ROUTE_EVENT_COUNT did not advance — the gateway PUT \
-         at HTL=3 should have produced a routing event at every relay \
-         hop. \
-         Baseline: {relay_put_route_event_baseline}, after: {relay_put_route_event_after}."
-    );
-
-    // SUBSCRIBE route-event coverage is intentionally NOT asserted in
-    // this test. With the gateway PUT seeded at HTL=3 and 12 nodes
-    // subscribing, every subscribe in this workload hits the local-hit
-    // fast path at `subscribe/op_ctx_task.rs::drive_relay_subscribe`
-    // step 1 — the first relay always has the contract cached and
-    // replies `Subscribed` without forwarding downstream. That's a
-    // correct zero for the route-event counter, since the route-event
-    // hook only fires on actual forwards. A dedicated SUBSCRIBE forward
-    // test (subscriber + sparse cache topology) belongs as a follow-up.
-    // The relay SUBSCRIBE driver itself is still exercised — see the
-    // RELAY_SUBSCRIBE_DRIVER_CALL_COUNT assertion above.
-    let _ = (
-        RELAY_SUBSCRIBE_ROUTE_EVENT_COUNT.load(Ordering::SeqCst),
-        relay_subscribe_route_event_baseline,
-    );
+    // Relay-hop *route-event* coverage (RELAY_*_ROUTE_EVENT_COUNT) is asserted
+    // separately in `test_relay_route_events_multihop`. Those counters only
+    // fire when a relay forwards a downstream response, which needs a sparse
+    // topology where an op actually traverses >=2 hops. This test keeps the
+    // mesh dense (max_connections=7) so the GET-coverage assertion above holds;
+    // post-#4348 that density makes ops resolve in 0-1 hops, so route events do
+    // not fire here (#4348). The relay *drivers* are still exercised — see the
+    // RELAY_*_DRIVER_CALL_COUNT assertions above.
 
     // StateVerifier anomaly check
     let rt = create_runtime();
@@ -7675,6 +7634,126 @@ fn test_get_routing_coverage_low_htl() {
          relay_driver_calls={relay_delta}",
         report.anomalies.len(),
         report.total_events,
+    );
+}
+
+/// Relay-hop route-event telemetry (#1454): a relay that forwards a downstream
+/// GET/PUT response must feed the result into the local Router via
+/// `record_relay_route_event`, or the per-peer dashboard panels stay empty and
+/// the failure-probability model is undertrained on relay-heavy nodes.
+///
+/// These assertions previously lived in `test_get_routing_coverage_low_htl`,
+/// but that test must keep a DENSE mesh so every node's GET resolves
+/// (its #3431 coverage assertion). The #4348 connection-convergence fix made
+/// that mesh converge dense enough that ops resolved in 0-1 hops, so
+/// `RELAY_*_ROUTE_EVENT_COUNT` never advanced — the test was implicitly relying
+/// on the under-connectivity bug #4348 fixed. This dedicated test instead uses a
+/// deliberately SPARSE topology where multi-hop forwarding is structural, and
+/// asserts ONLY that the route-event hooks fire. It makes NO GET-coverage claim
+/// (a NotFound reply still exercises the relay route-event hook), so improved
+/// connectivity can never invalidate it.
+///
+/// SUBSCRIBE route events are intentionally not asserted (subscribes hit the
+/// relay local-cache fast path without forwarding downstream — see the note in
+/// `test_get_routing_coverage_low_htl`); the relay SUBSCRIBE *driver* is still
+/// covered there.
+#[test_log::test]
+fn test_relay_route_events_multihop() {
+    use std::sync::atomic::Ordering;
+
+    use freenet::dev_tool::{
+        NodeLabel, RELAY_GET_ROUTE_EVENT_COUNT, RELAY_PUT_ROUTE_EVENT_COUNT, ScheduledOperation,
+        SimOperation, register_crdt_contract,
+    };
+
+    const SEED: u64 = 0xC0DE_B0CA_0040;
+    const NETWORK_NAME: &str = "relay-route-events";
+
+    GlobalTestMetrics::reset();
+    setup_deterministic_state(SEED);
+
+    let get_route_baseline = RELAY_GET_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
+    let put_route_baseline = RELAY_PUT_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
+
+    let rt = create_runtime();
+    let num_nodes = 15;
+
+    let sim = rt.block_on(async {
+        SimNetwork::new(
+            NETWORK_NAME,
+            1,         // gateways
+            num_nodes, // nodes
+            3,         // ring_max_htl
+            1,         // rnd_if_htl_above
+            // max_connections — deliberately LOW. A sparse mesh keeps requesters
+            // >=2 hops from the few holders, so GET/PUT requests forward through a
+            // non-holding relay and fire the route-event hooks. We assert only
+            // that the hooks fire, NOT that every GET resolves, so sparsity (which
+            // would fail a coverage assertion) is exactly what we want here.
+            4, // max_connections
+            3, // min_connections
+            SEED,
+        )
+        .await
+    });
+
+    let contract = SimOperation::create_test_contract(0xC0);
+    let contract_id = *contract.key().id();
+    register_crdt_contract(contract_id);
+
+    // Gateway seeds the contract; only a few nodes subscribe so the cache stays
+    // sparse and most requesters are several hops from a holder.
+    let mut operations = vec![ScheduledOperation::new(
+        NodeLabel::gateway(NETWORK_NAME, 0),
+        SimOperation::Put {
+            contract: contract.clone(),
+            state: SimOperation::create_crdt_state(1, 0xC0),
+            subscribe: true,
+        },
+    )];
+    for i in 1..=4 {
+        operations.push(ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, i),
+            SimOperation::Subscribe { contract_id },
+        ));
+    }
+    for i in 1..=num_nodes {
+        operations.push(ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, i),
+            SimOperation::Get {
+                contract_id,
+                return_contract_code: true,
+                subscribe: false,
+            },
+        ));
+    }
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(300),
+        Duration::from_secs(90),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "Simulation failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let get_route_after = RELAY_GET_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
+    let put_route_after = RELAY_PUT_ROUTE_EVENT_COUNT.load(Ordering::SeqCst);
+    assert!(
+        get_route_after > get_route_baseline,
+        "RELAY_GET_ROUTE_EVENT_COUNT did not advance — in a sparse {num_nodes}-node \
+         mesh (max_connections=4) at least one GET must forward through a relay that \
+         feeds a route event to the local Router (a NotFound reply counts too). \
+         Baseline: {get_route_baseline}, after: {get_route_after}."
+    );
+    assert!(
+        put_route_after > put_route_baseline,
+        "RELAY_PUT_ROUTE_EVENT_COUNT did not advance — the gateway PUT at HTL=3 in a \
+         sparse {num_nodes}-node mesh must forward through at least one relay. \
+         Baseline: {put_route_baseline}, after: {put_route_after}."
     );
 }
 


### PR DESCRIPTION
## Problem

The **Simulation Tests (Nightly)** workflow's `test_nightly_*` connectivity tests plateaued at a flat median of ~7 connections, never reaching `min_connections = 10`:

```
Final median=7 < min_connections=10. Checkpoints: [(300,7),(900,7),(1800,7),(3600,7)]
```

Flat checkpoints across the whole simulated hour = the network bootstraps, then **stops acquiring new connections**.

### Root cause (bisected)

These tests are not aspirational — CI ran them green at **median 16** in April (run `24116882646`). Bisecting on a fixed seed pinpoints the **#1454 CONNECT task-per-tx migration** (mid-May), which made the new drivers hold CONNECT transactions far longer than the old mediator did:

| Commit | Trajectory | Result |
|--------|-----------|--------|
| `ca7fa7a0` (pre-#1454) | 12→17→17→19 grows | PASS |
| `d90a6c09` (post-#1454) | 9→9→9→9 flat | FAIL |
| `HEAD` (pre-fix) | 7→7→7→7 flat | FAIL |

`Ring::connection_maintenance` throttles concurrent connection-*acquisition* attempts on `LiveTransactionTracker`'s live CONNECT count (`active_count >= max_concurrent` → stop calling `acquire_new`). That count summed `tx_per_peer`, which includes CONNECTs the node is merely **relaying** for other peers (held until completion / the 60s `OPERATION_TTL`) and double-counts a CONNECT rebound across hops. Once at/above `min_connections`, `calculate_max_concurrent_connections` returns `BASE = 3`, so a relay-heavy node's own acquisition budget was consumed by others' traffic and it stopped acquiring — topology stalled flat.

A secondary effect left a residual straggler tail: nodes that route into saturated ring regions get `Rejected`, stamp 30s→600s **location backoff**, and the maintenance loop then skips those locations — trapping a poorly-positioned node below min.

## Approach

1. **Throttle on self-initiated acquisitions only.** Track CONNECTs the node initiates itself in a dedicated `acquisition_txs` set and throttle on `active_acquisition_transaction_count()`. Registration happens once in `start_client_connect` — the single entry for every originator CONNECT (ring acquisition, gateway join, version probe) — so relayed CONNECTs (`start_relay_connect`) and the rebind double-count are excluded, while all genuinely self-initiated CONNECTs still count toward the storm-safety cap. The gauge is cleared only by `remove_finished_transaction` (completion / orphan-wake / 60s TTL), never by prune — race-free and erring toward over-counting during churn (the safe direction).

2. **Under-min backoff escape.** Honor target-location backoff only once at/above `min_connections` (`should_respect_location_backoff`). A node below min keeps probing recently-rejected regions — its under-connection is a local capacity problem, not the target's fault (cf. ring.md "backoff target must match failure cause"). Mirrors the existing zero-connection re-bootstrap escape; above-min steady-state backoff is unchanged. Storm-bounded by the adaptive fast-tick backoff + `max_concurrent`.

The deeper structural cause of the residual straggler tail (no capacity reservation for under-min joiners when peers grow to `max_connections` — the gateway/hub-imbalance class) is tracked by **#3362** and out of scope here.

## Testing

Local (`--features "simulation_tests,testing,nightly_tests" --test-threads=1`):

| Test | Before | After |
|------|--------|-------|
| `test_nightly_connection_growth_checkpoints` | flat median 7 (FAIL) | median 18–19, **PASS** |
| `test_nightly_50_node_topology_formation` | flat median 7 (FAIL) | median 18, **93–98% reach min**, **PASS** |
| `test_nightly_fault_recovery_speed` | flat median 7 (FAIL) | median 18, 0% isolated, **PASS** |
| `test_six_peer_contract_lifecycle` | PASS | PASS (no regression) |
| `test_connection_growth_stall_regression` | PASS | PASS |

New unit tests (`live_tx.rs`, `ring.rs`): acquisition count excludes relayed CONNECTs, is unaffected by cross-peer rebind, drains on completion, is unaffected by prune; under-min backoff predicate boundary tests. All fail on the pre-fix behavior, pass on the fix.

**Sim-test redesign:** `test_get_routing_coverage_low_htl`'s relay-hop *route-event* assertions were extracted to a new `test_relay_route_events_multihop` on a deliberately **sparse** topology. The coverage test needs a *dense* mesh (so every node's GET resolves, #3431); once this fix lets nodes actually converge, that mesh resolves GETs in 0–1 hops and the route-event counters never fired — i.e. those assertions were implicitly depending on the under-connectivity bug this PR fixes. The new test asserts only that the route-event hooks fire (a NotFound reply counts), so improved connectivity can't invalidate it; the coverage test keeps #3431 + the relay driver-call assertions.

`cargo fmt` clean; `cargo clippy --locked -- -D warnings` clean.

Why didn't CI catch the regression earlier? The nightly job was already red for an unrelated, older reason (the 500-node large-scale step), so the `test_nightly_*` failure was just another red — exactly the masking this issue is about. The `test_nightly_*` tests are cron-only (not PR-gating); PR CI exercises the fix via `test_get_routing_coverage_low_htl`, `test_relay_route_events_multihop`, and the `live_tx`/`ring` unit tests.

## Note: separate Phase-1 500-node step

The nightly's "Large scale test (500 nodes)" step is a separate, older failure (timing out since ~2026-03-26), currently masked because nextest fails first. After this fix nextest passes and that step becomes reachable; the same throttle bug plausibly slowed it, so it may now pass — if not, track/re-scope separately as the issue notes.

## Review

Full multi-model review (A-networking, high-risk): four Claude perspective reviewers (code-first, skeptical, testing, big-picture) + an external Codex pass. All findings addressed — see the consolidated review comment below.

Closes #4348

[AI-assisted - Claude]
