### PR TITLE
ci: run simulation nextest before fdev load sims to fix queue flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,7 +481,7 @@ jobs:
     # slots on every queue entry — the runner stays cheap there since every step
     # is gated off (see skip_check below).
     runs-on: "${{ (github.event_name == 'merge_group' && !startsWith(github.event.merge_group.head_commit.message, 'build: release')) && 'ubuntu-latest' || 'ubicloud-standard-16' }}"
-    timeout-minutes: 30
+    timeout-minutes: 40
     needs: fmt_check
     # Same skip conditions as test_unit (see test_unit comment for details)
     if: |
@@ -553,7 +553,7 @@ jobs:
             --features simulation_tests,testing --profile ci
           cargo build -p fdev --release --locked
 
-      - name: Run simulation tests (nextest + fdev in parallel)
+      - name: Run simulation tests (nextest first, then fdev load sims)
         if: steps.skip_check.outputs.skip != 'true'
         env:
           RUST_LOG: info,turmoil=warn
@@ -563,8 +563,19 @@ jobs:
           # we can upload them as artifacts and tell which one wedged.
           mkdir -p sim-logs
 
-          # Nextest simulation tests (already built above with --no-run).
-          {
+          # Phase 1: run the precise nextest simulation tests FIRST and ALONE
+          # (already built above with --no-run). Previously these ran
+          # concurrently with the fdev load sims below; under a high-contention
+          # runner the Turmoil `start_paused` clock auto-advances past the 120s
+          # RealTime connection idle timeout during `spawn_blocking` (WASM
+          # execution), spuriously tearing down healthy connections and flaking
+          # the precise streaming/GET sim tests on EVERY nextest retry (the fdev
+          # sims run ~8m, overlapping all 3 retries). Running nextest uncontended
+          # first removes that interference; the fdev load sims run afterwards
+          # (still parallel among themselves). Use a ( ) subshell so `exit $rc`
+          # ends the subshell, not this whole step.
+          NEXTEST_FAILED=0
+          (
             echo "== $(date -u +%H:%M:%S) nextest starting"
             cargo nextest run -p freenet --locked \
               --test simulation_integration \
@@ -575,8 +586,8 @@ jobs:
             rc=$?
             echo "== $(date -u +%H:%M:%S) nextest done rc=${rc}"
             exit $rc
-          } > sim-logs/nextest.log 2>&1 &
-          NEXTEST_PID=$!
+          ) > sim-logs/nextest.log 2>&1 || NEXTEST_FAILED=1
+          echo "nextest phase done (failed=${NEXTEST_FAILED}) — starting fdev load sims"
 
           # 8 minute cap per sim, SIGKILL 30s later if it refuses to die.
           # Background directly (no function) so $! refers to the actual child
@@ -650,11 +661,11 @@ jobs:
           } > sim-logs/ci-churn-20.log 2>&1 &
           PID4=$!
 
-          echo "Started: nextest=$NEXTEST_PID medium=$PID1 fault=$PID2 latency=$PID3 churn=$PID4"
+          echo "Started fdev: medium=$PID1 fault=$PID2 latency=$PID3 churn=$PID4"
 
-          # Wait for all and fail if any failed
-          FAILED=0
-          wait $NEXTEST_PID || { echo "nextest FAILED"; FAILED=1; }
+          # Wait for the fdev sims and fail if any (or nextest above) failed
+          FAILED=$NEXTEST_FAILED
+          [ "$NEXTEST_FAILED" -eq 1 ] && echo "nextest FAILED"
           wait $PID1 || { echo "ci-medium-50 FAILED"; FAILED=1; }
           wait $PID2 || { echo "ci-fault-loss FAILED"; FAILED=1; }
           wait $PID3 || { echo "ci-high-latency FAILED"; FAILED=1; }


### PR DESCRIPTION
## Problem
The `Simulation` CI job runs the precise nextest sim suite **concurrently** with four heavy `fdev` load sims (ci-medium-50, ci-fault-loss, ci-high-latency, ci-churn-20) on the same `ubicloud-standard-16` runner. Under a high-contention runner instance, the Turmoil `start_paused` clock auto-advances past the **120s `RealTime` connection idle timeout** during `spawn_blocking` (WASM execution), spuriously tearing down healthy connections. The precise streaming/GET sim tests then can't reach a holder and fail. Because the `fdev` sims run ~8 min, they overlap **all 3** of nextest's retries, so the built-in retry doesn't help.

This is **intermittent** (it passed at 09:32, failed at 13:05) and has repeatedly blocked the merge queue — most recently the v0.2.73 release bump PR, where one merge_group run failed three sim tests at once: `test_streaming_get_retries_after_assembly_failure`, `test_streaming_get_through_relay`, and `test_get_dead_ends_at_close_cluster_without_migration`. All three pass on branch CI and exhausted nextest retries (TRY 3 FAIL) only under the queue's parallel load — i.e. CI-infrastructure contention, not a code regression.

(#4420 fixed one of these tests by opting it into the 24h simulation idle timeout, but that is per-test whack-a-mole; the load itself affects multiple Turmoil sim tests.)

## Solution
Run the nextest sim suite **first and alone** (uncontended), then the `fdev` load sims afterwards (still parallel among themselves). The precise tests — and their retries — no longer compete with the `fdev` WASM load, so the `start_paused` clock stays accurate and connections aren't spuriously reaped. The `fdev` sims (which tolerate contention via `--min-success-rate` thresholds) are unaffected. Job `timeout-minutes` bumped 30→40 for the now-sequential run (estimated ~20-25 min total). No change to any test's semantics.

## Testing
YAML validated; shell restructured to run nextest in a `( )` subshell (so `exit $rc` scopes to the subshell) with failure captured in `NEXTEST_FAILED`. The real verification is this PR's own `Simulation` job and the release merge_group running the new sequential layout. Self-testing: if the de-contention works, the previously-flaky tests pass reliably here and in the queue.

[AI-assisted - Claude]