### PR TITLE
feat(transport): phase 1.6 shadow demand/queue/iface/class telemetry

### DIFF
--- a/.claude/rules/transport.md
+++ b/.claude/rules/transport.md
@@ -137,15 +137,67 @@ from CI runners (which would perturb timing-sensitive multi-node
 tests — see PR #4292 root-cause). The shadow aggregator is
 always-on; only reference-ping is gated.
 
+### Shadow demand / queue / OS-counter / class telemetry (Phase 1.6)
+
+`transport/shadow_demand.rs` adds the *demand* side of the floor
+analysis. Three process-wide observation hooks are written from the
+hot send path with a single relaxed atomic add each, and read only
+by the 1Hz aggregator tasks:
+
+- **Outbound class counters** (`record_outbound`): cumulative bytes
+  split into must-flow / short / bulk. `classify()` keys off the
+  `SymmetricMessagePayload` variant — `StreamFragment` is `Bulk`
+  (the only class the token bucket meters, i.e. the only slowable
+  traffic), `ShortMessage` is `Short` (opaque serialized `NetMessage`
+  — small contract op or control plane, unsplittable at the transport
+  layer), and `Ping`/`Pong`/`NoOp`/`AckConnection` are `MustFlow`.
+  Tagged at `packet_sending` (covers short/noop/ack/stream) plus the
+  two bypass sites `send_pong` and the keep-alive `Ping`.
+- **Broadcast-queue depth gauge** (`record_broadcast_queue_depth`):
+  updated by `node/network_bridge/broadcast_queue.rs` under its own
+  queue lock, so the shadow reader never contends on the queue mutex.
+- **Global-bandwidth handle** (`register_global_bandwidth`): a `Weak`
+  to the node's `GlobalBandwidthManager`, registered at construction
+  in `p2p_protoc.rs`, so the demand aggregator can read the effective
+  aggregate rate `R` — present only in global-pool mode
+  (`total_bandwidth_limit` set); null under the default per-connection
+  FixedRate mode.
+
+Two always-on 1Hz tasks (spawned from `p2p_impl.rs`, registered with
+`BackgroundTaskMonitor` as `shadow_demand_aggregator` /
+`shadow_outbound_class_aggregator`) emit `shadow_rate_demand`
+(achieved throughput vs `R`, active-connection count, broadcast-queue
+depth) and `shadow_outbound_class` (the must-flow / short / bulk byte
+split). Same OTLP shape and peer-id tagging as `shadow_rtt_aggregate`.
+
+`transport/shadow_iface_tx.rs` adds the OS-interface counter: a 1Hz
+read of Linux `/proc/net/dev` summing non-loopback `tx_bytes`, emitting
+`shadow_iface_tx` with the derived `op = total_tx − freenet_own_tx`
+(`freenet_own_tx` = `TRANSPORT_METRICS.cumulative_bytes_sent`). It is
+**opt-in and best-effort**: gated by `telemetry.iface-tx-enabled`
+(default `false`, same gating as reference-ping); if `/proc/net/dev`
+is unavailable the tick is silently omitted, never blocking.
+
+The class tagging is the only Phase 1.6 hook that touches the hot send
+path; it is a single relaxed atomic add per packet (no allocation, no
+lock, no blocking). Everything else is read from the separate
+aggregator tasks.
+
 ```
 NEVER read SHADOW_RTT_REGISTRY, cross_connection_median_inflation,
-or the reference_ping stats from the production data path (rate
-limiter, retry, congestion control). They exist only for the
-staged rollout in #4074:
+the reference_ping stats, OR the Phase 1.6 shadow_demand counters /
+broadcast-depth gauge / registered bandwidth handle from the
+production data path (rate limiter, retry, congestion control). The
+hot path only WRITES the cheap class counters; all reads happen in
+the aggregator tasks. They exist only for the staged rollout in
+#4074:
   Phase 1   → observation only — per-peer overlay RTT (current)
   Phase 1.5 → observation only — adds reference-path RTT + peer_id
               tagging so signals can be disaggregated per node and
               the overlay-vs-uplink confound can be tested
+  Phase 1.6 → observation only — adds outbound demand vs R, broadcast
+              queue depth, OS interface tx (op = total − own), and the
+              must-flow-vs-bulk outbound split
   Phase 2   → shadow controller, still no behaviour change
   Phase 3   → opt-in flag
   Phase 4   → default switch only after Phase 3 shows improvement

--- a/.claude/rules/transport.md
+++ b/.claude/rules/transport.md
@@ -151,8 +151,13 @@ by the 1Hz aggregator tasks:
   traffic), `ShortMessage` is `Short` (opaque serialized `NetMessage`
   — small contract op or control plane, unsplittable at the transport
   layer), and `Ping`/`Pong`/`NoOp`/`AckConnection` are `MustFlow`.
-  Tagged at `packet_sending` (covers short/noop/ack/stream) plus the
-  two bypass sites `send_pong` and the keep-alive `Ping`.
+  Tagged at `packet_sending` (covers `ShortMessage` / `NoOp` /
+  `StreamFragment`) plus the two bypass sites `send_pong` and the
+  keep-alive `Ping`. The split is a classified *subset* of the node
+  total: it excludes retransmits, handshake/intro `AckConnection`, and
+  standalone connection ACKs, which are still counted in
+  `cumulative_bytes_sent` (the `shadow_rate_demand` total) but not the
+  per-class breakdown.
 - **Broadcast-queue depth gauge** (`record_broadcast_queue_depth`):
   updated by `node/network_bridge/broadcast_queue.rs` under its own
   queue lock, so the shadow reader never contends on the queue mutex.

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -404,6 +404,11 @@ impl ConfigArgs {
             if cfg.telemetry.reference_ping_enabled {
                 self.telemetry.reference_ping_enabled = true;
             }
+            // iface-tx-enabled: same one-directional override as
+            // reference-ping (clap default is already false).
+            if cfg.telemetry.iface_tx_enabled {
+                self.telemetry.iface_tx_enabled = true;
+            }
         }
 
         let mode = self.mode.unwrap_or(OperationMode::Network);
@@ -798,6 +803,7 @@ impl ConfigArgs {
                 // environments to avoid flooding the collector with test data.
                 is_test_environment: self.id.is_some(),
                 reference_ping_enabled: self.telemetry.reference_ping_enabled,
+                iface_tx_enabled: self.telemetry.iface_tx_enabled,
             },
         };
 
@@ -1569,6 +1575,21 @@ pub struct TelemetryArgs {
         default = "default_reference_ping_enabled"
     )]
     pub reference_ping_enabled: bool,
+
+    /// Enable the Phase 1.6 OS-interface-tx shadow probe (#4074): a 1Hz
+    /// read of `/proc/net/dev` (Linux) that emits aggregate interface tx
+    /// bytes and the derived `op = total - freenet_own` so the floor
+    /// analysis can attribute uplink saturation to Freenet vs the
+    /// operator's other traffic. Best-effort and opt-in: defaults to
+    /// false; production gateway configs set this to true. Like
+    /// reference-ping, it stays off on developer machines and in tests.
+    #[arg(
+        long = "iface-tx-enabled",
+        env = "FREENET_IFACE_TX_ENABLED",
+        default_value = "false"
+    )]
+    #[serde(rename = "iface-tx-enabled", default = "default_iface_tx_enabled")]
+    pub iface_tx_enabled: bool,
 }
 
 impl Default for TelemetryArgs {
@@ -1578,6 +1599,7 @@ impl Default for TelemetryArgs {
             endpoint: None,
             transport_snapshot_interval_secs: None,
             reference_ping_enabled: false,
+            iface_tx_enabled: false,
         }
     }
 }
@@ -1618,6 +1640,12 @@ pub struct TelemetryConfig {
         rename = "reference-ping-enabled"
     )]
     pub reference_ping_enabled: bool,
+
+    /// Enable the Phase 1.6 OS-interface-tx shadow probe (#4074).
+    /// Opt-in: defaults to false; production gateway configs set this to
+    /// true. See `TelemetryArgs::iface_tx_enabled`.
+    #[serde(default = "default_iface_tx_enabled", rename = "iface-tx-enabled")]
+    pub iface_tx_enabled: bool,
 }
 
 fn default_transport_snapshot_interval_secs() -> u64 {
@@ -1632,6 +1660,10 @@ fn default_reference_ping_enabled() -> bool {
     false
 }
 
+fn default_iface_tx_enabled() -> bool {
+    false
+}
+
 impl Default for TelemetryConfig {
     fn default() -> Self {
         Self {
@@ -1640,6 +1672,7 @@ impl Default for TelemetryConfig {
             transport_snapshot_interval_secs: default_transport_snapshot_interval_secs(),
             is_test_environment: false,
             reference_ping_enabled: false,
+            iface_tx_enabled: false,
         }
     }
 }

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -181,6 +181,12 @@ mod queue {
                 queue.order.push_back(dedup_key);
             }
 
+            // Phase 1.6 shadow telemetry (#4074): publish the post-mutation
+            // depth while still under the lock so the depth gauge is exact;
+            // the shadow demand aggregator reads it lock-free. Observation
+            // only — see transport/shadow_demand.rs.
+            crate::transport::shadow_demand::record_broadcast_queue_depth(queue.len());
+
             drop(queue);
             self.notify.notify_one();
         }
@@ -210,7 +216,11 @@ mod queue {
                     loop {
                         let entry = {
                             let mut q = queue.lock().await;
-                            q.pop_front()
+                            let entry = q.pop_front();
+                            // Phase 1.6 (#4074): publish post-drain depth
+                            // under the lock for the shadow demand gauge.
+                            crate::transport::shadow_demand::record_broadcast_queue_depth(q.len());
+                            entry
                         };
 
                         let Some(entry) = entry else {

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -589,10 +589,16 @@ impl P2pConnManager {
                 .network_api
                 .total_bandwidth_limit
                 .map(|total| {
-                    Arc::new(GlobalBandwidthManager::new(
+                    let manager = Arc::new(GlobalBandwidthManager::new(
                         total,
                         config.config.network_api.min_bandwidth_per_connection,
-                    ))
+                    ));
+                    // Phase 1.6 shadow telemetry (#4074): expose the
+                    // effective aggregate rate R to the demand aggregator.
+                    // Observation only — the manager is read, never written,
+                    // by the shadow side. See transport/shadow_demand.rs.
+                    crate::transport::shadow_demand::register_global_bandwidth(&manager);
+                    manager
                 }),
             ledbat_min_ssthresh: config.config.network_api.ledbat_min_ssthresh,
             congestion_config: config.config.network_api.build_congestion_config(),

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -418,15 +418,40 @@ impl NodeP2P {
         let reference_ping_enabled = config.config.telemetry.enabled
             && !config.config.telemetry.is_test_environment
             && config.config.telemetry.reference_ping_enabled;
+        // Phase 1.6 OS-interface-tx probe (#4074): same opt-in gating as
+        // reference-ping (telemetry on + not a test env + flag set). It
+        // reads /proc/net/dev at 1Hz, so it must not fire on dev machines
+        // or in CI by default.
+        let iface_tx_enabled = config.config.telemetry.enabled
+            && !config.config.telemetry.is_test_environment
+            && config.config.telemetry.iface_tx_enabled;
         let local_peer_id = config.local_peer_id_string();
         crate::transport::rolling_rtt_stats::spawn_aggregator(
             local_peer_id.clone(),
             &background_task_monitor,
         );
+        // Phase 1.6 demand + outbound-class aggregators (#4074). Both are
+        // always-on like the RTT aggregator: they only read atomics + the
+        // bandwidth handle and emit one OTLP event per second each (no
+        // I/O). Observation only.
+        crate::transport::shadow_demand::spawn_demand_aggregator(
+            local_peer_id.clone(),
+            &background_task_monitor,
+        );
+        crate::transport::shadow_demand::spawn_outbound_class_aggregator(
+            local_peer_id.clone(),
+            &background_task_monitor,
+        );
         if reference_ping_enabled {
             crate::transport::reference_ping::spawn_reference_ping(
-                local_peer_id,
+                local_peer_id.clone(),
                 crate::transport::reference_ping::DEFAULT_REFERENCE_TARGET,
+                &background_task_monitor,
+            );
+        }
+        if iface_tx_enabled {
+            crate::transport::shadow_iface_tx::spawn_iface_tx_monitor(
+                local_peer_id,
                 &background_task_monitor,
             );
         }

--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -204,6 +204,8 @@ pub(crate) mod ledbat;
 pub mod metrics;
 pub(crate) mod reference_ping;
 pub(crate) mod rolling_rtt_stats;
+pub(crate) mod shadow_demand;
+pub(crate) mod shadow_iface_tx;
 
 // Type alias for the in-crate concrete `Socket` impl so callers in
 // this crate can obtain a real UDP socket via a stable alias. The

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -2171,7 +2171,15 @@ async fn packet_sending<S: super::Socket, T: crate::simulation::TimeSource>(
             );
             // Accumulate on-wire bytes across all packets of this multi-part
             // message so the Phase 1.6 class counters see the full cost,
-            // attributed to the primary payload's class.
+            // attributed to the primary payload's class. Two accepted
+            // accounting nits (observation-only, see shadow_demand.rs): the
+            // trailing NoOp confirm-receipt packets are counted under the
+            // primary class rather than as must-flow, and on a mid-burst
+            // `send_to` failure the `?` below returns before the
+            // `record_outbound` call, so the class split can undercount the
+            // already-sent bytes relative to `cumulative_bytes_sent` (which
+            // is incremented per packet at the socket layer). Both are tiny
+            // and only affect the rarely-hit multi-packet path.
             let mut sent_on_wire = 0usize;
             macro_rules! send {
                 ($packets:ident) => {{
@@ -2455,6 +2463,118 @@ mod tests {
             assert!(
                 !matches!(err, TransportError::ConnectionClosed(_)),
                 "should NOT be ConnectionClosed"
+            );
+        });
+    }
+
+    /// Phase 1.6 (#4074): the hot-path instrumentation must feed the
+    /// classified byte counters, and only on a successful send. A
+    /// `ShortMessage` advances `short`, a `StreamFragment` advances `bulk`,
+    /// and a failing send records nothing. The class counters are
+    /// process-global and monotonic, so the success assertions are framed
+    /// as lower bounds (delta ≥ payload) and the failure assertion as an
+    /// upper bound well below the payload size — both robust under
+    /// shared-process (`cargo test`) execution where another test might
+    /// also touch the same statics.
+    #[test]
+    fn packet_sending_feeds_classified_counters_on_success_only() {
+        use crate::transport::shadow_demand::outbound_counters_snapshot;
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let outbound_key = {
+                use aes_gcm::KeyInit;
+                Aes128Gcm::new(&[0u8; 16].into())
+            };
+            let sent_tracker = Arc::new(parking_lot::Mutex::new(
+                crate::transport::sent_packet_tracker::tests::mock_sent_packet_tracker(),
+            ));
+            let remote_addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
+
+            // ---- success: ShortMessage advances `short` ----
+            let ok_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let (tx, _rx) = mpsc::channel(16);
+            let socket = Arc::new(FailableTestSocket::new(tx, ok_flag));
+
+            let (_, short_before, bulk_before) = outbound_counters_snapshot();
+            packet_sending(
+                remote_addr,
+                &socket,
+                1,
+                &outbound_key,
+                vec![],
+                SymmetricMessagePayload::ShortMessage {
+                    payload: bytes::Bytes::from(vec![7u8; 200]),
+                },
+                &sent_tracker,
+                None,
+            )
+            .await
+            .expect("short send should succeed");
+            let (_, short_after, _) = outbound_counters_snapshot();
+            assert!(
+                short_after - short_before >= 200,
+                "ShortMessage send must add >= its 200-byte payload to `short` (delta {})",
+                short_after - short_before
+            );
+
+            // ---- success: StreamFragment advances `bulk` ----
+            packet_sending(
+                remote_addr,
+                &socket,
+                2,
+                &outbound_key,
+                vec![],
+                SymmetricMessagePayload::StreamFragment {
+                    stream_id: StreamId::next(),
+                    total_length_bytes: 300,
+                    fragment_number: 0,
+                    payload: bytes::Bytes::from(vec![9u8; 300]),
+                    metadata_bytes: None,
+                },
+                &sent_tracker,
+                None,
+            )
+            .await
+            .expect("stream fragment send should succeed");
+            let (_, _, bulk_after) = outbound_counters_snapshot();
+            assert!(
+                bulk_after - bulk_before >= 300,
+                "StreamFragment send must add >= its 300-byte payload to `bulk` (delta {})",
+                bulk_after - bulk_before
+            );
+
+            // ---- failure: a failing send records nothing ----
+            let fail_flag = Arc::new(std::sync::atomic::AtomicBool::new(true));
+            let (tx2, _rx2) = mpsc::channel(16);
+            let failing = Arc::new(FailableTestSocket::new(tx2, fail_flag));
+            let (_, short_pre_fail, _) = outbound_counters_snapshot();
+            let res = packet_sending(
+                remote_addr,
+                &failing,
+                3,
+                &outbound_key,
+                vec![],
+                SymmetricMessagePayload::ShortMessage {
+                    payload: bytes::Bytes::from(vec![3u8; 600]),
+                },
+                &sent_tracker,
+                None,
+            )
+            .await;
+            assert!(res.is_err(), "failing socket must return Err");
+            let (_, short_post_fail, _) = outbound_counters_snapshot();
+            // A wrongly-recorded error path would jump `short` by >= 600;
+            // concurrent unit tests only add tiny amounts, so a delta well
+            // under 600 proves nothing was recorded on the failure path.
+            assert!(
+                short_post_fail - short_pre_fail < 600,
+                "failing send must not record its 600-byte payload (delta {})",
+                short_post_fail - short_pre_fail
             );
         });
     }

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -579,6 +579,13 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
 
                 match socket.send_to(&ping_packet, remote_addr).await {
                     Ok(_) => {
+                        // Phase 1.6 (#4074): keep-alive Ping bypasses
+                        // `packet_sending`; count it as must-flow here.
+                        // Observation only.
+                        crate::transport::shadow_demand::record_outbound(
+                            crate::transport::shadow_demand::OutboundClass::MustFlow,
+                            ping_packet.len(),
+                        );
                         tracing::debug!(
                             target: "freenet_core::transport::keepalive_lifecycle",
                             remote = ?remote_addr,
@@ -1842,6 +1849,12 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
             .await
         {
             Ok(_) => {
+                // Phase 1.6 (#4074): Pong bypasses `packet_sending`, so
+                // classify it as must-flow here. Observation only.
+                super::shadow_demand::record_outbound(
+                    super::shadow_demand::OutboundClass::MustFlow,
+                    pong_packet.len(),
+                );
                 tracing::trace!(
                     peer_addr = %self.remote_conn.remote_addr,
                     packet_id,
@@ -2095,6 +2108,16 @@ async fn packet_sending<S: super::Socket, T: crate::simulation::TimeSource>(
         "Attempting to send packet"
     );
 
+    // Phase 1.6 shadow telemetry (#4074): classify this outbound payload
+    // (must-flow / short / bulk) before it is consumed by serialization,
+    // so the must-flow-vs-bulk split can be measured. Converting to the
+    // concrete payload here is a no-op for callers that already pass one
+    // and a cheap `Into` for the rest; `try_serialize_msg_to_packet_data`
+    // still accepts it via `Into<Self>`. Observation only — see
+    // `transport/shadow_demand.rs` and `.claude/rules/transport.md`.
+    let payload: SymmetricMessagePayload = payload.into();
+    let outbound_class = super::shadow_demand::classify(&payload);
+
     match SymmetricMessage::try_serialize_msg_to_packet_data(
         packet_id,
         payload,
@@ -2119,6 +2142,9 @@ async fn packet_sending<S: super::Socket, T: crate::simulation::TimeSource>(
                         elapsed_ms = elapsed.as_millis(),
                         "Successfully sent packet"
                     );
+                    // Record the classified on-wire bytes once the packet
+                    // is actually sent (not on the error path).
+                    super::shadow_demand::record_outbound(outbound_class, packet_data.len());
                     sent_tracker.lock().report_sent_packet_with_token(
                         packet_id,
                         packet_data,
@@ -2143,6 +2169,10 @@ async fn packet_sending<S: super::Socket, T: crate::simulation::TimeSource>(
                 packet_id,
                 "Sending multi-packet message"
             );
+            // Accumulate on-wire bytes across all packets of this multi-part
+            // message so the Phase 1.6 class counters see the full cost,
+            // attributed to the primary payload's class.
+            let mut sent_on_wire = 0usize;
             macro_rules! send {
                 ($packets:ident) => {{
                     for packet in $packets {
@@ -2151,6 +2181,7 @@ async fn packet_sending<S: super::Socket, T: crate::simulation::TimeSource>(
                             .send_to(&packet_data, remote_addr)
                             .await
                             .map_err(|e| TransportError::SendFailed(remote_addr, e.kind()))?;
+                        sent_on_wire += packet_data.len();
                         sent_tracker.lock().report_sent_packet_with_token(
                             packet_id,
                             packet_data,
@@ -2180,6 +2211,7 @@ async fn packet_sending<S: super::Socket, T: crate::simulation::TimeSource>(
                 ];
 
                 send!(packets);
+                super::shadow_demand::record_outbound(outbound_class, sent_on_wire);
                 return Ok(());
             }
 
@@ -2209,6 +2241,7 @@ async fn packet_sending<S: super::Socket, T: crate::simulation::TimeSource>(
             }
 
             send!(packets);
+            super::shadow_demand::record_outbound(outbound_class, sent_on_wire);
             Ok(())
         }
     }

--- a/crates/core/src/transport/shadow_demand.rs
+++ b/crates/core/src/transport/shadow_demand.rs
@@ -1,0 +1,477 @@
+//! Phase 1.6 outbound-demand / queue-depth / must-flow-vs-bulk shadow
+//! telemetry for the outer-loop rate controller (issue #4074).
+//!
+//! Phases 1 and 1.5 (`rolling_rtt_stats.rs`, `reference_ping.rs`) measure
+//! RTT-based contention signals. Phase 1.6 adds the *demand* side of the
+//! floor analysis: how much the node is trying to push, how that compares
+//! to the rate cap `R`, how deep the broadcast backlog is, and how the
+//! outbound bytes split between traffic the controller can slow (bulk
+//! contract transfers) and traffic it cannot (keepalives / control).
+//!
+//! This module owns three process-wide observation hooks, all written
+//! from the hot send path with a single relaxed atomic add and read only
+//! by the 1 Hz aggregator tasks below:
+//!
+//! - **Outbound class counters** (`record_outbound`): cumulative bytes
+//!   split into `MustFlow` / `Short` / `Bulk`. Fed from `packet_sending`,
+//!   `send_pong`, and the keep-alive `Ping` site.
+//! - **Broadcast-queue depth gauge** (`record_broadcast_queue_depth`):
+//!   updated by `broadcast_queue.rs` under its own lock so the shadow
+//!   reader never contends on the queue mutex.
+//! - **Global-bandwidth handle** (`register_global_bandwidth`): a `Weak`
+//!   to the node's `GlobalBandwidthManager` so the demand aggregator can
+//!   read the effective aggregate rate `R` when the node runs in
+//!   global-pool mode.
+//!
+//! Two 1 Hz tasks emit the telemetry:
+//!
+//! - `shadow_rate_demand` — achieved outbound throughput vs `R`, plus
+//!   active-connection count and broadcast-queue depth.
+//! - `shadow_outbound_class` — the must-flow / short / bulk byte split.
+//!
+//! The OS-interface-tx signal (`shadow_iface_tx`) lives in the sibling
+//! `shadow_iface_tx.rs` module because it is Linux-specific, gated, and
+//! does file I/O.
+//!
+//! **Observation only.** Exactly like the Phase 1/1.5 shadow registry,
+//! nothing in the production data path reads these counters or the
+//! registered bandwidth handle back — the rule in
+//! `.claude/rules/transport.md` ("NEVER read … from the production data
+//! path") applies here too. The hot path only *writes* the cheap
+//! counters; all reads happen in the aggregator tasks.
+//!
+//! ## Process-wide, single-node-per-process
+//!
+//! The class counters and the broadcast gauge are process-global statics,
+//! matching the existing `TRANSPORT_METRICS.cumulative_bytes_sent` and
+//! `TELEMETRY_SENDER` patterns. A real deployment is one node per process,
+//! so the globals reflect that node. In multi-node in-process simulation
+//! the globals are shared across nodes, but simulation builds initialise
+//! no telemetry sender, so the events are dropped and nothing depends on
+//! the values being per-node.
+
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock, Weak};
+use std::time::Duration;
+
+use super::global_bandwidth::GlobalBandwidthManager;
+use super::symmetric_message::SymmetricMessagePayload;
+use crate::node::background_task_monitor::BackgroundTaskMonitor;
+use crate::transport::TRANSPORT_METRICS;
+
+/// Classification of an outbound transport payload for the floor
+/// lower/upper-bound analysis in #4074.
+///
+/// The split is by transport variant because that is all the transport
+/// layer can see without parsing the encrypted application payload. It is
+/// also the operationally meaningful axis: `Bulk` (stream fragments) is
+/// the *only* class the token bucket meters today, i.e. the only outbound
+/// traffic a future rate controller could actually slow. Everything else
+/// flows unthrottled and therefore behaves as "must-flow" under the
+/// current lever.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OutboundClass {
+    /// Keepalive / liveness / handshake control that flows regardless of
+    /// bulk transfer: `Ping`, `Pong`, `NoOp` (ACK carrier), and
+    /// `AckConnection`. Not rate-limited today.
+    MustFlow,
+    /// `ShortMessage` — a serialized `NetMessage`. Opaque at the transport
+    /// layer: it may be a control op (Connect / Subscribe / routing) or a
+    /// small contract op (a sub-streaming-threshold GET / PUT / UPDATE).
+    /// Not token-bucket metered today. Kept as its own bucket because the
+    /// transport cannot split it further without decrypting and parsing
+    /// the application payload — the analysis can fold it into must-flow
+    /// or treat it separately.
+    Short,
+    /// `StreamFragment` — large contract / state payload, the only
+    /// outbound class the token bucket meters, i.e. the slowable bulk.
+    Bulk,
+}
+
+/// Classify an outbound payload by its transport variant.
+///
+/// Cheap: a single exhaustive match, no allocation, no lock. Safe to call
+/// on the hot send path. Intentionally exhaustive (no wildcard) so a new
+/// `SymmetricMessagePayload` variant forces a compile error here rather
+/// than being silently miscounted.
+pub(crate) fn classify(payload: &SymmetricMessagePayload) -> OutboundClass {
+    match payload {
+        SymmetricMessagePayload::StreamFragment { .. } => OutboundClass::Bulk,
+        SymmetricMessagePayload::ShortMessage { .. } => OutboundClass::Short,
+        SymmetricMessagePayload::NoOp
+        | SymmetricMessagePayload::AckConnection { .. }
+        | SymmetricMessagePayload::Ping { .. }
+        | SymmetricMessagePayload::Pong { .. } => OutboundClass::MustFlow,
+    }
+}
+
+/// Cumulative outbound byte counters, split by class. Monotonic; the
+/// aggregator reports per-interval deltas.
+struct OutboundCounters {
+    must_flow_bytes: AtomicU64,
+    short_bytes: AtomicU64,
+    bulk_bytes: AtomicU64,
+}
+
+static OUTBOUND: OutboundCounters = OutboundCounters {
+    must_flow_bytes: AtomicU64::new(0),
+    short_bytes: AtomicU64::new(0),
+    bulk_bytes: AtomicU64::new(0),
+};
+
+/// Record `bytes` of outbound traffic of the given class. One relaxed
+/// atomic add — no allocation, no lock, no blocking. Called from the hot
+/// send path after the bytes are actually put on the wire.
+pub(crate) fn record_outbound(class: OutboundClass, bytes: usize) {
+    let counter = match class {
+        OutboundClass::MustFlow => &OUTBOUND.must_flow_bytes,
+        OutboundClass::Short => &OUTBOUND.short_bytes,
+        OutboundClass::Bulk => &OUTBOUND.bulk_bytes,
+    };
+    counter.fetch_add(bytes as u64, Ordering::Relaxed);
+}
+
+/// Snapshot of the cumulative class counters at one instant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OutboundSnapshot {
+    must_flow_bytes: u64,
+    short_bytes: u64,
+    bulk_bytes: u64,
+}
+
+fn snapshot_outbound() -> OutboundSnapshot {
+    OutboundSnapshot {
+        must_flow_bytes: OUTBOUND.must_flow_bytes.load(Ordering::Relaxed),
+        short_bytes: OUTBOUND.short_bytes.load(Ordering::Relaxed),
+        bulk_bytes: OUTBOUND.bulk_bytes.load(Ordering::Relaxed),
+    }
+}
+
+/// Bytes accumulated in each class between two snapshots.
+///
+/// `saturating_sub` guards the (practically impossible for u64, but free
+/// to defend) wrap / reset case so a counter reset can never produce a
+/// nonsensically huge delta.
+fn outbound_delta(prev: OutboundSnapshot, now: OutboundSnapshot) -> (u64, u64, u64) {
+    (
+        now.must_flow_bytes.saturating_sub(prev.must_flow_bytes),
+        now.short_bytes.saturating_sub(prev.short_bytes),
+        now.bulk_bytes.saturating_sub(prev.bulk_bytes),
+    )
+}
+
+/// Current broadcast-queue depth (entries pending fan-out). Updated by
+/// `broadcast_queue.rs` under its queue lock; the default per-connection
+/// build has no global queue so this stays at 0.
+static BROADCAST_QUEUE_DEPTH: AtomicUsize = AtomicUsize::new(0);
+
+/// Record the current broadcast-queue depth. Called from
+/// `broadcast_queue.rs` *under the queue lock* after each enqueue / drain
+/// mutation, so the gauge tracks the real depth while the shadow reader
+/// (the demand aggregator) reads it lock-free and never contends on the
+/// queue's async mutex.
+pub(crate) fn record_broadcast_queue_depth(depth: usize) {
+    BROADCAST_QUEUE_DEPTH.store(depth, Ordering::Relaxed);
+}
+
+/// Weak handle to the node's global bandwidth manager. `OnceLock` because
+/// it is registered exactly once at construction; `Weak` so the shadow
+/// side never extends the manager's lifetime. Unset under the default
+/// per-connection FixedRate mode (no `total_bandwidth_limit` configured),
+/// in which case the demand event's `R` fields are null.
+static GLOBAL_BANDWIDTH: OnceLock<Weak<GlobalBandwidthManager>> = OnceLock::new();
+
+/// Register the node's `GlobalBandwidthManager` so the demand aggregator
+/// can read the effective aggregate rate `R`. Called once at GBM
+/// construction. A no-op if a handle was already registered (only one GBM
+/// exists per node).
+pub(crate) fn register_global_bandwidth(manager: &Arc<GlobalBandwidthManager>) {
+    // `set` returns `Err` if already initialised; that only happens if
+    // construction ran twice (it doesn't — one GBM per node), so ignoring
+    // the result is correct rather than merely convenient.
+    if GLOBAL_BANDWIDTH.set(Arc::downgrade(manager)).is_err() {
+        tracing::debug!(
+            target: "freenet::transport::shadow_demand",
+            "global bandwidth handle already registered; keeping the first"
+        );
+    }
+}
+
+fn global_bandwidth() -> Option<Arc<GlobalBandwidthManager>> {
+    GLOBAL_BANDWIDTH.get().and_then(Weak::upgrade)
+}
+
+/// Number of live peer connections, read from the Phase 1 shadow RTT
+/// registry (one entry per `RemoteConnection`). Always available,
+/// independent of bandwidth mode, so the demand event can express
+/// per-connection demand even when the global-pool `R` fields are null.
+fn active_connections() -> usize {
+    super::rolling_rtt_stats::SHADOW_RTT_REGISTRY.len()
+}
+
+/// 1 Hz cadence, matching the Phase 1/1.5 aggregators so all shadow
+/// streams align at the collector.
+const AGGREGATOR_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Spawn the `shadow_rate_demand` aggregator and register it with the
+/// `BackgroundTaskMonitor`. Always-on (cheap: atomic loads + one OTLP
+/// event per second), like the RTT aggregator. Call once at node startup.
+///
+/// Emits achieved outbound throughput (a faithful proxy for offered
+/// demand, since the transport never drops outbound — it sleeps on the
+/// token bucket / cwnd instead, which surfaces as broadcast-queue depth),
+/// the active-connection count, the broadcast-queue depth, and the
+/// global-pool rate `R` when available.
+pub(crate) fn spawn_demand_aggregator(local_peer_id: String, monitor: &BackgroundTaskMonitor) {
+    let handle = tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(AGGREGATOR_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // Skip the immediate first tick; take the throughput baseline once
+        // the loop is aligned to the cadence.
+        ticker.tick().await;
+        let mut prev_sent = TRANSPORT_METRICS.cumulative_bytes_sent();
+        loop {
+            ticker.tick().await;
+            let now_sent = TRANSPORT_METRICS.cumulative_bytes_sent();
+            let sent_delta = now_sent.saturating_sub(prev_sent);
+            prev_sent = now_sent;
+            emit_demand_snapshot(&local_peer_id, sent_delta);
+        }
+    });
+    monitor.register("shadow_demand_aggregator", handle);
+}
+
+/// Emit one `shadow_rate_demand` event. See the module-level rustdoc for
+/// why the OTLP send is independent of the `tracing::debug!` level: the
+/// local mirror is at DEBUG (compiled out of release builds via
+/// `release_max_level_info`), while `send_standalone_event_with_peer_id`
+/// reaches the collector regardless of log level.
+fn emit_demand_snapshot(local_peer_id: &str, sent_bytes_last_interval: u64) {
+    let active_connections = active_connections();
+    let broadcast_queue_depth = BROADCAST_QUEUE_DEPTH.load(Ordering::Relaxed);
+    let gbm = global_bandwidth();
+    let global_total_limit_bytes = gbm.as_ref().map(|m| m.total_limit() as u64);
+    let global_per_connection_rate_bytes =
+        gbm.as_ref().map(|m| m.current_per_connection_rate() as u64);
+    let global_active_connections = gbm.as_ref().map(|m| m.connection_count() as u64);
+
+    tracing::debug!(
+        target: "freenet::transport::shadow_demand",
+        sent_bytes_last_interval,
+        active_connections,
+        broadcast_queue_depth,
+        global_total_limit_bytes,
+        global_per_connection_rate_bytes,
+        "shadow_rate_demand"
+    );
+    crate::tracing::telemetry::send_standalone_event_with_peer_id(
+        "shadow_rate_demand",
+        local_peer_id,
+        serde_json::json!({
+            // Achieved wire throughput over the last interval (~1 s). A
+            // proxy for offered demand; true offered>granted backlog shows
+            // up as broadcast_queue_depth and (Phase 2) token-bucket debt.
+            "sent_bytes_per_sec": sent_bytes_last_interval,
+            "active_connections": active_connections,
+            "broadcast_queue_depth": broadcast_queue_depth,
+            // Effective aggregate rate R — present only in global-pool
+            // mode (total_bandwidth_limit configured). Null under the
+            // default per-connection FixedRate mode, where the effective
+            // per-connection R is the FixedRate default constant.
+            "global_total_limit_bytes": global_total_limit_bytes,
+            "global_per_connection_rate_bytes": global_per_connection_rate_bytes,
+            "global_active_connections": global_active_connections,
+        }),
+    );
+}
+
+/// Spawn the `shadow_outbound_class` aggregator and register it with the
+/// `BackgroundTaskMonitor`. Always-on, like the demand aggregator. Reports
+/// the per-interval must-flow / short / bulk byte split that feeds both
+/// floor bounds (lower bound = must-flow rate when not bulk-transferring;
+/// upper bound combines with the OS counter).
+pub(crate) fn spawn_outbound_class_aggregator(
+    local_peer_id: String,
+    monitor: &BackgroundTaskMonitor,
+) {
+    let handle = tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(AGGREGATOR_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ticker.tick().await;
+        let mut prev = snapshot_outbound();
+        loop {
+            ticker.tick().await;
+            let now = snapshot_outbound();
+            let (must_flow, short, bulk) = outbound_delta(prev, now);
+            prev = now;
+            emit_class_snapshot(&local_peer_id, must_flow, short, bulk);
+        }
+    });
+    monitor.register("shadow_outbound_class_aggregator", handle);
+}
+
+fn emit_class_snapshot(
+    local_peer_id: &str,
+    must_flow_bytes: u64,
+    short_bytes: u64,
+    bulk_bytes: u64,
+) {
+    tracing::debug!(
+        target: "freenet::transport::shadow_demand",
+        must_flow_bytes,
+        short_bytes,
+        bulk_bytes,
+        "shadow_outbound_class"
+    );
+    crate::tracing::telemetry::send_standalone_event_with_peer_id(
+        "shadow_outbound_class",
+        local_peer_id,
+        serde_json::json!({
+            "must_flow_bytes_per_sec": must_flow_bytes,
+            "short_message_bytes_per_sec": short_bytes,
+            "bulk_bytes_per_sec": bulk_bytes,
+        }),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn short_message() -> SymmetricMessagePayload {
+        SymmetricMessagePayload::ShortMessage {
+            payload: bytes::Bytes::new(),
+        }
+    }
+
+    fn stream_fragment() -> SymmetricMessagePayload {
+        SymmetricMessagePayload::StreamFragment {
+            stream_id: crate::transport::peer_connection::StreamId::next(),
+            total_length_bytes: 1000,
+            fragment_number: 0,
+            payload: bytes::Bytes::new(),
+            metadata_bytes: None,
+        }
+    }
+
+    #[test]
+    fn classify_maps_every_variant_to_its_bucket() {
+        assert_eq!(classify(&stream_fragment()), OutboundClass::Bulk);
+        assert_eq!(classify(&short_message()), OutboundClass::Short);
+        assert_eq!(
+            classify(&SymmetricMessagePayload::NoOp),
+            OutboundClass::MustFlow
+        );
+        assert_eq!(
+            classify(&SymmetricMessagePayload::Ping { sequence: 1 }),
+            OutboundClass::MustFlow
+        );
+        assert_eq!(
+            classify(&SymmetricMessagePayload::Pong { sequence: 1 }),
+            OutboundClass::MustFlow
+        );
+        assert_eq!(
+            classify(&SymmetricMessagePayload::AckConnection {
+                result: Err(std::borrow::Cow::Borrowed("rejected")),
+            }),
+            OutboundClass::MustFlow
+        );
+    }
+
+    #[test]
+    fn outbound_delta_is_per_interval_difference() {
+        let prev = OutboundSnapshot {
+            must_flow_bytes: 100,
+            short_bytes: 50,
+            bulk_bytes: 1000,
+        };
+        let now = OutboundSnapshot {
+            must_flow_bytes: 175,
+            short_bytes: 50,
+            bulk_bytes: 4000,
+        };
+        assert_eq!(outbound_delta(prev, now), (75, 0, 3000));
+    }
+
+    #[test]
+    fn outbound_delta_saturates_on_reset() {
+        // A counter that appears to go backwards (reset / wrap) must yield
+        // 0, never a giant spurious delta.
+        let prev = OutboundSnapshot {
+            must_flow_bytes: 5000,
+            short_bytes: 5000,
+            bulk_bytes: 5000,
+        };
+        let now = OutboundSnapshot {
+            must_flow_bytes: 10,
+            short_bytes: 5000,
+            bulk_bytes: 6000,
+        };
+        assert_eq!(outbound_delta(prev, now), (0, 0, 1000));
+    }
+
+    #[test]
+    fn record_outbound_accumulates_into_the_right_counter() {
+        // Delta-based so this is robust to other tests touching the same
+        // process-global counters (cf. the rolling_rtt_stats registry
+        // tests). Record a unique amount and assert it shows up.
+        let before = snapshot_outbound();
+        record_outbound(OutboundClass::MustFlow, 11);
+        record_outbound(OutboundClass::Short, 22);
+        record_outbound(OutboundClass::Bulk, 33);
+        let after = snapshot_outbound();
+        assert!(after.must_flow_bytes - before.must_flow_bytes >= 11);
+        assert!(after.short_bytes - before.short_bytes >= 22);
+        assert!(after.bulk_bytes - before.bulk_bytes >= 33);
+    }
+
+    #[test]
+    fn broadcast_queue_depth_gauge_round_trips() {
+        record_broadcast_queue_depth(42);
+        assert_eq!(BROADCAST_QUEUE_DEPTH.load(Ordering::Relaxed), 42);
+        record_broadcast_queue_depth(0);
+        assert_eq!(BROADCAST_QUEUE_DEPTH.load(Ordering::Relaxed), 0);
+    }
+
+    /// `spawn_demand_aggregator` must produce a task that survives across
+    /// several ticks without the JoinHandle exiting. Mirror of
+    /// `rolling_rtt_stats::aggregator_emits_periodically`.
+    #[tokio::test(start_paused = true)]
+    async fn demand_aggregator_survives_multiple_ticks() {
+        let monitor = BackgroundTaskMonitor::new();
+        spawn_demand_aggregator("test-peer".to_string(), &monitor);
+
+        tokio::time::advance(AGGREGATOR_INTERVAL * 3 + Duration::from_millis(100)).await;
+        tokio::task::yield_now().await;
+
+        let exit = monitor.wait_for_any_exit();
+        tokio::pin!(exit);
+        let still_running = tokio::time::timeout(Duration::from_millis(50), &mut exit)
+            .await
+            .is_err();
+        assert!(
+            still_running,
+            "demand aggregator task should still be alive after a few ticks"
+        );
+    }
+
+    /// Same survival pin for the class aggregator.
+    #[tokio::test(start_paused = true)]
+    async fn class_aggregator_survives_multiple_ticks() {
+        let monitor = BackgroundTaskMonitor::new();
+        spawn_outbound_class_aggregator("test-peer".to_string(), &monitor);
+
+        tokio::time::advance(AGGREGATOR_INTERVAL * 3 + Duration::from_millis(100)).await;
+        tokio::task::yield_now().await;
+
+        let exit = monitor.wait_for_any_exit();
+        tokio::pin!(exit);
+        let still_running = tokio::time::timeout(Duration::from_millis(50), &mut exit)
+            .await
+            .is_err();
+        assert!(
+            still_running,
+            "class aggregator task should still be alive after a few ticks"
+        );
+    }
+}

--- a/crates/core/src/transport/shadow_demand.rs
+++ b/crates/core/src/transport/shadow_demand.rs
@@ -40,6 +40,41 @@
 //! path") applies here too. The hot path only *writes* the cheap
 //! counters; all reads happen in the aggregator tasks.
 //!
+//! ## What the class split covers — and what it does not
+//!
+//! The class counters are tagged at the data-path send choke point
+//! (`packet_sending`, which carries `ShortMessage` / `NoOp` /
+//! `StreamFragment`) plus the two bypass sites `send_pong` and the
+//! keep-alive `Ping`. They deliberately do **not** cover: retransmits
+//! (resent below `packet_sending`), the handshake / intro `AckConnection`
+//! sends, or standalone connection ACKs. Those bytes are still counted in
+//! the node total (`shadow_rate_demand.sent_bytes_per_sec`, derived from
+//! `TRANSPORT_METRICS.cumulative_bytes_sent` at the socket layer), so the
+//! split is a classified *subset* of the total, not the whole of it. The
+//! excluded paths are connection-establishment or recovery traffic, not
+//! steady-state data flow, so the #4074 floor lower bound (must-flow rate
+//! *when not bulk-transferring*) is essentially unaffected.
+//!
+//! Note for the analysis consumer: `must_flow` here is strictly
+//! transport-level liveness (`Ping` / `Pong` / `NoOp` / `AckConnection`).
+//! The issue's conceptual "must-flow" also includes subscription
+//! heartbeats and relay obligations, but those ride inside `ShortMessage`
+//! / `StreamFragment` at the transport layer and so land in the `short` /
+//! `bulk` buckets — the transport cannot see them. The `short` bucket
+//! therefore likely needs partial apportionment to must-flow during the
+//! offline analysis.
+//!
+//! ## Telemetry budget
+//!
+//! These two always-on emitters plus the Phase 1 RTT aggregator put three
+//! 1 Hz shadow events (and, on a gateway with reference-ping and iface-tx
+//! enabled, up to five) into an OTLP pipe rate-limited at 10 events/sec
+//! with no priority ordering (`tracing/telemetry.rs`). On a busy gateway
+//! some events — shadow or operational — may be dropped within a 1 s
+//! window. Acceptable as a statistical tradeoff for shadow telemetry; a
+//! shadow-event priority / sub-budget should land before Phase 2 adds
+//! more always-on streams (tracked separately).
+//!
 //! ## Process-wide, single-node-per-process
 //!
 //! The class counters and the broadcast gauge are process-global statics,
@@ -145,6 +180,17 @@ fn snapshot_outbound() -> OutboundSnapshot {
         short_bytes: OUTBOUND.short_bytes.load(Ordering::Relaxed),
         bulk_bytes: OUTBOUND.bulk_bytes.load(Ordering::Relaxed),
     }
+}
+
+/// Test-only accessor for the process-global class counters, returned as
+/// `(must_flow, short, bulk)` cumulative byte totals. Used by the
+/// send-path integration tests in `peer_connection.rs` to assert the
+/// hot-path hooks feed the right counter. Callers use delta assertions to
+/// stay robust against other tests touching these monotonic statics.
+#[cfg(test)]
+pub(crate) fn outbound_counters_snapshot() -> (u64, u64, u64) {
+    let s = snapshot_outbound();
+    (s.must_flow_bytes, s.short_bytes, s.bulk_bytes)
 }
 
 /// Bytes accumulated in each class between two snapshots.
@@ -426,7 +472,23 @@ mod tests {
     }
 
     #[test]
+    fn outbound_delta_is_zero_for_a_quiet_interval() {
+        // Equal prev/now snapshots (no traffic in the interval) must yield
+        // all-zero deltas, not a spurious value.
+        let snap = OutboundSnapshot {
+            must_flow_bytes: 12_345,
+            short_bytes: 67_890,
+            bulk_bytes: 1_000_000,
+        };
+        assert_eq!(outbound_delta(snap, snap), (0, 0, 0));
+    }
+
+    #[test]
     fn broadcast_queue_depth_gauge_round_trips() {
+        // Store-then-load is atomic and safe here: the only production
+        // writer (`broadcast_queue.rs`) is `#[cfg(not(feature =
+        // "simulation_tests"))]` and never instantiated in `--lib` unit
+        // tests, so no concurrent writer races this assertion.
         record_broadcast_queue_depth(42);
         assert_eq!(BROADCAST_QUEUE_DEPTH.load(Ordering::Relaxed), 42);
         record_broadcast_queue_depth(0);

--- a/crates/core/src/transport/shadow_iface_tx.rs
+++ b/crates/core/src/transport/shadow_iface_tx.rs
@@ -1,0 +1,232 @@
+//! Phase 1.6 OS-interface tx-bytes shadow telemetry for the outer-loop
+//! rate controller (issue #4074).
+//!
+//! Cross-connection RTT (Phase 1) and reference-ping (Phase 1.5) can tell
+//! us *that* the local uplink is contended, but not *who* is contending.
+//! The one signal that disambiguates "Freenet is saturating its own link"
+//! from "the operator's other apps are competing" is the aggregate OS
+//! interface transmit counter:
+//!
+//! ```text
+//! op = total_interface_tx − freenet_own_tx
+//! ```
+//!
+//! where `freenet_own_tx` is `TRANSPORT_METRICS.cumulative_bytes_sent`
+//! (every byte Freenet put on the wire) and `total_interface_tx` is the
+//! sum of `tx_bytes` across all non-loopback interfaces from Linux
+//! `/proc/net/dev`. A large `op` while the uplink is saturated means the
+//! operator's own traffic is the cause; a small `op` means Freenet is.
+//!
+//! **Best-effort and opt-in.** This probe is gated behind the bare
+//! `telemetry.iface-tx-enabled` flag (default `false`), the same way
+//! reference-ping is gated, and only spawned when telemetry is enabled and
+//! the node is not a test environment. If `/proc/net/dev` is unavailable
+//! (non-Linux, sandbox, restricted), each read returns `None` and that
+//! tick is silently omitted — the loop never blocks and never crashes.
+//!
+//! **Observation only.** Like every other #4074 shadow signal, nothing in
+//! the production data path reads this; the rule in
+//! `.claude/rules/transport.md` applies.
+//!
+//! ## Accounting caveat
+//!
+//! `cumulative_bytes_sent` counts UDP *payload* bytes, whereas the
+//! interface counter includes the IP + UDP headers (28 bytes/packet) that
+//! Freenet's own packets also carry. So `op = total − own` slightly
+//! over-attributes Freenet's own header overhead to "other" traffic — a
+//! small, roughly-constant offset that does not affect the
+//! saturation-attribution question. `saturating_sub` keeps `op` at 0 in
+//! the rare case the two counters are read across a skewed window and
+//! `own` momentarily exceeds `total`.
+
+use std::time::Duration;
+
+use crate::node::background_task_monitor::BackgroundTaskMonitor;
+use crate::transport::TRANSPORT_METRICS;
+
+/// 1 Hz cadence, matching the other shadow aggregators so the streams
+/// align at the collector.
+const MONITOR_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Linux per-interface byte/packet counters.
+const PROC_NET_DEV: &str = "/proc/net/dev";
+
+/// Spawn the `shadow_iface_tx` monitor and register it with the
+/// `BackgroundTaskMonitor`. Call once at node startup *only when the
+/// iface-tx flag is enabled* (the caller in `p2p_impl.rs` gates this the
+/// same way as reference-ping).
+///
+/// The task takes a baseline reading, then once per second reads the
+/// interface counter again and emits the per-interval deltas. A failed
+/// read omits that tick and leaves the baseline untouched, so a transient
+/// failure cannot produce a spurious huge delta on recovery.
+pub(crate) fn spawn_iface_tx_monitor(local_peer_id: String, monitor: &BackgroundTaskMonitor) {
+    let handle = tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(MONITOR_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // Skip the immediate first tick, then take the baseline aligned to
+        // the cadence. `prev_total` and `prev_own` are sampled together so
+        // their deltas cover the same window.
+        ticker.tick().await;
+        let mut prev_total = read_total_tx_bytes().await;
+        let mut prev_own = TRANSPORT_METRICS.cumulative_bytes_sent();
+
+        loop {
+            ticker.tick().await;
+            let now_total = read_total_tx_bytes().await;
+            let now_own = TRANSPORT_METRICS.cumulative_bytes_sent();
+
+            if let (Some(prev), Some(now)) = (prev_total, now_total) {
+                let total_delta = now.saturating_sub(prev);
+                let own_delta = now_own.saturating_sub(prev_own);
+                let op_delta = total_delta.saturating_sub(own_delta);
+                emit_iface_snapshot(&local_peer_id, total_delta, own_delta, op_delta);
+            }
+            // Advance the baseline only on a successful read so that a
+            // failed tick is bridged (the next success measures over the
+            // longer gap for BOTH counters consistently) rather than
+            // producing a misattributed delta.
+            if now_total.is_some() {
+                prev_total = now_total;
+                prev_own = now_own;
+            }
+        }
+    });
+    monitor.register("shadow_iface_tx_monitor", handle);
+}
+
+/// Read `/proc/net/dev` and sum `tx_bytes` across non-loopback
+/// interfaces. Returns `None` if the file cannot be read or no interface
+/// line parses (non-Linux, sandboxed, malformed).
+///
+/// Uses `tokio::fs` so the (tiny, ~1 KB) procfs read is offloaded to the
+/// blocking pool and never stalls the reactor.
+async fn read_total_tx_bytes() -> Option<u64> {
+    let contents = tokio::fs::read_to_string(PROC_NET_DEV).await.ok()?;
+    parse_total_tx_bytes(&contents)
+}
+
+/// Parse `/proc/net/dev` contents and sum `tx_bytes` across all
+/// non-loopback interfaces.
+///
+/// Line format (RFC-less kernel format) after the two header lines:
+/// ```text
+///   eth0: <rx_bytes> <rx_packets> <rx_errs> <rx_drop> <rx_fifo> \
+///         <rx_frame> <rx_compressed> <rx_multicast> \
+///         <tx_bytes> <tx_packets> ...
+/// ```
+/// The interface name precedes a `:`; the receive block is 8 fields, so
+/// `tx_bytes` is field index 8 in the whitespace-split remainder.
+fn parse_total_tx_bytes(contents: &str) -> Option<u64> {
+    const TX_BYTES_FIELD: usize = 8;
+    let mut total: u64 = 0;
+    let mut found = false;
+    for line in contents.lines() {
+        let Some((iface, rest)) = line.split_once(':') else {
+            // Header lines have no ':' in the name position — skip.
+            continue;
+        };
+        let iface = iface.trim();
+        // Loopback never leaves the host; exclude it from "uplink" tx.
+        if iface.is_empty() || iface == "lo" {
+            continue;
+        }
+        if let Some(tx) = rest
+            .split_whitespace()
+            .nth(TX_BYTES_FIELD)
+            .and_then(|s| s.parse::<u64>().ok())
+        {
+            total = total.saturating_add(tx);
+            found = true;
+        }
+    }
+    found.then_some(total)
+}
+
+fn emit_iface_snapshot(
+    local_peer_id: &str,
+    total_tx_bytes: u64,
+    own_tx_bytes: u64,
+    op_tx_bytes: u64,
+) {
+    tracing::debug!(
+        target: "freenet::transport::shadow_iface_tx",
+        total_tx_bytes,
+        own_tx_bytes,
+        op_tx_bytes,
+        "shadow_iface_tx"
+    );
+    crate::tracing::telemetry::send_standalone_event_with_peer_id(
+        "shadow_iface_tx",
+        local_peer_id,
+        serde_json::json!({
+            "total_tx_bytes_per_sec": total_tx_bytes,
+            "freenet_own_tx_bytes_per_sec": own_tx_bytes,
+            "op_tx_bytes_per_sec": op_tx_bytes,
+        }),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "Inter-|   Receive                                                |  Transmit\n\
+         face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed\n\
+    lo:  1000     10    0    0    0     0          0         0    1000      10    0    0    0     0       0          0\n\
+  eth0: 500000   1000    0    0    0     0          0         0  250000     800    0    0    0     0       0          0\n\
+  wlan0: 10     1    0    0    0     0          0         0    7500       5    0    0    0     0       0          0\n";
+
+    #[test]
+    fn parse_sums_tx_excluding_loopback() {
+        // eth0 tx 250000 + wlan0 tx 7500 = 257500; lo (1000) excluded.
+        assert_eq!(parse_total_tx_bytes(SAMPLE), Some(257_500));
+    }
+
+    #[test]
+    fn parse_returns_none_when_no_interface_lines() {
+        // Header only — no data lines means no signal.
+        let headers = "Inter-|   Receive  |  Transmit\n face |bytes ... |bytes ...\n";
+        assert_eq!(parse_total_tx_bytes(headers), None);
+        assert_eq!(parse_total_tx_bytes(""), None);
+    }
+
+    #[test]
+    fn parse_skips_only_loopback_named_lo() {
+        // An interface whose name merely contains "lo" (e.g. "flannel")
+        // must NOT be excluded — only the exact "lo" device is loopback.
+        let input = "  lodev: 1 2 3 4 5 6 7 8 999 10\n";
+        assert_eq!(parse_total_tx_bytes(input), Some(999));
+    }
+
+    #[test]
+    fn parse_tolerates_short_or_garbage_lines() {
+        // A line with fewer than 9 post-colon fields contributes nothing
+        // but must not crash or poison the sum.
+        let input = "  eth0: 1 2 3\n  eth1: 1 2 3 4 5 6 7 8 4242 9\n";
+        assert_eq!(parse_total_tx_bytes(input), Some(4242));
+    }
+
+    /// `spawn_iface_tx_monitor` must keep its task alive across ticks even
+    /// when `/proc/net/dev` is read every second. On non-Linux CI the read
+    /// returns `None` and the tick is omitted, which also exercises the
+    /// "omit, never block" path. Mirror of the reference-ping survival pin.
+    #[tokio::test(start_paused = true)]
+    async fn monitor_survives_multiple_ticks() {
+        let monitor = BackgroundTaskMonitor::new();
+        spawn_iface_tx_monitor("test-peer".to_string(), &monitor);
+
+        tokio::time::advance(MONITOR_INTERVAL * 4 + Duration::from_millis(100)).await;
+        tokio::task::yield_now().await;
+
+        let exit = monitor.wait_for_any_exit();
+        tokio::pin!(exit);
+        let still_running = tokio::time::timeout(Duration::from_millis(50), &mut exit)
+            .await
+            .is_err();
+        assert!(
+            still_running,
+            "iface-tx monitor task should still be alive after a few ticks"
+        );
+    }
+}

--- a/crates/core/src/transport/shadow_iface_tx.rs
+++ b/crates/core/src/transport/shadow_iface_tx.rs
@@ -38,6 +38,13 @@
 //! saturation-attribution question. `saturating_sub` keeps `op` at 0 in
 //! the rare case the two counters are read across a skewed window and
 //! `own` momentarily exceeds `total`.
+//!
+//! The probe also sums tx across *all* non-loopback interfaces, including
+//! virtual ones (docker/veth/bridge/bonded). On a container host a packet
+//! can traverse `docker0` → `eno1` and be counted on both, inflating
+//! `total` (and therefore `op`). The intended targets are bare-metal
+//! gateways where this is a non-issue; on container hosts treat `op` as an
+//! upper bound on competing traffic, not an exact figure.
 
 use std::time::Duration;
 
@@ -79,7 +86,7 @@ pub(crate) fn spawn_iface_tx_monitor(local_peer_id: String, monitor: &Background
             if let (Some(prev), Some(now)) = (prev_total, now_total) {
                 let total_delta = now.saturating_sub(prev);
                 let own_delta = now_own.saturating_sub(prev_own);
-                let op_delta = total_delta.saturating_sub(own_delta);
+                let op_delta = iface_op(total_delta, own_delta);
                 emit_iface_snapshot(&local_peer_id, total_delta, own_delta, op_delta);
             }
             // Advance the baseline only on a successful read so that a
@@ -141,6 +148,15 @@ fn parse_total_tx_bytes(contents: &str) -> Option<u64> {
         }
     }
     found.then_some(total)
+}
+
+/// `op = total_tx − freenet_own_tx`, the bytes attributable to traffic
+/// other than Freenet. `saturating_sub` keeps it at 0 when `own` exceeds
+/// `total` — which can happen across a skewed read window or because
+/// `own` counts UDP payload while the interface counter and Freenet's own
+/// header overhead interact (see the module-level accounting caveat).
+fn iface_op(total_delta: u64, own_delta: u64) -> u64 {
+    total_delta.saturating_sub(own_delta)
 }
 
 fn emit_iface_snapshot(
@@ -205,6 +221,40 @@ mod tests {
         // but must not crash or poison the sum.
         let input = "  eth0: 1 2 3\n  eth1: 1 2 3 4 5 6 7 8 4242 9\n";
         assert_eq!(parse_total_tx_bytes(input), Some(4242));
+    }
+
+    #[test]
+    fn parse_handles_colon_glued_to_first_counter() {
+        // On busy interfaces the kernel does not pad, so a large rx_bytes
+        // can abut the colon with no separating space, e.g.
+        // `eth0:123456789 ...`. `split_once(':')` removes the colon and
+        // `rest` then starts with rx_bytes, so field index 8 still lands
+        // on tx_bytes. Pin that the no-space-after-colon form parses
+        // identically to the spaced form.
+        let glued = "eth0:100 1 2 3 4 5 6 7 9999 10\n";
+        assert_eq!(parse_total_tx_bytes(glued), Some(9999));
+    }
+
+    #[test]
+    fn parse_handles_huge_counters_without_overflow() {
+        // 64-bit interface counters near u64::MAX must parse and sum
+        // without panicking (saturating_add guards the sum).
+        let big = u64::MAX - 1;
+        let input = format!("eth0: 1 2 3 4 5 6 7 8 {big} 9\neth1: 1 2 3 4 5 6 7 8 5 9\n");
+        assert_eq!(parse_total_tx_bytes(&input), Some(u64::MAX));
+    }
+
+    #[test]
+    fn iface_op_is_total_minus_own() {
+        assert_eq!(iface_op(10_000, 3_000), 7_000);
+        assert_eq!(iface_op(0, 0), 0);
+    }
+
+    #[test]
+    fn iface_op_saturates_when_own_exceeds_total() {
+        // The skewed-window case the module rustdoc promises to handle:
+        // own > total must clamp op to 0, never wrap.
+        assert_eq!(iface_op(1_000, 4_000), 0);
     }
 
     /// `spawn_iface_tx_monitor` must keep its task alive across ticks even


### PR DESCRIPTION
## Problem

Issue #4074 (the outer-loop rate-controller design-of-record) needs the
*demand* side of the floor analysis before a controller can be designed.
Phases 1 and 1.5 added RTT-based contention signals; Phase 1.6 — the
explicit next step in the issue's "Implementation checklist — Phase 1.6
telemetry" — adds observation-only telemetry for how much each node is
trying to send, how that compares to the rate cap `R`, how deep the
broadcast backlog gets, who is competing for the uplink, and how outbound
traffic splits between slowable bulk and unslowable must-flow.

This is **observation only**: no change to transport behaviour. The data
feeds the floor lower/upper-bound analysis in the #4074 body
("What to look for in the telemetry").

## Solution

Three new ~1 Hz shadow signals, each emitted from its own background task,
peer_id-tagged, same OTLP shape as the existing `shadow_rtt_aggregate`:

1. **`shadow_rate_demand`** — achieved outbound throughput (a faithful
   offered-demand proxy: the transport never drops outbound, it sleeps on
   the token bucket / cwnd, so backlog surfaces as queue depth), active
   connection count, broadcast-queue depth, and the effective aggregate
   rate `R` (`GlobalBandwidthManager`, present only in global-pool mode).
2. **`shadow_iface_tx`** — aggregate OS interface tx bytes from Linux
   `/proc/net/dev` and the derived `op = total_tx − freenet_own_tx`
   (`freenet_own_tx` = `TRANSPORT_METRICS.cumulative_bytes_sent`). Behind
   the bare `telemetry.iface-tx-enabled` flag (default off), best-effort:
   if `/proc/net/dev` is unavailable the tick is omitted, never blocking.
3. **`shadow_outbound_class`** — the must-flow / short / bulk byte split.
   `Bulk` = `StreamFragment` (the only class the token bucket meters, i.e.
   the only slowable traffic); `Short` = `ShortMessage` (opaque serialized
   `NetMessage` — small contract op or control plane, unsplittable at the
   transport layer); must-flow = `Ping` / `Pong` / `NoOp` / `AckConnection`.

### Design notes

- **Nothing in the production data path reads the shadow state.** The hot
  send path only *writes* the cheap class counters — one relaxed atomic add
  per packet at `packet_sending`, plus the keep-alive `Ping` and `send_pong`
  bypass sites (no allocation, no lock, no blocking). All reads happen in
  the separate aggregator tasks. The "NEVER read … from the production data
  path" rule in `.claude/rules/transport.md` is preserved and extended.
- **`R` mapping.** `R` maps to `GlobalBandwidthManager`, which is `Option`
  (only set in global-pool mode, i.e. when `total_bandwidth_limit` is
  configured). The demand event also emits `active_connections` (from the
  Phase 1 RTT registry, always available) so per-connection demand is
  computable under the default per-connection FixedRate mode, where the
  effective per-connection `R` is the known FixedRate default.
- **Broadcast-queue depth** is published by `broadcast_queue.rs` under its
  own queue lock into a relaxed gauge, so the shadow reader never contends
  on the queue mutex.
- **Telemetry budget.** These add up to 3 always-on + 1 gated 1 Hz events
  to an OTLP pipe rate-limited at 10 events/sec (no priority ordering). On a
  busy gateway some events (shadow or operational) may be dropped within a
  1 s window — an accepted, statistical tradeoff for shadow telemetry, and
  the cadence is trivially tunable if it proves too aggressive.

### Extractor (separate repo)

The matching `EVENT_TYPES` change in the nova admin repo
(`extract-shadow-telemetry.py`) adds the three new event names so they
survive the ~3-day raw-log rotation into the durable shadow archive. It is
deployed to nova separately and harmlessly matches nothing until nodes pick
up a release carrying these events.

## Testing

- `classify` maps every `SymmetricMessagePayload` variant to its bucket
  (exhaustive match, no wildcard — a new variant is a compile error).
- per-interval delta math, including saturation on counter reset.
- `/proc/net/dev` parsing: sums tx excluding `lo`, tolerates short / garbage
  lines, returns `None` on header-only / empty input, excludes only the
  exact `lo` device.
- the broadcast-depth gauge round-trips.
- all three aggregator / monitor tasks survive multiple ticks without the
  `BackgroundTaskMonitor` JoinHandle exiting (mirrors the Phase 1 / 1.5
  survival pins).

`cargo fmt`, `cargo clippy -- -D warnings`, and the transport + config
suites are green locally.

Part of #4074.

[AI-assisted - Claude]
