### PR TITLE
fix: deactivate placement migration after v0.2.73 UPDATE-degradation incident

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -626,7 +626,15 @@ pub(in crate::node) struct P2pConnManager {
 /// Simulation tests that want the cascade lower the floor per-node at runtime via
 /// `NodeConfig::subscribe_hint_floor_override` (set by
 /// `SimNetwork::enable_placement_migration`), which never touches production.
-const SUBSCRIBE_HINT_MIN_VERSION: (u8, u8, u16) = (0, 2, 73);
+// DEACTIVATED 2026-06-16: v0.2.73 shipped #4404's placement migration ACTIVE
+// (floor == 0.2.73). On the live network this correlated with a climbing
+// UPDATE-broadcast stream-assembly + WASM compute-time failure rate — the
+// migration's extra directed-subscribes and per-GET/PUT
+// `ConsiderContractMigration` emits re-load the notification/broadcast
+// backpressure surface that wedged the gateways in #4145/#4231. Raised the
+// floor to (0, 3, 0) so the migration stays DORMANT on all 0.2.x; re-lower it
+// to the intended activation version once the cause is fixed and validated.
+const SUBSCRIBE_HINT_MIN_VERSION: (u8, u8, u16) = (0, 3, 0);
 
 /// Pure version-gate decision, factored out so the comparison and the
 /// fail-closed-on-unknown-version (`None`) behavior are unit-testable with an


### PR DESCRIPTION
## Problem
v0.2.73 shipped #4404's placement migration **active** (`SUBSCRIBE_HINT_MIN_VERSION = (0,2,73)`, so a 0.2.73 build's version reaches the floor). As nova, vega, and technic updated to 0.2.73, UPDATE-operation failures climbed and did **not** recede:

```
technic:  0.2.72 = ~0/hr  ->  0.2.73 = 29, then 168/hr (04h pacing ~350/hr)
nova:     0.2.72 = 0/hr   ->  0.2.73 = 21, then 140/hr
```

Dominant error: `UPDATE relay (driver streaming): failed to assemble stream (broadcast) ... no fragments received within inactivity timeout`, plus WASM `exceeded the maximum allowed compute time` driving engine-store recoveries. Nodes stayed up (no panics/crash-loops), so it's degradation, not an outage. The broadcast-assembly error pre-exists on 0.2.72 but was rare; it spiked with the migration's activation. The migration adds directed-subscribes + per-GET/PUT `ConsiderContractMigration` emits that re-load the notification/broadcast backpressure surface that wedged both gateways in #4145/#4231.

## Solution
Raise `SUBSCRIBE_HINT_MIN_VERSION` to `(0, 3, 0)` so the migration ships **dormant** on all 0.2.x — a targeted, reversible mitigation. The migration code is untouched; re-lower the floor to the intended activation version once the cause is root-caused and validated (investigation in parallel). Ship as v0.2.74.

## Testing
With the floor above the build version the migration is off by default (its previous, well-tested state), so the existing sim suite passes unchanged. A const-value change to disable a feature has no meaningful regression test; the real verification is the live UPDATE-failure rate receding as 0.2.74 rolls out. `test-exempt` applied.

[AI-assisted - Claude]