### PR TITLE
fix(contract): off-load network related-fetch from contract_handling loop (#4391)

### DIFF
--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -257,6 +257,26 @@ MUST:
   and the local-only path forced wasted ResyncRequest round trips
   on every send. The escalation is bounded by RELATED_FETCH_TIMEOUT.
   See PR #4006 / freenet/mail#80.
+
+- Off-loop deferral (#4391): there are now TWO entry points into the
+  bridged upsert.
+  * The NON-deferrable path (`upsert_contract_state`, used by
+    delegate-driven PUTs and direct callers) keeps the INLINE
+    `start_sub_op_get` escalation described above — it awaits the
+    network GET in place, bounded by RELATED_FETCH_TIMEOUT.
+  * The DEFERRABLE path (`upsert_contract_state_deferrable`, used by the
+    serial `contract_handling` loop) resolves related contracts
+    LOCAL-ONLY first. On a local miss it does NOT await the network GET
+    inline — it returns `UpsertOutcome::DeferRelated(missing)`, and the
+    loop off-loads the fetch to a background task and re-enqueues a
+    continuation (`contract.rs::maybe_defer_upsert` /
+    `handle_deferred_resume`). This keeps the single-threaded loop from
+    stalling on the 10s fetch while other contracts' events (including
+    cached GETs) drain. WASM validate/store still runs serially on the
+    loop; only the network WAIT moves off-loop. While a contract has an
+    in-flight deferral the loop HOLDS that contract's later events to
+    preserve per-contract FIFO; the block is released (and held events
+    re-queued at the FRONT) on resume or on a TTL sweep.
 ```
 
 ### WHEN a contract's validate_state returns RequestRelated

--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -273,14 +273,18 @@ MUST:
     `handle_deferred_resume`). This keeps the single-threaded loop from
     stalling on the 10s fetch while other contracts' events (including
     cached GETs) drain. WASM validate/store still runs serially on the
-    loop; only the network WAIT moves off-loop. While a contract has an
-    in-flight deferral the loop HOLDS that contract's later events to
-    preserve per-contract FIFO; the block is released (and held events
-    re-queued at the FRONT) by the deferral's resume. The off-loop waiter
+    loop; only the network WAIT moves off-loop. The off-loop waiter
     delivers EXACTLY ONE resume via an RAII `ResumeGuard` (Drop delivers a
     MissingRelated resume if the task is dropped before sending), so every
-    deferral terminates with exactly one client answer — no TTL sweep or
-    stale-resume guard is needed.
+    deferral terminates with exactly one client answer.
+    There is NO per-contract ordering/blocking: a GET/UPDATE for a contract
+    whose PUT is mid-deferral runs immediately in normal fair-queue order and
+    may observe the pre-deferral state — this reordering is intended (the
+    per-contract-FIFO machinery was removed in #4391 round 5). The deferring
+    op's own response is still delivered only on commit (its responder is
+    parked by `deferral_id`), and the resume re-reads CURRENT state, so
+    concurrent same-key deferrals reconcile via the contract's CRDT merge
+    exactly as two concurrent same-key UPDATEs would — no lost update.
 ```
 
 ### WHEN a contract's validate_state returns RequestRelated

--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -276,7 +276,11 @@ MUST:
     loop; only the network WAIT moves off-loop. While a contract has an
     in-flight deferral the loop HOLDS that contract's later events to
     preserve per-contract FIFO; the block is released (and held events
-    re-queued at the FRONT) on resume or on a TTL sweep.
+    re-queued at the FRONT) by the deferral's resume. The off-loop waiter
+    delivers EXACTLY ONE resume via an RAII `ResumeGuard` (Drop delivers a
+    MissingRelated resume if the task is dropped before sending), so every
+    deferral terminates with exactly one client answer — no TTL sweep or
+    stale-resume guard is needed.
 ```
 
 ### WHEN a contract's validate_state returns RequestRelated

--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -79,8 +79,18 @@ On a relay driver's response path, any operation that enqueues on the
 single-threaded `contract_handling` event loop (GetQuery, PutQuery,
 validate_state, `RequestRelated` recursion, etc.) MUST be sequenced
 AFTER the upstream forward. Reversing this puts WASM `validate_state`
-and the 10s `RELATED_FETCH_TIMEOUT` directly on the upstream-visible
-critical path, where they stack across multi-hop traversals.
+directly on the upstream-visible critical path, where it stacks across
+multi-hop traversals.
+
+Note (#4391): the related-contract NETWORK fetch's 10s
+`RELATED_FETCH_TIMEOUT` is no longer awaited inline on the
+`contract_handling` loop — a PUT/UPDATE that needs a related contract
+not held locally now off-loads that fetch to a background task and
+re-enqueues a continuation (see `contract.rs::maybe_defer_upsert`), so
+the loop no longer stalls for that 10s window. WASM
+`validate_state`/`update_state`/store still run serially on the loop,
+so this invariant still holds for the WASM work; only the related-fetch
+WAIT no longer contributes to the stall.
 
 ```
 RIGHT (issue #4155 fix):

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -4521,6 +4521,73 @@ mod hol_4391_tests {
         );
     }
 
+    /// Round-3.2 (unit): on GLOBAL-cap overflow, `requeue_front` must accept the
+    /// OLDEST held event (which pops first) and reject the NEWEST ones — never
+    /// the reverse. With held `[e1,e2,e3]` and exactly ONE global slot free, e1
+    /// must be re-queued (and pop first) while e2,e3 are returned as overflow in
+    /// FIFO order. The previous reverse-iterate-with-per-event-cap code accepted
+    /// e3 (newest) and rejected e1,e2 — a per-contract FIFO violation. (Codex.)
+    #[test]
+    fn requeue_front_global_overflow_keeps_oldest_rejects_newest() {
+        let mut fq = fair_queue::FairEventQueue::new();
+
+        // Saturate the GLOBAL queue to MAX_TOTAL_FAIR_QUEUE - 1 (one slot free),
+        // spread across distinct contract keys so no single per-contract bucket
+        // overflows (each key holds at most MAX_QUEUED_PER_CONTRACT).
+        let target = fair_queue::MAX_TOTAL_FAIR_QUEUE - 1;
+        let mut pushed = 0u64;
+        let mut filler = 0u64;
+        while (pushed as usize) < target {
+            let key = instance_id(format!("filler_{filler}").as_bytes());
+            filler += 1;
+            let room = (target - pushed as usize).min(fair_queue::MAX_QUEUED_PER_CONTRACT);
+            for _ in 0..room {
+                fq.try_push(
+                    handler::EventId {
+                        id: 10_000 + pushed,
+                    },
+                    get_event(key),
+                )
+                .expect("filler push under caps");
+                pushed += 1;
+            }
+        }
+        assert_eq!(fq.total_queued(), target, "exactly one global slot free");
+
+        // Held events for a FRESH key (its bucket is empty → bucket_free=100, so
+        // the binding constraint is the single free GLOBAL slot → capacity 1).
+        let held_key = instance_id(b"held_global_overflow");
+        let mut held = std::collections::VecDeque::new();
+        held.push_back((handler::EventId { id: 1 }, get_event(held_key)));
+        held.push_back((handler::EventId { id: 2 }, get_event(held_key)));
+        held.push_back((handler::EventId { id: 3 }, get_event(held_key)));
+
+        let rejected = fq.requeue_front(held);
+
+        // e2, e3 (newest) rejected, in FIFO order.
+        let rejected_ids: Vec<u64> = rejected.iter().map(|(id, _)| id.id).collect();
+        assert_eq!(
+            rejected_ids,
+            vec![2, 3],
+            "on global overflow, the NEWEST events must be rejected (in FIFO order), \
+             keeping the oldest — got {rejected_ids:?}"
+        );
+
+        // e1 (oldest) was accepted and, for its key, pops first. Drain the
+        // held_key bucket and confirm e1 is the only/first event from it.
+        let mut from_held_key = Vec::new();
+        while let Some((id, ev)) = fq.pop() {
+            if fair_queue::extract_contract_id(&ev) == Some(held_key) {
+                from_held_key.push(id.id);
+            }
+        }
+        assert_eq!(
+            from_held_key,
+            vec![1],
+            "the OLDEST held event (e1) must be the one accepted on overflow"
+        );
+    }
+
     /// SHOULD-FIX (unit): the per-deferral held buffer caps at
     /// MAX_HELD_PER_DEFERRAL — the (cap+1)th hold returns `Full` carrying the
     /// event back.

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -121,6 +121,110 @@ struct DeferredResume {
     fetched: Result<Vec<(ContractInstanceId, WrappedState)>, ExecutorError>,
 }
 
+/// RAII guard that guarantees the off-loop waiter delivers EXACTLY ONE terminal
+/// [`DeferredResume`] for its deferral — whether the fetch completes, or the
+/// waiter task is dropped/panics/cancelled before sending.
+///
+/// This is the load-bearing invariant of the #4391 deferral lifecycle: because
+/// every deferral is answered by exactly one resume, the loop never needs a TTL
+/// sweep to recover a wedged waiter, and `handle_deferred_resume` never needs a
+/// stale-resume guard (a resume is always for the live, still-blocked deferral).
+///
+/// - On the success path the waiter calls [`send`](Self::send) with the real
+///   fetch result; this takes the payload so `Drop` becomes a no-op.
+/// - On any early exit (drop / panic / cancellation) before `send`, `Drop`
+///   delivers a terminal resume carrying a `MissingRelated` fetch error, which
+///   `handle_deferred_resume` surfaces to the client and uses to release the
+///   contract's per-contract block.
+///
+/// Exactly once: never zero (Drop covers the early-exit path), never twice (the
+/// success send `take`s the payload, so Drop sees `None` and does nothing).
+///
+/// The resume channel is unbounded, so both sends are non-blocking
+/// `unbounded_send` (no `.await`, no back-pressure). A send failure means the
+/// loop has shut down — nothing left to answer.
+struct ResumeGuard {
+    /// `None` once a resume has been sent (success or drop). Holds everything a
+    /// [`DeferredResume`] needs except its `fetched` result.
+    payload: Option<ResumePayload>,
+}
+
+struct ResumePayload {
+    resume_tx: tokio::sync::mpsc::UnboundedSender<DeferredResume>,
+    deferral_id: u64,
+    key: ContractKey,
+    update: Either<WrappedState, StateDelta<'static>>,
+    related_contracts: RelatedContracts<'static>,
+    code: Option<ContractContainer>,
+    is_put: bool,
+}
+
+impl ResumeGuard {
+    fn new(payload: ResumePayload) -> Self {
+        Self {
+            payload: Some(payload),
+        }
+    }
+
+    /// Deliver the terminal resume with the real fetch result. Consumes the
+    /// payload so a subsequent `Drop` is a no-op (exactly-once).
+    fn send(mut self, fetched: Result<Vec<(ContractInstanceId, WrappedState)>, ExecutorError>) {
+        if let Some(p) = self.payload.take() {
+            Self::deliver(p, fetched);
+        }
+    }
+
+    fn deliver(
+        p: ResumePayload,
+        fetched: Result<Vec<(ContractInstanceId, WrappedState)>, ExecutorError>,
+    ) {
+        let ResumePayload {
+            resume_tx,
+            deferral_id,
+            key,
+            update,
+            related_contracts,
+            code,
+            is_put,
+        } = p;
+        if resume_tx
+            .send(DeferredResume {
+                deferral_id,
+                key,
+                update,
+                related_contracts,
+                code,
+                is_put,
+                fetched,
+            })
+            .is_err()
+        {
+            tracing::debug!(
+                contract = %key,
+                "Deferred resume channel closed; contract-handling loop gone"
+            );
+        }
+    }
+}
+
+impl Drop for ResumeGuard {
+    fn drop(&mut self) {
+        // Early exit before `send` (waiter dropped / panicked / cancelled):
+        // deliver a terminal MissingRelated resume so the deferral is still
+        // answered exactly once and its per-contract block is released.
+        if let Some(p) = self.payload.take() {
+            let key_id = *p.key.id();
+            tracing::warn!(
+                contract = %p.key,
+                deferral_id = p.deferral_id,
+                "Off-loop waiter dropped before sending — delivering MissingRelated \
+                 resume so the deferral terminates and its block is released (#4391)"
+            );
+            Self::deliver(p, Err(ExecutorError::missing_related(key_id)));
+        }
+    }
+}
+
 /// Outcome of attempting to hold a same-key event behind an in-flight deferral.
 enum HoldOutcome {
     /// The event was held behind the deferral (FIFO).
@@ -135,17 +239,11 @@ enum HoldOutcome {
 /// Bookkeeping for one contract whose PUT/UPDATE has an in-flight off-loop
 /// related-contract fetch. While this entry exists, the loop HOLDS every other
 /// event for the same contract (per-contract FIFO), releasing them only when
-/// the deferral commits, fails, or times out. See issue #4391.
+/// the deferral's (guaranteed exactly-one) resume runs. See issue #4391.
 struct DeferralEntry {
     /// `deferral_id` of the in-flight op (links to the stashed responder).
+    /// Used to assert the resume is for this live deferral (#4391 invariant).
     deferral_id: u64,
-    /// `true` if the deferred op was a PUT (build `PutResponse` on timeout),
-    /// `false` for UPDATE (`UpdateResponse`). Carried so the TTL sweep answers
-    /// the stranded client with the correct response variant.
-    is_put: bool,
-    /// `init_tracker::now_nanos()` (deterministic `tokio::time::Instant`) when
-    /// the deferral started — drives the TTL sweep.
-    started_nanos: u64,
     /// Same-key events that arrived while this contract was deferred, kept in
     /// FIFO arrival order. Re-queued ahead of fresh events when the deferral
     /// releases.
@@ -221,19 +319,11 @@ impl DeferralCtx {
 
     /// Mark `contract_id` as having an in-flight deferral so its later events
     /// are held until the deferral resolves.
-    fn block_key(
-        &mut self,
-        contract_id: ContractInstanceId,
-        deferral_id: u64,
-        is_put: bool,
-        now_nanos: u64,
-    ) {
+    fn block_key(&mut self, contract_id: ContractInstanceId, deferral_id: u64) {
         self.deferred_keys.insert(
             contract_id,
             DeferralEntry {
                 deferral_id,
-                is_put,
-                started_nanos: now_nanos,
                 held: std::collections::VecDeque::new(),
             },
         );
@@ -995,20 +1085,6 @@ where
     let mut deferral_ctx = DeferralCtx::new(resume_tx);
 
     loop {
-        // Sweep deferrals whose off-loop fetch never reported (waiter task
-        // wedged/dropped): answer their stranded clients with MissingRelated,
-        // release their per-contract block, and re-queue / backpressure their
-        // held events so the contract isn't wedged forever. TTL-bounded per
-        // AGENTS.md "cleanup exemptions MUST be time-bounded".
-        let now = executor::now_nanos();
-        sweep_stale_deferrals(
-            &mut contract_handler,
-            &mut deferral_ctx,
-            &mut fair_queue,
-            now,
-        )
-        .await;
-
         // Drain resumed (deferred) upserts so a completed off-loop fetch is
         // applied promptly and its client answered, ahead of new queued work —
         // but cap the batch (each resume is a full WASM upsert) and interleave
@@ -1120,9 +1196,6 @@ where
             notification = recv_delegate_notification(&mut delegate_rx) => {
                 handle_delegate_notification(&mut contract_handler, notification, &prompter).await;
             }
-            // A held deferral could time out while we're otherwise idle; wake
-            // periodically to run the TTL sweep even when no events arrive.
-            _ = tokio::time::sleep(DEFERRED_RELATED_FETCH_TIMEOUT), if !deferral_ctx.deferred_keys.is_empty() => {}
         }
     }
 }
@@ -1167,76 +1240,6 @@ fn pop_runnable_event(
         }
     }
     RunnableEvent::None
-}
-
-/// Answer and release any deferral whose off-loop fetch never reported within
-/// [`DEFERRED_RELATED_FETCH_TIMEOUT`]. Without this, a waiter task that wedged
-/// or was dropped would leak its stashed responder (client hangs) AND leave the
-/// contract permanently blocked; once `MAX_INFLIGHT_DEFERRALS` leak,
-/// `at_capacity()` is permanently true and the off-loading silently disables
-/// itself. See issue #4391 and AGENTS.md (cleanup exemptions must be
-/// time-bounded).
-/// `now_nanos` is injected (rather than read from `executor::now_nanos()`
-/// internally) so the sweep is deterministically unit-testable. The loop call
-/// site passes `executor::now_nanos()`.
-async fn sweep_stale_deferrals<CH>(
-    contract_handler: &mut CH,
-    deferral_ctx: &mut DeferralCtx,
-    fair_queue: &mut fair_queue::FairEventQueue,
-    now_nanos: u64,
-) where
-    CH: ContractHandler + Send + 'static,
-{
-    if deferral_ctx.deferred_keys.is_empty() {
-        return;
-    }
-    let ttl_nanos = DEFERRED_RELATED_FETCH_TIMEOUT.as_nanos() as u64;
-    // Stale if it has out-lived 2× the fetch timeout — well past when the
-    // waiter should have reported (the waiter itself times out at 1×).
-    let stale: Vec<(ContractInstanceId, u64, bool)> = deferral_ctx
-        .deferred_keys
-        .iter()
-        .filter(|(_, e)| now_nanos.saturating_sub(e.started_nanos) >= ttl_nanos.saturating_mul(2))
-        .map(|(k, e)| (*k, e.deferral_id, e.is_put))
-        .collect();
-    for (contract_id, deferral_id, is_put) in stale {
-        tracing::warn!(
-            contract = %contract_id,
-            deferral_id,
-            "Deferred related-contract fetch never reported within TTL — \
-             answering client with MissingRelated and releasing the contract"
-        );
-        if let Some(responder) = deferral_ctx.stashed.remove(&deferral_id) {
-            let err = ExecutorError::missing_related(contract_id);
-            // Answer with the variant matching the original op so the client
-            // sees a well-formed terminal response (not a PUT response for an
-            // UPDATE op). A wedged waiter is a node-internal fault, not a
-            // normal path; the client surfaces an error and may retry.
-            let response = if is_put {
-                ContractHandlerEvent::PutResponse {
-                    new_value: Err(err),
-                    state_changed: false,
-                }
-            } else {
-                ContractHandlerEvent::UpdateResponse {
-                    new_value: Err(err),
-                    state_changed: false,
-                }
-            };
-            // Client may have disconnected; non-fatal.
-            if responder.respond(response).is_err() {
-                tracing::debug!(
-                    contract = %contract_id,
-                    "Stale-deferral client already disconnected"
-                );
-            }
-        }
-        // Release the swept deferral's block and re-queue its held events at the
-        // FRONT (per-contract FIFO); answer any that don't fit with backpressure
-        // so their waiting_response slots aren't leaked.
-        let rejected = requeue_released_events(deferral_ctx.release_key(&contract_id), fair_queue);
-        answer_rejected_held_events(contract_handler, rejected).await;
-    }
 }
 
 /// Re-enqueue the events that were held behind a now-released deferral, at the
@@ -1314,36 +1317,26 @@ where
         fetched,
     } = resume;
 
-    // STALE-RESUME GUARD (#4391 round-3): only act if THIS deferral still owns
-    // the contract's block. Two stale cases must be skipped entirely:
-    //   * The entry is absent → the TTL sweep already answered this client and
-    //     released the block. Acting now would re-run a stale upsert and (since
-    //     `release_key` is keyed by contract, not deferral_id) is a no-op on the
-    //     map but the upsert/commit would still be stale.
-    //   * The entry exists but a DIFFERENT deferral_id owns it → a newer
-    //     deferral D2 took the key after this one (D1) was swept and a held
-    //     event re-deferred. Running D1's stale upsert would commit older data,
-    //     and `release_key` would remove D2's LIVE block (breaking FIFO).
-    // In both cases the client was already answered by the sweep, so we drop
-    // D1's resume without touching the executor, the block, or held events.
-    let owns_block = deferral_ctx
-        .deferred_keys
-        .get(key.id())
-        .is_some_and(|e| e.deferral_id == deferral_id);
-    if !owns_block {
-        tracing::debug!(
-            contract = %key,
-            deferral_id,
-            "Dropping stale deferred resume — its block was swept or a newer \
-             deferral owns the key (#4391)"
-        );
-        // The stashed responder, if any, was already removed+answered by the
-        // sweep; remove defensively in case of an unexpected duplicate.
-        deferral_ctx.stashed.remove(&deferral_id);
-        return Ok(());
-    }
-
-    // We own the block; reclaim the parked client responder.
+    // INVARIANT (#4391 round-4): every deferral receives EXACTLY ONE resume (the
+    // `ResumeGuard` guarantees delivery even if the waiter is dropped), and a
+    // contract's per-contract block is released ONLY by its own resume here. A
+    // second deferral for the same key cannot form while the key is blocked,
+    // because `pop_runnable_event` HOLDS that key's events instead of running
+    // them (so no new PUT/UPDATE for the key reaches `maybe_defer_upsert` to
+    // create one). Therefore, when this resume arrives, `deferred_keys[key]` is
+    // present and is THIS deferral's entry — there is no swept case and no
+    // newer-deferral case, so no stale-resume guard is needed.
+    //
+    // The stashed responder may legitimately be `None` only if the client
+    // disconnected (its receiver dropped); we still run the upsert for its side
+    // effects and release the block below.
+    debug_assert!(
+        deferral_ctx
+            .deferred_keys
+            .get(key.id())
+            .is_some_and(|e| e.deferral_id == deferral_id),
+        "resume must be for the live, still-blocked deferral (#4391 invariant)"
+    );
     let responder = deferral_ctx.stashed.remove(&deferral_id);
     if responder.is_none() {
         tracing::debug!(contract = %key, "Deferred resume has no stashed responder");
@@ -1551,10 +1544,10 @@ where
     deferral.stashed.insert(deferral_id, responder);
     // Block this contract's subsequent events until the deferral resolves, so a
     // later same-key GET/UPDATE can't run (and see MissingContract/stale state)
-    // before the deferred upsert commits. The block's lifetime is tied to the
-    // stashed responder: released on resume (`handle_deferred_resume`) or on TTL
-    // timeout (`sweep_stale_deferrals`). (#4391 per-contract FIFO.)
-    deferral.block_key(*key.id(), deferral_id, is_put, executor::now_nanos());
+    // before the deferred upsert commits. The block is released ONLY by this
+    // deferral's resume in `handle_deferred_resume`, which is guaranteed to run
+    // exactly once by the `ResumeGuard` below. (#4391 per-contract FIFO.)
+    deferral.block_key(*key.id(), deferral_id);
 
     let op_manager = contract_handler.executor().op_manager_handle();
     let resume_tx = deferral.resume_tx.clone();
@@ -1566,34 +1559,27 @@ where
         "Off-loading related-contract fetch from the contract-handling loop (#4391)"
     );
 
-    // Spawn the off-loop waiter. It drives the related GET(s), then sends a
-    // DeferredResume back to the loop. Fire-and-forget is acceptable per
-    // code-style.md ("short-lived work"): the task is bounded by
-    // MAX_INFLIGHT_DEFERRALS, self-terminates at DEFERRED_RELATED_FETCH_TIMEOUT,
-    // and the loop's `sweep_stale_deferrals` answers + releases any deferral
-    // whose waiter never reports — so a dropped/wedged waiter cannot leak the
-    // stashed responder or permanently wedge the contract.
+    // Spawn the off-loop waiter. It drives the related GET(s), then delivers a
+    // DeferredResume back to the loop via the `ResumeGuard`. Fire-and-forget is
+    // acceptable per code-style.md ("short-lived work"): the task is bounded by
+    // MAX_INFLIGHT_DEFERRALS and self-terminates at DEFERRED_RELATED_FETCH_TIMEOUT.
+    // The `ResumeGuard` guarantees EXACTLY ONE terminal resume even if the task
+    // is dropped/panics before sending (its Drop delivers a MissingRelated
+    // resume) — so a wedged/dropped waiter cannot leak the stashed responder or
+    // permanently wedge the contract. This exactly-once delivery is what lets
+    // the loop omit the old TTL sweep and the stale-resume guard entirely.
+    let guard = ResumeGuard::new(ResumePayload {
+        resume_tx,
+        deferral_id,
+        key,
+        update,
+        related_contracts,
+        code,
+        is_put,
+    });
     GlobalExecutor::spawn(async move {
         let fetched = fetch_related_off_loop(op_manager, missing).await;
-        // Non-blocking send on an unbounded channel; if it fails the loop has
-        // shut down and the client will time out (same as the legacy path).
-        if resume_tx
-            .send(DeferredResume {
-                deferral_id,
-                key,
-                update,
-                related_contracts,
-                code,
-                is_put,
-                fetched,
-            })
-            .is_err()
-        {
-            tracing::debug!(
-                contract = %key,
-                "Deferred resume channel closed; contract-handling loop gone"
-            );
-        }
+        guard.send(fetched);
     });
 
     DeferStep::Deferred
@@ -4596,7 +4582,7 @@ mod hol_4391_tests {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let mut ctx = DeferralCtx::new(tx);
         let k = instance_id(b"held_cap_k");
-        ctx.block_key(k, 1, true, 0);
+        ctx.block_key(k, 1);
 
         for i in 0..MAX_HELD_PER_DEFERRAL as u64 {
             match ctx.hold_event(k, handler::EventId { id: i }, get_event(k)) {
@@ -4624,105 +4610,113 @@ mod hol_4391_tests {
         }
     }
 
-    /// MUST-FIX #4 (unit): the TTL sweep answers a stale deferral's client with
-    /// the correct response variant, releases its block, re-queues its held
-    /// event, and does NOT sweep a fresh (age < 2×TTL) entry.
+    /// Round-4 (unit): the `ResumeGuard` delivers a terminal MissingRelated
+    /// resume when the off-loop waiter is DROPPED before sending (task
+    /// cancelled / panicked). Driving that resume through `handle_deferred_resume`
+    /// must answer the client (MissingRelated), release the per-contract block,
+    /// and re-queue the held same-key events — i.e. the wedge-prevention now
+    /// comes from the drop-guard, NOT a TTL sweep.
     #[tokio::test]
-    async fn sweep_releases_stale_answers_client_and_requeues_held() {
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        let mut ctx = DeferralCtx::new(tx);
+    async fn dropped_waiter_guard_answers_client_and_releases_block() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<DeferredResume>();
+        let mut ctx = DeferralCtx::new(tx.clone());
         let mut handler =
-            MockWasmContractHandler::new_test(handler::contract_handler_channel().1, None, "sweep")
+            MockWasmContractHandler::new_test(handler::contract_handler_channel().1, None, "drop")
                 .await;
         let mut fq = fair_queue::FairEventQueue::new();
 
-        let ttl = DEFERRED_RELATED_FETCH_TIMEOUT.as_nanos() as u64;
+        let contract = make_contract(b"drop_guard_k");
+        let key = contract.key();
 
-        // STALE deferral (started at t=0), an UPDATE op, with one held event.
-        let stale_key = instance_id(b"sweep_stale");
-        ctx.block_key(stale_key, 1, /* is_put */ false, 0);
+        // Set up the loop-side state for an in-flight deferral: stash the client
+        // responder, block the key, and hold a same-key event.
+        ctx.block_key(*key.id(), 7);
         let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
         ctx.stashed
-            .insert(1, StashedResponder::for_test(1, resp_tx));
-        let _ = ctx.hold_event(stale_key, handler::EventId { id: 50 }, get_event(stale_key));
+            .insert(7, StashedResponder::for_test(7, resp_tx));
+        let _ = ctx.hold_event(*key.id(), handler::EventId { id: 50 }, get_event(*key.id()));
 
-        // FRESH deferral (started recently) — must NOT be swept.
-        let fresh_key = instance_id(b"sweep_fresh");
-        let fresh_started = ttl * 2; // so at now below, age = 1 < 2*ttl
-        ctx.block_key(fresh_key, 2, true, fresh_started);
+        // Build the waiter's guard and DROP it WITHOUT calling `send` (simulating
+        // the waiter task being cancelled/dropped before the fetch reports).
+        {
+            let guard = ResumeGuard::new(ResumePayload {
+                resume_tx: tx,
+                deferral_id: 7,
+                key,
+                update: Either::Left(WrappedState::new(vec![1])),
+                related_contracts: RelatedContracts::default(),
+                code: Some(contract),
+                is_put: true,
+            });
+            drop(guard);
+        }
 
-        // Sweep at now = 2*ttl + 1: the stale entry (age 2*ttl+1) is swept; the
-        // fresh entry (age 1) is not.
-        let now = ttl * 2 + 1;
-        sweep_stale_deferrals(&mut handler, &mut ctx, &mut fq, now).await;
-
-        // (a) stale key released; (b) its held event requeued.
+        // The guard's Drop must have delivered exactly one terminal resume.
+        let resume = rx.try_recv().expect("Drop must deliver one resume");
+        assert_eq!(resume.deferral_id, 7);
         assert!(
-            !ctx.is_key_deferred(&stale_key),
-            "stale deferral must be released"
+            resume.fetched.is_err(),
+            "dropped-waiter resume must carry a MissingRelated fetch error"
+        );
+        assert!(rx.try_recv().is_err(), "exactly one resume — no extra");
+
+        // Process it on the loop: client answered (PUT error), block released,
+        // held event re-queued.
+        handle_deferred_resume(&mut handler, &mut ctx, &mut fq, resume)
+            .await
+            .expect("resume handled");
+
+        assert!(
+            !ctx.is_key_deferred(key.id()),
+            "the dropped deferral's block must be released"
         );
         assert_eq!(
             fq.pop().map(|(id, _)| id.id),
             Some(50),
-            "the stale deferral's held event must be re-queued"
+            "the held same-key event must be re-queued"
         );
-
-        // (c) client answered with an UpdateResponse error (matching is_put=false).
-        let (_id, ev) = resp_rx.await.expect("stale client must be answered");
+        let (_id, ev) = resp_rx.await.expect("client must be answered");
         match ev {
-            ContractHandlerEvent::UpdateResponse { new_value, .. } => {
-                assert!(new_value.is_err(), "swept UPDATE must surface an error");
+            ContractHandlerEvent::PutResponse { new_value, .. } => {
+                assert!(
+                    new_value.is_err(),
+                    "dropped-waiter PUT must surface MissingRelated"
+                );
             }
-            other => panic!("expected UpdateResponse for swept UPDATE op, got {other}"),
+            other => panic!("expected PutResponse error, got {other}"),
         }
-
-        // (d) fresh entry survives.
-        assert!(
-            ctx.is_key_deferred(&fresh_key),
-            "a fresh deferral (age < 2×TTL) must NOT be swept"
-        );
     }
 
-    /// MUST-FIX #3 (unit): a stale resume whose deferral_id no longer owns the
-    /// key (a newer deferral took over) is DROPPED — it must not release the
-    /// newer deferral's block.
+    /// Round-4 (unit): the success path delivers EXACTLY ONE resume — the
+    /// explicit `send` consumes the payload, so the guard's `Drop` is a no-op
+    /// (never a double-send).
     #[tokio::test]
-    async fn stale_resume_does_not_release_newer_deferral_block() {
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        let mut ctx = DeferralCtx::new(tx);
-        let mut fq = fair_queue::FairEventQueue::new();
-        let mut handler =
-            MockWasmContractHandler::new_test(handler::contract_handler_channel().1, None, "stale")
-                .await;
+    async fn resume_guard_success_sends_exactly_one_resume() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<DeferredResume>();
+        let key = make_contract(b"once_k").key();
 
-        let contract = make_contract(b"stale_resume_k");
-        let key = contract.key();
-
-        // D2 (the LIVE deferral) currently owns the key, deferral_id = 2.
-        ctx.block_key(*key.id(), 2, true, 0);
-
-        // D1's late resume arrives with deferral_id = 1 (already swept/superseded).
-        let stale_resume = DeferredResume {
-            deferral_id: 1,
+        let guard = ResumeGuard::new(ResumePayload {
+            resume_tx: tx,
+            deferral_id: 3,
             key,
             update: Either::Left(WrappedState::new(vec![1])),
             related_contracts: RelatedContracts::default(),
-            code: Some(contract),
-            is_put: true,
-            fetched: Ok(vec![]),
-        };
+            code: None,
+            is_put: false,
+        });
+        // Success send, then the guard is dropped at end of scope.
+        guard.send(Ok(vec![]));
 
-        handle_deferred_resume(&mut handler, &mut ctx, &mut fq, stale_resume)
-            .await
-            .expect("stale resume handled");
-
-        // D2's block must SURVIVE (the stale D1 resume must not release it).
+        let resume = rx.try_recv().expect("success path must deliver one resume");
+        assert_eq!(resume.deferral_id, 3);
         assert!(
-            ctx.is_key_deferred(key.id()),
-            "stale resume must NOT release the newer deferral's block (#4391 MUST-FIX #3)"
+            resume.fetched.is_ok(),
+            "success resume must carry the real fetch result"
         );
-        let entry = ctx.deferred_keys.get(key.id()).expect("D2 still present");
-        assert_eq!(entry.deferral_id, 2, "the live deferral (D2) must remain");
+        assert!(
+            rx.try_recv().is_err(),
+            "exactly one resume — Drop must NOT send again after a success send"
+        );
     }
 
     /// SHOULD-FIX (unit): with no op_manager, the real `fetch_related_off_loop`

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -64,7 +64,17 @@ const MAX_DELEGATE_DRAIN_BATCH: usize = 16;
 /// (The separate 120s `SUB_OP_FETCH_TIMEOUT` in `local_state_or_from_network`
 /// is on the `OperationMode::Local`-only GET path, NOT on the serial loop's
 /// `upsert_contract_state` path, so it is unrelated to this fix and unchanged.)
-const DEFERRED_RELATED_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+/// Upper bound on the OFF-LOOP related-contract fetch. The fetch runs in a
+/// spawned waiter task (NOT on the serial `contract_handling` loop), so it does
+/// not block other contract ops — there is therefore no reason to cut it shorter
+/// than the GET sub-op's own budget. `start_sub_op_get` self-terminates at
+/// `OPERATION_TTL` (60s); this is that budget plus a small margin so the GET's
+/// own outcome (including a successful late Found) wins over this backstop. An
+/// earlier 10s value (inherited from the inline-fetch era, where a shorter cap
+/// kept the loop from stalling) prematurely failed slow-but-successful related
+/// GETs on lossy/cross-node paths — the exact #4391 / freenet-mail scenario.
+const DEFERRED_RELATED_FETCH_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(crate::config::OPERATION_TTL.as_secs() + 2);
 
 /// Maximum number of PUT/UPDATE operations that may have an in-flight
 /// off-loop related-contract fetch at once.
@@ -94,7 +104,8 @@ const MAX_RESUME_DRAIN_BATCH: usize = 16;
 /// WASM stays serial) with `fetched` supplied, then answers the stashed client
 /// responder. See issue #4391.
 struct DeferredResume {
-    /// Key into the loop's stashed-responder map (and the inflight set).
+    /// Key into the loop's stashed-responder map (which doubles as the
+    /// in-flight-deferral accounting for the `MAX_INFLIGHT_DEFERRALS` cap).
     deferral_id: u64,
     /// The contract being PUT/UPDATEd.
     key: ContractKey,
@@ -119,14 +130,15 @@ struct DeferredResume {
 /// This is the load-bearing invariant of the #4391 deferral lifecycle: because
 /// every deferral is answered by exactly one resume, the loop never needs a TTL
 /// sweep to recover a wedged waiter, and `handle_deferred_resume` never needs a
-/// stale-resume guard (a resume is always for the live, still-blocked deferral).
+/// stale-resume guard (a resume is always for the live deferral identified by
+/// its unique `deferral_id`).
 ///
 /// - On the success path the waiter calls [`send`](Self::send) with the real
 ///   fetch result; this takes the payload so `Drop` becomes a no-op.
 /// - On any early exit (drop / panic / cancellation) before `send`, `Drop`
 ///   delivers a terminal resume carrying a `MissingRelated` fetch error, which
-///   `handle_deferred_resume` surfaces to the client and uses to release the
-///   contract's per-contract block.
+///   `handle_deferred_resume` surfaces to the client (answering the parked
+///   responder exactly once).
 ///
 /// Exactly once: never zero (Drop covers the early-exit path), never twice (the
 /// success send `take`s the payload, so Drop sees `None` and does nothing).
@@ -202,14 +214,15 @@ impl Drop for ResumeGuard {
     fn drop(&mut self) {
         // Early exit before `send` (waiter dropped / panicked / cancelled):
         // deliver a terminal MissingRelated resume so the deferral is still
-        // answered exactly once and its per-contract block is released.
+        // answered exactly once (the parked client responder gets a response
+        // instead of hanging).
         if let Some(p) = self.payload.take() {
             let key_id = *p.key.id();
             tracing::warn!(
                 contract = %p.key,
                 deferral_id = p.deferral_id,
                 "Off-loop waiter dropped before sending — delivering MissingRelated \
-                 resume so the deferral terminates and its block is released (#4391)"
+                 resume so the deferral terminates and the client is answered (#4391)"
             );
             Self::deliver(p, Err(ExecutorError::missing_related(key_id)));
         }
@@ -3268,6 +3281,124 @@ mod hol_4391_tests {
             }
             other => panic!("expected PutResponse for A, got {other}"),
         }
+
+        set_off_loop_fetch_override(None);
+        handle.abort();
+    }
+
+    /// The OFF-LOOP related fetch must not be cut shorter than the GET sub-op's
+    /// own budget. The fetch runs in a spawned waiter (not on the serial loop),
+    /// so a short cap no longer serves a "don't stall the loop" purpose; an
+    /// inline-era 10s value prematurely failed slow-but-successful related GETs
+    /// on lossy/cross-node paths — the exact #4391 / freenet-mail scenario.
+    #[test]
+    fn off_loop_related_fetch_budget_is_at_least_operation_ttl() {
+        assert!(
+            DEFERRED_RELATED_FETCH_TIMEOUT >= crate::config::OPERATION_TTL,
+            "off-loop related-fetch budget {:?} must be >= GET OPERATION_TTL {:?} \
+             so a slow-but-successful related GET is not failed prematurely (#4391)",
+            DEFERRED_RELATED_FETCH_TIMEOUT,
+            crate::config::OPERATION_TTL,
+        );
+    }
+
+    /// Round 5 (no FIFO block): TWO same-key PUTs can both defer CONCURRENTLY
+    /// (the stash is keyed by unique `deferral_id`, not by contract key), and
+    /// BOTH clients must receive their own response — neither responder is lost
+    /// or evicted by the other. This is the headline behavior the per-contract
+    /// FIFO deletion enables; the deleted machinery used to serialize same-key
+    /// ops, which would have masked a lost-responder bug class. (#4391)
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_same_key_deferrals_both_clients_answered() {
+        let _guard = TEST_GUARD.lock().await;
+
+        let key_seed = b"concurrent_a";
+        let key_a = make_contract(key_seed).key();
+        let id_b = *make_contract(b"concurrent_b").key().id();
+        let b_state = WrappedState::new(b"concurrent_b_state".to_vec());
+
+        let (handler, send) = build_handler(vec![(
+            *key_a.id(),
+            ValidateOverride::RequestRelated(vec![id_b]),
+        )])
+        .await;
+
+        // Off-loop fetch returns B's state, gated by a semaphore so BOTH PUTs
+        // park before either resumes — two same-key deferrals live at once.
+        // (A semaphore avoids the Notify registration race for two waiters.)
+        let sem = Arc::new(tokio::sync::Semaphore::new(0));
+        let sem_for_stub = sem.clone();
+        let b_for_stub = b_state.clone();
+        set_off_loop_fetch_override(Some(Arc::new(move |missing| {
+            let sem = sem_for_stub.clone();
+            let b = b_for_stub.clone();
+            Box::pin(async move {
+                let _permit = sem.acquire_owned().await.expect("sem open");
+                Ok(vec![(missing[0], b.clone())])
+            })
+        })));
+
+        let send = Arc::new(send);
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            crate::contract::user_input::AutoApprovePrompter,
+        ));
+
+        // Fire TWO same-key PUTs; each defers and parks its own responder.
+        let send1 = send.clone();
+        let contract1 = make_contract(key_seed);
+        let put1 = GlobalExecutor::spawn(async move {
+            send1
+                .send_to_handler(ContractHandlerEvent::PutQuery {
+                    key: contract1.key(),
+                    state: WrappedState::new(b"a_state_1".to_vec()),
+                    related_contracts: RelatedContracts::default(),
+                    contract: Some(contract1),
+                })
+                .await
+        });
+        let send2 = send.clone();
+        let contract2 = make_contract(key_seed);
+        let put2 = GlobalExecutor::spawn(async move {
+            send2
+                .send_to_handler(ContractHandlerEvent::PutQuery {
+                    key: contract2.key(),
+                    state: WrappedState::new(b"a_state_2".to_vec()),
+                    related_contracts: RelatedContracts::default(),
+                    contract: Some(contract2),
+                })
+                .await
+        });
+
+        // Let the loop pick up both PUTs and enter the deferral path for each.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Release BOTH parked fetches at once.
+        sem.add_permits(2);
+
+        // BOTH clients must be answered (neither responder lost) — the core
+        // invariant of deferral_id-keyed stashing. (We assert each gets a
+        // PutResponse, not a specific Ok/Err, so the test is robust to the
+        // mock's merge semantics; the lost-responder failure class would show
+        // up as one of these hanging.)
+        let r1 = tokio::time::timeout(Duration::from_secs(5), put1)
+            .await
+            .expect("put1 must not hang")
+            .expect("put1 join")
+            .expect("put1 responds");
+        let r2 = tokio::time::timeout(Duration::from_secs(5), put2)
+            .await
+            .expect("put2 must not hang")
+            .expect("put2 join")
+            .expect("put2 responds");
+        assert!(
+            matches!(r1, ContractHandlerEvent::PutResponse { .. }),
+            "put1 client must get its own PutResponse, got {r1}"
+        );
+        assert!(
+            matches!(r2, ContractHandlerEvent::PutResponse { .. }),
+            "put2 client must get its own PutResponse, got {r2}"
+        );
 
         set_off_loop_fetch_override(None);
         handle.abort();

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -86,15 +86,6 @@ const MAX_INFLIGHT_DEFERRALS: usize = 256;
 /// bounded-batch rationale.
 const MAX_RESUME_DRAIN_BATCH: usize = 16;
 
-/// Maximum same-key events held behind a single in-flight deferral before the
-/// loop rejects further same-key events with backpressure.
-///
-/// While a contract's PUT/UPDATE defers, later same-key events are held to
-/// preserve per-contract FIFO (#4391). This bounds that held buffer so a
-/// contract flooded with events during a long deferral can't grow it without
-/// limit — matching the spirit of the fair queue's per-contract cap.
-const MAX_HELD_PER_DEFERRAL: usize = 100;
-
 /// A PUT/UPDATE that deferred its related-contract fetch off the serial loop,
 /// carrying everything needed to re-run the upsert once the fetch resolves.
 ///
@@ -225,49 +216,29 @@ impl Drop for ResumeGuard {
     }
 }
 
-/// Outcome of attempting to hold a same-key event behind an in-flight deferral.
-enum HoldOutcome {
-    /// The event was held behind the deferral (FIFO).
-    Held,
-    /// The key isn't deferred (raced a release) — the caller should run the event.
-    NotDeferred(handler::EventId, ContractHandlerEvent),
-    /// The per-deferral held buffer is full — the caller must reject the event
-    /// with backpressure rather than hold it.
-    Full(handler::EventId, ContractHandlerEvent),
-}
-
-/// Bookkeeping for one contract whose PUT/UPDATE has an in-flight off-loop
-/// related-contract fetch. While this entry exists, the loop HOLDS every other
-/// event for the same contract (per-contract FIFO), releasing them only when
-/// the deferral's (guaranteed exactly-one) resume runs. See issue #4391.
-struct DeferralEntry {
-    /// `deferral_id` of the in-flight op (links to the stashed responder).
-    /// Used to assert the resume is for this live deferral (#4391 invariant).
-    deferral_id: u64,
-    /// Same-key events that arrived while this contract was deferred, kept in
-    /// FIFO arrival order. Re-queued ahead of fresh events when the deferral
-    /// releases.
-    held: std::collections::VecDeque<(handler::EventId, ContractHandlerEvent)>,
-}
-
 /// Loop-side state for off-loading deferred related-contract fetches (#4391).
 ///
 /// Owned by `contract_handling`; passed by `&mut` into `handle_contract_event`
 /// so the PUT/UPDATE arms can defer. When this context is absent (e.g. the
 /// delegate-driven PUT path, or direct unit-test calls to
 /// `handle_contract_event`), the arms keep the legacy inline-fetch behavior.
+///
+/// NOTE: there is deliberately NO per-contract ordering/blocking here. A GET or
+/// UPDATE for a contract whose PUT is mid-deferral runs immediately in normal
+/// fair-queue order and may observe the pre-PUT state; the PUT issuer's own
+/// response is still delivered only on commit (via its stashed responder), so
+/// its causality holds. Two same-key ops can also defer concurrently (bounded
+/// globally by `MAX_INFLIGHT_DEFERRALS`); each resumes independently and
+/// re-runs its upsert against CURRENT state, so the contract's CRDT merge
+/// reconciles them exactly as it would two concurrent same-key UPDATEs — no
+/// lost update. This reordering is the intended, accepted behavior (the
+/// per-contract-FIFO machinery was removed in #4391 round 5).
 struct DeferralCtx {
     /// Off-loop waiters send completed [`DeferredResume`]s back to the loop here.
     resume_tx: tokio::sync::mpsc::UnboundedSender<DeferredResume>,
     /// Client responders parked while their op's related fetch runs off-loop,
     /// keyed by `deferral_id`. Drained by the loop when the resume arrives.
     stashed: std::collections::HashMap<u64, StashedResponder>,
-    /// Contracts with an in-flight deferral, keyed by `ContractInstanceId`.
-    /// While a key is present here, the loop holds that contract's subsequent
-    /// events (per-contract FIFO) instead of running them before the deferred
-    /// upsert commits — see [`DeferralEntry`]. Keyed by the same id the fair
-    /// queue uses (`extract_contract_id`).
-    deferred_keys: std::collections::HashMap<ContractInstanceId, DeferralEntry>,
     /// Monotonic id generator for `deferral_id`.
     next_deferral_id: u64,
 }
@@ -277,7 +248,6 @@ impl DeferralCtx {
         Self {
             resume_tx,
             stashed: std::collections::HashMap::new(),
-            deferred_keys: std::collections::HashMap::new(),
             next_deferral_id: 0,
         }
     }
@@ -286,57 +256,6 @@ impl DeferralCtx {
     /// defer (it falls back to surfacing `MissingRelated`).
     fn at_capacity(&self) -> bool {
         self.stashed.len() >= MAX_INFLIGHT_DEFERRALS
-    }
-
-    /// `true` if `contract_id` currently has an in-flight deferral, meaning its
-    /// other events must be held rather than processed.
-    fn is_key_deferred(&self, contract_id: &ContractInstanceId) -> bool {
-        self.deferred_keys.contains_key(contract_id)
-    }
-
-    /// Park a same-key event behind an in-flight deferral, preserving FIFO.
-    /// See [`HoldOutcome`] for the three outcomes.
-    fn hold_event(
-        &mut self,
-        contract_id: ContractInstanceId,
-        id: handler::EventId,
-        event: ContractHandlerEvent,
-    ) -> HoldOutcome {
-        match self.deferred_keys.get_mut(&contract_id) {
-            Some(entry) => {
-                // Bound the held buffer so a contract that keeps receiving
-                // events during a long deferral can't grow it without limit.
-                // Mirrors the fair queue's per-contract cap.
-                if entry.held.len() >= MAX_HELD_PER_DEFERRAL {
-                    return HoldOutcome::Full(id, event);
-                }
-                entry.held.push_back((id, event));
-                HoldOutcome::Held
-            }
-            None => HoldOutcome::NotDeferred(id, event),
-        }
-    }
-
-    /// Mark `contract_id` as having an in-flight deferral so its later events
-    /// are held until the deferral resolves.
-    fn block_key(&mut self, contract_id: ContractInstanceId, deferral_id: u64) {
-        self.deferred_keys.insert(
-            contract_id,
-            DeferralEntry {
-                deferral_id,
-                held: std::collections::VecDeque::new(),
-            },
-        );
-    }
-
-    /// Release a contract's deferral block, returning the held same-key events
-    /// (FIFO) so the loop can re-enqueue them. Returns `None` if the key wasn't
-    /// blocked.
-    fn release_key(
-        &mut self,
-        contract_id: &ContractInstanceId,
-    ) -> Option<std::collections::VecDeque<(handler::EventId, ContractHandlerEvent)>> {
-        self.deferred_keys.remove(contract_id).map(|e| e.held)
     }
 }
 
@@ -1092,13 +1011,8 @@ where
         for _ in 0..MAX_RESUME_DRAIN_BATCH {
             match resume_rx.try_recv() {
                 Ok(resume) => {
-                    handle_deferred_resume(
-                        &mut contract_handler,
-                        &mut deferral_ctx,
-                        &mut fair_queue,
-                        resume,
-                    )
-                    .await?;
+                    handle_deferred_resume(&mut contract_handler, &mut deferral_ctx, resume)
+                        .await?;
                 }
                 Err(_) => break,
             }
@@ -1144,38 +1058,27 @@ where
             }
         }
 
-        // Process one RUNNABLE event from the fair queue. Events for a contract
-        // that currently has an in-flight deferral are HELD (not run) so the
-        // deferred upsert commits before any later same-key op — preserving
-        // per-contract FIFO (#4391). Other contracts keep draining: that is the
-        // whole point of off-loading the fetch.
-        match pop_runnable_event(&mut fair_queue, &mut deferral_ctx) {
-            RunnableEvent::Run(id, event) => {
-                handle_contract_event(
-                    &mut contract_handler,
-                    id,
-                    event,
-                    &prompter,
-                    Some(&mut deferral_ctx),
-                )
-                .await?;
-                continue;
-            }
-            RunnableEvent::RejectFull(id, event) => {
-                // A deferred contract's held buffer is full: reject this event
-                // with backpressure rather than hold it unboundedly.
-                let rejected = Box::new(fair_queue::RejectedEvent { id, event });
-                track_pending_reclamation_if_evict(&mut contract_handler, &rejected);
-                send_queue_full_response(contract_handler.channel(), rejected).await;
-                continue;
-            }
-            RunnableEvent::None => {}
+        // Process one event from the fair queue in normal round-robin order.
+        // There is NO per-contract holding: an event for a contract whose
+        // PUT/UPDATE is mid-deferral runs immediately and may observe the
+        // pre-deferral state. The deferring op's own response is still delivered
+        // only on commit (its responder is parked in `deferral_ctx.stashed`), so
+        // its causality is preserved; concurrent same-key ops reconcile via the
+        // contract's CRDT merge on resume. This reordering is intended (#4391).
+        if let Some((id, event)) = fair_queue.pop() {
+            handle_contract_event(
+                &mut contract_handler,
+                id,
+                event,
+                &prompter,
+                Some(&mut deferral_ctx),
+            )
+            .await?;
+            continue;
         }
 
-        // Nothing runnable (queue empty, or every queued event is held behind a
-        // deferral). Block-wait for a new event, a resumed deferral, or a
-        // delegate notification. A resume releases its key's held events, so
-        // progress always resumes once an off-loop fetch reports.
+        // Fair queue is empty. Block-wait for a new event, a resumed deferral,
+        // or a delegate notification.
         tokio::select! {
             result = contract_handler.channel().recv_from_sender() => {
                 let (id, event) = result?;
@@ -1185,102 +1088,12 @@ where
                 }
             }
             Some(resume) = resume_rx.recv() => {
-                handle_deferred_resume(
-                    &mut contract_handler,
-                    &mut deferral_ctx,
-                    &mut fair_queue,
-                    resume,
-                )
-                .await?;
+                handle_deferred_resume(&mut contract_handler, &mut deferral_ctx, resume).await?;
             }
             notification = recv_delegate_notification(&mut delegate_rx) => {
                 handle_delegate_notification(&mut contract_handler, notification, &prompter).await;
             }
         }
-    }
-}
-
-/// What the loop should do with the next fair-queue event, accounting for
-/// per-contract deferral blocks (#4391).
-enum RunnableEvent {
-    /// Run this event now.
-    Run(handler::EventId, ContractHandlerEvent),
-    /// This event belongs to a deferred contract whose held buffer is full —
-    /// reject it with backpressure rather than hold it.
-    RejectFull(handler::EventId, ContractHandlerEvent),
-    /// Nothing runnable (queue empty, or everything is held behind deferrals).
-    None,
-}
-
-/// Pop the next event the loop may run right now: events for a contract with an
-/// in-flight deferral are moved to that deferral's held buffer (FIFO) and
-/// skipped, so the deferred upsert commits before any later same-key op
-/// (per-contract FIFO, #4391). Returns `None` when the fair queue holds nothing
-/// runnable (empty, or everything is held behind deferrals).
-fn pop_runnable_event(
-    fair_queue: &mut fair_queue::FairEventQueue,
-    deferral_ctx: &mut DeferralCtx,
-) -> RunnableEvent {
-    while let Some((id, event)) = fair_queue.pop() {
-        match fair_queue::extract_contract_id(&event) {
-            Some(contract_id) if deferral_ctx.is_key_deferred(&contract_id) => {
-                // Hold this same-key event behind the in-flight deferral.
-                match deferral_ctx.hold_event(contract_id, id, event) {
-                    HoldOutcome::Held => {} // Try the next queued event.
-                    HoldOutcome::NotDeferred(id, event) => {
-                        // Race: key was released between the check and the hold.
-                        return RunnableEvent::Run(id, event);
-                    }
-                    HoldOutcome::Full(id, event) => {
-                        return RunnableEvent::RejectFull(id, event);
-                    }
-                }
-            }
-            _ => return RunnableEvent::Run(id, event),
-        }
-    }
-    RunnableEvent::None
-}
-
-/// Re-enqueue the events that were held behind a now-released deferral, at the
-/// FRONT of their per-contract bucket in original FIFO order (so they run
-/// before any fresh same-key event that arrived during the deferral — the
-/// per-contract FIFO guarantee of #4391).
-///
-/// Returns the events that could NOT be re-enqueued (fair queue full); the
-/// caller MUST answer each with a queue-full response so its
-/// `waiting_response` slot is not leaked and the client doesn't hang for the
-/// full 300s `CH_EV_RESPONSE_TIME_OUT`. (#4391 round-3 leak fix.)
-#[must_use = "rejected held events must be answered with send_queue_full_response \
-              or their waiting_response slot leaks and the client hangs"]
-fn requeue_released_events(
-    held: Option<std::collections::VecDeque<(handler::EventId, ContractHandlerEvent)>>,
-    fair_queue: &mut fair_queue::FairEventQueue,
-) -> Vec<(handler::EventId, ContractHandlerEvent)> {
-    match held {
-        Some(held) => fair_queue.requeue_front(held),
-        None => Vec::new(),
-    }
-}
-
-/// Answer every event that `requeue_released_events` could not re-enqueue with a
-/// queue-full response (drops its `waiting_response` slot — no leak, no 300s
-/// client hang). Mirrors the normal drain-path rejection handling, including the
-/// `EvictContract` pending-reclamation hook so a rejected held `EvictContract`
-/// doesn't silently leak on-disk storage (the #4212 disk-leak class).
-async fn answer_rejected_held_events<CH>(
-    contract_handler: &mut CH,
-    rejected: Vec<(handler::EventId, ContractHandlerEvent)>,
-) where
-    CH: ContractHandler + Send + 'static,
-{
-    for (id, event) in rejected {
-        let rejected = Box::new(fair_queue::RejectedEvent { id, event });
-        // Mirror the normal drain path: an EvictContract dropped here loses its
-        // hosting-cache entry, so register it for pending-reclamation retry
-        // BEFORE answering, or its disk storage leaks. (#4212)
-        track_pending_reclamation_if_evict(contract_handler, &rejected);
-        send_queue_full_response(contract_handler.channel(), rejected).await;
     }
 }
 
@@ -1294,14 +1107,14 @@ async fn answer_rejected_held_events<CH>(
 /// — the second `DeferRelated` is converted to `MissingRelated` (the depth=1 /
 /// one-deferral cap of #4391).
 ///
-/// After the resumed upsert commits, the contract's per-contract block is
-/// released and any events held behind it (per-contract FIFO) are re-enqueued
-/// ahead of fresh events for the same key — so a same-key GET/UPDATE that
-/// arrived during the deferral now sees the committed state.
+/// The upsert re-reads CURRENT state, so concurrent same-key deferrals (or any
+/// same-key op that ran while this one was deferred) are reconciled by the
+/// contract's CRDT merge — there is no lost update. The client is answered
+/// exactly once via its stashed responder (the `ResumeGuard` guarantees this
+/// resume runs exactly once per deferral, even if the waiter was dropped).
 async fn handle_deferred_resume<CH>(
     contract_handler: &mut CH,
     deferral_ctx: &mut DeferralCtx,
-    fair_queue: &mut fair_queue::FairEventQueue,
     resume: DeferredResume,
 ) -> Result<(), ContractError>
 where
@@ -1317,26 +1130,9 @@ where
         fetched,
     } = resume;
 
-    // INVARIANT (#4391 round-4): every deferral receives EXACTLY ONE resume (the
-    // `ResumeGuard` guarantees delivery even if the waiter is dropped), and a
-    // contract's per-contract block is released ONLY by its own resume here. A
-    // second deferral for the same key cannot form while the key is blocked,
-    // because `pop_runnable_event` HOLDS that key's events instead of running
-    // them (so no new PUT/UPDATE for the key reaches `maybe_defer_upsert` to
-    // create one). Therefore, when this resume arrives, `deferred_keys[key]` is
-    // present and is THIS deferral's entry — there is no swept case and no
-    // newer-deferral case, so no stale-resume guard is needed.
-    //
-    // The stashed responder may legitimately be `None` only if the client
-    // disconnected (its receiver dropped); we still run the upsert for its side
-    // effects and release the block below.
-    debug_assert!(
-        deferral_ctx
-            .deferred_keys
-            .get(key.id())
-            .is_some_and(|e| e.deferral_id == deferral_id),
-        "resume must be for the live, still-blocked deferral (#4391 invariant)"
-    );
+    // Reclaim the parked client responder. It may legitimately be `None` only if
+    // the client disconnected (its receiver dropped); we still run the upsert for
+    // its side effects.
     let responder = deferral_ctx.stashed.remove(&deferral_id);
     if responder.is_none() {
         tracing::debug!(contract = %key, "Deferred resume has no stashed responder");
@@ -1417,17 +1213,8 @@ where
         }
     };
 
-    // The resumed upsert has now committed (or errored). Release THIS
-    // deferral's block (we verified above it still owns the key) and re-enqueue
-    // any same-key events held during the deferral at the FRONT of the bucket,
-    // in FIFO order, so they observe the committed state. Events that don't fit
-    // are answered with backpressure so their waiting_response slots aren't
-    // leaked. The released events land in the fair queue and are popped by
-    // `pop_runnable_event` after the resume-drain batch finishes (later in this
-    // same loop iteration, or a subsequent one) — never before the upsert above
-    // committed, since this runs synchronously on the loop.
-    let rejected = requeue_released_events(deferral_ctx.release_key(key.id()), fair_queue);
-
+    // The resumed upsert has committed (or errored). Answer the parked client
+    // exactly once.
     if let Some(responder) = responder {
         if let Err(error) = responder.respond(event_result) {
             tracing::debug!(
@@ -1437,8 +1224,6 @@ where
             );
         }
     }
-
-    answer_rejected_held_events(contract_handler, rejected).await;
     Ok(())
 }
 
@@ -1539,15 +1324,13 @@ where
         );
     };
 
+    // Park the client responder keyed by deferral_id; the (exactly-once) resume
+    // answers it on commit. There is NO per-contract block: same-key events keep
+    // running in normal fair-queue order and reconcile via CRDT merge on resume
+    // (see DeferralCtx docs). (#4391 round 5: per-contract-FIFO machinery removed.)
     let deferral_id = deferral.next_deferral_id;
     deferral.next_deferral_id = deferral.next_deferral_id.wrapping_add(1);
     deferral.stashed.insert(deferral_id, responder);
-    // Block this contract's subsequent events until the deferral resolves, so a
-    // later same-key GET/UPDATE can't run (and see MissingContract/stale state)
-    // before the deferred upsert commits. The block is released ONLY by this
-    // deferral's resume in `handle_deferred_resume`, which is guaranteed to run
-    // exactly once by the `ResumeGuard` below. (#4391 per-contract FIFO.)
-    deferral.block_key(*key.id(), deferral_id);
 
     let op_manager = contract_handler.executor().op_manager_handle();
     let resume_tx = deferral.resume_tx.clone();
@@ -2543,36 +2326,6 @@ mod tests {
         );
     }
 
-    /// Pin: `answer_rejected_held_events` must call `track_pending_reclamation_if_evict`
-    /// before `send_queue_full_response`, so a held `EvictContract` rejected on
-    /// requeue doesn't silently leak its on-disk storage (the #4212 disk-leak
-    /// class). The other three reject sites already do this; this helper is the
-    /// fourth and must match.
-    #[test]
-    fn answer_rejected_held_events_tracks_evict_reclamation_pin_test() {
-        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/contract.rs");
-        let source = std::fs::read_to_string(&path)
-            .unwrap_or_else(|e| panic!("must read own source at {}: {e}", path.display()));
-        let body = source
-            .split("async fn answer_rejected_held_events")
-            .nth(1)
-            .expect("answer_rejected_held_events must exist")
-            .split("\n}\n")
-            .next()
-            .expect("function body");
-        let track_idx = body
-            .find("track_pending_reclamation_if_evict")
-            .expect("must call track_pending_reclamation_if_evict (EvictContract disk-leak #4212)");
-        let send_idx = body
-            .find("send_queue_full_response")
-            .expect("must answer with send_queue_full_response");
-        assert!(
-            track_idx < send_idx,
-            "reclamation tracking must run BEFORE the queue-full response, \
-             mirroring the normal drain path"
-        );
-    }
-
     fn make_contract_key() -> ContractKey {
         let code = ContractCode::from(vec![42u8; 32]);
         let params = Parameters::from(vec![7u8; 8]);
@@ -3520,6 +3273,99 @@ mod hol_4391_tests {
         handle.abort();
     }
 
+    /// Round 5 (accepted reordering): a SAME-KEY GET issued while a PUT for that
+    /// key is mid-deferral runs PROMPTLY — it is NOT held behind the deferring
+    /// PUT. This is the intended behavior after the per-contract-FIFO machinery
+    /// was removed: the GET observes the pre-PUT state (here: not-found, since
+    /// the contract was never stored before the deferring PUT), while the PUT's
+    /// own response is still delivered only on commit. The point of this test is
+    /// the absence of holding — the GET must not wait for the gated fetch.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn same_key_get_during_deferred_put_runs_promptly() {
+        let _guard = TEST_GUARD.lock().await;
+
+        // Contract A requests related B (never local); its off-loop fetch hangs
+        // on the gate, so A's PUT stays mid-deferral.
+        let contract_a = make_contract(b"reorder_a");
+        let key_a = contract_a.key();
+        let id_b = *make_contract(b"reorder_b").key().id();
+
+        let (handler, send) = build_handler(vec![(
+            *key_a.id(),
+            ValidateOverride::RequestRelated(vec![id_b]),
+        )])
+        .await;
+
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let gate_for_stub = gate.clone();
+        set_off_loop_fetch_override(Some(Arc::new(move |missing| {
+            let gate = gate_for_stub.clone();
+            Box::pin(async move {
+                gate.notified().await;
+                Err(ExecutorError::missing_related(missing[0]))
+            })
+        })));
+
+        let send = Arc::new(send);
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            crate::contract::user_input::AutoApprovePrompter,
+        ));
+
+        // Fire A's related-needing PUT in the background: it defers and parks.
+        let send_a = send.clone();
+        let a_task: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
+            GlobalExecutor::spawn(async move {
+                send_a
+                    .send_to_handler(ContractHandlerEvent::PutQuery {
+                        key: key_a,
+                        state: WrappedState::new(b"a_state".to_vec()),
+                        related_contracts: RelatedContracts::default(),
+                        contract: Some(contract_a),
+                    })
+                    .await
+            });
+
+        // Let the loop pick up A's PUT and enter the deferral path.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // A SAME-KEY GET for A must resolve PROMPTLY (NOT held behind the gated
+        // PUT). With no holding, it runs immediately and observes the pre-PUT
+        // state — the contract isn't stored yet, so a not-found GetResponse.
+        let get_a = tokio::time::timeout(
+            Duration::from_secs(2),
+            send.send_to_handler(ContractHandlerEvent::GetQuery {
+                instance_id: *key_a.id(),
+                return_contract_code: false,
+            }),
+        )
+        .await
+        .expect("same-key GET must NOT be held behind the deferring PUT (#4391 round 5)")
+        .expect("GET for A must respond");
+        match get_a {
+            ContractHandlerEvent::GetResponse { .. } => {
+                // Either a not-found response (contract not stored yet) — the
+                // expected pre-PUT observation. We only assert it RAN promptly.
+            }
+            other => panic!("expected GetResponse for A, got {other}"),
+        }
+
+        // Release the gate so A's PUT resolves and its client is answered.
+        gate.notify_one();
+        let a_resp = tokio::time::timeout(Duration::from_secs(5), a_task)
+            .await
+            .expect("A's PUT must resolve after the fetch completes")
+            .expect("A task join")
+            .expect("A's PUT must respond");
+        assert!(
+            matches!(a_resp, ContractHandlerEvent::PutResponse { .. }),
+            "A's PUT must still receive its own response on resume"
+        );
+
+        set_off_loop_fetch_override(None);
+        handle.abort();
+    }
+
     /// Happy path: a deferred PUT whose off-loop fetch SUCCEEDS resumes and
     /// stores the contract, answering the original client.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -3772,309 +3618,6 @@ mod hol_4391_tests {
     }
 
     // ========================================================================
-    // MUST-FIX #1: per-contract FIFO is preserved across a deferral
-    // ========================================================================
-
-    /// While contract K's PUT is deferred (off-loop fetch gated), a later
-    /// SAME-KEY GET must NOT run before the PUT commits — it must wait and then
-    /// observe the committed state (not MissingContract / not-found). At the
-    /// same time, a GET for a DIFFERENT contract K2 must return PROMPTLY (the
-    /// whole point of #4391: only the deferred key is held, not the loop).
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn deferred_put_holds_same_key_get_but_not_other_key() {
-        let _guard = TEST_GUARD.lock().await;
-
-        // Contract K requests related B; B is supplied off-loop on release so
-        // K's PUT ultimately COMMITS (so the held same-key GET sees real state).
-        let contract_k = make_contract(b"fifo_k");
-        let key_k = contract_k.key();
-        let id_b = *make_contract(b"fifo_k_related").key().id();
-
-        let (handler, send) = build_handler(vec![(
-            *key_k.id(),
-            ValidateOverride::RequestRelated(vec![id_b]),
-        )])
-        .await;
-
-        // Off-loop fetch hangs on the gate, then SUCCEEDS (supplies B) so K's
-        // PUT commits when released.
-        let gate = Arc::new(tokio::sync::Notify::new());
-        let gate_stub = gate.clone();
-        let _override =
-            OverrideGuard::install(Arc::new(move |missing: Vec<ContractInstanceId>| {
-                let gate = gate_stub.clone();
-                Box::pin(async move {
-                    gate.notified().await;
-                    Ok(missing
-                        .into_iter()
-                        .map(|id| (id, WrappedState::new(b"b_state".to_vec())))
-                        .collect())
-                })
-            }));
-
-        // A locally-stored, unrelated contract K2 for the cross-key prompt check.
-        let contract_k2 = make_contract(b"fifo_k2_cached");
-        let key_k2 = contract_k2.key();
-
-        let send = Arc::new(send);
-        let handle = GlobalExecutor::spawn(contract_handling(
-            handler,
-            crate::contract::user_input::AutoApprovePrompter,
-        ));
-
-        // Seed K2 so a GET for it is a pure local hit.
-        let put_k2 = put_local(
-            send.as_ref(),
-            contract_k2,
-            WrappedState::new(b"k2_state".to_vec()),
-        )
-        .await;
-        assert!(
-            matches!(
-                put_k2,
-                ContractHandlerEvent::PutResponse {
-                    new_value: Ok(_),
-                    ..
-                }
-            ),
-            "seed PUT for K2 must succeed"
-        );
-
-        // Fire K's related-needing PUT in the background: it defers and parks.
-        let send_k = send.clone();
-        let k_state = WrappedState::new(br#"{"committed":true}"#.to_vec());
-        let k_state_expect = k_state.clone();
-        let k_put: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
-            GlobalExecutor::spawn(async move {
-                send_k
-                    .send_to_handler(ContractHandlerEvent::PutQuery {
-                        key: key_k,
-                        state: k_state,
-                        related_contracts: RelatedContracts::default(),
-                        contract: Some(contract_k),
-                    })
-                    .await
-            });
-
-        // Let the loop pick up K's PUT and enter the deferral path.
-        tokio::time::sleep(Duration::from_millis(150)).await;
-
-        // Fire a SAME-KEY GET for K in the background. It must NOT resolve while
-        // K's PUT is still deferred (held behind the per-contract block).
-        let send_k_get = send.clone();
-        let k_get: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
-            GlobalExecutor::spawn(async move {
-                send_k_get
-                    .send_to_handler(ContractHandlerEvent::GetQuery {
-                        instance_id: *key_k.id(),
-                        return_contract_code: false,
-                    })
-                    .await
-            });
-
-        // Give the same-key GET a chance to (wrongly) resolve if FIFO is broken.
-        tokio::time::sleep(Duration::from_millis(150)).await;
-        assert!(
-            !k_get.is_finished(),
-            "same-key GET for K must be HELD until K's deferred PUT commits \
-             (per-contract FIFO, #4391 MUST-FIX #1)"
-        );
-
-        // Cross-key: a GET for K2 must return PROMPTLY despite K being deferred.
-        let k2_get = tokio::time::timeout(
-            Duration::from_secs(2),
-            send.send_to_handler(ContractHandlerEvent::GetQuery {
-                instance_id: *key_k2.id(),
-                return_contract_code: false,
-            }),
-        )
-        .await
-        .expect("GET for unrelated K2 must NOT be blocked by K's deferral")
-        .expect("K2 GET must respond");
-        match k2_get {
-            ContractHandlerEvent::GetResponse { response, .. } => {
-                let store = response.expect("K2 GET ok");
-                assert_eq!(store.state.expect("K2 has state").as_ref(), b"k2_state");
-            }
-            other => panic!("expected GetResponse for K2, got {other}"),
-        }
-
-        // Release the gate: K's PUT commits, then the held same-key GET runs.
-        gate.notify_one();
-
-        let k_put_resp = tokio::time::timeout(Duration::from_secs(5), k_put)
-            .await
-            .expect("K PUT resolves after release")
-            .expect("K put join")
-            .expect("K PUT responds");
-        match k_put_resp {
-            ContractHandlerEvent::PutResponse { new_value, .. } => {
-                new_value.expect("K PUT must commit once B is supplied");
-            }
-            other => panic!("expected PutResponse for K, got {other}"),
-        }
-
-        // The previously-held same-key GET must now resolve AND observe the
-        // committed state (proving it ran AFTER the PUT, not before).
-        let k_get_resp = tokio::time::timeout(Duration::from_secs(5), k_get)
-            .await
-            .expect("held same-key GET resolves after PUT commits")
-            .expect("K get join")
-            .expect("K GET responds");
-        match k_get_resp {
-            ContractHandlerEvent::GetResponse { response, .. } => {
-                let store = response.expect("K GET ok after commit");
-                assert_eq!(
-                    store.state.expect("K has committed state").as_ref(),
-                    k_state_expect.as_ref(),
-                    "held same-key GET must observe the committed PUT state, \
-                     not a stale/missing value"
-                );
-            }
-            other => panic!("expected GetResponse for K, got {other}"),
-        }
-
-        handle.abort();
-    }
-
-    /// An UPDATE that arrives for a contract whose PUT is still deferred must be
-    /// applied AFTER the deferred PUT commits (per-contract FIFO across op
-    /// types). We assert the UPDATE succeeds and its result reflects the
-    /// post-PUT state.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn deferred_put_then_same_key_update_is_ordered_after_commit() {
-        let _guard = TEST_GUARD.lock().await;
-
-        let contract_k = make_contract(b"fifo_upd_k");
-        let key_k = contract_k.key();
-        let id_b = *make_contract(b"fifo_upd_related").key().id();
-
-        let (handler, send) = build_handler(vec![(
-            *key_k.id(),
-            ValidateOverride::RequestRelated(vec![id_b]),
-        )])
-        .await;
-
-        // A "release all" gate: once `released` is set, every stub invocation
-        // (the PUT's deferral AND any re-deferral by the held UPDATE) proceeds.
-        // Poll the flag (no `Notify` race where a late waiter misses a one-shot
-        // wake) — see the design note in the test body.
-        let released = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let released_stub = released.clone();
-        let _override =
-            OverrideGuard::install(Arc::new(move |missing: Vec<ContractInstanceId>| {
-                let released = released_stub.clone();
-                Box::pin(async move {
-                    while !released.load(std::sync::atomic::Ordering::SeqCst) {
-                        tokio::time::sleep(Duration::from_millis(10)).await;
-                    }
-                    Ok(missing
-                        .into_iter()
-                        .map(|id| (id, WrappedState::new(b"b_state".to_vec())))
-                        .collect())
-                })
-            }));
-
-        let send = Arc::new(send);
-        let handle = GlobalExecutor::spawn(contract_handling(
-            handler,
-            crate::contract::user_input::AutoApprovePrompter,
-        ));
-
-        // Deferred PUT for K (seeds the initial state once it commits).
-        let send_k = send.clone();
-        let k_put: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
-            GlobalExecutor::spawn(async move {
-                send_k
-                    .send_to_handler(ContractHandlerEvent::PutQuery {
-                        key: key_k,
-                        state: WrappedState::new(vec![1, 2, 3]),
-                        related_contracts: RelatedContracts::default(),
-                        contract: Some(contract_k),
-                    })
-                    .await
-            });
-
-        tokio::time::sleep(Duration::from_millis(150)).await;
-
-        // Same-key UPDATE arrives while K's PUT is deferred. The mock applies a
-        // delta by concatenation; this must NOT MissingContract (which it would
-        // if it ran before the PUT committed).
-        //
-        // NOTE: contract K's `ValidateOverride::RequestRelated` fires on the
-        // UPDATE's post-merge validate too, and the off-loop-fetched B is only
-        // injected into the upsert's related_contracts (not persisted to the
-        // state_store) — exactly as the inline path behaves. So the held UPDATE
-        // legitimately RE-DEFERS once. The "release all" gate handles that
-        // second deferral; the ordering invariant under test (UPDATE applies
-        // against the committed PUT state, never MissingContract) still holds.
-        let send_u = send.clone();
-        let k_update: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
-            GlobalExecutor::spawn(async move {
-                send_u
-                    .send_to_handler(ContractHandlerEvent::UpdateQuery {
-                        key: key_k,
-                        data: freenet_stdlib::prelude::UpdateData::Delta(StateDelta::from(vec![
-                            4, 5,
-                        ])),
-                        related_contracts: RelatedContracts::default(),
-                    })
-                    .await
-            });
-
-        tokio::time::sleep(Duration::from_millis(150)).await;
-        assert!(
-            !k_update.is_finished(),
-            "same-key UPDATE must be held until the deferred PUT commits"
-        );
-
-        // Release all deferrals (the PUT's, plus the held UPDATE's re-deferral).
-        released.store(true, std::sync::atomic::Ordering::SeqCst);
-
-        let put_resp = tokio::time::timeout(Duration::from_secs(5), k_put)
-            .await
-            .expect("PUT resolves")
-            .expect("join")
-            .expect("PUT responds");
-        assert!(
-            matches!(
-                put_resp,
-                ContractHandlerEvent::PutResponse {
-                    new_value: Ok(_),
-                    ..
-                }
-            ),
-            "deferred PUT must commit"
-        );
-
-        let upd_resp = tokio::time::timeout(Duration::from_secs(5), k_update)
-            .await
-            .expect("UPDATE resolves after PUT commits")
-            .expect("join")
-            .expect("UPDATE responds");
-        match upd_resp {
-            ContractHandlerEvent::UpdateResponse { new_value, .. } => {
-                // Must NOT be a MissingContract error: the UPDATE ran after the
-                // PUT installed the contract.
-                let stored = new_value.expect(
-                    "UPDATE must apply against the committed PUT state, not \
-                     MissingContract (per-contract FIFO, #4391)",
-                );
-                assert!(
-                    stored.as_ref().ends_with(&[4, 5]),
-                    "UPDATE delta must have been applied on top of the PUT state"
-                );
-            }
-            ContractHandlerEvent::UpdateNoChange { .. } => {
-                panic!("UPDATE should have changed state, got NoChange")
-            }
-            other => panic!("expected UpdateResponse, got {other}"),
-        }
-
-        handle.abort();
-    }
-
-    // ========================================================================
     // SHOULD-FIX #5: UPDATE-path deferral, real off-loop fetch, cap, disconnect
     // ========================================================================
 
@@ -4241,11 +3784,10 @@ mod hol_4391_tests {
     }
 
     /// A client that disconnects mid-deferral (drops its response receiver) must
-    /// NOT leak the stashed responder and MUST release the contract's block.
-    /// Proven by: after the client drops, a fresh same-key PUT eventually
-    /// resolves (the contract wasn't permanently wedged).
+    /// NOT leak the stashed responder or wedge the contract. Proven by: after the
+    /// client drops, a fresh same-key op resolves promptly.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn client_disconnect_during_deferral_releases_block() {
+    async fn client_disconnect_during_deferral_does_not_wedge() {
         let _guard = TEST_GUARD.lock().await;
 
         let contract_k = make_contract(b"disc_k");
@@ -4297,14 +3839,11 @@ mod hol_4391_tests {
         });
         let _ = disconnect_task.await;
 
-        // Let the deferral resume (and discover the dropped responder) and the
-        // block be released.
+        // Let the deferral resume and discover the dropped responder.
         tokio::time::sleep(Duration::from_millis(400)).await;
 
-        // A fresh same-key PUT must eventually resolve — proving the contract
-        // wasn't permanently wedged by the disconnected deferral. This second
-        // PUT supplies B inline (related already cached from the resume) OR
-        // re-defers and resolves; either way it must not hang.
+        // A fresh same-key GET must resolve promptly — proving the disconnected
+        // deferral didn't wedge the contract or leak its responder.
         let resp = tokio::time::timeout(
             DEFERRED_RELATED_FETCH_TIMEOUT + Duration::from_secs(2),
             send.send_to_handler(ContractHandlerEvent::GetQuery {
@@ -4313,14 +3852,11 @@ mod hol_4391_tests {
             }),
         )
         .await
-        .expect(
-            "same-key op after a disconnected deferral must not hang \
-                 (block was released)",
-        )
+        .expect("same-key op after a disconnected deferral must not hang")
         .expect("GET responds");
         assert!(
             matches!(resp, ContractHandlerEvent::GetResponse { .. }),
-            "expected a GetResponse after the block released"
+            "expected a GetResponse"
         );
 
         handle.abort();
@@ -4434,207 +3970,34 @@ mod hol_4391_tests {
     }
 
     // ========================================================================
-    // Round-3 fixes: requeue leak/FIFO, stale-resume guard, sweep, held cap
+    // ResumeGuard exactly-once delivery + off-loop fetch mapping (unit)
     // ========================================================================
 
     fn instance_id(seed: &[u8]) -> ContractInstanceId {
         *make_contract(seed).key().id()
     }
 
-    fn get_event(id: ContractInstanceId) -> ContractHandlerEvent {
-        ContractHandlerEvent::GetQuery {
-            instance_id: id,
-            return_contract_code: false,
-        }
-    }
-
-    /// MUST-FIX #2 (unit): held events re-queue at the FRONT of the per-contract
-    /// bucket in FIFO order, ahead of a fresh same-key event already queued.
-    #[test]
-    fn requeue_front_orders_held_before_fresh_same_key() {
-        let mut fq = fair_queue::FairEventQueue::new();
-        let k = instance_id(b"front_k");
-
-        // A FRESH same-key event is already queued (arrived "after" the held
-        // ones in wall-clock, but reached the fair queue first because the held
-        // ones were diverted into the deferral buffer).
-        fq.try_push(handler::EventId { id: 99 }, get_event(k))
-            .expect("fresh push");
-
-        // Two held events (ids 1, 2) re-queued at the front, FIFO order.
-        let mut held = std::collections::VecDeque::new();
-        held.push_back((handler::EventId { id: 1 }, get_event(k)));
-        held.push_back((handler::EventId { id: 2 }, get_event(k)));
-        let rejected = fq.requeue_front(held);
-        assert!(rejected.is_empty(), "nothing should be rejected under cap");
-
-        // Pop order must be 1, 2 (held FIFO), THEN 99 (fresh) — proving the held
-        // older events run before the fresh one.
-        let order: Vec<u64> = std::iter::from_fn(|| fq.pop().map(|(id, _)| id.id)).collect();
-        assert_eq!(
-            order,
-            vec![1, 2, 99],
-            "held events must run in FIFO order before the fresh same-key event"
-        );
-    }
-
-    /// MUST-FIX #2 + #1 (unit): when the per-contract bucket is at capacity,
-    /// `requeue_front` returns the events it could not enqueue, in FIFO order,
-    /// so the caller can answer them with backpressure (no silent drop / leak).
-    #[test]
-    fn requeue_front_returns_overflow_in_fifo_order() {
-        let mut fq = fair_queue::FairEventQueue::new();
-        let k = instance_id(b"overflow_k");
-
-        // Saturate the per-contract bucket via normal pushes.
-        for i in 0..fair_queue::MAX_QUEUED_PER_CONTRACT as u64 {
-            fq.try_push(handler::EventId { id: 1000 + i }, get_event(k))
-                .expect("fill bucket");
-        }
-
-        // Now try to re-queue 3 held events at the front — all should be rejected
-        // (bucket full), returned in original FIFO order.
-        let mut held = std::collections::VecDeque::new();
-        held.push_back((handler::EventId { id: 1 }, get_event(k)));
-        held.push_back((handler::EventId { id: 2 }, get_event(k)));
-        held.push_back((handler::EventId { id: 3 }, get_event(k)));
-        let rejected = fq.requeue_front(held);
-        let rejected_ids: Vec<u64> = rejected.iter().map(|(id, _)| id.id).collect();
-        assert_eq!(
-            rejected_ids,
-            vec![1, 2, 3],
-            "overflow held events must be returned in FIFO order for backpressure"
-        );
-    }
-
-    /// Round-3.2 (unit): on GLOBAL-cap overflow, `requeue_front` must accept the
-    /// OLDEST held event (which pops first) and reject the NEWEST ones — never
-    /// the reverse. With held `[e1,e2,e3]` and exactly ONE global slot free, e1
-    /// must be re-queued (and pop first) while e2,e3 are returned as overflow in
-    /// FIFO order. The previous reverse-iterate-with-per-event-cap code accepted
-    /// e3 (newest) and rejected e1,e2 — a per-contract FIFO violation. (Codex.)
-    #[test]
-    fn requeue_front_global_overflow_keeps_oldest_rejects_newest() {
-        let mut fq = fair_queue::FairEventQueue::new();
-
-        // Saturate the GLOBAL queue to MAX_TOTAL_FAIR_QUEUE - 1 (one slot free),
-        // spread across distinct contract keys so no single per-contract bucket
-        // overflows (each key holds at most MAX_QUEUED_PER_CONTRACT).
-        let target = fair_queue::MAX_TOTAL_FAIR_QUEUE - 1;
-        let mut pushed = 0u64;
-        let mut filler = 0u64;
-        while (pushed as usize) < target {
-            let key = instance_id(format!("filler_{filler}").as_bytes());
-            filler += 1;
-            let room = (target - pushed as usize).min(fair_queue::MAX_QUEUED_PER_CONTRACT);
-            for _ in 0..room {
-                fq.try_push(
-                    handler::EventId {
-                        id: 10_000 + pushed,
-                    },
-                    get_event(key),
-                )
-                .expect("filler push under caps");
-                pushed += 1;
-            }
-        }
-        assert_eq!(fq.total_queued(), target, "exactly one global slot free");
-
-        // Held events for a FRESH key (its bucket is empty → bucket_free=100, so
-        // the binding constraint is the single free GLOBAL slot → capacity 1).
-        let held_key = instance_id(b"held_global_overflow");
-        let mut held = std::collections::VecDeque::new();
-        held.push_back((handler::EventId { id: 1 }, get_event(held_key)));
-        held.push_back((handler::EventId { id: 2 }, get_event(held_key)));
-        held.push_back((handler::EventId { id: 3 }, get_event(held_key)));
-
-        let rejected = fq.requeue_front(held);
-
-        // e2, e3 (newest) rejected, in FIFO order.
-        let rejected_ids: Vec<u64> = rejected.iter().map(|(id, _)| id.id).collect();
-        assert_eq!(
-            rejected_ids,
-            vec![2, 3],
-            "on global overflow, the NEWEST events must be rejected (in FIFO order), \
-             keeping the oldest — got {rejected_ids:?}"
-        );
-
-        // e1 (oldest) was accepted and, for its key, pops first. Drain the
-        // held_key bucket and confirm e1 is the only/first event from it.
-        let mut from_held_key = Vec::new();
-        while let Some((id, ev)) = fq.pop() {
-            if fair_queue::extract_contract_id(&ev) == Some(held_key) {
-                from_held_key.push(id.id);
-            }
-        }
-        assert_eq!(
-            from_held_key,
-            vec![1],
-            "the OLDEST held event (e1) must be the one accepted on overflow"
-        );
-    }
-
-    /// SHOULD-FIX (unit): the per-deferral held buffer caps at
-    /// MAX_HELD_PER_DEFERRAL — the (cap+1)th hold returns `Full` carrying the
-    /// event back.
-    #[test]
-    fn hold_event_caps_at_max_held_per_deferral() {
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        let mut ctx = DeferralCtx::new(tx);
-        let k = instance_id(b"held_cap_k");
-        ctx.block_key(k, 1);
-
-        for i in 0..MAX_HELD_PER_DEFERRAL as u64 {
-            match ctx.hold_event(k, handler::EventId { id: i }, get_event(k)) {
-                HoldOutcome::Held => {}
-                other => panic!("expected Held within cap, got {:?}", DbgHold(&other)),
-            }
-        }
-        // The (cap+1)th must be Full and hand the event back.
-        match ctx.hold_event(k, handler::EventId { id: 9999 }, get_event(k)) {
-            HoldOutcome::Full(id, _ev) => assert_eq!(id.id, 9999),
-            other => panic!("expected Full at cap, got {:?}", DbgHold(&other)),
-        }
-    }
-
-    // Small debug helper for HoldOutcome (it intentionally has no Debug derive
-    // to avoid requiring ContractHandlerEvent: Debug in non-test code paths).
-    struct DbgHold<'a>(&'a HoldOutcome);
-    impl std::fmt::Debug for DbgHold<'_> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self.0 {
-                HoldOutcome::Held => write!(f, "Held"),
-                HoldOutcome::NotDeferred(..) => write!(f, "NotDeferred"),
-                HoldOutcome::Full(..) => write!(f, "Full"),
-            }
-        }
-    }
-
     /// Round-4 (unit): the `ResumeGuard` delivers a terminal MissingRelated
     /// resume when the off-loop waiter is DROPPED before sending (task
     /// cancelled / panicked). Driving that resume through `handle_deferred_resume`
-    /// must answer the client (MissingRelated), release the per-contract block,
-    /// and re-queue the held same-key events — i.e. the wedge-prevention now
-    /// comes from the drop-guard, NOT a TTL sweep.
+    /// must answer the parked client with MissingRelated — the wedge-prevention
+    /// comes from the drop-guard's exactly-once delivery.
     #[tokio::test]
-    async fn dropped_waiter_guard_answers_client_and_releases_block() {
+    async fn dropped_waiter_guard_answers_client_missing_related() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<DeferredResume>();
         let mut ctx = DeferralCtx::new(tx.clone());
         let mut handler =
             MockWasmContractHandler::new_test(handler::contract_handler_channel().1, None, "drop")
                 .await;
-        let mut fq = fair_queue::FairEventQueue::new();
 
         let contract = make_contract(b"drop_guard_k");
         let key = contract.key();
 
-        // Set up the loop-side state for an in-flight deferral: stash the client
-        // responder, block the key, and hold a same-key event.
-        ctx.block_key(*key.id(), 7);
+        // Stash the client responder (as `maybe_defer_upsert` would) for an
+        // in-flight deferral whose waiter is about to be dropped.
         let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
         ctx.stashed
             .insert(7, StashedResponder::for_test(7, resp_tx));
-        let _ = ctx.hold_event(*key.id(), handler::EventId { id: 50 }, get_event(*key.id()));
 
         // Build the waiter's guard and DROP it WITHOUT calling `send` (simulating
         // the waiter task being cancelled/dropped before the fetch reports).
@@ -4660,21 +4023,15 @@ mod hol_4391_tests {
         );
         assert!(rx.try_recv().is_err(), "exactly one resume — no extra");
 
-        // Process it on the loop: client answered (PUT error), block released,
-        // held event re-queued.
-        handle_deferred_resume(&mut handler, &mut ctx, &mut fq, resume)
+        // Process it on the loop: the parked client is answered with a PUT error.
+        handle_deferred_resume(&mut handler, &mut ctx, resume)
             .await
             .expect("resume handled");
-
         assert!(
-            !ctx.is_key_deferred(key.id()),
-            "the dropped deferral's block must be released"
+            !ctx.stashed.contains_key(&7),
+            "the stashed responder must be consumed (no leak)"
         );
-        assert_eq!(
-            fq.pop().map(|(id, _)| id.id),
-            Some(50),
-            "the held same-key event must be re-queued"
-        );
+
         let (_id, ev) = resp_rx.await.expect("client must be answered");
         match ev {
             ContractHandlerEvent::PutResponse { new_value, .. } => {
@@ -4732,48 +4089,5 @@ mod hol_4391_tests {
             result.is_err(),
             "no op_manager must surface MissingRelated, got {result:?}"
         );
-    }
-
-    /// MUST-FIX #1 (e2e): a held event that can't be re-queued (fair queue full)
-    /// must be ANSWERED with a queue-full response — NOT silently dropped (which
-    /// would leak its waiting_response slot and hang the client 300s). Drives a
-    /// real GetQuery through the channel, then rejects it via the same path the
-    /// sweep/resume use, and asserts the client gets a prompt QueueFull error.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn rejected_held_event_is_answered_not_leaked() {
-        let (send, rcv_halve, _wait) = handler::contract_handler_channel();
-        let mut handler = MockWasmContractHandler::new_test(rcv_halve, None, "leak").await;
-        let k = instance_id(b"leak_k");
-
-        // Client sends a GetQuery and awaits the response.
-        let client = GlobalExecutor::spawn(async move { send.send_to_handler(get_event(k)).await });
-
-        // Handler side receives it (registers the waiting_response slot).
-        let (id, event) = handler
-            .channel()
-            .recv_from_sender()
-            .await
-            .expect("event received");
-
-        // Simulate the requeue-overflow path: this event couldn't be re-queued,
-        // so the loop must answer it with backpressure.
-        answer_rejected_held_events(&mut handler, vec![(id, event)]).await;
-
-        // The client must receive a prompt queue-full error, NOT hang.
-        let resp = tokio::time::timeout(Duration::from_secs(2), client)
-            .await
-            .expect("client must be answered promptly, not leaked/hung")
-            .expect("join")
-            .expect("client receives a response");
-        match resp {
-            ContractHandlerEvent::GetResponse { response, .. } => {
-                let err = response.expect_err("rejected held GET must be an error");
-                assert!(
-                    err.is_contract_queue_full(),
-                    "rejected held event must surface ContractQueueFull, got {err}"
-                );
-            }
-            other => panic!("expected GetResponse(queue-full), got {other}"),
-        }
     }
 }

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -51,18 +51,19 @@ const MAX_CONTRACT_REQUEST_ITERATIONS: usize = 100;
 /// preventing delegate notification channel growth under sustained contract load.
 const MAX_DELEGATE_DRAIN_BATCH: usize = 16;
 
-/// Unified timeout for the off-loop related-contract fetch that backs a
-/// deferred PUT/UPDATE (#4391).
+/// Timeout for the off-loop related-contract fetch that backs a deferred
+/// PUT/UPDATE (#4391).
 ///
-/// This reconciles the two legacy inline timeouts (`RELATED_FETCH_TIMEOUT`=10s
-/// for validate-side fetches, `SUB_OP_FETCH_TIMEOUT`=120s in
-/// `local_state_or_from_network`): the 120s value only existed because the
-/// wait sat on the serial loop and we did not want to fail a slow cross-node
-/// fetch prematurely. Now that the wait is OFF the loop, the loop keeps
-/// draining other events regardless, so we apply the tighter
-/// `RELATED_FETCH_TIMEOUT` consistently — a deferred op that cannot resolve
-/// its related contracts within 10s surfaces `MissingRelated` to the client,
-/// exactly as the inline validate path did.
+/// This matches the executor's `RELATED_FETCH_TIMEOUT` (10s) — the ONLY timeout
+/// that was ever on the serial `contract_handling` loop's upsert path. The
+/// inline related-fetch sites the loop hits (validate-side
+/// `fetch_related_for_validation` and the `update_state requires()` branch) are
+/// all bounded by that 10s budget, so off-loading them under the same budget
+/// preserves the client-visible timeout exactly.
+///
+/// (The separate 120s `SUB_OP_FETCH_TIMEOUT` in `local_state_or_from_network`
+/// is on the `OperationMode::Local`-only GET path, NOT on the serial loop's
+/// `upsert_contract_state` path, so it is unrelated to this fix and unchanged.)
 const DEFERRED_RELATED_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Maximum number of PUT/UPDATE operations that may have an in-flight
@@ -74,6 +75,25 @@ const DEFERRED_RELATED_FETCH_TIMEOUT: std::time::Duration = std::time::Duration:
 /// `MissingRelated` to the client rather than deferring — backpressure, not
 /// unbounded growth (see code-style.md "per-key/per-client caps").
 const MAX_INFLIGHT_DEFERRALS: usize = 256;
+
+/// Maximum number of deferred resumes applied per loop iteration before
+/// yielding back to the fair queue.
+///
+/// Each resume is a full WASM upsert; draining all of them back-to-back would
+/// re-introduce head-of-line latency for cached GETs (the exact thing #4391
+/// fixes). Capping the per-iteration resume work and interleaving it with the
+/// fair queue keeps both moving. Mirrors `fair_queue::MAX_DRAIN_BATCH`'s
+/// bounded-batch rationale.
+const MAX_RESUME_DRAIN_BATCH: usize = 16;
+
+/// Maximum same-key events held behind a single in-flight deferral before the
+/// loop rejects further same-key events with backpressure.
+///
+/// While a contract's PUT/UPDATE defers, later same-key events are held to
+/// preserve per-contract FIFO (#4391). This bounds that held buffer so a
+/// contract flooded with events during a long deferral can't grow it without
+/// limit — matching the spirit of the fair queue's per-contract cap.
+const MAX_HELD_PER_DEFERRAL: usize = 100;
 
 /// A PUT/UPDATE that deferred its related-contract fetch off the serial loop,
 /// carrying everything needed to re-run the upsert once the fetch resolves.
@@ -101,6 +121,37 @@ struct DeferredResume {
     fetched: Result<Vec<(ContractInstanceId, WrappedState)>, ExecutorError>,
 }
 
+/// Outcome of attempting to hold a same-key event behind an in-flight deferral.
+enum HoldOutcome {
+    /// The event was held behind the deferral (FIFO).
+    Held,
+    /// The key isn't deferred (raced a release) — the caller should run the event.
+    NotDeferred(handler::EventId, ContractHandlerEvent),
+    /// The per-deferral held buffer is full — the caller must reject the event
+    /// with backpressure rather than hold it.
+    Full(handler::EventId, ContractHandlerEvent),
+}
+
+/// Bookkeeping for one contract whose PUT/UPDATE has an in-flight off-loop
+/// related-contract fetch. While this entry exists, the loop HOLDS every other
+/// event for the same contract (per-contract FIFO), releasing them only when
+/// the deferral commits, fails, or times out. See issue #4391.
+struct DeferralEntry {
+    /// `deferral_id` of the in-flight op (links to the stashed responder).
+    deferral_id: u64,
+    /// `true` if the deferred op was a PUT (build `PutResponse` on timeout),
+    /// `false` for UPDATE (`UpdateResponse`). Carried so the TTL sweep answers
+    /// the stranded client with the correct response variant.
+    is_put: bool,
+    /// `init_tracker::now_nanos()` (deterministic `tokio::time::Instant`) when
+    /// the deferral started — drives the TTL sweep.
+    started_nanos: u64,
+    /// Same-key events that arrived while this contract was deferred, kept in
+    /// FIFO arrival order. Re-queued ahead of fresh events when the deferral
+    /// releases.
+    held: std::collections::VecDeque<(handler::EventId, ContractHandlerEvent)>,
+}
+
 /// Loop-side state for off-loading deferred related-contract fetches (#4391).
 ///
 /// Owned by `contract_handling`; passed by `&mut` into `handle_contract_event`
@@ -113,6 +164,12 @@ struct DeferralCtx {
     /// Client responders parked while their op's related fetch runs off-loop,
     /// keyed by `deferral_id`. Drained by the loop when the resume arrives.
     stashed: std::collections::HashMap<u64, StashedResponder>,
+    /// Contracts with an in-flight deferral, keyed by `ContractInstanceId`.
+    /// While a key is present here, the loop holds that contract's subsequent
+    /// events (per-contract FIFO) instead of running them before the deferred
+    /// upsert commits — see [`DeferralEntry`]. Keyed by the same id the fair
+    /// queue uses (`extract_contract_id`).
+    deferred_keys: std::collections::HashMap<ContractInstanceId, DeferralEntry>,
     /// Monotonic id generator for `deferral_id`.
     next_deferral_id: u64,
 }
@@ -122,14 +179,74 @@ impl DeferralCtx {
         Self {
             resume_tx,
             stashed: std::collections::HashMap::new(),
+            deferred_keys: std::collections::HashMap::new(),
             next_deferral_id: 0,
         }
     }
 
     /// `true` when the in-flight deferral cap is reached and a new op must NOT
-    /// defer (it falls back to surfacing the related-fetch failure inline).
+    /// defer (it falls back to surfacing `MissingRelated`).
     fn at_capacity(&self) -> bool {
         self.stashed.len() >= MAX_INFLIGHT_DEFERRALS
+    }
+
+    /// `true` if `contract_id` currently has an in-flight deferral, meaning its
+    /// other events must be held rather than processed.
+    fn is_key_deferred(&self, contract_id: &ContractInstanceId) -> bool {
+        self.deferred_keys.contains_key(contract_id)
+    }
+
+    /// Park a same-key event behind an in-flight deferral, preserving FIFO.
+    /// See [`HoldOutcome`] for the three outcomes.
+    fn hold_event(
+        &mut self,
+        contract_id: ContractInstanceId,
+        id: handler::EventId,
+        event: ContractHandlerEvent,
+    ) -> HoldOutcome {
+        match self.deferred_keys.get_mut(&contract_id) {
+            Some(entry) => {
+                // Bound the held buffer so a contract that keeps receiving
+                // events during a long deferral can't grow it without limit.
+                // Mirrors the fair queue's per-contract cap.
+                if entry.held.len() >= MAX_HELD_PER_DEFERRAL {
+                    return HoldOutcome::Full(id, event);
+                }
+                entry.held.push_back((id, event));
+                HoldOutcome::Held
+            }
+            None => HoldOutcome::NotDeferred(id, event),
+        }
+    }
+
+    /// Mark `contract_id` as having an in-flight deferral so its later events
+    /// are held until the deferral resolves.
+    fn block_key(
+        &mut self,
+        contract_id: ContractInstanceId,
+        deferral_id: u64,
+        is_put: bool,
+        now_nanos: u64,
+    ) {
+        self.deferred_keys.insert(
+            contract_id,
+            DeferralEntry {
+                deferral_id,
+                is_put,
+                started_nanos: now_nanos,
+                held: std::collections::VecDeque::new(),
+            },
+        );
+    }
+
+    /// Release a contract's deferral block, returning the held same-key events
+    /// (FIFO) so the loop can re-enqueue them. Returns `None` if the key wasn't
+    /// blocked.
+    fn release_key(
+        &mut self,
+        contract_id: &ContractInstanceId,
+    ) -> Option<std::collections::VecDeque<(handler::EventId, ContractHandlerEvent)>> {
+        self.deferred_keys.remove(contract_id).map(|e| e.held)
     }
 }
 
@@ -161,6 +278,24 @@ static OFF_LOOP_FETCH_OVERRIDE: std::sync::Mutex<Option<OffLoopFetchStub>> =
 #[cfg(test)]
 pub(crate) fn set_off_loop_fetch_override(stub: Option<OffLoopFetchStub>) {
     *OFF_LOOP_FETCH_OVERRIDE.lock().unwrap() = stub;
+}
+
+/// Map a sub-op GET outcome to a related-contract fetch result: `Found` yields
+/// the fetched state; `NotFound`/`Infra` map to `MissingRelated` for `id`.
+/// Factored out so the mapping is unit-testable without an `OpManager`.
+fn map_sub_op_outcome(
+    outcome: crate::operations::get::op_ctx_task::SubOpGetOutcome,
+    id: ContractInstanceId,
+) -> Result<WrappedState, ExecutorError> {
+    use crate::operations::get::op_ctx_task::SubOpGetOutcome;
+    match outcome {
+        SubOpGetOutcome::Found(get_result) => {
+            Ok(WrappedState::from(get_result.state.as_ref().to_vec()))
+        }
+        SubOpGetOutcome::NotFound(_) | SubOpGetOutcome::Infra(_) => {
+            Err(ExecutorError::missing_related(id))
+        }
+    }
 }
 
 /// Drive the related-contract GET(s) for a deferred upsert OFF the serial
@@ -205,18 +340,9 @@ async fn fetch_related_off_loop(
                         id,
                         false,
                     );
-                    let outcome = match rx.await {
-                        Ok(outcome) => outcome,
-                        Err(_) => return (id, Err(ExecutorError::missing_related(id))),
-                    };
-                    let mapped = match outcome {
-                        crate::operations::get::op_ctx_task::SubOpGetOutcome::Found(get_result) => {
-                            Ok(WrappedState::from(get_result.state.as_ref().to_vec()))
-                        }
-                        crate::operations::get::op_ctx_task::SubOpGetOutcome::NotFound(_)
-                        | crate::operations::get::op_ctx_task::SubOpGetOutcome::Infra(_) => {
-                            Err(ExecutorError::missing_related(id))
-                        }
+                    let mapped = match rx.await {
+                        Ok(outcome) => map_sub_op_outcome(outcome, id),
+                        Err(_) => Err(ExecutorError::missing_related(id)),
                     };
                     (id, mapped)
                 }
@@ -869,11 +995,31 @@ where
     let mut deferral_ctx = DeferralCtx::new(resume_tx);
 
     loop {
-        // Drain resumed (deferred) upserts FIRST so a completed off-loop fetch
-        // is applied promptly and its client answered, ahead of new queued work.
-        // Bounded by MAX_INFLIGHT_DEFERRALS (no resume can enqueue another).
-        while let Ok(resume) = resume_rx.try_recv() {
-            handle_deferred_resume(&mut contract_handler, &mut deferral_ctx, resume).await?;
+        // Sweep deferrals whose off-loop fetch never reported (waiter task
+        // wedged/dropped): answer their stranded clients with MissingRelated
+        // and release their per-contract block so the contract isn't wedged
+        // forever. TTL-bounded per AGENTS.md "cleanup exemptions MUST be
+        // time-bounded". Responses go straight to the stashed oneshot, so this
+        // needs neither the handler nor `.await`.
+        sweep_stale_deferrals(&mut deferral_ctx, &mut fair_queue);
+
+        // Drain resumed (deferred) upserts so a completed off-loop fetch is
+        // applied promptly and its client answered, ahead of new queued work —
+        // but cap the batch (each resume is a full WASM upsert) and interleave
+        // with the fair queue so resumes can't head-of-line-block cached GETs.
+        for _ in 0..MAX_RESUME_DRAIN_BATCH {
+            match resume_rx.try_recv() {
+                Ok(resume) => {
+                    handle_deferred_resume(
+                        &mut contract_handler,
+                        &mut deferral_ctx,
+                        &mut fair_queue,
+                        resume,
+                    )
+                    .await?;
+                }
+                Err(_) => break,
+            }
         }
 
         // Drain pending events from the channel into the fair queue (bounded batch).
@@ -916,21 +1062,38 @@ where
             }
         }
 
-        // Process one event from the fair queue (round-robin across contracts)
-        if let Some((id, event)) = fair_queue.pop() {
-            handle_contract_event(
-                &mut contract_handler,
-                id,
-                event,
-                &prompter,
-                Some(&mut deferral_ctx),
-            )
-            .await?;
-            continue;
+        // Process one RUNNABLE event from the fair queue. Events for a contract
+        // that currently has an in-flight deferral are HELD (not run) so the
+        // deferred upsert commits before any later same-key op — preserving
+        // per-contract FIFO (#4391). Other contracts keep draining: that is the
+        // whole point of off-loading the fetch.
+        match pop_runnable_event(&mut fair_queue, &mut deferral_ctx) {
+            RunnableEvent::Run(id, event) => {
+                handle_contract_event(
+                    &mut contract_handler,
+                    id,
+                    event,
+                    &prompter,
+                    Some(&mut deferral_ctx),
+                )
+                .await?;
+                continue;
+            }
+            RunnableEvent::RejectFull(id, event) => {
+                // A deferred contract's held buffer is full: reject this event
+                // with backpressure rather than hold it unboundedly.
+                let rejected = Box::new(fair_queue::RejectedEvent { id, event });
+                track_pending_reclamation_if_evict(&mut contract_handler, &rejected);
+                send_queue_full_response(contract_handler.channel(), rejected).await;
+                continue;
+            }
+            RunnableEvent::None => {}
         }
 
-        // Fair queue is empty — block-wait for a new event, a resumed deferral,
-        // or a delegate notification.
+        // Nothing runnable (queue empty, or every queued event is held behind a
+        // deferral). Block-wait for a new event, a resumed deferral, or a
+        // delegate notification. A resume releases its key's held events, so
+        // progress always resumes once an off-loop fetch reports.
         tokio::select! {
             result = contract_handler.channel().recv_from_sender() => {
                 let (id, event) = result?;
@@ -940,11 +1103,142 @@ where
                 }
             }
             Some(resume) = resume_rx.recv() => {
-                handle_deferred_resume(&mut contract_handler, &mut deferral_ctx, resume).await?;
+                handle_deferred_resume(
+                    &mut contract_handler,
+                    &mut deferral_ctx,
+                    &mut fair_queue,
+                    resume,
+                )
+                .await?;
             }
             notification = recv_delegate_notification(&mut delegate_rx) => {
                 handle_delegate_notification(&mut contract_handler, notification, &prompter).await;
             }
+            // A held deferral could time out while we're otherwise idle; wake
+            // periodically to run the TTL sweep even when no events arrive.
+            _ = tokio::time::sleep(DEFERRED_RELATED_FETCH_TIMEOUT), if !deferral_ctx.deferred_keys.is_empty() => {}
+        }
+    }
+}
+
+/// What the loop should do with the next fair-queue event, accounting for
+/// per-contract deferral blocks (#4391).
+enum RunnableEvent {
+    /// Run this event now.
+    Run(handler::EventId, ContractHandlerEvent),
+    /// This event belongs to a deferred contract whose held buffer is full —
+    /// reject it with backpressure rather than hold it.
+    RejectFull(handler::EventId, ContractHandlerEvent),
+    /// Nothing runnable (queue empty, or everything is held behind deferrals).
+    None,
+}
+
+/// Pop the next event the loop may run right now: events for a contract with an
+/// in-flight deferral are moved to that deferral's held buffer (FIFO) and
+/// skipped, so the deferred upsert commits before any later same-key op
+/// (per-contract FIFO, #4391). Returns `None` when the fair queue holds nothing
+/// runnable (empty, or everything is held behind deferrals).
+fn pop_runnable_event(
+    fair_queue: &mut fair_queue::FairEventQueue,
+    deferral_ctx: &mut DeferralCtx,
+) -> RunnableEvent {
+    while let Some((id, event)) = fair_queue.pop() {
+        match fair_queue::extract_contract_id(&event) {
+            Some(contract_id) if deferral_ctx.is_key_deferred(&contract_id) => {
+                // Hold this same-key event behind the in-flight deferral.
+                match deferral_ctx.hold_event(contract_id, id, event) {
+                    HoldOutcome::Held => {} // Try the next queued event.
+                    HoldOutcome::NotDeferred(id, event) => {
+                        // Race: key was released between the check and the hold.
+                        return RunnableEvent::Run(id, event);
+                    }
+                    HoldOutcome::Full(id, event) => {
+                        return RunnableEvent::RejectFull(id, event);
+                    }
+                }
+            }
+            _ => return RunnableEvent::Run(id, event),
+        }
+    }
+    RunnableEvent::None
+}
+
+/// Answer and release any deferral whose off-loop fetch never reported within
+/// [`DEFERRED_RELATED_FETCH_TIMEOUT`]. Without this, a waiter task that wedged
+/// or was dropped would leak its stashed responder (client hangs) AND leave the
+/// contract permanently blocked; once `MAX_INFLIGHT_DEFERRALS` leak,
+/// `at_capacity()` is permanently true and the off-loading silently disables
+/// itself. See issue #4391 and AGENTS.md (cleanup exemptions must be
+/// time-bounded).
+fn sweep_stale_deferrals(
+    deferral_ctx: &mut DeferralCtx,
+    fair_queue: &mut fair_queue::FairEventQueue,
+) {
+    if deferral_ctx.deferred_keys.is_empty() {
+        return;
+    }
+    let now = executor::now_nanos();
+    let ttl_nanos = DEFERRED_RELATED_FETCH_TIMEOUT.as_nanos() as u64;
+    // Stale if it has out-lived 2× the fetch timeout — well past when the
+    // waiter should have reported (the waiter itself times out at 1×).
+    let stale: Vec<(ContractInstanceId, u64, bool)> = deferral_ctx
+        .deferred_keys
+        .iter()
+        .filter(|(_, e)| now.saturating_sub(e.started_nanos) >= ttl_nanos.saturating_mul(2))
+        .map(|(k, e)| (*k, e.deferral_id, e.is_put))
+        .collect();
+    for (contract_id, deferral_id, is_put) in stale {
+        tracing::warn!(
+            contract = %contract_id,
+            deferral_id,
+            "Deferred related-contract fetch never reported within TTL — \
+             answering client with MissingRelated and releasing the contract"
+        );
+        if let Some(responder) = deferral_ctx.stashed.remove(&deferral_id) {
+            let err = ExecutorError::missing_related(contract_id);
+            // Answer with the variant matching the original op so the client
+            // sees a well-formed terminal response (not a PUT response for an
+            // UPDATE op). A wedged waiter is a node-internal fault, not a
+            // normal path; the client surfaces an error and may retry.
+            let response = if is_put {
+                ContractHandlerEvent::PutResponse {
+                    new_value: Err(err),
+                    state_changed: false,
+                }
+            } else {
+                ContractHandlerEvent::UpdateResponse {
+                    new_value: Err(err),
+                    state_changed: false,
+                }
+            };
+            // Client may have disconnected; non-fatal.
+            if responder.respond(response).is_err() {
+                tracing::debug!(
+                    contract = %contract_id,
+                    "Stale-deferral client already disconnected"
+                );
+            }
+        }
+        requeue_released_events(deferral_ctx.release_key(&contract_id), fair_queue);
+    }
+}
+
+/// Re-enqueue the events that were held behind a now-released deferral, in
+/// their original FIFO order, ahead of fresh events for the same key.
+fn requeue_released_events(
+    held: Option<std::collections::VecDeque<(handler::EventId, ContractHandlerEvent)>>,
+    fair_queue: &mut fair_queue::FairEventQueue,
+) {
+    let Some(held) = held else { return };
+    for (id, event) in held {
+        if let Err(rejected) = fair_queue.try_push(id, event) {
+            // Queue full: drop the held event's response slot rather than leak
+            // it. This is the same backpressure the normal drain path applies;
+            // the client times out (rare — only under sustained saturation).
+            tracing::debug!(
+                event = %rejected.event,
+                "Held deferred-key event dropped on re-enqueue (fair queue full)"
+            );
         }
     }
 }
@@ -954,13 +1248,19 @@ where
 ///
 /// The fetched related states are injected into `related_contracts` so the
 /// resumed upsert finds them locally and does NOT re-fetch. The upsert runs
-/// via the plain (non-deferrable) `upsert_contract_state`, so if the contract
-/// *still* requests a different related contract it cannot defer again — it
-/// surfaces `MissingRelated` to the client (the depth=1 / one-deferral cap,
-/// constraint of #4391).
+/// via the deferrable path (`upsert_contract_state_deferrable`) again, so if the
+/// contract *still* requests a DIFFERENT related contract it cannot defer again
+/// — the second `DeferRelated` is converted to `MissingRelated` (the depth=1 /
+/// one-deferral cap of #4391).
+///
+/// After the resumed upsert commits, the contract's per-contract block is
+/// released and any events held behind it (per-contract FIFO) are re-enqueued
+/// ahead of fresh events for the same key — so a same-key GET/UPDATE that
+/// arrived during the deferral now sees the committed state.
 async fn handle_deferred_resume<CH>(
     contract_handler: &mut CH,
     deferral_ctx: &mut DeferralCtx,
+    fair_queue: &mut fair_queue::FairEventQueue,
     resume: DeferredResume,
 ) -> Result<(), ContractError>
 where
@@ -977,11 +1277,12 @@ where
     } = resume;
 
     // Reclaim the parked client responder. If it's gone the loop is shutting
-    // down or the entry was already consumed — nothing to answer.
-    let Some(responder) = deferral_ctx.stashed.remove(&deferral_id) else {
-        tracing::debug!(contract = %key, "Deferred resume has no stashed responder; dropping");
-        return Ok(());
-    };
+    // down or the entry was already consumed — still release the per-contract
+    // block below so the contract isn't wedged.
+    let responder = deferral_ctx.stashed.remove(&deferral_id);
+    if responder.is_none() {
+        tracing::debug!(contract = %key, "Deferred resume has no stashed responder");
+    }
 
     let event_result = match fetched {
         Ok(states) => {
@@ -1058,12 +1359,21 @@ where
         }
     };
 
-    if let Err(error) = responder.respond(event_result) {
-        tracing::debug!(
-            error = %error,
-            contract = %key,
-            "Failed to deliver deferred upsert response (client may have disconnected)"
-        );
+    // The resumed upsert has now committed (or errored). Release the
+    // per-contract block and re-enqueue any same-key events that were held
+    // during the deferral, in FIFO order, so they observe the committed state.
+    // This MUST happen after the upsert above and before answering the client,
+    // so the released events can't be popped until the next loop iteration.
+    requeue_released_events(deferral_ctx.release_key(key.id()), fair_queue);
+
+    if let Some(responder) = responder {
+        if let Err(error) = responder.respond(event_result) {
+            tracing::debug!(
+                error = %error,
+                contract = %key,
+                "Failed to deliver deferred upsert response (client may have disconnected)"
+            );
+        }
     }
     Ok(())
 }
@@ -1082,9 +1392,15 @@ enum DeferStep {
 /// Run an upsert in deferrable mode when a [`DeferralCtx`] is available,
 /// off-loading the related-contract network fetch from the serial loop (#4391).
 ///
-/// When `deferral` is `None` (delegate-driven PUTs, direct unit tests) or the
-/// in-flight deferral cap is reached, this falls back to the legacy inline
-/// `upsert_contract_state` and always returns `Completed`.
+/// When `deferral` is `None` (delegate-driven PUTs, direct unit tests), this
+/// uses the legacy inline `upsert_contract_state` and always returns
+/// `Completed` — preserving existing behavior for callers that don't drive the
+/// serial loop.
+///
+/// When the in-flight deferral cap is reached, it does NOT fall back to an
+/// inline network fetch (that would re-introduce the head-of-line stall on the
+/// loop for the over-cap op). Instead it surfaces `MissingRelated` immediately
+/// — backpressure that fails fast rather than blocking the loop (#4391 SF#4).
 #[allow(clippy::too_many_arguments)]
 async fn maybe_defer_upsert<CH>(
     contract_handler: &mut CH,
@@ -1099,10 +1415,8 @@ async fn maybe_defer_upsert<CH>(
 where
     CH: ContractHandler + Send + 'static,
 {
-    // No deferral context (or at capacity) → behave exactly as the legacy
-    // inline path: await the network related-fetch on this loop. This keeps
-    // delegate-driven PUTs and direct unit-test calls unchanged, and provides
-    // backpressure (rather than unbounded waiter tasks) under a deferral flood.
+    // No deferral context → legacy inline path (delegate-driven PUTs, direct
+    // unit-test calls). Behavior is unchanged for these callers.
     let Some(deferral) = deferral else {
         return DeferStep::Completed(
             contract_handler
@@ -1112,21 +1426,6 @@ where
                 .await,
         );
     };
-    if deferral.at_capacity() {
-        tracing::warn!(
-            contract = %key,
-            inflight = deferral.stashed.len(),
-            limit = MAX_INFLIGHT_DEFERRALS,
-            "Deferral capacity reached — falling back to inline related fetch"
-        );
-        return DeferStep::Completed(
-            contract_handler
-                .executor()
-                .upsert_contract_state(key, update, related_contracts, code)
-                .instrument(tracing::info_span!("upsert_contract_state", %key))
-                .await,
-        );
-    }
 
     let outcome = contract_handler
         .executor()
@@ -1145,11 +1444,28 @@ where
         Err(err) => return DeferStep::Completed(Err(err)),
     };
 
+    // At the in-flight cap: fail fast with MissingRelated instead of doing an
+    // inline network fetch on the loop (which would re-introduce the HoL stall
+    // for the over-cap op). The deferrable upsert already rolled back any
+    // partial work, so this is a clean rejection. (#4391 SF#4.)
+    if deferral.at_capacity() {
+        tracing::warn!(
+            contract = %key,
+            inflight = deferral.stashed.len(),
+            limit = MAX_INFLIGHT_DEFERRALS,
+            "Deferral capacity reached — failing fast with MissingRelated (not deferring)"
+        );
+        let id = missing.first().copied().unwrap_or_else(|| *key.id());
+        return DeferStep::Completed(Err(ExecutorError::missing_related(id)));
+    }
+
     // Park the client responder so it survives the off-loop wait.
     let Some(responder) = contract_handler.channel().take_waiting_response(id) else {
         // Fire-and-forget event (no responder): nothing to answer, and there's
         // no client awaiting the resume. Fall back to the inline path so the
-        // upsert's side effects (store/broadcast) still happen.
+        // upsert's side effects (store/broadcast) still happen. (Fire-and-forget
+        // upserts have no per-contract-FIFO concern: there is no client whose
+        // ordering we must preserve.)
         return DeferStep::Completed(
             contract_handler
                 .executor()
@@ -1162,6 +1478,12 @@ where
     let deferral_id = deferral.next_deferral_id;
     deferral.next_deferral_id = deferral.next_deferral_id.wrapping_add(1);
     deferral.stashed.insert(deferral_id, responder);
+    // Block this contract's subsequent events until the deferral resolves, so a
+    // later same-key GET/UPDATE can't run (and see MissingContract/stale state)
+    // before the deferred upsert commits. The block's lifetime is tied to the
+    // stashed responder: released on resume (`handle_deferred_resume`) or on TTL
+    // timeout (`sweep_stale_deferrals`). (#4391 per-contract FIFO.)
+    deferral.block_key(*key.id(), deferral_id, is_put, executor::now_nanos());
 
     let op_manager = contract_handler.executor().op_manager_handle();
     let resume_tx = deferral.resume_tx.clone();
@@ -1174,9 +1496,12 @@ where
     );
 
     // Spawn the off-loop waiter. It drives the related GET(s), then sends a
-    // DeferredResume back to the loop. Fire-and-forget is acceptable: the task
-    // is short-lived and bounded by MAX_INFLIGHT_DEFERRALS, and a dropped task
-    // simply lets the client time out (same as the legacy timeout path).
+    // DeferredResume back to the loop. Fire-and-forget is acceptable per
+    // code-style.md ("short-lived work"): the task is bounded by
+    // MAX_INFLIGHT_DEFERRALS, self-terminates at DEFERRED_RELATED_FETCH_TIMEOUT,
+    // and the loop's `sweep_stale_deferrals` answers + releases any deferral
+    // whose waiter never reports — so a dropped/wedged waiter cannot leak the
+    // stashed responder or permanently wedge the contract.
     GlobalExecutor::spawn(async move {
         let fetched = fetch_related_off_loop(op_manager, missing).await;
         // Non-blocking send on an unbounded channel; if it fails the loop has
@@ -2113,6 +2438,54 @@ mod tests {
         );
     }
 
+    /// Pin: the PUT and UPDATE arms of `handle_contract_event` route their
+    /// upsert through `maybe_defer_upsert` (the #4391 off-load path) rather than
+    /// calling `upsert_contract_state` directly inline. A refactor that
+    /// re-inlined the blocking upsert into the arm would silently re-introduce
+    /// the head-of-line stall the fix removes. Anchored on the two arm bodies.
+    #[test]
+    fn put_update_arms_route_through_maybe_defer_upsert_pin_test() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/contract.rs");
+        let source = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("must read own source at {}: {e}", path.display()));
+
+        // Extract the body of `handle_contract_event` (the dispatch fn), then
+        // check each arm delegates to maybe_defer_upsert.
+        let body = source
+            .split("async fn handle_contract_event")
+            .nth(1)
+            .expect("handle_contract_event must exist");
+
+        // PutQuery arm.
+        let put_arm = body
+            .split("ContractHandlerEvent::PutQuery {")
+            .nth(1)
+            .expect("PutQuery arm must exist");
+        let put_arm = put_arm
+            .split("ContractHandlerEvent::UpdateQuery {")
+            .next()
+            .expect("PutQuery arm bounded by UpdateQuery arm");
+        assert!(
+            put_arm.contains("maybe_defer_upsert"),
+            "PUT arm must route its upsert through maybe_defer_upsert (#4391); \
+             re-inlining upsert_contract_state restores the HoL stall"
+        );
+
+        // UpdateQuery arm.
+        let update_arm = body
+            .split("ContractHandlerEvent::UpdateQuery {")
+            .nth(1)
+            .expect("UpdateQuery arm must exist");
+        let update_arm = update_arm
+            .split("ContractHandlerEvent::DelegateRequest {")
+            .next()
+            .expect("UpdateQuery arm bounded by DelegateRequest arm");
+        assert!(
+            update_arm.contains("maybe_defer_upsert"),
+            "UPDATE arm must route its upsert through maybe_defer_upsert (#4391)"
+        );
+    }
+
     fn make_contract_key() -> ContractKey {
         let code = ContractCode::from(vec![42u8; 32]);
         let params = Parameters::from(vec![7u8; 8]);
@@ -2853,6 +3226,9 @@ mod tests {
 // work keeps draining.
 #[cfg(test)]
 #[allow(clippy::wildcard_enum_match_arm)]
+// These tests intentionally discard `JoinHandle`/`timeout` results in cleanup
+// paths (the assertions that matter run before cleanup).
+#[allow(clippy::let_underscore_must_use)]
 mod hol_4391_tests {
     use super::*;
     use crate::config::GlobalExecutor;
@@ -2865,6 +3241,23 @@ mod hol_4391_tests {
     /// other's stub. Each test holds this guard for its duration. An
     /// async-aware mutex so the guard can be held across the tests' `.await`s.
     static TEST_GUARD: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    /// RAII wrapper around `set_off_loop_fetch_override`: installs a stub on
+    /// construction and clears it on `Drop`, so a panicking test can't leak a
+    /// stale stub into the next test even though they share the process-global
+    /// hook. (#4391 SF#5.)
+    struct OverrideGuard;
+    impl OverrideGuard {
+        fn install(stub: OffLoopFetchStub) -> Self {
+            set_off_loop_fetch_override(Some(stub));
+            OverrideGuard
+        }
+    }
+    impl Drop for OverrideGuard {
+        fn drop(&mut self) {
+            set_off_loop_fetch_override(None);
+        }
+    }
 
     fn make_contract(code_bytes: &[u8]) -> ContractContainer {
         let code = ContractCode::from(code_bytes.to_vec());
@@ -3288,6 +3681,668 @@ mod hol_4391_tests {
         );
 
         set_off_loop_fetch_override(None);
+        handle.abort();
+    }
+
+    // ========================================================================
+    // MUST-FIX #1: per-contract FIFO is preserved across a deferral
+    // ========================================================================
+
+    /// While contract K's PUT is deferred (off-loop fetch gated), a later
+    /// SAME-KEY GET must NOT run before the PUT commits — it must wait and then
+    /// observe the committed state (not MissingContract / not-found). At the
+    /// same time, a GET for a DIFFERENT contract K2 must return PROMPTLY (the
+    /// whole point of #4391: only the deferred key is held, not the loop).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn deferred_put_holds_same_key_get_but_not_other_key() {
+        let _guard = TEST_GUARD.lock().await;
+
+        // Contract K requests related B; B is supplied off-loop on release so
+        // K's PUT ultimately COMMITS (so the held same-key GET sees real state).
+        let contract_k = make_contract(b"fifo_k");
+        let key_k = contract_k.key();
+        let id_b = *make_contract(b"fifo_k_related").key().id();
+
+        let (handler, send) = build_handler(vec![(
+            *key_k.id(),
+            ValidateOverride::RequestRelated(vec![id_b]),
+        )])
+        .await;
+
+        // Off-loop fetch hangs on the gate, then SUCCEEDS (supplies B) so K's
+        // PUT commits when released.
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let gate_stub = gate.clone();
+        let _override =
+            OverrideGuard::install(Arc::new(move |missing: Vec<ContractInstanceId>| {
+                let gate = gate_stub.clone();
+                Box::pin(async move {
+                    gate.notified().await;
+                    Ok(missing
+                        .into_iter()
+                        .map(|id| (id, WrappedState::new(b"b_state".to_vec())))
+                        .collect())
+                })
+            }));
+
+        // A locally-stored, unrelated contract K2 for the cross-key prompt check.
+        let contract_k2 = make_contract(b"fifo_k2_cached");
+        let key_k2 = contract_k2.key();
+
+        let send = Arc::new(send);
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            crate::contract::user_input::AutoApprovePrompter,
+        ));
+
+        // Seed K2 so a GET for it is a pure local hit.
+        let put_k2 = put_local(
+            send.as_ref(),
+            contract_k2,
+            WrappedState::new(b"k2_state".to_vec()),
+        )
+        .await;
+        assert!(
+            matches!(
+                put_k2,
+                ContractHandlerEvent::PutResponse {
+                    new_value: Ok(_),
+                    ..
+                }
+            ),
+            "seed PUT for K2 must succeed"
+        );
+
+        // Fire K's related-needing PUT in the background: it defers and parks.
+        let send_k = send.clone();
+        let k_state = WrappedState::new(br#"{"committed":true}"#.to_vec());
+        let k_state_expect = k_state.clone();
+        let k_put: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
+            GlobalExecutor::spawn(async move {
+                send_k
+                    .send_to_handler(ContractHandlerEvent::PutQuery {
+                        key: key_k,
+                        state: k_state,
+                        related_contracts: RelatedContracts::default(),
+                        contract: Some(contract_k),
+                    })
+                    .await
+            });
+
+        // Let the loop pick up K's PUT and enter the deferral path.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        // Fire a SAME-KEY GET for K in the background. It must NOT resolve while
+        // K's PUT is still deferred (held behind the per-contract block).
+        let send_k_get = send.clone();
+        let k_get: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
+            GlobalExecutor::spawn(async move {
+                send_k_get
+                    .send_to_handler(ContractHandlerEvent::GetQuery {
+                        instance_id: *key_k.id(),
+                        return_contract_code: false,
+                    })
+                    .await
+            });
+
+        // Give the same-key GET a chance to (wrongly) resolve if FIFO is broken.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(
+            !k_get.is_finished(),
+            "same-key GET for K must be HELD until K's deferred PUT commits \
+             (per-contract FIFO, #4391 MUST-FIX #1)"
+        );
+
+        // Cross-key: a GET for K2 must return PROMPTLY despite K being deferred.
+        let k2_get = tokio::time::timeout(
+            Duration::from_secs(2),
+            send.send_to_handler(ContractHandlerEvent::GetQuery {
+                instance_id: *key_k2.id(),
+                return_contract_code: false,
+            }),
+        )
+        .await
+        .expect("GET for unrelated K2 must NOT be blocked by K's deferral")
+        .expect("K2 GET must respond");
+        match k2_get {
+            ContractHandlerEvent::GetResponse { response, .. } => {
+                let store = response.expect("K2 GET ok");
+                assert_eq!(store.state.expect("K2 has state").as_ref(), b"k2_state");
+            }
+            other => panic!("expected GetResponse for K2, got {other}"),
+        }
+
+        // Release the gate: K's PUT commits, then the held same-key GET runs.
+        gate.notify_one();
+
+        let k_put_resp = tokio::time::timeout(Duration::from_secs(5), k_put)
+            .await
+            .expect("K PUT resolves after release")
+            .expect("K put join")
+            .expect("K PUT responds");
+        match k_put_resp {
+            ContractHandlerEvent::PutResponse { new_value, .. } => {
+                new_value.expect("K PUT must commit once B is supplied");
+            }
+            other => panic!("expected PutResponse for K, got {other}"),
+        }
+
+        // The previously-held same-key GET must now resolve AND observe the
+        // committed state (proving it ran AFTER the PUT, not before).
+        let k_get_resp = tokio::time::timeout(Duration::from_secs(5), k_get)
+            .await
+            .expect("held same-key GET resolves after PUT commits")
+            .expect("K get join")
+            .expect("K GET responds");
+        match k_get_resp {
+            ContractHandlerEvent::GetResponse { response, .. } => {
+                let store = response.expect("K GET ok after commit");
+                assert_eq!(
+                    store.state.expect("K has committed state").as_ref(),
+                    k_state_expect.as_ref(),
+                    "held same-key GET must observe the committed PUT state, \
+                     not a stale/missing value"
+                );
+            }
+            other => panic!("expected GetResponse for K, got {other}"),
+        }
+
+        handle.abort();
+    }
+
+    /// An UPDATE that arrives for a contract whose PUT is still deferred must be
+    /// applied AFTER the deferred PUT commits (per-contract FIFO across op
+    /// types). We assert the UPDATE succeeds and its result reflects the
+    /// post-PUT state.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn deferred_put_then_same_key_update_is_ordered_after_commit() {
+        let _guard = TEST_GUARD.lock().await;
+
+        let contract_k = make_contract(b"fifo_upd_k");
+        let key_k = contract_k.key();
+        let id_b = *make_contract(b"fifo_upd_related").key().id();
+
+        let (handler, send) = build_handler(vec![(
+            *key_k.id(),
+            ValidateOverride::RequestRelated(vec![id_b]),
+        )])
+        .await;
+
+        // A "release all" gate: once `released` is set, every stub invocation
+        // (the PUT's deferral AND any re-deferral by the held UPDATE) proceeds.
+        // Poll the flag (no `Notify` race where a late waiter misses a one-shot
+        // wake) — see the design note in the test body.
+        let released = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let released_stub = released.clone();
+        let _override =
+            OverrideGuard::install(Arc::new(move |missing: Vec<ContractInstanceId>| {
+                let released = released_stub.clone();
+                Box::pin(async move {
+                    while !released.load(std::sync::atomic::Ordering::SeqCst) {
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                    Ok(missing
+                        .into_iter()
+                        .map(|id| (id, WrappedState::new(b"b_state".to_vec())))
+                        .collect())
+                })
+            }));
+
+        let send = Arc::new(send);
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            crate::contract::user_input::AutoApprovePrompter,
+        ));
+
+        // Deferred PUT for K (seeds the initial state once it commits).
+        let send_k = send.clone();
+        let k_put: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
+            GlobalExecutor::spawn(async move {
+                send_k
+                    .send_to_handler(ContractHandlerEvent::PutQuery {
+                        key: key_k,
+                        state: WrappedState::new(vec![1, 2, 3]),
+                        related_contracts: RelatedContracts::default(),
+                        contract: Some(contract_k),
+                    })
+                    .await
+            });
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        // Same-key UPDATE arrives while K's PUT is deferred. The mock applies a
+        // delta by concatenation; this must NOT MissingContract (which it would
+        // if it ran before the PUT committed).
+        //
+        // NOTE: contract K's `ValidateOverride::RequestRelated` fires on the
+        // UPDATE's post-merge validate too, and the off-loop-fetched B is only
+        // injected into the upsert's related_contracts (not persisted to the
+        // state_store) — exactly as the inline path behaves. So the held UPDATE
+        // legitimately RE-DEFERS once. The "release all" gate handles that
+        // second deferral; the ordering invariant under test (UPDATE applies
+        // against the committed PUT state, never MissingContract) still holds.
+        let send_u = send.clone();
+        let k_update: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
+            GlobalExecutor::spawn(async move {
+                send_u
+                    .send_to_handler(ContractHandlerEvent::UpdateQuery {
+                        key: key_k,
+                        data: freenet_stdlib::prelude::UpdateData::Delta(StateDelta::from(vec![
+                            4, 5,
+                        ])),
+                        related_contracts: RelatedContracts::default(),
+                    })
+                    .await
+            });
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(
+            !k_update.is_finished(),
+            "same-key UPDATE must be held until the deferred PUT commits"
+        );
+
+        // Release all deferrals (the PUT's, plus the held UPDATE's re-deferral).
+        released.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let put_resp = tokio::time::timeout(Duration::from_secs(5), k_put)
+            .await
+            .expect("PUT resolves")
+            .expect("join")
+            .expect("PUT responds");
+        assert!(
+            matches!(
+                put_resp,
+                ContractHandlerEvent::PutResponse {
+                    new_value: Ok(_),
+                    ..
+                }
+            ),
+            "deferred PUT must commit"
+        );
+
+        let upd_resp = tokio::time::timeout(Duration::from_secs(5), k_update)
+            .await
+            .expect("UPDATE resolves after PUT commits")
+            .expect("join")
+            .expect("UPDATE responds");
+        match upd_resp {
+            ContractHandlerEvent::UpdateResponse { new_value, .. } => {
+                // Must NOT be a MissingContract error: the UPDATE ran after the
+                // PUT installed the contract.
+                let stored = new_value.expect(
+                    "UPDATE must apply against the committed PUT state, not \
+                     MissingContract (per-contract FIFO, #4391)",
+                );
+                assert!(
+                    stored.as_ref().ends_with(&[4, 5]),
+                    "UPDATE delta must have been applied on top of the PUT state"
+                );
+            }
+            ContractHandlerEvent::UpdateNoChange { .. } => {
+                panic!("UPDATE should have changed state, got NoChange")
+            }
+            other => panic!("expected UpdateResponse, got {other}"),
+        }
+
+        handle.abort();
+    }
+
+    // ========================================================================
+    // SHOULD-FIX #5: UPDATE-path deferral, real off-loop fetch, cap, disconnect
+    // ========================================================================
+
+    /// An UPDATE whose `update_state` returns `requires(missing)` for a related
+    /// contract not held locally must defer off-loop and, on success, resume and
+    /// apply the merge — exercising the UPDATE response path through the loop.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn update_path_deferral_resumes_and_applies() {
+        use crate::contract::executor::mock_wasm_runtime::UpdateOverride;
+        let _guard = TEST_GUARD.lock().await;
+
+        let contract_k = make_contract(b"upd_defer_k");
+        let key_k = contract_k.key();
+        let id_b = *make_contract(b"upd_defer_related").key().id();
+
+        let (send_halve, rcv_halve, _) = handler::contract_handler_channel();
+        let mut handler = MockWasmContractHandler::new_test(rcv_halve, None, "upd_defer").await;
+        handler
+            .runtime_mut()
+            .update_overrides
+            .insert(*key_k.id(), UpdateOverride::RequiresRelated(vec![id_b]));
+        let send = Arc::new(send_halve);
+
+        let _override =
+            OverrideGuard::install(Arc::new(move |missing: Vec<ContractInstanceId>| {
+                Box::pin(async move {
+                    Ok(missing
+                        .into_iter()
+                        .map(|id| (id, WrappedState::new(b"b_state".to_vec())))
+                        .collect())
+                })
+            }));
+
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            crate::contract::user_input::AutoApprovePrompter,
+        ));
+
+        // Seed K's initial state (no override fires for a State PUT, only the
+        // delta UPDATE triggers RequiresRelated).
+        let put = put_local(send.as_ref(), contract_k, WrappedState::new(vec![0])).await;
+        assert!(matches!(
+            put,
+            ContractHandlerEvent::PutResponse {
+                new_value: Ok(_),
+                ..
+            }
+        ));
+
+        let resp = tokio::time::timeout(
+            Duration::from_secs(5),
+            send.send_to_handler(ContractHandlerEvent::UpdateQuery {
+                key: key_k,
+                data: freenet_stdlib::prelude::UpdateData::Delta(StateDelta::from(vec![1])),
+                related_contracts: RelatedContracts::default(),
+            }),
+        )
+        .await
+        .expect("deferred UPDATE must resume and respond")
+        .expect("UPDATE responds");
+        match resp {
+            ContractHandlerEvent::UpdateResponse { new_value, .. } => {
+                new_value.expect("UPDATE must succeed once B is supplied off-loop");
+            }
+            ContractHandlerEvent::UpdateNoChange { .. } => {}
+            other => panic!("expected UpdateResponse, got {other}"),
+        }
+
+        handle.abort();
+    }
+
+    /// An UPDATE-path deferral whose off-loop fetch FAILS surfaces an
+    /// UpdateResponse error (not a hang, not a PUT response).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn update_path_deferral_failure_surfaces_update_error() {
+        use crate::contract::executor::mock_wasm_runtime::UpdateOverride;
+        let _guard = TEST_GUARD.lock().await;
+
+        let contract_k = make_contract(b"upd_fail_k");
+        let key_k = contract_k.key();
+        let id_b = *make_contract(b"upd_fail_related").key().id();
+
+        let (send_halve, rcv_halve, _) = handler::contract_handler_channel();
+        let mut handler = MockWasmContractHandler::new_test(rcv_halve, None, "upd_fail").await;
+        handler
+            .runtime_mut()
+            .update_overrides
+            .insert(*key_k.id(), UpdateOverride::RequiresRelated(vec![id_b]));
+        let send = Arc::new(send_halve);
+
+        let _override =
+            OverrideGuard::install(Arc::new(move |missing: Vec<ContractInstanceId>| {
+                Box::pin(async move { Err(ExecutorError::missing_related(missing[0])) })
+            }));
+
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            crate::contract::user_input::AutoApprovePrompter,
+        ));
+
+        let put = put_local(send.as_ref(), contract_k, WrappedState::new(vec![0])).await;
+        assert!(matches!(
+            put,
+            ContractHandlerEvent::PutResponse {
+                new_value: Ok(_),
+                ..
+            }
+        ));
+
+        let resp = tokio::time::timeout(
+            Duration::from_secs(5),
+            send.send_to_handler(ContractHandlerEvent::UpdateQuery {
+                key: key_k,
+                data: freenet_stdlib::prelude::UpdateData::Delta(StateDelta::from(vec![1])),
+                related_contracts: RelatedContracts::default(),
+            }),
+        )
+        .await
+        .expect("deferred UPDATE must resolve (not hang) when the fetch fails")
+        .expect("UPDATE responds");
+        match resp {
+            ContractHandlerEvent::UpdateResponse { new_value, .. } => {
+                assert!(
+                    new_value.is_err(),
+                    "a failed off-loop fetch must surface an UpdateResponse error"
+                );
+            }
+            other => panic!("expected UpdateResponse error, got {other}"),
+        }
+
+        handle.abort();
+    }
+
+    /// Unit-test the production `SubOpGetOutcome → Result` mapping that backs
+    /// the REAL `fetch_related_off_loop` (the path the stubbed loop tests skip).
+    /// `Found` → the fetched state; `NotFound`/`Infra` → `MissingRelated`. This
+    /// is deterministic (no OpManager / network timing), covering the mapping
+    /// without a flaky real-network harness. (#4391 SF#5.)
+    #[test]
+    fn off_loop_sub_op_outcome_mapping() {
+        use crate::operations::get::op_ctx_task::SubOpGetOutcome;
+        let id = *make_contract(b"map_id").key().id();
+
+        let found = SubOpGetOutcome::Found(crate::operations::get::GetResult::new(
+            WrappedState::new(b"fetched".to_vec()),
+            None,
+        ));
+        match map_sub_op_outcome(found, id) {
+            Ok(state) => assert_eq!(state.as_ref(), b"fetched"),
+            Err(e) => panic!("Found must map to the fetched state, got {e}"),
+        }
+
+        let not_found = SubOpGetOutcome::NotFound("nope".to_string());
+        assert!(
+            map_sub_op_outcome(not_found, id).is_err(),
+            "NotFound must map to MissingRelated"
+        );
+
+        let infra = SubOpGetOutcome::Infra(crate::operations::OpError::UnexpectedOpState);
+        assert!(
+            map_sub_op_outcome(infra, id).is_err(),
+            "Infra must map to MissingRelated"
+        );
+    }
+
+    /// A client that disconnects mid-deferral (drops its response receiver) must
+    /// NOT leak the stashed responder and MUST release the contract's block.
+    /// Proven by: after the client drops, a fresh same-key PUT eventually
+    /// resolves (the contract wasn't permanently wedged).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn client_disconnect_during_deferral_releases_block() {
+        let _guard = TEST_GUARD.lock().await;
+
+        let contract_k = make_contract(b"disc_k");
+        let key_k = contract_k.key();
+        let id_b = *make_contract(b"disc_related").key().id();
+
+        let (handler, send) = build_handler(vec![(
+            *key_k.id(),
+            ValidateOverride::RequestRelated(vec![id_b]),
+        )])
+        .await;
+
+        // Off-loop fetch resolves quickly so the deferral completes shortly
+        // after the client has gone away.
+        let _override =
+            OverrideGuard::install(Arc::new(move |missing: Vec<ContractInstanceId>| {
+                Box::pin(async move {
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    Ok(missing
+                        .into_iter()
+                        .map(|id| (id, WrappedState::new(b"b_state".to_vec())))
+                        .collect())
+                })
+            }));
+
+        let send = Arc::new(send);
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            crate::contract::user_input::AutoApprovePrompter,
+        ));
+
+        // Fire K's PUT with a SHORT client-side timeout so the client gives up
+        // (drops its receiver) while the fetch is still in flight.
+        let send_k = send.clone();
+        let contract_k_owned = contract_k;
+        let disconnect_task = GlobalExecutor::spawn(async move {
+            let _ = tokio::time::timeout(
+                Duration::from_millis(50),
+                send_k.send_to_handler(ContractHandlerEvent::PutQuery {
+                    key: key_k,
+                    state: WrappedState::new(vec![9]),
+                    related_contracts: RelatedContracts::default(),
+                    contract: Some(contract_k_owned),
+                }),
+            )
+            .await;
+            // On timeout, the future is dropped → response receiver dropped →
+            // the client has "disconnected".
+        });
+        let _ = disconnect_task.await;
+
+        // Let the deferral resume (and discover the dropped responder) and the
+        // block be released.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+
+        // A fresh same-key PUT must eventually resolve — proving the contract
+        // wasn't permanently wedged by the disconnected deferral. This second
+        // PUT supplies B inline (related already cached from the resume) OR
+        // re-defers and resolves; either way it must not hang.
+        let resp = tokio::time::timeout(
+            DEFERRED_RELATED_FETCH_TIMEOUT + Duration::from_secs(2),
+            send.send_to_handler(ContractHandlerEvent::GetQuery {
+                instance_id: *key_k.id(),
+                return_contract_code: false,
+            }),
+        )
+        .await
+        .expect(
+            "same-key op after a disconnected deferral must not hang \
+                 (block was released)",
+        )
+        .expect("GET responds");
+        assert!(
+            matches!(resp, ContractHandlerEvent::GetResponse { .. }),
+            "expected a GetResponse after the block released"
+        );
+
+        handle.abort();
+    }
+
+    /// The in-flight deferral cap is enforced: once `MAX_INFLIGHT_DEFERRALS`
+    /// PUTs are deferred (gated open), the next related-needing PUT must FAIL
+    /// FAST with MissingRelated rather than (a) deferring a 257th waiter or
+    /// (b) falling back to an inline network fetch that would re-stall the loop.
+    /// (#4391 MUST-FIX #2 boundary / SHOULD-FIX #4.)
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn deferral_cap_fails_fast_with_missing_related() {
+        let _guard = TEST_GUARD.lock().await;
+
+        // All deferrals hang until `released` is set, so they stay in-flight,
+        // saturating the cap. Poll the flag (release-all) so every parked stub
+        // drains on cleanup, not just one.
+        let released = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let released_stub = released.clone();
+        let _override =
+            OverrideGuard::install(Arc::new(move |missing: Vec<ContractInstanceId>| {
+                let released = released_stub.clone();
+                Box::pin(async move {
+                    while !released.load(std::sync::atomic::Ordering::SeqCst) {
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                    Err(ExecutorError::missing_related(missing[0]))
+                })
+            }));
+
+        // Build a handler whose contracts each request a distinct related id.
+        // Use MAX_INFLIGHT_DEFERRALS distinct contracts to saturate the cap,
+        // plus one more to probe the over-cap behavior.
+        let n = MAX_INFLIGHT_DEFERRALS;
+        let mut overrides = Vec::with_capacity(n + 1);
+        let mut put_keys = Vec::with_capacity(n + 1);
+        let mut put_contracts = Vec::with_capacity(n + 1);
+        for i in 0..=n {
+            let c = make_contract(format!("cap_{i}").as_bytes());
+            let related = *make_contract(format!("cap_rel_{i}").as_bytes()).key().id();
+            overrides.push((
+                *c.key().id(),
+                ValidateOverride::RequestRelated(vec![related]),
+            ));
+            put_keys.push(c.key());
+            put_contracts.push(c);
+        }
+
+        let (handler, send) = build_handler(overrides).await;
+        let send = Arc::new(send);
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            crate::contract::user_input::AutoApprovePrompter,
+        ));
+
+        // Fire the first N PUTs in the background; each defers and parks (gate
+        // held), saturating the cap. We don't await them.
+        let mut tasks = Vec::with_capacity(n);
+        for i in 0..n {
+            let send_i = send.clone();
+            let key_i = put_keys[i];
+            let contract_i = put_contracts[i].clone();
+            tasks.push(GlobalExecutor::spawn(async move {
+                let _ = send_i
+                    .send_to_handler(ContractHandlerEvent::PutQuery {
+                        key: key_i,
+                        state: WrappedState::new(vec![i as u8]),
+                        related_contracts: RelatedContracts::default(),
+                        contract: Some(contract_i),
+                    })
+                    .await;
+            }));
+        }
+
+        // Wait until the cap is saturated (all N deferrals registered). Poll by
+        // giving the loop time to process all N PUTs into deferrals.
+        tokio::time::sleep(Duration::from_millis(800)).await;
+
+        // The (N+1)th related-needing PUT must FAIL FAST: at capacity, the loop
+        // surfaces MissingRelated immediately instead of deferring or doing an
+        // inline fetch. It must respond well within the off-loop timeout
+        // (which would apply if it had wrongly deferred behind the gate).
+        let over = tokio::time::timeout(
+            Duration::from_secs(3),
+            send.send_to_handler(ContractHandlerEvent::PutQuery {
+                key: put_keys[n],
+                state: WrappedState::new(vec![0xFF]),
+                related_contracts: RelatedContracts::default(),
+                contract: Some(put_contracts[n].clone()),
+            }),
+        )
+        .await
+        .expect("over-cap PUT must FAIL FAST, not block behind the gated cap")
+        .expect("over-cap PUT responds");
+        match over {
+            ContractHandlerEvent::PutResponse { new_value, .. } => {
+                assert!(
+                    new_value.is_err(),
+                    "over-cap related-needing PUT must surface MissingRelated"
+                );
+            }
+            other => panic!("expected PutResponse error at cap, got {other}"),
+        }
+
+        // Release all gated deferrals so the saturating PUTs drain, then clean up.
+        released.store(true, std::sync::atomic::Ordering::SeqCst);
+        for t in tasks {
+            let _ = tokio::time::timeout(Duration::from_secs(10), t).await;
+        }
         handle.abort();
     }
 }

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1002,9 +1002,9 @@ where
         // AGENTS.md "cleanup exemptions MUST be time-bounded".
         let now = executor::now_nanos();
         sweep_stale_deferrals(
+            &mut contract_handler,
             &mut deferral_ctx,
             &mut fair_queue,
-            contract_handler.channel(),
             now,
         )
         .await;
@@ -1179,12 +1179,14 @@ fn pop_runnable_event(
 /// `now_nanos` is injected (rather than read from `executor::now_nanos()`
 /// internally) so the sweep is deterministically unit-testable. The loop call
 /// site passes `executor::now_nanos()`.
-async fn sweep_stale_deferrals(
+async fn sweep_stale_deferrals<CH>(
+    contract_handler: &mut CH,
     deferral_ctx: &mut DeferralCtx,
     fair_queue: &mut fair_queue::FairEventQueue,
-    channel: &mut handler::ContractHandlerChannel<handler::ContractHandlerHalve>,
     now_nanos: u64,
-) {
+) where
+    CH: ContractHandler + Send + 'static,
+{
     if deferral_ctx.deferred_keys.is_empty() {
         return;
     }
@@ -1233,7 +1235,7 @@ async fn sweep_stale_deferrals(
         // FRONT (per-contract FIFO); answer any that don't fit with backpressure
         // so their waiting_response slots aren't leaked.
         let rejected = requeue_released_events(deferral_ctx.release_key(&contract_id), fair_queue);
-        answer_rejected_held_events(channel, rejected).await;
+        answer_rejected_held_events(contract_handler, rejected).await;
     }
 }
 
@@ -1260,13 +1262,22 @@ fn requeue_released_events(
 
 /// Answer every event that `requeue_released_events` could not re-enqueue with a
 /// queue-full response (drops its `waiting_response` slot — no leak, no 300s
-/// client hang). Mirrors the normal drain-path rejection handling.
-async fn answer_rejected_held_events(
-    channel: &mut handler::ContractHandlerChannel<handler::ContractHandlerHalve>,
+/// client hang). Mirrors the normal drain-path rejection handling, including the
+/// `EvictContract` pending-reclamation hook so a rejected held `EvictContract`
+/// doesn't silently leak on-disk storage (the #4212 disk-leak class).
+async fn answer_rejected_held_events<CH>(
+    contract_handler: &mut CH,
     rejected: Vec<(handler::EventId, ContractHandlerEvent)>,
-) {
+) where
+    CH: ContractHandler + Send + 'static,
+{
     for (id, event) in rejected {
-        send_queue_full_response(channel, Box::new(fair_queue::RejectedEvent { id, event })).await;
+        let rejected = Box::new(fair_queue::RejectedEvent { id, event });
+        // Mirror the normal drain path: an EvictContract dropped here loses its
+        // hosting-cache entry, so register it for pending-reclamation retry
+        // BEFORE answering, or its disk storage leaks. (#4212)
+        track_pending_reclamation_if_evict(contract_handler, &rejected);
+        send_queue_full_response(contract_handler.channel(), rejected).await;
     }
 }
 
@@ -1434,7 +1445,7 @@ where
         }
     }
 
-    answer_rejected_held_events(contract_handler.channel(), rejected).await;
+    answer_rejected_held_events(contract_handler, rejected).await;
     Ok(())
 }
 
@@ -2543,6 +2554,36 @@ mod tests {
         assert!(
             update_arm.contains("maybe_defer_upsert"),
             "UPDATE arm must route its upsert through maybe_defer_upsert (#4391)"
+        );
+    }
+
+    /// Pin: `answer_rejected_held_events` must call `track_pending_reclamation_if_evict`
+    /// before `send_queue_full_response`, so a held `EvictContract` rejected on
+    /// requeue doesn't silently leak its on-disk storage (the #4212 disk-leak
+    /// class). The other three reject sites already do this; this helper is the
+    /// fourth and must match.
+    #[test]
+    fn answer_rejected_held_events_tracks_evict_reclamation_pin_test() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/contract.rs");
+        let source = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("must read own source at {}: {e}", path.display()));
+        let body = source
+            .split("async fn answer_rejected_held_events")
+            .nth(1)
+            .expect("answer_rejected_held_events must exist")
+            .split("\n}\n")
+            .next()
+            .expect("function body");
+        let track_idx = body
+            .find("track_pending_reclamation_if_evict")
+            .expect("must call track_pending_reclamation_if_evict (EvictContract disk-leak #4212)");
+        let send_idx = body
+            .find("send_queue_full_response")
+            .expect("must answer with send_queue_full_response");
+        assert!(
+            track_idx < send_idx,
+            "reclamation tracking must run BEFORE the queue-full response, \
+             mirroring the normal drain path"
         );
     }
 
@@ -4523,7 +4564,9 @@ mod hol_4391_tests {
     async fn sweep_releases_stale_answers_client_and_requeues_held() {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let mut ctx = DeferralCtx::new(tx);
-        let (_send, mut handler_half, _wait) = handler::contract_handler_channel();
+        let mut handler =
+            MockWasmContractHandler::new_test(handler::contract_handler_channel().1, None, "sweep")
+                .await;
         let mut fq = fair_queue::FairEventQueue::new();
 
         let ttl = DEFERRED_RELATED_FETCH_TIMEOUT.as_nanos() as u64;
@@ -4544,7 +4587,7 @@ mod hol_4391_tests {
         // Sweep at now = 2*ttl + 1: the stale entry (age 2*ttl+1) is swept; the
         // fresh entry (age 1) is not.
         let now = ttl * 2 + 1;
-        sweep_stale_deferrals(&mut ctx, &mut fq, &mut handler_half, now).await;
+        sweep_stale_deferrals(&mut handler, &mut ctx, &mut fq, now).await;
 
         // (a) stale key released; (b) its held event requeued.
         assert!(
@@ -4637,21 +4680,23 @@ mod hol_4391_tests {
     /// sweep/resume use, and asserts the client gets a prompt QueueFull error.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn rejected_held_event_is_answered_not_leaked() {
-        let (send, mut handler_half, _wait) = handler::contract_handler_channel();
+        let (send, rcv_halve, _wait) = handler::contract_handler_channel();
+        let mut handler = MockWasmContractHandler::new_test(rcv_halve, None, "leak").await;
         let k = instance_id(b"leak_k");
 
         // Client sends a GetQuery and awaits the response.
         let client = GlobalExecutor::spawn(async move { send.send_to_handler(get_event(k)).await });
 
         // Handler side receives it (registers the waiting_response slot).
-        let (id, event) = handler_half
+        let (id, event) = handler
+            .channel()
             .recv_from_sender()
             .await
             .expect("event received");
 
         // Simulate the requeue-overflow path: this event couldn't be re-queued,
         // so the loop must answer it with backpressure.
-        answer_rejected_held_events(&mut handler_half, vec![(id, event)]).await;
+        answer_rejected_held_events(&mut handler, vec![(id, event)]).await;
 
         // The client must receive a prompt queue-full error, NOT hang.
         let resp = tokio::time::timeout(Duration::from_secs(2), client)

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -996,12 +996,18 @@ where
 
     loop {
         // Sweep deferrals whose off-loop fetch never reported (waiter task
-        // wedged/dropped): answer their stranded clients with MissingRelated
-        // and release their per-contract block so the contract isn't wedged
-        // forever. TTL-bounded per AGENTS.md "cleanup exemptions MUST be
-        // time-bounded". Responses go straight to the stashed oneshot, so this
-        // needs neither the handler nor `.await`.
-        sweep_stale_deferrals(&mut deferral_ctx, &mut fair_queue);
+        // wedged/dropped): answer their stranded clients with MissingRelated,
+        // release their per-contract block, and re-queue / backpressure their
+        // held events so the contract isn't wedged forever. TTL-bounded per
+        // AGENTS.md "cleanup exemptions MUST be time-bounded".
+        let now = executor::now_nanos();
+        sweep_stale_deferrals(
+            &mut deferral_ctx,
+            &mut fair_queue,
+            contract_handler.channel(),
+            now,
+        )
+        .await;
 
         // Drain resumed (deferred) upserts so a completed off-loop fetch is
         // applied promptly and its client answered, ahead of new queued work —
@@ -1170,21 +1176,25 @@ fn pop_runnable_event(
 /// `at_capacity()` is permanently true and the off-loading silently disables
 /// itself. See issue #4391 and AGENTS.md (cleanup exemptions must be
 /// time-bounded).
-fn sweep_stale_deferrals(
+/// `now_nanos` is injected (rather than read from `executor::now_nanos()`
+/// internally) so the sweep is deterministically unit-testable. The loop call
+/// site passes `executor::now_nanos()`.
+async fn sweep_stale_deferrals(
     deferral_ctx: &mut DeferralCtx,
     fair_queue: &mut fair_queue::FairEventQueue,
+    channel: &mut handler::ContractHandlerChannel<handler::ContractHandlerHalve>,
+    now_nanos: u64,
 ) {
     if deferral_ctx.deferred_keys.is_empty() {
         return;
     }
-    let now = executor::now_nanos();
     let ttl_nanos = DEFERRED_RELATED_FETCH_TIMEOUT.as_nanos() as u64;
     // Stale if it has out-lived 2× the fetch timeout — well past when the
     // waiter should have reported (the waiter itself times out at 1×).
     let stale: Vec<(ContractInstanceId, u64, bool)> = deferral_ctx
         .deferred_keys
         .iter()
-        .filter(|(_, e)| now.saturating_sub(e.started_nanos) >= ttl_nanos.saturating_mul(2))
+        .filter(|(_, e)| now_nanos.saturating_sub(e.started_nanos) >= ttl_nanos.saturating_mul(2))
         .map(|(k, e)| (*k, e.deferral_id, e.is_put))
         .collect();
     for (contract_id, deferral_id, is_put) in stale {
@@ -1219,27 +1229,44 @@ fn sweep_stale_deferrals(
                 );
             }
         }
-        requeue_released_events(deferral_ctx.release_key(&contract_id), fair_queue);
+        // Release the swept deferral's block and re-queue its held events at the
+        // FRONT (per-contract FIFO); answer any that don't fit with backpressure
+        // so their waiting_response slots aren't leaked.
+        let rejected = requeue_released_events(deferral_ctx.release_key(&contract_id), fair_queue);
+        answer_rejected_held_events(channel, rejected).await;
     }
 }
 
-/// Re-enqueue the events that were held behind a now-released deferral, in
-/// their original FIFO order, ahead of fresh events for the same key.
+/// Re-enqueue the events that were held behind a now-released deferral, at the
+/// FRONT of their per-contract bucket in original FIFO order (so they run
+/// before any fresh same-key event that arrived during the deferral — the
+/// per-contract FIFO guarantee of #4391).
+///
+/// Returns the events that could NOT be re-enqueued (fair queue full); the
+/// caller MUST answer each with a queue-full response so its
+/// `waiting_response` slot is not leaked and the client doesn't hang for the
+/// full 300s `CH_EV_RESPONSE_TIME_OUT`. (#4391 round-3 leak fix.)
+#[must_use = "rejected held events must be answered with send_queue_full_response \
+              or their waiting_response slot leaks and the client hangs"]
 fn requeue_released_events(
     held: Option<std::collections::VecDeque<(handler::EventId, ContractHandlerEvent)>>,
     fair_queue: &mut fair_queue::FairEventQueue,
+) -> Vec<(handler::EventId, ContractHandlerEvent)> {
+    match held {
+        Some(held) => fair_queue.requeue_front(held),
+        None => Vec::new(),
+    }
+}
+
+/// Answer every event that `requeue_released_events` could not re-enqueue with a
+/// queue-full response (drops its `waiting_response` slot — no leak, no 300s
+/// client hang). Mirrors the normal drain-path rejection handling.
+async fn answer_rejected_held_events(
+    channel: &mut handler::ContractHandlerChannel<handler::ContractHandlerHalve>,
+    rejected: Vec<(handler::EventId, ContractHandlerEvent)>,
 ) {
-    let Some(held) = held else { return };
-    for (id, event) in held {
-        if let Err(rejected) = fair_queue.try_push(id, event) {
-            // Queue full: drop the held event's response slot rather than leak
-            // it. This is the same backpressure the normal drain path applies;
-            // the client times out (rare — only under sustained saturation).
-            tracing::debug!(
-                event = %rejected.event,
-                "Held deferred-key event dropped on re-enqueue (fair queue full)"
-            );
-        }
+    for (id, event) in rejected {
+        send_queue_full_response(channel, Box::new(fair_queue::RejectedEvent { id, event })).await;
     }
 }
 
@@ -1276,9 +1303,36 @@ where
         fetched,
     } = resume;
 
-    // Reclaim the parked client responder. If it's gone the loop is shutting
-    // down or the entry was already consumed — still release the per-contract
-    // block below so the contract isn't wedged.
+    // STALE-RESUME GUARD (#4391 round-3): only act if THIS deferral still owns
+    // the contract's block. Two stale cases must be skipped entirely:
+    //   * The entry is absent → the TTL sweep already answered this client and
+    //     released the block. Acting now would re-run a stale upsert and (since
+    //     `release_key` is keyed by contract, not deferral_id) is a no-op on the
+    //     map but the upsert/commit would still be stale.
+    //   * The entry exists but a DIFFERENT deferral_id owns it → a newer
+    //     deferral D2 took the key after this one (D1) was swept and a held
+    //     event re-deferred. Running D1's stale upsert would commit older data,
+    //     and `release_key` would remove D2's LIVE block (breaking FIFO).
+    // In both cases the client was already answered by the sweep, so we drop
+    // D1's resume without touching the executor, the block, or held events.
+    let owns_block = deferral_ctx
+        .deferred_keys
+        .get(key.id())
+        .is_some_and(|e| e.deferral_id == deferral_id);
+    if !owns_block {
+        tracing::debug!(
+            contract = %key,
+            deferral_id,
+            "Dropping stale deferred resume — its block was swept or a newer \
+             deferral owns the key (#4391)"
+        );
+        // The stashed responder, if any, was already removed+answered by the
+        // sweep; remove defensively in case of an unexpected duplicate.
+        deferral_ctx.stashed.remove(&deferral_id);
+        return Ok(());
+    }
+
+    // We own the block; reclaim the parked client responder.
     let responder = deferral_ctx.stashed.remove(&deferral_id);
     if responder.is_none() {
         tracing::debug!(contract = %key, "Deferred resume has no stashed responder");
@@ -1359,12 +1413,16 @@ where
         }
     };
 
-    // The resumed upsert has now committed (or errored). Release the
-    // per-contract block and re-enqueue any same-key events that were held
-    // during the deferral, in FIFO order, so they observe the committed state.
-    // This MUST happen after the upsert above and before answering the client,
-    // so the released events can't be popped until the next loop iteration.
-    requeue_released_events(deferral_ctx.release_key(key.id()), fair_queue);
+    // The resumed upsert has now committed (or errored). Release THIS
+    // deferral's block (we verified above it still owns the key) and re-enqueue
+    // any same-key events held during the deferral at the FRONT of the bucket,
+    // in FIFO order, so they observe the committed state. Events that don't fit
+    // are answered with backpressure so their waiting_response slots aren't
+    // leaked. The released events land in the fair queue and are popped by
+    // `pop_runnable_event` after the resume-drain batch finishes (later in this
+    // same loop iteration, or a subsequent one) — never before the upsert above
+    // committed, since this runs synchronously on the loop.
+    let rejected = requeue_released_events(deferral_ctx.release_key(key.id()), fair_queue);
 
     if let Some(responder) = responder {
         if let Err(error) = responder.respond(event_result) {
@@ -1375,6 +1433,8 @@ where
             );
         }
     }
+
+    answer_rejected_held_events(contract_handler.channel(), rejected).await;
     Ok(())
 }
 
@@ -4344,5 +4404,270 @@ mod hol_4391_tests {
             let _ = tokio::time::timeout(Duration::from_secs(10), t).await;
         }
         handle.abort();
+    }
+
+    // ========================================================================
+    // Round-3 fixes: requeue leak/FIFO, stale-resume guard, sweep, held cap
+    // ========================================================================
+
+    fn instance_id(seed: &[u8]) -> ContractInstanceId {
+        *make_contract(seed).key().id()
+    }
+
+    fn get_event(id: ContractInstanceId) -> ContractHandlerEvent {
+        ContractHandlerEvent::GetQuery {
+            instance_id: id,
+            return_contract_code: false,
+        }
+    }
+
+    /// MUST-FIX #2 (unit): held events re-queue at the FRONT of the per-contract
+    /// bucket in FIFO order, ahead of a fresh same-key event already queued.
+    #[test]
+    fn requeue_front_orders_held_before_fresh_same_key() {
+        let mut fq = fair_queue::FairEventQueue::new();
+        let k = instance_id(b"front_k");
+
+        // A FRESH same-key event is already queued (arrived "after" the held
+        // ones in wall-clock, but reached the fair queue first because the held
+        // ones were diverted into the deferral buffer).
+        fq.try_push(handler::EventId { id: 99 }, get_event(k))
+            .expect("fresh push");
+
+        // Two held events (ids 1, 2) re-queued at the front, FIFO order.
+        let mut held = std::collections::VecDeque::new();
+        held.push_back((handler::EventId { id: 1 }, get_event(k)));
+        held.push_back((handler::EventId { id: 2 }, get_event(k)));
+        let rejected = fq.requeue_front(held);
+        assert!(rejected.is_empty(), "nothing should be rejected under cap");
+
+        // Pop order must be 1, 2 (held FIFO), THEN 99 (fresh) — proving the held
+        // older events run before the fresh one.
+        let order: Vec<u64> = std::iter::from_fn(|| fq.pop().map(|(id, _)| id.id)).collect();
+        assert_eq!(
+            order,
+            vec![1, 2, 99],
+            "held events must run in FIFO order before the fresh same-key event"
+        );
+    }
+
+    /// MUST-FIX #2 + #1 (unit): when the per-contract bucket is at capacity,
+    /// `requeue_front` returns the events it could not enqueue, in FIFO order,
+    /// so the caller can answer them with backpressure (no silent drop / leak).
+    #[test]
+    fn requeue_front_returns_overflow_in_fifo_order() {
+        let mut fq = fair_queue::FairEventQueue::new();
+        let k = instance_id(b"overflow_k");
+
+        // Saturate the per-contract bucket via normal pushes.
+        for i in 0..fair_queue::MAX_QUEUED_PER_CONTRACT as u64 {
+            fq.try_push(handler::EventId { id: 1000 + i }, get_event(k))
+                .expect("fill bucket");
+        }
+
+        // Now try to re-queue 3 held events at the front — all should be rejected
+        // (bucket full), returned in original FIFO order.
+        let mut held = std::collections::VecDeque::new();
+        held.push_back((handler::EventId { id: 1 }, get_event(k)));
+        held.push_back((handler::EventId { id: 2 }, get_event(k)));
+        held.push_back((handler::EventId { id: 3 }, get_event(k)));
+        let rejected = fq.requeue_front(held);
+        let rejected_ids: Vec<u64> = rejected.iter().map(|(id, _)| id.id).collect();
+        assert_eq!(
+            rejected_ids,
+            vec![1, 2, 3],
+            "overflow held events must be returned in FIFO order for backpressure"
+        );
+    }
+
+    /// SHOULD-FIX (unit): the per-deferral held buffer caps at
+    /// MAX_HELD_PER_DEFERRAL — the (cap+1)th hold returns `Full` carrying the
+    /// event back.
+    #[test]
+    fn hold_event_caps_at_max_held_per_deferral() {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut ctx = DeferralCtx::new(tx);
+        let k = instance_id(b"held_cap_k");
+        ctx.block_key(k, 1, true, 0);
+
+        for i in 0..MAX_HELD_PER_DEFERRAL as u64 {
+            match ctx.hold_event(k, handler::EventId { id: i }, get_event(k)) {
+                HoldOutcome::Held => {}
+                other => panic!("expected Held within cap, got {:?}", DbgHold(&other)),
+            }
+        }
+        // The (cap+1)th must be Full and hand the event back.
+        match ctx.hold_event(k, handler::EventId { id: 9999 }, get_event(k)) {
+            HoldOutcome::Full(id, _ev) => assert_eq!(id.id, 9999),
+            other => panic!("expected Full at cap, got {:?}", DbgHold(&other)),
+        }
+    }
+
+    // Small debug helper for HoldOutcome (it intentionally has no Debug derive
+    // to avoid requiring ContractHandlerEvent: Debug in non-test code paths).
+    struct DbgHold<'a>(&'a HoldOutcome);
+    impl std::fmt::Debug for DbgHold<'_> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self.0 {
+                HoldOutcome::Held => write!(f, "Held"),
+                HoldOutcome::NotDeferred(..) => write!(f, "NotDeferred"),
+                HoldOutcome::Full(..) => write!(f, "Full"),
+            }
+        }
+    }
+
+    /// MUST-FIX #4 (unit): the TTL sweep answers a stale deferral's client with
+    /// the correct response variant, releases its block, re-queues its held
+    /// event, and does NOT sweep a fresh (age < 2×TTL) entry.
+    #[tokio::test]
+    async fn sweep_releases_stale_answers_client_and_requeues_held() {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut ctx = DeferralCtx::new(tx);
+        let (_send, mut handler_half, _wait) = handler::contract_handler_channel();
+        let mut fq = fair_queue::FairEventQueue::new();
+
+        let ttl = DEFERRED_RELATED_FETCH_TIMEOUT.as_nanos() as u64;
+
+        // STALE deferral (started at t=0), an UPDATE op, with one held event.
+        let stale_key = instance_id(b"sweep_stale");
+        ctx.block_key(stale_key, 1, /* is_put */ false, 0);
+        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+        ctx.stashed
+            .insert(1, StashedResponder::for_test(1, resp_tx));
+        let _ = ctx.hold_event(stale_key, handler::EventId { id: 50 }, get_event(stale_key));
+
+        // FRESH deferral (started recently) — must NOT be swept.
+        let fresh_key = instance_id(b"sweep_fresh");
+        let fresh_started = ttl * 2; // so at now below, age = 1 < 2*ttl
+        ctx.block_key(fresh_key, 2, true, fresh_started);
+
+        // Sweep at now = 2*ttl + 1: the stale entry (age 2*ttl+1) is swept; the
+        // fresh entry (age 1) is not.
+        let now = ttl * 2 + 1;
+        sweep_stale_deferrals(&mut ctx, &mut fq, &mut handler_half, now).await;
+
+        // (a) stale key released; (b) its held event requeued.
+        assert!(
+            !ctx.is_key_deferred(&stale_key),
+            "stale deferral must be released"
+        );
+        assert_eq!(
+            fq.pop().map(|(id, _)| id.id),
+            Some(50),
+            "the stale deferral's held event must be re-queued"
+        );
+
+        // (c) client answered with an UpdateResponse error (matching is_put=false).
+        let (_id, ev) = resp_rx.await.expect("stale client must be answered");
+        match ev {
+            ContractHandlerEvent::UpdateResponse { new_value, .. } => {
+                assert!(new_value.is_err(), "swept UPDATE must surface an error");
+            }
+            other => panic!("expected UpdateResponse for swept UPDATE op, got {other}"),
+        }
+
+        // (d) fresh entry survives.
+        assert!(
+            ctx.is_key_deferred(&fresh_key),
+            "a fresh deferral (age < 2×TTL) must NOT be swept"
+        );
+    }
+
+    /// MUST-FIX #3 (unit): a stale resume whose deferral_id no longer owns the
+    /// key (a newer deferral took over) is DROPPED — it must not release the
+    /// newer deferral's block.
+    #[tokio::test]
+    async fn stale_resume_does_not_release_newer_deferral_block() {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut ctx = DeferralCtx::new(tx);
+        let mut fq = fair_queue::FairEventQueue::new();
+        let mut handler =
+            MockWasmContractHandler::new_test(handler::contract_handler_channel().1, None, "stale")
+                .await;
+
+        let contract = make_contract(b"stale_resume_k");
+        let key = contract.key();
+
+        // D2 (the LIVE deferral) currently owns the key, deferral_id = 2.
+        ctx.block_key(*key.id(), 2, true, 0);
+
+        // D1's late resume arrives with deferral_id = 1 (already swept/superseded).
+        let stale_resume = DeferredResume {
+            deferral_id: 1,
+            key,
+            update: Either::Left(WrappedState::new(vec![1])),
+            related_contracts: RelatedContracts::default(),
+            code: Some(contract),
+            is_put: true,
+            fetched: Ok(vec![]),
+        };
+
+        handle_deferred_resume(&mut handler, &mut ctx, &mut fq, stale_resume)
+            .await
+            .expect("stale resume handled");
+
+        // D2's block must SURVIVE (the stale D1 resume must not release it).
+        assert!(
+            ctx.is_key_deferred(key.id()),
+            "stale resume must NOT release the newer deferral's block (#4391 MUST-FIX #3)"
+        );
+        let entry = ctx.deferred_keys.get(key.id()).expect("D2 still present");
+        assert_eq!(entry.deferral_id, 2, "the live deferral (D2) must remain");
+    }
+
+    /// SHOULD-FIX (unit): with no op_manager, the real `fetch_related_off_loop`
+    /// (override cleared) surfaces MissingRelated for the missing ids — covers
+    /// the orchestration's `op_manager.is_none()` branch.
+    #[tokio::test]
+    async fn fetch_related_off_loop_no_op_manager_is_missing_related() {
+        let _guard = TEST_GUARD.lock().await;
+        set_off_loop_fetch_override(None);
+        let id = instance_id(b"off_loop_none");
+        let result = fetch_related_off_loop(None, vec![id]).await;
+        assert!(
+            result.is_err(),
+            "no op_manager must surface MissingRelated, got {result:?}"
+        );
+    }
+
+    /// MUST-FIX #1 (e2e): a held event that can't be re-queued (fair queue full)
+    /// must be ANSWERED with a queue-full response — NOT silently dropped (which
+    /// would leak its waiting_response slot and hang the client 300s). Drives a
+    /// real GetQuery through the channel, then rejects it via the same path the
+    /// sweep/resume use, and asserts the client gets a prompt QueueFull error.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rejected_held_event_is_answered_not_leaked() {
+        let (send, mut handler_half, _wait) = handler::contract_handler_channel();
+        let k = instance_id(b"leak_k");
+
+        // Client sends a GetQuery and awaits the response.
+        let client = GlobalExecutor::spawn(async move { send.send_to_handler(get_event(k)).await });
+
+        // Handler side receives it (registers the waiting_response slot).
+        let (id, event) = handler_half
+            .recv_from_sender()
+            .await
+            .expect("event received");
+
+        // Simulate the requeue-overflow path: this event couldn't be re-queued,
+        // so the loop must answer it with backpressure.
+        answer_rejected_held_events(&mut handler_half, vec![(id, event)]).await;
+
+        // The client must receive a prompt queue-full error, NOT hang.
+        let resp = tokio::time::timeout(Duration::from_secs(2), client)
+            .await
+            .expect("client must be answered promptly, not leaked/hung")
+            .expect("join")
+            .expect("client receives a response");
+        match resp {
+            ContractHandlerEvent::GetResponse { response, .. } => {
+                let err = response.expect_err("rejected held GET must be an error");
+                assert!(
+                    err.is_contract_queue_full(),
+                    "rejected held event must surface ContractQueueFull, got {err}"
+                );
+            }
+            other => panic!("expected GetResponse(queue-full), got {other}"),
+        }
     }
 }

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -17,15 +17,16 @@ pub(crate) mod user_input;
 pub(crate) use executor::{
     ContractExecutor, ExecutorTransactionStream, MAX_CREATED_DELEGATES_PER_NODE,
     MAX_DELEGATE_CREATION_DEPTH, MAX_DELEGATE_CREATIONS_PER_CALL,
-    SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE, UpsertResult, mock_runtime::MockRuntime,
+    SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE, UpsertOutcome, UpsertResult, mock_runtime::MockRuntime,
 };
 
 // Re-export CRDT emulation functions for testing
 pub use executor::mock_runtime::{clear_crdt_contracts, is_crdt_contract, register_crdt_contract};
 pub(crate) use handler::{
     ClientResponsesReceiver, ClientResponsesSender, ContractHandler, ContractHandlerChannel,
-    ContractHandlerEvent, NetworkContractHandler, SenderHalve, SessionMessage, StoreResponse,
-    WaitingResolution, WaitingTransaction, client_responses_channel, contract_handler_channel,
+    ContractHandlerEvent, NetworkContractHandler, SenderHalve, SessionMessage, StashedResponder,
+    StoreResponse, WaitingResolution, WaitingTransaction, client_responses_channel,
+    contract_handler_channel,
     in_memory::{
         MemoryContractHandler, MockWasmContractHandler, MockWasmHandlerBuilder,
         SimulationContractHandler, SimulationHandlerBuilder,
@@ -40,6 +41,7 @@ use tracing::Instrument;
 
 use self::executor::DelegateNotificationReceiver;
 use self::user_input::{CallerIdentity, UserInputPrompter};
+use crate::config::GlobalExecutor;
 
 /// Maximum iterations when handling contract requests to prevent infinite loops
 const MAX_CONTRACT_REQUEST_ITERATIONS: usize = 100;
@@ -48,6 +50,196 @@ const MAX_CONTRACT_REQUEST_ITERATIONS: usize = 100;
 /// Matches the same bounded-drain pattern as MAX_DRAIN_BATCH for contract events,
 /// preventing delegate notification channel growth under sustained contract load.
 const MAX_DELEGATE_DRAIN_BATCH: usize = 16;
+
+/// Unified timeout for the off-loop related-contract fetch that backs a
+/// deferred PUT/UPDATE (#4391).
+///
+/// This reconciles the two legacy inline timeouts (`RELATED_FETCH_TIMEOUT`=10s
+/// for validate-side fetches, `SUB_OP_FETCH_TIMEOUT`=120s in
+/// `local_state_or_from_network`): the 120s value only existed because the
+/// wait sat on the serial loop and we did not want to fail a slow cross-node
+/// fetch prematurely. Now that the wait is OFF the loop, the loop keeps
+/// draining other events regardless, so we apply the tighter
+/// `RELATED_FETCH_TIMEOUT` consistently — a deferred op that cannot resolve
+/// its related contracts within 10s surfaces `MissingRelated` to the client,
+/// exactly as the inline validate path did.
+const DEFERRED_RELATED_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Maximum number of PUT/UPDATE operations that may have an in-flight
+/// off-loop related-contract fetch at once.
+///
+/// Bounds the number of concurrently spawned waiter tasks so a flood of
+/// related-needing PUTs cannot spawn unbounded background work. When the cap
+/// is reached, a new related-needing op falls back to surfacing
+/// `MissingRelated` to the client rather than deferring — backpressure, not
+/// unbounded growth (see code-style.md "per-key/per-client caps").
+const MAX_INFLIGHT_DEFERRALS: usize = 256;
+
+/// A PUT/UPDATE that deferred its related-contract fetch off the serial loop,
+/// carrying everything needed to re-run the upsert once the fetch resolves.
+///
+/// Built by the off-loop waiter task and sent back to the `contract_handling`
+/// loop via the resume channel; the loop re-runs the upsert ON the loop (so
+/// WASM stays serial) with `fetched` supplied, then answers the stashed client
+/// responder. See issue #4391.
+struct DeferredResume {
+    /// Key into the loop's stashed-responder map (and the inflight set).
+    deferral_id: u64,
+    /// The contract being PUT/UPDATEd.
+    key: ContractKey,
+    /// The original update payload (full state for PUT, delta/state for UPDATE).
+    update: Either<WrappedState, StateDelta<'static>>,
+    /// Caller-supplied related contracts from the original event.
+    related_contracts: RelatedContracts<'static>,
+    /// Contract code (Some for PUT, None for UPDATE).
+    code: Option<ContractContainer>,
+    /// `true` for PUT (build `PutResponse`), `false` for UPDATE
+    /// (build `UpdateResponse`).
+    is_put: bool,
+    /// The states fetched off-loop, or `Err` if the fetch failed/timed out
+    /// (→ resume surfaces `MissingRelated`).
+    fetched: Result<Vec<(ContractInstanceId, WrappedState)>, ExecutorError>,
+}
+
+/// Loop-side state for off-loading deferred related-contract fetches (#4391).
+///
+/// Owned by `contract_handling`; passed by `&mut` into `handle_contract_event`
+/// so the PUT/UPDATE arms can defer. When this context is absent (e.g. the
+/// delegate-driven PUT path, or direct unit-test calls to
+/// `handle_contract_event`), the arms keep the legacy inline-fetch behavior.
+struct DeferralCtx {
+    /// Off-loop waiters send completed [`DeferredResume`]s back to the loop here.
+    resume_tx: tokio::sync::mpsc::UnboundedSender<DeferredResume>,
+    /// Client responders parked while their op's related fetch runs off-loop,
+    /// keyed by `deferral_id`. Drained by the loop when the resume arrives.
+    stashed: std::collections::HashMap<u64, StashedResponder>,
+    /// Monotonic id generator for `deferral_id`.
+    next_deferral_id: u64,
+}
+
+impl DeferralCtx {
+    fn new(resume_tx: tokio::sync::mpsc::UnboundedSender<DeferredResume>) -> Self {
+        Self {
+            resume_tx,
+            stashed: std::collections::HashMap::new(),
+            next_deferral_id: 0,
+        }
+    }
+
+    /// `true` when the in-flight deferral cap is reached and a new op must NOT
+    /// defer (it falls back to surfacing the related-fetch failure inline).
+    fn at_capacity(&self) -> bool {
+        self.stashed.len() >= MAX_INFLIGHT_DEFERRALS
+    }
+}
+
+#[cfg(test)]
+pub(crate) type OffLoopFetchStub = Arc<
+    dyn Fn(
+            Vec<ContractInstanceId>,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = Result<Vec<(ContractInstanceId, WrappedState)>, ExecutorError>,
+                    > + Send,
+            >,
+        > + Send
+        + Sync,
+>;
+
+#[cfg(test)]
+static OFF_LOOP_FETCH_OVERRIDE: std::sync::Mutex<Option<OffLoopFetchStub>> =
+    std::sync::Mutex::new(None);
+
+/// Install (or clear) the test override for [`fetch_related_off_loop`].
+///
+/// Unlike the executor's `TEST_NETWORK_FETCH_OVERRIDE` (a thread-local, sync
+/// stub), this override is `Arc`-based and async so a test running on a
+/// multi-thread runtime can make the off-loop fetch *hang* until the test
+/// releases it — the deterministic way to reproduce the head-of-line stall
+/// the fix removes (#4391).
+#[cfg(test)]
+pub(crate) fn set_off_loop_fetch_override(stub: Option<OffLoopFetchStub>) {
+    *OFF_LOOP_FETCH_OVERRIDE.lock().unwrap() = stub;
+}
+
+/// Drive the related-contract GET(s) for a deferred upsert OFF the serial
+/// `contract_handling` loop.
+///
+/// Each missing id races its own background sub-op GET (`start_sub_op_get`
+/// already spawns the GET on its own task); we await the oneshots under a
+/// single [`DEFERRED_RELATED_FETCH_TIMEOUT`] budget. Any miss/timeout/infra
+/// error fails the whole fetch with `MissingRelated`, mirroring the inline
+/// validate path's all-or-nothing semantics. Runs in a `GlobalExecutor::spawn`
+/// task; nothing here touches the executor or the serial loop.
+async fn fetch_related_off_loop(
+    op_manager: Option<Arc<crate::node::OpManager>>,
+    missing: Vec<ContractInstanceId>,
+) -> Result<Vec<(ContractInstanceId, WrappedState)>, ExecutorError> {
+    #[cfg(test)]
+    {
+        let stub = OFF_LOOP_FETCH_OVERRIDE.lock().unwrap().clone();
+        if let Some(stub) = stub {
+            return stub(missing).await;
+        }
+    }
+
+    let Some(op_manager) = op_manager else {
+        // No network available (local-only executor): surface the first
+        // missing id as MissingRelated, matching the legacy local-only path.
+        let id = missing
+            .first()
+            .copied()
+            .unwrap_or_else(|| ContractInstanceId::new([0u8; 32]));
+        return Err(ExecutorError::missing_related(id));
+    };
+
+    let fetch_all = async {
+        let results: Vec<(ContractInstanceId, Result<WrappedState, ExecutorError>)> =
+            futures::future::join_all(missing.iter().map(|id| {
+                let id = *id;
+                let op_manager = op_manager.clone();
+                async move {
+                    let (_tx, rx) = crate::operations::get::op_ctx_task::start_sub_op_get(
+                        &op_manager,
+                        id,
+                        false,
+                    );
+                    let outcome = match rx.await {
+                        Ok(outcome) => outcome,
+                        Err(_) => return (id, Err(ExecutorError::missing_related(id))),
+                    };
+                    let mapped = match outcome {
+                        crate::operations::get::op_ctx_task::SubOpGetOutcome::Found(get_result) => {
+                            Ok(WrappedState::from(get_result.state.as_ref().to_vec()))
+                        }
+                        crate::operations::get::op_ctx_task::SubOpGetOutcome::NotFound(_)
+                        | crate::operations::get::op_ctx_task::SubOpGetOutcome::Infra(_) => {
+                            Err(ExecutorError::missing_related(id))
+                        }
+                    };
+                    (id, mapped)
+                }
+            }))
+            .await;
+        let mut fetched = Vec::with_capacity(results.len());
+        for (id, res) in results {
+            fetched.push((id, res?));
+        }
+        Ok::<_, ExecutorError>(fetched)
+    };
+
+    match tokio::time::timeout(DEFERRED_RELATED_FETCH_TIMEOUT, fetch_all).await {
+        Ok(result) => result,
+        Err(_) => {
+            let id = missing
+                .first()
+                .copied()
+                .unwrap_or_else(|| ContractInstanceId::new([0u8; 32]));
+            Err(ExecutorError::missing_related(id))
+        }
+    }
+}
 
 /// Handle a delegate request, including any contract request messages in the response.
 ///
@@ -664,7 +856,26 @@ where
     let mut delegate_rx = contract_handler.executor().take_delegate_notification_rx();
     let mut fair_queue = fair_queue::FairEventQueue::new();
 
+    // Resume channel for PUT/UPDATE operations whose related-contract fetch was
+    // off-loaded from this serial loop (#4391). Off-loop waiter tasks send the
+    // fetched states back here; the loop re-runs the upsert ON the loop so WASM
+    // stays serial. Unbounded is acceptable per channel-safety.md's carve-out:
+    // the producer count is bounded by MAX_INFLIGHT_DEFERRALS, the receiver is
+    // this loop (which drains every iteration), and there is no cycle (the
+    // waiter never reads what the loop produces). The waiter sends with a
+    // non-blocking `unbounded_send` (no `.await`), so it can never back-pressure
+    // anything.
+    let (resume_tx, mut resume_rx) = tokio::sync::mpsc::unbounded_channel::<DeferredResume>();
+    let mut deferral_ctx = DeferralCtx::new(resume_tx);
+
     loop {
+        // Drain resumed (deferred) upserts FIRST so a completed off-loop fetch
+        // is applied promptly and its client answered, ahead of new queued work.
+        // Bounded by MAX_INFLIGHT_DEFERRALS (no resume can enqueue another).
+        while let Ok(resume) = resume_rx.try_recv() {
+            handle_deferred_resume(&mut contract_handler, &mut deferral_ctx, resume).await?;
+        }
+
         // Drain pending events from the channel into the fair queue (bounded batch).
         // Capped at MAX_DRAIN_BATCH (256) to bound the synchronous work per iteration
         // before yielding back to the Tokio scheduler. Each iteration of this loop is
@@ -707,11 +918,19 @@ where
 
         // Process one event from the fair queue (round-robin across contracts)
         if let Some((id, event)) = fair_queue.pop() {
-            handle_contract_event(&mut contract_handler, id, event, &prompter).await?;
+            handle_contract_event(
+                &mut contract_handler,
+                id,
+                event,
+                &prompter,
+                Some(&mut deferral_ctx),
+            )
+            .await?;
             continue;
         }
 
-        // Fair queue is empty — block-wait for a new event or delegate notification
+        // Fair queue is empty — block-wait for a new event, a resumed deferral,
+        // or a delegate notification.
         tokio::select! {
             result = contract_handler.channel().recv_from_sender() => {
                 let (id, event) = result?;
@@ -720,11 +939,401 @@ where
                     send_queue_full_response(contract_handler.channel(), rejected).await;
                 }
             }
+            Some(resume) = resume_rx.recv() => {
+                handle_deferred_resume(&mut contract_handler, &mut deferral_ctx, resume).await?;
+            }
             notification = recv_delegate_notification(&mut delegate_rx) => {
                 handle_delegate_notification(&mut contract_handler, notification, &prompter).await;
             }
         }
     }
+}
+
+/// Re-run a deferred PUT/UPDATE upsert ON the serial loop once its related
+/// contracts have been fetched off-loop, then answer the original client.
+///
+/// The fetched related states are injected into `related_contracts` so the
+/// resumed upsert finds them locally and does NOT re-fetch. The upsert runs
+/// via the plain (non-deferrable) `upsert_contract_state`, so if the contract
+/// *still* requests a different related contract it cannot defer again — it
+/// surfaces `MissingRelated` to the client (the depth=1 / one-deferral cap,
+/// constraint of #4391).
+async fn handle_deferred_resume<CH>(
+    contract_handler: &mut CH,
+    deferral_ctx: &mut DeferralCtx,
+    resume: DeferredResume,
+) -> Result<(), ContractError>
+where
+    CH: ContractHandler + Send + 'static,
+{
+    let DeferredResume {
+        deferral_id,
+        key,
+        update,
+        mut related_contracts,
+        code,
+        is_put,
+        fetched,
+    } = resume;
+
+    // Reclaim the parked client responder. If it's gone the loop is shutting
+    // down or the entry was already consumed — nothing to answer.
+    let Some(responder) = deferral_ctx.stashed.remove(&deferral_id) else {
+        tracing::debug!(contract = %key, "Deferred resume has no stashed responder; dropping");
+        return Ok(());
+    };
+
+    let event_result = match fetched {
+        Ok(states) => {
+            // Inject the off-loop-fetched related states so the resumed upsert
+            // resolves them locally (no second network round trip).
+            for (id, state) in states {
+                inject_related_state(
+                    &mut related_contracts,
+                    id,
+                    freenet_stdlib::prelude::State::from(state.as_ref().to_vec()),
+                );
+            }
+            // Preserve the original incoming full state (PUT only) for the
+            // NoChange response, since `update` is consumed by the upsert.
+            let incoming_state = match &update {
+                Either::Left(state) => Some(state.clone()),
+                Either::Right(_) => None,
+            };
+            // Re-run the upsert ON the loop in DEFERRABLE mode again. With the
+            // related states supplied, validation/merge resolves locally and
+            // returns `Completed`. The one-deferral cap (#4391): if the contract
+            // now requests a DIFFERENT related contract not held locally, the
+            // deferrable path returns `DeferRelated` again — we convert that to
+            // MissingRelated rather than spawning a second off-loop fetch, so a
+            // misbehaving contract cannot defer indefinitely and the network
+            // wait never re-enters the loop.
+            let result = match contract_handler
+                .executor()
+                .upsert_contract_state_deferrable(key, update, related_contracts, code)
+                .instrument(tracing::info_span!("upsert_contract_state_resumed", %key))
+                .await
+            {
+                Ok(UpsertOutcome::Completed(result)) => Ok(result),
+                Ok(UpsertOutcome::DeferRelated(missing)) => {
+                    tracing::debug!(
+                        contract = %key,
+                        missing = missing.len(),
+                        "Resumed upsert still needs a related contract — surfacing \
+                         MissingRelated (one-deferral cap, #4391)"
+                    );
+                    Err(ExecutorError::missing_related(
+                        missing.first().copied().unwrap_or_else(|| *key.id()),
+                    ))
+                }
+                Err(err) => Err(err),
+            };
+            if is_put {
+                let incoming_state =
+                    incoming_state.unwrap_or_else(|| WrappedState::new(Vec::new()));
+                put_response_from_result(contract_handler, key, incoming_state, result).await?
+            } else {
+                update_response_from_result(contract_handler, key, result).await?
+            }
+        }
+        Err(err) => {
+            // Off-loop fetch failed/timed out: surface the related-fetch error
+            // to the client (do NOT defer again).
+            tracing::debug!(
+                contract = %key,
+                error = %err,
+                "Deferred related-contract fetch failed; surfacing to client"
+            );
+            if is_put {
+                ContractHandlerEvent::PutResponse {
+                    new_value: Err(err),
+                    state_changed: false,
+                }
+            } else {
+                ContractHandlerEvent::UpdateResponse {
+                    new_value: Err(err),
+                    state_changed: false,
+                }
+            }
+        }
+    };
+
+    if let Err(error) = responder.respond(event_result) {
+        tracing::debug!(
+            error = %error,
+            contract = %key,
+            "Failed to deliver deferred upsert response (client may have disconnected)"
+        );
+    }
+    Ok(())
+}
+
+/// Result of attempting a deferrable upsert in the PUT/UPDATE arms.
+enum DeferStep {
+    /// The upsert ran to completion (no related fetch needed, or it was
+    /// resolvable locally). Build the response from this result.
+    Completed(Result<UpsertResult, ExecutorError>),
+    /// The upsert deferred its related-contract fetch off-loop. The client
+    /// responder has been parked; the arm must return immediately and let the
+    /// resume path answer the client later.
+    Deferred,
+}
+
+/// Run an upsert in deferrable mode when a [`DeferralCtx`] is available,
+/// off-loading the related-contract network fetch from the serial loop (#4391).
+///
+/// When `deferral` is `None` (delegate-driven PUTs, direct unit tests) or the
+/// in-flight deferral cap is reached, this falls back to the legacy inline
+/// `upsert_contract_state` and always returns `Completed`.
+#[allow(clippy::too_many_arguments)]
+async fn maybe_defer_upsert<CH>(
+    contract_handler: &mut CH,
+    deferral: Option<&mut DeferralCtx>,
+    id: &handler::EventId,
+    key: ContractKey,
+    update: Either<WrappedState, StateDelta<'static>>,
+    related_contracts: RelatedContracts<'static>,
+    code: Option<ContractContainer>,
+    is_put: bool,
+) -> DeferStep
+where
+    CH: ContractHandler + Send + 'static,
+{
+    // No deferral context (or at capacity) → behave exactly as the legacy
+    // inline path: await the network related-fetch on this loop. This keeps
+    // delegate-driven PUTs and direct unit-test calls unchanged, and provides
+    // backpressure (rather than unbounded waiter tasks) under a deferral flood.
+    let Some(deferral) = deferral else {
+        return DeferStep::Completed(
+            contract_handler
+                .executor()
+                .upsert_contract_state(key, update, related_contracts, code)
+                .instrument(tracing::info_span!("upsert_contract_state", %key))
+                .await,
+        );
+    };
+    if deferral.at_capacity() {
+        tracing::warn!(
+            contract = %key,
+            inflight = deferral.stashed.len(),
+            limit = MAX_INFLIGHT_DEFERRALS,
+            "Deferral capacity reached — falling back to inline related fetch"
+        );
+        return DeferStep::Completed(
+            contract_handler
+                .executor()
+                .upsert_contract_state(key, update, related_contracts, code)
+                .instrument(tracing::info_span!("upsert_contract_state", %key))
+                .await,
+        );
+    }
+
+    let outcome = contract_handler
+        .executor()
+        .upsert_contract_state_deferrable(
+            key,
+            update.clone(),
+            related_contracts.clone(),
+            code.clone(),
+        )
+        .instrument(tracing::info_span!("upsert_contract_state_deferrable", %key))
+        .await;
+
+    let missing = match outcome {
+        Ok(UpsertOutcome::Completed(result)) => return DeferStep::Completed(Ok(result)),
+        Ok(UpsertOutcome::DeferRelated(missing)) => missing,
+        Err(err) => return DeferStep::Completed(Err(err)),
+    };
+
+    // Park the client responder so it survives the off-loop wait.
+    let Some(responder) = contract_handler.channel().take_waiting_response(id) else {
+        // Fire-and-forget event (no responder): nothing to answer, and there's
+        // no client awaiting the resume. Fall back to the inline path so the
+        // upsert's side effects (store/broadcast) still happen.
+        return DeferStep::Completed(
+            contract_handler
+                .executor()
+                .upsert_contract_state(key, update, related_contracts, code)
+                .instrument(tracing::info_span!("upsert_contract_state", %key))
+                .await,
+        );
+    };
+
+    let deferral_id = deferral.next_deferral_id;
+    deferral.next_deferral_id = deferral.next_deferral_id.wrapping_add(1);
+    deferral.stashed.insert(deferral_id, responder);
+
+    let op_manager = contract_handler.executor().op_manager_handle();
+    let resume_tx = deferral.resume_tx.clone();
+
+    tracing::debug!(
+        contract = %key,
+        missing = missing.len(),
+        deferral_id,
+        "Off-loading related-contract fetch from the contract-handling loop (#4391)"
+    );
+
+    // Spawn the off-loop waiter. It drives the related GET(s), then sends a
+    // DeferredResume back to the loop. Fire-and-forget is acceptable: the task
+    // is short-lived and bounded by MAX_INFLIGHT_DEFERRALS, and a dropped task
+    // simply lets the client time out (same as the legacy timeout path).
+    GlobalExecutor::spawn(async move {
+        let fetched = fetch_related_off_loop(op_manager, missing).await;
+        // Non-blocking send on an unbounded channel; if it fails the loop has
+        // shut down and the client will time out (same as the legacy path).
+        if resume_tx
+            .send(DeferredResume {
+                deferral_id,
+                key,
+                update,
+                related_contracts,
+                code,
+                is_put,
+                fetched,
+            })
+            .is_err()
+        {
+            tracing::debug!(
+                contract = %key,
+                "Deferred resume channel closed; contract-handling loop gone"
+            );
+        }
+    });
+
+    DeferStep::Deferred
+}
+
+/// Build the `PutResponse` (or fatal error) for a PUT upsert result. Shared by
+/// the inline PUT arm and the deferred-resume path so both produce identical
+/// responses.
+///
+/// `incoming_state` is the full state the PUT carried; it is returned on the
+/// `NoChange` outcome (the incoming state was identical to / older than the
+/// stored state), matching the legacy inline behavior exactly.
+async fn put_response_from_result<CH>(
+    contract_handler: &mut CH,
+    key: ContractKey,
+    incoming_state: WrappedState,
+    put_result: Result<UpsertResult, ExecutorError>,
+) -> Result<ContractHandlerEvent, ContractError>
+where
+    CH: ContractHandler + Send + 'static,
+{
+    let _ = contract_handler;
+    Ok(match put_result {
+        Ok(UpsertResult::NoChange) => ContractHandlerEvent::PutResponse {
+            new_value: Ok(incoming_state),
+            state_changed: false,
+        },
+        Ok(UpsertResult::Updated(new_state)) => ContractHandlerEvent::PutResponse {
+            new_value: Ok(new_state),
+            state_changed: true,
+        },
+        Ok(UpsertResult::CurrentWon(current_state)) => {
+            // Merge resulted in no change (incoming state was old/already incorporated).
+            ContractHandlerEvent::PutResponse {
+                new_value: Ok(current_state),
+                state_changed: false,
+            }
+        }
+        Err(err) => {
+            if err.is_fatal() {
+                tracing::error!(
+                    contract = %key,
+                    error = %err,
+                    phase = "fatal_error",
+                    "Fatal executor error during put query"
+                );
+                return Err(ContractError::FatalExecutorError { key, error: err });
+            }
+            ContractHandlerEvent::PutResponse {
+                new_value: Err(err),
+                state_changed: false,
+            }
+        }
+    })
+}
+
+/// Build the `UpdateResponse`/`UpdateNoChange` (or fatal error) for an UPDATE
+/// upsert result. Shared by the inline UPDATE arm and the deferred-resume path.
+async fn update_response_from_result<CH>(
+    contract_handler: &mut CH,
+    key: ContractKey,
+    update_result: Result<UpsertResult, ExecutorError>,
+) -> Result<ContractHandlerEvent, ContractError>
+where
+    CH: ContractHandler + Send + 'static,
+{
+    Ok(match update_result {
+        Ok(UpsertResult::NoChange) => {
+            tracing::debug!(
+                contract = %key,
+                phase = "update_no_change",
+                "UPDATE resulted in NoChange, fetching current state to return UpdateResponse"
+            );
+            // When there's no change, we still need to return the current state
+            // so the client gets a proper response
+            match contract_handler.executor().fetch_contract(key, false).await {
+                Ok((Some(current_state), _)) => {
+                    tracing::debug!(
+                        contract = %key,
+                        phase = "fetch_complete",
+                        "Successfully fetched current state for NoChange update"
+                    );
+                    ContractHandlerEvent::UpdateResponse {
+                        new_value: Ok(current_state),
+                        state_changed: false,
+                    }
+                }
+                Ok((None, _)) => {
+                    tracing::warn!(
+                        contract = %key,
+                        phase = "fetch_failed",
+                        "No state found when fetching for NoChange update"
+                    );
+                    // Fallback to the old behavior if we can't fetch the state
+                    ContractHandlerEvent::UpdateNoChange { key }
+                }
+                Err(err) => {
+                    tracing::error!(
+                        contract = %key,
+                        error = %err,
+                        phase = "fetch_error",
+                        "Error fetching state for NoChange update"
+                    );
+                    // Fallback to the old behavior if we can't fetch the state
+                    ContractHandlerEvent::UpdateNoChange { key }
+                }
+            }
+        }
+        Ok(UpsertResult::Updated(state)) => ContractHandlerEvent::UpdateResponse {
+            new_value: Ok(state),
+            state_changed: true,
+        },
+        Ok(UpsertResult::CurrentWon(current_state)) => {
+            // Merge resulted in no change (incoming state was old/already incorporated).
+            // Return current state with state_changed=false.
+            ContractHandlerEvent::UpdateResponse {
+                new_value: Ok(current_state),
+                state_changed: false,
+            }
+        }
+        Err(err) => {
+            if err.is_fatal() {
+                tracing::error!(
+                    contract = %key,
+                    error = %err,
+                    phase = "fatal_error",
+                    "Fatal executor error during update query"
+                );
+                return Err(ContractError::FatalExecutorError { key, error: err });
+            }
+            ContractHandlerEvent::UpdateResponse {
+                new_value: Err(err),
+                state_changed: false,
+            }
+        }
+    })
 }
 
 /// When the fair queue rejects an `EvictContract` event (queue-full),
@@ -911,6 +1520,7 @@ async fn handle_contract_event<CH, P>(
     id: handler::EventId,
     event: ContractHandlerEvent,
     prompter: &P,
+    deferral: Option<&mut DeferralCtx>,
 ) -> Result<(), ContractError>
 where
     CH: ContractHandler + Send + 'static,
@@ -1057,49 +1667,32 @@ where
                 );
             }
 
-            let put_result = contract_handler
-                .executor()
-                .upsert_contract_state(
-                    key,
-                    Either::Left(state.clone()),
-                    related_contracts,
-                    contract,
-                )
-                .instrument(tracing::info_span!("upsert_contract_state", %key))
-                .await;
-
-            let event_result = match put_result {
-                Ok(UpsertResult::NoChange) => ContractHandlerEvent::PutResponse {
-                    new_value: Ok(state),
-                    state_changed: false,
-                },
-                Ok(UpsertResult::Updated(new_state)) => ContractHandlerEvent::PutResponse {
-                    new_value: Ok(new_state),
-                    state_changed: true,
-                },
-                Ok(UpsertResult::CurrentWon(current_state)) => {
-                    // Merge resulted in no change (incoming state was old/already incorporated).
-                    ContractHandlerEvent::PutResponse {
-                        new_value: Ok(current_state),
-                        state_changed: false,
-                    }
-                }
-                Err(err) => {
-                    if err.is_fatal() {
-                        tracing::error!(
-                            contract = %key,
-                            error = %err,
-                            phase = "fatal_error",
-                            "Fatal executor error during put query"
-                        );
-                        return Err(ContractError::FatalExecutorError { key, error: err });
-                    }
-                    ContractHandlerEvent::PutResponse {
-                        new_value: Err(err),
-                        state_changed: false,
-                    }
-                }
+            // Run the upsert in deferrable mode when a deferral context is
+            // present (the production loop). If the contract needs a related
+            // contract that isn't held locally, the executor returns
+            // `DeferRelated` instead of awaiting the network GET inline; we
+            // off-load that fetch so the serial loop keeps draining other
+            // events (e.g. cached GETs) — issue #4391. Without a deferral
+            // context (delegate-driven PUTs, direct unit tests), this falls
+            // back to the inline-fetch `upsert_contract_state`.
+            let put_result = match maybe_defer_upsert(
+                contract_handler,
+                deferral,
+                &id,
+                key,
+                Either::Left(state.clone()),
+                related_contracts,
+                contract,
+                true,
+            )
+            .await
+            {
+                DeferStep::Deferred => return Ok(()),
+                DeferStep::Completed(result) => result,
             };
+
+            let event_result =
+                put_response_from_result(contract_handler, key, state, put_result).await?;
 
             // Send response back to caller. If the caller disconnected (e.g., WebSocket closed),
             // the response channel may be dropped. This is not fatal - the contract has already
@@ -1213,82 +1806,27 @@ where
                     return Ok(());
                 }
             };
-            let update_result = contract_handler
-                .executor()
-                .upsert_contract_state(key, update_value, related_contracts, None)
-                .instrument(tracing::info_span!("upsert_contract_state", %key))
-                .await;
-
-            let event_result = match update_result {
-                Ok(UpsertResult::NoChange) => {
-                    tracing::debug!(
-                        contract = %key,
-                        phase = "update_no_change",
-                        "UPDATE resulted in NoChange, fetching current state to return UpdateResponse"
-                    );
-                    // When there's no change, we still need to return the current state
-                    // so the client gets a proper response
-                    match contract_handler.executor().fetch_contract(key, false).await {
-                        Ok((Some(current_state), _)) => {
-                            tracing::debug!(
-                                contract = %key,
-                                phase = "fetch_complete",
-                                "Successfully fetched current state for NoChange update"
-                            );
-                            ContractHandlerEvent::UpdateResponse {
-                                new_value: Ok(current_state),
-                                state_changed: false,
-                            }
-                        }
-                        Ok((None, _)) => {
-                            tracing::warn!(
-                                contract = %key,
-                                phase = "fetch_failed",
-                                "No state found when fetching for NoChange update"
-                            );
-                            // Fallback to the old behavior if we can't fetch the state
-                            ContractHandlerEvent::UpdateNoChange { key }
-                        }
-                        Err(err) => {
-                            tracing::error!(
-                                contract = %key,
-                                error = %err,
-                                phase = "fetch_error",
-                                "Error fetching state for NoChange update"
-                            );
-                            // Fallback to the old behavior if we can't fetch the state
-                            ContractHandlerEvent::UpdateNoChange { key }
-                        }
-                    }
-                }
-                Ok(UpsertResult::Updated(state)) => ContractHandlerEvent::UpdateResponse {
-                    new_value: Ok(state),
-                    state_changed: true,
-                },
-                Ok(UpsertResult::CurrentWon(current_state)) => {
-                    // Merge resulted in no change (incoming state was old/already incorporated).
-                    // Return current state with state_changed=false.
-                    ContractHandlerEvent::UpdateResponse {
-                        new_value: Ok(current_state),
-                        state_changed: false,
-                    }
-                }
-                Err(err) => {
-                    if err.is_fatal() {
-                        tracing::error!(
-                            contract = %key,
-                            error = %err,
-                            phase = "fatal_error",
-                            "Fatal executor error during update query"
-                        );
-                        return Err(ContractError::FatalExecutorError { key, error: err });
-                    }
-                    ContractHandlerEvent::UpdateResponse {
-                        new_value: Err(err),
-                        state_changed: false,
-                    }
-                }
+            // Deferrable upsert: off-load the related-contract fetch from the
+            // serial loop when the contract needs a related contract not held
+            // locally (#4391). See the PUT arm above for the rationale.
+            let update_result = match maybe_defer_upsert(
+                contract_handler,
+                deferral,
+                &id,
+                key,
+                update_value,
+                related_contracts,
+                None,
+                false,
+            )
+            .await
+            {
+                DeferStep::Deferred => return Ok(()),
+                DeferStep::Completed(result) => result,
             };
+
+            let event_result =
+                update_response_from_result(contract_handler, key, update_result).await?;
 
             // Send response back to caller. If the caller disconnected, the response channel
             // may be dropped. This is not fatal - the update has already been applied.
@@ -2010,9 +2548,15 @@ mod tests {
                 .recv_from_sender()
                 .await
                 .expect("handler channel should be open");
-            handle_contract_event(handler, id, received, &user_input::AutoApprovePrompter)
-                .await
-                .expect("dispatch must not error for a well-formed UpdateQuery");
+            handle_contract_event(
+                handler,
+                id,
+                received,
+                &user_input::AutoApprovePrompter,
+                None,
+            )
+            .await
+            .expect("dispatch must not error for a well-formed UpdateQuery");
         };
         let (send_res, ()) = tokio::join!(send_fut, recv_fut);
         send_res.expect("sender must receive a response")
@@ -2041,9 +2585,15 @@ mod tests {
                 .recv_from_sender()
                 .await
                 .expect("handler channel should be open");
-            handle_contract_event(handler, id, received, &user_input::AutoApprovePrompter)
-                .await
-                .expect("seed PutQuery must not error");
+            handle_contract_event(
+                handler,
+                id,
+                received,
+                &user_input::AutoApprovePrompter,
+                None,
+            )
+            .await
+            .expect("seed PutQuery must not error");
         };
         let (send_res, ()) = tokio::join!(send_fut, recv_fut);
         match send_res.expect("seed PutQuery must respond") {
@@ -2288,5 +2838,456 @@ mod tests {
                 other => panic!("expected UpdateResponse for {label}, got {other}"),
             }
         }
+    }
+}
+
+// ============================================================================
+// Head-of-line blocking regression tests (issue #4391)
+// ============================================================================
+//
+// The serial `contract_handling` loop used to await a PUT/UPDATE's related-
+// contract NETWORK fetch INLINE, pinning the loop for up to
+// RELATED_FETCH_TIMEOUT and blocking every queued event behind it — including
+// local-store-hit GETs that need no network at all. These tests drive the REAL
+// `contract_handling` loop and assert the fix off-loads that wait so unrelated
+// work keeps draining.
+#[cfg(test)]
+#[allow(clippy::wildcard_enum_match_arm)]
+mod hol_4391_tests {
+    use super::*;
+    use crate::config::GlobalExecutor;
+    use crate::contract::executor::mock_wasm_runtime::ValidateOverride;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    /// Serializes these tests: `OFF_LOOP_FETCH_OVERRIDE` is a process-global
+    /// hook, so two of these tests running concurrently would clobber each
+    /// other's stub. Each test holds this guard for its duration. An
+    /// async-aware mutex so the guard can be held across the tests' `.await`s.
+    static TEST_GUARD: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    fn make_contract(code_bytes: &[u8]) -> ContractContainer {
+        let code = ContractCode::from(code_bytes.to_vec());
+        let params = Parameters::from(vec![]);
+        ContractContainer::Wasm(ContractWasmAPIVersion::V1(WrappedContract::new(
+            Arc::new(code),
+            params,
+        )))
+    }
+
+    /// Build a handler over a `MockWasmRuntime` executor (no `op_manager`), with
+    /// the given per-contract validate overrides installed, plus the sender
+    /// halve used to drive it.
+    async fn build_handler(
+        overrides: Vec<(ContractInstanceId, ValidateOverride)>,
+    ) -> (
+        MockWasmContractHandler,
+        handler::ContractHandlerChannel<handler::SenderHalve>,
+    ) {
+        let (send_halve, rcv_halve, _) = handler::contract_handler_channel();
+        let mut handler = MockWasmContractHandler::new_test(rcv_halve, None, "hol_4391").await;
+        for (id, ov) in overrides {
+            handler.runtime_mut().validate_overrides.insert(id, ov);
+        }
+        (handler, send_halve)
+    }
+
+    /// PUT a contract with no related dependencies (a plain local store).
+    async fn put_local(
+        send: &handler::ContractHandlerChannel<handler::SenderHalve>,
+        contract: ContractContainer,
+        state: WrappedState,
+    ) -> ContractHandlerEvent {
+        send.send_to_handler(ContractHandlerEvent::PutQuery {
+            key: contract.key(),
+            state,
+            related_contracts: RelatedContracts::default(),
+            contract: Some(contract),
+        })
+        .await
+        .expect("PUT must respond")
+    }
+
+    /// The core regression: a PUT whose related fetch hangs must NOT block a
+    /// subsequent local-store-hit GET on the serial loop. Before the fix the
+    /// GET would wait the full related-fetch timeout; after the fix the fetch
+    /// is off-loaded and the GET returns promptly.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn deferred_related_fetch_does_not_block_local_get() {
+        let _guard = TEST_GUARD.lock().await;
+        // Contract A requests related contract B (which is never local). The
+        // off-loop fetch hangs until we release `gate`, simulating a slow /
+        // unavailable network GET.
+        let contract_a = make_contract(b"hol_a_blocking");
+        let key_a = contract_a.key();
+        let id_b = *make_contract(b"hol_b_missing").key().id();
+
+        let (handler, send) = build_handler(vec![(
+            *key_a.id(),
+            ValidateOverride::RequestRelated(vec![id_b]),
+        )])
+        .await;
+
+        // Off-loop fetch hangs on this gate, then reports B as missing so A
+        // ultimately fails with MissingRelated (we only care that it does NOT
+        // block the loop while it hangs).
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let gate_for_stub = gate.clone();
+        set_off_loop_fetch_override(Some(Arc::new(move |missing| {
+            let gate = gate_for_stub.clone();
+            Box::pin(async move {
+                gate.notified().await;
+                Err(ExecutorError::missing_related(missing[0]))
+            })
+        })));
+
+        // Seed a locally-stored contract C (no related, plain local store).
+        let contract_c = make_contract(b"hol_c_cached");
+        let key_c = contract_c.key();
+
+        // Share the sender across the test task and the background PUT task
+        // (the channel itself is not `Clone`).
+        let send = Arc::new(send);
+
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            crate::contract::user_input::AutoApprovePrompter,
+        ));
+
+        // Store C so a later GET for it is a pure local-store hit.
+        let put_c = put_local(
+            send.as_ref(),
+            contract_c,
+            WrappedState::new(b"c_state".to_vec()),
+        )
+        .await;
+        assert!(
+            matches!(
+                put_c,
+                ContractHandlerEvent::PutResponse {
+                    new_value: Ok(_),
+                    ..
+                }
+            ),
+            "seed PUT for C must succeed, got {put_c}"
+        );
+
+        // Fire the related-needing PUT for A on a background task: it will defer
+        // (off-loop fetch hangs on the gate) and not respond until we release it.
+        let send_a = send.clone();
+        let a_state = WrappedState::new(b"a_state".to_vec());
+        let a_task: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
+            GlobalExecutor::spawn(async move {
+                send_a
+                    .send_to_handler(ContractHandlerEvent::PutQuery {
+                        key: key_a,
+                        state: a_state,
+                        related_contracts: RelatedContracts::default(),
+                        contract: Some(contract_a),
+                    })
+                    .await
+            });
+
+        // Give the loop a beat to pick up A's PUT and enter the deferral path.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // The crux: a local-store-hit GET for C must complete PROMPTLY while
+        // A's fetch is still hanging. Before the fix this would block on A's
+        // inline network wait. Use a tight timeout — well under the deferred
+        // fetch timeout — so a regression (inline blocking) fails the test.
+        let get_c = tokio::time::timeout(
+            Duration::from_secs(2),
+            send.send_to_handler(ContractHandlerEvent::GetQuery {
+                instance_id: *key_c.id(),
+                return_contract_code: false,
+            }),
+        )
+        .await
+        .expect("GET for cached C must NOT block behind A's deferred network fetch (#4391)")
+        .expect("GET for C must respond");
+
+        match get_c {
+            ContractHandlerEvent::GetResponse { response, .. } => {
+                let store = response.expect("GET for C must succeed");
+                assert_eq!(
+                    store.state.expect("C has state").as_ref(),
+                    b"c_state",
+                    "GET must return C's stored state"
+                );
+            }
+            other => panic!("expected GetResponse for C, got {other}"),
+        }
+
+        // Release the gate: A's deferred fetch reports B missing, so A's PUT
+        // resolves (with a MissingRelated error) and its client is answered.
+        gate.notify_one();
+        let a_resp = tokio::time::timeout(Duration::from_secs(5), a_task)
+            .await
+            .expect("A's PUT must eventually resolve after the fetch completes")
+            .expect("A task join")
+            .expect("A's PUT must respond");
+        match a_resp {
+            ContractHandlerEvent::PutResponse { new_value, .. } => {
+                assert!(
+                    new_value.is_err(),
+                    "A's PUT must surface MissingRelated once the off-loop fetch fails"
+                );
+            }
+            other => panic!("expected PutResponse for A, got {other}"),
+        }
+
+        set_off_loop_fetch_override(None);
+        handle.abort();
+    }
+
+    /// Happy path: a deferred PUT whose off-loop fetch SUCCEEDS resumes and
+    /// stores the contract, answering the original client.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn deferred_related_fetch_success_resumes_and_completes() {
+        let _guard = TEST_GUARD.lock().await;
+        let contract_a = make_contract(b"hol_resume_a");
+        let key_a = contract_a.key();
+        let id_b = *make_contract(b"hol_resume_b").key().id();
+
+        let (handler, send) = build_handler(vec![(
+            *key_a.id(),
+            ValidateOverride::RequestRelated(vec![id_b]),
+        )])
+        .await;
+
+        // Off-loop fetch returns a synthetic state for B immediately.
+        set_off_loop_fetch_override(Some(Arc::new(move |missing| {
+            Box::pin(async move {
+                Ok(missing
+                    .into_iter()
+                    .map(|id| (id, WrappedState::new(b"fetched_b".to_vec())))
+                    .collect())
+            })
+        })));
+
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            crate::contract::user_input::AutoApprovePrompter,
+        ));
+
+        let resp = tokio::time::timeout(
+            Duration::from_secs(5),
+            send.send_to_handler(ContractHandlerEvent::PutQuery {
+                key: key_a,
+                state: WrappedState::new(b"a_state".to_vec()),
+                related_contracts: RelatedContracts::default(),
+                contract: Some(contract_a),
+            }),
+        )
+        .await
+        .expect("deferred PUT must resume and respond")
+        .expect("PUT must respond");
+
+        match resp {
+            ContractHandlerEvent::PutResponse { new_value, .. } => {
+                new_value.expect("deferred PUT must succeed once B is supplied off-loop");
+            }
+            other => panic!("expected PutResponse, got {other}"),
+        }
+
+        set_off_loop_fetch_override(None);
+        handle.abort();
+    }
+
+    /// Failure path: a deferred PUT whose off-loop fetch FAILS surfaces
+    /// MissingRelated to the client (and does not hang or defer again).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn deferred_related_fetch_failure_surfaces_missing_related() {
+        let _guard = TEST_GUARD.lock().await;
+        let contract_a = make_contract(b"hol_fail_a");
+        let key_a = contract_a.key();
+        let id_b = *make_contract(b"hol_fail_b").key().id();
+
+        let (handler, send) = build_handler(vec![(
+            *key_a.id(),
+            ValidateOverride::RequestRelated(vec![id_b]),
+        )])
+        .await;
+
+        set_off_loop_fetch_override(Some(Arc::new(move |missing| {
+            Box::pin(async move { Err(ExecutorError::missing_related(missing[0])) })
+        })));
+
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            crate::contract::user_input::AutoApprovePrompter,
+        ));
+
+        let resp = tokio::time::timeout(
+            Duration::from_secs(5),
+            send.send_to_handler(ContractHandlerEvent::PutQuery {
+                key: key_a,
+                state: WrappedState::new(b"a_state".to_vec()),
+                related_contracts: RelatedContracts::default(),
+                contract: Some(contract_a),
+            }),
+        )
+        .await
+        .expect("deferred PUT must resolve (not hang) when the fetch fails")
+        .expect("PUT must respond");
+
+        match resp {
+            ContractHandlerEvent::PutResponse { new_value, .. } => {
+                assert!(
+                    new_value.is_err(),
+                    "a failed off-loop fetch must surface an error to the client"
+                );
+            }
+            other => panic!("expected PutResponse, got {other}"),
+        }
+
+        set_off_loop_fetch_override(None);
+        handle.abort();
+    }
+
+    /// A PUT whose related contract IS already local must NOT defer — it
+    /// behaves exactly as before (no off-loop fetch invoked). We prove this by
+    /// installing an override that PANICS if called, then PUTting a contract
+    /// whose only related dependency was stored locally first.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn all_related_local_does_not_defer() {
+        let _guard = TEST_GUARD.lock().await;
+        // B is stored locally first, then A requests B — validation must
+        // resolve B from the local store and never reach the off-loop fetch.
+        let contract_b = make_contract(b"hol_local_b");
+        let key_b = contract_b.key();
+        let contract_a = make_contract(b"hol_local_a");
+        let key_a = contract_a.key();
+
+        let (handler, send) = build_handler(vec![(
+            *key_a.id(),
+            ValidateOverride::RequestRelated(vec![*key_b.id()]),
+        )])
+        .await;
+
+        // Override panics if the off-loop fetch is ever invoked — proving the
+        // all-local path never defers.
+        set_off_loop_fetch_override(Some(Arc::new(|_missing| {
+            Box::pin(async move {
+                panic!("off-loop fetch must NOT be invoked when all related contracts are local");
+            })
+        })));
+
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            crate::contract::user_input::AutoApprovePrompter,
+        ));
+
+        // Store B locally so A's RequestRelated([B]) resolves without network.
+        let put_b = put_local(&send, contract_b, WrappedState::new(b"b_state".to_vec())).await;
+        assert!(
+            matches!(
+                put_b,
+                ContractHandlerEvent::PutResponse {
+                    new_value: Ok(_),
+                    ..
+                }
+            ),
+            "seed PUT for B must succeed, got {put_b}"
+        );
+
+        let resp = tokio::time::timeout(
+            Duration::from_secs(5),
+            send.send_to_handler(ContractHandlerEvent::PutQuery {
+                key: key_a,
+                state: WrappedState::new(b"a_state".to_vec()),
+                related_contracts: RelatedContracts::default(),
+                contract: Some(contract_a),
+            }),
+        )
+        .await
+        .expect("local-resolvable PUT must complete inline")
+        .expect("PUT must respond");
+
+        match resp {
+            ContractHandlerEvent::PutResponse { new_value, .. } => {
+                new_value.expect("A must store successfully when B is already local");
+            }
+            other => panic!("expected PutResponse, got {other}"),
+        }
+
+        set_off_loop_fetch_override(None);
+        handle.abort();
+    }
+
+    /// One-deferral cap: a contract that requests a related contract on EVERY
+    /// validate call (even after the first round's states are supplied) must
+    /// surface MissingRelated after a single deferral — it must NOT spawn a
+    /// second off-loop fetch or loop forever. We prove the off-loop fetch runs
+    /// at most once by counting stub invocations.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn second_related_request_after_resume_does_not_defer_again() {
+        let _guard = TEST_GUARD.lock().await;
+        let contract_a = make_contract(b"hol_cap_a");
+        let key_a = contract_a.key();
+        let id_b = *make_contract(b"hol_cap_b").key().id();
+
+        // AlwaysRequestRelated: returns RequestRelated([B]) on EVERY call, so
+        // even after B is supplied on resume the contract asks again — the
+        // depth>1 / one-deferral cap must kick in.
+        let (handler, send) = build_handler(vec![(
+            *key_a.id(),
+            ValidateOverride::AlwaysRequestRelated(vec![id_b]),
+        )])
+        .await;
+
+        // Count how many times the off-loop fetch is invoked. The cap requires
+        // it be invoked AT MOST once (the first/only deferral); the resume must
+        // not spawn a second fetch.
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let calls_stub = calls.clone();
+        set_off_loop_fetch_override(Some(Arc::new(move |missing| {
+            calls_stub.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Box::pin(async move {
+                Ok(missing
+                    .into_iter()
+                    .map(|id| (id, WrappedState::new(b"fetched".to_vec())))
+                    .collect())
+            })
+        })));
+
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            crate::contract::user_input::AutoApprovePrompter,
+        ));
+
+        let resp = tokio::time::timeout(
+            Duration::from_secs(5),
+            send.send_to_handler(ContractHandlerEvent::PutQuery {
+                key: key_a,
+                state: WrappedState::new(b"a_state".to_vec()),
+                related_contracts: RelatedContracts::default(),
+                contract: Some(contract_a),
+            }),
+        )
+        .await
+        .expect("deferred-then-resumed PUT must resolve, not loop forever")
+        .expect("PUT must respond");
+
+        match resp {
+            ContractHandlerEvent::PutResponse { new_value, .. } => {
+                assert!(
+                    new_value.is_err(),
+                    "a contract that keeps requesting related contracts must be \
+                     rejected after one deferral (depth=1 / one-deferral cap)"
+                );
+            }
+            other => panic!("expected PutResponse, got {other}"),
+        }
+
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the off-loop fetch must run exactly once — the resume must NOT \
+             defer again (#4391 one-deferral cap)"
+        );
+
+        set_off_loop_fetch_override(None);
+        handle.abort();
     }
 }

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -117,6 +117,37 @@ impl std::fmt::Display for ContractQueueFull {
 
 impl std::error::Error for ContractQueueFull {}
 
+/// Typed marker carried by an [`ExecutorError`] when an upsert was invoked
+/// in *deferrable* mode (see [`ContractExecutor::upsert_contract_state_deferrable`])
+/// and discovered it needs to fetch related contracts from the network to
+/// finish validation/merge.
+///
+/// Instead of awaiting that network GET inline — which would pin the serial
+/// `contract_handling` loop for up to `RELATED_FETCH_TIMEOUT`, blocking every
+/// queued event behind it (including local-store-hit GETs) — the executor
+/// aborts the upsert cleanly (running the same init-tracker/contract-store
+/// rollback the error paths use) and surfaces the missing related ids here.
+/// The caller off-loads the GET to a background task and re-runs the upsert
+/// once the states arrive. See issue #4391.
+#[derive(Debug, Clone)]
+pub struct DeferRelatedFetch {
+    /// Related contract instance ids that are not held locally and must be
+    /// fetched from the network before the upsert can complete.
+    pub missing: Vec<ContractInstanceId>,
+}
+
+impl std::fmt::Display for DeferRelatedFetch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "upsert needs {} related contract(s) fetched from the network",
+            self.missing.len()
+        )
+    }
+}
+
+impl std::error::Error for DeferRelatedFetch {}
+
 #[derive(Debug)]
 pub struct ExecutorError {
     inner: Either<Box<RequestError>, anyhow::Error>,
@@ -312,6 +343,42 @@ impl ExecutorError {
         }
     }
 
+    /// Construct a `MissingRelated` request error for `id`. Used by the
+    /// off-loop related-fetch path (#4391) to surface a fetch failure to the
+    /// client with the same error shape the inline path produces.
+    pub(crate) fn missing_related(id: ContractInstanceId) -> Self {
+        Self::request(StdContractError::MissingRelated { key: id })
+    }
+
+    /// Construct the typed [`DeferRelatedFetch`] signal. Only produced by the
+    /// deferrable-upsert path when the missing related contracts must be
+    /// fetched from the network. See `DeferRelatedFetch`.
+    pub(crate) fn defer_related_fetch(missing: Vec<ContractInstanceId>) -> Self {
+        Self {
+            inner: Either::Right(anyhow::Error::new(DeferRelatedFetch { missing })),
+            fatal: false,
+        }
+    }
+
+    /// If this error is the typed [`DeferRelatedFetch`] signal, return the
+    /// missing related contract ids; otherwise `None`. Consuming the error so
+    /// the caller can re-run the upsert with the fetched states.
+    pub(crate) fn into_defer_related_fetch(self) -> Result<Vec<ContractInstanceId>, Self> {
+        match self.inner {
+            Either::Right(err) => match err.downcast::<DeferRelatedFetch>() {
+                Ok(defer) => Ok(defer.missing),
+                Err(err) => Err(Self {
+                    inner: Either::Right(err),
+                    fatal: self.fatal,
+                }),
+            },
+            inner @ Either::Left(_) => Err(Self {
+                inner,
+                fatal: self.fatal,
+            }),
+        }
+    }
+
     pub fn is_fatal(&self) -> bool {
         self.fatal
     }
@@ -413,6 +480,26 @@ pub(crate) enum UpsertResult {
     CurrentWon(WrappedState),
 }
 
+/// Outcome of a *deferrable* upsert (see
+/// [`ContractExecutor::upsert_contract_state_deferrable`]).
+///
+/// A normal upsert either completes (`Completed`) or, when it needs related
+/// contracts that aren't held locally, signals that the network fetch should
+/// be off-loaded from the serial event loop (`DeferRelated`) instead of being
+/// awaited inline. See issue #4391 for why the inline wait is harmful.
+#[derive(Debug)]
+pub(crate) enum UpsertOutcome {
+    /// The upsert ran to completion (all related contracts were resolvable
+    /// locally, or none were needed). Carries the same result a plain
+    /// `upsert_contract_state` would return.
+    Completed(UpsertResult),
+    /// The upsert needs these related contracts fetched from the network
+    /// before it can finish. No state was committed and any in-progress
+    /// initialization was rolled back; the caller must fetch the listed
+    /// contracts off-loop and re-run the upsert with them supplied.
+    DeferRelated(Vec<ContractInstanceId>),
+}
+
 pub(crate) trait ContractExecutor: Send + 'static {
     /// Look up the full ContractKey from a ContractInstanceId.
     /// Returns None if the contract is not known to this node.
@@ -440,6 +527,33 @@ pub(crate) trait ContractExecutor: Send + 'static {
         related_contracts: RelatedContracts<'static>,
         code: Option<ContractContainer>,
     ) -> impl Future<Output = Result<UpsertResult, ExecutorError>> + Send;
+
+    /// Like [`upsert_contract_state`](Self::upsert_contract_state), but when the
+    /// upsert needs related contracts that are not held locally, it does NOT
+    /// await the network GET inline. Instead it rolls back any partial work and
+    /// returns [`UpsertOutcome::DeferRelated`] with the missing ids so the
+    /// caller can off-load the fetch from the serial event loop and re-run the
+    /// upsert once the states are available.
+    ///
+    /// The default implementation never defers — it simply forwards to
+    /// `upsert_contract_state` and wraps the result in
+    /// [`UpsertOutcome::Completed`]. Only executors that perform network
+    /// related-contract fetches (the production `RuntimePool` / `Executor<Runtime>`
+    /// and the `MockWasmRuntime` test executor) override it to defer. Local-only
+    /// and mock executors keep their existing inline behavior. See issue #4391.
+    fn upsert_contract_state_deferrable(
+        &mut self,
+        key: ContractKey,
+        update: Either<WrappedState, StateDelta<'static>>,
+        related_contracts: RelatedContracts<'static>,
+        code: Option<ContractContainer>,
+    ) -> impl Future<Output = Result<UpsertOutcome, ExecutorError>> + Send {
+        async move {
+            self.upsert_contract_state(key, update, related_contracts, code)
+                .await
+                .map(UpsertOutcome::Completed)
+        }
+    }
 
     fn register_contract_notifier(
         &mut self,
@@ -527,6 +641,17 @@ pub(crate) trait ContractExecutor: Send + 'static {
     /// notifications. Returns `None` for mock/test executors.
     /// This can only be called once — subsequent calls return `None`.
     fn take_delegate_notification_rx(&mut self) -> Option<DelegateNotificationReceiver> {
+        None
+    }
+
+    /// Clone the executor's [`OpManager`] handle, if it has one.
+    ///
+    /// The `contract_handling` loop uses this to drive an off-loop related-
+    /// contract GET (via `start_sub_op_get`) when a PUT/UPDATE deferred its
+    /// network fetch (#4391): the loop cannot move the `&mut` executor into a
+    /// background task, but it can clone this `Arc<OpManager>` into one.
+    /// Returns `None` for local-only / mock executors with no network.
+    fn op_manager_handle(&self) -> Option<Arc<OpManager>> {
         None
     }
 }

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -274,6 +274,10 @@ impl ContractExecutor for Executor<MockWasmRuntime, MockStateStorage> {
         self.bridged_lookup_key(instance_id)
     }
 
+    fn op_manager_handle(&self) -> Option<std::sync::Arc<crate::node::OpManager>> {
+        self.op_manager.clone()
+    }
+
     async fn fetch_contract(
         &mut self,
         key: ContractKey,
@@ -291,6 +295,19 @@ impl ContractExecutor for Executor<MockWasmRuntime, MockStateStorage> {
     ) -> Result<UpsertResult, ExecutorError> {
         self.bridged_upsert_contract_state(key, update, related_contracts, code)
             .await
+    }
+
+    async fn upsert_contract_state_deferrable(
+        &mut self,
+        key: ContractKey,
+        update: Either<WrappedState, StateDelta<'static>>,
+        related_contracts: RelatedContracts<'static>,
+        code: Option<ContractContainer>,
+    ) -> Result<UpsertOutcome, ExecutorError> {
+        super::runtime::bridged_upsert_outcome(
+            self.bridged_upsert_contract_state_inner(key, update, related_contracts, code, true)
+                .await,
+        )
     }
 
     fn register_contract_notifier(
@@ -359,5 +376,14 @@ impl Executor<MockWasmRuntime, MockStateStorage> {
             op_manager,
         )
         .await
+    }
+
+    /// Mutable access to the inner `MockWasmRuntime` so tests can install
+    /// per-contract `validate_overrides` / `update_overrides` after the
+    /// executor is wrapped in a handler. The `runtime` field is private to
+    /// the `executor` module, so this accessor exists to surface it.
+    #[cfg(test)]
+    pub(crate) fn mock_runtime_mut(&mut self) -> &mut MockWasmRuntime {
+        &mut self.runtime
     }
 }

--- a/crates/core/src/contract/executor/pool_tests/related_contract_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/related_contract_tests.rs
@@ -12,7 +12,7 @@ use freenet_stdlib::prelude::*;
 use std::sync::Arc;
 
 use crate::contract::executor::mock_wasm_runtime::{MockWasmRuntime, ValidateOverride};
-use crate::contract::executor::{ContractExecutor, Executor, UpsertResult};
+use crate::contract::executor::{ContractExecutor, Executor, UpsertOutcome, UpsertResult};
 use crate::wasm_runtime::MockStateStorage;
 
 /// Create a MockWasmRuntime executor.
@@ -1104,4 +1104,95 @@ async fn test_update_state_requires_related_self_reference_rejected() {
         result.is_err(),
         "self-reference in update_state requires() must be rejected: {result:?}"
     );
+}
+
+// =========================================================================
+// Test (#4391 round-3.1 P2): in DEFERRABLE mode, a contract that re-requests
+// an already-SUPPLIED related contract MUST NOT trigger an inline network
+// fetch on the serial loop. The supplied state must resolve locally; a
+// misbehaving re-request hits the depth>1 cap — never `fetch_related_via_network`.
+//
+// Regression for the gap where the deferrable local-only check counted a
+// caller-supplied (but not state_store-persisted) related as "local" and fell
+// through to the join_all/network path, which checks ONLY state_store and so
+// escalated to an inline network GET — bypassing the one-deferral cap.
+// =========================================================================
+
+#[tokio::test(flavor = "current_thread")]
+async fn deferrable_supplied_related_never_inline_fetches() {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    let mut executor = create_executor().await;
+
+    // PUT the main contract A with an initial state.
+    let contract_a = make_contract(b"defer_supplied_a");
+    let key_a = contract_a.key();
+    executor
+        .upsert_contract_state(
+            key_a,
+            Either::Left(WrappedState::new(br#"{"v":0}"#.to_vec())),
+            RelatedContracts::default(),
+            Some(contract_a.clone()),
+        )
+        .await
+        .expect("initial PUT for A");
+
+    // A ALWAYS re-requests related B, even after B is supplied — this drives the
+    // re-request-on-resume path. B is NOT in the state_store (never PUT).
+    let id_b = *make_contract(b"defer_supplied_b").key().id();
+    executor.runtime.validate_overrides.insert(
+        *key_a.id(),
+        ValidateOverride::AlwaysRequestRelated(vec![id_b]),
+    );
+
+    // Supply B's state via the caller-provided related map (NOT persisted).
+    let mut supplied: std::collections::HashMap<ContractInstanceId, Option<State<'static>>> =
+        std::collections::HashMap::new();
+    supplied.insert(id_b, Some(State::from(br#"{"b":"supplied"}"#.to_vec())));
+    let related_with_b = RelatedContracts::from(supplied);
+
+    // PANIC if the inline network fetch ever fires for the supplied id — the
+    // whole point is that deferrable mode resolves B locally and never escalates.
+    let calls: Rc<RefCell<usize>> = Rc::new(RefCell::new(0));
+    let calls_inner = calls.clone();
+    crate::contract::executor::runtime::set_test_network_fetch_override(Some(Rc::new(move |id| {
+        *calls_inner.borrow_mut() += 1;
+        panic!("deferrable mode must NOT inline-fetch a supplied related (id={id})");
+    })));
+
+    // Drive the DEFERRABLE path (the serial-loop entry point).
+    let result = executor
+        .upsert_contract_state_deferrable(
+            key_a,
+            Either::Left(WrappedState::new(br#"{"v":1}"#.to_vec())),
+            related_with_b,
+            Some(contract_a),
+        )
+        .await;
+
+    crate::contract::executor::runtime::set_test_network_fetch_override(None);
+
+    // The network override must NEVER have fired.
+    assert_eq!(
+        *calls.borrow(),
+        0,
+        "deferrable mode must resolve a supplied related locally, never inline-fetch"
+    );
+
+    // B was supplied (resolved locally), so the second validate runs and
+    // AlwaysRequestRelated returns RequestRelated again → depth>1 reject, which
+    // surfaces as a plain executor `Err` (NOT a DeferRelated — the supplied
+    // related was resolved, so it must not be deferred again; and NOT a network
+    // result, since no inline fetch ran). The critical assertion is the calls==0
+    // above; this just confirms the outcome shape.
+    match result {
+        Err(_) => {} // depth>1 rejection — expected, no inline fetch
+        Ok(UpsertOutcome::DeferRelated(missing)) => {
+            panic!("a SUPPLIED related must NOT be deferred again; got DeferRelated({missing:?})")
+        }
+        Ok(UpsertOutcome::Completed(r)) => {
+            panic!("AlwaysRequestRelated must surface a depth>1 error, got Completed({r:?})")
+        }
+    }
 }

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -561,6 +561,10 @@ impl ContractExecutor for RuntimePool {
         })
     }
 
+    fn op_manager_handle(&self) -> Option<Arc<crate::node::OpManager>> {
+        Some(self.op_manager.clone())
+    }
+
     async fn fetch_contract(
         &mut self,
         key: ContractKey,
@@ -773,6 +777,26 @@ impl ContractExecutor for RuntimePool {
             .upsert_contract_state(key, update, related_contracts, code)
             .await;
         self.return_checked(executor, "upsert_contract_state").await;
+        self.track_contract_return(&key);
+        result
+    }
+
+    async fn upsert_contract_state_deferrable(
+        &mut self,
+        key: ContractKey,
+        update: Either<WrappedState, StateDelta<'static>>,
+        related_contracts: RelatedContracts<'static>,
+        code: Option<ContractContainer>,
+    ) -> Result<UpsertOutcome, ExecutorError> {
+        self.track_contract_checkout(&key);
+        let mut executor = self.pop_executor().await;
+        let result = bridged_upsert_outcome(
+            executor
+                .bridged_upsert_contract_state_inner(key, update, related_contracts, code, true)
+                .await,
+        );
+        self.return_checked(executor, "upsert_contract_state_deferrable")
+            .await;
         self.track_contract_return(&key);
         result
     }
@@ -1041,6 +1065,29 @@ where
         related_contracts: RelatedContracts<'static>,
         code: Option<ContractContainer>,
     ) -> Result<UpsertResult, ExecutorError> {
+        self.bridged_upsert_contract_state_inner(key, update, related_contracts, code, false)
+            .await
+    }
+
+    /// Inner implementation of [`bridged_upsert_contract_state`].
+    ///
+    /// `defer_related_fetch` controls what happens when validation/merge needs
+    /// a related contract that is not held locally:
+    /// - `false` (the default, used by `upsert_contract_state`): fetch it from
+    ///   the network inline, awaiting the GET (legacy behavior).
+    /// - `true` (used by `upsert_contract_state_deferrable`): do NOT fetch
+    ///   inline. Roll back any partial work via the normal error path and
+    ///   return [`ExecutorError::defer_related_fetch`] carrying the missing ids,
+    ///   so the caller can off-load the GET from the serial event loop and
+    ///   re-run the upsert with the states supplied. See issue #4391.
+    pub(super) async fn bridged_upsert_contract_state_inner(
+        &mut self,
+        key: ContractKey,
+        update: Either<WrappedState, StateDelta<'static>>,
+        related_contracts: RelatedContracts<'static>,
+        code: Option<ContractContainer>,
+        defer_related_fetch: bool,
+    ) -> Result<UpsertResult, ExecutorError> {
         // CRITICAL: When a ContractContainer is provided, use its key instead of the passed-in key.
         let key = if let Some(ref container) = code {
             let container_key = container.key();
@@ -1279,6 +1326,7 @@ where
                         &params,
                         &incoming_state,
                         &related_contracts,
+                        defer_related_fetch,
                     )
                     .await
                     .inspect_err(|_| {
@@ -1632,6 +1680,29 @@ where
                     }));
                 }
 
+                // In deferrable mode, resolve related contracts LOCAL-ONLY
+                // first. If any are missing locally, surface them to the
+                // caller for an off-loop network fetch instead of awaiting
+                // the network GET inline on the serial event loop (#4391).
+                // When everything is local this is a no-op and we fall
+                // through to the normal merge below.
+                if defer_related_fetch {
+                    let mut missing = Vec::new();
+                    for id in &unique_ids {
+                        let local = if let Some(full_key) = self.bridged_lookup_key(id) {
+                            self.state_store.get(&full_key).await.is_ok()
+                        } else {
+                            false
+                        };
+                        if !local {
+                            missing.push(*id);
+                        }
+                    }
+                    if !missing.is_empty() {
+                        return Err(ExecutorError::defer_related_fetch(missing));
+                    }
+                }
+
                 // Parallel fetch: each related contract goes through its
                 // own GET sub-op concurrently. Previously this loop ran
                 // serially under a single 10s wall-clock budget, so a
@@ -1818,7 +1889,13 @@ where
         }
 
         let result = self
-            .fetch_related_for_validation(&key, &params, &updated_state, &related_contracts)
+            .fetch_related_for_validation(
+                &key,
+                &params,
+                &updated_state,
+                &related_contracts,
+                defer_related_fetch,
+            )
             .await?;
 
         if result != ValidateResult::Valid {
@@ -2560,6 +2637,7 @@ where
         params: &Parameters<'_>,
         state: &WrappedState,
         initial_related: &RelatedContracts<'_>,
+        defer_related_fetch: bool,
     ) -> Result<ValidateResult, ExecutorError> {
         let result = self
             .runtime
@@ -2616,6 +2694,34 @@ where
                 )
                 .into(),
             }));
+        }
+
+        // In deferrable mode, resolve related contracts LOCAL-ONLY first
+        // (caller-supplied `initial_related` states count as local). If any
+        // are missing locally, surface them so the caller can fetch them
+        // off-loop instead of awaiting the network GET inline on the serial
+        // event loop (#4391). When everything is already local this is a
+        // no-op and we fall through to the normal fetch+revalidate below.
+        if defer_related_fetch {
+            let initial_owned = initial_related.clone().into_owned();
+            let mut missing = Vec::new();
+            for id in &unique_ids {
+                let supplied = initial_owned
+                    .states()
+                    .any(|(rid, s)| rid == id && s.is_some());
+                let local = supplied
+                    || if let Some(full_key) = self.bridged_lookup_key(id) {
+                        self.state_store.get(&full_key).await.is_ok()
+                    } else {
+                        false
+                    };
+                if !local {
+                    missing.push(*id);
+                }
+            }
+            if !missing.is_empty() {
+                return Err(ExecutorError::defer_related_fetch(missing));
+            }
         }
 
         tracing::debug!(
@@ -3049,6 +3155,10 @@ impl ContractExecutor for Executor<Runtime> {
         self.bridged_lookup_key(instance_id)
     }
 
+    fn op_manager_handle(&self) -> Option<Arc<crate::node::OpManager>> {
+        self.op_manager.clone()
+    }
+
     async fn fetch_contract(
         &mut self,
         key: ContractKey,
@@ -3066,6 +3176,19 @@ impl ContractExecutor for Executor<Runtime> {
     ) -> Result<UpsertResult, ExecutorError> {
         self.bridged_upsert_contract_state(key, update, related_contracts, code)
             .await
+    }
+
+    async fn upsert_contract_state_deferrable(
+        &mut self,
+        key: ContractKey,
+        update: Either<WrappedState, StateDelta<'static>>,
+        related_contracts: RelatedContracts<'static>,
+        code: Option<ContractContainer>,
+    ) -> Result<UpsertOutcome, ExecutorError> {
+        bridged_upsert_outcome(
+            self.bridged_upsert_contract_state_inner(key, update, related_contracts, code, true)
+                .await,
+        )
     }
 
     fn register_contract_notifier(
@@ -4299,6 +4422,24 @@ async fn fetch_related_via_network(
     }
 }
 
+/// Map the result of a deferrable `bridged_upsert_contract_state_inner` call
+/// into an [`UpsertOutcome`].
+///
+/// A clean completion becomes [`UpsertOutcome::Completed`]; the typed
+/// [`ExecutorError::defer_related_fetch`] signal becomes
+/// [`UpsertOutcome::DeferRelated`]; any other error propagates unchanged.
+pub(super) fn bridged_upsert_outcome(
+    result: Result<UpsertResult, ExecutorError>,
+) -> Result<UpsertOutcome, ExecutorError> {
+    match result {
+        Ok(res) => Ok(UpsertOutcome::Completed(res)),
+        Err(err) => match err.into_defer_related_fetch() {
+            Ok(missing) => Ok(UpsertOutcome::DeferRelated(missing)),
+            Err(other) => Err(other),
+        },
+    }
+}
+
 #[cfg(test)]
 pub(crate) type NetworkFetchStub =
     std::rc::Rc<dyn Fn(ContractInstanceId) -> Result<WrappedState, ExecutorError>>;
@@ -4583,14 +4724,21 @@ mod executor_pin_tests {
                 "{name} must call futures::future::join_all — serial fetch \
                  regressed in freenet/freenet-core#4077; do not revert"
             );
-            // Spot-check the loop construct doesn't reappear: a plain
-            // `for id in &unique_ids` inside the function body almost
-            // certainly means the parallel fan-out is gone.
-            let serial_needle = ["for ", "id in &unique_ids"].concat();
+            // Spot-check the NETWORK fetch doesn't regress to a serial
+            // `for id in &unique_ids { ... fetch_related_via_network ... await }`
+            // loop (the exact pre-#4077 shape). NOTE: the deferrable-mode block
+            // (#4391) legitimately iterates `&unique_ids` to do a LOCAL-ONLY
+            // presence check that contains NO `fetch_related_via_network`, so
+            // the bare `for id in &unique_ids` form is no longer a reliable
+            // signal. Anchor instead on a serial `for` segment that calls the
+            // network helper — that is the actual #4077 regression shape.
+            let serial_network_fetch = body.split("for ").skip(1).any(|seg| {
+                seg.contains("id in &unique_ids") && seg.contains("fetch_related_via_network")
+            });
             assert!(
-                !body.contains(&serial_needle),
-                "{name} must not iterate serially over &unique_ids — \
-                 regressed to pre-#4077 behavior"
+                !serial_network_fetch,
+                "{name} must not iterate serially over &unique_ids to call \
+                 fetch_related_via_network — regressed to pre-#4077 behavior"
             );
         }
 

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1693,6 +1693,17 @@ where
                     // `requires()` no longer lists it), OR — if a misbehaving
                     // contract keeps requiring it — hits the one-deferral cap →
                     // MissingRelated, never an inline network GET. See #4391.
+                    //
+                    // Asymmetry with the validate-side deferrable block (which
+                    // ALSO consults the caller-supplied `initial_related`) is
+                    // INTENTIONAL: here, any related state the caller supplied
+                    // was already folded into `updates` as `UpdateData::RelatedState`
+                    // before `update_state` ran, so a well-behaved contract's
+                    // `requires()` never lists a supplied id. A misbehaving one
+                    // that re-requires it defers once, then the one-deferral cap
+                    // converts the second `DeferRelated` to `MissingRelated`.
+                    // Either way the no-inline-fetch invariant holds, so checking
+                    // only the state_store here is sufficient.
                     let mut missing = Vec::new();
                     for id in &unique_ids {
                         let resolved = if let Some(full_key) = self.bridged_lookup_key(id) {

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1680,86 +1680,96 @@ where
                     }));
                 }
 
-                // In deferrable mode, resolve related contracts LOCAL-ONLY
-                // first. If any are missing locally, surface them to the
-                // caller for an off-loop network fetch instead of awaiting
-                // the network GET inline on the serial event loop (#4391).
-                // When everything is local this is a no-op and we fall
-                // through to the normal merge below.
+                let mut fetched_updates = updates.clone();
+
                 if defer_related_fetch {
+                    // DEFERRABLE mode (serial `contract_handling` loop): resolve
+                    // LOCAL-ONLY. This path MUST NEVER call
+                    // `fetch_related_via_network` (an inline network GET on the
+                    // serial loop). Resolve each id from the local state_store;
+                    // anything missing is surfaced via `DeferRelated` so the
+                    // caller off-loads the fetch. On resume this re-enters with
+                    // the state supplied as a `RelatedState` update entry (so
+                    // `requires()` no longer lists it), OR — if a misbehaving
+                    // contract keeps requiring it — hits the one-deferral cap →
+                    // MissingRelated, never an inline network GET. See #4391.
                     let mut missing = Vec::new();
                     for id in &unique_ids {
-                        let local = if let Some(full_key) = self.bridged_lookup_key(id) {
-                            self.state_store.get(&full_key).await.is_ok()
+                        let resolved = if let Some(full_key) = self.bridged_lookup_key(id) {
+                            self.state_store.get(&full_key).await.ok()
                         } else {
-                            false
+                            None
                         };
-                        if !local {
-                            missing.push(*id);
+                        match resolved {
+                            Some(state) => fetched_updates.push(UpdateData::RelatedState {
+                                related_to: *id,
+                                state: State::from(state.as_ref().to_vec()),
+                            }),
+                            None => missing.push(*id),
                         }
                     }
                     if !missing.is_empty() {
                         return Err(ExecutorError::defer_related_fetch(missing));
                     }
-                }
-
-                // Parallel fetch: each related contract goes through its
-                // own GET sub-op concurrently. Previously this loop ran
-                // serially under a single 10s wall-clock budget, so a
-                // contract requesting N>1 related ids could time out at
-                // ~10s/N effective per fetch. Fan-out via `join_all`
-                // turns the budget back into 10s _per id_ in the common
-                // case (network bandwidth, not CPU, is the constraint).
-                // See freenet/freenet-core#4077.
-                let mut fetched_updates = updates.clone();
-                let fetch_results: Vec<(
-                    ContractInstanceId,
-                    Result<State<'static>, ExecutorError>,
-                )> = {
-                    // Reborrow as `&Self` so the per-id futures all share
-                    // an immutable borrow; this releases the outer
-                    // `&mut self` only for the duration of `fetch_all`,
-                    // which is fully awaited before the next `&mut self`
-                    // call (`attempt_state_update` below).
-                    let this: &Self = &*self;
-                    futures::future::join_all(unique_ids.iter().map(|id| {
-                        let id = *id;
-                        async move {
-                            if let Some(full_key) = this.bridged_lookup_key(&id) {
-                                if let Ok(state) = this.state_store.get(&full_key).await {
-                                    return (id, Ok(State::from(state.as_ref().to_vec())));
+                } else {
+                    // NON-deferrable mode: parallel fetch — each related contract
+                    // goes through its own GET sub-op concurrently. Previously
+                    // serial under a single 10s wall-clock budget, so a contract
+                    // requesting N>1 related ids could time out at ~10s/N
+                    // effective per fetch. Fan-out via `join_all` turns the
+                    // budget back into 10s _per id_ in the common case (network
+                    // bandwidth, not CPU, is the constraint). See
+                    // freenet/freenet-core#4077.
+                    let fetch_results: Vec<(
+                        ContractInstanceId,
+                        Result<State<'static>, ExecutorError>,
+                    )> = {
+                        // Reborrow as `&Self` so the per-id futures all share
+                        // an immutable borrow; this releases the outer
+                        // `&mut self` only for the duration of `fetch_all`,
+                        // which is fully awaited before the next `&mut self`
+                        // call (`attempt_state_update` below).
+                        let this: &Self = &*self;
+                        futures::future::join_all(unique_ids.iter().map(|id| {
+                            let id = *id;
+                            async move {
+                                if let Some(full_key) = this.bridged_lookup_key(&id) {
+                                    if let Ok(state) = this.state_store.get(&full_key).await {
+                                        return (id, Ok(State::from(state.as_ref().to_vec())));
+                                    }
                                 }
+                                let outcome =
+                                    fetch_related_via_network(this.op_manager.as_ref(), &id)
+                                        .await
+                                        .map(|state| State::from(state.as_ref().to_vec()));
+                                (id, outcome)
                             }
-                            let outcome = fetch_related_via_network(this.op_manager.as_ref(), &id)
-                                .await
-                                .map(|state| State::from(state.as_ref().to_vec()));
-                            (id, outcome)
-                        }
-                    }))
-                    .await
-                };
-                let mut failed_id: Option<ContractInstanceId> = None;
-                for (id, res) in fetch_results {
-                    match res {
-                        Ok(state) => fetched_updates.push(UpdateData::RelatedState {
-                            related_to: id,
-                            state,
-                        }),
-                        Err(err) => {
-                            tracing::warn!(
-                                contract = %key,
-                                related_id = %id,
-                                error = %err,
-                                "Failed to fetch related contract for update_state requires()"
-                            );
-                            failed_id.get_or_insert(id);
+                        }))
+                        .await
+                    };
+                    let mut failed_id: Option<ContractInstanceId> = None;
+                    for (id, res) in fetch_results {
+                        match res {
+                            Ok(state) => fetched_updates.push(UpdateData::RelatedState {
+                                related_to: id,
+                                state,
+                            }),
+                            Err(err) => {
+                                tracing::warn!(
+                                    contract = %key,
+                                    related_id = %id,
+                                    error = %err,
+                                    "Failed to fetch related contract for update_state requires()"
+                                );
+                                failed_id.get_or_insert(id);
+                            }
                         }
                     }
-                }
-                if let Some(id) = failed_id {
-                    return Err(ExecutorError::request(StdContractError::MissingRelated {
-                        key: id,
-                    }));
+                    if let Some(id) = failed_id {
+                        return Err(ExecutorError::request(StdContractError::MissingRelated {
+                            key: id,
+                        }));
+                    }
                 }
                 match self
                     .attempt_state_update(&params, &current_state, &key, &fetched_updates)
@@ -2696,116 +2706,129 @@ where
             }));
         }
 
-        // In deferrable mode, resolve related contracts LOCAL-ONLY first
-        // (caller-supplied `initial_related` states count as local). If any
-        // are missing locally, surface them so the caller can fetch them
-        // off-loop instead of awaiting the network GET inline on the serial
-        // event loop (#4391). When everything is already local this is a
-        // no-op and we fall through to the normal fetch+revalidate below.
+        let initial_owned = initial_related.clone().into_owned();
+
+        // `related_map` is the populated set fed to the second validate_state
+        // call. It is built differently per mode (see below), but both modes
+        // end at the same `populated_related` / re-validate.
+        let mut related_map: HashMap<ContractInstanceId, Option<State<'static>>> =
+            HashMap::with_capacity(unique_ids.len());
+
         if defer_related_fetch {
-            let initial_owned = initial_related.clone().into_owned();
+            // DEFERRABLE mode (serial `contract_handling` loop): resolve
+            // LOCAL-ONLY — caller-supplied `initial_related` states OR the local
+            // `state_store`. This path MUST NEVER call `fetch_related_via_network`
+            // (which awaits a network GET inline on the serial loop). Anything
+            // still unresolved is surfaced via `DeferRelated` so the caller
+            // off-loads the fetch; on resume that re-enters here with the state
+            // supplied, OR (if a misbehaving contract re-requests something never
+            // supplied) hits the one-deferral cap → MissingRelated — never an
+            // inline network GET. See #4391.
             let mut missing = Vec::new();
             for id in &unique_ids {
-                let supplied = initial_owned
+                if let Some(s) = initial_owned
                     .states()
-                    .any(|(rid, s)| rid == id && s.is_some());
-                let local = supplied
-                    || if let Some(full_key) = self.bridged_lookup_key(id) {
-                        self.state_store.get(&full_key).await.is_ok()
-                    } else {
-                        false
-                    };
-                if !local {
-                    missing.push(*id);
+                    .find_map(|(rid, s)| if rid == id { s.as_ref() } else { None })
+                {
+                    related_map.insert(*id, Some(s.clone().into_owned()));
+                    continue;
                 }
+                if let Some(full_key) = self.bridged_lookup_key(id) {
+                    if let Ok(state) = self.state_store.get(&full_key).await {
+                        related_map.insert(*id, Some(State::from(state.as_ref().to_vec())));
+                        continue;
+                    }
+                }
+                missing.push(*id);
             }
             if !missing.is_empty() {
                 return Err(ExecutorError::defer_related_fetch(missing));
             }
-        }
+        } else {
+            tracing::debug!(
+                contract = %key,
+                related_count = unique_ids.len(),
+                "Fetching related contracts for validation"
+            );
 
-        tracing::debug!(
-            contract = %key,
-            related_count = unique_ids.len(),
-            "Fetching related contracts for validation"
-        );
-
-        // Fetch each related contract: try local state_store first, escalate
-        // to network GET when the executor has an `op_manager` attached. The
-        // previous version was local-only, which silently failed cross-node
-        // UPDATE flows where the validating node was a fresh receiver that
-        // hadn't yet cached the related contract (see freenet/mail#80 — the
-        // recipient's inbox UPDATE always carried `RequestRelated` for the
-        // sender's AFT record, which the receiver hadn't seen before).
-        let mut related_map: HashMap<ContractInstanceId, Option<State<'static>>> =
-            HashMap::with_capacity(unique_ids.len());
-
-        // Parallel fetch via `join_all`: previously serial under a single
-        // 10s wall-clock budget, so N related ids each got ~10s/N
-        // effective. Each id now races its own sub-op GET, so the budget
-        // is per-id in the common case. See freenet/freenet-core#4077.
-        //
-        // Reborrow as `&Self` so the per-id futures share an immutable
-        // borrow; the outer `&mut self` is reclaimed once `fetch_all`
-        // is awaited.
-        let this: &Self = &*self;
-        let fetch_all = async {
-            let results: Vec<(ContractInstanceId, Result<State<'static>, ExecutorError>)> =
-                futures::future::join_all(unique_ids.iter().map(|id| {
-                    let id = *id;
-                    async move {
-                        if let Some(full_key) = this.bridged_lookup_key(&id) {
-                            if let Ok(state) = this.state_store.get(&full_key).await {
-                                return (id, Ok(State::from(state.as_ref().to_vec())));
+            // NON-deferrable mode (delegate-driven PUTs, direct callers): fetch
+            // each related contract — try the local state_store first, escalate
+            // to a network GET when the executor has an `op_manager` attached.
+            // The previous version was local-only, which silently failed
+            // cross-node UPDATE flows where the validating node was a fresh
+            // receiver that hadn't yet cached the related contract (see
+            // freenet/mail#80 — the recipient's inbox UPDATE always carried
+            // `RequestRelated` for the sender's AFT record, which the receiver
+            // hadn't seen before).
+            //
+            // Parallel fetch via `join_all`: previously serial under a single
+            // 10s wall-clock budget, so N related ids each got ~10s/N effective.
+            // Each id now races its own sub-op GET, so the budget is per-id in
+            // the common case. See freenet/freenet-core#4077.
+            //
+            // Reborrow as `&Self` so the per-id futures share an immutable
+            // borrow; the outer `&mut self` is reclaimed once `fetch_all`
+            // is awaited.
+            let this: &Self = &*self;
+            let fetch_all = async {
+                let results: Vec<(ContractInstanceId, Result<State<'static>, ExecutorError>)> =
+                    futures::future::join_all(unique_ids.iter().map(|id| {
+                        let id = *id;
+                        async move {
+                            if let Some(full_key) = this.bridged_lookup_key(&id) {
+                                if let Ok(state) = this.state_store.get(&full_key).await {
+                                    return (id, Ok(State::from(state.as_ref().to_vec())));
+                                }
                             }
+                            // Local lookup miss → escalate via the
+                            // network-fallback helper (factored out so the
+                            // per-id branch logic is testable with a stubbed
+                            // fetcher). Mock executors that lack an
+                            // `op_manager` get the legacy MissingRelated.
+                            let outcome = fetch_related_via_network(this.op_manager.as_ref(), &id)
+                                .await
+                                .map(|state| State::from(state.as_ref().to_vec()));
+                            (id, outcome)
                         }
-                        // Local lookup miss → escalate via the
-                        // network-fallback helper (factored out so the
-                        // per-id branch logic is testable with a stubbed
-                        // fetcher). Mock executors that lack an
-                        // `op_manager` get the legacy MissingRelated.
-                        let outcome = fetch_related_via_network(this.op_manager.as_ref(), &id)
-                            .await
-                            .map(|state| State::from(state.as_ref().to_vec()));
-                        (id, outcome)
-                    }
-                }))
-                .await;
-            for (id, res) in results {
-                related_map.insert(id, Some(res?));
-            }
-            Ok::<(), ExecutorError>(())
-        };
+                    }))
+                    .await;
+                for (id, res) in results {
+                    related_map.insert(id, Some(res?));
+                }
+                Ok::<(), ExecutorError>(())
+            };
 
-        match tokio::time::timeout(RELATED_FETCH_TIMEOUT, fetch_all).await {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
-                tracing::warn!(
-                    contract = %key,
-                    error = %e,
-                    "Failed to fetch related contracts"
-                );
-                return Err(e);
-            }
-            Err(_elapsed) => {
-                tracing::warn!(
-                    contract = %key,
-                    timeout_secs = RELATED_FETCH_TIMEOUT.as_secs(),
-                    fetched = related_map.len(),
-                    total = unique_ids.len(),
-                    "Timed out fetching related contracts"
-                );
-                return Err(ExecutorError::request(StdContractError::Put {
-                    key: *key,
-                    cause: "timed out fetching related contracts".into(),
-                }));
+            match tokio::time::timeout(RELATED_FETCH_TIMEOUT, fetch_all).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    tracing::warn!(
+                        contract = %key,
+                        error = %e,
+                        "Failed to fetch related contracts"
+                    );
+                    return Err(e);
+                }
+                Err(_elapsed) => {
+                    tracing::warn!(
+                        contract = %key,
+                        timeout_secs = RELATED_FETCH_TIMEOUT.as_secs(),
+                        fetched = related_map.len(),
+                        total = unique_ids.len(),
+                        "Timed out fetching related contracts"
+                    );
+                    return Err(ExecutorError::request(StdContractError::Put {
+                        key: *key,
+                        cause: "timed out fetching related contracts".into(),
+                    }));
+                }
             }
         }
 
-        // Merge initial_related (caller-provided) with newly fetched states.
-        // The contract's first call saw initial_related; the second call should see
-        // both the original entries and the newly fetched ones.
-        let initial_owned = initial_related.clone().into_owned();
+        // Merge initial_related (caller-provided) with the resolved states.
+        // The contract's first call saw initial_related; the second call should
+        // see both the original entries and the resolved ones. (Deferrable mode
+        // already inserted supplied states above; `or_insert` makes this a no-op
+        // there and only fills gaps for the non-deferrable fetch path.)
         for (id, state) in initial_owned.states() {
             if let Some(s) = state {
                 related_map

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -174,15 +174,18 @@ impl FairEventQueue {
             }
             match extract_contract_id(&event) {
                 Some(contract_id) => {
-                    let queue = self.contract_queues.entry(contract_id).or_default();
-                    if queue.len() >= MAX_QUEUED_PER_CONTRACT {
-                        // Drop the empty bucket we may have just inserted.
-                        if queue.is_empty() {
-                            self.contract_queues.remove(&contract_id);
-                        }
+                    // Check the bucket length WITHOUT `or_default()`, so a
+                    // rejected push for a brand-new id doesn't leave an empty
+                    // bucket behind (which would otherwise need cleanup).
+                    let cur_len = self
+                        .contract_queues
+                        .get(&contract_id)
+                        .map_or(0, |q| q.len());
+                    if cur_len >= MAX_QUEUED_PER_CONTRACT {
                         rejected.push((id, event));
                         continue;
                     }
+                    let queue = self.contract_queues.entry(contract_id).or_default();
                     if queue.is_empty() {
                         self.round_robin.push_back(QueueKey::Contract(contract_id));
                     }

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -211,7 +211,7 @@ impl FairEventQueue {
 ///
 /// Returns `Some(ContractInstanceId)` for events associated with a specific contract,
 /// or `None` for events with no contract identity (delegate requests, disconnects, etc.).
-fn extract_contract_id(event: &ContractHandlerEvent) -> Option<ContractInstanceId> {
+pub(super) fn extract_contract_id(event: &ContractHandlerEvent) -> Option<ContractInstanceId> {
     match event {
         ContractHandlerEvent::PutQuery { key, .. }
         | ContractHandlerEvent::UpdateQuery { key, .. }

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -146,98 +146,6 @@ impl FairEventQueue {
         Ok(())
     }
 
-    /// Re-enqueue events at the FRONT of their per-contract bucket, preserving
-    /// the given FIFO order (`events[0]` ends up first to be popped).
-    ///
-    /// Used by the #4391 deferral machinery to restore events that were held
-    /// behind an in-flight deferral: those events arrived BEFORE any fresh
-    /// same-key event still sitting in the bucket, so per-contract FIFO requires
-    /// them to run first. `try_push` (back-append) would wrongly order them
-    /// after fresh events.
-    ///
-    /// On overflow (the queue can't fit all of `events`), the OLDEST prefix is
-    /// accepted and the NEWEST suffix is rejected — we must never re-queue a
-    /// newer same-key event while rejecting an older one (that would itself
-    /// violate the per-contract FIFO this machinery exists to provide). The
-    /// reachable cap here is the GLOBAL one (`MAX_TOTAL_FAIR_QUEUE`): held events
-    /// from one deferral are all for the same contract key and number at most
-    /// `MAX_HELD_PER_DEFERRAL == MAX_QUEUED_PER_CONTRACT`, so the per-contract
-    /// bucket cannot overflow from this call alone, but the global total can
-    /// under load.
-    ///
-    /// Returns the rejected events in their original FIFO order so the caller
-    /// can answer those clients with backpressure rather than silently dropping
-    /// them.
-    ///
-    /// # Assumption
-    /// All `events` are expected to share one `extract_contract_id` (the loop
-    /// only holds events for the single deferred key), so capacity can be
-    /// computed once against that one bucket. A `debug_assert` enforces this;
-    /// in release builds a stray differing key is still handled correctly (it
-    /// just lands in its own bucket via the per-event routing below).
-    pub(super) fn requeue_front(
-        &mut self,
-        events: std::collections::VecDeque<(EventId, ContractHandlerEvent)>,
-    ) -> Vec<(EventId, ContractHandlerEvent)> {
-        if events.is_empty() {
-            return Vec::new();
-        }
-
-        // Determine the single target bucket (all held events share one key).
-        let target_id = extract_contract_id(&events[0].1);
-        debug_assert!(
-            events
-                .iter()
-                .all(|(_, e)| extract_contract_id(e) == target_id),
-            "requeue_front assumes all held events share one contract id"
-        );
-
-        // Compute capacity ONCE so we accept the oldest prefix and reject the
-        // newest suffix, never the reverse. Bound by both the global cap and the
-        // target bucket's per-contract cap.
-        let global_free = MAX_TOTAL_FAIR_QUEUE.saturating_sub(self.total_queued);
-        let bucket_len = match target_id {
-            Some(id) => self.contract_queues.get(&id).map_or(0, |q| q.len()),
-            None => self.default_queue.len(),
-        };
-        let bucket_free = MAX_QUEUED_PER_CONTRACT.saturating_sub(bucket_len);
-        let capacity = global_free.min(bucket_free);
-
-        let mut events: Vec<(EventId, ContractHandlerEvent)> = events.into_iter().collect();
-        // Reject the NEWEST suffix (events[capacity..]); the split_off keeps the
-        // rejected list in original FIFO order for the caller.
-        let rejected = if events.len() > capacity {
-            events.split_off(capacity)
-        } else {
-            Vec::new()
-        };
-
-        // Front-push the accepted prefix in REVERSE so that after all
-        // push_fronts the bucket front holds events[0], events[1], ... in order
-        // (events[0] pops first).
-        for (id, event) in events.into_iter().rev() {
-            match extract_contract_id(&event) {
-                Some(contract_id) => {
-                    let queue = self.contract_queues.entry(contract_id).or_default();
-                    if queue.is_empty() {
-                        self.round_robin.push_back(QueueKey::Contract(contract_id));
-                    }
-                    queue.push_front((id, event));
-                    self.total_queued += 1;
-                }
-                None => {
-                    if self.default_queue.is_empty() {
-                        self.round_robin.push_back(QueueKey::Default);
-                    }
-                    self.default_queue.push_front((id, event));
-                    self.total_queued += 1;
-                }
-            }
-        }
-
-        rejected
-    }
-
     /// Pop one event in round-robin order.
     ///
     /// Takes the front key from the round-robin, pops one event from that queue.
@@ -303,7 +211,7 @@ impl FairEventQueue {
 ///
 /// Returns `Some(ContractInstanceId)` for events associated with a specific contract,
 /// or `None` for events with no contract identity (delegate requests, disconnects, etc.).
-pub(super) fn extract_contract_id(event: &ContractHandlerEvent) -> Option<ContractInstanceId> {
+fn extract_contract_id(event: &ContractHandlerEvent) -> Option<ContractInstanceId> {
     match event {
         ContractHandlerEvent::PutQuery { key, .. }
         | ContractHandlerEvent::UpdateQuery { key, .. }

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -155,36 +155,69 @@ impl FairEventQueue {
     /// them to run first. `try_push` (back-append) would wrongly order them
     /// after fresh events.
     ///
-    /// Returns any events that could not be re-enqueued (per-contract or total
-    /// cap reached), in their original order, so the caller can answer those
-    /// clients with backpressure rather than silently dropping them.
+    /// On overflow (the queue can't fit all of `events`), the OLDEST prefix is
+    /// accepted and the NEWEST suffix is rejected — we must never re-queue a
+    /// newer same-key event while rejecting an older one (that would itself
+    /// violate the per-contract FIFO this machinery exists to provide). The
+    /// reachable cap here is the GLOBAL one (`MAX_TOTAL_FAIR_QUEUE`): held events
+    /// from one deferral are all for the same contract key and number at most
+    /// `MAX_HELD_PER_DEFERRAL == MAX_QUEUED_PER_CONTRACT`, so the per-contract
+    /// bucket cannot overflow from this call alone, but the global total can
+    /// under load.
+    ///
+    /// Returns the rejected events in their original FIFO order so the caller
+    /// can answer those clients with backpressure rather than silently dropping
+    /// them.
+    ///
+    /// # Assumption
+    /// All `events` are expected to share one `extract_contract_id` (the loop
+    /// only holds events for the single deferred key), so capacity can be
+    /// computed once against that one bucket. A `debug_assert` enforces this;
+    /// in release builds a stray differing key is still handled correctly (it
+    /// just lands in its own bucket via the per-event routing below).
     pub(super) fn requeue_front(
         &mut self,
         events: std::collections::VecDeque<(EventId, ContractHandlerEvent)>,
     ) -> Vec<(EventId, ContractHandlerEvent)> {
-        let mut rejected = Vec::new();
-        // Insert in REVERSE so that after all push_fronts the bucket front holds
-        // events[0], events[1], ... in order. Reverse-iterate but keep rejected
-        // in original order by reversing the rejected list at the end.
+        if events.is_empty() {
+            return Vec::new();
+        }
+
+        // Determine the single target bucket (all held events share one key).
+        let target_id = extract_contract_id(&events[0].1);
+        debug_assert!(
+            events
+                .iter()
+                .all(|(_, e)| extract_contract_id(e) == target_id),
+            "requeue_front assumes all held events share one contract id"
+        );
+
+        // Compute capacity ONCE so we accept the oldest prefix and reject the
+        // newest suffix, never the reverse. Bound by both the global cap and the
+        // target bucket's per-contract cap.
+        let global_free = MAX_TOTAL_FAIR_QUEUE.saturating_sub(self.total_queued);
+        let bucket_len = match target_id {
+            Some(id) => self.contract_queues.get(&id).map_or(0, |q| q.len()),
+            None => self.default_queue.len(),
+        };
+        let bucket_free = MAX_QUEUED_PER_CONTRACT.saturating_sub(bucket_len);
+        let capacity = global_free.min(bucket_free);
+
+        let mut events: Vec<(EventId, ContractHandlerEvent)> = events.into_iter().collect();
+        // Reject the NEWEST suffix (events[capacity..]); the split_off keeps the
+        // rejected list in original FIFO order for the caller.
+        let rejected = if events.len() > capacity {
+            events.split_off(capacity)
+        } else {
+            Vec::new()
+        };
+
+        // Front-push the accepted prefix in REVERSE so that after all
+        // push_fronts the bucket front holds events[0], events[1], ... in order
+        // (events[0] pops first).
         for (id, event) in events.into_iter().rev() {
-            // Global cap.
-            if self.total_queued >= MAX_TOTAL_FAIR_QUEUE {
-                rejected.push((id, event));
-                continue;
-            }
             match extract_contract_id(&event) {
                 Some(contract_id) => {
-                    // Check the bucket length WITHOUT `or_default()`, so a
-                    // rejected push for a brand-new id doesn't leave an empty
-                    // bucket behind (which would otherwise need cleanup).
-                    let cur_len = self
-                        .contract_queues
-                        .get(&contract_id)
-                        .map_or(0, |q| q.len());
-                    if cur_len >= MAX_QUEUED_PER_CONTRACT {
-                        rejected.push((id, event));
-                        continue;
-                    }
                     let queue = self.contract_queues.entry(contract_id).or_default();
                     if queue.is_empty() {
                         self.round_robin.push_back(QueueKey::Contract(contract_id));
@@ -193,10 +226,6 @@ impl FairEventQueue {
                     self.total_queued += 1;
                 }
                 None => {
-                    if self.default_queue.len() >= MAX_QUEUED_PER_CONTRACT {
-                        rejected.push((id, event));
-                        continue;
-                    }
                     if self.default_queue.is_empty() {
                         self.round_robin.push_back(QueueKey::Default);
                     }
@@ -205,9 +234,7 @@ impl FairEventQueue {
                 }
             }
         }
-        // We iterated in reverse, so `rejected` is in reverse order; restore the
-        // original FIFO order for the caller.
-        rejected.reverse();
+
         rejected
     }
 

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -146,6 +146,68 @@ impl FairEventQueue {
         Ok(())
     }
 
+    /// Re-enqueue events at the FRONT of their per-contract bucket, preserving
+    /// the given FIFO order (`events[0]` ends up first to be popped).
+    ///
+    /// Used by the #4391 deferral machinery to restore events that were held
+    /// behind an in-flight deferral: those events arrived BEFORE any fresh
+    /// same-key event still sitting in the bucket, so per-contract FIFO requires
+    /// them to run first. `try_push` (back-append) would wrongly order them
+    /// after fresh events.
+    ///
+    /// Returns any events that could not be re-enqueued (per-contract or total
+    /// cap reached), in their original order, so the caller can answer those
+    /// clients with backpressure rather than silently dropping them.
+    pub(super) fn requeue_front(
+        &mut self,
+        events: std::collections::VecDeque<(EventId, ContractHandlerEvent)>,
+    ) -> Vec<(EventId, ContractHandlerEvent)> {
+        let mut rejected = Vec::new();
+        // Insert in REVERSE so that after all push_fronts the bucket front holds
+        // events[0], events[1], ... in order. Reverse-iterate but keep rejected
+        // in original order by reversing the rejected list at the end.
+        for (id, event) in events.into_iter().rev() {
+            // Global cap.
+            if self.total_queued >= MAX_TOTAL_FAIR_QUEUE {
+                rejected.push((id, event));
+                continue;
+            }
+            match extract_contract_id(&event) {
+                Some(contract_id) => {
+                    let queue = self.contract_queues.entry(contract_id).or_default();
+                    if queue.len() >= MAX_QUEUED_PER_CONTRACT {
+                        // Drop the empty bucket we may have just inserted.
+                        if queue.is_empty() {
+                            self.contract_queues.remove(&contract_id);
+                        }
+                        rejected.push((id, event));
+                        continue;
+                    }
+                    if queue.is_empty() {
+                        self.round_robin.push_back(QueueKey::Contract(contract_id));
+                    }
+                    queue.push_front((id, event));
+                    self.total_queued += 1;
+                }
+                None => {
+                    if self.default_queue.len() >= MAX_QUEUED_PER_CONTRACT {
+                        rejected.push((id, event));
+                        continue;
+                    }
+                    if self.default_queue.is_empty() {
+                        self.round_robin.push_back(QueueKey::Default);
+                    }
+                    self.default_queue.push_front((id, event));
+                    self.total_queued += 1;
+                }
+            }
+        }
+        // We iterated in reverse, so `rejected` is in reverse order; restore the
+        // original FIFO order for the caller.
+        rejected.reverse();
+        rejected
+    }
+
     /// Pop one event in round-robin order.
     ///
     /// Takes the front key from the round-robin, pops one event from that queue.

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -228,6 +228,18 @@ impl StashedResponder {
             .send((EventId { id: self.id }, ev))
             .map_err(|_| ContractError::NoEvHandlerResponse)
     }
+
+    /// Construct a `StashedResponder` directly from a oneshot sender, for unit
+    /// tests of the deferral machinery (e.g. the TTL sweep) that need to
+    /// observe the response a stranded client receives without standing up the
+    /// full channel + loop.
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        id: u64,
+        sender: tokio::sync::oneshot::Sender<(EventId, ContractHandlerEvent)>,
+    ) -> Self {
+        Self { id, sender }
+    }
 }
 
 pub(crate) struct SenderHalve {

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -230,9 +230,9 @@ impl StashedResponder {
     }
 
     /// Construct a `StashedResponder` directly from a oneshot sender, for unit
-    /// tests of the deferral machinery (e.g. the TTL sweep) that need to
-    /// observe the response a stranded client receives without standing up the
-    /// full channel + loop.
+    /// tests of the deferral machinery (e.g. the drop-guard delivering a
+    /// `MissingRelated` resume) that need to observe the response a stranded
+    /// client receives without standing up the full channel + loop.
     #[cfg(test)]
     pub(crate) fn for_test(
         id: u64,

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -206,6 +206,30 @@ pub(crate) struct ContractHandlerHalve {
     waiting_response: BTreeMap<u64, tokio::sync::oneshot::Sender<(EventId, ContractHandlerEvent)>>,
 }
 
+/// Ownership of a client's response oneshot, removed from `waiting_response`
+/// so it can outlive a single `handle_contract_event` call.
+///
+/// Created by [`ContractHandlerChannel::take_waiting_response`] when a PUT/UPDATE
+/// defers its related-contract fetch off the serial loop (#4391). The loop holds
+/// this until the deferred upsert resumes, then calls [`respond`](Self::respond)
+/// to deliver the result to the original client — the same delivery
+/// `send_to_sender` performs for the inline path.
+pub(crate) struct StashedResponder {
+    id: u64,
+    sender: tokio::sync::oneshot::Sender<(EventId, ContractHandlerEvent)>,
+}
+
+impl StashedResponder {
+    /// Deliver `ev` to the original client. Returns `Err` if the client
+    /// already disconnected (its receiver was dropped) — non-fatal, the
+    /// upsert side effects have already been applied.
+    pub fn respond(self, ev: ContractHandlerEvent) -> Result<(), ContractError> {
+        self.sender
+            .send((EventId { id: self.id }, ev))
+            .map_err(|_| ContractError::NoEvHandlerResponse)
+    }
+}
+
 pub(crate) struct SenderHalve {
     event_sender: mpsc::UnboundedSender<InternalCHEvent>,
     wait_for_res_tx: mpsc::Sender<(ClientId, WaitingTransaction)>,
@@ -555,6 +579,22 @@ impl ContractHandlerChannel<ContractHandlerHalve> {
     /// the `waiting_response` map.
     pub fn drop_waiting_response(&mut self, id: EventId) {
         self.end.waiting_response.remove(&id.id);
+    }
+
+    /// Remove and return the response oneshot for `id` so the caller can hold
+    /// it across an off-loop wait and answer the original client later.
+    ///
+    /// Used by the `contract_handling` loop when a PUT/UPDATE must defer its
+    /// related-contract network fetch off the serial loop (#4391): the loop
+    /// takes ownership of the oneshot here, drives the fetch on a background
+    /// task, re-runs the upsert, and finally fires the stashed oneshot via
+    /// [`StashedResponder::respond`]. Returns `None` if no entry exists (e.g. a
+    /// fire-and-forget event whose receiver was already dropped).
+    pub fn take_waiting_response(&mut self, id: &EventId) -> Option<StashedResponder> {
+        self.end
+            .waiting_response
+            .remove(&id.id)
+            .map(|sender| StashedResponder { id: id.id, sender })
     }
 
     /// Check if a waiting_response entry exists for the given event ID.
@@ -1271,6 +1311,31 @@ pub(super) mod in_memory {
     pub(crate) struct MockWasmContractHandler {
         channel: ContractHandlerChannel<ContractHandlerHalve>,
         runtime: Executor<MockWasmRuntime, MockStateStorage>,
+    }
+
+    #[cfg(test)]
+    impl MockWasmContractHandler {
+        /// Construct a handler over a `MockWasmRuntime` executor with an
+        /// optional `op_manager`. Used by the head-of-line-blocking regression
+        /// test (#4391) to drive the real `contract_handling` loop without
+        /// standing up a full network `OpManager`.
+        pub(crate) async fn new_test(
+            channel: ContractHandlerChannel<ContractHandlerHalve>,
+            op_manager: Option<Arc<OpManager>>,
+            identifier: &str,
+        ) -> Self {
+            let runtime =
+                Executor::new_mock_wasm(identifier, MockStateStorage::new(), None, op_manager)
+                    .await
+                    .expect("create MockWasmRuntime executor for test");
+            Self { channel, runtime }
+        }
+
+        /// Mutable access to the executor's `MockWasmRuntime` so a test can
+        /// install per-contract `validate_overrides` / `update_overrides`.
+        pub(crate) fn runtime_mut(&mut self) -> &mut MockWasmRuntime {
+            self.runtime.mock_runtime_mut()
+        }
     }
 
     /// Builder for MockWasmContractHandler.


### PR DESCRIPTION
## Problem

All contract operations are processed by ONE serial loop, `contract_handling`
(`crates/core/src/contract.rs`), which awaits `handle_contract_event(...)` to
completion before processing the next event.

When a PUT or UPDATE's validation needs a "related contract" that isn't held
locally, the runtime did a NETWORK fetch and **awaited it inline on this loop**:

- `fetch_related_for_validation` / the `update_state requires()` branch in
  `bridged_upsert_contract_state` → `start_sub_op_get` then `rx.await`, bounded
  by `RELATED_FETCH_TIMEOUT = 10s`.
- (the older `local_state_or_from_network` path used `SUB_OP_FETCH_TIMEOUT = 120s`).

Because the loop is serial, **everything queued behind that PUT/UPDATE waited the
full timeout** — including local-store-hit `GetQuery` reads that only touch the
local store. That is the user-visible "all GETs stall, even cached ones, for a
while" bug.

## Approach

The sub-op GET already runs as its own background task (`start_sub_op_get`
spawns it); the only thing pinning the loop was the inline `rx.await`. This PR
moves that wait off the loop and re-enqueues a continuation:

1. **Deferrable upsert.** `bridged_upsert_contract_state_inner` takes a new
   `defer_related_fetch` flag. The related-fetch sites resolve related contracts
   **local-only first**. If everything needed is already local, behavior is
   identical to today (no network, no deferral). If a related contract requires
   the network, the upsert rolls back any partial work via the existing error
   path (init-tracker / contract-store rollback) and returns a typed
   `DeferRelatedFetch` carrying the missing ids — surfaced as
   `UpsertOutcome::DeferRelated`. Exposed via a new
   `ContractExecutor::upsert_contract_state_deferrable` (default impl never
   defers, so local-only / mock executors are unchanged).

2. **Off-loop waiter + re-enqueue.** On `DeferRelated`, the loop parks the
   client's response oneshot (new `take_waiting_response` / `StashedResponder`
   on the handler half) and spawns a `GlobalExecutor::spawn` waiter that drives
   the GET(s) under a single unified `RELATED_FETCH_TIMEOUT`, then re-enqueues a
   `DeferredResume` via a **loop-owned unbounded channel** (non-blocking
   `unbounded_send`, never `.send().await` — see channel-safety.md). The loop
   returns immediately so queued events (the cached GETs) drain.

3. **Resume on the loop.** The loop re-runs the upsert ON the loop with the
   fetched related states supplied (so it resolves locally, no re-fetch), then
   answers the original client through the stashed oneshot. **WASM validate /
   store still runs serially on the loop** — only the network *wait* moved
   off-loop.

### Invariants preserved

- **depth=1 / one round.** The resume uses the deferrable path again; if the
  contract now requests a *different* related contract not held locally, that
  is converted to `MissingRelated` rather than deferring a second time — exactly
  one deferral per op, no infinite loop.
- **Client response routing.** The original `EventId`/oneshot is carried through
  the deferral and fired on resume.
- **No new executor concurrency.** Only the network wait is off-loop; WASM stays
  serial on the loop.
- **channel-safety.** Re-enqueue is a non-blocking unbounded send; in-flight
  deferrals are capped (`MAX_INFLIGHT_DEFERRALS`) so a flood of related-needing
  PUTs falls back to the inline path rather than spawning unbounded waiters.

## Testing

New `hol_4391_tests` module drives the **real `contract_handling` loop**:

- `deferred_related_fetch_does_not_block_local_get` — the core regression: a PUT
  whose related fetch hangs must NOT block a subsequent local-store-hit GET.
  **Verified this FAILS without the fix** (temporarily forcing the inline wait
  back onto the loop makes the cached GET time out: `Elapsed(())`) and **PASSES
  with it**.
- `deferred_related_fetch_success_resumes_and_completes` — deferred PUT resumes
  and stores once the off-loop fetch succeeds.
- `deferred_related_fetch_failure_surfaces_missing_related` — a failed off-loop
  fetch surfaces an error to the client (no hang).
- `all_related_local_does_not_defer` — a PUT whose related contract is already
  local never invokes the off-loop fetch (no behavior change).
- `second_related_request_after_resume_does_not_defer_again` — the one-deferral
  cap: a contract that keeps requesting related contracts is rejected after a
  single off-loop fetch (asserts the fetch runs exactly once).

All 275 `contract::` module tests pass; the `#4077` parallel-fetch pin test was
updated to account for the new local-only resolution loop while still rejecting
a serial *network* fetch. `cargo fmt` + `cargo clippy -- -D warnings` clean.

[AI-assisted - Claude]



---

## Review round 2 update (per-contract FIFO, cap, TTL)

Addressed the multi-model review's blocking design fix and Should-Fixes on top of the original off-loading mechanism:

### MUST-FIX #1 — per-contract FIFO preserved across a deferral
While a contract's PUT/UPDATE has an in-flight off-loop fetch, the loop now
HOLDS that contract's subsequent events (`DeferralCtx.deferred_keys`,
`pop_runnable_event`) and re-enqueues them in FIFO order when the deferral
commits/fails/times out. So a same-key GET/UPDATE issued during the deferral
waits and observes the committed state instead of `MissingContract`/stale.
Other contracts keep draining — the whole point of #4391. The block's lifetime
is tied to the stashed responder (released on resume in `handle_deferred_resume`
or on TTL in `sweep_stale_deferrals`).

### MUST-FIX #2 — capped resume drain
The resume drain is now bounded (`MAX_RESUME_DRAIN_BATCH = 16`) and interleaved
with the fair queue, so back-to-back WASM resumes can't head-of-line-block
cached GETs.

### MUST-FIX #3 — TTL + lifecycle for the deferral machinery
`sweep_stale_deferrals` runs each loop iteration: any deferral whose off-loop
fetch never reported within 2× `DEFERRED_RELATED_FETCH_TIMEOUT` is answered with
the correct response variant (Put/Update, tracked per-entry) and its
per-contract block is released — so a wedged/dropped waiter can't leak the
stashed responder (client hang) or permanently wedge the contract (which would
make `at_capacity()` permanently true and silently disable the whole fix). The
held buffer is itself bounded (`MAX_HELD_PER_DEFERRAL = 100`). The fire-and-forget
waiter rationale is documented at the spawn site (short-lived, bounded,
self-terminating, sweep-covered) per code-style.md.

### SHOULD-FIX #4 — capacity fail-fast
At the in-flight cap, a new related-needing op now surfaces `MissingRelated`
immediately instead of falling back to an inline network fetch (which would
re-stall the loop for the over-cap op).

### SHOULD-FIX #5 — test coverage
New tests (all drive the real `contract_handling` loop unless noted):
- `deferred_put_holds_same_key_get_but_not_other_key` — the MUST-FIX #1
  regression: same-key GET waits + sees committed state; cross-key GET prompt.
- `deferred_put_then_same_key_update_is_ordered_after_commit` — UPDATE-after-
  deferred-PUT-same-key ordering (no MissingContract).
- `update_path_deferral_resumes_and_applies` / `..._failure_surfaces_update_error`
  — UPDATE-path deferral (the response path differs from PUT).
- `off_loop_sub_op_outcome_mapping` — deterministic unit test of the real
  `SubOpGetOutcome → MissingRelated` mapping (factored into `map_sub_op_outcome`),
  covering the production path without a flaky real-network harness.
- `client_disconnect_during_deferral_releases_block` — disconnect mid-deferral
  doesn't leak the responder or wedge the contract.
- `deferral_cap_fails_fast_with_missing_related` — the 256-cap boundary.
- `put_update_arms_route_through_maybe_defer_upsert_pin_test` — source pin so a
  refactor can't silently re-inline the blocking upsert.
- RAII `OverrideGuard` so a panicking test can't leak the process-global stub.

### Docs
- Corrected the timeout-reconciliation claim: only the 10s
  `RELATED_FETCH_TIMEOUT` was ever on the loop's upsert path; the 120s
  `local_state_or_from_network` is `OperationMode::Local`-only and unrelated.
- Updated `.claude/rules/operations.md` — the `RELATED_FETCH_TIMEOUT`-on-the-loop
  claim is now off-loaded (WASM still serial, only the fetch wait moved).
- Fixed the `handle_deferred_resume` doc (uses the deferrable path); documented
  the per-contract ordering semantics at the deferral site.

Rebased onto current `origin/main` (drops the stale #4390 nat_subscription diff
artifact). `cargo fmt` + `clippy --lib --tests -D warnings` clean.

[AI-assisted - Claude]



---

## Review round 3 update (FIFO/sweep edge cases)

Round-2's per-contract-FIFO machinery introduced 4 blocking edge-case defects; round 3 closes them. They all interact through the per-contract deferral block, so they were fixed together and the D1-swept/D2-reblock timeline is walked in the resume-guard comment.

- **#1 — requeue leak.** `requeue_released_events` dropped held events it couldn't re-enqueue (fair queue full), leaking their `waiting_response` slot and hanging the client 300s. It's now `#[must_use]` and RETURNS the overflow; both call sites (sweep + resume) feed them to `answer_rejected_held_events`, which sends a queue-full response (drops the slot) like the normal drain path.
- **#2 — FIFO violation.** Held events were re-queued at the BACK of the bucket, so a fresh same-key event could run before the older held one. Added `FairEventQueue::requeue_front`, which front-loads held events in original FIFO order and returns any overflow.
- **#3 — stale resume clobber.** `release_key` is keyed by contract, not deferral_id, so a late D1 resume after D1 was swept and a held event re-deferred as D2 would re-run D1's stale upsert and remove D2's live block. Added a guard at the top of `handle_deferred_resume`: it proceeds only if `deferred_keys[key].deferral_id == resume.deferral_id`; otherwise it drops the resume untouched (the sweep already answered that client).
- **#4 — untested sweep.** Parameterized `now_nanos` into `sweep_stale_deferrals` for a deterministic unit test (stale released + held requeued + correct Put/Update variant answered + fresh entry not swept).

New tests: `requeue_front_orders_held_before_fresh_same_key`, `requeue_front_returns_overflow_in_fifo_order`, `hold_event_caps_at_max_held_per_deferral`, `sweep_releases_stale_answers_client_and_requeues_held`, `stale_resume_does_not_release_newer_deferral_block`, `fetch_related_off_loop_no_op_manager_is_missing_related`, `rejected_held_event_is_answered_not_leaked`. Added `StashedResponder::for_test`. Updated `.claude/rules/contracts.md` (deferrable vs inline upsert paths).

`cargo fmt` + `clippy --lib --tests -- -D warnings` clean.

[AI-assisted - Claude]



---

## Review round 3.1 update (deferrable-never-inline; evict reclaim; dead branch)

- **[P2] Deferrable mode can no longer inline-fetch on the serial loop.** The deferrable local-only check counted a caller-SUPPLIED related (`initial_related`) as "local" and fell through to the join_all/network path, which checks ONLY the `state_store` — so a supplied-but-unpersisted related re-requested on resume could hit `fetch_related_via_network` inline, bypassing the one-deferral cap. Both deferrable branches (`fetch_related_for_validation` and the `update_state requires()` branch) now resolve from `state_store` + `initial_related` ONLY and return `DeferRelated(missing)` for anything unresolved; the network join_all is structurally the `else` (non-deferrable) branch, so it's unreachable in deferrable mode. The non-deferrable path (delegates/direct callers) still escalates inline — correct there. New test `deferrable_supplied_related_never_inline_fetches` asserts the network override is NEVER called (calls==0) for a re-requested supplied related, and the outcome is a depth>1 error, not a network result.
- **[LOW #1] EvictContract disk-reclamation on the reject path.** `answer_rejected_held_events` now calls `track_pending_reclamation_if_evict` before `send_queue_full_response` (matching the other three reject sites), so a held `EvictContract` rejected on requeue doesn't silently leak on-disk storage (#4212 class). The helper (and `sweep_stale_deferrals`) now take `&mut CH`. Pinned by `answer_rejected_held_events_tracks_evict_reclamation_pin_test`.
- **[LOW #2] Dead branch removed** in `fair_queue::requeue_front`: the unreachable `if queue.len() >= MAX && queue.is_empty()` cleanup. The bucket length is now checked WITHOUT `or_default()`, so a rejected push for a brand-new id never creates an empty bucket.

292 contract-module + fair_queue tests pass; `cargo fmt` + `clippy --lib --tests -- -D warnings` clean. Rebased onto current origin/main.

[AI-assisted - Claude]




---

## Review round 5 update (delete the per-contract-FIFO machinery)

Rounds 2–3 built a per-contract-FIFO hold mechanism so a contract's later
events would queue behind a mid-deferral op for the same key, and patched its
edge cases twice (global-cap requeue, stale held events, stale resume clobber).
The external reviewer then found another defect of the same class: under heavy
same-key load, `requeue_front` rejects older held events while newer
bucket-resident same-key events stay. Rather than patch the FIFO machinery a
third time, this round **deletes it entirely and accepts reordering** (the
maintainer-approved decision).

### What was deleted
- `deferred_keys` map + `block_key` / `release_key` / `is_key_deferred`
- `hold_event` / `HoldOutcome` / the `held` `VecDeque` / `MAX_HELD_PER_DEFERRAL`
- `pop_runnable_event` + `RunnableEvent` — the loop now drains the fair queue
  directly into `handle_contract_event`
- `FairEventQueue::requeue_front`, `requeue_released_events`,
  `answer_rejected_held_events`
- All the per-contract-FIFO / sweep-ordering tests
- `sweep_stale_deferrals` is no longer needed for FIFO lifecycle; the
  `ResumeGuard` (round-4) already guarantees exactly-once resume delivery, so a
  dropped waiter answers the parked client with `MissingRelated` via Drop.

### What was kept (the sound off-load core)
- `maybe_defer_upsert` off-loading: spawn the waiter, park the client responder
  in `stashed` keyed by `deferral_id`, re-enqueue via the loop-owned resume
  channel (non-blocking `unbounded_send`)
- `ResumeGuard` exactly-once delivery (`Option::take` on success; Drop delivers
  `MissingRelated`)
- `handle_deferred_resume` re-runs the deferrable upsert against current state
  and answers the stashed client exactly once
- `MAX_INFLIGHT_DEFERRALS` cap + fail-fast → `MissingRelated`
- depth=1 / one-deferral-per-op (a 2nd `DeferRelated` converts to
  `MissingRelated`)
- `track_pending_reclamation_if_evict` — still used on the normal channel-drain
  reject paths, so `EvictContract` disk reclamation is unaffected

### Correctness: no lost update on concurrent same-key deferrals
Without the per-key block, two same-key ops can now both defer concurrently. The
resume re-runs the deferrable upsert via
`bridged_upsert_contract_state_inner`, which reads `current_state` FRESH from
`state_store.get(&key)` at upsert time (`runtime.rs:1563`). So two same-key ops
that both defer reconcile through the contract's CRDT merge — neither clobbers
the other.

### Accepted behavior change
A GET/UPDATE for a contract whose PUT is mid-deferral now runs **immediately**
instead of waiting behind it. Documented at the deferral site and in
`.claude/rules/contracts.md` (the per-contract-FIFO claim is dropped).

### Tests
- Deleted the per-contract-FIFO tests.
- New `same_key_get_during_deferred_put_runs_promptly`: gates an off-loop fetch
  for a PUT of contract A, then issues a same-key GET for A under a 2s timeout
  and asserts it resolves promptly (not held); releases the gate and asserts A's
  PUT still gets its own `PutResponse`.
- Kept survivors green: `dropped_waiter_guard_answers_client_missing_related`,
  `resume_guard_success_sends_exactly_one_resume`,
  `deferred_related_fetch_does_not_block_local_get`,
  `deferral_cap_fails_fast_with_missing_related`, the UPDATE-defer tests,
  `second_related_request_after_resume_does_not_defer_again`,
  `client_disconnect_during_deferral_does_not_wedge`,
  `fetch_related_off_loop_no_op_manager_is_missing_related`.

14 hol_4391 + 287 contract-module + 14 fair_queue tests pass; `cargo fmt` +
`clippy --lib --tests -- -D warnings` clean. Net **-774 lines** (substantially
net-negative — the FIFO machinery was more complex than the problem it solved).
Rebased onto current `origin/main`.

[AI-assisted - Claude]
