### PR TITLE
fix(transport): abandon never-ACKed packets so lossy multi-fragment GETs don't wedge

### DIFF
--- a/.claude/rules/transport.md
+++ b/.claude/rules/transport.md
@@ -83,6 +83,26 @@ BEFORE changing LEDBAT++ parameters:
   4. Document reasoning in commit message
 ```
 
+### Flight-size release invariant (issue #4345)
+
+```
+Flight size MUST have a release path other than ACK. A packet whose ACKs
+never arrive (lossy path / starved reverse-ACK channel) is retransmitted up
+to MAX_PACKET_RETRANSMITS times, then SentPacketTracker returns
+ResendAction::Abandon and the recv loop calls
+CongestionControl::release_flightsize(len). Without this, a never-ACKed
+packet's on_send bytes stay in flight size for the connection's life,
+pinning flight size at cwnd and stalling every subsequent stream
+(the #4345 "cwnd wait timeout" / "no fragments received" failure).
+
+  - on_timeout() applies the cwnd loss response only; it MUST NOT change
+    flight size (the timed-out packet is immediately re-sent and stays in
+    flight). Do NOT reintroduce a decrement-on-RTO + re-add-on-resend pair —
+    the recv loop always re-sends on RTO, so that is net-zero and does not
+    drain a never-ACKed packet.
+  - Retransmissions MUST stay bounded. Do not make retransmit infinite again.
+```
+
 ### Shadow per-peer RTT registry (issue #4074, Phases 1 + 1.5)
 
 `transport/rolling_rtt_stats.rs` maintains a process-wide

--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -678,7 +678,9 @@ mod tests {
                     // Simulate resending packet
                     sent_tracker.report_sent_packet(id, packet);
                 }
-                ResendAction::WaitUntil(_) | ResendAction::TlpProbe(..) => {
+                ResendAction::WaitUntil(_)
+                | ResendAction::TlpProbe(..)
+                | ResendAction::Abandon { .. } => {
                     panic!("Expected resend action for packet {id}")
                 }
             }

--- a/crates/core/src/transport/bbr/controller.rs
+++ b/crates/core/src/transport/bbr/controller.rs
@@ -428,6 +428,20 @@ impl<T: TimeSource> BbrController<T> {
         }
     }
 
+    /// Release an abandoned packet's bytes from flight size (issue #4345).
+    ///
+    /// Called when a packet is permanently abandoned after
+    /// `MAX_PACKET_RETRANSMITS`. Atomic saturating decrement (matches the ACK
+    /// path's accounting and never underflows under the concurrent `on_send`
+    /// from the sender task). Does NOT touch cwnd or the delivery sampler.
+    pub fn release_flightsize(&self, bytes: usize) {
+        self.flightsize
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                Some(current.saturating_sub(bytes))
+            })
+            .ok();
+    }
+
     /// Get the current congestion window in bytes.
     pub fn current_cwnd(&self) -> usize {
         self.cwnd.load(Ordering::Acquire)

--- a/crates/core/src/transport/bbr/tests.rs
+++ b/crates/core/src/transport/bbr/tests.rs
@@ -496,6 +496,87 @@ fn test_timeout_storm_prevents_recovery() {
     );
 }
 
+/// Regression test for issue #4345: BBR flightsize leak on retransmission
+/// timeout.
+///
+/// Before the fix, `flightsize` was decremented ONLY on ACK. A packet that is
+/// never ACKed but retransmitted forever (lossy path / starved reverse-ACK
+/// channel) kept its initial `on_send` bytes counted in flight size for the
+/// life of the connection. `on_timeout()` resets cwnd/state/bounds but does
+/// not (and should not) touch flight size, since the timed-out packet is
+/// immediately re-sent and stays in flight.
+///
+/// The fix adds an explicit release path: once `SentPacketTracker` abandons a
+/// packet after `MAX_PACKET_RETRANSMITS`, the recv loop calls
+/// `release_flightsize(len)`. This test verifies the BBR controller's
+/// `release_flightsize` actually drains flight size and re-opens cwnd.
+///
+/// Symptom on the live network (issue #4345): `flightsize` pins at `cwnd`
+/// (telemetry showed `flightsize=59436B, cwnd=60398B`), the cwnd-wait loop
+/// `flightsize + packet_size <= cwnd` never finds headroom, every subsequent
+/// stream on the connection aborts with "cwnd wait timeout" (90% of all
+/// transfer failures), and large multi-fragment GETs (freenet-email inbox
+/// state) fail with "no fragments received within inactivity timeout".
+#[test]
+fn test_issue_4345_release_flightsize_drains_abandoned_bytes() {
+    let time = VirtualTime::new();
+    let controller = BbrController::new_with_time_source(BbrConfig::default(), time.clone());
+
+    let packet_size = 1400usize;
+    let num_packets = 40usize;
+
+    // Send a burst; none of these will ever be ACKed (the receiver / reverse
+    // ACK path is dead, exactly the lossy-stream scenario).
+    for _ in 0..num_packets {
+        let _token = controller.on_send(packet_size);
+    }
+    let flight_after_send = controller.flightsize();
+    assert_eq!(
+        flight_after_send,
+        num_packets * packet_size,
+        "flightsize should account for every in-flight byte after send"
+    );
+
+    // on_timeout() alone (the per-RTO call) must NOT change flight size —
+    // the packet is still in flight, being retransmitted.
+    controller.on_timeout();
+    assert_eq!(
+        controller.flightsize(),
+        num_packets * packet_size,
+        "on_timeout() must not change flight size; only abandonment/ACK does"
+    );
+
+    // Each packet is eventually abandoned after MAX_PACKET_RETRANSMITS — the
+    // recv loop calls release_flightsize() for each. Without this release the
+    // bytes leak for the life of the connection.
+    for _ in 0..num_packets {
+        time.advance(Duration::from_secs(1));
+        controller.release_flightsize(packet_size);
+    }
+
+    let flight_after_giveup = controller.flightsize();
+    assert!(
+        flight_after_giveup <= packet_size,
+        "issue #4345: flightsize leaked after abandonment — expected ~0, got \
+         {} bytes ({} packets still counted as in-flight). release_flightsize() \
+         must drain abandoned in-flight bytes.",
+        flight_after_giveup,
+        flight_after_giveup / packet_size,
+    );
+
+    // The connection must be usable again: a fresh packet should fit in cwnd.
+    let cwnd = controller.current_cwnd();
+    assert!(
+        controller.flightsize() + packet_size <= cwnd,
+        "issue #4345: after abandonment a new packet ({} B) must fit in cwnd \
+         ({} B) but flightsize is still {} B — the cwnd-wait loop would never \
+         open and every subsequent stream aborts",
+        packet_size,
+        cwnd,
+        controller.flightsize(),
+    );
+}
+
 /// Test that BBR's adaptive timeout floor kicks in with high BDP.
 ///
 /// When max_bdp_seen is high enough (>4x initial_cwnd), the adaptive floor

--- a/crates/core/src/transport/congestion_control.rs
+++ b/crates/core/src/transport/congestion_control.rs
@@ -206,8 +206,22 @@ pub trait CongestionControl: Send + Sync {
     /// Called when a retransmission timeout (RTO) occurs.
     ///
     /// This indicates severe congestion. Implementations typically
-    /// reset to minimum cwnd and re-enter slow start.
+    /// reset to minimum cwnd and re-enter slow start. Flight size is NOT
+    /// changed: the timed-out packet is immediately retransmitted and stays in
+    /// flight. Bytes are released only when a packet is permanently abandoned
+    /// (see [`release_flightsize`](Self::release_flightsize)).
     fn on_timeout(&self);
+
+    /// Release `bytes` from flight size for a packet that has been permanently
+    /// abandoned — retransmitted `MAX_PACKET_RETRANSMITS` times with no ACK and
+    /// dropped from tracking (see `SentPacketTracker`).
+    ///
+    /// Without this, a never-ACKed packet is retransmitted forever and its
+    /// initial `on_send` bytes stay counted in flight size for the life of the
+    /// connection, pinning flight size at cwnd and stalling every subsequent
+    /// stream on that connection (issue #4345). This is the only flight-size
+    /// release path other than ACK; the decrement saturates at zero.
+    fn release_flightsize(&self, bytes: usize);
 
     // =========================================================================
     // State Queries
@@ -350,6 +364,14 @@ impl<T: TimeSource> CongestionControl for CongestionController<T> {
         }
     }
 
+    fn release_flightsize(&self, bytes: usize) {
+        match self {
+            Self::Bbr(c) => c.release_flightsize(bytes),
+            Self::Ledbat(c) => c.release_flightsize(bytes),
+            Self::FixedRate(c) => c.release_flightsize(bytes),
+        }
+    }
+
     fn current_cwnd(&self) -> usize {
         match self {
             Self::Bbr(c) => c.current_cwnd(),
@@ -477,6 +499,10 @@ impl<T: TimeSource> CongestionControl for BbrController<T> {
         BbrController::on_timeout(self)
     }
 
+    fn release_flightsize(&self, bytes: usize) {
+        BbrController::release_flightsize(self, bytes)
+    }
+
     fn current_cwnd(&self) -> usize {
         BbrController::current_cwnd(self)
     }
@@ -551,6 +577,10 @@ impl<T: TimeSource> CongestionControl for LedbatController<T> {
         LedbatController::on_timeout(self)
     }
 
+    fn release_flightsize(&self, bytes: usize) {
+        LedbatController::release_flightsize(self, bytes)
+    }
+
     fn current_cwnd(&self) -> usize {
         LedbatController::current_cwnd(self)
     }
@@ -619,6 +649,10 @@ impl<T: TimeSource> CongestionControl for FixedRateController<T> {
 
     fn on_timeout(&self) {
         FixedRateController::on_timeout(self)
+    }
+
+    fn release_flightsize(&self, bytes: usize) {
+        FixedRateController::release_flightsize(self, bytes)
     }
 
     fn current_cwnd(&self) -> usize {

--- a/crates/core/src/transport/fixed_rate/controller.rs
+++ b/crates/core/src/transport/fixed_rate/controller.rs
@@ -163,10 +163,28 @@ impl<T: TimeSource> FixedRateController<T> {
     }
 
     /// Called when a retransmission timeout occurs.
-    /// Activates the loss pause (same as on_loss).
+    /// Activates the loss pause (caps cwnd at the current flightsize). Flight
+    /// size is unchanged: the timed-out packet is immediately re-sent and stays
+    /// in flight.
     pub fn on_timeout(&self) {
         let fs = self.flightsize.load(Ordering::Relaxed);
         self.loss_pause_cwnd.store(fs.max(1), Ordering::Release);
+    }
+
+    /// Release an abandoned packet's bytes from flight size (issue #4345).
+    ///
+    /// Called when a packet is permanently abandoned after
+    /// `MAX_PACKET_RETRANSMITS`. This is what lets a flight size pinned by a
+    /// never-ACKed packet actually drain (otherwise the frozen
+    /// `loss_pause_cwnd + LOSS_PAUSE_MARGIN` ceiling stalls every subsequent
+    /// stream — 64% of live `cwnd wait timeout` failures). Saturating; does NOT
+    /// touch the loss pause (only an ACK clears that).
+    pub fn release_flightsize(&self, bytes: usize) {
+        self.flightsize
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                Some(current.saturating_sub(bytes))
+            })
+            .ok();
     }
 
     /// Returns the effective congestion window.
@@ -383,6 +401,82 @@ mod tests {
             "loss_pause margin should allow at least 20 packets for recovery, \
              got {packets_allowed} (margin={margin}B). A 2-packet margin caused \
              production stream stalls when both trickle packets were lost."
+        );
+    }
+
+    /// Regression test for issue #4345: flightsize must be released when a
+    /// stream's packets are abandoned after repeated retransmission timeouts
+    /// with no ACK ever arriving.
+    ///
+    /// FixedRate is the production default. Live telemetry (issue #4345)
+    /// showed 64% of all `cwnd wait timeout` failures clustered at
+    /// `cwnd ≈ 60-70KB` (LOSS_PAUSE_MARGIN + a small frozen `loss_pause_cwnd`)
+    /// with the cwnd-flightsize gap pinned at ~110 bytes — below one packet.
+    ///
+    /// Mechanism: on a lossy path the reverse ACK channel is starved, so
+    /// `on_ack_without_rtt` (the ONLY place flightsize is decremented AND the
+    /// only place loss_pause is cleared) never runs. The sending stream keeps
+    /// calling `on_send`, flightsize climbs to the frozen cwnd ceiling, and
+    /// the cwnd-wait loop `flightsize + packet_size <= cwnd` can never find
+    /// headroom → 3s abort at ~39% of the stream. Worse, because flightsize
+    /// is never released, the NEXT stream on the same connection starts
+    /// already pinned (telemetry: `sent 0/2`).
+    ///
+    /// This test sends a burst that is never ACKed, then releases each packet
+    /// as abandonment would, and asserts a fresh packet can be sent — i.e.
+    /// flightsize was drained. Before the fix there was no release path, so
+    /// flightsize stayed at the full burst and the new packet could not fit.
+    #[test]
+    fn test_issue_4345_release_flightsize_drains_abandoned_bytes() {
+        let controller = FixedRateController::new(FixedRateConfig::default());
+
+        let packet_size = MAX_PACKET_SIZE;
+        let num_packets = 60usize; // > LOSS_PAUSE_MARGIN / MAX_PACKET_SIZE (50)
+
+        // Send a burst; none will ever be ACKed (dead reverse ACK path).
+        for _ in 0..num_packets {
+            controller.on_send(packet_size);
+        }
+        assert_eq!(
+            controller.flightsize(),
+            num_packets * packet_size,
+            "flightsize should account for every in-flight byte after send"
+        );
+
+        // on_timeout() (per-RTO) caps cwnd via loss_pause but must NOT change
+        // flight size — the packet is still in flight, being retransmitted.
+        controller.on_timeout();
+        assert_eq!(
+            controller.flightsize(),
+            num_packets * packet_size,
+            "on_timeout() must not change flight size; only abandonment/ACK does"
+        );
+
+        // After each packet is abandoned (MAX_PACKET_RETRANSMITS), the recv
+        // loop calls release_flightsize(). Without it, flightsize leaks for the
+        // life of the connection and stalls every subsequent stream.
+        for _ in 0..num_packets {
+            controller.release_flightsize(packet_size);
+        }
+
+        let leaked = controller.flightsize();
+        assert!(
+            leaked <= packet_size,
+            "issue #4345: flightsize leaked after abandonment — expected ~0, \
+             got {leaked} B ({} packets still counted in flight). \
+             release_flightsize() must drain abandoned in-flight bytes.",
+            leaked / packet_size,
+        );
+
+        // The connection must be usable again: a fresh packet must fit in cwnd.
+        let cwnd = controller.current_cwnd();
+        assert!(
+            controller.flightsize() + packet_size <= cwnd,
+            "issue #4345: after abandonment a fresh packet ({packet_size} B) \
+             must fit in cwnd ({cwnd} B) but flightsize is still {} B — the \
+             cwnd-wait loop would never open and every subsequent stream aborts \
+             with 'cwnd wait timeout'",
+            controller.flightsize(),
         );
     }
 

--- a/crates/core/src/transport/ledbat/controller.rs
+++ b/crates/core/src/transport/ledbat/controller.rs
@@ -942,6 +942,19 @@ impl<T: TimeSource> LedbatController<T> {
         );
     }
 
+    /// Release an abandoned packet's bytes from flight size (issue #4345).
+    ///
+    /// Called when a packet is permanently abandoned after
+    /// `MAX_PACKET_RETRANSMITS`. Saturating; does NOT touch cwnd or the delay
+    /// controller.
+    pub fn release_flightsize(&self, bytes: usize) {
+        self.flightsize
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                Some(current.saturating_sub(bytes))
+            })
+            .ok();
+    }
+
     /// Get LEDBAT congestion control statistics.
     pub fn stats(&self) -> LedbatStats {
         LedbatStats {
@@ -4973,6 +4986,35 @@ mod tests {
             "Base delay should return to near baseline: {:?}",
             final_base_delay
         );
+    }
+
+    /// Issue #4345: `release_flightsize` drains an abandoned packet's bytes
+    /// (saturating), while `on_timeout` leaves flight size unchanged. Mirrors
+    /// the BBR/FixedRate `release_flightsize_drains_abandoned_bytes` tests for
+    /// the non-default LEDBAT controller.
+    #[test]
+    fn test_issue_4345_release_flightsize_drains_abandoned_bytes() {
+        let controller = LedbatController::new(100_000, 2848, 10_000_000);
+
+        controller.on_send(5000);
+        assert_eq!(controller.flightsize(), 5000);
+
+        // on_timeout (per-RTO) must NOT change flight size — the packet is still
+        // in flight, being retransmitted.
+        controller.on_timeout();
+        assert_eq!(
+            controller.flightsize(),
+            5000,
+            "on_timeout() must not change flight size; only abandonment/ACK does"
+        );
+
+        // Abandonment releases the bytes.
+        controller.release_flightsize(3000);
+        assert_eq!(controller.flightsize(), 2000);
+
+        // Saturating: releasing more than remains floors at 0, never underflows.
+        controller.release_flightsize(9999);
+        assert_eq!(controller.flightsize(), 0);
     }
 
     // ============================================================================

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -1285,13 +1285,41 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                             .get_resend();
                         // Extract (idx, packet) from the resend action, applying
                         // action-specific side effects (congestion notification, logging).
+                        // Abandon releases flight size and is handled inline (it neither
+                        // re-sends nor re-registers). See #4345.
                         let (idx, packet) = match maybe_resend {
                             ResendAction::WaitUntil(deadline_nanos) => {
                                 resend_check_sleep = Some(self.time_source.sleep_until(deadline_nanos));
                                 break;
                             }
+                            ResendAction::Abandon { packet_id, payload_len } => {
+                                // The packet was retransmitted MAX_PACKET_RETRANSMITS times
+                                // with no ACK and is now permanently lost. Release its bytes
+                                // from flight size — this is the give-up that drains a flight
+                                // size pinned by a never-ACKed packet (issue #4345). The
+                                // tracker already dropped it, so we neither re-send nor
+                                // re-register; continue draining the resend queue.
+                                self.remote_conn
+                                    .congestion_controller
+                                    .release_flightsize(payload_len);
+                                tracing::debug!(
+                                    peer_addr = %self.remote_conn.remote_addr,
+                                    packet_id,
+                                    payload_len,
+                                    "Resend abandoned packet — released flight size (#4345)"
+                                );
+                                resend_count += 1;
+                                if resend_count >= MAX_RESENDS_PER_ITERATION {
+                                    resend_check_sleep = Some(self.time_source.sleep(resend_yield));
+                                    break;
+                                }
+                                continue;
+                            }
                             ResendAction::Resend(idx, packet) => {
-                                // Notify congestion controller of packet loss (timeout-based retransmission)
+                                // Notify congestion controller of packet loss (timeout-based
+                                // retransmission). The packet stays in flight — it is
+                                // immediately re-sent and re-registered below — so flight size
+                                // is unchanged; on_timeout only applies the cwnd loss response.
                                 self.remote_conn.congestion_controller.on_timeout();
                                 (idx, packet)
                             }
@@ -1316,8 +1344,9 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                             .await
                         {
                             Ok(_) => {
-                                // Re-register packet for ACK/RTO tracking. on_send() is NOT called
-                                // because bytes were already counted in flightsize during the initial send.
+                                // Re-register packet for ACK/RTO tracking. Flight size is
+                                // unchanged: the packet never left flight (on_timeout did not
+                                // decrement), so neither on_send() nor a re-add is called.
                                 self.remote_conn.sent_tracker.lock().report_sent_packet(idx, packet);
                             }
                             Err(e) => {
@@ -2716,6 +2745,126 @@ mod tests {
             congestion.flightsize(),
             0,
             "All packets ACKed, flightsize should be 0"
+        );
+    }
+
+    /// Regression test for issue #4345: flight size must drain when a packet is
+    /// retransmitted forever with no ACK — the real production recv-loop path.
+    ///
+    /// This drives the EXACT production sequence (not a synthetic give-up): for
+    /// each fired RTO the recv loop calls `on_timeout()` (cwnd loss response
+    /// only — flight size unchanged), successfully re-sends, and re-registers
+    /// the packet, because with no ACK arriving the tracker keeps re-queueing
+    /// it. Crucially, since `on_timeout()` never touches flight size, it would
+    /// stay pinned forever WITHOUT a give-up mechanism. The fix is the
+    /// tracker's bounded-retransmit abandonment: after `MAX_PACKET_RETRANSMITS`
+    /// it returns `ResendAction::Abandon`, the recv loop calls
+    /// `release_flightsize(len)`, and the packet is dropped — so flight size
+    /// finally drains.
+    ///
+    /// This is the integration-level companion to the pure-controller unit
+    /// tests (`bbr`/`fixed_rate`
+    /// `test_issue_4345_release_flightsize_drains_abandoned_bytes`): it confirms
+    /// the END-TO-END path through `SentPacketTracker` actually reaches the
+    /// give-up branch in production, which the earlier draft missed (the recv
+    /// loop always re-sends on RTO, so only abandonment drains the leak).
+    ///
+    /// Before this fix, no abandonment existed: a never-ACKed packet was
+    /// retransmitted forever, its initial `on_send` bytes pinned flight size at
+    /// `cwnd`, and every subsequent stream on the connection aborted with
+    /// "cwnd wait timeout".
+    #[test]
+    fn test_issue_4345_flightsize_drains_via_bounded_retransmit() {
+        use crate::simulation::VirtualTime;
+        use crate::transport::bbr::{BbrConfig, BbrController};
+        use crate::transport::sent_packet_tracker::{ResendAction, SentPacketTracker};
+        use std::sync::Arc;
+
+        let time = VirtualTime::new();
+        let congestion = Arc::new(BbrController::new_with_time_source(
+            BbrConfig {
+                initial_cwnd: 60_000,
+                min_cwnd: 2_000,
+                max_cwnd: 10_000_000,
+                ..Default::default()
+            },
+            time.clone(),
+        ));
+        let mut tracker = SentPacketTracker::new_with_time_source(time.clone());
+
+        // Send a burst that will never be ACKed (dead reverse-ACK path).
+        let packet_size = 1424usize;
+        let num_packets = 30u32;
+        for packet_id in 0..num_packets {
+            let payload: Box<[u8]> = vec![0u8; packet_size].into_boxed_slice();
+            tracker.report_sent_packet(packet_id, payload);
+            congestion.on_send(packet_size);
+        }
+        assert_eq!(
+            congestion.flightsize(),
+            num_packets as usize * packet_size,
+            "flightsize should account for the whole in-flight burst"
+        );
+
+        // Drive the REAL production recv-loop sequence: each RTO calls
+        // on_timeout() (cwnd loss response only — the packet is immediately
+        // re-sent and stays in flight, so flight size is UNCHANGED) and
+        // re-registers, repeating (no ACK ever arrives). Because every re-send
+        // leaves flight size untouched, it would stay pinned forever WITHOUT a
+        // give-up. The fix: after MAX_PACKET_RETRANSMITS the tracker returns
+        // Abandon, the recv loop calls release_flightsize(len), and flight size
+        // finally drains.
+        let mut abandoned = 0u32;
+        let mut resends = 0u32;
+        for _ in 0..20_000 {
+            match tracker.get_resend() {
+                ResendAction::Resend(id, packet) => {
+                    // Production recv-loop Resend arm: cwnd loss response, re-send
+                    // (succeeds here), re-register. Flight size unchanged.
+                    congestion.on_timeout();
+                    tracker.report_sent_packet(id, packet);
+                    resends += 1;
+                }
+                ResendAction::Abandon { payload_len, .. } => {
+                    // The give-up that actually drains the leak.
+                    congestion.release_flightsize(payload_len);
+                    abandoned += 1;
+                }
+                ResendAction::TlpProbe(_id, _packet) => {
+                    // Speculative probe — no flight-size effect.
+                }
+                ResendAction::WaitUntil(_) => {
+                    if abandoned >= num_packets {
+                        break; // every packet abandoned
+                    }
+                    // Jump past the (backed-off) next deadline and retry.
+                    time.advance(std::time::Duration::from_secs(120));
+                }
+            }
+        }
+
+        // Sanity: flight size stayed pinned across the net-zero re-send rounds,
+        // i.e. on_timeout alone never released it — only abandonment does.
+        assert!(
+            resends >= num_packets,
+            "issue #4345: expected the production re-send path to run before \
+             abandonment (resends={resends}); the test did not exercise the \
+             real recv-loop re-send sequence"
+        );
+        assert_eq!(
+            abandoned, num_packets,
+            "issue #4345: every never-ACKed packet must eventually be abandoned \
+             (abandoned={abandoned}/{num_packets})"
+        );
+        assert!(
+            congestion.flightsize() <= packet_size,
+            "issue #4345: flight size did not drain after bounded-retransmit \
+             abandonment — got {} bytes ({} packets still in flight). Re-sends \
+             alone never release a never-ACKed packet (on_timeout leaves flight \
+             size unchanged); the tracker MUST abandon it (ResendAction::Abandon) \
+             so the recv loop calls release_flightsize().",
+            congestion.flightsize(),
+            congestion.flightsize() / packet_size,
         );
     }
 

--- a/crates/core/src/transport/sent_packet_tracker.rs
+++ b/crates/core/src/transport/sent_packet_tracker.rs
@@ -46,6 +46,40 @@ pub(super) const MESSAGE_CONFIRMATION_TIMEOUT: Duration = {
 /// reached with smaller backoff multipliers.
 const MAX_RTO_BACKOFF: u32 = 512;
 
+/// Maximum number of times a single packet is retransmitted before it is
+/// abandoned (declared permanently lost).
+///
+/// Without an upper bound, a packet whose ACKs never arrive (e.g. a stream
+/// whose sender task already gave up on the `CWND_WAIT_TIMEOUT`, or a starved
+/// reverse-ACK channel) is retransmitted forever. Its bytes then stay counted
+/// in the congestion controller's flight size for the life of the connection,
+/// pinning flight size at `cwnd` and stalling every subsequent stream on that
+/// connection (issue #4345).
+///
+/// On abandon, `get_resend` returns [`ResendAction::Abandon`] instead of
+/// `Resend`; the recv loop releases the bytes from flight size via
+/// `CongestionControl::release_flightsize(len)`, and the packet is dropped from
+/// tracking.
+///
+/// Wall-clock to abandonment depends on whether OTHER packets are still being
+/// ACKed, because `rto_backoff` is tracker-wide and resets to 1 on any ACK
+/// while this count is per-packet:
+/// - **Partial loss (the common multi-fragment case):** other fragments keep
+///   ACKing, so `rto_backoff` stays at 1 and the black-holed fragment retries
+///   at the 500ms `MIN_RTO` floor — abandoned after ~6s (12 × 500ms). That is
+///   just above `STREAM_INACTIVITY_TIMEOUT` (5s), i.e. the receiver has already
+///   given up on the stream; abandoning frees the connection's flight size for
+///   the next stream.
+/// - **Fully dead link (no ACKs at all):** `rto_backoff` escalates (1→512,
+///   capped at a 60s effective RTO), so 12 retransmits span ~6 minutes; here
+///   the 120s connection idle timeout tears the connection down first, so the
+///   abandon path mainly serves the partial-loss case.
+///
+/// A still-progressing transfer is never abandoned: any ACK for the stuck
+/// packet resets its count, and a 12-consecutive-RTO black hole on an otherwise
+/// healthy path is a genuinely dead fragment.
+const MAX_PACKET_RETRANSMITS: u32 = 12;
+
 /// Minimum RTO after RTT samples have been collected.
 ///
 /// RFC 6298 recommends 1 second, but Linux TCP uses 200ms. We use 500ms because it must
@@ -127,6 +161,12 @@ pub(super) struct SentPacketTracker<T: TimeSource> {
     /// Track packets that have had TLP probes sent.
     /// TLP fires once per packet before RTO - if no ACK, RTO handles it.
     tlp_sent_packets: HashSet<PacketId>,
+
+    /// Per-packet RTO retransmission count, used to abandon a packet after
+    /// `MAX_PACKET_RETRANSMITS` (issue #4345). Incremented on each RTO fire,
+    /// cleared on ACK. An entry is removed when its packet is ACKed or
+    /// abandoned, so this map tracks only currently-unacked packets.
+    retransmit_counts: HashMap<PacketId, u32>,
 }
 
 impl<T: TimeSource> SentPacketTracker<T> {
@@ -146,6 +186,7 @@ impl<T: TimeSource> SentPacketTracker<T> {
             total_packets_sent: 0,
             rto_backoff: 1, // No backoff initially
             tlp_sent_packets: HashSet::new(),
+            retransmit_counts: HashMap::new(),
         }
     }
 
@@ -244,10 +285,11 @@ impl<T: TimeSource> SentPacketTracker<T> {
                 }
             }
 
-            // Remove from pending, retransmitted, and TLP tracking
+            // Remove from pending, retransmitted, TLP, and retransmit-count tracking
             self.pending_receipts.remove(packet_id);
             self.retransmitted_packets.remove(packet_id);
             self.tlp_sent_packets.remove(packet_id);
+            self.retransmit_counts.remove(packet_id);
         }
 
         let loss_rate = if self.total_packets_sent > 0 {
@@ -434,6 +476,30 @@ impl<T: TimeSource> SentPacketTracker<T> {
                         * (1.0 - PACKET_LOSS_DECAY_FACTOR)
                         + PACKET_LOSS_DECAY_FACTOR;
 
+                    // Count this RTO. After MAX_PACKET_RETRANSMITS with no ACK,
+                    // abandon the packet so its bytes are released from flight
+                    // size instead of being retransmitted forever (issue #4345).
+                    let count = self.retransmit_counts.entry(entry.packet_id).or_insert(0);
+                    *count += 1;
+                    if *count > MAX_PACKET_RETRANSMITS {
+                        let payload_len = packet.len();
+                        // Drop all tracking for this packet — it will NOT be
+                        // re-queued, so the recv loop stops retransmitting it.
+                        self.retransmit_counts.remove(&entry.packet_id);
+                        self.retransmitted_packets.remove(&entry.packet_id);
+                        self.tlp_sent_packets.remove(&entry.packet_id);
+                        tracing::debug!(
+                            packet_id = entry.packet_id,
+                            retransmits = MAX_PACKET_RETRANSMITS,
+                            payload_len,
+                            "Abandoning packet after max retransmits — releasing flight size (#4345)"
+                        );
+                        return ResendAction::Abandon {
+                            packet_id: entry.packet_id,
+                            payload_len,
+                        };
+                    }
+
                     // Mark as retransmitted for Karn's algorithm
                     self.mark_retransmitted(entry.packet_id);
 
@@ -473,6 +539,13 @@ pub enum ResendAction {
     /// TLP (Tail Loss Probe) - send a probe to detect tail loss earlier than RTO.
     /// Unlike Resend, this doesn't apply backoff since it's speculative.
     TlpProbe(u32, Box<[u8]>),
+    /// The packet has been retransmitted `MAX_PACKET_RETRANSMITS` times without
+    /// an ACK and is declared permanently lost (issue #4345). It has been
+    /// removed from tracking; the caller MUST release its `payload_len` bytes
+    /// from the congestion controller's flight size via
+    /// `CongestionControl::release_flightsize(payload_len)` and MUST NOT
+    /// re-register or re-send it.
+    Abandon { packet_id: u32, payload_len: usize },
 }
 
 struct ResendQueueEntry {
@@ -566,7 +639,9 @@ pub(in crate::transport) mod tests {
         // This should not trigger a resend yet (TLP fires at 10ms)
         match tracker.get_resend() {
             ResendAction::WaitUntil(_) => (),
-            ResendAction::Resend(..) | ResendAction::TlpProbe(..) => {
+            ResendAction::Resend(..)
+            | ResendAction::TlpProbe(..)
+            | ResendAction::Abandon { .. } => {
                 panic!("Expected WaitUntil, got Resend/TlpProbe too early")
             }
         }
@@ -581,6 +656,7 @@ pub(in crate::transport) mod tests {
             }
             ResendAction::Resend(_, _) => panic!("Expected TlpProbe, got Resend"),
             ResendAction::WaitUntil(_) => panic!("Expected TlpProbe, got WaitUntil"),
+            ResendAction::Abandon { .. } => panic!("Expected TlpProbe, got Abandon"),
         }
     }
 
@@ -608,7 +684,9 @@ pub(in crate::transport) mod tests {
                     "Wait deadline should be in the future"
                 );
             }
-            ResendAction::Resend(..) | ResendAction::TlpProbe(..) => {
+            ResendAction::Resend(..)
+            | ResendAction::TlpProbe(..)
+            | ResendAction::Abandon { .. } => {
                 panic!("Expected ResendAction::WaitUntil")
             }
         }
@@ -1114,7 +1192,9 @@ pub(in crate::transport) mod tests {
         tracker.time_source.advance(Duration::from_millis(39));
         match tracker.get_resend() {
             ResendAction::WaitUntil(_) => {} // Expected - still waiting
-            ResendAction::Resend(..) | ResendAction::TlpProbe(..) => {
+            ResendAction::Resend(..)
+            | ResendAction::TlpProbe(..)
+            | ResendAction::Abandon { .. } => {
                 panic!("Should not fire before TLP timeout (40ms)")
             }
         }
@@ -1127,6 +1207,7 @@ pub(in crate::transport) mod tests {
                 assert_eq!(id, 2, "Or Resend if TLP not yet implemented")
             }
             ResendAction::WaitUntil(_) => panic!("Should have triggered TLP after 40ms"),
+            ResendAction::Abandon { .. } => panic!("unexpected Abandon"),
         }
     }
 
@@ -1147,6 +1228,7 @@ pub(in crate::transport) mod tests {
             ResendAction::WaitUntil(_) => {} // Expected
             ResendAction::TlpProbe(_, _) => panic!("TLP shouldn't fire without RTT samples"),
             ResendAction::Resend(_, _) => panic!("Should not resend before RTO expires"),
+            ResendAction::Abandon { .. } => panic!("unexpected Abandon"),
         }
 
         // Advance 1 more ms to trigger timeout
@@ -1170,6 +1252,7 @@ pub(in crate::transport) mod tests {
             ResendAction::WaitUntil(_) => {} // Expected
             ResendAction::TlpProbe(_, _) => panic!("TLP shouldn't fire without RTT samples"),
             ResendAction::Resend(_, _) => panic!("Should not resend before backed-off RTO (2s)"),
+            ResendAction::Abandon { .. } => panic!("unexpected Abandon"),
         }
 
         // Advance 1 more ms to trigger timeout
@@ -1193,6 +1276,7 @@ pub(in crate::transport) mod tests {
             ResendAction::WaitUntil(_) => {} // Expected
             ResendAction::TlpProbe(_, _) => panic!("TLP shouldn't fire without RTT samples"),
             ResendAction::Resend(_, _) => panic!("Should not resend before backed-off RTO (4s)"),
+            ResendAction::Abandon { .. } => panic!("unexpected Abandon"),
         }
 
         // Advance 1 more ms to trigger timeout
@@ -1238,7 +1322,9 @@ pub(in crate::transport) mod tests {
         tracker.time_source.advance(Duration::from_millis(99));
         match tracker.get_resend() {
             ResendAction::WaitUntil(_) => {} // Expected
-            ResendAction::Resend(..) | ResendAction::TlpProbe(..) => {
+            ResendAction::Resend(..)
+            | ResendAction::TlpProbe(..)
+            | ResendAction::Abandon { .. } => {
                 panic!("Should not fire before TLP timeout")
             }
         }
@@ -1249,6 +1335,7 @@ pub(in crate::transport) mod tests {
             ResendAction::TlpProbe(id, _) => assert_eq!(id, 2, "TLP should probe packet 2"),
             ResendAction::Resend(_, _) => panic!("Should be TLP probe, not full RTO resend"),
             ResendAction::WaitUntil(_) => panic!("TLP should have fired at 2*SRTT"),
+            ResendAction::Abandon { .. } => panic!("unexpected Abandon"),
         }
     }
 
@@ -1269,7 +1356,9 @@ pub(in crate::transport) mod tests {
 
         match tracker.get_resend() {
             ResendAction::TlpProbe(_, _) => {}
-            ResendAction::WaitUntil(_) | ResendAction::Resend(..) => panic!("Expected TLP probe"),
+            ResendAction::WaitUntil(_)
+            | ResendAction::Resend(..)
+            | ResendAction::Abandon { .. } => panic!("Expected TLP probe"),
         }
 
         // Backoff should NOT have increased (TLP is speculative)
@@ -1297,7 +1386,9 @@ pub(in crate::transport) mod tests {
                 assert_eq!(id, 2);
                 payload
             }
-            ResendAction::WaitUntil(_) | ResendAction::Resend(..) => panic!("Expected TLP probe"),
+            ResendAction::WaitUntil(_)
+            | ResendAction::Resend(..)
+            | ResendAction::Abandon { .. } => panic!("Expected TLP probe"),
         };
 
         // Re-register for RTO tracking after TLP
@@ -1308,7 +1399,9 @@ pub(in crate::transport) mod tests {
         tracker.time_source.advance(Duration::from_millis(499));
         match tracker.get_resend() {
             ResendAction::WaitUntil(_) => {} // Still waiting for RTO
-            ResendAction::Resend(..) | ResendAction::TlpProbe(..) => {
+            ResendAction::Resend(..)
+            | ResendAction::TlpProbe(..)
+            | ResendAction::Abandon { .. } => {
                 panic!("Should still be waiting for RTO")
             }
         }
@@ -1347,6 +1440,7 @@ pub(in crate::transport) mod tests {
             ResendAction::WaitUntil(_) => {} // Good - no pending packets
             ResendAction::TlpProbe(_, _) => panic!("TLP should be cancelled by ACK"),
             ResendAction::Resend(_, _) => panic!("No resend needed, packet was ACKed"),
+            ResendAction::Abandon { .. } => panic!("unexpected Abandon"),
         }
     }
 
@@ -1367,7 +1461,9 @@ pub(in crate::transport) mod tests {
         tracker.time_source.advance(Duration::from_millis(9));
         match tracker.get_resend() {
             ResendAction::WaitUntil(_) => {}
-            ResendAction::Resend(..) | ResendAction::TlpProbe(..) => {
+            ResendAction::Resend(..)
+            | ResendAction::TlpProbe(..)
+            | ResendAction::Abandon { .. } => {
                 panic!("Should not fire before minimum TLP timeout")
             }
         }
@@ -1376,7 +1472,9 @@ pub(in crate::transport) mod tests {
         tracker.time_source.advance(Duration::from_millis(2));
         match tracker.get_resend() {
             ResendAction::TlpProbe(id, _) => assert_eq!(id, 2),
-            ResendAction::WaitUntil(_) | ResendAction::Resend(..) => {
+            ResendAction::WaitUntil(_)
+            | ResendAction::Resend(..)
+            | ResendAction::Abandon { .. } => {
                 panic!("TLP should fire at minimum 10ms")
             }
         }
@@ -1397,6 +1495,7 @@ pub(in crate::transport) mod tests {
             ResendAction::WaitUntil(_) => {}
             ResendAction::TlpProbe(_, _) => panic!("TLP should not fire without RTT samples"),
             ResendAction::Resend(_, _) => panic!("RTO is 1s, should not fire at 500ms"),
+            ResendAction::Abandon { .. } => panic!("unexpected Abandon"),
         }
 
         // At 1001ms, RTO fires (no TLP)
@@ -1429,7 +1528,173 @@ pub(in crate::transport) mod tests {
                 // Should probe the oldest unacked packet
                 assert_eq!(id, 2, "TLP should probe oldest unacked packet");
             }
-            ResendAction::WaitUntil(_) | ResendAction::Resend(..) => panic!("Expected TLP probe"),
+            ResendAction::WaitUntil(_)
+            | ResendAction::Resend(..)
+            | ResendAction::Abandon { .. } => panic!("Expected TLP probe"),
         }
+    }
+
+    /// Regression test for issue #4345: a packet that is never ACKed is
+    /// retransmitted at most `MAX_PACKET_RETRANSMITS` times, then abandoned —
+    /// `get_resend` returns `Abandon` and the packet is dropped from tracking,
+    /// so it is no longer re-queued (which would otherwise pin flight size
+    /// forever). An ACK before the limit resets the count.
+    #[test]
+    fn test_issue_4345_packet_abandoned_after_max_retransmits() {
+        let mut tracker = mock_sent_packet_tracker();
+        let payload_len = 3usize;
+        tracker.report_sent_packet(1, vec![1, 2, 3].into());
+
+        // Drive RTOs, re-sending each time (production re-registers), with no ACK.
+        let mut resends = 0u32;
+        let mut abandoned = false;
+        for _ in 0..1000 {
+            // Jump past the (backed-off) RTO deadline.
+            tracker.time_source.advance(Duration::from_secs(120));
+            match tracker.get_resend() {
+                ResendAction::Resend(id, packet) => {
+                    assert_eq!(id, 1);
+                    // Re-register exactly as the production recv loop does.
+                    tracker.report_sent_packet(id, packet);
+                    resends += 1;
+                }
+                ResendAction::Abandon {
+                    packet_id,
+                    payload_len: len,
+                } => {
+                    assert_eq!(packet_id, 1);
+                    assert_eq!(len, payload_len);
+                    abandoned = true;
+                    break;
+                }
+                ResendAction::TlpProbe(..) => {}
+                ResendAction::WaitUntil(_) => {}
+            }
+        }
+
+        assert!(
+            abandoned,
+            "issue #4345: packet must be abandoned, never was"
+        );
+        assert_eq!(
+            resends, MAX_PACKET_RETRANSMITS,
+            "issue #4345: packet should be re-sent exactly MAX_PACKET_RETRANSMITS \
+             times before abandonment (got {resends})"
+        );
+        // After abandonment the packet is gone from tracking — no further resend.
+        assert!(
+            tracker.pending_receipts.is_empty(),
+            "abandoned packet must be removed from pending_receipts"
+        );
+        assert!(
+            tracker.retransmit_counts.is_empty(),
+            "abandoned packet's retransmit count must be cleared"
+        );
+        tracker.time_source.advance(Duration::from_secs(120));
+        assert!(
+            matches!(tracker.get_resend(), ResendAction::WaitUntil(_)),
+            "abandoned packet must NOT be re-queued for resend"
+        );
+    }
+
+    /// An ACK arriving before the retransmit limit resets the count, so a
+    /// flaky-but-recovering packet is never abandoned.
+    #[test]
+    fn test_issue_4345_ack_resets_retransmit_count() {
+        let mut tracker = mock_sent_packet_tracker();
+        tracker.report_sent_packet(1, vec![1, 2, 3].into());
+
+        // Fire a few RTOs (re-sending each), short of the limit.
+        for _ in 0..(MAX_PACKET_RETRANSMITS - 2) {
+            tracker.time_source.advance(Duration::from_secs(120));
+            match tracker.get_resend() {
+                ResendAction::Resend(id, packet) => tracker.report_sent_packet(id, packet),
+                other => panic!("expected Resend, got {other:?}"),
+            }
+        }
+        assert_eq!(
+            tracker.retransmit_counts.get(&1).copied(),
+            Some(MAX_PACKET_RETRANSMITS - 2)
+        );
+
+        // ACK arrives → count cleared.
+        tracker.report_received_receipts(&[1]);
+        assert!(
+            tracker.retransmit_counts.is_empty(),
+            "ACK must clear the retransmit count so the packet can't be abandoned later"
+        );
+    }
+
+    /// Issue #4345: a flaky-but-progressing packet (intermittent loss with an
+    /// ACK before every `MAX_PACKET_RETRANSMITS`-th retransmit) is NEVER
+    /// abandoned — the per-packet count is reset by each ACK, so a slow but
+    /// alive transfer survives indefinitely.
+    #[test]
+    fn test_issue_4345_flaky_but_alive_packet_never_abandoned() {
+        let mut tracker = mock_sent_packet_tracker();
+
+        // Run many more than MAX_PACKET_RETRANSMITS total RTO fires, but slip an
+        // ACK in before the limit each time. The packet must never be abandoned.
+        let mut id = 1u32;
+        tracker.report_sent_packet(id, vec![1, 2, 3].into());
+        for cycle in 0..(MAX_PACKET_RETRANSMITS as usize * 5) {
+            tracker.time_source.advance(Duration::from_secs(120));
+            match tracker.get_resend() {
+                ResendAction::Resend(rid, packet) => {
+                    tracker.report_sent_packet(rid, packet);
+                    // Every (MAX-1) retransmits, an ACK lands for this packet,
+                    // resetting its count — then we "send" a fresh packet id so
+                    // the flow keeps making progress.
+                    if (cycle + 1) % (MAX_PACKET_RETRANSMITS as usize - 1) == 0 {
+                        tracker.report_received_receipts(&[rid]);
+                        id += 1;
+                        tracker.report_sent_packet(id, vec![1, 2, 3].into());
+                    }
+                }
+                ResendAction::Abandon { .. } => {
+                    panic!(
+                        "issue #4345: a flaky-but-alive packet was abandoned at \
+                         cycle {cycle} — ACKs before the limit must keep it alive"
+                    );
+                }
+                ResendAction::TlpProbe(_, _) | ResendAction::WaitUntil(_) => {}
+            }
+        }
+    }
+
+    /// Issue #4345: after a packet is abandoned, a late ACK for it must NOT
+    /// release flight size a second time. Abandon removes the packet from
+    /// `pending_receipts`, so `report_received_receipts` returns no entry for it
+    /// (no `bytes_acked` for the caller to subtract) — guarding against a
+    /// double-decrement that would under-count flight size.
+    #[test]
+    fn test_issue_4345_late_ack_after_abandon_is_noop() {
+        let mut tracker = mock_sent_packet_tracker();
+        tracker.report_sent_packet(7, vec![9, 9, 9].into());
+
+        // Drive RTOs (re-sending) until the packet is abandoned.
+        let mut abandoned = false;
+        for _ in 0..1000 {
+            tracker.time_source.advance(Duration::from_secs(120));
+            match tracker.get_resend() {
+                ResendAction::Resend(id, packet) => tracker.report_sent_packet(id, packet),
+                ResendAction::Abandon { packet_id, .. } => {
+                    assert_eq!(packet_id, 7);
+                    abandoned = true;
+                    break;
+                }
+                ResendAction::TlpProbe(_, _) | ResendAction::WaitUntil(_) => {}
+            }
+        }
+        assert!(abandoned, "packet should have been abandoned");
+
+        // A late ACK for the abandoned packet must produce NO ack entry — so the
+        // caller does not call release/decrement a second time.
+        let (ack_info, _) = tracker.report_received_receipts(&[7]);
+        assert!(
+            ack_info.is_empty(),
+            "issue #4345: a late ACK for an abandoned packet must be a no-op \
+             (no double release of flight size); got {ack_info:?}"
+        );
     }
 }

--- a/docs/architecture/transport/README.md
+++ b/docs/architecture/transport/README.md
@@ -244,7 +244,10 @@ flowchart TB
 2. Decrypt + deserialize
 3. **RTT update**: If ACK, update smoothed RTT and cwnd (LEDBAT feedback)
 4. **Rate update**: Recalculate `min(ledbat_rate, global_pool_rate)` (RTT-adaptive timing)
-5. **Flightsize update**: Decrement flightsize on ACK
+5. **Flightsize update**: Decrement flightsize on ACK. Flightsize is also
+   released when a packet is permanently abandoned after
+   `MAX_PACKET_RETRANSMITS` (via `CongestionControl::release_flightsize`), so a
+   never-ACKed packet cannot pin flightsize for the connection's life (#4345).
 6. Deliver to application
 
 ## Development History


### PR DESCRIPTION
## Problem

A `GET` for a multi-fragment contract state intermittently fails on the real
network with `stream assembly: no fragments received within inactivity
timeout`. The node classifies the terminal reply as success, the local store
has no state, a `ContractError::Get` is synthesized, the contract is never
cached, and a follow-up `SUBSCRIBE` is rejected. For freenet-email this blocks
inbox contact import (issue #4345; downstream freenet/mail#288, #302).

### Root cause: flight-size pinned by never-ACKed packets that are retransmitted forever

`flightsize` (bytes in flight per connection) is decremented only on ACK. A
packet whose ACKs never arrive — a stream whose sender task already gave up on
the `CWND_WAIT_TIMEOUT`, or a starved reverse-ACK channel on a lossy path — is
retransmitted **forever**: `SentPacketTracker` had no upper bound on
retransmissions (a packet left `pending_receipts` only on ACK, or to be
immediately re-queued). Its initial `on_send` bytes therefore stayed counted in
flight size for the life of the connection.

The production default controller is **FixedRate**, whose `on_timeout` freezes
`cwnd ≈ loss_pause_cwnd + 60KB` on first loss. With flight size pinned by the
leaked bytes, the cwnd-wait loop `flightsize + packet_size <= cwnd` can never
open, `send_stream`/`pipe_stream` aborts after the 3s `CWND_WAIT_TIMEOUT` (~39%
of the stream), the receiver hits the 5s inactivity timeout, and the **next**
stream on the same connection starts already pinned.

Live telemetry (nova OTLP collector) confirmed the mechanism:

- **90% of all `transfer_failed` events were "cwnd wait timeout"** (4883 / 5407).
- **64% clustered at `cwnd ≈ 60–70KB`** = `LOSS_PAUSE_MARGIN (60KB)` + a small
  frozen `loss_pause_cwnd`, with the cwnd−flightsize gap pinned below one packet.
- Median `sent/total` ratio **0.39** — streams die ~40% through.
- `sent 0/2, flightsize=60172B` events = the cross-stream pinning (a fresh
  stream that can't send packet #1).

Not a recent regression — the unbounded retransmit / ACK-only decrement has
been there since each controller was written; the freenet-email large
multi-fragment workload plus the 5s inactivity timeout (#3750) newly exposed it.

## Solution

Bound retransmissions and release flight size on abandonment:

- `SentPacketTracker` counts per-packet RTO retransmits. After
  `MAX_PACKET_RETRANSMITS` (12) with no ACK, `get_resend` returns the new
  `ResendAction::Abandon { packet_id, payload_len }`, drops the packet from
  tracking, and stops re-queueing it. With the 500ms base RTO and exponential
  backoff (capped at a 60s effective RTO), 12 retransmits spans minutes — far
  beyond any live transfer (production p95 large-transfer ~1.8s), so a
  still-progressing connection is never abandoned. An ACK resets the count.
- The recv loop handles `Abandon` by calling the new
  `CongestionControl::release_flightsize(len)` — a saturating decrement
  (`fetch_update`) in all three controllers (BBR/LEDBAT/FixedRate). This is the
  only flight-size release path other than ACK.
- `on_timeout()` is unchanged: it applies the cwnd loss response but does NOT
  touch flight size, because the timed-out packet is immediately re-sent and
  stays in flight.

This drains the flight size pinned by a dead stream's packets, so the cwnd-wait
loop re-opens and subsequent streams on the connection are no longer wedged.

### Why not "release on RTO"

An earlier draft decremented flight size on every RTO and re-added it on the
re-send. The recv loop *always* re-sends on RTO, so that pair is net-zero and
never drained a never-ACKed packet — it didn't fix the bug. The fix has to be
"release on abandon," and the tracker had no abandonment, so this PR adds it.

### Abandonment timing

Wall-clock to abandonment depends on whether other packets keep ACKing, because
the RTO backoff is tracker-wide and resets on any ACK while the retransmit count
is per-packet:

- **Partial loss (common multi-fragment case):** other fragments keep ACKing →
  backoff stays at the 500ms floor → a black-holed fragment is abandoned after
  ~6s (12 × 500ms), just above `STREAM_INACTIVITY_TIMEOUT` (5s) — the receiver
  has already given up; abandoning frees the connection for the next stream.
- **Fully dead link:** no ACKs → backoff escalates (capped at 60s effective) →
  ~6 minutes, by which point the 120s idle timeout tears the connection down.

A still-progressing transfer is never abandoned: any ACK for the stuck packet
resets its count, and a 12-consecutive-RTO black hole on an otherwise healthy
path is a genuinely dead fragment.

## Testing

Eight regression tests; the core ones verified to fail with abandonment
disabled and pass with the fix:

- `sent_packet_tracker::tests::test_issue_4345_packet_abandoned_after_max_retransmits`
  — a never-ACKed packet is re-sent exactly `MAX_PACKET_RETRANSMITS` times, then
  `Abandon` fires, the packet is dropped, and it is not re-queued.
- `peer_connection::tests::test_issue_4345_flightsize_drains_via_bounded_retransmit`
  — drives the real recv-loop sequence (per-RTO `on_timeout()` + re-send +
  re-register, no ACK) through the real `SentPacketTracker`; flight size stays
  pinned across the re-sends and drains only once each packet is abandoned.
  (Neutering abandonment makes this fail with `abandoned=0/30`.)
- `sent_packet_tracker::tests::test_issue_4345_ack_resets_retransmit_count` and
  `…_flaky_but_alive_packet_never_abandoned` — an ACK before the limit resets
  the count; a flaky-but-progressing packet is never abandoned across many
  RTO/ACK cycles.
- `sent_packet_tracker::tests::test_issue_4345_late_ack_after_abandon_is_noop` —
  a late ACK for an abandoned packet yields no ack entry, so flight size is not
  released twice (no double-decrement).
- `bbr` / `fixed_rate` / `ledbat`
  `test_issue_4345_release_flightsize_drains_abandoned_bytes` — per-controller:
  `on_timeout()` leaves flight size unchanged; `release_flightsize` drains it
  (saturating) and re-opens cwnd.

All 616 transport lib tests pass; CI `cargo clippy --locked -- -D warnings` is
clean. Docs updated: `docs/architecture/transport/README.md` (abandonment as a
second flight-size release path) and `.claude/rules/transport.md` (flight-size
release invariant + "don't reintroduce unbounded retransmit / net-zero RTO").

### Why no network-level (mock-peer) test

A true end-to-end test was attempted (two `PeerConnection`s, peer B drops all
post-handshake outbound, assert peer A's flight size drains) but the
`create_mock_peer_with_virtual_time` harness does not drive the recv-loop's
RTO/resend timer deterministically under the auto-advance pattern — flight size
rises on send but the resend cycle does not progress to abandonment in the test.
The mechanism is instead proven at the layer it lives in: the tracker test
drives the real `get_resend → Abandon` decision, and the `peer_connection` test
drives the real recv-loop resend/abandon sequence through the real
`SentPacketTracker`. The production recv-loop `Abandon` arm is a 3-line
`release_flightsize` call guarded by exhaustive-match compile checking.

## Fixes

Fixes #4345
