### PR TITLE
ci: announce main CI failures, nightly, and PR merges to the freenet-dev room

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -23,13 +23,18 @@ Does the body explain WHY, not WHAT?
   → NO: Add reasoning. Code diff shows WHAT; message explains WHY.
 ```
 
-**Valid prefixes:**
+**Valid prefixes** (must match the `conventional_commits` CI check in `ci.yml`):
 - `feat:` – new feature
 - `fix:` – bug fix
 - `docs:` – documentation only
 - `refactor:` – code change that doesn't fix bug or add feature
 - `test:` – adding/updating tests
 - `build:` – build system or dependencies
+- `ci:` – CI/workflow configuration
+- `perf:` – performance improvement
+- `style:` – formatting/whitespace, no code-behavior change
+- `chore:` – maintenance with no src/test change
+- `revert:` – revert a previous commit
 
 ### BEFORE opening a PR — is this change in scope?
 

--- a/.github/actions/river-dev-notify/action.yml
+++ b/.github/actions/river-dev-notify/action.yml
@@ -1,0 +1,75 @@
+name: Notify Freenet dev room
+description: >
+  Post a message to the private freenet-dev River room via riverctl. Best
+  effort: never fails the calling job. No-ops with a warning when the dev-room
+  secrets are not configured (e.g. on forks).
+
+inputs:
+  message:
+    description: The message body to post.
+    required: true
+  bot-config:
+    description: >
+      base64-encoded riverctl rooms.json carrying the CI bot's signing key and
+      the room's invitation secrets (the RIVER_DEV_BOT_CONFIG secret). Posting
+      into a PRIVATE room needs both the member signing key AND the room's
+      symmetric secret; this config supplies both.
+    required: true
+  room-id:
+    description: base58 room owner verifying key (RIVER_DEV_ROOM_ID secret).
+    required: true
+  gateway-url:
+    description: Freenet gateway WebSocket URL (RIVER_GATEWAY_URL secret).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: 1.93.0
+
+    - name: Install riverctl
+      shell: bash
+      # Private-room message sending landed in riverctl 0.1.70 (freenet/river#350);
+      # earlier versions can only post to PUBLIC rooms and would fail here.
+      run: cargo install riverctl --version '^0.1.70'
+
+    - name: Post to the dev room (with exponential backoff)
+      shell: bash
+      env:
+        BOT_CONFIG: ${{ inputs.bot-config }}
+        ROOM_ID: ${{ inputs.room-id }}
+        NODE_URL: ${{ inputs.gateway-url }}
+        MESSAGE: ${{ inputs.message }}
+      run: |
+        set -u
+        if [ -z "${BOT_CONFIG}" ] || [ -z "${ROOM_ID}" ] || [ -z "${NODE_URL}" ]; then
+          echo "::warning::Freenet dev-room secrets not configured; skipping notification"
+          exit 0
+        fi
+
+        # Materialise the bot's riverctl config from the secret. `message send`
+        # fetches fresh room state from the network, so the config only needs
+        # the signing key + invitation secrets — the stored state is ignored.
+        CFG="$(mktemp -d)"
+        trap 'rm -rf "$CFG"' EXIT
+        printf '%s' "$BOT_CONFIG" | base64 -d > "$CFG/rooms.json"
+
+        max_attempts=7
+        delay=10
+        for attempt in $(seq 1 "$max_attempts"); do
+          echo "Attempt $attempt/$max_attempts (delay ${delay}s)..."
+          if riverctl --config-dir "$CFG" --node-url "$NODE_URL" \
+               message send "$ROOM_ID" "$MESSAGE" 2>&1; then
+            echo "Dev-room notification sent on attempt $attempt"
+            exit 0
+          fi
+          if [ "$attempt" -lt "$max_attempts" ]; then
+            sleep "$delay"
+            delay=$((delay * 2))
+          fi
+        done
+        echo "::warning::Failed to send Freenet dev-room notification after $max_attempts attempts (gateway may be restarting)"
+        exit 0

--- a/.github/actions/river-dev-notify/action.yml
+++ b/.github/actions/river-dev-notify/action.yml
@@ -74,7 +74,7 @@ runs:
         max_attempts=7
         delay=10
         for attempt in $(seq 1 "$max_attempts"); do
-          echo "Attempt $attempt/$max_attempts (delay ${delay}s)..."
+          echo "Attempt $attempt/$max_attempts..."
           # Output is sent to /dev/null on purpose: freenet-core's Actions logs
           # are public, and RIVER_DEV_BOT_CONFIG carries the room's symmetric
           # secret. GitHub auto-redacts the registered secret value but NOT the
@@ -86,7 +86,11 @@ runs:
             exit 0
           fi
           if [ "$attempt" -lt "$max_attempts" ]; then
-            sleep "$delay"
+            # Exponential backoff with +/-20% jitter so a burst of notifier
+            # instances (a merge-queue flush, back-to-back merges) don't retry
+            # in lockstep and synchronously hammer the gateway. (freenet-core
+            # retry/backoff rule: jitter required.)
+            sleep $(( delay - delay / 5 + RANDOM % (2 * delay / 5 + 1) ))
             delay=$((delay * 2))
           fi
         done

--- a/.github/actions/river-dev-notify/action.yml
+++ b/.github/actions/river-dev-notify/action.yml
@@ -25,15 +25,26 @@ inputs:
 runs:
   using: composite
   steps:
+    # The two setup steps are continue-on-error so a transient toolchain /
+    # crates.io hiccup never red-fails the calling job: the action is
+    # best-effort notification plumbing. If install fails, the post step below
+    # still runs and degrades to a `::warning::` (riverctl simply isn't found).
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
+      continue-on-error: true
       with:
         toolchain: 1.93.0
 
     - name: Install riverctl
       shell: bash
+      continue-on-error: true
       # Private-room message sending landed in riverctl 0.1.70 (freenet/river#350);
-      # earlier versions can only post to PUBLIC rooms and would fail here.
+      # earlier versions can only post to PUBLIC rooms and would fail here. The
+      # `^0.1.70` range (>=0.1.70, <0.2.0) is deliberately NOT pinned to an exact
+      # version: the room contract key is derived from the bundled room-contract
+      # WASM, so if that WASM changes and riverctl is republished, an exact pin
+      # would keep computing the OLD contract key and silently send nowhere.
+      # Tracking the latest 0.1.x keeps CI in sync with the deployed contract.
       run: cargo install riverctl --version '^0.1.70'
 
     - name: Post to the dev room (with exponential backoff)
@@ -55,14 +66,22 @@ runs:
         # the signing key + invitation secrets — the stored state is ignored.
         CFG="$(mktemp -d)"
         trap 'rm -rf "$CFG"' EXIT
-        printf '%s' "$BOT_CONFIG" | base64 -d > "$CFG/rooms.json"
+        if ! printf '%s' "$BOT_CONFIG" | base64 -d > "$CFG/rooms.json" 2>/dev/null; then
+          echo "::warning::RIVER_DEV_BOT_CONFIG is not valid base64; skipping notification"
+          exit 0
+        fi
 
         max_attempts=7
         delay=10
         for attempt in $(seq 1 "$max_attempts"); do
           echo "Attempt $attempt/$max_attempts (delay ${delay}s)..."
+          # Output is sent to /dev/null on purpose: freenet-core's Actions logs
+          # are public, and RIVER_DEV_BOT_CONFIG carries the room's symmetric
+          # secret. GitHub auto-redacts the registered secret value but NOT the
+          # base64-decoded config, so any riverctl diagnostic that echoed config
+          # bytes would leak. The exit code is the only signal we consume.
           if riverctl --config-dir "$CFG" --node-url "$NODE_URL" \
-               message send "$ROOM_ID" "$MESSAGE" 2>&1; then
+               message send "$ROOM_ID" "$MESSAGE" >/dev/null 2>&1; then
             echo "Dev-room notification sent on attempt $attempt"
             exit 0
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -851,14 +851,18 @@ jobs:
 
   # Notify the private freenet-dev River room when CI fails on the main branch.
   # Only fires on push to main (post-merge): the merge queue already gates PRs,
-  # so a failure here means main itself is red and someone should fix it.
-  # On push to main only fmt_check + clippy_check run (the heavy jobs are
-  # PR/merge_group-gated), so those are the dependencies that define "main CI".
+  # so a failure on the main run means main is red — a bad merge, or a transient
+  # infra/toolchain flake (the linked run shows which). On push to main only
+  # fmt_check + clippy_check run (the heavy jobs are PR/merge_group-gated), so
+  # those are the dependencies that define "main CI".
   notify_dev_room_main_failure:
     name: Notify dev room on main CI failure
     runs-on: ubuntu-latest
     needs: [fmt_check, clippy_check]
     if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Best-effort: a failure in this notifier itself must not add a second red
+    # job to an already-red run (parity with the nightly notify job).
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/river-dev-notify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -848,3 +848,22 @@ jobs:
             - After pushing, CI will run automatically
 
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*),Bash(gh run view:*),Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git log:*)"'
+
+  # Notify the private freenet-dev River room when CI fails on the main branch.
+  # Only fires on push to main (post-merge): the merge queue already gates PRs,
+  # so a failure here means main itself is red and someone should fix it.
+  # On push to main only fmt_check + clippy_check run (the heavy jobs are
+  # PR/merge_group-gated), so those are the dependencies that define "main CI".
+  notify_dev_room_main_failure:
+    name: Notify dev room on main CI failure
+    runs-on: ubuntu-latest
+    needs: [fmt_check, clippy_check]
+    if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/river-dev-notify
+        with:
+          message: "🚨 main CI failed — ${{ github.repository }}@${{ github.sha }} — ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          bot-config: ${{ secrets.RIVER_DEV_BOT_CONFIG }}
+          room-id: ${{ secrets.RIVER_DEV_ROOM_ID }}
+          gateway-url: ${{ secrets.RIVER_GATEWAY_URL }}

--- a/.github/workflows/river_pr_merge_notify.yml
+++ b/.github/workflows/river_pr_merge_notify.yml
@@ -19,12 +19,22 @@ jobs:
         run: cargo install riverctl
 
       - name: Send message to River (with exponential backoff)
+        # Untrusted PR fields (title/author are attacker-controlled) are bound
+        # to env vars and expanded by the shell as `${PR_*}` rather than
+        # interpolated as `${{ }}` script text — otherwise a crafted PR title
+        # would inject shell commands into this step. See GitHub's
+        # script-injection guidance.
         env:
           RIVER_SIGNING_KEY: ${{ secrets.RIVER_SIGNING_KEY }}
+          NODE_URL: ${{ secrets.RIVER_GATEWAY_URL }}
+          ROOM_ID: ${{ secrets.RIVER_ROOM_ID }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_MERGER: ${{ github.event.pull_request.merged_by.login }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          MESSAGE="PR #${{ github.event.pull_request.number }} merged: ${{ github.event.pull_request.title }} (by @${{ github.event.pull_request.user.login }}, merged by @${{ github.event.pull_request.merged_by.login }}) - ${{ github.event.pull_request.html_url }}"
-          NODE_URL="${{ secrets.RIVER_GATEWAY_URL }}"
-          ROOM_ID="${{ secrets.RIVER_ROOM_ID }}"
+          MESSAGE="PR #${PR_NUMBER} merged: ${PR_TITLE} (by @${PR_AUTHOR}, merged by @${PR_MERGER}) - ${PR_URL}"
 
           max_attempts=7
           delay=10
@@ -42,3 +52,27 @@ jobs:
           done
           echo "::warning::Failed to send River notification after $max_attempts attempts (gateway may be restarting)"
           exit 0
+
+  # Mirror the PR-merge notification into the private freenet-dev room (the
+  # notify_river job above posts to the public official room).
+  notify_dev_room:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: github.event.pull_request.merged == true
+    # Bind the (untrusted) PR title/author through job-level env so it never
+    # reaches a shell as interpolated script text — the composite action then
+    # forwards it via env into a quoted `"$MESSAGE"` argument.
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      PR_MERGER: ${{ github.event.pull_request.merged_by.login }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/river-dev-notify
+        with:
+          message: "✅ PR #${{ env.PR_NUMBER }} merged: ${{ env.PR_TITLE }} (by @${{ env.PR_AUTHOR }}, merged by @${{ env.PR_MERGER }}) — ${{ env.PR_URL }}"
+          bot-config: ${{ secrets.RIVER_DEV_BOT_CONFIG }}
+          room-id: ${{ secrets.RIVER_DEV_ROOM_ID }}
+          gateway-url: ${{ secrets.RIVER_GATEWAY_URL }}

--- a/.github/workflows/river_pr_merge_notify.yml
+++ b/.github/workflows/river_pr_merge_notify.yml
@@ -59,6 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: github.event.pull_request.merged == true
+    # Best-effort: a riverctl/toolchain install hiccup must not red-X a merged
+    # PR's workflow run.
+    continue-on-error: true
     # Bind the (untrusted) PR title/author through job-level env so it never
     # reaches a shell as interpolated script text — the composite action then
     # forwards it via env into a quoted `"$MESSAGE"` argument.

--- a/.github/workflows/simulation-nightly.yml
+++ b/.github/workflows/simulation-nightly.yml
@@ -199,3 +199,20 @@ jobs:
           done
           echo "::warning::Failed to send River notification after $max_attempts attempts (gateway may be restarting)"
           exit 0
+
+  # Mirror the nightly-failure notification into the private freenet-dev room
+  # (the existing notify-failure job above posts to the public official room).
+  notify-dev-room-failure:
+    name: Notify dev room on Failure
+    runs-on: ubuntu-latest
+    needs: large-scale-simulation
+    if: failure() && needs.large-scale-simulation.result == 'failure'
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/river-dev-notify
+        with:
+          message: "🚨 Nightly simulation tests failed — ${{ github.repository }} — branch ${{ github.ref_name }} — commit ${{ github.sha }} — seed ${{ github.event.inputs.seed || '0xDEADBEEF' }} — ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          bot-config: ${{ secrets.RIVER_DEV_BOT_CONFIG }}
+          room-id: ${{ secrets.RIVER_DEV_ROOM_ID }}
+          gateway-url: ${{ secrets.RIVER_GATEWAY_URL }}


### PR DESCRIPTION
## Problem

@iduartgomez asked (in the freenet-dev River room) for CI bot announcements like the team had in Matrix — **main CI failures** and **nightly** results especially, "for visibility and discipline" — plus PR merges. @sanity approved. There is currently **no main-CI-failure notification at all** (only nightly-failure and PR-merge exist, both to the *public* official room).

## Solution

A shared composite action `.github/actions/river-dev-notify` posts to the **private** freenet-dev room via `riverctl`, wired into three workflows:

- **`ci.yml`** — new `notify_dev_room_main_failure` job, fires only on `push` to `main` when CI fails. The merge queue already gates PRs, so a failure on the post-merge main run means main itself is red. On push to main only `fmt_check` + `clippy_check` run (heavy jobs are PR/merge_group-gated), so those are the job's dependencies.
- **`simulation-nightly.yml`** — `notify-dev-room-failure` job mirrors the nightly-failure post into the dev room.
- **`river_pr_merge_notify.yml`** — `notify_dev_room` job mirrors the PR-merge post into the dev room.

The existing **public official-room** notifications are left untouched (this adds the dev room alongside them — see "Open question" below).

**Key insight — why this needs more than a signing key:** posting into a *private* room requires both the bot's member signing key (to sign) **and** the room's symmetric secret (to encrypt the body). Both are supplied via the `RIVER_DEV_BOT_CONFIG` secret (a base64 `riverctl` config). This requires **riverctl ≥ 0.1.70** (freenet/river#350), the first version that can send encrypted private-room messages; earlier versions only post to public rooms and would fail here.

The action is best-effort: it never fails the calling job and no-ops with a `::warning::` when the dev-room secrets are absent (e.g. on forks).

**Drive-by hardening (same file):** the existing `notify_river` job interpolated the attacker-controlled PR **title** directly into a shell `run:` script — a script-injection vector flagged by `actionlint`. Bound the untrusted PR fields through env vars (`${PR_*}`) so the shell expands them as values, never as script text. The new dev-room jobs use the same safe pattern. Happy to split this out if preferred, but it's the same file and pattern.

## Testing

- `actionlint` clean on all three changed workflows (only pre-existing `ubicloud-*` runner labels and an unrelated `steps.test` reference remain; the script-injection warning is resolved).
- The end-to-end path was validated live: `riverctl` 0.1.70 posting via the exact `RIVER_DEV_BOT_CONFIG` shape (a trimmed config) successfully delivered an AES-256-GCM-sealed message into the private freenet-dev room on the live network (contract-accepted, propagated, sealed at the current secret version).
- Secrets `RIVER_DEV_ROOM_ID` + `RIVER_DEV_BOT_CONFIG` are configured on this repo; `RIVER_GATEWAY_URL` reused.

## Open question for reviewers

The existing nightly-failure and PR-merge notifications still post to the **public official room** too. Now that the dev room exists, those public-room posts may be redundant noise for quickstart users — but removing them changes existing behavior, so this PR leaves them. Say the word and I'll repoint (rather than duplicate) them.

## Notes

- `riverctl` config secret carries the room's read-secret, so its access ≈ dev-room membership; acceptable since freenet-core CI-secret holders are the dev team. A future hardening (room owner provisions the bot's `encrypted_secrets` blob) would let CI sign with only the signing key (post-only).

Issue: #4357

[AI-assisted - Claude]