### PR TITLE
fix: drain tracker by stream_id on abort

### DIFF
--- a/.claude/rules/transport.md
+++ b/.claude/rules/transport.md
@@ -103,6 +103,51 @@ pinning flight size at cwnd and stalling every subsequent stream
   - Retransmissions MUST stay bounded. Do not make retransmit infinite again.
 ```
 
+### Atomic stream-abort drain (issue #4345, follow-up to #4353)
+
+```
+A THIRD flight-size release path exists alongside ACK and abandonment: when an
+outbound stream aborts before its packets reach MAX_PACKET_RETRANSMITS, the
+abort site MUST atomically remove the stream's in-flight packets from the
+tracker AND release their bytes from flight size, in that order. The
+per-packet abandonment path (#4353) takes ~6s (12 × 500ms RTO floor) — longer
+than CWND_WAIT_TIMEOUT (3s) — so a same-connection retry (PR #4367) opening a
+new stream before abandonment fires would inherit the wedge.
+
+Mechanism:
+  - Packets are tagged with Option<StreamId> at report_sent_packet_with_token.
+    Some(id) for StreamFragment payloads; None for handshake / short / no-op /
+    ping packets that have no owning stream (those are invisible to drop_stream).
+  - SentPacketTracker::drop_stream(stream_id) -> usize sweeps pending_receipts
+    for that stream and returns the byte total. It does NOT touch flight size.
+  - The caller (outbound_stream.rs abort sites) then calls
+    CongestionControl::release_flightsize(bytes) with that total.
+
+Why split tracker drain from flight-size release:
+  - Atomicity. Once a packet is removed from pending_receipts, any subsequent
+    ACK or abandon path finds it gone and becomes a no-op. This guarantees
+    each packet's bytes are decremented exactly once across its lifetime,
+    preventing the double-decrement that would otherwise silently under-count
+    live streams under saturating arithmetic.
+  - Decoupling. The tracker owns "what is in flight"; the controller owns
+    "the counter." No tracker code path touches flight size; no controller
+    code path touches tracker entries. This keeps the modules unit-testable
+    in isolation and makes the single-source-of-truth easy to audit.
+
+Abort sites in outbound_stream.rs that MUST drain (all use the
+drain_stream_from_tracker helper):
+  1. send_stream cwnd-wait timeout
+  2. pipe_stream cwnd-wait timeout
+  3. pipe_stream inactivity stall (upstream feed dry)
+  4. pipe_stream inbound-stream error (upstream cancelled)
+  5. send_stream post-packet_sending Err(e) propagation
+  6. pipe_stream post-packet_sending Err(e) propagation
+
+A new release path that touches flight size without also removing tracker
+entries is PROHIBITED — saturating arithmetic would mask the resulting
+under-count and corrupt live streams' accounting on lossy paths.
+```
+
 ### Shadow per-peer RTT registry (issue #4074, Phases 1 + 1.5)
 
 `transport/rolling_rtt_stats.rs` maintains a process-wide

--- a/apps/freenet-ping/Cargo.lock
+++ b/apps/freenet-ping/Cargo.lock
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.2.70"
+version = "0.2.71"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -697,7 +697,7 @@ mod tests {
         sent_tracker.time_source.advance(effective_rto);
         for id in [2, 4] {
             match sent_tracker.get_resend() {
-                ResendAction::Resend(packet_id, packet) => {
+                ResendAction::Resend(packet_id, packet, _) => {
                     assert_eq!(packet_id, id);
                     // Simulate resending packet
                     sent_tracker.report_sent_packet(id, packet);

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -1294,7 +1294,7 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                         // action-specific side effects (congestion notification, logging).
                         // Abandon releases flight size and is handled inline (it neither
                         // re-sends nor re-registers). See #4345.
-                        let (idx, packet) = match maybe_resend {
+                        let (idx, packet, stream_id) = match maybe_resend {
                             ResendAction::WaitUntil(deadline_nanos) => {
                                 resend_check_sleep = Some(self.time_source.sleep_until(deadline_nanos));
                                 break;
@@ -1322,15 +1322,15 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                                 }
                                 continue;
                             }
-                            ResendAction::Resend(idx, packet) => {
+                            ResendAction::Resend(idx, packet, stream_id) => {
                                 // Notify congestion controller of packet loss (timeout-based
                                 // retransmission). The packet stays in flight — it is
                                 // immediately re-sent and re-registered below — so flight size
                                 // is unchanged; on_timeout only applies the cwnd loss response.
                                 self.remote_conn.congestion_controller.on_timeout();
-                                (idx, packet)
+                                (idx, packet, stream_id)
                             }
-                            ResendAction::TlpProbe(idx, packet) => {
+                            ResendAction::TlpProbe(idx, packet, stream_id) => {
                                 // TLP (Tail Loss Probe) - send probe to detect tail loss earlier.
                                 // Unlike RTO, TLP does NOT call on_timeout() because it's speculative.
                                 // If the probe gets an ACK, no loss occurred. If not, RTO will fire later.
@@ -1339,7 +1339,7 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                                     packet_id = idx,
                                     "Sending TLP probe"
                                 );
-                                (idx, packet)
+                                (idx, packet, stream_id)
                             }
                         };
 
@@ -1354,7 +1354,7 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                                 // Re-register packet for ACK/RTO tracking. Flight size is
                                 // unchanged: the packet never left flight (on_timeout did not
                                 // decrement), so neither on_send() nor a re-add is called.
-                                self.remote_conn.sent_tracker.lock().report_sent_packet(idx, packet);
+                                self.remote_conn.sent_tracker.lock().report_sent_packet_with_token(idx, stream_id, packet, None);
                             }
                             Err(e) => {
                                 tracing::warn!(
@@ -1365,11 +1365,12 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                                 );
                                 // Re-insert packet so RTO will retry it. Without this,
                                 // the packet would be permanently lost from tracking since
-                                // resend_check() already removed it.
+                                // resend_check() already removed it. Preserve stream_id tag
+                                // so `drop_stream` can still sweep it on a later abort (#4345).
                                 self.remote_conn
                                     .sent_tracker
                                     .lock()
-                                    .report_sent_packet(idx, packet);
+                                    .report_sent_packet_with_token(idx, stream_id, packet, None);
                                 break;
                             }
                         }
@@ -2090,6 +2091,22 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
     }
 }
 
+/// Extract the owning stream id for tracker tagging (#4345).
+///
+/// Only `StreamFragment` payloads belong to a stream; everything else (`ShortMessage`,
+/// `NoOp`, `Ping`, `Pong`, `AckConnection`) is single-shot or control plane and has no
+/// stream owner. The tracker uses `None` to mean "not eligible for `drop_stream` sweeps".
+fn extract_stream_id_from_payload(payload: &SymmetricMessagePayload) -> Option<StreamId> {
+    match payload {
+        SymmetricMessagePayload::StreamFragment { stream_id, .. } => Some(*stream_id),
+        SymmetricMessagePayload::ShortMessage { .. }
+        | SymmetricMessagePayload::NoOp
+        | SymmetricMessagePayload::AckConnection { .. }
+        | SymmetricMessagePayload::Ping { .. }
+        | SymmetricMessagePayload::Pong { .. } => None,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn packet_sending<S: super::Socket, T: crate::simulation::TimeSource>(
     remote_addr: SocketAddr,
@@ -2117,6 +2134,9 @@ async fn packet_sending<S: super::Socket, T: crate::simulation::TimeSource>(
     // `transport/shadow_demand.rs` and `.claude/rules/transport.md`.
     let payload: SymmetricMessagePayload = payload.into();
     let outbound_class = super::shadow_demand::classify(&payload);
+    // Stream-id tag for tracker (#4345). `Some` only for `StreamFragment`; `None` for
+    // ShortMessage / NoOp / Ping / Pong / AckConnection. Drives `drop_stream` sweeps on abort.
+    let stream_id = extract_stream_id_from_payload(&payload);
 
     match SymmetricMessage::try_serialize_msg_to_packet_data(
         packet_id,
@@ -2147,6 +2167,7 @@ async fn packet_sending<S: super::Socket, T: crate::simulation::TimeSource>(
                     super::shadow_demand::record_outbound(outbound_class, packet_data.len());
                     sent_tracker.lock().report_sent_packet_with_token(
                         packet_id,
+                        stream_id,
                         packet_data,
                         delivery_token,
                     );
@@ -2192,6 +2213,7 @@ async fn packet_sending<S: super::Socket, T: crate::simulation::TimeSource>(
                         sent_on_wire += packet_data.len();
                         sent_tracker.lock().report_sent_packet_with_token(
                             packet_id,
+                            stream_id,
                             packet_data,
                             delivery_token,
                         );
@@ -2331,6 +2353,39 @@ mod tests {
     use crate::transport::packet_data::MAX_PACKET_SIZE;
     use crate::transport::received_packet_tracker::MAX_PENDING_RECEIPTS;
     use crate::transport::sent_packet_tracker::MAX_CONFIRMATION_DELAY;
+
+    #[test]
+    fn test_issue_4345_extract_stream_id_only_tags_stream_fragments() {
+        let stream_id = StreamId::next();
+        let frag = SymmetricMessagePayload::StreamFragment {
+            stream_id,
+            total_length_bytes: 4,
+            fragment_number: 1,
+            payload: bytes::Bytes::from_static(b"data"),
+            metadata_bytes: None,
+        };
+        assert_eq!(extract_stream_id_from_payload(&frag), Some(stream_id));
+
+        // Non-streaming payloads have no owning stream and must be invisible to
+        // drop_stream — sweeping a Ping or ShortMessage by mistake would break
+        // keep-alive / lose op requests.
+        let short = SymmetricMessagePayload::ShortMessage {
+            payload: bytes::Bytes::from_static(b"x"),
+        };
+        assert_eq!(extract_stream_id_from_payload(&short), None);
+        assert_eq!(
+            extract_stream_id_from_payload(&SymmetricMessagePayload::NoOp),
+            None
+        );
+        assert_eq!(
+            extract_stream_id_from_payload(&SymmetricMessagePayload::Ping { sequence: 0 }),
+            None
+        );
+        assert_eq!(
+            extract_stream_id_from_payload(&SymmetricMessagePayload::Pong { sequence: 0 }),
+            None
+        );
+    }
 
     /// Simple test socket that writes to a channel
     struct TestSocket {
@@ -2971,7 +3026,7 @@ mod tests {
         let mut resends = 0u32;
         for _ in 0..20_000 {
             match tracker.get_resend() {
-                ResendAction::Resend(id, packet) => {
+                ResendAction::Resend(id, packet, _) => {
                     // Production recv-loop Resend arm: cwnd loss response, re-send
                     // (succeeds here), re-register. Flight size unchanged.
                     congestion.on_timeout();
@@ -2983,7 +3038,7 @@ mod tests {
                     congestion.release_flightsize(payload_len);
                     abandoned += 1;
                 }
-                ResendAction::TlpProbe(_id, _packet) => {
+                ResendAction::TlpProbe(_id, _packet, _) => {
                     // Speculative probe — no flight-size effect.
                 }
                 ResendAction::WaitUntil(_) => {

--- a/crates/core/src/transport/peer_connection/outbound_stream.rs
+++ b/crates/core/src/transport/peer_connection/outbound_stream.rs
@@ -52,6 +52,34 @@ pub(crate) type SerializedStream = Bytes;
 /// The extra byte vs. the original 40 comes from the Option discriminant of `metadata_bytes`.
 const MAX_DATA_SIZE: usize = packet_data::MAX_DATA_SIZE - 41;
 
+/// Drain `stream_id`'s in-flight packets from the tracker and release their bytes from
+/// flight size atomically (#4345). Used by every stream-terminating early return so the
+/// next stream on the same connection finds a clean flight size instead of inheriting
+/// the dead stream's wedge.
+///
+/// The order matters: `drop_stream` removes entries first (so a late ACK or the per-packet
+/// abandon path can't double-decrement), then `release_flightsize` adjusts the counter
+/// once with the returned byte total. The tracker lock is released before touching the
+/// congestion controller — the controller's `release_flightsize` is its own atomic, so
+/// we avoid holding both locks simultaneously.
+fn drain_stream_from_tracker<T: TimeSource>(
+    sent_packet_tracker: &parking_lot::Mutex<SentPacketTracker<T>>,
+    congestion_controller: &CongestionController<T>,
+    stream_id: StreamId,
+    site: &'static str,
+) {
+    let drained = sent_packet_tracker.lock().drop_stream(stream_id);
+    if drained > 0 {
+        congestion_controller.release_flightsize(drained);
+        tracing::debug!(
+            stream_id = %stream_id.0,
+            drained_bytes = drained,
+            site,
+            "drained stream from tracker + released flight size on abort (#4345)"
+        );
+    }
+}
+
 // TODO: unit test
 /// Handles sending a stream that is *not piped*. In the future this will be replaced by
 /// piped streams which start forwarding before the stream has been received.
@@ -190,6 +218,19 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
                 // permit immediately. Do NOT "fix" this by adding a blocking
                 // `tx.send(())` here — a blocking send in this stream task is the
                 // backpressure pattern channel-safety.md warns against.
+                //
+                // Atomic drain (#4345): remove this stream's in-flight packets from
+                // the tracker AND release their bytes from flight size, in that order.
+                // Doing both atomically here is what prevents the next stream on this
+                // connection from inheriting a pinned flight size; relying on the
+                // per-packet abandon path alone takes ~6s (12 × 500ms RTO floor),
+                // which exceeds CWND_WAIT_TIMEOUT.
+                drain_stream_from_tracker(
+                    &sent_packet_tracker,
+                    &congestion_controller,
+                    stream_id,
+                    "send_stream cwnd-wait abort",
+                );
                 return Err(TransportError::OutboundStreamFailed(destination_addr));
             }
 
@@ -300,6 +341,16 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
                 // Receiver may be dropped if queue timed out; ignore the error.
                 let _ignored = tx.send(());
             }
+            // Drain earlier fragments of THIS stream from tracker (#4345). The failing
+            // packet itself was never registered (`report_sent_packet` runs only on
+            // socket success), but successfully-sent prior fragments are still in flight.
+            // A same-connection retry would inherit their wedge without this drain.
+            drain_stream_from_tracker(
+                &sent_packet_tracker,
+                &congestion_controller,
+                stream_id,
+                "send_stream send-failed abort",
+            );
             return Err(e);
         }
 
@@ -466,6 +517,12 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
                 // on the downstream connection survive (#4345). The op layer
                 // times out and retries; the idle timeout decides connection
                 // liveness.
+                drain_stream_from_tracker(
+                    &sent_packet_tracker,
+                    &congestion_controller,
+                    outbound_stream_id,
+                    "pipe_stream inactivity abort",
+                );
                 return Err(TransportError::OutboundStreamFailed(destination_addr));
             }
         };
@@ -484,6 +541,12 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
                 // Error is on the UPSTREAM inbound stream, not the downstream
                 // connection — fail only this stream (#4345), same rationale as
                 // the inactivity-stall arm above.
+                drain_stream_from_tracker(
+                    &sent_packet_tracker,
+                    &congestion_controller,
+                    outbound_stream_id,
+                    "pipe_stream inbound-error abort",
+                );
                 return Err(TransportError::OutboundStreamFailed(destination_addr));
             }
         };
@@ -554,6 +617,12 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
                 );
                 // Fail only this stream, not the connection (#4345). See the
                 // matching site in send_stream for the rationale.
+                drain_stream_from_tracker(
+                    &sent_packet_tracker,
+                    &congestion_controller,
+                    outbound_stream_id,
+                    "pipe_stream cwnd-wait abort",
+                );
                 return Err(TransportError::OutboundStreamFailed(destination_addr));
             }
 
@@ -630,6 +699,14 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
                 e.to_string(),
                 elapsed.as_millis() as u64,
                 TransferDirection::Send,
+            );
+            // Drain earlier fragments of THIS stream (#4345); same rationale as the
+            // matching site in send_stream.
+            drain_stream_from_tracker(
+                &sent_packet_tracker,
+                &congestion_controller,
+                outbound_stream_id,
+                "pipe_stream send-failed abort",
             );
             return Err(e);
         }
@@ -1183,6 +1260,76 @@ mod tests {
             err.is_transient_send_failure(),
             "cwnd timeout must be classified transient so the connection survives: {err:?}"
         );
+
+        Ok(())
+    }
+
+    /// #4345 regression: after a stream aborts on CWND_WAIT_TIMEOUT, the same
+    /// tracker + congestion controller must be drained so a follow-up stream on
+    /// the SAME connection (the op-layer retry from PR #4367) does not inherit
+    /// the wedge. Pre-seed the tracker with stream A's in-flight bytes; with
+    /// cwnd=1, send_stream's cwnd-wait loop times out; assert tracker and
+    /// flightsize are clean and a fresh stream B can register.
+    #[tokio::test(start_paused = true)]
+    async fn cwnd_wait_abort_drains_tracker_and_unwedges_connection()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (outbound_sender, _outbound_receiver) = mpsc::channel(100);
+        let remote_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8080);
+        let cipher = {
+            let mut key = [0u8; 16];
+            crate::config::GlobalRng::fill_bytes(&mut key);
+            Aes128Gcm::new(&key.into())
+        };
+
+        let time_source = RealTime::new();
+        let congestion_controller = CongestionControlConfig::from_ledbat_config(LedbatConfig {
+            initial_cwnd: 1,
+            min_cwnd: 1,
+            max_cwnd: 1,
+            ..Default::default()
+        })
+        .build_arc();
+        let sent_tracker = Arc::new(parking_lot::Mutex::new(SentPacketTracker::new()));
+        let token_bucket = Arc::new(TokenBucket::new(1_000_000, 100_000_000));
+
+        // Stream A: pre-seeded in-flight bytes, will wedge on cwnd-wait.
+        let stream_a_id = StreamId::next();
+        {
+            let mut t = sent_tracker.lock();
+            t.report_sent_packet_with_token(201, Some(stream_a_id), vec![0u8; 1500].into(), None);
+            t.report_sent_packet_with_token(202, Some(stream_a_id), vec![0u8; 1500].into(), None);
+        }
+        congestion_controller.on_send(3000);
+
+        let send_a = GlobalExecutor::spawn(send_stream(
+            stream_a_id,
+            Arc::new(AtomicU32::new(0)),
+            Arc::new(TestSocket::new(outbound_sender)),
+            remote_addr,
+            Bytes::from(vec![0u8; 10_000]),
+            cipher,
+            sent_tracker.clone(),
+            token_bucket,
+            congestion_controller.clone(),
+            time_source,
+            None,
+            None,
+        ));
+        let err_a = send_a.await.expect("join").expect_err("A must wedge");
+        assert!(matches!(err_a, TransportError::OutboundStreamFailed(_)));
+
+        assert_eq!(sent_tracker.lock().pending_count(), 0);
+        assert_eq!(congestion_controller.flightsize(), 0);
+
+        // Stream B registers on the same tracker — proves no state inherited from A.
+        let stream_b_id = StreamId::next();
+        sent_tracker.lock().report_sent_packet_with_token(
+            301,
+            Some(stream_b_id),
+            vec![0u8; 1].into(),
+            None,
+        );
+        assert_eq!(sent_tracker.lock().pending_count(), 1);
 
         Ok(())
     }

--- a/crates/core/src/transport/sent_packet_tracker.rs
+++ b/crates/core/src/transport/sent_packet_tracker.rs
@@ -1,13 +1,27 @@
 use super::PacketId;
 use super::bbr::DeliveryRateToken;
+use super::peer_connection::StreamId;
 #[cfg(test)]
 use crate::simulation::RealTime;
 use crate::simulation::TimeSource;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::Duration;
 
-/// Entry for pending packet receipts: (payload, sent_time_nanos, delivery_token)
-type PendingReceiptEntry = (Box<[u8]>, u64, Option<DeliveryRateToken>);
+/// Entry stored per in-flight packet awaiting ACK.
+///
+/// `stream_id` is `Some` when the packet carries a `StreamFragment` payload owned by a
+/// streaming transfer (so it can be drained atomically when the stream aborts — #4345);
+/// `None` for handshake / short / no-op / ping packets that have no stream owner.
+///
+/// Using a struct (rather than a positional tuple) means future per-packet metadata can
+/// be added without breaking every existing pattern match — destructuring matches use
+/// `..` to ignore unused fields, so additive evolution is free.
+struct PendingReceiptEntry {
+    payload: Box<[u8]>,
+    sent_time_nanos: u64,
+    token: Option<DeliveryRateToken>,
+    stream_id: Option<StreamId>,
+}
 
 /// Result of processing received receipts: (acked_packets_info, loss_proportion)
 /// Each acked packet contains: (rtt_option, bytes_acked, delivery_token)
@@ -120,7 +134,7 @@ const PACKET_LOSS_DECAY_FACTOR: f64 = 1.0 / 1000.0;
 ///      ResendAction::WaitUntil(wait_until) => {
 ///        sleep_until(wait_until).await;
 ///      }
-///      ResendAction::Resend(packet_id, packet) => {
+///      ResendAction::Resend(packet_id, packet, _) => {
 ///       // Send packet and then call report_sent_packet again with the same packet_id.
 ///      }
 ///   }
@@ -203,10 +217,17 @@ impl<T: TimeSource> SentPacketTracker<T> {
 
 impl<T: TimeSource> SentPacketTracker<T> {
     pub(super) fn report_sent_packet(&mut self, packet_id: PacketId, payload: Box<[u8]>) {
-        self.report_sent_packet_with_token(packet_id, payload, None);
+        self.report_sent_packet_with_token(packet_id, None, payload, None);
     }
 
-    /// Report a sent packet with an optional BBR delivery rate token.
+    /// Report a sent packet with an optional BBR delivery rate token and optional owning
+    /// stream id.
+    ///
+    /// `stream_id` is set by `packet_sending` for `StreamFragment` payloads so a
+    /// subsequent `drop_stream` call can sweep this packet out atomically when the stream
+    /// aborts (#4345). Pass `None` for handshake / short / no-op / ping packets that have
+    /// no owning stream — those entries are then invisible to `drop_stream` and survive
+    /// any stream-abort sweep.
     ///
     /// The token is used by BBR for accurate delivery rate estimation. When an ACK
     /// arrives, the token is returned alongside the RTT sample so it can be passed
@@ -214,14 +235,75 @@ impl<T: TimeSource> SentPacketTracker<T> {
     pub(super) fn report_sent_packet_with_token(
         &mut self,
         packet_id: PacketId,
+        stream_id: Option<StreamId>,
         payload: Box<[u8]>,
         token: Option<DeliveryRateToken>,
     ) {
         let sent_time_nanos = self.time_source.now_nanos();
-        self.pending_receipts
-            .insert(packet_id, (payload, sent_time_nanos, token));
+        self.pending_receipts.insert(
+            packet_id,
+            PendingReceiptEntry {
+                payload,
+                sent_time_nanos,
+                token,
+                stream_id,
+            },
+        );
         self.resend_queue.push_back(ResendQueueEntry { packet_id });
         self.total_packets_sent += 1;
+    }
+
+    /// Test-only accessor: number of in-flight packets currently tracked.
+    /// Used by transport-level tests in sibling modules (e.g. outbound_stream.rs).
+    #[cfg(test)]
+    pub(in crate::transport) fn pending_count(&self) -> usize {
+        self.pending_receipts.len()
+    }
+
+    /// Atomically drain all packets belonging to `stream_id` from the tracker and return
+    /// the sum of their payload bytes (#4345).
+    ///
+    /// The caller MUST pass the returned byte count to
+    /// `CongestionControl::release_flightsize(bytes)` so the connection's flight-size
+    /// counter reflects that those bytes are no longer in flight. This method intentionally
+    /// does NOT touch flight size itself — keeping the responsibilities split (tracker
+    /// owns "what is in flight"; controller owns "the counter") prevents double-decrement:
+    /// once a packet is removed from `pending_receipts`, any subsequent ACK or abandon
+    /// path finds the entry already gone and becomes a no-op, so its bytes are
+    /// decremented exactly once across the packet's lifetime.
+    ///
+    /// `resend_queue` is not eagerly compacted — `get_resend` already skips queue entries
+    /// whose packet_id is no longer in `pending_receipts`, so stale entries naturally
+    /// fall off as the queue drains.
+    pub(super) fn drop_stream(&mut self, stream_id: StreamId) -> usize {
+        let mut bytes_drained: usize = 0;
+        let to_remove: Vec<PacketId> = self
+            .pending_receipts
+            .iter()
+            .filter_map(|(pid, entry)| {
+                if entry.stream_id == Some(stream_id) {
+                    bytes_drained = bytes_drained.saturating_add(entry.payload.len());
+                    Some(*pid)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for pid in &to_remove {
+            self.pending_receipts.remove(pid);
+            self.retransmitted_packets.remove(pid);
+            self.tlp_sent_packets.remove(pid);
+            self.retransmit_counts.remove(pid);
+        }
+        if !to_remove.is_empty() {
+            tracing::debug!(
+                stream_id = %stream_id,
+                drained_packets = to_remove.len(),
+                bytes_drained,
+                "drop_stream swept tracker entries on stream abort (#4345)"
+            );
+        }
+        bytes_drained
     }
 
     /// Reports that receipts have been received for the given packet IDs.
@@ -247,7 +329,13 @@ impl<T: TimeSource> SentPacketTracker<T> {
             // Get packet info before removing
             let is_retransmitted = self.retransmitted_packets.contains(packet_id);
 
-            if let Some((payload, sent_time_nanos, token)) = self.pending_receipts.get(packet_id) {
+            if let Some(PendingReceiptEntry {
+                payload,
+                sent_time_nanos,
+                token,
+                ..
+            }) = self.pending_receipts.get(packet_id)
+            {
                 let packet_size = payload.len();
                 let token = *token; // Copy the token before removing
 
@@ -425,7 +513,7 @@ impl<T: TimeSource> SentPacketTracker<T> {
             let sent_time_nanos = self
                 .pending_receipts
                 .get(&entry.packet_id)
-                .map(|(_, ts, _)| *ts)
+                .map(|e| e.sent_time_nanos)
                 .unwrap_or(0);
 
             // Calculate RTO deadline from current sent_time (not stored value)
@@ -447,8 +535,12 @@ impl<T: TimeSource> SentPacketTracker<T> {
             if let Some(tlp_at) = tlp_deadline {
                 if now_nanos >= tlp_at && now_nanos < rto_deadline {
                     // TLP fires! Clone packet data for the probe
-                    if let Some((packet, _, _)) = self.pending_receipts.get(&entry.packet_id) {
-                        let packet_clone = packet.clone();
+                    if let Some(PendingReceiptEntry {
+                        payload, stream_id, ..
+                    }) = self.pending_receipts.get(&entry.packet_id)
+                    {
+                        let packet_clone = payload.clone();
+                        let stream_id = *stream_id;
                         let packet_id = entry.packet_id;
 
                         // Mark TLP as sent for this packet (won't fire again)
@@ -461,15 +553,18 @@ impl<T: TimeSource> SentPacketTracker<T> {
                         self.mark_retransmitted(packet_id);
 
                         // TLP does NOT apply backoff - it's speculative
-                        return ResendAction::TlpProbe(packet_id, packet_clone);
+                        return ResendAction::TlpProbe(packet_id, packet_clone, stream_id);
                     }
                 }
             }
 
             // Check if RTO should fire
             if now_nanos >= rto_deadline {
-                if let Some((packet, _sent_time_nanos, _token)) =
-                    self.pending_receipts.remove(&entry.packet_id)
+                if let Some(PendingReceiptEntry {
+                    payload: packet,
+                    stream_id,
+                    ..
+                }) = self.pending_receipts.remove(&entry.packet_id)
                 {
                     // Update packet loss proportion for a lost packet
                     self.packet_loss_proportion = self.packet_loss_proportion
@@ -509,7 +604,7 @@ impl<T: TimeSource> SentPacketTracker<T> {
                     // Clean up TLP tracking for this packet
                     self.tlp_sent_packets.remove(&entry.packet_id);
 
-                    return ResendAction::Resend(entry.packet_id, packet);
+                    return ResendAction::Resend(entry.packet_id, packet, stream_id);
                 }
             }
 
@@ -534,11 +629,14 @@ impl<T: TimeSource> SentPacketTracker<T> {
 pub enum ResendAction {
     /// Wait until the given deadline (nanoseconds since TimeSource epoch) before checking again.
     WaitUntil(u64),
-    /// Full RTO timeout - resend the packet and apply backoff
-    Resend(u32, Box<[u8]>),
+    /// Full RTO timeout - resend the packet and apply backoff. Carries the owning stream id
+    /// (if any) so the recv loop re-registers the packet preserving its stream tag — without
+    /// this, retransmissions would lose the tag and `drop_stream` would miss those bytes (#4345).
+    Resend(u32, Box<[u8]>, Option<StreamId>),
     /// TLP (Tail Loss Probe) - send a probe to detect tail loss earlier than RTO.
-    /// Unlike Resend, this doesn't apply backoff since it's speculative.
-    TlpProbe(u32, Box<[u8]>),
+    /// Unlike Resend, this doesn't apply backoff since it's speculative. Carries the
+    /// owning stream id for the same re-registration reason as `Resend`.
+    TlpProbe(u32, Box<[u8]>, Option<StreamId>),
     /// The packet has been retransmitted `MAX_PACKET_RETRANSMITS` times without
     /// an ACK and is declared permanently lost (issue #4345). It has been
     /// removed from tracking; the caller MUST release its `payload_len` bytes
@@ -574,6 +672,79 @@ pub(in crate::transport) mod tests {
     pub(in crate::transport) fn mock_sent_packet_tracker() -> SentPacketTracker<VirtualTime> {
         let time_source = VirtualTime::new();
         SentPacketTracker::new_with_time_source(time_source)
+    }
+
+    #[test]
+    fn test_issue_4345_drop_stream_filters_by_stream_id() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream_a = StreamId::next();
+        let stream_b = StreamId::next();
+
+        // Setup mixes three categories: two stream_a packets (must be drained),
+        // one stream_b packet (different stream — must survive), one untagged
+        // packet (None — handshake/ping/short-message, must survive).
+        tracker.report_sent_packet_with_token(1, Some(stream_a), vec![0; 100].into(), None);
+        tracker.report_sent_packet_with_token(2, Some(stream_a), vec![0; 250].into(), None);
+        tracker.report_sent_packet_with_token(3, Some(stream_b), vec![0; 999].into(), None);
+        tracker.report_sent_packet_with_token(4, None, vec![0; 50].into(), None);
+
+        let drained = tracker.drop_stream(stream_a);
+        assert_eq!(drained, 350);
+        assert!(!tracker.pending_receipts.contains_key(&1));
+        assert!(!tracker.pending_receipts.contains_key(&2));
+        assert!(tracker.pending_receipts.contains_key(&3));
+        assert!(tracker.pending_receipts.contains_key(&4));
+    }
+
+    #[test]
+    fn test_issue_4345_drop_stream_clears_per_packet_state() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream = StreamId::next();
+
+        // Seed the auxiliary per-packet maps directly instead of driving 12 RTOs
+        // + a TLP probe to populate them naturally — the assertion is about what
+        // drop_stream cleans up, not about how those maps get populated.
+        tracker.report_sent_packet_with_token(7, Some(stream), vec![0; 10].into(), None);
+        tracker.retransmit_counts.insert(7, 5);
+        tracker.retransmitted_packets.insert(7);
+        tracker.tlp_sent_packets.insert(7);
+
+        tracker.drop_stream(stream);
+        assert!(!tracker.retransmit_counts.contains_key(&7));
+        assert!(!tracker.retransmitted_packets.contains(&7));
+        assert!(!tracker.tlp_sent_packets.contains(&7));
+    }
+
+    #[test]
+    fn test_issue_4345_late_ack_after_drop_stream_is_noop() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream = StreamId::next();
+        tracker.report_sent_packet_with_token(11, Some(stream), vec![0; 200].into(), None);
+        tracker.drop_stream(stream);
+
+        let (ack_info, _) = tracker.report_received_receipts(&[11]);
+        assert!(
+            ack_info.is_empty(),
+            "issue #4345: a late ACK for a dropped packet must be a no-op \
+             so the caller does not decrement flightsize a second time"
+        );
+    }
+
+    #[test]
+    fn test_issue_4345_drop_stream_skips_stale_resend_queue_entries() {
+        let mut tracker = mock_sent_packet_tracker();
+        let stream = StreamId::next();
+        tracker.report_sent_packet_with_token(21, Some(stream), vec![0; 100].into(), None);
+        tracker.drop_stream(stream);
+
+        // Stale ResendQueueEntry remains; get_resend must skip it (would otherwise
+        // surface as Abandon and double-release flightsize via the #4353 path).
+        tracker.time_source.advance(Duration::from_secs(10));
+        let action = tracker.get_resend();
+        assert!(
+            matches!(action, ResendAction::WaitUntil(_)),
+            "issue #4345: stale resend_queue entry for a dropped packet must be skipped, got {action:?}"
+        );
     }
 
     #[rstest]
@@ -615,7 +786,10 @@ pub(in crate::transport) mod tests {
         // Packets now use effective_rto() which is 1s initially (not MESSAGE_CONFIRMATION_TIMEOUT)
         tracker.time_source.advance(tracker.effective_rto());
         let resend_action = tracker.get_resend();
-        assert_eq!(resend_action, ResendAction::Resend(1, vec![1, 2, 3].into()));
+        assert_eq!(
+            resend_action,
+            ResendAction::Resend(1, vec![1, 2, 3].into(), None)
+        );
         assert_eq!(tracker.pending_receipts.len(), 0);
         assert_eq!(tracker.resend_queue.len(), 0);
         assert_eq!(tracker.packet_loss_proportion, PACKET_LOSS_DECAY_FACTOR);
@@ -651,10 +825,10 @@ pub(in crate::transport) mod tests {
 
         // This should now trigger a TLP probe for packet 2
         match tracker.get_resend() {
-            ResendAction::TlpProbe(packet_id, _) => {
+            ResendAction::TlpProbe(packet_id, _, _) => {
                 assert_eq!(packet_id, 2)
             }
-            ResendAction::Resend(_, _) => panic!("Expected TlpProbe, got Resend"),
+            ResendAction::Resend(_, _, _) => panic!("Expected TlpProbe, got Resend"),
             ResendAction::WaitUntil(_) => panic!("Expected TlpProbe, got WaitUntil"),
             ResendAction::Abandon { .. } => panic!("Expected TlpProbe, got Abandon"),
         }
@@ -823,7 +997,7 @@ pub(in crate::transport) mod tests {
 
         // Get resend action
         match tracker.get_resend() {
-            ResendAction::Resend(packet_id, _) | ResendAction::TlpProbe(packet_id, _) => {
+            ResendAction::Resend(packet_id, _, _) | ResendAction::TlpProbe(packet_id, _, _) => {
                 assert_eq!(packet_id, 1);
                 // Packet should be marked as retransmitted
                 assert!(tracker.retransmitted_packets.contains(&1));
@@ -1029,10 +1203,10 @@ pub(in crate::transport) mod tests {
 
         // Get resend - this should trigger backoff (RTO, not TLP since no RTT samples)
         match tracker.get_resend() {
-            ResendAction::Resend(packet_id, _) => {
+            ResendAction::Resend(packet_id, _, _) => {
                 assert_eq!(packet_id, 1);
             }
-            ResendAction::TlpProbe(_, _) => panic!("TLP shouldn't fire without RTT samples"),
+            ResendAction::TlpProbe(_, _, _) => panic!("TLP shouldn't fire without RTT samples"),
             _ => panic!("Expected Resend action"),
         }
 
@@ -1052,11 +1226,11 @@ pub(in crate::transport) mod tests {
         // First timeout after 1s, resend triggers backoff to 2
         tracker.time_source.advance(Duration::from_secs(1));
         match tracker.get_resend() {
-            ResendAction::Resend(_, payload) => {
+            ResendAction::Resend(_, payload, _) => {
                 // Re-register the packet - now enqueued with effective_rto() = 2s
                 tracker.report_sent_packet(1, payload);
             }
-            ResendAction::TlpProbe(_, _) => panic!("TLP shouldn't fire without RTT samples"),
+            ResendAction::TlpProbe(_, _, _) => panic!("TLP shouldn't fire without RTT samples"),
             _ => panic!("Expected Resend"),
         }
         assert_eq!(tracker.rto_backoff(), 2);
@@ -1065,11 +1239,11 @@ pub(in crate::transport) mod tests {
         // Second timeout after 2s (not 1s!), resend triggers backoff to 4
         tracker.time_source.advance(Duration::from_secs(2));
         match tracker.get_resend() {
-            ResendAction::Resend(_, payload) => {
+            ResendAction::Resend(_, payload, _) => {
                 // Re-register - now enqueued with effective_rto() = 4s
                 tracker.report_sent_packet(1, payload);
             }
-            ResendAction::TlpProbe(_, _) => panic!("TLP shouldn't fire without RTT samples"),
+            ResendAction::TlpProbe(_, _, _) => panic!("TLP shouldn't fire without RTT samples"),
             _ => panic!("Expected Resend"),
         }
         assert_eq!(tracker.rto_backoff(), 4);
@@ -1078,8 +1252,8 @@ pub(in crate::transport) mod tests {
         // Third timeout after 4s (not 1s or 2s!), resend triggers backoff to 8
         tracker.time_source.advance(Duration::from_secs(4));
         match tracker.get_resend() {
-            ResendAction::Resend(_, _) => {}
-            ResendAction::TlpProbe(_, _) => panic!("TLP shouldn't fire without RTT samples"),
+            ResendAction::Resend(_, _, _) => {}
+            ResendAction::TlpProbe(_, _, _) => panic!("TLP shouldn't fire without RTT samples"),
             _ => panic!("Expected Resend"),
         }
         assert_eq!(tracker.rto_backoff(), 8);
@@ -1202,8 +1376,8 @@ pub(in crate::transport) mod tests {
         // At 41ms total, TLP should fire (faster than 500ms RTO!)
         tracker.time_source.advance(Duration::from_millis(2));
         match tracker.get_resend() {
-            ResendAction::TlpProbe(id, _) => assert_eq!(id, 2, "TLP should probe packet 2"),
-            ResendAction::Resend(id, _) => {
+            ResendAction::TlpProbe(id, _, _) => assert_eq!(id, 2, "TLP should probe packet 2"),
+            ResendAction::Resend(id, _, _) => {
                 assert_eq!(id, 2, "Or Resend if TLP not yet implemented")
             }
             ResendAction::WaitUntil(_) => panic!("Should have triggered TLP after 40ms"),
@@ -1226,19 +1400,19 @@ pub(in crate::transport) mod tests {
         tracker.time_source.advance(Duration::from_millis(999));
         match tracker.get_resend() {
             ResendAction::WaitUntil(_) => {} // Expected
-            ResendAction::TlpProbe(_, _) => panic!("TLP shouldn't fire without RTT samples"),
-            ResendAction::Resend(_, _) => panic!("Should not resend before RTO expires"),
+            ResendAction::TlpProbe(_, _, _) => panic!("TLP shouldn't fire without RTT samples"),
+            ResendAction::Resend(_, _, _) => panic!("Should not resend before RTO expires"),
             ResendAction::Abandon { .. } => panic!("unexpected Abandon"),
         }
 
         // Advance 1 more ms to trigger timeout
         tracker.time_source.advance(Duration::from_millis(1));
         let payload = match tracker.get_resend() {
-            ResendAction::Resend(id, payload) => {
+            ResendAction::Resend(id, payload, _) => {
                 assert_eq!(id, 1);
                 payload
             }
-            ResendAction::TlpProbe(_, _) => panic!("TLP shouldn't fire without RTT samples"),
+            ResendAction::TlpProbe(_, _, _) => panic!("TLP shouldn't fire without RTT samples"),
             _ => panic!("Expected Resend after 1s"),
         };
 
@@ -1250,19 +1424,19 @@ pub(in crate::transport) mod tests {
         tracker.time_source.advance(Duration::from_millis(1999));
         match tracker.get_resend() {
             ResendAction::WaitUntil(_) => {} // Expected
-            ResendAction::TlpProbe(_, _) => panic!("TLP shouldn't fire without RTT samples"),
-            ResendAction::Resend(_, _) => panic!("Should not resend before backed-off RTO (2s)"),
+            ResendAction::TlpProbe(_, _, _) => panic!("TLP shouldn't fire without RTT samples"),
+            ResendAction::Resend(_, _, _) => panic!("Should not resend before backed-off RTO (2s)"),
             ResendAction::Abandon { .. } => panic!("unexpected Abandon"),
         }
 
         // Advance 1 more ms to trigger timeout
         tracker.time_source.advance(Duration::from_millis(1));
         let payload = match tracker.get_resend() {
-            ResendAction::Resend(id, payload) => {
+            ResendAction::Resend(id, payload, _) => {
                 assert_eq!(id, 1);
                 payload
             }
-            ResendAction::TlpProbe(_, _) => panic!("TLP shouldn't fire without RTT samples"),
+            ResendAction::TlpProbe(_, _, _) => panic!("TLP shouldn't fire without RTT samples"),
             _ => panic!("Expected Resend after 2s"),
         };
 
@@ -1274,16 +1448,16 @@ pub(in crate::transport) mod tests {
         tracker.time_source.advance(Duration::from_millis(3999));
         match tracker.get_resend() {
             ResendAction::WaitUntil(_) => {} // Expected
-            ResendAction::TlpProbe(_, _) => panic!("TLP shouldn't fire without RTT samples"),
-            ResendAction::Resend(_, _) => panic!("Should not resend before backed-off RTO (4s)"),
+            ResendAction::TlpProbe(_, _, _) => panic!("TLP shouldn't fire without RTT samples"),
+            ResendAction::Resend(_, _, _) => panic!("Should not resend before backed-off RTO (4s)"),
             ResendAction::Abandon { .. } => panic!("unexpected Abandon"),
         }
 
         // Advance 1 more ms to trigger timeout
         tracker.time_source.advance(Duration::from_millis(1));
         match tracker.get_resend() {
-            ResendAction::Resend(id, _) => assert_eq!(id, 1),
-            ResendAction::TlpProbe(_, _) => panic!("TLP shouldn't fire without RTT samples"),
+            ResendAction::Resend(id, _, None) => assert_eq!(id, 1),
+            ResendAction::TlpProbe(_, _, _) => panic!("TLP shouldn't fire without RTT samples"),
             _ => panic!("Expected Resend after 4s"),
         }
 
@@ -1332,8 +1506,8 @@ pub(in crate::transport) mod tests {
         // At 101ms, TLP should fire (not full RTO)
         tracker.time_source.advance(Duration::from_millis(2));
         match tracker.get_resend() {
-            ResendAction::TlpProbe(id, _) => assert_eq!(id, 2, "TLP should probe packet 2"),
-            ResendAction::Resend(_, _) => panic!("Should be TLP probe, not full RTO resend"),
+            ResendAction::TlpProbe(id, _, _) => assert_eq!(id, 2, "TLP should probe packet 2"),
+            ResendAction::Resend(_, _, _) => panic!("Should be TLP probe, not full RTO resend"),
             ResendAction::WaitUntil(_) => panic!("TLP should have fired at 2*SRTT"),
             ResendAction::Abandon { .. } => panic!("unexpected Abandon"),
         }
@@ -1355,7 +1529,7 @@ pub(in crate::transport) mod tests {
         tracker.time_source.advance(Duration::from_millis(101)); // Past PTO = 100ms
 
         match tracker.get_resend() {
-            ResendAction::TlpProbe(_, _) => {}
+            ResendAction::TlpProbe(_, _, _) => {}
             ResendAction::WaitUntil(_)
             | ResendAction::Resend(..)
             | ResendAction::Abandon { .. } => panic!("Expected TLP probe"),
@@ -1382,7 +1556,7 @@ pub(in crate::transport) mod tests {
         // TLP fires at ~100ms
         tracker.time_source.advance(Duration::from_millis(101));
         let payload = match tracker.get_resend() {
-            ResendAction::TlpProbe(id, payload) => {
+            ResendAction::TlpProbe(id, payload, _) => {
                 assert_eq!(id, 2);
                 payload
             }
@@ -1408,8 +1582,10 @@ pub(in crate::transport) mod tests {
 
         tracker.time_source.advance(Duration::from_millis(2));
         match tracker.get_resend() {
-            ResendAction::Resend(id, _) => assert_eq!(id, 2, "RTO should fire after TLP failed"),
-            ResendAction::TlpProbe(_, _) => panic!("Should be RTO, not another TLP"),
+            ResendAction::Resend(id, _, None) => {
+                assert_eq!(id, 2, "RTO should fire after TLP failed")
+            }
+            ResendAction::TlpProbe(_, _, _) => panic!("Should be RTO, not another TLP"),
             _ => panic!("RTO should have fired"),
         }
 
@@ -1438,8 +1614,8 @@ pub(in crate::transport) mod tests {
         // Now get_resend should just wait, not fire TLP
         match tracker.get_resend() {
             ResendAction::WaitUntil(_) => {} // Good - no pending packets
-            ResendAction::TlpProbe(_, _) => panic!("TLP should be cancelled by ACK"),
-            ResendAction::Resend(_, _) => panic!("No resend needed, packet was ACKed"),
+            ResendAction::TlpProbe(_, _, _) => panic!("TLP should be cancelled by ACK"),
+            ResendAction::Resend(_, _, _) => panic!("No resend needed, packet was ACKed"),
             ResendAction::Abandon { .. } => panic!("unexpected Abandon"),
         }
     }
@@ -1471,7 +1647,7 @@ pub(in crate::transport) mod tests {
         // At 11ms, TLP should fire
         tracker.time_source.advance(Duration::from_millis(2));
         match tracker.get_resend() {
-            ResendAction::TlpProbe(id, _) => assert_eq!(id, 2),
+            ResendAction::TlpProbe(id, _, _) => assert_eq!(id, 2),
             ResendAction::WaitUntil(_)
             | ResendAction::Resend(..)
             | ResendAction::Abandon { .. } => {
@@ -1493,16 +1669,16 @@ pub(in crate::transport) mod tests {
         tracker.time_source.advance(Duration::from_millis(500));
         match tracker.get_resend() {
             ResendAction::WaitUntil(_) => {}
-            ResendAction::TlpProbe(_, _) => panic!("TLP should not fire without RTT samples"),
-            ResendAction::Resend(_, _) => panic!("RTO is 1s, should not fire at 500ms"),
+            ResendAction::TlpProbe(_, _, _) => panic!("TLP should not fire without RTT samples"),
+            ResendAction::Resend(_, _, _) => panic!("RTO is 1s, should not fire at 500ms"),
             ResendAction::Abandon { .. } => panic!("unexpected Abandon"),
         }
 
         // At 1001ms, RTO fires (no TLP)
         tracker.time_source.advance(Duration::from_millis(501));
         match tracker.get_resend() {
-            ResendAction::Resend(id, _) => assert_eq!(id, 1),
-            ResendAction::TlpProbe(_, _) => panic!("Should be RTO, not TLP"),
+            ResendAction::Resend(id, _, None) => assert_eq!(id, 1),
+            ResendAction::TlpProbe(_, _, _) => panic!("Should be RTO, not TLP"),
             _ => panic!("RTO should fire at 1s"),
         }
     }
@@ -1524,7 +1700,7 @@ pub(in crate::transport) mod tests {
         // TLP fires once for the tail (last packet)
         tracker.time_source.advance(Duration::from_millis(101));
         match tracker.get_resend() {
-            ResendAction::TlpProbe(id, _) => {
+            ResendAction::TlpProbe(id, _, _) => {
                 // Should probe the oldest unacked packet
                 assert_eq!(id, 2, "TLP should probe oldest unacked packet");
             }
@@ -1552,7 +1728,7 @@ pub(in crate::transport) mod tests {
             // Jump past the (backed-off) RTO deadline.
             tracker.time_source.advance(Duration::from_secs(120));
             match tracker.get_resend() {
-                ResendAction::Resend(id, packet) => {
+                ResendAction::Resend(id, packet, _) => {
                     assert_eq!(id, 1);
                     // Re-register exactly as the production recv loop does.
                     tracker.report_sent_packet(id, packet);
@@ -1608,7 +1784,7 @@ pub(in crate::transport) mod tests {
         for _ in 0..(MAX_PACKET_RETRANSMITS - 2) {
             tracker.time_source.advance(Duration::from_secs(120));
             match tracker.get_resend() {
-                ResendAction::Resend(id, packet) => tracker.report_sent_packet(id, packet),
+                ResendAction::Resend(id, packet, _) => tracker.report_sent_packet(id, packet),
                 other => panic!("expected Resend, got {other:?}"),
             }
         }
@@ -1640,7 +1816,7 @@ pub(in crate::transport) mod tests {
         for cycle in 0..(MAX_PACKET_RETRANSMITS as usize * 5) {
             tracker.time_source.advance(Duration::from_secs(120));
             match tracker.get_resend() {
-                ResendAction::Resend(rid, packet) => {
+                ResendAction::Resend(rid, packet, _) => {
                     tracker.report_sent_packet(rid, packet);
                     // Every (MAX-1) retransmits, an ACK lands for this packet,
                     // resetting its count — then we "send" a fresh packet id so
@@ -1657,7 +1833,7 @@ pub(in crate::transport) mod tests {
                          cycle {cycle} — ACKs before the limit must keep it alive"
                     );
                 }
-                ResendAction::TlpProbe(_, _) | ResendAction::WaitUntil(_) => {}
+                ResendAction::TlpProbe(_, _, _) | ResendAction::WaitUntil(_) => {}
             }
         }
     }
@@ -1677,13 +1853,13 @@ pub(in crate::transport) mod tests {
         for _ in 0..1000 {
             tracker.time_source.advance(Duration::from_secs(120));
             match tracker.get_resend() {
-                ResendAction::Resend(id, packet) => tracker.report_sent_packet(id, packet),
+                ResendAction::Resend(id, packet, _) => tracker.report_sent_packet(id, packet),
                 ResendAction::Abandon { packet_id, .. } => {
                     assert_eq!(packet_id, 7);
                     abandoned = true;
                     break;
                 }
-                ResendAction::TlpProbe(_, _) | ResendAction::WaitUntil(_) => {}
+                ResendAction::TlpProbe(_, _, _) | ResendAction::WaitUntil(_) => {}
             }
         }
         assert!(abandoned, "packet should have been abandoned");


### PR DESCRIPTION
## Problem

#4353 capped per-packet retransmissions at 12 so never-ACKed packets eventually release their flight-size bytes via `ResendAction::Abandon`. #4374 turned stream-level aborts into the stream-scoped `OutboundStreamFailed` so they no longer tear down the whole connection. #4367 gave the GET driver a retry loop so a single assembly failure does not burn the operation.

What remains: abandonment is slower than the abort. `CWND_WAIT_TIMEOUT` is 3 s; the per-packet abandon path needs ≥6 s (12 × 500 ms `MIN_RTO` floor). During that gap the aborted stream's bytes stay pinned in `flightsize`, and any other operation multiplexed onto the same connection — a concurrent GET, a follow-up SUBSCRIBE, an op the router routes through the same peer — inherits the wedge and dies the same way. The user-reported "Rejecting SUBSCRIBE: contract WASM not cached locally" cascade is exactly this: the multi-fragment GET wedged the connection; the follow-up SUBSCRIBE arrived inside the 3–6 s window and inherited it.

The fix has to release flight-size at abort time, atomically with removing the dying stream's packets from the tracker — otherwise late ACKs or the abandon path double-decrement and silently under-count live streams (per sanity's design constraint on the issue, 2026-06-08).

## Solution

Tag each entry in `SentPacketTracker::pending_receipts` with `Option<StreamId>`. `Some(id)` for `StreamFragment` payloads, `None` for handshake / `ShortMessage` / `NoOp` / `Ping` / `Pong` so they are invisible to the new sweep. Extraction happens in one place — `extract_stream_id_from_payload` called from `packet_sending` — and the tag rides on `ResendAction::Resend` / `TlpProbe` so retransmissions re-register without losing it.

New `SentPacketTracker::drop_stream(id) -> usize` sweeps every entry tagged with `id` out of `pending_receipts`, `retransmit_counts`, `retransmitted_packets`, and `tlp_sent_packets`, and returns the byte total. It does NOT touch flight size — the caller passes the returned count to `CongestionControl::release_flightsize(bytes)`. The split is what prevents double-decrement: once a packet leaves the tracker, any later ACK or per-packet abandon finds nothing and becomes a no-op, so each packet contributes exactly once to flight-size accounting.

A `drain_stream_from_tracker` helper in `outbound_stream.rs` does drop + release in one call. Six stream-terminating early returns invoke it: cwnd-wait in `send_stream` and `pipe_stream`, the two `packet_sending` send-failure returns in both, plus `pipe_stream`'s inactivity-stall and inbound-error arms. The two send-failure sites drain even though the failing packet itself never registered — earlier fragments of the same stream are already in flight and must not bleed into the next attempt.

`PendingReceiptEntry` becomes a struct (was a positional tuple) so future per-packet metadata can be added additively — destructuring matches use `..` to ignore unused fields. `.claude/rules/transport.md` documents the new invariant alongside the #4353 release path.

## Testing

Four `drop_stream` unit tests in `sent_packet_tracker.rs` pin the contract: filtering by `stream_id` (other streams and untagged entries survive), per-packet auxiliary state cleared, late ACK after drop is a no-op (the anti-double-decrement guarantee), stale `resend_queue` entries no longer surface as `Resend`/`Abandon`. `extract_stream_id_from_payload`'s test pins the exhaustive match so adding a new `SymmetricMessagePayload` variant fails compilation rather than silently defaulting to untagged.

`cwnd_wait_abort_drains_tracker_and_unwedges_connection` in `outbound_stream.rs` runs the real `send_stream` with a pre-seeded wedge (`cwnd = 1`, tracker pre-loaded with 3000 bytes), asserts that after the abort the tracker and `flightsize` are both at 0, and registers a fresh stream B's packet to prove the connection accepts new work. Temporarily reverting `drain_stream_from_tracker` to a no-op makes this test fail with `tracker still contains 2 packets`; restoring it returns to green.

Existing E2E coverage (`test_streaming_with_packet_loss`, `test_streaming_get_1mb_with_packet_loss`, `test_streaming_get_retries_after_assembly_failure`) passes on this branch. No new E2E test: a deterministic reproduction of the concurrent-ops-on-shared-connection scenario needs fault-injection infrastructure that does not yet exist. Per the validation pattern from #4353, the empirical signal post-merge is the OTLP `transfer_failed` rate with cause `cwnd wait timeout` (currently ~91% of all transfer failures on the nova gateway).

## Fixes

Closes #4345.