### PR TITLE
fix(transport): release flight-size on stream abort (#4345)

### DIFF
--- a/.claude/rules/transport.md
+++ b/.claude/rules/transport.md
@@ -86,20 +86,44 @@ BEFORE changing LEDBAT++ parameters:
 ### Flight-size release invariant (issue #4345)
 
 ```
-Flight size MUST have a release path other than ACK. A packet whose ACKs
-never arrive (lossy path / starved reverse-ACK channel) is retransmitted up
-to MAX_PACKET_RETRANSMITS times, then SentPacketTracker returns
-ResendAction::Abandon and the recv loop calls
-CongestionControl::release_flightsize(len). Without this, a never-ACKed
-packet's on_send bytes stay in flight size for the connection's life,
-pinning flight size at cwnd and stalling every subsequent stream
-(the #4345 "cwnd wait timeout" / "no fragments received" failure).
+Flight size has THREE release paths. ACK is the normal one; the other two
+exist so a stream whose ACKs never arrive (lossy path / starved reverse-ACK
+channel) cannot pin flight size at cwnd and stall every subsequent stream
+(the #4345 "cwnd wait timeout" / "no fragments received" failure):
+
+  1. ACK — report_received_receipts returns the packet size; the recv loop
+     calls on_ack* which decrements flight size.
+  2. ABANDON — after MAX_PACKET_RETRANSMITS with no ACK, SentPacketTracker
+     returns ResendAction::Abandon and the recv loop calls
+     CongestionControl::release_flightsize(len). Bounds the worst case for a
+     black-holed individual packet.
+  3. STREAM ABORT (drop_stream) — when an outbound stream aborts (cwnd-wait
+     timeout, upstream stall/error, or mid-send failure in
+     outbound_stream.rs), release_aborted_stream_flightsize() calls
+     SentPacketTracker::drop_stream(stream_id), which removes ALL of that
+     stream's still-tracked packets and returns their byte total; the abort
+     then release_flightsize(total). This frees the stranded bytes in one
+     shot instead of waiting ~6s for each fragment to abandon individually.
+
+Each in-flight packet is released EXACTLY ONCE across these paths, because
+drop_stream / Abandon / ACK each REMOVE the packet from pending_receipts; a
+packet absent from pending_receipts yields no ack-info and cannot abandon.
 
   - on_timeout() applies the cwnd loss response only; it MUST NOT change
     flight size (the timed-out packet is immediately re-sent and stays in
     flight). Do NOT reintroduce a decrement-on-RTO + re-add-on-resend pair —
     the recv loop always re-sends on RTO, so that is net-zero and does not
     drain a never-ACKed packet.
+  - get_resend KEEPS a resent packet in pending_receipts (clones the payload,
+    refreshes send-time in place). This is what lets a concurrent drop_stream
+    (spawned abort task) still see and release an in-flight-being-resent
+    packet. Pure tracker bookkeeping — it does NOT touch flight size.
+  - The recv loop's resend re-registration MUST use refresh_sent_packet
+    (update-only, no-op if the packet was already removed), NOT
+    report_sent_packet (insert-capable). Using the insert path would
+    RESURRECT a packet that a concurrent drop_stream just removed+released,
+    and a later ACK/abandon of that zombie would release its bytes a SECOND
+    time (flight-size under-count). See #4345 stage-2 review.
   - Retransmissions MUST stay bounded. Do not make retransmit infinite again.
 ```
 

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -1351,9 +1351,13 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                             .await
                         {
                             Ok(_) => {
-                                // Re-register packet for ACK/RTO tracking. Flight size is
-                                // unchanged: the packet never left flight (on_timeout did not
-                                // decrement), so neither on_send() nor a re-add is called.
+                                // Refresh the packet's send timestamp to the actual
+                                // post-send instant. Since #4345, get_resend KEEPS the
+                                // packet in the tracker across a resend, so this is an
+                                // idempotent in-place refresh (NOT a re-insert) that
+                                // preserves the packet's stream tag. Flight size is
+                                // unchanged: the packet never left flight (on_timeout did
+                                // not decrement), so neither on_send() nor a re-add runs.
                                 self.remote_conn.sent_tracker.lock().report_sent_packet(idx, packet);
                             }
                             Err(e) => {
@@ -1363,9 +1367,9 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                                     error = %e,
                                     "Resend send failed, will retry on next RTO"
                                 );
-                                // Re-insert packet so RTO will retry it. Without this,
-                                // the packet would be permanently lost from tracking since
-                                // resend_check() already removed it.
+                                // The packet is still tracked (get_resend keeps it since
+                                // #4345), so RTO will retry it. This refresh is harmless;
+                                // we keep it so the send-time reflects this attempt.
                                 self.remote_conn
                                     .sent_tracker
                                     .lock()

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -1363,7 +1363,23 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                                 // still tracked, flight size is unchanged: it never left
                                 // flight (on_timeout did not decrement), so no on_send /
                                 // re-add runs. See refresh_sent_packet's rustdoc.
-                                self.remote_conn.sent_tracker.lock().refresh_sent_packet(idx, packet, None);
+                                //
+                                // `false` (the deliberate no-op-on-drop) is the
+                                // resurrection-safe path, not an error — surface it at
+                                // trace level rather than silently discarding the bool.
+                                let still_tracked = self
+                                    .remote_conn
+                                    .sent_tracker
+                                    .lock()
+                                    .refresh_sent_packet(idx, packet, None);
+                                if !still_tracked {
+                                    tracing::trace!(
+                                        peer_addr = %self.remote_conn.remote_addr,
+                                        packet_id = idx,
+                                        "Resent packet was dropped (stream aborted) before \
+                                         re-registration — refresh no-op (#4345)"
+                                    );
+                                }
                             }
                             Err(e) => {
                                 tracing::warn!(
@@ -1376,7 +1392,11 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                                 // If a concurrent drop_stream already removed it, this
                                 // no-ops (the stream is being torn down anyway), avoiding
                                 // a resurrected zombie. See refresh_sent_packet's rustdoc.
-                                self.remote_conn
+                                // The bool is intentionally discarded: on this error path
+                                // we're breaking out regardless of whether the packet was
+                                // still tracked.
+                                let _ = self
+                                    .remote_conn
                                     .sent_tracker
                                     .lock()
                                     .refresh_sent_packet(idx, packet, None);

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -44,7 +44,7 @@ use super::{
     packet_data::{self, PacketData},
     received_packet_tracker::ReceivedPacketTracker,
     received_packet_tracker::ReportResult,
-    sent_packet_tracker::{ResendAction, SentPacketTracker},
+    sent_packet_tracker::{PacketStream, ResendAction, SentPacketTracker},
     symmetric_message::{self, SymmetricMessage, SymmetricMessagePayload},
     token_bucket::TokenBucket,
 };
@@ -1822,6 +1822,7 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
             (),
             &self.remote_conn.sent_tracker,
             token,
+            PacketStream::Control,
         )
         .await
     }
@@ -1898,6 +1899,7 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
             symmetric_message::ShortMessage(data.into()),
             &self.remote_conn.sent_tracker,
             token,
+            PacketStream::Control,
         )
         .await?;
         Ok(())
@@ -2077,6 +2079,7 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
             },
             &self.remote_conn.sent_tracker,
             token,
+            PacketStream::Stream(fragment.stream_id),
         )
         .await?;
 
@@ -2091,6 +2094,30 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
     }
 }
 
+/// Register a freshly-sent packet with the tracker, tagging it with its owning
+/// stream for flight-size accounting (issue #4345).
+///
+/// `Stream(id)` first sends route to `report_sent_stream_packet` (which records
+/// the tag); `Control` sends route to `report_sent_packet_with_token` (which
+/// preserves any existing tag, so resend re-registration of a stream fragment
+/// keeps its stream, and genuinely-new control packets stay `Control`).
+fn report_sent_tagged<T: crate::simulation::TimeSource>(
+    tracker: &mut SentPacketTracker<T>,
+    packet_id: u32,
+    payload: Box<[u8]>,
+    delivery_token: Option<DeliveryRateToken>,
+    stream: PacketStream,
+) {
+    match stream {
+        PacketStream::Stream(stream_id) => {
+            tracker.report_sent_stream_packet(packet_id, payload, delivery_token, stream_id);
+        }
+        PacketStream::Control => {
+            tracker.report_sent_packet_with_token(packet_id, payload, delivery_token);
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn packet_sending<S: super::Socket, T: crate::simulation::TimeSource>(
     remote_addr: SocketAddr,
@@ -2101,6 +2128,11 @@ async fn packet_sending<S: super::Socket, T: crate::simulation::TimeSource>(
     payload: impl Into<SymmetricMessagePayload>,
     sent_tracker: &parking_lot::Mutex<SentPacketTracker<T>>,
     delivery_token: Option<DeliveryRateToken>,
+    // Owning stream for flight-size accounting (issue #4345). `Stream(id)` for
+    // `StreamFragment` sends so an aborted stream's bytes can be released
+    // atomically via `SentPacketTracker::drop_stream`; `Control` for everything
+    // else (handshake, NoOp, short message).
+    stream: PacketStream,
 ) -> Result<()> {
     let start_time = tokio::time::Instant::now();
     tracing::trace!(
@@ -2146,10 +2178,12 @@ async fn packet_sending<S: super::Socket, T: crate::simulation::TimeSource>(
                     // Record the classified on-wire bytes once the packet
                     // is actually sent (not on the error path).
                     super::shadow_demand::record_outbound(outbound_class, packet_data.len());
-                    sent_tracker.lock().report_sent_packet_with_token(
+                    report_sent_tagged(
+                        &mut sent_tracker.lock(),
                         packet_id,
                         packet_data,
                         delivery_token,
+                        stream,
                     );
                     Ok(())
                 }
@@ -2191,10 +2225,12 @@ async fn packet_sending<S: super::Socket, T: crate::simulation::TimeSource>(
                             .await
                             .map_err(|e| TransportError::SendFailed(remote_addr, e.kind()))?;
                         sent_on_wire += packet_data.len();
-                        sent_tracker.lock().report_sent_packet_with_token(
+                        report_sent_tagged(
+                            &mut sent_tracker.lock(),
                             packet_id,
                             packet_data,
                             delivery_token,
+                            stream,
                         );
                     }
                 }};
@@ -2453,6 +2489,7 @@ mod tests {
                 (),
                 &sent_tracker,
                 None,
+                PacketStream::Control,
             )
             .await;
 
@@ -2513,6 +2550,7 @@ mod tests {
                 },
                 &sent_tracker,
                 None,
+                PacketStream::Control,
             )
             .await
             .expect("short send should succeed");
@@ -2524,6 +2562,7 @@ mod tests {
             );
 
             // ---- success: StreamFragment advances `bulk` ----
+            let frag_stream_id = StreamId::next();
             packet_sending(
                 remote_addr,
                 &socket,
@@ -2531,7 +2570,7 @@ mod tests {
                 &outbound_key,
                 vec![],
                 SymmetricMessagePayload::StreamFragment {
-                    stream_id: StreamId::next(),
+                    stream_id: frag_stream_id,
                     total_length_bytes: 300,
                     fragment_number: 0,
                     payload: bytes::Bytes::from(vec![9u8; 300]),
@@ -2539,6 +2578,7 @@ mod tests {
                 },
                 &sent_tracker,
                 None,
+                PacketStream::Stream(frag_stream_id),
             )
             .await
             .expect("stream fragment send should succeed");
@@ -2565,6 +2605,7 @@ mod tests {
                 },
                 &sent_tracker,
                 None,
+                PacketStream::Control,
             )
             .await;
             assert!(res.is_err(), "failing socket must return Err");

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -1352,13 +1352,18 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                         {
                             Ok(_) => {
                                 // Refresh the packet's send timestamp to the actual
-                                // post-send instant. Since #4345, get_resend KEEPS the
+                                // post-send instant. Since #4345 get_resend KEEPS the
                                 // packet in the tracker across a resend, so this is an
-                                // idempotent in-place refresh (NOT a re-insert) that
-                                // preserves the packet's stream tag. Flight size is
-                                // unchanged: the packet never left flight (on_timeout did
-                                // not decrement), so neither on_send() nor a re-add runs.
-                                self.remote_conn.sent_tracker.lock().report_sent_packet(idx, packet);
+                                // in-place refresh — BUT only if the packet is still
+                                // tracked. A concurrent drop_stream (spawned abort task)
+                                // may have removed and released it while we were awaiting
+                                // send_to; refresh_sent_packet then no-ops instead of
+                                // resurrecting it as a Control zombie (which a later
+                                // ACK/abandon would double-release). When the packet IS
+                                // still tracked, flight size is unchanged: it never left
+                                // flight (on_timeout did not decrement), so no on_send /
+                                // re-add runs. See refresh_sent_packet's rustdoc.
+                                self.remote_conn.sent_tracker.lock().refresh_sent_packet(idx, packet, None);
                             }
                             Err(e) => {
                                 tracing::warn!(
@@ -1367,13 +1372,14 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                                     error = %e,
                                     "Resend send failed, will retry on next RTO"
                                 );
-                                // The packet is still tracked (get_resend keeps it since
-                                // #4345), so RTO will retry it. This refresh is harmless;
-                                // we keep it so the send-time reflects this attempt.
+                                // Refresh only if still tracked — RTO then retries it.
+                                // If a concurrent drop_stream already removed it, this
+                                // no-ops (the stream is being torn down anyway), avoiding
+                                // a resurrected zombie. See refresh_sent_packet's rustdoc.
                                 self.remote_conn
                                     .sent_tracker
                                     .lock()
-                                    .report_sent_packet(idx, packet);
+                                    .refresh_sent_packet(idx, packet, None);
                                 break;
                             }
                         }

--- a/crates/core/src/transport/peer_connection/outbound_stream.rs
+++ b/crates/core/src/transport/peer_connection/outbound_stream.rs
@@ -36,6 +36,47 @@ use super::streaming::StreamHandle;
 /// to fail and report before the receiver's inactivity timeout fires.
 const CWND_WAIT_TIMEOUT: Duration = Duration::from_secs(3);
 
+/// Release the in-flight bytes of an aborting outbound stream from the
+/// connection's flight size (issue #4345).
+///
+/// When a stream aborts (cwnd-wait timeout, upstream stall/error, or a mid-send
+/// `packet_sending` failure) its already-sent, unacked fragments are still
+/// counted in the connection-wide flight size. Without this they stay pinned
+/// until each fragment is independently ACKed or ages out via
+/// `MAX_PACKET_RETRANSMITS` (~6s) — and FixedRate's loss-pause caps cwnd at the
+/// frozen flight size, so a single aborted stream starves every subsequent
+/// stream on the connection (the #4345 symptom). `drop_stream` removes the
+/// stream's packets from the tracker and returns their exact byte total, which
+/// we hand to `release_flightsize` so the next stream sees an open cwnd.
+///
+/// # Locking
+///
+/// Mirrors the ACK path's ordering (`peer_connection.rs`): the tracker lock is
+/// dropped BEFORE calling into the congestion controller, so the tracker mutex
+/// is never held across a `release_flightsize` call (and never across an
+/// `.await` — neither call awaits). This avoids any tracker↔controller
+/// lock-ordering hazard.
+///
+/// Idempotent and cheap on the common path: a stream with no in-flight packets
+/// (already fully ACKed, or zero fragments sent) drops nothing and releases 0.
+fn release_aborted_stream_flightsize<T: TimeSource>(
+    stream_id: StreamId,
+    sent_packet_tracker: &parking_lot::Mutex<SentPacketTracker<T>>,
+    congestion_controller: &CongestionController<T>,
+) {
+    let released = sent_packet_tracker.lock().drop_stream(stream_id);
+    if released > 0 {
+        // u64 -> usize: a connection's in-flight bytes never approach usize::MAX
+        // on any supported platform; saturate defensively rather than wrap.
+        congestion_controller.release_flightsize(released.min(usize::MAX as u64) as usize);
+        tracing::debug!(
+            stream_id = %stream_id.0,
+            released_bytes = released,
+            "Released aborted stream's in-flight bytes from flight size (#4345)"
+        );
+    }
+}
+
 // Compile-time guard: sender must fail before receiver so the failure is diagnostic.
 const _: () = assert!(
     CWND_WAIT_TIMEOUT.as_secs() < super::streaming::STREAM_INACTIVITY_TIMEOUT.as_secs(),
@@ -183,6 +224,14 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
                 // multiplexed on it. The op layer times out and retries against
                 // another candidate; the idle timeout decides connection liveness.
                 //
+                // Release this stream's already-sent in-flight bytes so the
+                // frozen flight size doesn't starve the next stream (#4345).
+                release_aborted_stream_flightsize(
+                    stream_id,
+                    sent_packet_tracker.as_ref(),
+                    congestion_controller.as_ref(),
+                );
+                //
                 // NOTE: `completion_tx` is intentionally NOT signaled here — it
                 // is dropped by this early return. broadcast_queue awaits it with
                 // a timeout and treats the resulting oneshot RecvError as a
@@ -297,6 +346,18 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
                 elapsed.as_millis() as u64,
                 TransferDirection::Send,
             );
+            // Release this stream's in-flight bytes (#4345). Two parts:
+            // (1) drop_stream releases the already-sent, tracked fragments;
+            // (2) the CURRENT fragment's on_send bytes were added to flight size
+            //     just above (`on_send_with_token`) but the send failed, so the
+            //     packet was never registered in the tracker — drop_stream can't
+            //     see it. Release packet_size explicitly so those bytes don't leak.
+            release_aborted_stream_flightsize(
+                stream_id,
+                sent_packet_tracker.as_ref(),
+                congestion_controller.as_ref(),
+            );
+            congestion_controller.release_flightsize(packet_size);
             // Signal completion (error path) so broadcast queue can release the
             // permit. The transfer failed mid-flight, so report a drop (#4235):
             // the queue must NOT treat this as a delivery.
@@ -471,7 +532,13 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
                 // connection — fail only this stream so other ops multiplexed
                 // on the downstream connection survive (#4345). The op layer
                 // times out and retries; the idle timeout decides connection
-                // liveness.
+                // liveness. Release the bytes already forwarded for this stream
+                // so the frozen flight size doesn't starve the next stream.
+                release_aborted_stream_flightsize(
+                    outbound_stream_id,
+                    sent_packet_tracker.as_ref(),
+                    congestion_controller.as_ref(),
+                );
                 return Err(TransportError::OutboundStreamFailed(destination_addr));
             }
         };
@@ -489,7 +556,12 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
                 );
                 // Error is on the UPSTREAM inbound stream, not the downstream
                 // connection — fail only this stream (#4345), same rationale as
-                // the inactivity-stall arm above.
+                // the inactivity-stall arm above. Release already-forwarded bytes.
+                release_aborted_stream_flightsize(
+                    outbound_stream_id,
+                    sent_packet_tracker.as_ref(),
+                    congestion_controller.as_ref(),
+                );
                 return Err(TransportError::OutboundStreamFailed(destination_addr));
             }
         };
@@ -559,7 +631,14 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
                     TransferDirection::Send,
                 );
                 // Fail only this stream, not the connection (#4345). See the
-                // matching site in send_stream for the rationale.
+                // matching site in send_stream for the rationale. Release the
+                // bytes already forwarded for this stream so the frozen flight
+                // size doesn't starve the next stream.
+                release_aborted_stream_flightsize(
+                    outbound_stream_id,
+                    sent_packet_tracker.as_ref(),
+                    congestion_controller.as_ref(),
+                );
                 return Err(TransportError::OutboundStreamFailed(destination_addr));
             }
 
@@ -638,6 +717,16 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
                 elapsed.as_millis() as u64,
                 TransferDirection::Send,
             );
+            // Release this stream's in-flight bytes (#4345): drop_stream for the
+            // already-forwarded tracked fragments, plus packet_size for the
+            // CURRENT fragment whose on_send bytes were added just above but
+            // whose send failed (so it was never registered in the tracker).
+            release_aborted_stream_flightsize(
+                outbound_stream_id,
+                sent_packet_tracker.as_ref(),
+                congestion_controller.as_ref(),
+            );
+            congestion_controller.release_flightsize(packet_size);
             return Err(e);
         }
 
@@ -1233,6 +1322,158 @@ mod tests {
             "cwnd timeout must be classified transient so the connection survives: {err:?}"
         );
 
+        Ok(())
+    }
+
+    /// Core regression for issue #4345: when an outbound stream aborts on a
+    /// cwnd-wait timeout, the fragments it already put in flight MUST be released
+    /// from the connection's flight size immediately — not left pinned until each
+    /// ages out via `MAX_PACKET_RETRANSMITS` (~6s).
+    ///
+    /// Reproduces the stranded-flightsize symptom: a cwnd just large enough for a
+    /// couple of fragments, a socket that accepts sends but NO ACKs ever arrive,
+    /// so flight size climbs to ~cwnd and the next fragment's cwnd wait times out.
+    /// Before the stage-2 wiring, `send_stream` returned the error while leaving
+    /// those bytes in flight; FixedRate/LEDBAT then keep cwnd pinned at the frozen
+    /// flight size and every subsequent stream starves. This test asserts:
+    ///   1. flight size is > 0 at the moment of abort (fragments are stranded),
+    ///   2. flight size is back to 0 once `send_stream` returns (abort released
+    ///      the stream's in-flight bytes via drop_stream + release_flightsize).
+    #[tokio::test(start_paused = true)]
+    async fn cwnd_wait_timeout_releases_stranded_flightsize()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Generous channel + a drain task so sends never block; we never ACK.
+        let (outbound_sender, mut outbound_receiver) = mpsc::channel(1024);
+        let remote_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8080);
+        // ~7 fragments worth of data, but cwnd only admits a couple.
+        let message = vec![0u8; 10_000];
+        let cipher = {
+            let mut key = [0u8; 16];
+            crate::config::GlobalRng::fill_bytes(&mut key);
+            Aes128Gcm::new(&key.into())
+        };
+
+        let time_source = RealTime::new();
+
+        // cwnd admits ~2 fragments (2 * MAX_DATA_SIZE), so a few fragments go out
+        // and fill flight size, then the next fragment's cwnd wait times out.
+        let cwnd = 2 * MAX_DATA_SIZE;
+        let congestion_controller = CongestionControlConfig::from_ledbat_config(LedbatConfig {
+            initial_cwnd: cwnd,
+            min_cwnd: cwnd,
+            max_cwnd: cwnd,
+            ..Default::default()
+        })
+        .build_arc();
+
+        let sent_tracker = Arc::new(parking_lot::Mutex::new(SentPacketTracker::new()));
+        let token_bucket = Arc::new(TokenBucket::new(1_000_000, 100_000_000));
+
+        // Drain the socket so send_to never blocks; deliberately never ACK, so
+        // flight size only ever grows until the abort releases it.
+        let drain =
+            GlobalExecutor::spawn(async move { while outbound_receiver.recv().await.is_some() {} });
+
+        let cc_for_send = congestion_controller.clone();
+        let send_task = GlobalExecutor::spawn(send_stream(
+            StreamId::next(),
+            Arc::new(AtomicU32::new(0)),
+            Arc::new(TestSocket::new(outbound_sender)),
+            remote_addr,
+            Bytes::from(message),
+            cipher,
+            sent_tracker,
+            token_bucket,
+            cc_for_send,
+            time_source,
+            None,
+            None,
+        ));
+
+        let err = send_task
+            .await
+            .expect("join error")
+            .expect_err("cwnd wait should time out");
+        assert!(
+            matches!(err, TransportError::OutboundStreamFailed(addr) if addr == remote_addr),
+            "expected OutboundStreamFailed, got: {err:?}"
+        );
+
+        // The stranded fragments must have been released on abort. With no ACKs,
+        // the ONLY release path is the #4345 abort wiring; without it this reads
+        // ~cwnd (pinned) instead of 0.
+        assert_eq!(
+            congestion_controller.flightsize(),
+            0,
+            "issue #4345: aborting the stream must release its in-flight bytes \
+             (flight size should be drained, was {})",
+            congestion_controller.flightsize()
+        );
+
+        drain.abort();
+        Ok(())
+    }
+
+    /// Issue #4345 (stage 2): aborting a stream that has NO in-flight packets
+    /// (cwnd too small for even the first fragment, so nothing was ever sent)
+    /// must be a clean no-op — drop_stream releases 0 and flight size stays 0.
+    /// Guards against the abort wiring panicking or mis-releasing on the empty
+    /// case.
+    #[tokio::test(start_paused = true)]
+    async fn cwnd_wait_timeout_zero_inflight_is_noop() -> Result<(), Box<dyn std::error::Error>> {
+        let (outbound_sender, _outbound_receiver) = mpsc::channel(100);
+        let remote_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8080);
+        let message = vec![0u8; 10_000];
+        let cipher = {
+            let mut key = [0u8; 16];
+            crate::config::GlobalRng::fill_bytes(&mut key);
+            Aes128Gcm::new(&key.into())
+        };
+
+        let time_source = RealTime::new();
+
+        // 1-byte cwnd: no fragment ever fits, so the FIRST cwnd wait times out
+        // before anything is sent. Flight size is 0 the whole time.
+        let congestion_controller = CongestionControlConfig::from_ledbat_config(LedbatConfig {
+            initial_cwnd: 1,
+            min_cwnd: 1,
+            max_cwnd: 1,
+            ..Default::default()
+        })
+        .build_arc();
+
+        let sent_tracker = Arc::new(parking_lot::Mutex::new(SentPacketTracker::new()));
+        let token_bucket = Arc::new(TokenBucket::new(1_000_000, 100_000_000));
+
+        let cc_for_send = congestion_controller.clone();
+        let send_task = GlobalExecutor::spawn(send_stream(
+            StreamId::next(),
+            Arc::new(AtomicU32::new(0)),
+            Arc::new(TestSocket::new(outbound_sender)),
+            remote_addr,
+            Bytes::from(message),
+            cipher,
+            sent_tracker,
+            token_bucket,
+            cc_for_send,
+            time_source,
+            None,
+            None,
+        ));
+
+        let err = send_task
+            .await
+            .expect("join error")
+            .expect_err("cwnd wait should time out");
+        assert!(
+            matches!(err, TransportError::OutboundStreamFailed(_)),
+            "expected OutboundStreamFailed, got: {err:?}"
+        );
+        assert_eq!(
+            congestion_controller.flightsize(),
+            0,
+            "aborting a stream with zero in-flight packets must keep flight size 0"
+        );
         Ok(())
     }
 

--- a/crates/core/src/transport/peer_connection/outbound_stream.rs
+++ b/crates/core/src/transport/peer_connection/outbound_stream.rs
@@ -352,6 +352,22 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
             //     just above (`on_send_with_token`) but the send failed, so the
             //     packet was never registered in the tracker — drop_stream can't
             //     see it. Release packet_size explicitly so those bytes don't leak.
+            //
+            // CORRECTNESS GUARD: step (2) is correct ONLY because a failed send
+            // never registers the packet. `packet_sending` registers per
+            // successfully-sent packet; with the empty `confirm_receipt` used
+            // here it takes the single-packet path, so a send error means ZERO
+            // registrations and drop_stream cannot have already released this
+            // packet_id. If a future caller passes non-empty receipts (multi-
+            // packet path) some sub-packets could register before a later one
+            // fails — then drop_stream would release them AND this explicit call
+            // would double-count. The debug_assert pins the invariant so that
+            // change trips tests.
+            debug_assert!(
+                !sent_packet_tracker.lock().contains_packet(packet_id),
+                "mid-send failure: failed packet {packet_id} must be absent from \
+                 the tracker before explicit release (else double-release, #4345)"
+            );
             release_aborted_stream_flightsize(
                 stream_id,
                 sent_packet_tracker.as_ref(),
@@ -721,6 +737,19 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
             // already-forwarded tracked fragments, plus packet_size for the
             // CURRENT fragment whose on_send bytes were added just above but
             // whose send failed (so it was never registered in the tracker).
+            //
+            // CORRECTNESS GUARD (same as send_stream's mid-send site): the
+            // explicit packet_size release is correct ONLY because a failed send
+            // never registers the packet — the empty `confirm_receipt` here
+            // forces the single-packet path, so a send error means ZERO
+            // registrations and drop_stream cannot have already released this
+            // packet_id. A future multi-packet wiring would break this; the
+            // debug_assert pins the invariant.
+            debug_assert!(
+                !sent_packet_tracker.lock().contains_packet(packet_id),
+                "mid-send failure: failed packet {packet_id} must be absent from \
+                 the tracker before explicit release (else double-release, #4345)"
+            );
             release_aborted_stream_flightsize(
                 outbound_stream_id,
                 sent_packet_tracker.as_ref(),
@@ -1590,6 +1619,7 @@ mod tests {
         ));
 
         let (completion_tx, completion_rx) = oneshot::channel();
+        let cc_handle = congestion_controller.clone();
         let background_task = GlobalExecutor::spawn(send_stream(
             StreamId::next(),
             Arc::new(AtomicU32::new(0)),
@@ -1614,6 +1644,90 @@ mod tests {
             completion_rx.await,
             Ok(crate::transport::BroadcastDeliveryOutcome::Dropped),
             "a mid-flight send failure MUST signal Dropped (#4235)"
+        );
+        // #4345 mid-send-failure release: the first fragment's on_send bytes were
+        // added to flight size, then its send failed (so it was NEVER registered
+        // in the tracker). The mid-send error path must release exactly those
+        // bytes — once, via the explicit release_flightsize(packet_size) — so
+        // flight size returns to 0. A double-release would saturate to 0 too, but
+        // a future multi-packet wiring (non-empty confirm_receipt) could register
+        // a packet AND hit this path, so the dedicated single-packet guard at the
+        // call site (debug_assert) protects against that; here we pin the net-0.
+        assert_eq!(
+            cc_handle.flightsize(),
+            0,
+            "send_stream mid-send failure must release the failed fragment's bytes (net 0)"
+        );
+        Ok(())
+    }
+
+    /// #4345 mid-send-failure release for the PIPE path (outbound_stream.rs:692).
+    /// Mirror of `send_stream_failure_signals_dropped`'s flight-size assertion
+    /// but driving `pipe_stream`: a fragment is buffered, the socket fails on
+    /// send, and the mid-send error path must release the failed fragment's
+    /// on_send bytes exactly once so flight size returns to 0.
+    #[tokio::test]
+    async fn pipe_stream_mid_send_failure_releases_flightsize()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use crate::transport::peer_connection::streaming::StreamHandle;
+
+        let (outbound_sender, outbound_receiver) = mpsc::channel(1);
+        // Drop the receiver so TestSocket::send_to returns ConnectionAborted on
+        // the first send — the mid-send error path runs.
+        drop(outbound_receiver);
+
+        let remote_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8080);
+        let cipher = {
+            let mut key = [0u8; 16];
+            crate::config::GlobalRng::fill_bytes(&mut key);
+            Aes128Gcm::new(&key.into())
+        };
+
+        let time_source = RealTime::new();
+
+        // One buffered fragment (<= FRAGMENT_PAYLOAD_SIZE, 1130 bytes).
+        let stream_id = StreamId::next();
+        let handle = StreamHandle::new(stream_id, 1000);
+        handle
+            .push_fragment(1, Bytes::from(vec![0u8; 1000]))
+            .unwrap();
+
+        // Large cwnd so the cwnd wait passes immediately and we reach
+        // packet_sending (which then fails on the dead socket).
+        let congestion_controller = CongestionControlConfig::from_ledbat_config(LedbatConfig {
+            initial_cwnd: 1_000_000,
+            min_cwnd: 1_000_000,
+            max_cwnd: 1_000_000_000,
+            ..Default::default()
+        })
+        .build_arc();
+        let sent_tracker = Arc::new(parking_lot::Mutex::new(SentPacketTracker::new()));
+        let token_bucket = Arc::new(TokenBucket::new(1_000_000, 100_000_000));
+
+        let cc_handle = congestion_controller.clone();
+        let pipe_task = GlobalExecutor::spawn(pipe_stream(
+            handle,
+            StreamId::next(),
+            Arc::new(AtomicU32::new(0)),
+            Arc::new(TestSocket::new(outbound_sender)),
+            remote_addr,
+            cipher,
+            sent_tracker,
+            token_bucket,
+            congestion_controller,
+            time_source,
+            None,
+        ));
+
+        let result = pipe_task.await.expect("join error");
+        assert!(
+            result.is_err(),
+            "pipe_stream should fail when the socket is closed: {result:?}"
+        );
+        assert_eq!(
+            cc_handle.flightsize(),
+            0,
+            "pipe_stream mid-send failure must release the failed fragment's bytes (net 0)"
         );
         Ok(())
     }
@@ -1752,6 +1866,7 @@ mod tests {
         let sent_tracker = Arc::new(parking_lot::Mutex::new(SentPacketTracker::new()));
         let token_bucket = Arc::new(TokenBucket::new(1_000_000, 100_000_000));
 
+        let cc_handle = congestion_controller.clone();
         let pipe_task = GlobalExecutor::spawn(pipe_stream(
             handle,
             StreamId::next(),
@@ -1771,6 +1886,14 @@ mod tests {
             matches!(result, Err(TransportError::OutboundStreamFailed(_))),
             "Expected OutboundStreamFailed after pipe_stream cwnd wait timeout, got: {:?}",
             result
+        );
+        // #4345: the abort must leave flight size released. Here a 1-byte cwnd
+        // means no fragment ever went out, so this guards that the abort's
+        // drop_stream is a clean no-op (0) rather than mis-releasing or panicking.
+        assert_eq!(
+            cc_handle.flightsize(),
+            0,
+            "pipe_stream cwnd-wait abort must leave flight size at 0"
         );
 
         Ok(())
@@ -1813,6 +1936,7 @@ mod tests {
         let sent_tracker = Arc::new(parking_lot::Mutex::new(SentPacketTracker::new()));
         let token_bucket = Arc::new(TokenBucket::new(1_000_000, 100_000_000));
 
+        let cc_handle = congestion_controller.clone();
         let pipe_task = GlobalExecutor::spawn(pipe_stream(
             handle,
             StreamId::next(),
@@ -1843,6 +1967,13 @@ mod tests {
         assert!(
             err.is_transient_send_failure(),
             "inactivity stall must be classified transient so the connection survives: {err:?}"
+        );
+        // #4345: the stall fires before any fragment is sent, so the abort's
+        // drop_stream is a clean no-op and flight size stays 0.
+        assert_eq!(
+            cc_handle.flightsize(),
+            0,
+            "pipe_stream inactivity-stall abort must leave flight size at 0"
         );
 
         Ok(())
@@ -1887,6 +2018,7 @@ mod tests {
         let sent_tracker = Arc::new(parking_lot::Mutex::new(SentPacketTracker::new()));
         let token_bucket = Arc::new(TokenBucket::new(1_000_000, 100_000_000));
 
+        let cc_handle = congestion_controller.clone();
         let pipe_task = GlobalExecutor::spawn(pipe_stream(
             handle,
             StreamId::next(),
@@ -1917,6 +2049,13 @@ mod tests {
         assert!(
             err.is_transient_send_failure(),
             "inbound error must be classified transient so the connection survives: {err:?}"
+        );
+        // #4345: the inbound error fires before any fragment is sent, so the
+        // abort's drop_stream is a clean no-op and flight size stays 0.
+        assert_eq!(
+            cc_handle.flightsize(),
+            0,
+            "pipe_stream inbound-error abort must leave flight size at 0"
         );
 
         Ok(())

--- a/crates/core/src/transport/peer_connection/outbound_stream.rs
+++ b/crates/core/src/transport/peer_connection/outbound_stream.rs
@@ -16,7 +16,7 @@ use crate::{
         congestion_control::{CongestionControl, CongestionController},
         metrics::{emit_transfer_completed, emit_transfer_failed, emit_transfer_started},
         packet_data,
-        sent_packet_tracker::SentPacketTracker,
+        sent_packet_tracker::{PacketStream, SentPacketTracker},
         symmetric_message::{self},
     },
 };
@@ -282,6 +282,7 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
             },
             sent_packet_tracker.as_ref(),
             token,
+            PacketStream::Stream(stream_id),
         )
         .await
         {
@@ -624,6 +625,7 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
             },
             sent_packet_tracker.as_ref(),
             token,
+            PacketStream::Stream(outbound_stream_id),
         )
         .await
         {

--- a/crates/core/src/transport/sent_packet_tracker.rs
+++ b/crates/core/src/transport/sent_packet_tracker.rs
@@ -1878,4 +1878,330 @@ pub(in crate::transport) mod tests {
              (no double release of flight size); got {ack_info:?}"
         );
     }
+
+    // =========================================================================
+    // Tests for drop_stream (issue #4345, stage 1)
+    // =========================================================================
+    //
+    // drop_stream releases the in-flight bytes of an aborted outbound stream in
+    // one shot. The defining safety property is NO DOUBLE-DECREMENT: after a
+    // stream's packets are dropped, no later ACK or abandon may release their
+    // bytes a second time. These tests pin both the exact byte total and the
+    // absence of any second release path.
+
+    /// Drive the tracker through RTOs (re-registering each resent packet, as the
+    /// production recv loop does) until `packet_id` is abandoned. Any OTHER
+    /// packet that resends is re-registered too; if any other packet is
+    /// abandoned first the helper panics, since callers rely on the target being
+    /// the one that ages out.
+    fn drive_to_abandon(tracker: &mut SentPacketTracker<VirtualTime>, packet_id: PacketId) {
+        for _ in 0..1000 {
+            tracker.time_source.advance(Duration::from_secs(120));
+            match tracker.get_resend() {
+                ResendAction::Resend(id, packet) => {
+                    // Re-register exactly as the production recv loop does. The
+                    // Control-default path must preserve a stream packet's tag.
+                    tracker.report_sent_packet(id, packet);
+                }
+                ResendAction::Abandon { packet_id: id, .. } => {
+                    assert_eq!(
+                        id, packet_id,
+                        "an unexpected packet ({id}) abandoned before the target ({packet_id})"
+                    );
+                    return;
+                }
+                ResendAction::TlpProbe(..) | ResendAction::WaitUntil(_) => {}
+            }
+        }
+        panic!("packet {packet_id} was never abandoned");
+    }
+
+    /// drop_stream returns the EXACT byte total of the dropped stream's packets
+    /// and removes them from every tracking structure.
+    #[test]
+    fn test_drop_stream_returns_exact_byte_total() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream = StreamId::next();
+
+        // Three fragments of distinct sizes: 3 + 5 + 7 = 15 bytes.
+        tracker.report_sent_stream_packet(1, vec![0u8; 3].into(), None, stream);
+        tracker.report_sent_stream_packet(2, vec![0u8; 5].into(), None, stream);
+        tracker.report_sent_stream_packet(3, vec![0u8; 7].into(), None, stream);
+
+        let released = tracker.drop_stream(stream);
+        assert_eq!(
+            released, 15,
+            "must return the sum of dropped payload lengths"
+        );
+
+        // Every tracking structure is now empty for those packets.
+        assert!(tracker.pending_receipts.is_empty());
+        assert!(tracker.packet_streams.is_empty());
+        assert!(tracker.retransmit_counts.is_empty());
+        // resend_queue entries for the dropped packets are gone.
+        assert!(
+            tracker.resend_queue.is_empty(),
+            "dropped packets must be purged from the resend queue"
+        );
+    }
+
+    /// After drop_stream, a later ACK for a dropped packet does NOT produce an
+    /// ack entry — so the caller never subtracts its bytes from flight size a
+    /// second time (no double-credit on the ACK path).
+    #[test]
+    fn test_drop_stream_then_ack_is_noop() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream = StreamId::next();
+
+        tracker.report_sent_stream_packet(10, vec![1, 2, 3, 4].into(), None, stream);
+        tracker.report_sent_stream_packet(11, vec![5, 6].into(), None, stream);
+
+        let released = tracker.drop_stream(stream);
+        assert_eq!(released, 6);
+
+        // A late ACK for both dropped packets must yield NO ack-info entries.
+        let (ack_info, _) = tracker.report_received_receipts(&[10, 11]);
+        assert!(
+            ack_info.is_empty(),
+            "issue #4345: ACK after drop_stream must not release bytes again; got {ack_info:?}"
+        );
+    }
+
+    /// After drop_stream, a dropped packet can never reach the Abandon path
+    /// (get_resend skips ids absent from pending_receipts), so abandonment can
+    /// not release its bytes a second time (no double-credit on the abandon
+    /// path).
+    #[test]
+    fn test_drop_stream_then_abandon_path_is_noop() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream = StreamId::next();
+
+        tracker.report_sent_stream_packet(20, vec![0u8; 8].into(), None, stream);
+
+        let released = tracker.drop_stream(stream);
+        assert_eq!(released, 8);
+
+        // The dropped packet is gone from pending_receipts, so get_resend never
+        // re-emits it (no Resend, no Abandon) no matter how long we wait.
+        for _ in 0..(MAX_PACKET_RETRANSMITS + 5) {
+            tracker.time_source.advance(Duration::from_secs(120));
+            match tracker.get_resend() {
+                ResendAction::WaitUntil(_) => {}
+                other => {
+                    panic!("issue #4345: a dropped packet must never resend/abandon; got {other:?}")
+                }
+            }
+        }
+    }
+
+    /// Interleaving: dropping stream A leaves stream B's accounting fully
+    /// intact — B's bytes are still pending, still ACKable, and B's byte total
+    /// is unaffected by A's drop.
+    #[test]
+    fn test_drop_stream_leaves_other_stream_intact() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream_a = StreamId::next();
+        let stream_b = StreamId::next();
+
+        // Interleave A and B packets in send order.
+        tracker.report_sent_stream_packet(1, vec![0u8; 3].into(), None, stream_a);
+        tracker.report_sent_stream_packet(2, vec![0u8; 100].into(), None, stream_b);
+        tracker.report_sent_stream_packet(3, vec![0u8; 3].into(), None, stream_a);
+        tracker.report_sent_stream_packet(4, vec![0u8; 200].into(), None, stream_b);
+
+        // Dropping A releases only A's 6 bytes.
+        assert_eq!(tracker.drop_stream(stream_a), 6);
+
+        // B's two packets are untouched.
+        assert!(tracker.pending_receipts.contains_key(&2));
+        assert!(tracker.pending_receipts.contains_key(&4));
+        assert_eq!(
+            tracker.packet_streams.get(&2),
+            Some(&PacketStream::Stream(stream_b))
+        );
+        assert_eq!(
+            tracker.packet_streams.get(&4),
+            Some(&PacketStream::Stream(stream_b))
+        );
+        // A's packets are gone.
+        assert!(!tracker.pending_receipts.contains_key(&1));
+        assert!(!tracker.pending_receipts.contains_key(&3));
+
+        // B can still be ACKed normally and reports its full size.
+        let (ack_info, _) = tracker.report_received_receipts(&[2, 4]);
+        let acked_bytes: usize = ack_info.iter().map(|(_, size, _)| *size).sum();
+        assert_eq!(
+            acked_bytes, 300,
+            "stream B's bytes must still be ACK-creditable"
+        );
+
+        // Dropping B now releases exactly B's 300 bytes (nothing double-counted).
+        assert_eq!(
+            tracker.drop_stream(stream_b),
+            0,
+            "stream B was already fully ACKed, so nothing left to release"
+        );
+    }
+
+    /// Dropping a stream does NOT touch control (non-stream) packets that share
+    /// the connection.
+    #[test]
+    fn test_drop_stream_leaves_control_packets_intact() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream = StreamId::next();
+
+        // A control packet (e.g. a NoOp/handshake) and a stream fragment.
+        tracker.report_sent_packet(1, vec![0u8; 50].into()); // Control (default)
+        tracker.report_sent_stream_packet(2, vec![0u8; 9].into(), None, stream);
+
+        assert_eq!(tracker.drop_stream(stream), 9);
+
+        // The control packet survives and is still ACKable.
+        assert!(tracker.pending_receipts.contains_key(&1));
+        assert_eq!(tracker.packet_streams.get(&1), Some(&PacketStream::Control));
+        let (ack_info, _) = tracker.report_received_receipts(&[1]);
+        assert_eq!(ack_info.len(), 1);
+        assert_eq!(ack_info[0].1, 50);
+    }
+
+    /// Empty / unknown stream id → returns 0, no panic. Also covers a stream
+    /// whose packets were all already ACKed (drained).
+    #[test]
+    fn test_drop_stream_unknown_or_drained_returns_zero() {
+        let mut tracker = mock_sent_packet_tracker();
+
+        // Never-seen stream → 0.
+        assert_eq!(tracker.drop_stream(StreamId::next()), 0);
+
+        // A stream whose only packet was already ACKed → 0 (already drained).
+        let stream = StreamId::next();
+        tracker.report_sent_stream_packet(1, vec![0u8; 5].into(), None, stream);
+        tracker.report_received_receipts(&[1]);
+        assert_eq!(
+            tracker.drop_stream(stream),
+            0,
+            "a fully-ACKed stream has no bytes left to release"
+        );
+
+        // Dropping again is still a no-op (idempotent, no panic).
+        assert_eq!(tracker.drop_stream(stream), 0);
+    }
+
+    /// Boundary: a single-packet stream releases exactly that packet's bytes.
+    #[test]
+    fn test_drop_stream_single_packet() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream = StreamId::next();
+        tracker.report_sent_stream_packet(1, vec![0u8; 42].into(), None, stream);
+        assert_eq!(tracker.drop_stream(stream), 42);
+        assert!(tracker.pending_receipts.is_empty());
+        assert!(tracker.packet_streams.is_empty());
+    }
+
+    /// Boundary: many packets in one stream are all released in a single call.
+    #[test]
+    fn test_drop_stream_many_packets() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream = StreamId::next();
+        let n = 500u32;
+        let per_packet = 4usize;
+        for id in 0..n {
+            tracker.report_sent_stream_packet(id, vec![0u8; per_packet].into(), None, stream);
+        }
+        assert_eq!(
+            tracker.drop_stream(stream),
+            (n as u64) * (per_packet as u64)
+        );
+        assert!(tracker.pending_receipts.is_empty());
+        assert!(tracker.packet_streams.is_empty());
+        assert!(tracker.resend_queue.is_empty());
+    }
+
+    /// drop_stream sweeps packets that have already been retransmitted (so their
+    /// resend-queue entry was re-pushed and their Karn/retransmit/TLP state is
+    /// populated) as well as fresh pending packets — i.e. packets in BOTH the
+    /// pending set and the resend machinery.
+    #[test]
+    fn test_drop_stream_sweeps_retransmitted_and_pending() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream = StreamId::next();
+
+        // Packet 1: send, let it RTO once, and re-register (as the recv loop
+        // does). The resend re-registration goes through report_sent_packet,
+        // which must PRESERVE the stream tag.
+        tracker.report_sent_stream_packet(1, vec![0u8; 10].into(), None, stream);
+        tracker.time_source.advance(Duration::from_secs(2));
+        match tracker.get_resend() {
+            ResendAction::Resend(id, packet) => {
+                assert_eq!(id, 1);
+                // Re-register exactly as production does (Control-default path),
+                // which must keep packet 1 tagged with `stream`.
+                tracker.report_sent_packet(id, packet);
+            }
+            other => panic!("expected Resend for packet 1, got {other:?}"),
+        }
+        assert_eq!(
+            tracker.packet_streams.get(&1),
+            Some(&PacketStream::Stream(stream)),
+            "resend re-registration must preserve the stream tag"
+        );
+        assert!(tracker.retransmitted_packets.contains(&1));
+
+        // Packet 2: fresh, never retransmitted.
+        tracker.report_sent_stream_packet(2, vec![0u8; 20].into(), None, stream);
+
+        // Drop the stream: both the retransmitted packet 1 and the fresh
+        // packet 2 are released, 10 + 20 = 30 bytes.
+        assert_eq!(tracker.drop_stream(stream), 30);
+        assert!(tracker.pending_receipts.is_empty());
+        assert!(tracker.packet_streams.is_empty());
+        assert!(
+            tracker.retransmitted_packets.is_empty(),
+            "retransmitted-packet state for dropped packets must be cleared"
+        );
+        assert!(tracker.retransmit_counts.is_empty());
+    }
+
+    /// A packet that was ABANDONED (its bytes already released via the Abandon
+    /// action) is gone from tracking, so a subsequent drop_stream of its stream
+    /// must NOT release those bytes again — the abandon and drop_stream paths
+    /// don't double-credit each other.
+    #[test]
+    fn test_drop_stream_does_not_double_release_abandoned_packet() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream = StreamId::next();
+
+        // Abandon packet 1 first (its 4 bytes are released by the Abandon
+        // action). Sending packet 2 only AFTER abandonment keeps it out of the
+        // shared RTO timeline, so the only abandonment is packet 1's.
+        tracker.report_sent_stream_packet(1, vec![0u8; 4].into(), None, stream);
+        drive_to_abandon(&mut tracker, 1);
+
+        // Packet 1 is gone from tracking after abandonment.
+        assert!(!tracker.packet_streams.contains_key(&1));
+        assert!(!tracker.pending_receipts.contains_key(&1));
+
+        // Now a fresh fragment of the SAME stream is still in flight.
+        tracker.report_sent_stream_packet(2, vec![0u8; 6].into(), None, stream);
+
+        // drop_stream now releases ONLY packet 2's 6 bytes, NOT packet 1's
+        // already-released 4 bytes.
+        assert_eq!(
+            tracker.drop_stream(stream),
+            6,
+            "issue #4345: drop_stream must not re-release bytes already released by Abandon"
+        );
+    }
+
+    /// Saturating-arithmetic / zero correctness: dropping a stream whose only
+    /// packet is empty returns 0 and removes the packet (no panic, no underflow).
+    #[test]
+    fn test_drop_stream_zero_length_packet() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream = StreamId::next();
+        tracker.report_sent_stream_packet(1, Box::from(&[][..]), None, stream);
+        assert_eq!(tracker.drop_stream(stream), 0);
+        assert!(tracker.pending_receipts.is_empty());
+        assert!(tracker.packet_streams.is_empty());
+    }
 }

--- a/crates/core/src/transport/sent_packet_tracker.rs
+++ b/crates/core/src/transport/sent_packet_tracker.rs
@@ -291,6 +291,55 @@ impl<T: TimeSource> SentPacketTracker<T> {
         self.report_sent_packet_inner(packet_id, payload, token, PacketStream::Stream(stream_id));
     }
 
+    /// Refresh an already-tracked packet's payload / send-time / token in place
+    /// after a resend, WITHOUT resurrecting it if it has been removed.
+    ///
+    /// Returns `true` if the packet was still tracked and was refreshed, `false`
+    /// if it had already left `pending_receipts` (ACKed, abandoned, or dropped by
+    /// [`Self::drop_stream`]) — in which case this is a no-op and `payload` is
+    /// dropped.
+    ///
+    /// # Why this exists (issue #4345 — resurrection-safety)
+    ///
+    /// The recv loop's resend cycle releases the tracker lock across the UDP
+    /// `send_to().await`, then re-registers the packet. A concurrent
+    /// `drop_stream` (from the spawned outbound-stream abort task) can remove the
+    /// packet in that window and release its bytes. If re-registration went
+    /// through an insert-on-absent path (`report_sent_packet_*`), it would
+    /// RESURRECT the packet as a `Control`-tagged zombie; a later ACK/abandon of
+    /// that zombie would then release its bytes a SECOND time (flight-size
+    /// under-count) and violate the "in `pending_receipts` iff in flight"
+    /// invariant. This method only ever UPDATES an existing entry, never inserts,
+    /// so a dropped packet stays dropped and its bytes are released exactly once.
+    ///
+    /// The recv loop MUST use this (not `report_sent_packet*`) for resend
+    /// re-registration. `report_sent_packet*` remain insert-capable for first
+    /// sends (and for test re-registration, which never races a `drop_stream`).
+    pub(super) fn refresh_sent_packet(
+        &mut self,
+        packet_id: PacketId,
+        payload: Box<[u8]>,
+        token: Option<DeliveryRateToken>,
+    ) -> bool {
+        let sent_time_nanos = self.time_source.now_nanos();
+        match self.pending_receipts.get_mut(&packet_id) {
+            Some(slot) => {
+                // In-place refresh. The packet is still tracked, still queued for
+                // resend (get_resend re-queued it), and its stream tag in
+                // `packet_streams` is untouched — so it is preserved across the
+                // resend. `payload` is the same bytes the caller just sent.
+                *slot = (payload, sent_time_nanos, token);
+                true
+            }
+            None => {
+                // Already removed (ACK / Abandon / drop_stream). Do NOT
+                // re-insert — that would resurrect a dropped packet and enable a
+                // double-release. Drop the payload and report the no-op.
+                false
+            }
+        }
+    }
+
     fn report_sent_packet_inner(
         &mut self,
         packet_id: PacketId,
@@ -300,19 +349,17 @@ impl<T: TimeSource> SentPacketTracker<T> {
     ) {
         let sent_time_nanos = self.time_source.now_nanos();
 
-        // Resend re-registration (issue #4345): since `get_resend` now KEEPS a
-        // resent packet in `pending_receipts`, a re-register for an
-        // already-tracked packet is an idempotent in-place refresh — update the
-        // payload / send-time / token, do NOT push a duplicate resend-queue
-        // entry, and do NOT bump `total_packets_sent`. The stream tag is
-        // preserved (the existing entry's tag stays); the `stream` argument from
-        // a `Control`-default re-register is intentionally ignored so a resent
-        // stream fragment keeps its stream. (First sends never hit this branch
-        // because packet ids are monotonic per connection.)
+        // NOTE (issue #4345 resurrection-safety): production resend
+        // re-registration does NOT come through here — the recv loop uses
+        // `refresh_sent_packet`, which never inserts, so a packet removed by a
+        // concurrent `drop_stream` cannot be resurrected. This insert-or-refresh
+        // path serves first sends (packet_sending / handshake) and test
+        // re-registration (which never races a `drop_stream`). The refresh
+        // branch keeps an already-present re-register idempotent (no duplicate
+        // resend-queue entry, no `total_packets_sent` bump, stream tag
+        // preserved); the `stream` argument is ignored when the entry exists.
         if let Some(slot) = self.pending_receipts.get_mut(&packet_id) {
             *slot = (payload, sent_time_nanos, token);
-            // packet_streams entry already exists and is left untouched so the
-            // owning stream is preserved across resends.
             return;
         }
 
@@ -398,6 +445,16 @@ impl<T: TimeSource> SentPacketTracker<T> {
             .retain(|entry| !dropped.contains(&entry.packet_id));
 
         released_bytes
+    }
+
+    /// Whether `packet_id` is currently tracked (present in `pending_receipts`,
+    /// i.e. in flight). Used by the mid-send-failure abort sites to
+    /// `debug_assert` that a packet whose send failed was never registered
+    /// before they explicitly release its `on_send` bytes (issue #4345) — which
+    /// would otherwise double-release if a future multi-packet send path
+    /// registered the packet and then failed.
+    pub(super) fn contains_packet(&self, packet_id: PacketId) -> bool {
+        self.pending_receipts.contains_key(&packet_id)
     }
 
     /// Reports that receipts have been received for the given packet IDs.
@@ -2320,6 +2377,114 @@ pub(in crate::transport) mod tests {
         assert!(
             ack_info.is_empty(),
             "a late ACK after the gap-drop must not release bytes again"
+        );
+    }
+
+    /// MUST-FIX regression (issue #4345, stage-2 review): the MIRROR of the
+    /// resend-gap test. The recv loop's resend re-registration, when it runs
+    /// AFTER a concurrent `drop_stream` already removed and released the packet,
+    /// must NOT resurrect it — otherwise a later ACK/abandon of the resurrected
+    /// "zombie" releases its bytes a SECOND time (flight-size under-count) and
+    /// breaks the "in pending_receipts iff in flight" invariant.
+    ///
+    /// Models the race tail: get_resend hands the packet out, the abort task
+    /// runs drop_stream (releases the bytes once), THEN the recv loop resumes and
+    /// re-registers via `refresh_sent_packet` — which must be a no-op because the
+    /// entry is gone.
+    ///
+    /// Asserts (a) the packet is NOT resurrected into any tracking structure, and
+    /// (b) a later ACK and a later abandon attempt each release ZERO.
+    ///
+    /// This FAILS without the fix: the old recv-loop path called
+    /// `report_sent_packet`, whose insert-on-absent branch resurrects the packet
+    /// as a `Control` zombie (see `test_report_sent_packet_resurrects_*` which
+    /// pins that footgun). `refresh_sent_packet` closes it.
+    #[test]
+    fn test_refresh_after_drop_stream_does_not_resurrect() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream = StreamId::next();
+
+        tracker.report_sent_stream_packet(1, vec![0u8; 13].into(), None, stream);
+
+        // get_resend hands the packet out for resend (recv loop now "awaiting
+        // send_to"). Capture the payload as the recv loop would.
+        tracker.time_source.advance(tracker.effective_rto());
+        let resent_payload = match tracker.get_resend() {
+            ResendAction::Resend(id, packet) => {
+                assert_eq!(id, 1);
+                packet
+            }
+            other => panic!("expected Resend, got {other:?}"),
+        };
+
+        // Concurrent abort task drops the stream — releases the 13 bytes ONCE.
+        assert_eq!(tracker.drop_stream(stream), 13);
+        assert!(!tracker.pending_receipts.contains_key(&1));
+
+        // recv loop resumes and re-registers via the production path. Must no-op.
+        let refreshed = tracker.refresh_sent_packet(1, resent_payload, None);
+        assert!(
+            !refreshed,
+            "refresh_sent_packet must report no-op for a dropped packet"
+        );
+
+        // (a) NOT resurrected into any structure.
+        assert!(
+            !tracker.pending_receipts.contains_key(&1),
+            "dropped packet must NOT be resurrected into pending_receipts"
+        );
+        assert!(!tracker.packet_streams.contains_key(&1));
+        assert!(!tracker.retransmit_counts.contains_key(&1));
+
+        // (b1) A later ACK releases ZERO (no ack-info entry → caller decrements
+        // nothing).
+        let (ack_info, _) = tracker.report_received_receipts(&[1]);
+        assert!(
+            ack_info.is_empty(),
+            "ACK of a dropped-then-refreshed packet must release zero bytes; got {ack_info:?}"
+        );
+
+        // (b2) A later abandon attempt also releases ZERO: the packet is absent
+        // from the resend queue / pending, so get_resend never emits Abandon for
+        // it no matter how long we wait.
+        for _ in 0..(MAX_PACKET_RETRANSMITS + 5) {
+            tracker.time_source.advance(Duration::from_secs(120));
+            match tracker.get_resend() {
+                ResendAction::WaitUntil(_) => {}
+                other => panic!(
+                    "dropped packet must never resend/abandon after refresh no-op; got {other:?}"
+                ),
+            }
+        }
+    }
+
+    /// Pins the FOOTGUN that `refresh_sent_packet` exists to avoid: the
+    /// insert-capable `report_sent_packet` DOES resurrect a dropped packet. This
+    /// documents why the recv loop must NOT use `report_sent_packet` for resend
+    /// re-registration (issue #4345 stage-2 review). It is the "without the fix"
+    /// behavior, asserted directly so a future refactor that points the recv loop
+    /// back at `report_sent_packet` is caught by `test_refresh_after_drop_stream_
+    /// does_not_resurrect` failing.
+    #[test]
+    fn test_report_sent_packet_resurrects_dropped_packet_footgun() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream = StreamId::next();
+        tracker.report_sent_stream_packet(1, vec![0u8; 13].into(), None, stream);
+        assert_eq!(tracker.drop_stream(stream), 13);
+
+        // The insert-on-absent path resurrects the packet (as Control) — exactly
+        // the bug. refresh_sent_packet is what the production recv loop uses to
+        // avoid this; report_sent_packet remains insert-capable for first sends.
+        tracker.report_sent_packet(1, vec![0u8; 13].into());
+        assert!(
+            tracker.pending_receipts.contains_key(&1),
+            "report_sent_packet IS insert-capable (resurrects) — this is why the \
+             recv loop must use refresh_sent_packet instead"
+        );
+        assert_eq!(
+            tracker.packet_streams.get(&1),
+            Some(&PacketStream::Control),
+            "the resurrected packet is mis-tagged Control (the double-release footgun)"
         );
     }
 }

--- a/crates/core/src/transport/sent_packet_tracker.rs
+++ b/crates/core/src/transport/sent_packet_tracker.rs
@@ -1,4 +1,5 @@
 use super::PacketId;
+use super::StreamId;
 use super::bbr::DeliveryRateToken;
 #[cfg(test)]
 use crate::simulation::RealTime;
@@ -8,6 +9,28 @@ use std::time::Duration;
 
 /// Entry for pending packet receipts: (payload, sent_time_nanos, delivery_token)
 type PendingReceiptEntry = (Box<[u8]>, u64, Option<DeliveryRateToken>);
+
+/// Identifies which outbound stream (if any) owns a sent packet's bytes.
+///
+/// Flight size is a single connection-wide counter, but a packet's bytes are
+/// only credited back to it on ACK or abandonment. When an outbound stream
+/// aborts (e.g. a cwnd-wait timeout in `outbound_stream.rs`), its in-flight
+/// fragments are still tracked here and pin flight size until each one ages out
+/// via `MAX_PACKET_RETRANSMITS` (~6s) — starving every later stream on the
+/// connection (issue #4345). Tagging each pending packet with its owning stream
+/// lets [`SentPacketTracker::drop_stream`] release that stranded flight size
+/// atomically when the stream aborts.
+///
+/// `Control` is the explicit "no owning stream" sentinel for handshake packets,
+/// keep-alive NoOps, short messages, and any other non-stream traffic;
+/// `drop_stream` never touches `Control` packets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PacketStream {
+    /// The packet carries a fragment of the given outbound stream.
+    Stream(StreamId),
+    /// The packet is not owned by any stream (handshake, NoOp, short message).
+    Control,
+}
 
 /// Result of processing received receipts: (acked_packets_info, loss_proportion)
 /// Each acked packet contains: (rtt_option, bytes_acked, delivery_token)
@@ -167,6 +190,21 @@ pub(super) struct SentPacketTracker<T: TimeSource> {
     /// cleared on ACK. An entry is removed when its packet is ACKed or
     /// abandoned, so this map tracks only currently-unacked packets.
     retransmit_counts: HashMap<PacketId, u32>,
+
+    /// Owning stream for each currently-tracked packet (issue #4345).
+    ///
+    /// Indexed by `PacketId`. Unlike `pending_receipts`, an entry here is NOT
+    /// removed when `get_resend` pops a packet for retransmission — it persists
+    /// across resends so the re-registration in the recv loop preserves the
+    /// packet's stream tag. An entry is removed only when the packet leaves
+    /// tracking for good: on ACK (`report_received_receipts`), on abandonment
+    /// (`get_resend` Abandon), or when its stream is dropped (`drop_stream`).
+    ///
+    /// This is what makes `drop_stream` double-decrement-safe: after it removes
+    /// a stream's packets from BOTH this map and `pending_receipts`, no later
+    /// ACK or abandon can find those packets, so their bytes are released
+    /// exactly once.
+    packet_streams: HashMap<PacketId, PacketStream>,
 }
 
 impl<T: TimeSource> SentPacketTracker<T> {
@@ -187,6 +225,7 @@ impl<T: TimeSource> SentPacketTracker<T> {
             rto_backoff: 1, // No backoff initially
             tlp_sent_packets: HashSet::new(),
             retransmit_counts: HashMap::new(),
+            packet_streams: HashMap::new(),
         }
     }
 
@@ -211,17 +250,138 @@ impl<T: TimeSource> SentPacketTracker<T> {
     /// The token is used by BBR for accurate delivery rate estimation. When an ACK
     /// arrives, the token is returned alongside the RTT sample so it can be passed
     /// to `BbrController::on_ack_with_token`.
+    ///
+    /// The packet's stream tag is **preserved if already known** and otherwise
+    /// defaults to [`PacketStream::Control`]. This is exactly the behaviour the
+    /// recv loop's resend re-registration needs: `get_resend` removes the packet
+    /// from `pending_receipts` but NOT from `packet_streams`, so re-sending a
+    /// stream fragment through this method keeps its original stream tag. A
+    /// genuinely new packet (monotonic `packet_id`, never colliding with an old
+    /// tag) has no entry yet and is correctly tagged `Control`. First sends of
+    /// stream fragments must use [`Self::report_sent_stream_packet`] instead so
+    /// they are tagged with their owning stream.
     pub(super) fn report_sent_packet_with_token(
         &mut self,
         packet_id: PacketId,
         payload: Box<[u8]>,
         token: Option<DeliveryRateToken>,
     ) {
+        let stream = self
+            .packet_streams
+            .get(&packet_id)
+            .copied()
+            .unwrap_or(PacketStream::Control);
+        self.report_sent_packet_inner(packet_id, payload, token, stream);
+    }
+
+    /// Report a sent packet that carries bytes owned by `stream`.
+    ///
+    /// Used for the first send of a `StreamFragment`. The packet is tagged with
+    /// its owning stream so that, when the stream aborts, [`Self::drop_stream`]
+    /// can release the packet's flight-size bytes atomically (issue #4345).
+    /// Resends of the same packet re-register through
+    /// [`Self::report_sent_packet_with_token`], which preserves this tag.
+    pub(super) fn report_sent_stream_packet(
+        &mut self,
+        packet_id: PacketId,
+        payload: Box<[u8]>,
+        token: Option<DeliveryRateToken>,
+        stream_id: StreamId,
+    ) {
+        self.report_sent_packet_inner(packet_id, payload, token, PacketStream::Stream(stream_id));
+    }
+
+    fn report_sent_packet_inner(
+        &mut self,
+        packet_id: PacketId,
+        payload: Box<[u8]>,
+        token: Option<DeliveryRateToken>,
+        stream: PacketStream,
+    ) {
         let sent_time_nanos = self.time_source.now_nanos();
         self.pending_receipts
             .insert(packet_id, (payload, sent_time_nanos, token));
+        self.packet_streams.insert(packet_id, stream);
         self.resend_queue.push_back(ResendQueueEntry { packet_id });
         self.total_packets_sent += 1;
+    }
+
+    /// Remove every currently-tracked packet owned by `stream_id` and return the
+    /// total payload byte count removed (issue #4345).
+    ///
+    /// Called when an outbound stream aborts (e.g. a cwnd-wait timeout) so the
+    /// caller can release the aborted stream's stranded bytes from the
+    /// congestion controller's flight size in one shot, instead of waiting for
+    /// each fragment to age out via `MAX_PACKET_RETRANSMITS` (~6s) or be ACKed.
+    /// The returned byte count is exactly what the caller must pass to
+    /// `CongestionControl::release_flightsize`.
+    ///
+    /// # Double-decrement safety
+    ///
+    /// This removes the stream's packets from **all** tracking structures —
+    /// `pending_receipts`, `packet_streams`, `retransmit_counts`,
+    /// `retransmitted_packets`, `tlp_sent_packets`, and the `resend_queue`. Once
+    /// removed, those packets cannot be released a second time by any other
+    /// path:
+    ///
+    /// - A subsequent ACK in `report_received_receipts` finds no entry in
+    ///   `pending_receipts`, so it produces no ack-info tuple and the caller
+    ///   never subtracts its bytes again.
+    /// - `get_resend` skips packet ids absent from `pending_receipts`, so it can
+    ///   never emit a `Resend`/`TlpProbe`/`Abandon` for a dropped packet — in
+    ///   particular it cannot `Abandon` it and trigger a second
+    ///   `release_flightsize`.
+    ///
+    /// The byte count is therefore released exactly once: here.
+    ///
+    /// Returns `0` for an unknown or already-drained stream, and never panics.
+    ///
+    /// NOTE (stage 1, #4345): this mechanism is intentionally NOT yet wired into
+    /// the abort paths in `outbound_stream.rs`; calling it has no effect on
+    /// flight size until the caller passes the returned count to
+    /// `release_flightsize`. It is added and tested in isolation first because
+    /// the double-decrement hazard is the riskiest part of the fix. The
+    /// `allow(dead_code)` is removed in stage 2 when the abort paths call it.
+    #[allow(dead_code)]
+    pub(super) fn drop_stream(&mut self, stream_id: StreamId) -> u64 {
+        let target = PacketStream::Stream(stream_id);
+
+        // Identify the owned packet ids first (one pass over the small
+        // per-connection stream map), then remove from every structure.
+        let owned: Vec<PacketId> = self
+            .packet_streams
+            .iter()
+            .filter_map(|(&pid, &stream)| (stream == target).then_some(pid))
+            .collect();
+
+        if owned.is_empty() {
+            return 0;
+        }
+
+        let mut released_bytes: u64 = 0;
+        for pid in &owned {
+            // Sum the payload bytes still pending (i.e. counted in flight size).
+            // A packet whose tag is present but that is absent from
+            // `pending_receipts` cannot occur: the tag is removed in lockstep on
+            // ACK and abandon. The `if let` is a defensive no-panic guard.
+            if let Some((payload, _, _)) = self.pending_receipts.remove(pid) {
+                released_bytes = released_bytes.saturating_add(payload.len() as u64);
+            }
+            self.packet_streams.remove(pid);
+            self.retransmit_counts.remove(pid);
+            self.retransmitted_packets.remove(pid);
+            self.tlp_sent_packets.remove(pid);
+        }
+
+        // Drop the dropped packets' resend-queue entries. `get_resend` already
+        // skips ids missing from `pending_receipts`, so this is not strictly
+        // required for correctness, but it keeps the queue from growing with
+        // dead entries across many stream drops.
+        let dropped: HashSet<PacketId> = owned.into_iter().collect();
+        self.resend_queue
+            .retain(|entry| !dropped.contains(&entry.packet_id));
+
+        released_bytes
     }
 
     /// Reports that receipts have been received for the given packet IDs.
@@ -285,11 +445,16 @@ impl<T: TimeSource> SentPacketTracker<T> {
                 }
             }
 
-            // Remove from pending, retransmitted, TLP, and retransmit-count tracking
+            // Remove from pending, retransmitted, TLP, retransmit-count, and
+            // stream tracking. Dropping the stream tag here is what keeps
+            // `drop_stream` double-decrement-safe: once a packet is ACKed it is
+            // no longer associated with any stream, so a later `drop_stream`
+            // for that stream cannot release its bytes a second time (#4345).
             self.pending_receipts.remove(packet_id);
             self.retransmitted_packets.remove(packet_id);
             self.tlp_sent_packets.remove(packet_id);
             self.retransmit_counts.remove(packet_id);
+            self.packet_streams.remove(packet_id);
         }
 
         let loss_rate = if self.total_packets_sent > 0 {
@@ -485,9 +650,15 @@ impl<T: TimeSource> SentPacketTracker<T> {
                         let payload_len = packet.len();
                         // Drop all tracking for this packet — it will NOT be
                         // re-queued, so the recv loop stops retransmitting it.
+                        // Removing the stream tag here keeps `drop_stream`
+                        // double-decrement-safe: an abandoned packet's bytes are
+                        // released once (by the recv loop, via the Abandon
+                        // action), so a later `drop_stream` must not release
+                        // them again (#4345).
                         self.retransmit_counts.remove(&entry.packet_id);
                         self.retransmitted_packets.remove(&entry.packet_id);
                         self.tlp_sent_packets.remove(&entry.packet_id);
+                        self.packet_streams.remove(&entry.packet_id);
                         tracing::debug!(
                             packet_id = entry.packet_id,
                             retransmits = MAX_PACKET_RETRANSMITS,

--- a/crates/core/src/transport/sent_packet_tracker.rs
+++ b/crates/core/src/transport/sent_packet_tracker.rs
@@ -398,6 +398,34 @@ impl<T: TimeSource> SentPacketTracker<T> {
     ///
     /// The byte count is therefore released exactly once: here.
     ///
+    /// # Why the returned count is the *encrypted* stored-payload length
+    ///
+    /// `drop_stream` sums `pending_receipts[id].0.len()` — the ENCRYPTED
+    /// on-wire payload that was stored when the packet was sent — NOT the
+    /// plaintext fragment size that `on_send`/`on_send_with_token` added to
+    /// flight size. This is INTENTIONAL and is the same byte count the other two
+    /// release paths use:
+    ///
+    /// - ACK: `report_received_receipts` returns `payload.len()` (the stored
+    ///   encrypted length) and the recv loop passes it to `on_ack*`.
+    /// - Abandon: `ResendAction::Abandon { payload_len }` is `packet.len()` (the
+    ///   stored encrypted length) and the recv loop passes it to
+    ///   `release_flightsize`.
+    ///
+    /// So `drop_stream` releases EXACTLY what an ACK or Abandon for those same
+    /// packets would have released — it substitutes for the ACKs that will never
+    /// arrive. The plaintext-add / encrypted-release asymmetry is a pre-existing
+    /// convention across ALL three release paths (flight size is conservative —
+    /// it can read low because encrypted ≥ plaintext, and `release_flightsize`
+    /// saturates at 0); it is NOT introduced or worsened here.
+    ///
+    /// A future change MUST NOT "fix" one release path to plaintext bytes without
+    /// fixing `on_send` AND all three release paths together — switching only one
+    /// reintroduces an inconsistency. The plaintext-vs-encrypted accounting
+    /// convention is tracked separately in
+    /// <https://github.com/freenet/freenet-core/issues/4402> and is out of scope
+    /// for #4345.
+    ///
     /// Returns `0` for an unknown or already-drained stream, and never panics.
     ///
     /// Wired into the outbound-stream abort paths (`outbound_stream.rs`,

--- a/crates/core/src/transport/sent_packet_tracker.rs
+++ b/crates/core/src/transport/sent_packet_tracker.rs
@@ -299,6 +299,23 @@ impl<T: TimeSource> SentPacketTracker<T> {
         stream: PacketStream,
     ) {
         let sent_time_nanos = self.time_source.now_nanos();
+
+        // Resend re-registration (issue #4345): since `get_resend` now KEEPS a
+        // resent packet in `pending_receipts`, a re-register for an
+        // already-tracked packet is an idempotent in-place refresh — update the
+        // payload / send-time / token, do NOT push a duplicate resend-queue
+        // entry, and do NOT bump `total_packets_sent`. The stream tag is
+        // preserved (the existing entry's tag stays); the `stream` argument from
+        // a `Control`-default re-register is intentionally ignored so a resent
+        // stream fragment keeps its stream. (First sends never hit this branch
+        // because packet ids are monotonic per connection.)
+        if let Some(slot) = self.pending_receipts.get_mut(&packet_id) {
+            *slot = (payload, sent_time_nanos, token);
+            // packet_streams entry already exists and is left untouched so the
+            // owning stream is preserved across resends.
+            return;
+        }
+
         self.pending_receipts
             .insert(packet_id, (payload, sent_time_nanos, token));
         self.packet_streams.insert(packet_id, stream);
@@ -336,13 +353,12 @@ impl<T: TimeSource> SentPacketTracker<T> {
     ///
     /// Returns `0` for an unknown or already-drained stream, and never panics.
     ///
-    /// NOTE (stage 1, #4345): this mechanism is intentionally NOT yet wired into
-    /// the abort paths in `outbound_stream.rs`; calling it has no effect on
-    /// flight size until the caller passes the returned count to
-    /// `release_flightsize`. It is added and tested in isolation first because
-    /// the double-decrement hazard is the riskiest part of the fix. The
-    /// `allow(dead_code)` is removed in stage 2 when the abort paths call it.
-    #[allow(dead_code)]
+    /// Wired into the outbound-stream abort paths (`outbound_stream.rs`,
+    /// `release_aborted_stream_flightsize`): on a cwnd-wait timeout, upstream
+    /// stall/error, or mid-send failure, the abort calls this and passes the
+    /// returned count to `CongestionControl::release_flightsize` so the aborted
+    /// stream's stranded bytes are freed immediately instead of waiting out
+    /// `MAX_PACKET_RETRANSMITS`.
     pub(super) fn drop_stream(&mut self, stream_id: StreamId) -> u64 {
         let target = PacketStream::Stream(stream_id);
 
@@ -569,8 +585,31 @@ impl<T: TimeSource> SentPacketTracker<T> {
     }
 
     /// Either get a packet that needs to be resent, or how long the caller should wait until
-    /// calling this function again. If a packet is resent you **must** call
-    /// `report_sent_packet` again with the same packet_id.
+    /// calling this function again.
+    ///
+    /// On `Resend`/`TlpProbe` the packet **stays in `pending_receipts`** — the
+    /// returned `Box<[u8]>` is a clone of the still-tracked payload, and the
+    /// packet's RTO timer is refreshed to "now" in place. The caller sends the
+    /// bytes; it MAY call `report_sent_packet` again with the same packet_id to
+    /// refresh the send timestamp to the post-`send_to` instant, but this is an
+    /// idempotent in-place refresh, not a re-insert (issue #4345).
+    ///
+    /// WHY keep the packet across resend (issue #4345): `drop_stream` runs
+    /// concurrently from the spawned outbound-stream abort path while the
+    /// per-connection recv loop drives resends. If `get_resend` removed the
+    /// packet from `pending_receipts` and relied on the caller to re-insert it
+    /// after an `await`ed UDP send, a `drop_stream` landing in that gap would
+    /// see no `pending_receipts` entry (release 0 bytes for a genuinely in-flight
+    /// packet) and strip its stream tag — leaving the fragment's bytes pinned in
+    /// flight size, the exact #4345 symptom. Keeping the entry makes the
+    /// invariant total: a packet is in `pending_receipts` iff it is in flight, so
+    /// `drop_stream` always sees and releases it. This is the same keep-the-entry
+    /// shape the TLP branch below already uses.
+    ///
+    /// NOTE: this does NOT touch flight size. Flight size lives in the congestion
+    /// controller; keeping the packet here is pure resend bookkeeping and does
+    /// not reintroduce the forbidden decrement-on-RTO + re-add-on-resend pair
+    /// (see `.claude/rules/transport.md` flight-size release invariant).
     ///
     /// TLP (Tail Loss Probe) fires before RTO to detect tail loss earlier.
     /// - TLP returns TlpProbe action (no backoff applied, speculative)
@@ -631,57 +670,76 @@ impl<T: TimeSource> SentPacketTracker<T> {
                 }
             }
 
-            // Check if RTO should fire
-            if now_nanos >= rto_deadline {
-                if let Some((packet, _sent_time_nanos, _token)) =
-                    self.pending_receipts.remove(&entry.packet_id)
-                {
-                    // Update packet loss proportion for a lost packet
-                    self.packet_loss_proportion = self.packet_loss_proportion
-                        * (1.0 - PACKET_LOSS_DECAY_FACTOR)
-                        + PACKET_LOSS_DECAY_FACTOR;
+            // Check if RTO should fire (only for a still-tracked packet —
+            // get_resend keeps resent packets in pending_receipts since #4345).
+            if now_nanos >= rto_deadline && self.pending_receipts.contains_key(&entry.packet_id) {
+                // Update packet loss proportion for a lost packet
+                self.packet_loss_proportion = self.packet_loss_proportion
+                    * (1.0 - PACKET_LOSS_DECAY_FACTOR)
+                    + PACKET_LOSS_DECAY_FACTOR;
 
-                    // Count this RTO. After MAX_PACKET_RETRANSMITS with no ACK,
-                    // abandon the packet so its bytes are released from flight
-                    // size instead of being retransmitted forever (issue #4345).
-                    let count = self.retransmit_counts.entry(entry.packet_id).or_insert(0);
-                    *count += 1;
-                    if *count > MAX_PACKET_RETRANSMITS {
-                        let payload_len = packet.len();
-                        // Drop all tracking for this packet — it will NOT be
-                        // re-queued, so the recv loop stops retransmitting it.
-                        // Removing the stream tag here keeps `drop_stream`
-                        // double-decrement-safe: an abandoned packet's bytes are
-                        // released once (by the recv loop, via the Abandon
-                        // action), so a later `drop_stream` must not release
-                        // them again (#4345).
-                        self.retransmit_counts.remove(&entry.packet_id);
-                        self.retransmitted_packets.remove(&entry.packet_id);
-                        self.tlp_sent_packets.remove(&entry.packet_id);
-                        self.packet_streams.remove(&entry.packet_id);
-                        tracing::debug!(
-                            packet_id = entry.packet_id,
-                            retransmits = MAX_PACKET_RETRANSMITS,
-                            payload_len,
-                            "Abandoning packet after max retransmits — releasing flight size (#4345)"
-                        );
-                        return ResendAction::Abandon {
-                            packet_id: entry.packet_id,
-                            payload_len,
-                        };
-                    }
-
-                    // Mark as retransmitted for Karn's algorithm
-                    self.mark_retransmitted(entry.packet_id);
-
-                    // RFC 6298 Section 5.5: Back off the timer on retransmission
-                    self.on_timeout();
-
-                    // Clean up TLP tracking for this packet
+                // Count this RTO. After MAX_PACKET_RETRANSMITS with no ACK,
+                // abandon the packet so its bytes are released from flight
+                // size instead of being retransmitted forever (issue #4345).
+                let count = self.retransmit_counts.entry(entry.packet_id).or_insert(0);
+                *count += 1;
+                if *count > MAX_PACKET_RETRANSMITS {
+                    // Abandonment is terminal: NOW remove the packet from
+                    // every tracking structure (including pending_receipts).
+                    // It will NOT be re-queued, so the recv loop stops
+                    // retransmitting it. Removing the stream tag here keeps
+                    // `drop_stream` double-decrement-safe: an abandoned
+                    // packet's bytes are released once (by the recv loop, via
+                    // the Abandon action), so a later `drop_stream` must not
+                    // release them again (#4345).
+                    let payload_len = self
+                        .pending_receipts
+                        .remove(&entry.packet_id)
+                        .map(|(payload, _, _)| payload.len())
+                        .unwrap_or(0);
+                    self.retransmit_counts.remove(&entry.packet_id);
+                    self.retransmitted_packets.remove(&entry.packet_id);
                     self.tlp_sent_packets.remove(&entry.packet_id);
-
-                    return ResendAction::Resend(entry.packet_id, packet);
+                    self.packet_streams.remove(&entry.packet_id);
+                    tracing::debug!(
+                        packet_id = entry.packet_id,
+                        retransmits = MAX_PACKET_RETRANSMITS,
+                        payload_len,
+                        "Abandoning packet after max retransmits — releasing flight size (#4345)"
+                    );
+                    return ResendAction::Abandon {
+                        packet_id: entry.packet_id,
+                        payload_len,
+                    };
                 }
+
+                // Resend: KEEP the packet in pending_receipts (issue #4345 —
+                // see the rustdoc above). Clone the payload for the caller,
+                // refresh the send timestamp to now so the next RTO is
+                // measured from this resend, and push the entry back so the
+                // packet stays tracked for the next timeout.
+                let packet = {
+                    let slot = self
+                        .pending_receipts
+                        .get_mut(&entry.packet_id)
+                        .expect("checked contains_key above");
+                    slot.1 = now_nanos;
+                    slot.0.clone()
+                };
+                self.resend_queue.push_back(ResendQueueEntry {
+                    packet_id: entry.packet_id,
+                });
+
+                // Mark as retransmitted for Karn's algorithm
+                self.mark_retransmitted(entry.packet_id);
+
+                // RFC 6298 Section 5.5: Back off the timer on retransmission
+                self.on_timeout();
+
+                // Clean up TLP tracking for this packet
+                self.tlp_sent_packets.remove(&entry.packet_id);
+
+                return ResendAction::Resend(entry.packet_id, packet);
             }
 
             // Neither TLP nor RTO fired yet - calculate when to wake up
@@ -797,8 +855,12 @@ pub(in crate::transport) mod tests {
         tracker.time_source.advance(tracker.effective_rto());
         let resend_action = tracker.get_resend();
         assert_eq!(resend_action, ResendAction::Resend(1, vec![1, 2, 3].into()));
-        assert_eq!(tracker.pending_receipts.len(), 0);
-        assert_eq!(tracker.resend_queue.len(), 0);
+        // Since #4345, a resent packet STAYS tracked (get_resend keeps it in
+        // pending_receipts and re-queues it) so it remains visible to a
+        // concurrent drop_stream; it is no longer removed on Resend. The payload
+        // is returned as a clone.
+        assert_eq!(tracker.pending_receipts.len(), 1);
+        assert_eq!(tracker.resend_queue.len(), 1);
         assert_eq!(tracker.packet_loss_proportion, PACKET_LOSS_DECAY_FACTOR);
     }
 
@@ -2203,5 +2265,61 @@ pub(in crate::transport) mod tests {
         assert_eq!(tracker.drop_stream(stream), 0);
         assert!(tracker.pending_receipts.is_empty());
         assert!(tracker.packet_streams.is_empty());
+    }
+
+    /// Resend-gap race (issue #4345, stage 2): a packet that `get_resend` has
+    /// just handed out for retransmission — but that the recv loop has NOT yet
+    /// re-registered (it is mid `send_to().await`) — must STILL be released by a
+    /// concurrent `drop_stream`.
+    ///
+    /// `drop_stream` runs from the spawned outbound-stream abort task while the
+    /// per-connection recv loop drives resends; both share the tracker mutex.
+    /// Before the keep-the-entry-on-resend fix, `get_resend` removed the packet
+    /// from `pending_receipts` and relied on the recv loop to re-insert it after
+    /// the await. A `drop_stream` landing in that window would see no
+    /// `pending_receipts` entry — release 0 bytes for a genuinely in-flight
+    /// packet AND strip its stream tag — leaving the fragment pinned in flight
+    /// size (partial defeat of the fix). Now the packet stays in
+    /// `pending_receipts` across the resend, so this test asserts it is released.
+    ///
+    /// This is the exact interleaving the gap describes: Resend handed out, NO
+    /// re-registration yet, then drop_stream.
+    #[test]
+    fn test_drop_stream_releases_packet_out_for_resend() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream = StreamId::next();
+
+        tracker.report_sent_stream_packet(1, vec![0u8; 13].into(), None, stream);
+
+        // Fire the RTO so the packet is "out for resend": get_resend returns it
+        // to the (recv-loop) caller. We deliberately do NOT re-register it,
+        // modelling the recv task being suspended on its UDP send_to().await.
+        tracker.time_source.advance(tracker.effective_rto());
+        match tracker.get_resend() {
+            ResendAction::Resend(id, _packet) => assert_eq!(id, 1),
+            other => panic!("expected Resend for the out-for-resend packet, got {other:?}"),
+        }
+
+        // The packet is still tracked (keep-the-entry fix) and still tagged with
+        // its stream, so a concurrent drop_stream in this gap releases its bytes.
+        assert!(tracker.pending_receipts.contains_key(&1));
+        assert_eq!(
+            tracker.packet_streams.get(&1),
+            Some(&PacketStream::Stream(stream))
+        );
+        assert_eq!(
+            tracker.drop_stream(stream),
+            13,
+            "issue #4345: a packet out-for-resend must still be released by drop_stream"
+        );
+
+        // And it is fully gone afterwards (no later double-release).
+        assert!(tracker.pending_receipts.is_empty());
+        assert!(tracker.packet_streams.is_empty());
+        let (ack_info, _) = tracker.report_received_receipts(&[1]);
+        assert!(
+            ack_info.is_empty(),
+            "a late ACK after the gap-drop must not release bytes again"
+        );
     }
 }

--- a/docs/architecture/transport/README.md
+++ b/docs/architecture/transport/README.md
@@ -244,10 +244,17 @@ flowchart TB
 2. Decrypt + deserialize
 3. **RTT update**: If ACK, update smoothed RTT and cwnd (LEDBAT feedback)
 4. **Rate update**: Recalculate `min(ledbat_rate, global_pool_rate)` (RTT-adaptive timing)
-5. **Flightsize update**: Decrement flightsize on ACK. Flightsize is also
-   released when a packet is permanently abandoned after
-   `MAX_PACKET_RETRANSMITS` (via `CongestionControl::release_flightsize`), so a
-   never-ACKed packet cannot pin flightsize for the connection's life (#4345).
+5. **Flightsize update**: Decrement flightsize on ACK. Flightsize has two
+   additional release paths so a stream whose ACKs never arrive cannot pin
+   flightsize for the connection's life (#4345): (a) when a packet is
+   permanently abandoned after `MAX_PACKET_RETRANSMITS`, and (b) when an
+   outbound stream aborts (cwnd-wait timeout, upstream stall/error, or mid-send
+   failure) — `SentPacketTracker::drop_stream(stream_id)` removes all of the
+   aborted stream's still-tracked packets and the abort releases their byte
+   total in one shot. All three paths go through
+   `CongestionControl::release_flightsize`, and each in-flight packet is
+   released exactly once (ACK / abandon / drop_stream each remove it from
+   tracking).
 6. Deliver to application
 
 ## Development History


### PR DESCRIPTION
## Problem

Large multi-fragment GETs on lossy paths intermittently fail (`stream assembly:
no fragments received within inactivity timeout`); the contract never caches and
a follow-up SUBSCRIBE is then rejected (issue #4345).

The remaining root cause this PR fixes: **flight-size accounting strands credit
when a stream aborts.** Flight size is a single connection-wide counter. When an
outbound stream aborts (cwnd-wait timeout, upstream stall/error, or a mid-send
failure) its already-sent, unacked fragments stay counted in flight size until
each one is ACKed or ages out via `MAX_PACKET_RETRANSMITS` (~6s). FixedRate's
loss-pause caps cwnd at the frozen flight size, so a single lossy/aborted stream
starves every subsequent stream on that connection.

Already merged (not redone here): #4353 (abandon never-ACKed packets), #4367
(op-layer retry), #4374 (a stalled stream fails the stream, not the connection).
This PR adds the atomic flight-size release on stream abort.

## Approach

Built and reviewed in two stages on this branch; merged as one PR (shipping the
per-packet stream index without the abort wiring would add hot-path cost for no
benefit).

**Stage 1 — mechanism (commits 1–2):** tag each tracked packet with its owning
stream (`PacketStream::Stream(id)` | `Control` sentinel) via a `packet_streams`
map, and add `SentPacketTracker::drop_stream(stream_id) -> u64` that removes the
stream's packets from ALL tracking structures and returns the exact byte total.
Removal from `pending_receipts` is what makes it double-decrement-safe: no later
ACK or abandon can release those bytes again.

**Stage 2 — wiring + the resend-gap race (commit 3):**

- **The resend-gap race.** `send_stream`/`pipe_stream` run in spawned tasks and
  share the `Arc<Mutex<SentPacketTracker>>` with the per-connection recv loop.
  The recv loop's resend cycle released the tracker lock across the UDP
  `send_to().await`: `get_resend` removed the packet from `pending_receipts` and
  the caller re-registered it only after the await. A `drop_stream` landing in
  that window saw no `pending_receipts` entry — released 0 bytes for a genuinely
  in-flight packet and stripped its stream tag — leaving the fragment pinned
  (partial defeat of the fix; safe direction, not a double-decrement).
  **Fix:** `get_resend` now KEEPS a resent packet in `pending_receipts` (clones
  the payload, refreshes its send-time in place, re-queues it) — the same
  keep-the-entry shape the TLP branch already used. The invariant becomes total:
  a packet is in `pending_receipts` iff it is in flight, so a concurrent
  `drop_stream` always sees and releases it. This does NOT touch flight size and
  does not reintroduce the forbidden decrement-on-RTO + re-add-on-resend pair —
  it is pure tracker bookkeeping. Resend re-registration becomes an idempotent
  in-place refresh; the recv loop is otherwise unchanged.
- **Abort wiring.** New `release_aborted_stream_flightsize()` helper calls
  `drop_stream` under the tracker lock, drops the lock, then
  `release_flightsize(returned)` on the congestion controller — mirroring the
  ACK path's lock ordering (tracker lock never held across the controller call
  or across an await). Wired into all six stream-failing return sites in
  `send_stream`/`pipe_stream`. The two mid-send-failure sites additionally
  release the current fragment's `on_send` bytes (added just before a send that
  then failed, so the packet was never tracked).

`drop_stream` returns the encrypted tracker-payload byte sum — exactly what an
ACK or Abandon for those same packets would have released — so the abort
substitutes cleanly for the ACKs that never come, consistent with the existing
release accounting.

## Testing

- `cwnd_wait_timeout_releases_stranded_flightsize` (integration): reproduces the
  core symptom — fragments fill flight size to ~cwnd, no ACKs ever arrive, the
  next fragment's cwnd wait times out; asserts flight size returns to 0 on
  abort. **Verified to FAIL without the wiring** (flight size pinned at 2260B).
- `cwnd_wait_timeout_zero_inflight_is_noop` (integration): abort with nothing in
  flight is a clean no-op.
- `test_drop_stream_releases_packet_out_for_resend` (unit): the exact resend-gap
  interleaving — Resend handed out, NOT re-registered, then `drop_stream` must
  still release the packet.
- Stage-1 unit suite (11 tests) pins the byte total and the no-double-decrement
  invariant (ACK / abandon / interleaved streams / control packets / boundaries).
- `test_packet_lost` updated to the new keep-the-entry-on-resend semantics.

`cargo fmt`, `cargo clippy -p freenet --tests -- -D warnings`, and
`cargo test -p freenet --lib` all green (3035 lib tests pass; 654 transport
tests pass; 0 failures, no new ignores).

Part of #4345 (the flight-size angle; #4345 tracks the multi-fragment-GET
symptom across several fixes, so this does not fully close it).

[AI-assisted - Claude]
