### PR TITLE
ci(release): tolerate transient gh errors in the wait_for_pr poll

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,8 +236,15 @@ jobs:
 
           echo "⏳ Waiting for PR #$PR_NUMBER to merge..."
 
-          while [ $ELAPSED -lt $MAX_WAIT ]; do
-            PR_STATE=$(gh pr view $PR_NUMBER --json state --jq '.state')
+          while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+            # Guard the gh call so a transient API error (e.g. the
+            # HTTP 401 that aborted the v0.2.71 release on the first
+            # poll) doesn't kill the whole step under `bash -e`. A
+            # non-zero exit or empty/unparseable output is treated as
+            # "retry next interval" rather than a fatal failure; the
+            # MAX_WAIT budget still bounds total waiting, so persistent
+            # API failure eventually times out (exit 1) below.
+            PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null || true)
 
             if [ "$PR_STATE" == "MERGED" ]; then
               echo "✅ PR #$PR_NUMBER merged successfully!"
@@ -245,10 +252,13 @@ jobs:
             elif [ "$PR_STATE" == "CLOSED" ]; then
               echo "❌ PR #$PR_NUMBER was closed without merging"
               exit 1
+            elif [ -z "$PR_STATE" ]; then
+              echo "  ⚠️  transient gh error querying PR state, will retry (${ELAPSED}s elapsed)"
+            else
+              echo "  Still waiting... (${ELAPSED}s elapsed)"
             fi
 
-            echo "  Still waiting... (${ELAPSED}s elapsed)"
-            sleep $WAIT_INTERVAL
+            sleep "$WAIT_INTERVAL"
             ELAPSED=$((ELAPSED + WAIT_INTERVAL))
           done
 


### PR DESCRIPTION
## Problem

The `wait_for_pr` job's "Wait for PR to be merged" step in `.github/workflows/release.yml` polls the bump PR's state in a loop under `bash -e`:

```bash
PR_STATE=$(gh pr view $PR_NUMBER --json state --jq '.state')
```

Because this is a bare command substitution, any non-zero exit from `gh` makes the substitution fail, and `set -e` (the GitHub Actions `run:` default for `bash`) then aborts the entire step with exit 1.

During the **v0.2.71 release** this fired on the very FIRST poll: `gh pr view` hit a transient `HTTP 401: Requires authentication` from the GitHub API. The poll aborted, the `wait_for_pr` job failed, and the whole release was killed — even though the bump PR existed and later merged cleanly. A single transient API blip should not abort a 60-minute wait.

## Solution

Guard the `gh` call so a transient error can't abort the loop, without changing the merge/abort logic for real states:

```bash
PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null || true)
```

- A non-zero exit or empty/unparseable output now yields an empty `PR_STATE`, which is treated as "transient gh error querying PR state, will retry" — the loop logs it, sleeps, advances `ELAPSED`, and continues.
- Real states are unchanged: `MERGED` still exits 0, `CLOSED` still exits 1.
- No unbounded retries: the existing `MAX_WAIT` (60 min) budget is the bound, so a *persistently* failing API still eventually times out (exit 1).
- Quoted the loop/test variables (`$ELAPSED`, `$MAX_WAIT`, `$PR_NUMBER`, `$WAIT_INTERVAL`) while touching the loop.

Scope is deliberately minimal: this is the only poll/wait loop in `release.yml`. The one-shot `gh` calls (`gh pr create`, `gh pr merge --auto`, `gh release create`) and the already-guarded `gh release list` / `gh api` calls fail cleanly with no partial-state risk and are intentionally left unchanged.

## Testing

This is a `.github/workflows/` change with no Rust impact.

- **YAML validity:** `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` → `YAML OK`.
- **Logic walkthrough (simulated under `bash -e` with a stateful mock `gh`):**
  - transient FAIL (exit 1) → EMPTY output → OPEN → MERGED: loop does NOT abort, logs "transient retry", retries, exits **0** on MERGED.
  - OPEN → CLOSED: exits **1** immediately (real failure preserved).
  - persistent FAIL: bounded by `MAX_WAIT`, eventually times out with exit **1**.
  - Confirmed the pre-fix code aborts on the first FAIL under `bash -e`, reproducing the v0.2.71 failure.

[AI-assisted - Claude]