### PR TITLE
fix(server): guard web contract unpack against path traversal

### DIFF
--- a/crates/core/src/server/app_packaging.rs
+++ b/crates/core/src/server/app_packaging.rs
@@ -68,13 +68,84 @@ impl WebApp {
         Ok(output)
     }
 
+    /// Unpacks the web archive into `dst`, confining every written file to that
+    /// directory.
+    ///
+    /// Web contracts are authored by untrusted third parties, so the embedded
+    /// tar archive is adversarial input. A malicious author can hand-craft tar
+    /// bytes whose entry paths contain `..`, are absolute, or are symlinks /
+    /// hardlinks pointing outside `dst`; left unchecked, those entries let the
+    /// archive write arbitrary files on the node operator's filesystem (CWE-22
+    /// path traversal / zip-slip). See freenet/freenet-core#3946.
+    ///
+    /// We therefore validate each entry ourselves and **reject** (rather than
+    /// silently skip) anything that could escape the destination:
+    ///
+    /// - absolute paths,
+    /// - any component equal to `..` (`ParentDir`),
+    /// - symlink and hardlink entries (web apps have no legitimate need for
+    ///   them, and they are the primary symlink-escape vector).
+    ///
+    /// Overwrite is disabled so a republished contract cannot clobber files
+    /// already present at the destination via a crafted duplicate entry.
     #[instrument(level = "debug", skip(self, dst))]
     pub fn unpack(&mut self, dst: impl AsRef<Path>) -> Result<(), WebContractError> {
-        debug!("Unpacking web content to {:?}", dst.as_ref());
+        use std::path::Component;
+        use tar::EntryType;
+
+        let dst = dst.as_ref();
+        debug!("Unpacking web content to {:?}", dst);
+
         let mut decoded_web = self.decode_web();
-        decoded_web
-            .unpack(dst)
-            .map_err(WebContractError::StoringError)?;
+        decoded_web.set_overwrite(false);
+        decoded_web.set_preserve_mtime(false);
+
+        let entries = decoded_web
+            .entries()
+            .map_err(|e| WebContractError::UnpackingError(anyhow::anyhow!(e)))?;
+
+        for entry in entries {
+            let mut entry =
+                entry.map_err(|e| WebContractError::UnpackingError(anyhow::anyhow!(e)))?;
+
+            // Reject link entries outright: a symlink/hardlink whose target is
+            // outside `dst` (or a symlink followed by a later write-through
+            // entry) is the classic zip-slip escape, and a web app never needs
+            // links on disk.
+            let entry_type = entry.header().entry_type();
+            if entry_type == EntryType::Symlink || entry_type == EntryType::Link {
+                let path = entry.path().map(|p| p.to_path_buf()).unwrap_or_default();
+                return Err(WebContractError::UnpackingError(anyhow::anyhow!(
+                    "refusing to unpack link entry from web archive: {path:?}"
+                )));
+            }
+
+            let path = entry
+                .path()
+                .map_err(|e| WebContractError::UnpackingError(anyhow::anyhow!(e)))?;
+
+            // Reject absolute paths and any `..` component before touching the
+            // filesystem. `tar`'s own `unpack_in` would merely *skip* such
+            // entries; we want a hard error so a malicious archive is visible
+            // to the operator instead of partially extracting.
+            if path.is_absolute()
+                || path
+                    .components()
+                    .any(|c| matches!(c, Component::ParentDir | Component::Prefix(_)))
+            {
+                return Err(WebContractError::UnpackingError(anyhow::anyhow!(
+                    "path traversal attempt in web archive entry: {path:?}"
+                )));
+            }
+
+            // `unpack_in` performs an additional canonicalization-based
+            // containment check as defense in depth and returns the destination
+            // it would write into.
+            entry
+                .unpack_in(dst)
+                .map_err(WebContractError::StoringError)?;
+        }
+
         Ok(())
     }
 
@@ -121,6 +192,155 @@ impl WebApp {
 
         // Create a fresh archive since we consumed the entries
         Archive::new(XzDecoder::new(self.web.as_slice()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tar::{Builder, EntryType, Header};
+
+    /// Append a regular-file entry whose in-header path is written from raw
+    /// bytes, deliberately bypassing `tar::Builder`'s append-time path
+    /// validation.
+    ///
+    /// `tar::Builder::append_data` rejects paths containing `..` or absolute
+    /// paths, so a benign packer can never *produce* a malicious archive
+    /// through the high-level API. A real attacker, however, writes the tar
+    /// bytes directly with any tool, so the header name field can contain
+    /// arbitrary bytes. Writing the name field directly here reproduces that
+    /// adversarial archive faithfully.
+    fn append_raw_path_file(
+        builder: &mut Builder<Cursor<Vec<u8>>>,
+        raw_path: &str,
+        payload: &[u8],
+    ) {
+        let mut header = Header::new_gnu();
+        header.set_entry_type(EntryType::Regular);
+        header.set_size(payload.len() as u64);
+        // Write the path straight into the old-header name field, skipping the
+        // `set_path` validation that would otherwise reject `..`/absolute.
+        let name_bytes = raw_path.as_bytes();
+        let name_field = &mut header.as_old_mut().name;
+        name_field.fill(0);
+        name_field[..name_bytes.len()].copy_from_slice(name_bytes);
+        // Checksum must be recomputed after mutating the header in place.
+        header.set_cksum();
+        builder.append(&header, payload).unwrap();
+    }
+
+    /// Append a symlink entry whose target points wherever the caller wants
+    /// (including outside the destination).
+    fn append_symlink(builder: &mut Builder<Cursor<Vec<u8>>>, link_name: &str, target: &str) {
+        let mut header = Header::new_gnu();
+        header.set_entry_type(EntryType::Symlink);
+        header.set_size(0);
+        builder.append_link(&mut header, link_name, target).unwrap();
+    }
+
+    fn finish(builder: Builder<Cursor<Vec<u8>>>) -> WebApp {
+        WebApp::from_data(b"meta".to_vec(), builder).unwrap()
+    }
+
+    #[test]
+    fn unpack_rejects_parent_dir_traversal() {
+        let dst = tempfile::tempdir().unwrap();
+        let mut builder = Builder::new(Cursor::new(Vec::new()));
+        append_raw_path_file(&mut builder, "../escape.txt", b"pwned");
+        let mut web = finish(builder);
+
+        let result = web.unpack(dst.path());
+
+        // The escaping entry must be rejected with an error, not silently
+        // skipped: a partial unpack that swallows traversal entries hides
+        // the attack from the operator.
+        assert!(
+            result.is_err(),
+            "unpack must reject an archive entry containing `..`"
+        );
+        // And nothing may be written outside the destination directory.
+        let escaped = dst.path().parent().unwrap().join("escape.txt");
+        assert!(
+            !escaped.exists(),
+            "path-traversal entry escaped the destination: {escaped:?}"
+        );
+    }
+
+    #[test]
+    fn unpack_rejects_absolute_path() {
+        let dst = tempfile::tempdir().unwrap();
+        // An absolute target the attacker hopes to overwrite.
+        let abs_target = dst.path().parent().unwrap().join("abs_escape.txt");
+        let mut builder = Builder::new(Cursor::new(Vec::new()));
+        append_raw_path_file(&mut builder, abs_target.to_str().unwrap(), b"pwned");
+        let mut web = finish(builder);
+
+        let result = web.unpack(dst.path());
+
+        assert!(
+            result.is_err(),
+            "unpack must reject an archive entry with an absolute path"
+        );
+        assert!(
+            !abs_target.exists(),
+            "absolute-path entry escaped the destination: {abs_target:?}"
+        );
+    }
+
+    #[test]
+    fn unpack_rejects_escaping_symlink() {
+        let dst = tempfile::tempdir().unwrap();
+        // Symlink whose target points outside the destination. A follow-up
+        // entry writing "through" this link is the classic zip-slip escalation;
+        // rejecting the symlink itself closes the door before that can happen.
+        let outside = dst.path().parent().unwrap().join("symlink_target");
+        let mut builder = Builder::new(Cursor::new(Vec::new()));
+        append_symlink(&mut builder, "link", outside.to_str().unwrap());
+        let mut web = finish(builder);
+
+        let result = web.unpack(dst.path());
+
+        assert!(
+            result.is_err(),
+            "unpack must reject symlink entries to prevent symlink-escape writes"
+        );
+        assert!(
+            !dst.path().join("link").exists(),
+            "symlink entry was created despite pointing outside the destination"
+        );
+    }
+
+    #[test]
+    fn unpack_accepts_legitimate_nested_entries() {
+        let dst = tempfile::tempdir().unwrap();
+        let mut builder = Builder::new(Cursor::new(Vec::new()));
+        let mut h = Header::new_gnu();
+        h.set_entry_type(EntryType::Regular);
+        h.set_size(b"<html></html>".len() as u64);
+        h.set_cksum();
+        builder
+            .append_data(&mut h, "index.html", b"<html></html>" as &[u8])
+            .unwrap();
+        let mut h = Header::new_gnu();
+        h.set_entry_type(EntryType::Regular);
+        h.set_size(b"console.log(1)".len() as u64);
+        h.set_cksum();
+        builder
+            .append_data(&mut h, "assets/app.js", b"console.log(1)" as &[u8])
+            .unwrap();
+        let mut web = finish(builder);
+
+        web.unpack(dst.path())
+            .expect("a well-formed web archive must still unpack");
+
+        assert_eq!(
+            std::fs::read(dst.path().join("index.html")).unwrap(),
+            b"<html></html>"
+        );
+        assert_eq!(
+            std::fs::read(dst.path().join("assets/app.js")).unwrap(),
+            b"console.log(1)"
+        );
     }
 }
 


### PR DESCRIPTION
## Problem

`WebApp::unpack` (`crates/core/src/server/app_packaging.rs`) extracted the embedded tar archive of a web contract with tar's default `Archive::unpack(dst)`. That default:

- only *silently skips* entries whose path contains `..` or is absolute (returns `Ok`, leaving no signal to the operator that a malicious archive was processed),
- relies on tar-rs internal canonicalization to catch symlink/hardlink escapes,
- leaves overwrite **enabled**, so a republished contract can clobber existing cache files.

Web contracts are authored by untrusted third parties, so the archive is adversarial input. A malicious author can hand-craft tar bytes whose entries escape `webapp_cache_dir()` and write arbitrary files on the **node operator's filesystem** (CWE-22 path traversal / zip-slip — e.g. overwriting shell configs or SSH `authorized_keys`). Before PR #3942 this required a user to navigate to the malicious contract's root; after #3942 it is reachable whenever any page links to `/v1/contract/web/<malicious-key>/anything`, which triggers the cold-cache unpack.

Flagged during review of #3942.

## Solution

Stop delegating containment entirely to tar's defaults and validate every entry ourselves before it touches the filesystem:

- **Reject** (hard `UnpackingError`, not a silent skip) any entry with an absolute path or a `..` / prefix component, so a malicious archive surfaces as an error to the operator instead of partially extracting.
- **Reject** symlink and hardlink entries outright — web apps have no legitimate need for on-disk links, and a symlink-then-write-through is the classic zip-slip escalation.
- Keep `entry.unpack_in(dst)` as a defense-in-depth second check (it performs canonicalization-based containment).
- `set_overwrite(false)` so a crafted duplicate entry can't clobber files already at the destination; `set_preserve_mtime(false)` to avoid honoring attacker-controlled mtimes.

This matches the fix sketch in the issue, hardened to reject (rather than skip) and to refuse link entries. Behavior for legitimate archives is unchanged.

## Testing

Added four unit tests in `app_packaging.rs`. The three adversarial archives are constructed by writing the tar header's name field **directly**, deliberately bypassing `tar::Builder`'s append-time path validation — `Builder::append_data` refuses to *produce* `..`/absolute paths, but a real attacker writes the bytes directly with any tool, so this faithfully reproduces the on-the-wire attack:

- `unpack_rejects_parent_dir_traversal` — `../escape.txt` entry must error and write nothing outside `dst`.
- `unpack_rejects_absolute_path` — absolute-path entry must error and write nothing outside `dst`.
- `unpack_rejects_escaping_symlink` — symlink pointing outside `dst` must error and not be created.
- `unpack_accepts_legitimate_nested_entries` — a well-formed `index.html` + `assets/app.js` archive still unpacks correctly.

Verified the three escape tests **FAIL** against the unfixed code (all return `Ok` / create the symlink) and **PASS** after the fix; the legitimate-archive test passes throughout. `cargo fmt` and `cargo clippy --locked -- -D warnings` (the CI invocation) are clean.

Closes #3946

[AI-assisted - Claude]