### PR TITLE
test: lock transport send-failure resilience and backoff cap

### DIFF
--- a/crates/core/src/ring/peer_connection_backoff.rs
+++ b/crates/core/src/ring/peer_connection_backoff.rs
@@ -38,8 +38,9 @@ impl PeerConnectionBackoff {
 
     /// Default maximum backoff interval (90 seconds).
     ///
-    /// With 30s base and exponential growth (30s → 60s → 90s), persistent failures
-    /// cap quickly at 90s.  The previous 600s cap was appropriate for random ring
+    /// With 30s base and exponential growth (30s → 60s → 120s clamped to the
+    /// 90s cap), persistent failures cap quickly at 90s by the third failure.
+    /// The previous 600s cap was appropriate for random ring
     /// peers but far too aggressive for configured gateways: a single gateway in a
     /// 10-minute backoff means the node cannot bootstrap at all.  NAT traversal
     /// failures are transient (network change, temporary congestion) so a 90s cap
@@ -169,6 +170,61 @@ mod tests {
             remaining <= Duration::from_secs(108),
             "Gateway backoff exceeded 90s cap + jitter: {remaining:?} — issue #3304"
         );
+    }
+
+    /// Regression guard for issue #3329 / #3304: the gateway backoff
+    /// progression must escalate at most to the 90s cap and NEVER reach the
+    /// old 600s (10-minute) blackout, no matter how many consecutive failures
+    /// accrue.
+    ///
+    /// The production incident was a single configured gateway whose repeated
+    /// NAT-traversal failures pushed the per-address backoff to 600s, isolating
+    /// the node for ten minutes.  Here we drive the *deterministic* delay
+    /// calculator (`delay_for_failures`, which applies no jitter) straight off
+    /// the production defaults so the assertion pins the exact cap rather than
+    /// a jittered upper bound.
+    ///
+    /// The config is built env-independently via `with_config` from the
+    /// production `DEFAULT_*` constants — NOT `new()`, which reads
+    /// `FREENET_BACKOFF_BASE_SECS` and would yield a CI-overridden base (CI
+    /// sets it to 5s on the workspace test step). The asserted progression and
+    /// cap are derived from those same constants so the test tracks the
+    /// source-of-truth rather than drifting literals.
+    #[test]
+    fn test_gateway_backoff_progression_caps_at_90s_never_600s() {
+        let backoff = PeerConnectionBackoff::with_config(
+            PeerConnectionBackoff::DEFAULT_BASE_INTERVAL,
+            PeerConnectionBackoff::DEFAULT_MAX_BACKOFF,
+            PeerConnectionBackoff::DEFAULT_MAX_ENTRIES,
+        );
+        let config = backoff.inner.config();
+        let base = PeerConnectionBackoff::DEFAULT_BASE_INTERVAL;
+        let cap = PeerConnectionBackoff::DEFAULT_MAX_BACKOFF;
+
+        // Production defaults give 30s base, 90s cap, so the deterministic
+        // progression is base → base*2 → base*2^2 clamped to the cap:
+        // 30s → 60s → 120s-clamped-to-90s.
+        assert_eq!(config.max(), cap);
+        assert_eq!(config.delay_for_failures(1), base);
+        assert_eq!(config.delay_for_failures(2), base * 2);
+        assert_eq!(config.delay_for_failures(3), cap);
+
+        // From the 3rd failure onward the delay is pinned at the cap and never
+        // escalates — even a pathological 50-failure streak stays at the cap
+        // and never approaches the old 600s blackout. The explicit
+        // `< 600s` guard is the named #3329/#3304 tripwire: 600 is the
+        // intentional historical literal the cap regression must never reach.
+        for failures in 3..=50 {
+            let delay = config.delay_for_failures(failures);
+            assert_eq!(
+                delay, cap,
+                "backoff escalated past the {cap:?} cap at {failures} failures — issue #3329"
+            );
+            assert!(
+                delay < Duration::from_secs(600),
+                "backoff reached the old 600s blackout at {failures} failures — issue #3329"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -2548,6 +2548,137 @@ mod tests {
         });
     }
 
+    /// Regression guard for issue #3318/#3321 at the `packet_sending` layer:
+    /// a transient send failure must map to a recoverable, transient error and
+    /// must not leave the send path in a poisoned state.
+    ///
+    /// The production incident saw a brief ENETUNREACH blip tear down all 11
+    /// ring connections in under two seconds because every failed
+    /// `socket.send_to()` surfaced as `ConnectionClosed`.  This drives the
+    /// exact same `packet_sending` path through a transient failure and then
+    /// asserts that, once the blip clears, the *same* socket and key send
+    /// successfully again.
+    ///
+    /// Scope note: `packet_sending` is a stateless free function, so this locks
+    /// only its error-mapping (blip → transient, not `ConnectionClosed`) and
+    /// its statelessness/recoverability — a failed datagram leaves nothing
+    /// behind that blocks the next send on the same socket+key. It does NOT
+    /// exercise connection teardown: the decision to keep or drop the
+    /// connection lives in the callers that consume this error
+    /// (`is_transient_send_failure` dispatch sites), which this free function
+    /// does not drive. That residual caller-level gap is the #3321 follow-up.
+    #[test]
+    fn transient_send_failure_then_recovery_succeeds() {
+        let fail_flag = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let (tx, mut rx) = mpsc::channel(16);
+        let socket = Arc::new(FailableTestSocket::new(tx, fail_flag.clone()));
+        let remote_addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let outbound_key = {
+                use aes_gcm::KeyInit;
+                Aes128Gcm::new(&[0u8; 16].into())
+            };
+            let sent_tracker = Arc::new(parking_lot::Mutex::new(
+                crate::transport::sent_packet_tracker::tests::mock_sent_packet_tracker(),
+            ));
+
+            // ---- blip: send fails transiently ----
+            let err = packet_sending(
+                remote_addr,
+                &socket,
+                1,
+                &outbound_key,
+                vec![],
+                (),
+                &sent_tracker,
+                None,
+                PacketStream::Control,
+            )
+            .await
+            .expect_err("send during blip should fail");
+            assert!(
+                err.is_transient_send_failure(),
+                "blip must surface as a transient failure callers can swallow, got: {err:?}"
+            );
+            assert!(
+                !matches!(err, TransportError::ConnectionClosed(_)),
+                "a single failed datagram must NOT report the connection closed — issue #3321"
+            );
+
+            // ---- blip clears: the same socket + key recover ----
+            fail_flag.store(false, std::sync::atomic::Ordering::Relaxed);
+            packet_sending(
+                remote_addr,
+                &socket,
+                2,
+                &outbound_key,
+                vec![],
+                (),
+                &sent_tracker,
+                None,
+                PacketStream::Control,
+            )
+            .await
+            .expect("send after the blip clears must succeed on the same connection");
+
+            let (target, _) = rx.recv().await.expect("recovered packet must be sent");
+            assert_eq!(
+                target, remote_addr,
+                "recovered packet must go to the same peer"
+            );
+        });
+    }
+
+    /// All transient send error kinds observed in production (the ENETUNREACH
+    /// family and friends) must classify as transient so the p2p error
+    /// handlers swallow them instead of closing the connection.  This locks
+    /// the `is_transient_send_failure` contract the #3321 fix relies on.
+    ///
+    /// Classification is deliberately kind-agnostic: `is_transient_send_failure`
+    /// matches `SendFailed(..)` on the *variant*, not the inner `ErrorKind`, so
+    /// every send error is connection-local regardless of errno. The loop below
+    /// therefore pins "every `SendFailed` is transient"; the explicit negative
+    /// assertion on a non-`SendFailed` variant pins the *boundary* — a genuine
+    /// `ConnectionClosed` must NOT be swallowed as transient — so the test
+    /// nails down both sides of the predicate rather than only the true case.
+    #[test]
+    fn send_failed_kinds_classify_as_transient() {
+        use std::io::ErrorKind;
+        let remote_addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
+        for kind in [
+            ErrorKind::NetworkUnreachable,
+            ErrorKind::HostUnreachable,
+            ErrorKind::ConnectionReset,
+            ErrorKind::WouldBlock,
+            ErrorKind::TimedOut,
+        ] {
+            let err = TransportError::SendFailed(remote_addr, kind);
+            assert!(
+                err.is_transient_send_failure(),
+                "SendFailed({kind:?}) must be transient so the connection survives — issue #3321"
+            );
+        }
+
+        // Boundary: a real connection-teardown error must NOT be classified as
+        // a transient send blip, otherwise the swallow path would mask genuine
+        // closures. `ConnectionClosed` and `ChannelClosed` are the canonical
+        // non-transient variants.
+        assert!(
+            !TransportError::ConnectionClosed(remote_addr).is_transient_send_failure(),
+            "ConnectionClosed must NOT be swallowed as a transient send failure — issue #3321"
+        );
+        assert!(
+            !TransportError::ChannelClosed.is_transient_send_failure(),
+            "ChannelClosed must NOT be swallowed as a transient send failure — issue #3321"
+        );
+    }
+
     /// Phase 1.6 (#4074): the hot-path instrumentation must feed the
     /// classified byte counters, and only on a successful send. A
     /// `ShortMessage` advances `short`, a `StreamFragment` advances `bulk`,


### PR DESCRIPTION
## Problem

Two transport resilience behaviors had no unit coverage (Gap 3 of #3367): a single transient
send failure must not tear down the connection (the bug behind #3321, where one UDP send failure
killed all 11 connections), and gateway connection backoff must stay capped (the bug behind
#3329/#3304, where backoff escalated to a ~10-minute blackout).

## Solution

Add pure unit tests (no real network; <1 s):

- **Send-failure classification** — drives the real `packet_sending` path through a transient
  blip via the existing `FailableTestSocket` (Socket-trait seam), asserts the error maps to a
  transient kind (not `ConnectionClosed`), and that the same socket+key succeeds once the blip
  clears. A negative assertion pins the boundary (`ConnectionClosed`/`ChannelClosed` are **not**
  transient); classification is deliberately variant-based, not `ErrorKind`-based.
- **Backoff cap** — asserts the 30 s → 60 s → (120 s clamped to) **90 s** progression off the
  production constants and that even a 50-failure streak stays pinned at the 90 s cap, never
  reaching the historical 600 s blackout (kept as a named #3329/#3304 tripwire).

The backoff test builds its config **env-independently** (`with_config(DEFAULT_*)`) rather than
via `new()`, which honors `FREENET_BACKOFF_BASE_SECS` — a var this repo's CI exports as `5`, which
would otherwise make the test fail in CI.

## Testing

- `cargo test -p freenet --lib` send-path + backoff tests pass, **including under
  `FREENET_BACKOFF_BASE_SECS=5`** (the CI condition).
- `cargo clippy -p freenet --lib --tests -- -D warnings` clean.

Residual: the caller-level #3321 teardown decision (callers that branch on
`is_transient_send_failure`) is noted as a follow-up; this PR locks the classification + the cap.

## Fixes

Refs #3367 (Gap 3: transport resilience)
