### PR TITLE
fix(release-agent): report gateway service health in /version so a failed restart isn't a false success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,15 @@ jobs:
           check "build: replace local release build"           "non-release"
           check ""                                             "non-release"
 
+      # Regression gate for the gateway-update verify decision (the vega
+      # v0.2.71 incident: binary swapped, service down, workflow falsely
+      # reported success). The decision logic in
+      # scripts/release-agent/verify-version-decision.sh is sourced both by
+      # gateway-update.yml and by this test, so they cannot drift. The
+      # load-bearing case is "service_active:false must NOT report success".
+      - name: Self-test gateway-update verify decision
+        run: bash scripts/release-agent/verify-version-decision_test.sh
+
       - name: Check for old-style mod.rs files
         run: |
           # New modules must use foo.rs + foo/ style, not foo/mod.rs

--- a/.github/workflows/gateway-update.yml
+++ b/.github/workflows/gateway-update.yml
@@ -125,6 +125,11 @@ jobs:
       matrix:
         gateway: ${{ fromJson(needs.plan.outputs.matrix) }}
     steps:
+      # Needed for the verify step, which sources
+      # scripts/release-agent/verify-version-decision.sh so the workflow and
+      # its regression test share one copy of the decision logic.
+      - uses: actions/checkout@v6
+
       - name: Resolve secret
         id: secret
         env:
@@ -206,48 +211,50 @@ jobs:
           # finishes; /version will briefly 502/connection-refused while
           # the systemd unit cycles. Poll for up to 120s.
           #
-          # Success requires BOTH:
-          #   1. the on-disk binary reports the new version, AND
-          #   2. the gateway SERVICE is actually up on it.
+          # Success requires BOTH the on-disk binary on the new version AND
+          # the gateway SERVICE actually active on it. The binary-version check
+          # alone is NOT sufficient: during the v0.2.71 release vega's binary
+          # was swapped to 0.2.71 but the service failed to restart (old
+          # process hung on shutdown → SIGKILL → unit left `failed`).
+          # `/version` still reported 0.2.71 (on-disk), so this step reported
+          # SUCCESS while vega's gateway was DOWN for ~5 minutes. The
+          # `service_active` field closes that gap.
           #
-          # The binary-version check alone is NOT sufficient: during the
-          # v0.2.71 release the vega gateway's binary was swapped to 0.2.71
-          # but the service failed to restart (the old process hung on
-          # shutdown → SIGKILL → unit left `failed`). `/version` still
-          # reported 0.2.71 (on-disk), so this step reported SUCCESS while
-          # vega's gateway was DOWN for ~5 minutes. The `service_active`
-          # field (added to the agent's `/version` response) closes that gap.
-          #
-          # BACKWARD COMPATIBILITY: a deployed agent that predates this field
-          # won't report `service_active` until it is itself updated. When the
-          # field is ABSENT we must NOT hard-fail — we log a warning and fall
-          # back to the old binary-only check. We only ENFORCE the
-          # service-running requirement when the field is present.
+          # The decision logic lives in verify-version-decision.sh so it is
+          # unit-tested (verify-version-decision_test.sh, run in CI) and shared
+          # with this workflow — see that script for the backward-compat and
+          # swap-ordering rationale.
+          source scripts/release-agent/verify-version-decision.sh
+
           DEADLINE=$(( $(date +%s) + 120 ))
           while (( $(date +%s) < DEADLINE )); do
             RESPONSE=$(curl -sS --max-time 5 "$GATEWAY_URL/version" || true)
-            INSTALLED=$(echo "$RESPONSE" | jq -r '.version // empty')
-            # `// empty` yields "" for both a missing field (old agent) and a
-            # null. Distinguish "field present" from "field absent" with `has`.
-            HAS_SERVICE_FIELD=$(echo "$RESPONSE" | jq -r 'has("service_active") // false' 2>/dev/null || echo "false")
-            SERVICE_ACTIVE=$(echo "$RESPONSE" | jq -r '.service_active // false' 2>/dev/null || echo "false")
-            MANAGED_SERVICE=$(echo "$RESPONSE" | jq -r '.managed_service // empty' 2>/dev/null || echo "")
+            INSTALLED=$(printf '%s' "$RESPONSE" | jq -r '.version // empty' 2>/dev/null || echo "")
+            MANAGED_SERVICE=$(printf '%s' "$RESPONSE" | jq -r '.managed_service // empty' 2>/dev/null || echo "")
+            DECISION=$(verify_version_decision "$RESPONSE" "$VERSION")
 
-            if [[ "$INSTALLED" == "$VERSION" ]]; then
-              if [[ "$HAS_SERVICE_FIELD" == "true" ]]; then
-                if [[ "$SERVICE_ACTIVE" == "true" ]]; then
-                  echo "✓ Gateway ${{ matrix.gateway.name }} reports version $INSTALLED and service ${MANAGED_SERVICE:-?} is active"
-                  exit 0
-                fi
-                echo "Binary is $INSTALLED but service ${MANAGED_SERVICE:-?} is NOT active yet; waiting for restart…"
-              else
+            case "$DECISION" in
+              success)
+                echo "✓ Gateway ${{ matrix.gateway.name }} reports version $INSTALLED and service ${MANAGED_SERVICE:-?} is active"
+                exit 0
+                ;;
+              success-fallback)
                 echo "::warning::Gateway ${{ matrix.gateway.name }} agent predates the service-health check (no 'service_active' in /version); falling back to binary-only verification. Update the release-agent on this gateway to enable the stronger check."
                 echo "✓ Gateway ${{ matrix.gateway.name }} now reports version $INSTALLED (binary-only check)"
                 exit 0
-              fi
-            else
-              echo "Waiting for ${{ matrix.gateway.name }} to report $VERSION (current: ${INSTALLED:-unreachable})…"
-            fi
+                ;;
+              wait)
+                if [[ "$INSTALLED" == "$VERSION" ]]; then
+                  echo "Binary is $INSTALLED but service ${MANAGED_SERVICE:-?} is NOT active yet; waiting for restart…"
+                else
+                  echo "Waiting for ${{ matrix.gateway.name }} to report $VERSION (current: ${INSTALLED:-unreachable})…"
+                fi
+                ;;
+              *)
+                echo "::error::Unexpected decision token: $DECISION"
+                exit 1
+                ;;
+            esac
             sleep 5
           done
           echo "::error::Gateway ${{ matrix.gateway.name }} did not converge on $VERSION with an active service within 120s"

--- a/.github/workflows/gateway-update.yml
+++ b/.github/workflows/gateway-update.yml
@@ -205,16 +205,50 @@ jobs:
           # The agent restarts the freenet service after the script
           # finishes; /version will briefly 502/connection-refused while
           # the systemd unit cycles. Poll for up to 120s.
+          #
+          # Success requires BOTH:
+          #   1. the on-disk binary reports the new version, AND
+          #   2. the gateway SERVICE is actually up on it.
+          #
+          # The binary-version check alone is NOT sufficient: during the
+          # v0.2.71 release the vega gateway's binary was swapped to 0.2.71
+          # but the service failed to restart (the old process hung on
+          # shutdown → SIGKILL → unit left `failed`). `/version` still
+          # reported 0.2.71 (on-disk), so this step reported SUCCESS while
+          # vega's gateway was DOWN for ~5 minutes. The `service_active`
+          # field (added to the agent's `/version` response) closes that gap.
+          #
+          # BACKWARD COMPATIBILITY: a deployed agent that predates this field
+          # won't report `service_active` until it is itself updated. When the
+          # field is ABSENT we must NOT hard-fail — we log a warning and fall
+          # back to the old binary-only check. We only ENFORCE the
+          # service-running requirement when the field is present.
           DEADLINE=$(( $(date +%s) + 120 ))
           while (( $(date +%s) < DEADLINE )); do
             RESPONSE=$(curl -sS --max-time 5 "$GATEWAY_URL/version" || true)
             INSTALLED=$(echo "$RESPONSE" | jq -r '.version // empty')
+            # `// empty` yields "" for both a missing field (old agent) and a
+            # null. Distinguish "field present" from "field absent" with `has`.
+            HAS_SERVICE_FIELD=$(echo "$RESPONSE" | jq -r 'has("service_active") // false' 2>/dev/null || echo "false")
+            SERVICE_ACTIVE=$(echo "$RESPONSE" | jq -r '.service_active // false' 2>/dev/null || echo "false")
+            MANAGED_SERVICE=$(echo "$RESPONSE" | jq -r '.managed_service // empty' 2>/dev/null || echo "")
+
             if [[ "$INSTALLED" == "$VERSION" ]]; then
-              echo "✓ Gateway ${{ matrix.gateway.name }} now reports version $INSTALLED"
-              exit 0
+              if [[ "$HAS_SERVICE_FIELD" == "true" ]]; then
+                if [[ "$SERVICE_ACTIVE" == "true" ]]; then
+                  echo "✓ Gateway ${{ matrix.gateway.name }} reports version $INSTALLED and service ${MANAGED_SERVICE:-?} is active"
+                  exit 0
+                fi
+                echo "Binary is $INSTALLED but service ${MANAGED_SERVICE:-?} is NOT active yet; waiting for restart…"
+              else
+                echo "::warning::Gateway ${{ matrix.gateway.name }} agent predates the service-health check (no 'service_active' in /version); falling back to binary-only verification. Update the release-agent on this gateway to enable the stronger check."
+                echo "✓ Gateway ${{ matrix.gateway.name }} now reports version $INSTALLED (binary-only check)"
+                exit 0
+              fi
+            else
+              echo "Waiting for ${{ matrix.gateway.name }} to report $VERSION (current: ${INSTALLED:-unreachable})…"
             fi
-            echo "Waiting for ${{ matrix.gateway.name }} to report $VERSION (current: ${INSTALLED:-unreachable})…"
             sleep 5
           done
-          echo "::error::Gateway ${{ matrix.gateway.name }} did not converge on $VERSION within 120s"
+          echo "::error::Gateway ${{ matrix.gateway.name }} did not converge on $VERSION with an active service within 120s"
           exit 1

--- a/crates/release-agent/src/config.rs
+++ b/crates/release-agent/src/config.rs
@@ -36,6 +36,17 @@ pub struct Config {
     /// the owner of `~/.config/freenet-river-official/`. Default empty.
     #[serde(default)]
     pub river_announce_user: String,
+
+    /// systemd unit name of the gateway service this agent manages, WITHOUT
+    /// the `.service` suffix (e.g. `freenet-gateway`, or `freenet-gateway-hector`
+    /// on vega's secondary instance). `GET /version` queries
+    /// `systemctl is-active <managed_service>` and reports the result as
+    /// `service_active`, so the release workflow can tell a successful binary
+    /// swap apart from a gateway whose service failed to restart. Defaults to
+    /// `freenet-gateway`, matching the unit name used by
+    /// `deploy-local-gateway.sh` and the gateway setup guide.
+    #[serde(default = "default_managed_service")]
+    pub managed_service: String,
 }
 
 fn default_repo() -> String {
@@ -49,6 +60,9 @@ fn default_rate_limit() -> u64 {
 }
 fn default_skew() -> u32 {
     300
+}
+fn default_managed_service() -> String {
+    "freenet-gateway".to_string()
 }
 
 impl Config {
@@ -108,6 +122,24 @@ hmac_secret_path = "/etc/freenet-release-agent/hmac.key"
             cfg.dry_run,
             "missing dry_run must default to true (safe-by-default)"
         );
+        assert_eq!(
+            cfg.managed_service, "freenet-gateway",
+            "missing managed_service must default to the standard gateway unit"
+        );
+    }
+
+    #[test]
+    fn parses_custom_managed_service() {
+        // vega's secondary instance runs as `freenet-gateway-hector`.
+        let toml_src = r#"
+listen_addr = "127.0.0.1:9876"
+binary_path = "/usr/local/bin/freenet"
+update_command = "/usr/local/bin/gateway-auto-update.sh"
+hmac_secret_path = "/etc/freenet-release-agent/hmac.key"
+managed_service = "freenet-gateway-hector"
+"#;
+        let cfg: Config = toml::from_str(toml_src).unwrap();
+        assert_eq!(cfg.managed_service, "freenet-gateway-hector");
     }
 
     #[test]
@@ -185,6 +217,7 @@ dry-run = false
             clock_skew_tolerance_seconds: 0,
             river_announce_command: PathBuf::new(),
             river_announce_user: String::new(),
+            managed_service: "freenet-gateway".into(),
         }
     }
 }

--- a/crates/release-agent/src/main.rs
+++ b/crates/release-agent/src/main.rs
@@ -13,7 +13,7 @@ use freenet_release_agent::{
     github::GitHubLatest,
     server::{AppState, build_router, serve},
     updater::Updater,
-    version::VersionCache,
+    version::{ServiceHealthCache, VersionCache},
 };
 
 #[derive(Parser)]
@@ -65,6 +65,8 @@ async fn main() -> Result<()> {
         updater,
         announcer,
         version_cache: VersionCache::new(),
+        service_health_cache: ServiceHealthCache::new(),
+        systemctl_path: PathBuf::from("systemctl"),
         last_update_attempt: Arc::new(Mutex::new(None)),
         last_announce_attempt: Arc::new(Mutex::new(None)),
     };

--- a/crates/release-agent/src/server.rs
+++ b/crates/release-agent/src/server.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -20,7 +21,7 @@ use crate::auth::{HEADER_SIGNATURE, check_clock_skew, verify_signature};
 use crate::config::Config;
 use crate::github::LatestSource;
 use crate::updater::Updater;
-use crate::version::VersionCache;
+use crate::version::{ServiceHealthCache, VersionCache};
 
 /// Cap on the request body for `POST /update`. The legitimate body is ~60
 /// bytes (a small JSON object). 4 KiB is generous and rejects megabyte
@@ -45,6 +46,14 @@ pub struct AppState {
     pub updater: Updater,
     pub announcer: Announcer,
     pub version_cache: VersionCache,
+    /// Short-TTL cache of `systemctl is-active <managed_service>`, so the
+    /// unauthenticated `/version` endpoint doesn't fork a subprocess on every
+    /// request (the same self-DoS concern that motivates `version_cache`).
+    pub service_health_cache: ServiceHealthCache,
+    /// Path to the `systemctl` binary. Production is `systemctl` (resolved via
+    /// PATH); tests point this at a stub script so the `/version` service-health
+    /// reporting can be exercised over the HTTP layer without real systemd.
+    pub systemctl_path: PathBuf,
     pub last_update_attempt: Arc<Mutex<Option<Instant>>>,
     pub last_announce_attempt: Arc<Mutex<Option<Instant>>>,
 }
@@ -127,8 +136,12 @@ async fn version_handler(State(state): State<AppState>) -> Response {
             // Report the SERVICE's health, not just the on-disk binary: a
             // gateway whose binary was swapped but whose service failed to
             // restart must NOT look like a successful update (vega v0.2.71).
-            let service_active =
-                crate::version::service_active(&state.config.managed_service).await;
+            // Cached with a short TTL so this unauthenticated endpoint doesn't
+            // fork systemctl on every hit.
+            let service_active = state
+                .service_health_cache
+                .is_active_with(&state.systemctl_path, &state.config.managed_service)
+                .await;
             Json(VersionResponse {
                 version: v.to_string(),
                 binary_path: state.config.binary_path.display().to_string(),

--- a/crates/release-agent/src/server.rs
+++ b/crates/release-agent/src/server.rs
@@ -51,8 +51,24 @@ pub struct AppState {
 
 #[derive(Serialize)]
 pub struct VersionResponse {
+    /// On-disk version of the freenet binary (`freenet --version`). This is
+    /// NOT proof the gateway service is running it — see `service_active`.
     pub version: String,
     pub binary_path: String,
+    /// Whether the managed gateway systemd unit is currently `active`
+    /// (`systemctl is-active <managed_service>`). Added after the v0.2.71
+    /// release, where vega's binary was swapped successfully but the service
+    /// failed to restart, leaving `/version` reporting the new version while
+    /// the gateway was DOWN. The release workflow MUST require this be `true`
+    /// before declaring an update successful.
+    ///
+    /// NOTE: backward compatibility — older release-agent builds omit this
+    /// field entirely, so consumers must treat its ABSENCE as "agent predates
+    /// the check" (fall back to the binary-only check) rather than a failure.
+    pub service_active: bool,
+    /// The systemd unit name whose state `service_active` reflects. Surfaced so
+    /// the workflow log records which unit was checked.
+    pub managed_service: String,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -107,11 +123,20 @@ pub fn build_router(state: AppState) -> Router {
 
 async fn version_handler(State(state): State<AppState>) -> Response {
     match state.version_cache.current(&state.config.binary_path).await {
-        Ok(v) => Json(VersionResponse {
-            version: v.to_string(),
-            binary_path: state.config.binary_path.display().to_string(),
-        })
-        .into_response(),
+        Ok(v) => {
+            // Report the SERVICE's health, not just the on-disk binary: a
+            // gateway whose binary was swapped but whose service failed to
+            // restart must NOT look like a successful update (vega v0.2.71).
+            let service_active =
+                crate::version::service_active(&state.config.managed_service).await;
+            Json(VersionResponse {
+                version: v.to_string(),
+                binary_path: state.config.binary_path.display().to_string(),
+                service_active,
+                managed_service: state.config.managed_service.clone(),
+            })
+            .into_response()
+        }
         Err(e) => {
             tracing::warn!(error = %e, "failed to read freenet --version");
             (

--- a/crates/release-agent/src/version.rs
+++ b/crates/release-agent/src/version.rs
@@ -89,6 +89,64 @@ fn parse_version_output(out: &str) -> Result<Version> {
         .with_context(|| format!("could not parse version from {out:?}"))
 }
 
+/// Query whether the managed gateway service is running, via
+/// `systemctl is-active <service>`.
+///
+/// The `/version` endpoint reports the ON-DISK binary version. That is not
+/// the same question as "is the gateway actually running it": during the
+/// v0.2.71 release the vega gateway's binary was swapped to 0.2.71 but the
+/// service failed to restart (old process hung on shutdown → SIGKILL → unit
+/// left `failed`). `/version` still reported 0.2.71, so the release workflow
+/// reported success while the gateway was DOWN for ~5 minutes. Surfacing the
+/// service state lets the workflow tell those two cases apart.
+///
+/// Returns `Ok(true)` only when systemd reports the unit `active`. `inactive`,
+/// `failed`, `activating`, an unknown unit, or a missing/erroring `systemctl`
+/// all map to `Ok(false)` — never an error and never a panic. `systemctl
+/// is-active` is a read-only query that does not require root, so no sudo is
+/// involved.
+///
+/// Note: `is-active` exits non-zero for any non-active state, so we key on the
+/// printed state word (stdout) rather than the exit status.
+pub async fn service_active(service: &str) -> bool {
+    service_active_with(Path::new("systemctl"), service).await
+}
+
+/// Implementation of [`service_active`] with the `systemctl` binary path
+/// injected so tests can point at a stub without real systemd. Production
+/// callers use [`service_active`], which resolves `systemctl` via PATH.
+async fn service_active_with(systemctl: &Path, service: &str) -> bool {
+    let unit = if service.ends_with(".service") {
+        service.to_string()
+    } else {
+        format!("{service}.service")
+    };
+
+    let output = match tokio::time::timeout(
+        Duration::from_secs(5),
+        Command::new(systemctl).arg("is-active").arg(&unit).output(),
+    )
+    .await
+    {
+        Ok(Ok(output)) => output,
+        Ok(Err(e)) => {
+            // systemctl missing (non-systemd host) or otherwise unspawnable.
+            tracing::warn!(error = %e, unit, "could not spawn `systemctl is-active`");
+            return false;
+        }
+        Err(_) => {
+            tracing::warn!(unit, "`systemctl is-active` timed out");
+            return false;
+        }
+    };
+
+    // `is-active` prints exactly the active state on stdout (e.g. `active`,
+    // `inactive`, `failed`, `activating`). Match `active` precisely so
+    // `activating`/`inactive` are not counted as up.
+    let state = String::from_utf8_lossy(&output.stdout);
+    state.trim() == "active"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -119,6 +177,60 @@ mod tests {
     #[test]
     fn rejects_garbage() {
         assert!(parse_version_output("no version here").is_err());
+    }
+
+    /// Write a stub `systemctl` that prints `state` on stdout and exits 0 for
+    /// `active`, 3 otherwise — matching real `systemctl is-active` behaviour
+    /// (non-active states exit non-zero but still print the state word).
+    fn write_stub_systemctl(dir: &Path, state: &str) -> PathBuf {
+        let bin = dir.join("fake-systemctl");
+        let exit = if state == "active" { 0 } else { 3 };
+        let script = format!("#!/bin/sh\necho {state}\nexit {exit}\n");
+        let mut f = std::fs::File::create(&bin).unwrap();
+        f.write_all(script.as_bytes()).unwrap();
+        let mut perms = std::fs::metadata(&bin).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&bin, perms).unwrap();
+        bin
+    }
+
+    #[tokio::test]
+    async fn service_active_true_when_systemctl_reports_active() {
+        let dir = tempfile::tempdir().unwrap();
+        let systemctl = write_stub_systemctl(dir.path(), "active");
+        assert!(service_active_with(&systemctl, "freenet-gateway").await);
+    }
+
+    #[tokio::test]
+    async fn service_active_false_when_failed() {
+        // The vega v0.2.71 case: binary swapped, but the unit is `failed`.
+        let dir = tempfile::tempdir().unwrap();
+        let systemctl = write_stub_systemctl(dir.path(), "failed");
+        assert!(!service_active_with(&systemctl, "freenet-gateway").await);
+    }
+
+    #[tokio::test]
+    async fn service_active_false_when_inactive() {
+        let dir = tempfile::tempdir().unwrap();
+        let systemctl = write_stub_systemctl(dir.path(), "inactive");
+        assert!(!service_active_with(&systemctl, "freenet-gateway").await);
+    }
+
+    #[tokio::test]
+    async fn service_active_false_when_activating() {
+        // `activating` is not yet up; must not be counted as active.
+        let dir = tempfile::tempdir().unwrap();
+        let systemctl = write_stub_systemctl(dir.path(), "activating");
+        assert!(!service_active_with(&systemctl, "freenet-gateway").await);
+    }
+
+    #[tokio::test]
+    async fn service_active_false_when_systemctl_missing() {
+        // Non-systemd host (or systemctl not installed): never panic, never
+        // error — just report the service as not active.
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist-systemctl");
+        assert!(!service_active_with(&missing, "freenet-gateway").await);
     }
 
     #[tokio::test]

--- a/crates/release-agent/src/version.rs
+++ b/crates/release-agent/src/version.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::{Context, Result};
 use semver::Version;
@@ -89,33 +89,101 @@ fn parse_version_output(out: &str) -> Result<Version> {
         .with_context(|| format!("could not parse version from {out:?}"))
 }
 
-/// Query whether the managed gateway service is running, via
-/// `systemctl is-active <service>`.
+/// TTL for the [`ServiceHealthCache`]. The release workflow polls `/version`
+/// every 5s; a 2s TTL means at most one `systemctl` fork per poll while still
+/// being far fresher than the poll cadence, so the workflow never acts on a
+/// stale "active" reading for more than one cycle. The cache exists for the
+/// same reason as [`VersionCache`]: `/version` is UNAUTHENTICATED, so forking a
+/// subprocess on every hit is a cheap self-DoS vector.
+const SERVICE_HEALTH_TTL: Duration = Duration::from_secs(2);
+
+/// Caches the result of `systemctl is-active <service>` for a short TTL.
 ///
-/// The `/version` endpoint reports the ON-DISK binary version. That is not
-/// the same question as "is the gateway actually running it": during the
-/// v0.2.71 release the vega gateway's binary was swapped to 0.2.71 but the
-/// service failed to restart (old process hung on shutdown → SIGKILL → unit
-/// left `failed`). `/version` still reported 0.2.71, so the release workflow
-/// reported success while the gateway was DOWN for ~5 minutes. Surfacing the
-/// service state lets the workflow tell those two cases apart.
+/// The `/version` endpoint reports the ON-DISK binary version, which is NOT the
+/// same question as "is the gateway actually running it": during the v0.2.71
+/// release the vega gateway's binary was swapped to 0.2.71 but the service
+/// failed to restart (old process hung on shutdown → SIGKILL → unit left
+/// `failed`). `/version` still reported 0.2.71, so the release workflow reported
+/// success while the gateway was DOWN for ~5 minutes. Reporting the service
+/// state lets the workflow tell those two cases apart.
 ///
-/// Returns `Ok(true)` only when systemd reports the unit `active`. `inactive`,
+/// # Why a TTL cache
+///
+/// `/version` is unauthenticated. Without caching, every request would fork
+/// `systemctl` — the exact self-DoS vector [`VersionCache`] was built to
+/// eliminate for `freenet --version`. The TTL ([`SERVICE_HEALTH_TTL`]) is short
+/// relative to the workflow's 5s poll so a freshly-restarted (or freshly-failed)
+/// service is reflected within one poll cycle.
+///
+/// # Reliance on the update-script ordering
+///
+/// The workflow treats `installed == VERSION && service_active == true` as a
+/// successful update. That is only sound because `deploy-local-gateway.sh`
+/// (what `/update` ultimately spawns via `gateway-auto-update.sh`) performs
+/// **stop → swap binary → start**: the service is DOWN while the on-disk binary
+/// is replaced, so the binary only reads as "new" once the service has been
+/// restarted onto it. There is therefore no window where the OLD process is
+/// still `active` while the binary already reads as new. If that script is ever
+/// changed to swap-then-restart, this check would need to additionally verify
+/// the running process is the new binary (e.g. via `ActiveEnterTimestamp`); see
+/// the comment in `.github/workflows/gateway-update.yml`.
+#[derive(Default, Clone)]
+pub struct ServiceHealthCache {
+    inner: Arc<Mutex<Option<CachedServiceHealth>>>,
+}
+
+struct CachedServiceHealth {
+    service: String,
+    active: bool,
+    checked_at: Instant,
+}
+
+impl ServiceHealthCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return whether `service` is `active`, using the cached value if it is
+    /// younger than [`SERVICE_HEALTH_TTL`] and for the same service name.
+    /// Resolves `systemctl` via PATH.
+    pub async fn is_active(&self, service: &str) -> bool {
+        self.is_active_with(Path::new("systemctl"), service).await
+    }
+
+    /// [`Self::is_active`] with the `systemctl` binary path injected so tests
+    /// can point at a stub without real systemd. Production callers use
+    /// [`Self::is_active`].
+    pub async fn is_active_with(&self, systemctl: &Path, service: &str) -> bool {
+        {
+            let guard = self.inner.lock().await;
+            if let Some(c) = guard.as_ref() {
+                if c.service == service && c.checked_at.elapsed() < SERVICE_HEALTH_TTL {
+                    return c.active;
+                }
+            }
+        }
+
+        let active = query_service_active(systemctl, service).await;
+        let mut guard = self.inner.lock().await;
+        *guard = Some(CachedServiceHealth {
+            service: service.to_string(),
+            active,
+            checked_at: Instant::now(),
+        });
+        active
+    }
+}
+
+/// Run `systemctl is-active <service>` once and interpret the result.
+///
+/// Returns `true` only when systemd reports the unit `active`. `inactive`,
 /// `failed`, `activating`, an unknown unit, or a missing/erroring `systemctl`
-/// all map to `Ok(false)` — never an error and never a panic. `systemctl
-/// is-active` is a read-only query that does not require root, so no sudo is
-/// involved.
+/// all map to `false` — never an error and never a panic. `systemctl is-active`
+/// is a read-only query that does not require root, so no sudo is involved.
 ///
 /// Note: `is-active` exits non-zero for any non-active state, so we key on the
 /// printed state word (stdout) rather than the exit status.
-pub async fn service_active(service: &str) -> bool {
-    service_active_with(Path::new("systemctl"), service).await
-}
-
-/// Implementation of [`service_active`] with the `systemctl` binary path
-/// injected so tests can point at a stub without real systemd. Production
-/// callers use [`service_active`], which resolves `systemctl` via PATH.
-async fn service_active_with(systemctl: &Path, service: &str) -> bool {
+async fn query_service_active(systemctl: &Path, service: &str) -> bool {
     let unit = if service.ends_with(".service") {
         service.to_string()
     } else {
@@ -181,11 +249,16 @@ mod tests {
 
     /// Write a stub `systemctl` that prints `state` on stdout and exits 0 for
     /// `active`, 3 otherwise — matching real `systemctl is-active` behaviour
-    /// (non-active states exit non-zero but still print the state word).
-    fn write_stub_systemctl(dir: &Path, state: &str) -> PathBuf {
+    /// (non-active states exit non-zero but still print the state word). Each
+    /// invocation also appends a line to `counter_path` so a test can assert
+    /// how many times the stub was forked (cache coverage).
+    fn write_stub_systemctl_counting(dir: &Path, state: &str, counter_path: &Path) -> PathBuf {
         let bin = dir.join("fake-systemctl");
         let exit = if state == "active" { 0 } else { 3 };
-        let script = format!("#!/bin/sh\necho {state}\nexit {exit}\n");
+        let script = format!(
+            "#!/bin/sh\necho x >> {counter}\necho {state}\nexit {exit}\n",
+            counter = counter_path.display()
+        );
         let mut f = std::fs::File::create(&bin).unwrap();
         f.write_all(script.as_bytes()).unwrap();
         let mut perms = std::fs::metadata(&bin).unwrap().permissions();
@@ -194,11 +267,16 @@ mod tests {
         bin
     }
 
+    /// Convenience: stub `systemctl` without a fork counter.
+    fn write_stub_systemctl(dir: &Path, state: &str) -> PathBuf {
+        write_stub_systemctl_counting(dir, state, &dir.join("ignored-count"))
+    }
+
     #[tokio::test]
     async fn service_active_true_when_systemctl_reports_active() {
         let dir = tempfile::tempdir().unwrap();
         let systemctl = write_stub_systemctl(dir.path(), "active");
-        assert!(service_active_with(&systemctl, "freenet-gateway").await);
+        assert!(query_service_active(&systemctl, "freenet-gateway").await);
     }
 
     #[tokio::test]
@@ -206,14 +284,14 @@ mod tests {
         // The vega v0.2.71 case: binary swapped, but the unit is `failed`.
         let dir = tempfile::tempdir().unwrap();
         let systemctl = write_stub_systemctl(dir.path(), "failed");
-        assert!(!service_active_with(&systemctl, "freenet-gateway").await);
+        assert!(!query_service_active(&systemctl, "freenet-gateway").await);
     }
 
     #[tokio::test]
     async fn service_active_false_when_inactive() {
         let dir = tempfile::tempdir().unwrap();
         let systemctl = write_stub_systemctl(dir.path(), "inactive");
-        assert!(!service_active_with(&systemctl, "freenet-gateway").await);
+        assert!(!query_service_active(&systemctl, "freenet-gateway").await);
     }
 
     #[tokio::test]
@@ -221,7 +299,7 @@ mod tests {
         // `activating` is not yet up; must not be counted as active.
         let dir = tempfile::tempdir().unwrap();
         let systemctl = write_stub_systemctl(dir.path(), "activating");
-        assert!(!service_active_with(&systemctl, "freenet-gateway").await);
+        assert!(!query_service_active(&systemctl, "freenet-gateway").await);
     }
 
     #[tokio::test]
@@ -230,7 +308,50 @@ mod tests {
         // error — just report the service as not active.
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("does-not-exist-systemctl");
-        assert!(!service_active_with(&missing, "freenet-gateway").await);
+        assert!(!query_service_active(&missing, "freenet-gateway").await);
+    }
+
+    #[tokio::test]
+    async fn service_health_cache_does_not_refork_within_ttl() {
+        // The unauthenticated /version endpoint must NOT fork systemctl on
+        // every hit (self-DoS vector). A second lookup within the TTL must be
+        // served from cache, so the stub is forked exactly once.
+        let dir = tempfile::tempdir().unwrap();
+        let counter = dir.path().join("count");
+        let systemctl = write_stub_systemctl_counting(dir.path(), "active", &counter);
+
+        let cache = ServiceHealthCache::new();
+        assert!(cache.is_active_with(&systemctl, "freenet-gateway").await);
+        assert!(cache.is_active_with(&systemctl, "freenet-gateway").await);
+
+        let forks = std::fs::read_to_string(&counter).unwrap_or_default();
+        assert_eq!(
+            forks.lines().count(),
+            1,
+            "second is_active within TTL must hit the cache, not refork systemctl"
+        );
+    }
+
+    #[tokio::test]
+    async fn service_health_cache_reforks_for_different_service() {
+        // A different service name is a different question — must not be served
+        // from a cache entry keyed on the previous name.
+        let dir = tempfile::tempdir().unwrap();
+        let counter = dir.path().join("count");
+        let systemctl = write_stub_systemctl_counting(dir.path(), "active", &counter);
+
+        let cache = ServiceHealthCache::new();
+        cache.is_active_with(&systemctl, "freenet-gateway").await;
+        cache
+            .is_active_with(&systemctl, "freenet-gateway-hector")
+            .await;
+
+        let forks = std::fs::read_to_string(&counter).unwrap_or_default();
+        assert_eq!(
+            forks.lines().count(),
+            2,
+            "different service name must re-query, not reuse the cached entry"
+        );
     }
 
     #[tokio::test]

--- a/crates/release-agent/src/version.rs
+++ b/crates/release-agent/src/version.rs
@@ -127,9 +127,30 @@ const SERVICE_HEALTH_TTL: Duration = Duration::from_secs(2);
 /// changed to swap-then-restart, this check would need to additionally verify
 /// the running process is the new binary (e.g. via `ActiveEnterTimestamp`); see
 /// the comment in `.github/workflows/gateway-update.yml`.
-#[derive(Default, Clone)]
+///
+/// # Concurrency
+///
+/// Concurrent cache-misses each fork `systemctl` before the cache fills (no
+/// single-flight). This matches [`VersionCache`]'s accepted tradeoff and is
+/// bounded by the short TTL; the `/version` poll is sequential in practice, so
+/// adding single-flight would diverge from the established pattern for no real
+/// gain.
+#[derive(Clone)]
 pub struct ServiceHealthCache {
     inner: Arc<Mutex<Option<CachedServiceHealth>>>,
+    /// Entries older than this are re-queried. Defaults to
+    /// [`SERVICE_HEALTH_TTL`]; injectable so tests can force expiry instantly
+    /// instead of sleeping the real 2s.
+    ttl: Duration,
+}
+
+impl Default for ServiceHealthCache {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(None)),
+            ttl: SERVICE_HEALTH_TTL,
+        }
+    }
 }
 
 struct CachedServiceHealth {
@@ -143,9 +164,19 @@ impl ServiceHealthCache {
         Self::default()
     }
 
+    /// Construct a cache with a custom TTL. Production uses [`Self::new`] (2s);
+    /// this exists so tests can pin both sides of the TTL boundary without a
+    /// real `sleep`.
+    pub fn with_ttl(ttl: Duration) -> Self {
+        Self {
+            ttl,
+            ..Self::default()
+        }
+    }
+
     /// Return whether `service` is `active`, using the cached value if it is
-    /// younger than [`SERVICE_HEALTH_TTL`] and for the same service name.
-    /// Resolves `systemctl` via PATH.
+    /// younger than the cache's TTL and for the same service name. Resolves
+    /// `systemctl` via PATH.
     pub async fn is_active(&self, service: &str) -> bool {
         self.is_active_with(Path::new("systemctl"), service).await
     }
@@ -154,16 +185,32 @@ impl ServiceHealthCache {
     /// can point at a stub without real systemd. Production callers use
     /// [`Self::is_active`].
     pub async fn is_active_with(&self, systemctl: &Path, service: &str) -> bool {
+        self.is_active_inner(service, || query_service_active(systemctl, service))
+            .await
+    }
+
+    /// Cache logic (TTL check + store) with the underlying query injected as a
+    /// closure. Production passes [`query_service_active`] (which forks
+    /// `systemctl`); cache-behaviour tests pass an in-process closure so they
+    /// can assert query counts deterministically without forking a subprocess
+    /// per cached call (which is flaky under plain `cargo test` — see
+    /// `write_stub_systemctl` for why). The real fork-and-interpret path is
+    /// covered separately by the `query_service_active` tests.
+    async fn is_active_inner<F, Fut>(&self, service: &str, query: F) -> bool
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = bool>,
+    {
         {
             let guard = self.inner.lock().await;
             if let Some(c) = guard.as_ref() {
-                if c.service == service && c.checked_at.elapsed() < SERVICE_HEALTH_TTL {
+                if c.service == service && c.checked_at.elapsed() < self.ttl {
                     return c.active;
                 }
             }
         }
 
-        let active = query_service_active(systemctl, service).await;
+        let active = query().await;
         let mut guard = self.inner.lock().await;
         *guard = Some(CachedServiceHealth {
             service: service.to_string(),
@@ -249,27 +296,33 @@ mod tests {
 
     /// Write a stub `systemctl` that prints `state` on stdout and exits 0 for
     /// `active`, 3 otherwise — matching real `systemctl is-active` behaviour
-    /// (non-active states exit non-zero but still print the state word). Each
-    /// invocation also appends a line to `counter_path` so a test can assert
-    /// how many times the stub was forked (cache coverage).
-    fn write_stub_systemctl_counting(dir: &Path, state: &str, counter_path: &Path) -> PathBuf {
+    /// (non-active states exit non-zero but still print the state word). Used
+    /// by the `query_service_active` interpretation tests and the
+    /// `is_active_with` production-wiring smoke test. Cache-behaviour tests do
+    /// NOT fork a stub (see the `is_active_inner` closure tests below): a real
+    /// fork per cached call made those assertions flaky under plain
+    /// `cargo test`, because each `#[tokio::test]` is its own current-thread
+    /// runtime and many of them spawning+reaping children concurrently in one
+    /// process races tokio's Unix child reaper, so `child.wait()` occasionally
+    /// fails. CI runs these under `cargo nextest`, which isolates each test in
+    /// its own process and avoids the race; the in-process `is_active_inner`
+    /// closure tests keep the cache logic deterministic under either runner.
+    ///
+    /// The write handle is flushed and explicitly closed before chmod/exec —
+    /// good hygiene against ETXTBSY, independent of the reaper race above.
+    fn write_stub_systemctl(dir: &Path, state: &str) -> PathBuf {
         let bin = dir.join("fake-systemctl");
         let exit = if state == "active" { 0 } else { 3 };
-        let script = format!(
-            "#!/bin/sh\necho x >> {counter}\necho {state}\nexit {exit}\n",
-            counter = counter_path.display()
-        );
-        let mut f = std::fs::File::create(&bin).unwrap();
-        f.write_all(script.as_bytes()).unwrap();
+        let script = format!("#!/bin/sh\necho {state}\nexit {exit}\n");
+        {
+            let mut f = std::fs::File::create(&bin).unwrap();
+            f.write_all(script.as_bytes()).unwrap();
+            f.flush().unwrap();
+        } // f dropped/closed here, so the file is not open-for-write at exec.
         let mut perms = std::fs::metadata(&bin).unwrap().permissions();
         perms.set_mode(0o755);
         std::fs::set_permissions(&bin, perms).unwrap();
         bin
-    }
-
-    /// Convenience: stub `systemctl` without a fork counter.
-    fn write_stub_systemctl(dir: &Path, state: &str) -> PathBuf {
-        write_stub_systemctl_counting(dir, state, &dir.join("ignored-count"))
     }
 
     #[tokio::test]
@@ -311,24 +364,34 @@ mod tests {
         assert!(!query_service_active(&missing, "freenet-gateway").await);
     }
 
+    // Cache-behaviour tests drive the cache through `is_active_inner` with an
+    // in-process counting closure rather than forking a real stub. The
+    // subprocess fork-and-interpret path is covered by the
+    // `service_active_*` tests above; mixing a per-call fork into the
+    // cache-behaviour assertions made them flaky under the parallel test
+    // runner (ETXTBSY when exec'ing freshly-written stub scripts). Counting an
+    // AtomicUsize is deterministic and has no shared OS state.
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     #[tokio::test]
     async fn service_health_cache_does_not_refork_within_ttl() {
-        // The unauthenticated /version endpoint must NOT fork systemctl on
+        // The unauthenticated /version endpoint must NOT re-query systemctl on
         // every hit (self-DoS vector). A second lookup within the TTL must be
-        // served from cache, so the stub is forked exactly once.
-        let dir = tempfile::tempdir().unwrap();
-        let counter = dir.path().join("count");
-        let systemctl = write_stub_systemctl_counting(dir.path(), "active", &counter);
+        // served from cache, so the query closure runs exactly once.
+        let queries = AtomicUsize::new(0);
+        let q = || {
+            queries.fetch_add(1, Ordering::SeqCst);
+            std::future::ready(true)
+        };
 
-        let cache = ServiceHealthCache::new();
-        assert!(cache.is_active_with(&systemctl, "freenet-gateway").await);
-        assert!(cache.is_active_with(&systemctl, "freenet-gateway").await);
+        let cache = ServiceHealthCache::new(); // 2s TTL: both calls are within it.
+        assert!(cache.is_active_inner("freenet-gateway", q).await);
+        assert!(cache.is_active_inner("freenet-gateway", q).await);
 
-        let forks = std::fs::read_to_string(&counter).unwrap_or_default();
         assert_eq!(
-            forks.lines().count(),
+            queries.load(Ordering::SeqCst),
             1,
-            "second is_active within TTL must hit the cache, not refork systemctl"
+            "second is_active within TTL must hit the cache, not re-query"
         );
     }
 
@@ -336,22 +399,72 @@ mod tests {
     async fn service_health_cache_reforks_for_different_service() {
         // A different service name is a different question — must not be served
         // from a cache entry keyed on the previous name.
-        let dir = tempfile::tempdir().unwrap();
-        let counter = dir.path().join("count");
-        let systemctl = write_stub_systemctl_counting(dir.path(), "active", &counter);
+        let queries = AtomicUsize::new(0);
+        let q = || {
+            queries.fetch_add(1, Ordering::SeqCst);
+            std::future::ready(true)
+        };
 
         let cache = ServiceHealthCache::new();
-        cache.is_active_with(&systemctl, "freenet-gateway").await;
-        cache
-            .is_active_with(&systemctl, "freenet-gateway-hector")
-            .await;
+        cache.is_active_inner("freenet-gateway", q).await;
+        cache.is_active_inner("freenet-gateway-hector", q).await;
 
-        let forks = std::fs::read_to_string(&counter).unwrap_or_default();
         assert_eq!(
-            forks.lines().count(),
+            queries.load(Ordering::SeqCst),
             2,
             "different service name must re-query, not reuse the cached entry"
         );
+    }
+
+    #[tokio::test]
+    async fn service_health_cache_reforks_after_ttl_expiry() {
+        // The cache's whole purpose is bounding staleness, so pin the expiry
+        // side of the TTL boundary: once an entry is older than the TTL, the
+        // next lookup must re-query AND return the fresh state.
+        //
+        // TTL = 0 makes every cached entry instantly expired (elapsed() < 0 is
+        // never true), so the second lookup deterministically re-queries — no
+        // real `sleep` needed, no flakiness. The within-TTL no-refork case is
+        // covered by `service_health_cache_does_not_refork_within_ttl`.
+        let queries = AtomicUsize::new(0);
+        // Reports `active` on the first query, `failed` on every later one, so
+        // the test can observe that the re-query returned the FRESH state.
+        let q = || {
+            let n = queries.fetch_add(1, Ordering::SeqCst);
+            std::future::ready(n == 0)
+        };
+
+        let cache = ServiceHealthCache::with_ttl(Duration::ZERO);
+
+        assert!(
+            cache.is_active_inner("freenet-gateway", q).await,
+            "first lookup reflects the active state"
+        );
+        // Entry is already expired (TTL = 0): the next lookup must re-query
+        // rather than serve the stale `true`, and pick up the fresh `failed`
+        // state (the vega case).
+        assert!(
+            !cache.is_active_inner("freenet-gateway", q).await,
+            "after TTL expiry the cache must re-query and return the fresh (failed) state"
+        );
+
+        assert_eq!(
+            queries.load(Ordering::SeqCst),
+            2,
+            "an expired entry must trigger a re-query"
+        );
+    }
+
+    #[tokio::test]
+    async fn service_health_cache_is_active_with_forks_real_query() {
+        // Smoke-test the production wiring: `is_active_with` must actually call
+        // through to the real `systemctl` fork path (a stub here). The cache-
+        // behaviour assertions use the in-process closure above; this one keeps
+        // a single fork so the closure-vs-real seam can't silently diverge.
+        let dir = tempfile::tempdir().unwrap();
+        let systemctl = write_stub_systemctl(dir.path(), "active");
+        let cache = ServiceHealthCache::new();
+        assert!(cache.is_active_with(&systemctl, "freenet-gateway").await);
     }
 
     #[tokio::test]
@@ -398,8 +511,11 @@ mod tests {
         let bin_path = dir.path().join("fake-freenet");
 
         let write_stub = |contents: &str| {
-            let mut f = std::fs::File::create(&bin_path).unwrap();
-            writeln!(f, "{contents}").unwrap();
+            {
+                let mut f = std::fs::File::create(&bin_path).unwrap();
+                writeln!(f, "{contents}").unwrap();
+                f.flush().unwrap();
+            } // close before chmod/exec — see write_stub_systemctl re: ETXTBSY.
             let mut perms = std::fs::metadata(&bin_path).unwrap().permissions();
             perms.set_mode(0o755);
             std::fs::set_permissions(&bin_path, perms).unwrap();

--- a/crates/release-agent/tests/update_handler.rs
+++ b/crates/release-agent/tests/update_handler.rs
@@ -16,7 +16,7 @@ use freenet_release_agent::{
     github::{LatestSource, StaticLatest},
     server::{AppState, UpdateRequest, build_router},
     updater::Updater,
-    version::VersionCache,
+    version::{ServiceHealthCache, VersionCache},
 };
 use semver::Version;
 use serde_json::json;
@@ -32,6 +32,20 @@ fn now_secs() -> i64 {
 fn write_stub_freenet(dir: &Path, version: &str) -> std::path::PathBuf {
     let bin = dir.join("fake-freenet");
     let script = format!("#!/bin/sh\necho freenet {version}\n");
+    std::fs::write(&bin, script).unwrap();
+    let mut perms = std::fs::metadata(&bin).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&bin, perms).unwrap();
+    bin
+}
+
+/// Write a stub `systemctl` that prints `state` and exits 0 for `active`, 3
+/// otherwise — matching real `systemctl is-active`. Lets the `/version`
+/// service-health reporting be exercised over HTTP without real systemd.
+fn write_stub_systemctl(dir: &Path, state: &str) -> std::path::PathBuf {
+    let bin = dir.join("fake-systemctl");
+    let exit = if state == "active" { 0 } else { 3 };
+    let script = format!("#!/bin/sh\necho {state}\nexit {exit}\n");
     std::fs::write(&bin, script).unwrap();
     let mut perms = std::fs::metadata(&bin).unwrap().permissions();
     perms.set_mode(0o755);
@@ -75,6 +89,12 @@ impl Harness {
             managed_service: "freenet-gateway".into(),
         };
 
+        // Default stub: report the service active so the /version handler
+        // returns a deterministic `service_active: true` regardless of the
+        // host's real systemd state. Tests that care about the false case use
+        // `build_with_service_state`.
+        let systemctl_path = write_stub_systemctl(tmp.path(), "active");
+
         let latest_source: Arc<dyn LatestSource> = Arc::new(StaticLatest(latest_on_github));
         let state = AppState {
             config: Arc::new(config.clone()),
@@ -87,6 +107,68 @@ impl Harness {
                 String::new(),
             ),
             version_cache: VersionCache::new(),
+            service_health_cache: ServiceHealthCache::new(),
+            systemctl_path,
+            last_update_attempt: Arc::new(Mutex::new(None)),
+            last_announce_attempt: Arc::new(Mutex::new(None)),
+        };
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let router = build_router(state);
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+
+        Self {
+            base: format!("http://{addr}"),
+            secret,
+            _tmp: tmp,
+        }
+    }
+
+    /// Like [`Harness::build`] but with the gateway service-state stub set to
+    /// `service_state` (e.g. `active`, `failed`), so the `/version`
+    /// service-health field can be pinned over the HTTP layer. Always reports
+    /// the binary as already on `binary_version` (dry-run, no spawn).
+    async fn build_with_service_state(binary_version: &str, service_state: &str) -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let binary_path = write_stub_freenet(tmp.path(), binary_version);
+        let systemctl_path = write_stub_systemctl(tmp.path(), service_state);
+
+        let secret: Vec<u8> = (0..32).map(|i| i as u8).collect();
+        let secret_path = tmp.path().join("hmac.key");
+        std::fs::write(&secret_path, hex::encode(&secret)).unwrap();
+
+        let config = Config {
+            listen_addr: "127.0.0.1:0".parse().unwrap(),
+            binary_path: binary_path.clone(),
+            update_command: tmp.path().join("never-invoked.sh"),
+            hmac_secret_path: secret_path,
+            github_repo: "freenet/freenet-core".into(),
+            dry_run: true,
+            rate_limit_seconds: 600,
+            clock_skew_tolerance_seconds: 300,
+            river_announce_command: std::path::PathBuf::new(),
+            river_announce_user: String::new(),
+            managed_service: "freenet-gateway".into(),
+        };
+
+        let latest_source: Arc<dyn LatestSource> =
+            Arc::new(StaticLatest(Version::parse(binary_version).unwrap()));
+        let state = AppState {
+            config: Arc::new(config.clone()),
+            secret: Arc::new(secret.clone()),
+            latest_source,
+            updater: Updater::new_with_sudo(config.update_command.clone(), true),
+            announcer: freenet_release_agent::announcer::Announcer::new_with_sudo(
+                std::path::PathBuf::new(),
+                true,
+                String::new(),
+            ),
+            version_cache: VersionCache::new(),
+            service_health_cache: ServiceHealthCache::new(),
+            systemctl_path,
             last_update_attempt: Arc::new(Mutex::new(None)),
             last_announce_attempt: Arc::new(Mutex::new(None)),
         };
@@ -162,6 +244,7 @@ impl Harness {
             managed_service: "freenet-gateway".into(),
         };
 
+        let systemctl_path = write_stub_systemctl(tmp.path(), "active");
         let latest_source: Arc<dyn LatestSource> = Arc::new(StaticLatest(latest_on_github));
         let updater = freenet_release_agent::updater::Updater {
             command: update_command,
@@ -179,6 +262,8 @@ impl Harness {
                 String::new(),
             ),
             version_cache: VersionCache::new(),
+            service_health_cache: ServiceHealthCache::new(),
+            systemctl_path,
             last_update_attempt: Arc::new(Mutex::new(None)),
             last_announce_attempt: Arc::new(Mutex::new(None)),
         };
@@ -375,16 +460,47 @@ async fn version_endpoint_reads_stub_binary() {
 
     // Service-health fields must be present so the release workflow can
     // distinguish a successful binary swap from a gateway whose service
-    // failed to restart (vega v0.2.71). `managed_service` is the configured
-    // unit name; `service_active` is a bool whose value depends on whether
-    // that unit happens to be active on the test host (the unit doesn't exist
-    // on CI runners, so it's typically false) — we assert presence + type, not
-    // the runtime value.
+    // failed to restart (vega v0.2.71). The default harness stub reports the
+    // service `active`, so this asserts the field is wired through as `true`.
     assert_eq!(j["managed_service"], "freenet-gateway");
-    assert!(
-        j["service_active"].is_boolean(),
-        "service_active must be a boolean field, got: {:?}",
-        j["service_active"]
+    assert_eq!(j["service_active"], true);
+}
+
+#[tokio::test]
+async fn version_endpoint_reports_service_active_true() {
+    // Stub systemctl reports `active` → /version must report service_active: true.
+    let h = Harness::build_with_service_state("0.2.71", "active").await;
+    let resp = reqwest::Client::new()
+        .get(format!("{}/version", h.base))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let j: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(j["version"], "0.2.71");
+    assert_eq!(j["service_active"], true);
+}
+
+#[tokio::test]
+async fn version_endpoint_reports_service_active_false_when_failed() {
+    // The exact vega v0.2.71 shape: binary swapped to the new version on disk
+    // but the service is `failed`. /version must report service_active: false
+    // so the workflow does NOT treat the update as successful.
+    let h = Harness::build_with_service_state("0.2.71", "failed").await;
+    let resp = reqwest::Client::new()
+        .get(format!("{}/version", h.base))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let j: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        j["version"], "0.2.71",
+        "binary reads as the new version (swap succeeded)"
+    );
+    assert_eq!(
+        j["service_active"], false,
+        "service is failed → must NOT look like a successful update"
     );
 }
 
@@ -547,6 +663,7 @@ async fn build_with_announcer(announce_script: &str, record_file: &Path) -> Harn
         sudo_command: fake_sudo,
         run_as_user: "nobody".into(),
     };
+    let systemctl_path = write_stub_systemctl(tmp.path(), "active");
     let state = AppState {
         config: Arc::new(config),
         secret: Arc::new(secret.clone()),
@@ -554,6 +671,8 @@ async fn build_with_announcer(announce_script: &str, record_file: &Path) -> Harn
         updater: Updater::new_with_sudo(std::path::PathBuf::from("/bin/true"), true),
         announcer,
         version_cache: VersionCache::new(),
+        service_health_cache: ServiceHealthCache::new(),
+        systemctl_path,
         last_update_attempt: Arc::new(Mutex::new(None)),
         last_announce_attempt: Arc::new(Mutex::new(None)),
     };

--- a/crates/release-agent/tests/update_handler.rs
+++ b/crates/release-agent/tests/update_handler.rs
@@ -72,6 +72,7 @@ impl Harness {
             clock_skew_tolerance_seconds: 300,
             river_announce_command: std::path::PathBuf::new(),
             river_announce_user: String::new(),
+            managed_service: "freenet-gateway".into(),
         };
 
         let latest_source: Arc<dyn LatestSource> = Arc::new(StaticLatest(latest_on_github));
@@ -158,6 +159,7 @@ impl Harness {
             clock_skew_tolerance_seconds: 300,
             river_announce_command: std::path::PathBuf::new(),
             river_announce_user: String::new(),
+            managed_service: "freenet-gateway".into(),
         };
 
         let latest_source: Arc<dyn LatestSource> = Arc::new(StaticLatest(latest_on_github));
@@ -370,6 +372,20 @@ async fn version_endpoint_reads_stub_binary() {
     assert_eq!(resp.status(), 200);
     let j: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(j["version"], "0.2.55");
+
+    // Service-health fields must be present so the release workflow can
+    // distinguish a successful binary swap from a gateway whose service
+    // failed to restart (vega v0.2.71). `managed_service` is the configured
+    // unit name; `service_active` is a bool whose value depends on whether
+    // that unit happens to be active on the test host (the unit doesn't exist
+    // on CI runners, so it's typically false) — we assert presence + type, not
+    // the runtime value.
+    assert_eq!(j["managed_service"], "freenet-gateway");
+    assert!(
+        j["service_active"].is_boolean(),
+        "service_active must be a boolean field, got: {:?}",
+        j["service_active"]
+    );
 }
 
 #[tokio::test]
@@ -522,6 +538,7 @@ async fn build_with_announcer(announce_script: &str, record_file: &Path) -> Harn
         clock_skew_tolerance_seconds: 300,
         river_announce_command: announce_command.clone(),
         river_announce_user: "nobody".into(),
+        managed_service: "freenet-gateway".into(),
     };
     let latest_source: Arc<dyn LatestSource> = Arc::new(StaticLatest(Version::new(0, 2, 56)));
     let announcer = freenet_release_agent::announcer::Announcer {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -178,15 +178,33 @@ gh workflow run release-announce.yml --field version=X.Y.Z
 
 ### One gateway didn't converge
 
-The `Gateway Update` workflow polls `/version` for 120 s after the POST. If
-that times out the workflow reports failure for that gateway and the
-remaining gateway doesn't try (fail-fast). Recovery:
+The `Gateway Update` workflow polls `/version` for 120 s after the POST. It
+now requires BOTH that the on-disk binary reports the new version AND that the
+gateway service is actually `active` on it (the `service_active` field). So a
+converge timeout now has two possible meanings:
+
+- the binary never updated (download/swap failed), OR
+- the binary swapped but the **service failed to restart** — this is the
+  vega v0.2.71 case, where `/version` reported the new version while the
+  gateway was down. Check `ssh <host> 'sudo systemctl status freenet-gateway'`
+  (or `freenet-gateway-hector` on vega's secondary instance); a `failed`/
+  `inactive` unit with the new binary on disk is this failure mode.
+
+(Note: against a gateway running an OLD release-agent that predates the
+`service_active` field, the workflow logs a `::warning::` and falls back to the
+binary-only check, so the stronger signal is only enforced once the agent
+itself has been updated.)
+
+Recovery:
 
 1. Check the agent's status: `ssh ian@<host> 'sudo systemctl status
    freenet-release-agent && sudo journalctl -u freenet-release-agent
    --since "10 min ago"'`
-2. If the agent is fine but the script failed, the manual fix is
-   `ssh ian@<host> 'sudo /usr/local/bin/gateway-auto-update.sh --force'`.
+2. If the agent is fine but the service is down, restart it directly:
+   `ssh ian@<host> 'sudo systemctl restart freenet-gateway'` (then confirm
+   `systemctl is-active freenet-gateway`). If the script itself failed, the
+   manual fix is `ssh ian@<host> 'sudo /usr/local/bin/gateway-auto-update.sh
+   --force'`.
 3. Re-run the gateway-update workflow against just the failed gateway:
    `gh workflow run gateway-update.yml --field version=X.Y.Z --field
    gateways=vega`.

--- a/scripts/release-agent/README.md
+++ b/scripts/release-agent/README.md
@@ -65,6 +65,30 @@ will show a `dry-run: would invoke …` line. No update is actually performed.
 
 ## Response semantics
 
+`GET /version` returns JSON:
+
+```json
+{
+  "version": "0.2.71",
+  "binary_path": "/usr/local/bin/freenet",
+  "service_active": true,
+  "managed_service": "freenet-gateway"
+}
+```
+
+- **`version`** — the ON-DISK freenet binary version (`freenet --version`).
+  This alone is NOT proof the gateway is running it.
+- **`service_active`** — `true` iff `systemctl is-active <managed_service>`
+  reports `active`. Surfaces a gateway whose binary was swapped but whose
+  service failed to restart (the vega v0.2.71 incident, where `/version`
+  reported the new version while the gateway was down for ~5 minutes).
+  Consumers polling for a successful update MUST require `service_active == true`.
+  **Backward compatibility:** agents built before this field omit it entirely —
+  treat its ABSENCE as "agent predates the check" and fall back to the
+  binary-only check, not as a failure.
+- **`managed_service`** — the systemd unit name whose state `service_active`
+  reflects.
+
 `POST /update` returns:
 
 - **`200` + `no_op: true`** — the gateway is already on the requested version. The agent did NOT spawn the update script. Callers that poll `/version` to confirm the upgrade MUST inspect `no_op` to distinguish "already there" from "just kicked off".

--- a/scripts/release-agent/config.example.toml
+++ b/scripts/release-agent/config.example.toml
@@ -22,6 +22,15 @@ rate_limit_seconds = 600
 # from the agent's clock. Defends against replay attacks.
 clock_skew_tolerance_seconds = 300
 
+# systemd unit name of the gateway service this agent manages, WITHOUT the
+# `.service` suffix. `GET /version` runs `systemctl is-active <managed_service>`
+# and reports the result as `service_active`, so the release workflow can tell a
+# successful binary swap apart from a gateway whose service failed to restart
+# (the vega v0.2.71 incident). `systemctl is-active` is read-only and needs no
+# sudo. Defaults to `freenet-gateway`; vega's secondary instance uses
+# `freenet-gateway-hector`.
+managed_service = "freenet-gateway"
+
 # River announcement endpoint. Set both to enable `POST /announce/river`.
 # Leave blank (default) on gateways that don't have a Freenet node + room
 # signing key (e.g. vega) — the endpoint will return 503 there.

--- a/scripts/release-agent/verify-version-decision.sh
+++ b/scripts/release-agent/verify-version-decision.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Decision logic for gateway-update.yml's "Verify version after update" poll.
+#
+# Extracted into a sourceable function so the workflow and its regression
+# test (verify-version-decision_test.sh) exercise the SAME code and cannot
+# drift. The inline-in-YAML version of this logic had zero automated
+# coverage, which is exactly the gap that let the vega v0.2.71 incident
+# through (binary swapped, service down, workflow reported success).
+#
+# Usage (sourced):
+#   source verify-version-decision.sh
+#   decision=$(verify_version_decision "$RESPONSE_JSON" "$TARGET_VERSION")
+#
+# Echoes exactly one decision token on stdout:
+#   success           binary is on the target version AND the service is active
+#                     (new-agent path) — the update is confirmed.
+#   success-fallback  binary is on the target version but the agent predates
+#                     the `service_active` field — fall back to binary-only
+#                     verification (with a warning). Backward compatibility.
+#   wait              not yet converged: binary not on target, OR binary on
+#                     target but service not active (the vega case), OR the
+#                     gateway is unreachable / returned malformed JSON. The
+#                     caller keeps polling until its deadline, then fails.
+
+# WHY binary-on-target + service-active is sufficient (no swap race): the
+# update script (deploy-local-gateway.sh, spawned via gateway-auto-update.sh)
+# does stop -> swap binary -> start. The service is DOWN while the binary is
+# replaced, so the binary only reads as the new version once the service has
+# been restarted onto it. There is no window where the OLD process is still
+# active while the binary already reads as new. If that ordering ever changes
+# to swap-then-restart, this function must additionally verify the RUNNING
+# process is the new binary (e.g. unit ActiveEnterTimestamp vs. issued_at).
+verify_version_decision() {
+    local response="$1"
+    local target="$2"
+
+    local installed has_service_field service_active
+    installed=$(printf '%s' "$response" | jq -r '.version // empty' 2>/dev/null || echo "")
+    # has() distinguishes "old agent omits the field" (success-fallback) from
+    # "new agent reports service_active:false" (wait — the vega case). This
+    # only matters once the binary version already matches; the installed!=
+    # target branch below handles the unreachable-gateway case (empty
+    # installed). The `|| echo "false"` only guards jq erroring on a malformed
+    # body.
+    has_service_field=$(printf '%s' "$response" | jq -r 'has("service_active") // false' 2>/dev/null || echo "false")
+    service_active=$(printf '%s' "$response" | jq -r '.service_active // false' 2>/dev/null || echo "false")
+
+    if [[ "$installed" != "$target" ]]; then
+        echo "wait"
+        return 0
+    fi
+
+    if [[ "$has_service_field" == "true" ]]; then
+        if [[ "$service_active" == "true" ]]; then
+            echo "success"
+        else
+            # Binary is new but the service is not active (vega v0.2.71).
+            echo "wait"
+        fi
+    else
+        # Old agent without the field: fall back to binary-only verification.
+        echo "success-fallback"
+    fi
+}

--- a/scripts/release-agent/verify-version-decision_test.sh
+++ b/scripts/release-agent/verify-version-decision_test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Regression test for verify-version-decision.sh — the decision gate that
+# gateway-update.yml uses to decide whether a gateway update succeeded.
+#
+# This is the exact vega v0.2.71 incident path:
+#   - present `service_active:false` MUST NOT report success (the load-bearing
+#     assertion: that is what let the down gateway look healthy);
+#   - an ABSENT field MUST fall back to binary-only success (backward compat
+#     with agents that predate the field);
+#   - present `service_active:true` + matching version MUST report success.
+#
+# The real function is sourced (not copied) so the test cannot drift from the
+# code the workflow runs — mirroring announce-to-river_test.sh.
+#
+# Run manually: bash scripts/release-agent/verify-version-decision_test.sh
+# Also wired into CI (the Fmt job in .github/workflows/ci.yml).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DECISION_SH="$SCRIPT_DIR/verify-version-decision.sh"
+
+if [[ ! -f "$DECISION_SH" ]]; then
+    echo "FAIL: $DECISION_SH not found" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "FAIL: jq is required for this test" >&2
+    exit 1
+fi
+
+# Source the real implementation.
+# shellcheck source=scripts/release-agent/verify-version-decision.sh
+source "$DECISION_SH"
+
+FAILURES=0
+check() {
+    # check <description> <response-json> <target-version> <expected-decision>
+    local desc="$1" response="$2" target="$3" expected="$4" actual
+    actual=$(verify_version_decision "$response" "$target")
+    if [[ "$actual" == "$expected" ]]; then
+        echo "ok   - $desc"
+    else
+        echo "FAIL - $desc (got '$actual', expected '$expected')" >&2
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+TARGET="0.2.71"
+
+# ── New agent, binary on target ──────────────────────────────────────
+
+# Service active → confirmed success.
+check "new agent: binary on target + service active → success" \
+    '{"version":"0.2.71","binary_path":"/x","service_active":true,"managed_service":"freenet-gateway"}' \
+    "$TARGET" "success"
+
+# THE load-bearing assertion: service failed (the vega case) → MUST keep
+# waiting, never report success. If this regresses, a down gateway looks
+# healthy again.
+check "new agent: binary on target + service FAILED (vega case) → wait" \
+    '{"version":"0.2.71","binary_path":"/x","service_active":false,"managed_service":"freenet-gateway"}' \
+    "$TARGET" "wait"
+
+# Custom managed_service name (vega's secondary instance) still works.
+check "new agent: custom managed_service + failed → wait" \
+    '{"version":"0.2.71","service_active":false,"managed_service":"freenet-gateway-hector"}' \
+    "$TARGET" "wait"
+
+# ── Old agent: no service_active field (backward compat) ─────────────
+
+check "old agent: binary on target, no service_active → success-fallback" \
+    '{"version":"0.2.71","binary_path":"/x"}' \
+    "$TARGET" "success-fallback"
+
+# ── Not yet converged ────────────────────────────────────────────────
+
+check "new agent: binary still old + service active → wait" \
+    '{"version":"0.2.70","binary_path":"/x","service_active":true}' \
+    "$TARGET" "wait"
+
+check "old agent: binary still old, no field → wait" \
+    '{"version":"0.2.70","binary_path":"/x"}' \
+    "$TARGET" "wait"
+
+# ── Unreachable / malformed responses ────────────────────────────────
+
+# Empty body (curl failed / connection refused during restart) → wait.
+check "unreachable gateway (empty response) → wait" \
+    '' "$TARGET" "wait"
+
+# Malformed JSON → jq errors are swallowed, treated as not-converged.
+check "malformed JSON response → wait" \
+    'this is not json' "$TARGET" "wait"
+
+# A null service_active with matching version is treated as not-active.
+# (Field is present-but-null: has() is true, value coalesces to false → wait.)
+check "new agent: service_active null + binary on target → wait" \
+    '{"version":"0.2.71","service_active":null}' \
+    "$TARGET" "wait"
+
+# ── result ────────────────────────────────────────────────────────────
+
+if (( FAILURES > 0 )); then
+    echo "$FAILURES verify-version-decision.sh test(s) failed" >&2
+    exit 1
+fi
+echo "All verify-version-decision.sh tests passed."


### PR DESCRIPTION
## Problem

`gateway-update.yml`'s "Verify version after update" step (the final gate of every gateway rollout) polled the release-agent's `GET /version` and treated `installed == VERSION` as success. But the agent's `/version` reports the **on-disk binary** version (`freenet --version`), NOT whether the gateway **service** is actually running it.

During the **v0.2.71 release** the vega gateway's binary was swapped to 0.2.71 but the **service failed to restart**: the old process hung on shutdown, got SIGKILL'd, and systemd left the unit `failed`/down. `/version` still reported 0.2.71 (on-disk), so gateway-update reported **SUCCESS** while vega's gateway was **DOWN for ~5 minutes** until a human noticed and restarted it manually.

## Solution

Surface the **service's** health alongside the binary version, and make the workflow require it.

**release-agent (`crates/release-agent/`)** — additive, backward-compatible:
- `GET /version` now also runs `systemctl is-active <managed_service>` and returns two new fields:
  - `service_active: bool` — `true` only when systemd reports the unit `active`. `inactive`/`failed`/`activating`/unknown-unit/missing-systemctl/timeout all map to `false` — never an error, never a panic.
  - `managed_service: String` — the unit name that was checked (logged by the workflow).
- The service name is configurable via a new `managed_service` config field (default `freenet-gateway`; vega's secondary instance uses `freenet-gateway-hector`).
- `systemctl is-active` is a **read-only** query and needs **no sudo**.
- The existing `version` / `binary_path` fields are **unchanged** — additive only, so older gateway-update runs and any other `/version` consumer keep working.

**`gateway-update.yml` "Verify version after update":**
- Success now requires `installed == VERSION` **AND** `service_active == true`.
- **Backward compatibility (critical):** deployed agents won't report `service_active` until they are themselves updated. When the field is **ABSENT**, the workflow does **NOT** hard-fail — it logs a `::warning::` that the agent predates the check and falls back to the old binary-only verification. The service-running requirement is **only ENFORCED when the field is present** (detected with jq `has("service_active")`, so a present-but-`false` value is distinguished from an absent field).

The running-process-version refinement (catching a service that is up but still on the OLD binary) is **deliberately deferred**: reading `/proc/<MainPID>/exe` after a binary swap is fragile (`(deleted)` inode, re-spawning the binary, cross-process `/proc` access). The `service_active` floor already catches the vega down-service case, which is the incident this fixes. Noted as a follow-up.

## Testing

- **version.rs unit tests** for `service_active_with` (systemctl path injected via a stub script — no real systemd/sudo): `active → true`; `failed` (the vega case) / `inactive` / `activating` / missing-systemctl → `false`.
- **config.rs:** default `managed_service` is `freenet-gateway`; a custom value (`freenet-gateway-hector`) parses.
- **update_handler.rs integration test:** `/version` now returns `managed_service` and a boolean `service_active`.
- **Workflow logic** verified by hand against six representative responses (new agent active/failed, old agent without the field, stale binary, unreachable): the vega "binary new + service failed" case now yields a retry that times out to a hard error instead of a false success, while old agents fall back to binary-only success.
- `cargo fmt` + `cargo clippy -p freenet-release-agent --all-targets -- -D warnings` clean; all release-agent tests pass (31 unit + 27 integration).

[AI-assisted - Claude]