### PR TITLE
feat: migrate contracts toward their key to resolve GET dead-ends (#4404)

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -22,7 +22,7 @@ Driver entry points:
 | GET | `get/op_ctx_task.rs::start_client_get`, `start_relay_get`, `start_sub_op_get`, `start_targeted_sub_op_get` |
 | PUT | `put/op_ctx_task.rs::start_client_put`, `start_relay_put`, `start_relay_put_streaming` |
 | UPDATE | `update/op_ctx_task.rs::start_client_update`, `start_relay_request_update`, `start_relay_broadcast_to`, `start_relay_request_update_streaming`, `start_relay_broadcast_to_streaming` |
-| SUBSCRIBE | `subscribe/op_ctx_task.rs::start_client_subscribe`, `run_executor_subscribe`, `run_renewal_subscribe`, `start_relay_subscribe`; `subscribe.rs::handle_unsubscribe_inbound` for `Unsubscribe` |
+| SUBSCRIBE | `subscribe/op_ctx_task.rs::start_client_subscribe`, `start_directed_subscribe` (SubscribeHint placement nudge, #4404), `run_executor_subscribe`, `run_renewal_subscribe`, `start_relay_subscribe`; `subscribe.rs::handle_unsubscribe_inbound` for `Unsubscribe` |
 
 The shared retry-loop driver lives in `op_ctx.rs` (`RetryDriver` trait
 + `drive_retry_loop`). UPDATE is fire-and-forget (no retry loop, no

--- a/crates/core/CLAUDE.md
+++ b/crates/core/CLAUDE.md
@@ -64,6 +64,7 @@ Driver entry points:
                               start_relay_request_update_streaming,
                               start_relay_broadcast_to_streaming
   subscribe/op_ctx_task.rs  → start_client_subscribe,
+                              start_directed_subscribe,
                               run_executor_subscribe,
                               run_renewal_subscribe,
                               start_relay_subscribe

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -367,6 +367,24 @@ pub(crate) enum NetMessageV1 {
     ReadyState {
         ready: bool,
     },
+    /// Fire-and-forget hint nudging the recipient to host a contract.
+    ///
+    /// A host sends this to a connected neighbor that is closer to the
+    /// contract's key but isn't hosting it. The recipient should subscribe to
+    /// `key` directed through `holder` (the sender), thereby fetching and
+    /// hosting it. There is no reply: the recipient may act on it or ignore it.
+    SubscribeHint(SubscribeHintMsg),
+}
+
+/// Payload for [`NetMessageV1::SubscribeHint`]: a directed nudge to host a contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubscribeHintMsg {
+    /// The contract the recipient is being nudged to host.
+    pub key: ContractKey,
+    /// The peer that currently holds (hosts) the contract — the sender of this
+    /// hint. The recipient subscribes to `key` directed through `holder` (a
+    /// plain greedy subscribe would route away from it), thereby hosting it.
+    pub holder: PeerKeyLocation,
 }
 
 /// Messages for the neighbor hosting protocol.
@@ -584,6 +602,7 @@ impl Versioned for NetMessageV1 {
             // Version 1.1.0 for delta-based interest sync
             NetMessageV1::InterestSync { .. } => semver::Version::new(1, 1, 0),
             NetMessageV1::ReadyState { .. } => semver::Version::new(1, 2, 0),
+            NetMessageV1::SubscribeHint(_) => semver::Version::new(1, 3, 0),
         }
     }
 }
@@ -717,6 +736,13 @@ pub(crate) enum NodeEvent {
         new_state: WrappedState,
         target: SocketAddr,
     },
+    /// Nudge the node to consider migrating a contract we host toward a
+    /// closer, non-hosting neighbor (directed-subscribe placement). Emitted
+    /// best-effort when we begin hosting a contract or gain a new neighbor;
+    /// handled in `p2p_protoc` where the connection table and version gate live.
+    ConsiderContractMigration {
+        key: ContractKey,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -849,6 +875,9 @@ impl Display for NodeEvent {
             NodeEvent::SyncStateToPeer { key, target, .. } => {
                 write!(f, "SyncStateToPeer (contract: {key}, target: {target})")
             }
+            NodeEvent::ConsiderContractMigration { key } => {
+                write!(f, "ConsiderContractMigration (contract: {key})")
+            }
         }
     }
 }
@@ -879,6 +908,7 @@ impl MessageStats for NetMessageV1 {
             NetMessageV1::NeighborHosting { .. } => Transaction::NULL,
             NetMessageV1::InterestSync { .. } => Transaction::NULL,
             NetMessageV1::ReadyState { .. } => Transaction::NULL,
+            NetMessageV1::SubscribeHint(_) => Transaction::NULL,
         }
     }
 
@@ -893,6 +923,7 @@ impl MessageStats for NetMessageV1 {
             NetMessageV1::NeighborHosting { .. } => None,
             NetMessageV1::InterestSync { .. } => None,
             NetMessageV1::ReadyState { .. } => None,
+            NetMessageV1::SubscribeHint(_) => None,
         }
     }
 }
@@ -917,6 +948,9 @@ impl Display for NetMessage {
                 }
                 ReadyState { ready } => {
                     write!(f, "ReadyState {{ ready: {ready} }}")?;
+                }
+                SubscribeHint(msg) => {
+                    write!(f, "SubscribeHint(key: {}, holder: {})", msg.key, msg.holder)?;
                 }
             },
         };
@@ -957,6 +991,34 @@ const _: () = {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn subscribe_hint_wire_roundtrip_and_version() {
+        use freenet_stdlib::prelude::CodeHash;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([7u8; 32]),
+            CodeHash::new([8u8; 32]),
+        );
+        let holder = PeerKeyLocation::random();
+        // `ContractKey` is `Copy`; `holder` is not, so it is cloned.
+        let msg = NetMessageV1::SubscribeHint(SubscribeHintMsg {
+            key,
+            holder: holder.clone(),
+        });
+        let bytes = bincode::serialize(&msg).expect("serialize SubscribeHint");
+        let decoded: NetMessageV1 =
+            bincode::deserialize(&bytes).expect("deserialize SubscribeHint");
+        // `matches!` with a guard avoids a wildcard match arm over NetMessageV1.
+        assert!(
+            matches!(&decoded, NetMessageV1::SubscribeHint(m) if m.key == key && m.holder == holder),
+            "SubscribeHint did not round-trip: {decoded:?}"
+        );
+        // Pin the per-variant entry in the NetMessageV1 version map so an
+        // accidental reorder/bump is caught. (This map has no production
+        // consumer today; the live wire-compat gate is the negotiated build
+        // version vs SUBSCRIBE_HINT_MIN_VERSION.)
+        assert_eq!(msg.version(), semver::Version::new(1, 3, 0));
+    }
 
     #[test]
     fn pack_transaction_type() {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -299,6 +299,19 @@ pub struct NodeConfig {
     /// `Option` is simply always `None` outside tests.
     #[serde(skip)]
     pub(crate) governance_config_override: Option<crate::contract::governance::GovernanceConfig>,
+    /// Test-only override for the placement-migration version floor
+    /// (`SUBSCRIBE_HINT_MIN_VERSION`). Simulation peers all report the current
+    /// build version, which is below the production floor until release, so the
+    /// `SubscribeHint` gate would never fire in a sim. A test that exercises the
+    /// migration cascade sets this to `Some((0,0,0))` for its own nodes, leaving
+    /// every other sim (and production) at the real floor — so the cascade is
+    /// opt-in and cannot perturb unrelated simulations.
+    ///
+    /// `None` in production. Not cfg-gated for the same reason as
+    /// `governance_config_override`: `node::testing_impl` sets it and is compiled
+    /// unconditionally. `#[serde(skip)]`; never serialized.
+    #[serde(skip)]
+    pub(crate) subscribe_hint_floor_override: Option<(u8, u8, u16)>,
 }
 
 impl NodeConfig {
@@ -435,6 +448,7 @@ impl NodeConfig {
                 Some(3) // Production: require 3 relay-ready upstream peers
             },
             governance_config_override: None,
+            subscribe_hint_floor_override: None,
         })
     }
 
@@ -1670,6 +1684,50 @@ where
                 ready,
                 "Processed ReadyState from peer"
             );
+            return Ok(());
+        }
+        NetMessageV1::SubscribeHint(hint) => {
+            // Directed-subscribe placement (#4404): a holder is nudging us to
+            // host `hint.key` because we are closer to it in the ring. If we
+            // already host it there is nothing to do. Otherwise start a
+            // fire-and-forget directed subscribe routed THROUGH the holder
+            // (`hint.holder`), which fetches and thereby hosts the contract.
+            if op_manager.ring.is_hosting_contract(&hint.key) {
+                tracing::debug!(
+                    key = %hint.key,
+                    ?source_addr,
+                    "Received SubscribeHint for an already-hosted contract — ignoring"
+                );
+                return Ok(());
+            }
+            // `hint.holder` is network-sourced. A legitimate sender always sets
+            // `holder = its own location`, so the holder's address must equal the
+            // address this hint actually arrived from. Requiring that:
+            //   - drops an address-less holder (the directed-subscribe driver
+            //     routes through the holder's socket address and would otherwise
+            //     panic), and
+            //   - prevents a peer from redirecting us to directed-subscribe
+            //     through an arbitrary THIRD party (a cheap 1-packet → 1-spawned-
+            //     -op amplification / SSRF-style vector). A peer can still nudge
+            //     us toward ITSELF, which is exactly a legitimate hint.
+            // Fail-safe: a dropped legitimate hint is re-sent on the next
+            // migration trigger, so being strict here costs nothing.
+            if hint.holder.socket_addr() != source_addr {
+                tracing::debug!(
+                    key = %hint.key,
+                    holder = ?hint.holder.socket_addr(),
+                    ?source_addr,
+                    "Received SubscribeHint whose holder is not the sender — ignoring"
+                );
+                return Ok(());
+            }
+            tracing::debug!(
+                key = %hint.key,
+                holder = %hint.holder,
+                ?source_addr,
+                "Received SubscribeHint — starting directed subscribe to holder"
+            );
+            subscribe::start_directed_subscribe(op_manager.clone(), hint.key, hint.holder);
             return Ok(());
         }
         NetMessageV1::Aborted(tx) => {

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -27,9 +27,9 @@ use crate::node::network_bridge::handshake::{
 };
 use crate::node::network_bridge::priority_select;
 use crate::operations::connect::ConnectMsg;
-use crate::ring::Location;
 #[cfg(feature = "simulation_tests")]
 use crate::ring::PeerKey;
+use crate::ring::{Distance, Location};
 use crate::transport::{
     BroadcastDeliveryOutcome, CongestionControlConfig, ExpectedInboundTracker, PeerConnectionApi,
     Socket, TransportError, TransportKeypair, TransportPublicKey, create_connection_handler,
@@ -396,6 +396,10 @@ struct ConnectionEntry {
     /// Used for zombie detection: connections not promoted to the ring
     /// within a timeout are considered zombies and dropped.
     created_at: Instant,
+    /// The remote peer's negotiated protocol version, if known.
+    /// `None` when the version wasn't exchanged (e.g. joiner->gateway path).
+    /// Used to gate version-dependent message types (e.g. SubscribeHint).
+    remote_version: Option<(u8, u8, u16)>,
 }
 
 /// Check whether a transport connection is a zombie: old enough but not
@@ -599,7 +603,338 @@ pub(in crate::node) struct P2pConnManager {
     broadcast_queue: super::broadcast_queue::BroadcastQueue,
 }
 
+/// Minimum negotiated protocol version a peer must report before we send it a
+/// [`SubscribeHint`](crate::message::NetMessageV1::SubscribeHint).
+///
+/// MUST equal the release version that first ships SubscribeHint. A peer is only
+/// sent SubscribeHint if its negotiated version is >= this; older peers cannot
+/// deserialize the new wire variant and would drop the connection. None (unknown,
+/// e.g. joiner->gateway) is treated as unsupported.
+///
+/// UPDATE AT RELEASE TIME, then FREEZE: set this to the exact release version
+/// that first ships SubscribeHint and do NOT keep bumping it afterward to track
+/// the crate version. Once shipped in release R, peers running R can deserialize
+/// the variant, so the floor must stay at R forever — raising it above R would
+/// silently stop sending hints to fully-capable R peers. (This is why there is
+/// no `floor` vs `CARGO_PKG_VERSION` unit test; see docs/RELEASING.md.)
+///
+/// This is a single non-cfg constant: deliberately NOT lowered under any test
+/// feature, because `testing` is pulled into the SHIPPED release binary (`fdev`
+/// depends on `freenet` with `features = ["testing"]` and the release builds
+/// `-p freenet -p fdev` together, unifying `testing` onto the freenet binary),
+/// so a cfg-gated test floor would defeat the wire-compat gate in production.
+/// Simulation tests that want the cascade lower the floor per-node at runtime via
+/// `NodeConfig::subscribe_hint_floor_override` (set by
+/// `SimNetwork::enable_placement_migration`), which never touches production.
+const SUBSCRIBE_HINT_MIN_VERSION: (u8, u8, u16) = (0, 2, 73);
+
+/// Pure version-gate decision, factored out so the comparison and the
+/// fail-closed-on-unknown-version (`None`) behavior are unit-testable with an
+/// explicit floor rather than the production [`SUBSCRIBE_HINT_MIN_VERSION`].
+///
+/// Returns `true` iff `remote` is known (`Some`) and at least `floor`. An
+/// unknown remote version is treated as unsupported: an older peer that cannot
+/// deserialize the appended `SubscribeHint` wire variant would drop the
+/// connection, so when in doubt we do not send the hint.
+fn version_supports_subscribe_hint(remote: Option<(u8, u8, u16)>, floor: (u8, u8, u16)) -> bool {
+    remote.is_some_and(|v| v >= floor)
+}
+
+/// Upper bound on the number of hosted contracts examined per new-peer
+/// migration trigger. Each examined contract may emit a best-effort
+/// non-blocking `try_send` (the SubscribeHint nudge), so an unbounded scan
+/// would still put O(hosted-contracts) work inline on the connection-handling
+/// path per connection (see `.claude/rules/channel-safety.md`). 32 keeps the
+/// per-event work bounded; remaining contracts are reconsidered on the next
+/// hosting/peer event.
+const MIGRATION_SCAN_CAP_PER_NEW_PEER: usize = 32;
+
+/// Pure selection core for directed-subscribe placement (#4404).
+///
+/// Given the contract's ring location, OUR distance to it (`my_dist`), the set
+/// of peers already known to host it, and an iterator over candidate
+/// neighbors, return the single best neighbor to nudge — or `None`.
+///
+/// A candidate qualifies iff it has a known socket address, a known ring
+/// location, is not already hosting (per `hosting`), and is STRICTLY closer to
+/// the contract than we are (`dist < my_dist`). Among qualifying candidates the
+/// closest wins; ties are broken deterministically by public-key bytes
+/// (`TransportPublicKey: Ord` compares `as_bytes()`), so the choice is
+/// reproducible regardless of iteration order.
+///
+/// Factored out of [`P2pConnManager::select_migration_target`] so the decision
+/// logic is unit-testable without constructing a full connection manager.
+fn pick_closest_migration_target<'a, I>(
+    contract_loc: Location,
+    my_dist: Distance,
+    hosting: &HashSet<TransportPublicKey>,
+    candidates: I,
+) -> Option<PeerKeyLocation>
+where
+    I: IntoIterator<Item = &'a PeerKeyLocation>,
+{
+    let mut best: Option<(Distance, &'a TransportPublicKey, &'a PeerKeyLocation)> = None;
+    for pkl in candidates {
+        if pkl.socket_addr().is_none() {
+            continue;
+        }
+        if hosting.contains(pkl.pub_key()) {
+            continue;
+        }
+        let Some(pkl_loc) = pkl.location() else {
+            continue;
+        };
+        let dist = contract_loc.distance(pkl_loc);
+        if dist >= my_dist {
+            continue;
+        }
+        let candidate_pk = pkl.pub_key();
+        let replace = match &best {
+            None => true,
+            Some((best_dist, best_pk, _)) => {
+                dist < *best_dist || (dist == *best_dist && candidate_pk < *best_pk)
+            }
+        };
+        if replace {
+            best = Some((dist, candidate_pk, pkl));
+        }
+    }
+    best.map(|(_, _, pkl)| pkl.clone())
+}
+
 impl P2pConnManager {
+    /// Whether the peer at `addr` reports a negotiated protocol version new
+    /// enough to understand [`SubscribeHint`](crate::message::NetMessageV1::SubscribeHint).
+    ///
+    /// `None` (unknown version) is treated as unsupported, since an older peer
+    /// would fail to deserialize the new wire variant and drop the connection.
+    fn peer_supports_subscribe_hint(&self, addr: &SocketAddr) -> bool {
+        let remote = self.connections.get(addr).and_then(|e| e.remote_version);
+        // Production floor, unless a sim test opted into the cascade by setting a
+        // per-node override (never set in production — see NodeConfig).
+        let floor = self
+            .bridge
+            .op_manager
+            .ring
+            .connection_manager
+            .subscribe_hint_floor_override()
+            .unwrap_or(SUBSCRIBE_HINT_MIN_VERSION);
+        version_supports_subscribe_hint(remote, floor)
+    }
+
+    /// Pick the single best peer to nudge into hosting `key`, or `None`.
+    ///
+    /// Directed-subscribe placement (#4404): we host `key` but a connected
+    /// neighbor may be strictly closer to the contract's key in the ring than
+    /// we are. Nudging that neighbor to subscribe-and-host migrates the
+    /// contract toward its ideal location. We pick ONLY the single closest
+    /// qualifying neighbor (not a fan-out), and ONLY when it is strictly
+    /// closer than us and not already hosting.
+    ///
+    /// A candidate qualifies iff it has a known socket address, a known ring
+    /// location, is not already hosting `key` (per neighbor-hosting state),
+    /// reports a protocol version new enough to understand `SubscribeHint`, and
+    /// is strictly closer to the contract location than we are. Returns the
+    /// qualifying candidate with the smallest distance to the contract, breaking
+    /// ties deterministically by public-key bytes.
+    ///
+    /// The version filter is applied HERE (before the pure selection core) so
+    /// that an old/unknown-version peer that happens to be closest does not
+    /// suppress migration: we fall through to the next-closest peer that CAN
+    /// receive the hint. This matters during a mixed-version rolling upgrade.
+    fn select_migration_target(
+        &self,
+        key: &freenet_stdlib::prelude::ContractKey,
+    ) -> Option<PeerKeyLocation> {
+        let contract_loc = Location::from(key);
+        let me = self
+            .bridge
+            .op_manager
+            .ring
+            .connection_manager
+            .own_location();
+        let my_dist = contract_loc.distance(me.location()?);
+
+        let hosting: HashSet<TransportPublicKey> = self
+            .bridge
+            .op_manager
+            .neighbor_hosting
+            .neighbors_with_contract(key)
+            .into_iter()
+            .collect();
+
+        let connections = self
+            .bridge
+            .op_manager
+            .ring
+            .connection_manager
+            .get_connections_by_location();
+
+        pick_closest_migration_target(
+            contract_loc,
+            my_dist,
+            &hosting,
+            connections
+                .values()
+                .flatten()
+                .map(|conn| &conn.location)
+                // Only peers that can understand the appended wire variant are
+                // eligible; a closer but too-old peer is skipped so the next
+                // eligible peer is chosen (mixed-version safety).
+                .filter(|pkl| {
+                    pkl.socket_addr()
+                        .is_some_and(|addr| self.peer_supports_subscribe_hint(&addr))
+                }),
+        )
+    }
+
+    /// Best-effort nudge for a single contract we host: if there is a closer,
+    /// non-hosting neighbor that understands `SubscribeHint`, tell it we are
+    /// the current holder so it can directed-subscribe and host `key`.
+    ///
+    /// No-op if we do not host `key` or if there is no qualifying target
+    /// (closer, non-hosting, AND version-supported — the selection skips peers
+    /// too old to understand the hint). Fire-and-forget and
+    /// NON-BLOCKING: the nudge is dispatched with `try_send`, so a congested
+    /// bridge channel drops the hint (logged at debug) rather than stalling the
+    /// connection-handling event loop — see `.claude/rules/channel-safety.md`.
+    /// Migration is reconsidered on the next hosting/peer event, so a dropped
+    /// hint is self-healing.
+    fn consider_contract_migration(&self, key: freenet_stdlib::prelude::ContractKey) {
+        if !self.bridge.op_manager.ring.is_hosting_contract(&key) {
+            return;
+        }
+        let Some(target) = self.select_migration_target(&key) else {
+            return;
+        };
+        let Some(addr) = target.socket_addr() else {
+            return;
+        };
+        // Defense-in-depth: `select_migration_target` already filters to
+        // version-supported peers, but re-gate here so a SubscribeHint can NEVER
+        // be sent to a peer too old to deserialize it (which would drop the
+        // connection) even if the selection path changes.
+        if !self.peer_supports_subscribe_hint(&addr) {
+            return;
+        }
+        // The migration target is a connected neighbor we just looked up and
+        // version-checked, so it resolves via `get_peer_by_addr`.
+        let Some(target_pkl) = self
+            .bridge
+            .op_manager
+            .ring
+            .connection_manager
+            .get_peer_by_addr(addr)
+        else {
+            return;
+        };
+        let me = self
+            .bridge
+            .op_manager
+            .ring
+            .connection_manager
+            .own_location();
+        let msg = NetMessage::V1(NetMessageV1::SubscribeHint(
+            crate::message::SubscribeHintMsg { key, holder: me },
+        ));
+        self.bridge
+            .op_manager
+            .sending_transaction(&target_pkl, &msg);
+        // Non-blocking dispatch: never `.send().await` from the event loop.
+        if let Err(e) = self
+            .bridge
+            .ev_listener_tx
+            .try_send(P2pBridgeEvent::Message(target_pkl, Box::new(msg)))
+        {
+            tracing::debug!(%addr, %key, error = %e, "SubscribeHint nudge dropped (bridge busy or closed)");
+        }
+    }
+
+    /// On gaining a new neighbor, reconsider migrating each contract we host.
+    ///
+    /// The new peer may be the closest non-hosting neighbor for some of our
+    /// contracts; `consider_contract_migration` recomputes the single best
+    /// target per contract, so we do not special-case `peer_addr` here beyond
+    /// an early skip when the new peer is not even closer than us. The number
+    /// of contracts examined per call is capped at
+    /// [`MIGRATION_SCAN_CAP_PER_NEW_PEER`] so we never do an unbounded inline
+    /// scan + nudge fan-out from the event loop (channel-safety).
+    fn consider_migration_for_new_peer(&self, peer_addr: SocketAddr) {
+        let new_peer_loc = self
+            .connections
+            .get(&peer_addr)
+            .and_then(|e| e.pub_key.as_ref())
+            .and_then(|pk| {
+                self.bridge
+                    .op_manager
+                    .ring
+                    .connection_manager
+                    .get_peer_by_addr(peer_addr)
+                    .filter(|p| p.pub_key() == pk)
+                    .and_then(|p| p.location())
+            })
+            .or_else(|| {
+                self.bridge
+                    .op_manager
+                    .ring
+                    .connection_manager
+                    .get_peer_by_addr(peer_addr)
+                    .and_then(|p| p.location())
+            });
+        let my_loc = self
+            .bridge
+            .op_manager
+            .ring
+            .connection_manager
+            .own_location()
+            .location();
+
+        let keys = self.bridge.op_manager.ring.hosting_contract_keys();
+        let total = keys.len();
+        if total == 0 {
+            return;
+        }
+        // Bound the per-event scan: examine at most
+        // MIGRATION_SCAN_CAP_PER_NEW_PEER keys even when most of them skip the
+        // cheap test below, so a node hosting thousands of contracts can't walk
+        // its entire hosting set on every new connection (unbounded work on the
+        // connection-handling path). A rotating start offset (the
+        // `migration_scan_cursor`) makes successive events cover different
+        // windows, so contracts past the cap are reached on later events rather
+        // than being starved in a fixed prefix.
+        let window = MIGRATION_SCAN_CAP_PER_NEW_PEER;
+        let start = self
+            .bridge
+            .op_manager
+            .ring
+            .connection_manager
+            .next_migration_scan_offset(window)
+            % total;
+        if total > window {
+            tracing::debug!(
+                cap = window,
+                total,
+                start,
+                %peer_addr,
+                "Capping migration scan for new peer; rotating window covers the rest on later events"
+            );
+        }
+        for i in 0..window.min(total) {
+            let key = keys[(start + i) % total];
+            // Optimization: if we know both locations and the new peer isn't
+            // strictly closer to this contract than we are, it can't become
+            // the migration target this contract gained from the new peer, so
+            // skip the full selection join.
+            if let (Some(new_loc), Some(my_loc)) = (new_peer_loc, my_loc) {
+                let contract_loc = Location::from(&key);
+                if contract_loc.distance(new_loc) >= contract_loc.distance(my_loc) {
+                    continue;
+                }
+            }
+            self.consider_contract_migration(key);
+        }
+    }
+
     pub(in crate::node) fn listening_port(&self) -> u16 {
         self.listening_port
     }
@@ -1161,6 +1496,7 @@ impl P2pConnManager {
                                             }
                                             NetMessageV1::InterestSync { .. } => "InterestSync",
                                             NetMessageV1::ReadyState { .. } => "ReadyState",
+                                            NetMessageV1::SubscribeHint(_) => "SubscribeHint",
                                         },
                                     };
                                     match tokio::time::timeout(
@@ -2272,6 +2608,9 @@ impl P2pConnManager {
                                 ctx.handle_sync_state_to_peer(&op_manager, key, new_state, target)
                                     .await;
                             }
+                            NodeEvent::ConsiderContractMigration { key } => {
+                                ctx.consider_contract_migration(key);
+                            }
                         },
                     }
                 }
@@ -2812,6 +3151,10 @@ impl P2pConnManager {
                         );
                     }
                 }
+
+                // Directed-subscribe placement (#4404): the new neighbor may be
+                // the closest non-hosting peer for some contracts we host.
+                self.consider_migration_for_new_peer(peer_addr);
 
                 // Broadcast readiness if we just crossed the threshold
                 if just_became_ready {
@@ -3452,6 +3795,10 @@ impl P2pConnManager {
             }
         }
         let conn_id = next_connection_id();
+        // Capture the remote's negotiated protocol version BEFORE the connection
+        // is moved into the spawned listener task below. Used to gate
+        // version-dependent message types (e.g. SubscribeHint).
+        let remote_version = connection.remote_version();
         let (tx, rx) = mpsc::channel(10);
         tracing::debug!(
             self_peer = %self.bridge.op_manager.ring.connection_manager.pub_key,
@@ -3470,6 +3817,7 @@ impl P2pConnManager {
                 pub_key: peer_id.as_ref().map(|p| p.pub_key().clone()),
                 connection_id: conn_id,
                 created_at: Instant::now(),
+                remote_version,
             },
         );
         // Only add to reverse lookup if we know the pub_key
@@ -3633,6 +3981,10 @@ impl P2pConnManager {
                         );
                     }
                 }
+
+                // Directed-subscribe placement (#4404): the new neighbor may be
+                // the closest non-hosting peer for some contracts we host.
+                self.consider_migration_for_new_peer(peer_addr);
 
                 // Broadcast readiness if we just crossed the threshold (deferred)
                 if just_became_ready {
@@ -5466,7 +5818,8 @@ fn extract_sender_from_message(msg: &NetMessage) -> Option<PeerKeyLocation> {
             NetMessageV1::Aborted(_)
             | NetMessageV1::NeighborHosting { .. }
             | NetMessageV1::InterestSync { .. }
-            | NetMessageV1::ReadyState { .. } => None,
+            | NetMessageV1::ReadyState { .. }
+            | NetMessageV1::SubscribeHint(_) => None,
         },
     }
 }
@@ -5484,7 +5837,8 @@ fn extract_sender_from_message_mut(msg: &mut NetMessage) -> Option<&mut PeerKeyL
             NetMessageV1::Aborted(_)
             | NetMessageV1::NeighborHosting { .. }
             | NetMessageV1::InterestSync { .. }
-            | NetMessageV1::ReadyState { .. } => None,
+            | NetMessageV1::ReadyState { .. }
+            | NetMessageV1::SubscribeHint(_) => None,
         },
     }
 }
@@ -5599,6 +5953,199 @@ mod tests {
         );
         assert!(states.contains_key(&a.to_string()));
         assert!(states.contains_key(&b.to_string()));
+    }
+
+    mod version_gate {
+        use super::super::version_supports_subscribe_hint;
+
+        const FLOOR: (u8, u8, u16) = (0, 2, 73);
+
+        // NOTE: there is deliberately NO test asserting the floor relative to
+        // CARGO_PKG_VERSION. The floor must be set to the EXACT release that
+        // first ships SubscribeHint and then FROZEN; the crate version keeps
+        // climbing afterward, so any `floor >= crate_version` / `floor <=
+        // crate_version` assertion would false-fail on a later release and
+        // invite the wrong "fix" (bumping the floor above the ship version,
+        // silently cutting off capable peers). The release coupling is enforced
+        // by docs/RELEASING.md + the const's "UPDATE AT RELEASE TIME" doc, not a
+        // unit test.
+
+        #[test]
+        fn unknown_remote_version_fails_closed() {
+            // A peer whose negotiated version we never captured (e.g. the
+            // joiner->gateway path) must NOT be sent the appended wire variant.
+            assert!(!version_supports_subscribe_hint(None, FLOOR));
+        }
+
+        #[test]
+        fn older_remote_version_is_rejected() {
+            assert!(!version_supports_subscribe_hint(Some((0, 2, 72)), FLOOR));
+            assert!(!version_supports_subscribe_hint(Some((0, 1, 99)), FLOOR));
+        }
+
+        #[test]
+        fn equal_or_newer_remote_version_is_accepted() {
+            // Exactly at the floor qualifies.
+            assert!(version_supports_subscribe_hint(Some((0, 2, 73)), FLOOR));
+            // Strictly newer (patch, minor, major) qualifies.
+            assert!(version_supports_subscribe_hint(Some((0, 2, 74)), FLOOR));
+            assert!(version_supports_subscribe_hint(Some((0, 3, 0)), FLOOR));
+            assert!(version_supports_subscribe_hint(Some((1, 0, 0)), FLOOR));
+        }
+
+        #[test]
+        fn tuple_ordering_is_major_then_minor_then_patch() {
+            // (0,3,0) >= (0,2,73) even though its patch is smaller: minor wins.
+            assert!(version_supports_subscribe_hint(Some((0, 3, 0)), FLOOR));
+            // A zero floor accepts any known version but still fails closed on None
+            // (this is the simulation/test floor behavior).
+            assert!(version_supports_subscribe_hint(Some((0, 0, 0)), (0, 0, 0)));
+            assert!(!version_supports_subscribe_hint(None, (0, 0, 0)));
+        }
+    }
+
+    mod migration_selection {
+        use super::super::pick_closest_migration_target;
+        use crate::ring::{Location, PeerKeyLocation};
+        use crate::transport::TransportPublicKey;
+        use std::collections::HashSet;
+        use std::net::SocketAddr;
+
+        /// Build a `PeerKeyLocation` with a deterministic public key (so the
+        /// tie-break is reproducible) and the given socket address (which
+        /// determines its ring `location()`).
+        fn pkl(pk_byte: u8, addr: &str) -> PeerKeyLocation {
+            let pub_key = TransportPublicKey::from_bytes([pk_byte; 32]);
+            let addr: SocketAddr = addr.parse().expect("valid socket addr");
+            PeerKeyLocation::new(pub_key, addr)
+        }
+
+        /// Distance from the contract location to a candidate's ring location.
+        fn dist_to(contract: Location, p: &PeerKeyLocation) -> crate::ring::Distance {
+            contract.distance(p.location().expect("known location"))
+        }
+
+        #[test]
+        fn picks_strictly_closest_non_hosting_candidate() {
+            let contract = Location::new(0.5);
+            // Three candidates at distinct ring locations.
+            let a = pkl(1, "10.0.0.1:1000");
+            let b = pkl(2, "10.0.0.2:1000");
+            let c = pkl(3, "10.0.0.3:1000");
+            let candidates = [a.clone(), b.clone(), c.clone()];
+
+            // Identify which candidate is actually closest to `contract`.
+            let closest = candidates
+                .iter()
+                .min_by_key(|p| dist_to(contract, p))
+                .unwrap()
+                .clone();
+
+            // `my_dist` is larger than every candidate's distance, so all
+            // qualify and the single closest must be chosen.
+            let my_dist = candidates
+                .iter()
+                .map(|p| dist_to(contract, p))
+                .max()
+                .unwrap();
+            // Make `my_dist` strictly larger than all candidates so each is
+            // strictly closer than us.
+            let my_dist = crate::ring::Distance::new(my_dist.as_f64() + 0.01);
+
+            let hosting = HashSet::new();
+            let chosen = pick_closest_migration_target(contract, my_dist, &hosting, &candidates)
+                .expect("a qualifying candidate exists");
+            assert_eq!(
+                chosen.pub_key(),
+                closest.pub_key(),
+                "must pick the candidate closest to the contract location"
+            );
+        }
+
+        #[test]
+        fn excludes_candidates_not_closer_than_us() {
+            let contract = Location::new(0.5);
+            let a = pkl(1, "10.0.0.1:1000");
+            let candidates = [a.clone()];
+            // `my_dist` smaller than the candidate's distance → it does NOT
+            // qualify (not strictly closer than us).
+            let my_dist = crate::ring::Distance::new(dist_to(contract, &a).as_f64() - 0.0001);
+            let hosting = HashSet::new();
+            assert!(
+                pick_closest_migration_target(contract, my_dist, &hosting, &candidates).is_none(),
+                "a candidate no closer than us must be excluded"
+            );
+        }
+
+        #[test]
+        fn excludes_already_hosting_candidates() {
+            let contract = Location::new(0.5);
+            let a = pkl(1, "10.0.0.1:1000");
+            let candidates = [a.clone()];
+            let my_dist = crate::ring::Distance::new(dist_to(contract, &a).as_f64() + 0.01);
+            let mut hosting = HashSet::new();
+            hosting.insert(a.pub_key().clone());
+            assert!(
+                pick_closest_migration_target(contract, my_dist, &hosting, &candidates).is_none(),
+                "a candidate already hosting the contract must be excluded"
+            );
+        }
+
+        #[test]
+        fn excludes_unknown_address_candidates() {
+            let contract = Location::new(0.5);
+            let unknown =
+                PeerKeyLocation::with_unknown_addr(TransportPublicKey::from_bytes([7; 32]));
+            let candidates = [unknown];
+            let my_dist = crate::ring::Distance::new(1.0);
+            let hosting = HashSet::new();
+            assert!(
+                pick_closest_migration_target(contract, my_dist, &hosting, &candidates).is_none(),
+                "a candidate without a known socket address must be excluded"
+            );
+        }
+
+        #[test]
+        fn breaks_ties_deterministically_by_pubkey() {
+            // Two candidates at the SAME ring location (same address) but
+            // different pub keys: the smaller pub-key bytes must win,
+            // regardless of input order.
+            let contract = Location::new(0.5);
+            let low = pkl(1, "10.0.0.9:1000");
+            let high = pkl(9, "10.0.0.9:1000");
+            assert_eq!(
+                dist_to(contract, &low),
+                dist_to(contract, &high),
+                "test setup: both candidates must be equidistant"
+            );
+            let my_dist = crate::ring::Distance::new(dist_to(contract, &low).as_f64() + 0.01);
+            let hosting = HashSet::new();
+
+            let forward = [low.clone(), high.clone()];
+            let reverse = [high.clone(), low.clone()];
+            let chosen_fwd =
+                pick_closest_migration_target(contract, my_dist, &hosting, &forward).unwrap();
+            let chosen_rev =
+                pick_closest_migration_target(contract, my_dist, &hosting, &reverse).unwrap();
+            assert_eq!(chosen_fwd.pub_key(), low.pub_key());
+            assert_eq!(chosen_rev.pub_key(), low.pub_key());
+        }
+
+        #[test]
+        fn returns_none_when_no_candidates() {
+            let contract = Location::new(0.5);
+            let candidates: [PeerKeyLocation; 0] = [];
+            let hosting = HashSet::new();
+            assert!(
+                pick_closest_migration_target(
+                    contract,
+                    crate::ring::Distance::new(1.0),
+                    &hosting,
+                    &candidates
+                )
+                .is_none()
+            );
+        }
     }
 
     /// Regression test for message loss during shutdown.
@@ -5861,6 +6408,7 @@ mod tests {
                 pub_key: None,
                 connection_id: 10,
                 created_at: Instant::now(),
+                remote_version: None,
             },
         );
         let (tx2, _rx2) = mpsc::channel(1);
@@ -5871,6 +6419,7 @@ mod tests {
                 pub_key: None,
                 connection_id: 20,
                 created_at: Instant::now(),
+                remote_version: None,
             },
         );
 

--- a/crates/core/src/node/network_bridge/priority_select/tests.rs
+++ b/crates/core/src/node/network_bridge/priority_select/tests.rs
@@ -2782,6 +2782,10 @@ impl crate::transport::PeerConnectionApi for MockPeerConnection {
         self.addr
     }
 
+    fn remote_version(&self) -> Option<(u8, u8, u16)> {
+        None
+    }
+
     fn send_message(
         &mut self,
         _msg: crate::message::NetMessage,

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -177,6 +177,25 @@ pub enum SimOperation {
         /// Initial state bytes
         state: Vec<u8>,
     },
+    /// Seed a contract into a node's local store AND register the node as
+    /// genuinely HOSTING it (state + `host_contract` + active subscription),
+    /// without any network propagation.
+    ///
+    /// Unlike [`SeedContract`](Self::SeedContract) — which only writes the raw
+    /// state/params into `MockStateStorage` — this routes the contract through
+    /// the node's startup `append_contracts` path with `subscription = true`,
+    /// so `ring.is_hosting_contract` / `ring.hosting_contract_keys` report it.
+    /// That is what makes the node a valid migration source: the
+    /// placement-migration trigger only nudges contracts the node actually
+    /// hosts. Use this when a test needs a node to be the authoritative holder
+    /// of a contract that was never PUT through the network (e.g. reproducing
+    /// the GET-dead-end placement gap, #4404).
+    SeedHostedContract {
+        /// The contract container (code + parameters)
+        contract: ContractContainer,
+        /// Initial state bytes
+        state: Vec<u8>,
+    },
     /// Simulate a client disconnecting from this node.
     ///
     /// Emits `ClientRequest::Disconnect` through the same
@@ -304,6 +323,12 @@ impl SimOperation {
                      by run_controlled_simulation before event dispatch"
                 )
             }
+            SimOperation::SeedHostedContract { .. } => {
+                panic!(
+                    "SeedHostedContract is not a client request — it must be handled \
+                     by run_controlled_simulation before event dispatch"
+                )
+            }
             SimOperation::Disconnect => ClientRequest::Disconnect { cause: None },
         }
     }
@@ -350,6 +375,23 @@ pub struct ControlledSimulationResult {
     #[cfg(any(test, feature = "testing"))]
     #[allow(dead_code)]
     pub(crate) node_rings: HashMap<NodeLabel, Arc<crate::ring::Ring>>,
+}
+
+#[cfg(any(test, feature = "testing"))]
+impl ControlledSimulationResult {
+    /// Whether `label`'s node was hosting `key` in its live Ring at the end of
+    /// the simulation.
+    ///
+    /// Reads the per-node `Ring` captured via the `shared_ring` slots, so it
+    /// reflects `ring.is_hosting_contract` exactly (not a storage proxy). Used
+    /// by placement/migration tests to assert a contract has migrated onto a
+    /// given peer. Returns `false` if the node never started or never published
+    /// its Ring.
+    pub fn is_node_hosting(&self, label: &NodeLabel, key: &ContractKey) -> bool {
+        self.node_rings
+            .get(label)
+            .is_some_and(|ring| ring.is_hosting_contract(key))
+    }
 }
 
 #[derive(PartialEq, Eq, Hash, Clone, PartialOrd, Ord, Debug)]
@@ -824,6 +866,49 @@ impl Default for ChurnConfig {
     }
 }
 
+/// For each target ring location, find a distinct IPv6-loopback port whose
+/// `Location::from_address((::1, port))` is closest (in ring distance) to that
+/// target. Used by [`SimNetwork::new_with_node_locations`] to place nodes at
+/// chosen locations without decoupling a peer's advertised location from its
+/// address-derived one.
+///
+/// Ports are unique across the returned vector (a port already chosen for an
+/// earlier target is skipped for later targets), so the resulting peers occupy
+/// distinct addresses. The achieved location for each target is the closest
+/// available port's location — approximate (ports are discrete) but fully
+/// deterministic. Read the achieved locations back with
+/// [`SimNetwork::get_peer_locations`].
+///
+/// The search range excludes the `50000..=59999` band used by
+/// `derive_deterministic_port`, so explicit ports never collide with the
+/// default-path derived ports.
+pub fn loopback_ports_for_locations(targets: &[f64]) -> Vec<u16> {
+    use std::collections::HashSet;
+    const SEARCH_RANGE: std::ops::RangeInclusive<u16> = 1024..=49999;
+    let mut used: HashSet<u16> = HashSet::new();
+    let mut out = Vec::with_capacity(targets.len());
+    for &target in targets {
+        let mut best_port = *SEARCH_RANGE.start();
+        let mut best_dist = f64::INFINITY;
+        for port in SEARCH_RANGE {
+            if used.contains(&port) {
+                continue;
+            }
+            let addr: SocketAddr = (Ipv6Addr::LOCALHOST, port).into();
+            let loc = Location::from_address(&addr).as_f64();
+            let raw = (loc - target).abs();
+            let dist = raw.min(1.0 - raw); // ring distance
+            if dist < best_dist {
+                best_dist = dist;
+                best_port = port;
+            }
+        }
+        used.insert(best_port);
+        out.push(best_port);
+    }
+    out
+}
+
 /// A simulated in-memory network topology.
 pub struct SimNetwork {
     name: String,
@@ -871,6 +956,13 @@ pub struct SimNetwork {
     /// Pair with `use_mock_wasm = true` so the production cost-reporting
     /// path actually feeds the detector. See #4301.
     governance_config_override: Option<crate::contract::governance::GovernanceConfig>,
+    /// Per-node placement-migration version-floor override (see
+    /// [`SimNetwork::enable_placement_migration`]). `None` leaves the production
+    /// floor, so the `SubscribeHint` cascade stays OFF in sim (its peers report a
+    /// version below the floor) — only a test that explicitly enables migration
+    /// gets the cascade. Keeps the migration feature from perturbing unrelated
+    /// simulations.
+    subscribe_hint_floor_override: Option<(u8, u8, u16)>,
     /// Per-node capture slots for the live `Arc<Ring>`, populated by
     /// `run_controlled_simulation` so governance sim tests can read each
     /// node's `contract_ban_list` after the simulation completes. Keyed by
@@ -884,6 +976,15 @@ pub struct SimNetwork {
     /// as write-only.
     #[allow(dead_code)]
     shared_rings: HashMap<NodeLabel, Arc<parking_lot::Mutex<Option<Arc<crate::ring::Ring>>>>>,
+    /// Optional explicit loopback ports for regular nodes, indexed by
+    /// regular-node order (i.e. `node_no - number_of_gateways`). When present,
+    /// `config_nodes` uses these instead of `derive_deterministic_port`, which
+    /// lets a test place nodes at chosen ring locations: a peer's location is
+    /// `Location::from_address(&addr)`, a pure function of the loopback port, so
+    /// choosing the port chooses the location *consistently* (the address-derived
+    /// location and the advertised `own_location` stay equal, exactly as the
+    /// default port path keeps them). Build via `new_with_node_locations`.
+    node_port_override: Option<Vec<u16>>,
 }
 
 impl SimNetwork {
@@ -900,6 +1001,74 @@ impl SimNetwork {
         max_connections: usize,
         min_connections: usize,
         seed: u64,
+    ) -> Self {
+        Self::new_inner(
+            name,
+            gateways,
+            nodes,
+            ring_max_htl,
+            rnd_if_htl_above,
+            max_connections,
+            min_connections,
+            seed,
+            None,
+        )
+        .await
+    }
+
+    /// Like [`new`](Self::new), but places each regular node at (approximately)
+    /// a chosen ring location. `node_target_locations` is matched to regular
+    /// nodes in order and must have exactly `nodes` entries.
+    ///
+    /// Locations are realised by choosing, for each target, a distinct loopback
+    /// port whose `Location::from_address` is closest to the target (see
+    /// [`loopback_ports_for_locations`]). The achieved locations are therefore
+    /// approximate (discrete ports); read them back with [`get_peer_locations`]
+    /// (gateways first, then regular nodes in order) and build the scenario
+    /// around the actual values. Gateways keep their derived locations.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new_with_node_locations(
+        name: &str,
+        gateways: usize,
+        nodes: usize,
+        ring_max_htl: usize,
+        rnd_if_htl_above: usize,
+        max_connections: usize,
+        min_connections: usize,
+        seed: u64,
+        node_target_locations: &[f64],
+    ) -> Self {
+        assert_eq!(
+            node_target_locations.len(),
+            nodes,
+            "node_target_locations must have exactly `nodes` entries"
+        );
+        let ports = loopback_ports_for_locations(node_target_locations);
+        Self::new_inner(
+            name,
+            gateways,
+            nodes,
+            ring_max_htl,
+            rnd_if_htl_above,
+            max_connections,
+            min_connections,
+            seed,
+            Some(ports),
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn new_inner(
+        name: &str,
+        gateways: usize,
+        nodes: usize,
+        ring_max_htl: usize,
+        rnd_if_htl_above: usize,
+        max_connections: usize,
+        min_connections: usize,
+        seed: u64,
+        node_port_override: Option<Vec<u16>>,
     ) -> Self {
         assert!(nodes > 0);
 
@@ -944,7 +1113,9 @@ impl SimNetwork {
             use_mock_wasm: false,
             churn_config: None,
             governance_config_override: None,
+            subscribe_hint_floor_override: None,
             shared_rings: HashMap::new(),
+            node_port_override,
         };
         net.config_gateways(
             gateways
@@ -1068,6 +1239,29 @@ impl SimNetwork {
         }
         for (builder, _) in self.nodes.iter_mut() {
             builder.config.governance_config_override = Some(config.clone());
+        }
+        self
+    }
+
+    /// Enable the placement-migration (`SubscribeHint`) cascade for this
+    /// simulation by lowering the version floor to `(0,0,0)` on every node.
+    ///
+    /// The cascade is OFF by default in sim: its peers report the current build
+    /// version, which is below the production `SUBSCRIBE_HINT_MIN_VERSION`, so
+    /// the gate never fires. A test that specifically exercises migration calls
+    /// this; every other sim is left untouched (so an unrelated test cannot be
+    /// perturbed by hosting migrating mid-run). Like `with_governance_config`,
+    /// this patches the already-built node/gateway configs (config_* ran during
+    /// construction when the override was still `None`).
+    #[allow(dead_code)]
+    pub fn enable_placement_migration(&mut self) -> &mut Self {
+        const TEST_FLOOR: (u8, u8, u16) = (0, 0, 0);
+        self.subscribe_hint_floor_override = Some(TEST_FLOOR);
+        for (builder, _) in self.gateways.iter_mut() {
+            builder.config.subscribe_hint_floor_override = Some(TEST_FLOOR);
+        }
+        for (builder, _) in self.nodes.iter_mut() {
+            builder.config.subscribe_hint_floor_override = Some(TEST_FLOOR);
         }
         self
     }
@@ -1590,6 +1784,7 @@ impl SimNetwork {
                 .await
                 .unwrap();
             config.governance_config_override = self.governance_config_override.clone();
+            config.subscribe_hint_floor_override = self.subscribe_hint_floor_override;
             config.key_pair = keypair;
             config.network_listener_ip = Ipv6Addr::LOCALHOST.into();
             config.network_listener_port = port;
@@ -1681,6 +1876,7 @@ impl SimNetwork {
                 .await
                 .unwrap();
             config.governance_config_override = self.governance_config_override.clone();
+            config.subscribe_hint_floor_override = self.subscribe_hint_floor_override;
             for GatewayConfig {
                 peer_key_location,
                 location,
@@ -1689,7 +1885,15 @@ impl SimNetwork {
             {
                 config.add_gateway(InitPeerNode::new(peer_key_location.clone(), *location));
             }
-            let port = self.derive_deterministic_port(node_no);
+            // Use an explicit per-node port when the test requested specific
+            // ring locations (see `new_with_node_locations`); otherwise the
+            // deterministic derived port. Either way location is computed from
+            // the address below, so it stays consistent with what other peers
+            // compute from this peer's address.
+            let port = match &self.node_port_override {
+                Some(ports) => ports[node_no - self.number_of_gateways],
+                None => self.derive_deterministic_port(node_no),
+            };
             let addr: SocketAddr = (Ipv6Addr::LOCALHOST, port).into();
             // Use location computed from address for consistency with PeerKeyLocation::location().
             // This ensures the stored location matches what other peers compute when looking at our address.
@@ -3498,6 +3702,11 @@ impl SimNetwork {
         // Separate SeedContract operations (pre-simulation storage seeding)
         // from event operations (dispatched during simulation).
         let mut seed_ops: Vec<(NodeLabel, ContractContainer, Vec<u8>)> = Vec::new();
+        // SeedHostedContract operations: like seed_ops, but the contract is
+        // injected into the owning node's `contracts` list (below, before the
+        // nodes are drained into Turmoil host closures) so startup
+        // `append_contracts` registers genuine hosting + subscription.
+        let mut seed_hosted_ops: Vec<(NodeLabel, ContractContainer, Vec<u8>)> = Vec::new();
         let mut event_ops: Vec<ScheduledOperation> = Vec::new();
         for scheduled_op in operations {
             match scheduled_op.operation {
@@ -3507,12 +3716,46 @@ impl SimNetwork {
                 } => {
                     seed_ops.push((scheduled_op.node, contract.clone(), state.clone()));
                 }
+                SimOperation::SeedHostedContract {
+                    ref contract,
+                    ref state,
+                } => {
+                    seed_hosted_ops.push((scheduled_op.node, contract.clone(), state.clone()));
+                }
                 SimOperation::Put { .. }
                 | SimOperation::Get { .. }
                 | SimOperation::Subscribe { .. }
                 | SimOperation::Update { .. }
                 | SimOperation::Disconnect => event_ops.push(scheduled_op),
             }
+        }
+
+        // Inject SeedHostedContract contracts into the owning node's `contracts`
+        // list BEFORE the gateway/node Vecs are drained into Turmoil host
+        // closures. At startup `append_contracts` runs a local PutQuery (no
+        // network propagation) and, for `subscription = true`, registers the
+        // contract in the Ring hosting manager (`host_contract` + `subscribe`)
+        // so the node genuinely HOSTS it and the placement-migration trigger
+        // (`ring.hosting_contract_keys`) sees it.
+        for (target_label, contract, state) in seed_hosted_ops {
+            let wrapped = WrappedState::new(state);
+            let injected = self
+                .nodes
+                .iter_mut()
+                .find(|(_, label)| *label == target_label)
+                .map(|(node, _)| &mut node.contracts)
+                .or_else(|| {
+                    self.gateways
+                        .iter_mut()
+                        .find(|(_, cfg)| cfg.label == target_label)
+                        .map(|(node, _)| &mut node.contracts)
+                })
+                .map(|contracts| contracts.push((contract, wrapped, true)))
+                .is_some();
+            assert!(
+                injected,
+                "SeedHostedContract: node {target_label:?} not found among gateways/nodes"
+            );
         }
 
         // Build a map of label -> list of (event_id, operation)

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -43,7 +43,7 @@ use freenet_stdlib::prelude::*;
 use crate::client_events::HostResult;
 use crate::config::{GlobalExecutor, OPERATION_TTL};
 use crate::contract::{ContractHandlerEvent, StoreResponse};
-use crate::message::{NetMessage, NetMessageV1, Transaction};
+use crate::message::{NetMessage, NetMessageV1, NodeEvent, Transaction};
 use crate::node::NetworkBridge;
 use crate::node::OpManager;
 #[rustfmt::skip]
@@ -1312,6 +1312,15 @@ async fn cache_contract_locally(
     // persistence there's nothing to announce hosting for.
     if access_result.is_new && put_persisted {
         crate::operations::announce_contract_hosted(op_manager, &key).await;
+        // Directed-subscribe placement (#4404): best-effort nudge the node to
+        // consider migrating this freshly-hosted contract toward a closer
+        // neighbor. Dropped silently if the event channel is full — the next
+        // hosting/peer event re-triggers consideration.
+        if let Err(err) =
+            op_manager.try_notify_node_event(NodeEvent::ConsiderContractMigration { key })
+        {
+            tracing::debug!(%key, %err, "ConsiderContractMigration emit dropped (GET)");
+        }
         let became_interested = op_manager.interest_manager.register_local_hosting(&key);
         let added = if became_interested { vec![key] } else { vec![] };
         if !added.is_empty() || !removed_contracts.is_empty() {

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -29,7 +29,7 @@ use freenet_stdlib::prelude::*;
 
 use crate::client_events::HostResult;
 use crate::config::{GlobalExecutor, OPERATION_TTL};
-use crate::message::{NetMessage, NetMessageV1, Transaction};
+use crate::message::{NetMessage, NetMessageV1, NodeEvent, Transaction};
 use crate::node::NetworkBridge;
 use crate::node::OpManager;
 use crate::node::WaiterReply;
@@ -1565,6 +1565,16 @@ async fn relay_put_store_locally(
             .evicted;
 
         crate::operations::announce_contract_hosted(op_manager, &key).await;
+
+        // Directed-subscribe placement (#4404): best-effort nudge the node to
+        // consider migrating this freshly-hosted contract toward a closer
+        // neighbor. Dropped silently if the event channel is full — the next
+        // hosting/peer event re-triggers consideration.
+        if let Err(err) =
+            op_manager.try_notify_node_event(NodeEvent::ConsiderContractMigration { key })
+        {
+            tracing::debug!(%key, %err, "ConsiderContractMigration emit dropped (PUT)");
+        }
 
         let mut removed_contracts = Vec::new();
         for (evicted_key, expected_generation) in evicted {

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -150,11 +150,17 @@ pub(super) enum InitialRequest {
 /// 4. If no fallback is available either, check local contract availability
 ///    one more time (standalone node / sole holder case) and either complete
 ///    locally or return `NoHostingPeers`.
+///
+/// When `first_hop` is `Some(holder)`, the ring-selection block (branches 2–4)
+/// is bypassed entirely and `holder` is used as the target directly (a directed
+/// subscribe, e.g. driven by a received `SubscribeHint`). The peer-not-joined
+/// check still applies. There are no alternatives in this mode.
 pub(super) async fn prepare_initial_request(
     op_manager: &OpManager,
     id: Transaction,
     instance_id: ContractInstanceId,
     is_renewal: bool,
+    first_hop: Option<PeerKeyLocation>,
 ) -> Result<InitialRequest, OpError> {
     let own_addr = match op_manager.ring.connection_manager.peer_addr() {
         Ok(addr) => addr,
@@ -192,66 +198,83 @@ pub(super) async fn prepare_initial_request(
     let mut visited = super::VisitedPeers::new(&id);
     visited.mark_visited(own_addr);
 
-    let mut candidates =
-        op_manager
-            .ring
-            .k_closest_potentially_hosting(&instance_id, &visited, MAX_BREADTH);
-
-    // First try the best candidates from k_closest_potentially_hosting.
-    // If that returns empty, fall back to any available connection.
-    // This ensures we join the subscription tree even when the routing algorithm
-    // can't find ideal candidates (e.g., due to timing or location filtering).
-    let target = if !candidates.is_empty() {
-        candidates.remove(0)
+    // Directed subscribe: a caller (e.g. a received SubscribeHint) named the
+    // first hop explicitly. Bypass ring selection and target `holder` directly,
+    // with no alternatives.
+    let (target, candidates): (PeerKeyLocation, Vec<PeerKeyLocation>) = if let Some(holder) =
+        first_hop
+    {
+        tracing::debug!(
+            tx = %id,
+            contract = %instance_id,
+            target = ?holder.socket_addr(),
+            phase = "directed_first_hop",
+            "Using caller-supplied first hop for subscription (bypassing ring selection)"
+        );
+        (holder, Vec::new())
     } else {
-        // k_closest_potentially_hosting returned empty - try any connected peer as fallback.
-        // The subscription will be forwarded toward the contract location.
-        let connections = op_manager
-            .ring
-            .connection_manager
-            .get_connections_by_location();
-        // Sort keys for deterministic iteration order (HashMap iteration is non-deterministic)
-        let mut sorted_keys: Vec<_> = connections.keys().collect();
-        sorted_keys.sort();
-        let fallback_target = sorted_keys
-            .into_iter()
-            .filter_map(|loc| connections.get(loc))
-            .flatten()
-            .find(|conn| {
-                conn.location
-                    .socket_addr()
-                    .map(|addr| !visited.probably_visited(addr))
-                    .unwrap_or(false)
-            })
-            .map(|conn| conn.location.clone());
+        let mut candidates =
+            op_manager
+                .ring
+                .k_closest_potentially_hosting(&instance_id, &visited, MAX_BREADTH);
 
-        match fallback_target {
-            Some(target) => {
-                tracing::debug!(
-                    tx = %id,
-                    contract = %instance_id,
-                    target = ?target.socket_addr(),
-                    phase = "fallback_routing",
-                    "Using fallback connection for subscription (k_closest returned empty)"
-                );
-                target
-            }
-            None => {
-                // Truly no connections available - fall back to local completion only if isolated.
-                // This handles the case of a standalone node or when we're the only node with the contract.
-                if let Some(key) = super::has_contract(op_manager, instance_id).await? {
-                    tracing::info!(
+        // First try the best candidates from k_closest_potentially_hosting.
+        // If that returns empty, fall back to any available connection.
+        // This ensures we join the subscription tree even when the routing algorithm
+        // can't find ideal candidates (e.g., due to timing or location filtering).
+        let target = if !candidates.is_empty() {
+            candidates.remove(0)
+        } else {
+            // k_closest_potentially_hosting returned empty - try any connected peer as fallback.
+            // The subscription will be forwarded toward the contract location.
+            let connections = op_manager
+                .ring
+                .connection_manager
+                .get_connections_by_location();
+            // Sort keys for deterministic iteration order (HashMap iteration is non-deterministic)
+            let mut sorted_keys: Vec<_> = connections.keys().collect();
+            sorted_keys.sort();
+            let fallback_target = sorted_keys
+                .into_iter()
+                .filter_map(|loc| connections.get(loc))
+                .flatten()
+                .find(|conn| {
+                    conn.location
+                        .socket_addr()
+                        .map(|addr| !visited.probably_visited(addr))
+                        .unwrap_or(false)
+                })
+                .map(|conn| conn.location.clone());
+
+            match fallback_target {
+                Some(target) => {
+                    tracing::debug!(
                         tx = %id,
-                        contract = %key,
-                        phase = "local_complete",
-                        "Contract available locally and no network connections, completing subscription locally"
+                        contract = %instance_id,
+                        target = ?target.socket_addr(),
+                        phase = "fallback_routing",
+                        "Using fallback connection for subscription (k_closest returned empty)"
                     );
-                    return Ok(InitialRequest::LocallyComplete { key });
+                    target
                 }
-                tracing::warn!(tx = %id, contract = %instance_id, phase = "error", "No remote peers available for subscription");
-                return Ok(InitialRequest::NoHostingPeers);
+                None => {
+                    // Truly no connections available - fall back to local completion only if isolated.
+                    // This handles the case of a standalone node or when we're the only node with the contract.
+                    if let Some(key) = super::has_contract(op_manager, instance_id).await? {
+                        tracing::info!(
+                            tx = %id,
+                            contract = %key,
+                            phase = "local_complete",
+                            "Contract available locally and no network connections, completing subscription locally"
+                        );
+                        return Ok(InitialRequest::LocallyComplete { key });
+                    }
+                    tracing::warn!(tx = %id, contract = %instance_id, phase = "error", "No remote peers available for subscription");
+                    return Ok(InitialRequest::NoHostingPeers);
+                }
             }
-        }
+        };
+        (target, candidates)
     };
 
     let target_addr = target
@@ -362,16 +385,30 @@ async fn complete_local_subscription(
 pub(super) async fn fetch_contract_if_missing(
     op_manager: &OpManager,
     instance_id: ContractInstanceId,
+    directed_holder: Option<PeerKeyLocation>,
 ) -> Result<Option<ContractKey>, OpError> {
     if let Some(key) = super::has_contract(op_manager, instance_id).await? {
         return Ok(Some(key));
     }
 
-    // Spawn the sub-op GET. We drop the receiver — we don't care about
-    // the structured `SubOpGetOutcome`, only the side effect of caching
-    // the contract locally. `wait_for_contract_with_timeout` (storage
-    // poll + wait_for_contract channel + timeout) detects arrival.
-    let (_tx, _rx) = super::get::op_ctx_task::start_sub_op_get(op_manager, instance_id, true);
+    // Spawn the sub-op GET. We drop the receiver/transaction — we don't care
+    // about the structured `SubOpGetOutcome`, only the side effect of caching
+    // the contract locally. `wait_for_contract_with_timeout` (storage poll +
+    // wait_for_contract channel + timeout) detects arrival.
+    match directed_holder {
+        // Placement nudge: fetch the body THROUGH the holder, not greedily.
+        // A greedy GET toward the key could dead-end at the close non-hosting
+        // cluster (the very failure the migration resolves), leaving this peer
+        // subscribed-but-bodyless.
+        Some(holder) => {
+            let _tx =
+                super::get::op_ctx_task::start_targeted_sub_op_get(op_manager, instance_id, holder);
+        }
+        None => {
+            let (_tx, _rx) =
+                super::get::op_ctx_task::start_sub_op_get(op_manager, instance_id, true);
+        }
+    }
 
     wait_for_contract_with_timeout(op_manager, instance_id, CONTRACT_WAIT_TIMEOUT_MS).await
 }
@@ -434,6 +471,13 @@ pub(super) async fn finalize_originator_subscribe(
     key: ContractKey,
     upstream_addr: std::net::SocketAddr,
     is_renewal: bool,
+    // `Some(_)` marks a directed placement nudge (`SubscribeHint`) subscribe;
+    // `None` marks an ordinary subscribe. When `Some`, the body fetch is routed
+    // through the peer that accepted the subscription (`upstream_addr`) so it
+    // cannot dead-end the way a greedy GET would; when `None` the fetch is
+    // greedy. (The value is only used as the directed/ordinary marker — the
+    // actual fetch target is the responder, resolved below.)
+    directed_holder: Option<PeerKeyLocation>,
 ) {
     if let Some(pkl) = op_manager
         .ring
@@ -457,33 +501,51 @@ pub(super) async fn finalize_originator_subscribe(
     // later via UPDATE propagation or the sub-op GET completing past
     // the 2 s wait window, at which point the GET driver's own
     // `announce_contract_hosted` call fires.
-    let have_body = match fetch_contract_if_missing(op_manager, *key.id()).await {
-        Ok(Some(_)) => true,
-        Ok(None) => {
-            tracing::debug!(
-                contract = %key,
-                timeout_ms = CONTRACT_WAIT_TIMEOUT_MS,
-                "subscribe: contract body did not arrive within timeout; \
-                 deferring announce_contract_hosted — the sub-op GET will \
-                 announce when it caches, or UPDATE delivery will fill the gap"
-            );
-            false
-        }
-        Err(err) => {
-            // Infrastructure failure (notification channel closed,
-            // contract handler down). `warn` rather than `debug`
-            // because this signals broken local plumbing, not a
-            // routine cache miss.
-            tracing::warn!(
-                contract = %key,
-                error = %err,
-                "subscribe: fetch_contract_if_missing returned infra error; \
-                 deferring announce_contract_hosted — operator should \
-                 investigate (contract handler / notification channel)"
-            );
-            false
-        }
-    };
+    //
+    // For a directed (migration) subscribe, route the body fetch through the
+    // peer that ACTUALLY accepted the subscription (`upstream_addr`) — which
+    // holds the contract — rather than the original hint holder. In the common
+    // case the responder IS the hint holder; but if the hinted holder went away
+    // and the subscribe fell back to a greedy peer, the responder is that peer,
+    // so the targeted fetch still goes to a peer that has the body instead of
+    // the stale holder (which would dead-end the fetch). A greedy GET toward the
+    // key could dead-end at the same close non-hosting cluster the migration is
+    // resolving, hence the targeted fetch. `None` (ordinary subscribe) keeps the
+    // greedy fetch.
+    let directed_fetch_target = directed_holder.as_ref().and_then(|_| {
+        op_manager
+            .ring
+            .connection_manager
+            .get_peer_by_addr(upstream_addr)
+    });
+    let have_body =
+        match fetch_contract_if_missing(op_manager, *key.id(), directed_fetch_target).await {
+            Ok(Some(_)) => true,
+            Ok(None) => {
+                tracing::debug!(
+                    contract = %key,
+                    timeout_ms = CONTRACT_WAIT_TIMEOUT_MS,
+                    "subscribe: contract body did not arrive within timeout; \
+                     deferring announce_contract_hosted — the sub-op GET will \
+                     announce when it caches, or UPDATE delivery will fill the gap"
+                );
+                false
+            }
+            Err(err) => {
+                // Infrastructure failure (notification channel closed,
+                // contract handler down). `warn` rather than `debug`
+                // because this signals broken local plumbing, not a
+                // routine cache miss.
+                tracing::warn!(
+                    contract = %key,
+                    error = %err,
+                    "subscribe: fetch_contract_if_missing returned infra error; \
+                     deferring announce_contract_hosted — operator should \
+                     investigate (contract handler / notification channel)"
+                );
+                false
+            }
+        };
 
     if have_body {
         super::announce_contract_hosted(op_manager, &key).await;
@@ -658,7 +720,7 @@ pub(crate) mod op_ctx_task;
 
 pub(crate) use op_ctx_task::{
     RenewalOutcome, run_client_subscribe, run_executor_subscribe, run_renewal_subscribe,
-    start_client_subscribe,
+    start_client_subscribe, start_directed_subscribe,
 };
 
 mod messages {

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -137,6 +137,94 @@ pub(crate) async fn start_client_subscribe(
     Ok(client_tx)
 }
 
+/// Start a node-initiated **directed** subscribe toward a specific first hop.
+///
+/// Used by the directed-subscribe placement path (#4404): on receiving a
+/// [`SubscribeHint`](crate::message::NetMessageV1::SubscribeHint), the
+/// recipient subscribes to `key` routed THROUGH `holder` (the hint sender,
+/// the current holder) rather than via greedy ring selection — a plain
+/// greedy subscribe would route away from the holder. Fetching the contract
+/// as part of the subscribe causes the recipient to host it, migrating the
+/// contract toward its ideal ring location.
+///
+/// Fire-and-forget: there is no client waiter. Like `start_client_subscribe`,
+/// failures are swallowed inside the spawned driver (no result delivery).
+/// Mirrors `start_client_subscribe`'s admission/ban guards but threads
+/// `first_hop = Some(holder)` into the driver.
+pub(crate) fn start_directed_subscribe(
+    op_manager: Arc<OpManager>,
+    key: freenet_stdlib::prelude::ContractKey,
+    holder: PeerKeyLocation,
+) {
+    let instance_id = *key.id();
+
+    // Egress self-block (#4300): refuse to originate a directed subscribe for
+    // a contract this node has banned, mirroring `start_client_subscribe`.
+    if crate::operations::reject_if_contract_banned(&op_manager, &instance_id).is_err() {
+        tracing::debug!(
+            contract = %instance_id,
+            "directed subscribe: contract banned, ignoring hint"
+        );
+        return;
+    }
+
+    let inflight_guard = match op_manager.admit_client_op() {
+        Some(g) => g,
+        None => return,
+    };
+    let directed_tx = Transaction::new::<SubscribeMsg>();
+    tracing::debug!(
+        tx = %directed_tx,
+        contract = %instance_id,
+        holder = ?holder.socket_addr(),
+        "directed subscribe: spawning hint-initiated task"
+    );
+    GlobalExecutor::spawn(async move {
+        let _inflight_guard = inflight_guard;
+        let outcome = drive_client_subscribe(
+            op_manager.clone(),
+            instance_id,
+            directed_tx,
+            /* is_renewal */ false,
+            /* first_hop */ Some(holder),
+        )
+        .await;
+        // Internal (migration) subscribe: there is NO client waiter. The
+        // hosting side effects (host_contract, announce) already ran inside the
+        // driver's `finalize_originator_subscribe`, so completion is just a log
+        // here. Deliberately NOT routed through `deliver_outcome`: that would
+        // count this toward the user-facing SUBSCRIBE op-stats and push a result
+        // into `result_router_tx` that no client consumes (skewing stats and
+        // occupying router capacity during a migration cascade). Best-effort:
+        // a failed directed subscribe is retried on the next migration trigger.
+        match outcome {
+            DriverOutcome::Publish(Ok(_)) | DriverOutcome::SkipAlreadyDelivered => {
+                tracing::debug!(
+                    tx = %directed_tx,
+                    contract = %instance_id,
+                    "directed subscribe: completed (now hosting/subscribed)"
+                );
+            }
+            DriverOutcome::Publish(Err(e)) => {
+                tracing::debug!(
+                    tx = %directed_tx,
+                    contract = %instance_id,
+                    error = ?e,
+                    "directed subscribe: did not complete (best-effort; will retry on next trigger)"
+                );
+            }
+            DriverOutcome::InfrastructureError(err) => {
+                tracing::debug!(
+                    tx = %directed_tx,
+                    contract = %instance_id,
+                    error = %err,
+                    "directed subscribe: infrastructure error (best-effort)"
+                );
+            }
+        }
+    });
+}
+
 /// Drive a client-initiated subscribe to completion and publish the result
 /// to `result_router_tx` keyed by `client_tx`.
 ///
@@ -162,6 +250,7 @@ pub(crate) async fn run_client_subscribe(
         instance_id,
         client_tx,
         /* is_renewal */ false,
+        /* first_hop */ None,
     )
     .await;
     deliver_outcome(&op_manager, client_tx, instance_id, outcome);
@@ -248,6 +337,7 @@ pub(crate) async fn run_renewal_subscribe(
         instance_id,
         renewal_tx,
         /* is_renewal */ true,
+        /* first_hop */ None,
     )
     .await;
     classify_renewal_result(result)
@@ -342,6 +432,7 @@ pub(crate) async fn run_executor_subscribe(
         executor_tx,
         instance_id,
         /* is_renewal */ false,
+        /* first_hop */ None,
     )
     .await
     {
@@ -393,6 +484,7 @@ pub(crate) async fn run_executor_subscribe(
         instance_id,
         executor_tx,
         /* is_renewal */ false,
+        /* first_hop */ None,
     )
     .await;
     classify_executor_subscribe_result(result)
@@ -469,8 +561,11 @@ async fn drive_client_subscribe(
     instance_id: ContractInstanceId,
     client_tx: Transaction,
     is_renewal: bool,
+    first_hop: Option<PeerKeyLocation>,
 ) -> DriverOutcome {
-    match drive_client_subscribe_inner(&op_manager, instance_id, client_tx, is_renewal).await {
+    match drive_client_subscribe_inner(&op_manager, instance_id, client_tx, is_renewal, first_hop)
+        .await
+    {
         Ok(outcome) => outcome,
         Err(err) => DriverOutcome::InfrastructureError(err),
     }
@@ -481,6 +576,7 @@ async fn drive_client_subscribe_inner(
     instance_id: ContractInstanceId,
     client_tx: Transaction,
     is_renewal: bool,
+    first_hop: Option<PeerKeyLocation>,
 ) -> Result<DriverOutcome, OpError> {
     // Decide: local-completion, give up, or send to the network.
     // `prepare_initial_request` uses `client_tx` for its visited-peers
@@ -488,7 +584,14 @@ async fn drive_client_subscribe_inner(
     // filter is per-attempt-first-peer only and telemetry correlates on
     // the client-visible tx (matching legacy behaviour for the first
     // attempt).
-    let initial = prepare_initial_request(op_manager, client_tx, instance_id, is_renewal).await?;
+    // Retain the directed holder (if any) so the post-Subscribed body fetch can
+    // be routed THROUGH it rather than greedily. A greedy sub-op GET toward the
+    // key could dead-end at the same close non-hosting cluster the migration is
+    // resolving, leaving this peer subscribed-but-bodyless. `None` for ordinary
+    // (non-directed) subscribes, which keep the greedy fetch.
+    let directed_holder = first_hop.clone();
+    let initial =
+        prepare_initial_request(op_manager, client_tx, instance_id, is_renewal, first_hop).await?;
 
     let (target_peer, target_addr, mut visited, mut alternatives, htl) = match initial {
         InitialRequest::LocallyComplete { key } => {
@@ -783,6 +886,7 @@ async fn drive_client_subscribe_inner(
                     key,
                     current_target_addr,
                     is_renewal,
+                    directed_holder.clone(),
                 )
                 .await;
                 return Ok(DriverOutcome::Publish(Ok(HostResponse::ContractResponse(
@@ -1768,6 +1872,49 @@ mod tests {
              before GlobalExecutor::spawn so a banned contract's SUBSCRIBE \
              is rejected with a typed error instead of registering interest \
              (#4300 egress self-block)."
+        );
+    }
+
+    /// `start_directed_subscribe` (the SubscribeHint receive path) MUST keep
+    /// the same ban + admission guards as `start_client_subscribe` before it
+    /// spawns a driver — a network-triggered directed subscribe must not bypass
+    /// the egress ban check (#4300) or the inflight admission gate. And it must
+    /// NOT route its outcome through `deliver_outcome` (the client result path):
+    /// there is no client waiter, so doing so would skew the user-facing
+    /// SUBSCRIBE op-stats and push an unconsumed result into result_router_tx
+    /// during a migration cascade (Codex r2).
+    #[test]
+    fn start_directed_subscribe_guards_and_completes_internally() {
+        let src = include_str!("op_ctx_task.rs");
+        let entry = src
+            .find("pub(crate) fn start_directed_subscribe(")
+            .expect("start_directed_subscribe must exist");
+        let after_spawn_off = src[entry..]
+            .find("GlobalExecutor::spawn(")
+            .expect("start_directed_subscribe must spawn a driver task");
+        let before_spawn = &src[entry..entry + after_spawn_off];
+        assert!(
+            before_spawn.contains("reject_if_contract_banned"),
+            "start_directed_subscribe must call reject_if_contract_banned() before spawn"
+        );
+        assert!(
+            before_spawn.contains("op_manager.admit_client_op()"),
+            "start_directed_subscribe must acquire the inflight admission guard before spawn"
+        );
+        // Bound the spawned-block scan to this function (up to the next fn).
+        let rest = &src[entry + after_spawn_off..];
+        let block_end = rest.find("\npub(crate) async fn ").unwrap_or(rest.len());
+        let spawn_block = &rest[..block_end];
+        assert!(
+            spawn_block.contains("let _inflight_guard = inflight_guard;"),
+            "the inflight guard must be moved into the spawned directed-subscribe future"
+        );
+        // Check for the CALL form `deliver_outcome(` — the explanatory comment in
+        // the function mentions the name without a paren, so this won't false-trip.
+        assert!(
+            !spawn_block.contains("deliver_outcome("),
+            "start_directed_subscribe must complete internally (log only), NOT via \
+             deliver_outcome() — there is no client waiter for a migration subscribe"
         );
     }
 

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -284,6 +284,18 @@ pub(crate) struct ConnectionManager {
     /// Our own socket address, set once we know it (e.g., from gateway observation).
     own_addr: Arc<Mutex<Option<SocketAddr>>>,
     is_gateway: bool,
+    /// Test-only override for the placement-migration version floor. `None` in
+    /// production (the real `SUBSCRIBE_HINT_MIN_VERSION` applies); `Some(floor)`
+    /// only in a sim test that opted into the migration cascade via
+    /// `SimNetwork::enable_placement_migration`. See `NodeConfig`.
+    subscribe_hint_floor_override: Option<(u8, u8, u16)>,
+    /// Rotating start offset for the per-new-peer migration scan. The scan
+    /// examines at most `MIGRATION_SCAN_CAP_PER_NEW_PEER` hosted contracts per
+    /// event; advancing this cursor each event makes successive events cover
+    /// different windows of the hosting set, so a node hosting more contracts
+    /// than the cap doesn't repeatedly examine the same prefix (which would
+    /// starve the rest of new-peer-triggered migration).
+    migration_scan_cursor: Arc<AtomicUsize>,
     /// Transient connections keyed by socket address.
     transient_connections: Arc<DashMap<SocketAddr, TransientEntry>>,
     transient_in_use: Arc<AtomicUsize>,
@@ -379,7 +391,7 @@ impl ConnectionManager {
 
         let min_ready_connections = config.relay_ready_connections.unwrap_or(0);
 
-        Self::init(
+        let mut cm = Self::init(
             max_upstream_bandwidth,
             max_downstream_bandwidth,
             min_connections,
@@ -394,7 +406,12 @@ impl ConnectionManager {
             config.transient_budget,
             config.transient_ttl,
             min_ready_connections,
-        )
+        );
+        // Set after init (rather than threading through init's many call sites):
+        // None for all the test-helper constructions, Some(floor) only when a
+        // sim opted into the migration cascade.
+        cm.subscribe_hint_floor_override = config.subscribe_hint_floor_override;
+        cm
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -425,6 +442,9 @@ impl ConnectionManager {
             own_location: own_location.into(),
             own_addr: Arc::new(Mutex::new(own_addr)),
             is_gateway,
+            // Default off; `new(config)` overrides from config after init.
+            subscribe_hint_floor_override: None,
+            migration_scan_cursor: Arc::new(AtomicUsize::new(0)),
             transient_connections: Arc::new(DashMap::new()),
             transient_in_use: Arc::new(AtomicUsize::new(0)),
             transient_budget,
@@ -773,6 +793,22 @@ impl ConnectionManager {
     /// If the node's external address is not yet known (e.g., peer behind NAT
     /// that hasn't received ObservedAddress yet), returns a PeerKeyLocation
     /// with PeerAddr::Unknown.
+    /// Test-only placement-migration version-floor override (`None` in
+    /// production). See `NodeConfig::subscribe_hint_floor_override`.
+    pub(crate) fn subscribe_hint_floor_override(&self) -> Option<(u8, u8, u16)> {
+        self.subscribe_hint_floor_override
+    }
+
+    /// Reserve the next `window`-sized slice of the hosting set for a migration
+    /// scan and advance the rotating cursor by `window`. Returns the start
+    /// offset (callers should take it modulo the current hosting-set size). Over
+    /// successive new-peer events this rotates coverage across all hosted
+    /// contracts rather than repeatedly scanning the same prefix.
+    pub(crate) fn next_migration_scan_offset(&self, window: usize) -> usize {
+        self.migration_scan_cursor
+            .fetch_add(window, Ordering::Relaxed)
+    }
+
     pub fn own_location(&self) -> PeerKeyLocation {
         match self.get_own_addr() {
             Some(addr) => PeerKeyLocation::new((*self.pub_key).clone(), addr),

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -1480,7 +1480,8 @@ impl<'a> NetEventLog<'a> {
             | NetMessageV1::Aborted(_)
             | NetMessageV1::NeighborHosting { .. }
             | NetMessageV1::InterestSync { .. }
-            | NetMessageV1::ReadyState { .. } => EventKind::Ignored,
+            | NetMessageV1::ReadyState { .. }
+            | NetMessageV1::SubscribeHint(_) => EventKind::Ignored,
         };
         let own_loc = op_manager.ring.connection_manager.own_location();
         let Some(own_addr) = own_loc.socket_addr() else {

--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -631,6 +631,13 @@ pub(crate) trait PeerConnectionApi: Send {
     /// Returns the remote peer's socket address.
     fn remote_addr(&self) -> SocketAddr;
 
+    /// Returns the remote peer's negotiated protocol version, if known.
+    ///
+    /// `None` when the version was not exchanged (e.g. the joiner->gateway
+    /// path whose `AckConnection` carries no version). Callers must treat
+    /// `None` as "unsupported" when gating version-dependent message types.
+    fn remote_version(&self) -> Option<(u8, u8, u16)>;
+
     /// Sends a network message to the remote peer.
     ///
     /// The message is serialized and sent over the transport connection.

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -2340,6 +2340,10 @@ impl<S: super::Socket> super::PeerConnectionApi for PeerConnection<S> {
         self.remote_conn.remote_addr
     }
 
+    fn remote_version(&self) -> Option<(u8, u8, u16)> {
+        PeerConnection::remote_version(self)
+    }
+
     fn send_message(
         &mut self,
         msg: crate::message::NetMessage,

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -9645,3 +9645,289 @@ fn test_hop_count_populated_on_terminal_get_events() {
         RING_MAX_HTL
     );
 }
+
+/// Verifies the contract-placement migration (#4404): a contract held only by a
+/// peer FAR from its key migrates onto the cluster of peers CLOSEST to the key,
+/// resolving the GET dead-end.
+///
+/// Setup (peer ring locations controlled via `new_with_node_locations`):
+///   - a dense cluster of peers sits right on the contract's key location;
+///   - exactly one peer, far from the key, initially hosts the contract (seeded
+///     into its store AND Ring hosting manager, with no network propagation);
+///   - a requester, also far from the key, issues a GET.
+///
+/// GET is single-path greedy (k=1), so it routes toward the key and reaches the
+/// close cluster. WITHOUT the migration that cluster lacks the state, so the GET
+/// dead-ends with NotFound (the far host is never on the greedy path toward the
+/// key) — that is the placement gap #4404 describes. The migration nudges the
+/// contract from the far host toward the key: each hosting peer, on gaining a
+/// connected neighbor strictly closer to the key, sends a `SubscribeHint` so
+/// that neighbor directed-subscribes through the holder and begins hosting. The
+/// contract therefore climbs onto the close cluster, and a key-routed GET now
+/// lands on a host. (The dead-end itself is not asserted separately here; the
+/// migration trigger is always-on, so this test pins the resolved state.)
+///
+/// Asserts the migration outcome directly via each node's live Ring: the far
+/// host still hosts the contract, and at least one close-cluster peer (the peers
+/// a key-routed GET actually reaches) ends up hosting it via migration.
+#[test_log::test]
+fn test_contract_migrates_to_close_cluster_resolving_get_dead_end() {
+    use freenet::dev_tool::{Location, NodeLabel, ScheduledOperation, SimNetwork, SimOperation};
+
+    const SEED: u64 = 0xDEAD_F00D_0001;
+    const NETWORK_NAME: &str = "get-placement-deadend";
+    setup_deterministic_state(SEED);
+
+    // Pick a contract and read its ring location; place peers relative to it.
+    let contract = SimOperation::create_test_contract(0xBE);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    let key_loc = Location::from(&contract_key).as_f64();
+
+    // Six peers clustered tightly around the key (none will host it), then one
+    // far host (seeded) and one far requester. `rem_euclid` wraps onto the ring.
+    let wrap = |x: f64| x.rem_euclid(1.0);
+    let cluster: Vec<f64> = [-0.010, -0.006, -0.003, 0.003, 0.006, 0.010]
+        .iter()
+        .map(|o| wrap(key_loc + o))
+        .collect();
+    let host_loc = wrap(key_loc + 0.40); // far from the key
+    let requester_loc = wrap(key_loc + 0.70); // far from the key, other side
+    let mut node_locations = cluster.clone();
+    node_locations.push(host_loc); // regular-node order 6 -> node_no 7
+    node_locations.push(requester_loc); // regular-node order 7 -> node_no 8
+    let num_nodes = node_locations.len(); // 8
+
+    let rt = create_runtime();
+    let mut sim = rt.block_on(async {
+        SimNetwork::new_with_node_locations(
+            NETWORK_NAME,
+            1,         // 1 gateway
+            num_nodes, // 8 regular nodes
+            10,        // ring_max_htl
+            7,         // rnd_if_htl_above
+            8,         // max_connections
+            3,         // min_connections
+            SEED,
+            &node_locations,
+        )
+        .await
+    });
+    // Opt this simulation into the placement-migration cascade (off by default in
+    // sim so it can't perturb unrelated tests, e.g. the streaming assembly-retry
+    // test). This lowers the per-node SubscribeHint version floor to (0,0,0).
+    sim.enable_placement_migration();
+
+    // Regular nodes are node_no = 1..=8 (gateway is node 0); node_locations[i]
+    // maps to node_no i+1.
+    let host_label = NodeLabel::node(NETWORK_NAME, 7); // host_loc
+    let requester_label = NodeLabel::node(NETWORK_NAME, 8); // requester_loc
+
+    // Setup sanity: a cluster node must be strictly closer to the key than the
+    // host, so a key-routed GET genuinely lands in the (non-hosting) cluster
+    // rather than near the holder. get_peer_locations() is [gateway, node1..8].
+    let locs = sim.get_peer_locations();
+    let ring_dist = |a: f64, b: f64| {
+        let d = (a - b).abs();
+        d.min(1.0 - d)
+    };
+    let host_dist = ring_dist(locs[7], key_loc);
+    let cluster_min = (1..=6)
+        .map(|i| ring_dist(locs[i], key_loc))
+        .fold(f64::INFINITY, f64::min);
+    assert!(
+        cluster_min < host_dist,
+        "scenario setup wrong: a cluster node must be closer to the key than the host \
+         (cluster_min={cluster_min}, host_dist={host_dist})"
+    );
+
+    let operations = vec![
+        // Only the far host holds the contract initially — seeded into both its
+        // store and Ring hosting manager (no network propagation), so it is a
+        // genuine migration source (`ring.is_hosting_contract` is true).
+        ScheduledOperation::new(
+            host_label.clone(),
+            SimOperation::SeedHostedContract {
+                contract: contract.clone(),
+                state: vec![10, 20, 30, 40],
+            },
+        ),
+        // The far requester asks for it (greedy GET toward the key).
+        ScheduledOperation::new(
+            requester_label.clone(),
+            SimOperation::Get {
+                contract_id,
+                return_contract_code: true,
+                subscribe: false,
+            },
+        ),
+    ];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(180),
+        Duration::from_secs(60),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "simulation failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    // The far host still hosts the seeded contract (it remains a source).
+    assert!(
+        result.is_node_hosting(&host_label, &contract_key),
+        "host should still host the seeded contract after the simulation"
+    );
+
+    // CORE OF THE FIX: the contract migrated onto the close cluster. At least
+    // one of the peers a key-routed GET actually reaches (node_no 1..=6) now
+    // hosts it. Before the migration NONE of them did — this test previously
+    // asserted exactly that dead-end (see git history). With the contract now
+    // present on a peer the greedy path lands on, the dead-end is resolved.
+    let migrated: Vec<usize> = (1..=6usize)
+        .filter(|n| result.is_node_hosting(&NodeLabel::node(NETWORK_NAME, *n), &contract_key))
+        .collect();
+    let requester_has_state = result
+        .node_storages
+        .get(&requester_label)
+        .is_some_and(|s| s.get_stored_state(&contract_key).is_some());
+    assert!(
+        !migrated.is_empty(),
+        "placement migration FAILED: no close-cluster peer (node_no 1..=6) hosts the \
+         contract after the simulation. The contract never migrated from the far host \
+         toward the key, so a key-routed GET would still dead-end. \
+         host_hosting={}, requester_has_state={requester_has_state}",
+        result.is_node_hosting(&host_label, &contract_key),
+    );
+
+    // End-to-end payoff: with the contract migrated onto the close cluster, the
+    // requester's greedy GET toward the key now lands on a host instead of
+    // dead-ending, so it obtains the state. This is the user-visible symptom
+    // from the original telemetry (a web GET that needed several retries before
+    // the contract had migrated onto the key-close peers).
+    assert!(
+        requester_has_state,
+        "requester GET should now succeed: with the contract migrated onto the close \
+         cluster, the greedy GET toward the key lands on a host instead of dead-ending \
+         (migrated cluster nodes: {migrated:?})"
+    );
+
+    tracing::info!(
+        migrated_cluster_nodes = ?migrated,
+        requester_has_state,
+        "placement migration converged onto the close cluster"
+    );
+}
+
+/// Negative control for `test_contract_migrates_to_close_cluster_resolving_get_dead_end`.
+///
+/// IDENTICAL scenario, but WITHOUT `enable_placement_migration()` — so the
+/// SubscribeHint cascade stays off (sim peers report a build version below the
+/// production floor). This reproduces the #4404 dead-end and, paired with the
+/// positive test, proves that the migration cascade (not some incidental GET
+/// caching path) is what makes the close cluster host the contract: same seed,
+/// same topology, the ONLY difference is whether migration is enabled.
+#[test_log::test]
+fn test_get_dead_ends_at_close_cluster_without_migration() {
+    use freenet::dev_tool::{Location, NodeLabel, ScheduledOperation, SimNetwork, SimOperation};
+
+    const SEED: u64 = 0xDEAD_F00D_0001;
+    const NETWORK_NAME: &str = "get-placement-deadend-control";
+    setup_deterministic_state(SEED);
+
+    let contract = SimOperation::create_test_contract(0xBE);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    let key_loc = Location::from(&contract_key).as_f64();
+
+    let wrap = |x: f64| x.rem_euclid(1.0);
+    let cluster: Vec<f64> = [-0.010, -0.006, -0.003, 0.003, 0.006, 0.010]
+        .iter()
+        .map(|o| wrap(key_loc + o))
+        .collect();
+    let host_loc = wrap(key_loc + 0.40);
+    let requester_loc = wrap(key_loc + 0.70);
+    let mut node_locations = cluster.clone();
+    node_locations.push(host_loc);
+    node_locations.push(requester_loc);
+    let num_nodes = node_locations.len();
+
+    let rt = create_runtime();
+    // NOTE: deliberately NO `enable_placement_migration()` — that is the whole
+    // point of this control.
+    let sim = rt.block_on(async {
+        SimNetwork::new_with_node_locations(
+            NETWORK_NAME,
+            1,
+            num_nodes,
+            10,
+            7,
+            8,
+            3,
+            SEED,
+            &node_locations,
+        )
+        .await
+    });
+
+    let host_label = NodeLabel::node(NETWORK_NAME, 7);
+    let requester_label = NodeLabel::node(NETWORK_NAME, 8);
+
+    let operations = vec![
+        ScheduledOperation::new(
+            host_label.clone(),
+            SimOperation::SeedHostedContract {
+                contract: contract.clone(),
+                state: vec![10, 20, 30, 40],
+            },
+        ),
+        ScheduledOperation::new(
+            requester_label.clone(),
+            SimOperation::Get {
+                contract_id,
+                return_contract_code: true,
+                subscribe: false,
+            },
+        ),
+    ];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(180),
+        Duration::from_secs(60),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "simulation failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    // The far host still hosts the seeded contract.
+    assert!(
+        result.is_node_hosting(&host_label, &contract_key),
+        "host should hold the seeded contract"
+    );
+
+    // DEAD-END (expected without migration): no close-cluster peer hosts the
+    // contract, so a key-routed GET dead-ends and the requester gets nothing.
+    let migrated: Vec<usize> = (1..=6usize)
+        .filter(|n| result.is_node_hosting(&NodeLabel::node(NETWORK_NAME, *n), &contract_key))
+        .collect();
+    assert!(
+        migrated.is_empty(),
+        "without migration, no close-cluster peer should host the contract, but these do: \
+         {migrated:?} (cascade leaked into a migration-disabled sim?)"
+    );
+    let requester_has_state = result
+        .node_storages
+        .get(&requester_label)
+        .is_some_and(|s| s.get_stored_state(&contract_key).is_some());
+    assert!(
+        !requester_has_state,
+        "without migration the requester GET must dead-end at the close non-hosting cluster \
+         and obtain NO state (the far host is off the greedy path toward the key)"
+    );
+}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -70,6 +70,23 @@ requests, Metadata) and `workflow` scopes. See AGENTS.md → "Release Workflow
 workflow-triggering events as an anti-recursion safeguard, so PAT is
 required for the cascade to fire automatically).
 
+### Wire-gated feature floors (one-time, per feature)
+
+Some features that add a new `NetMessageV1` wire variant are version-gated:
+a node only sends the new variant to peers whose negotiated protocol version
+is at or above a hardcoded floor, so older peers never receive a variant they
+can't deserialize (they'd drop the connection). When you cut the release that
+**first** ships such a feature, set its floor to **exactly that release
+version**, then leave it frozen — do NOT bump it on later releases (raising it
+above the first-shipping version would silently stop sending to fully-capable
+peers).
+
+Current wire-gated floors to set at first ship:
+
+- `SUBSCRIBE_HINT_MIN_VERSION` in `crates/core/src/node/network_bridge/p2p_protoc.rs`
+  (SubscribeHint placement migration, #4404). Must equal the first release that
+  includes it.
+
 ## What fires when
 
 ```


### PR DESCRIPTION
## Problem

A contract is hosted wherever traffic placed it (the PUT chain, or a successful GET); it is never migrated toward the peers closest to its key. When the peer closest to a contract's key does not host it, a greedy GET (k=1) routes to the key, reaches that closest non-hosting peer, and dead-ends with `NotFound`, even though a real host exists off the greedy path. This was diagnosed from production telemetry: a ~1 MB web contract needed several GET retries before it loaded (#4404).

## Approach

A fire-and-forget "subscribe-nudge" migration. A peer that hosts a contract, on gaining a connected neighbor strictly closer to the contract's key that is not already hosting it, sends a `SubscribeHint { key, holder }` to that single closest neighbor. The recipient performs a *directed* subscribe through the holder (a plain greedy subscribe would route away from the holder), fetches the state, and begins hosting, then repeats for its own closer neighbors. The contract therefore climbs onto the peers closest to its key, where greedy GETs land.

Design constraints:

- **Bounded, not a flood.** Only the single closest neighbor is nudged, only if strictly closer than us, only if it is not already hosting, and only if it is version-supported (selection skips peers too old to understand the hint, so one old closest peer can't suppress migration to a capable closer peer during a rolling upgrade). The per-event scan is capped (32) with a rotating cursor so high-hosting nodes cover all contracts across events, and the nudge is a non-blocking `try_send` (channel-safety).
- **Wire-compatible.** `SubscribeHint` is appended last to `NetMessageV1`, so existing variant discriminants stay byte-identical. An old peer cannot deserialize an unknown appended variant and would drop the connection, so the send is **version-gated** on the per-connection negotiated protocol version (precursor #4405), failing closed on an unknown version. `SUBSCRIBE_HINT_MIN_VERSION` is a single non-`cfg` constant (= the release version) so it can never be lowered in the shipped binary; simulation tests that exercise the cascade lower the floor per-node at runtime via `NodeConfig::subscribe_hint_floor_override` (set by `SimNetwork::enable_placement_migration`), which never reaches production. Migration is therefore opt-in in sim and cannot perturb unrelated simulations. The gate's comparison and fail-closed-on-`None` behavior are unit-tested with explicit floors; the floor must be frozen at the first-shipping release (see `docs/RELEASING.md`).

## Testing

- **Simulation (positive):** `test_contract_migrates_to_close_cluster_resolving_get_dead_end`. A far host holds a contract, a dense non-hosting cluster sits on the key, and a far requester issues a GET. With migration enabled (opt-in), asserts via each node's live `Ring` that the contract migrates onto the close cluster and that the requester's GET (a dead-end without the fix) now succeeds; in the run all 6 close-cluster peers host it and the far gateway/requester do not over-replicate.
- **Simulation (negative control):** `test_get_dead_ends_at_close_cluster_without_migration`. Identical scenario, migration NOT enabled — asserts the dead-end (no cluster peer hosts it, requester gets nothing). Same seed/topology; the only difference is the opt-in, so the pair proves the cascade (not some incidental path) is what resolves the dead-end.
- **Unit tests:** `version_gate` (comparison + fail-closed-on-`None`), `migration_selection` (6 tests for the pure selection core), a `SubscribeHintMsg` wire round-trip + version-map pin, and a `start_directed_subscribe` source-scrape pin (keeps its ban/admission guards, completes internally not via the client path).
- **Sim harness additions:** `SimNetwork::new_with_node_locations` (place peers at chosen ring locations), `SimNetwork::enable_placement_migration` (opt a sim into the cascade), `SimOperation::SeedHostedContract` (seed + register genuine hosting without network propagation), `ControlledSimulationResult::is_node_hosting`.

Builds on #4405 (per-connection protocol version capture), now merged.

Closes #4404

Related: #4414 — the SUBSCRIBE-side of the same placement gap. This PR removes its root cause (contracts not replicated near their key), so a key-routed SUBSCRIBE also lands on a host; the subscribe flood fallback and the convergence-window robustness remain tracked there.

[AI-assisted - Claude]
