### PR TITLE
fix: deliver prune disconnect cause through the waiter channel

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -314,8 +314,48 @@ at the dispatch site. Do NOT treat as an error.
 □ Test race conditions (fast responses)
 ```
 
+### WHEN awaiting a reply on `pending_op_results[tx]` (#4313)
+
+When a connection is pruned, `handle_orphaned_transactions` wakes each
+parked driver. The cause travels **through the waiter channel itself**:
+the `TransactionOrphaned { tx, peer }` event-loop handler does
+`sender.try_send(WaiterReply::PeerDisconnected { peer })` and *then*
+drops the sender. tokio mpsc delivers a buffered item before the
+channel reads `None`, so the driver deterministically observes
+`PeerDisconnected` (mapped to `OpError::PeerDisconnected`) — never the
+`"failed notifying, channel closed"` FORBIDDEN_MARKER that
+`tests/error_notification.rs` asserts against. There is no side
+registry and no record-before-release ordering to get wrong.
+
+```
+The waiter channel item is `WaiterReply` (Reply | PeerDisconnected),
+  NOT a bare NetMessage. Every recv site MUST handle PeerDisconnected
+  — the type system enforces this. Funnel through
+  OpCtx::recv_waiter_reply (used by send_and_await, send_to_and_await,
+  and the PUT/CONNECT relays) rather than matching the enum by hand.
+
+The TransactionOrphaned handler MUST send PeerDisconnected on the
+  sender it removes from pending_op_results BEFORE that sender drops
+  (send-before-drop). Dropping without sending re-opens the #4313
+  race (driver wakes on close with no cause → FORBIDDEN_MARKER).
+
+PeerDisconnected routes to the generic advance arm in
+  drive_retry_loop (the peer is gone — advance to the next route),
+  NOT the NotificationError same-peer infra-retry arm. MUST preserve
+  `{err}` interpolation in the Exhausted format so the cause Display
+  reaches the user.
+```
+
+Pins (source-scrape, fail the build on regression):
+- `transaction_orphaned_handler_sends_cause_before_dropping_sender` (p2p_protoc.rs)
+- `handle_orphaned_transactions_wakes_parked_drivers` (p2p_protoc.rs)
+- behavioural: `parked_driver_always_observes_peer_disconnected_under_churn`,
+  `recv_waiter_reply_*` (op_ctx.rs) and
+  `orphaned_transaction_wakes_parked_waiter_with_peer_disconnected` (op_state_manager.rs)
+
 ## Documentation
 
 - Architecture: `docs/architecture/operations/README.md`
 - OpManager: `crates/core/src/node/op_state_manager.rs`
 - Round-trip primitive: `crates/core/src/operations/op_ctx.rs`
+- Orphan-wake signal: `crate::node::WaiterReply::PeerDisconnected` + `NodeEvent::TransactionOrphaned` (#4313)

--- a/apps/freenet-ping/Cargo.lock
+++ b/apps/freenet-ping/Cargo.lock
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.2.67"
+version = "0.2.70"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -344,6 +344,7 @@ async fn report_op_init_error(
         | OpError::UnexpectedOpState
         | OpError::InvalidStateTransition { .. }
         | OpError::NotificationError
+        | OpError::PeerDisconnected { .. }
         | OpError::NotificationChannelError(_)
         | OpError::IncorrectTxType(..)
         | OpError::OpNotPresent(_)

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -634,6 +634,13 @@ pub(crate) enum NodeEvent {
     TransactionTimedOut(Transaction),
     /// Transaction completed successfully - cleanup client subscription
     TransactionCompleted(Transaction),
+    /// A parked op whose awaited peer was just pruned (#4313). The event-loop
+    /// handler delivers `WaiterReply::PeerDisconnected` into the waiter channel
+    /// before dropping the sender, then cleans up like `TransactionCompleted`.
+    TransactionOrphaned {
+        tx: Transaction,
+        peer: SocketAddr,
+    },
     /// **Standalone** subscription completed - deliver SubscribeResponse to client via result router.
     ///
     /// **IMPORTANT:** This event is ONLY used for standalone subscriptions (no remote peers available).
@@ -778,6 +785,9 @@ impl Display for NodeEvent {
             }
             NodeEvent::TransactionCompleted(transaction) => {
                 write!(f, "Transaction completed ({transaction})")
+            }
+            NodeEvent::TransactionOrphaned { tx, peer } => {
+                write!(f, "Transaction orphaned (tx: {tx}, peer: {peer})")
             }
             NodeEvent::LocalSubscribeComplete {
                 tx,

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -49,7 +49,7 @@ use freenet_stdlib::client_api::DelegateRequest;
 use serde::{Deserialize, Serialize};
 
 pub(crate) use network_bridge::{
-    ConnectionError, EventLoopNotificationsSender, NetworkBridge, OpExecutionPayload,
+    ConnectionError, EventLoopNotificationsSender, NetworkBridge, OpExecutionPayload, WaiterReply,
 };
 #[cfg(test)]
 pub(crate) use network_bridge::{EventLoopNotificationsReceiver, event_loop_notification_channel};
@@ -753,7 +753,7 @@ pub(crate) async fn process_message_decoupled<CB>(
     op_manager: Arc<OpManager>,
     conn_manager: CB,
     mut event_listener: Box<dyn NetEventRegister>,
-    pending_op_result: Option<tokio::sync::mpsc::Sender<NetMessage>>,
+    pending_op_result: Option<tokio::sync::mpsc::Sender<crate::node::WaiterReply>>,
 ) where
     CB: NetworkBridge + Clone + 'static,
 {
@@ -782,7 +782,7 @@ async fn handle_pure_network_message<CB>(
     op_manager: Arc<OpManager>,
     conn_manager: CB,
     event_listener: &mut dyn NetEventRegister,
-    pending_op_result: Option<tokio::sync::mpsc::Sender<NetMessage>>,
+    pending_op_result: Option<tokio::sync::mpsc::Sender<crate::node::WaiterReply>>,
 ) -> Result<(), crate::node::OpError>
 where
     CB: NetworkBridge + Clone + 'static,
@@ -857,7 +857,7 @@ where
 ///
 /// Either way the handler still makes progress and returns `true`.
 fn try_forward_driver_reply(
-    pending_op_result: Option<&tokio::sync::mpsc::Sender<NetMessage>>,
+    pending_op_result: Option<&tokio::sync::mpsc::Sender<crate::node::WaiterReply>>,
     reply: NetMessage,
     op_label: &'static str,
 ) -> bool {
@@ -865,7 +865,7 @@ fn try_forward_driver_reply(
         return false;
     };
     let tx_id = *reply.id();
-    if let Err(err) = callback.try_send(reply) {
+    if let Err(err) = callback.try_send(crate::node::WaiterReply::Reply(reply)) {
         // Benign, expected, and intentionally lossy (see `# Channel safety`):
         // the reply could not be delivered (receiver closed, or the channel
         // full for a CONNECT-style capacity-N fan-in) and the operation
@@ -926,7 +926,7 @@ async fn handle_pure_network_message_v1<CB>(
     op_manager: Arc<OpManager>,
     conn_manager: CB,
     event_listener: &mut dyn NetEventRegister,
-    pending_op_result: Option<tokio::sync::mpsc::Sender<NetMessage>>,
+    pending_op_result: Option<tokio::sync::mpsc::Sender<crate::node::WaiterReply>>,
 ) -> Result<(), crate::node::OpError>
 where
     CB: NetworkBridge + Clone + 'static,
@@ -2810,7 +2810,7 @@ mod tests {
 
         #[tokio::test]
         async fn bypass_forwards_when_callback_registered() {
-            let (tx, mut rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::node::WaiterReply>(1);
             let reply = dummy_reply();
             let expected_id = *reply.id();
 
@@ -2820,7 +2820,10 @@ mod tests {
             let received = rx
                 .try_recv()
                 .expect("helper should forward the reply to the callback");
-            assert_eq!(*received.id(), expected_id);
+            match received {
+                crate::node::WaiterReply::Reply(msg) => assert_eq!(*msg.id(), expected_id),
+                other => panic!("expected WaiterReply::Reply, got: {other:?}"),
+            }
         }
 
         #[tokio::test]
@@ -2846,7 +2849,7 @@ mod tests {
             // `OpNotPresent`, which is meaningless for a tx owned by a
             // (now-dead) task and pointlessly wastes a pipeline
             // iteration.
-            let (tx, rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let (tx, rx) = tokio::sync::mpsc::channel::<crate::node::WaiterReply>(1);
             drop(rx);
 
             let taken = try_forward_driver_reply(Some(&tx), dummy_reply(), "subscribe");
@@ -3087,9 +3090,9 @@ mod tests {
             // channel must fail without blocking the handler. Future
             // refactors must not switch to `.send().await` (see
             // `.claude/rules/channel-safety.md`).
-            let (tx, _rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let (tx, _rx) = tokio::sync::mpsc::channel::<crate::node::WaiterReply>(1);
             // Pre-fill the capacity-1 channel.
-            tx.try_send(dummy_reply())
+            tx.try_send(crate::node::WaiterReply::Reply(dummy_reply()))
                 .expect("capacity-1 channel should accept first message");
 
             let taken = try_forward_driver_reply(Some(&tx), dummy_reply(), "subscribe");
@@ -3141,7 +3144,7 @@ mod tests {
         /// driver channel (and the branch would return early).
         fn subscribe_branch_would_forward(
             op: &SubscribeMsg,
-            callback: Option<&tokio::sync::mpsc::Sender<NetMessage>>,
+            callback: Option<&tokio::sync::mpsc::Sender<crate::node::WaiterReply>>,
         ) -> bool {
             matches!(op, SubscribeMsg::Response { .. })
                 && try_forward_driver_reply(
@@ -3153,7 +3156,7 @@ mod tests {
 
         #[tokio::test]
         async fn subscribe_response_is_forwarded_to_task() {
-            let (tx, mut rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::node::WaiterReply>(1);
             let sub_tx = Transaction::new::<SubscribeMsg>();
             let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([1u8; 32]);
             let key = freenet_stdlib::prelude::ContractKey::from_id_and_code(
@@ -3170,8 +3173,10 @@ mod tests {
             let taken = subscribe_branch_would_forward(&op, Some(&tx));
             assert!(taken, "Response with callback → must be forwarded");
 
-            let received = rx.try_recv().expect("Response should be in channel");
-            assert_eq!(*received.id(), sub_tx);
+            match rx.try_recv().expect("Response should be in channel") {
+                crate::node::WaiterReply::Reply(msg) => assert_eq!(*msg.id(), sub_tx),
+                other => panic!("expected WaiterReply::Reply, got: {other:?}"),
+            }
         }
 
         #[tokio::test]
@@ -3179,7 +3184,7 @@ mod tests {
             // ForwardingAck is non-terminal: relay peers send it to
             // signal "I'm working on it". Forwarding it would fill
             // the capacity-1 channel and block the real Response.
-            let (tx, mut rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::node::WaiterReply>(1);
             let sub_tx = Transaction::new::<SubscribeMsg>();
             let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([3u8; 32]);
             let op = SubscribeMsg::ForwardingAck {
@@ -3200,7 +3205,7 @@ mod tests {
 
         #[tokio::test]
         async fn unsubscribe_is_not_forwarded_to_task() {
-            let (tx, mut rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::node::WaiterReply>(1);
             let sub_tx = Transaction::new::<SubscribeMsg>();
             let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([4u8; 32]);
             let op = SubscribeMsg::Unsubscribe {
@@ -3215,7 +3220,7 @@ mod tests {
 
         #[tokio::test]
         async fn request_is_not_forwarded_to_task() {
-            let (tx, mut rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::node::WaiterReply>(1);
             let sub_tx = Transaction::new::<SubscribeMsg>();
             let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([5u8; 32]);
             let op = SubscribeMsg::Request {
@@ -3324,7 +3329,7 @@ mod tests {
 
         fn put_branch_would_forward(
             op: &PutMsg,
-            callback: Option<&tokio::sync::mpsc::Sender<NetMessage>>,
+            callback: Option<&tokio::sync::mpsc::Sender<crate::node::WaiterReply>>,
         ) -> bool {
             matches!(
                 op,
@@ -3338,7 +3343,7 @@ mod tests {
 
         #[tokio::test]
         async fn put_response_is_forwarded_to_task() {
-            let (tx, mut rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::node::WaiterReply>(1);
             let put_tx = Transaction::new::<PutMsg>();
             let key = dummy_put_key(10, 11);
             let op = PutMsg::Response {
@@ -3350,13 +3355,15 @@ mod tests {
             let taken = put_branch_would_forward(&op, Some(&tx));
             assert!(taken, "Response with callback → must be forwarded");
 
-            let received = rx.try_recv().expect("Response should be in channel");
-            assert_eq!(*received.id(), put_tx);
+            match rx.try_recv().expect("Response should be in channel") {
+                crate::node::WaiterReply::Reply(msg) => assert_eq!(*msg.id(), put_tx),
+                other => panic!("expected WaiterReply::Reply, got: {other:?}"),
+            }
         }
 
         #[tokio::test]
         async fn put_response_streaming_is_forwarded_to_task() {
-            let (tx, mut rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::node::WaiterReply>(1);
             let put_tx = Transaction::new::<PutMsg>();
             let key = dummy_put_key(12, 13);
             let op = PutMsg::ResponseStreaming {
@@ -3369,15 +3376,18 @@ mod tests {
             let taken = put_branch_would_forward(&op, Some(&tx));
             assert!(taken, "ResponseStreaming with callback → must be forwarded");
 
-            let received = rx
+            match rx
                 .try_recv()
-                .expect("ResponseStreaming should be in channel");
-            assert_eq!(*received.id(), put_tx);
+                .expect("ResponseStreaming should be in channel")
+            {
+                crate::node::WaiterReply::Reply(msg) => assert_eq!(*msg.id(), put_tx),
+                other => panic!("expected WaiterReply::Reply, got: {other:?}"),
+            }
         }
 
         #[tokio::test]
         async fn put_forwarding_ack_is_not_forwarded_to_task() {
-            let (tx, mut rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::node::WaiterReply>(1);
             let put_tx = Transaction::new::<PutMsg>();
             let key = dummy_put_key(14, 15);
             let op = PutMsg::ForwardingAck {
@@ -3398,7 +3408,7 @@ mod tests {
 
         #[tokio::test]
         async fn put_request_is_not_forwarded_to_task() {
-            let (tx, mut rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::node::WaiterReply>(1);
             let put_tx = Transaction::new::<PutMsg>();
             let op = PutMsg::Request {
                 id: put_tx,

--- a/crates/core/src/node/network_bridge.rs
+++ b/crates/core/src/node/network_bridge.rs
@@ -206,7 +206,28 @@ pub(crate) fn event_loop_notification_channel_with_capacity(
 /// SUBSCRIBE has the contract cached locally, the loop-back `InboundMessage`
 /// was short-circuiting in `process_message` instead of propagating upstream
 /// to register as a downstream subscriber on the home node.
-pub(crate) type OpExecutionPayload = (Sender<NetMessage>, NetMessage, Option<SocketAddr>);
+/// Item delivered on a `pending_op_results[tx]` waiter channel.
+///
+/// The terminal `PeerDisconnected` variant lets a prune deliver the
+/// disconnect *cause* through the channel itself (sent before the sender
+/// drops), so the parked driver reads it deterministically — no side
+/// registry, no race (#4313).
+///
+/// `Reply` is the hot path (every op reply) and is intentionally NOT boxed:
+/// the channel previously carried `NetMessage` by value, so the enum's
+/// footprint is unchanged. Boxing to satisfy `large_enum_variant` would add
+/// an allocation per reply to save space only on the rare `PeerDisconnected`.
+#[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum WaiterReply {
+    /// A terminal op reply routed back to the parked driver.
+    Reply(NetMessage),
+    /// The peer this op was awaiting was pruned before it replied; the
+    /// driver should advance to another route.
+    PeerDisconnected { peer: SocketAddr },
+}
+
+pub(crate) type OpExecutionPayload = (Sender<WaiterReply>, NetMessage, Option<SocketAddr>);
 
 pub(crate) struct EventLoopNotificationsReceiver {
     pub(crate) notifications_receiver: Receiver<Either<NetMessage, NodeEvent>>,

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -40,7 +40,9 @@ use crate::{
     config::GlobalExecutor,
     contract::{ContractHandlerChannel, ExecutorTransactionStream, WaitingResolution},
     message::{MessageStats, NetMessage, NodeEvent, Transaction, TransactionType},
-    node::{NetEventRegister, NodeConfig, OpManager, PeerId, process_message_decoupled},
+    node::{
+        NetEventRegister, NodeConfig, OpManager, PeerId, WaiterReply, process_message_decoupled,
+    },
     ring::{KnownPeerKeyLocation, PeerConnectionBackoff, PeerKeyLocation},
     tracing::NetEventLog,
 };
@@ -177,28 +179,31 @@ impl P2pBridge {
 
     /// Wake any drivers whose downstream peer just disconnected.
     ///
-    /// For each orphaned `tx` we emit
-    /// `NodeEvent::TransactionCompleted(tx)` via `try_send`. The event-
-    /// loop handler at `NodeEvent::TransactionCompleted` drops the
-    /// matching `pending_op_results` sender, which closes the channel
-    /// the driver is awaiting in `OpCtx::send_and_await`. The driver
-    /// then sees `Err(OpError::NotificationError)`; the shared retry
-    /// loop (`drive_retry_loop`) routes that to `advance()` and tries
-    /// the next peer.
+    /// For each orphaned tx, emit `NodeEvent::TransactionOrphaned`. The
+    /// event-loop handler delivers `WaiterReply::PeerDisconnected` into the
+    /// waiter channel *before* dropping the sender, so the parked driver
+    /// reads the cause deterministically and surfaces
+    /// `OpError::PeerDisconnected`, which the retry loop advances past to
+    /// the next peer (#4313).
     ///
-    /// Without this hop, a GET (or other relayed op) issued just before
-    /// its downstream peer disconnected would block for the full
-    /// `OPERATION_TTL` (60 s) before retrying — see #4154.
-    pub(crate) async fn handle_orphaned_transactions(&self, transactions: Vec<Transaction>) {
+    /// Without the wake at all, a GET issued just before its peer
+    /// disconnected stalls for `OPERATION_TTL` (60 s) — see #4154.
+    pub(crate) async fn handle_orphaned_transactions(
+        &self,
+        transactions: Vec<Transaction>,
+        disconnected_peer_addr: SocketAddr,
+    ) {
         if transactions.is_empty() {
             return;
         }
         tracing::debug!(
             count = transactions.len(),
+            peer = %disconnected_peer_addr,
             "Orphaned transactions from pruned connection — waking parked drivers"
         );
         for tx in transactions {
-            self.op_manager.try_release_pending_op_slot(tx);
+            self.op_manager
+                .notify_orphaned_transaction(tx, disconnected_peer_addr);
         }
     }
 
@@ -1458,10 +1463,11 @@ impl P2pConnManager {
                                         // Note: In the simplified architecture (2026-01), subscriptions are lease-based
                                         // and don't require explicit pruning notifications. Just handle orphaned transactions.
 
-                                        // Handle orphaned transactions immediately (retry via alternate routes)
+                                        // Handle orphaned transactions immediately (retry via alternate routes).
                                         ctx.bridge
                                             .handle_orphaned_transactions(
                                                 prune_result.orphaned_transactions,
+                                                peer_addr,
                                             )
                                             .await;
 
@@ -2030,6 +2036,28 @@ impl P2pConnManager {
                                     .live_tx_tracker
                                     .remove_finished_transaction(tx);
                             }
+                            NodeEvent::TransactionOrphaned { tx, peer } => {
+                                // The awaited peer was pruned mid-flight (#4313).
+                                // Deliver the cause THROUGH the waiter channel
+                                // before the sender drops, so the parked driver's
+                                // recv() yields PeerDisconnected before None —
+                                // race-free, no side registry. Then clean up like
+                                // TransactionCompleted.
+                                state.tx_to_client.remove(&tx);
+                                if let Some(sender) = state.pending_op_results.remove(&tx) {
+                                    // Best-effort: a full channel means a real
+                                    // reply is already queued, a closed one means
+                                    // the driver already exited — both benign.
+                                    #[allow(clippy::let_underscore_must_use)]
+                                    let _ = sender.try_send(WaiterReply::PeerDisconnected { peer });
+                                    crate::config::GlobalTestMetrics::record_pending_op_remove();
+                                }
+                                ctx.bridge
+                                    .op_manager
+                                    .ring
+                                    .live_tx_tracker
+                                    .remove_finished_transaction(tx);
+                            }
                             NodeEvent::LocalSubscribeComplete {
                                 tx,
                                 key,
@@ -2240,9 +2268,9 @@ impl P2pConnManager {
             .prune_connection(PeerId::new(peer.pub_key().clone(), peer_addr))
             .await;
 
-        // Handle orphaned transactions immediately (retry via alternate routes)
+        // Handle orphaned transactions immediately (retry via alternate routes).
         self.bridge
-            .handle_orphaned_transactions(prune_result.orphaned_transactions)
+            .handle_orphaned_transactions(prune_result.orphaned_transactions, peer_addr)
             .await;
 
         // Broadcast unready if we dropped below the readiness threshold
@@ -2340,7 +2368,7 @@ impl P2pConnManager {
 
         // Handle orphaned transactions
         self.bridge
-            .handle_orphaned_transactions(prune_result.orphaned_transactions)
+            .handle_orphaned_transactions(prune_result.orphaned_transactions, peer_addr)
             .await;
 
         if prune_result.became_unready {
@@ -3310,7 +3338,7 @@ impl P2pConnManager {
                     .prune_connection(PeerId::new(old_peer.pub_key().clone(), peer_addr))
                     .await;
                 self.bridge
-                    .handle_orphaned_transactions(prune_result.orphaned_transactions)
+                    .handle_orphaned_transactions(prune_result.orphaned_transactions, peer_addr)
                     .await;
                 if prune_result.became_unready {
                     // Deferred: broadcast after connection_manager borrow ends
@@ -3755,7 +3783,10 @@ impl P2pConnManager {
 
                     // Handle orphaned transactions immediately (retry via alternate routes)
                     self.bridge
-                        .handle_orphaned_transactions(prune_result.orphaned_transactions)
+                        .handle_orphaned_transactions(
+                            prune_result.orphaned_transactions,
+                            remote_addr,
+                        )
                         .await;
 
                     if prune_result.became_unready {
@@ -4797,7 +4828,7 @@ struct EventListenerState {
     client_waiting_transaction: Vec<(WaitingTransaction, HashSet<ClientId>)>,
     awaiting_connection: HashMap<SocketAddr, Vec<Box<dyn ConnectResultSender>>>,
     awaiting_connection_txs: HashMap<SocketAddr, Vec<Transaction>>,
-    pending_op_results: HashMap<Transaction, Sender<NetMessage>>,
+    pending_op_results: HashMap<Transaction, Sender<WaiterReply>>,
     /// Last time pending_op_results was scanned for closed senders.
     last_pending_op_cleanup: Instant,
     /// Per-peer backoff tracking for failed connection attempts.
@@ -5580,9 +5611,9 @@ mod tests {
             .expect("handle_orphaned_transactions must close cleanly");
         let body = &body_after[..end];
         assert!(
-            body.contains("try_release_pending_op_slot"),
+            body.contains("notify_orphaned_transaction"),
             "handle_orphaned_transactions must call \
-             try_release_pending_op_slot to wake parked drivers (#4154). \
+             notify_orphaned_transaction to wake parked drivers (#4154/#4313). \
              Found body:\n{body}"
         );
     }
@@ -6027,6 +6058,38 @@ mod tests {
             body.contains(".reserve()"),
             "PipeStream dispatch must use `reserve()` instead of `send().await` — \
              see #4145. Body:\n{body}"
+        );
+    }
+
+    /// Pin: the `TransactionOrphaned` handler must deliver the cause
+    /// THROUGH the waiter channel (`try_send(WaiterReply::PeerDisconnected ...)`)
+    /// before dropping the sender via `pending_op_results.remove`. A future
+    /// refactor that drops the sender without sending the signal re-opens the
+    /// #4313 race (driver wakes on close with no cause → FORBIDDEN_MARKER).
+    #[test]
+    fn transaction_orphaned_handler_sends_cause_before_dropping_sender() {
+        const SOURCE: &str = include_str!("p2p_protoc.rs");
+
+        let arm_anchor = "NodeEvent::TransactionOrphaned { tx, peer } => {";
+        let arm_start = SOURCE
+            .find(arm_anchor)
+            .expect("TransactionOrphaned handler renamed or removed");
+        let arm_end = SOURCE[arm_start..]
+            .find("\n                            }\n")
+            .map(|p| arm_start + p)
+            .expect("TransactionOrphaned arm closer not found");
+        let body = &SOURCE[arm_start..arm_end];
+
+        let send_pos = body
+            .find("WaiterReply::PeerDisconnected")
+            .expect("missing PeerDisconnected delivery — #4313 cause is dropped");
+        let remove_pos = body
+            .find("pending_op_results.remove(&tx)")
+            .expect("missing pending_op_results.remove — sender never dropped");
+        assert!(
+            send_pos > remove_pos,
+            "the PeerDisconnected send must happen on the sender taken out by \
+             pending_op_results.remove (send-before-drop). Arm body:\n{body}"
         );
     }
 }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -569,15 +569,18 @@ impl OpManager {
         }
     }
 
-    /// Non-blocking variant of [`Self::release_pending_op_slot`] for callers
-    /// that run on the network event loop (where `send().await` could
-    /// deadlock). Used by `P2pBridge::handle_orphaned_transactions` to wake
-    /// drivers whose downstream peer has just disconnected (#4154). The
-    /// notification is best-effort: on a transiently-full channel the
-    /// driver falls back to its `OPERATION_TTL` timeout. See
-    /// [`try_release_pending_op_slot_on`] for the underlying send logic.
-    pub(crate) fn try_release_pending_op_slot(&self, tx: Transaction) {
-        try_release_pending_op_slot_on(&self.to_event_listener.notifications_sender, tx);
+    /// Wake a parked op whose awaited `peer` was just pruned (#4313).
+    ///
+    /// Emits `NodeEvent::TransactionOrphaned`; the event-loop handler
+    /// delivers `WaiterReply::PeerDisconnected` into the waiter channel
+    /// *before* dropping the sender, so the parked driver reads the cause
+    /// deterministically — no side registry, no race. Best-effort and
+    /// non-blocking (runs on the event loop, where `send().await` could
+    /// deadlock): a dropped event under backpressure leaves the driver to
+    /// its `OPERATION_TTL` fallback (#4154). See
+    /// [`notify_orphaned_transaction_on`] for the underlying send logic.
+    pub(crate) fn notify_orphaned_transaction(&self, tx: Transaction, peer: SocketAddr) {
+        notify_orphaned_transaction_on(&self.to_event_listener.notifications_sender, tx, peer);
     }
 
     /// Timeout for sending notifications to the event loop.
@@ -739,7 +742,6 @@ impl OpManager {
     /// Construct an [`OpCtx`] for `tx`. Clones the event-loop
     /// `op_execution_sender`; the only supported way to obtain an
     /// `OpCtx` outside this crate's unit tests.
-    #[allow(dead_code)]
     pub fn op_ctx(&self, tx: Transaction) -> OpCtx {
         OpCtx::new(tx, self.to_event_listener.op_execution_sender.clone())
     }
@@ -1056,33 +1058,29 @@ async fn release_pending_op_slot_on(
     }
 }
 
-/// Non-blocking emit of `NodeEvent::TransactionCompleted(tx)` on the
-/// event-loop notification channel; returns `true` when enqueued.
+/// Non-blocking emit of `NodeEvent::TransactionOrphaned { tx, peer }` on
+/// the event-loop notification channel; returns `true` when enqueued.
 ///
-/// Extracted from [`OpManager::try_release_pending_op_slot`] so it can be
+/// Extracted from [`OpManager::notify_orphaned_transaction`] so it can be
 /// exercised in unit tests without building a full `OpManager`. Best-effort:
 /// a momentarily-full channel produces a debug-level log (benign back-
-/// pressure under load — was flooding gateways at 30K+/hr, see #4238); a
-/// closed channel produces a warn-level log (receiver torn down). Either
-/// arm leaves the parked driver to fall back to its `OPERATION_TTL`
-/// timeout (#4154).
-fn try_release_pending_op_slot_on(
+/// pressure under load — per-occurrence WARN flooded gateways at 30K+/hr,
+/// see #4238); a closed channel produces a warn-level log (receiver torn
+/// down). Either arm leaves the parked driver to fall back to its
+/// `OPERATION_TTL` timeout (#4154).
+fn notify_orphaned_transaction_on(
     notifications_sender: &mpsc::Sender<Either<NetMessage, NodeEvent>>,
     tx: Transaction,
+    peer: SocketAddr,
 ) -> bool {
-    match notifications_sender.try_send(Either::Right(NodeEvent::TransactionCompleted(tx))) {
+    match notifications_sender.try_send(Either::Right(NodeEvent::TransactionOrphaned { tx, peer }))
+    {
         Ok(()) => true,
         Err(mpsc::error::TrySendError::Full(_)) => {
-            // Benign back-pressure: the driver parks on its
-            // OPERATION_TTL fallback and the 60s sweep reclaims the
-            // slot. Per-occurrence WARN here flooded production
-            // gateways at 30K+/hr (#4238); the rate-limited
-            // `release_pending_op_slot: notification channel full for
-            // too long` error in `release_pending_op_slot_on` is the
-            // signal operators should grep for.
             tracing::debug!(
                 %tx,
-                "try_release_pending_op_slot: notification channel full; \
+                %peer,
+                "notify_orphaned_transaction: notification channel full; \
                  driver will wait for OPERATION_TTL timeout"
             );
             false
@@ -1090,7 +1088,8 @@ fn try_release_pending_op_slot_on(
         Err(mpsc::error::TrySendError::Closed(_)) => {
             tracing::warn!(
                 %tx,
-                "try_release_pending_op_slot: notification channel closed; \
+                %peer,
+                "notify_orphaned_transaction: notification channel closed; \
                  receiver likely dropped"
             );
             false
@@ -1724,21 +1723,27 @@ mod tests {
     }
 
     // ──────────────────────────────────────────────────────────
-    // Regression tests for #4154: parked drivers must be woken when
-    // their downstream peer disconnects, not wait `OPERATION_TTL`.
-    // Pre-fix, `handle_orphaned_transactions` only logged orphans and
-    // a forwarded GET blocked the full 60 s before retrying. The fix
-    // emits `TransactionCompleted(tx)` per orphan via
-    // `try_release_pending_op_slot_on`, the event loop drops the
-    // matching `pending_op_results` sender, and the driver's `recv()`
-    // returns `None` — `send_and_await` maps that to
-    // `OpError::NotificationError` and the retry loop advances.
+    // Regression tests for #4154/#4313: parked drivers must be woken
+    // when their awaited peer disconnects, not wait `OPERATION_TTL`,
+    // and must surface the disconnect cause rather than the
+    // FORBIDDEN_MARKER. The orphan handler emits
+    // `TransactionOrphaned { tx, peer }` per orphan via
+    // `notify_orphaned_transaction_on`; the event loop sends
+    // `WaiterReply::PeerDisconnected` into the waiter channel and then
+    // drops the sender, so the driver's `recv()` yields the cause
+    // (mapped to `OpError::PeerDisconnected`) before any close.
     // ──────────────────────────────────────────────────────────
 
+    fn test_peer() -> SocketAddr {
+        "203.0.113.7:9999"
+            .parse()
+            .expect("test peer addr must be valid")
+    }
+
     #[tokio::test]
-    async fn try_release_pending_op_slot_emits_transaction_completed() {
+    async fn notify_orphaned_transaction_emits_transaction_orphaned() {
         // Happy path: the standalone helper enqueues exactly one
-        // `TransactionCompleted(tx)` on the notification channel.
+        // `TransactionOrphaned { tx, peer }` on the notification channel.
         let (receiver, notifier) = event_loop_notification_channel();
         let EventLoopNotificationsReceiver {
             mut notifications_receiver,
@@ -1746,27 +1751,33 @@ mod tests {
         } = receiver;
 
         let tx = Transaction::ttl_transaction();
+        let peer = test_peer();
 
-        let delivered = super::try_release_pending_op_slot_on(notifier.notifications_sender(), tx);
+        let delivered =
+            super::notify_orphaned_transaction_on(notifier.notifications_sender(), tx, peer);
         assert!(delivered, "helper must enqueue on a live channel");
 
         let received = timeout(Duration::from_millis(100), notifications_receiver.recv())
             .await
-            .expect("timed out waiting for TransactionCompleted emission")
+            .expect("timed out waiting for TransactionOrphaned emission")
             .expect("notification channel closed");
 
         match received {
-            Either::Right(NodeEvent::TransactionCompleted(observed)) => {
-                assert_eq!(observed, tx, "emitted tx must match the argument");
+            Either::Right(NodeEvent::TransactionOrphaned {
+                tx: observed_tx,
+                peer: observed_peer,
+            }) => {
+                assert_eq!(observed_tx, tx, "emitted tx must match the argument");
+                assert_eq!(observed_peer, peer, "emitted peer must match the argument");
             }
             other @ Either::Left(_) | other @ Either::Right(_) => {
-                panic!("expected TransactionCompleted, got {other:?}")
+                panic!("expected TransactionOrphaned, got {other:?}")
             }
         }
     }
 
     #[tokio::test]
-    async fn try_release_pending_op_slot_handles_dropped_receiver() {
+    async fn notify_orphaned_transaction_handles_dropped_receiver() {
         // Closed channel: helper must return `false` rather than panic
         // — disconnect cleanup must remain robust when the event loop
         // has already torn down (e.g. shutdown races).
@@ -1774,7 +1785,8 @@ mod tests {
         drop(receiver);
 
         let tx = Transaction::ttl_transaction();
-        let delivered = super::try_release_pending_op_slot_on(notifier.notifications_sender(), tx);
+        let delivered =
+            super::notify_orphaned_transaction_on(notifier.notifications_sender(), tx, test_peer());
         assert!(
             !delivered,
             "helper must return false once receiver is dropped"
@@ -1782,55 +1794,69 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn orphaned_transaction_wakes_parked_pending_op_results_waiter() {
-        // End-to-end pipeline test for #4154 without standing up a full
-        // node. Reproduces the driver → notification-channel → event-
-        // loop → sender-drop → driver-wakeup sequence and asserts it
-        // completes in under 100 ms (pre-fix it would hang `OPERATION_TTL`).
+    async fn orphaned_transaction_wakes_parked_waiter_with_peer_disconnected() {
+        // End-to-end pipeline test for #4154/#4313 without standing up a
+        // full node. Reproduces the orphan-handler → notification-channel
+        // → event-loop → send-cause-then-drop-sender → driver-wakeup
+        // sequence and asserts the parked driver observes
+        // `WaiterReply::PeerDisconnected` (NOT a bare close) in under
+        // 100 ms (pre-#4154 it hung `OPERATION_TTL`; the deleted registry
+        // approach raced and surfaced the FORBIDDEN_MARKER instead).
         let (mut event_loop_receiver, notifier) = event_loop_notification_channel();
 
         // Stand in for `pending_op_results[tx] = sender` and the driver's
         // pending `recv()` on the matching receiver.
         let (response_sender, mut driver_response_rx) =
-            tokio::sync::mpsc::channel::<crate::message::NetMessage>(1);
+            tokio::sync::mpsc::channel::<crate::node::WaiterReply>(1);
         let mut pending_op_results: std::collections::HashMap<
             Transaction,
-            tokio::sync::mpsc::Sender<crate::message::NetMessage>,
+            tokio::sync::mpsc::Sender<crate::node::WaiterReply>,
         > = std::collections::HashMap::new();
         let tx = Transaction::ttl_transaction();
+        let peer = test_peer();
         pending_op_results.insert(tx, response_sender);
 
         // Trigger the wake — this is the orphan-handler path under test.
-        let delivered = super::try_release_pending_op_slot_on(notifier.notifications_sender(), tx);
+        let delivered =
+            super::notify_orphaned_transaction_on(notifier.notifications_sender(), tx, peer);
         assert!(delivered, "orphan-handler helper must enqueue notification");
 
-        // Mimic the event loop's `TransactionCompleted` arm by dropping the
-        // sender out of `pending_op_results`.
+        // Mimic the event loop's `TransactionOrphaned` arm: take the sender
+        // out and deliver the cause THROUGH the channel before it drops.
         let event = timeout(
             Duration::from_millis(100),
             event_loop_receiver.notifications_receiver.recv(),
         )
         .await
-        .expect("event loop never received TransactionCompleted")
-        .expect("notification channel closed before TransactionCompleted arrived");
+        .expect("event loop never received TransactionOrphaned")
+        .expect("notification channel closed before TransactionOrphaned arrived");
         match event {
-            Either::Right(NodeEvent::TransactionCompleted(observed)) => {
-                assert_eq!(observed, tx);
-                pending_op_results.remove(&observed);
+            Either::Right(NodeEvent::TransactionOrphaned {
+                tx: observed_tx,
+                peer: observed_peer,
+            }) => {
+                assert_eq!(observed_tx, tx);
+                assert_eq!(observed_peer, peer);
+                if let Some(sender) = pending_op_results.remove(&observed_tx) {
+                    #[allow(clippy::let_underscore_must_use)]
+                    let _ = sender.try_send(crate::node::WaiterReply::PeerDisconnected {
+                        peer: observed_peer,
+                    });
+                }
             }
             other @ Either::Left(_) | other @ Either::Right(_) => {
-                panic!("expected TransactionCompleted, got {other:?}")
+                panic!("expected TransactionOrphaned, got {other:?}")
             }
         }
 
-        // The driver's `recv()` must now resolve to `None` immediately —
+        // The driver's `recv()` must now resolve to the cause immediately —
         // pre-fix this hung the full `OPERATION_TTL`. Cap at 100 ms.
         let driver_wakeup = timeout(Duration::from_millis(100), driver_response_rx.recv()).await;
         match driver_wakeup {
-            Ok(None) => {
-                // Channel closed, driver wakes with `Err(NotificationError)` — correct.
+            Ok(Some(crate::node::WaiterReply::PeerDisconnected { peer: observed })) => {
+                assert_eq!(observed, peer, "driver must receive the disconnect cause");
             }
-            Ok(Some(msg)) => panic!("driver received unexpected message: {msg:?}"),
+            Ok(other) => panic!("driver received unexpected item: {other:?}"),
             Err(_) => panic!(
                 "driver did not wake after orphan handling — \
                  pre-#4154 behavior reproduced"
@@ -2062,7 +2088,7 @@ mod tests {
     // ──────────────────────────────────────────────────────────
 
     #[tokio::test]
-    async fn try_release_pending_op_slot_full_does_not_emit_warn() {
+    async fn notify_orphaned_transaction_full_does_not_emit_warn() {
         // #4238 regression pin: per-occurrence Full must NOT emit a
         // WARN. Pre-fix this fired 30K+/hr on nova; post-fix the
         // helper logs at DEBUG and a WARN-level subscriber sees
@@ -2094,11 +2120,12 @@ mod tests {
         }
 
         let tx = Transaction::ttl_transaction();
-        let delivered = super::try_release_pending_op_slot_on(notifier.notifications_sender(), tx);
+        let delivered =
+            super::notify_orphaned_transaction_on(notifier.notifications_sender(), tx, test_peer());
         assert!(!delivered, "helper must return false on a full channel");
 
         assert!(
-            !logger.contains("try_release_pending_op_slot: notification channel full"),
+            !logger.contains("notify_orphaned_transaction: notification channel full"),
             "Full arm must not emit WARN (would re-spam gateways at 30K+/hr — #4238); \
              captured: {:?}",
             logger.logs()
@@ -2106,7 +2133,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn try_release_pending_op_slot_closed_still_emits_warn() {
+    async fn notify_orphaned_transaction_closed_still_emits_warn() {
         // #4238 inverse: the Closed arm is genuinely abnormal
         // (receiver torn down) and MUST stay at WARN even after the
         // Full-arm downgrade.
@@ -2119,11 +2146,12 @@ mod tests {
         drop(receiver);
 
         let tx = Transaction::ttl_transaction();
-        let delivered = super::try_release_pending_op_slot_on(notifier.notifications_sender(), tx);
+        let delivered =
+            super::notify_orphaned_transaction_on(notifier.notifications_sender(), tx, test_peer());
         assert!(!delivered, "helper must return false on a closed channel");
 
         assert!(
-            logger.contains("try_release_pending_op_slot: notification channel closed"),
+            logger.contains("notify_orphaned_transaction: notification channel closed"),
             "Closed arm must still emit WARN — receiver-dropped is not benign back-pressure; \
              captured: {:?}",
             logger.logs()

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -87,6 +87,13 @@ pub(crate) enum OpError {
     },
     #[error("failed notifying, channel closed")]
     NotificationError,
+    /// The peer this op was awaiting was pruned before sending its terminal
+    /// reply (#4313). Delivered through the waiter channel by the
+    /// `TransactionOrphaned` handler. Routes to the generic advance arm in
+    /// `drive_retry_loop` (the peer is gone — do not infra-retry it), unlike
+    /// `NotificationError` which infra-retries the same peer.
+    #[error("awaited peer {peer} disconnected before replying")]
+    PeerDisconnected { peer: std::net::SocketAddr },
     #[error("notification channel error: {0}")]
     NotificationChannelError(String),
     #[allow(dead_code)]

--- a/crates/core/src/operations/connect/op_ctx_task.rs
+++ b/crates/core/src/operations/connect/op_ctx_task.rs
@@ -31,7 +31,7 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 
 use crate::message::{NetMessage, NetMessageV1, NodeEvent, Transaction};
-use crate::node::OpManager;
+use crate::node::{OpManager, WaiterReply};
 use crate::operations::OpError;
 use crate::ring::{ConnectionFailureReason, Location, PeerKeyLocation};
 use crate::tracing::NetEventLog;
@@ -257,7 +257,7 @@ async fn drive_client_connect_inner(
     desired_location: Location,
     target_connections: usize,
     started_without_address: bool,
-    mut receiver: mpsc::Receiver<NetMessage>,
+    mut receiver: mpsc::Receiver<WaiterReply>,
     op_manager: &OpManager,
 ) -> Result<(), OpError> {
     use std::collections::HashSet;
@@ -283,7 +283,19 @@ async fn drive_client_connect_inner(
         // reachable network).
         const RECV_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
         let msg = match tokio::time::timeout(RECV_POLL_INTERVAL, receiver.recv()).await {
-            Ok(Some(msg)) => msg,
+            Ok(Some(WaiterReply::Reply(msg))) => msg,
+            Ok(Some(WaiterReply::PeerDisconnected { peer })) => {
+                // The gateway we sent the CONNECT Request to was pruned
+                // mid-flight (#4313). No further Responses will arrive on
+                // this waiter; end collection with whatever was accepted.
+                tracing::debug!(
+                    %tx,
+                    %peer,
+                    accepted = accepted.len(),
+                    "connect driver: gateway disconnected mid-connect; ending reply collection"
+                );
+                break;
+            }
             Ok(None) => break,
             Err(_) => continue,
         };
@@ -893,7 +905,17 @@ async fn drive_relay_connect(
         }
 
         let msg = match tokio::time::timeout(RELAY_RECV_POLL_INTERVAL, receiver.recv()).await {
-            Ok(Some(msg)) => msg,
+            Ok(Some(WaiterReply::Reply(msg))) => msg,
+            Ok(Some(WaiterReply::PeerDisconnected { peer })) => {
+                // Downstream peer pruned mid-flight (#4313); no further
+                // re-entry replies will arrive. End the relay driver.
+                tracing::debug!(
+                    tx = %incoming_tx,
+                    %peer,
+                    "CONNECT relay: downstream peer disconnected; exiting"
+                );
+                return Ok(());
+            }
             Ok(None) => return Ok(()),
             Err(_) => continue,
         };

--- a/crates/core/src/operations/op_ctx.rs
+++ b/crates/core/src/operations/op_ctx.rs
@@ -10,7 +10,7 @@ use std::net::SocketAddr;
 use tokio::sync::mpsc;
 
 use crate::message::{MessageStats, NetMessage, Transaction};
-use crate::node::OpExecutionPayload;
+use crate::node::{OpExecutionPayload, WaiterReply};
 use crate::operations::OpError;
 
 /// Per-transaction execution context for the driver model.
@@ -160,7 +160,7 @@ impl OpCtx {
             "OpCtx::send_fire_and_forget: msg.id must match ctx.tx"
         );
 
-        let (response_sender, _response_receiver) = mpsc::channel::<NetMessage>(1);
+        let (response_sender, _response_receiver) = mpsc::channel::<WaiterReply>(1);
         // _response_receiver is dropped here. The sender stored in
         // pending_op_results becomes is_closed() == true, reclaimable by
         // the 60s sweep or an explicit release_pending_op_slot call.
@@ -189,7 +189,7 @@ impl OpCtx {
             "OpCtx::send_local_loopback: msg.id must match ctx.tx"
         );
 
-        let (response_sender, _response_receiver) = mpsc::channel::<NetMessage>(1);
+        let (response_sender, _response_receiver) = mpsc::channel::<WaiterReply>(1);
 
         self.op_execution_sender
             .send((response_sender, msg, None))
@@ -231,14 +231,14 @@ impl OpCtx {
         &mut self,
         target_addr: SocketAddr,
         msg: NetMessage,
-    ) -> Result<mpsc::Receiver<NetMessage>, OpError> {
+    ) -> Result<mpsc::Receiver<WaiterReply>, OpError> {
         debug_assert_eq!(
             msg.id(),
             &self.tx,
             "OpCtx::send_to_and_register_waiter: msg.id must match ctx.tx"
         );
 
-        let (response_sender, response_receiver) = mpsc::channel::<NetMessage>(1);
+        let (response_sender, response_receiver) = mpsc::channel::<WaiterReply>(1);
 
         self.op_execution_sender
             .send((response_sender, msg, Some(target_addr)))
@@ -286,7 +286,7 @@ impl OpCtx {
         &mut self,
         msg: NetMessage,
         capacity: usize,
-    ) -> Result<mpsc::Receiver<NetMessage>, OpError> {
+    ) -> Result<mpsc::Receiver<WaiterReply>, OpError> {
         debug_assert_eq!(
             msg.id(),
             &self.tx,
@@ -297,7 +297,7 @@ impl OpCtx {
             "OpCtx::send_and_collect_replies: capacity must be >= 1"
         );
 
-        let (response_sender, response_receiver) = mpsc::channel::<NetMessage>(capacity);
+        let (response_sender, response_receiver) = mpsc::channel::<WaiterReply>(capacity);
 
         self.op_execution_sender
             .send((response_sender, msg, None))
@@ -319,7 +319,7 @@ impl OpCtx {
         target_addr: SocketAddr,
         msg: NetMessage,
         capacity: usize,
-    ) -> Result<mpsc::Receiver<NetMessage>, OpError> {
+    ) -> Result<mpsc::Receiver<WaiterReply>, OpError> {
         debug_assert_eq!(
             msg.id(),
             &self.tx,
@@ -330,7 +330,7 @@ impl OpCtx {
             "OpCtx::send_to_and_collect_replies: capacity must be >= 1"
         );
 
-        let (response_sender, response_receiver) = mpsc::channel::<NetMessage>(capacity);
+        let (response_sender, response_receiver) = mpsc::channel::<WaiterReply>(capacity);
 
         self.op_execution_sender
             .send((response_sender, msg, Some(target_addr)))
@@ -351,29 +351,42 @@ impl OpCtx {
             "OpCtx::send_and_await: msg.id must match ctx.tx"
         );
 
-        let (response_sender, mut response_receiver) = mpsc::channel::<NetMessage>(1);
+        let (response_sender, mut response_receiver) = mpsc::channel::<WaiterReply>(1);
 
         self.op_execution_sender
             .send((response_sender, msg, target_addr))
             .await
             .map_err(|_| OpError::NotificationError)?;
 
-        match response_receiver.recv().await {
-            Some(reply) => {
-                // Debug-only defense-in-depth. In a release build a
-                // mismatched reply tx would silently return to the
-                // caller (the reply is for a *different* transaction).
-                // That would be a correctness bug in whatever mislabeled
-                // the message in `p2p_protoc::pending_op_results`, not a
-                // failure mode of `send_and_await` itself — the assert
-                // exists to catch such bugs at development time.
+        self.recv_waiter_reply(&mut response_receiver).await
+    }
+
+    /// Await the next reply on a `pending_op_results[tx]` waiter channel.
+    ///
+    /// Single chokepoint: the `WaiterReply` enum forces every caller to
+    /// handle the terminal `PeerDisconnected` signal the prune path
+    /// delivers through the channel (#4313). On a `PeerDisconnected`
+    /// item the awaited peer was pruned mid-flight, so the driver should
+    /// advance to another route; a bare channel close with no terminal
+    /// item is a genuine teardown and falls back to `NotificationError`.
+    pub(crate) async fn recv_waiter_reply(
+        &self,
+        receiver: &mut mpsc::Receiver<WaiterReply>,
+    ) -> Result<NetMessage, OpError> {
+        match receiver.recv().await {
+            Some(WaiterReply::Reply(reply)) => {
+                // A mismatched reply tx would be a bug in the bypass
+                // layer; catch it in debug builds.
                 debug_assert_eq!(
                     reply.id(),
                     &self.tx,
-                    "OpCtx::send_and_await: reply tx must match ctx.tx"
+                    "recv_waiter_reply: reply tx must match ctx.tx"
                 );
                 Ok(reply)
             }
+            Some(WaiterReply::PeerDisconnected { peer }) => Err(OpError::PeerDisconnected { peer }),
+            // Genuine teardown with no terminal signal (executor torn
+            // down, callback dropped): pre-#4313 fallback.
             None => Err(OpError::NotificationError),
         }
     }
@@ -735,6 +748,15 @@ mod tests {
         NetMessage::V1(NetMessageV1::Aborted(tx))
     }
 
+    /// Unwrap a `WaiterReply::Reply` in collect-replies tests; panic on the
+    /// terminal `PeerDisconnected` variant (not expected on the happy path).
+    fn expect_reply(item: WaiterReply) -> NetMessage {
+        match item {
+            WaiterReply::Reply(msg) => msg,
+            other => panic!("expected WaiterReply::Reply, got: {other:?}"),
+        }
+    }
+
     /// Happy path: `send_and_await` fires an outbound message, the fake
     /// executor reads it, replies with a terminal message keyed by the
     /// same tx, and `send_and_await` returns `Ok(reply)`.
@@ -772,7 +794,7 @@ mod tests {
                 "send_and_await should not specify a target"
             );
             reply_sender
-                .try_send(dummy_reply_with_tx(tx))
+                .try_send(WaiterReply::Reply(dummy_reply_with_tx(tx)))
                 .expect("capacity-1 reply channel should accept the first send");
         });
 
@@ -833,7 +855,7 @@ mod tests {
                  through the op execution channel (regression for #3838)"
             );
             reply_sender
-                .try_send(dummy_reply_with_tx(tx))
+                .try_send(WaiterReply::Reply(dummy_reply_with_tx(tx)))
                 .expect("capacity-1 reply channel should accept the first send");
         });
 
@@ -1195,7 +1217,7 @@ mod tests {
                 .await
                 .expect("first outbound delivered");
             reply_sender_1
-                .try_send(dummy_reply_with_tx(tx))
+                .try_send(WaiterReply::Reply(dummy_reply_with_tx(tx)))
                 .expect("first reply accepted");
 
             // Second outbound: hold `reply_sender_2` alive — do NOT
@@ -1386,7 +1408,7 @@ mod tests {
             );
             for _ in 0..3 {
                 reply_sender
-                    .try_send(dummy_reply_with_tx(tx))
+                    .try_send(WaiterReply::Reply(dummy_reply_with_tx(tx)))
                     .expect("capacity-N reply channel should accept all sends within capacity");
             }
             // Hold reply_sender to keep the channel open while the caller drains.
@@ -1410,7 +1432,7 @@ mod tests {
             let reply = timeout(Duration::from_secs(1), rx.recv())
                 .await
                 .unwrap_or_else(|_| panic!("recv #{i} should yield buffered reply"));
-            let reply = reply.unwrap_or_else(|| panic!("recv #{i} returned None"));
+            let reply = expect_reply(reply.unwrap_or_else(|| panic!("recv #{i} returned None")));
             assert_eq!(reply.id(), &tx, "reply #{i} tx must match ctx tx");
         }
     }
@@ -1446,7 +1468,7 @@ mod tests {
                 "send_to_and_collect_replies must propagate target_addr"
             );
             reply_sender
-                .try_send(dummy_reply_with_tx(tx))
+                .try_send(WaiterReply::Reply(dummy_reply_with_tx(tx)))
                 .expect("capacity-N channel accepts first send");
             reply_sender
         });
@@ -1464,10 +1486,12 @@ mod tests {
             .await
             .expect("executor task should complete without panicking");
 
-        let reply = timeout(Duration::from_secs(1), rx.recv())
-            .await
-            .expect("recv should yield buffered reply")
-            .expect("recv returned None");
+        let reply = expect_reply(
+            timeout(Duration::from_secs(1), rx.recv())
+                .await
+                .expect("recv should yield buffered reply")
+                .expect("recv returned None"),
+        );
         assert_eq!(reply.id(), &tx);
     }
 
@@ -1493,7 +1517,7 @@ mod tests {
                 .await
                 .expect("outbound msg should be delivered");
             reply_sender
-                .try_send(dummy_reply_with_tx(tx))
+                .try_send(WaiterReply::Reply(dummy_reply_with_tx(tx)))
                 .expect("capacity-1 channel accepts first send");
             reply_sender
         });
@@ -1506,7 +1530,112 @@ mod tests {
 
         let _reply_sender = executor.await.expect("executor task should complete");
 
-        let reply = rx.recv().await.expect("first recv should yield reply");
+        let reply = expect_reply(rx.recv().await.expect("first recv should yield reply"));
         assert_eq!(reply.id(), &tx);
+    }
+
+    /// A `WaiterReply::Reply` item resolves to the carried `NetMessage`.
+    #[tokio::test]
+    async fn recv_waiter_reply_returns_reply_on_reply_item() {
+        let (_receiver, sender) = event_loop_notification_channel();
+        let tx = Transaction::new::<ConnectMsg>();
+        let ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+
+        let (waiter_sender, mut rx) = mpsc::channel::<WaiterReply>(1);
+        waiter_sender
+            .try_send(WaiterReply::Reply(dummy_reply_with_tx(tx)))
+            .expect("capacity-1 channel accepts first send");
+
+        let reply = ctx
+            .recv_waiter_reply(&mut rx)
+            .await
+            .expect("Reply item must resolve to Ok");
+        assert_eq!(reply.id(), &tx);
+    }
+
+    /// A `WaiterReply::PeerDisconnected` item (the prune signal) surfaces as
+    /// `OpError::PeerDisconnected` carrying the peer — NOT the FORBIDDEN_MARKER
+    /// (#4313). Delivering it before the sender drops is what makes this
+    /// deterministic; see the concurrency regression below.
+    #[tokio::test]
+    async fn recv_waiter_reply_returns_peer_disconnected_signal() {
+        let (_receiver, sender) = event_loop_notification_channel();
+        let tx = Transaction::new::<ConnectMsg>();
+        let ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+        let peer: SocketAddr = "1.2.3.4:5678"
+            .parse()
+            .expect("test peer addr must be valid");
+
+        // Deliver the cause, then drop the sender — mirrors the
+        // `TransactionOrphaned` handler's send-before-drop.
+        let (waiter_sender, mut rx) = mpsc::channel::<WaiterReply>(1);
+        waiter_sender
+            .try_send(WaiterReply::PeerDisconnected { peer })
+            .expect("capacity-1 channel accepts first send");
+        drop(waiter_sender);
+
+        let err = ctx
+            .recv_waiter_reply(&mut rx)
+            .await
+            .expect_err("PeerDisconnected item must surface as Err");
+        assert!(
+            matches!(err, OpError::PeerDisconnected { peer: p } if p == peer),
+            "expected PeerDisconnected({peer}), got: {err:?}"
+        );
+    }
+
+    /// A bare channel close with no terminal item is a genuine teardown
+    /// and falls back to `NotificationError` (pre-#4313 semantics).
+    #[tokio::test]
+    async fn recv_waiter_reply_falls_back_to_notification_error_on_bare_close() {
+        let (_receiver, sender) = event_loop_notification_channel();
+        let tx = Transaction::new::<ConnectMsg>();
+        let ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+
+        let (waiter_sender, mut rx) = mpsc::channel::<WaiterReply>(1);
+        drop(waiter_sender);
+
+        let err = ctx
+            .recv_waiter_reply(&mut rx)
+            .await
+            .expect_err("closed channel must surface as Err");
+        assert!(
+            matches!(err, OpError::NotificationError),
+            "expected NotificationError fallback, got: {err:?}"
+        );
+    }
+
+    /// #4313 regression: the prune path delivers `PeerDisconnected` through
+    /// the channel BEFORE dropping the sender, so a parked driver reads it
+    /// deterministically even under multi-thread scheduling. The deleted
+    /// orphan-cause registry approach raced a `drop_entry` against this
+    /// `recv` and lost ~99.99% of the time, surfacing the FORBIDDEN_MARKER.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn parked_driver_always_observes_peer_disconnected_under_churn() {
+        let (_receiver, sender) = event_loop_notification_channel();
+        let peer: SocketAddr = "9.9.9.9:9999".parse().expect("valid addr");
+
+        for _ in 0..2_000 {
+            let tx = Transaction::new::<ConnectMsg>();
+            let ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+            let (waiter_sender, mut rx) = mpsc::channel::<WaiterReply>(1);
+
+            let driver = tokio::spawn(async move { ctx.recv_waiter_reply(&mut rx).await });
+
+            // Let the driver actually park on recv() before the wake.
+            tokio::task::yield_now().await;
+
+            // Production handler order: send the cause, THEN drop the sender.
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = waiter_sender.try_send(WaiterReply::PeerDisconnected { peer });
+            drop(waiter_sender);
+
+            match driver.await.expect("driver task panicked") {
+                Err(OpError::PeerDisconnected { peer: observed }) => {
+                    assert_eq!(observed, peer);
+                }
+                other => panic!("expected PeerDisconnected, got: {other:?}"),
+            }
+        }
     }
 }

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -32,6 +32,7 @@ use crate::config::{GlobalExecutor, OPERATION_TTL};
 use crate::message::{NetMessage, NetMessageV1, Transaction};
 use crate::node::NetworkBridge;
 use crate::node::OpManager;
+use crate::node::WaiterReply;
 use crate::operations::OpError;
 use crate::operations::op_ctx::{
     AdvanceOutcome, AttemptOutcome, OpCtx, RetryDriver, RetryLoopOutcome, drive_retry_loop,
@@ -1306,7 +1307,10 @@ where
         }
 
         tokio::time::timeout(OPERATION_TTL, async move {
-            reply_rx.recv().await.ok_or(OpError::NotificationError)
+            // Route through `recv_waiter_reply` so a `PeerDisconnected`
+            // signal on the waiter channel surfaces as the matching
+            // `OpError` instead of a bare close (#4313).
+            ctx.recv_waiter_reply(&mut reply_rx).await
         })
         .await
     } else {
@@ -2131,12 +2135,12 @@ where
     // `handle_pure_network_message_v1` before the waiter installs —
     // `try_forward_driver_reply` would drop the reply as
     // OpNotPresent and the driver would hang until `OPERATION_TTL`.
-    let downstream_reply_rx: Option<(SocketAddr, tokio::sync::mpsc::Receiver<NetMessage>)> =
+    let downstream_reply_rx: Option<(SocketAddr, tokio::sync::mpsc::Receiver<WaiterReply>)> =
         if let Some((next_addr, metadata_net, outbound_sid, forked_handle, embedded_metadata)) =
             piping
         {
             let mut ctx = op_manager.op_ctx(incoming_tx);
-            let rx_opt: Option<tokio::sync::mpsc::Receiver<NetMessage>> = match ctx
+            let rx_opt: Option<tokio::sync::mpsc::Receiver<WaiterReply>> = match ctx
                 .send_to_and_register_waiter(next_addr, metadata_net)
                 .await
             {
@@ -2235,12 +2239,23 @@ where
     // these into the local Router lets the failure-probability model
     // learn from forwarded traffic, not just originator-side ops.
     if let Some((next_addr, mut rx)) = downstream_reply_rx {
-        let reply = match tokio::time::timeout(OPERATION_TTL, rx.recv()).await {
-            Ok(Some(reply)) => reply,
-            Ok(None) => {
+        // Route through `recv_waiter_reply` so a `PeerDisconnected` signal
+        // delivered by `handle_orphaned_transactions` surfaces as the
+        // matching `OpError` (mapped to the downstream-failure arm below)
+        // rather than a bare channel close (#4313).
+        let ctx_for_recv = op_manager.op_ctx(incoming_tx);
+        let reply = match tokio::time::timeout(
+            OPERATION_TTL,
+            ctx_for_recv.recv_waiter_reply(&mut rx),
+        )
+        .await
+        {
+            Ok(Ok(reply)) => reply,
+            Ok(Err(err)) => {
                 tracing::warn!(
                     tx = %incoming_tx,
                     target = %next_addr,
+                    error = %err,
                     "PUT streaming relay: downstream reply channel closed before reply"
                 );
                 if let Some(ref peer) = next_hop {

--- a/crates/core/tests/error_notification.rs
+++ b/crates/core/tests/error_notification.rs
@@ -745,8 +745,11 @@ async fn test_connection_drop_error_notification() -> anyhow::Result<()> {
 
         client.send(put_request).await?;
 
-        // Give the PUT a moment to start processing
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        // Drop the peer almost immediately so the PUT is still in flight at
+        // prune time — that is what exercises the orphan-wake path (#4313).
+        // A long pre-drop sleep lets the PUT complete first, leaving the
+        // orphan path untested.
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
         // Now forcibly drop the peer connection
         info!("Dropping peer connection to simulate network failure...");
@@ -756,16 +759,33 @@ async fn test_connection_drop_error_notification() -> anyhow::Result<()> {
         tokio::time::sleep(Duration::from_secs(2)).await;
 
         // The PUT may or may not succeed depending on timing, but we should get SOME response
-        // The key is that we don't hang indefinitely
+        // The key is that we don't hang indefinitely.
         info!("Waiting for response after connection drop...");
         let response_result = timeout(Duration::from_secs(30), client.recv()).await;
 
+        // Whatever response (or error) the client gets, it MUST NOT carry the
+        // FORBIDDEN_MARKER: an orphan-wake closing the waiter channel must
+        // surface `PeerDisconnected`, never the bare "channel closed" string
+        // (#4313). Pre-fix, a prune racing the terminal reply leaked this.
+        const FORBIDDEN_MARKER: &str = "failed notifying, channel closed";
         match response_result {
             Ok(Ok(response)) => {
+                let rendered = format!("{response:?}");
+                assert!(
+                    !rendered.contains(FORBIDDEN_MARKER),
+                    "connection-drop response leaked the orphan-wake marker \
+                     ({FORBIDDEN_MARKER:?}). Response was: {rendered}"
+                );
                 info!("✓ Received response after connection drop: {:?}", response);
                 info!("✓ Client properly handled connection drop scenario");
             }
             Ok(Err(e)) => {
+                let rendered = e.to_string();
+                assert!(
+                    !rendered.contains(FORBIDDEN_MARKER),
+                    "connection-drop error leaked the orphan-wake marker \
+                     ({FORBIDDEN_MARKER:?}). Error was: {rendered}"
+                );
                 info!("✓ Received error notification after connection drop: {}", e);
                 info!("✓ Client properly notified of connection issues");
             }


### PR DESCRIPTION
## Problem

Under connection churn, prune_connection produces orphaned transactions
(ops whose awaited downstream peer just disconnected). The prune path woke
each parked driver by *closing* its pending_op_results[tx] waiter channel.
The originator, parked in OpCtx::send_and_await -> recv(), saw the close
(None) and returned OpError::NotificationError, whose Display is the
"failed notifying, channel closed" FORBIDDEN_MARKER that
tests/error_notification.rs asserts must never reach a client. This is the
low-rate flake in test_put_error_notification* / test_put_error_*.

## Solution

Carry the disconnect cause through the waiter channel itself, so the close
*delivers* the reason instead of relying on a bare channel close that
collapses every teardown into NotificationError.

- The waiter channel item changes from NetMessage to
  WaiterReply { Reply(NetMessage), PeerDisconnected { peer } }.
- New NodeEvent::TransactionOrphaned { tx, peer }. Its event-loop handler
  takes the sender out of pending_op_results, try_sends
  WaiterReply::PeerDisconnected { peer }, *then* drops the sender.
- Key insight: tokio mpsc delivers a buffered item before the channel reads
  None, so the parked driver observes PeerDisconnected deterministically
  (send-before-drop). No side registry, no race.
- recv_waiter_reply is extracted from the inline recv in send_and_await as
  the single chokepoint; the WaiterReply enum makes the compiler force every
  recv site -- including the CONNECT and PUT relays -- to handle
  PeerDisconnected.
- New OpError::PeerDisconnected { peer } (added alongside the unchanged
  NotificationError). It routes to the generic *advance* arm in
  drive_retry_loop (the peer is gone -- try the next route), not the
  same-peer infra-retry that NotificationError uses.
- The #4154 orphan-wake emitter try_release_pending_op_slot[_on] is renamed
  to notify_orphaned_transaction[_on] and enhanced to carry the peer; its
  #4154/#4238 behavior (best-effort try_send, Full->DEBUG, Closed->WARN) is
  preserved. The prior wake reused NodeEvent::TransactionCompleted, which
  only dropped the sender; this replaces it with the dedicated
  TransactionOrphaned event that carries the cause through the channel.

This removes the failure class structurally rather than narrowing a race
window.

## Testing

- Concurrency stress -- parked_driver_always_observes_peer_disconnected_under_churn
  (op_ctx, multi-thread, 2 workers, 2000 iterations): pins the load-bearing
  tokio buffered-item-before-None property by driving the post-fix
  send-before-drop order against a parked driver. (It pins the channel
  property, not the production prune->handler sequence -- that ordering is
  guarded by the source-scrape pin below.)
- Chokepoint behaviour (op_ctx): recv_waiter_reply_returns_reply_on_reply_item,
  recv_waiter_reply_returns_peer_disconnected_signal,
  recv_waiter_reply_falls_back_to_notification_error_on_bare_close.
- End-to-end at op-state level (op_state_manager):
  orphaned_transaction_wakes_parked_waiter_with_peer_disconnected, plus
  ported #4154/#4238 guards (notify_orphaned_transaction_emits_transaction_orphaned,
  _handles_dropped_receiver, _full_does_not_emit_warn, _closed_still_emits_warn).
- Source-scrape pins (p2p_protoc):
  transaction_orphaned_handler_sends_cause_before_dropping_sender (guards the
  send-before-drop order the type system can't),
  handle_orphaned_transactions_wakes_parked_drivers.
- CONNECT arms (connect/op_ctx_task): both_connect_drivers_handle_peer_disconnected
  pins the explicit PeerDisconnected arm in both connect drivers (they
  pattern-match WaiterReply inline rather than via the recv_waiter_reply
  chokepoint).
- Integration: test_connection_drop_error_notification asserts the response
  carries no FORBIDDEN_MARKER and drops the peer at 50 ms so the PUT is in
  flight at prune time. It warns (not fails) when timing makes the run
  vacuous, since it is a real-network test with no mocked time.
- .claude/rules/operations.md updated to document the channel-carried design.

## Fixes

Closes #4313.
