### PR TITLE
fix: restore network performance after v0.2.73 regression (migration off + fd limit + refresh_router resilience)

### DIFF
--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -887,6 +887,13 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn raise_fd_limit_does_not_lower_soft_limit() {
+        // Normalize `rlim_t` (u64 on linux-gnu, varies elsewhere) to u64 for
+        // arithmetic / comparison without tripping clippy on the redundant cast.
+        #[allow(clippy::unnecessary_cast)]
+        fn as_u64(v: libc::rlim_t) -> u64 {
+            v as u64
+        }
+
         let mut before = libc::rlimit {
             rlim_cur: 0,
             rlim_max: 0,
@@ -895,6 +902,37 @@ mod tests {
         // exclusively-borrowed out-param is sound; we check the return code.
         let rc = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut before) };
         assert_eq!(rc, 0, "getrlimit should succeed");
+
+        let orig_soft = as_u64(before.rlim_cur);
+        let hard = as_u64(before.rlim_max);
+
+        // To exercise the ACTUAL raise branch (not the soft==hard no-op that is
+        // the common CI case), first LOWER our soft limit to a finite value
+        // strictly below hard, then call `raise_fd_limit()` and assert it raised
+        // back up to hard. Lowering one's OWN soft limit never requires
+        // privilege, but if the sandbox forbids even that we fall back to the
+        // weaker "no-decrease" assertion so the test is never flaky.
+        let lowered_to: Option<u64> = if hard != as_u64(libc::RLIM_INFINITY) && hard > 1 {
+            // Pick a finite target strictly below hard: min(orig_soft, hard/2),
+            // floored at 1 so we never request 0 fds.
+            let target = orig_soft.min(hard / 2).max(1);
+            // Guard: only meaningful if we can land strictly below hard.
+            if target < hard {
+                let lowered = libc::rlimit {
+                    rlim_cur: target as libc::rlim_t,
+                    rlim_max: before.rlim_max,
+                };
+                // SAFETY: setrlimit with a valid resource id and a fully
+                // initialized rlimit whose soft (target < hard) does not exceed
+                // the unchanged hard limit is sound.
+                let rc = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &lowered) };
+                if rc == 0 { Some(target) } else { None }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
 
         // Must not panic and must be safe to call.
         super::raise_fd_limit();
@@ -906,25 +944,51 @@ mod tests {
         // SAFETY: same invariants as the `before` read above.
         let rc = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut after) };
         assert_eq!(rc, 0, "getrlimit should succeed after raising");
+        let after_soft = as_u64(after.rlim_cur);
+        let after_hard = as_u64(after.rlim_max);
 
-        // The soft limit must never decrease. We do NOT assert an exact value:
-        // CI runners differ in their hard limits, and a sandbox may forbid the
-        // raise entirely (in which case the helper warns and leaves the soft
-        // limit unchanged — still >= the previous soft limit).
-        assert!(
-            after.rlim_cur >= before.rlim_cur,
-            "soft fd limit must not decrease: before={}, after={}",
-            before.rlim_cur,
-            after.rlim_cur
-        );
+        match lowered_to {
+            Some(target) => {
+                // We genuinely lowered the soft limit, so `raise_fd_limit` had a
+                // real raise to perform. It must have raised the soft limit back
+                // up to the hard limit (and at minimum strictly above where we
+                // lowered it to).
+                assert_eq!(
+                    after_soft, after_hard,
+                    "raise_fd_limit must raise the soft limit up to the hard limit \
+                     (lowered_to={target}, hard={after_hard}, after_soft={after_soft})"
+                );
+                assert!(
+                    after_soft > target,
+                    "raise_fd_limit must strictly increase the lowered soft limit: \
+                     lowered_to={target}, after={after_soft}"
+                );
+            }
+            None => {
+                // Could not lower (already minimal, infinite hard limit, or
+                // sandbox forbade it): fall back to the no-decrease invariant.
+                assert!(
+                    after_soft >= orig_soft,
+                    "soft fd limit must not decrease: before={orig_soft}, after={after_soft}"
+                );
+            }
+        }
+
         // The soft limit must never exceed the hard limit (an invariant the OS
         // enforces, but we assert it to catch a logic error in the helper).
         assert!(
-            after.rlim_cur <= after.rlim_max,
-            "soft fd limit must not exceed hard limit: soft={}, hard={}",
-            after.rlim_cur,
-            after.rlim_max
+            after_soft <= after_hard,
+            "soft fd limit must not exceed hard limit: soft={after_soft}, hard={after_hard}"
         );
+
+        // Restore the original soft limit so we don't leak a changed limit into
+        // other tests sharing this process. Best-effort; ignore failures.
+        let restore = libc::rlimit {
+            rlim_cur: before.rlim_cur,
+            rlim_max: before.rlim_max,
+        };
+        // SAFETY: restoring the exact limits we read at entry is sound.
+        let _ = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &restore) };
     }
 
     #[test]

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -65,7 +65,88 @@ mod build_info {
     pub const BUILD_TIMESTAMP: &str = env!("BUILD_TIMESTAMP");
 }
 
+/// Raise the process's `RLIMIT_NOFILE` (open file-descriptor) soft limit up to
+/// its hard limit, so a busy node does not hit `EMFILE` ("No file descriptors
+/// available", os error 24).
+///
+/// WHY: the WASM module cache holds up to ~1024 compiled contracts, each backed
+/// by a `memfd`, plus AOF segment files, UDP sockets, the WS API, etc. systemd's
+/// `DefaultLimitNOFILE` soft limit is typically 1024, and freenet never raised
+/// it, so a busy gateway exhausted file descriptors. The resulting `EMFILE`
+/// killed a monitored background task (`refresh_router` opening an AOF segment),
+/// which the `BackgroundTaskMonitor` treats as node-fatal — producing a
+/// systemd crash-loop. Raising the soft limit to the hard limit at startup gives
+/// the node the FD headroom the kernel already permits, without operator
+/// intervention or a unit-file change.
+///
+/// Best-effort and non-fatal: on any error we `warn!` and continue with the
+/// inherited limit rather than failing startup. No-op on non-unix.
+#[cfg(unix)]
+fn raise_fd_limit() {
+    let mut limits = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: `getrlimit` with a valid resource id and a properly initialized,
+    // exclusively-borrowed `rlimit` out-param is sound; we check the return code
+    // before reading the struct.
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) } != 0 {
+        let err = std::io::Error::last_os_error();
+        tracing::warn!(error = %err, "failed to read RLIMIT_NOFILE; leaving fd limit unchanged");
+        return;
+    }
+
+    // `rlim_t` is `u64` on linux-gnu but `i64`/`u64` varies across unix targets;
+    // normalize to `u64` for logging. The cast is redundant on the CI target,
+    // hence the scoped allow rather than a bare `as u64` that trips clippy.
+    #[allow(clippy::unnecessary_cast)]
+    let previous_soft = limits.rlim_cur as u64;
+    #[allow(clippy::unnecessary_cast)]
+    let hard = limits.rlim_max as u64;
+
+    if previous_soft >= hard {
+        // Already at (or above) the hard limit — nothing to raise.
+        tracing::info!(
+            soft = previous_soft,
+            hard,
+            "RLIMIT_NOFILE soft limit already at hard limit"
+        );
+        return;
+    }
+
+    limits.rlim_cur = limits.rlim_max;
+    // SAFETY: `setrlimit` with a valid resource id and an exclusively-borrowed,
+    // fully-initialized `rlimit` whose soft limit (rlim_cur) does not exceed the
+    // hard limit (rlim_max) is sound.
+    if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &limits) } != 0 {
+        let err = std::io::Error::last_os_error();
+        tracing::warn!(
+            error = %err,
+            soft = previous_soft,
+            hard,
+            "failed to raise RLIMIT_NOFILE soft limit; leaving fd limit unchanged"
+        );
+        return;
+    }
+
+    tracing::info!(
+        soft = hard,
+        hard,
+        previous_soft,
+        "raised RLIMIT_NOFILE soft limit"
+    );
+}
+
+#[cfg(not(unix))]
+fn raise_fd_limit() {
+    // No RLIMIT_NOFILE concept on non-unix targets; nothing to do.
+}
+
 async fn run(config: Config) -> anyhow::Result<()> {
+    // Raise the open-fd soft limit before the node starts serving, so a busy
+    // node does not crash-loop on EMFILE (see `raise_fd_limit` rustdoc).
+    raise_fd_limit();
+
     // Log build info on startup - critical for correlating logs with code version
     tracing::info!(
         version = build_info::VERSION,
@@ -802,6 +883,49 @@ fn main() {
 mod tests {
     #[cfg(target_os = "linux")]
     use super::parse_listening_inode;
+
+    #[test]
+    #[cfg(unix)]
+    fn raise_fd_limit_does_not_lower_soft_limit() {
+        let mut before = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        // SAFETY: getrlimit with a valid resource id and an initialized,
+        // exclusively-borrowed out-param is sound; we check the return code.
+        let rc = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut before) };
+        assert_eq!(rc, 0, "getrlimit should succeed");
+
+        // Must not panic and must be safe to call.
+        super::raise_fd_limit();
+
+        let mut after = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        // SAFETY: same invariants as the `before` read above.
+        let rc = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut after) };
+        assert_eq!(rc, 0, "getrlimit should succeed after raising");
+
+        // The soft limit must never decrease. We do NOT assert an exact value:
+        // CI runners differ in their hard limits, and a sandbox may forbid the
+        // raise entirely (in which case the helper warns and leaves the soft
+        // limit unchanged — still >= the previous soft limit).
+        assert!(
+            after.rlim_cur >= before.rlim_cur,
+            "soft fd limit must not decrease: before={}, after={}",
+            before.rlim_cur,
+            after.rlim_cur
+        );
+        // The soft limit must never exceed the hard limit (an invariant the OS
+        // enforces, but we assert it to catch a logic error in the helper).
+        assert!(
+            after.rlim_cur <= after.rlim_max,
+            "soft fd limit must not exceed hard limit: soft={}, hard={}",
+            after.rlim_cur,
+            after.rlim_max
+        );
+    }
 
     #[test]
     #[cfg(target_os = "linux")]

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1698,6 +1698,48 @@ where
             return Ok(());
         }
         NetMessageV1::SubscribeHint(hint) => {
+            // Placement-migration deactivation gate (v0.2.74 hotfix). The
+            // placement migration was disabled after the v0.2.73 UPDATE-broadcast
+            // degradation by parking the SubscribeHint version floor at
+            // `(0, 3, 0)`, above every shipped 0.2.x release. The SEND side
+            // (`p2p_protoc::peer_supports_subscribe_hint`) already respects this
+            // floor, but the floor bump alone only stops US from emitting hints —
+            // a 0.2.74 node receiving a hint from a not-yet-upgraded 0.2.73 peer
+            // would still ACT on it and keep the migration load alive throughout
+            // the multi-hour staggered rollout.
+            //
+            // So gate the RECEIVE path too. The symmetric (sender-version) gate is
+            // not cleanly reachable here — the per-connection remote version lives
+            // in `P2pConnManager.connections` and is not exposed through the
+            // `NetworkBridge` trait — so use this node's OWN version against the
+            // SAME floor the send side uses. With the floor parked at `(0, 3, 0)`
+            // and our own version on the 0.2.x line this evaluates to "migration
+            // off → ignore"; lowering the floor re-activates both sides together.
+            //
+            // Read the floor via `subscribe_hint_floor_override().unwrap_or(...)`,
+            // identical to the send side, so a simulation that opts into the
+            // cascade (`SimNetwork::enable_placement_migration`, which lowers the
+            // per-node floor to `(0,0,0)`) still has its receivers act on hints.
+            let floor = op_manager
+                .ring
+                .connection_manager
+                .subscribe_hint_floor_override()
+                .unwrap_or(crate::node::network_bridge::p2p_protoc::SUBSCRIBE_HINT_MIN_VERSION);
+            let own_version = crate::node::network_bridge::p2p_protoc::own_crate_version();
+            if !crate::node::network_bridge::p2p_protoc::version_supports_subscribe_hint(
+                Some(own_version),
+                floor,
+            ) {
+                tracing::debug!(
+                    key = %hint.key,
+                    ?own_version,
+                    ?floor,
+                    ?source_addr,
+                    "Ignoring inbound SubscribeHint — placement migration deactivated \
+                     (own version below the SubscribeHint floor)"
+                );
+                return Ok(());
+            }
             // Directed-subscribe placement (#4404): a holder is nudging us to
             // host `hint.key` because we are closer to it in the ring. If we
             // already host it there is nothing to do. Otherwise start a
@@ -2869,6 +2911,94 @@ mod tests {
 
         assert_eq!(init_peer.peer_key_location, peer_key_location);
         assert_eq!(init_peer.location, location);
+    }
+
+    // Tests for the INBOUND `SubscribeHint` receive gate (v0.2.74 hotfix).
+    //
+    // FIX 1: the floor bump to `(0, 3, 0)` only gates the SEND side; the
+    // receive handler must ALSO ignore inbound hints while the placement
+    // migration is deactivated, so a 0.2.74 node does not act on hints sent
+    // by a not-yet-upgraded 0.2.73 peer during the staggered rollout.
+    mod inbound_subscribe_hint_gate {
+        use crate::node::network_bridge::p2p_protoc::{
+            SUBSCRIBE_HINT_MIN_VERSION, own_crate_version, version_supports_subscribe_hint,
+        };
+
+        /// The gate predicate ignores an inbound hint while the migration is
+        /// deactivated: for THIS node's own (0.2.x) version against the parked
+        /// production floor, `version_supports_subscribe_hint` returns `false`,
+        /// which is the "ignore the hint" branch in the receive handler.
+        #[test]
+        fn receive_gate_ignores_hint_while_deactivated() {
+            let own = own_crate_version();
+            // Sanity: this hotfix ships on the 0.2.x line, strictly below the
+            // parked floor. If the crate ever crosses the floor this guard
+            // (and the deactivation it pins) must be revisited.
+            assert!(
+                own < SUBSCRIBE_HINT_MIN_VERSION,
+                "own version {own:?} must be below the parked floor \
+                 {SUBSCRIBE_HINT_MIN_VERSION:?} for the migration to stay off"
+            );
+            assert!(
+                !version_supports_subscribe_hint(Some(own), SUBSCRIBE_HINT_MIN_VERSION),
+                "while deactivated, the receive gate must IGNORE inbound hints \
+                 (own version below the floor)"
+            );
+            // A concrete 0.2.73 sender's own-version analogue is likewise ignored.
+            assert!(!version_supports_subscribe_hint(
+                Some((0, 2, 73)),
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
+        }
+
+        /// Lowering the floor (as `SimNetwork::enable_placement_migration` does
+        /// to `(0, 0, 0)`) re-activates the receive side: the gate now ACTS on
+        /// the hint. This is the symmetry the cascade simulation test relies on.
+        #[test]
+        fn receive_gate_acts_on_hint_when_floor_lowered() {
+            let own = own_crate_version();
+            assert!(
+                version_supports_subscribe_hint(Some(own), (0, 0, 0)),
+                "with the floor lowered to (0,0,0) the receive side must act on hints"
+            );
+        }
+
+        /// Source-pin: the `SubscribeHint` receive arm must compute the floor
+        /// the SAME way as the send side (`subscribe_hint_floor_override()`
+        /// `unwrap_or` the production constant) and bail via the gate predicate
+        /// BEFORE invoking `start_directed_subscribe`. Without this pin a future
+        /// refactor could delete the gate and the predicate unit tests above
+        /// would still pass.
+        #[test]
+        fn receive_gate_is_wired_before_directed_subscribe() {
+            const SOURCE: &str = include_str!("node.rs");
+            let arm_anchor: String = ["NetMessageV1::", "SubscribeHint(hint)", " => {"].concat();
+            let arm_start = SOURCE
+                .find(&arm_anchor)
+                .expect("SubscribeHint receive arm not found — update this guard");
+            // Bound at the start of the next match arm.
+            let next_anchor: String = ["NetMessageV1::", "Aborted(tx)", " => {"].concat();
+            let arm_end = SOURCE[arm_start..]
+                .find(&next_anchor)
+                .map(|i| arm_start + i)
+                .expect("end of SubscribeHint arm not found — update guard");
+            let arm = &SOURCE[arm_start..arm_end];
+
+            let gate_idx = arm
+                .find("version_supports_subscribe_hint(")
+                .expect("receive arm must call version_supports_subscribe_hint as a gate");
+            let directed_idx = arm
+                .find("start_directed_subscribe(")
+                .expect("receive arm must still call start_directed_subscribe");
+            assert!(
+                gate_idx < directed_idx,
+                "the deactivation gate must run BEFORE start_directed_subscribe"
+            );
+            assert!(
+                arm.contains("subscribe_hint_floor_override()"),
+                "receive gate must read the same per-node floor override as the send side"
+            );
+        }
     }
 
     // Tests for `try_forward_driver_reply`.

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -638,7 +638,57 @@ pub(in crate::node) struct P2pConnManager {
 /// Simulation tests that want the cascade lower the floor per-node at runtime via
 /// `NodeConfig::subscribe_hint_floor_override` (set by
 /// `SimNetwork::enable_placement_migration`), which never touches production.
-const SUBSCRIBE_HINT_MIN_VERSION: (u8, u8, u16) = (0, 3, 0);
+///
+/// `pub(crate)` so the INBOUND `SubscribeHint` receive handler in
+/// [`crate::node`] can share the same floor: the send-side gate alone is not
+/// enough, because a 0.2.74 node would otherwise still ACT on hints sent by a
+/// pre-floor 0.2.73 peer and keep the (deactivated) migration load alive during
+/// the staggered rollout.
+pub(crate) const SUBSCRIBE_HINT_MIN_VERSION: (u8, u8, u16) = (0, 3, 0);
+
+/// This node's own crate version as a `(major, minor, patch)` tuple, parsed at
+/// compile time from `CARGO_PKG_VERSION`.
+///
+/// Used by the INBOUND `SubscribeHint` receive gate (see [`crate::node`]) to ask
+/// "is the placement migration active for a node running THIS version?" via
+/// [`version_supports_subscribe_hint`]. With the floor parked at `(0, 3, 0)` and
+/// our own version on the 0.2.x line, the gate evaluates to "migration off →
+/// ignore inbound hints"; lowering the floor re-activates both the send and the
+/// receive side together.
+pub(crate) const fn own_crate_version() -> (u8, u8, u16) {
+    parse_crate_version(env!("CARGO_PKG_VERSION"))
+}
+
+/// `const` parser for `"X.Y.Z"` / `"X.Y.Z-pre"` into `(major, minor, patch)`.
+///
+/// Mirrors `connection_handler::parse_semver` (kept local so this gate does not
+/// reach into the transport module). Pre-release suffixes are ignored.
+const fn parse_crate_version(version: &str) -> (u8, u8, u16) {
+    let bytes = version.as_bytes();
+    let mut major = 0u8;
+    let mut minor = 0u8;
+    let mut patch = 0u16;
+    let mut state = 0u8; // 0: major, 1: minor, 2: patch
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'.' {
+            state += 1;
+        } else if c.is_ascii_digit() {
+            let digit = (c - b'0') as u16;
+            match state {
+                0 => major = (major as u16 * 10 + digit) as u8,
+                1 => minor = (minor as u16 * 10 + digit) as u8,
+                2 => patch = patch * 10 + digit,
+                _ => {}
+            }
+        } else {
+            break; // Pre-release suffix — ignored.
+        }
+        i += 1;
+    }
+    (major, minor, patch)
+}
 
 /// Pure version-gate decision, factored out so the comparison and the
 /// fail-closed-on-unknown-version (`None`) behavior are unit-testable with an
@@ -648,7 +698,13 @@ const SUBSCRIBE_HINT_MIN_VERSION: (u8, u8, u16) = (0, 3, 0);
 /// unknown remote version is treated as unsupported: an older peer that cannot
 /// deserialize the appended `SubscribeHint` wire variant would drop the
 /// connection, so when in doubt we do not send the hint.
-fn version_supports_subscribe_hint(remote: Option<(u8, u8, u16)>, floor: (u8, u8, u16)) -> bool {
+///
+/// `pub(crate)` so the inbound `SubscribeHint` receive gate in [`crate::node`]
+/// can reuse the identical predicate (kept symmetric with the send side).
+pub(crate) fn version_supports_subscribe_hint(
+    remote: Option<(u8, u8, u16)>,
+    floor: (u8, u8, u16),
+) -> bool {
     remote.is_some_and(|v| v >= floor)
 }
 
@@ -6047,7 +6103,7 @@ mod tests {
     }
 
     mod version_gate {
-        use super::super::version_supports_subscribe_hint;
+        use super::super::{SUBSCRIBE_HINT_MIN_VERSION, version_supports_subscribe_hint};
 
         const FLOOR: (u8, u8, u16) = (0, 2, 73);
 
@@ -6092,6 +6148,29 @@ mod tests {
             // (this is the simulation/test floor behavior).
             assert!(version_supports_subscribe_hint(Some((0, 0, 0)), (0, 0, 0)));
             assert!(!version_supports_subscribe_hint(None, (0, 0, 0)));
+        }
+
+        /// Pin the PRODUCTION constant (not the local `FLOOR`): with
+        /// `SUBSCRIBE_HINT_MIN_VERSION` parked at `(0, 3, 0)` the placement
+        /// migration is dormant for EVERY shipped 0.2.x peer — both the lowest
+        /// shipped patch and any conceivable future 0.2.x — and stays fail-closed
+        /// on an unknown version. If someone lowers the floor to a 0.2.x release
+        /// (silently re-enabling the migration disabled in v0.2.74), this test
+        /// fails. See docs/RELEASING.md and issue #4145.
+        #[test]
+        fn placement_migration_deactivated_for_all_0_2_x() {
+            assert!(!version_supports_subscribe_hint(
+                Some((0, 2, 73)),
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
+            assert!(!version_supports_subscribe_hint(
+                Some((0, 2, 255)),
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
+            assert!(!version_supports_subscribe_hint(
+                None,
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
         }
     }
 

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -606,17 +606,29 @@ pub(in crate::node) struct P2pConnManager {
 /// Minimum negotiated protocol version a peer must report before we send it a
 /// [`SubscribeHint`](crate::message::NetMessageV1::SubscribeHint).
 ///
-/// MUST equal the release version that first ships SubscribeHint. A peer is only
+/// DEACTIVATED after the v0.2.73 UPDATE-broadcast-degradation incident. Set to
+/// `(0, 3, 0)`, which is ABOVE every shipped 0.2.x release, so the gate
+/// (`remote.is_some_and(|v| v >= floor)`, fail-closed on unknown) evaluates to
+/// `false` for all 0.2.x peers and the placement-migration wire behavior never
+/// fires in production. The placement-migration path (directed subscribes plus
+/// the `ConsiderContractMigration` emits) amplified the #4145/#4231
+/// broadcast-backpressure surface and drove a network-wide UPDATE-broadcast
+/// degradation on 0.2.73. The migration code is intentionally left in place;
+/// re-enable it by LOWERING this floor back to the release that first ships a
+/// load-safe SubscribeHint once the broadcast-backpressure load issue is fixed.
+///
+/// Original (pre-deactivation) contract, still true mechanically: a peer is only
 /// sent SubscribeHint if its negotiated version is >= this; older peers cannot
 /// deserialize the new wire variant and would drop the connection. None (unknown,
 /// e.g. joiner->gateway) is treated as unsupported.
 ///
-/// UPDATE AT RELEASE TIME, then FREEZE: set this to the exact release version
-/// that first ships SubscribeHint and do NOT keep bumping it afterward to track
-/// the crate version. Once shipped in release R, peers running R can deserialize
-/// the variant, so the floor must stay at R forever — raising it above R would
-/// silently stop sending hints to fully-capable R peers. (This is why there is
-/// no `floor` vs `CARGO_PKG_VERSION` unit test; see docs/RELEASING.md.)
+/// WHEN RE-ENABLING — UPDATE AT RELEASE TIME, then FREEZE: set this to the exact
+/// release version that first ships the load-safe SubscribeHint and do NOT keep
+/// bumping it afterward to track the crate version. Once shipped in release R,
+/// peers running R can deserialize the variant, so the floor must stay at R
+/// forever — raising it above R would silently stop sending hints to
+/// fully-capable R peers. (This is why there is no `floor` vs `CARGO_PKG_VERSION`
+/// unit test; see docs/RELEASING.md.)
 ///
 /// This is a single non-cfg constant: deliberately NOT lowered under any test
 /// feature, because `testing` is pulled into the SHIPPED release binary (`fdev`
@@ -626,7 +638,7 @@ pub(in crate::node) struct P2pConnManager {
 /// Simulation tests that want the cascade lower the floor per-node at runtime via
 /// `NodeConfig::subscribe_hint_floor_override` (set by
 /// `SimNetwork::enable_placement_migration`), which never touches production.
-const SUBSCRIBE_HINT_MIN_VERSION: (u8, u8, u16) = (0, 2, 73);
+const SUBSCRIBE_HINT_MIN_VERSION: (u8, u8, u16) = (0, 3, 0);
 
 /// Pure version-gate decision, factored out so the comparison and the
 /// fail-closed-on-unknown-version (`None`) behavior are unit-testable with an

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1011,11 +1011,21 @@ impl Ring {
             let history = match register.get_router_events(Self::ROUTER_HISTORY_LIMIT).await {
                 Ok(h) => h,
                 Err(error) => {
-                    // Previously this was an `expect()` that would silently panic
-                    // the task. Now that the task is monitored, returning will
-                    // trigger the BackgroundTaskMonitor and propagate the failure.
-                    tracing::error!(error = %error, "Shutting down refresh router task");
-                    return;
+                    // get_router_events errors are transient and recoverable —
+                    // e.g. file-descriptor exhaustion ("os error 24") when the
+                    // AOF segment file can't be opened during a connection-churn
+                    // spike. Router refresh is a best-effort optimization, so we
+                    // keep the existing in-memory router in place and retry on
+                    // the next interval rather than killing the node. (A genuine
+                    // panic inside this task is still caught by the
+                    // BackgroundTaskMonitor — only this expected, transient read
+                    // failure is swallowed here.)
+                    tracing::error!(
+                        error = %error,
+                        "Failed to refresh routing history from event log; \
+                         keeping existing router and retrying on next interval"
+                    );
+                    continue;
                 }
             };
             if !history.is_empty() {
@@ -4237,6 +4247,7 @@ mod op_manager_state_tests {
 #[cfg(test)]
 mod refresh_router_tests {
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     use either::Either;
@@ -4346,6 +4357,111 @@ mod refresh_router_tests {
         let snapshot = router.read().snapshot();
         assert_eq!(snapshot.failure_events, 0);
         assert_eq!(snapshot.success_events, 0);
+    }
+
+    /// Mock register whose `get_router_events` fails the first `fail_first`
+    /// times it is called, then returns the configured events on every
+    /// subsequent call. Records the total call count so tests can confirm the
+    /// refresh loop keeps polling past a transient error rather than dying.
+    #[derive(Clone)]
+    struct FlakyRegister {
+        events: Vec<RouteEvent>,
+        fail_first: usize,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl NetEventRegister for FlakyRegister {
+        fn register_events<'a>(
+            &'a self,
+            _events: Either<NetEventLog<'a>, Vec<NetEventLog<'a>>>,
+        ) -> futures::future::BoxFuture<'a, ()> {
+            async {}.boxed()
+        }
+
+        fn notify_of_time_out(
+            &mut self,
+            _tx: crate::message::Transaction,
+            _op_type: &str,
+            _target_peer: Option<String>,
+        ) -> futures::future::BoxFuture<'_, ()> {
+            async {}.boxed()
+        }
+
+        fn trait_clone(&self) -> Box<dyn NetEventRegister> {
+            Box::new(self.clone())
+        }
+
+        fn get_router_events(
+            &self,
+            number: usize,
+        ) -> futures::future::BoxFuture<'_, anyhow::Result<Vec<RouteEvent>>> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            let fail = call < self.fail_first;
+            let events: Vec<RouteEvent> = self.events.iter().take(number).cloned().collect();
+            async move {
+                if fail {
+                    // Mimics the production failure: an AOF segment read failing
+                    // under fd exhaustion ("No file descriptors available").
+                    Err(anyhow::anyhow!(
+                        "No file descriptors available (os error 24)"
+                    ))
+                } else {
+                    Ok(events)
+                }
+            }
+            .boxed()
+        }
+    }
+
+    /// Regression test: a transient `get_router_events` error inside the
+    /// periodic refresh loop must NOT terminate the task (which, as a monitored
+    /// background task, would be node-fatal and crash-loop the gateway).
+    ///
+    /// The mock fails the startup load plus the first few periodic ticks, then
+    /// succeeds. We assert the loop kept polling past the errors (call count >
+    /// the number of injected failures) AND eventually recovered by loading the
+    /// history — both impossible if the error arm had `return`ed.
+    #[tokio::test(start_paused = true)]
+    async fn refresh_router_survives_transient_get_router_events_error() {
+        let events = make_route_events(100);
+        let calls = Arc::new(AtomicUsize::new(0));
+        // Fail the startup load (call 0) and the first 3 periodic ticks
+        // (calls 1..=3), then succeed from call 4 onward.
+        let register = FlakyRegister {
+            events: events.clone(),
+            fail_first: 4,
+            calls: calls.clone(),
+        };
+        let router = Arc::new(RwLock::new(Router::new(&[])));
+
+        // The periodic loop ticks every 5 minutes; under start_paused the
+        // timeout auto-advances virtual time, so ~40 min covers >5 ticks and
+        // lets the loop poll well past the injected failures and recover.
+        tokio::time::timeout(
+            Duration::from_secs(60 * 40),
+            super::Ring::refresh_router(router.clone(), register),
+        )
+        .await
+        .ok(); // timeout is expected — the loop runs forever when healthy
+
+        // The loop must have kept polling past every injected failure rather
+        // than returning on the first Err.
+        let total_calls = calls.load(Ordering::SeqCst);
+        assert!(
+            total_calls > 4,
+            "refresh loop should keep polling past transient errors, but only \
+             called get_router_events {total_calls} times (<= the 4 injected failures), \
+             implying it returned/died instead of retrying"
+        );
+
+        // And it must have recovered: once get_router_events started succeeding,
+        // the router got populated from the historical events.
+        let snapshot = router.read().snapshot();
+        assert_eq!(
+            snapshot.success_events, 100,
+            "router should have recovered and loaded history after the transient \
+             errors cleared"
+        );
     }
 }
 

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -289,10 +289,17 @@ impl Router {
             if let RouteOutcome::Success {
                 time_to_response_start: _,
                 payload_size,
-                payload_transfer_time: _,
+                payload_transfer_time,
             } = event.outcome
             {
-                mean_transfer_size.add(payload_size as f64);
+                // Only feed transfer size estimator when there's actual payload
+                // data. Operations like SUBSCRIBE report payload_size=0 and
+                // payload_transfer_time=ZERO; counting those would bias
+                // mean_transfer_size downward on a router reload. Mirrors the
+                // incremental `add_event` guard.
+                if payload_size > 0 && !payload_transfer_time.is_zero() {
+                    mean_transfer_size.add(payload_size as f64);
+                }
             }
         }
 
@@ -2942,12 +2949,13 @@ mod tests {
     /// successes with finite-rate GET successes at that shared location is what
     /// actually exercises the NaN path; a single homogeneous event does not.
     ///
-    /// Asserts: (1) `Router::new` does not panic, and (2) the resulting
+    /// Asserts: (1) `Router::new` completes, and (2) the resulting
     /// `transfer_rate_estimator`'s raw regression curve is entirely finite —
     /// which fails (NaN) if the NaN subscribe events are not screened out of
-    /// the batch path.
+    /// the batch path. (`Router::new` itself does not panic on this NaN; the
+    /// load-bearing assertion is regression finiteness, hence the name.)
     #[test]
-    fn router_new_does_not_panic_on_subscribe_nan_transfer_rates() {
+    fn router_new_does_not_poison_transfer_rate_regression_with_nan() {
         use crate::transport::TransportKeypair;
         use std::net::SocketAddr;
 

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -261,11 +261,19 @@ impl Router {
                     payload_transfer_time,
                 } = re.outcome
                 {
-                    Some(IsotonicEvent {
-                        peer: re.peer.clone(),
-                        contract_location: re.contract_location,
-                        result: payload_size as f64 / payload_transfer_time.as_secs_f64(),
-                    })
+                    // Mirror the per-op / add_event guard: SUBSCRIBE successes
+                    // report payload_size=0 and payload_transfer_time=ZERO, so
+                    // 0/0 = NaN. Skip those so NaN never enters the isotonic
+                    // regression (a single NaN poisons interpolation).
+                    if payload_size > 0 && !payload_transfer_time.is_zero() {
+                        Some(IsotonicEvent {
+                            peer: re.peer.clone(),
+                            contract_location: re.contract_location,
+                            result: payload_size as f64 / payload_transfer_time.as_secs_f64(),
+                        })
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }
@@ -2911,6 +2919,105 @@ mod tests {
                 pred.expected_total_time.is_finite(),
                 "expected_total_time must be finite, got {}",
                 pred.expected_total_time
+            );
+        }
+    }
+
+    /// Regression test for the latent NaN bug in the GLOBAL `transfer_rates`
+    /// batch path of `Router::new`. A SUBSCRIBE success reports payload_size=0
+    /// and payload_transfer_time=ZERO, so the rate is 0/0 = NaN. Without the
+    /// guard, that NaN flows into the `transfer_rate_estimator` isotonic
+    /// regression and poisons it: `interpolate()` at the affected distance then
+    /// returns NaN (verified against pav_regression 0.7.0). The per-op and
+    /// `add_event` paths already screen these events out; this test pins the
+    /// equivalent guard on the batch path.
+    ///
+    /// To exercise the bug the events must land at the SAME route distance (so
+    /// the NaN and finite points share an x in the regression) with enough
+    /// interleaved NaN/finite events to populate the estimator. We use DISTINCT
+    /// peers that nonetheless share a ring location: `Location::from_address`
+    /// masks the low byte of the IP and ignores the port for non-loopback
+    /// addresses, so peers on the same /24 map to one location while remaining
+    /// distinct `PeerKeyLocation`s. Interleaving ≥40 NaN-producing subscribe
+    /// successes with finite-rate GET successes at that shared location is what
+    /// actually exercises the NaN path; a single homogeneous event does not.
+    ///
+    /// Asserts: (1) `Router::new` does not panic, and (2) the resulting
+    /// `transfer_rate_estimator`'s raw regression curve is entirely finite —
+    /// which fails (NaN) if the NaN subscribe events are not screened out of
+    /// the batch path.
+    #[test]
+    fn router_new_does_not_panic_on_subscribe_nan_transfer_rates() {
+        use crate::transport::TransportKeypair;
+        use std::net::SocketAddr;
+
+        let contract_location = Location::random();
+
+        // Build distinct peers that all share the SAME ring location: same /24
+        // (so the masked IP is identical), varying only the host byte/port.
+        // Distinct pub keys + distinct addresses make them distinct peers, while
+        // the masked location (and thus route_distance) is identical for all.
+        let make_peer = |i: usize| {
+            let pub_key = TransportKeypair::new().public().clone();
+            // 203.0.113.0/24 (TEST-NET-3, non-loopback): low byte is masked out,
+            // so every host in this /24 hashes to the same Location.
+            let addr: SocketAddr = format!("203.0.113.{}:{}", i % 250, 9000 + i)
+                .parse()
+                .unwrap();
+            PeerKeyLocation::new(pub_key, addr)
+        };
+
+        // Interleave NaN-producing SUBSCRIBE successes with finite-rate GET
+        // successes — all at the shared location so their points share x.
+        let events: Vec<RouteEvent> = (0..120)
+            .map(|i| {
+                let peer = make_peer(i);
+                if i % 2 == 0 {
+                    // SUBSCRIBE success: payload_size=0, transfer_time=ZERO -> 0/0 = NaN
+                    RouteEvent {
+                        peer,
+                        contract_location,
+                        outcome: RouteOutcome::Success {
+                            time_to_response_start: Duration::from_millis(40),
+                            payload_size: 0,
+                            payload_transfer_time: Duration::ZERO,
+                        },
+                        op_type: Some(OpType::Subscribe),
+                    }
+                } else {
+                    // GET success with a finite transfer rate.
+                    RouteEvent {
+                        peer,
+                        contract_location,
+                        outcome: RouteOutcome::Success {
+                            time_to_response_start: Duration::from_millis(40),
+                            payload_size: 4096,
+                            payload_transfer_time: Duration::from_millis(20),
+                        },
+                        op_type: Some(OpType::Get),
+                    }
+                }
+            })
+            .collect();
+
+        // (1) Must not panic: the guard keeps the NaN out of the global isotonic
+        // regression, mirroring the per-op / add_event paths.
+        let router = Router::new(&events);
+
+        // (2) The transfer-rate estimator must not be NaN-poisoned. Sample its
+        // raw regression curve (which exposes `interpolate()` outputs directly,
+        // unlike `estimate_retrieval_time` which masks NaN via `.max(0.0)`).
+        // Without the guard, the NaN subscribe points poison the regression and
+        // at least one sampled y comes back NaN.
+        let curve = router
+            .transfer_rate_estimator
+            .sampled_curve(0.0, f64::MAX, 64);
+        for (x, y) in &curve {
+            assert!(
+                y.is_finite(),
+                "transfer_rate regression produced a non-finite value {y} at \
+                 distance {x} — NaN subscribe events leaked into the batch \
+                 regression"
             );
         }
     }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -81,11 +81,29 @@ version**, then leave it frozen — do NOT bump it on later releases (raising it
 above the first-shipping version would silently stop sending to fully-capable
 peers).
 
-Current wire-gated floors to set at first ship:
+Current wire-gated floors:
 
 - `SUBSCRIBE_HINT_MIN_VERSION` in `crates/core/src/node/network_bridge/p2p_protoc.rs`
-  (SubscribeHint placement migration, #4404). Must equal the first release that
-  includes it.
+  (SubscribeHint placement migration, #4404).
+
+  **DO NOT lower this to the release version.** It is intentionally **parked at
+  `(0, 3, 0)`** — above every shipped 0.2.x release — to keep the placement
+  migration **DEACTIVATED**. The migration's directed-subscribe / hint-broadcast
+  load drove a network-wide UPDATE-broadcast degradation after the v0.2.73
+  release, and v0.2.74 disabled it by raising this floor above all live peers
+  (the SEND side **and** the inbound-hint RECEIVE gate in `node.rs` both read
+  this floor, so the migration is dormant in both directions). This is the one
+  wire-gated floor that does **NOT** follow the "set to the first-shipping
+  release version" rule above.
+
+  Lowering it to the release version would **silently re-enable** the migration
+  and reproduce the degradation. Leave it at `(0, 3, 0)` until the
+  broadcast-backpressure load issue (#4145) is fixed; only then drop it to the
+  release that first ships a load-safe SubscribeHint and freeze it there per the
+  general rule.
+
+When a NEW wire-gated feature first ships (not this one), set its floor to
+**exactly that release version** and freeze it, as described above.
 
 ## What fires when
 


### PR DESCRIPTION
## Problem

v0.2.73 introduced two regressions on the live network:

1. **Gateway crash-loop (fd exhaustion).** The WASM module cache holds up to ~1024 compiled contracts, each backed by a `memfd`. systemd's default `RLIMIT_NOFILE` *soft* limit is 1024, and freenet never raised it. On a busy gateway the module cache alone sits at the ceiling, so the next socket / AOF-segment open hits `EMFILE` ("No file descriptors available", os error 24). That error makes the monitored `refresh_router` task return `Err`, which the `BackgroundTaskMonitor` treats as **node-fatal** → systemd restart loop (every ~15–45 min on vega). Gateway-specific: technic (same 0.2.73 binary, no inbound-connection load) never crashed. **Not** migration-caused.

2. **Network-wide UPDATE-broadcast degradation.** The #4404 placement migration's directed-subscribes + per-GET/PUT `ConsiderContractMigration` emits amplified the #4145/#4231 broadcast-backpressure surface, driving "UPDATE relay broadcast stream assembly failed — no fragments received within inactivity timeout" up across the network.

Investigation also cleared two red herrings: no contract data loss / orphaning (migration only ever *adds* hosting, never drops the origin), and the NaN-in-router theory is defused (NaN lands only in the transfer-rate telemetry channel, not the failure estimator that gates peer selection).

## Approach (fix-forward — keeps all other 0.2.73 fixes; revert is last resort)

1. **Deactivate the placement migration** — raise `SUBSCRIBE_HINT_MIN_VERSION` to `(0, 3, 0)` (above every shipped 0.2.x), so the fail-closed gate never fires it in production. Removes the UPDATE-broadcast load amplifier. Migration code stays in place; re-enable by lowering the floor once the broadcast-backpressure load is fixed.
2. **freenet self-raises `RLIMIT_NOFILE` soft→hard at startup** — the permanent, universal fix for the gateway fd exhaustion (the live systemd drop-in only covers nova/vega; this protects every gateway and survives any restart path). Best-effort, non-fatal, unix-only.
3. **Harden `refresh_router`** — a transient fd/AOF read error no longer kills the node; it logs and retries on the next interval. Genuine panics are still caught by the monitor.
4. **Guard NaN in the batch transfer-rate path** (`Router::new`) — mirrors the existing per-op / `add_event` guards so a SUBSCRIBE-success (0/0) never enters the isotonic regression. Latent correctness fix / defense-in-depth.

## Testing

- `refresh_router_survives_transient_get_router_events_error` — flaky mock register fails then recovers; asserts the loop keeps polling instead of dying.
- `router_new_does_not_panic_on_subscribe_nan_transfer_rates` — 120 interleaved NaN-subscribe / finite-GET events at a shared location; `Router::new` must not panic.
- `raise_fd_limit_does_not_lower_soft_limit` (unix) — soft limit never decreases / never exceeds hard.
- Existing `version_gate` tests pass with `(0,3,0)`.
- `cargo fmt` / `cargo clippy -D warnings` / build clean.

## Incident context

Gateways were already mitigated live (`prlimit` + a systemd `LimitNOFILE=524288` drop-in on nova/vega); this PR makes that fix permanent in the binary and removes the migration load network-wide. Supersedes #4437 (which was the migration-deactivation change alone).

[AI-assisted - Claude]
