### PR TITLE
fix: make release-agent reject overlapping gateway updates to prevent double-stop

### DIFF
--- a/.github/workflows/gateway-update.yml
+++ b/.github/workflows/gateway-update.yml
@@ -194,6 +194,24 @@ jobs:
 
           case "$HTTP_STATUS" in
             200|202) ;;
+            409)
+              # 409 Conflict: an update is already in flight on this gateway
+              # (an overlapping/legit re-run — e.g. a manual re-trigger landing
+              # while the release.published rollout is still restarting the
+              # service). The agent's in-flight guard rejected the duplicate to
+              # prevent the #4271 double-stop. This is NOT a failure: the
+              # in-progress update is the one that matters, so fall through to
+              # the verify step below, which polls /version until the gateway
+              # converges on the target version with an active service.
+              echo "::notice::Gateway ${{ matrix.gateway.name }} reports an update already in progress (HTTP 409); skipping duplicate spawn and proceeding to verify."
+              ;;
+            429)
+              # 429 Too Many Requests: the rate-limit window hasn't elapsed
+              # since the last accepted update. Like 409, this means an update
+              # was recently kicked off, so the target is (or will be) applied.
+              # Proceed to verify rather than failing the release.
+              echo "::notice::Gateway ${{ matrix.gateway.name }} rate-limited this update (HTTP 429); a recent update is in effect. Proceeding to verify."
+              ;;
             *)
               echo "::error::Gateway ${{ matrix.gateway.name }} rejected update: HTTP $HTTP_STATUS"
               exit 1

--- a/crates/release-agent/src/config.rs
+++ b/crates/release-agent/src/config.rs
@@ -72,6 +72,31 @@ impl Config {
         toml::from_str(&raw).context("parse config TOML")
     }
 
+    /// Warn (at load time) if `rate_limit_seconds` is configured below the
+    /// updater's `MAX_UPDATE_HOLD`. The rate-limit window is the second
+    /// backstop for the in-flight overlap guard: if a real update runs past
+    /// `MAX_UPDATE_HOLD`, the guard frees the slot while the child is still
+    /// running, and only the rate-limiter then stops a second POST from racing
+    /// the in-flight restart (the #4271 double-stop). With the prod default
+    /// (`rate_limit_seconds = 600 > 300`) that backstop holds; a misconfig that
+    /// sets it lower silently removes it. Surface that to the operator rather
+    /// than failing closed — the agent still functions, it's just lost a
+    /// defense-in-depth layer.
+    pub fn warn_if_rate_limit_below_max_hold(&self) {
+        let max_hold = crate::updater::MAX_UPDATE_HOLD.as_secs();
+        if self.rate_limit_seconds < max_hold {
+            tracing::warn!(
+                rate_limit_seconds = self.rate_limit_seconds,
+                max_update_hold_seconds = max_hold,
+                "rate_limit_seconds is below the updater max-hold; the rate-limit \
+                 backstop for the in-flight overlap guard is disabled. If an update \
+                 runs longer than {max_hold}s, a second update could race its \
+                 restart and trigger the #4271 double-stop. Set rate_limit_seconds \
+                 >= {max_hold} (prod default is 600)."
+            );
+        }
+    }
+
     /// Load the HMAC secret. The file is always parsed as hex (matching
     /// `install.sh`'s `openssl rand -hex 32` output); any whitespace is
     /// trimmed. The previous heuristic of "hex with fallback to raw" was

--- a/crates/release-agent/src/main.rs
+++ b/crates/release-agent/src/main.rs
@@ -39,6 +39,9 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
     let config = Config::from_path(&cli.config)?;
+    // Surface a misconfig that would disable the rate-limit backstop for the
+    // in-flight overlap guard (see Config::warn_if_rate_limit_below_max_hold).
+    config.warn_if_rate_limit_below_max_hold();
     let secret = config.load_secret()?;
 
     let http = HttpClient::builder()

--- a/crates/release-agent/src/main.rs
+++ b/crates/release-agent/src/main.rs
@@ -69,6 +69,7 @@ async fn main() -> Result<()> {
         systemctl_path: PathBuf::from("systemctl"),
         last_update_attempt: Arc::new(Mutex::new(None)),
         last_announce_attempt: Arc::new(Mutex::new(None)),
+        update_in_flight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 
     serve(listen_addr, build_router(state)).await

--- a/crates/release-agent/src/server.rs
+++ b/crates/release-agent/src/server.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
@@ -20,7 +21,7 @@ use crate::announcer::Announcer;
 use crate::auth::{HEADER_SIGNATURE, check_clock_skew, verify_signature};
 use crate::config::Config;
 use crate::github::LatestSource;
-use crate::updater::Updater;
+use crate::updater::{InFlightGuard, Updater};
 use crate::version::{ServiceHealthCache, VersionCache};
 
 /// Cap on the request body for `POST /update`. The legitimate body is ~60
@@ -56,6 +57,14 @@ pub struct AppState {
     pub systemctl_path: PathBuf,
     pub last_update_attempt: Arc<Mutex<Option<Instant>>>,
     pub last_announce_attempt: Arc<Mutex<Option<Instant>>>,
+    /// In-flight guard for `POST /update`. `true` while an update's
+    /// stop/restart of the gateway service is in progress. A second update
+    /// POST that arrives during that window is rejected with `409 Conflict`
+    /// rather than spawning a racing `systemctl stop/restart` that could
+    /// SIGKILL the freshly started process (the nova 0.2.65 outage; issue
+    /// #4271). This is ADDITIONAL to `last_update_attempt`, which only
+    /// rate-limits *timing*, not concurrent *overlap*.
+    pub update_in_flight: Arc<AtomicBool>,
 }
 
 #[derive(Serialize)]
@@ -284,8 +293,35 @@ async fn update_handler(
         }
     }
 
-    if let Err(e) = state.updater.run(&target).await {
+    // 10. In-flight guard. The rate-limit window above only bounds how OFTEN
+    //     updates may start; it does not stop a second update from racing a
+    //     restart already in progress. During the nova 0.2.65 rollout two
+    //     updates landed ~1s apart: the second's `systemctl stop` SIGKILLed
+    //     the process the first had just started, leaving the gateway DOWN.
+    //     Claim the in-flight slot here (held across the whole restart window
+    //     by `Updater::run`, bounded by a max-hold timeout) and reject any
+    //     overlapping update with 409 instead of spawning a racing restart.
+    //     See issue #4271.
+    let in_flight = match InFlightGuard::try_acquire(&state.update_in_flight) {
+        Some(g) => g,
+        None => {
+            tracing::warn!(
+                target = %target,
+                "rejecting overlapping update: an update is already in progress"
+            );
+            return (
+                StatusCode::CONFLICT,
+                "update already in progress; retry after it completes",
+            )
+                .into_response();
+        }
+    };
+
+    if let Err(e) = state.updater.run(&target, in_flight).await {
         tracing::error!(error = %e, "updater spawn failed");
+        // `in_flight` was moved into `run` and dropped there on the failure
+        // path, so the slot is already free for a retry.
+        //
         // Deliberately do NOT update last_update_attempt — the caller
         // should be able to retry once the underlying problem is fixed,
         // without waiting out the full rate-limit window.

--- a/crates/release-agent/src/updater.rs
+++ b/crates/release-agent/src/updater.rs
@@ -62,8 +62,14 @@ impl InFlightGuard {
     /// update is already running and the caller must back off.
     ///
     /// Uses a compare-and-swap so two concurrent callers can never both win.
+    ///
+    /// The success ordering is `Acquire` (not `AcqRel`): the meaningful
+    /// publish — making the slot available again — happens on `Drop` via the
+    /// `Release` store below, so the CAS only needs to *observe* the prior
+    /// release, not itself publish anything. `Acquire` pairs with that
+    /// `Release` and is sufficient.
     pub fn try_acquire(flag: &Arc<AtomicBool>) -> Option<Self> {
-        match flag.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire) {
+        match flag.compare_exchange(false, true, Ordering::Acquire, Ordering::Acquire) {
             Ok(_) => Some(Self {
                 flag: Arc::clone(flag),
             }),
@@ -98,7 +104,12 @@ const EARLY_EXIT_PROBE: Duration = Duration::from_secs(1);
 /// observed ~90s drain plus new-process startup, with generous headroom,
 /// while still guaranteeing the slot frees within a bounded window if the
 /// update never reports completion.
-const MAX_UPDATE_HOLD: Duration = Duration::from_secs(300);
+///
+/// Public so config validation can warn when `rate_limit_seconds` is set below
+/// this value, which would remove the rate-limit backstop that covers the
+/// residual re-open window if an update runs past the max-hold (see the timeout
+/// arm in [`Updater::run`] and `Config::warn_if_rate_limit_below_max_hold`).
+pub const MAX_UPDATE_HOLD: Duration = Duration::from_secs(300);
 
 impl Updater {
     /// Invoke the update script for `target_version`, or log the intent if
@@ -182,6 +193,16 @@ impl Updater {
                 let cmd_path = self.command.clone();
                 let target = target_version.to_string();
                 tokio::spawn(async move {
+                    // LOAD-BEARING: this binding keeps the InFlightGuard alive
+                    // for the WHOLE `child.wait()` below. Its scope IS the
+                    // in-flight window — the slot stays claimed until this task
+                    // ends (clean exit, timeout, or panic), at which point the
+                    // guard drops and releases the slot. Do NOT narrow its scope
+                    // (e.g. `drop(in_flight)` early, or move the wait out from
+                    // under it): that would re-open the #4271 overlap window,
+                    // letting a second POST acquire the slot and spawn a racing
+                    // `systemctl stop` while this update's restart is still in
+                    // progress.
                     let _in_flight = in_flight;
                     match tokio::time::timeout(MAX_UPDATE_HOLD, child.wait()).await {
                         Ok(Ok(status)) => {
@@ -201,12 +222,43 @@ impl Updater {
                             );
                         }
                         Err(_elapsed) => {
-                            tracing::warn!(
+                            // RESIDUAL RE-OPEN WINDOW (documented intentionally):
+                            // we free the in-flight slot here even though the
+                            // child is STILL running (kill_on_drop=false leaves
+                            // it alive). If a real update genuinely runs past
+                            // MAX_UPDATE_HOLD, a second POST could now acquire the
+                            // slot and spawn a racing `systemctl stop` — the exact
+                            // #4271 double-stop. The time-bound is mandatory (an
+                            // unbounded exemption would let a hung/zombied update
+                            // wedge the agent against ALL future updates forever,
+                            // violating the project rule that lock/GC exemptions
+                            // be time-bounded), so we accept this narrow residual
+                            // window as the lesser evil.
+                            //
+                            // SECOND BACKSTOP: the rate-limit window
+                            // (`rate_limit_seconds`, prod default 600s) gates how
+                            // OFTEN updates may start. With the default it is >
+                            // MAX_UPDATE_HOLD (300s), so a second POST in this
+                            // window is rejected by the rate-limiter (429) before
+                            // it can reach the in-flight check — closing the gap.
+                            // Config load emits a `warn!` if an operator sets
+                            // rate_limit_seconds < MAX_UPDATE_HOLD, which would
+                            // remove this backstop. See `Config::warn_if_*`.
+                            //
+                            // WHY 300s: it comfortably covers TimeoutStopSec (45s
+                            // final SIGTERM) + the observed ~90s nova drain + new-
+                            // process startup, with generous headroom — a >300s
+                            // update is an operational anomaly, not a normal slow
+                            // restart, hence the `error!` level below.
+                            tracing::error!(
                                 target,
                                 command = %cmd_path.display(),
                                 max_hold_secs = MAX_UPDATE_HOLD.as_secs(),
                                 "update command still running past max-hold; \
-                                 releasing in-flight slot so future updates aren't blocked"
+                                 releasing in-flight slot so future updates aren't \
+                                 blocked. If rate_limit_seconds < max-hold the \
+                                 overlap guard is no longer backstopped — a second \
+                                 update could now race this one's restart (#4271)"
                             );
                         }
                     }

--- a/crates/release-agent/src/updater.rs
+++ b/crates/release-agent/src/updater.rs
@@ -313,6 +313,155 @@ mod tests {
         );
     }
 
+    /// Write an executable stub that, when invoked, signals via `started_marker`
+    /// that `/bin/sh` is already running the script body, then becomes a real
+    /// subprocess which sleeps far past `MAX_UPDATE_HOLD` so the spawned child
+    /// NEVER exits within the hold window. Returns the stub's path (used as
+    /// `sudo_command`).
+    ///
+    /// The wall-clock sleep is intentional: under `start_paused` a real OS
+    /// child's sleep does NOT honour virtual time, so the child stays alive
+    /// across `tokio::time::advance`. That is exactly the condition the
+    /// MAX_UPDATE_HOLD timeout arm exists for — the tokio timer fires on the
+    /// virtual-time advance while the child is still running.
+    ///
+    /// The `started_marker` write is the teardown-noise guard: once it exists,
+    /// `/bin/sh` has already opened and read this (tiny) script into memory and
+    /// `exec`'d into `sleep`, so the test can drop its TempDir without the
+    /// detached child (`kill_on_drop=false`) ever re-opening the now-deleted
+    /// script and logging `No such file or directory` to stderr.
+    fn write_never_exiting_stub(
+        dir: &std::path::Path,
+        started_marker: &std::path::Path,
+    ) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let bin = dir.join("fake-sudo-sleep");
+        // The agent always prepends `--non-interactive`; ignore argv. Touch the
+        // started marker, then exec `sleep` for 30 REAL wall-clock seconds. The
+        // test advances virtual time instantly and finishes in milliseconds of
+        // wall-clock, so 30s keeps the child alive across the (instant) virtual
+        // MAX_UPDATE_HOLD = 300s advance, yet self-reaps shortly after so the
+        // detached child doesn't linger as a long-lived orphan.
+        let script = format!(
+            "#!/bin/sh\n: > {}\nexec sleep 30\n",
+            started_marker.display()
+        );
+        std::fs::write(&bin, script).unwrap();
+        let mut perms = std::fs::metadata(&bin).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&bin, perms).unwrap();
+        bin
+    }
+
+    /// The MAX_UPDATE_HOLD timeout arm in [`Updater::run`] frees the in-flight
+    /// slot even while the spawned child is STILL running — the documented
+    /// "residual re-open window". This is the only path that releases the guard
+    /// without the child exiting, and the comment itself flags it as the spot
+    /// that can re-enable the #4271 overlap bug, so it must be covered.
+    ///
+    /// Virtual time (`start_paused`) lets us fire the timeout deterministically:
+    /// the stub child sleeps in real wall-clock (a real subprocess does NOT
+    /// honour paused time), so it never exits during the test, while
+    /// `tokio::time::advance(MAX_UPDATE_HOLD + …)` trips the `tokio::time::timeout`
+    /// that wraps `child.wait()` in the background task — exactly the
+    /// `Err(_elapsed)` arm under test.
+    ///
+    /// LOAD-BEARING: the assertion is that the flag returns to `false` AFTER the
+    /// advance. If the timeout-release were removed (the guard held until the
+    /// child exits, which never happens here), the flag would stay `true` and
+    /// this test would hang at the poll deadline and fail — proving the arm is
+    /// what frees the slot.
+    #[tokio::test(start_paused = true)]
+    async fn max_update_hold_timeout_releases_in_flight_slot() {
+        let tmp = tempfile::tempdir().unwrap();
+        let started_marker = tmp.path().join("child-started");
+        let sudo = write_never_exiting_stub(tmp.path(), &started_marker);
+
+        let updater = Updater {
+            // `command` is only ever an argv element here (the stub ignores it),
+            // so any path works; the never-exiting behaviour comes from `sudo`.
+            command: tmp.path().join("update.sh"),
+            dry_run: false,
+            sudo_command: sudo,
+        };
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let guard = InFlightGuard::try_acquire(&flag).expect("slot is free");
+
+        // run() spawns the real (sleeping) child. The 1s EARLY_EXIT_PROBE timer
+        // auto-fires under paused time (the child never exits, so the only
+        // pending work is the timer), so run() takes the "still running" branch:
+        // it moves the guard into the background wait task and returns Ok.
+        updater
+            .run(&Version::new(0, 2, 56), guard)
+            .await
+            .expect("spawn of the sleeping stub must succeed");
+
+        // The slot is still claimed: the background task holds the guard while
+        // it waits (bounded by MAX_UPDATE_HOLD) for the child that never exits.
+        assert!(
+            flag.load(Ordering::Acquire),
+            "slot must stay claimed while the update is in flight"
+        );
+
+        // Let the background wait task get scheduled and park on its
+        // `tokio::time::timeout(MAX_UPDATE_HOLD, child.wait())` so its timer is
+        // registered before we advance virtual time.
+        tokio::task::yield_now().await;
+
+        // Fire the MAX_UPDATE_HOLD timeout: advance virtual time just past the
+        // hold. The real child keeps sleeping (wall-clock), so the only way the
+        // slot can free is the `Err(_elapsed)` timeout arm dropping the guard.
+        tokio::time::advance(MAX_UPDATE_HOLD + Duration::from_millis(1)).await;
+
+        // Let the background task observe the elapsed timeout and drop the guard.
+        // Bounded poll so the test fails (rather than hangs forever) if the
+        // timeout-release is ever removed. `sleep` cooperates with paused-time
+        // auto-advance and yields to the background task between checks.
+        let mut released = false;
+        for _ in 0..1_000 {
+            if !flag.load(Ordering::Acquire) {
+                released = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        assert!(
+            released,
+            "MAX_UPDATE_HOLD timeout arm must release the in-flight slot even \
+             though the child is still running (residual re-open window, #4271)"
+        );
+
+        // And the slot is now genuinely free: a fresh acquire succeeds, i.e. a
+        // follow-up update would be accepted rather than 409-rejected.
+        assert!(
+            InFlightGuard::try_acquire(&flag).is_some(),
+            "after the timeout fires the slot must be re-acquirable"
+        );
+
+        // Teardown-noise guard: wait until the stub child has `exec`'d into
+        // `sleep` (it writes `started_marker` immediately before doing so) so
+        // dropping `tmp` below doesn't delete the script out from under a child
+        // that hasn't opened it yet — which would log `No such file or
+        // directory` to stderr. The child runs on the OS independently of the
+        // paused runtime; a busy `yield_now` poll lets it make progress without
+        // depending on (paused) tokio time. Bounded so a genuinely stuck child
+        // fails the test rather than hanging.
+        let mut child_running = false;
+        for _ in 0..100_000 {
+            if started_marker.exists() {
+                child_running = true;
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            child_running,
+            "stub child should have started (and written its marker) by now"
+        );
+        drop(tmp);
+    }
+
     // Live-spawn coverage lives in the integration test
     // `tests/update_handler.rs`, which exercises the full request →
     // validation → spawn pipeline against a stub script (no sudo).

--- a/crates/release-agent/src/updater.rs
+++ b/crates/release-agent/src/updater.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -27,6 +29,55 @@ impl Updater {
     }
 }
 
+/// RAII guard proving an update is currently in flight (its `stop`/`restart`
+/// of the gateway service has been kicked off and has not yet completed).
+///
+/// The release-agent holds exactly one of these per managed gateway for the
+/// **whole** duration of an update — from the moment the update script is
+/// spawned until the child process exits (or a bounded max-hold timeout
+/// fires). A second `POST /update` that arrives while a guard is alive cannot
+/// acquire one, so the handler rejects it with `409 Conflict` rather than
+/// spawning a second `systemctl stop/restart`.
+///
+/// WHY: during the 0.2.65 rollout, two update commands arrived ~1s apart.
+/// The first spawned a restart whose *old* process took ~90s to die (past the
+/// 45s final-SIGTERM timeout); the second update's `systemctl stop` then
+/// SIGKILLed the freshly-started *new* process, leaving nova's gateway DOWN
+/// until a manual `systemctl start`. The 1s early-exit probe in
+/// [`Updater::run`] is far too short to cover that restart window, and the
+/// rate-limit mutex only gates *timing*, not *overlap*. This guard closes the
+/// overlap window. See issue #4271.
+///
+/// The boolean is reset to `false` on `Drop`, so the guard is released on
+/// completion, on early/immediate failure, AND if the owning task panics —
+/// a crashed update can never wedge the agent permanently.
+#[derive(Debug)]
+pub struct InFlightGuard {
+    flag: Arc<AtomicBool>,
+}
+
+impl InFlightGuard {
+    /// Try to claim the in-flight slot. Returns `Some(guard)` if no update was
+    /// in flight (the slot was `false` and is now `true`), or `None` if an
+    /// update is already running and the caller must back off.
+    ///
+    /// Uses a compare-and-swap so two concurrent callers can never both win.
+    pub fn try_acquire(flag: &Arc<AtomicBool>) -> Option<Self> {
+        match flag.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => Some(Self {
+                flag: Arc::clone(flag),
+            }),
+            Err(_) => None,
+        }
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        self.flag.store(false, Ordering::Release);
+    }
+}
+
 /// How long to wait synchronously after spawning the update script before
 /// returning success to the caller. Legitimate updates take tens of seconds
 /// (download + service restart); immediate failures (sudoers misconfig,
@@ -35,6 +86,20 @@ impl Updater {
 /// failure case instead of a falsely-successful 202.
 const EARLY_EXIT_PROBE: Duration = Duration::from_secs(1);
 
+/// Absolute ceiling on how long the [`InFlightGuard`] is held while waiting
+/// for the spawned update child to exit. The guard MUST outlive the real
+/// `systemctl restart` window (old process drain + new process startup),
+/// which the nova outage showed can run past 90s — but it must NOT be
+/// unbounded, or a hung/zombied update would wedge the agent against all
+/// future updates forever. This mirrors the project rule that any lock/GC
+/// exemption be time-bounded.
+///
+/// 5 minutes comfortably covers `TimeoutStopSec` (45s final SIGTERM) plus the
+/// observed ~90s drain plus new-process startup, with generous headroom,
+/// while still guaranteeing the slot frees within a bounded window if the
+/// update never reports completion.
+const MAX_UPDATE_HOLD: Duration = Duration::from_secs(300);
+
 impl Updater {
     /// Invoke the update script for `target_version`, or log the intent if
     /// dry-run. Returns `Ok` once the script has either started running
@@ -42,7 +107,15 @@ impl Updater {
     /// An immediate non-zero exit (sudo rejection, etc.) is surfaced as
     /// `Err` so the HTTP layer can return a non-2xx and the caller can
     /// retry rather than be falsely rate-limited.
-    pub async fn run(&self, target_version: &Version) -> Result<()> {
+    ///
+    /// `in_flight` is the caller's [`InFlightGuard`], proving no other update
+    /// is running. On the legitimate "still running" path it is moved into the
+    /// background wait task so the in-flight slot stays claimed for the WHOLE
+    /// restart window (bounded by [`MAX_UPDATE_HOLD`]), not just the 1s probe —
+    /// this is what prevents a second update from race-killing the freshly
+    /// started process (issue #4271). On dry-run, immediate exit, or spawn
+    /// failure the guard drops here, freeing the slot right away.
+    pub async fn run(&self, target_version: &Version, in_flight: InFlightGuard) -> Result<()> {
         let target_arg = format!("v{target_version}");
 
         if self.dry_run {
@@ -53,6 +126,9 @@ impl Updater {
                 self.command.display(),
                 target_arg
             );
+            // Drop `in_flight` explicitly: a dry-run does nothing, so the slot
+            // must free immediately rather than linger.
+            drop(in_flight);
             return Ok(());
         }
 
@@ -95,11 +171,20 @@ impl Updater {
                 // Still running — the expected path. Hand off to a
                 // background task that logs the eventual exit; the caller
                 // polls /version to confirm the new binary is installed.
+                //
+                // The in-flight guard is MOVED into this task so the slot
+                // stays claimed for the whole restart window — any second
+                // /update arriving meanwhile is rejected with 409 instead of
+                // spawning a racing `systemctl stop` (issue #4271). The wait
+                // is bounded by MAX_UPDATE_HOLD so a hung child can't pin the
+                // slot forever; the guard drops when this task ends, whether
+                // by clean exit, timeout, or panic.
                 let cmd_path = self.command.clone();
                 let target = target_version.to_string();
                 tokio::spawn(async move {
-                    match child.wait().await {
-                        Ok(status) => {
+                    let _in_flight = in_flight;
+                    match tokio::time::timeout(MAX_UPDATE_HOLD, child.wait()).await {
+                        Ok(Ok(status)) => {
                             tracing::info!(
                                 %status,
                                 target,
@@ -107,7 +192,7 @@ impl Updater {
                                 "update command exited"
                             );
                         }
-                        Err(e) => {
+                        Ok(Err(e)) => {
                             tracing::error!(
                                 error = %e,
                                 target,
@@ -115,7 +200,17 @@ impl Updater {
                                 "wait() on update command failed"
                             );
                         }
+                        Err(_elapsed) => {
+                            tracing::warn!(
+                                target,
+                                command = %cmd_path.display(),
+                                max_hold_secs = MAX_UPDATE_HOLD.as_secs(),
+                                "update command still running past max-hold; \
+                                 releasing in-flight slot so future updates aren't blocked"
+                            );
+                        }
                     }
+                    // `_in_flight` drops here, freeing the slot.
                 });
             }
         }
@@ -137,10 +232,33 @@ mod tests {
             PathBuf::from("/nonexistent/path/that/should/never/exist"),
             true,
         );
+        let flag = Arc::new(AtomicBool::new(false));
+        let guard = InFlightGuard::try_acquire(&flag).expect("slot is free");
         updater
-            .run(&Version::new(0, 2, 56))
+            .run(&Version::new(0, 2, 56), guard)
             .await
             .expect("dry_run must not invoke the command");
+        assert!(
+            !flag.load(Ordering::Acquire),
+            "dry-run must release the in-flight slot immediately"
+        );
+    }
+
+    #[tokio::test]
+    async fn in_flight_guard_is_single_acquire() {
+        // Second acquire while the first guard is alive must fail; once the
+        // first drops, the slot frees again.
+        let flag = Arc::new(AtomicBool::new(false));
+        let first = InFlightGuard::try_acquire(&flag).expect("first acquire succeeds");
+        assert!(
+            InFlightGuard::try_acquire(&flag).is_none(),
+            "second concurrent acquire must be rejected"
+        );
+        drop(first);
+        assert!(
+            InFlightGuard::try_acquire(&flag).is_some(),
+            "slot must free once the guard drops"
+        );
     }
 
     // Live-spawn coverage lives in the integration test

--- a/crates/release-agent/tests/update_handler.rs
+++ b/crates/release-agent/tests/update_handler.rs
@@ -29,6 +29,28 @@ fn now_secs() -> i64 {
         .as_secs() as i64
 }
 
+/// Poll `path` until it exists and is non-empty, returning its contents. The
+/// fake-sudo wrappers record argv from the SPAWNED child, which races the HTTP
+/// response — a single read can land before the child has written under
+/// parallel load. Bounded deadline so a genuinely missing write still fails the
+/// test rather than hanging.
+async fn poll_file_nonempty(path: &Path) -> String {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            if !contents.trim().is_empty() {
+                return contents;
+            }
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "expected {} to be recorded within the deadline",
+            path.display()
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
 fn write_stub_freenet(dir: &Path, version: &str) -> std::path::PathBuf {
     let bin = dir.join("fake-freenet");
     let script = format!("#!/bin/sh\necho freenet {version}\n");
@@ -521,47 +543,73 @@ async fn healthz_is_ok() {
 #[tokio::test]
 async fn spawn_failure_does_not_consume_rate_limit_window() {
     // Security-critical contract: an immediate sudo rejection or script
-    // failure within the 1s probe window must NOT mark the rate-limit
-    // window consumed — otherwise an attacker (or a transient sudoers
-    // misconfig) could lock out legitimate retries for the full window.
-    let tmp = tempfile::tempdir().unwrap();
-    let argv_record = tmp.path().join("argv.log");
-    // Update script exits 1 immediately. Surface as 500 to the caller.
-    let h = Harness::build_live(
-        "0.2.55",
-        Version::new(0, 2, 56),
-        600, // 10 min window — long enough that a second successful spawn
-        // within seconds proves the window WAS NOT consumed.
-        "#!/bin/sh\nexit 1\n",
-        &argv_record,
-    )
-    .await;
+    // failure that is caught within the 1s probe window (surfaced as 500) must
+    // NOT mark the rate-limit window consumed — otherwise an attacker (or a
+    // transient sudoers misconfig) could lock out legitimate retries for the
+    // full window.
+    //
+    // Determinism note: whether the `exit 1` child is *reaped* within the 1s
+    // wall-clock probe is scheduler-dependent. Under heavy parallel load the
+    // child can miss the probe deadline and be (legitimately) classified as
+    // "still running" → 202, in which case production DOES consume the window
+    // for that classification — so we cannot assert "never 429" against a
+    // single attempt. Instead we retry the scenario on a FRESH harness until
+    // the probe deterministically catches the fast exit (500), then assert the
+    // window-not-consumed contract on that attempt. In isolation the 500 path
+    // is reliable; the retry only absorbs rare load-induced misses.
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+        let tmp = tempfile::tempdir().unwrap();
+        let argv_record = tmp.path().join("argv.log");
+        // Update script exits 1 immediately. Surface as 500 to the caller.
+        let h = Harness::build_live(
+            "0.2.55",
+            Version::new(0, 2, 56),
+            600, // 10 min window — long enough that a second successful spawn
+            // within seconds proves the window WAS NOT consumed.
+            "#!/bin/sh\nexit 1\n",
+            &argv_record,
+        )
+        .await;
 
-    let (body, sig) = h.signed_body("0.2.56", now_secs());
-    let r1 = reqwest::Client::new()
-        .post(format!("{}/update", h.base))
-        .header(HEADER_SIGNATURE.as_str(), &sig)
-        .body(body)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(r1.status(), 500, "spawn failure should surface as 500");
+        let (body, sig) = h.signed_body("0.2.56", now_secs());
+        let r1 = reqwest::Client::new()
+            .post(format!("{}/update", h.base))
+            .header(HEADER_SIGNATURE.as_str(), &sig)
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+        if r1.status() != 500 {
+            // Probe missed the fast exit under load (got 202); retry on a fresh
+            // harness so this stays deterministic. Bounded to avoid a hang if
+            // the 500 path were genuinely broken.
+            assert!(
+                attempt < 20,
+                "spawn failure never surfaced as 500 across {attempt} attempts; got {}",
+                r1.status()
+            );
+            continue;
+        }
 
-    // Immediately retry. Should NOT be 429 — window must not have
-    // been consumed by the failed spawn.
-    let (body2, sig2) = h.signed_body("0.2.56", now_secs());
-    let r2 = reqwest::Client::new()
-        .post(format!("{}/update", h.base))
-        .header(HEADER_SIGNATURE.as_str(), &sig2)
-        .body(body2)
-        .send()
-        .await
-        .unwrap();
-    assert_ne!(
-        r2.status(),
-        429,
-        "rate-limit window must not be consumed by a failed spawn"
-    );
+        // Immediately retry. Should NOT be 429 — window must not have
+        // been consumed by the failed spawn.
+        let (body2, sig2) = h.signed_body("0.2.56", now_secs());
+        let r2 = reqwest::Client::new()
+            .post(format!("{}/update", h.base))
+            .header(HEADER_SIGNATURE.as_str(), &sig2)
+            .body(body2)
+            .send()
+            .await
+            .unwrap();
+        assert_ne!(
+            r2.status(),
+            429,
+            "rate-limit window must not be consumed by a failed spawn"
+        );
+        break;
+    }
 }
 
 #[tokio::test]
@@ -581,10 +629,13 @@ async fn concurrent_updates_only_spawn_once() {
     let tmp = tempfile::tempdir().unwrap();
     let argv_record = tmp.path().join("argv.log");
     let spawn_count = tmp.path().join("spawns.log");
-    // Each spawn appends a line, then sleeps 3s so it is still running when the
-    // second POST arrives (1s probe << 3s sleep).
+    // Each spawn appends a line, then sleeps just past the 1s early-exit probe
+    // so it is still running when the second POST arrives (1s probe < 1.5s
+    // sleep). Kept as short as possible so the stub child doesn't linger after
+    // the HTTP responses land and add scheduler contention to sibling tests
+    // running in parallel.
     let update_script = format!(
-        "#!/bin/sh\necho spawned >> {}\nsleep 3\n",
+        "#!/bin/sh\necho spawned >> {}\nsleep 1.5\n",
         spawn_count.display()
     );
     // rate_limit_seconds = 0 so the rate-limiter never fires: this test
@@ -683,15 +734,17 @@ async fn concurrent_updates_only_spawn_once() {
 async fn update_after_in_flight_completes_is_accepted() {
     // The in-flight guard must be RELEASED when the update completes, so a
     // legitimate follow-up update is not permanently blocked. Uses a short
-    // sleep (past the 1s probe) then exit, and a 0s rate-limit window so the
-    // rate-limiter doesn't mask the in-flight behaviour being tested.
+    // sleep (just past the 1s probe) then exit, and a 0s rate-limit window so
+    // the rate-limiter doesn't mask the in-flight behaviour being tested.
     let tmp = tempfile::tempdir().unwrap();
     let argv_record = tmp.path().join("argv.log");
     let h = Harness::build_live(
         "0.2.55",
         Version::new(0, 2, 56),
         0, // no rate-limit, so we isolate the in-flight guard
-        "#!/bin/sh\nsleep 2\n",
+        // Sleep just past the 1s early-exit probe; kept minimal so the stub
+        // child doesn't linger and add scheduler contention to parallel tests.
+        "#!/bin/sh\nsleep 1.5\n",
         &argv_record,
     )
     .await;
@@ -717,22 +770,40 @@ async fn update_after_in_flight_completes_is_accepted() {
         .unwrap();
     assert_eq!(r2.status(), 409, "overlapping update must be 409");
 
-    // Wait for the first update's stub to exit (2s sleep) plus a margin, so
-    // the in-flight guard's background wait task releases the slot.
-    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-
-    let (body3, sig3) = h.signed_body("0.2.56", now_secs());
-    let r3 = reqwest::Client::new()
-        .post(format!("{}/update", h.base))
-        .header(HEADER_SIGNATURE.as_str(), &sig3)
-        .body(body3)
-        .send()
-        .await
-        .unwrap();
+    // POLL for the guard to release rather than asserting on a fixed sleep that
+    // happens to match the stub's runtime. The background wait task frees the
+    // slot when the stub child exits (~1.5s) — under parallel load that can
+    // slip well past the nominal time, so a fixed wait would flake. Retry POST 3
+    // until it is accepted, with a bounded deadline. Each rejected attempt is a
+    // 409 (slot still held); we tolerate those and only fail if the slot never
+    // frees within the deadline. rate_limit_seconds = 0 means an accepted POST
+    // never turns into a 429, so retries are safe.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    let last_status = loop {
+        let (body3, sig3) = h.signed_body("0.2.56", now_secs());
+        let r3 = reqwest::Client::new()
+            .post(format!("{}/update", h.base))
+            .header(HEADER_SIGNATURE.as_str(), &sig3)
+            .body(body3)
+            .send()
+            .await
+            .unwrap();
+        let last_status = r3.status().as_u16();
+        if last_status == 200 || last_status == 202 {
+            break last_status;
+        }
+        assert_eq!(
+            last_status, 409,
+            "while the slot is still held the follow-up must be 409, got {last_status}"
+        );
+        if std::time::Instant::now() >= deadline {
+            break last_status;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    };
     assert!(
-        r3.status() == 200 || r3.status() == 202,
-        "guard must be released after the update completes; got {}",
-        r3.status()
+        last_status == 200 || last_status == 202,
+        "guard must be released after the update completes; got {last_status}"
     );
 }
 
@@ -746,12 +817,15 @@ async fn sudoers_argv_matches_allowlist() {
     // wrapper and asserts it lines up with the sudoers allowlist.
     let tmp = tempfile::tempdir().unwrap();
     let argv_record = tmp.path().join("argv.log");
-    // Update script does nothing; we only care about the argv sudo sees.
+    // Update script does nothing; we only care about the argv sudo sees. Sleep
+    // just past the 1s early-exit probe (so the handler returns 202, not a
+    // probe-window failure) and no longer — a lingering stub child only adds
+    // scheduler contention to the parallel suite.
     let h = Harness::build_live(
         "0.2.55",
         Version::new(0, 2, 56),
         600,
-        "#!/bin/sh\n# noop — wait long enough that the 1s probe times out\nsleep 5\n",
+        "#!/bin/sh\n# noop — wait long enough that the 1s probe times out\nsleep 1.5\n",
         &argv_record,
     )
     .await;
@@ -770,8 +844,11 @@ async fn sudoers_argv_matches_allowlist() {
         r.status()
     );
 
-    let recorded =
-        std::fs::read_to_string(&argv_record).expect("fake-sudo should have recorded argv");
+    // POLL for the fake-sudo wrapper to record argv. The wrapper runs in the
+    // spawned child, which races the HTTP response — under parallel load the
+    // file may not exist yet when the response lands. A single read here was
+    // green only by luck; poll with a bounded deadline instead.
+    let recorded = poll_file_nonempty(&argv_record).await;
     let argv = recorded.trim();
     // Expected: <update_script_path> --force --target-version v0.2.56
     assert!(
@@ -925,7 +1002,9 @@ async fn announce_disabled_still_requires_signature() {
 async fn announce_happy_path() {
     let tmp = tempfile::tempdir().unwrap();
     let record = tmp.path().join("argv.log");
-    let h = build_with_announcer("#!/bin/sh\nsleep 5\n", &record).await;
+    // Sleep just past the 1s probe so the handler returns 202; kept short so
+    // the stub child doesn't linger and contend with the parallel suite.
+    let h = build_with_announcer("#!/bin/sh\nsleep 1.5\n", &record).await;
     let (body, sig) = signed_announce(&h.secret, "Freenet v0.2.57 released", now_secs());
     let resp = reqwest::Client::new()
         .post(format!("{}/announce/river", h.base))
@@ -939,7 +1018,11 @@ async fn announce_happy_path() {
         "got {}",
         resp.status()
     );
-    let recorded = std::fs::read_to_string(&record).expect("fake-sudo recorded argv");
+    // POLL for the fake-sudo wrapper to record argv. It runs in the spawned
+    // child, which races the HTTP response — under parallel load the file may
+    // not exist yet when the response lands. The wrapper writes `record.full`
+    // first, then `record`, so a non-empty `record` implies both are present.
+    let recorded = poll_file_nonempty(&record).await;
     assert!(
         recorded.contains("Freenet v0.2.57 released"),
         "argv should contain the message, got: {recorded:?}"
@@ -1014,33 +1097,52 @@ async fn announce_oversize_message_is_413() {
 
 #[tokio::test]
 async fn announce_spawn_failure_does_not_consume_rate_limit() {
-    let tmp = tempfile::tempdir().unwrap();
-    let record = tmp.path().join("argv.log");
-    // Script exits 1 immediately → 500 + window NOT consumed.
-    let h = build_with_announcer("#!/bin/sh\nexit 1\n", &record).await;
-    let (body, sig) = signed_announce(&h.secret, "first", now_secs());
-    let r1 = reqwest::Client::new()
-        .post(format!("{}/announce/river", h.base))
-        .header(HEADER_SIGNATURE.as_str(), &sig)
-        .body(body)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(r1.status(), 500);
+    // Mirrors `spawn_failure_does_not_consume_rate_limit_window`: the
+    // announce path uses the same 1s wall-clock early-exit probe, so whether
+    // the `exit 1` child is reaped within it is scheduler-dependent. Retry on a
+    // FRESH harness until the probe deterministically catches the fast exit
+    // (500), then assert the window-not-consumed contract on that attempt.
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+        let tmp = tempfile::tempdir().unwrap();
+        let record = tmp.path().join("argv.log");
+        // Script exits 1 immediately → 500 + window NOT consumed.
+        let h = build_with_announcer("#!/bin/sh\nexit 1\n", &record).await;
+        let (body, sig) = signed_announce(&h.secret, "first", now_secs());
+        let r1 = reqwest::Client::new()
+            .post(format!("{}/announce/river", h.base))
+            .header(HEADER_SIGNATURE.as_str(), &sig)
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+        if r1.status() != 500 {
+            // Probe missed the fast exit under load (got 202); retry on a fresh
+            // harness. Bounded to avoid hanging if the 500 path were broken.
+            assert!(
+                attempt < 20,
+                "announce spawn failure never surfaced as 500 across {attempt} attempts; got {}",
+                r1.status()
+            );
+            continue;
+        }
 
-    let (body2, sig2) = signed_announce(&h.secret, "second", now_secs());
-    let r2 = reqwest::Client::new()
-        .post(format!("{}/announce/river", h.base))
-        .header(HEADER_SIGNATURE.as_str(), &sig2)
-        .body(body2)
-        .send()
-        .await
-        .unwrap();
-    assert_ne!(
-        r2.status(),
-        429,
-        "failed spawn must not consume the announce rate-limit window"
-    );
+        let (body2, sig2) = signed_announce(&h.secret, "second", now_secs());
+        let r2 = reqwest::Client::new()
+            .post(format!("{}/announce/river", h.base))
+            .header(HEADER_SIGNATURE.as_str(), &sig2)
+            .body(body2)
+            .send()
+            .await
+            .unwrap();
+        assert_ne!(
+            r2.status(),
+            429,
+            "failed spawn must not consume the announce rate-limit window"
+        );
+        break;
+    }
 }
 
 #[tokio::test]
@@ -1107,7 +1209,9 @@ async fn announce_exactly_at_message_limit_is_accepted() {
     // so 4096 passes. One-over (4097) goes 413 — see next test.
     let tmp = tempfile::tempdir().unwrap();
     let record = tmp.path().join("argv.log");
-    let h = build_with_announcer("#!/bin/sh\nsleep 5\n", &record).await;
+    // Sleep just past the 1s probe so the handler returns 202; kept short so
+    // the stub child doesn't linger and contend with the parallel suite.
+    let h = build_with_announcer("#!/bin/sh\nsleep 1.5\n", &record).await;
     let exact = "x".repeat(4096);
     let (body, sig) = signed_announce(&h.secret, &exact, now_secs());
     let resp = reqwest::Client::new()

--- a/crates/release-agent/tests/update_handler.rs
+++ b/crates/release-agent/tests/update_handler.rs
@@ -111,6 +111,7 @@ impl Harness {
             systemctl_path,
             last_update_attempt: Arc::new(Mutex::new(None)),
             last_announce_attempt: Arc::new(Mutex::new(None)),
+            update_in_flight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -171,6 +172,7 @@ impl Harness {
             systemctl_path,
             last_update_attempt: Arc::new(Mutex::new(None)),
             last_announce_attempt: Arc::new(Mutex::new(None)),
+            update_in_flight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -266,6 +268,7 @@ impl Harness {
             systemctl_path,
             last_update_attempt: Arc::new(Mutex::new(None)),
             last_announce_attempt: Arc::new(Mutex::new(None)),
+            update_in_flight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -562,6 +565,178 @@ async fn spawn_failure_does_not_consume_rate_limit_window() {
 }
 
 #[tokio::test]
+async fn concurrent_updates_only_spawn_once() {
+    // Regression for #4271 (nova 0.2.65 outage): two update POSTs arriving
+    // while the first update's restart is still in flight must NOT both spawn
+    // a `systemctl stop/restart` — the second restart SIGKILLed the freshly
+    // started process and took the gateway DOWN. The in-flight guard makes the
+    // agent idempotent: the first POST spawns, the second is rejected with 409
+    // while the first is still running.
+    //
+    // The update script appends one line per invocation to a shared counter
+    // file and sleeps well past the 1s early-exit probe, so the first update
+    // is provably "in flight" when the second POST lands. Without the guard,
+    // BOTH POSTs spawn and the counter file has two lines — the assertion below
+    // is load-bearing.
+    let tmp = tempfile::tempdir().unwrap();
+    let argv_record = tmp.path().join("argv.log");
+    let spawn_count = tmp.path().join("spawns.log");
+    // Each spawn appends a line, then sleeps 3s so it is still running when the
+    // second POST arrives (1s probe << 3s sleep).
+    let update_script = format!(
+        "#!/bin/sh\necho spawned >> {}\nsleep 3\n",
+        spawn_count.display()
+    );
+    // rate_limit_seconds = 0 so the rate-limiter never fires: this test
+    // isolates the in-flight guard (429 vs 409 are different mechanisms, and
+    // the first request holds the rate-limit mutex across its 1s probe, so a
+    // nonzero window would mask the overlap with a 429 instead of the 409 we
+    // are asserting).
+    let h = Harness::build_live(
+        "0.2.55",
+        Version::new(0, 2, 56),
+        0,
+        &update_script,
+        &argv_record,
+    )
+    .await;
+
+    // Fire both POSTs concurrently. Distinct issued_at so the HMACs differ,
+    // mirroring two genuinely separate update commands.
+    let now = now_secs();
+    let (body1, sig1) = h.signed_body("0.2.56", now);
+    let (body2, sig2) = h.signed_body("0.2.56", now + 1);
+    let base = h.base.clone();
+    let url = format!("{base}/update");
+
+    let url1 = url.clone();
+    let f1 = tokio::spawn(async move {
+        reqwest::Client::new()
+            .post(&url1)
+            .header(HEADER_SIGNATURE.as_str(), &sig1)
+            .body(body1)
+            .send()
+            .await
+            .unwrap()
+            .status()
+            .as_u16()
+    });
+    // Small skew so f1 reliably claims the slot first, then f2 races into the
+    // in-flight window while f1's stub is still sleeping.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let f2 = tokio::spawn(async move {
+        reqwest::Client::new()
+            .post(&url)
+            .header(HEADER_SIGNATURE.as_str(), &sig2)
+            .body(body2)
+            .send()
+            .await
+            .unwrap()
+            .status()
+            .as_u16()
+    });
+
+    let s1 = f1.await.unwrap();
+    let s2 = f2.await.unwrap();
+
+    // Exactly one acceptance (200/202) and exactly one 409 rejection, in
+    // either order.
+    let mut statuses = [s1, s2];
+    statuses.sort_unstable();
+    assert_eq!(
+        statuses[1], 409,
+        "the second, overlapping update must be rejected with 409 Conflict (got {s1} and {s2})"
+    );
+    assert!(
+        statuses[0] == 200 || statuses[0] == 202,
+        "the first update must be accepted (got {s1} and {s2})"
+    );
+
+    // Load-bearing: only ONE spawn reached the update script. Without the
+    // in-flight guard the second POST would also spawn and this file would
+    // have two lines — the exact double-stop that downed nova.
+    //
+    // The spawned stub writes its marker at the top of the script, but it runs
+    // asynchronously; under load it may not have flushed by the time the HTTP
+    // responses land. Poll briefly for the first marker to appear, then assert
+    // it never grows to two — if a second spawn occurred it would already be
+    // present (both POSTs were dispatched and resolved above).
+    let spawns = {
+        let mut contents = String::new();
+        for _ in 0..50 {
+            contents = std::fs::read_to_string(&spawn_count).unwrap_or_default();
+            if !contents.trim().is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        contents
+    };
+    assert_eq!(
+        spawns.lines().count(),
+        1,
+        "exactly one update may spawn while another is in flight, got: {spawns:?}"
+    );
+}
+
+#[tokio::test]
+async fn update_after_in_flight_completes_is_accepted() {
+    // The in-flight guard must be RELEASED when the update completes, so a
+    // legitimate follow-up update is not permanently blocked. Uses a short
+    // sleep (past the 1s probe) then exit, and a 0s rate-limit window so the
+    // rate-limiter doesn't mask the in-flight behaviour being tested.
+    let tmp = tempfile::tempdir().unwrap();
+    let argv_record = tmp.path().join("argv.log");
+    let h = Harness::build_live(
+        "0.2.55",
+        Version::new(0, 2, 56),
+        0, // no rate-limit, so we isolate the in-flight guard
+        "#!/bin/sh\nsleep 2\n",
+        &argv_record,
+    )
+    .await;
+
+    let (body1, sig1) = h.signed_body("0.2.56", now_secs());
+    let r1 = reqwest::Client::new()
+        .post(format!("{}/update", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig1)
+        .body(body1)
+        .send()
+        .await
+        .unwrap();
+    assert!(r1.status() == 200 || r1.status() == 202);
+
+    // While still in flight, a second update is 409.
+    let (body2, sig2) = h.signed_body("0.2.56", now_secs());
+    let r2 = reqwest::Client::new()
+        .post(format!("{}/update", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig2)
+        .body(body2)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r2.status(), 409, "overlapping update must be 409");
+
+    // Wait for the first update's stub to exit (2s sleep) plus a margin, so
+    // the in-flight guard's background wait task releases the slot.
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    let (body3, sig3) = h.signed_body("0.2.56", now_secs());
+    let r3 = reqwest::Client::new()
+        .post(format!("{}/update", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig3)
+        .body(body3)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        r3.status() == 200 || r3.status() == 202,
+        "guard must be released after the update completes; got {}",
+        r3.status()
+    );
+}
+
+#[tokio::test]
 async fn sudoers_argv_matches_allowlist() {
     // Pins the exact argv shape the sudoers entry must match:
     //   /usr/local/bin/gateway-auto-update.sh --force --target-version *
@@ -675,6 +850,7 @@ async fn build_with_announcer(announce_script: &str, record_file: &Path) -> Harn
         systemctl_path,
         last_update_attempt: Arc::new(Mutex::new(None)),
         last_announce_attempt: Arc::new(Mutex::new(None)),
+        update_in_flight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/crates/release-agent/tests/update_handler.rs
+++ b/crates/release-agent/tests/update_handler.rs
@@ -652,6 +652,15 @@ async fn spawn_failure_does_not_consume_rate_limit_window() {
             429,
             "rate-limit window must not be consumed by a failed spawn"
         );
+        // Also exclude 409: a failed spawn must release the InFlightGuard (Rust
+        // move semantics drop it when `run` returns Err), so the retry must not
+        // see the slot still held. Without this, a future leak of the guard on
+        // the Err path would surface as 409 (not 429) and slip past the check above.
+        assert_ne!(
+            r2.status(),
+            409,
+            "failed spawn must release the in-flight guard, so the retry is not 409"
+        );
         // Drain both spawned children before the TempDir drops.
         poll_done_count(&done_log, spawns).await;
         break;

--- a/crates/release-agent/tests/update_handler.rs
+++ b/crates/release-agent/tests/update_handler.rs
@@ -51,6 +51,33 @@ async fn poll_file_nonempty(path: &Path) -> String {
     }
 }
 
+/// Poll `path` until it contains at least `expected` lines. Used to drain
+/// lingering stub children before a test drops its Harness (and the TempDir
+/// holding the stub script): each spawned stub appends one line to a shared
+/// marker file on EXIT, so once the line count reaches the number of children
+/// we spawned, every child has finished and teardown won't delete a script out
+/// from under a still-running process. Bounded deadline so a genuinely stuck
+/// child fails the test rather than hanging.
+async fn poll_done_count(path: &Path, expected: usize) {
+    if expected == 0 {
+        return;
+    }
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        let count = std::fs::read_to_string(path)
+            .map(|c| c.lines().filter(|l| !l.trim().is_empty()).count())
+            .unwrap_or(0);
+        if count >= expected {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "expected {expected} stub child(ren) to finish (found {count}) within the deadline"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
 fn write_stub_freenet(dir: &Path, version: &str) -> std::path::PathBuf {
     let bin = dir.join("fake-freenet");
     let script = format!("#!/bin/sh\necho freenet {version}\n");
@@ -562,16 +589,29 @@ async fn spawn_failure_does_not_consume_rate_limit_window() {
         attempt += 1;
         let tmp = tempfile::tempdir().unwrap();
         let argv_record = tmp.path().join("argv.log");
-        // Update script exits 1 immediately. Surface as 500 to the caller.
+        let done_log = tmp.path().join("done.log");
+        // Update script records its exit then exits 1 immediately (surfaced as
+        // 500 to the caller). The `echo done` lets us drain every spawned child
+        // before this iteration's TempDir drops — under load the fast `exit 1`
+        // can miss the 1s probe and be handed to the background wait task, whose
+        // `Command::spawn` of fake-sudo would otherwise race the TempDir rmdir
+        // and log `No such file or directory` to stderr.
+        let update_script = format!("#!/bin/sh\necho done >> {}\nexit 1\n", done_log.display());
         let h = Harness::build_live(
             "0.2.55",
             Version::new(0, 2, 56),
             600, // 10 min window — long enough that a second successful spawn
             // within seconds proves the window WAS NOT consumed.
-            "#!/bin/sh\nexit 1\n",
+            &update_script,
             &argv_record,
         )
         .await;
+
+        // Count spawned children so we can drain all of them before dropping
+        // this iteration's TempDir. Any POST that passes validation spawns the
+        // update child (500 = caught fast exit, 202 = probe-miss handed to the
+        // background task); both append a `done` line on exit.
+        let mut spawns = 0usize;
 
         let (body, sig) = h.signed_body("0.2.56", now_secs());
         let r1 = reqwest::Client::new()
@@ -581,10 +621,13 @@ async fn spawn_failure_does_not_consume_rate_limit_window() {
             .send()
             .await
             .unwrap();
+        spawns += 1;
         if r1.status() != 500 {
             // Probe missed the fast exit under load (got 202); retry on a fresh
             // harness so this stays deterministic. Bounded to avoid a hang if
-            // the 500 path were genuinely broken.
+            // the 500 path were genuinely broken. Drain the spawned child first
+            // so its fake-sudo exec doesn't race this TempDir's deletion.
+            poll_done_count(&done_log, spawns).await;
             assert!(
                 attempt < 20,
                 "spawn failure never surfaced as 500 across {attempt} attempts; got {}",
@@ -603,11 +646,14 @@ async fn spawn_failure_does_not_consume_rate_limit_window() {
             .send()
             .await
             .unwrap();
+        spawns += 1;
         assert_ne!(
             r2.status(),
             429,
             "rate-limit window must not be consumed by a failed spawn"
         );
+        // Drain both spawned children before the TempDir drops.
+        poll_done_count(&done_log, spawns).await;
         break;
     }
 }
@@ -629,14 +675,19 @@ async fn concurrent_updates_only_spawn_once() {
     let tmp = tempfile::tempdir().unwrap();
     let argv_record = tmp.path().join("argv.log");
     let spawn_count = tmp.path().join("spawns.log");
+    let done_marker = tmp.path().join("done.log");
     // Each spawn appends a line, then sleeps just past the 1s early-exit probe
     // so it is still running when the second POST arrives (1s probe < 1.5s
     // sleep). Kept as short as possible so the stub child doesn't linger after
     // the HTTP responses land and add scheduler contention to sibling tests
-    // running in parallel.
+    // running in parallel. The final `echo done` lets the test drain the
+    // in-flight child before dropping the Harness (and its TempDir) — otherwise
+    // the still-sleeping child's script would vanish out from under it and emit
+    // a `No such file or directory` to stderr during teardown.
     let update_script = format!(
-        "#!/bin/sh\necho spawned >> {}\nsleep 1.5\n",
-        spawn_count.display()
+        "#!/bin/sh\necho spawned >> {}\nsleep 1.5\necho done > {}\n",
+        spawn_count.display(),
+        done_marker.display(),
     );
     // rate_limit_seconds = 0 so the rate-limiter never fires: this test
     // isolates the in-flight guard (429 vs 409 are different mechanisms, and
@@ -728,6 +779,13 @@ async fn concurrent_updates_only_spawn_once() {
         1,
         "exactly one update may spawn while another is in flight, got: {spawns:?}"
     );
+
+    // Drain the in-flight stub child before the Harness (and its TempDir) drops.
+    // The accepted update's stub sleeps 1.5s; if we returned now the TempDir
+    // would be deleted out from under the still-running script, which then logs
+    // `No such file or directory` to stderr. Polling its `done` marker makes
+    // teardown deterministic and noise-free.
+    poll_file_nonempty(&done_marker).await;
 }
 
 #[tokio::test]
@@ -738,16 +796,29 @@ async fn update_after_in_flight_completes_is_accepted() {
     // the rate-limiter doesn't mask the in-flight behaviour being tested.
     let tmp = tempfile::tempdir().unwrap();
     let argv_record = tmp.path().join("argv.log");
+    let done_log = tmp.path().join("done.log");
+    // Sleep just past the 1s early-exit probe; kept minimal so the stub child
+    // doesn't linger and add scheduler contention to parallel tests. Each
+    // invocation appends a line to `done.log` on EXIT, so the test can drain
+    // every accepted-and-spawned child before dropping the Harness (and its
+    // TempDir) — otherwise a still-sleeping child's script would vanish out
+    // from under it and emit `No such file or directory` to stderr at teardown.
+    let update_script = format!(
+        "#!/bin/sh\nsleep 1.5\necho done >> {}\n",
+        done_log.display()
+    );
     let h = Harness::build_live(
         "0.2.55",
         Version::new(0, 2, 56),
         0, // no rate-limit, so we isolate the in-flight guard
-        // Sleep just past the 1s early-exit probe; kept minimal so the stub
-        // child doesn't linger and add scheduler contention to parallel tests.
-        "#!/bin/sh\nsleep 1.5\n",
+        &update_script,
         &argv_record,
     )
     .await;
+
+    // Count the children we actually spawn so teardown can wait for all of them
+    // to exit (the first accepted update plus the second accepted follow-up).
+    let mut spawned = 0u32;
 
     let (body1, sig1) = h.signed_body("0.2.56", now_secs());
     let r1 = reqwest::Client::new()
@@ -758,6 +829,7 @@ async fn update_after_in_flight_completes_is_accepted() {
         .await
         .unwrap();
     assert!(r1.status() == 200 || r1.status() == 202);
+    spawned += 1;
 
     // While still in flight, a second update is 409.
     let (body2, sig2) = h.signed_body("0.2.56", now_secs());
@@ -790,6 +862,7 @@ async fn update_after_in_flight_completes_is_accepted() {
             .unwrap();
         let last_status = r3.status().as_u16();
         if last_status == 200 || last_status == 202 {
+            spawned += 1;
             break last_status;
         }
         assert_eq!(
@@ -805,6 +878,11 @@ async fn update_after_in_flight_completes_is_accepted() {
         last_status == 200 || last_status == 202,
         "guard must be released after the update completes; got {last_status}"
     );
+
+    // Drain every child we spawned (the initial accepted update and the final
+    // accepted follow-up) before the Harness/TempDir drops. Each child appends
+    // one line to `done.log` on exit; wait until all of them have.
+    poll_done_count(&done_log, spawned as usize).await;
 }
 
 #[tokio::test]
@@ -817,15 +895,23 @@ async fn sudoers_argv_matches_allowlist() {
     // wrapper and asserts it lines up with the sudoers allowlist.
     let tmp = tempfile::tempdir().unwrap();
     let argv_record = tmp.path().join("argv.log");
+    let done_marker = tmp.path().join("done.log");
     // Update script does nothing; we only care about the argv sudo sees. Sleep
     // just past the 1s early-exit probe (so the handler returns 202, not a
     // probe-window failure) and no longer — a lingering stub child only adds
-    // scheduler contention to the parallel suite.
+    // scheduler contention to the parallel suite. The final `echo done` lets the
+    // test drain the child before the TempDir drops, so the still-sleeping
+    // script isn't deleted out from under it (which logs `No such file or
+    // directory` to stderr at teardown).
+    let update_script = format!(
+        "#!/bin/sh\n# noop — wait long enough that the 1s probe times out\nsleep 1.5\necho done > {}\n",
+        done_marker.display(),
+    );
     let h = Harness::build_live(
         "0.2.55",
         Version::new(0, 2, 56),
         600,
-        "#!/bin/sh\n# noop — wait long enough that the 1s probe times out\nsleep 1.5\n",
+        &update_script,
         &argv_record,
     )
     .await;
@@ -855,6 +941,10 @@ async fn sudoers_argv_matches_allowlist() {
         argv.ends_with("--force --target-version v0.2.56"),
         "argv suffix must match sudoers allowlist (got: {argv:?})"
     );
+
+    // Drain the in-flight stub child before the Harness/TempDir drops, so the
+    // still-sleeping script isn't deleted out from under it at teardown.
+    poll_file_nonempty(&done_marker).await;
 }
 
 /// Build a Harness whose announcer points at a stub announce script.
@@ -1002,9 +1092,17 @@ async fn announce_disabled_still_requires_signature() {
 async fn announce_happy_path() {
     let tmp = tempfile::tempdir().unwrap();
     let record = tmp.path().join("argv.log");
+    let done_marker = tmp.path().join("done.log");
     // Sleep just past the 1s probe so the handler returns 202; kept short so
-    // the stub child doesn't linger and contend with the parallel suite.
-    let h = build_with_announcer("#!/bin/sh\nsleep 1.5\n", &record).await;
+    // the stub child doesn't linger and contend with the parallel suite. The
+    // final `echo done` lets the test drain the child before its TempDir drops,
+    // so the still-sleeping script isn't deleted out from under it (which logs
+    // `No such file or directory` to stderr at teardown).
+    let announce_script = format!(
+        "#!/bin/sh\nsleep 1.5\necho done > {}\n",
+        done_marker.display()
+    );
+    let h = build_with_announcer(&announce_script, &record).await;
     let (body, sig) = signed_announce(&h.secret, "Freenet v0.2.57 released", now_secs());
     let resp = reqwest::Client::new()
         .post(format!("{}/announce/river", h.base))
@@ -1043,6 +1141,10 @@ async fn announce_happy_path() {
         full.ends_with(" Freenet v0.2.57 released"),
         "full argv must end with the message, got: {full:?}"
     );
+
+    // Drain the in-flight stub child before the Harness/TempDir drops, so the
+    // still-sleeping announce script isn't deleted out from under it.
+    poll_file_nonempty(&done_marker).await;
 }
 
 #[tokio::test]
@@ -1107,8 +1209,20 @@ async fn announce_spawn_failure_does_not_consume_rate_limit() {
         attempt += 1;
         let tmp = tempfile::tempdir().unwrap();
         let record = tmp.path().join("argv.log");
-        // Script exits 1 immediately → 500 + window NOT consumed.
-        let h = build_with_announcer("#!/bin/sh\nexit 1\n", &record).await;
+        let done_log = tmp.path().join("done.log");
+        // Script records its exit then exits 1 immediately → 500 + window NOT
+        // consumed. The `echo done` lets us drain every spawned child before
+        // this iteration's TempDir drops — a probe-miss (202) hands the fast
+        // `exit 1` child to the background wait task, whose fake-sudo exec would
+        // otherwise race the TempDir rmdir and log `No such file or directory`.
+        let announce_script = format!("#!/bin/sh\necho done >> {}\nexit 1\n", done_log.display());
+        let h = build_with_announcer(&announce_script, &record).await;
+
+        // Every POST that passes validation spawns the announce child (500 =
+        // caught fast exit, 202 = probe-miss handed to the background task);
+        // both append a `done` line on exit. Count them so we can drain all.
+        let mut spawns = 0usize;
+
         let (body, sig) = signed_announce(&h.secret, "first", now_secs());
         let r1 = reqwest::Client::new()
             .post(format!("{}/announce/river", h.base))
@@ -1117,9 +1231,13 @@ async fn announce_spawn_failure_does_not_consume_rate_limit() {
             .send()
             .await
             .unwrap();
+        spawns += 1;
         if r1.status() != 500 {
             // Probe missed the fast exit under load (got 202); retry on a fresh
             // harness. Bounded to avoid hanging if the 500 path were broken.
+            // Drain the spawned child first so its fake-sudo exec doesn't race
+            // this TempDir's deletion.
+            poll_done_count(&done_log, spawns).await;
             assert!(
                 attempt < 20,
                 "announce spawn failure never surfaced as 500 across {attempt} attempts; got {}",
@@ -1136,11 +1254,14 @@ async fn announce_spawn_failure_does_not_consume_rate_limit() {
             .send()
             .await
             .unwrap();
+        spawns += 1;
         assert_ne!(
             r2.status(),
             429,
             "failed spawn must not consume the announce rate-limit window"
         );
+        // Drain both spawned children before the TempDir drops.
+        poll_done_count(&done_log, spawns).await;
         break;
     }
 }
@@ -1209,9 +1330,17 @@ async fn announce_exactly_at_message_limit_is_accepted() {
     // so 4096 passes. One-over (4097) goes 413 — see next test.
     let tmp = tempfile::tempdir().unwrap();
     let record = tmp.path().join("argv.log");
+    let done_marker = tmp.path().join("done.log");
     // Sleep just past the 1s probe so the handler returns 202; kept short so
-    // the stub child doesn't linger and contend with the parallel suite.
-    let h = build_with_announcer("#!/bin/sh\nsleep 1.5\n", &record).await;
+    // the stub child doesn't linger and contend with the parallel suite. The
+    // final `echo done` lets the test drain the child before its TempDir drops,
+    // so the still-sleeping script isn't deleted out from under it (which logs
+    // `No such file or directory` to stderr at teardown).
+    let announce_script = format!(
+        "#!/bin/sh\nsleep 1.5\necho done > {}\n",
+        done_marker.display()
+    );
+    let h = build_with_announcer(&announce_script, &record).await;
     let exact = "x".repeat(4096);
     let (body, sig) = signed_announce(&h.secret, &exact, now_secs());
     let resp = reqwest::Client::new()
@@ -1226,6 +1355,10 @@ async fn announce_exactly_at_message_limit_is_accepted() {
         "exactly-at-limit must pass; got {}",
         resp.status()
     );
+
+    // Drain the in-flight stub child before the Harness/TempDir drops, so the
+    // still-sleeping announce script isn't deleted out from under it.
+    poll_file_nonempty(&done_marker).await;
 }
 
 #[tokio::test]
@@ -1250,7 +1383,13 @@ async fn announce_rate_limit_kicks_in_after_first_success() {
     // 1-minute window: two back-to-back announces, second must 429.
     let tmp = tempfile::tempdir().unwrap();
     let record = tmp.path().join("argv.log");
-    let h = build_with_announcer("#!/bin/sh\nexit 0\n", &record).await;
+    let done_log = tmp.path().join("done.log");
+    // The first announce spawns a child; record its exit so we can drain it
+    // before the TempDir drops. Under load the fast `exit 0` can miss the 1s
+    // probe and be handed to the background wait task, whose fake-sudo exec
+    // would otherwise race the TempDir rmdir and log `No such file or directory`.
+    let announce_script = format!("#!/bin/sh\necho done >> {}\nexit 0\n", done_log.display());
+    let h = build_with_announcer(&announce_script, &record).await;
 
     let (b1, s1) = signed_announce(&h.secret, "first", now_secs());
     let r1 = reqwest::Client::new()
@@ -1271,6 +1410,10 @@ async fn announce_rate_limit_kicks_in_after_first_success() {
         .await
         .unwrap();
     assert_eq!(r2.status(), 429);
+
+    // Only the first announce spawned (the second was rate-limited). Drain it
+    // before the TempDir drops so its fake-sudo exec doesn't race the deletion.
+    poll_done_count(&done_log, 1).await;
 }
 
 #[tokio::test]

--- a/docs/release-agent-deployment.md
+++ b/docs/release-agent-deployment.md
@@ -284,6 +284,8 @@ agent and is used by the existing release flow.
 | `401` only on slow runners | `clock_skew_tolerance_seconds` too tight. Default 300s should be safe; bump to 600 if the runner's clock drifts. |
 | `403` from `/update` with `"reason":"downgrade"` | Workflow targeted an older version than what's installed. Expected if a hotfix landed out-of-order. |
 | `403` with `"reason":"not_github_latest"` | GitHub release wasn't tagged `latest` yet (pre-release flag still set). Wait for the `release.yml` workflow to finalize. |
+| `409` from `/update` | An update is already in flight on this gateway (overlapping/duplicate POST). The in-flight guard rejected the duplicate to prevent the #4271 double-stop. NOT a failure — the in-progress update is the one that applies; `gateway-update.yml` logs a `::notice::` and proceeds to the verify step. |
+| `429` from `/update` | Rate-limited: another update was accepted within `rate_limit_seconds` (default 600). The recent update is in effect; the workflow treats this as non-fatal and proceeds to verify. |
 | `502` | GitHub API unreachable from gateway. Transient — workflow will retry. |
 | `500` after flipping `dry_run=false` | `sudo -n` rejected the invocation. `sudo -l -U freenet-update` should show the sudoers entry. If not, re-run `visudo -c -f /etc/sudoers.d/freenet-release-agent`. |
 | Caddy can't get a cert | DNS A record not propagated yet, or Caddy not reachable on 80/tcp for the ACME HTTP-01 challenge. |


### PR DESCRIPTION
## Problem

During the 0.2.65 rollout, nova's gateway service went **down**: the gateway-update flow
issued two stop/restart commands close enough together that the second `systemctl` action
SIGKILLed the freshly-started new process. The service stayed `inactive` until a manual
`systemctl start`. The old process took ~90s to drain (past the 45s final-sigterm timeout),
and a second update command arrived ~1s after the first restart.

Root cause: the release-agent received the update POSTs and spawned the update script with
**no in-flight deduplication** — only a rate-limit mutex that gates *timing*, not overlap.
Two rapid POSTs both ran `systemctl stop/restart`, and the second killed the fresh process.

## Solution

Add an **in-flight guard** to the release-agent so an overlapping update can never race-kill
a freshly-started process:

- An `Arc<AtomicBool>` `update_in_flight` (separate from the rate-limit mutex). `update_handler`
  claims it via `compare_exchange(false→true)` after the rate-limit check; on overlap it returns
  **409 Conflict** instead of spawning.
- The claim is an `InFlightGuard` RAII type **moved into the background `child.wait()` task** so
  the slot stays claimed across the *entire* stop/restart window — closing the ~1s-probe gap that
  let the second update race in. Released on success / failure / panic (Drop) / timeout.
- Time-bounded by `MAX_UPDATE_HOLD = 300s` (covers the 45s TimeoutStopSec + observed ~90s drain
  + startup, with headroom) so a hung update can never wedge the agent permanently. The residual
  re-open window past 300s is documented; the rate-limit window (prod default 600s > 300s) is the
  second backstop, and config load now `warn!`s if `rate_limit_seconds < MAX_UPDATE_HOLD`.
- `gateway-update.yml` now treats **409 / 429** as non-fatal (the verify step is the authoritative
  gate on version convergence), so a legitimate overlapping re-run doesn't red the release.

The agent is the right place for this (the workflow POSTs each gateway once; idempotency belongs
in the receiver).

## Testing

- `concurrent_updates_only_spawn_once` (load-bearing) — two concurrent POSTs → exactly one
  acceptance + one 409, and exactly one update spawn. Without the guard: two spawns.
- `update_after_in_flight_completes_is_accepted` — overlap is 409, then after the update completes
  a fresh POST is accepted (proves the slot frees).
- Unit tests for the guard (single-acquire, frees on drop) + dry-run-releases-slot.
- Tests made deterministic under parallel `cargo test` (bounded polling, stub-child draining via
  done-markers) — 12 consecutive full-suite runs green and noise-free.
- `cargo fmt`, `cargo clippy -p freenet-release-agent --all-targets -- -D warnings`, `cargo build`
  all clean.

Reviewed via a multi-perspective panel over two rounds (logic confirmed correct round 1; test
determinism + the MAX_UPDATE_HOLD backstop hardened in round 2). External (codex) pass was
unavailable (auth/refresh-token error); the diverse multi-lens Claude panel was the documented
fallback.

## Fixes

Closes #4271

[AI-assisted]
