### PR TITLE
fix(network): distinguish broadcast delivery from permit release (#4235)

### DIFF
--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -17,6 +17,7 @@ use freenet_stdlib::prelude::{ContractKey, WrappedState};
 
 use crate::node::OpManager;
 use crate::ring::PeerKeyLocation;
+use crate::transport::BroadcastDeliveryOutcome;
 
 use super::p2p_protoc::P2pBridge;
 
@@ -277,6 +278,118 @@ mod queue {
 #[cfg(not(feature = "simulation_tests"))]
 pub(crate) use queue::BroadcastQueue;
 
+/// Classify the result of awaiting the streaming completion oneshot into
+/// "the message was actually delivered" vs "the permit can be released but the
+/// message was dropped".
+///
+/// Issue #4235: the broadcast queue holds a semaphore permit for the duration
+/// of a streaming broadcast and releases it when the completion signal fires.
+/// The signal fires in *every* terminal case so the permit is never leaked —
+/// including drops (peer channel closed, congestion timeout per #4145, no
+/// connection, transport send error, cwnd-wait early return). Only a real
+/// [`BroadcastDeliveryOutcome::Delivered`] must be treated as a send; treating
+/// a drop as a delivery refreshes the peer's interest TTL on a transfer that
+/// never landed and caches its summary, suppressing the next summary-mismatch
+/// resend that should have detected the drop.
+///
+/// The argument is the result of `timeout(.., completion_rx).await`:
+/// - `Ok(Ok(Delivered))` → delivered.
+/// - `Ok(Ok(Dropped))`   → dropped (an explicit drop path signaled the permit).
+/// - `Ok(Err(_))`        → dropped (oneshot dropped without a signal, e.g. the
+///   cwnd-wait early return in `outbound_stream.rs`).
+/// - `Err(_)`            → dropped (we timed out waiting for completion).
+fn streaming_completion_delivered(completion: StreamCompletionResult) -> bool {
+    matches!(completion, Ok(Ok(BroadcastDeliveryOutcome::Delivered)))
+}
+
+/// Result of awaiting the streaming completion oneshot under a timeout:
+/// `timeout(.., completion_rx).await`. The inner `Ok`/`Err` distinguishes a
+/// delivered/dropped signal from a dropped oneshot; the outer `Err` is the
+/// wait timeout.
+type StreamCompletionResult = Result<
+    Result<BroadcastDeliveryOutcome, tokio::sync::oneshot::error::RecvError>,
+    tokio::time::error::Elapsed,
+>;
+
+/// Apply the broadcast queue's post-send delivery gate to the interest manager.
+///
+/// This is the single production gate for #4235: it classifies the streaming
+/// `completion` result and, ONLY on a real delivery, records the send telemetry,
+/// refreshes the peer's interest TTL, and caches the peer summary. A drop or a
+/// timeout releases the permit (handled by the caller) but must not touch the
+/// interest manager — refreshing on a transfer that never landed extends the
+/// peer's TTL falsely and caching the summary suppresses the next
+/// summary-mismatch resend that should have re-sent the dropped state.
+///
+/// Returns the classified delivery outcome so the caller can log it.
+///
+/// The classification and the gated side effects are deliberately co-located in
+/// one function so a regression test can drive the *real* gate. A future
+/// refactor that mis-binds delivery here (e.g. reverting to a bare "the send was
+/// enqueued" check) is caught by
+/// `drop_outcome_does_not_refresh_interest_or_cache_summary`.
+// The args mirror the streaming call site's locals; bundling them into a struct
+// would obscure the (otherwise mechanical) gate this function exists to make
+// testable.
+#[allow(clippy::too_many_arguments)]
+fn record_streaming_delivery<T: crate::util::time_source::TimeSource + Sync>(
+    interest_manager: &crate::ring::interest::InterestManager<T>,
+    completion: StreamCompletionResult,
+    sent_delta: bool,
+    key: &ContractKey,
+    peer_key: &crate::ring::PeerKey,
+    our_summary: Option<&freenet_stdlib::prelude::StateSummary<'static>>,
+    state_size: usize,
+    payload_size: usize,
+) -> bool {
+    let delivered = streaming_completion_delivered(completion);
+    if delivered {
+        record_delivery_to_interest(
+            interest_manager,
+            sent_delta,
+            key,
+            peer_key,
+            our_summary,
+            state_size,
+            payload_size,
+        );
+    }
+    delivered
+}
+
+/// The side effects a *delivered* broadcast applies to the interest manager:
+/// record send telemetry, refresh the peer interest TTL, and (for deltas) cache
+/// the peer summary. Factored out so both the streaming gate
+/// ([`record_streaming_delivery`]) and the non-streaming path share one body.
+fn record_delivery_to_interest<T: crate::util::time_source::TimeSource + Sync>(
+    interest_manager: &crate::ring::interest::InterestManager<T>,
+    sent_delta: bool,
+    key: &ContractKey,
+    peer_key: &crate::ring::PeerKey,
+    our_summary: Option<&freenet_stdlib::prelude::StateSummary<'static>>,
+    state_size: usize,
+    payload_size: usize,
+) {
+    // Track delta vs full state sends for testing (PR #2763)
+    if sent_delta {
+        interest_manager.record_delta_send(state_size, payload_size);
+        crate::config::GlobalTestMetrics::record_delta_send();
+    } else {
+        interest_manager.record_full_state_send();
+        crate::config::GlobalTestMetrics::record_full_state_send();
+    }
+
+    // Issue #3046: Refresh the peer's interest TTL on every successful send
+    interest_manager.refresh_peer_interest(key, peer_key);
+
+    // PR #2763: Only update cached summary when we sent a delta
+    if sent_delta {
+        if let Some(summary) = our_summary {
+            interest_manager.update_peer_summary(key, peer_key, Some(summary.clone()));
+        }
+    }
+}
+
 /// Send a state change broadcast to a single peer.
 ///
 /// This is the per-target body extracted from `broadcast_state_to_peers`.
@@ -372,6 +485,17 @@ pub(super) async fn broadcast_to_single_peer(
     let use_streaming = matches!(&payload, DeltaOrFullState::FullState(_))
         && crate::operations::should_use_streaming(op_manager.streaming_threshold, payload_size);
 
+    // Each branch below tracks whether the message was *actually delivered* to
+    // the peer, as distinct from merely being enqueued for dispatch, and applies
+    // the delivery gate itself. For the non-streaming path the two coincide (a
+    // successful `bridge.send` is the terminal state we can observe). For the
+    // streaming path they DON'T: the stream dispatch can be enqueued
+    // successfully and then dropped (peer channel closed, congestion timeout per
+    // #4145, no connection, transport error), and the completion oneshot fires
+    // in all those cases purely to release the semaphore permit. Issue #4235:
+    // only a real delivery should refresh the peer's interest TTL or cache its
+    // summary — treating a drop as a delivery defeats the next summary-mismatch
+    // round that would re-send the state.
     let send_result = if use_streaming {
         let sender_summary_bytes = our_summary
             .as_ref()
@@ -450,30 +574,39 @@ pub(super) async fn broadcast_to_single_peer(
             } else {
                 // Wait for the stream transfer to actually complete before
                 // releasing back to the queue worker (semaphore permit is held
-                // by our caller). Timeout prevents permanent stall.
-                match tokio::time::timeout(STREAM_COMPLETION_TIMEOUT, completion_rx).await {
-                    Ok(Ok(())) => {
-                        tracing::debug!(
-                            tx = %update_tx,
-                            peer = %peer_addr,
-                            "Broadcast stream completed successfully"
-                        );
-                    }
-                    Ok(Err(_)) => {
-                        tracing::debug!(
-                            tx = %update_tx,
-                            peer = %peer_addr,
-                            "Broadcast stream completion channel dropped (task ended)"
-                        );
-                    }
-                    Err(_) => {
-                        tracing::warn!(
-                            tx = %update_tx,
-                            peer = %peer_addr,
-                            timeout_secs = STREAM_COMPLETION_TIMEOUT.as_secs(),
-                            "Broadcast stream completion timed out, releasing permit"
-                        );
-                    }
+                // by our caller). Timeout prevents permanent stall. The
+                // completion signal carries a `BroadcastDeliveryOutcome` so we
+                // distinguish a real delivery from a drop (#4235); a drop still
+                // releases the permit but must NOT be recorded as a send.
+                let completion =
+                    tokio::time::timeout(STREAM_COMPLETION_TIMEOUT, completion_rx).await;
+                // Classify AND apply the delivery gate in one production call
+                // (#4235): only a real `Delivered` refreshes interest / caches
+                // the summary. See `record_streaming_delivery`.
+                let delivered = record_streaming_delivery(
+                    &op_manager.interest_manager,
+                    completion,
+                    sent_delta,
+                    &key,
+                    &peer_key,
+                    our_summary.as_ref(),
+                    new_state.size(),
+                    payload_size,
+                );
+                if delivered {
+                    tracing::debug!(
+                        tx = %update_tx,
+                        peer = %peer_addr,
+                        "Broadcast stream completed successfully"
+                    );
+                } else {
+                    tracing::debug!(
+                        tx = %update_tx,
+                        peer = %peer_addr,
+                        timeout_secs = STREAM_COMPLETION_TIMEOUT.as_secs(),
+                        "Broadcast stream dropped or timed out before delivery \
+                         (permit released, interest NOT refreshed)"
+                    );
                 }
             }
         }
@@ -488,42 +621,232 @@ pub(super) async fn broadcast_to_single_peer(
                 .map(|s| s.as_ref().to_vec())
                 .unwrap_or_default(),
         };
-        bridge.send(peer_addr, msg.into()).await
+        let res = bridge.send(peer_addr, msg.into()).await;
+        // Non-streaming inline broadcasts have no separate transfer phase: a
+        // successful enqueue is the terminal state we can observe, so delivery
+        // tracks the send result (unchanged pre-#4235 behavior for this path).
+        if res.is_ok() {
+            // Record telemetry, refresh peer interest, and cache the peer
+            // summary — see `record_delivery_to_interest`. The streaming branch
+            // applies the same gate via `record_streaming_delivery` (#4235);
+            // this inline branch shares that body.
+            record_delivery_to_interest(
+                &op_manager.interest_manager,
+                sent_delta,
+                &key,
+                &peer_key,
+                our_summary.as_ref(),
+                new_state.size(),
+                payload_size,
+            );
+        }
+        res
     };
 
-    let send_ok = send_result.is_ok();
-
-    if let Err(err) = send_result {
+    if let Err(err) = &send_result {
         tracing::warn!(
             tx = %update_tx,
             peer = %peer_addr,
             error = %err,
             "Failed to send state change broadcast (queued)"
         );
-    } else {
-        // Track delta vs full state sends for testing (PR #2763)
-        if sent_delta {
-            op_manager
-                .interest_manager
-                .record_delta_send(new_state.size(), payload_size);
-            crate::config::GlobalTestMetrics::record_delta_send();
-        } else {
-            op_manager.interest_manager.record_full_state_send();
-            crate::config::GlobalTestMetrics::record_full_state_send();
-        }
-
-        // Issue #3046: Refresh the peer's interest TTL on every successful send
-        op_manager
-            .interest_manager
-            .refresh_peer_interest(&key, &peer_key);
     }
 
-    // PR #2763: Only update cached summary when we sent a delta
-    if send_ok && sent_delta {
-        if let Some(summary) = &our_summary {
-            op_manager
-                .interest_manager
-                .update_peer_summary(&key, &peer_key, Some(summary.clone()));
+    // NOTE: telemetry / interest-refresh / summary-cache are intentionally NOT
+    // applied here. Issue #4235: each branch above applies the delivery gate
+    // itself — the streaming branch via `record_streaming_delivery` (gated on a
+    // real `Delivered` completion, NOT on the enqueue succeeding), the inline
+    // branch via `record_delivery_to_interest` (gated on the send succeeding). A
+    // dropped stream still released the permit but must not refresh interest or
+    // cache the summary.
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey, StateSummary};
+
+    use crate::ring::PeerKey;
+    use crate::ring::interest::InterestManager;
+    use crate::transport::{BroadcastDeliveryOutcome, TransportKeypair};
+    use crate::util::time_source::SharedMockTimeSource;
+
+    use super::{record_streaming_delivery, streaming_completion_delivered};
+
+    fn make_contract_key(seed: u8) -> ContractKey {
+        ContractKey::from_id_and_code(
+            ContractInstanceId::new([seed; 32]),
+            CodeHash::new([seed.wrapping_add(1); 32]),
+        )
+    }
+
+    fn make_peer_key() -> PeerKey {
+        PeerKey(TransportKeypair::new().public().clone())
+    }
+
+    /// A `RecvError` modeling the oneshot being dropped without a signal — the
+    /// path `outbound_stream.rs` takes on a cwnd-wait early return. Awaiting a
+    /// oneshot whose sender was dropped resolves to `Err(RecvError)`.
+    async fn dropped_oneshot()
+    -> Result<BroadcastDeliveryOutcome, tokio::sync::oneshot::error::RecvError> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<BroadcastDeliveryOutcome>();
+        drop(tx);
+        rx.await.map(|_| unreachable!("sender was dropped"))
+    }
+
+    /// An `Elapsed` modeling the broadcast queue timing out waiting for the
+    /// completion signal.
+    async fn elapsed_timeout() -> tokio::time::error::Elapsed {
+        let (tx, rx) = tokio::sync::oneshot::channel::<BroadcastDeliveryOutcome>();
+        // Keep tx alive so rx never resolves; force the timeout to elapse.
+        let res = tokio::time::timeout(Duration::from_millis(1), rx).await;
+        drop(tx);
+        res.expect_err("never-resolving recv must time out")
+    }
+
+    /// Issue #4235 — core regression: ONLY an explicit `Delivered` outcome is a
+    /// delivery. Every other completion result (an explicit `Dropped`, an
+    /// oneshot dropped without a signal, or a wait timeout) is NOT a delivery
+    /// even though all of them release the permit.
+    ///
+    /// Pre-fix the queue computed `send_ok = send_result.is_ok()`, which was
+    /// `true` for the timeout and dropped-oneshot cases (the send had been
+    /// enqueued), so those falsely counted as deliveries. The assertions on the
+    /// `Dropped` / `Ok(Err)` / `Err(Elapsed)` cases below FAIL against that old
+    /// logic.
+    #[tokio::test]
+    async fn streaming_completion_delivered_only_on_explicit_delivery() {
+        // Real delivery → counts as delivered.
+        assert!(
+            streaming_completion_delivered(Ok(Ok(BroadcastDeliveryOutcome::Delivered))),
+            "an explicit Delivered outcome must be treated as a delivery"
+        );
+
+        // Explicit drop (peer channel closed / congestion timeout #4145 /
+        // no connection / transport send error) → NOT a delivery.
+        assert!(
+            !streaming_completion_delivered(Ok(Ok(BroadcastDeliveryOutcome::Dropped))),
+            "an explicit Dropped outcome must NOT be treated as a delivery (#4235)"
+        );
+
+        // Oneshot dropped without a signal (cwnd-wait early return) →
+        // NOT a delivery.
+        assert!(
+            !streaming_completion_delivered(Ok(dropped_oneshot().await)),
+            "a dropped completion oneshot must NOT be treated as a delivery (#4235)"
+        );
+
+        // Queue timed out waiting for completion → NOT a delivery.
+        assert!(
+            !streaming_completion_delivered(Err(elapsed_timeout().await)),
+            "a completion-wait timeout must NOT be treated as a delivery (#4235)"
+        );
+    }
+
+    /// Issue #4235 — production-gate regression: drives the REAL gate the
+    /// broadcast queue's streaming path applies — [`record_streaming_delivery`],
+    /// the smallest extractable production unit that both classifies the
+    /// completion result AND applies the side effects (record send / refresh
+    /// interest TTL / cache summary) — against a real `InterestManager`, once
+    /// per completion outcome.
+    ///
+    /// Unlike [`streaming_completion_delivered_only_on_explicit_delivery`],
+    /// which guards the classifier helper in isolation, this test invokes the
+    /// production gate function the queue actually calls. It therefore FAILS if
+    /// a refactor reverts the production gate binding — e.g. switching
+    /// `record_streaming_delivery` to apply the side effects unconditionally or
+    /// on a bare "the send was enqueued" check rather than on a real
+    /// `Delivered` outcome — even if the standalone classifier stays correct.
+    ///
+    /// Proves the user-visible consequence of the conflation: when the stream
+    /// dispatch drops/times-out the message, the peer's interest TTL is NOT
+    /// refreshed and its summary is NOT cached — so the next summary-mismatch
+    /// round still fires — while a genuine delivery does refresh and cache.
+    #[tokio::test]
+    async fn drop_outcome_does_not_refresh_interest_or_cache_summary() {
+        let our_summary = StateSummary::from(vec![9, 9, 9, 9]);
+
+        // Each case pairs a completion result with whether it should be a
+        // delivery.
+        let dropped = dropped_oneshot().await;
+        let timed_out = elapsed_timeout().await;
+        let cases: Vec<(&str, super::StreamCompletionResult, bool)> = vec![
+            (
+                "delivered",
+                Ok(Ok(BroadcastDeliveryOutcome::Delivered)),
+                true,
+            ),
+            (
+                "explicit-drop",
+                Ok(Ok(BroadcastDeliveryOutcome::Dropped)),
+                false,
+            ),
+            ("dropped-oneshot", Ok(dropped), false),
+            ("timeout", Err(timed_out), false),
+        ];
+
+        for (name, completion, expect_delivered) in cases {
+            let time_source = SharedMockTimeSource::new();
+            let manager = InterestManager::new(time_source.clone());
+            let contract = make_contract_key(7);
+            let peer = make_peer_key();
+
+            // Peer is interested but has NO cached summary yet (mimics a peer
+            // whose summary mismatches ours, so a broadcast is queued).
+            manager.register_peer_interest(&contract, peer.clone(), None, false);
+            let baseline = manager
+                .get_peer_interest(&contract, &peer)
+                .expect("peer interest registered")
+                .last_refreshed;
+
+            // Let wall-clock advance so a refresh would be observable.
+            time_source.advance_time(Duration::from_secs(5));
+
+            // Drive the REAL production gate. `sent_delta = true` so the summary
+            // cache (`update_peer_summary`) is exercised on the delivered arm.
+            let delivered = record_streaming_delivery(
+                &manager,
+                completion,
+                /* sent_delta */ true,
+                &contract,
+                &peer,
+                Some(&our_summary),
+                /* state_size */ 1024,
+                /* payload_size */ 64,
+            );
+            assert_eq!(
+                delivered, expect_delivered,
+                "[{name}] classification mismatch"
+            );
+
+            let interest = manager
+                .get_peer_interest(&contract, &peer)
+                .expect("peer interest still registered");
+
+            if expect_delivered {
+                assert!(
+                    interest.last_refreshed > baseline,
+                    "[{name}] a real delivery MUST refresh the peer interest TTL"
+                );
+                assert_eq!(
+                    manager.get_peer_summary(&contract, &peer),
+                    Some(our_summary.clone()),
+                    "[{name}] a real delivery MUST cache the peer summary"
+                );
+            } else {
+                assert_eq!(
+                    interest.last_refreshed, baseline,
+                    "[{name}] a dropped/timed-out broadcast MUST NOT refresh the \
+                     peer interest TTL (#4235)"
+                );
+                assert_eq!(
+                    manager.get_peer_summary(&contract, &peer),
+                    None,
+                    "[{name}] a dropped/timed-out broadcast MUST NOT cache the peer \
+                     summary, or the next summary-mismatch resend is suppressed (#4235)"
+                );
+            }
         }
     }
 }

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -31,8 +31,8 @@ use crate::ring::Location;
 #[cfg(feature = "simulation_tests")]
 use crate::ring::PeerKey;
 use crate::transport::{
-    CongestionControlConfig, ExpectedInboundTracker, PeerConnectionApi, Socket, TransportError,
-    TransportKeypair, TransportPublicKey, create_connection_handler,
+    BroadcastDeliveryOutcome, CongestionControlConfig, ExpectedInboundTracker, PeerConnectionApi,
+    Socket, TransportError, TransportKeypair, TransportPublicKey, create_connection_handler,
     global_bandwidth::GlobalBandwidthManager, peer_connection::StreamId,
 };
 use crate::{
@@ -104,8 +104,10 @@ pub(crate) enum P2pBridgeEvent {
         data: bytes::Bytes,
         metadata: Option<bytes::Bytes>,
         /// Optional completion signal for broadcast queue concurrency control.
-        /// Signaled when the actual stream transfer finishes (not just enqueue).
-        completion_tx: Option<tokio::sync::oneshot::Sender<()>>,
+        /// Signaled when the actual stream transfer finishes (not just enqueue),
+        /// carrying a [`BroadcastDeliveryOutcome`] so the queue distinguishes a
+        /// real delivery from a drop (#4235).
+        completion_tx: Option<tokio::sync::oneshot::Sender<BroadcastDeliveryOutcome>>,
     },
     /// Pipe an inbound stream to a target, forwarding fragments incrementally.
     PipeStream {
@@ -218,7 +220,7 @@ impl P2pBridge {
         stream_id: StreamId,
         data: bytes::Bytes,
         metadata: Option<bytes::Bytes>,
-        completion_tx: Option<tokio::sync::oneshot::Sender<()>>,
+        completion_tx: Option<tokio::sync::oneshot::Sender<BroadcastDeliveryOutcome>>,
     ) -> super::ConnResult<()> {
         self.ev_listener_tx
             .send(P2pBridgeEvent::StreamSend {
@@ -1317,7 +1319,8 @@ impl P2pConnManager {
                                              cannot route stream fragment"
                                         );
                                         if let Some(tx) = completion_tx {
-                                            let _ignored = tx.send(());
+                                            let _ignored =
+                                                tx.send(BroadcastDeliveryOutcome::Dropped);
                                         }
                                     }
                                     Err(_timeout) => {
@@ -1330,7 +1333,8 @@ impl P2pConnManager {
                                              to keep event loop responsive"
                                         );
                                         if let Some(tx) = completion_tx {
-                                            let _ignored = tx.send(());
+                                            let _ignored =
+                                                tx.send(BroadcastDeliveryOutcome::Dropped);
                                         }
                                     }
                                 }
@@ -1342,9 +1346,10 @@ impl P2pConnManager {
                                     "No connection found for stream send target"
                                 );
                                 // Signal completion so the broadcast queue permit
-                                // is released immediately.
+                                // is released immediately. No connection means the
+                                // fragment was dropped, not delivered (#4235).
                                 if let Some(tx) = completion_tx {
-                                    let _ignored = tx.send(());
+                                    let _ignored = tx.send(BroadcastDeliveryOutcome::Dropped);
                                 }
                             }
                         }
@@ -4939,8 +4944,9 @@ pub(super) enum ConnEvent {
         stream_id: StreamId,
         data: bytes::Bytes,
         metadata: Option<bytes::Bytes>,
-        /// Optional completion signal for broadcast queue concurrency control.
-        completion_tx: Option<tokio::sync::oneshot::Sender<()>>,
+        /// Optional completion signal for broadcast queue concurrency control,
+        /// carrying a [`BroadcastDeliveryOutcome`] (#4235).
+        completion_tx: Option<tokio::sync::oneshot::Sender<BroadcastDeliveryOutcome>>,
     },
     /// Pipe an inbound stream to a peer, forwarding fragments as they arrive.
     /// Used for low-latency forwarding at intermediate nodes.
@@ -5958,16 +5964,19 @@ mod tests {
     /// a 120 s production stall.
     #[tokio::test]
     async fn stream_send_pattern_fires_completion_tx_on_timeout() {
+        use crate::transport::BroadcastDeliveryOutcome;
         const SEND_TIMEOUT: Duration = Duration::from_millis(100);
         let (tx, _rx) = mpsc::channel::<u32>(1);
         tx.try_send(0).expect("first send must succeed");
 
-        let (completion_tx, completion_rx) = tokio::sync::oneshot::channel::<()>();
+        let (completion_tx, completion_rx) =
+            tokio::sync::oneshot::channel::<BroadcastDeliveryOutcome>();
 
         // Mirror the StreamSend dispatch pattern:
         //   reserve() → permit OR closed OR timeout
         // The timeout branch MUST signal completion_tx (we retain
-        // ownership because reserve() never consumed it).
+        // ownership because reserve() never consumed it). Post-#4235 the
+        // signal carries `Dropped` because the fragment was NOT delivered.
         match tokio::time::timeout(SEND_TIMEOUT, tx.reserve()).await {
             Ok(Ok(_permit)) => {
                 // Wouldn't happen in this test (channel saturated), but
@@ -5976,16 +5985,16 @@ mod tests {
                 panic!("reserve unexpectedly succeeded on saturated channel");
             }
             Ok(Err(_closed)) => {
-                let _ignored = completion_tx.send(());
+                let _ignored = completion_tx.send(BroadcastDeliveryOutcome::Dropped);
             }
             Err(_timeout) => {
-                let _ignored = completion_tx.send(());
+                let _ignored = completion_tx.send(BroadcastDeliveryOutcome::Dropped);
             }
         }
 
         let signal = timeout(Duration::from_millis(50), completion_rx).await;
         assert!(
-            matches!(signal, Ok(Ok(()))),
+            matches!(signal, Ok(Ok(BroadcastDeliveryOutcome::Dropped))),
             "completion_tx must be fired on the dispatch timeout path so the \
              broadcast queue releases its permit immediately (not after \
              120s STREAM_COMPLETION_TIMEOUT). Got {signal:?}"
@@ -6045,22 +6054,30 @@ mod tests {
         // timeout / no-connection) MUST signal `completion_tx` so the
         // broadcast queue's semaphore permit releases immediately.
         // Per-arm count instead of a single match: a refactor that
-        // drops just the timeout arm's fire (the one this PR added)
+        // drops just the timeout arm's fire (the one #4145 added)
         // would otherwise silently reintroduce the 120 s
-        // STREAM_COMPLETION_TIMEOUT stall. Pre-fix the StreamSend
-        // branch had ONE `tx.send(())` (channel-closed only); the
-        // current PR adds two more (timeout + no-connection).
-        // Tested behaviourally by
-        // `stream_send_pattern_fires_completion_tx_on_timeout`.
-        let fire_count = body.matches("tx.send(())").count();
+        // STREAM_COMPLETION_TIMEOUT stall.
+        //
+        // Post-#4235 the signal carries a `BroadcastDeliveryOutcome` instead
+        // of `()`, and every drop arm reports `Dropped` so the broadcast queue
+        // releases the permit WITHOUT treating the drop as a delivery. Counting
+        // `Dropped` fires here pins both invariants at once: a regression that
+        // dropped an arm OR that mislabeled a drop arm as `Delivered` (the
+        // exact conflation #4235 fixed) trips this assertion. Tested
+        // behaviourally by `stream_send_pattern_fires_completion_tx_on_timeout`.
+        let fire_count = body
+            .matches("tx.send(BroadcastDeliveryOutcome::Dropped)")
+            .count();
         assert_eq!(
             fire_count, 3,
-            "StreamSend dispatch must signal completion_tx in all three \
-             non-success arms (closed / timeout / no-connection) — found \
-             {fire_count} `tx.send(())` occurrences, expected exactly 3. \
-             If you REMOVED one, a refactor reintroduced the 120 s \
-             STREAM_COMPLETION_TIMEOUT stall (#4145). If you ADDED a new \
-             arm with its own fire, bump this count to match. Body:\n{body}"
+            "StreamSend dispatch must signal completion_tx with \
+             BroadcastDeliveryOutcome::Dropped in all three non-success arms \
+             (closed / timeout / no-connection) — found {fire_count} such \
+             occurrences, expected exactly 3. If you REMOVED one, a refactor \
+             reintroduced the 120 s STREAM_COMPLETION_TIMEOUT stall (#4145). \
+             If you relabeled a drop arm as Delivered, you reintroduced the \
+             delivery/permit conflation (#4235). If you ADDED a new arm with \
+             its own fire, bump this count to match. Body:\n{body}"
         );
     }
 

--- a/crates/core/src/node/network_bridge/priority_select/tests.rs
+++ b/crates/core/src/node/network_bridge/priority_select/tests.rs
@@ -2818,7 +2818,9 @@ impl crate::transport::PeerConnectionApi for MockPeerConnection {
         _stream_id: crate::transport::peer_connection::StreamId,
         _data: bytes::Bytes,
         _metadata: Option<bytes::Bytes>,
-        _completion_tx: Option<tokio::sync::oneshot::Sender<()>>,
+        _completion_tx: Option<
+            tokio::sync::oneshot::Sender<crate::transport::BroadcastDeliveryOutcome>,
+        >,
     ) -> std::pin::Pin<
         Box<
             dyn std::future::Future<Output = Result<(), crate::transport::TransportError>>
@@ -2826,9 +2828,10 @@ impl crate::transport::PeerConnectionApi for MockPeerConnection {
                 + '_,
         >,
     > {
-        // Signal completion so callers awaiting the oneshot don't hang
+        // Signal completion so callers awaiting the oneshot don't hang. The mock
+        // stands in for a successful transfer, so report a delivery (#4235).
         if let Some(tx) = _completion_tx {
-            let _ignored = tx.send(());
+            let _ignored = tx.send(crate::transport::BroadcastDeliveryOutcome::Delivered);
         }
         Box::pin(async { Ok(()) })
     }

--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -590,6 +590,37 @@ impl Socket for UdpSocket {
 
 use crate::message::NetMessage;
 
+/// Outcome carried by the broadcast-queue stream-completion oneshot.
+///
+/// The broadcast queue holds a semaphore permit while a streaming broadcast is
+/// in flight and releases it when the completion signal fires. Historically the
+/// signal was a bare `()` and the queue treated *any* signal as a successful
+/// delivery (issue #4235). That conflated two unrelated facts:
+///
+/// 1. **Permit release** — the permit MUST be released in every terminal case
+///    (delivered, dropped, timed out) so concurrency slots are never leaked.
+/// 2. **Delivery success** — only an actual transfer completion should refresh
+///    the peer's interest TTL and cache its summary.
+///
+/// Several drop paths (peer channel closed, congestion timeout per #4145,
+/// no connection, transport send error) fire the signal purely to release the
+/// permit. Carrying an explicit outcome lets the queue release the permit in
+/// all cases while only treating `Delivered` as a real send.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BroadcastDeliveryOutcome {
+    /// All stream fragments were transmitted (the last fragment was handed to
+    /// the packet sender). Signaled after the final fragment leaves the sender,
+    /// NOT after a receiver ACK — this path has no end-to-end delivery
+    /// acknowledgement. It is the strongest "the send actually happened" signal
+    /// the broadcast queue can observe, as distinct from the message being
+    /// dropped before/while transmitting.
+    Delivered,
+    /// The stream fragment was dropped before/while transferring (channel
+    /// closed, congestion timeout, no connection, transport send error). The
+    /// permit is released but the message was NOT delivered.
+    Dropped,
+}
+
 /// Type-erased interface for peer connections.
 ///
 /// This trait provides the minimal interface needed by `peer_connection_listener`
@@ -634,14 +665,16 @@ pub(crate) trait PeerConnectionApi: Send {
     /// the legacy InboundStream decode path.
     ///
     /// If `completion_tx` is provided, it will be signaled when the stream transfer
-    /// completes (success or failure). Used by the broadcast queue to track when the
-    /// actual data transfer finishes, not just when the send is enqueued.
+    /// completes, carrying a [`BroadcastDeliveryOutcome`] that distinguishes an
+    /// actual delivery from a drop (see #4235). Used by the broadcast queue to
+    /// release its semaphore permit in all cases while only treating a real
+    /// delivery as a successful send.
     fn send_stream_data(
         &mut self,
         stream_id: crate::transport::peer_connection::StreamId,
         data: bytes::Bytes,
         metadata: Option<bytes::Bytes>,
-        completion_tx: Option<tokio::sync::oneshot::Sender<()>>,
+        completion_tx: Option<tokio::sync::oneshot::Sender<BroadcastDeliveryOutcome>>,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + '_>>;
 
     /// Pipes an inbound stream to the remote peer, forwarding fragments as they arrive.

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -1914,14 +1914,15 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
     /// in the metadata message and must match the data stream.
     ///
     /// If `completion_tx` is provided, it will be signaled when the stream
-    /// transfer completes (success or failure). Used by the broadcast queue
+    /// transfer completes, carrying a [`BroadcastDeliveryOutcome`] that
+    /// distinguishes delivery from a drop (#4235). Used by the broadcast queue
     /// to hold a semaphore permit until the actual transfer finishes.
     async fn outbound_stream_with_id(
         &mut self,
         stream_id: StreamId,
         data: bytes::Bytes,
         metadata: Option<bytes::Bytes>,
-        completion_tx: Option<tokio::sync::oneshot::Sender<()>>,
+        completion_tx: Option<tokio::sync::oneshot::Sender<super::BroadcastDeliveryOutcome>>,
     ) {
         let task = GlobalExecutor::spawn(
             outbound_stream::send_stream(
@@ -2290,7 +2291,7 @@ impl<S: super::Socket> super::PeerConnectionApi for PeerConnection<S> {
         stream_id: StreamId,
         data: bytes::Bytes,
         metadata: Option<bytes::Bytes>,
-        completion_tx: Option<tokio::sync::oneshot::Sender<()>>,
+        completion_tx: Option<tokio::sync::oneshot::Sender<super::BroadcastDeliveryOutcome>>,
     ) -> std::pin::Pin<
         Box<dyn futures::Future<Output = Result<(), super::TransportError>> + Send + '_>,
     > {

--- a/crates/core/src/transport/peer_connection/outbound_stream.rs
+++ b/crates/core/src/transport/peer_connection/outbound_stream.rs
@@ -71,7 +71,7 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
     congestion_controller: Arc<CongestionController<T>>,
     time_source: T,
     metadata: Option<Bytes>,
-    completion_tx: Option<oneshot::Sender<()>>,
+    completion_tx: Option<oneshot::Sender<crate::transport::BroadcastDeliveryOutcome>>,
 ) -> Result<TransferStats, TransportError> {
     let start_time = time_source.now();
     let bytes_to_send = stream_to_send.len() as u64;
@@ -185,10 +185,11 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
                 //
                 // NOTE: `completion_tx` is intentionally NOT signaled here — it
                 // is dropped by this early return. broadcast_queue awaits it with
-                // a timeout and treats the resulting oneshot RecvError as
-                // completion (broadcast_queue.rs: `Ok(Err(_))` arm), releasing the
-                // permit immediately. Do NOT "fix" this by adding a blocking
-                // `tx.send(())` here — a blocking send in this stream task is the
+                // a timeout and treats the resulting oneshot RecvError as a
+                // *drop, not a delivery* (broadcast_queue.rs: `Ok(Err(_))` arm,
+                // #4235), releasing the permit immediately without refreshing
+                // peer interest. Do NOT "fix" this by adding a blocking
+                // `tx.send(..)` here — a blocking send in this stream task is the
                 // backpressure pattern channel-safety.md warns against.
                 return Err(TransportError::OutboundStreamFailed(destination_addr));
             }
@@ -295,10 +296,12 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
                 elapsed.as_millis() as u64,
                 TransferDirection::Send,
             );
-            // Signal completion (error path) so broadcast queue can release permit
+            // Signal completion (error path) so broadcast queue can release the
+            // permit. The transfer failed mid-flight, so report a drop (#4235):
+            // the queue must NOT treat this as a delivery.
             if let Some(tx) = completion_tx {
                 // Receiver may be dropped if queue timed out; ignore the error.
-                let _ignored = tx.send(());
+                let _ignored = tx.send(crate::transport::BroadcastDeliveryOutcome::Dropped);
             }
             return Err(e);
         }
@@ -347,10 +350,12 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
         TransferDirection::Send,
     );
 
-    // Signal completion (success path) so broadcast queue can release permit
+    // Signal completion (success path) so broadcast queue can release the
+    // permit. The transfer completed end-to-end, so report a real delivery
+    // (#4235) — only this case refreshes peer interest / caches the summary.
     if let Some(tx) = completion_tx {
         // Receiver may be dropped if queue timed out; ignore the error.
-        let _ignored = tx.send(());
+        let _ignored = tx.send(crate::transport::BroadcastDeliveryOutcome::Delivered);
     }
 
     Ok(TransferStats {
@@ -1184,6 +1189,147 @@ mod tests {
             "cwnd timeout must be classified transient so the connection survives: {err:?}"
         );
 
+        Ok(())
+    }
+
+    /// Issue #4235 — producer-side emission: a `send_stream` that runs to a
+    /// successful completion MUST signal `BroadcastDeliveryOutcome::Delivered`
+    /// on its `completion_tx`.
+    ///
+    /// The broadcast queue gates interest-refresh / summary-cache on this exact
+    /// outcome. If the success arm regressed to emit `Dropped` (or stopped
+    /// emitting), the queue would suppress interest refresh on real deliveries —
+    /// the inverse of #4235's symptom — and silently stop re-converging peers.
+    #[tokio::test]
+    async fn send_stream_success_signals_delivered() -> Result<(), Box<dyn std::error::Error>> {
+        let (outbound_sender, mut outbound_receiver) = mpsc::channel(1);
+        let remote_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8080);
+        let mut message = vec![0u8; 100_000];
+        crate::config::GlobalRng::fill_bytes(&mut message);
+        let cipher = {
+            let mut key = [0u8; 16];
+            crate::config::GlobalRng::fill_bytes(&mut key);
+            Aes128Gcm::new(&key.into())
+        };
+
+        // VirtualTime + a cwnd/token bucket large enough that no sleeping or
+        // cwnd waiting is needed (mirrors test_send_stream_success).
+        let time_source = VirtualTime::new();
+        let sent_tracker = Arc::new(parking_lot::Mutex::new(
+            SentPacketTracker::new_with_time_source(time_source.clone()),
+        ));
+        let congestion_controller = CongestionControlConfig::from_ledbat_config(LedbatConfig {
+            initial_cwnd: 1_000_000,
+            min_cwnd: 1_000_000,
+            max_cwnd: 1_000_000_000,
+            ..Default::default()
+        })
+        .build_arc_with_time_source(time_source.clone());
+        let token_bucket = Arc::new(TokenBucket::new_with_time_source(
+            1_000_000,
+            10_000_000,
+            time_source.clone(),
+        ));
+
+        let (completion_tx, completion_rx) = oneshot::channel();
+        let background_task = GlobalExecutor::spawn(send_stream(
+            StreamId::next(),
+            Arc::new(AtomicU32::new(0)),
+            Arc::new(TestSocket::new(outbound_sender)),
+            remote_addr,
+            Bytes::from(message.clone()),
+            cipher.clone(),
+            sent_tracker,
+            token_bucket,
+            congestion_controller,
+            time_source,
+            None,
+            Some(completion_tx),
+        ));
+
+        // Drain the socket so the stream can run to completion.
+        while outbound_receiver.recv().await.is_some() {}
+
+        let result = background_task.await?;
+        assert!(result.is_ok(), "send_stream should succeed: {result:?}");
+        assert_eq!(
+            completion_rx.await,
+            Ok(crate::transport::BroadcastDeliveryOutcome::Delivered),
+            "a successful stream MUST signal Delivered (#4235)"
+        );
+        Ok(())
+    }
+
+    /// Issue #4235 — producer-side emission: a `send_stream` that fails mid-flight
+    /// (a `packet_sending` error) MUST signal `BroadcastDeliveryOutcome::Dropped`
+    /// on its `completion_tx`, so the broadcast queue releases the permit WITHOUT
+    /// refreshing interest or caching the summary.
+    ///
+    /// The failure is induced by dropping the outbound socket receiver before the
+    /// stream starts: `TestSocket::send_to` then returns `ConnectionAborted`, so
+    /// the first `packet_sending` call errors and the error arm runs. A large
+    /// cwnd ensures the cwnd-wait early return (which drops the oneshot instead
+    /// of signaling) is NOT taken — we want the explicit `Dropped` send.
+    #[tokio::test]
+    async fn send_stream_failure_signals_dropped() -> Result<(), Box<dyn std::error::Error>> {
+        let (outbound_sender, outbound_receiver) = mpsc::channel(1);
+        // Drop the receiver: every TestSocket::send_to now fails with
+        // ConnectionAborted, so the first packet_sending() errors out.
+        drop(outbound_receiver);
+
+        let remote_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8080);
+        let message = vec![0u8; 10_000];
+        let cipher = {
+            let mut key = [0u8; 16];
+            crate::config::GlobalRng::fill_bytes(&mut key);
+            Aes128Gcm::new(&key.into())
+        };
+
+        let time_source = VirtualTime::new();
+        let sent_tracker = Arc::new(parking_lot::Mutex::new(
+            SentPacketTracker::new_with_time_source(time_source.clone()),
+        ));
+        // Large cwnd so we reach packet_sending immediately rather than the
+        // cwnd-wait early return (which would drop the oneshot, not send Dropped).
+        let congestion_controller = CongestionControlConfig::from_ledbat_config(LedbatConfig {
+            initial_cwnd: 1_000_000,
+            min_cwnd: 1_000_000,
+            max_cwnd: 1_000_000_000,
+            ..Default::default()
+        })
+        .build_arc_with_time_source(time_source.clone());
+        let token_bucket = Arc::new(TokenBucket::new_with_time_source(
+            1_000_000,
+            10_000_000,
+            time_source.clone(),
+        ));
+
+        let (completion_tx, completion_rx) = oneshot::channel();
+        let background_task = GlobalExecutor::spawn(send_stream(
+            StreamId::next(),
+            Arc::new(AtomicU32::new(0)),
+            Arc::new(TestSocket::new(outbound_sender)),
+            remote_addr,
+            Bytes::from(message),
+            cipher,
+            sent_tracker,
+            token_bucket,
+            congestion_controller,
+            time_source,
+            None,
+            Some(completion_tx),
+        ));
+
+        let result = background_task.await?;
+        assert!(
+            result.is_err(),
+            "send_stream should fail when the socket is closed: {result:?}"
+        );
+        assert_eq!(
+            completion_rx.await,
+            Ok(crate::transport::BroadcastDeliveryOutcome::Dropped),
+            "a mid-flight send failure MUST signal Dropped (#4235)"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

The broadcast queue holds a semaphore permit while a streaming broadcast is in flight and releases it when a completion oneshot fires. The signal was a bare `()` and the queue treated **any** completion as a successful delivery — it computed `send_ok = send_result.is_ok()` (true once the `StreamSend` was merely enqueued) and downstream refreshed the peer's interest TTL and cached its summary on that basis.

But the completion fires in **every** terminal case so the permit is never leaked — including drops: peer channel closed, congestion timeout (#4145), no connection, transport send error, and the cwnd-wait early return (which drops the oneshot, surfacing as a `RecvError` the queue also treated as success). Refreshing interest on a send that never landed extends the peer's TTL falsely; caching the summary suppresses the next summary-mismatch round that should have re-sent the dropped state.

## Solution

Carry an explicit `BroadcastDeliveryOutcome { Delivered, Dropped }` on the completion oneshot instead of `()`. Every drop path reports `Dropped`; the outbound stream's success path reports `Delivered` (after all fragments are handed to `packet_sending` — not a receiver ACK). The queue now **releases the permit in all cases** but records the send, refreshes peer interest, and caches the summary only on `Delivered` (a timeout or a dropped oneshot is also treated as a drop).

The `()` → `BroadcastDeliveryOutcome` change is the necessary mechanical propagation through the completion-oneshot call chain (`transport.rs` defines the type; `outbound_stream.rs` / `peer_connection.rs` fire it; `p2p_protoc.rs` dispatches). No scope creep; wire format untouched (the outcome is an in-process oneshot payload). The #4145 immediate-permit-release-on-timeout invariant is preserved.

**Telemetry note:** on the streaming path, `record_delta_send` / `record_full_state_send` / `GlobalTestMetrics` now fire only on `Delivered` (previously on enqueue success) — intrinsic to the fix and arguably more correct.

## Testing

- `streaming_completion_delivered_only_on_explicit_delivery` — only explicit `Delivered` classifies as delivery; `Dropped`, a dropped oneshot, and a wait timeout do not.
- `drop_outcome_does_not_refresh_interest_or_cache_summary` — drives the **real production gate** (`record_streaming_delivery`) against a real `InterestManager<SharedMockTimeSource>` and proves a dropped/timed-out broadcast neither refreshes the interest TTL nor caches the peer summary, while a real delivery does both. Verified to fail when the production gate binding is reverted to the pre-fix conflation (not just the standalone classifier).
- `send_stream_success_signals_delivered` / `send_stream_failure_signals_dropped` — producer-side: `send_stream` emits `Delivered` on success and `Dropped` on a `packet_sending` error.
- `p2p_protoc.rs` dispatch pins assert the drop arms signal `Dropped`.
- `cargo clippy -p freenet --locked -- -D warnings` clean; `broadcast_queue::` (2) + `outbound_stream::` (11) tests pass.

These guard the extracted helper + InterestManager wiring + the production-gate binding, validated by an in-branch revert (the new types/helpers do not compile against pre-fix `main`, so a literal bisect is N/A).

## Fixes

Fixes #4235