### PR TITLE
fix: re-broadcast fresh-contract PUT when interest resolves so it reaches the network

### DIFF
--- a/crates/core/src/contract/executor/mock_runtime.rs
+++ b/crates/core/src/contract/executor/mock_runtime.rs
@@ -260,6 +260,7 @@ where
                 key,
                 new_state: state.clone(),
                 is_retry: false,
+                is_reemit: false,
             }) {
                 // Best-effort by design (mirrors the production
                 // executor; see runtime.rs for the #4145 / #4238

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -2443,6 +2443,7 @@ where
                     key: *key,
                     new_state: new_state.clone(),
                     is_retry: false,
+                    is_reemit: false,
                 })
             {
                 // Non-blocking emit: a 30-second `notify_node_event(...).await`
@@ -2807,6 +2808,7 @@ where
                     key,
                     new_state,
                     is_retry: false,
+                    is_reemit: false,
                 })
             {
                 // Best-effort by design — see #4145 and the sibling

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -708,6 +708,16 @@ pub(crate) enum NodeEvent {
         /// re-counting (or being confused by) retries that share the
         /// per-contract `broadcast_retries` state.
         is_retry: bool,
+        /// `true` when this broadcast is a deferred re-emission of a
+        /// fresh-contract state that earlier found no targets and was stashed
+        /// in `PendingBroadcastStore`, now re-driven because an interested
+        /// peer appeared (issue #4359). The handler treats it like a fresh
+        /// broadcast for fan-out, but must NOT re-record a `no_targets`
+        /// propagation-summary event for it: the originating PUT already
+        /// counted one `no_targets` when it first gave up, and counting again
+        /// per flush would inflate the #4281 stats. `false` for executor-fresh
+        /// and retry re-emissions.
+        is_reemit: bool,
     },
     /// Send state to a specific peer that reported a stale summary.
     /// Unlike BroadcastStateChange (which fans out to ALL subscribers),

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1595,6 +1595,17 @@ where
                 if let Some((key, state)) =
                     get_contract_state_by_id(&op_manager, &instance_id).await
                 {
+                    // #4359 (MUST-FIX 1, Source 1 / proximity): this neighbor
+                    // just announced it hosts a contract we also host, so it is
+                    // now a `neighbors_with_contract` broadcast target. If a
+                    // fresh-contract PUT gave up with no targets and is stashed,
+                    // flush it here — this is the proximity first-viable-target
+                    // signal, distinct from the interest-manager (Source 2)
+                    // signals. Must run BEFORE the receiving-updates/downstream
+                    // gate below, which `continue`s for exactly the
+                    // locally-hosted-only fresh-PUT case this fix targets.
+                    op_manager.flush_pending_broadcast_on_interest(&key).await;
+
                     if !op_manager.ring.is_receiving_updates(&key)
                         && !op_manager.ring.has_downstream_subscribers(&key)
                     {
@@ -1765,12 +1776,21 @@ async fn handle_interest_sync_message(
                             .interest_manager
                             .refresh_peer_interest(&contract, pk);
                     } else {
-                        op_manager.interest_manager.register_peer_interest(
+                        let is_new = op_manager.interest_manager.register_peer_interest(
                             &contract,
                             pk.clone(),
                             None, // New entry; summary arrives in their Summaries response
                             false,
                         );
+                        if is_new {
+                            // #4359 (MUST-FIX 1): an Interests-sync registration
+                            // makes this peer a viable broadcast target. Flush
+                            // any deferred fresh-contract broadcast so a cold-id
+                            // PUT that gave up with no targets reaches it.
+                            op_manager
+                                .flush_pending_broadcast_on_interest(&contract)
+                                .await;
+                        }
                     }
                 }
             }
@@ -1954,12 +1974,21 @@ async fn handle_interest_sync_message(
                         }
 
                         // Register their interest
-                        op_manager.interest_manager.register_peer_interest(
+                        let is_new = op_manager.interest_manager.register_peer_interest(
                             &contract,
                             pk.clone(),
                             None,
                             false,
                         );
+                        if is_new {
+                            // #4359 (MUST-FIX 1): a ChangeInterests addition
+                            // makes this peer a viable broadcast target. Flush
+                            // any deferred fresh-contract broadcast so a cold-id
+                            // PUT that gave up with no targets reaches it.
+                            op_manager
+                                .flush_pending_broadcast_on_interest(&contract)
+                                .await;
+                        }
 
                         // Get our summary to send back
                         let summary = get_contract_summary(op_manager, &contract).await;

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -4397,6 +4397,21 @@ impl P2pConnManager {
                 // suppress repetitive WARN logging after the first occurrence.
                 self.broadcast_retries.remove(&key);
 
+                // Issue #4359: a fresh contract id loses the race between this
+                // broadcast give-up (~6 s) and the much slower interest/
+                // subscription resolve for a never-before-seen key. Instead of
+                // permanently abandoning the state — which silently leaves it
+                // locally-hosted only while every other node GETs NotFound —
+                // stash it. When the first interested peer/subscriber for this
+                // contract appears later, the subscribe path drains the stash
+                // and re-emits a single BroadcastStateChange, which then finds
+                // the freshly-registered target and propagates. The store is
+                // bounded by size and TTL so a churn of fresh ids that never
+                // gain a subscriber cannot pin memory.
+                op_manager
+                    .pending_broadcasts
+                    .stash(*key.id(), new_state.clone());
+
                 // Evict oldest entry if at capacity to prevent unbounded growth.
                 if !self.broadcast_no_target_streak.contains_key(&key)
                     && self.broadcast_no_target_streak.len() >= Self::MAX_BROADCAST_STREAK_ENTRIES
@@ -4457,6 +4472,10 @@ impl P2pConnManager {
         // Targets found - clear any pending retry and streak state for this contract
         self.broadcast_retries.remove(&key);
         self.broadcast_no_target_streak.remove(&key);
+        // Also drop any deferred re-broadcast stash (#4359): this fan-out is
+        // reaching targets now, so a previously-abandoned state for this
+        // contract is superseded and must not be re-emitted later as stale.
+        let _ = op_manager.pending_broadcasts.take(key.id());
 
         // Record a successful fan-out for the #4281 propagation summary. Fires
         // whether targets were found on the initial attempt or on a healing

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -6352,57 +6352,237 @@ mod tests {
         );
     }
 
+    /// Strip every `#[cfg(test)]` region (single item *or* brace-delimited
+    /// module/block) from a Rust source string, leaving only production code.
+    ///
+    /// This is deliberately a small ad-hoc scanner rather than a real parser:
+    /// it only needs to be precise enough that test-only
+    /// `register_peer_interest(` calls (which all live under `#[cfg(test)]`)
+    /// don't count toward the production tally walked by
+    /// `pending_broadcast_flush_wired_at_all_interest_sites`. It handles the
+    /// two cfg(test) shapes that occur in this crate:
+    ///
+    /// * single item — `#[cfg(test)]\npub(crate) use ...;` / `mod foo;`
+    ///   (removed up to and including the terminating `;`), and
+    /// * block — `#[cfg(test)]\nmod tests { ... }` (removed with brace
+    ///   balancing, so nested `{}` inside the block don't end it early).
+    ///
+    /// Braces inside string/char literals or comments are ignored well enough
+    /// for this purpose because the only thing we measure afterward is the
+    /// count of two specific identifiers, and those never appear inside a
+    /// literal in production source.
+    fn strip_cfg_test_regions(src: &str) -> String {
+        const MARKER: &str = "#[cfg(test)]";
+        let bytes = src.as_bytes();
+        let mut out = String::with_capacity(src.len());
+        let mut i = 0usize;
+        while i < src.len() {
+            if src[i..].starts_with(MARKER) {
+                // Advance past the marker and any following attributes/whitespace
+                // until the first significant token of the gated item.
+                let mut j = i + MARKER.len();
+                // Skip whitespace and additional `#[...]` attribute lines.
+                loop {
+                    while j < src.len() && bytes[j].is_ascii_whitespace() {
+                        j += 1;
+                    }
+                    if src[j..].starts_with("#[") {
+                        // Skip a balanced `#[ ... ]` attribute.
+                        let mut depth = 0i32;
+                        while j < src.len() {
+                            match bytes[j] {
+                                b'[' => depth += 1,
+                                b']' => {
+                                    depth -= 1;
+                                    if depth == 0 {
+                                        j += 1;
+                                        break;
+                                    }
+                                }
+                                _ => {}
+                            }
+                            j += 1;
+                        }
+                        continue;
+                    }
+                    break;
+                }
+                // From `j`, find the end of this gated item: either the matching
+                // `}` of the first `{ ... }` block, or the terminating `;`.
+                let mut k = j;
+                let mut found_brace = false;
+                while k < src.len() {
+                    match bytes[k] {
+                        b'{' => {
+                            found_brace = true;
+                            break;
+                        }
+                        b';' => break,
+                        _ => {}
+                    }
+                    k += 1;
+                }
+                if found_brace {
+                    // Brace-balance to the matching close.
+                    let mut depth = 0i32;
+                    while k < src.len() {
+                        match bytes[k] {
+                            b'{' => depth += 1,
+                            b'}' => {
+                                depth -= 1;
+                                if depth == 0 {
+                                    k += 1;
+                                    break;
+                                }
+                            }
+                            _ => {}
+                        }
+                        k += 1;
+                    }
+                } else if k < src.len() {
+                    // Consume the terminating `;`.
+                    k += 1;
+                }
+                i = k;
+                continue;
+            }
+            // Copy one byte of production source. `src` is valid UTF-8 and we
+            // only ever split on ASCII boundaries (markers/braces/`;`), so
+            // pushing the char at this index is safe.
+            let ch = src[i..].chars().next().unwrap();
+            out.push(ch);
+            i += ch.len_utf8();
+        }
+        out
+    }
+
+    /// Recursively collect every `*.rs` file under `dir`.
+    fn collect_rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        let entries = match std::fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_rs_files(&path, out);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                out.push(path);
+            }
+        }
+    }
+
     /// #4359 trigger-completeness pin (MUST-FIX 1). The deferred broadcast only
     /// drains when a viable target appears, signalled by
     /// `flush_pending_broadcast_on_interest`. The interest-manager (Source 2)
     /// path makes a peer a target via `register_peer_interest`; EVERY such call
     /// site that can be the first viable target for a never-seen id must flush.
-    /// This pin asserts that each `register_peer_interest` call in the
-    /// production interest-registration files is accompanied by a nearby
-    /// `flush_pending_broadcast_on_interest`, so a future call site cannot
-    /// silently regress the fix (the failure mode the re-review caught: flush
-    /// wired at one caller while several others made a peer a target with no
-    /// flush). Source 1 (proximity) is guarded by the node.rs assertion below.
+    ///
+    /// Rather than trusting a static allow-list of files (the brittle shape the
+    /// re-review flagged — a NEW production `register_peer_interest` added in
+    /// some other module would silently escape the pin and re-open the
+    /// unflushed-target bug), this pin WALKS the entire crate source tree
+    /// (`$CARGO_MANIFEST_DIR/src/**/*.rs`), strips `#[cfg(test)]` regions, and
+    /// asserts that:
+    ///
+    ///   1. the SET of production files that contain a `register_peer_interest(`
+    ///      call equals the known-wired set (so a brand-new file with such a
+    ///      call trips the pin even before we reach the per-file count), and
+    ///   2. within each such file, production
+    ///      `flush_pending_broadcast_on_interest(` calls >= production
+    ///      `register_peer_interest(` calls (the pairing convention the fix
+    ///      established).
+    ///
+    /// Source 1 (proximity) is guarded by the node.rs assertion at the end.
     #[test]
     fn pending_broadcast_flush_wired_at_all_interest_sites() {
-        // (file, how many register_peer_interest calls in this file are
-        // first-viable-target sites that must be flush-paired). Test files are
-        // excluded by checking only the listed production modules.
-        let cases: &[(&str, &str)] = &[
-            (
-                "../../operations/subscribe.rs",
-                include_str!("../../operations/subscribe.rs"),
-            ),
-            ("../../operations.rs", include_str!("../../operations.rs")),
-            (
-                "../../operations/get/op_ctx_task.rs",
-                include_str!("../../operations/get/op_ctx_task.rs"),
-            ),
-            ("../../node.rs", include_str!("../../node.rs")),
-        ];
+        // The set of production files (relative to `src/`) that are known to
+        // make a peer a first-viable-target via `register_peer_interest` and
+        // are correctly flush-paired. A NEW production call site in any other
+        // file must FAIL this pin — see the set-equality assertion below.
+        let known_wired: std::collections::BTreeSet<&str> = [
+            "node.rs",
+            "operations.rs",
+            "operations/subscribe.rs",
+            "operations/get/op_ctx_task.rs",
+        ]
+        .into_iter()
+        .collect();
 
-        for (path, src) in cases {
-            // Strip the `#[cfg(test)] mod tests` region so test-only
-            // register_peer_interest calls don't trip the pin.
-            let prod = src.find("\nmod tests").map(|p| &src[..p]).unwrap_or(src);
+        let src_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut files = Vec::new();
+        collect_rs_files(&src_root, &mut files);
+        assert!(
+            !files.is_empty(),
+            "#4359 MUST-FIX 1: source walk found no .rs files under {} — the pin cannot \
+             guarantee completeness if it can't read the crate source.",
+            src_root.display()
+        );
+
+        let mut found_with_register: std::collections::BTreeSet<String> = Default::default();
+        // Per-file pairing failures: (relative path, reg_count, flush_count).
+        let mut pairing_failures: Vec<(String, usize, usize)> = Vec::new();
+
+        for path in &files {
+            let rel = path
+                .strip_prefix(&src_root)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            let src = match std::fs::read_to_string(path) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            let prod = strip_cfg_test_regions(&src);
             let reg_count = prod.matches("register_peer_interest(").count();
+            if reg_count == 0 {
+                continue;
+            }
+            // The interest-manager method *definition* itself lives in
+            // ring/interest.rs and is not a call site; ignore it. Detect by the
+            // presence of the `pub fn register_peer_interest` definition.
+            if prod.contains("fn register_peer_interest(") {
+                continue;
+            }
+            found_with_register.insert(rel.clone());
             let flush_count = prod.matches("flush_pending_broadcast_on_interest(").count();
-            assert!(
-                flush_count >= reg_count,
-                "#4359 MUST-FIX 1: {path} has {reg_count} register_peer_interest call(s) but only \
-                 {flush_count} flush_pending_broadcast_on_interest call(s). Every interest \
-                 registration that can be the first viable broadcast target for a cold id must \
-                 flush the deferred broadcast, or the fix silently fails for that path. If a new \
-                 register_peer_interest site genuinely cannot be a first viable target, document \
-                 why and adjust this pin."
-            );
+            if flush_count < reg_count {
+                pairing_failures.push((rel, reg_count, flush_count));
+            }
         }
+
+        // (1) Set equality: no NEW production file may carry a
+        // register_peer_interest call without being deliberately wired here.
+        let found_refs: std::collections::BTreeSet<&str> =
+            found_with_register.iter().map(|s| s.as_str()).collect();
+        assert_eq!(
+            found_refs, known_wired,
+            "#4359 MUST-FIX 1: the set of production files that call \
+             register_peer_interest changed. Found {found_refs:?}, expected {known_wired:?}. \
+             A NEW register_peer_interest call site can be the first viable broadcast target \
+             for a cold id; it MUST flush the deferred broadcast (call \
+             flush_pending_broadcast_on_interest) or the #4359 fix silently fails for that \
+             path. Wire the flush, then add the file to `known_wired` in this pin. If the new \
+             site genuinely cannot be a first viable target, document why and adjust this pin."
+        );
+
+        // (2) Per-file pairing: every wired file's flush count covers its
+        // register count.
+        assert!(
+            pairing_failures.is_empty(),
+            "#4359 MUST-FIX 1: interest registration without a paired broadcast flush: \
+             {pairing_failures:?} (file, register_peer_interest count, \
+             flush_pending_broadcast_on_interest count). Every interest registration that can \
+             be the first viable broadcast target for a cold id must flush the deferred \
+             broadcast, or the fix silently fails for that path."
+        );
 
         // Source 1 (proximity): the NeighborHosting overlap path must flush too,
         // since a neighbor newly announcing it hosts our contract is a viable
         // target with no interest_manager entry.
-        const NODE: &str = include_str!("../../node.rs");
-        let node_prod = NODE.find("\nmod tests").map(|p| &NODE[..p]).unwrap_or(NODE);
+        let node_path = src_root.join("node.rs");
+        let node_src = std::fs::read_to_string(&node_path).expect("node.rs must be readable");
+        let node_prod = strip_cfg_test_regions(&node_src);
         assert!(
             node_prod.contains("Source 1 / proximity")
                 && node_prod.contains("flush_pending_broadcast_on_interest(&key)"),

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -2197,12 +2197,14 @@ impl P2pConnManager {
                                 key,
                                 new_state,
                                 is_retry,
+                                is_reemit,
                             } => {
                                 ctx.handle_broadcast_state_change(
                                     &op_manager,
                                     key,
                                     new_state,
                                     is_retry,
+                                    is_reemit,
                                 )
                                 .await;
                             }
@@ -4274,6 +4276,12 @@ impl P2pConnManager {
         // no-target retry re-emission this handler scheduled. Used only to
         // count fresh logical broadcasts once for the #4281 summary.
         is_retry: bool,
+        // `true` when this is a deferred re-emission of a stashed fresh-contract
+        // broadcast (issue #4359). Suppresses re-recording a `no_targets`
+        // propagation-summary event on give-up (the originating PUT already
+        // counted one when it first gave up) so a flush per interested peer
+        // does not inflate the #4281 stats.
+        is_reemit: bool,
     ) {
         tracing::debug!(
             contract = %key,
@@ -4337,7 +4345,14 @@ impl P2pConnManager {
             // double-count. If a later retry heals (finds targets), the
             // targets-found path below additionally records that success — both
             // the initial miss and the eventual propagation are surfaced.
-            if !is_retry {
+            //
+            // `is_reemit` (issue #4359) is also excluded: a deferred re-emission
+            // of a stashed fresh-contract broadcast that STILL finds no targets
+            // must not re-record a `no_targets` event — the originating PUT
+            // already counted one when it first gave up, and counting again per
+            // interested-peer flush would inflate the #4281 no_targets/targets_avg
+            // stats.
+            if !is_retry && !is_reemit {
                 op_manager.update_propagation_stats.record_broadcast(
                     *key.id(),
                     0,
@@ -4382,6 +4397,7 @@ impl P2pConnManager {
                             key,
                             new_state,
                             is_retry: true,
+                            is_reemit: false,
                         })
                         .await
                     {
@@ -4403,7 +4419,7 @@ impl P2pConnManager {
                 // permanently abandoning the state — which silently leaves it
                 // locally-hosted only while every other node GETs NotFound —
                 // stash it. When the first interested peer/subscriber for this
-                // contract appears later, the subscribe path drains the stash
+                // contract appears later, the interest path drains the stash
                 // and re-emits a single BroadcastStateChange, which then finds
                 // the freshly-registered target and propagates. The store is
                 // bounded by size and TTL so a churn of fresh ids that never
@@ -4411,6 +4427,50 @@ impl P2pConnManager {
                 op_manager
                     .pending_broadcasts
                     .stash(*key.id(), new_state.clone());
+
+                // Lost-wakeup guard (#4359 re-review): stash() runs here on the
+                // event-loop task while the interest-resolve flush runs on the
+                // subscribe/op driver task — they are concurrent with no
+                // happens-before. An interested peer could have registered (and
+                // already flushed → found nothing to take) in the window between
+                // `get_broadcast_targets_update` above and this stash. That would
+                // leave the state stashed with the only interested peer already
+                // past its flush, draining nothing until the NEXT subscriber or
+                // the TTL. Re-resolve targets now that the stash is in place: if a
+                // target has appeared, take the stash back and re-emit
+                // immediately rather than waiting on a future flush.
+                let recheck = op_manager.get_broadcast_targets_update(&key, &self_addr);
+                if !recheck.targets.is_empty() {
+                    if let Some(stashed) = op_manager.pending_broadcasts.take(key.id()) {
+                        tracing::debug!(
+                            contract = %key,
+                            target_count = recheck.targets.len(),
+                            phase = "pending_broadcast_stash_recheck",
+                            "A target appeared while giving up; re-emitting the deferred \
+                             fresh-contract broadcast immediately instead of leaving it \
+                             stashed for a future flush (#4359)"
+                        );
+                        if let Err(e) = op_manager.try_notify_node_event(
+                            crate::message::NodeEvent::BroadcastStateChange {
+                                key,
+                                new_state: stashed.clone(),
+                                is_retry: false,
+                                is_reemit: true,
+                            },
+                        ) {
+                            // Channel full/closed: re-stash so the next interest
+                            // flush still recovers it. Losing it would re-open the
+                            // locally-hosted-only failure this fix closes.
+                            op_manager.pending_broadcasts.stash(*key.id(), stashed);
+                            tracing::debug!(
+                                contract = %key,
+                                error = %e,
+                                "pending_broadcast_stash_recheck: immediate re-emit dropped; \
+                                 re-stashed for the next interest signal"
+                            );
+                        }
+                    }
+                }
 
                 // Evict oldest entry if at capacity to prevent unbounded growth.
                 if !self.broadcast_no_target_streak.contains_key(&key)
@@ -6229,6 +6289,126 @@ mod tests {
             "banned-egress skip must clear broadcast_no_target_streak for the \
              contract so a ban mid-retry-cycle doesn't leave a stale entry. \
              Branch:\n{banned_branch}"
+        );
+    }
+
+    /// #4359 wiring pin (MUST-FIX 2). The only behavioral unit tests for the
+    /// deferred-broadcast feature exercise the emit-core in isolation; they do
+    /// NOT drive `handle_broadcast_state_change`, so deleting the production
+    /// stash/take calls would re-open the bug with zero failing behavioral
+    /// tests. This source-grep pin (mirroring
+    /// `handle_broadcast_state_change_gates_banned_egress`) locks the wiring:
+    /// the give-up (retries-exhausted) branch MUST stash, and the targets-found
+    /// branch MUST take. Driving the full async handler needs a complete
+    /// OpManager + contract handler, hence the grep floor.
+    #[test]
+    fn handle_broadcast_state_change_stashes_on_giveup_and_takes_on_targets() {
+        const SOURCE: &str = include_str!("p2p_protoc.rs");
+
+        let fn_anchor = "async fn handle_broadcast_state_change(";
+        let fn_start = SOURCE
+            .find(fn_anchor)
+            .expect("handle_broadcast_state_change renamed or removed (#4359 wiring pin)");
+        let after_header = &SOURCE[fn_start + fn_anchor.len()..];
+        let body_end = after_header
+            .find("\n    async fn ")
+            .map(|p| fn_start + fn_anchor.len() + p)
+            .unwrap_or(SOURCE.len());
+        let body = &SOURCE[fn_start..body_end];
+
+        // The targets-empty branch (`if target_result.targets.is_empty() {`)
+        // ends at the `return;` that precedes the targets-found code. Everything
+        // after that return is the targets-found path.
+        let empty_branch_anchor = "if target_result.targets.is_empty() {";
+        let empty_start = body.find(empty_branch_anchor).expect(
+            "#4359: targets-empty branch anchor missing — give-up stash wiring cannot be located",
+        );
+        let empty_branch = &body[empty_start..];
+        let empty_return = empty_branch
+            .find("\n            return;")
+            .expect("#4359: targets-empty branch must early-return before the targets-found path");
+        let giveup_branch = &empty_branch[..empty_return];
+        let targets_found_branch = &empty_branch[empty_return..];
+
+        assert!(
+            giveup_branch.contains("pending_broadcasts\n                    .stash(")
+                || giveup_branch.contains("pending_broadcasts.stash("),
+            "#4359: the broadcast give-up (retries-exhausted) branch MUST stash the state in \
+             op_manager.pending_broadcasts — otherwise a fresh-contract PUT that loses the \
+             broadcast/interest-resolve race is permanently abandoned (locally-hosted only). \
+             Give-up branch:\n{giveup_branch}"
+        );
+        assert!(
+            giveup_branch.contains("pending_broadcast_stash_recheck"),
+            "#4359: the give-up branch MUST re-resolve targets after stashing (the \
+             pending_broadcast_stash_recheck guard) to close the stash-after-flush \
+             lost-wakeup race. Give-up branch:\n{giveup_branch}"
+        );
+        assert!(
+            targets_found_branch.contains("pending_broadcasts.take("),
+            "#4359: the targets-found branch MUST take()/clear any stashed deferred broadcast \
+             so a recovered contract is not later re-emitted with superseded state. \
+             Targets-found branch:\n{targets_found_branch}"
+        );
+    }
+
+    /// #4359 trigger-completeness pin (MUST-FIX 1). The deferred broadcast only
+    /// drains when a viable target appears, signalled by
+    /// `flush_pending_broadcast_on_interest`. The interest-manager (Source 2)
+    /// path makes a peer a target via `register_peer_interest`; EVERY such call
+    /// site that can be the first viable target for a never-seen id must flush.
+    /// This pin asserts that each `register_peer_interest` call in the
+    /// production interest-registration files is accompanied by a nearby
+    /// `flush_pending_broadcast_on_interest`, so a future call site cannot
+    /// silently regress the fix (the failure mode the re-review caught: flush
+    /// wired at one caller while several others made a peer a target with no
+    /// flush). Source 1 (proximity) is guarded by the node.rs assertion below.
+    #[test]
+    fn pending_broadcast_flush_wired_at_all_interest_sites() {
+        // (file, how many register_peer_interest calls in this file are
+        // first-viable-target sites that must be flush-paired). Test files are
+        // excluded by checking only the listed production modules.
+        let cases: &[(&str, &str)] = &[
+            (
+                "../../operations/subscribe.rs",
+                include_str!("../../operations/subscribe.rs"),
+            ),
+            ("../../operations.rs", include_str!("../../operations.rs")),
+            (
+                "../../operations/get/op_ctx_task.rs",
+                include_str!("../../operations/get/op_ctx_task.rs"),
+            ),
+            ("../../node.rs", include_str!("../../node.rs")),
+        ];
+
+        for (path, src) in cases {
+            // Strip the `#[cfg(test)] mod tests` region so test-only
+            // register_peer_interest calls don't trip the pin.
+            let prod = src.find("\nmod tests").map(|p| &src[..p]).unwrap_or(src);
+            let reg_count = prod.matches("register_peer_interest(").count();
+            let flush_count = prod.matches("flush_pending_broadcast_on_interest(").count();
+            assert!(
+                flush_count >= reg_count,
+                "#4359 MUST-FIX 1: {path} has {reg_count} register_peer_interest call(s) but only \
+                 {flush_count} flush_pending_broadcast_on_interest call(s). Every interest \
+                 registration that can be the first viable broadcast target for a cold id must \
+                 flush the deferred broadcast, or the fix silently fails for that path. If a new \
+                 register_peer_interest site genuinely cannot be a first viable target, document \
+                 why and adjust this pin."
+            );
+        }
+
+        // Source 1 (proximity): the NeighborHosting overlap path must flush too,
+        // since a neighbor newly announcing it hosts our contract is a viable
+        // target with no interest_manager entry.
+        const NODE: &str = include_str!("../../node.rs");
+        let node_prod = NODE.find("\nmod tests").map(|p| &NODE[..p]).unwrap_or(NODE);
+        assert!(
+            node_prod.contains("Source 1 / proximity")
+                && node_prod.contains("flush_pending_broadcast_on_interest(&key)"),
+            "#4359 MUST-FIX 1: the NeighborHosting proximity overlap path in node.rs must flush \
+             the deferred broadcast (Source 1 first-viable-target signal), or a cold-id PUT whose \
+             first target arrives via proximity announcement never drains."
         );
     }
 }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -19,7 +19,7 @@ use std::{
 
 use dashmap::{DashMap, DashSet};
 use either::Either;
-use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
+use freenet_stdlib::prelude::{ContractInstanceId, ContractKey, WrappedState};
 use parking_lot::{Mutex, RwLock};
 use tokio::sync::{mpsc, oneshot};
 use tracing::Instrument;
@@ -653,27 +653,107 @@ impl OpManager {
     // the broader pattern.
 
     /// Re-broadcast a fresh-contract state that earlier found no targets, now
-    /// that the first interested peer/subscriber for `key` has appeared.
+    /// that the first viable broadcast target for `key` has appeared.
     ///
     /// Issue #4359: a never-before-seen contract id loses the race between the
     /// broadcast give-up window (~6 s) and the much slower interest/
-    /// subscription resolve. When the broadcast handler gives up it stashes the
-    /// state in [`Self::pending_broadcasts`]; the subscribe path calls this on
-    /// the *first* new interest for the contract so the deferred state is
-    /// re-emitted as a fresh `BroadcastStateChange` (`is_retry: false`), which
-    /// now finds the just-registered target and propagates.
+    /// subscription/proximity resolve. When the broadcast handler gives up it
+    /// stashes the state in [`Self::pending_broadcasts`]. This is called on the
+    /// **first viable-target signal** for the contract — see the call-site list
+    /// in the trigger-completeness note below — so the deferred state is
+    /// re-emitted as a `BroadcastStateChange { is_retry: false, is_reemit: true }`,
+    /// which now finds the just-appeared target and propagates.
+    ///
+    /// ## Stale-state safety (issue #4359 re-review, SHOULD-FIX 4)
+    ///
+    /// Rather than re-emit the give-up-time *bytes* (which a newer locally
+    /// applied UPDATE could have superseded in the meantime), this re-reads the
+    /// **current** local state for the contract and broadcasts that. The stash
+    /// entry's role is "this contract still owes a fan-out"; its bytes are only
+    /// a fallback used when the live read fails (contract handler unavailable),
+    /// which is strictly no worse than the give-up-time state we would otherwise
+    /// have re-emitted.
+    ///
+    /// ## Trigger completeness (issue #4359 re-review, MUST-FIX 1)
+    ///
+    /// `get_broadcast_targets_update` resolves targets from two sources, so the
+    /// *first viable target* for a cold id can appear via either. This method is
+    /// invoked from every site that makes a peer a target for the first time:
+    ///
+    /// * **Source 2 — interest manager** (`register_peer_interest` is_new):
+    ///   - `subscribe::register_downstream_subscriber` (downstream subscriber)
+    ///   - `subscribe::finalize_originator_subscribe` (originator upstream)
+    ///   - `operations::complete_piggyback_subscription` (GET-piggyback sub)
+    ///   - `get::op_ctx_task` remote GET `subscribe=false` (requester interest)
+    ///   - `node.rs` Interests / Summaries interest-sync handlers
+    /// * **Source 1 — proximity cache** (`neighbors_with_contract`):
+    ///   - `node.rs` NeighborHosting overlap path, when a neighbor newly
+    ///     announces hosting one of our contracts (the neighbor just became a
+    ///     `neighbors_with_contract` target).
+    ///
+    /// That set is the complete first-viable-target signal: a never-seen id can
+    /// only gain a broadcast target by a peer expressing interest (Source 2) or
+    /// by a connected neighbor announcing it hosts the id (Source 1), and each
+    /// such transition routes through one of the sites above. The give-up path
+    /// itself also re-checks targets immediately after stashing
+    /// (`pending_broadcast_stash_recheck`) to close the stash-after-flush race.
+    /// A grep pin test (`pending_broadcast_flush_wired_at_all_interest_sites`)
+    /// guards against a future `register_peer_interest` call site forgetting the
+    /// flush.
     ///
     /// Best-effort via [`Self::try_notify_node_event`]: if the channel is full
-    /// the state is re-stashed for the next interest signal. No-op when there
-    /// is no pending broadcast for the contract (the common case).
-    pub(crate) fn flush_pending_broadcast_on_interest(&self, key: &ContractKey) {
-        flush_pending_broadcast_on(
+    /// the state is re-stashed for the next signal. No-op (no read, no emit)
+    /// when nothing is pending for the contract — the overwhelmingly common
+    /// case, kept cheap by checking membership before any contract-handler read.
+    pub(crate) async fn flush_pending_broadcast_on_interest(&self, key: &ContractKey) {
+        // Fast path: nothing stashed for this contract (the common case for the
+        // many interest registrations on already-propagated contracts). Avoid
+        // the take()/contract-handler read entirely.
+        if !self.pending_broadcasts.contains(key.id()) {
+            return;
+        }
+        // Drain the stash marker. If it raced away (TTL expiry, a concurrent
+        // targets-found take, or another flush) there is nothing to do.
+        let Some(stashed) = self.pending_broadcasts.take(key.id()) else {
+            return;
+        };
+
+        // Stale-state safety: re-read the CURRENT local state instead of
+        // re-broadcasting the give-up-time bytes. Fall back to the stashed bytes
+        // if the live read fails so we never regress to dropping the broadcast.
+        let state = self
+            .read_current_contract_state(key)
+            .await
+            .unwrap_or(stashed);
+
+        emit_pending_broadcast_reemit_on(
             self.to_event_listener.notifications_sender(),
             self.to_event_listener.notification_channel_pending(),
             self.to_event_listener.notifications_sender().capacity(),
             &self.pending_broadcasts,
             key,
+            state,
         );
+    }
+
+    /// Read the current local state for `key` from the contract handler, or
+    /// `None` if we don't host it / the read fails. Used by the #4359 deferred
+    /// re-broadcast flush to avoid re-emitting superseded give-up-time bytes.
+    async fn read_current_contract_state(&self, key: &ContractKey) -> Option<WrappedState> {
+        use crate::contract::ContractHandlerEvent;
+        match self
+            .notify_contract_handler(ContractHandlerEvent::GetQuery {
+                instance_id: *key.id(),
+                return_contract_code: false,
+            })
+            .await
+        {
+            Ok(ContractHandlerEvent::GetResponse {
+                response: Ok(store_response),
+                ..
+            }) => store_response.state,
+            _ => None,
+        }
     }
 
     /// Get all active subscriptions.
@@ -1227,40 +1307,42 @@ fn try_notify_node_event_on(
     }
 }
 
-/// Drain a deferred fresh-contract broadcast for `key` (if one is stashed) and
-/// re-emit it as a fresh `BroadcastStateChange` on the event-loop notification
-/// channel. Extracted as a free function so it can be unit-tested against a raw
-/// notifier + store without building a full `OpManager` (same pattern as
+/// Emit a deferred fresh-contract re-broadcast for `key` carrying `state` on the
+/// event-loop notification channel, re-stashing `state` in `pending` if the
+/// channel can't accept it. The emit-core of
+/// [`OpManager::flush_pending_broadcast_on_interest`], extracted as a free
+/// function so the channel-full re-stash mechanics are unit-testable against a
+/// raw notifier + store without building a full `OpManager` (same pattern as
 /// [`release_pending_op_slot_on`] / [`try_notify_node_event_on`]).
 ///
 /// Issue #4359: when the broadcast handler gives up on a never-before-seen id
-/// (no targets), it stashes the state in `pending`. This is called from the
-/// subscribe path on the *first* new interest for the contract — the deferred
-/// state is re-emitted (`is_retry: false`) so the now-present target receives
-/// it instead of the state staying locally-hosted only.
+/// (no targets), it stashes the state in `pending`. The caller has already
+/// drained the stash and resolved the (current) `state` to broadcast; this
+/// re-emits it as `BroadcastStateChange { is_retry: false, is_reemit: true }`
+/// so the now-present target receives it instead of the state staying
+/// locally-hosted only. `is_reemit` suppresses #4281 no_targets double-counting
+/// on a still-no-target re-emission.
 ///
 /// Best-effort: if the channel is full the state is re-stashed so a later
-/// interest signal retries it (losing it would re-open the bug). No-op (and no
-/// emission) when nothing is pending for the contract.
-fn flush_pending_broadcast_on(
+/// signal retries it (losing it would re-open the bug).
+fn emit_pending_broadcast_reemit_on(
     notifications_sender: &mpsc::Sender<Either<NetMessage, NodeEvent>>,
     channel_pending: usize,
     channel_remaining: usize,
     pending: &crate::operations::update::pending_broadcast::PendingBroadcastStore,
     key: &ContractKey,
+    state: WrappedState,
 ) {
-    let Some(state) = pending.take(key.id()) else {
-        return;
-    };
     tracing::debug!(
         contract = %key,
         phase = "pending_broadcast_flush",
-        "Re-broadcasting deferred fresh-contract state now that an interested peer appeared (#4359)"
+        "Re-broadcasting deferred fresh-contract state now that an interested peer/target appeared (#4359)"
     );
     let msg = NodeEvent::BroadcastStateChange {
         key: *key,
         new_state: state.clone(),
         is_retry: false,
+        is_reemit: true,
     };
     if try_notify_node_event_on(
         notifications_sender,
@@ -1271,12 +1353,12 @@ fn flush_pending_broadcast_on(
     .is_err()
     {
         // Re-emit dropped (channel full / closed). Put the state back so a
-        // later interest signal can retry — losing it here would re-open the
+        // later signal can retry — losing it here would re-open the
         // locally-hosted-only failure this fix closes.
         pending.stash(*key.id(), state);
         tracing::debug!(
             contract = %key,
-            "flush_pending_broadcast_on: re-emit dropped; re-stashed for the next interest signal"
+            "emit_pending_broadcast_reemit_on: re-emit dropped; re-stashed for the next signal"
         );
     }
 }
@@ -1816,11 +1898,15 @@ mod tests {
     // ──────────────────────────────────────────────────────────
     // Regression tests for #4359: a fresh-contract PUT whose initial
     // broadcast found no targets must be re-emitted (not permanently
-    // abandoned) once the first interested peer/subscriber appears.
-    // These exercise `flush_pending_broadcast_on` — the helper the
-    // subscribe path calls on a new interest — directly against a raw
-    // notifier + store, the same way the `release_pending_op_slot_on`
-    // tests above avoid building a full OpManager.
+    // abandoned) once the first interested peer/subscriber/target appears.
+    // These exercise `emit_pending_broadcast_reemit_on` — the emit-core that
+    // `OpManager::flush_pending_broadcast_on_interest` delegates to — directly
+    // against a raw notifier + store, the same way the
+    // `release_pending_op_slot_on` tests above avoid building a full OpManager.
+    // The give-up→stash and targets-found→take WIRING into the real handler is
+    // additionally guarded by source-grep pin tests in p2p_protoc.rs
+    // (`handle_broadcast_state_change_*` pins), since driving the full async
+    // handler needs a complete OpManager + contract handler.
     // ──────────────────────────────────────────────────────────
 
     fn test_contract_key(seed: u8) -> ContractKey {
@@ -1830,8 +1916,9 @@ mod tests {
         )
     }
 
-    /// Load-bearing: a stashed broadcast (the give-up outcome) is re-emitted as
-    /// a fresh `BroadcastStateChange { is_retry: false }` carrying the stashed
+    /// Load-bearing: a resolved deferred broadcast (the give-up outcome, after
+    /// the flush drained the stash and re-read current state) is emitted as a
+    /// `BroadcastStateChange { is_retry: false, is_reemit: true }` carrying the
     /// state when interest resolves. WITHOUT the #4359 fix the give-up path
     /// drops the state permanently and nothing is ever re-broadcast — this
     /// emission is exactly the behavior the fix adds.
@@ -1848,17 +1935,16 @@ mod tests {
 
         let store = PendingBroadcastStore::new();
         let key = test_contract_key(7);
-        let stashed = freenet_stdlib::prelude::WrappedState::new(vec![0xCD; 16]);
-        // Simulate the fan-out handler giving up with no targets.
-        store.stash(*key.id(), stashed.clone());
+        let state = freenet_stdlib::prelude::WrappedState::new(vec![0xCD; 16]);
 
-        // Interest resolves → flush. Must re-emit the stashed state.
-        super::flush_pending_broadcast_on(
+        // Interest resolves → emit the resolved deferred broadcast.
+        super::emit_pending_broadcast_reemit_on(
             notifier.notifications_sender(),
             notifier.notification_channel_pending(),
             notifier.notifications_sender().capacity(),
             &store,
             &key,
+            state.clone(),
         );
 
         let received = timeout(Duration::from_millis(200), notifications_receiver.recv())
@@ -1871,16 +1957,22 @@ mod tests {
                 key: observed_key,
                 new_state,
                 is_retry,
+                is_reemit,
             }) => {
                 assert_eq!(observed_key, key, "re-broadcast must target the contract");
                 assert_eq!(
                     new_state.as_ref(),
-                    stashed.as_ref(),
-                    "re-broadcast must carry the stashed state"
+                    state.as_ref(),
+                    "re-broadcast must carry the resolved state"
                 );
                 assert!(
                     !is_retry,
                     "the deferred flush is a fresh logical broadcast, not a retry re-emission"
+                );
+                assert!(
+                    is_reemit,
+                    "the deferred flush must be tagged is_reemit so the give-up handler does \
+                     not double-count a still-no-targets re-emission in the #4281 stats"
                 );
             }
             other @ Either::Left(_) | other @ Either::Right(_) => {
@@ -1890,40 +1982,7 @@ mod tests {
         GlobalSimulationTime::clear_time();
     }
 
-    /// No pending broadcast for the contract ⇒ flush is a silent no-op (no
-    /// spurious re-broadcasts on every subscribe for already-propagated
-    /// contracts, which is the overwhelmingly common case).
-    #[tokio::test]
-    async fn flush_pending_broadcast_noop_when_nothing_stashed() {
-        use crate::operations::update::pending_broadcast::PendingBroadcastStore;
-
-        GlobalSimulationTime::set_time_ms(0);
-        let (receiver, notifier) = event_loop_notification_channel();
-        let EventLoopNotificationsReceiver {
-            mut notifications_receiver,
-            ..
-        } = receiver;
-
-        let store = PendingBroadcastStore::new();
-        let key = test_contract_key(9);
-
-        super::flush_pending_broadcast_on(
-            notifier.notifications_sender(),
-            notifier.notification_channel_pending(),
-            notifier.notifications_sender().capacity(),
-            &store,
-            &key,
-        );
-
-        let got = timeout(Duration::from_millis(50), notifications_receiver.recv()).await;
-        assert!(
-            got.is_err(),
-            "no emission expected when nothing is stashed, got {got:?}"
-        );
-        GlobalSimulationTime::clear_time();
-    }
-
-    /// If the notification channel is saturated, the flush must re-stash the
+    /// If the notification channel is saturated, the emit must re-stash the
     /// state rather than dropping it — otherwise a transiently-full channel
     /// would re-open the locally-hosted-only failure the fix closes.
     #[tokio::test]
@@ -1958,22 +2017,22 @@ mod tests {
 
         let store = PendingBroadcastStore::new();
         let key = test_contract_key(11);
-        let stashed = freenet_stdlib::prelude::WrappedState::new(vec![0xEF; 8]);
-        store.stash(*key.id(), stashed.clone());
+        let state = freenet_stdlib::prelude::WrappedState::new(vec![0xEF; 8]);
 
-        super::flush_pending_broadcast_on(
+        super::emit_pending_broadcast_reemit_on(
             notifier.notifications_sender(),
             notifier.notification_channel_pending(),
             notifier.notifications_sender().capacity(),
             &store,
             &key,
+            state.clone(),
         );
 
         // State must still be present (re-stashed) for a later retry.
         let recovered = store
             .take(key.id())
             .expect("state must be re-stashed after a full-channel drop, not lost");
-        assert_eq!(recovered.as_ref(), stashed.as_ref());
+        assert_eq!(recovered.as_ref(), state.as_ref());
 
         drop(notifications_receiver);
         GlobalSimulationTime::clear_time();

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -706,34 +706,17 @@ impl OpManager {
     /// when nothing is pending for the contract — the overwhelmingly common
     /// case, kept cheap by checking membership before any contract-handler read.
     pub(crate) async fn flush_pending_broadcast_on_interest(&self, key: &ContractKey) {
-        // Fast path: nothing stashed for this contract (the common case for the
-        // many interest registrations on already-propagated contracts). Avoid
-        // the take()/contract-handler read entirely.
-        if !self.pending_broadcasts.contains(key.id()) {
-            return;
-        }
-        // Drain the stash marker. If it raced away (TTL expiry, a concurrent
-        // targets-found take, or another flush) there is nothing to do.
-        let Some(stashed) = self.pending_broadcasts.take(key.id()) else {
-            return;
-        };
-
-        // Stale-state safety: re-read the CURRENT local state instead of
-        // re-broadcasting the give-up-time bytes. Fall back to the stashed bytes
-        // if the live read fails so we never regress to dropping the broadcast.
-        let state = self
-            .read_current_contract_state(key)
-            .await
-            .unwrap_or(stashed);
-
-        emit_pending_broadcast_reemit_on(
+        flush_pending_broadcast_on_interest_on(
+            &self.pending_broadcasts,
             self.to_event_listener.notifications_sender(),
             self.to_event_listener.notification_channel_pending(),
             self.to_event_listener.notifications_sender().capacity(),
-            &self.pending_broadcasts,
             key,
-            state,
-        );
+            // Live read of the CURRENT local state, evaluated lazily so the
+            // fast path (nothing stashed) never touches the contract handler.
+            || self.read_current_contract_state(key),
+        )
+        .await;
     }
 
     /// Read the current local state for `key` from the contract handler, or
@@ -1305,6 +1288,65 @@ fn try_notify_node_event_on(
             Err(OpError::NotificationError)
         }
     }
+}
+
+/// Orchestration-core of [`OpManager::flush_pending_broadcast_on_interest`],
+/// extracted as a free function so its three branches are unit-testable against
+/// a raw store + notifier + a stubbed "read current state" step, without
+/// building a full `OpManager` (same pattern as [`emit_pending_broadcast_reemit_on`]
+/// / [`release_pending_op_slot_on`]).
+///
+/// Issue #4359 (re-review, SHOULD-FIX 4 stale-state safety + fast-path):
+///
+/// 1. **Fast path / no-op** — nothing stashed for `key` (the common case: most
+///    interest registrations are on already-propagated contracts). Returns
+///    without invoking `read_current_state` or emitting anything, so the
+///    contract handler is never touched on the hot path.
+/// 2. **take()-None** — the membership check passed but `take()` lost the entry
+///    to a concurrent drain (TTL expiry, a targets-found take, another flush);
+///    again a no-op.
+/// 3. **stashed → re-read current state** — re-broadcast the CURRENT local
+///    state (`read_current_state` returned `Some`) rather than the possibly
+///    superseded give-up-time bytes; fall back to the stashed `bytes` when the
+///    live read fails (`None`) so we never regress to dropping the broadcast.
+///
+/// `read_current_state` is a closure returning the read future so it is only
+/// polled once a stash entry is actually drained (preserving the fast path).
+async fn flush_pending_broadcast_on_interest_on<F, Fut>(
+    pending: &crate::operations::update::pending_broadcast::PendingBroadcastStore,
+    notifications_sender: &mpsc::Sender<Either<NetMessage, NodeEvent>>,
+    channel_pending: usize,
+    channel_remaining: usize,
+    key: &ContractKey,
+    read_current_state: F,
+) where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Option<WrappedState>>,
+{
+    // Fast path: nothing stashed for this contract. Avoid the take()/contract-
+    // handler read entirely.
+    if !pending.contains(key.id()) {
+        return;
+    }
+    // Drain the stash marker. If it raced away (TTL expiry, a concurrent
+    // targets-found take, or another flush) there is nothing to do.
+    let Some(stashed) = pending.take(key.id()) else {
+        return;
+    };
+
+    // Stale-state safety: re-read the CURRENT local state instead of
+    // re-broadcasting the give-up-time bytes. Fall back to the stashed bytes
+    // if the live read fails so we never regress to dropping the broadcast.
+    let state = read_current_state().await.unwrap_or(stashed);
+
+    emit_pending_broadcast_reemit_on(
+        notifications_sender,
+        channel_pending,
+        channel_remaining,
+        pending,
+        key,
+        state,
+    );
 }
 
 /// Emit a deferred fresh-contract re-broadcast for `key` carrying `state` on the
@@ -2035,6 +2077,195 @@ mod tests {
         assert_eq!(recovered.as_ref(), state.as_ref());
 
         drop(notifications_receiver);
+        GlobalSimulationTime::clear_time();
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // Regression tests for #4359 re-review (SHOULD-FIX 4 + fast-path):
+    // `flush_pending_broadcast_on_interest`'s OWN branching — the
+    // contains() no-op fast path, the take()-None race path, and the
+    // read_current_contract_state Some/None handling — exercised through
+    // `flush_pending_broadcast_on_interest_on`, the orchestration-core the
+    // method delegates to (the method itself only wires `self`'s store,
+    // notifier, and `read_current_contract_state` into this function). The
+    // `read_current_state` step is stubbed so the live-read Some/None
+    // branches are driven deterministically without a contract handler.
+    //
+    // These restore coverage that an earlier revision dropped when it kept
+    // only the `emit_pending_broadcast_reemit_on` tests above — those cover
+    // the emit-core, NOT the stash-membership / stale-state branching.
+    // ──────────────────────────────────────────────────────────
+
+    /// Load-bearing: nothing stashed → the flush is a pure no-op. It must NOT
+    /// read current state and must NOT emit anything, so the overwhelmingly
+    /// common interest-registration-on-an-already-propagated-contract case
+    /// stays cheap. If the membership fast path regressed (e.g. always
+    /// take()/read), this test fails: `read_current_state` would be invoked and
+    /// the channel would receive an emission.
+    #[tokio::test]
+    async fn flush_noop_when_nothing_stashed() {
+        use crate::operations::update::pending_broadcast::PendingBroadcastStore;
+
+        GlobalSimulationTime::set_time_ms(0);
+        let (receiver, notifier) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut notifications_receiver,
+            ..
+        } = receiver;
+
+        let store = PendingBroadcastStore::new();
+        let key = test_contract_key(21);
+        let read_called = std::cell::Cell::new(false);
+
+        super::flush_pending_broadcast_on_interest_on(
+            &store,
+            notifier.notifications_sender(),
+            notifier.notification_channel_pending(),
+            notifier.notifications_sender().capacity(),
+            &key,
+            || {
+                read_called.set(true);
+                std::future::ready(None)
+            },
+        )
+        .await;
+
+        assert!(
+            !read_called.get(),
+            "no-op fast path must NOT read current contract state when nothing is stashed"
+        );
+        // No emission must reach the channel.
+        match notifications_receiver.try_recv() {
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {}
+            other => panic!("expected no emission on the no-op path, got {other:?}"),
+        }
+        GlobalSimulationTime::clear_time();
+    }
+
+    /// Load-bearing: stashed + live read returns `Some(current)` → the re-emit
+    /// must carry the CURRENT state, NOT the stale give-up-time bytes. This pins
+    /// the stale-state safety (SHOULD-FIX 4): a locally-applied UPDATE between
+    /// give-up and flush must win. If the method regressed to re-emitting the
+    /// stashed bytes, the asserted state would be the stale ones and this fails.
+    #[tokio::test]
+    async fn flush_reemits_current_state_when_live_read_present() {
+        use crate::operations::update::pending_broadcast::PendingBroadcastStore;
+
+        GlobalSimulationTime::set_time_ms(0);
+        let (receiver, notifier) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut notifications_receiver,
+            ..
+        } = receiver;
+
+        let store = PendingBroadcastStore::new();
+        let key = test_contract_key(22);
+        let stale = freenet_stdlib::prelude::WrappedState::new(vec![0xAA; 8]);
+        let current = freenet_stdlib::prelude::WrappedState::new(vec![0xBB; 12]);
+        store.stash(*key.id(), stale.clone());
+
+        let current_for_read = current.clone();
+        super::flush_pending_broadcast_on_interest_on(
+            &store,
+            notifier.notifications_sender(),
+            notifier.notification_channel_pending(),
+            notifier.notifications_sender().capacity(),
+            &key,
+            || std::future::ready(Some(current_for_read.clone())),
+        )
+        .await;
+
+        let received = timeout(Duration::from_millis(200), notifications_receiver.recv())
+            .await
+            .expect("timed out waiting for re-broadcast emission")
+            .expect("notification channel closed");
+        match received {
+            Either::Right(NodeEvent::BroadcastStateChange {
+                key: observed_key,
+                new_state,
+                is_reemit,
+                ..
+            }) => {
+                assert_eq!(observed_key, key);
+                assert_eq!(
+                    new_state.as_ref(),
+                    current.as_ref(),
+                    "must re-emit the CURRENT live state, not the stale stashed bytes"
+                );
+                assert_ne!(
+                    new_state.as_ref(),
+                    stale.as_ref(),
+                    "stale give-up-time bytes must not be broadcast when a live read succeeds"
+                );
+                assert!(is_reemit, "deferred flush must be tagged is_reemit");
+            }
+            other @ Either::Left(_) | other @ Either::Right(_) => {
+                panic!("expected BroadcastStateChange, got {other:?}")
+            }
+        }
+        // The stash must have been drained.
+        assert!(
+            store.take(key.id()).is_none(),
+            "the stash entry must be drained by the flush"
+        );
+        GlobalSimulationTime::clear_time();
+    }
+
+    /// Load-bearing: stashed + live read returns `None` (contract handler
+    /// unavailable / not hosted) → the re-emit must FALL BACK to the stashed
+    /// bytes rather than dropping the broadcast. This pins the None-fallback
+    /// branch of `read_current_contract_state` handling: a failed live read is
+    /// strictly no worse than re-emitting the give-up-time state. If the
+    /// fallback regressed (e.g. `?`-style early return on None), nothing would
+    /// be emitted and this fails on the recv timeout.
+    #[tokio::test]
+    async fn flush_falls_back_to_stashed_bytes_when_live_read_absent() {
+        use crate::operations::update::pending_broadcast::PendingBroadcastStore;
+
+        GlobalSimulationTime::set_time_ms(0);
+        let (receiver, notifier) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut notifications_receiver,
+            ..
+        } = receiver;
+
+        let store = PendingBroadcastStore::new();
+        let key = test_contract_key(23);
+        let stashed = freenet_stdlib::prelude::WrappedState::new(vec![0xCC; 10]);
+        store.stash(*key.id(), stashed.clone());
+
+        super::flush_pending_broadcast_on_interest_on(
+            &store,
+            notifier.notifications_sender(),
+            notifier.notification_channel_pending(),
+            notifier.notifications_sender().capacity(),
+            &key,
+            // Live read fails (handler unavailable / not hosted).
+            || std::future::ready(None),
+        )
+        .await;
+
+        let received = timeout(Duration::from_millis(200), notifications_receiver.recv())
+            .await
+            .expect("timed out: the None live-read path must fall back to stashed bytes, not drop")
+            .expect("notification channel closed");
+        match received {
+            Either::Right(NodeEvent::BroadcastStateChange {
+                key: observed_key,
+                new_state,
+                ..
+            }) => {
+                assert_eq!(observed_key, key);
+                assert_eq!(
+                    new_state.as_ref(),
+                    stashed.as_ref(),
+                    "must fall back to the stashed bytes when the live read returns None"
+                );
+            }
+            other @ Either::Left(_) | other @ Either::Right(_) => {
+                panic!("expected BroadcastStateChange, got {other:?}")
+            }
+        }
         GlobalSimulationTime::clear_time();
     }
 

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -107,6 +107,14 @@ pub(crate) struct OpManager {
     /// UPDATE log sites to DEBUG (issue #4281).
     pub(crate) update_propagation_stats:
         Arc<crate::operations::update::propagation_stats::UpdatePropagationStats>,
+    /// Deferred re-broadcast store for fresh-contract PUTs whose initial
+    /// broadcast found no targets and exhausted its retry budget. Stashed by
+    /// the fan-out handler on give-up and drained by the subscribe path when
+    /// the first interested peer for the contract appears, so a never-before-
+    /// seen id that lost the broadcast/interest-resolve race still reaches the
+    /// network instead of landing locally-hosted only (issue #4359).
+    pub(crate) pending_broadcasts:
+        Arc<crate::operations::update::pending_broadcast::PendingBroadcastStore>,
     /// Request router for client request deduplication.
     ///
     /// This is initialized lazily from `client_event_handling` because the router is only
@@ -221,6 +229,7 @@ impl Clone for OpManager {
             interest_manager: self.interest_manager.clone(),
             broadcast_dedup_cache: self.broadcast_dedup_cache.clone(),
             update_propagation_stats: self.update_propagation_stats.clone(),
+            pending_broadcasts: self.pending_broadcasts.clone(),
             request_router: self.request_router.clone(),
             orphan_stream_registry: self.orphan_stream_registry.clone(),
             streaming_threshold: self.streaming_threshold,
@@ -404,6 +413,9 @@ impl OpManager {
             interest_manager,
             broadcast_dedup_cache: Arc::new(crate::operations::update::BroadcastDedupCache::new()),
             update_propagation_stats,
+            pending_broadcasts: Arc::new(
+                crate::operations::update::pending_broadcast::PendingBroadcastStore::new(),
+            ),
             request_router,
             orphan_stream_registry,
             streaming_threshold,
@@ -639,6 +651,30 @@ impl OpManager {
     // has already consumed a one-shot transition). See
     // `try_notify_node_event` and `.claude/rules/channel-safety.md` for
     // the broader pattern.
+
+    /// Re-broadcast a fresh-contract state that earlier found no targets, now
+    /// that the first interested peer/subscriber for `key` has appeared.
+    ///
+    /// Issue #4359: a never-before-seen contract id loses the race between the
+    /// broadcast give-up window (~6 s) and the much slower interest/
+    /// subscription resolve. When the broadcast handler gives up it stashes the
+    /// state in [`Self::pending_broadcasts`]; the subscribe path calls this on
+    /// the *first* new interest for the contract so the deferred state is
+    /// re-emitted as a fresh `BroadcastStateChange` (`is_retry: false`), which
+    /// now finds the just-registered target and propagates.
+    ///
+    /// Best-effort via [`Self::try_notify_node_event`]: if the channel is full
+    /// the state is re-stashed for the next interest signal. No-op when there
+    /// is no pending broadcast for the contract (the common case).
+    pub(crate) fn flush_pending_broadcast_on_interest(&self, key: &ContractKey) {
+        flush_pending_broadcast_on(
+            self.to_event_listener.notifications_sender(),
+            self.to_event_listener.notification_channel_pending(),
+            self.to_event_listener.notifications_sender().capacity(),
+            &self.pending_broadcasts,
+            key,
+        );
+    }
 
     /// Get all active subscriptions.
     /// In the simplified lease-based model, this returns contracts we're actively subscribed to.
@@ -1191,6 +1227,60 @@ fn try_notify_node_event_on(
     }
 }
 
+/// Drain a deferred fresh-contract broadcast for `key` (if one is stashed) and
+/// re-emit it as a fresh `BroadcastStateChange` on the event-loop notification
+/// channel. Extracted as a free function so it can be unit-tested against a raw
+/// notifier + store without building a full `OpManager` (same pattern as
+/// [`release_pending_op_slot_on`] / [`try_notify_node_event_on`]).
+///
+/// Issue #4359: when the broadcast handler gives up on a never-before-seen id
+/// (no targets), it stashes the state in `pending`. This is called from the
+/// subscribe path on the *first* new interest for the contract — the deferred
+/// state is re-emitted (`is_retry: false`) so the now-present target receives
+/// it instead of the state staying locally-hosted only.
+///
+/// Best-effort: if the channel is full the state is re-stashed so a later
+/// interest signal retries it (losing it would re-open the bug). No-op (and no
+/// emission) when nothing is pending for the contract.
+fn flush_pending_broadcast_on(
+    notifications_sender: &mpsc::Sender<Either<NetMessage, NodeEvent>>,
+    channel_pending: usize,
+    channel_remaining: usize,
+    pending: &crate::operations::update::pending_broadcast::PendingBroadcastStore,
+    key: &ContractKey,
+) {
+    let Some(state) = pending.take(key.id()) else {
+        return;
+    };
+    tracing::debug!(
+        contract = %key,
+        phase = "pending_broadcast_flush",
+        "Re-broadcasting deferred fresh-contract state now that an interested peer appeared (#4359)"
+    );
+    let msg = NodeEvent::BroadcastStateChange {
+        key: *key,
+        new_state: state.clone(),
+        is_retry: false,
+    };
+    if try_notify_node_event_on(
+        notifications_sender,
+        channel_pending,
+        channel_remaining,
+        msg,
+    )
+    .is_err()
+    {
+        // Re-emit dropped (channel full / closed). Put the state back so a
+        // later interest signal can retry — losing it here would re-open the
+        // locally-hosted-only failure this fix closes.
+        pending.stash(*key.id(), state);
+        tracing::debug!(
+            contract = %key,
+            "flush_pending_broadcast_on: re-emit dropped; re-stashed for the next interest signal"
+        );
+    }
+}
+
 /// Notify the event loop about a timed-out transaction without blocking.
 ///
 /// Uses `try_send` instead of `.send().await` to avoid blocking the garbage
@@ -1518,6 +1608,7 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
 mod tests {
     use super::super::network_bridge::event_loop_notification_channel;
     use super::*;
+    use crate::config::GlobalSimulationTime;
     use crate::node::network_bridge::EventLoopNotificationsReceiver;
     use either::Either;
     use tokio::time::{Duration, Instant, timeout};
@@ -1720,6 +1811,172 @@ mod tests {
             result.is_ok(),
             "helper must return promptly on closed channel"
         );
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // Regression tests for #4359: a fresh-contract PUT whose initial
+    // broadcast found no targets must be re-emitted (not permanently
+    // abandoned) once the first interested peer/subscriber appears.
+    // These exercise `flush_pending_broadcast_on` — the helper the
+    // subscribe path calls on a new interest — directly against a raw
+    // notifier + store, the same way the `release_pending_op_slot_on`
+    // tests above avoid building a full OpManager.
+    // ──────────────────────────────────────────────────────────
+
+    fn test_contract_key(seed: u8) -> ContractKey {
+        ContractKey::from_id_and_code(
+            ContractInstanceId::new([seed; 32]),
+            freenet_stdlib::prelude::CodeHash::new([seed.wrapping_add(1); 32]),
+        )
+    }
+
+    /// Load-bearing: a stashed broadcast (the give-up outcome) is re-emitted as
+    /// a fresh `BroadcastStateChange { is_retry: false }` carrying the stashed
+    /// state when interest resolves. WITHOUT the #4359 fix the give-up path
+    /// drops the state permanently and nothing is ever re-broadcast — this
+    /// emission is exactly the behavior the fix adds.
+    #[tokio::test]
+    async fn flush_pending_broadcast_reemits_stashed_state_on_interest() {
+        use crate::operations::update::pending_broadcast::PendingBroadcastStore;
+
+        GlobalSimulationTime::set_time_ms(0);
+        let (receiver, notifier) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut notifications_receiver,
+            ..
+        } = receiver;
+
+        let store = PendingBroadcastStore::new();
+        let key = test_contract_key(7);
+        let stashed = freenet_stdlib::prelude::WrappedState::new(vec![0xCD; 16]);
+        // Simulate the fan-out handler giving up with no targets.
+        store.stash(*key.id(), stashed.clone());
+
+        // Interest resolves → flush. Must re-emit the stashed state.
+        super::flush_pending_broadcast_on(
+            notifier.notifications_sender(),
+            notifier.notification_channel_pending(),
+            notifier.notifications_sender().capacity(),
+            &store,
+            &key,
+        );
+
+        let received = timeout(Duration::from_millis(200), notifications_receiver.recv())
+            .await
+            .expect("timed out waiting for re-broadcast emission")
+            .expect("notification channel closed");
+
+        match received {
+            Either::Right(NodeEvent::BroadcastStateChange {
+                key: observed_key,
+                new_state,
+                is_retry,
+            }) => {
+                assert_eq!(observed_key, key, "re-broadcast must target the contract");
+                assert_eq!(
+                    new_state.as_ref(),
+                    stashed.as_ref(),
+                    "re-broadcast must carry the stashed state"
+                );
+                assert!(
+                    !is_retry,
+                    "the deferred flush is a fresh logical broadcast, not a retry re-emission"
+                );
+            }
+            other @ Either::Left(_) | other @ Either::Right(_) => {
+                panic!("expected BroadcastStateChange, got {other:?}")
+            }
+        }
+        GlobalSimulationTime::clear_time();
+    }
+
+    /// No pending broadcast for the contract ⇒ flush is a silent no-op (no
+    /// spurious re-broadcasts on every subscribe for already-propagated
+    /// contracts, which is the overwhelmingly common case).
+    #[tokio::test]
+    async fn flush_pending_broadcast_noop_when_nothing_stashed() {
+        use crate::operations::update::pending_broadcast::PendingBroadcastStore;
+
+        GlobalSimulationTime::set_time_ms(0);
+        let (receiver, notifier) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut notifications_receiver,
+            ..
+        } = receiver;
+
+        let store = PendingBroadcastStore::new();
+        let key = test_contract_key(9);
+
+        super::flush_pending_broadcast_on(
+            notifier.notifications_sender(),
+            notifier.notification_channel_pending(),
+            notifier.notifications_sender().capacity(),
+            &store,
+            &key,
+        );
+
+        let got = timeout(Duration::from_millis(50), notifications_receiver.recv()).await;
+        assert!(
+            got.is_err(),
+            "no emission expected when nothing is stashed, got {got:?}"
+        );
+        GlobalSimulationTime::clear_time();
+    }
+
+    /// If the notification channel is saturated, the flush must re-stash the
+    /// state rather than dropping it — otherwise a transiently-full channel
+    /// would re-open the locally-hosted-only failure the fix closes.
+    #[tokio::test]
+    async fn flush_pending_broadcast_restashes_when_channel_full() {
+        use crate::operations::update::pending_broadcast::PendingBroadcastStore;
+
+        GlobalSimulationTime::set_time_ms(0);
+        let (receiver, notifier) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            notifications_receiver,
+            ..
+        } = receiver;
+
+        // Saturate the channel so the re-emit's try_send fails.
+        let filler_tx = Transaction::ttl_transaction();
+        let mut pre_filled = 0usize;
+        loop {
+            match notifier
+                .notifications_sender()
+                .try_send(Either::Right(NodeEvent::TransactionCompleted(filler_tx)))
+            {
+                Ok(()) => pre_filled += 1,
+                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => break,
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                    panic!("channel unexpectedly closed while pre-filling")
+                }
+            }
+            if pre_filled > 4096 {
+                panic!("channel did not backpressure after 4096 entries");
+            }
+        }
+
+        let store = PendingBroadcastStore::new();
+        let key = test_contract_key(11);
+        let stashed = freenet_stdlib::prelude::WrappedState::new(vec![0xEF; 8]);
+        store.stash(*key.id(), stashed.clone());
+
+        super::flush_pending_broadcast_on(
+            notifier.notifications_sender(),
+            notifier.notification_channel_pending(),
+            notifier.notifications_sender().capacity(),
+            &store,
+            &key,
+        );
+
+        // State must still be present (re-stashed) for a later retry.
+        let recovered = store
+            .take(key.id())
+            .expect("state must be re-stashed after a full-channel drop, not lost");
+        assert_eq!(recovered.as_ref(), stashed.as_ref());
+
+        drop(notifications_receiver);
+        GlobalSimulationTime::clear_time();
     }
 
     // ──────────────────────────────────────────────────────────

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -369,9 +369,15 @@ pub(crate) async fn complete_piggyback_subscription(
 
     if let Some(upstream_pkl) = sender_from_addr.as_ref() {
         let peer_key = crate::ring::interest::PeerKey::from(upstream_pkl.pub_key.clone());
-        op_manager
+        let is_new = op_manager
             .interest_manager
             .register_peer_interest(key, peer_key, None, true);
+        if is_new {
+            // #4359 (MUST-FIX 1): the piggyback upstream is now a viable
+            // broadcast target — flush any deferred fresh-contract broadcast so
+            // a cold-id PUT that gave up with no targets reaches the network.
+            op_manager.flush_pending_broadcast_on_interest(key).await;
+        }
         tracing::debug!(tx = %tx, contract = %key, "Subscription completed via GET piggyback");
     } else {
         // sender_from_addr can be None for transient connections not yet in the ring.

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -2702,9 +2702,16 @@ where
             .get_peer_by_addr(upstream_addr)
         {
             let peer_key = crate::ring::interest::PeerKey::from(pkl.pub_key);
-            op_manager
+            let is_new = op_manager
                 .interest_manager
                 .register_peer_interest(&key, peer_key, None, false);
+            if is_new {
+                // #4359 (MUST-FIX 1): a remote GET with subscribe=false still
+                // registers the requester's interest, making them a viable
+                // broadcast target. Flush any deferred fresh-contract broadcast
+                // so a cold-id PUT that gave up reaches this requester.
+                op_manager.flush_pending_broadcast_on_interest(&key).await;
+            }
         }
 
         // Forward upstream FIRST to keep cache work off the critical

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -441,9 +441,15 @@ pub(super) async fn finalize_originator_subscribe(
         .get_peer_by_addr(upstream_addr)
     {
         let peer_key = crate::ring::interest::PeerKey::from(pkl.pub_key);
-        op_manager
+        let is_new = op_manager
             .interest_manager
             .register_peer_interest(&key, peer_key, None, true);
+        if is_new {
+            // #4359 (MUST-FIX 1): this upstream peer is now a viable broadcast
+            // target. If a fresh-contract PUT gave up with no targets and is
+            // stashed, flush it so the deferred state reaches the network.
+            op_manager.flush_pending_broadcast_on_interest(&key).await;
+        }
     }
 
     op_manager.ring.subscribe(key);
@@ -544,7 +550,7 @@ pub(crate) async fn register_downstream_subscriber(
                 // downstream subscriber is the first viable target — flush the
                 // deferred state to it so the never-before-seen id reaches the
                 // network instead of staying locally-hosted only.
-                op_manager.flush_pending_broadcast_on_interest(key);
+                op_manager.flush_pending_broadcast_on_interest(key).await;
                 let became_interested = op_manager.interest_manager.add_downstream_subscriber(key);
                 if became_interested {
                     super::broadcast_change_interests(op_manager, vec![*key], vec![]).await;

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -539,6 +539,12 @@ pub(crate) async fn register_downstream_subscriber(
             // both new and renewed peers, so use register_peer_interest's
             // is_new return to avoid over-counting on renewal cycles.
             if is_new_peer {
+                // #4359: a fresh-contract PUT whose initial broadcast found no
+                // targets is stashed by the fan-out handler. This new
+                // downstream subscriber is the first viable target — flush the
+                // deferred state to it so the never-before-seen id reaches the
+                // network instead of staying locally-hosted only.
+                op_manager.flush_pending_broadcast_on_interest(key);
                 let became_interested = op_manager.interest_manager.add_downstream_subscriber(key);
                 if became_interested {
                     super::broadcast_change_interests(op_manager, vec![*key], vec![]).await;

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -10,6 +10,7 @@
 //! drivers consume them.
 
 pub(crate) mod op_ctx_task;
+pub(crate) mod pending_broadcast;
 pub(crate) mod propagation_stats;
 
 use freenet_stdlib::prelude::*;

--- a/crates/core/src/operations/update/pending_broadcast.rs
+++ b/crates/core/src/operations/update/pending_broadcast.rs
@@ -16,10 +16,30 @@
 //!
 //! Rather than lengthen the give-up timeout (a band-aid that still races), this
 //! store keeps the last broadcast state for a contract that exhausted its retry
-//! budget with no targets. When the *first* interested peer / subscriber for
-//! that contract appears later (`register_peer_interest` returns "new"), the
-//! subscribe path drains the stash and re-emits a single `BroadcastStateChange`
-//! — which now finds the freshly-registered target and propagates.
+//! budget with no targets. When the *first viable broadcast target* for that
+//! contract appears later, the deferred state is drained and re-emitted as a
+//! single `BroadcastStateChange { is_reemit: true }` — which now finds the
+//! freshly-appeared target and propagates.
+//!
+//! ## First-viable-target signal set (issue #4359 re-review, MUST-FIX 1)
+//!
+//! `get_broadcast_targets_update` resolves targets from two sources, so the
+//! flush must fire from BOTH:
+//!
+//! * **Source 2 — interest manager**: every `register_peer_interest` call that
+//!   returns "new" (downstream subscriber, originator upstream, GET-piggyback,
+//!   remote GET `subscribe=false`, and the Interests/ChangeInterests sync
+//!   handlers) calls [`OpManager::flush_pending_broadcast_on_interest`].
+//! * **Source 1 — proximity cache**: when a neighbor newly announces it hosts a
+//!   contract we also host (`NeighborHosting` overlap path), it becomes a
+//!   `neighbors_with_contract` target and the same flush fires.
+//!
+//! That set is complete: a never-seen id can only gain a broadcast target by a
+//! peer expressing interest (Source 2) or a connected neighbor announcing it
+//! hosts the id (Source 1). The give-up path additionally re-checks targets
+//! immediately after stashing to close the stash-after-flush lost-wakeup race.
+//! The flush re-reads the *current* local state (not the stale give-up-time
+//! bytes) so a newer locally-applied UPDATE is never clobbered.
 //!
 //! ## Bounding (per `.claude/rules/code-style.md` per-key-collection rule and
 //! the AGENTS.md "cleanup exemptions must be time-bounded" rule)
@@ -35,6 +55,26 @@
 //!
 //! Timestamps come from [`GlobalSimulationTime`](crate::config::GlobalSimulationTime)
 //! so the TTL is deterministic under the simulation clock (DST).
+//!
+//! ## Cross-thread clock consistency (issue #4359 re-review, SHOULD-FIX 5)
+//!
+//! `stash` records `inserted_at_ms` on the event-loop task while `take`'s TTL
+//! check reads the clock on the subscribe/op-driver task. `GlobalSimulationTime`
+//! is *thread-local*, so in principle those two reads could come from different
+//! clock bases. This is benign for both run modes:
+//!
+//! * **Production**: no simulation time is set, so both reads fall back to the
+//!   process-global, monotonic `SystemTime` — a single shared clock.
+//! * **DST**: the deterministic/turmoil harness runs on a
+//!   `new_current_thread()` single-threaded paused-time runtime
+//!   (`simulation_integration.rs::create_runtime`), so the event loop and the
+//!   subscribe driver — and any `tokio::spawn`ed give-up retry / flush task —
+//!   all execute on the SAME thread and therefore share one thread-local
+//!   simulation clock. The clocks cannot diverge.
+//!
+//! The TTL is a coarse 5-minute liveness bound, not a fine-grained deadline, so
+//! even a hypothetical small skew could only shift an eviction by a tolerance
+//! far below the window. No shared/atomic clock is needed here.
 
 use dashmap::DashMap;
 use freenet_stdlib::prelude::{ContractInstanceId, WrappedState};
@@ -96,6 +136,15 @@ impl PendingBroadcastStore {
                 inserted_at_ms: now_ms,
             },
         );
+    }
+
+    /// Whether a (possibly expired) entry exists for `contract`. Used as a
+    /// cheap fast-path guard so the flush can skip an async contract-handler
+    /// read on the common case where nothing is stashed. Does not prune; a
+    /// stale entry returning `true` here is then dropped by the subsequent
+    /// [`Self::take`] (which enforces the TTL and returns `None`).
+    pub(crate) fn contains(&self, contract: &ContractInstanceId) -> bool {
+        self.entries.contains_key(contract)
     }
 
     /// Remove and return the pending broadcast state for `contract`, if any and
@@ -160,6 +209,21 @@ mod tests {
         assert_eq!(taken.as_ref(), &[0xAA; 8]);
         assert_eq!(store.len(), 0, "take must remove the entry");
         assert!(store.take(&cid(1)).is_none(), "second take yields nothing");
+        GlobalSimulationTime::clear_time();
+    }
+
+    #[test]
+    fn contains_reflects_membership_without_removing() {
+        GlobalSimulationTime::set_time_ms(0);
+        let store = PendingBroadcastStore::new();
+        assert!(!store.contains(&cid(1)), "absent before stash");
+        store.stash(cid(1), state(0xAA));
+        assert!(store.contains(&cid(1)), "present after stash");
+        // contains must NOT remove — the flush fast-path relies on this so a
+        // subsequent take() still finds the entry.
+        assert!(store.contains(&cid(1)), "contains is non-destructive");
+        assert!(store.take(&cid(1)).is_some(), "take still finds it");
+        assert!(!store.contains(&cid(1)), "absent after take");
         GlobalSimulationTime::clear_time();
     }
 

--- a/crates/core/src/operations/update/pending_broadcast.rs
+++ b/crates/core/src/operations/update/pending_broadcast.rs
@@ -1,0 +1,247 @@
+//! Deferred re-broadcast store for fresh-contract PUTs that found no targets.
+//!
+//! ## Why this exists (issue #4359)
+//!
+//! When a brand-new contract id is PUT, the node applies the state locally and
+//! emits a `BroadcastStateChange` to fan it out to interested peers. For a
+//! never-before-seen id, no peer has subscribed/announced interest yet, so the
+//! initial broadcast resolves **zero** targets. The fan-out handler retries a
+//! few times over ~6 s (`MAX_BROADCAST_RETRIES` × `BROADCAST_RETRY_BASE_DELAY`)
+//! and then **gives up permanently**. But a fresh id's interest/subscription
+//! resolves on a *much* longer timescale (the second-PUT-of-the-same-id case in
+//! #4359 propagated only ~31 s after the PUT). The give-up window is shorter
+//! than the interest-resolve latency, so the state silently lands
+//! locally-hosted only: the originating node's GET looks healthy while every
+//! other node GETs `NotFound`.
+//!
+//! Rather than lengthen the give-up timeout (a band-aid that still races), this
+//! store keeps the last broadcast state for a contract that exhausted its retry
+//! budget with no targets. When the *first* interested peer / subscriber for
+//! that contract appears later (`register_peer_interest` returns "new"), the
+//! subscribe path drains the stash and re-emits a single `BroadcastStateChange`
+//! — which now finds the freshly-registered target and propagates.
+//!
+//! ## Bounding (per `.claude/rules/code-style.md` per-key-collection rule and
+//! the AGENTS.md "cleanup exemptions must be time-bounded" rule)
+//!
+//! The store is bounded two ways so a churn of network-influenced fresh ids
+//! cannot pin memory:
+//!
+//! * **Size**: at most [`MAX_PENDING_BROADCASTS`] contracts. A new insert at
+//!   capacity evicts the oldest entry (it pruning expired entries first).
+//! * **Age (TTL)**: an entry older than [`PENDING_BROADCAST_TTL`] is dropped on
+//!   the next insert/take and never re-broadcast. A fresh PUT that never gains a
+//!   subscriber is therefore released, not pinned forever.
+//!
+//! Timestamps come from [`GlobalSimulationTime`](crate::config::GlobalSimulationTime)
+//! so the TTL is deterministic under the simulation clock (DST).
+
+use dashmap::DashMap;
+use freenet_stdlib::prelude::{ContractInstanceId, WrappedState};
+
+use crate::config::GlobalSimulationTime;
+
+/// Maximum number of distinct contracts with a deferred broadcast pending. A
+/// fresh insert at capacity evicts the oldest entry rather than growing the
+/// map. 1024 comfortably covers the realistic count of fresh-id PUTs in flight
+/// on a busy node while capping worst-case memory at a bounded multiple of the
+/// largest stashed state.
+const MAX_PENDING_BROADCASTS: usize = 1024;
+
+/// How long a deferred broadcast stays eligible for re-emission. After this the
+/// entry is dropped without re-broadcasting: if no subscriber/interest appeared
+/// within the window, the fresh PUT is treated as locally-hosted-only and the
+/// stash is released. 5 minutes is well past the observed ~31 s
+/// interest-resolve latency for fresh ids (#4359) with a wide safety margin,
+/// while still bounding how long an un-propagated state lingers.
+const PENDING_BROADCAST_TTL_MS: u64 = 5 * 60 * 1_000;
+
+struct PendingEntry {
+    state: WrappedState,
+    inserted_at_ms: u64,
+}
+
+/// Bounded store of broadcasts that found no targets and are awaiting the first
+/// interested peer to re-fan-out to. See module docs.
+pub(crate) struct PendingBroadcastStore {
+    entries: DashMap<ContractInstanceId, PendingEntry>,
+}
+
+impl PendingBroadcastStore {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: DashMap::new(),
+        }
+    }
+
+    /// Stash the latest broadcast `state` for `contract` after its initial
+    /// broadcast exhausted its retry budget with zero targets. A later
+    /// re-stash for the same contract overwrites the previous state (the newest
+    /// state is the one worth propagating). Prunes expired entries and enforces
+    /// the size cap on the way in.
+    pub(crate) fn stash(&self, contract: ContractInstanceId, state: WrappedState) {
+        let now_ms = GlobalSimulationTime::read_time_ms();
+        self.prune_expired(now_ms);
+
+        // Enforce the size cap only when inserting a genuinely new contract;
+        // overwriting an existing entry never grows the map.
+        if !self.entries.contains_key(&contract) && self.entries.len() >= MAX_PENDING_BROADCASTS {
+            self.evict_oldest();
+        }
+
+        self.entries.insert(
+            contract,
+            PendingEntry {
+                state,
+                inserted_at_ms: now_ms,
+            },
+        );
+    }
+
+    /// Remove and return the pending broadcast state for `contract`, if any and
+    /// not expired. Called when the first interested peer/subscriber appears so
+    /// the caller can re-emit `BroadcastStateChange` and let it find the new
+    /// target. An expired entry is removed and `None` is returned (no
+    /// re-broadcast).
+    pub(crate) fn take(&self, contract: &ContractInstanceId) -> Option<WrappedState> {
+        let (_, entry) = self.entries.remove(contract)?;
+        let now_ms = GlobalSimulationTime::read_time_ms();
+        if now_ms.saturating_sub(entry.inserted_at_ms) >= PENDING_BROADCAST_TTL_MS {
+            return None;
+        }
+        Some(entry.state)
+    }
+
+    /// Drop entries older than the TTL. Cheap: a single pass over the map, only
+    /// performed on the (rare) stash path.
+    fn prune_expired(&self, now_ms: u64) {
+        self.entries
+            .retain(|_, e| now_ms.saturating_sub(e.inserted_at_ms) < PENDING_BROADCAST_TTL_MS);
+    }
+
+    /// Evict the single oldest entry to make room under the size cap.
+    fn evict_oldest(&self) {
+        let oldest = self
+            .entries
+            .iter()
+            .min_by_key(|e| e.value().inserted_at_ms)
+            .map(|e| *e.key());
+        if let Some(key) = oldest {
+            self.entries.remove(&key);
+        }
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cid(seed: u8) -> ContractInstanceId {
+        ContractInstanceId::new([seed; 32])
+    }
+
+    fn state(byte: u8) -> WrappedState {
+        WrappedState::new(vec![byte; 8])
+    }
+
+    #[test]
+    fn stash_then_take_returns_state_and_removes_entry() {
+        GlobalSimulationTime::set_time_ms(0);
+        let store = PendingBroadcastStore::new();
+        store.stash(cid(1), state(0xAA));
+        assert_eq!(store.len(), 1);
+
+        let taken = store.take(&cid(1)).expect("pending state present");
+        assert_eq!(taken.as_ref(), &[0xAA; 8]);
+        assert_eq!(store.len(), 0, "take must remove the entry");
+        assert!(store.take(&cid(1)).is_none(), "second take yields nothing");
+        GlobalSimulationTime::clear_time();
+    }
+
+    #[test]
+    fn restash_overwrites_with_newest_state() {
+        GlobalSimulationTime::set_time_ms(0);
+        let store = PendingBroadcastStore::new();
+        store.stash(cid(1), state(0x01));
+        store.stash(cid(1), state(0x02));
+        assert_eq!(store.len(), 1, "re-stash must not duplicate the contract");
+        assert_eq!(store.take(&cid(1)).unwrap().as_ref(), &[0x02; 8]);
+        GlobalSimulationTime::clear_time();
+    }
+
+    #[test]
+    fn expired_entry_is_not_rebroadcast() {
+        GlobalSimulationTime::set_time_ms(0);
+        let store = PendingBroadcastStore::new();
+        store.stash(cid(1), state(0x01));
+
+        // Advance past the TTL: the entry must be dropped, not returned.
+        GlobalSimulationTime::set_time_ms(PENDING_BROADCAST_TTL_MS + 1);
+        assert!(
+            store.take(&cid(1)).is_none(),
+            "an entry past its TTL must not be re-broadcast"
+        );
+        GlobalSimulationTime::clear_time();
+    }
+
+    #[test]
+    fn prune_drops_expired_on_stash() {
+        GlobalSimulationTime::set_time_ms(0);
+        let store = PendingBroadcastStore::new();
+        store.stash(cid(1), state(0x01));
+
+        // Advance past TTL, then stash a different contract: the prune on the
+        // stash path must evict the stale entry.
+        GlobalSimulationTime::set_time_ms(PENDING_BROADCAST_TTL_MS + 1);
+        store.stash(cid(2), state(0x02));
+        assert_eq!(store.len(), 1, "stale entry must be pruned on stash");
+        assert!(store.take(&cid(1)).is_none());
+        assert!(store.take(&cid(2)).is_some());
+        GlobalSimulationTime::clear_time();
+    }
+
+    #[test]
+    fn size_cap_evicts_oldest() {
+        GlobalSimulationTime::set_time_ms(0);
+        let store = PendingBroadcastStore::new();
+
+        // Fill to capacity, each at a distinct (increasing) timestamp so
+        // "oldest" is well-defined.
+        for i in 0..MAX_PENDING_BROADCASTS {
+            GlobalSimulationTime::set_time_ms(i as u64);
+            let mut bytes = [0u8; 32];
+            bytes[..8].copy_from_slice(&(i as u64).to_le_bytes());
+            store.stash(ContractInstanceId::new(bytes), state(1));
+        }
+        assert_eq!(store.len(), MAX_PENDING_BROADCASTS);
+
+        // One more (still within TTL) evicts the oldest (i == 0), keeping the
+        // map at the cap.
+        GlobalSimulationTime::set_time_ms(MAX_PENDING_BROADCASTS as u64);
+        let overflow = {
+            let mut bytes = [0u8; 32];
+            bytes[0] = 0xFF;
+            bytes[16] = 0xFF;
+            ContractInstanceId::new(bytes)
+        };
+        store.stash(overflow, state(2));
+        assert_eq!(store.len(), MAX_PENDING_BROADCASTS, "cap holds");
+
+        let oldest = {
+            let mut bytes = [0u8; 32];
+            bytes[..8].copy_from_slice(&0u64.to_le_bytes());
+            ContractInstanceId::new(bytes)
+        };
+        assert!(
+            store.take(&oldest).is_none(),
+            "oldest entry must have been evicted"
+        );
+        assert!(store.take(&overflow).is_some(), "new entry retained");
+        GlobalSimulationTime::clear_time();
+    }
+}

--- a/crates/core/src/operations/update/propagation_stats.rs
+++ b/crates/core/src/operations/update/propagation_stats.rs
@@ -730,10 +730,11 @@ mod tests {
     ///
     /// The handler records each fresh logical broadcast's outcome exactly
     /// once: a NO_TARGETS record on the fresh-broadcast path (gated on
-    /// `!is_retry`, so retry re-emissions never record a miss), and a success
-    /// record on the targets-found path. That's two call sites; this pins both
-    /// so neither outcome arm is dropped, and pins the `!is_retry` gate so a
-    /// refactor can't start counting retry re-emissions as fresh misses.
+    /// `!is_retry && !is_reemit`, so neither retry re-emissions nor #4359
+    /// deferred-broadcast re-emissions record a miss), and a success record on
+    /// the targets-found path. That's two call sites; this pins both so neither
+    /// outcome arm is dropped, and pins the gate so a refactor can't start
+    /// counting retry / deferred re-emissions as fresh misses.
     #[test]
     fn broadcast_path_feeds_propagation_stats_pin_test() {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -753,12 +754,14 @@ mod tests {
              dropped (silent telemetry rot) or recording leaked elsewhere."
         );
 
-        // The no-target record must be gated on `!is_retry` so retry
-        // re-emissions don't get counted as fresh misses (Codex P2).
+        // The no-target record must be gated on `!is_retry && !is_reemit` so
+        // neither retry re-emissions (Codex P2) nor #4359 deferred-broadcast
+        // re-emissions get counted as fresh misses (re-review SHOULD-FIX 5:
+        // a flush per interested peer must not inflate no_targets).
         assert!(
-            source.contains("if !is_retry {"),
-            "the fresh-no-target record must be gated on `!is_retry` so retry \
-             re-emissions are not counted as fresh broadcasts."
+            source.contains("if !is_retry && !is_reemit {"),
+            "the fresh-no-target record must be gated on `!is_retry && !is_reemit` so retry \
+             and #4359 deferred re-emissions are not counted as fresh broadcasts."
         );
     }
 }


### PR DESCRIPTION
## Problem

Publishing a **brand-new contract id** could land the state **locally-hosted only** and never
propagate. The post-application broadcast fires ~224 ms after the PUT, finds zero targets (no
peer has subscribed to the never-before-seen id yet), retries ~3× over ~6 s, then **gives up** —
*before* subscription/interest for the new key resolves. Result: the originating node holds the
contract (local GET looks healthy) but **every other node GETs `NotFound`**. A second identical
PUT of the same id hours later propagated fine (broadcast fired 31 s after the PUT). So it is a
**timing race on cold ids**, not a connectivity problem.

## Solution

Root-cause fix (not a timeout band-aid): **don't permanently abandon the state — re-broadcast it
once a target exists.**

- On broadcast give-up with zero targets, stash the state in a bounded `PendingBroadcastStore`
  (TTL + size cap, DST time).
- When the **first viable broadcast target** for the contract appears, flush → re-emit a fresh
  `BroadcastStateChange` that now finds the target. Broadcast targets resolve from two sources, so
  the flush is wired at **all** of them: every `register_peer_interest` (interest manager) call
  site *and* the proximity `NeighborHosting` path. A source-walking pin test asserts any future
  `register_peer_interest` site is flush-paired, so the coverage can't silently regress.
- **Race-safe:** after stashing, targets are re-resolved immediately; if one already exists the
  state is re-emitted at once (closes the stash-after-flush lost-wakeup window).
- **Stale-state-safe:** the flush re-reads the *current* local state (stashed bytes are only a
  fallback), so a newer locally-applied UPDATE is never clobbered by give-up-time bytes.
- Telemetry: a new `is_reemit` flag keeps deferred re-broadcasts from inflating the `no_targets`
  propagation stats; the existing NO_TARGETS DEBUG pin and `update_propagation_summary` are intact.

The existing failure surfacing (NO_TARGETS logs, propagation summary) is unchanged — surfacing the
failure to `fdev` is separate (#4102).

## Testing

- `flush_pending_broadcast_reemits_stashed_state_on_interest` (load-bearing) — stash → flush →
  asserts a fresh `BroadcastStateChange { is_reemit: true }` carrying the current state. Without the
  flush: state is permanently abandoned, test times out.
- `flush_reemits_current_state_when_live_read_present` / `..._falls_back_to_stashed_bytes_when_live_read_absent`
  / `flush_noop_when_nothing_stashed` — mutation-tested load-bearing.
- Source-walk completeness pin (`pending_broadcast_flush_wired_at_all_interest_sites`) — fails if a
  new `register_peer_interest` site is added unflushed. Stash/take wiring pinned in
  `handle_broadcast_state_change`.
- Bounded-store unit tests (stash/take/TTL/prune/size-cap).
- `cargo fmt`, `cargo clippy --lib --tests -- -D warnings`, `cargo build -p freenet` clean.

**Maintainer note (this issue carries `S-needs-design`):** the design choices — flush wired at
both target sources with a completeness argument, re-read-current-state on flush, immediate
re-check to close the race, and the TTL/size constants (5 min / 1024) — are called out for review.
A full multi-node propagation simulation was deliberately *not* added: the cold-id 0-target race is
not deterministically reproducible in the current DST harness (consistent with the original
investigation note), so the trigger-completeness pin + handler-level tests are the load-bearing
guards instead. Reviewed via a multi-perspective panel over two rounds (a flush-coverage gap and a
lost-wakeup race were caught and fixed in round 1; the completeness pin was hardened from a
hardcoded list to a source walk in round 2). External (codex) pass unavailable (auth); diverse
Claude panel was the documented fallback.

## Fixes

Closes #4359

[AI-assisted]
