### PR TITLE
feat(governance): egress self-block for banned contracts at originator entry-points

### DIFF
--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -336,7 +336,14 @@ async fn report_op_init_error(
         // so this also serves as the source-of-truth for the
         // user-visible shape of `OpError::NodeShuttingDown`.
         OpError::NodeShuttingDown => ErrorKind::Shutdown,
-        OpError::RingError(crate::ring::RingError::ConnError(_))
+        // Phase 7 egress self-block (#4300): a local client originated a
+        // request for a contract this node has banned. Surface as a
+        // typed `OperationError` (no dedicated wire variant exists in
+        // stdlib, and adding one would be a wire-format change requiring
+        // a separate stdlib-first release) so the client sees a clear,
+        // contract-named reason instead of a silent timeout.
+        OpError::ContractBanned { .. }
+        | OpError::RingError(crate::ring::RingError::ConnError(_))
         | OpError::RingError(crate::ring::RingError::NoHostingPeers(_))
         | OpError::ConnError(_)
         | OpError::ContractError(_)
@@ -2343,5 +2350,46 @@ pub(crate) mod test {
              failure if the shutdown signal is swallowed into the \
              catch-all."
         );
+    }
+
+    /// Phase 7 egress self-block (#4300): `OpError::ContractBanned`
+    /// (returned by `start_client_*` when the local client originates a
+    /// request for a banned contract) must map to a client-visible
+    /// `ErrorKind::OperationError` whose cause names the contract — NOT a
+    /// silent proceed-then-timeout. Replicates the relevant arm of
+    /// `report_op_init_error` to avoid constructing the full `OpManager`
+    /// fixture (same approach as the NodeShuttingDown pin above). The
+    /// production match is exhaustive, so a missing arm fails to compile;
+    /// this test additionally locks the user-visible shape.
+    #[test]
+    fn op_error_contract_banned_maps_to_operation_error_with_cause() {
+        use crate::operations::OpError;
+        use freenet_stdlib::client_api::ErrorKind;
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let instance_id = ContractInstanceId::new([7u8; 32]);
+        let err = OpError::ContractBanned { instance_id };
+        let op_name = "PUT";
+        let kind = match err {
+            OpError::ContractBanned { .. } => ErrorKind::OperationError {
+                cause: format!("{op_name} operation failed: {err}").into(),
+            },
+            // Other variants are irrelevant to this test.
+            _ => ErrorKind::Unhandled {
+                cause: "irrelevant for this test".to_string().into(),
+            },
+        };
+        match kind {
+            ErrorKind::OperationError { cause } => {
+                assert!(
+                    cause.contains("banned"),
+                    "ContractBanned cause must mention the ban so the \
+                     client understands why the request was rejected; got: {cause}"
+                );
+            }
+            other => panic!(
+                "OpError::ContractBanned must map to ErrorKind::OperationError, got {other:?}"
+            ),
+        }
     }
 }

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -6162,5 +6162,31 @@ mod tests {
              contract's broadcast is skipped — including the no-target retry \
              re-emission. Body:\n{body}"
         );
+
+        // Regression guard for the `fix(governance): clear broadcast retry
+        // state on banned-egress skip` commit: the banned-skip branch must
+        // also clear the per-contract retry/streak bookkeeping, otherwise a
+        // contract banned mid-retry-cycle leaves a stale entry that nothing
+        // clears until it is unbanned and broadcast again. We scope the
+        // assertion to the banned-skip branch (between the gate and its
+        // early `return;`) so deleting either `remove()` call fails this
+        // test — the gate-ordering assertion above passes even without
+        // them.
+        let banned_branch = &body[gate_pos..];
+        let return_pos = banned_branch
+            .find("return;")
+            .expect("banned-egress branch must early-return");
+        let banned_branch = &banned_branch[..return_pos];
+        assert!(
+            banned_branch.contains("self.broadcast_retries.remove(&key)"),
+            "banned-egress skip must clear broadcast_retries for the contract \
+             so a ban mid-retry-cycle doesn't leave a stale entry. Branch:\n{banned_branch}"
+        );
+        assert!(
+            banned_branch.contains("self.broadcast_no_target_streak.remove(&key)"),
+            "banned-egress skip must clear broadcast_no_target_streak for the \
+             contract so a ban mid-retry-cycle doesn't leave a stale entry. \
+             Branch:\n{banned_branch}"
+        );
     }
 }

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -4286,6 +4286,14 @@ impl P2pConnManager {
                 phase = "broadcast_state_change_banned_skip",
                 "skipping state-change broadcast for banned contract"
             );
+            // Drop any in-flight retry/streak bookkeeping for this
+            // contract: if it was banned mid-retry-cycle, a previously
+            // scheduled re-emission would otherwise leave a stale entry
+            // here that nothing clears until the contract is unbanned and
+            // broadcast again. Mirrors the cleanup the targets-found and
+            // retries-exhausted paths perform.
+            self.broadcast_retries.remove(&key);
+            self.broadcast_no_target_streak.remove(&key);
             return;
         }
 

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -4269,6 +4269,26 @@ impl P2pConnManager {
             state_size = new_state.size(),
             "BroadcastStateChange event received"
         );
+
+        // Phase 7 egress self-block (#4300). A locally-applied UPDATE
+        // (e.g. delegate-driven) drives this fan-out to subscribers who
+        // don't know about our ban. If we have banned the contract, skip
+        // the fan-out entirely — and the no-target retry re-emission with
+        // it — rather than push state for a contract we have decided is
+        // harmful. There is no client to notify here (this is the
+        // fire-and-forget broadcast path), so we skip with a debug log
+        // instead of returning a typed error. Complements the
+        // client-originated UPDATE gate in `start_client_update` and the
+        // receive-side `UpdateMsg::*` drop in node.rs (PR #4299).
+        if op_manager.ring.contract_ban_list.is_banned(key.id()) {
+            tracing::debug!(
+                contract = %key,
+                phase = "broadcast_state_change_banned_skip",
+                "skipping state-change broadcast for banned contract"
+            );
+            return;
+        }
+
         let self_addr = op_manager.ring.connection_manager.get_own_addr();
         let Some(self_addr) = self_addr else {
             tracing::warn!(
@@ -6090,6 +6110,49 @@ mod tests {
             send_pos > remove_pos,
             "the PeerDisconnected send must happen on the sender taken out by \
              pending_op_results.remove (send-before-drop). Arm body:\n{body}"
+        );
+    }
+
+    /// Phase 7 egress self-block pin (#4300). `handle_broadcast_state_change`
+    /// MUST skip the fan-out for a banned contract — the egress
+    /// `contract_ban_list.is_banned(key.id())` check must appear BEFORE
+    /// the target resolution (`get_broadcast_targets_update`) so a
+    /// delegate-driven UPDATE for a banned contract is not fanned out to
+    /// subscribers who don't know about our ban, and so the no-target
+    /// retry re-emission is skipped too. Mirrors the receive-side
+    /// `update_dispatch_gates_banned_contracts` and the other egress
+    /// pins in the `start_client_*` entry points.
+    #[test]
+    fn handle_broadcast_state_change_gates_banned_egress() {
+        const SOURCE: &str = include_str!("p2p_protoc.rs");
+
+        let fn_anchor = "async fn handle_broadcast_state_change(";
+        let fn_start = SOURCE
+            .find(fn_anchor)
+            .expect("handle_broadcast_state_change renamed or removed");
+        // Bound the slice at the next `async fn ` so the assertion can't
+        // accidentally match a later function's body.
+        let after_header = &SOURCE[fn_start + fn_anchor.len()..];
+        let body_end = after_header
+            .find("\n    async fn ")
+            .map(|p| fn_start + fn_anchor.len() + p)
+            .unwrap_or(SOURCE.len());
+        let body = &SOURCE[fn_start..body_end];
+
+        let gate_pos = body.find("contract_ban_list.is_banned").expect(
+            "handle_broadcast_state_change is missing the ban-list egress gate — \
+             banned contracts would continue to be fanned out to subscribers \
+             (defeats the Phase 7 egress self-block, #4300)",
+        );
+        let target_pos = body
+            .find("get_broadcast_targets_update")
+            .expect("handle_broadcast_state_change is missing get_broadcast_targets_update");
+        assert!(
+            gate_pos < target_pos,
+            "BroadcastStateChange ban-list gate (offset {gate_pos}) must run \
+             BEFORE target resolution (offset {target_pos}) so a banned \
+             contract's broadcast is skipped — including the no-target retry \
+             re-emission. Body:\n{body}"
         );
     }
 }

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -218,7 +218,25 @@ pub(crate) fn reject_if_contract_banned(
     op_manager: &OpManager,
     instance_id: &ContractInstanceId,
 ) -> Result<(), OpError> {
-    if op_manager.ring.contract_ban_list.is_banned(instance_id) {
+    reject_if_contract_banned_on(&op_manager.ring.contract_ban_list, instance_id)
+}
+
+/// Egress-gate core, extracted from [`reject_if_contract_banned`] so the
+/// real `is_banned`-backed decision can be unit-tested against a
+/// `ContractBanList` fixture directly, without standing up a full
+/// `OpManager` (which spawns background tasks and needs a `NodeConfig`,
+/// channels, and a `NetEventRegister`). Mirrors the `*_on` extraction
+/// convention used throughout `op_state_manager.rs` for the same reason.
+///
+/// # Errors
+///
+/// Returns `Err(OpError::ContractBanned { instance_id })` when the
+/// contract is currently on `ban_list`. Returns `Ok(())` otherwise.
+pub(crate) fn reject_if_contract_banned_on(
+    ban_list: &crate::ring::contract_ban_list::ContractBanList,
+    instance_id: &ContractInstanceId,
+) -> Result<(), OpError> {
+    if ban_list.is_banned(instance_id) {
         tracing::debug!(
             %instance_id,
             phase = "egress_banned_reject",
@@ -1058,6 +1076,123 @@ mod sub_op_subscribe_pin_tests {
              subscribe driver `subscribe::run_client_subscribe` — \
              matches the `maybe_subscribe_child` pattern in \
              `put/op_ctx_task.rs` and `get/op_ctx_task.rs`."
+        );
+    }
+}
+
+#[cfg(test)]
+mod egress_banned_gate_tests {
+    //! Direct behavioral tests for the #4300 egress self-block gate
+    //! (`reject_if_contract_banned` → `reject_if_contract_banned_on`).
+    //!
+    //! The source-scrape pins in each `op_ctx_task.rs` prove the four
+    //! `start_client_*` entry points *call* the gate, and the mapping
+    //! test in `client_events.rs` proves `OpError::ContractBanned` maps
+    //! to the right `ErrorKind`. Neither exercises the gate's actual
+    //! decision against a real `ContractBanList`, so an inverted
+    //! predicate (`!is_banned`), a wrong-id lookup, or a swapped
+    //! `Ok`/`Err` return would pass every existing test. These tests
+    //! drive the real `is_banned`-backed logic so that class of bug
+    //! fails CI.
+    use super::{OpError, reject_if_contract_banned_on};
+    use crate::ring::contract_ban_list::{BanReason, ContractBanList};
+    use crate::util::time_source::{SharedMockTimeSource, TimeSource};
+    use freenet_stdlib::prelude::ContractInstanceId;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    fn mk_contract(byte: u8) -> ContractInstanceId {
+        ContractInstanceId::new([byte; 32])
+    }
+
+    fn mk_ban_list() -> (ContractBanList, SharedMockTimeSource) {
+        let ts = SharedMockTimeSource::new();
+        let bl = ContractBanList::new(Arc::new(ts.clone()));
+        (bl, ts)
+    }
+
+    /// A banned contract's id must be rejected with the typed
+    /// `OpError::ContractBanned` carrying that exact id. Catches an
+    /// inverted predicate (would return `Ok`) and a swapped return.
+    #[test]
+    fn banned_contract_is_rejected_with_typed_error() {
+        let (bl, ts) = mk_ban_list();
+        let banned = mk_contract(1);
+        bl.ban(
+            banned,
+            ts.now() + Duration::from_secs(60),
+            BanReason::AutoMad,
+        );
+
+        match reject_if_contract_banned_on(&bl, &banned) {
+            Err(OpError::ContractBanned { instance_id }) => {
+                assert_eq!(
+                    instance_id, banned,
+                    "the rejected id must be the banned contract's id, not some other id"
+                );
+            }
+            other => panic!(
+                "banned contract must be rejected with OpError::ContractBanned, got {other:?}"
+            ),
+        }
+    }
+
+    /// A contract that is NOT on the ban list must pass the gate.
+    /// Catches an inverted predicate (would reject everything).
+    #[test]
+    fn unbanned_contract_passes() {
+        let (bl, _ts) = mk_ban_list();
+        assert!(
+            reject_if_contract_banned_on(&bl, &mk_contract(2)).is_ok(),
+            "a contract that is not banned must pass the egress gate"
+        );
+    }
+
+    /// The gate keys on the specific id: banning contract A must not
+    /// reject a different, unbanned contract B. Catches a wrong-id
+    /// lookup that ignores the argument and consults the whole list.
+    #[test]
+    fn ban_is_scoped_to_the_specific_contract_id() {
+        let (bl, ts) = mk_ban_list();
+        let banned = mk_contract(1);
+        let other = mk_contract(2);
+        bl.ban(
+            banned,
+            ts.now() + Duration::from_secs(60),
+            BanReason::AutoMad,
+        );
+
+        assert!(
+            reject_if_contract_banned_on(&bl, &banned).is_err(),
+            "the banned contract must be rejected"
+        );
+        assert!(
+            reject_if_contract_banned_on(&bl, &other).is_ok(),
+            "a different, unbanned contract must NOT be rejected by another contract's ban"
+        );
+    }
+
+    /// Once a ban's TTL expires, the gate must let the contract through
+    /// again — the egress block is time-bounded, matching the
+    /// receive-side `is_banned` expiry semantics.
+    #[test]
+    fn expired_ban_no_longer_rejects() {
+        let (bl, ts) = mk_ban_list();
+        let contract = mk_contract(1);
+        bl.ban(
+            contract,
+            ts.now() + Duration::from_secs(60),
+            BanReason::AutoMad,
+        );
+        assert!(
+            reject_if_contract_banned_on(&bl, &contract).is_err(),
+            "contract must be rejected while the ban is active"
+        );
+
+        ts.advance_time(Duration::from_secs(61));
+        assert!(
+            reject_if_contract_banned_on(&bl, &contract).is_ok(),
+            "contract must pass the gate once its ban TTL has expired"
         );
     }
 }

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -117,6 +117,18 @@ pub(crate) enum OpError {
     /// `NodeEvent::Disconnect`.
     #[error("node is shutting down; client operation rejected")]
     NodeShuttingDown,
+
+    /// Phase 7 egress self-block (#4300): a local client tried to
+    /// originate a PUT/GET/SUBSCRIBE/UPDATE for a contract this node
+    /// has banned. The driver task is NOT spawned — we refuse to
+    /// launder requests for a contract we have decided is harmful. The
+    /// receive-side gate (PR #4299) already drops inbound requests for
+    /// the same contract; this is the complementary egress gate so the
+    /// ban is a true block, not just a receive-side filter. Surfaced to
+    /// the client as a typed error rather than silently proceeding into
+    /// a timeout.
+    #[error("contract {instance_id} is banned on this node; request rejected")]
+    ContractBanned { instance_id: ContractInstanceId },
 }
 
 impl OpError {
@@ -172,6 +184,45 @@ impl<T> From<SendError<T>> for OpError {
     fn from(_: SendError<T>) -> OpError {
         OpError::NotificationError
     }
+}
+
+/// Phase 7 egress self-block (#4300). Returns `Err(OpError::ContractBanned)`
+/// if `instance_id`'s contract is on this node's ban list, otherwise
+/// `Ok(())`.
+///
+/// Called at the top of every client-originator entry point
+/// (`start_client_put` / `_get` / `_subscribe` / `_update`) BEFORE the
+/// driver task is spawned, so a banned contract's request is rejected
+/// with a typed error instead of consuming this node's outbound network
+/// resources and then failing (or worse, succeeding at peers that don't
+/// know about our ban). This mirrors the receive-side wire-boundary drop
+/// added in PR #4299: a banned contract can neither receive new state via
+/// this node (receive gate) nor transmit new state via this node (this
+/// egress gate).
+///
+/// Keyed on `ContractInstanceId` because that is what the ban list keys
+/// on and what every entry point has available (`key.id()` for PUT/UPDATE,
+/// the bare `instance_id` for GET/SUBSCRIBE). Factored out of the four
+/// entry points so the gate logic is unit-testable against a
+/// `ContractBanList` directly, and so the early-return shape stays
+/// identical across ops. The fan-out egress path (`BroadcastStateChange`)
+/// has no client to notify, so it skips rather than erroring — that gate
+/// lives at its own call site in `p2p_protoc.rs`.
+pub(crate) fn reject_if_contract_banned(
+    op_manager: &OpManager,
+    instance_id: &ContractInstanceId,
+) -> Result<(), OpError> {
+    if op_manager.ring.contract_ban_list.is_banned(instance_id) {
+        tracing::debug!(
+            %instance_id,
+            phase = "egress_banned_reject",
+            "rejecting client-originated request for banned contract"
+        );
+        return Err(OpError::ContractBanned {
+            instance_id: *instance_id,
+        });
+    }
+    Ok(())
 }
 
 /// Announces to neighbors that we're hosting a contract.

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -208,6 +208,12 @@ impl<T> From<SendError<T>> for OpError {
 /// identical across ops. The fan-out egress path (`BroadcastStateChange`)
 /// has no client to notify, so it skips rather than erroring — that gate
 /// lives at its own call site in `p2p_protoc.rs`.
+///
+/// # Errors
+///
+/// Returns `Err(OpError::ContractBanned { instance_id })` when the
+/// contract is currently on this node's `ContractBanList`. Returns
+/// `Ok(())` for any non-banned (or expired-ban) contract.
 pub(crate) fn reject_if_contract_banned(
     op_manager: &OpManager,
     instance_id: &ContractInstanceId,

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -132,6 +132,12 @@ pub(crate) async fn start_client_get(
     subscribe: bool,
     blocking_subscribe: bool,
 ) -> Result<Transaction, OpError> {
+    // Phase 7 egress self-block (#4300): refuse to originate a GET for
+    // a contract this node has banned, BEFORE spawning the driver.
+    // Mirrors the receive-side `GetMsg::Request` drop in node.rs (PR
+    // #4299). The client gets a typed `ContractBanned` error.
+    crate::operations::reject_if_contract_banned(&op_manager, &instance_id)?;
+
     // Test-only: count driver invocations so integration tests can
     // assert the driver was actually called (as opposed to
     // `client_events.rs`'s local-cache shortcut satisfying the GET).
@@ -3426,6 +3432,30 @@ mod tests {
             spawn_block.contains("let _inflight_guard = inflight_guard;"),
             "the ClientOpGuard must be moved into the spawned future \
              via `let _inflight_guard = inflight_guard;`."
+        );
+    }
+
+    /// Phase 7 egress self-block pin (#4300). `start_client_get` MUST
+    /// reject a banned contract BEFORE spawning the driver task. Mirrors
+    /// the receive-side `get_dispatch_gates_banned_contracts` pin in
+    /// `ring/contract_ban_list.rs`. See the sibling pin in
+    /// `put/op_ctx_task.rs` for the full rationale.
+    #[test]
+    fn start_client_get_gates_banned_contracts_before_spawn() {
+        let src = include_str!("op_ctx_task.rs");
+        let entry = src
+            .find("pub(crate) async fn start_client_get(")
+            .expect("start_client_get must exist");
+        let after_spawn = src[entry..]
+            .find("GlobalExecutor::spawn(")
+            .expect("start_client_get must spawn a driver task");
+        let before_spawn = &src[entry..entry + after_spawn];
+        assert!(
+            before_spawn.contains("reject_if_contract_banned"),
+            "start_client_get must call reject_if_contract_banned() \
+             before GlobalExecutor::spawn so a banned contract's GET is \
+             rejected with a typed error instead of being driven to peers \
+             (#4300 egress self-block)."
         );
     }
 

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -64,6 +64,14 @@ pub(crate) async fn start_client_put(
     subscribe: bool,
     blocking_subscribe: bool,
 ) -> Result<Transaction, OpError> {
+    // Phase 7 egress self-block (#4300): refuse to originate a PUT for
+    // a contract this node has banned, BEFORE spawning the driver. The
+    // client gets a typed `ContractBanned` error instead of a request
+    // that proceeds to peers (who don't know about our ban) and then
+    // fails or silently succeeds. Mirrors the receive-side drop in
+    // node.rs added by PR #4299.
+    crate::operations::reject_if_contract_banned(&op_manager, contract.key().id())?;
+
     tracing::debug!(
         tx = %client_tx,
         contract = %contract.key(),
@@ -2629,6 +2637,34 @@ mod tests {
              for the full driver lifetime. A bare drop at the spawn \
              site would clear the counter before run_client_put even \
              starts."
+        );
+    }
+
+    /// Phase 7 egress self-block pin (#4300). `start_client_put` MUST
+    /// reject a banned contract BEFORE spawning the driver task, so a
+    /// banned contract's PUT never consumes outbound network resources.
+    /// Mirrors the receive-side `put_dispatch_gates_banned_contracts`
+    /// pin in `ring/contract_ban_list.rs`. Sibling pins live in the
+    /// other three `start_client_*` entry points and at the
+    /// `handle_broadcast_state_change` egress fan-out in p2p_protoc.rs.
+    /// If this fails, the egress gate was deleted or moved after the
+    /// spawn — re-establish it before re-running the suite.
+    #[test]
+    fn start_client_put_gates_banned_contracts_before_spawn() {
+        let src = include_str!("op_ctx_task.rs");
+        let entry = src
+            .find("pub(crate) async fn start_client_put(")
+            .expect("start_client_put must exist");
+        let after_spawn = src[entry..]
+            .find("GlobalExecutor::spawn(")
+            .expect("start_client_put must spawn a driver task");
+        let before_spawn = &src[entry..entry + after_spawn];
+        assert!(
+            before_spawn.contains("reject_if_contract_banned"),
+            "start_client_put must call reject_if_contract_banned() \
+             before GlobalExecutor::spawn so a banned contract's PUT is \
+             rejected with a typed error instead of being driven to peers \
+             that don't know about our ban (#4300 egress self-block)."
         );
     }
 

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -65,6 +65,14 @@ pub(crate) async fn start_client_subscribe(
     instance_id: ContractInstanceId,
     client_tx: Transaction,
 ) -> Result<Transaction, OpError> {
+    // Phase 7 egress self-block (#4300): refuse to originate a
+    // SUBSCRIBE for a contract this node has banned, BEFORE spawning
+    // the driver, so we don't register interest in something we have
+    // decided to reject. Mirrors the receive-side `SubscribeMsg::Request`
+    // drop in node.rs (PR #4299). The client gets a typed
+    // `ContractBanned` error.
+    crate::operations::reject_if_contract_banned(&op_manager, &instance_id)?;
+
     tracing::debug!(
         tx = %client_tx,
         contract = %instance_id,
@@ -1735,6 +1743,31 @@ mod tests {
         assert!(
             spawn_block.contains("let _inflight_guard = inflight_guard;"),
             "the ClientOpGuard must be moved into the spawned future."
+        );
+    }
+
+    /// Phase 7 egress self-block pin (#4300). `start_client_subscribe`
+    /// MUST reject a banned contract BEFORE spawning the driver, so we
+    /// don't register interest in a contract we have decided to reject.
+    /// Mirrors the receive-side `subscribe_dispatch_gates_banned_contracts`
+    /// pin in `ring/contract_ban_list.rs`. See the sibling pin in
+    /// `put/op_ctx_task.rs` for the full rationale.
+    #[test]
+    fn start_client_subscribe_gates_banned_contracts_before_spawn() {
+        let src = include_str!("op_ctx_task.rs");
+        let entry = src
+            .find("pub(crate) async fn start_client_subscribe(")
+            .expect("start_client_subscribe must exist");
+        let after_spawn = src[entry..]
+            .find("GlobalExecutor::spawn(")
+            .expect("start_client_subscribe must spawn a driver task");
+        let before_spawn = &src[entry..entry + after_spawn];
+        assert!(
+            before_spawn.contains("reject_if_contract_banned"),
+            "start_client_subscribe must call reject_if_contract_banned() \
+             before GlobalExecutor::spawn so a banned contract's SUBSCRIBE \
+             is rejected with a typed error instead of registering interest \
+             (#4300 egress self-block)."
         );
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -99,6 +99,14 @@ pub(crate) async fn start_client_update(
     update_data: UpdateData<'static>,
     related_contracts: RelatedContracts<'static>,
 ) -> Result<Transaction, OpError> {
+    // Phase 7 egress self-block (#4300): refuse to originate an UPDATE
+    // for a contract this node has banned, BEFORE spawning the driver.
+    // This covers the client-originated UPDATE path; the delegate-driven
+    // broadcast fan-out is gated separately at `handle_broadcast_state_change`
+    // in p2p_protoc.rs. Mirrors the receive-side `UpdateMsg::*` drop in
+    // node.rs (PR #4299). The client gets a typed `ContractBanned` error.
+    crate::operations::reject_if_contract_banned(&op_manager, key.id())?;
+
     tracing::debug!(
         tx = %client_tx,
         contract = %key,
@@ -1903,6 +1911,51 @@ mod tests {
         assert!(
             spawn_block.contains("let _inflight_guard = inflight_guard;"),
             "the ClientOpGuard must be moved into the spawned future."
+        );
+    }
+
+    /// Phase 7 egress self-block pin (#4300). `start_client_update` MUST
+    /// reject a banned contract BEFORE spawning the driver. Mirrors the
+    /// receive-side `update_dispatch_gates_banned_contracts` pin in
+    /// `ring/contract_ban_list.rs`. See the sibling pin in
+    /// `put/op_ctx_task.rs` for the full rationale. The delegate-driven
+    /// broadcast fan-out is gated separately at
+    /// `handle_broadcast_state_change` in p2p_protoc.rs (pinned there).
+    #[test]
+    fn start_client_update_gates_banned_contracts_before_spawn() {
+        let src = include_str!("op_ctx_task.rs");
+        let entry = src
+            .find("pub(crate) async fn start_client_update(")
+            .expect("start_client_update must exist");
+        let after_spawn = src[entry..]
+            .find("GlobalExecutor::spawn(")
+            .expect("start_client_update must spawn a driver task");
+        let before_spawn = &src[entry..entry + after_spawn];
+        assert!(
+            before_spawn.contains("reject_if_contract_banned"),
+            "start_client_update must call reject_if_contract_banned() \
+             before GlobalExecutor::spawn so a banned contract's UPDATE \
+             is rejected with a typed error instead of being driven to \
+             peers (#4300 egress self-block)."
+        );
+    }
+
+    /// Phase 7 egress self-block pin (#4300). The typed
+    /// `OpError::ContractBanned` raised by the egress gate MUST be
+    /// translated to a client-visible error in `report_op_init_error`
+    /// (`client_events.rs`). The match there is exhaustive (no wildcard),
+    /// so a missing arm fails to compile — but this pin documents the
+    /// requirement and fails loudly if someone routes ContractBanned to
+    /// an inappropriate handler (e.g. silently swallows it).
+    #[test]
+    fn report_op_init_error_handles_contract_banned() {
+        let src = include_str!("../../client_events.rs");
+        assert!(
+            src.contains("OpError::ContractBanned"),
+            "report_op_init_error in client_events.rs must explicitly \
+             handle OpError::ContractBanned so the egress self-block \
+             (#4300) surfaces a typed error to the client instead of a \
+             silent proceed-then-timeout."
         );
     }
 

--- a/crates/core/src/ring/contract_ban_list.rs
+++ b/crates/core/src/ring/contract_ban_list.rs
@@ -20,16 +20,30 @@
 //!
 //! - **Responses to our own outbound requests.** If we sent a request
 //!   before the ban kicked in, allowing the reply completes that
-//!   transaction cleanly. The next request we make for the contract
-//!   would be self-blocked at the egress (Phase 7 follow-up); for now
-//!   we focus on the receive side.
+//!   transaction cleanly. The next request we originate for the contract
+//!   is self-blocked at the egress entry points
+//!   (`operations::reject_if_contract_banned`, called from every
+//!   `start_client_*` driver — #4300).
 //! - **Peer-level messages** (ConnectMsg, etc.) — those are the peer
 //!   layer's concern, not the contract layer.
+//! ## Egress self-blocking (#4300)
+//!
+//! Beyond the receive boundary, the ban also gates every path by which
+//! this node could *transmit* state for a banned contract. These gates
+//! live at the egress sites, not here:
+//!
+//! - **Client-originated requests.** `start_client_put` / `_get` /
+//!   `_subscribe` / `_update` call `operations::reject_if_contract_banned`
+//!   before spawning the driver, returning `OpError::ContractBanned` to
+//!   the local client.
+//! - **Delegate-driven UPDATE fan-out.** `handle_broadcast_state_change`
+//!   (p2p_protoc.rs) skips the broadcast for a banned contract.
 //! - **Proactive state egress for already-hosted contracts**
 //!   (`NeighborHosting` overlap sync, `InterestSync::Summaries` stale
-//!   repair). These paths are also gated (see node.rs) but the gates
-//!   live at the egress sites, not here. See issue tracking egress
-//!   self-blocking for the full design.
+//!   repair). Gated in node.rs (PR #4299).
+//!
+//! Together with the receive-side drops, a banned contract can neither
+//! receive new state via this node nor transmit new state via it.
 //!
 //! ## Two ways entries get added
 //!


### PR DESCRIPTION
## Problem

PR #4299 landed the **receive-side** half of Phase 7 ban enforcement: a node consults its local `ContractBanList` at the wire dispatch site and drops inbound PUT/GET/UPDATE/SUBSCRIBE `Request` variants for banned contracts, and gates the two proactive state-egress paths for already-hosted contracts (`NeighborHosting` overlap-sync, `InterestSync` stale-summary repair).

What was **not** gated is **outbound REQUEST-initiation** for a self-banned contract:

- A local client of this node submits a PUT/GET/UPDATE/SUBSCRIBE for a contract this node has banned. The originator drives `start_relay_*`, sending a REQUEST to a peer that doesn't know about our ban and processes it normally.
- A locally-applied UPDATE (e.g. delegate-driven) drives `BroadcastStateChange` → outbound fan-out to subscribers who don't know about our ban.

Net effect: the ban was only a receive-side filter, not a true block. The node could launder requests for a contract it had decided is harmful, burning outbound resources, and local clients got a silent proceed-then-timeout instead of a clear error.

## Approach

Mirror the receive-side gate on the **egress** side, at the precise call sites the issue names:

- New typed `OpError::ContractBanned { instance_id }` and a shared `operations::reject_if_contract_banned` helper (keyed on `ContractInstanceId`, which is what the ban list keys on and what every entry point has available).
- `start_client_put` / `start_client_get` / `start_client_subscribe` / `start_client_update` call the helper **before spawning the driver task**, returning the typed error. The client gets a clear, contract-named reason via `result_router_tx` instead of a silent timeout.
- `report_op_init_error` (client_events.rs) maps `ContractBanned` → `ErrorKind::OperationError`. I deliberately did **not** add a `RequestError::ContractBanned` stdlib wire variant: that would be a wire-format change requiring a separate stdlib-first release (per the repo's stdlib-first policy and the high-bar-for-protocol-changes rule), and `OperationError` is the existing, wire-stable mapping the receive-side path already uses.
- `handle_broadcast_state_change` (p2p_protoc.rs) skips the delegate-driven UPDATE fan-out — **and its no-target retry re-emission** — for a banned contract, with a debug log (no client to notify on the fire-and-forget broadcast path).

**Scope:** renewals (`run_renewal_subscribe`) and executor-auto-subscribe (`run_executor_subscribe`) go through their own drivers and are intentionally **not** gated — the egress self-block is about new client-originated requests, not maintenance of already-established subscriptions.

Together with the receive-side drops, a banned contract can now neither receive new state via this node nor transmit new state via it.

## Testing

- **Source-grep pin tests on all five egress sites** (mirroring the existing receive-side pins in `ring/contract_ban_list.rs`): each `start_client_*` must call `reject_if_contract_banned` before `GlobalExecutor::spawn`, and `handle_broadcast_state_change` must gate before `get_broadcast_targets_update`. These fail CI if a gate is later deleted or reordered after the spawn/fan-out — the same "CI fails if the gate is deleted" guarantee PR #4299 established.
- **Behavioral unit tests** for the `OpError::ContractBanned` → `ErrorKind::OperationError` mapping (cause string names the ban), plus a pin that `report_op_init_error` handles the variant.
- **Failing-first verified**: temporarily removed the PUT entry-point gate and the broadcast gate; confirmed both pins fail with clear messages, then restored.
- `cargo fmt` clean, `cargo clippy --features testing -- -D warnings` clean, all `operations::*::op_ctx_task`, `client_events`, `p2p_protoc`, and `contract_ban_list` unit tests pass (including the unchanged receive-side pins).

Closes #4300

[AI-assisted - Claude]