### PR TITLE
fix(broadcast): cache peer summary on delivered full-state broadcasts to end the full-state storm (#4145)

### DIFF
--- a/.claude/rules/channel-safety.md
+++ b/.claude/rules/channel-safety.md
@@ -61,6 +61,24 @@ stalling the entire event loop. This has caused 5+ production deadlocks:
   because it carries a one-shot transition — see its inline
   `DELIBERATELY blocking` comment for the rationale.
 
+  The same #4145/#4231 investigation surfaced a SECOND, separate
+  degradation under the same fan-out — not a deadlock but a full-state
+  broadcast STORM (#4442). A peer's summary was cached only after a
+  *delta* send (PR #2763's `if sent_delta`), but a delta needs the
+  peer's cached summary to compute against — a chicken-and-egg that
+  trapped every summary-less subscriber (any new subscriber, or one
+  whose summary was cleared) on full state forever. Under sustained
+  fan-out that meant every update re-sent full state to every
+  subscriber, swamping the event loop. Fixed (#4442) by caching the
+  summary on any *delivered* broadcast (delta OR full state): #4235's
+  real-delivery signal (`BroadcastDeliveryOutcome::Delivered`) makes
+  caching on a full-state delivery safe, so the next broadcast to that
+  peer collapses to a small delta. A wrongly-cached summary (e.g. a
+  lost stream tail — `Delivered` is sender-side completion, not a
+  receiver ack) is corrected by the periodic InterestSync summary
+  exchange and by the delta-apply-failure → ResyncRequest path that
+  clears the sender's cached summary.
+
 ## Exception: same-runtime internal consumers
 
 `.send().await` on a bounded channel is acceptable when **all** of the

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -4285,6 +4285,60 @@ mod tests {
         }
     }
 
+    /// Source-level pin for the #4145 non-streaming caching safety net.
+    ///
+    /// The summary-cache fix (#4145) caches a peer's summary on any
+    /// *delivered* broadcast. That is only safe because the
+    /// `ResyncRequest` handler clears the SENDER's cached summary for the
+    /// peer when a downstream delta fails to apply — otherwise a wrongly
+    /// cached summary would trap the pair sending unappliable deltas.
+    /// If a refactor drops the `update_peer_summary(.., None)` clear from
+    /// this handler, the #4145 caching loses its corrective backstop and
+    /// the behavioural sim test would still pass. Pin it at the source
+    /// level so the omission fails CI.
+    mod resync_request_clears_sender_summary {
+        const SOURCE: &str = include_str!("node.rs");
+
+        /// The body of the `InterestMessage::ResyncRequest` match arm,
+        /// bounded by the start of the following `ResyncResponse` arm.
+        fn resync_request_arm() -> &'static str {
+            let arm_anchor = "InterestMessage::ResyncRequest { key } => {";
+            let arm_start = SOURCE.find(arm_anchor).expect(
+                "ResyncRequest arm of handle_interest_sync_message not found — \
+                 the match arm has been renamed or moved; update this guard",
+            );
+            let next_anchor = "InterestMessage::ResyncResponse {";
+            let arm_end = SOURCE[arm_start..]
+                .find(next_anchor)
+                .map(|i| arm_start + i)
+                .expect("end of ResyncRequest arm not found — update guard");
+            &SOURCE[arm_start..arm_end]
+        }
+
+        #[test]
+        fn resync_request_handler_clears_cached_peer_summary() {
+            let arm = resync_request_arm();
+            assert!(
+                arm.contains("update_peer_summary"),
+                "ResyncRequest handler no longer calls update_peer_summary. \
+                 #4145 caching relies on this handler clearing the sender's \
+                 cached summary so a delta-apply failure forces a fresh \
+                 full-state resend instead of looping on unappliable deltas."
+            );
+            // The clear MUST pass `None` (clear), not a `Some(summary)` cache.
+            // Strip whitespace so the multi-line call (`op_manager\n
+            // .interest_manager\n .update_peer_summary(&key, pk, None);`)
+            // matches regardless of formatting.
+            let collapsed: String = arm.chars().filter(|c| !c.is_whitespace()).collect();
+            assert!(
+                collapsed.contains("update_peer_summary(&key,pk,None)"),
+                "ResyncRequest handler must clear the cached summary with \
+                 `update_peer_summary(&key, pk, None)` (the `None` clears it). \
+                 Caching a summary here instead would defeat the #4145 backstop."
+            );
+        }
+    }
+
     /// Tests for `ShutdownHandle::shutdown`'s drain behaviour. The
     /// drain stops in-flight client PUT/GET/UPDATE/SUBSCRIBE drivers
     /// from being torn down mid-operation when the gateway is stopped

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -358,9 +358,10 @@ fn record_streaming_delivery<T: crate::util::time_source::TimeSource + Sync>(
 }
 
 /// The side effects a *delivered* broadcast applies to the interest manager:
-/// record send telemetry, refresh the peer interest TTL, and (for deltas) cache
-/// the peer summary. Factored out so both the streaming gate
-/// ([`record_streaming_delivery`]) and the non-streaming path share one body.
+/// record send telemetry, refresh the peer interest TTL, and cache the peer
+/// summary (on ANY delivered broadcast — delta or full state — per #4145).
+/// Factored out so both the streaming gate ([`record_streaming_delivery`]) and
+/// the non-streaming path share one body.
 fn record_delivery_to_interest<T: crate::util::time_source::TimeSource + Sync>(
     interest_manager: &crate::ring::interest::InterestManager<T>,
     sent_delta: bool,
@@ -382,11 +383,30 @@ fn record_delivery_to_interest<T: crate::util::time_source::TimeSource + Sync>(
     // Issue #3046: Refresh the peer's interest TTL on every successful send
     interest_manager.refresh_peer_interest(key, peer_key);
 
-    // PR #2763: Only update cached summary when we sent a delta
-    if sent_delta {
-        if let Some(summary) = our_summary {
-            interest_manager.update_peer_summary(key, peer_key, Some(summary.clone()));
-        }
+    // Issue #4145: Cache the peer summary on ANY delivered broadcast — delta OR
+    // full state — not just deltas.
+    //
+    // PR #2763 originally gated this on `sent_delta` because a streamed
+    // full-state "success" didn't reliably mean the peer received the state:
+    // caching `our_summary` for a peer that never got the state would make the
+    // next delta unappliable (wrong base) and diverge. That gate created a
+    // chicken-and-egg: a delta needs the peer's cached summary, but the summary
+    // was only cached after a delta — so every NEW subscriber (and any peer
+    // whose summary was cleared) starts on full state and is trapped sending
+    // full state forever. Under sustained fan-out that is the #4233 full-state
+    // broadcast storm.
+    //
+    // #4235 added a real-delivery signal (`BroadcastDeliveryOutcome::Delivered`).
+    // This helper now runs ONLY on a real delivery: for the streaming
+    // (full-state) path the caller gates it behind
+    // `record_streaming_delivery` → `streaming_completion_delivered`, and for
+    // the non-streaming path it runs only inside the send-success arm. After a
+    // real delivery the peer has `our_summary` regardless of how the state was
+    // sent, so caching it here is safe and lets the NEXT broadcast be a small
+    // delta. Each peer now gets exactly ONE bootstrap full-state, then deltas.
+    // (Telemetry above still records delta-vs-full-state separately.)
+    if let Some(summary) = our_summary {
+        interest_manager.update_peer_summary(key, peer_key, Some(summary.clone()));
     }
 }
 
@@ -847,6 +867,130 @@ mod tests {
                      summary, or the next summary-mismatch resend is suppressed (#4235)"
                 );
             }
+        }
+    }
+
+    /// Issue #4145 — the chicken-and-egg fix. A peer that starts with NO cached
+    /// summary receives a *full-state* broadcast (`sent_delta = false`). After a
+    /// real delivery its summary MUST be cached, so the NEXT broadcast can be a
+    /// small delta instead of full state again.
+    ///
+    /// This is the bug #4145/#4233 describe: PR #2763 gated the summary cache on
+    /// `sent_delta`, so a peer bootstrapped on full state never got a cached
+    /// summary and was trapped sending full state forever (the broadcast storm).
+    ///
+    /// Pre-fix (`if sent_delta { update_peer_summary(..) }`) the `sent_delta =
+    /// false` call below cached nothing, so `get_peer_summary` would stay `None`
+    /// and this test FAILS. With the fix it caches on any delivery and the
+    /// summary is present, mirroring the precondition
+    /// `broadcast_to_single_peer` checks (a present peer summary → `compute_delta`
+    /// → `sent_delta = true`) on the subsequent broadcast.
+    #[tokio::test]
+    async fn full_state_delivery_caches_summary_so_next_broadcast_is_delta() {
+        let our_summary = StateSummary::from(vec![1, 2, 3, 4]);
+
+        let time_source = SharedMockTimeSource::new();
+        let manager = InterestManager::new(time_source.clone());
+        let contract = make_contract_key(42);
+        let peer = make_peer_key();
+
+        // New subscriber: interested, but no cached summary yet — exactly the
+        // state that forces a full-state broadcast on the first send.
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+        assert_eq!(
+            manager.get_peer_summary(&contract, &peer),
+            None,
+            "precondition: a brand-new subscriber has no cached summary, so the \
+             first broadcast must be full state"
+        );
+
+        // A FULL-STATE broadcast (`sent_delta = false`) is really Delivered.
+        let delivered = record_streaming_delivery(
+            &manager,
+            Ok(Ok(BroadcastDeliveryOutcome::Delivered)),
+            /* sent_delta */ false,
+            &contract,
+            &peer,
+            Some(&our_summary),
+            /* state_size */ 4096,
+            /* payload_size */ 4096,
+        );
+        assert!(delivered, "a Delivered outcome must classify as delivered");
+
+        // #4145 FIX: the summary is now cached even though we sent FULL STATE.
+        // This is the assertion that fails on the old `if sent_delta` gate.
+        assert_eq!(
+            manager.get_peer_summary(&contract, &peer),
+            Some(our_summary.clone()),
+            "#4145: a delivered FULL-STATE broadcast must cache the peer summary, \
+             so the next broadcast can be a delta — otherwise the peer is trapped \
+             sending full state forever (the #4233 storm)"
+        );
+
+        // The cached summary is the exact precondition `broadcast_to_single_peer`
+        // uses to compute a delta: `their_summary = get_peer_summary(..)` being
+        // `Some` drives the delta branch (`sent_delta = true`) next time.
+        let their_summary = manager.get_peer_summary(&contract, &peer);
+        assert!(
+            their_summary.is_some(),
+            "#4145: with a cached peer summary the next broadcast takes the delta \
+             path (compute_delta), not another full state"
+        );
+    }
+
+    /// Issue #4145 / #2763 — divergence guard preserved. The #4145 fix caches on
+    /// any *delivered* broadcast, but a DROPPED full-state stream (peer never
+    /// received the state) MUST still NOT cache the summary — otherwise the next
+    /// delta would be computed against a base the peer doesn't have, and the
+    /// summary-mismatch resend that should re-send the state is suppressed.
+    ///
+    /// This is the full-state (`sent_delta = false`) counterpart to
+    /// [`drop_outcome_does_not_refresh_interest_or_cache_summary`], pinning that
+    /// the #4145 change did NOT weaken the #4235/#2763 drop guard for full state.
+    #[tokio::test]
+    async fn dropped_full_state_stream_does_not_cache_summary() {
+        let our_summary = StateSummary::from(vec![5, 6, 7, 8]);
+
+        let dropped = dropped_oneshot().await;
+        let timed_out = elapsed_timeout().await;
+        // Every non-delivery completion for a FULL-STATE (`sent_delta = false`)
+        // stream must leave the summary uncached.
+        let cases: Vec<(&str, super::StreamCompletionResult)> = vec![
+            ("explicit-drop", Ok(Ok(BroadcastDeliveryOutcome::Dropped))),
+            ("dropped-oneshot", Ok(dropped)),
+            ("timeout", Err(timed_out)),
+        ];
+
+        for (name, completion) in cases {
+            let time_source = SharedMockTimeSource::new();
+            let manager = InterestManager::new(time_source.clone());
+            let contract = make_contract_key(43);
+            let peer = make_peer_key();
+
+            manager.register_peer_interest(&contract, peer.clone(), None, false);
+
+            let delivered = record_streaming_delivery(
+                &manager,
+                completion,
+                /* sent_delta */ false,
+                &contract,
+                &peer,
+                Some(&our_summary),
+                /* state_size */ 4096,
+                /* payload_size */ 4096,
+            );
+            assert!(
+                !delivered,
+                "[{name}] a dropped/timed-out full-state stream must NOT classify \
+                 as delivered"
+            );
+            assert_eq!(
+                manager.get_peer_summary(&contract, &peer),
+                None,
+                "[{name}] #4145 must not weaken the #2763/#4235 guard: a DROPPED \
+                 full-state stream must NOT cache the summary (the peer never got \
+                 the state), or the next summary-mismatch resend is suppressed"
+            );
         }
     }
 }

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -397,13 +397,23 @@ fn record_delivery_to_interest<T: crate::util::time_source::TimeSource + Sync>(
     // broadcast storm.
     //
     // #4235 added a real-delivery signal (`BroadcastDeliveryOutcome::Delivered`).
-    // This helper now runs ONLY on a real delivery: for the streaming
+    // This helper runs only on a delivered broadcast: for the streaming
     // (full-state) path the caller gates it behind
     // `record_streaming_delivery` → `streaming_completion_delivered`, and for
-    // the non-streaming path it runs only inside the send-success arm. After a
-    // real delivery the peer has `our_summary` regardless of how the state was
-    // sent, so caching it here is safe and lets the NEXT broadcast be a small
-    // delta. Each peer now gets exactly ONE bootstrap full-state, then deltas.
+    // the non-streaming path it runs only inside the send-success arm.
+    //
+    // Caching `our_summary` on ANY delivered broadcast (delta or full state) is
+    // safe even though `Delivered` is a SENDER-SIDE completion (the last
+    // fragment was handed to the transport — see outbound_stream.rs ~434 — NOT a
+    // receiver ACK), so on the streaming path a lost stream tail could leave the
+    // peer without the state and the cached summary momentarily wrong. Two
+    // backstops bound that window: the periodic InterestSync summary exchange
+    // (~5 min, node.rs) re-reconciles what each peer actually has, and a delta
+    // that fails to apply at the receiver triggers a ResyncRequest that clears
+    // the sender's cached summary (node.rs ~2119). The streaming `Delivered`
+    // signal is sender-side completion, so the rare tail-loss case is corrected
+    // by those backstops rather than by an end-to-end ack here. Caching lets the
+    // NEXT broadcast to this peer be a small delta instead of full state.
     // (Telemetry above still records delta-vs-full-state separately.)
     if let Some(summary) = our_summary {
         interest_manager.update_peer_summary(key, peer_key, Some(summary.clone()));

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -5296,21 +5296,37 @@ impl P2pConnManager {
                     }
                 };
                 let send_res = bridge.send(peer_addr, net_msg).await;
-                if send_res.is_ok() {
-                    // Send the stream data after the metadata message
-                    if let Err(err) = bridge
-                        .send_stream(peer_addr, sid, bytes::Bytes::from(payload_bytes), metadata)
-                        .await
-                    {
-                        tracing::warn!(
-                            tx = %update_tx,
-                            peer = %peer_addr,
-                            error = %err,
-                            "Failed to send broadcast stream data"
-                        );
+                match send_res {
+                    Ok(()) => {
+                        // The metadata message went out; the streamed full state is
+                        // the actual payload. The success arm below caches
+                        // `our_summary` for this peer (FIX 1 of #4145), which is only
+                        // correct if the STATE was sent — so this branch's result must
+                        // reflect the stream send, not just the metadata send. If
+                        // `send_stream` fails, a streamed full state that never landed
+                        // would otherwise be marked as delivered, recreating the
+                        // #2763/#4235 divergence hazard (a wrongly-cached summary makes
+                        // the next delta unappliable). Propagate the stream-send error.
+                        bridge
+                            .send_stream(
+                                peer_addr,
+                                sid,
+                                bytes::Bytes::from(payload_bytes),
+                                metadata,
+                            )
+                            .await
+                            .inspect_err(|err| {
+                                tracing::warn!(
+                                    tx = %update_tx,
+                                    peer = %peer_addr,
+                                    error = %err,
+                                    "Failed to send broadcast stream data"
+                                );
+                            })
                     }
+                    // Metadata send failed; nothing was streamed. Propagate the error.
+                    Err(err) => Err(err),
                 }
-                send_res
             } else {
                 let msg = crate::operations::update::UpdateMsg::BroadcastTo {
                     id: update_tx,
@@ -5372,11 +5388,17 @@ impl P2pConnManager {
                 // Safe now because this runs only inside the send-success (`else`)
                 // arm. This is the inline non-streaming `BroadcastTo` path: a
                 // successful `bridge.send` is the terminal state we can observe
-                // (the same assumption the delta path already made), and any rare
-                // wrong cache is corrected by the summary-mismatch resync. Caching
-                // here lets the NEXT broadcast to this peer be a small delta. The
-                // streaming (full-state) path is gated more strictly on a real
-                // `Delivered` completion (#4235) in `broadcast_queue.rs`.
+                // (the same assumption the delta path already made). Caching on a
+                // delivered broadcast is safe even when the cache is momentarily
+                // wrong: a wrongly-cached summary is corrected by the periodic
+                // InterestSync summary exchange (~5 min, node.rs) and by the
+                // delta-apply-failure → ResyncRequest path that clears the
+                // sender's cached summary (node.rs ~2119). Caching here lets the
+                // NEXT broadcast to this peer be a small delta. The streaming
+                // (full-state) path is gated more strictly on a `Delivered`
+                // completion (#4235) in `broadcast_queue.rs` — note that signal is
+                // sender-side completion, not a receiver ack, so a lost stream
+                // tail is covered by the same two backstops.
                 // (Telemetry above still records delta-vs-full-state separately.)
                 if let Some(summary) = &our_summary {
                     op_manager.interest_manager.update_peer_summary(

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -5355,13 +5355,29 @@ impl P2pConnManager {
                 op_manager
                     .interest_manager
                     .refresh_peer_interest(&key, &peer_key);
-            }
 
-            // PR #2763 FIX: Only update cached summary when we sent a delta.
-            // This is separate from the TTL refresh above — update_peer_summary
-            // sets the cached summary (used for delta computation), while
-            // refresh_peer_interest only extends the TTL.
-            if sent_delta {
+                // Issue #4145: Cache the peer summary on ANY successful broadcast
+                // send — delta OR full state — not just deltas. Separate from the
+                // TTL refresh above: update_peer_summary sets the cached summary
+                // (used for delta computation), refresh_peer_interest only extends
+                // the TTL.
+                //
+                // PR #2763 originally gated this on `sent_delta`, which created a
+                // chicken-and-egg: a delta needs the peer's cached summary, but the
+                // summary was only cached after a delta — so every NEW subscriber
+                // (or a peer whose summary was cleared) starts on full state and is
+                // trapped sending full state forever. Under sustained fan-out that
+                // is the #4233 full-state broadcast storm.
+                //
+                // Safe now because this runs only inside the send-success (`else`)
+                // arm. This is the inline non-streaming `BroadcastTo` path: a
+                // successful `bridge.send` is the terminal state we can observe
+                // (the same assumption the delta path already made), and any rare
+                // wrong cache is corrected by the summary-mismatch resync. Caching
+                // here lets the NEXT broadcast to this peer be a small delta. The
+                // streaming (full-state) path is gated more strictly on a real
+                // `Delivered` completion (#4235) in `broadcast_queue.rs`.
+                // (Telemetry above still records delta-vs-full-state separately.)
                 if let Some(summary) = &our_summary {
                     op_manager.interest_manager.update_peer_summary(
                         &key,

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -3140,7 +3140,8 @@ fn test_pr2763_crdt_convergence_with_resync() {
 ///
 /// A clean star (the host broadcasts directly to its subscribers, no relay tree)
 /// removes that floor, so the metric isolates exactly the bug the fix addresses:
-/// with the fix `full_state_sends` stays at roughly one bootstrap per subscriber
+/// with the fix `full_state_sends` collapses below `delta_sends` (the host caches
+/// each subscriber's summary after a delivered broadcast and switches to deltas)
 /// while `delta_sends` grows with the update count; reverted, `full_state_sends`
 /// scales with updates × subscribers and overtakes `delta_sends`. The unit tests
 /// in `broadcast_queue.rs` pin the gate logic directly; this sim pins the
@@ -3152,10 +3153,13 @@ fn test_pr2763_crdt_convergence_with_resync() {
 /// - (a) Event-loop liveness: no `StalePeer` anomaly — every subscriber keeps
 ///   receiving broadcasts; none goes silent under the fan-out.
 /// - (b) Full-state-send rate collapses: `delta_sends > full_state_sends`. With
-///   the fix each subscriber takes one bootstrap full state then transitions to
-///   deltas, so deltas dominate. Reverted, every update is full state to every
-///   subscriber and `delta_sends` stays low → this assertion fails. (Measured:
-///   fix ≈ 78 delta / 47 full; reverted ≈ 21 delta / 104 full.)
+///   the fix the host caches each subscriber's summary after a delivered
+///   broadcast, so subsequent updates go out as deltas and deltas dominate.
+///   (Full-state sends are reduced below delta sends but NOT to one-per-
+///   subscriber — bootstrap + retry jitter mean several full states per
+///   subscriber.) Reverted, every update is full state to every subscriber and
+///   `delta_sends` stays low → this assertion fails. (Measured on this star
+///   topology: fix = 78 delta / 47 full; reverted = 40 delta / 85 full.)
 /// - (c) Broadcast delivery / update propagation stays high: all peers converge.
 #[test_log::test]
 fn test_sustained_update_fanout_no_full_state_storm() {
@@ -3255,6 +3259,11 @@ fn test_sustained_update_fanout_no_full_state_storm() {
     let delta_sends = GlobalTestMetrics::delta_sends();
     let full_state_sends = GlobalTestMetrics::full_state_sends();
     let resync_count = GlobalTestMetrics::resync_requests();
+    // Event-loop backlog proxy: the high-water mark of in-flight transactions
+    // awaiting a reply (`pending_op_results` map size). A full-state storm that
+    // pins the event loop lets replies pile up, pushing this mark up; a healthy
+    // run keeps it low. See `GlobalTestMetrics::pending_op_high_water_mark`.
+    let pending_op_hwm = GlobalTestMetrics::pending_op_high_water_mark();
 
     // Anomaly report for liveness (StalePeer = a subscriber that stopped
     // receiving broadcasts while others kept getting them).
@@ -3266,10 +3275,11 @@ fn test_sustained_update_fanout_no_full_state_storm() {
     let stale = report.stale_peers();
 
     tracing::info!(
-        "i4233 fanout: delta_sends={}, full_state_sends={}, resyncs={}, converged={}/{}, stale_peers={}",
+        "i4233 fanout: delta_sends={}, full_state_sends={}, resyncs={}, pending_op_hwm={}, converged={}/{}, stale_peers={}",
         delta_sends,
         full_state_sends,
         resync_count,
+        pending_op_hwm,
         convergence.converged.len(),
         convergence.total_contracts(),
         stale.len(),
@@ -3293,18 +3303,39 @@ fn test_sustained_update_fanout_no_full_state_storm() {
         stale,
     );
 
+    // (a2) EVENT-LOOP BACKLOG STAYS BOUNDED. StalePeer is a content-divergence
+    // proxy for liveness; this is a more direct event-loop-backlog signal. The
+    // high-water mark of `pending_op_results` (in-flight transactions awaiting a
+    // reply) tracks how far the event loop falls behind: if the loop is pinned by
+    // a broadcast storm, replies pile up and the mark climbs. Measured steady
+    // state on this star is ~15 (identical on both the fixed and reverted gate —
+    // in this small deterministic harness the storm shows up as full-state-send
+    // volume, not as op-result backlog, so this bound is a SATURATION guard, not
+    // the fix-vs-revert discriminator; assertion (b) is that discriminator). The
+    // bound is set well above steady state but far below a level that would
+    // indicate the loop is wedged and replies are accumulating unboundedly.
+    const PENDING_OP_BACKLOG_BOUND: u64 = 200;
+    assert!(
+        pending_op_hwm < PENDING_OP_BACKLOG_BOUND,
+        "#4233 liveness: event-loop backlog high-water mark {pending_op_hwm} \
+         reached {PENDING_OP_BACKLOG_BOUND}+ in-flight op-results under sustained \
+         UPDATE fan-out — the event loop is falling behind (replies piling up), \
+         a sign the broadcast path is pinning the loop."
+    );
+
     // (b) FULL-STATE-SEND RATE COLLAPSES — the load-bearing #4145 discriminator.
     //
-    // With the fix each subscriber takes exactly ONE bootstrap full state and
-    // then transitions to deltas, so over SUSTAINED_UPDATES updates the delta
-    // sends dominate the (bounded) bootstrap full states: delta_sends >
-    // full_state_sends.
+    // With the fix the host caches a subscriber's summary after a delivered
+    // broadcast, so subsequent updates go out as deltas. Full-state sends collapse
+    // BELOW delta sends (not to one-per-subscriber — bootstrap plus retry jitter
+    // produce several full states per subscriber), so over SUSTAINED_UPDATES
+    // updates the delta sends dominate: delta_sends > full_state_sends.
     //
     // Reverted to `if sent_delta`, the host never caches a subscriber's summary,
     // so EVERY update is full state to EVERY subscriber and delta_sends stays
     // low — full_state_sends overtakes delta_sends and THIS assertion fails.
-    // (Measured on this star topology: fix ≈ 78 delta / 47 full; reverted ≈ 21
-    // delta / 104 full.)
+    // (Measured on this star topology: fix = 78 delta / 47 full; reverted = 40
+    // delta / 85 full.)
     //
     // We assert the *direction* (deltas dominate) rather than an absolute
     // full-state budget: a fixed numeric cap is brittle against topology/retry

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -3109,6 +3109,233 @@ fn test_pr2763_crdt_convergence_with_resync() {
     // Clean up
 }
 
+/// Regression test for the #4233 full-state broadcast storm (issue #4145).
+///
+/// ## What this guards
+///
+/// Sustained UPDATE fan-out from one host to its direct subscribers of a CRDT
+/// contract. After each subscriber bootstraps on a single full state, every
+/// subsequent broadcast to that subscriber must be a small delta — not another
+/// full state. The #4145 fix caches the target peer's summary on ANY delivered
+/// broadcast (delta OR full state), not just deltas, so the host can compute a
+/// delta for the next broadcast instead of re-sending full state forever.
+///
+/// ## Scenario
+///
+/// 1 gateway (the contract host / broadcast source) + a small number of direct
+/// subscriber nodes. The gateway PUTs+subscribes, every node subscribes, then
+/// the gateway drives a burst of sequential UPDATEs that fan out to all
+/// subscribers.
+///
+/// ## Why a *small* star topology (1 gateway + 2 direct subscribers)
+///
+/// The chicken-and-egg the fix targets is per-(sender, target): a sender that
+/// lacks a target's cached summary must send full state. A LARGER topology
+/// (e.g. 5+ subscribers forming a multi-hop relay tree) does NOT make this test
+/// more sensitive — it makes it LESS sensitive. Relay nodes cache a downstream
+/// peer's *full state* as its "summary", and `compute_delta` then rejects the
+/// diff as "not efficient" (`is_delta_efficient`), emitting full state
+/// regardless of the #4145 gate. Those relay-tree full-states swamp the signal:
+/// at 5 subscribers, fix vs reverted is ~199 vs ~201 full-state sends — noise.
+///
+/// A clean star (the host broadcasts directly to its subscribers, no relay tree)
+/// removes that floor, so the metric isolates exactly the bug the fix addresses:
+/// with the fix `full_state_sends` stays at roughly one bootstrap per subscriber
+/// while `delta_sends` grows with the update count; reverted, `full_state_sends`
+/// scales with updates × subscribers and overtakes `delta_sends`. The unit tests
+/// in `broadcast_queue.rs` pin the gate logic directly; this sim pins the
+/// system-level consequence on the path simulation builds actually exercise
+/// (the `#[cfg(simulation_tests)]` inline broadcast loop in `p2p_protoc.rs`).
+///
+/// ## Assertions (the delta-dominance one FAILS if the #4145 gate is reverted)
+///
+/// - (a) Event-loop liveness: no `StalePeer` anomaly — every subscriber keeps
+///   receiving broadcasts; none goes silent under the fan-out.
+/// - (b) Full-state-send rate collapses: `delta_sends > full_state_sends`. With
+///   the fix each subscriber takes one bootstrap full state then transitions to
+///   deltas, so deltas dominate. Reverted, every update is full state to every
+///   subscriber and `delta_sends` stays low → this assertion fails. (Measured:
+///   fix ≈ 78 delta / 47 full; reverted ≈ 21 delta / 104 full.)
+/// - (c) Broadcast delivery / update propagation stays high: all peers converge.
+#[test_log::test]
+fn test_sustained_update_fanout_no_full_state_storm() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation, register_crdt_contract};
+
+    const SEED: u64 = 0x4233_5701_0001;
+    const NETWORK_NAME: &str = "i4233-fanout-storm";
+    // Direct subscribers of the gateway (the broadcast fan-out width). Kept small
+    // so the host broadcasts directly to subscribers with no multi-hop relay tree
+    // — see the "Why a small star topology" note above.
+    const SUBSCRIBERS: usize = 2;
+    // UPDATEs driven into the hot contract AFTER all subscribers have bootstrapped.
+    // Enough that, reverted, the per-update full-state fan-out clearly overtakes
+    // the one-time bootstrap deltas.
+    const SUSTAINED_UPDATES: usize = 20;
+
+    GlobalTestMetrics::reset();
+    setup_deterministic_state(SEED);
+    let rt = create_runtime();
+
+    let (sim, logs_handle) = rt.block_on(async {
+        let sim = SimNetwork::new(
+            NETWORK_NAME,
+            1,           // 1 gateway (the broadcast source / contract host)
+            SUBSCRIBERS, // subscriber nodes (the fan-out targets)
+            7,           // max_htl
+            3,           // rnd_if_htl_above
+            10,          // max_connections
+            2,           // min_connections
+            SEED,
+        )
+        .await;
+        let logs_handle = sim.event_logs_handle();
+        (sim, logs_handle)
+    });
+
+    // CRDT contract so post-bootstrap broadcasts compute real version-aware
+    // deltas (a plain hash contract's "delta" is full state, which would not
+    // exercise the delta transition this test is about).
+    let contract = SimOperation::create_test_contract(0x42);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    register_crdt_contract(contract_id);
+
+    let initial_state = SimOperation::create_crdt_state(1, 0x10);
+
+    let mut operations = Vec::new();
+
+    // Bootstrap: gateway PUTs + subscribes (becomes the host/source), then every
+    // node subscribes. Each subscriber's FIRST broadcast is full state — that is
+    // the one bootstrap full-state per subscriber the fix permits.
+    operations.push(ScheduledOperation::new(
+        NodeLabel::gateway(NETWORK_NAME, 0),
+        SimOperation::Put {
+            contract: contract.clone(),
+            state: initial_state,
+            subscribe: true,
+        },
+    ));
+    for node_idx in 1..=SUBSCRIBERS {
+        operations.push(ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, node_idx),
+            SimOperation::Subscribe { contract_id },
+        ));
+    }
+
+    // Sustained UPDATE fan-out: a burst of UPDATEs from the gateway, each fanned
+    // out to all subscribers. With the fix every subscriber already has a cached
+    // summary after its bootstrap full state, so these all go out as deltas.
+    // Without the fix every one of these is another full state to every
+    // subscriber — the storm.
+    for v in 0..SUSTAINED_UPDATES {
+        let version = (v as u64) + 2; // versions 2.. (v1 was the PUT)
+        operations.push(ScheduledOperation::new(
+            NodeLabel::gateway(NETWORK_NAME, 0),
+            SimOperation::Update {
+                key: contract_key,
+                data: SimOperation::create_crdt_state(version, 0x20 + v as u8),
+            },
+        ));
+    }
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(240), // simulation duration (virtual)
+        Duration::from_secs(90),  // post-op propagation wait (virtual)
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "Simulation should complete: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let convergence =
+        rt.block_on(async { freenet::dev_tool::check_convergence_from_logs(&logs_handle).await });
+    let delta_sends = GlobalTestMetrics::delta_sends();
+    let full_state_sends = GlobalTestMetrics::full_state_sends();
+    let resync_count = GlobalTestMetrics::resync_requests();
+
+    // Anomaly report for liveness (StalePeer = a subscriber that stopped
+    // receiving broadcasts while others kept getting them).
+    let report = rt.block_on(async {
+        let logs = logs_handle.lock().await;
+        let verifier = freenet::tracing::StateVerifier::from_events(logs.clone());
+        verifier.verify()
+    });
+    let stale = report.stale_peers();
+
+    tracing::info!(
+        "i4233 fanout: delta_sends={}, full_state_sends={}, resyncs={}, converged={}/{}, stale_peers={}",
+        delta_sends,
+        full_state_sends,
+        resync_count,
+        convergence.converged.len(),
+        convergence.total_contracts(),
+        stale.len(),
+    );
+
+    // Sanity: the scenario must actually have broadcast something, otherwise the
+    // collapse assertion below would pass vacuously.
+    assert!(
+        delta_sends + full_state_sends > 0,
+        "no broadcasts were recorded — the fan-out scenario did not run"
+    );
+
+    // (a) LIVENESS: no subscriber goes silent under the fan-out. A full-state
+    // storm that pins the event loop strands a subscriber, which surfaces as a
+    // StalePeer anomaly.
+    assert!(
+        stale.is_empty(),
+        "#4233 liveness: {} subscriber(s) went stale under sustained UPDATE \
+         fan-out (event loop starved by the broadcast storm): {:?}",
+        stale.len(),
+        stale,
+    );
+
+    // (b) FULL-STATE-SEND RATE COLLAPSES — the load-bearing #4145 discriminator.
+    //
+    // With the fix each subscriber takes exactly ONE bootstrap full state and
+    // then transitions to deltas, so over SUSTAINED_UPDATES updates the delta
+    // sends dominate the (bounded) bootstrap full states: delta_sends >
+    // full_state_sends.
+    //
+    // Reverted to `if sent_delta`, the host never caches a subscriber's summary,
+    // so EVERY update is full state to EVERY subscriber and delta_sends stays
+    // low — full_state_sends overtakes delta_sends and THIS assertion fails.
+    // (Measured on this star topology: fix ≈ 78 delta / 47 full; reverted ≈ 21
+    // delta / 104 full.)
+    //
+    // We assert the *direction* (deltas dominate) rather than an absolute
+    // full-state budget: a fixed numeric cap is brittle against topology/retry
+    // jitter, whereas the delta-vs-full crossover flips cleanly between the fixed
+    // and reverted gate.
+    assert!(
+        delta_sends > full_state_sends,
+        "#4145 REGRESSION: deltas must dominate after bootstrap, but \
+         delta_sends={delta_sends} <= full_state_sends={full_state_sends}. \
+         A reverted summary-cache gate traps every subscriber on full state \
+         (the #4233 storm): every update re-sends full state to every subscriber \
+         instead of a delta."
+    );
+
+    // (c) DELIVERY / PROPAGATION stays high: all peers converge to one state.
+    assert!(
+        convergence.is_converged(),
+        "#4233: broadcast delivery degraded — peers failed to converge under \
+         sustained fan-out. {} converged, {} diverged",
+        convergence.converged.len(),
+        convergence.diverged.len(),
+    );
+
+    tracing::info!(
+        "test_sustained_update_fanout_no_full_state_storm PASSED: \
+         delta_sends={} > full_state_sends={}, converged, no stale peers",
+        delta_sends,
+        full_state_sends,
+    );
+}
+
 // =============================================================================
 // Extended Edge Case Tests for Ring Protocol
 // =============================================================================


### PR DESCRIPTION
## Problem

The remaining half of #4145. #4231 fixed the back-pressure *deadlock* (the event loop is provably not the bottleneck — our 2026-06-16 incident showed `slow_events=0`, `notification_channel_pending=0`, `peer_congested=0` throughout). The remaining degradation under sustained UPDATE fan-out is a **full-state broadcast storm**: popular contracts shipped their *entire state* (streamed) to every subscriber on every update, saturating gateway uplinks (47 distinct congested destinations, 113KB–42MB stalled transfers, GET/PUT relays collateral-damaged). Pre-migration (small fan-out) this was ~0; the placement migration made it acute by bloating subscription trees.

## Root cause — a chicken-and-egg in the summary cache (PR #2763)

Broadcasts send a small **delta** when the gateway has the target peer's cached *summary* to diff against, and otherwise fall back to **full state** (streamed if >64KB). But the peer's summary was cached **only after a delta send** (`if sent_delta { update_peer_summary(our_summary) }`), at both broadcast cache sites (`broadcast_queue.rs`, `p2p_protoc.rs`).

That's a trap: you need the peer's summary to send a delta, but the summary is only cached after a delta. So **any peer that ever starts on full state — every new subscriber, or anyone whose summary was cleared on a failure — is stuck sending full state forever**, never bootstrapping into deltas. The migration flooded the gateways with summary-less subscribers → permanent full-state storm.

PR #2763 gated on `sent_delta` because, at the time, a streamed full-state "success" did not reliably mean *real delivery* — caching the summary then risked telling the gateway the peer had state it didn't, making the next delta unappliable (divergence). **#4235 since added a real-delivery signal** (`BroadcastDeliveryOutcome::Delivered`), removing that risk on the streaming path.

## Approach

Cache the peer's summary on any **delivered** broadcast (delta *or* full state), not just deltas:
- **Streaming (full-state) path** caches via `record_delivery_to_interest`, reached only on `streaming_completion_delivered == Ok(Ok(Delivered))` — a verified real delivery (#4235). Safe.
- **Non-streaming path** (`p2p_protoc.rs`) caches inside the send-success arm only — same assumption the delta path already makes; the summary-mismatch resync corrects any rare wrong cache. (Also moved the cache block *inside* the success `else` arm — it previously ran regardless of send success/failure.)

After a real delivery the peer demonstrably has `our_summary` either way, so the next update is a small delta. Each peer now gets exactly **one** bootstrap full-state, then deltas — killing the storm at its source. No change to the delta-vs-fullstate decision, streaming threshold, concurrency limits, or wire format. The existing large-stream concurrency limit (2) already bounds the one-time bootstrap burst.

## Testing

- `full_state_delivery_caches_summary_so_next_broadcast_is_delta` — drives the real `Delivered` gate with `sent_delta=false`, asserts the summary is cached and the next broadcast is a delta. **Fails on the old `if sent_delta` gate.**
- `dropped_full_state_stream_does_not_cache_summary` — negative test: a dropped/timed-out full-state stream must NOT cache (preserves #2763/#4235's divergence guard).
- `test_sustained_update_fanout_no_full_state_storm` (the #4233 sim) — sustained UPDATE fan-out; asserts liveness, delta-send dominance / full-state collapse, and convergence. **Passes with the fix (78 delta / 47 full), fails on revert (40 delta / 85 full).**

`cargo fmt` + `cargo clippy -D warnings` clean.

Addresses (does not close) #4233 — the full production-path liveness test it specifies (≈40 subscribers, channel-pending bounded) remains open; this PR adds a summary-cache regression test on the sim path. Substantially addresses the remaining #4145 (re-enabling the placement migration, #4440 / #4404, is gated on this landing + validating under real fan-out).

[AI-assisted - Claude]