### PR TITLE
feat: warn on the homepage when served assets are stale (#4289)

### DIFF
--- a/crates/core/src/server/client_api/v1.rs
+++ b/crates/core/src/server/client_api/v1.rs
@@ -11,6 +11,11 @@ use super::*;
 pub(super) fn routes(config: Config) -> Router {
     Router::new()
         .route("/v1", get(home))
+        // Lightweight runtime-version probe. The homepage JS fetches this at
+        // page load and compares the live answer against the version baked into
+        // the served page; a mismatch means the browser is holding a stale
+        // cached page from an older binary (#4289).
+        .route("/v1/version", get(runtime_version))
         // No-trailing-slash redirect to the canonical contract root URL.
         // Without this, pasting `/v1/contract/web/<key>` (no slash)
         // into the address bar 404s — common HTTP UX is to either
@@ -22,6 +27,27 @@ pub(super) fn routes(config: Config) -> Router {
         .route("/v1/contract/web/{key}/", get(web_home_v1))
         .route("/v1/contract/web/{key}/{*path}", get(web_subpages_v1))
         .with_state(config)
+}
+
+/// JSON returned by `GET /v1/version`.
+#[derive(serde::Serialize)]
+struct RuntimeVersion {
+    /// Version of the binary currently serving requests
+    /// (`CARGO_PKG_VERSION` of the running process).
+    version: &'static str,
+}
+
+/// `GET /v1/version` — reports the running node's version so the homepage JS
+/// can detect when it is rendering a stale, cached page from an older binary.
+///
+/// Returns `PCK_VERSION` (the compile-time version of *this* live process)
+/// rather than the `network_status` snapshot: both are seeded from the same
+/// constant, but reading the constant directly is always available, even
+/// during the startup window before the snapshot exists.
+async fn runtime_version() -> impl IntoResponse {
+    axum::Json(RuntimeVersion {
+        version: crate::config::PCK_VERSION,
+    })
 }
 
 async fn web_home_v1(
@@ -71,6 +97,26 @@ mod tests {
 
     fn valid_key() -> &'static str {
         "EqJ5YpEEV3XLqEvKWLQHFhGAac2qXzSUoE6k2zbdnXBr"
+    }
+
+    /// `GET /v1/version` must report the running binary's version as JSON so
+    /// the homepage stale-assets check (#4289) has a live runtime version to
+    /// compare against. The reported version must match the compiled-in
+    /// `CARGO_PKG_VERSION`.
+    #[tokio::test]
+    async fn runtime_version_reports_running_pkg_version() {
+        use axum::body::to_bytes;
+
+        let response = runtime_version().await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            json.get("version").and_then(|v| v.as_str()),
+            Some(env!("CARGO_PKG_VERSION")),
+            "endpoint must report the running binary's CARGO_PKG_VERSION"
+        );
     }
 
     /// Regression test for freenet/freenet-core#4019.

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -20,48 +20,6 @@ pub(super) async fn peer_detail(Path(address): Path<String>) -> impl IntoRespons
     Html(peer_detail_html(&address))
 }
 
-/// Reference specification of the "stale assets" banner rule, used to test
-/// the logic the homepage JS implements client-side.
-///
-/// The actual mismatch detection runs in the browser (see
-/// `checkVersionMismatch` in [`JS`]): the served page bakes in its
-/// `asset_version` (the build that generated the HTML/JS the browser is
-/// running) and fetches the live `runtime_version` from `/v1/version` at page
-/// load. This Rust function is the canonical, unit-testable statement of when
-/// the banner should appear; the JS mirrors it exactly. Keeping it here (and
-/// tested) makes the rule's edge cases explicit and guards against the JS
-/// drifting from the intended behaviour. It is `#[cfg(test)]` because the
-/// production decision is made in JS, not in the server-side render.
-///
-/// The mismatch is meaningful in the #3967 / #4289 scenario: a browser is
-/// still holding a cached homepage emitted by an old binary while a newer
-/// binary is now the process actually answering requests. In that case the
-/// asset version (frozen in the cached page) differs from the live runtime
-/// version, and the page is genuinely stale — the user should refresh.
-///
-/// The banner is shown **only** when both versions are known and they
-/// differ. A missing/unknown version on either side (`""` or `"?"`, e.g. the
-/// node is mid-startup and `network_status` has no snapshot yet) is treated
-/// as "can't tell" and never triggers the banner, so the warning cannot fire
-/// spuriously during startup. The comparison is an exact string match: any
-/// difference in the published version string (including pre-release suffixes
-/// like `0.2.68-rc1`) is a real asset/runtime divergence worth surfacing.
-#[cfg(test)]
-fn should_show_version_banner(asset_version: &str, runtime_version: &str) -> bool {
-    if !version_is_known(asset_version) || !version_is_known(runtime_version) {
-        return false;
-    }
-    asset_version != runtime_version
-}
-
-/// A version string is "known" when it is non-empty and not the `"?"`
-/// placeholder used by the homepage when no `network_status` snapshot exists.
-/// Reference for the JS `versionIsKnown`; see [`should_show_version_banner`].
-#[cfg(test)]
-fn version_is_known(version: &str) -> bool {
-    !version.is_empty() && version != "?"
-}
-
 fn homepage_html() -> String {
     let snap = network_status::get_snapshot();
 
@@ -3996,6 +3954,50 @@ mod tests {
     }
 
     // ── Asset/runtime version mismatch banner (#4289) ──────────────────────
+
+    /// Reference specification of the "stale assets" banner rule, used to test
+    /// the logic the homepage JS implements client-side.
+    ///
+    /// The actual mismatch detection runs in the browser (see
+    /// `checkVersionMismatch` in [`JS`]): the served page bakes in its
+    /// `asset_version` (the build that generated the HTML/JS the browser is
+    /// running) and fetches the live `runtime_version` from `/v1/version` at page
+    /// load. This Rust function is the canonical, unit-testable statement of when
+    /// the banner should appear; the JS mirrors it exactly. Keeping it here (and
+    /// tested) makes the rule's edge cases explicit and guards against the JS
+    /// drifting from the intended behaviour. It lives in the test module (not as
+    /// production code) because the production decision is made in JS, not in the
+    /// server-side render — and keeping it inside the single `#[cfg(test)]`
+    /// boundary preserves the source-scrape pin invariant relied on by
+    /// `peer_detail_panel_calls_estimator_helper_for_all_three_components` (the
+    /// first `#[cfg(test)]` marker must be the production/test boundary).
+    ///
+    /// The mismatch is meaningful in the #3967 / #4289 scenario: a browser is
+    /// still holding a cached homepage emitted by an old binary while a newer
+    /// binary is now the process actually answering requests. In that case the
+    /// asset version (frozen in the cached page) differs from the live runtime
+    /// version, and the page is genuinely stale — the user should refresh.
+    ///
+    /// The banner is shown **only** when both versions are known and they
+    /// differ. A missing/unknown version on either side (`""` or `"?"`, e.g. the
+    /// node is mid-startup and `network_status` has no snapshot yet) is treated
+    /// as "can't tell" and never triggers the banner, so the warning cannot fire
+    /// spuriously during startup. The comparison is an exact string match: any
+    /// difference in the published version string (including pre-release suffixes
+    /// like `0.2.68-rc1`) is a real asset/runtime divergence worth surfacing.
+    fn should_show_version_banner(asset_version: &str, runtime_version: &str) -> bool {
+        if !version_is_known(asset_version) || !version_is_known(runtime_version) {
+            return false;
+        }
+        asset_version != runtime_version
+    }
+
+    /// A version string is "known" when it is non-empty and not the `"?"`
+    /// placeholder used by the homepage when no `network_status` snapshot exists.
+    /// Reference for the JS `versionIsKnown`; see [`should_show_version_banner`].
+    fn version_is_known(version: &str) -> bool {
+        !version.is_empty() && version != "?"
+    }
 
     #[test]
     fn version_banner_hidden_when_versions_match() {

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -20,6 +20,48 @@ pub(super) async fn peer_detail(Path(address): Path<String>) -> impl IntoRespons
     Html(peer_detail_html(&address))
 }
 
+/// Reference specification of the "stale assets" banner rule, used to test
+/// the logic the homepage JS implements client-side.
+///
+/// The actual mismatch detection runs in the browser (see
+/// `checkVersionMismatch` in [`JS`]): the served page bakes in its
+/// `asset_version` (the build that generated the HTML/JS the browser is
+/// running) and fetches the live `runtime_version` from `/v1/version` at page
+/// load. This Rust function is the canonical, unit-testable statement of when
+/// the banner should appear; the JS mirrors it exactly. Keeping it here (and
+/// tested) makes the rule's edge cases explicit and guards against the JS
+/// drifting from the intended behaviour. It is `#[cfg(test)]` because the
+/// production decision is made in JS, not in the server-side render.
+///
+/// The mismatch is meaningful in the #3967 / #4289 scenario: a browser is
+/// still holding a cached homepage emitted by an old binary while a newer
+/// binary is now the process actually answering requests. In that case the
+/// asset version (frozen in the cached page) differs from the live runtime
+/// version, and the page is genuinely stale — the user should refresh.
+///
+/// The banner is shown **only** when both versions are known and they
+/// differ. A missing/unknown version on either side (`""` or `"?"`, e.g. the
+/// node is mid-startup and `network_status` has no snapshot yet) is treated
+/// as "can't tell" and never triggers the banner, so the warning cannot fire
+/// spuriously during startup. The comparison is an exact string match: any
+/// difference in the published version string (including pre-release suffixes
+/// like `0.2.68-rc1`) is a real asset/runtime divergence worth surfacing.
+#[cfg(test)]
+fn should_show_version_banner(asset_version: &str, runtime_version: &str) -> bool {
+    if !version_is_known(asset_version) || !version_is_known(runtime_version) {
+        return false;
+    }
+    asset_version != runtime_version
+}
+
+/// A version string is "known" when it is non-empty and not the `"?"`
+/// placeholder used by the homepage when no `network_status` snapshot exists.
+/// Reference for the JS `versionIsKnown`; see [`should_show_version_banner`].
+#[cfg(test)]
+fn version_is_known(version: &str) -> bool {
+    !version.is_empty() && version != "?"
+}
+
 fn homepage_html() -> String {
     let snap = network_status::get_snapshot();
 
@@ -102,6 +144,8 @@ fn homepage_html() -> String {
         </div>
     </header>
 
+    <div class="version-banner" id="version-mismatch-banner" data-asset-version="{asset_version}" role="alert" hidden></div>
+
     <main>
         {status_card}
         {peers_card}
@@ -142,6 +186,10 @@ fn homepage_html() -> String {
         JS = JS,
         favicon = favicon,
         version = html_escape(version),
+        // Asset version = the build that compiled THIS served page. Baked in at
+        // compile time so the JS can compare it against the live runtime version
+        // fetched from /v1/version and warn when a cached page is stale (#4289).
+        asset_version = html_escape(crate::config::PCK_VERSION),
         uptime = uptime,
         peer_id = html_escape(peer_id),
         peer_copy_btn = peer_copy_btn,
@@ -1810,6 +1858,22 @@ main {
     margin-bottom: 0.35rem;
     font-size: 0.85rem;
 }
+/* Stale-assets warning bar (#4289): shown by the JS only when the served
+   page's compile-time version differs from the live runtime version. */
+.version-banner {
+    background: rgba(248, 113, 113, 0.15);
+    border-bottom: 2px solid rgba(248, 113, 113, 0.5);
+    color: #f87171;
+    padding: 0.6rem 1.5rem;
+    font-size: 0.9rem;
+    font-weight: 500;
+    text-align: center;
+}
+[data-theme="light"] .version-banner {
+    color: #b91c1c;
+    background: rgba(220, 38, 38, 0.1);
+    border-bottom-color: rgba(220, 38, 38, 0.4);
+}
 .attempts {
     color: var(--text-muted);
     font-size: 0.8rem;
@@ -2584,6 +2648,44 @@ function checkForUpdate() {
     });
 }
 
+/* A version string is "known" when it is non-empty and not the '?'
+   placeholder the homepage uses before a node snapshot exists.
+   Mirrors version_is_known() in home_page.rs — keep both in sync. */
+function versionIsKnown(v) {
+    return !!v && v !== '?';
+}
+
+/* Show the stale-assets banner iff both the asset version (baked into this
+   served page at compile time) and the live runtime version are known and
+   differ. Mirrors should_show_version_banner() in home_page.rs. The point
+   of comparing against a LIVE fetch (not the rendered data-version) is to
+   catch the #4289 case: the browser is holding a cached page emitted by an
+   old binary while a newer binary is now answering requests. */
+function checkVersionMismatch() {
+    var banner = document.getElementById('version-mismatch-banner');
+    if (!banner) return;
+    var assetVersion = banner.getAttribute('data-asset-version') || '';
+    if (!versionIsKnown(assetVersion)) return;
+    fetch('/v1/version', { headers: { 'Accept': 'application/json' } }).then(function(r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+    }).then(function(data) {
+        var runtimeVersion = data && data.version;
+        if (!versionIsKnown(runtimeVersion)) return;
+        if (runtimeVersion !== assetVersion) {
+            banner.textContent = 'Asset version ' + assetVersion + ' ≠ node version '
+                + runtimeVersion + ' — this page is stale, refresh to load the current version.';
+            banner.hidden = false;
+        } else {
+            /* Versions agree (e.g. after a refresh fixed the staleness). */
+            banner.hidden = true;
+        }
+    }).catch(function(e) {
+        /* Endpoint unreachable / node mid-startup — don't show a spurious banner. */
+        console.debug('Version check failed:', e);
+    });
+}
+
 /* Tab switching for per-operation-type charts */
 function switchTab(el) {
     var tabId = el.getAttribute('data-tab');
@@ -2619,6 +2721,7 @@ document.addEventListener('DOMContentLoaded', function() {
     restoreTab();
     restoreSort();
     checkForUpdate();
+    checkVersionMismatch();
 
     /* Delegated click handler \u2014 survives <main> innerHTML swaps from auto-refresh,
        so we don't need to re-bind after each refresh. */
@@ -2668,6 +2771,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 /* Restore tab selection and table sort after content swap */
                 restoreTab();
                 restoreSort();
+                /* Re-check the live runtime version so the stale-assets banner
+                   appears (or clears) if the serving process changes while the
+                   page stays open. The banner's data-asset-version stays anchored
+                   to the originally-loaded page, which is the version we're
+                   comparing against. */
+                checkVersionMismatch();
             }).catch(function(e) { console.warn('Dashboard refresh failed:', e); })
               .finally(scheduleRefresh);
         }, 5000);
@@ -3884,6 +3993,106 @@ mod tests {
             transport_snapshot: TransportSnapshot::default(),
             governance: Default::default(),
         }
+    }
+
+    // ── Asset/runtime version mismatch banner (#4289) ──────────────────────
+
+    #[test]
+    fn version_banner_hidden_when_versions_match() {
+        assert!(
+            !should_show_version_banner("0.2.49", "0.2.49"),
+            "identical asset and runtime versions must not show the banner"
+        );
+    }
+
+    #[test]
+    fn version_banner_shown_when_versions_differ() {
+        assert!(
+            should_show_version_banner("0.2.37", "0.2.49"),
+            "a stale cached asset version vs a newer runtime must show the banner"
+        );
+        // Direction is irrelevant: any divergence is worth surfacing.
+        assert!(
+            should_show_version_banner("0.2.49", "0.2.37"),
+            "asset newer than runtime is still a mismatch worth surfacing"
+        );
+    }
+
+    #[test]
+    fn version_banner_treats_prerelease_suffixes_as_distinct() {
+        // Pre-release / build-metadata suffixes are part of the published
+        // version string; an exact mismatch there is a real divergence.
+        assert!(
+            should_show_version_banner("0.2.68-rc1", "0.2.68"),
+            "0.2.68-rc1 and 0.2.68 are different builds and must mismatch"
+        );
+        assert!(
+            !should_show_version_banner("0.2.68-rc1", "0.2.68-rc1"),
+            "identical pre-release strings must not show the banner"
+        );
+    }
+
+    #[test]
+    fn version_banner_hidden_when_either_version_unknown() {
+        // Startup race: node has no snapshot yet, so the runtime version is
+        // the "?" placeholder or empty. The banner must not fire spuriously.
+        assert!(
+            !should_show_version_banner("0.2.49", "?"),
+            "unknown runtime version (?) must not trigger the banner"
+        );
+        assert!(
+            !should_show_version_banner("0.2.49", ""),
+            "empty runtime version must not trigger the banner"
+        );
+        assert!(
+            !should_show_version_banner("?", "0.2.49"),
+            "unknown asset version (?) must not trigger the banner"
+        );
+        assert!(
+            !should_show_version_banner("", "0.2.49"),
+            "empty asset version must not trigger the banner"
+        );
+        assert!(
+            !should_show_version_banner("?", "?"),
+            "both unknown must not trigger the banner"
+        );
+    }
+
+    #[test]
+    fn homepage_renders_version_mismatch_banner_slot() {
+        let html = homepage_html();
+        assert!(
+            html.contains("id=\"version-mismatch-banner\""),
+            "homepage must render a hidden banner slot the JS can reveal on mismatch"
+        );
+        assert!(
+            html.contains("data-asset-version="),
+            "banner slot must carry the compile-time asset version for the JS comparison"
+        );
+        // The slot must ship hidden so it never flashes before the live check.
+        let slot = extract_element_line(&html, "id=\"version-mismatch-banner\"");
+        assert!(
+            slot.contains("hidden"),
+            "version mismatch banner must be hidden by default, got: {slot}"
+        );
+    }
+
+    #[test]
+    fn js_contains_version_mismatch_check() {
+        assert!(
+            JS.contains("checkVersionMismatch"),
+            "JS must include the asset/runtime version mismatch check"
+        );
+        assert!(
+            JS.contains("/v1/version"),
+            "JS must query the runtime version endpoint"
+        );
+        // The JS must mirror should_show_version_banner: skip unknown ('?'/'')
+        // versions so the banner can't fire during startup.
+        assert!(
+            JS.contains("data-asset-version"),
+            "JS must read the baked-in asset version from the banner slot"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When a Freenet node binary on disk is updated to vX but the running
process is still vY (a stuck wrapper, a port-conflict orphan, or launchd
backoff), the homepage at `http://127.0.0.1:7509/` keeps serving the old
binary's embedded assets. To the user this looks like a frozen UI rather
than a stale node. In the #3967 incident the staleness went unnoticed
for days.

This is item 4 of #3967's acceptance checklist.

## Solution

Make the "stale assets" symptom self-diagnosing.

- The served homepage now carries its **asset version** — the
  `CARGO_PKG_VERSION` of the binary that emitted the page — baked into a
  hidden banner slot (`data-asset-version`).
- A new lightweight endpoint, `GET /v1/version`, returns the **runtime
  version** of the process actually answering requests right now (as
  JSON: `{"version": "0.2.x"}`).
- At page load the homepage JS fetches `/v1/version` and reveals a
  warning banner when the live runtime version differs from the asset
  version baked into the page the browser is running. The check re-runs
  on each auto-refresh, so the banner appears (or clears) live if the
  serving process changes while the page stays open.

The key insight is comparing against a **live fetch** rather than the
rendered `data-version`: within a single served page both come from the
same binary and always agree, so they can't detect the #4289 case. A
live fetch catches the scenario where the browser holds a cached page
from an old binary while a newer binary is now answering.

Why not a `build.rs` const (as the issue sketched): the asset version is
already available as the compile-time `PCK_VERSION`
(`env!("CARGO_PKG_VERSION")`), so no extra build plumbing is needed — the
page is emitted by the same binary whose version we bake in.

The mismatch decision is a pure, unit-tested helper
(`should_show_version_banner`): show only when both versions are known
and they differ; an unknown (`"?"`/empty) version on either side never
triggers the banner, so it cannot fire spuriously during startup. The JS
mirrors the same rule (`checkVersionMismatch` + `versionIsKnown`), and
the banner uses `textContent` (not `innerHTML`) so a version string can't
inject markup.

## Testing

New unit tests in `crates/core/src/server/home_page.rs`:

- `version_banner_hidden_when_versions_match` — match → no banner.
- `version_banner_shown_when_versions_differ` — mismatch (either
  direction) → banner.
- `version_banner_treats_prerelease_suffixes_as_distinct` —
  `0.2.68-rc1` vs `0.2.68` is a real mismatch; identical pre-release
  strings are not.
- `version_banner_hidden_when_either_version_unknown` — `"?"`/empty on
  either side never shows the banner (startup-race guard).
- `homepage_renders_version_mismatch_banner_slot` — the hidden banner
  slot with `data-asset-version` is rendered.
- `js_contains_version_mismatch_check` — the JS wires up the check and
  queries `/v1/version`.

New endpoint test in `crates/core/src/server/client_api/v1.rs`:

- `runtime_version_reports_running_pkg_version` — `GET /v1/version`
  returns the running binary's `CARGO_PKG_VERSION` as JSON.

`cargo fmt` and `cargo clippy -p freenet --all-targets -- -D warnings`
are clean.

## Fixes

Closes #4289

[AI-assisted - Claude]
