### PR TITLE
test: make placement-sensitive sim tests robust to migration activation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,7 +570,7 @@ jobs:
           # RealTime connection idle timeout during `spawn_blocking` (WASM
           # execution), spuriously tearing down healthy connections and flaking
           # the precise streaming/GET sim tests on EVERY nextest retry (the fdev
-          # sims run ~8m, overlapping all 3 retries). Running nextest uncontended
+          # sims run ~8-15m, overlapping all 3 retries). Running nextest uncontended
           # first removes that interference; the fdev load sims run afterwards
           # (still parallel among themselves). Use a ( ) subshell so `exit $rc`
           # ends the subshell, not this whole step.
@@ -589,12 +589,15 @@ jobs:
           ) > sim-logs/nextest.log 2>&1 || NEXTEST_FAILED=1
           echo "nextest phase done (failed=${NEXTEST_FAILED}) — starting fdev load sims"
 
-          # 8 minute cap per sim, SIGKILL 30s later if it refuses to die.
+          # 15 minute cap per sim, SIGKILL 30s later if it refuses to die.
+          # (#4404 placement migration roughly doubles per-sim cost when active,
+          # so 8m could be exceeded on a slow release-branch runner; the job's
+          # 40m timeout-minutes still covers the four sims running in parallel.)
           # Background directly (no function) so $! refers to the actual child
           # of this shell, which `wait` can then reap.
           {
             echo "== $(date -u +%H:%M:%S) ci-medium-50 starting"
-            timeout --kill-after=30s 8m target/release/fdev test \
+            timeout --kill-after=30s 15m target/release/fdev test \
               --name "ci-medium-50" \
               --seed 0xDEADBEEF \
               --gateways 4 --nodes 46 --events 2000 \
@@ -611,7 +614,7 @@ jobs:
 
           {
             echo "== $(date -u +%H:%M:%S) ci-fault-loss starting"
-            timeout --kill-after=30s 8m target/release/fdev test \
+            timeout --kill-after=30s 15m target/release/fdev test \
               --name "ci-fault-loss" \
               --seed 0xFA017001 \
               --gateways 3 --nodes 27 --events 1000 \
@@ -628,7 +631,7 @@ jobs:
 
           {
             echo "== $(date -u +%H:%M:%S) ci-high-latency starting"
-            timeout --kill-after=30s 8m target/release/fdev test \
+            timeout --kill-after=30s 15m target/release/fdev test \
               --name "ci-high-latency" \
               --seed 0x1A7E0C71 \
               --gateways 2 --nodes 12 --events 500 \
@@ -644,7 +647,7 @@ jobs:
 
           {
             echo "== $(date -u +%H:%M:%S) ci-churn-20 starting"
-            timeout --kill-after=30s 8m target/release/fdev test \
+            timeout --kill-after=30s 15m target/release/fdev test \
               --name "ci-churn-20" \
               --seed 0xC102FEED \
               --gateways 2 --nodes 18 --events 500 \

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -1266,6 +1266,36 @@ impl SimNetwork {
         self
     }
 
+    /// Force the placement-migration (`SubscribeHint`) cascade OFF for this
+    /// simulation, regardless of the build version, by raising the per-node
+    /// version floor to an unreachable value `(255, 255, 65535)`.
+    ///
+    /// The mirror of [`enable_placement_migration`](Self::enable_placement_migration).
+    /// The cascade is already OFF by default in sim *on a build below the
+    /// production `SUBSCRIBE_HINT_MIN_VERSION` floor* — but a test must not rely
+    /// on that build-version gating: when the build version reaches the floor
+    /// (e.g. on the v0.2.73 release branch, where #4404 ships active), the
+    /// default flips to ON and silently perturbs any test whose premise assumes
+    /// the contract stays put. A test that exercises relay/assembly/dead-end
+    /// mechanics (not placement) calls this to pin migration OFF at any build
+    /// version. Like `enable_placement_migration`, this patches the
+    /// already-built node/gateway configs (config_* ran during construction
+    /// when the override was still `None`).
+    #[allow(dead_code)]
+    pub fn disable_placement_migration(&mut self) -> &mut Self {
+        // Unreachable floor: no real or simulated peer version reaches it, so
+        // `version_supports_subscribe_hint` always returns false → cascade off.
+        const UNREACHABLE_FLOOR: (u8, u8, u16) = (255, 255, 65535);
+        self.subscribe_hint_floor_override = Some(UNREACHABLE_FLOOR);
+        for (builder, _) in self.gateways.iter_mut() {
+            builder.config.subscribe_hint_floor_override = Some(UNREACHABLE_FLOOR);
+        }
+        for (builder, _) in self.nodes.iter_mut() {
+            builder.config.subscribe_hint_floor_override = Some(UNREACHABLE_FLOOR);
+        }
+        self
+    }
+
     /// Returns the VirtualTime instance for this simulation.
     ///
     /// VirtualTime is always enabled. Use this to advance time and control

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -9855,9 +9855,7 @@ fn test_get_dead_ends_at_close_cluster_without_migration() {
     let num_nodes = node_locations.len();
 
     let rt = create_runtime();
-    // NOTE: deliberately NO `enable_placement_migration()` — that is the whole
-    // point of this control.
-    let sim = rt.block_on(async {
+    let mut sim = rt.block_on(async {
         SimNetwork::new_with_node_locations(
             NETWORK_NAME,
             1,
@@ -9871,6 +9869,14 @@ fn test_get_dead_ends_at_close_cluster_without_migration() {
         )
         .await
     });
+    // This control asserts the GET dead-ends *because migration is off* — it
+    // deliberately does NOT call `enable_placement_migration()`. But "off by
+    // default" only holds on a build below the production
+    // SUBSCRIBE_HINT_MIN_VERSION floor; on the v0.2.73 release branch (#4404
+    // ships active) the default flips to ON and this control would falsely
+    // fail. Pin migration OFF explicitly so the control's premise holds at any
+    // build version — do not rely on build-version gating.
+    sim.disable_placement_migration();
 
     let host_label = NodeLabel::node(NETWORK_NAME, 7);
     let requester_label = NodeLabel::node(NETWORK_NAME, 8);

--- a/crates/core/tests/streaming_e2e.rs
+++ b/crates/core/tests/streaming_e2e.rs
@@ -627,7 +627,7 @@ fn test_streaming_get_through_relay() {
     const BASE_EPOCH_MS: u64 = 1577836800000;
     const RANGE_MS: u64 = 5 * 365 * 24 * 60 * 60 * 1000;
     GlobalSimulationTime::set_time_ms(BASE_EPOCH_MS + (SEED % RANGE_MS));
-    let sim = rt.block_on(async {
+    let mut sim = rt.block_on(async {
         let mut sim = SimNetwork::new(
             NETWORK_NAME,
             1, // gateways
@@ -642,6 +642,14 @@ fn test_streaming_get_through_relay() {
         sim.with_streaming_threshold(THRESHOLD);
         sim
     });
+    // This test asserts a streaming relay-forward hop fires (node 5 must relay
+    // to reach the storer). Placement migration (#4404) spreads the contract
+    // toward the requester, so the relay hop never runs and the
+    // RELAY_GET_STREAMING_FORWARD_COUNT assertion fails. The test exercises the
+    // relay-streaming mechanic, not placement, so pin migration OFF — don't
+    // rely on build-version gating, which flips ON on the v0.2.73 release
+    // branch where #4404 ships active.
+    sim.disable_placement_migration();
 
     let contract = SimOperation::create_test_contract(0xAB);
     let large_state = SimOperation::create_large_state(LARGE_STATE_SIZE, 0xAB);
@@ -1315,6 +1323,15 @@ async fn setup_assembly_retry_network(name: &str, seed: u64, threshold: usize) -
     )
     .await;
     sim.with_streaming_threshold(threshold);
+    // The #4345 assembly-retry test hand-builds a cold-node → holder routing
+    // scenario. Placement migration (#4404) moves the contract toward the
+    // requester, disrupting that scenario (the injected assembly failure no
+    // longer drives the retry path under test). This helper feeds both the
+    // phase-1 and phase-2 sims, so pin migration OFF here — the test exercises
+    // assembly-retry mechanics, not placement, and must not rely on
+    // build-version gating (which flips ON on the v0.2.73 release branch where
+    // #4404 ships active).
+    sim.disable_placement_migration();
     sim
 }
 


### PR DESCRIPTION
## Problem

Ian decided to ship the #4404 placement-migration (`SubscribeHint`) cascade **active** in the v0.2.73 release. On that release branch the build version equals `SUBSCRIBE_HINT_MIN_VERSION = (0,2,73)`, so the migration **activates in every simulation** (it is dormant on the current 0.2.72 `main`).

Three simulation tests assumed migration stays OFF *via build-version gating* and break once it activates. These are **not code bugs** — the migration works as designed and GETs still succeed. The tests fail because their premise (the contract stays put) is violated:

1. `test_get_dead_ends_at_close_cluster_without_migration` (`simulation_integration.rs`) — the negative control for the #4404 dead-end. It asserts a GET dead-ends *because migration is off*, and deliberately does NOT call `enable_placement_migration()`, relying only on build-version gating. When migration activates, the close cluster hosts the contract and the control falsely fails.
2. `test_streaming_get_through_relay` (`streaming_e2e.rs`) — asserts a relay streaming-forward hop fires (`RELAY_GET_STREAMING_FORWARD_COUNT` increments). Migration spreads the contract toward the requester, so the relay hop never runs.
3. `test_streaming_get_retries_after_assembly_failure` (`streaming_e2e.rs`) — hand-builds a cold-node → holder routing scenario; migration moves the contract and disrupts the injected-assembly-failure retry path under test.

## Approach

All three tests exercise relay / assembly / dead-end **mechanics**, NOT placement. The right fix is to pin migration OFF for them rather than leave them at the mercy of the build version. There was previously an `enable_placement_migration()` helper but no force-OFF counterpart.

- Add a `disable_placement_migration()` helper on `SimNetwork`, mirroring `enable_placement_migration()`. It sets `subscribe_hint_floor_override` to an **unreachable** `(255, 255, 65535)` floor, so `version_supports_subscribe_hint` always returns false and the cascade is OFF regardless of build version. It threads through the same path (`NodeConfig.subscribe_hint_floor_override` → `ConnectionManager`) and works for both the `SimNetwork` tests and the Turmoil / `run_controlled_simulation` streaming tests (all three of these tests use `run_controlled_simulation`).
- Call `disable_placement_migration()` in all three tests, with a comment in each explaining that migration must be off for the test's premise and that it must not rely on build-version gating. For test 3 the call lives in the shared `setup_assembly_retry_network` helper so it covers both the phase-1 and phase-2 sims.
- Bump the fdev per-sim CI timeout `8m` → `15m` for all four fdev load sims in the Simulation job. The migration roughly doubles fdev sim cost when active, which can exceed 8m on a slow release-branch runner. The job's `timeout-minutes: 40` still covers the four sims running in parallel.

## Testing

Verified with `SUBSCRIBE_HINT_MIN_VERSION` **temporarily toggled to `(0,2,72)`** so the migration activates on this 0.2.72 build (then reverted — the committed change keeps the floor at `(0,2,73)`):

- The three tests pass **5/5 runs** with migration globally active.
- The `ci-medium-50` fdev sim (`--gateways 4 --nodes 46 --events 2000 ... --min-success-rate 1.0`) completes with exit 0 and 100% success rate under migration, well within the new 15m cap.
- `cargo fmt` clean; `cargo clippy -p freenet --tests --features simulation_tests,testing` clean.

This is test-infra + a CI-timeout tweak; no production behavior change (the production floor stays `(0,2,73)`).

[AI-assisted - Claude]