### PR TITLE
chore: silence simulation_tests dead-code lint for record_broadcast_queue_depth

### DIFF
--- a/crates/core/src/transport/shadow_demand.rs
+++ b/crates/core/src/transport/shadow_demand.rs
@@ -216,6 +216,14 @@ static BROADCAST_QUEUE_DEPTH: AtomicUsize = AtomicUsize::new(0);
 /// mutation, so the gauge tracks the real depth while the shadow reader
 /// (the demand aggregator) reads it lock-free and never contends on the
 /// queue's async mutex.
+///
+/// The only production caller (`broadcast_queue.rs`) is gated
+/// `#[cfg(not(feature = "simulation_tests"))]`, so under `simulation_tests`
+/// the fn has no production caller and clippy's `-D warnings` would promote
+/// the resulting `dead_code` warning to a hard error. The `cfg(test)` gauge
+/// round-trip test below still exercises it; the `allow` only suppresses the
+/// non-test simulation_tests build, leaving default-feature builds unchanged.
+#[cfg_attr(feature = "simulation_tests", allow(dead_code))]
 pub(crate) fn record_broadcast_queue_depth(depth: usize) {
     BROADCAST_QUEUE_DEPTH.store(depth, Ordering::Relaxed);
 }


### PR DESCRIPTION
## Problem

`cargo clippy -p freenet --features simulation_tests,testing -- -D warnings`
fails with a hard error:

```
error: function `record_broadcast_queue_depth` is never used
  --> crates/core/src/transport/shadow_demand.rs:219
```

The only production caller of `record_broadcast_queue_depth` lives in
`crates/core/src/node/network_bridge/broadcast_queue.rs`, but that module is
gated `#[cfg(not(feature = "simulation_tests"))]`. Under the `simulation_tests`
feature there is no production caller, so clippy's `dead_code` warning is
promoted to a hard error by `-D warnings`. The function is still exercised by a
`cfg(test)` gauge round-trip test (`broadcast_queue_depth_gauge_round_trips`),
so it is not genuinely dead — this is purely a cfg-interaction artifact.

This is **pre-existing**, introduced by #4379 (Phase 1.6 shadow-demand
telemetry). CI's clippy runs with **default features**, where the production
caller is present, so CI is green and this only bites someone running clippy
locally with `simulation_tests`.

## Solution

Add `#[cfg_attr(feature = "simulation_tests", allow(dead_code))]` to the
`record_broadcast_queue_depth` fn. This suppresses the lint **only** for the
non-test `simulation_tests` build. The default-feature build (what CI checks)
keeps the function fully lint-checked, so the default lint surface is unchanged
and no runtime behavior changes. A rustdoc comment on the function explains the
cfg interaction for future readers.

This is the minimal correct fix: it does not delete the function or its
callers, and does not broaden the `allow` beyond the feature set that actually
triggers the false positive.

## Testing

All four feature-set checks are clean (exit 0, no warnings):

- `cargo clippy -p freenet --features simulation_tests,testing -- -D warnings`
- `cargo clippy -p freenet --tests --features simulation_tests,testing -- -D warnings`
- `cargo clippy -p freenet -- -D warnings` (default features — stays clean)
- `cargo fmt -p freenet --check`

No behavioral change, so no new test is added (and `chore:` is used rather than
`fix:`, which the freenet CI requires to add a new test).

[AI-assisted - Claude]