### PR TITLE
fix(transport): fail stream not connection on outbound-stream failure

### DIFF
--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -346,6 +346,8 @@ pub enum TransportError {
     ProtocolVersionMismatch { expected: String, actual: String },
     #[error("send to {0} failed: {1}")]
     SendFailed(SocketAddr, std::io::ErrorKind),
+    #[error("outbound stream to {0} aborted: cwnd wait timeout")]
+    OutboundStreamTimeout(SocketAddr),
     #[error(transparent)]
     IO(#[from] std::io::Error),
     #[error(transparent)]
@@ -357,11 +359,25 @@ pub enum TransportError {
 }
 
 impl TransportError {
-    /// Returns true if this error is a transient UDP send failure that should
-    /// not kill the connection. The idle timeout is the sole authority on
-    /// connection liveness.
+    /// Returns true if this error is a stream-scoped failure that must NOT
+    /// kill the connection. The idle timeout remains the sole authority on
+    /// connection liveness; a single stalled or failed stream only fails
+    /// that stream, and the operation layer times out and retries against
+    /// another candidate.
+    ///
+    /// Covers:
+    /// - [`TransportError::SendFailed`]: a transient UDP send error (e.g.
+    ///   ENETUNREACH) on a single packet.
+    /// - [`TransportError::OutboundStreamTimeout`]: the outbound stream's
+    ///   congestion-window wait exceeded `CWND_WAIT_TIMEOUT`. Tearing down
+    ///   the whole connection here would kill every other operation
+    ///   multiplexed on it and force a re-handshake (#4345). The connection
+    ///   stays up and the idle timeout decides liveness instead.
     pub fn is_transient_send_failure(&self) -> bool {
-        matches!(self, TransportError::SendFailed(..))
+        matches!(
+            self,
+            TransportError::SendFailed(..) | TransportError::OutboundStreamTimeout(..)
+        )
     }
 }
 

--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -346,8 +346,8 @@ pub enum TransportError {
     ProtocolVersionMismatch { expected: String, actual: String },
     #[error("send to {0} failed: {1}")]
     SendFailed(SocketAddr, std::io::ErrorKind),
-    #[error("outbound stream to {0} aborted: cwnd wait timeout")]
-    OutboundStreamTimeout(SocketAddr),
+    #[error("outbound stream to {0} failed (stream-scoped, connection survives)")]
+    OutboundStreamFailed(SocketAddr),
     #[error(transparent)]
     IO(#[from] std::io::Error),
     #[error(transparent)]
@@ -368,15 +368,21 @@ impl TransportError {
     /// Covers:
     /// - [`TransportError::SendFailed`]: a transient UDP send error (e.g.
     ///   ENETUNREACH) on a single packet.
-    /// - [`TransportError::OutboundStreamTimeout`]: the outbound stream's
-    ///   congestion-window wait exceeded `CWND_WAIT_TIMEOUT`. Tearing down
-    ///   the whole connection here would kill every other operation
-    ///   multiplexed on it and force a re-handshake (#4345). The connection
-    ///   stays up and the idle timeout decides liveness instead.
+    /// - [`TransportError::OutboundStreamFailed`]: any stream-scoped failure
+    ///   in `outbound_stream::{send_stream, pipe_stream}` — the
+    ///   congestion-window wait exceeding `CWND_WAIT_TIMEOUT`, or (for the
+    ///   relay-pipe path) the upstream inbound feed stalling past
+    ///   `STREAM_INACTIVITY_TIMEOUT` or yielding an error. All three are
+    ///   problems with one transfer or its inbound feed, not with the
+    ///   downstream connection. Tearing down the whole connection here would
+    ///   kill every other operation multiplexed on it and force a
+    ///   re-handshake (#4345). The connection stays up and the idle timeout
+    ///   decides liveness instead; the op layer times out and retries against
+    ///   another candidate.
     pub fn is_transient_send_failure(&self) -> bool {
         matches!(
             self,
-            TransportError::SendFailed(..) | TransportError::OutboundStreamTimeout(..)
+            TransportError::SendFailed(..) | TransportError::OutboundStreamFailed(..)
         )
     }
 }

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -1625,7 +1625,7 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                                 TransportError::ProtocolVersionMismatch { .. } => {
                                     tracing::warn!(%error);
                                 }
-                                TransportError::ChannelClosed | TransportError::ConnectionClosed(_) | TransportError::ConnectionEstablishmentFailure { .. } | TransportError::SendFailed(..) | TransportError::IO(_) | TransportError::Other(_) | TransportError::PubKeyDecryptionError(_) | TransportError::Serialization(_) => {
+                                TransportError::ChannelClosed | TransportError::ConnectionClosed(_) | TransportError::ConnectionEstablishmentFailure { .. } | TransportError::SendFailed(..) | TransportError::OutboundStreamTimeout(_) | TransportError::IO(_) | TransportError::Other(_) | TransportError::PubKeyDecryptionError(_) | TransportError::Serialization(_) => {
                                     tracing::error!(error = %error, peer_addr = %remote_addr, "Failed NAT traversal");
                                 }
                             }
@@ -3668,6 +3668,7 @@ pub mod mock_transport {
             | TransportError::ConnectionClosed(_)
             | TransportError::ConnectionEstablishmentFailure { .. }
             | TransportError::SendFailed(..)
+            | TransportError::OutboundStreamTimeout(_)
             | TransportError::IO(_)
             | TransportError::Other(_)
             | TransportError::PubKeyDecryptionError(_)
@@ -3683,6 +3684,7 @@ pub mod mock_transport {
             | TransportError::ConnectionClosed(_)
             | TransportError::ProtocolVersionMismatch { .. }
             | TransportError::SendFailed(..)
+            | TransportError::OutboundStreamTimeout(_)
             | TransportError::IO(_)
             | TransportError::Other(_)
             | TransportError::PubKeyDecryptionError(_)

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -1625,7 +1625,7 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                                 TransportError::ProtocolVersionMismatch { .. } => {
                                     tracing::warn!(%error);
                                 }
-                                TransportError::ChannelClosed | TransportError::ConnectionClosed(_) | TransportError::ConnectionEstablishmentFailure { .. } | TransportError::SendFailed(..) | TransportError::OutboundStreamTimeout(_) | TransportError::IO(_) | TransportError::Other(_) | TransportError::PubKeyDecryptionError(_) | TransportError::Serialization(_) => {
+                                TransportError::ChannelClosed | TransportError::ConnectionClosed(_) | TransportError::ConnectionEstablishmentFailure { .. } | TransportError::SendFailed(..) | TransportError::OutboundStreamFailed(_) | TransportError::IO(_) | TransportError::Other(_) | TransportError::PubKeyDecryptionError(_) | TransportError::Serialization(_) => {
                                     tracing::error!(error = %error, peer_addr = %remote_addr, "Failed NAT traversal");
                                 }
                             }
@@ -3668,7 +3668,7 @@ pub mod mock_transport {
             | TransportError::ConnectionClosed(_)
             | TransportError::ConnectionEstablishmentFailure { .. }
             | TransportError::SendFailed(..)
-            | TransportError::OutboundStreamTimeout(_)
+            | TransportError::OutboundStreamFailed(_)
             | TransportError::IO(_)
             | TransportError::Other(_)
             | TransportError::PubKeyDecryptionError(_)
@@ -3684,7 +3684,7 @@ pub mod mock_transport {
             | TransportError::ConnectionClosed(_)
             | TransportError::ProtocolVersionMismatch { .. }
             | TransportError::SendFailed(..)
-            | TransportError::OutboundStreamTimeout(_)
+            | TransportError::OutboundStreamFailed(_)
             | TransportError::IO(_)
             | TransportError::Other(_)
             | TransportError::PubKeyDecryptionError(_)

--- a/crates/core/src/transport/peer_connection/outbound_stream.rs
+++ b/crates/core/src/transport/peer_connection/outbound_stream.rs
@@ -182,7 +182,15 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
                 // down the whole connection would kill every other operation
                 // multiplexed on it. The op layer times out and retries against
                 // another candidate; the idle timeout decides connection liveness.
-                return Err(TransportError::OutboundStreamTimeout(destination_addr));
+                //
+                // NOTE: `completion_tx` is intentionally NOT signaled here — it
+                // is dropped by this early return. broadcast_queue awaits it with
+                // a timeout and treats the resulting oneshot RecvError as
+                // completion (broadcast_queue.rs: `Ok(Err(_))` arm), releasing the
+                // permit immediately. Do NOT "fix" this by adding a blocking
+                // `tx.send(())` here — a blocking send in this stream task is the
+                // backpressure pattern channel-safety.md warns against.
+                return Err(TransportError::OutboundStreamFailed(destination_addr));
             }
 
             // Exponential backoff to balance responsiveness and CPU usage
@@ -453,7 +461,12 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
                     elapsed.as_millis() as u64,
                     TransferDirection::Send,
                 );
-                return Err(TransportError::ConnectionClosed(destination_addr));
+                // Stall is in the UPSTREAM inbound feed, not the downstream
+                // connection — fail only this stream so other ops multiplexed
+                // on the downstream connection survive (#4345). The op layer
+                // times out and retries; the idle timeout decides connection
+                // liveness.
+                return Err(TransportError::OutboundStreamFailed(destination_addr));
             }
         };
         let payload = match next_fragment {
@@ -468,7 +481,10 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
                     elapsed.as_millis() as u64,
                     TransferDirection::Send,
                 );
-                return Err(TransportError::ConnectionClosed(destination_addr));
+                // Error is on the UPSTREAM inbound stream, not the downstream
+                // connection — fail only this stream (#4345), same rationale as
+                // the inactivity-stall arm above.
+                return Err(TransportError::OutboundStreamFailed(destination_addr));
             }
         };
 
@@ -483,7 +499,7 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
         // relay GET streaming path (#3586) lost ACKs mid-transfer.
         //
         // Safety: the loop is bounded by CWND_WAIT_TIMEOUT. If cwnd space doesn't
-        // open within the timeout, the pipe fails with OutboundStreamTimeout
+        // open within the timeout, the pipe fails with OutboundStreamFailed
         // (stream-scoped, connection survives — #4345) rather than hanging
         // indefinitely.
         let cwnd_wait_start = time_source.now();
@@ -538,7 +554,7 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
                 );
                 // Fail only this stream, not the connection (#4345). See the
                 // matching site in send_stream for the rationale.
-                return Err(TransportError::OutboundStreamTimeout(destination_addr));
+                return Err(TransportError::OutboundStreamFailed(destination_addr));
             }
 
             if cwnd_wait_iterations <= 10 {
@@ -1007,8 +1023,7 @@ mod tests {
         Ok(())
     }
 
-    /// Test that fragment #1 with embedded metadata never exceeds MAX_DATA_SIZE.
-    /// Test that send_stream aborts with OutboundStreamTimeout when the cwnd
+    /// Test that send_stream aborts with OutboundStreamFailed when the cwnd
     /// wait exceeds CWND_WAIT_TIMEOUT. Simulates a dead outbound connection
     /// where cwnd is too small for any packet (#3608). Per #4345 this is a
     /// stream-scoped failure that must not tear down the connection.
@@ -1063,8 +1078,8 @@ mod tests {
         // instantly.
         let result = send_task.await.expect("join error");
         assert!(
-            matches!(result, Err(TransportError::OutboundStreamTimeout(_))),
-            "Expected OutboundStreamTimeout after cwnd wait timeout, got: {result:?}",
+            matches!(result, Err(TransportError::OutboundStreamFailed(_))),
+            "Expected OutboundStreamFailed after cwnd wait timeout, got: {result:?}",
         );
 
         Ok(())
@@ -1078,7 +1093,7 @@ mod tests {
     /// `TransportError::ConnectionClosed`, which the connection recv loop in
     /// `peer_connection.rs` treats as fatal — tearing the whole connection down
     /// and killing every other operation multiplexed on it, forcing a
-    /// re-handshake. The fix returns `TransportError::OutboundStreamTimeout`,
+    /// re-handshake. The fix returns `TransportError::OutboundStreamFailed`,
     /// which `is_transient_send_failure()` classifies as non-fatal, so the recv
     /// loop logs and lets the op layer retry while the connection survives (the
     /// idle timeout remains the sole authority on connection liveness).
@@ -1086,7 +1101,7 @@ mod tests {
     /// This test drives the real `send_stream` to the cwnd-wait timeout with a
     /// 1-byte cwnd (no packet ever fits, so the wait loop never breaks) and
     /// asserts:
-    ///   1. the error IS `OutboundStreamTimeout` (not `ConnectionClosed`), and
+    ///   1. the error IS `OutboundStreamFailed` (not `ConnectionClosed`), and
     ///   2. `is_transient_send_failure()` is `true`, i.e. the recv loop takes
     ///      the connection-survival arm.
     ///
@@ -1151,8 +1166,8 @@ mod tests {
 
         // (1) The new stream-scoped variant, carrying the destination addr.
         assert!(
-            matches!(err, TransportError::OutboundStreamTimeout(addr) if addr == remote_addr),
-            "expected OutboundStreamTimeout({remote_addr}), got: {err:?}"
+            matches!(err, TransportError::OutboundStreamFailed(addr) if addr == remote_addr),
+            "expected OutboundStreamFailed({remote_addr}), got: {err:?}"
         );
 
         // (2) It must NOT be ConnectionClosed — that is the fatal arm the recv
@@ -1260,7 +1275,7 @@ mod tests {
         );
     }
 
-    /// Test that pipe_stream aborts with OutboundStreamTimeout when the cwnd
+    /// Test that pipe_stream aborts with OutboundStreamFailed when the cwnd
     /// wait exceeds CWND_WAIT_TIMEOUT. This exercises the same timeout logic as
     /// send_stream but through the pipe_stream code path with different state
     /// variables (sent_so_far as u64 bytes, no completion_tx).
@@ -1322,9 +1337,155 @@ mod tests {
 
         let result = pipe_task.await.expect("join error");
         assert!(
-            matches!(result, Err(TransportError::OutboundStreamTimeout(_))),
-            "Expected OutboundStreamTimeout after pipe_stream cwnd wait timeout, got: {:?}",
+            matches!(result, Err(TransportError::OutboundStreamFailed(_))),
+            "Expected OutboundStreamFailed after pipe_stream cwnd wait timeout, got: {:?}",
             result
+        );
+
+        Ok(())
+    }
+
+    /// Regression test for #4345 (relay-pipe inactivity-stall path,
+    /// outbound_stream.rs:456): when the UPSTREAM inbound feed produces no
+    /// fragment within STREAM_INACTIVITY_TIMEOUT, pipe_stream must fail only
+    /// THIS stream — not tear down the DOWNSTREAM connection that carries other
+    /// multiplexed ops. Before this PR the site returned ConnectionClosed
+    /// (is_transient_send_failure() == false → recv loop's fatal arm).
+    ///
+    /// Drives the stall by registering a StreamHandle with NO fragment ever
+    /// pushed, so `stream.next()` stays Pending and the select!'s
+    /// inactivity-timeout arm fires. Asserts the error is OutboundStreamFailed,
+    /// is_transient_send_failure() is true, and it is NOT ConnectionClosed.
+    #[tokio::test(start_paused = true)]
+    async fn pipe_stream_inactivity_stall_fails_stream_not_connection()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use crate::transport::peer_connection::streaming::StreamHandle;
+
+        let (outbound_sender, _outbound_receiver) = mpsc::channel(100);
+        let remote_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8080);
+        let cipher = {
+            let mut key = [0u8; 16];
+            crate::config::GlobalRng::fill_bytes(&mut key);
+            Aes128Gcm::new(&key.into())
+        };
+
+        let time_source = RealTime::new();
+
+        // StreamHandle with NO fragment pushed: stream.next() stays Pending, so
+        // the inactivity timeout (STREAM_INACTIVITY_TIMEOUT) fires before any
+        // fragment can be sent. The stall is reached before the cwnd loop, so
+        // the congestion-control config is irrelevant; use the default.
+        let stream_id = StreamId::next();
+        let handle = StreamHandle::new(stream_id, 10_000);
+
+        let congestion_controller = CongestionControlConfig::default().build_arc();
+        let sent_tracker = Arc::new(parking_lot::Mutex::new(SentPacketTracker::new()));
+        let token_bucket = Arc::new(TokenBucket::new(1_000_000, 100_000_000));
+
+        let pipe_task = GlobalExecutor::spawn(pipe_stream(
+            handle,
+            StreamId::next(),
+            Arc::new(AtomicU32::new(0)),
+            Arc::new(TestSocket::new(outbound_sender)),
+            remote_addr,
+            cipher,
+            sent_tracker,
+            token_bucket,
+            congestion_controller,
+            time_source,
+            None,
+        ));
+
+        let err = pipe_task
+            .await
+            .expect("join error")
+            .expect_err("inactivity stall should fail the stream");
+
+        assert!(
+            matches!(err, TransportError::OutboundStreamFailed(addr) if addr == remote_addr),
+            "expected OutboundStreamFailed({remote_addr}) on inactivity stall, got: {err:?}"
+        );
+        assert!(
+            !matches!(err, TransportError::ConnectionClosed(_)),
+            "inactivity stall must NOT be ConnectionClosed (would kill the connection): {err:?}"
+        );
+        assert!(
+            err.is_transient_send_failure(),
+            "inactivity stall must be classified transient so the connection survives: {err:?}"
+        );
+
+        Ok(())
+    }
+
+    /// Regression test for #4345 (relay-pipe inbound-stream-error path,
+    /// outbound_stream.rs:471): when the UPSTREAM inbound stream yields an
+    /// error, pipe_stream must fail only THIS stream — not the DOWNSTREAM
+    /// connection. Before this PR the site returned ConnectionClosed
+    /// (is_transient_send_failure() == false → recv loop's fatal arm).
+    ///
+    /// Drives the error by cancelling the StreamHandle so the inbound stream
+    /// yields Err(StreamError::Cancelled). Asserts the error is
+    /// OutboundStreamFailed, is_transient_send_failure() is true, and it is NOT
+    /// ConnectionClosed.
+    #[tokio::test(start_paused = true)]
+    async fn pipe_stream_inbound_error_fails_stream_not_connection()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use crate::transport::peer_connection::streaming::StreamHandle;
+
+        let (outbound_sender, _outbound_receiver) = mpsc::channel(100);
+        let remote_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8080);
+        let cipher = {
+            let mut key = [0u8; 16];
+            crate::config::GlobalRng::fill_bytes(&mut key);
+            Aes128Gcm::new(&key.into())
+        };
+
+        let time_source = RealTime::new();
+
+        // Cancel the handle so the inbound stream yields Err(Cancelled). The
+        // poll_next cancelled-check fires before any cwnd wait, so the
+        // congestion-control config is irrelevant; use the default.
+        let stream_id = StreamId::next();
+        let handle = StreamHandle::new(stream_id, 10_000);
+        handle
+            .push_fragment(1, Bytes::from(vec![0u8; 1000]))
+            .unwrap();
+        handle.cancel();
+
+        let congestion_controller = CongestionControlConfig::default().build_arc();
+        let sent_tracker = Arc::new(parking_lot::Mutex::new(SentPacketTracker::new()));
+        let token_bucket = Arc::new(TokenBucket::new(1_000_000, 100_000_000));
+
+        let pipe_task = GlobalExecutor::spawn(pipe_stream(
+            handle,
+            StreamId::next(),
+            Arc::new(AtomicU32::new(0)),
+            Arc::new(TestSocket::new(outbound_sender)),
+            remote_addr,
+            cipher,
+            sent_tracker,
+            token_bucket,
+            congestion_controller,
+            time_source,
+            None,
+        ));
+
+        let err = pipe_task
+            .await
+            .expect("join error")
+            .expect_err("inbound stream error should fail the stream");
+
+        assert!(
+            matches!(err, TransportError::OutboundStreamFailed(addr) if addr == remote_addr),
+            "expected OutboundStreamFailed({remote_addr}) on inbound error, got: {err:?}"
+        );
+        assert!(
+            !matches!(err, TransportError::ConnectionClosed(_)),
+            "inbound error must NOT be ConnectionClosed (would kill the connection): {err:?}"
+        );
+        assert!(
+            err.is_transient_send_failure(),
+            "inbound error must be classified transient so the connection survives: {err:?}"
         );
 
         Ok(())

--- a/crates/core/src/transport/peer_connection/outbound_stream.rs
+++ b/crates/core/src/transport/peer_connection/outbound_stream.rs
@@ -177,7 +177,12 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
                     elapsed.as_millis() as u64,
                     TransferDirection::Send,
                 );
-                return Err(TransportError::ConnectionClosed(destination_addr));
+                // Fail only this stream, not the connection (#4345). A cwnd-wait
+                // timeout means ACKs stopped arriving for this transfer; tearing
+                // down the whole connection would kill every other operation
+                // multiplexed on it. The op layer times out and retries against
+                // another candidate; the idle timeout decides connection liveness.
+                return Err(TransportError::OutboundStreamTimeout(destination_addr));
             }
 
             // Exponential backoff to balance responsiveness and CPU usage
@@ -478,8 +483,9 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
         // relay GET streaming path (#3586) lost ACKs mid-transfer.
         //
         // Safety: the loop is bounded by CWND_WAIT_TIMEOUT. If cwnd space doesn't
-        // open within the timeout, the pipe fails with ConnectionClosed rather than
-        // hanging indefinitely.
+        // open within the timeout, the pipe fails with OutboundStreamTimeout
+        // (stream-scoped, connection survives — #4345) rather than hanging
+        // indefinitely.
         let cwnd_wait_start = time_source.now();
         let mut cwnd_wait_iterations = 0;
         loop {
@@ -530,7 +536,9 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
                     elapsed.as_millis() as u64,
                     TransferDirection::Send,
                 );
-                return Err(TransportError::ConnectionClosed(destination_addr));
+                // Fail only this stream, not the connection (#4345). See the
+                // matching site in send_stream for the rationale.
+                return Err(TransportError::OutboundStreamTimeout(destination_addr));
             }
 
             if cwnd_wait_iterations <= 10 {
@@ -1000,9 +1008,10 @@ mod tests {
     }
 
     /// Test that fragment #1 with embedded metadata never exceeds MAX_DATA_SIZE.
-    /// Test that send_stream aborts with ConnectionClosed when the cwnd wait
-    /// exceeds CWND_WAIT_TIMEOUT. Simulates a dead outbound connection where
-    /// cwnd is too small for any packet (#3608).
+    /// Test that send_stream aborts with OutboundStreamTimeout when the cwnd
+    /// wait exceeds CWND_WAIT_TIMEOUT. Simulates a dead outbound connection
+    /// where cwnd is too small for any packet (#3608). Per #4345 this is a
+    /// stream-scoped failure that must not tear down the connection.
     #[tokio::test(start_paused = true)]
     async fn test_send_stream_cwnd_wait_timeout() -> Result<(), Box<dyn std::error::Error>> {
         let (outbound_sender, _outbound_receiver) = mpsc::channel(100);
@@ -1049,12 +1058,115 @@ mod tests {
         ));
 
         // With start_paused=true, tokio auto-advances time through sleep calls.
-        // The cwnd wait loop sleeps in 1ms increments, and the timeout is 15s,
-        // so tokio will auto-advance through ~15,000 iterations instantly.
+        // The cwnd wait loop sleeps in 1ms increments, and the timeout is
+        // CWND_WAIT_TIMEOUT (3s), so tokio auto-advances through the iterations
+        // instantly.
         let result = send_task.await.expect("join error");
         assert!(
-            matches!(result, Err(TransportError::ConnectionClosed(_))),
-            "Expected ConnectionClosed after cwnd wait timeout, got: {result:?}",
+            matches!(result, Err(TransportError::OutboundStreamTimeout(_))),
+            "Expected OutboundStreamTimeout after cwnd wait timeout, got: {result:?}",
+        );
+
+        Ok(())
+    }
+
+    /// Regression test for #4345: a cwnd-wait timeout must fail only the stream,
+    /// NOT the connection.
+    ///
+    /// When an outbound stream's congestion-window wait times out, `send_stream`
+    /// returns an error. Before this fix it returned
+    /// `TransportError::ConnectionClosed`, which the connection recv loop in
+    /// `peer_connection.rs` treats as fatal — tearing the whole connection down
+    /// and killing every other operation multiplexed on it, forcing a
+    /// re-handshake. The fix returns `TransportError::OutboundStreamTimeout`,
+    /// which `is_transient_send_failure()` classifies as non-fatal, so the recv
+    /// loop logs and lets the op layer retry while the connection survives (the
+    /// idle timeout remains the sole authority on connection liveness).
+    ///
+    /// This test drives the real `send_stream` to the cwnd-wait timeout with a
+    /// 1-byte cwnd (no packet ever fits, so the wait loop never breaks) and
+    /// asserts:
+    ///   1. the error IS `OutboundStreamTimeout` (not `ConnectionClosed`), and
+    ///   2. `is_transient_send_failure()` is `true`, i.e. the recv loop takes
+    ///      the connection-survival arm.
+    ///
+    /// Asserting on `is_transient_send_failure()` is the load-bearing check:
+    /// the recv-loop classification (`peer_connection.rs`) is exactly
+    /// `Err(e) if e.is_transient_send_failure() => /* connection survives */`
+    /// vs the catch-all `Err(e) => return Err(e) /* connection torn down */`.
+    /// `send_failure_returns_transient_error` in `peer_connection.rs` exercises
+    /// the symmetric SendFailed case the same way. A full `PeerConnection::recv`
+    /// teardown harness would require substantial new scaffolding that the
+    /// stream-level unit harness here does not expose; the error-classification
+    /// assertions below pin the behavior the recv loop branches on.
+    #[tokio::test(start_paused = true)]
+    async fn cwnd_wait_timeout_fails_stream_not_connection()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (outbound_sender, _outbound_receiver) = mpsc::channel(100);
+        let remote_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8080);
+        let message = vec![0u8; 10_000];
+        let cipher = {
+            let mut key = [0u8; 16];
+            crate::config::GlobalRng::fill_bytes(&mut key);
+            Aes128Gcm::new(&key.into())
+        };
+
+        // RealTime under tokio's paused clock auto-advances through the cwnd
+        // wait loop's sleeps deterministically (same pattern as
+        // test_send_stream_cwnd_wait_timeout).
+        let time_source = RealTime::new();
+
+        // cwnd of 1 byte: every real packet exceeds it, so the cwnd wait loop
+        // never breaks and must hit CWND_WAIT_TIMEOUT.
+        let congestion_controller = CongestionControlConfig::from_ledbat_config(LedbatConfig {
+            initial_cwnd: 1,
+            min_cwnd: 1,
+            max_cwnd: 1,
+            ..Default::default()
+        })
+        .build_arc();
+
+        let sent_tracker = Arc::new(parking_lot::Mutex::new(SentPacketTracker::new()));
+        let token_bucket = Arc::new(TokenBucket::new(1_000_000, 100_000_000));
+
+        let send_task = GlobalExecutor::spawn(send_stream(
+            StreamId::next(),
+            Arc::new(AtomicU32::new(0)),
+            Arc::new(TestSocket::new(outbound_sender)),
+            remote_addr,
+            Bytes::from(message),
+            cipher,
+            sent_tracker,
+            token_bucket,
+            congestion_controller,
+            time_source,
+            None,
+            None,
+        ));
+
+        let err = send_task
+            .await
+            .expect("join error")
+            .expect_err("cwnd wait should time out");
+
+        // (1) The new stream-scoped variant, carrying the destination addr.
+        assert!(
+            matches!(err, TransportError::OutboundStreamTimeout(addr) if addr == remote_addr),
+            "expected OutboundStreamTimeout({remote_addr}), got: {err:?}"
+        );
+
+        // (2) It must NOT be ConnectionClosed — that is the fatal arm the recv
+        // loop would tear the connection down on.
+        assert!(
+            !matches!(err, TransportError::ConnectionClosed(_)),
+            "cwnd timeout must NOT be ConnectionClosed (would kill the connection): {err:?}"
+        );
+
+        // (3) The recv loop branches on is_transient_send_failure(); true means
+        // it logs and lets the op layer retry while the connection survives.
+        assert!(
+            err.is_transient_send_failure(),
+            "cwnd timeout must be classified transient so the connection survives: {err:?}"
         );
 
         Ok(())
@@ -1148,8 +1260,8 @@ mod tests {
         );
     }
 
-    /// Test that pipe_stream aborts with ConnectionClosed when the cwnd wait
-    /// exceeds CWND_WAIT_TIMEOUT. This exercises the same timeout logic as
+    /// Test that pipe_stream aborts with OutboundStreamTimeout when the cwnd
+    /// wait exceeds CWND_WAIT_TIMEOUT. This exercises the same timeout logic as
     /// send_stream but through the pipe_stream code path with different state
     /// variables (sent_so_far as u64 bytes, no completion_tx).
     #[tokio::test(start_paused = true)]
@@ -1166,8 +1278,10 @@ mod tests {
 
         let time_source = RealTime::new();
 
-        // Create a StreamHandle with a fragment already buffered so the
-        // inactivity timeout (30s) doesn't fire before the cwnd timeout (20s).
+        // Create a StreamHandle with a fragment already buffered so the cwnd
+        // wait loop has work to do. The fragment is never ACKed (no recv task),
+        // so the cwnd wait (CWND_WAIT_TIMEOUT = 3s) fires before the inactivity
+        // timeout (STREAM_INACTIVITY_TIMEOUT = 5s).
         // Fragment must be <= FRAGMENT_PAYLOAD_SIZE (1130 bytes).
         let stream_id = StreamId::next();
         let handle = StreamHandle::new(stream_id, 10_000);
@@ -1175,13 +1289,19 @@ mod tests {
             .push_fragment(1, Bytes::from(vec![0u8; 1000]))
             .unwrap();
 
-        // Stuck congestion controller: flightsize is very large so even with
-        // LOSS_PAUSE_MARGIN the pipe can send a few packets but the receiver
-        // never ACKs (no ACK task running), so flightsize keeps growing until
-        // the margin is consumed and the cwnd wait times out.
-        let congestion_controller = CongestionControlConfig::default().build_arc();
-        congestion_controller.on_send(1_000_000);
-        congestion_controller.on_timeout();
+        // LEDBAT controller with a 1-byte cwnd: every real packet exceeds it,
+        // so the cwnd wait loop never breaks and must hit CWND_WAIT_TIMEOUT.
+        // (The previous version used CongestionControlConfig::default(), which
+        // is FixedRate with current_cwnd() == usize::MAX/2 — the cwnd loop
+        // never blocked, so the test silently exercised the inactivity-timeout
+        // path instead of the cwnd-wait path it claims to test.)
+        let congestion_controller = CongestionControlConfig::from_ledbat_config(LedbatConfig {
+            initial_cwnd: 1,
+            min_cwnd: 1,
+            max_cwnd: 1,
+            ..Default::default()
+        })
+        .build_arc();
 
         let sent_tracker = Arc::new(parking_lot::Mutex::new(SentPacketTracker::new()));
         let token_bucket = Arc::new(TokenBucket::new(1_000_000, 100_000_000));
@@ -1202,8 +1322,8 @@ mod tests {
 
         let result = pipe_task.await.expect("join error");
         assert!(
-            matches!(result, Err(TransportError::ConnectionClosed(_))),
-            "Expected ConnectionClosed after pipe_stream cwnd wait timeout, got: {:?}",
+            matches!(result, Err(TransportError::OutboundStreamTimeout(_))),
+            "Expected OutboundStreamTimeout after pipe_stream cwnd wait timeout, got: {:?}",
             result
         );
 


### PR DESCRIPTION
## Problem

Several failure sites in `outbound_stream.rs` returned `TransportError::ConnectionClosed(destination_addr)`. The connection recv loop in `peer_connection.rs` (~line 1162) classifies any error that is not `is_transient_send_failure()` as fatal:

```rust
Err(e) if e.is_transient_send_failure() => { warn; op layer retries }  // connection SURVIVES
Err(e) => return Err(e),                                                // connection TORN DOWN
```

`is_transient_send_failure()` previously matched only `SendFailed`, so each of these stream-level failures hit the fatal arm and tore down the **entire** connection — killing every other operation multiplexed on it and forcing a re-handshake. A single stalled or failed stream became a connection-teardown amplifier. This is the user-visible "cwnd wait timeout" / "no fragments received" failure mode from #4345.

The affected sites — all problems with *one transfer or its upstream inbound feed*, none meaning the downstream socket/connection itself is dead:

- **cwnd-wait timeout** in `send_stream` and `pipe_stream` — the congestion-window wait exceeds `CWND_WAIT_TIMEOUT` (ACKs stopped arriving for this transfer).
- **relay-pipe inactivity stall** (`pipe_stream` :456) — the UPSTREAM inbound feed produced no fragment within `STREAM_INACTIVITY_TIMEOUT`.
- **relay-pipe inbound-stream error** (`pipe_stream` :471) — the UPSTREAM inbound stream yielded an error.

The pipe paths are arguably more central to the room-join GET path (#3586) than cwnd-wait, since they kill a connection carrying other multiplexed ops purely as collateral from an upstream problem.

Per #4345, a single stalled/failed stream must fail just the STREAM (the op layer already times out and retries against another candidate after PR #4367), NOT the connection.

## Solution

- Add a stream-scoped `TransportError::OutboundStreamFailed(SocketAddr)` variant (covers timeout AND error; generic message `"outbound stream to {0} failed (stream-scoped, connection survives)"`).
- Convert **all** stream-scoped sites in `outbound_stream.rs` from `ConnectionClosed` to `OutboundStreamFailed`: the cwnd-wait timeout in both `send_stream` and `pipe_stream`, the relay-pipe **inactivity stall**, and the relay-pipe **inbound-stream error**. Existing `emit_transfer_failed(...)` telemetry is unchanged.
- Audit result: the two remaining `return Err(e)` sites (`send_stream` :295, `pipe_stream` :618) propagate `packet_sending`'s error, which is already `SendFailed` (transient) — left as-is. No site in this file genuinely means "the connection itself is dead"; `ConnectionClosed` here was always a misnomer for stream-scoped failures.
- Include the new variant in `is_transient_send_failure()` so the recv loop logs and lets the op layer retry while the connection stays up. The idle timeout remains the sole authority on connection liveness. Updated the doc comment, all three exhaustive `TransportError` match arms in `connection_handler.rs`, and all test references.
- **Review nit:** documented at the `send_stream` cwnd-abort site that `completion_tx` is intentionally dropped (not signaled) — `broadcast_queue` awaits it with a timeout and treats the resulting oneshot `RecvError` as completion (`broadcast_queue.rs` `Ok(Err(_))` arm), releasing the permit immediately. A future editor must not "fix" it with a blocking `tx.send(())` (channel-safety.md).

This is the **connection-survival half only**. It does not change any timeout constants and does not attempt the transport flightsize-by-stream-id rework — that root cause remains open in #4345.

## Testing

Three regression tests drive the **real** `send_stream`/`pipe_stream` functions to each failure mode and assert the error IS `OutboundStreamFailed`, is NOT `ConnectionClosed`, and `is_transient_send_failure()` is `true` (the exact condition the recv loop branches on for connection survival):

- `cwnd_wait_timeout_fails_stream_not_connection` — 1-byte cwnd so no packet ever fits → cwnd-wait timeout in `send_stream`.
- `pipe_stream_inactivity_stall_fails_stream_not_connection` — `StreamHandle` with no fragment pushed so `stream.next()` stays Pending → inactivity-timeout arm (:456).
- `pipe_stream_inbound_error_fails_stream_not_connection` — cancel the `StreamHandle` so the inbound stream yields `Err(Cancelled)` → inbound-error arm (:471).

**Before/after verified for all three** (temporarily reverted the production sites to `ConnectionClosed`): each fails on the old behavior (`got: ConnectionClosed`) and passes with the fix.

Also updated the two existing cwnd-timeout tests (`test_send_stream_cwnd_wait_timeout`, `test_pipe_stream_cwnd_wait_timeout`) to expect the new variant. The `test_pipe_stream_cwnd_wait_timeout` rewire (prior commit) had found that test was misconfigured — it used `CongestionControlConfig::default()` (FixedRate, `current_cwnd() == usize::MAX/2`), so the cwnd loop never blocked and the test silently exercised the *inactivity-timeout* path rather than the cwnd-wait path it claims to test; switched it to a 1-byte-cwnd LEDBAT controller so it genuinely hits the cwnd-wait site. The two new pipe tests restore explicit coverage of the inactivity and inbound-error paths.

A full `PeerConnection::recv` teardown harness would need substantial new scaffolding the stream-level unit harness doesn't expose; the error-classification assertions pin the behavior the recv loop branches on (mirrors the existing `send_failure_returns_transient_error` test for `SendFailed`).

`cargo fmt` clean. `cargo test -p freenet --lib transport::peer_connection::outbound_stream` → **9 passed**. Note: local `cargo clippy` (rust-1.94.0) reports 13 pre-existing `wildcard_enum_match_arm` / `int_plus_one` errors in unrelated files (`sent_packet_tracker.rs`, `peer_connection.rs:3324`, `client_events.rs`); these are present on clean `main` too (verified via stash) and are a local-toolchain-version artifact — **zero new clippy findings introduced** by this change.

Addresses #4345 (connection-survival half; transport flightsize-by-stream-id root cause remains open).

[AI-assisted - Claude]
