### PR TITLE
build: repair clippy under --all-features and --tests (#4325)

### DIFF
--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -2333,10 +2333,17 @@ pub(crate) mod test {
         // this test catches the mismatch via the variant-equality
         // assertion below.
         let err = OpError::NodeShuttingDown;
+        // The wildcard arm below intentionally absorbs every current (and any
+        // future) `OpError` variant the way production's `report_op_init_error`
+        // catch-all does; this test only pins the `NodeShuttingDown` arm, so an
+        // exhaustive listing would add churn without strengthening the
+        // assertion. Mirrors the documented `non_exhaustive` wildcard pattern in
+        // `.claude/rules/git-workflow.md`. The allow sits on the match
+        // expression because clippy reports `wildcard_enum_match_arm` at the
+        // match scrutinee, not the individual arm.
+        #[allow(clippy::wildcard_enum_match_arm)]
         let kind = match err {
             OpError::NodeShuttingDown => ErrorKind::Shutdown,
-            // All other variants fall into the catch-all in
-            // production — they're irrelevant to this test.
             _ => ErrorKind::OperationError {
                 cause: "irrelevant for this test".to_string().into(),
             },
@@ -2370,15 +2377,24 @@ pub(crate) mod test {
         let instance_id = ContractInstanceId::new([7u8; 32]);
         let err = OpError::ContractBanned { instance_id };
         let op_name = "PUT";
+        // The wildcard arms below intentionally absorb every other (and any
+        // future) `OpError` / `ErrorKind` variant the way production's
+        // catch-alls do; this test only pins the `ContractBanned` mapping, so an
+        // exhaustive listing would add churn without strengthening the
+        // assertion. Mirrors the documented non_exhaustive wildcard pattern in
+        // `.claude/rules/git-workflow.md`. The allows sit on the match
+        // expressions because clippy reports `wildcard_enum_match_arm` at the
+        // match scrutinee, not the individual arm.
+        #[allow(clippy::wildcard_enum_match_arm)]
         let kind = match err {
             OpError::ContractBanned { .. } => ErrorKind::OperationError {
                 cause: format!("{op_name} operation failed: {err}").into(),
             },
-            // Other variants are irrelevant to this test.
             _ => ErrorKind::Unhandled {
                 cause: "irrelevant for this test".to_string().into(),
             },
         };
+        #[allow(clippy::wildcard_enum_match_arm)]
         match kind {
             ErrorKind::OperationError { cause } => {
                 assert!(

--- a/crates/core/src/server/app_packaging.rs
+++ b/crates/core/src/server/app_packaging.rs
@@ -195,6 +195,51 @@ impl WebApp {
     }
 }
 
+impl<'a> TryFrom<&'a [u8]> for WebApp {
+    type Error = WebContractError;
+
+    fn try_from(state: &'a [u8]) -> Result<Self, Self::Error> {
+        debug!(
+            "Attempting to create WebApp from {} bytes of state",
+            state.len()
+        );
+        const MAX_METADATA_SIZE: u64 = 1024;
+        const MAX_WEB_SIZE: u64 = 1024 * 1024 * 100;
+        // Decompose the state and extract the compressed web interface
+        let mut state = Cursor::new(state);
+
+        let metadata_size = state
+            .read_u64::<BigEndian>()
+            .map_err(|e| WebContractError::UnpackingError(anyhow::anyhow!(e)))?;
+        if metadata_size > MAX_METADATA_SIZE {
+            return Err(WebContractError::UnpackingError(anyhow::anyhow!(
+                "Exceeded metadata size of 1kB: {} bytes",
+                metadata_size
+            )));
+        }
+        let mut metadata = vec![0; metadata_size as usize];
+        state
+            .read_exact(&mut metadata)
+            .map_err(|e| WebContractError::UnpackingError(anyhow::anyhow!(e)))?;
+
+        let web_size = state
+            .read_u64::<BigEndian>()
+            .map_err(|e| WebContractError::UnpackingError(anyhow::anyhow!(e)))?;
+        if web_size > MAX_WEB_SIZE {
+            return Err(WebContractError::UnpackingError(anyhow::anyhow!(
+                "Exceeded packed web size of 100MB: {} bytes",
+                web_size
+            )));
+        }
+        let mut web = vec![0; web_size as usize];
+        state
+            .read_exact(&mut web)
+            .map_err(|e| WebContractError::UnpackingError(anyhow::anyhow!(e)))?;
+
+        Ok(Self { metadata, web })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -341,50 +386,5 @@ mod tests {
             std::fs::read(dst.path().join("assets/app.js")).unwrap(),
             b"console.log(1)"
         );
-    }
-}
-
-impl<'a> TryFrom<&'a [u8]> for WebApp {
-    type Error = WebContractError;
-
-    fn try_from(state: &'a [u8]) -> Result<Self, Self::Error> {
-        debug!(
-            "Attempting to create WebApp from {} bytes of state",
-            state.len()
-        );
-        const MAX_METADATA_SIZE: u64 = 1024;
-        const MAX_WEB_SIZE: u64 = 1024 * 1024 * 100;
-        // Decompose the state and extract the compressed web interface
-        let mut state = Cursor::new(state);
-
-        let metadata_size = state
-            .read_u64::<BigEndian>()
-            .map_err(|e| WebContractError::UnpackingError(anyhow::anyhow!(e)))?;
-        if metadata_size > MAX_METADATA_SIZE {
-            return Err(WebContractError::UnpackingError(anyhow::anyhow!(
-                "Exceeded metadata size of 1kB: {} bytes",
-                metadata_size
-            )));
-        }
-        let mut metadata = vec![0; metadata_size as usize];
-        state
-            .read_exact(&mut metadata)
-            .map_err(|e| WebContractError::UnpackingError(anyhow::anyhow!(e)))?;
-
-        let web_size = state
-            .read_u64::<BigEndian>()
-            .map_err(|e| WebContractError::UnpackingError(anyhow::anyhow!(e)))?;
-        if web_size > MAX_WEB_SIZE {
-            return Err(WebContractError::UnpackingError(anyhow::anyhow!(
-                "Exceeded packed web size of 100MB: {} bytes",
-                web_size
-            )));
-        }
-        let mut web = vec![0; web_size as usize];
-        state
-            .read_exact(&mut web)
-            .map_err(|e| WebContractError::UnpackingError(anyhow::anyhow!(e)))?;
-
-        Ok(Self { metadata, web })
     }
 }

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -2233,8 +2233,8 @@ mod opentelemetry_tracer {
 
     use dashmap::DashMap;
     use opentelemetry::{
-        KeyValue, global,
-        trace::{self, Span},
+        Context, KeyValue, global,
+        trace::{self, Span, TraceContextExt},
     };
 
     use super::*;
@@ -2253,17 +2253,31 @@ mod opentelemetry_tracer {
             let mut span_id = [0; 8];
             span_id.copy_from_slice(&tx_bytes[8..]);
             let start_time = transaction.started();
-            let inner = tracer.build(trace::SpanBuilder {
-                name: transaction.transaction_type().description().into(),
-                start_time: Some(start_time),
-                span_id: Some(trace::SpanId::from_bytes(span_id)),
-                trace_id: Some(trace::TraceId::from_bytes(tx_bytes)),
-                attributes: Some(vec![
-                    KeyValue::new("transaction", transaction.to_string()),
-                    KeyValue::new("tx_type", transaction.transaction_type().description()),
-                ]),
-                ..Default::default()
-            });
+            // opentelemetry 0.32 removed the `trace_id`/`span_id` fields from
+            // `SpanBuilder`; trace identity is now seeded from the parent
+            // `Context`. We anchor the span on a deterministic remote
+            // `SpanContext` derived from the transaction bytes so all events of
+            // a transaction continue to share a stable trace_id. The child span
+            // receives a fresh span_id from the SDK id generator (no longer
+            // settable through the public API), with our deterministic span_id
+            // recorded as the parent span_id.
+            let parent_span_context = trace::SpanContext::new(
+                trace::TraceId::from_bytes(tx_bytes),
+                trace::SpanId::from_bytes(span_id),
+                trace::TraceFlags::SAMPLED,
+                true,
+                trace::TraceState::default(),
+            );
+            let parent_cx = Context::current().with_remote_span_context(parent_span_context);
+            let builder = trace::SpanBuilder::from_name(
+                transaction.transaction_type().description().to_string(),
+            )
+            .with_start_time(start_time)
+            .with_attributes(vec![
+                KeyValue::new("transaction", transaction.to_string()),
+                KeyValue::new("tx_type", transaction.transaction_type().description()),
+            ]);
+            let inner = tracer.build_with_context(builder, &parent_cx);
             OTSpan {
                 inner,
                 last_log: SystemTime::now(),

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -3474,7 +3474,7 @@ mod tests {
 
         let samples_after = crate::transport::TRANSPORT_METRICS.rtt_sample_count();
         assert!(
-            samples_after >= samples_before + 1,
+            samples_after > samples_before,
             "Pong for a pending ping must record at least one RTT sample \
              (before={samples_before}, after={samples_after}). \
              The keep-alive RTT path (#4000) is not wired up."

--- a/crates/core/src/transport/sent_packet_tracker.rs
+++ b/crates/core/src/transport/sent_packet_tracker.rs
@@ -567,6 +567,16 @@ impl SentPacketTracker<RealTime> {
 // Unit tests
 #[cfg(test)]
 pub(in crate::transport) mod tests {
+    // These tests assert that `get_resend()` returns a specific `ResendAction`
+    // variant and `panic!` on anything else (`match action { Expected => ..,
+    // _ => panic!() }`). That wildcard-with-panic is the intended assertion
+    // idiom — expanding it into a `pat | _` listing would only add churn and
+    // would still need updating for any new variant. Scope the allow to the
+    // test module rather than annotating each identical arm. Mirrors the
+    // documented non_exhaustive wildcard pattern in
+    // `.claude/rules/git-workflow.md`.
+    #![allow(clippy::wildcard_enum_match_arm)]
+
     use super::*;
     use crate::simulation::VirtualTime;
     use rstest::rstest;


### PR DESCRIPTION
## Problem

Two pre-existing clippy failures that CI never catches (`clippy_check` runs `cargo clippy --locked -- -D warnings` — default features, no test code), but bite anyone running a broader clippy locally and block the repo's `--tests` pre-commit hook:

1. **`--all-features`**: `crates/core/src/tracing.rs` fails to compile — opentelemetry 0.32's `SpanBuilder` no longer exposes `span_id` / `trace_id` fields.
2. **`--tests`**: `clippy::wildcard_enum_match_arm` trips on `_ => …` arms over `OpError`/`ErrorKind` once test code compiles.

## Solution

1. Rebuilt `OTSpan::new` against the otel 0.32 builder API: construct a deterministic remote `SpanContext` from the transaction bytes (**preserving the stable per-transaction `trace_id`** that correlates all log events for a tx), seed via `Context::with_remote_span_context`, build with `SpanBuilder::from_name(...).with_start_time(...).with_attributes(...)`, `tracer.build_with_context(...)`. The deterministic span_id is recorded as the parent span_id (otel 0.32 removed the public hook to force a span_id; trace_id correlation is retained).
2. Scoped `#[allow(clippy::wildcard_enum_match_arm)]` with justifying comments on the test-only catch-all arms (per the non_exhaustive wildcard pattern in `.claude/rules/git-workflow.md` — not expanded to `pat | _`). Plus one `int_plus_one` fix and a behavior-identical `TryFrom` reorder above a test module.

## Testing

- `cargo clippy -p freenet --locked -- -D warnings` — clean (CI-equivalent, no regression).
- `cargo clippy --locked -p freenet --tests -- -D warnings` — now clean (FAILURE 2 fixed).
- `cargo clippy -p freenet --features trace-ot` — clean (validates the tracing.rs fix in isolation).
- Existing tests pass (`client_events`, `app_packaging` ×4 confirming the reorder is behavior-preserving, `sent_packet_tracker` ×46).

**Out of scope (follow-up):** `--all-features` still fails on **non-linux-gnu** hosts due to a separate pre-existing cfg-gate mismatch — `tikv_jemalloc_ctl` is consumed under `cfg(all(unix, feature="jemalloc-prof"))` while the dep is gated `cfg(target_os="linux", target_env="gnu")`. The tracing.rs error (the one #4325 names) is fully resolved. Left untouched to keep this a single logical change.

## Fixes

Fixes #4325