### PR TITLE
fix(get): fall back to configured gateways when the ring is empty

### DIFF
--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -285,7 +285,23 @@ async fn drive_client_get_inner(
             }
             peer
         }
-        None => op_manager.ring.connection_manager.own_location(),
+        // Bootstrap fallback (#4361): with an empty ring, attribute the
+        // attempt to a configured gateway — the loopback relay's own
+        // fallback forwards there, so the gateway IS the real first hop.
+        // `own_location()` (below) remains only for the genuinely
+        // isolated case (no ring, no gateways).
+        None => match bootstrap_gateway_target(op_manager, |addr| tried.contains(&addr)) {
+            Some((gw, addr)) => {
+                tracing::info!(
+                    %instance_id,
+                    gateway = %addr,
+                    "GET client: ring empty — initial target falls back to configured gateway"
+                );
+                tried.push(addr);
+                gw
+            }
+            None => op_manager.ring.connection_manager.own_location(),
+        },
     };
 
     let mut driver = GetRetryDriver {
@@ -577,14 +593,22 @@ async fn drive_client_get_inner(
 
             Ok(DriverOutcome::Publish(host_result))
         }
-        RetryLoopOutcome::Exhausted(_cause) => {
+        RetryLoopOutcome::Exhausted(cause) => {
             // Exhaustion after retry loop means every peer either responded
             // NotFound or the operation could not be forwarded at all
             // (e.g., isolated gateway with zero ring connections). Surface
             // as `ContractResponse::NotFound` so client integrations
             // (`fdev`, `apps/freenet-ping`, integration tests) can
             // distinguish "contract genuinely absent" from "operation
-            // failed".
+            // failed". Log the cause — silently discarding it made the
+            // empty-ring bootstrap failure invisible (#4361).
+            tracing::info!(
+                tx = %client_tx,
+                %instance_id,
+                ring_connections = op_manager.ring.connection_manager.connection_count(),
+                %cause,
+                "GET client: retry loop exhausted — returning NotFound to client"
+            );
             Ok(DriverOutcome::Publish(Ok(HostResponse::ContractResponse(
                 freenet_stdlib::client_api::ContractResponse::NotFound { instance_id },
             ))))
@@ -1122,6 +1146,63 @@ async fn lookup_stored_key(
 /// touch unrelated code paths.
 const MAX_RETRIES: usize = 3;
 
+/// Pure selection core for the bootstrap gateway fallback (#4361).
+///
+/// Returns the first configured gateway that is not this node and not
+/// excluded by the caller's skip predicate — but ONLY when the ring is
+/// empty (`ring_connection_count == 0`). A non-empty ring means normal
+/// routing had candidates and exhaustion is genuine, so the fallback
+/// must stay out of the way.
+///
+/// Split out from [`bootstrap_gateway_target`] so unit tests can
+/// exercise the selection rules without constructing an `OpManager`.
+fn select_bootstrap_gateway(
+    ring_connection_count: usize,
+    configured_gateways: &[PeerKeyLocation],
+    own_addr: Option<SocketAddr>,
+    is_excluded: impl Fn(SocketAddr) -> bool,
+) -> Option<(PeerKeyLocation, SocketAddr)> {
+    if ring_connection_count > 0 {
+        return None;
+    }
+    configured_gateways.iter().find_map(|gw| {
+        let addr = gw.socket_addr()?;
+        if Some(addr) == own_addr || is_excluded(addr) {
+            return None;
+        }
+        Some((gw.clone(), addr))
+    })
+}
+
+/// Bootstrap gateway fallback (#4361).
+///
+/// A node whose ring is still empty (`connections_by_location` has no
+/// entries) has zero routing candidates, so without a fallback every
+/// GET fails instantly with NotFound — even though the node has a live
+/// transient transport connection to its gateway (the same connection
+/// its CONNECT handshake is negotiating over). Production analog: a
+/// freshly started node fails all GETs for its first minutes until
+/// ring promotion completes.
+///
+/// When the ring is empty, fall back to a configured gateway. Wire
+/// delivery works before ring promotion: the event loop's
+/// `OutboundMessageWithTarget` handler resolves targets by socket addr
+/// against the transport map (which includes transient connections)
+/// and re-dials configured gateways if the transport lapsed. Mirrors
+/// the #3219 zero-connection CONNECT re-bootstrap shape, which gates
+/// on the same `connection_count() == 0` condition.
+fn bootstrap_gateway_target(
+    op_manager: &OpManager,
+    is_excluded: impl Fn(SocketAddr) -> bool,
+) -> Option<(PeerKeyLocation, SocketAddr)> {
+    select_bootstrap_gateway(
+        op_manager.ring.connection_manager.connection_count(),
+        &op_manager.configured_gateways,
+        op_manager.ring.connection_manager.get_own_addr(),
+        is_excluded,
+    )
+}
+
 fn advance_to_next_peer(
     op_manager: &OpManager,
     instance_id: &ContractInstanceId,
@@ -1133,12 +1214,49 @@ fn advance_to_next_peer(
     }
     *retries += 1;
 
-    let peer = op_manager
+    let peer = match op_manager
         .ring
         .k_closest_potentially_hosting(instance_id, tried.as_slice(), 1)
         .into_iter()
-        .next()?;
-    let addr = peer.socket_addr()?;
+        .next()
+    {
+        Some(peer) => peer,
+        None => {
+            // Bootstrap fallback (#4361): empty ring → route via a
+            // configured gateway instead of silently exhausting.
+            return match bootstrap_gateway_target(op_manager, |addr| tried.contains(&addr)) {
+                Some((gw, addr)) => {
+                    tracing::info!(
+                        %instance_id,
+                        gateway = %addr,
+                        "GET advance: ring empty — falling back to configured gateway"
+                    );
+                    tried.push(addr);
+                    Some((gw, addr))
+                }
+                None => {
+                    tracing::debug!(
+                        %instance_id,
+                        tried = tried.len(),
+                        retries = *retries,
+                        "GET advance: no routing candidates — exhausted"
+                    );
+                    None
+                }
+            };
+        }
+    };
+    let Some(addr) = peer.socket_addr() else {
+        // Should not happen — `k_closest_potentially_hosting` can return
+        // addressless candidates (ring.rs pushes them past the addr-gated
+        // filters), and an addressless pick is unusable as a wire target.
+        tracing::warn!(
+            %instance_id,
+            peer = ?peer,
+            "GET advance: selected routing candidate has no socket address — treating as exhausted"
+        );
+        return None;
+    };
     tried.push(addr);
     Some((peer, addr))
 }
@@ -1389,7 +1507,21 @@ async fn drive_sub_op_get(
             }
             peer
         }
-        None => op_manager.ring.connection_manager.own_location(),
+        // Bootstrap fallback (#4361) — same rationale as the client
+        // driver's initial pick: sub-op GETs (auto-fetch, related-contract
+        // fetches) hit the same empty-ring blind spot during bootstrap.
+        None => match bootstrap_gateway_target(op_manager, |addr| tried.contains(&addr)) {
+            Some((gw, addr)) => {
+                tracing::info!(
+                    %instance_id,
+                    gateway = %addr,
+                    "GET sub-op: ring empty — initial target falls back to configured gateway"
+                );
+                tried.push(addr);
+                gw
+            }
+            None => op_manager.ring.connection_manager.own_location(),
+        },
     };
 
     let mut driver = GetRetryDriver {
@@ -1871,14 +2003,61 @@ fn relay_advance_to_next_peer(
 
     // Use new_visited as the skip list so upstream's visited set and our own
     // marks are both respected.
-    let peer = op_manager
+    let peer = match op_manager
         .ring
         .k_closest_potentially_hosting(instance_id, new_visited.clone(), 1)
         .into_iter()
-        .next()?;
-    let addr = peer.socket_addr()?;
+        .next()
+    {
+        Some(peer) => peer,
+        None => {
+            // Bootstrap fallback (#4361): empty ring → forward via a
+            // configured gateway instead of silently exhausting. Respects
+            // both the request's visited bloom (cross-hop loop prevention —
+            // a gateway the request already traversed is never re-picked)
+            // and `tried` (exact local exclusion). Stays within
+            // MAX_RELAY_RETRIES, so the 3^HTL fan-out guard above is
+            // unaffected.
+            return match bootstrap_gateway_target(op_manager, |addr| {
+                tried.contains(&addr) || new_visited.probably_visited(addr)
+            }) {
+                Some((gw, addr)) => {
+                    tracing::info!(
+                        %instance_id,
+                        gateway = %addr,
+                        "GET relay advance: ring empty — forwarding to configured gateway"
+                    );
+                    tried.push(addr);
+                    Some((gw, addr))
+                }
+                None => {
+                    tracing::debug!(
+                        %instance_id,
+                        "GET relay advance: no routing candidates — exhausted"
+                    );
+                    None
+                }
+            };
+        }
+    };
+    let Some(addr) = peer.socket_addr() else {
+        // Should not happen — see the matching guard in
+        // `advance_to_next_peer` for why addressless candidates can leak
+        // out of `k_closest_potentially_hosting`.
+        tracing::warn!(
+            %instance_id,
+            peer = ?peer,
+            "GET relay advance: selected routing candidate has no socket address — treating as exhausted"
+        );
+        return None;
+    };
     // Double-check against tried (exact exclusion, no bloom false positives).
     if tried.contains(&addr) {
+        tracing::debug!(
+            %instance_id,
+            peer = %addr,
+            "GET relay advance: candidate already tried — exhausted"
+        );
         return None;
     }
     tried.push(addr);
@@ -2905,6 +3084,124 @@ mod tests {
             "the ClientOpGuard must be moved into the spawned future \
              via `let _inflight_guard = inflight_guard;`."
         );
+    }
+
+    // --- Bootstrap gateway fallback (#4361) ---
+
+    fn gw(port: u16) -> PeerKeyLocation {
+        let key = crate::transport::TransportPublicKey::from_bytes([port as u8; 32]);
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        PeerKeyLocation::new(key, addr)
+    }
+
+    /// Regression for #4361: a node with an empty ring but configured
+    /// gateways must select a gateway instead of exhausting. Before the
+    /// fix, every GET on a freshly-bootstrapped node returned NotFound
+    /// without sending a single wire message.
+    #[test]
+    fn bootstrap_fallback_selects_gateway_when_ring_empty() {
+        let gateway = gw(4001);
+        let selected = select_bootstrap_gateway(0, std::slice::from_ref(&gateway), None, |_| false);
+        let (peer, addr) = selected.expect("empty ring + configured gateway must select it");
+        assert_eq!(peer.socket_addr(), gateway.socket_addr());
+        assert_eq!(addr, gateway.socket_addr().unwrap());
+    }
+
+    /// The fallback must stay out of the way when the ring has ANY
+    /// connections — a non-empty ring means normal routing had its
+    /// chance and exhaustion is genuine.
+    #[test]
+    fn bootstrap_fallback_inactive_when_ring_non_empty() {
+        let gateway = gw(4001);
+        assert!(
+            select_bootstrap_gateway(1, &[gateway], None, |_| false).is_none(),
+            "fallback must not fire with ring connections present"
+        );
+    }
+
+    /// A gateway node must never select itself (self-loop guard), but
+    /// must still be able to fall back to OTHER configured gateways.
+    #[test]
+    fn bootstrap_fallback_skips_self() {
+        let gw1 = gw(4001);
+        let gw2 = gw(4002);
+        let own_addr = gw1.socket_addr();
+        let selected =
+            select_bootstrap_gateway(0, &[gw1.clone(), gw2.clone()], own_addr, |_| false);
+        let (peer, _) = selected.expect("second gateway should be selected");
+        assert_eq!(
+            peer.socket_addr(),
+            gw2.socket_addr(),
+            "self gateway must be skipped"
+        );
+        assert!(
+            select_bootstrap_gateway(0, std::slice::from_ref(&gw1), gw1.socket_addr(), |_| false)
+                .is_none(),
+            "sole self gateway must yield no fallback"
+        );
+    }
+
+    /// Already-tried/visited gateways are excluded, so retries cannot
+    /// loop on the same gateway and a request that already traversed a
+    /// gateway is never bounced back to it.
+    #[test]
+    fn bootstrap_fallback_excludes_tried_gateways() {
+        let gw1 = gw(4001);
+        let gw2 = gw(4002);
+        let tried = [gw1.socket_addr().unwrap()];
+        let selected = select_bootstrap_gateway(0, &[gw1.clone(), gw2.clone()], None, |addr| {
+            tried.contains(&addr)
+        });
+        let (peer, _) = selected.expect("untried gateway should be selected");
+        assert_eq!(peer.socket_addr(), gw2.socket_addr());
+        let all_tried = [gw1.socket_addr().unwrap(), gw2.socket_addr().unwrap()];
+        assert!(
+            select_bootstrap_gateway(0, &[gw1, gw2], None, |addr| all_tried.contains(&addr))
+                .is_none(),
+            "all gateways tried must yield no fallback"
+        );
+    }
+
+    /// Source pin (#4361): the three GET peer-selection sites — client
+    /// initial pick, client advance, relay advance — and the sub-op
+    /// initial pick must all consult `bootstrap_gateway_target` when
+    /// `k_closest_potentially_hosting` yields nothing. A refactor that
+    /// drops any of these calls silently reintroduces the empty-ring
+    /// instant-NotFound bug.
+    #[test]
+    fn all_selection_sites_use_bootstrap_gateway_fallback() {
+        let src = include_str!("op_ctx_task.rs");
+
+        for (fn_name, entry) in [
+            ("drive_client_get_inner", "async fn drive_client_get_inner"),
+            ("drive_sub_op_get", "async fn drive_sub_op_get"),
+            ("advance_to_next_peer", "fn advance_to_next_peer"),
+            (
+                "relay_advance_to_next_peer",
+                "fn relay_advance_to_next_peer",
+            ),
+        ] {
+            let start = src.find(entry).unwrap_or_else(|| {
+                panic!("{fn_name} must exist");
+            });
+            // Scan a window from the function entry to the next top-level
+            // fn (sync or async, whichever comes first); each of these
+            // functions consults the fallback within its own body.
+            let rest = &src[start + entry.len()..];
+            let next_fn = match (rest.find("\nfn "), rest.find("\nasync fn ")) {
+                (Some(a), Some(b)) => Some(a.min(b)),
+                (a, b) => a.or(b),
+            };
+            let window_end = next_fn
+                .map(|off| start + entry.len() + off)
+                .unwrap_or(src.len());
+            let body = &src[start..window_end];
+            assert!(
+                body.contains("bootstrap_gateway_target("),
+                "{fn_name} must consult bootstrap_gateway_target when \
+                 k_closest_potentially_hosting yields no candidates (#4361)"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -770,15 +770,24 @@ impl RetryDriver for GetRetryDriver<'_> {
         // skips gateways that already failed and converges on the same
         // gateway the client driver selected — keeping stream claims and
         // route telemetry (both attributed via `current_target`) aligned
-        // with the actual wire hop. Gated on the empty-ring case so
-        // normal-path retry routing semantics are unchanged.
+        // with the actual wire hop.
+        //
+        // The carried bloom travels the attempt's entire forward path, so
+        // a failed gateway is excluded at every hop of that attempt, not
+        // only at the loopback relay — bounded (empty-ring originators,
+        // <= MAX_RETRIES attempts) and re-keyed each retry.
+        //
+        // Gated on the empty-ring case so normal-path retry routing
+        // semantics are unchanged. The gate re-reads `connection_count()`
+        // and can race ring promotion between attempts; both directions
+        // degrade to a single wasted or spuriously-failed attempt (never
+        // a loop or hang) — see the #4364 review for the trace.
         if self.op_manager.ring.connection_manager.connection_count() == 0 {
-            let current_addr = self.current_target.socket_addr();
-            for addr in &self.tried {
-                if Some(*addr) != current_addr {
-                    self.attempt_visited.mark_visited(*addr);
-                }
-            }
+            carry_tried_into_visited(
+                &mut self.attempt_visited,
+                &self.tried,
+                self.current_target.socket_addr(),
+            );
         }
         tx
     }
@@ -1204,6 +1213,28 @@ fn select_bootstrap_gateway(
         }
         Some((gw.clone(), addr))
     })
+}
+
+/// Carry the client driver's tried set into a fresh attempt's visited
+/// bloom, excluding the attempt's intended destination (#4361 / #4364
+/// review H1). Split out so unit tests can pin the exclusion behavior
+/// without constructing an `OpManager`:
+///
+/// - dropping the carry entirely resurrects the "failover never reaches
+///   the wire" bug (the per-attempt loopback relay re-picks the first
+///   configured gateway forever);
+/// - dropping the current-target exclusion makes single-gateway retries
+///   exhaust instantly (the relay would skip the client's own pick).
+fn carry_tried_into_visited(
+    visited: &mut VisitedPeers,
+    tried: &[SocketAddr],
+    current_target_addr: Option<SocketAddr>,
+) {
+    for addr in tried {
+        if Some(*addr) != current_target_addr {
+            visited.mark_visited(*addr);
+        }
+    }
 }
 
 /// Bootstrap gateway fallback (#4361).
@@ -3203,43 +3234,28 @@ mod tests {
         );
     }
 
-    /// Source pin (#4361): the three GET peer-selection sites — client
-    /// initial pick, client advance, relay advance — and the sub-op
-    /// initial pick must all consult `bootstrap_gateway_target` when
+    /// Source pin (#4361): the GET peer-selection sites — client
+    /// initial pick, sub-op initial pick, client advance, relay advance —
+    /// must all consult `bootstrap_gateway_target` when
     /// `k_closest_potentially_hosting` yields nothing. A refactor that
     /// drops any of these calls silently reintroduces the empty-ring
-    /// instant-NotFound bug.
+    /// instant-NotFound bug. Uses `extract_fn_body` (brace-matched) so
+    /// the pins cannot false-pass on neighboring code or false-fail on
+    /// comment growth.
     #[test]
     fn all_selection_sites_use_bootstrap_gateway_fallback() {
-        let src = include_str!("op_ctx_task.rs");
+        let src = production_source();
 
-        for (fn_name, entry) in [
-            ("drive_client_get_inner", "async fn drive_client_get_inner"),
-            ("drive_sub_op_get", "async fn drive_sub_op_get"),
-            ("advance_to_next_peer", "fn advance_to_next_peer"),
-            (
-                "relay_advance_to_next_peer",
-                "fn relay_advance_to_next_peer",
-            ),
+        for entry in [
+            "async fn drive_client_get_inner",
+            "async fn drive_sub_op_get",
+            "fn advance_to_next_peer",
+            "fn relay_advance_to_next_peer",
         ] {
-            let start = src.find(entry).unwrap_or_else(|| {
-                panic!("{fn_name} must exist");
-            });
-            // Scan a window from the function entry to the next top-level
-            // fn (sync or async, whichever comes first); each of these
-            // functions consults the fallback within its own body.
-            let rest = &src[start + entry.len()..];
-            let next_fn = match (rest.find("\nfn "), rest.find("\nasync fn ")) {
-                (Some(a), Some(b)) => Some(a.min(b)),
-                (a, b) => a.or(b),
-            };
-            let window_end = next_fn
-                .map(|off| start + entry.len() + off)
-                .unwrap_or(src.len());
-            let body = &src[start..window_end];
+            let body = extract_fn_body(src, entry);
             assert!(
                 body.contains("bootstrap_gateway_target("),
-                "{fn_name} must consult bootstrap_gateway_target when \
+                "{entry} must consult bootstrap_gateway_target when \
                  k_closest_potentially_hosting yields no candidates (#4361)"
             );
         }
@@ -3248,10 +3264,7 @@ mod tests {
         // request's visited bloom — dropping the `probably_visited` half
         // would silently reintroduce gateway<->relay bounce (cross-hop
         // loop prevention; testing review of #4364).
-        let relay_start = src
-            .find("fn relay_advance_to_next_peer")
-            .expect("relay_advance_to_next_peer must exist");
-        let relay_body = &src[relay_start..relay_start + 4000];
+        let relay_body = extract_fn_body(src, "fn relay_advance_to_next_peer");
         assert!(
             relay_body.contains("new_visited.probably_visited"),
             "relay_advance_to_next_peer's fallback exclusion must include \
@@ -3259,20 +3272,65 @@ mod tests {
         );
 
         // The client driver must carry its tried set into each new
-        // attempt's visited bloom (minus the current target) — without
-        // it the per-attempt loopback relay re-picks the same first
-        // gateway and multi-gateway failover never reaches the wire
-        // (skeptical review H1 on #4364).
-        let nat_start = src
-            .find("fn new_attempt_tx")
-            .expect("new_attempt_tx must exist");
-        let nat_body = &src[nat_start..nat_start + 2500];
+        // attempt's visited bloom — without it the per-attempt loopback
+        // relay re-picks the same first gateway and multi-gateway
+        // failover never reaches the wire (skeptical review H1 on
+        // #4364). The carry's exclusion semantics are behaviorally
+        // pinned by the `carry_tried_into_visited_*` tests below.
+        let nat_body = extract_fn_body(src, "fn new_attempt_tx");
         assert!(
-            nat_body.contains("attempt_visited.mark_visited"),
+            nat_body.contains("carry_tried_into_visited("),
             "GetRetryDriver::new_attempt_tx must carry tried addrs into \
              the fresh attempt_visited bloom so gateway failover reaches \
              the wire (#4361 / #4364 H1)"
         );
+        assert!(
+            nat_body.contains("connection_count()"),
+            "the failover carry must stay gated on the empty-ring case so \
+             normal-path retry routing semantics are unchanged (#4364)"
+        );
+    }
+
+    /// Behavioral pin for the failover carry (#4364 H1): previously
+    /// tried addrs must be excluded from the next attempt, while the
+    /// attempt's intended destination must NOT be — marking it would
+    /// make the loopback relay skip the client's own pick, and
+    /// single-gateway retries would exhaust instantly.
+    #[test]
+    fn carry_tried_into_visited_excludes_current_target() {
+        let tx = dummy_tx();
+        let mut visited = VisitedPeers::new(&tx);
+        let own = SocketAddr::from(([127, 0, 0, 1], 4000));
+        let gw1 = SocketAddr::from(([127, 0, 0, 1], 4001));
+        let gw2 = SocketAddr::from(([127, 0, 0, 1], 4002));
+
+        carry_tried_into_visited(&mut visited, &[own, gw1, gw2], Some(gw2));
+
+        assert!(
+            visited.probably_visited(own),
+            "own addr must be carried into the bloom"
+        );
+        assert!(
+            visited.probably_visited(gw1),
+            "a previously tried gateway must be excluded from the next attempt"
+        );
+        assert!(
+            !visited.probably_visited(gw2),
+            "the attempt's intended destination must NOT be excluded"
+        );
+    }
+
+    /// With no current target (genuinely isolated retry), everything
+    /// tried is carried.
+    #[test]
+    fn carry_tried_into_visited_marks_all_without_current_target() {
+        let tx = dummy_tx();
+        let mut visited = VisitedPeers::new(&tx);
+        let own = SocketAddr::from(([127, 0, 0, 1], 4000));
+
+        carry_tried_into_visited(&mut visited, &[own], None);
+
+        assert!(visited.probably_visited(own));
     }
 
     #[test]

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1247,7 +1247,7 @@ fn advance_to_next_peer(
         }
     };
     let Some(addr) = peer.socket_addr() else {
-        // Should not happen — `k_closest_potentially_hosting` can return
+        // Rare but possible — `k_closest_potentially_hosting` can return
         // addressless candidates (ring.rs pushes them past the addr-gated
         // filters), and an addressless pick is unusable as a wire target.
         tracing::warn!(
@@ -2041,7 +2041,7 @@ fn relay_advance_to_next_peer(
         }
     };
     let Some(addr) = peer.socket_addr() else {
-        // Should not happen — see the matching guard in
+        // Rare but possible — see the matching guard in
         // `advance_to_next_peer` for why addressless candidates can leak
         // out of `k_closest_potentially_hosting`.
         tracing::warn!(

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -758,6 +758,28 @@ impl RetryDriver for GetRetryDriver<'_> {
     fn new_attempt_tx(&mut self) -> Transaction {
         let tx = Transaction::new::<GetMsg>();
         self.attempt_visited = VisitedPeers::new(&tx);
+        // Bootstrap fallback failover (#4361): the wire target for a
+        // client GET is re-picked per attempt by the originator-loopback
+        // relay, whose selection state is fresh each attempt. Without
+        // carrying the client's tried set into the new attempt's visited
+        // bloom, every retry would re-select the same first configured
+        // gateway — the client-side advance's "next gateway" pick would
+        // never reach the wire and multi-gateway failover would be
+        // bookkeeping only. Carry `tried` minus the current target (which
+        // IS this attempt's intended destination) so the relay's fallback
+        // skips gateways that already failed and converges on the same
+        // gateway the client driver selected — keeping stream claims and
+        // route telemetry (both attributed via `current_target`) aligned
+        // with the actual wire hop. Gated on the empty-ring case so
+        // normal-path retry routing semantics are unchanged.
+        if self.op_manager.ring.connection_manager.connection_count() == 0 {
+            let current_addr = self.current_target.socket_addr();
+            for addr in &self.tried {
+                if Some(*addr) != current_addr {
+                    self.attempt_visited.mark_visited(*addr);
+                }
+            }
+        }
         tx
     }
 
@@ -1151,8 +1173,18 @@ const MAX_RETRIES: usize = 3;
 /// Returns the first configured gateway that is not this node and not
 /// excluded by the caller's skip predicate — but ONLY when the ring is
 /// empty (`ring_connection_count == 0`). A non-empty ring means normal
-/// routing had candidates and exhaustion is genuine, so the fallback
-/// must stay out of the way.
+/// routing had ring entries to consider (its candidates may still all
+/// be filtered as transient/visited, but that exhaustion is genuine),
+/// so the fallback must stay out of the way.
+///
+/// Selection is deliberately deterministic (config order), unlike the
+/// randomized pick in #3219's CONNECT re-bootstrap: the client driver
+/// and the per-attempt loopback relay select independently and must
+/// converge on the same gateway given the same exclusion set — stream
+/// claims and route telemetry are attributed via the client's
+/// `current_target`, so divergence would mis-key both. Failover
+/// diversity comes from the exclusion predicate (tried/visited), not
+/// from randomization.
 ///
 /// Split out from [`bootstrap_gateway_target`] so unit tests can
 /// exercise the selection rules without constructing an `OpManager`.
@@ -1191,6 +1223,15 @@ fn select_bootstrap_gateway(
 /// and re-dials configured gateways if the transport lapsed. Mirrors
 /// the #3219 zero-connection CONNECT re-bootstrap shape, which gates
 /// on the same `connection_count() == 0` condition.
+///
+/// Tradeoff for genuinely unreachable gateways (e.g. an offline
+/// machine): a dial failure is not surfaced to the waiting driver, so
+/// each attempt waits its full per-attempt timeout (`OPERATION_TTL`,
+/// 60s) before advancing — up to ~3 minutes across the retry budget,
+/// where the pre-fallback behavior returned NotFound instantly. The
+/// instant NotFound was a false "contract absent" answer, so slower
+/// but honest is preferred; a distinct fail-fast "not bootstrapped /
+/// unreachable" client error is #4166's scope.
 fn bootstrap_gateway_target(
     op_manager: &OpManager,
     is_excluded: impl Fn(SocketAddr) -> bool,
@@ -3202,6 +3243,36 @@ mod tests {
                  k_closest_potentially_hosting yields no candidates (#4361)"
             );
         }
+
+        // The relay fallback's exclusion predicate must respect the
+        // request's visited bloom — dropping the `probably_visited` half
+        // would silently reintroduce gateway<->relay bounce (cross-hop
+        // loop prevention; testing review of #4364).
+        let relay_start = src
+            .find("fn relay_advance_to_next_peer")
+            .expect("relay_advance_to_next_peer must exist");
+        let relay_body = &src[relay_start..relay_start + 4000];
+        assert!(
+            relay_body.contains("new_visited.probably_visited"),
+            "relay_advance_to_next_peer's fallback exclusion must include \
+             new_visited.probably_visited (#4361 cross-hop loop prevention)"
+        );
+
+        // The client driver must carry its tried set into each new
+        // attempt's visited bloom (minus the current target) — without
+        // it the per-attempt loopback relay re-picks the same first
+        // gateway and multi-gateway failover never reaches the wire
+        // (skeptical review H1 on #4364).
+        let nat_start = src
+            .find("fn new_attempt_tx")
+            .expect("new_attempt_tx must exist");
+        let nat_body = &src[nat_start..nat_start + 2500];
+        assert!(
+            nat_body.contains("attempt_visited.mark_visited"),
+            "GetRetryDriver::new_attempt_tx must carry tried addrs into \
+             the fresh attempt_visited bloom so gateway failover reaches \
+             the wire (#4361 / #4364 H1)"
+        );
     }
 
     #[test]

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -31,11 +31,13 @@ use serde::{Deserialize, Serialize};
 use tokio::time::{Duration, sleep};
 
 /// Maximum peers to try per hop (breadth search).
-/// Matches GET operation's DEFAULT_MAX_BREADTH; change both together.
+/// (GET's former DEFAULT_MAX_BREADTH no longer exists — its selection
+/// uses k=1 per advance; this constant is now SUBSCRIBE-only.)
 pub(super) const MAX_BREADTH: usize = 3;
 
 /// Maximum retry rounds (each round queries k_closest for new candidates).
-/// Matches GET operation's MAX_RETRIES; change both together.
+/// (No longer tied to GET's MAX_RETRIES, which is 3; this constant is
+/// SUBSCRIBE-only.)
 pub(super) const MAX_RETRIES: usize = 10;
 
 /// Timeout for waiting on contract storage notification.

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1815,6 +1815,18 @@ impl Ring {
                         skipped_not_ready += 1;
                         continue;
                     }
+                } else {
+                    // Addressless candidates bypass every filter above (skip
+                    // list, dedup, transient, readiness) because all of them
+                    // key on the socket addr. If the router then selects one,
+                    // the GET advance helpers can't use it as a wire target
+                    // and the hop dies. Keep the inclusion (the candidate may
+                    // gain an addr by send time) but make it visible (#4361).
+                    tracing::debug!(
+                        peer = ?conn.location,
+                        target_location = %target_location.as_f64(),
+                        "k_closest: including addressless candidate (bypasses addr-keyed filters)"
+                    );
                 }
                 candidates.push(conn.location.clone());
             }

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -4980,6 +4980,18 @@ pub(super) mod test {
 /// operation outcomes. Grouping by attempt transaction — with success
 /// dominating any co-registered failure events — yields exactly one
 /// outcome per attempt.
+///
+/// Per-tx classification precedence: success > failure (any
+/// `GetFailure` event) > timeout (max elapsed >=
+/// [`GET_TIMEOUT_CLASSIFICATION_MS`]) > not_found.
+///
+/// Semantics caveat: these are WIRE-level attempt outcomes, not
+/// client-visible outcomes. A `Found` that bubbles up after the
+/// originator's per-attempt timeout still registers `GetSuccess` for
+/// that attempt tx and counts as a success here, even though the
+/// client saw NotFound; conversely each failed attempt of an
+/// ultimately-successful GET counts as its own not_found. Suitable for
+/// reliability diagnostics; not a client-SLA metric.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct GetOutcomeSummary {
     pub successes: u64,
@@ -5010,6 +5022,9 @@ pub const GET_TIMEOUT_CLASSIFICATION_MS: u64 = 55_000;
 /// Summarize GET outcomes from an event log, deduplicated per attempt
 /// transaction. See [`GetOutcomeSummary`] for why raw event counting is
 /// wrong.
+// Wildcard is deliberate, mirroring `hop_count`: only the three terminal
+// GET variants matter here; new variants should not require updates.
+#[allow(clippy::wildcard_enum_match_arm)]
 pub fn summarize_get_outcomes_per_tx(logs: &[NetLogMessage]) -> GetOutcomeSummary {
     use std::collections::HashMap;
 
@@ -5018,33 +5033,38 @@ pub fn summarize_get_outcomes_per_tx(logs: &[NetLogMessage]) -> GetOutcomeSummar
         success: bool,
         success_elapsed: Option<u64>,
         max_hop: Option<usize>,
+        saw_failure: bool,
         max_failure_elapsed: Option<u64>,
-        failure_without_elapsed: bool,
     }
 
     let mut per_tx: HashMap<Transaction, TxAgg> = HashMap::new();
     for log in logs {
-        let Some(outcome) = log.kind.get_outcome() else {
-            continue;
-        };
-        let agg = per_tx.entry(log.tx).or_default();
-        let elapsed = log.kind.get_elapsed_ms();
-        if outcome {
-            agg.success = true;
-            if let Some(ms) = elapsed {
-                agg.success_elapsed = Some(agg.success_elapsed.map_or(ms, |cur| cur.max(ms)));
-            }
-            if let Some(hops) = log.kind.hop_count() {
-                agg.max_hop = Some(agg.max_hop.map_or(hops, |cur| cur.max(hops)));
-            }
-        } else {
-            match elapsed {
-                Some(ms) => {
-                    agg.max_failure_elapsed =
-                        Some(agg.max_failure_elapsed.map_or(ms, |cur| cur.max(ms)));
+        // Match variants directly rather than going through
+        // `get_outcome()`, which collapses `GetNotFound` and `GetFailure`
+        // into the same bucket — classifying genuine network/system
+        // failures as contract absence (Codex review of #4364).
+        let agg = match &log.kind {
+            EventKind::Get(GetEvent::GetSuccess { .. }) => {
+                let agg = per_tx.entry(log.tx).or_default();
+                agg.success = true;
+                if let Some(ms) = log.kind.get_elapsed_ms() {
+                    agg.success_elapsed = Some(agg.success_elapsed.map_or(ms, |cur| cur.max(ms)));
                 }
-                None => agg.failure_without_elapsed = true,
+                if let Some(hops) = log.kind.hop_count() {
+                    agg.max_hop = Some(agg.max_hop.map_or(hops, |cur| cur.max(hops)));
+                }
+                continue;
             }
+            EventKind::Get(GetEvent::GetNotFound { .. }) => per_tx.entry(log.tx).or_default(),
+            EventKind::Get(GetEvent::GetFailure { .. }) => {
+                let agg = per_tx.entry(log.tx).or_default();
+                agg.saw_failure = true;
+                agg
+            }
+            _ => continue,
+        };
+        if let Some(ms) = log.kind.get_elapsed_ms() {
+            agg.max_failure_elapsed = Some(agg.max_failure_elapsed.map_or(ms, |cur| cur.max(ms)));
         }
     }
 
@@ -5058,6 +5078,8 @@ pub fn summarize_get_outcomes_per_tx(logs: &[NetLogMessage]) -> GetOutcomeSummar
             if let Some(ms) = agg.success_elapsed {
                 summary.success_elapsed_ms.push(ms);
             }
+        } else if agg.saw_failure {
+            summary.failures += 1;
         } else if let Some(ms) = agg.max_failure_elapsed {
             if ms >= GET_TIMEOUT_CLASSIFICATION_MS {
                 summary.timeouts += 1;
@@ -5065,6 +5087,8 @@ pub fn summarize_get_outcomes_per_tx(logs: &[NetLogMessage]) -> GetOutcomeSummar
                 summary.not_found += 1;
             }
         } else {
+            // Unreachable today (all three terminal GET events carry
+            // elapsed_ms) but kept as a defensive bucket.
             summary.failures += 1;
         }
     }
@@ -5193,6 +5217,34 @@ mod get_outcome_summary_tests {
         let summary = summarize_get_outcomes_per_tx(&logs);
         assert_eq!(summary.successes, 1);
         assert_eq!(summary.network_successes, 0);
+    }
+
+    /// `GetFailure` events classify as failures — not as not_found —
+    /// regardless of elapsed time. Regression for the Codex review
+    /// finding on #4364: classifying by elapsed time alone collapsed
+    /// genuine network/system failures into "contract absent".
+    #[test]
+    fn get_failure_classifies_as_failure_not_not_found() {
+        let tx = Transaction::new::<GetMsg>();
+        let logs = vec![NetLogMessage {
+            tx,
+            datetime: base_time(),
+            peer_id: make_peer_id(3001),
+            kind: EventKind::Get(GetEvent::GetFailure {
+                id: tx,
+                requester: make_pkl(3001),
+                instance_id: *make_key().id(),
+                target: make_pkl(3001),
+                hop_count: Some(0),
+                reason: OperationFailure::ConnectionDropped,
+                elapsed_ms: 10,
+                timestamp: 100,
+            }),
+        }];
+        let summary = summarize_get_outcomes_per_tx(&logs);
+        assert_eq!(summary.failures, 1, "GetFailure must land in failures");
+        assert_eq!(summary.not_found, 0);
+        assert_eq!(summary.total(), 1);
     }
 
     /// Failed outcomes at or above the timeout threshold classify as

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -2813,6 +2813,24 @@ impl EventKind {
         matches!(self, EventKind::Get(GetEvent::Request { .. }))
     }
 
+    /// Returns the HTL carried by a GET request event, `None` for all
+    /// other events.
+    ///
+    /// Useful for distinguishing originator-side dispatch from relay
+    /// hops in test analysis: the client driver's loopback Request is
+    /// registered at the originating node with `htl == max_hops_to_live`,
+    /// while every relay-received Request has already been decremented
+    /// (#4361 — dispatched-vs-scheduled accounting).
+    // Wildcard is deliberate, mirroring `hop_count`: this accessor cares
+    // about exactly one variant; new variants should not require updates.
+    #[allow(clippy::wildcard_enum_match_arm)]
+    pub fn get_request_htl(&self) -> Option<usize> {
+        match self {
+            EventKind::Get(GetEvent::Request { htl, .. }) => Some(*htl),
+            _ => None,
+        }
+    }
+
     /// Returns whether this is a subscribe outcome event (success or not-found).
     ///
     /// Returns `Some(true)` for `SubscribeSuccess`, `Some(false)` for `SubscribeNotFound`,
@@ -4944,5 +4962,252 @@ pub(super) mod test {
             8,
             "Empty state should still produce 8-char hash"
         );
+    }
+}
+
+/// Per-attempt-transaction GET outcome summary (#4361).
+///
+/// The raw event stream multi-counts GET outcomes:
+///
+/// - a failed attempt registers a `GetNotFound` TWICE on the originator's
+///   own node — once directly from the relay driver's exhaustion branch
+///   and once when the loopback `Response{NotFound}` re-enters inbound
+///   dispatch (`from_inbound_msg_v1`);
+/// - multi-hop responses register one outcome event at every hop they
+///   bubble through, so a single terminal outcome can appear N times.
+///
+/// Counting raw events therefore measures message traversal, not
+/// operation outcomes. Grouping by attempt transaction — with success
+/// dominating any co-registered failure events — yields exactly one
+/// outcome per attempt.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct GetOutcomeSummary {
+    pub successes: u64,
+    pub not_found: u64,
+    pub failures: u64,
+    pub timeouts: u64,
+    /// Subset of `successes` whose wire `hop_count >= 1` — the GET
+    /// actually traversed the network rather than completing on a node
+    /// that already held the contract locally.
+    pub network_successes: u64,
+    /// Elapsed ms per successful attempt (max across the hops that
+    /// registered the success — the originator registers last, with the
+    /// largest elapsed). Sorted ascending for deterministic output.
+    pub success_elapsed_ms: Vec<u64>,
+}
+
+impl GetOutcomeSummary {
+    pub fn total(&self) -> u64 {
+        self.successes + self.not_found + self.failures + self.timeouts
+    }
+}
+
+/// Failed GET outcomes with elapsed time at or above this threshold are
+/// classified as timeouts rather than NotFound (close to the 60s
+/// `OPERATION_TTL`).
+pub const GET_TIMEOUT_CLASSIFICATION_MS: u64 = 55_000;
+
+/// Summarize GET outcomes from an event log, deduplicated per attempt
+/// transaction. See [`GetOutcomeSummary`] for why raw event counting is
+/// wrong.
+pub fn summarize_get_outcomes_per_tx(logs: &[NetLogMessage]) -> GetOutcomeSummary {
+    use std::collections::HashMap;
+
+    #[derive(Default)]
+    struct TxAgg {
+        success: bool,
+        success_elapsed: Option<u64>,
+        max_hop: Option<usize>,
+        max_failure_elapsed: Option<u64>,
+        failure_without_elapsed: bool,
+    }
+
+    let mut per_tx: HashMap<Transaction, TxAgg> = HashMap::new();
+    for log in logs {
+        let Some(outcome) = log.kind.get_outcome() else {
+            continue;
+        };
+        let agg = per_tx.entry(log.tx).or_default();
+        let elapsed = log.kind.get_elapsed_ms();
+        if outcome {
+            agg.success = true;
+            if let Some(ms) = elapsed {
+                agg.success_elapsed = Some(agg.success_elapsed.map_or(ms, |cur| cur.max(ms)));
+            }
+            if let Some(hops) = log.kind.hop_count() {
+                agg.max_hop = Some(agg.max_hop.map_or(hops, |cur| cur.max(hops)));
+            }
+        } else {
+            match elapsed {
+                Some(ms) => {
+                    agg.max_failure_elapsed =
+                        Some(agg.max_failure_elapsed.map_or(ms, |cur| cur.max(ms)));
+                }
+                None => agg.failure_without_elapsed = true,
+            }
+        }
+    }
+
+    let mut summary = GetOutcomeSummary::default();
+    for agg in per_tx.values() {
+        if agg.success {
+            summary.successes += 1;
+            if agg.max_hop.unwrap_or(0) >= 1 {
+                summary.network_successes += 1;
+            }
+            if let Some(ms) = agg.success_elapsed {
+                summary.success_elapsed_ms.push(ms);
+            }
+        } else if let Some(ms) = agg.max_failure_elapsed {
+            if ms >= GET_TIMEOUT_CLASSIFICATION_MS {
+                summary.timeouts += 1;
+            } else {
+                summary.not_found += 1;
+            }
+        } else {
+            summary.failures += 1;
+        }
+    }
+    summary.success_elapsed_ms.sort_unstable();
+    summary
+}
+
+#[cfg(test)]
+mod get_outcome_summary_tests {
+    use super::*;
+    use crate::operations::get::GetMsg;
+    use crate::ring::PeerKeyLocation;
+    use crate::transport::TransportPublicKey;
+    use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+    use std::net::SocketAddr;
+
+    fn make_peer_id(port: u16) -> PeerId {
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        let key = TransportPublicKey::from_bytes([port as u8; 32]);
+        PeerId::new(key, addr)
+    }
+
+    fn make_pkl(port: u16) -> PeerKeyLocation {
+        let key = TransportPublicKey::from_bytes([port as u8; 32]);
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        PeerKeyLocation::new(key, addr)
+    }
+
+    fn make_key() -> ContractKey {
+        ContractKey::from_id_and_code(ContractInstanceId::new([1u8; 32]), CodeHash::new([2u8; 32]))
+    }
+
+    fn base_time() -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc)
+    }
+
+    fn not_found_event(tx: Transaction, port: u16, elapsed_ms: u64) -> NetLogMessage {
+        NetLogMessage {
+            tx,
+            datetime: base_time(),
+            peer_id: make_peer_id(port),
+            kind: EventKind::Get(GetEvent::GetNotFound {
+                id: tx,
+                requester: make_pkl(port),
+                instance_id: *make_key().id(),
+                target: make_pkl(port),
+                hop_count: Some(0),
+                elapsed_ms,
+                timestamp: 100,
+            }),
+        }
+    }
+
+    fn success_event(
+        tx: Transaction,
+        port: u16,
+        hop_count: Option<usize>,
+        elapsed_ms: u64,
+    ) -> NetLogMessage {
+        NetLogMessage {
+            tx,
+            datetime: base_time(),
+            peer_id: make_peer_id(port),
+            kind: EventKind::Get(GetEvent::GetSuccess {
+                id: tx,
+                requester: make_pkl(port),
+                target: make_pkl(port),
+                key: make_key(),
+                hop_count,
+                elapsed_ms,
+                timestamp: 100,
+                state_hash: None,
+            }),
+        }
+    }
+
+    /// Regression for #4361: one failed GET attempt registers TWO
+    /// `GetNotFound` events on the originator node (relay-direct +
+    /// loopback-Response inbound). Per-tx dedup must count it once.
+    #[test]
+    fn failed_attempt_double_registration_counts_once() {
+        let tx = Transaction::new::<GetMsg>();
+        let logs = vec![not_found_event(tx, 3001, 5), not_found_event(tx, 3001, 6)];
+        let summary = summarize_get_outcomes_per_tx(&logs);
+        assert_eq!(
+            summary.not_found, 1,
+            "double-registered NotFound must dedup"
+        );
+        assert_eq!(summary.total(), 1);
+    }
+
+    /// A success bubbling through multiple hops registers one event per
+    /// hop; it is still one outcome — and success dominates any
+    /// co-registered NotFound on the same tx (a relay that exhausted one
+    /// branch before another found the contract).
+    #[test]
+    fn multi_hop_success_counts_once_and_dominates() {
+        let tx = Transaction::new::<GetMsg>();
+        let logs = vec![
+            not_found_event(tx, 3003, 4),
+            success_event(tx, 3002, Some(2), 10),
+            success_event(tx, 3001, Some(2), 15),
+        ];
+        let summary = summarize_get_outcomes_per_tx(&logs);
+        assert_eq!(summary.successes, 1);
+        assert_eq!(summary.not_found, 0, "success must dominate per tx");
+        assert_eq!(
+            summary.network_successes, 1,
+            "hop_count >= 1 is a network success"
+        );
+        assert_eq!(
+            summary.success_elapsed_ms,
+            vec![15],
+            "originator-side (max) elapsed wins"
+        );
+    }
+
+    /// hop_count == 0 means the GET completed on a node that already had
+    /// the contract — counted as success but NOT as a network success.
+    #[test]
+    fn local_hit_is_not_a_network_success() {
+        let tx = Transaction::new::<GetMsg>();
+        let logs = vec![success_event(tx, 3001, Some(0), 1)];
+        let summary = summarize_get_outcomes_per_tx(&logs);
+        assert_eq!(summary.successes, 1);
+        assert_eq!(summary.network_successes, 0);
+    }
+
+    /// Failed outcomes at or above the timeout threshold classify as
+    /// timeouts; distinct transactions stay distinct.
+    #[test]
+    fn timeout_classification_and_distinct_txs() {
+        let tx1 = Transaction::new::<GetMsg>();
+        let tx2 = Transaction::new::<GetMsg>();
+        let logs = vec![
+            not_found_event(tx1, 3001, GET_TIMEOUT_CLASSIFICATION_MS),
+            not_found_event(tx2, 3002, 10),
+        ];
+        let summary = summarize_get_outcomes_per_tx(&logs);
+        assert_eq!(summary.timeouts, 1);
+        assert_eq!(summary.not_found, 1);
+        assert_eq!(summary.total(), 2);
     }
 }

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -5219,6 +5219,24 @@ mod get_outcome_summary_tests {
         assert_eq!(summary.network_successes, 0);
     }
 
+    fn failure_event(tx: Transaction, port: u16, elapsed_ms: u64) -> NetLogMessage {
+        NetLogMessage {
+            tx,
+            datetime: base_time(),
+            peer_id: make_peer_id(port),
+            kind: EventKind::Get(GetEvent::GetFailure {
+                id: tx,
+                requester: make_pkl(port),
+                instance_id: *make_key().id(),
+                target: make_pkl(port),
+                hop_count: Some(0),
+                reason: OperationFailure::ConnectionDropped,
+                elapsed_ms,
+                timestamp: 100,
+            }),
+        }
+    }
+
     /// `GetFailure` events classify as failures — not as not_found —
     /// regardless of elapsed time. Regression for the Codex review
     /// finding on #4364: classifying by elapsed time alone collapsed
@@ -5226,25 +5244,54 @@ mod get_outcome_summary_tests {
     #[test]
     fn get_failure_classifies_as_failure_not_not_found() {
         let tx = Transaction::new::<GetMsg>();
-        let logs = vec![NetLogMessage {
-            tx,
-            datetime: base_time(),
-            peer_id: make_peer_id(3001),
-            kind: EventKind::Get(GetEvent::GetFailure {
-                id: tx,
-                requester: make_pkl(3001),
-                instance_id: *make_key().id(),
-                target: make_pkl(3001),
-                hop_count: Some(0),
-                reason: OperationFailure::ConnectionDropped,
-                elapsed_ms: 10,
-                timestamp: 100,
-            }),
-        }];
+        let logs = vec![failure_event(tx, 3001, 10)];
         let summary = summarize_get_outcomes_per_tx(&logs);
         assert_eq!(summary.failures, 1, "GetFailure must land in failures");
         assert_eq!(summary.not_found, 0);
         assert_eq!(summary.total(), 1);
+    }
+
+    /// failure > timeout precedence: a `GetFailure` at or above the
+    /// timeout threshold is still a failure — the timeout bucket is a
+    /// heuristic for NotFound without an explicit reason. Pins the
+    /// branch order in the per-tx fold (#4364 testing review).
+    #[test]
+    fn get_failure_above_timeout_threshold_stays_failure() {
+        let tx = Transaction::new::<GetMsg>();
+        let logs = vec![failure_event(
+            tx,
+            3001,
+            GET_TIMEOUT_CLASSIFICATION_MS + 1_000,
+        )];
+        let summary = summarize_get_outcomes_per_tx(&logs);
+        assert_eq!(
+            summary.failures, 1,
+            "failure must outrank the timeout heuristic"
+        );
+        assert_eq!(summary.timeouts, 0);
+        assert_eq!(summary.total(), 1);
+    }
+
+    /// success > failure precedence on the same tx — and a mixed
+    /// NotFound + Failure tx resolves to failure.
+    #[test]
+    fn success_dominates_failure_and_failure_dominates_not_found() {
+        let tx1 = Transaction::new::<GetMsg>();
+        let tx2 = Transaction::new::<GetMsg>();
+        let logs = vec![
+            failure_event(tx1, 3002, 5),
+            success_event(tx1, 3001, Some(2), 20),
+            not_found_event(tx2, 3003, 5),
+            failure_event(tx2, 3003, 6),
+        ];
+        let summary = summarize_get_outcomes_per_tx(&logs);
+        assert_eq!(summary.successes, 1, "success must dominate failure per tx");
+        assert_eq!(
+            summary.failures, 1,
+            "failure must dominate not_found per tx"
+        );
+        assert_eq!(summary.not_found, 0);
+        assert_eq!(summary.total(), 2);
     }
 
     /// Failed outcomes at or above the timeout threshold classify as

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -8355,12 +8355,11 @@ fn test_get_reliability_diagnostic() {
         summary.timeouts,
     );
     let network_successes = summary.network_successes;
-    let elapsed_ms_list = summary.success_elapsed_ms.clone();
     let total_outcomes = summary.total();
 
     // Compute latency percentiles for successful GETs
-    let mut sorted_latencies = elapsed_ms_list.clone();
-    sorted_latencies.sort();
+    // (success_elapsed_ms is pre-sorted ascending).
+    let sorted_latencies = &summary.success_elapsed_ms;
 
     let p50 = sorted_latencies
         .get(sorted_latencies.len() / 2)
@@ -8550,7 +8549,7 @@ fn test_get_reliability_diagnostic() {
         NUM_NODES
     );
     // Network-traversal floor (#4361): before this assertion existed, every
-    // \"success\" in the failing runs was a local cache hit (hop_count == 0)
+    // "success" in the failing runs was a local cache hit (hop_count == 0)
     // on a node that already held the contract — multi-hop GET was never
     // exercised at all. Require that a meaningful number of successes
     // actually traversed the network.
@@ -8687,11 +8686,10 @@ fn test_get_reliability_with_latency() {
         summary.failures,
         summary.timeouts,
     );
-    let elapsed_ms_list = summary.success_elapsed_ms.clone();
     let total_outcomes = summary.total();
 
-    let mut sorted_latencies = elapsed_ms_list.clone();
-    sorted_latencies.sort();
+    // success_elapsed_ms is pre-sorted ascending.
+    let sorted_latencies = &summary.success_elapsed_ms;
 
     let p50 = sorted_latencies
         .get(sorted_latencies.len() / 2)
@@ -8906,11 +8904,10 @@ fn test_get_reliability_with_churn() {
         summary.failures,
         summary.timeouts,
     );
-    let elapsed_ms_list = summary.success_elapsed_ms.clone();
     let total_outcomes = summary.total();
 
-    let mut sorted_latencies = elapsed_ms_list.clone();
-    sorted_latencies.sort();
+    // success_elapsed_ms is pre-sorted ascending.
+    let sorted_latencies = &summary.success_elapsed_ms;
 
     let p50 = sorted_latencies
         .get(sorted_latencies.len() / 2)

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -8257,6 +8257,7 @@ fn test_get_reliability_diagnostic() {
     const NETWORK_NAME: &str = "get-reliability-diag";
     const NUM_NODES: usize = 100;
     const NUM_GATEWAYS: usize = 3;
+    const RING_MAX_HTL: usize = 10;
 
     GlobalTestMetrics::reset();
     setup_deterministic_state(SEED);
@@ -8268,10 +8269,10 @@ fn test_get_reliability_diagnostic() {
             NETWORK_NAME,
             NUM_GATEWAYS,
             NUM_NODES,
-            10, // ring_max_htl — realistic for 100-node network
-            7,  // rnd_if_htl_above
-            12, // max_connections
-            4,  // min_connections
+            RING_MAX_HTL, // realistic for 100-node network
+            7,            // rnd_if_htl_above
+            12,           // max_connections
+            4,            // min_connections
             SEED,
         )
         .await;
@@ -8322,43 +8323,40 @@ fn test_get_reliability_diagnostic() {
         result.turmoil_result.err()
     );
 
-    // Analyze GET outcomes from event logs
+    // Analyze GET outcomes from event logs, deduplicated per attempt
+    // transaction (#4361): raw event counting double-counts every failed
+    // attempt (relay-direct + loopback-Response registration) and counts
+    // multi-hop outcomes once per hop traversed.
     let rt = create_runtime();
-    let (successes, not_found, failures, timeouts, elapsed_ms_list) = rt.block_on(async {
+    let (summary, dispatched_nodes) = rt.block_on(async {
         let logs = logs_handle.lock().await;
-        let mut successes = 0u64;
-        let mut not_found = 0u64;
-        let mut failures = 0u64;
-        let mut timeouts = 0u64;
-        let mut elapsed_list = Vec::new();
+        let summary = freenet::tracing::summarize_get_outcomes_per_tx(&logs);
 
-        for log in logs.iter() {
-            match log.kind.get_outcome() {
-                Some(true) => {
-                    successes += 1;
-                    if let Some(ms) = log.kind.get_elapsed_ms() {
-                        elapsed_list.push(ms);
-                    }
-                }
-                Some(false) => {
-                    if let Some(ms) = log.kind.get_elapsed_ms() {
-                        if ms >= 55_000 {
-                            // Likely a timeout (close to OPERATION_TTL of 60s)
-                            timeouts += 1;
-                        } else {
-                            not_found += 1;
-                        }
-                    } else {
-                        failures += 1;
-                    }
-                }
-                None => {}
-            }
-        }
-        (successes, not_found, failures, timeouts, elapsed_list)
+        // Dispatched-vs-scheduled accounting (#4361): the client driver's
+        // loopback Request is registered at the originating node with
+        // htl == ring_max_htl; relay-received Requests have already been
+        // decremented. Unique originating peers therefore counts how many
+        // nodes actually dispatched a GET (sub-op GETs can inflate this
+        // slightly, which is why it feeds a floor assertion, not an
+        // exact-match one).
+        let dispatched_nodes: HashSet<_> = logs
+            .iter()
+            .filter(|log| log.kind.get_request_htl() == Some(RING_MAX_HTL))
+            .map(|log| log.peer_id.clone())
+            .collect();
+
+        (summary, dispatched_nodes.len())
     });
 
-    let total_outcomes = successes + not_found + failures + timeouts;
+    let (successes, not_found, failures, timeouts) = (
+        summary.successes,
+        summary.not_found,
+        summary.failures,
+        summary.timeouts,
+    );
+    let network_successes = summary.network_successes;
+    let elapsed_ms_list = summary.success_elapsed_ms.clone();
+    let total_outcomes = summary.total();
 
     // Compute latency percentiles for successful GETs
     let mut sorted_latencies = elapsed_ms_list.clone();
@@ -8443,9 +8441,11 @@ fn test_get_reliability_diagnostic() {
         NUM_GATEWAYS + NUM_NODES
     );
     tracing::info!(
-        "GET outcomes: {} total — {} success, {} not_found, {} failures, {} timeouts",
+        "GET outcomes (per attempt tx): {} total — {} success ({} network-traversed), \
+         {} not_found, {} failures, {} timeouts",
         total_outcomes,
         successes,
+        network_successes,
         not_found,
         failures,
         timeouts
@@ -8455,6 +8455,11 @@ fn test_get_reliability_diagnostic() {
         success_rate * 100.0,
         successes,
         total_outcomes
+    );
+    tracing::info!(
+        "GET dispatch: {}/{} scheduled GETs dispatched an operation",
+        dispatched_nodes,
+        NUM_NODES
     );
     tracing::info!(
         "Latency (successful GETs): p50={}ms, p90={}ms, p99={}ms, max={}ms",
@@ -8514,7 +8519,7 @@ fn test_get_reliability_diagnostic() {
     // Soft assertion — this is diagnostic, but catastrophic failure should still fail the test
     assert!(
         total_outcomes >= 10,
-        "Only {} GET outcome events — too few for meaningful analysis",
+        "Only {} GET outcome transactions — too few for meaningful analysis",
         total_outcomes
     );
     assert!(
@@ -8528,6 +8533,33 @@ fn test_get_reliability_diagnostic() {
         failures,
         timeouts,
         total_outcomes
+    );
+    // Dispatch accounting (#4361): scheduled GETs that never dispatch an
+    // operation silently shrink the denominator, so the success rate can
+    // look healthy while most of the test never ran. Currently 42/100
+    // dispatch: the rest are rejected with an explicit PeerNotJoined
+    // (the node had no completed transport handshake when its signal
+    // arrived — a footprint of the bootstrap acceptance collapse, #4362)
+    // and the harness does not retry. Catastrophic floor only — raise it
+    // when #4362 is fixed.
+    assert!(
+        dispatched_nodes >= NUM_NODES / 3,
+        "Only {}/{} scheduled GETs dispatched an operation — the test \
+         exercised only a fraction of its workload (#4361)",
+        dispatched_nodes,
+        NUM_NODES
+    );
+    // Network-traversal floor (#4361): before this assertion existed, every
+    // \"success\" in the failing runs was a local cache hit (hop_count == 0)
+    // on a node that already held the contract — multi-hop GET was never
+    // exercised at all. Require that a meaningful number of successes
+    // actually traversed the network.
+    assert!(
+        network_successes >= 5,
+        "Only {} of {} successful GETs traversed the network (hop_count >= 1) \
+         — the success metric is measuring local availability, not routing (#4361)",
+        network_successes,
+        successes
     );
 
     // StateVerifier anomaly check
@@ -8643,42 +8675,20 @@ fn test_get_reliability_with_latency() {
         result.turmoil_result.err()
     );
 
-    // Analyze GET outcomes
+    // Analyze GET outcomes, deduplicated per attempt transaction (#4361).
     let rt = create_runtime();
-    let (successes, not_found, failures, timeouts, elapsed_ms_list) = rt.block_on(async {
+    let summary = rt.block_on(async {
         let logs = logs_handle.lock().await;
-        let mut successes = 0u64;
-        let mut not_found = 0u64;
-        let mut failures = 0u64;
-        let mut timeouts = 0u64;
-        let mut elapsed_list = Vec::new();
-
-        for log in logs.iter() {
-            match log.kind.get_outcome() {
-                Some(true) => {
-                    successes += 1;
-                    if let Some(ms) = log.kind.get_elapsed_ms() {
-                        elapsed_list.push(ms);
-                    }
-                }
-                Some(false) => {
-                    if let Some(ms) = log.kind.get_elapsed_ms() {
-                        if ms >= 55_000 {
-                            timeouts += 1;
-                        } else {
-                            not_found += 1;
-                        }
-                    } else {
-                        failures += 1;
-                    }
-                }
-                None => {}
-            }
-        }
-        (successes, not_found, failures, timeouts, elapsed_list)
+        freenet::tracing::summarize_get_outcomes_per_tx(&logs)
     });
-
-    let total_outcomes = successes + not_found + failures + timeouts;
+    let (successes, not_found, failures, timeouts) = (
+        summary.successes,
+        summary.not_found,
+        summary.failures,
+        summary.timeouts,
+    );
+    let elapsed_ms_list = summary.success_elapsed_ms.clone();
+    let total_outcomes = summary.total();
 
     let mut sorted_latencies = elapsed_ms_list.clone();
     sorted_latencies.sort();
@@ -8710,9 +8720,11 @@ fn test_get_reliability_with_latency() {
         NUM_NODES
     );
     tracing::info!(
-        "GET outcomes: {} total — {} success, {} not_found, {} failures, {} timeouts",
+        "GET outcomes (per attempt tx): {} total — {} success ({} network-traversed), \
+         {} not_found, {} failures, {} timeouts",
         total_outcomes,
         successes,
+        summary.network_successes,
         not_found,
         failures,
         timeouts
@@ -8881,42 +8893,21 @@ fn test_get_reliability_with_churn() {
         tracing::warn!("Direct simulation completed with error (may be expected under churn): {e}");
     }
 
-    // Analyze GET outcomes from event logs
+    // Analyze GET outcomes from event logs, deduplicated per attempt
+    // transaction (#4361).
     let rt = create_runtime();
-    let (successes, not_found, failures, timeouts, elapsed_ms_list) = rt.block_on(async {
+    let summary = rt.block_on(async {
         let logs = logs_handle.lock().await;
-        let mut successes = 0u64;
-        let mut not_found = 0u64;
-        let mut failures = 0u64;
-        let mut timeouts = 0u64;
-        let mut elapsed_list = Vec::new();
-
-        for log in logs.iter() {
-            match log.kind.get_outcome() {
-                Some(true) => {
-                    successes += 1;
-                    if let Some(ms) = log.kind.get_elapsed_ms() {
-                        elapsed_list.push(ms);
-                    }
-                }
-                Some(false) => {
-                    if let Some(ms) = log.kind.get_elapsed_ms() {
-                        if ms >= 55_000 {
-                            timeouts += 1;
-                        } else {
-                            not_found += 1;
-                        }
-                    } else {
-                        failures += 1;
-                    }
-                }
-                None => {}
-            }
-        }
-        (successes, not_found, failures, timeouts, elapsed_list)
+        freenet::tracing::summarize_get_outcomes_per_tx(&logs)
     });
-
-    let total_outcomes = successes + not_found + failures + timeouts;
+    let (successes, not_found, failures, timeouts) = (
+        summary.successes,
+        summary.not_found,
+        summary.failures,
+        summary.timeouts,
+    );
+    let elapsed_ms_list = summary.success_elapsed_ms.clone();
+    let total_outcomes = summary.total();
 
     let mut sorted_latencies = elapsed_ms_list.clone();
     sorted_latencies.sort();
@@ -8948,9 +8939,11 @@ fn test_get_reliability_with_churn() {
         NUM_NODES
     );
     tracing::info!(
-        "GET outcomes: {} total — {} success, {} not_found, {} failures, {} timeouts",
+        "GET outcomes (per attempt tx): {} total — {} success ({} network-traversed), \
+         {} not_found, {} failures, {} timeouts",
         total_outcomes,
         successes,
+        summary.network_successes,
         not_found,
         failures,
         timeouts

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -8456,7 +8456,7 @@ fn test_get_reliability_diagnostic() {
         total_outcomes
     );
     tracing::info!(
-        "GET dispatch: {}/{} scheduled GETs dispatched an operation",
+        "GET dispatch: {}/{} nodes dispatched at least one GET attempt",
         dispatched_nodes,
         NUM_NODES
     );

--- a/docs/architecture/operations/README.md
+++ b/docs/architecture/operations/README.md
@@ -95,7 +95,6 @@ stateDiagram-v2
 **Key features:**
 - Network-first strategy with local cache fallback
 - MAX_RETRIES: 3 attempts (client-side peer advancement)
-- MAX_BREADTH: 3 parallel peer queries per hop
 - Bootstrap fallback: with an empty ring (zero ring connections), peer
   selection falls back to a configured gateway over the transient
   transport connection instead of failing instantly with NotFound (#4361)
@@ -445,7 +444,7 @@ sequenceDiagram
 | `streaming_threshold` | 64 KB | Size threshold for streaming |
 | `OPERATION_TTL` | configurable | Operation timeout |
 | `MAX_RETRIES` | 3 | GET retry attempts |
-| `MAX_BREADTH` | 3 | Parallel peer queries |
+| `MAX_BREADTH` | 3 | SUBSCRIBE parallel peer queries (subscribe.rs) |
 | `CONTRACT_WAIT_TIMEOUT_MS` | 2000 | SUBSCRIBE wait for contract |
 
 ## Source Files

--- a/docs/architecture/operations/README.md
+++ b/docs/architecture/operations/README.md
@@ -94,8 +94,11 @@ stateDiagram-v2
 
 **Key features:**
 - Network-first strategy with local cache fallback
-- MAX_RETRIES: 10 attempts
+- MAX_RETRIES: 3 attempts (client-side peer advancement)
 - MAX_BREADTH: 3 parallel peer queries per hop
+- Bootstrap fallback: with an empty ring (zero ring connections), peer
+  selection falls back to a configured gateway over the transient
+  transport connection instead of failing instantly with NotFound (#4361)
 
 **Messages:**
 - `GetMsg::Request` - Query for contract
@@ -441,7 +444,7 @@ sequenceDiagram
 |-----------|---------|-------------|
 | `streaming_threshold` | 64 KB | Size threshold for streaming |
 | `OPERATION_TTL` | configurable | Operation timeout |
-| `MAX_RETRIES` | 10 | GET retry attempts |
+| `MAX_RETRIES` | 3 | GET retry attempts |
 | `MAX_BREADTH` | 3 | Parallel peer queries |
 | `CONTRACT_WAIT_TIMEOUT_MS` | 2000 | SUBSCRIBE wait for contract |
 


### PR DESCRIPTION
## Problem

A node with an empty ring (`connections_by_location` has no entries) but live transient transport connectivity fails **every GET instantly with NotFound — zero wire messages sent**. All GET peer-selection points consult only ring connections via `k_closest_potentially_hosting`, and every exhaustion path was silent. Production analog: a freshly started node fails all GETs for its first minutes, until ring promotion completes.

This is the primary defect behind the nightly `test_get_reliability_diagnostic` failing three nights running at 18.3% (#4361): during the test's op window most nodes have empty rings, so not one GET traversed the network — every "success" was a local cache hit, and the metric itself multi-counted outcomes.

## Solution

**Bounded bootstrap fallback (defect 1).** When `connection_count() == 0`, the GET selection points — client initial pick, sub-op initial pick, client advance, relay advance — fall back to a configured gateway, skipping self, already-tried addrs, and the request's visited bloom (cross-hop loop prevention). Key insight: wire delivery needs no new plumbing — `OutboundMessageWithTarget` resolves targets by socket addr against the transport map (which includes transient connections) and re-dials configured gateways if the transport lapsed. This mirrors the #3219 zero-connection CONNECT re-bootstrap shape, gated on the same condition, so normal routing is untouched. The relay fallback stays within `MAX_RELAY_RETRIES = 1`, so the 3^HTL fan-out guard is unaffected.

**Silent exhaustion paths now log (defect 3):** empty-candidate exhaustion, addressless candidate selected (`peer.socket_addr()` holes), the previously-discarded `Exhausted` cause, and the addressless-candidate filter bypass in `k_closest_potentially_hosting`.

**Test metric integrity (defect 4):** new `tracing::summarize_get_outcomes_per_tx` dedups GET outcomes per attempt transaction — a failed attempt was registered twice on the originator (relay-direct + loopback-Response inbound), and multi-hop outcomes registered once per hop. New `EventKind::get_request_htl` enables dispatched-vs-scheduled accounting (originator loopback Requests carry `htl == max_htl`). The diagnostic test now asserts a dispatch floor and a network-traversal floor (`hop_count >= 1` successes), so local cache hits can never again masquerade as routing success. Sibling tests (`with_latency`, `with_churn`) updated in lockstep.

**Failover across gateways (added after the skeptical review's H1 finding):** the wire target for a client GET is re-picked per attempt by the originator-loopback relay, so the client driver carries its tried set (minus the current target) into each new attempt's visited bloom — making retries genuinely fail over to the next configured gateway instead of re-asking the first one. The carry is gated on the empty-ring case; normal-path retry semantics are unchanged.

**Known behavior change for unreachable gateways:** when configured gateways are genuinely unreachable (e.g. an offline machine), each attempt waits its full per-attempt timeout (60s, up to ~3 minutes across the retry budget) before returning NotFound — where the old behavior returned an instant but *false* "contract absent" answer. A distinct fail-fast "not bootstrapped" client error is #4166's scope.

## Testing

All runs deterministic (seed `0x3570_D1A6_0001`, byte-identical to CI per #4361):

- **Without the fix** (875b97a4 + strengthened metrics only): fails at **31.0%** per-tx success — 13 success / 29 not_found / 42 outcomes. The old raw count of 58 not_found was exactly these 29 double-counted, confirming #4361's analysis.
- **With the fix**: **passes** all assertions — ≥50% per-tx success rate, ≥1/3 dispatch floor (42/100 — see below), ≥5 network-traversed successes.
- 9 new unit tests: fallback selection rules (empty-ring-only activation, self-skip, tried/visited exclusion), per-tx dedup semantics (double-registration, multi-hop dominance, local-hit vs network classification, timeout split), plus a source pin asserting all four selection sites consult the fallback.
- `cargo fmt`, `cargo clippy --locked -- -D warnings` clean.

## Follow-ups (filed, out of scope per #4361's own analysis)

- #4362 — bootstrap acceptance collapse: only 42/100 scheduled GETs dispatch because 46 nodes still lack a completed transport handshake (`peer_ready == false`) minutes into the sim; they get the explicit `PeerNotJoined` client error. The test's dispatch floor documents this and should be raised when #4362 lands.
- #4363 — PUT finalizes far from the contract location on sparse bootstrap topology, with no re-replication.

## Fixes

Closes #4361

[AI-assisted - Claude]
