### PR TITLE
fix: release redb lock and stop detached executor/WS server on shutdown

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -147,6 +147,9 @@ freenet-macros = { path = "../freenet-macros" }
 httptest = { workspace = true }
 libc = { workspace = true }  # For sendmmsg syscall batching benchmarks
 parking_lot = { workspace = true, features = ["deadlock_detection"] }
+# Used by tests/in_process_restart.rs to directly probe the redb file lock as a
+# negative control (issue #4401).
+redb = { workspace = true }
 rstest = { workspace = true }
 statrs = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -452,6 +452,15 @@ impl std::ops::Deref for WebSocketRequest {
 pub struct WebSocketProxy {
     proxy_server_request: mpsc::Receiver<ClientConnection>,
     response_channels: HashMap<ClientId, mpsc::UnboundedSender<HostCallbackResult>>,
+    /// Abort guard for the detached `axum::serve` server task(s) and the
+    /// token-cleanup loop spawned by `serve_client_api_in_impl`. Held here so
+    /// that when the node tears down its client-events task (which owns this
+    /// proxy via the client combinator) those server tasks are aborted too,
+    /// freeing the bound ports on shutdown. See issue #4401.
+    ///
+    /// `None` for proxies created directly via `create_router*` in tests, where
+    /// no server task is spawned.
+    server_aborts: Option<crate::util::AbortOnDrop>,
 }
 
 /// Channel capacity for WebSocket client connections to the node event loop.
@@ -501,9 +510,17 @@ impl WebSocketProxy {
             WebSocketProxy {
                 proxy_server_request,
                 response_channels: HashMap::new(),
+                server_aborts: None,
             },
             router,
         )
+    }
+
+    /// Attach the abort guard for the detached server tasks so they are torn
+    /// down when this proxy is dropped (issue #4401).
+    pub(crate) fn with_server_aborts(mut self, aborts: crate::util::AbortOnDrop) -> Self {
+        self.server_aborts = Some(aborts);
+        self
     }
 
     /// Sets up a subscription notification channel and builds the `OpenRequest`.

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -42,17 +42,101 @@ pub(crate) struct NodeP2P {
     /// Abort handles for the detached client-events and contract-executor tasks.
     /// `run_node` selects on the tasks' result futures (which only *observe*
     /// completion); aborting via these handles on the way out is what actually
-    /// stops the tasks, dropping their `op_manager` clones, the client
-    /// combinator (and with it the WebSocket server), and the contract
-    /// executor's redb `Database` handle. Without this, those tasks keep
-    /// running — and holding the redb file lock — after a graceful shutdown.
-    /// See issue #4401.
+    /// stops the tasks, dropping their `op_manager` clones and the contract
+    /// executor's redb `Database` handle.
+    ///
+    /// Aborting the client-events task tears down the WebSocket server through a
+    /// load-bearing channel-close chain (NOT a direct drop): abort drops the
+    /// `ClientEventsCombinator` → drops the per-slot `Sender` it holds →
+    /// `client_fn`'s `rx.recv()` returns `None` → `client_fn` breaks its loop →
+    /// drops the `WebSocketProxy` → the proxy's `AbortOnDrop` fires, aborting the
+    /// detached `axum::serve` server + token-cleanup tasks. The "client_fn breaks
+    /// on rx close" step is the load-bearing link.
+    ///
+    /// Without these aborts, those tasks keep running — and holding the redb file
+    /// lock and the bound ports — after a graceful shutdown. See issue #4401.
     detached_task_aborts: Vec<tokio::task::AbortHandle>,
     initial_join_task: Option<JoinHandle<()>>,
     session_actor_task: JoinHandle<()>,
     result_router_task: JoinHandle<()>,
     /// Monitor for background tasks spawned during node construction (Ring, OpManager, etc.)
     background_task_monitor: BackgroundTaskMonitor,
+}
+
+/// Fires the node's shutdown teardown on *every* `run_node` exit path — both the
+/// normal post-event-loop return and any early `?`/return during setup (e.g. a
+/// failed initial join). Without a Drop-based guard the teardown only ran on the
+/// happy path, so an early return would leave the detached executor task running
+/// and the redb file lock held for the process lifetime (issue #4401).
+///
+/// On drop it:
+///   1. aborts the stored detached task handles (executor + client-events, plus
+///      the session-actor / result-router / initial-join / aggressive-connect
+///      tasks once they exist), and
+///   2. clears the ring's redb `Storage` clones via `clear_redb_storage()`.
+///
+/// ## Exhaustive redb `Arc<Database>` holder set (verified for #4401)
+///
+/// The redb file lock releases only once *all* of these drop. Aborting the
+/// executor task drops (1)+(2); `clear_redb_storage()` drops (3)+(4):
+///   1. `RuntimePool::shared_state_store` — the one shared `StateStore<Storage>`.
+///   2. Each `Executor<Runtime>` in the pool's `runtimes` Vec — every executor's
+///      contract/state/delegate/secret stores clone the same `Storage`.
+///      Both (1) and (2) live inside `NetworkContractHandler`, which is owned by
+///      the detached **contract-executor task** (`contract_executor_abort`).
+///   3. `ring.hosting_manager.storage`.
+///   4. `ring.broken_invariants.storage`.
+///
+/// The session-actor, result-router, client-events, and background-monitor tasks
+/// hold channels / in-memory maps only — verified to hold **no** `Storage` /
+/// `Arc<Database>` clone. If a future change moves a `Storage`/`Arc<Database>`
+/// clone into any other long-lived task, it MUST either be aborted here or its
+/// handle dropped on shutdown, or the lock will never release.
+struct ShutdownTeardown {
+    aborts: Vec<tokio::task::AbortHandle>,
+    ring: Arc<crate::ring::Ring>,
+    fired: bool,
+}
+
+impl ShutdownTeardown {
+    fn new(aborts: Vec<tokio::task::AbortHandle>, ring: Arc<crate::ring::Ring>) -> Self {
+        Self {
+            aborts,
+            ring,
+            fired: false,
+        }
+    }
+
+    /// Track an abort handle for a task spawned after the guard was created
+    /// (e.g. the initial-join and aggressive-connect tasks).
+    fn track(&mut self, handle: tokio::task::AbortHandle) {
+        self.aborts.push(handle);
+    }
+}
+
+impl Drop for ShutdownTeardown {
+    fn drop(&mut self) {
+        if self.fired {
+            return;
+        }
+        self.fired = true;
+        for abort in &self.aborts {
+            abort.abort();
+        }
+        // Drop the ring's clones of the redb `Storage` handle so the only
+        // remaining references live in the (now-aborted) executor task. These
+        // are the hosting-metadata and broken-invariants persistence handles
+        // wired in `NetworkContractHandler::build`.
+        //
+        // NOTE: lock release is ASYNCHRONOUS. `AbortHandle::abort()` only
+        // *signals* cancellation — the executor task's redb clones drop when the
+        // runtime next polls that task to completion, which can lag by any
+        // in-flight `block_in_place` WASM execution. So the OS file lock is not
+        // guaranteed free the instant `run_node` returns; a caller reopening the
+        // same data dir should tolerate a brief delay (the #4401 regression test
+        // polls up to 10s).
+        self.ring.clear_redb_storage();
+    }
 }
 
 impl NodeP2P {
@@ -131,6 +215,20 @@ impl NodeP2P {
     pub(super) async fn run_node(mut self) -> anyhow::Result<Infallible> {
         // Record the start time for uptime tracking in shutdown event
         let start_time = tokio::time::Instant::now();
+
+        // Install the shutdown teardown guard BEFORE any fallible setup so the
+        // detached executor/client-events tasks are aborted and the ring's redb
+        // `Storage` clones are dropped on EVERY exit path — including an early
+        // `?` return (e.g. a failed initial join). The session-actor and
+        // result-router abort handles are folded in too so those tasks don't
+        // leak on an early return; later-spawned tasks (initial-join,
+        // aggressive-connect) are added via `track`. See issue #4401.
+        let mut teardown = {
+            let mut aborts = std::mem::take(&mut self.detached_task_aborts);
+            aborts.push(self.session_actor_task.abort_handle());
+            aborts.push(self.result_router_task.abort_handle());
+            ShutdownTeardown::new(aborts, self.op_manager.ring.clone())
+        };
 
         // Initialize network status tracking for the connecting page diagnostics
         let gateway_addrs: std::collections::HashSet<std::net::SocketAddr> = self
@@ -217,18 +315,26 @@ impl NodeP2P {
             // connection phase concurrently with the event listener below.
         }
 
+        // The initial-join task (spawned above when connecting) outlives this
+        // setup phase too; fold its abort handle into the teardown guard so an
+        // early return below also stops it. The `JoinHandle` itself is detached
+        // (dropping it does not cancel the task) — the guard's abort handle is
+        // what tears it down.
+        if let Some(join_handle) = self.initial_join_task.take() {
+            teardown.track(join_handle.abort_handle());
+        }
+
         // Spawn aggressive connection task to run concurrently with event listener.
         // This is needed because connection handshakes are processed by the event
         // listener, so we can't block waiting for connections before it starts.
-        let aggressive_conn_task = if self.should_try_connect {
+        if self.should_try_connect {
             let op_manager = self.op_manager.clone();
             let min_connections = op_manager.ring.connection_manager.min_connections;
-            Some(GlobalExecutor::spawn(async move {
+            let aggressive_conn_task = GlobalExecutor::spawn(async move {
                 Self::aggressive_initial_connections_impl(&op_manager, min_connections).await;
-            }))
-        } else {
-            None
-        };
+            });
+            teardown.track(aggressive_conn_task.abort_handle());
+        }
 
         let f = self.conn_manager.run_event_listener(
             self.op_manager.clone(),
@@ -240,9 +346,9 @@ impl NodeP2P {
         // Monitor spawned infrastructure tasks (session actor, result router).
         // If any of these panics or exits unexpectedly, the node runs degraded with no
         // logs or detection. Combine into a single future that produces an error.
-        // Keep AbortHandles for cleanup since the JoinHandles are moved into the future.
-        let session_abort = self.session_actor_task.abort_handle();
-        let router_abort = self.result_router_task.abort_handle();
+        // Their abort handles already live in the teardown guard (folded in at
+        // the top of `run_node`), so the JoinHandles can be moved into the future
+        // here without losing the ability to cancel them on shutdown.
         let infra_monitor = {
             let mut session_handle = self.session_actor_task;
             let mut router_handle = self.result_router_task;
@@ -270,7 +376,6 @@ impl NodeP2P {
         // (Ring maintenance, garbage cleanup, etc.)
         let background_monitor = self.background_task_monitor.wait_for_any_exit();
 
-        let join_task = self.initial_join_task.take();
         let result = crate::deterministic_select! {
             r = f => {
                let Err(e) = r;
@@ -300,35 +405,26 @@ impl NodeP2P {
             },
         };
 
-        if let Some(handle) = join_task {
-            handle.abort();
-        }
-        if let Some(handle) = aggressive_conn_task {
-            handle.abort();
-        }
-        session_abort.abort();
-        router_abort.abort();
-
-        // Tear down the detached executor + client-events tasks (issue #4401).
+        // Tear down the detached executor + client-events tasks and clear the
+        // ring's redb `Storage` clones (issue #4401).
         //
         // `deterministic_select!` above only *observed* one of these futures
         // completing — the other detached tasks are still running on the
         // process-wide `GlobalExecutor`. Until they stop they keep their
-        // `op_manager` clones, the client combinator (and the WebSocket
-        // `axum::serve` server it owns), and the contract executor's redb
+        // `op_manager` clones, the `ClientEventsCombinator` (which, via the
+        // channel-close chain documented on `detached_task_aborts`, owns the
+        // WebSocket `axum::serve` server), and the contract executor's redb
         // `Database` handle alive — so a graceful shutdown would leave the
         // on-disk redb file locked and a stale WS server answering requests.
-        // Aborting them here, and clearing the ring's own redb references
-        // below, lets the file lock release once this node is dropped, which is
-        // what makes an in-process restart against the same data dir possible.
-        for abort in &self.detached_task_aborts {
-            abort.abort();
-        }
-        // Drop the ring's clones of the redb `Storage` handle so the only
-        // remaining references live in the (now-aborted) executor task. These
-        // are the hosting-metadata and broken-invariants persistence handles
-        // wired in `NetworkContractHandler::build`.
-        self.op_manager.ring.clear_redb_storage();
+        //
+        // The teardown now runs through `ShutdownTeardown::drop`, which also
+        // fires on any early `?`/return during setup above. Fire it explicitly
+        // here (idempotent) so the tasks are aborted and the redb `Storage`
+        // clones dropped BEFORE we emit the shutdown event below, preserving the
+        // original ordering on the happy path. Lock release is asynchronous (see
+        // the guard's docs): abort only signals, so the executor task's redb
+        // clones drop when the runtime next polls it to completion.
+        drop(teardown);
 
         // Emit peer shutdown event
         let (graceful, reason) = match &result {
@@ -556,8 +652,11 @@ impl NodeP2P {
             task.instrument(tracing::info_span!(parent: parent_span, "client_event_handling"))
         });
         // Retain the abort handle so shutdown can stop this task and drop the
-        // client combinator it owns — which in turn drops the WebSocket proxy
-        // and tears down the detached `axum::serve` server (issue #4401).
+        // `ClientEventsCombinator` it owns. That drops the combinator's per-slot
+        // `Sender`, which closes `client_fn`'s `rx`; `client_fn` then breaks its
+        // loop and drops the `WebSocketProxy`, whose `AbortOnDrop` tears down the
+        // detached `axum::serve` server + token-cleanup tasks (issue #4401). See
+        // `detached_task_aborts` for the full channel-close chain.
         let client_events_abort = client_events_handle.abort_handle();
         let client_events_task = client_events_handle
             .map(|r| match r {

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -39,6 +39,15 @@ pub(crate) struct NodeP2P {
     should_try_connect: bool,
     client_events_task: BoxFuture<'static, anyhow::Error>,
     contract_executor_task: BoxFuture<'static, anyhow::Error>,
+    /// Abort handles for the detached client-events and contract-executor tasks.
+    /// `run_node` selects on the tasks' result futures (which only *observe*
+    /// completion); aborting via these handles on the way out is what actually
+    /// stops the tasks, dropping their `op_manager` clones, the client
+    /// combinator (and with it the WebSocket server), and the contract
+    /// executor's redb `Database` handle. Without this, those tasks keep
+    /// running — and holding the redb file lock — after a graceful shutdown.
+    /// See issue #4401.
+    detached_task_aborts: Vec<tokio::task::AbortHandle>,
     initial_join_task: Option<JoinHandle<()>>,
     session_actor_task: JoinHandle<()>,
     result_router_task: JoinHandle<()>,
@@ -300,6 +309,27 @@ impl NodeP2P {
         session_abort.abort();
         router_abort.abort();
 
+        // Tear down the detached executor + client-events tasks (issue #4401).
+        //
+        // `deterministic_select!` above only *observed* one of these futures
+        // completing — the other detached tasks are still running on the
+        // process-wide `GlobalExecutor`. Until they stop they keep their
+        // `op_manager` clones, the client combinator (and the WebSocket
+        // `axum::serve` server it owns), and the contract executor's redb
+        // `Database` handle alive — so a graceful shutdown would leave the
+        // on-disk redb file locked and a stale WS server answering requests.
+        // Aborting them here, and clearing the ring's own redb references
+        // below, lets the file lock release once this node is dropped, which is
+        // what makes an in-process restart against the same data dir possible.
+        for abort in &self.detached_task_aborts {
+            abort.abort();
+        }
+        // Drop the ring's clones of the redb `Storage` handle so the only
+        // remaining references live in the (now-aborted) executor task. These
+        // are the hosting-metadata and broken-invariants persistence handles
+        // wired in `NetworkContractHandler::build`.
+        self.op_manager.ring.clear_redb_storage();
+
         // Emit peer shutdown event
         let (graceful, reason) = match &result {
             Ok(_) => (true, None),
@@ -475,7 +505,7 @@ impl NodeP2P {
             P2pConnManager::build(&config, op_manager.clone(), event_register).await?;
 
         let parent_span = tracing::Span::current();
-        let contract_executor_task = GlobalExecutor::spawn({
+        let contract_executor_handle = GlobalExecutor::spawn({
             let task = async move {
                 tracing::info!("Contract executor task starting");
                 let result = contract::contract_handling(
@@ -492,20 +522,24 @@ impl NodeP2P {
                 result
             };
             task.instrument(tracing::info_span!(parent: parent_span.clone(), "contract_handling"))
-        })
-        .map(|r| match r {
-            Ok(Err(e)) => anyhow::anyhow!("Error in contract handling task: {e}"),
-            Ok(Ok(_)) => anyhow::anyhow!("Contract handling task exited unexpectedly"),
-            Err(e) => anyhow::anyhow!(e),
-        })
-        .boxed();
+        });
+        // Retain the abort handle so shutdown can stop the executor task and
+        // drop its redb `Database` clone (issue #4401).
+        let contract_executor_abort = contract_executor_handle.abort_handle();
+        let contract_executor_task = contract_executor_handle
+            .map(|r| match r {
+                Ok(Err(e)) => anyhow::anyhow!("Error in contract handling task: {e}"),
+                Ok(Ok(_)) => anyhow::anyhow!("Contract handling task exited unexpectedly"),
+                Err(e) => anyhow::anyhow!(e),
+            })
+            .boxed();
         // Slot 0 = HTTP client API, Slot 1 = WebSocket proxy (from serve_client_api).
         let clients = ClientEventsCombinator::new(clients).with_slot_names(&["http", "websocket"]);
         // Create node controller channel with capacity for shutdown signal
         // We clone the sender to return it for external shutdown triggering
         let (node_controller_tx, node_controller_rx) = tokio::sync::mpsc::channel(1);
         let shutdown_tx = node_controller_tx.clone();
-        let client_events_task = GlobalExecutor::spawn({
+        let client_events_handle = GlobalExecutor::spawn({
             let op_manager_clone = op_manager.clone();
             let task = async move {
                 tracing::info!("Client events task starting");
@@ -520,12 +554,17 @@ impl NodeP2P {
                 result
             };
             task.instrument(tracing::info_span!(parent: parent_span, "client_event_handling"))
-        })
-        .map(|r| match r {
-            Ok(_) => anyhow::anyhow!("Client event handling task exited unexpectedly"),
-            Err(e) => anyhow::anyhow!(e),
-        })
-        .boxed();
+        });
+        // Retain the abort handle so shutdown can stop this task and drop the
+        // client combinator it owns — which in turn drops the WebSocket proxy
+        // and tears down the detached `axum::serve` server (issue #4401).
+        let client_events_abort = client_events_handle.abort_handle();
+        let client_events_task = client_events_handle
+            .map(|r| match r {
+                Ok(_) => anyhow::anyhow!("Client event handling task exited unexpectedly"),
+                Err(e) => anyhow::anyhow!(e),
+            })
+            .boxed();
 
         Ok((
             NodeP2P {
@@ -540,6 +579,7 @@ impl NodeP2P {
                 location: config.location,
                 client_events_task,
                 contract_executor_task,
+                detached_task_aborts: vec![client_events_abort, contract_executor_abort],
                 initial_join_task: None,
                 session_actor_task,
                 result_router_task,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1638,6 +1638,16 @@ impl Ring {
         self.hosting_manager.set_storage(storage);
     }
 
+    /// Drop the ring's clones of the redb `Storage` handle (hosting metadata +
+    /// broken-invariants persistence). Called on node shutdown so the redb
+    /// `Database` Arc count can fall to zero and release the on-disk file lock
+    /// — otherwise an in-process restart against the same data dir deadlocks on
+    /// the still-held lock. See issue #4401.
+    pub(crate) fn clear_redb_storage(&self) {
+        self.hosting_manager.clear_storage();
+        self.broken_invariants.clear_storage();
+    }
+
     /// Load hosting cache from persisted storage.
     ///
     /// Call this during startup after storage is available to restore

--- a/crates/core/src/ring/broken_invariants.rs
+++ b/crates/core/src/ring/broken_invariants.rs
@@ -120,7 +120,12 @@ struct FlagEntry {
 /// in-memory only — this matches the pattern used by `HostingManager`.
 pub(crate) struct BrokenInvariantsTracker {
     flags: Arc<DashMap<ContractInstanceId, FlagEntry>>,
-    storage: std::sync::OnceLock<Storage>,
+    // `RwLock<Option<Storage>>` (mirroring `HostingManager`) rather than a
+    // `OnceLock` so the handle can be dropped on shutdown via `clear_storage`,
+    // releasing its redb `Database` clone (issue #4401). None of the readers
+    // are on a hot path: only `record`/`remove_from_storage`/`set_storage`
+    // touch the handle, all off the broadcast/commit fast path.
+    storage: parking_lot::RwLock<Option<Storage>>,
     time_source: Arc<dyn TimeSource + Send + Sync>,
 }
 
@@ -128,7 +133,7 @@ impl BrokenInvariantsTracker {
     pub fn new(time_source: Arc<dyn TimeSource + Send + Sync>) -> Self {
         Self {
             flags: Arc::new(DashMap::new()),
-            storage: std::sync::OnceLock::new(),
+            storage: parking_lot::RwLock::new(None),
             time_source,
         }
     }
@@ -186,7 +191,7 @@ impl BrokenInvariantsTracker {
             // `HostingManager` makes — see #4279 deferred follow-up to
             // add sqlite parity.
             #[cfg(feature = "redb")]
-            if let Some(storage) = self.storage.get() {
+            if let Some(storage) = self.storage.read().as_ref() {
                 if let Err(e) = storage.store_broken_invariant(&id, kind.to_byte()) {
                     tracing::warn!(
                         contract = %id,
@@ -260,7 +265,7 @@ impl BrokenInvariantsTracker {
     /// next restart.
     fn remove_from_storage(&self, id: &ContractInstanceId) {
         #[cfg(feature = "redb")]
-        if let Some(storage) = self.storage.get() {
+        if let Some(storage) = self.storage.read().as_ref() {
             if let Err(e) = storage.remove_broken_invariant(id) {
                 tracing::warn!(
                     contract = %id,
@@ -273,18 +278,21 @@ impl BrokenInvariantsTracker {
         let _ = id;
     }
 
-    /// Wire persistent storage. Called once at startup; idempotent on the
-    /// `OnceLock` so callers cannot accidentally re-init with a different
-    /// database. Hydrates the in-memory map from previously-persisted
-    /// entries on first wiring.
+    /// Wire persistent storage. Called once at startup; ignores re-init so
+    /// callers cannot accidentally swap in a different database. Hydrates the
+    /// in-memory map from previously-persisted entries on first wiring.
     ///
     /// Loaded flags are stamped with the current time, so a node restart
     /// gives each previously-flagged contract a fresh TTL window rather than
     /// inheriting an unknown (and un-persisted) original timestamp.
     pub fn set_storage(&self, storage: Storage) {
-        if self.storage.set(storage.clone()).is_err() {
-            tracing::warn!("BrokenInvariantsTracker storage already set; ignoring re-init");
-            return;
+        {
+            let mut slot = self.storage.write();
+            if slot.is_some() {
+                tracing::warn!("BrokenInvariantsTracker storage already set; ignoring re-init");
+                return;
+            }
+            *slot = Some(storage.clone());
         }
         #[cfg(feature = "redb")]
         match storage.load_all_broken_invariants() {
@@ -310,6 +318,14 @@ impl BrokenInvariantsTracker {
                 tracing::warn!(error = %e, "Failed to load broken-invariant flags from storage");
             }
         }
+    }
+
+    /// Drop the storage handle so its redb `Database` clone is released. Called
+    /// on node shutdown to help free the on-disk file lock (issue #4401). The
+    /// in-memory flags are left intact — only the persistence backing is
+    /// dropped, since the node is going away.
+    pub(crate) fn clear_storage(&self) {
+        *self.storage.write() = None;
     }
 }
 

--- a/crates/core/src/ring/broken_invariants.rs
+++ b/crates/core/src/ring/broken_invariants.rs
@@ -324,6 +324,12 @@ impl BrokenInvariantsTracker {
     /// on node shutdown to help free the on-disk file lock (issue #4401). The
     /// in-memory flags are left intact — only the persistence backing is
     /// dropped, since the node is going away.
+    ///
+    /// Runs on the shutdown thread (`run_node`'s teardown) while `record` /
+    /// `remove_from_storage` run on the detached executor task. The write lock
+    /// taken here may briefly wait on an in-flight redb write held by those
+    /// readers, but cannot deadlock: the `RwLock` is non-reentrant and the
+    /// writer/readers are distinct tasks.
     pub(crate) fn clear_storage(&self) {
         *self.storage.write() = None;
     }

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -363,6 +363,12 @@ impl HostingManager {
         *self.storage.write() = Some(storage);
     }
 
+    /// Drop the storage reference so its redb `Database` clone is released.
+    /// Called on node shutdown to help free the on-disk file lock (issue #4401).
+    pub(crate) fn clear_storage(&self) {
+        *self.storage.write() = None;
+    }
+
     // =========================================================================
     // Pending Reclamation Retry Queue
     // =========================================================================

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -134,7 +134,7 @@ async fn serve_with_listener(
     socket: SocketAddr,
     router: axum::Router,
     pre_bound: Option<std::net::TcpListener>,
-) -> std::io::Result<()> {
+) -> std::io::Result<tokio::task::AbortHandle> {
     let listener = match pre_bound {
         Some(std_listener) => {
             std_listener.set_nonblocking(true)?;
@@ -194,7 +194,11 @@ async fn serve_with_listener(
         }
     };
     tracing::info!("HTTP client API listening on {}", socket);
-    GlobalExecutor::spawn(async move {
+    // Retain the spawn's AbortHandle so the node can tear the server down on
+    // graceful shutdown (issue #4401). Dropping the JoinHandle alone does NOT
+    // abort the task, so without this the server keeps serving on the bound
+    // port after the node has shut down.
+    let handle = GlobalExecutor::spawn(async move {
         axum::serve(
             listener,
             router.into_make_service_with_connect_info::<SocketAddr>(),
@@ -204,7 +208,7 @@ async fn serve_with_listener(
             tracing::error!("Error while running HTTP client API server: {e}");
         })
     });
-    Ok(())
+    Ok(handle.abort_handle())
 }
 
 /// Returns `true` if the IP is a private/local address suitable for LAN access.
@@ -265,7 +269,19 @@ pub mod local_node {
         // this path also binds an IPv4+IPv6 companion pair for loopback/wildcard
         // addresses — keeping every client-API serve path reachable over both
         // families (#4330).
-        serve_dual_stack(socket, ws_router.layer(TraceLayer::new_for_http()), None).await?;
+        //
+        // `run_local_node` owns the server for the lifetime of the process (it
+        // loops forever below), so the abort guard is leaked deliberately: there
+        // is no graceful-shutdown hook on this path to hand it to.
+        let mut aborts = crate::util::AbortOnDrop::new();
+        serve_dual_stack(
+            socket,
+            ws_router.layer(TraceLayer::new_for_http()),
+            None,
+            &mut aborts,
+        )
+        .await?;
+        std::mem::forget(aborts);
 
         // TODO: use combinator instead
         // let mut all_clients =
@@ -578,15 +594,24 @@ async fn serve_client_api_in_impl(
 ) -> std::io::Result<(HttpClientApi, WebSocketProxy)> {
     let ws_socket = (config.address, config.port).into();
 
+    // Collects the AbortHandles of every detached task this function spawns
+    // (token cleanup + the `axum::serve` server socket(s)) so they are torn
+    // down when the returned `WebSocketProxy` is dropped. The proxy is one of
+    // the node's `BoxedClient`s, so aborting the node's client-events task on
+    // shutdown drops the proxy and, with it, these server tasks — releasing the
+    // bound ports instead of leaving a stale server answering requests meant
+    // for a restarted node. See issue #4401.
+    let mut server_aborts = crate::util::AbortOnDrop::new();
+
     // Create a shared origin_contracts map with token expiration support
     let origin_contracts: OriginContractMap = Arc::new(DashMap::new());
 
     // Spawn background task to clean up expired tokens
-    spawn_token_cleanup_task(
+    server_aborts.push(spawn_token_cleanup_task(
         origin_contracts.clone(),
         config.token_ttl_seconds,
         config.token_cleanup_interval_seconds,
-    );
+    ));
 
     // Pass the shared map to both the HTTP client API and WebSocketProxy
     let (gw, gw_router) = HttpClientApi::as_router_with_origin_contracts(
@@ -650,7 +675,11 @@ async fn serve_client_api_in_impl(
             .layer(TraceLayer::new_for_http())
     };
 
-    serve_dual_stack(ws_socket, router, pre_bound).await?;
+    serve_dual_stack(ws_socket, router, pre_bound, &mut server_aborts).await?;
+
+    // Hand ownership of the server tasks' abort guard to the proxy so they are
+    // torn down when the proxy is dropped on node shutdown (issue #4401).
+    let ws_proxy = ws_proxy.with_server_aborts(server_aborts);
     Ok((gw, ws_proxy))
 }
 
@@ -668,6 +697,7 @@ async fn serve_dual_stack(
     primary: SocketAddr,
     router: axum::Router,
     pre_bound: Option<std::net::TcpListener>,
+    aborts: &mut crate::util::AbortOnDrop,
 ) -> std::io::Result<()> {
     let companion = if pre_bound.is_none() {
         companion_bind_addr(primary.ip()).map(|ip| SocketAddr::from((ip, primary.port())))
@@ -676,20 +706,21 @@ async fn serve_dual_stack(
     };
     match companion {
         Some(companion) => {
-            serve_with_listener(primary, router.clone(), pre_bound).await?;
-            if let Err(e) = serve_with_listener(companion, router, None).await {
-                tracing::warn!(
+            aborts.push(serve_with_listener(primary, router.clone(), pre_bound).await?);
+            match serve_with_listener(companion, router, None).await {
+                Ok(handle) => aborts.push(handle),
+                Err(e) => tracing::warn!(
                     %companion,
                     primary = %primary,
                     error = %e,
                     "Could not bind companion {} listener for the client API; \
                      continuing with the primary listener only",
                     if companion.is_ipv4() { "IPv4" } else { "IPv6" },
-                );
+                ),
             }
         }
         None => {
-            serve_with_listener(primary, router, pre_bound).await?;
+            aborts.push(serve_with_listener(primary, router, pre_bound).await?);
         }
     }
     Ok(())
@@ -731,7 +762,7 @@ fn spawn_token_cleanup_task(
     origin_contracts: OriginContractMap,
     token_ttl_seconds: u64,
     cleanup_interval_seconds: u64,
-) {
+) -> tokio::task::AbortHandle {
     let token_ttl = Duration::from_secs(token_ttl_seconds);
     let cleanup_interval = Duration::from_secs(cleanup_interval_seconds);
 
@@ -773,7 +804,8 @@ fn spawn_token_cleanup_task(
                 );
             }
         }
-    });
+    })
+    .abort_handle()
 }
 
 #[cfg(test)]
@@ -1251,9 +1283,13 @@ mod tests {
 
         let primary = SocketAddr::from((Ipv6Addr::LOCALHOST, port));
         let router = Router::new().route("/", get(handler));
-        serve_dual_stack(primary, router, None)
+        let mut aborts = crate::util::AbortOnDrop::new();
+        serve_dual_stack(primary, router, None, &mut aborts)
             .await
             .expect("binding the IPv6 loopback primary must succeed");
+        // Keep the servers alive for the duration of the assertions below; the
+        // guard would otherwise abort them as soon as this scope's locals drop.
+        std::mem::forget(aborts);
 
         // GET over BOTH families and assert OUR handler answered. Checking the
         // body (not just a TCP connect) rules out a false pass where an

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -298,7 +298,11 @@ where
 /// listener / redb references alive for as long as they run, so dropping their
 /// only handle is not enough — the handle does not abort the task on drop.
 /// Aborting on drop does. See issue #4401.
-#[derive(Default)]
+///
+/// Move-only / single-owner: the guard is not `Clone`, so exactly one owner is
+/// responsible for the tracked tasks. Moving it (e.g. into a struct field or
+/// `std::mem::forget`-ing it on a never-shutting-down path) transfers that
+/// responsibility; dropping it aborts every tracked task.
 pub(crate) struct AbortOnDrop {
     handles: Vec<tokio::task::AbortHandle>,
 }
@@ -326,6 +330,10 @@ impl Drop for AbortOnDrop {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use super::AbortOnDrop;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
     use tempfile::TempDir;
 
     /// Use this to guarantee unique directory names in case you are running multiple tests in parallel.
@@ -334,5 +342,51 @@ pub(crate) mod tests {
         tempfile::Builder::new()
             .tempdir()
             .expect("Failed to create a temporary directory")
+    }
+
+    /// Locks the load-bearing contract of `AbortOnDrop`: dropping the guard
+    /// aborts every task whose `AbortHandle` it holds. The integration test
+    /// (`tests/in_process_restart.rs`) exercises this only indirectly via the
+    /// WS-server teardown; this asserts it directly, so a regression that
+    /// neuters `Drop` (back to a no-op) fails here even if the integration test
+    /// happens to pass. See issue #4401.
+    #[tokio::test]
+    async fn abort_on_drop_cancels_tracked_task() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let task_counter = counter.clone();
+
+        // A task that advances a counter forever unless cancelled.
+        let handle = tokio::spawn(async move {
+            loop {
+                task_counter.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        });
+        let mut guard = AbortOnDrop::new();
+        guard.push(handle.abort_handle());
+
+        // Let the task advance, then drop the guard to abort it.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(
+            counter.load(Ordering::SeqCst) > 0,
+            "task should have advanced before abort"
+        );
+        drop(guard);
+
+        // The JoinHandle must resolve to a cancelled error once the abort lands.
+        let result = handle.await;
+        assert!(
+            result.is_err() && result.as_ref().unwrap_err().is_cancelled(),
+            "dropping AbortOnDrop must cancel the task; got {result:?}"
+        );
+
+        // And the sentinel must stop advancing: capture, wait, re-read.
+        let after_abort = counter.load(Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            after_abort,
+            "task kept running after AbortOnDrop was dropped"
+        );
     }
 }

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -286,6 +286,44 @@ where
     }
 }
 
+/// Aborts a set of spawned tasks when dropped.
+///
+/// Holds the [`AbortHandle`](tokio::task::AbortHandle)s of detached
+/// `GlobalExecutor::spawn` tasks (e.g. the WebSocket `axum::serve` server and
+/// its companion socket, plus the token-cleanup loop) so they are torn down
+/// when the owner is dropped, rather than leaking past a node's shutdown.
+///
+/// This is what makes graceful shutdown actually release resources held by
+/// fire-and-forget server tasks: the tasks keep their own `op_manager` /
+/// listener / redb references alive for as long as they run, so dropping their
+/// only handle is not enough — the handle does not abort the task on drop.
+/// Aborting on drop does. See issue #4401.
+#[derive(Default)]
+pub(crate) struct AbortOnDrop {
+    handles: Vec<tokio::task::AbortHandle>,
+}
+
+impl AbortOnDrop {
+    pub(crate) fn new() -> Self {
+        Self {
+            handles: Vec::new(),
+        }
+    }
+
+    /// Track a task's abort handle so it is aborted when `self` is dropped.
+    pub(crate) fn push(&mut self, handle: tokio::task::AbortHandle) {
+        self.handles.push(handle);
+    }
+}
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        for handle in &self.handles {
+            handle.abort();
+        }
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use tempfile::TempDir;

--- a/crates/core/tests/in_process_restart.rs
+++ b/crates/core/tests/in_process_restart.rs
@@ -6,7 +6,9 @@
 //! running. Those tasks kept holding the redb on-disk file lock and kept
 //! serving on the node's bound ports after the node had "shut down". As a
 //! result an in-process restart against the same data dir would either:
-//!   1. deadlock — node 2's redb open blocks on the lock node 1 still holds, OR
+//!   1. fail — node 2's redb open returns `DatabaseAlreadyOpen` in-process (the
+//!      surviving process still holds the lock); cross-process the same condition
+//!      surfaces as an OS file-lock block. Either way the restart can't proceed, OR
 //!   2. silently pass — node 1's still-live WS server answers the GET, so the
 //!      "restart" validated nothing.
 //!
@@ -131,7 +133,13 @@ macro_rules! recv_until {
     }};
 }
 
+// Runtime-ignore under sqlite (mirrors `tests/redb_migration.rs`): this test
+// probes the redb on-disk layout (`<data_dir>/db/db`) and opens `redb::Database`
+// directly. Under `--no-default-features --features sqlite` the node writes a
+// sqlite DB instead, so the probe would mis-target. Kept as a runtime `#[ignore]`
+// (not a file-level `#![cfg]`) so the file still compiles under sqlite.
 #[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+#[cfg_attr(not(feature = "redb"), ignore)]
 async fn test_in_process_restart_releases_redb_lock() -> anyhow::Result<()> {
     freenet::test_utils::ensure_contract_compiled(TEST_CONTRACT)?;
 
@@ -194,9 +202,11 @@ async fn test_in_process_restart_releases_redb_lock() -> anyhow::Result<()> {
     // ---- Negative control: the redb lock must be released promptly ----
     //
     // Before the fix the detached executor task survives shutdown and keeps the
-    // redb `Database` open, so this direct open blocks indefinitely and the
-    // bounded loop below fails. With the fix the lock is released within a
-    // fraction of a second of the run loop returning.
+    // redb `Database` open, so this direct open returns `DatabaseAlreadyOpen`
+    // in-process (and the bounded loop below fails). With the fix the lock is
+    // released shortly after the run loop returns — "shortly" rather than
+    // "instantly" because abort only signals the executor task; its redb clones
+    // drop when the runtime next polls it to completion, hence the 10s bound.
     let lock_deadline = Instant::now() + Duration::from_secs(10);
     loop {
         match try_open_redb(&db_path) {

--- a/crates/core/tests/in_process_restart.rs
+++ b/crates/core/tests/in_process_restart.rs
@@ -1,0 +1,267 @@
+//! In-process graceful-shutdown / restart round-trip test.
+//!
+//! Issue #4401: a node's graceful shutdown (`ShutdownHandle::shutdown()`) tore
+//! down the network event loop but left the detached contract-executor and
+//! WebSocket-server tasks (spawned on the process-wide `GlobalExecutor`)
+//! running. Those tasks kept holding the redb on-disk file lock and kept
+//! serving on the node's bound ports after the node had "shut down". As a
+//! result an in-process restart against the same data dir would either:
+//!   1. deadlock — node 2's redb open blocks on the lock node 1 still holds, OR
+//!   2. silently pass — node 1's still-live WS server answers the GET, so the
+//!      "restart" validated nothing.
+//!
+//! This is the exact scenario the process-based `persistence_roundtrip.rs`
+//! (PR #4398) had to work around by running the two nodes as separate OS
+//! processes. With the fix, shutdown aborts the detached tasks and drops the
+//! redb `Database` clones, so node 2 can open the same data dir IN THE SAME
+//! PROCESS.
+//!
+//! Negative control: after node 1's `run()` future returns we assert the redb
+//! lock is released within a tight bound by opening the database directly.
+//! Without the fix the executor task still holds the lock, so this open blocks
+//! and the bounded wait fails — proving the test is load-bearing.
+//!
+//! Binds `127.0.0.1` (a single loopback address, not the full 127/8 range), so
+//! unlike the connectivity tests it runs on macOS as well as Linux CI.
+
+use freenet::{
+    local_node::NodeConfig,
+    server::serve_client_api,
+    test_utils::{load_contract, make_get, make_put},
+};
+use freenet_stdlib::{
+    client_api::{ContractResponse, HostResponse, WebApi},
+    prelude::*,
+};
+use std::{
+    net::{Ipv4Addr, TcpListener},
+    path::Path,
+    time::{Duration, Instant},
+};
+use tokio::time::timeout;
+use tokio_tungstenite::connect_async;
+use tracing::info;
+
+const TEST_CONTRACT: &str = "test-contract-integration";
+
+/// Reserve an ephemeral port by binding then freeing it, so the node can rebind
+/// a moment later. Distinct ports per phase avoid TIME_WAIT contention; only the
+/// DATA DIR is shared across the restart.
+fn reserve_port() -> anyhow::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    Ok(listener.local_addr()?.port())
+}
+
+/// Build a single self-contained gateway node config rooted at `dir`, serving
+/// its WS API on `ws_port` and network on `network_port`. Reusing `dir` across a
+/// restart reuses the persisted redb stores; reusing `keypair_path` keeps a
+/// stable node identity.
+fn node_config(
+    dir: &Path,
+    ws_port: u16,
+    network_port: u16,
+    keypair_path: &Path,
+) -> freenet::config::ConfigArgs {
+    freenet::config::ConfigArgs {
+        ws_api: freenet::config::WebsocketApiArgs {
+            address: Some(Ipv4Addr::LOCALHOST.into()),
+            ws_api_port: Some(ws_port),
+            ..Default::default()
+        },
+        network_api: freenet::config::NetworkArgs {
+            public_address: Some(Ipv4Addr::LOCALHOST.into()),
+            public_port: Some(network_port),
+            is_gateway: true,
+            skip_load_from_network: true,
+            gateways: Some(vec![]),
+            location: Some(0.5),
+            ignore_protocol_checking: true,
+            address: Some(Ipv4Addr::LOCALHOST.into()),
+            network_port: Some(network_port),
+            ..Default::default()
+        },
+        config_paths: freenet::config::ConfigPathsArgs {
+            config_dir: Some(dir.to_path_buf()),
+            data_dir: Some(dir.to_path_buf()),
+            log_dir: Some(dir.to_path_buf()),
+        },
+        secrets: freenet::config::SecretArgs {
+            transport_keypair: Some(keypair_path.to_path_buf()),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Connect to the node's WS API, retrying until it accepts a connection or the
+/// deadline passes. The deadline is what makes the negative control bite: if
+/// node 2's redb open blocks on a lock node 1 never released, its WS API never
+/// comes up and this returns an error rather than hanging the whole test.
+async fn connect_ws(port: u16, within: Duration) -> anyhow::Result<WebApi> {
+    let url = format!("ws://127.0.0.1:{port}/v1/contract/command?encodingProtocol=native");
+    let deadline = Instant::now() + within;
+    loop {
+        match connect_async(&url).await {
+            Ok((ws_stream, _)) => return Ok(WebApi::start(ws_stream)),
+            Err(e) => {
+                if Instant::now() >= deadline {
+                    anyhow::bail!("WS API on port {port} did not come up within {within:?}: {e}");
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+}
+
+/// Await a `PutResponse`/`GetResponse`, ignoring other responses, up to `secs`.
+macro_rules! recv_until {
+    ($client:expr, $secs:expr, $pat:pat => $body:expr) => {{
+        let deadline = Instant::now() + Duration::from_secs($secs);
+        loop {
+            if Instant::now() >= deadline {
+                anyhow::bail!("timed out waiting for expected response");
+            }
+            match timeout(Duration::from_secs(5), $client.recv()).await {
+                Ok(Ok($pat)) => break $body,
+                Ok(Ok(other)) => info!("ignoring response while waiting: {other:?}"),
+                Ok(Err(e)) => anyhow::bail!("client error while waiting: {e}"),
+                Err(_) => {}
+            }
+        }
+    }};
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn test_in_process_restart_releases_redb_lock() -> anyhow::Result<()> {
+    freenet::test_utils::ensure_contract_compiled(TEST_CONTRACT)?;
+
+    // Data dir reused across the in-process restart — the whole point of the
+    // test: node 1 flushes to it, node 2 reloads from it WITHOUT a process exit
+    // in between.
+    let data_dir = tempfile::tempdir()?;
+    let data_path = data_dir.path().to_path_buf();
+    // The node lays out its redb file at `<data_dir>/db/db`: `Config::db_dir()`
+    // is `<data_dir>/db`, and `ReDb::new` joins `"db"` to that. This is the file
+    // whose OS lock the negative control probes.
+    let db_path = data_path.join("db").join("db");
+
+    // Stable transport identity reused across the restart.
+    let key = freenet::dev_tool::TransportKeypair::new();
+    let keypair_path = data_path.join("private.pem");
+    key.save(&keypair_path)?;
+    key.public().save(data_path.join("public.pem"))?;
+
+    let (ws_port1, net_port1) = (reserve_port()?, reserve_port()?);
+    let (ws_port2, net_port2) = (reserve_port()?, reserve_port()?);
+
+    let contract = load_contract(TEST_CONTRACT, Parameters::from(vec![]))?;
+    let contract_key = contract.key();
+    let initial_state = WrappedState::from(freenet::test_utils::create_empty_todo_list());
+
+    // ---- Phase 1: node 1 — PUT a contract, then graceful shutdown ----
+    let cfg1 = node_config(&data_path, ws_port1, net_port1, &keypair_path)
+        .build()
+        .await?;
+    let node1 = NodeConfig::new(cfg1.clone())
+        .await?
+        .build(serve_client_api(cfg1.ws_api.clone()).await?)
+        .await?;
+    let shutdown1 = node1.shutdown_handle();
+    // Drive the node on its own task; `run()` returns (with an Err carrying the
+    // shutdown cause) once the event loop tears down, at which point the node —
+    // and every redb `Database` clone it owns, now that the detached tasks are
+    // aborted — has been dropped.
+    let run1 = tokio::spawn(async move { node1.run().await });
+
+    {
+        let mut client = connect_ws(ws_port1, Duration::from_secs(30)).await?;
+        make_put(&mut client, initial_state.clone(), contract.clone(), false).await?;
+        let put_key = recv_until!(client, 30,
+            HostResponse::ContractResponse(ContractResponse::PutResponse { key }) => key);
+        assert_eq!(put_key, contract_key, "PUT acknowledged a different key");
+        info!("node 1 PUT acknowledged; triggering graceful shutdown");
+        // Drop the client so its WS connection closes before we shut down.
+    }
+
+    // Graceful shutdown, then wait for the node's run loop to actually return.
+    shutdown1.shutdown().await;
+    let run1_result = timeout(Duration::from_secs(30), run1)
+        .await
+        .map_err(|_| anyhow::anyhow!("node 1 run loop did not exit within 30s of shutdown()"))?
+        .map_err(|e| anyhow::anyhow!("node 1 run task panicked: {e}"))?;
+    info!(?run1_result, "node 1 run loop exited after shutdown");
+
+    // ---- Negative control: the redb lock must be released promptly ----
+    //
+    // Before the fix the detached executor task survives shutdown and keeps the
+    // redb `Database` open, so this direct open blocks indefinitely and the
+    // bounded loop below fails. With the fix the lock is released within a
+    // fraction of a second of the run loop returning.
+    let lock_deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match try_open_redb(&db_path) {
+            Ok(()) => {
+                info!(
+                    elapsed_ms = lock_deadline
+                        .saturating_duration_since(Instant::now())
+                        .as_millis(),
+                    "redb lock released after shutdown"
+                );
+                break;
+            }
+            Err(e) => {
+                assert!(
+                    Instant::now() < lock_deadline,
+                    "redb file lock was not released within 10s of node 1 shutdown \
+                     (detached executor task still holding it?): {e}"
+                );
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        }
+    }
+
+    // ---- Phase 2: node 2 — restart IN THE SAME PROCESS, same data dir ----
+    let cfg2 = node_config(&data_path, ws_port2, net_port2, &keypair_path)
+        .build()
+        .await?;
+    let node2 = NodeConfig::new(cfg2.clone())
+        .await?
+        .build(serve_client_api(cfg2.ws_api.clone()).await?)
+        .await?;
+    let shutdown2 = node2.shutdown_handle();
+    let run2 = tokio::spawn(async move { node2.run().await });
+
+    // If node 2 could not open the locked redb (pre-fix), its WS API never comes
+    // up and this fails within the bound rather than hanging forever.
+    let mut client = connect_ws(ws_port2, Duration::from_secs(30)).await?;
+    make_get(&mut client, contract_key, true, false).await?;
+    let got_state = recv_until!(client, 30,
+        HostResponse::ContractResponse(ContractResponse::GetResponse { state, .. }) => state);
+    assert_eq!(
+        got_state.as_ref(),
+        initial_state.as_ref(),
+        "node 2 served different state than node 1 persisted (stale server or bad reload)"
+    );
+    info!("node 2 GET after in-process restart returned the persisted state");
+
+    drop(client);
+    shutdown2.shutdown().await;
+    // Best-effort cleanup of node 2's run loop; the assertions above are what
+    // the test proves, so a slow teardown here should not fail it.
+    if timeout(Duration::from_secs(30), run2).await.is_err() {
+        info!("node 2 run loop did not exit within 30s of shutdown (cleanup only)");
+    }
+
+    Ok(())
+}
+
+/// Open the redb database file directly, returning Ok only if the OS file lock
+/// is currently free. Used as the negative control: a still-running executor
+/// task from node 1 would hold this lock and make the open block/fail.
+fn try_open_redb(db_path: &Path) -> anyhow::Result<()> {
+    // `Database::create` acquires the same exclusive file lock the node's
+    // contract store takes, so a successful open here proves the lock is free.
+    let db = redb::Database::create(db_path)?;
+    drop(db);
+    Ok(())
+}


### PR DESCRIPTION
## Problem

A node's graceful shutdown (`ShutdownHandle::shutdown()` / `run_node` event-loop exit)
tore down the network event loop but **did not abort the detached contract-executor,
WebSocket-server, and token-cleanup tasks** spawned on the process-wide `GlobalExecutor`.
Dropping a tokio `JoinHandle` does **not** abort the task, so those tasks kept running —
holding their `op_manager` clones, serving on the node's bound ports, and (critically)
keeping the contract executor's redb `Arc<Database>` clones alive. The redb on-disk file
lock is released only when the last `Arc<Database>` drops, so:

- an **in-process restart** against the same data dir deadlocked on the lock;
- a **stale WS server** kept answering requests meant for the restarted node;
- graceful shutdown advertised teardown it did not perform.

Discovered while building the #3367 Gap-1 persistence round-trip test (#4398), which had
to work around this by running two nodes as separate OS processes.

## Solution

Retain abort handles for the detached tasks and tear them down on **every** exit path of
`run_node`, then drop the ring's redb `Storage` clones so the `Arc<Database>` refcount
reaches zero and the lock releases:

- **`AbortOnDrop`** (new, `util.rs`) — a move-only guard that aborts its held `AbortHandle`s
  on drop. Threaded through `serve_with_listener` / `serve_dual_stack` /
  `spawn_token_cleanup_task` and owned by the `WebSocketProxy`, so the WS server + companion
  socket + token-cleanup tasks are aborted when the proxy drops.
- **`ShutdownTeardown`** Drop guard in `run_node`, installed *before* the fallible
  `initial_join` — aborts the executor / client-events / session-actor / result-router /
  initial-join / aggressive-connect tasks and calls `clear_redb_storage()` on every exit
  path (normal, early `?`, or unwind). Idempotent via a `fired` flag.
- **`Ring::clear_redb_storage()`** drops the ring's two `Storage` clones (hosting metadata +
  broken-invariants). `BrokenInvariantsTracker` migrated `OnceLock<Storage>` →
  `RwLock<Option<Storage>>` (mirroring `HostingManager`) so it can be cleared.

The exhaustive `Arc<Database>` holder set (executor-task `RuntimePool` stores + the two ring
clones) is documented at the clear site so a future clone into a longer-lived task is flagged
as lock-leak-prone. Lock release is **asynchronous** (abort only signals; the executor's
clones drop when the runtime polls the aborted task to completion, bounded by any in-flight
`block_in_place` WASM exec) — documented on the guard.

## Testing

- **`test_in_process_restart_releases_redb_lock`** (integration, redb-gated via
  `#[cfg_attr(not(feature="redb"), ignore)]`): build node 1, PUT a contract, `shutdown()`,
  await the run loop, then build node 2 **in the same process** against the same data dir and
  assert a GET returns the persisted state. **Load-bearing negative control:** opens the redb
  file directly and asserts the lock releases within 10 s of shutdown — with the abort/clear
  wiring disabled the test fails with `DatabaseAlreadyOpen` (the in-process deadlock from the
  issue).
- **`util::tests::abort_on_drop_cancels_tracked_task`** (unit): asserts a tracked task is
  cancelled when the `AbortOnDrop` guard drops (load-bearing — a no-op Drop fails it).
- `cargo fmt`, `cargo clippy --lib --tests -- -D warnings`, `cargo build --workspace --tests`
  all clean.

Reviewed via a multi-perspective panel (code-first / skeptical / testing) over two rounds —
all findings resolved. The external (codex) pass was unavailable (auth/refresh-token error);
the diverse multi-lens Claude panel was used as the documented fallback.

## Fixes

Closes #4401

[AI-assisted]
