### PR TITLE
fix: ttl-evict orphaned delegate inherited origins

### DIFF
--- a/apps/freenet-ping/Cargo.lock
+++ b/apps/freenet-ping/Cargo.lock
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.2.72"
+version = "0.2.74"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/apps/freenet-ping/Cargo.lock
+++ b/apps/freenet-ping/Cargo.lock
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.2.70"
+version = "0.2.72"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -4595,9 +4595,13 @@ fn resolve_message_origin(
     } else if let Some(contract_id) = origin_contract {
         Some(MessageOrigin::WebApp(*contract_id))
     } else {
+        // Plain read, no timestamp update. The "last used" time is refreshed in
+        // inbound_app_message instead, so a child that only ever gets messages
+        // from other delegates (those don't reach this branch) still counts as
+        // active and isn't dropped.
         crate::wasm_runtime::DELEGATE_INHERITED_ORIGINS
             .get(delegate_key)
-            .and_then(|ids| ids.first().map(|c| MessageOrigin::WebApp(*c)))
+            .and_then(|entry| entry.origins.first().copied().map(MessageOrigin::WebApp))
     }
 }
 
@@ -4670,10 +4674,10 @@ mod resolve_message_origin_tests {
 
         // Plant an inherited WebApp origin for the recipient so the
         // fallback branch would have something to return.
-        crate::wasm_runtime::DELEGATE_INHERITED_ORIGINS
-            .entry(recipient.clone())
-            .or_default()
-            .push(inherited_contract);
+        crate::wasm_runtime::DELEGATE_INHERITED_ORIGINS.insert(
+            recipient.clone(),
+            crate::wasm_runtime::InheritedOriginsEntry::new(vec![inherited_contract]),
+        );
 
         let origin = resolve_message_origin(Some(&caller), None, &recipient);
 
@@ -4685,6 +4689,30 @@ mod resolve_message_origin_tests {
             Some(MessageOrigin::Delegate(k)) => assert_eq!(k, caller),
             other => panic!("Expected Delegate(caller), got {other:?}"),
         }
+    }
+
+    /// Fallback branch (no live caller/origin) yields the child's inherited
+    /// WebApp origin via a pure read — it does not refresh `last_access`
+    /// (liveness lives in `inbound_app_message`). Pairs with
+    /// `no_arguments_and_no_inherited_yields_none`.
+    #[test]
+    fn inherited_origin_fallback_yields_webapp() {
+        use crate::wasm_runtime::{DELEGATE_INHERITED_ORIGINS, InheritedOriginsEntry};
+
+        let recipient = dkey(0xC5);
+        let contract = ContractInstanceId::new([0xC6; 32]);
+        DELEGATE_INHERITED_ORIGINS.insert(
+            recipient.clone(),
+            InheritedOriginsEntry::new(vec![contract]),
+        );
+
+        let origin = resolve_message_origin(None, None, &recipient);
+        DELEGATE_INHERITED_ORIGINS.remove(&recipient);
+
+        assert!(
+            matches!(origin, Some(MessageOrigin::WebApp(c)) if c == contract),
+            "fallback must yield the inherited WebApp origin, got {origin:?}"
+        );
     }
 }
 

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -29,6 +29,11 @@ pub(crate) use native_api::{
     CREATED_DELEGATES_COUNT, DELEGATE_INHERITED_ORIGINS, DELEGATE_SUBSCRIPTIONS,
     DelegateContextCache, new_delegate_context_cache,
 };
+// Only constructed by name in test code (e.g. resolve_message_origin tests);
+// production read/write paths access the entry through the DashMap without
+// naming the type, so gate the re-export to avoid an unused-import warning.
+#[cfg(test)]
+pub(crate) use native_api::InheritedOriginsEntry;
 pub use runtime::{ContractExecError, Runtime};
 pub(crate) use runtime::{RuntimeConfig, SharedModuleCache};
 pub use secrets_store::{SecretStoreError, SecretsStore};

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -530,6 +530,11 @@ impl DelegateRuntimeInterface for Runtime {
         // bytes for prompts whose `UserResponse` never arrives (user
         // dismisses, app crashes, network partition).
         native_api::prune_expired_contexts(&self.delegate_contexts);
+        // Keep the inherited-origins map tidy. Mark this delegate as just-used
+        // so the cleanup keeps its entry, then drop entries for delegates that
+        // have gone unused long enough. See `InheritedOriginsEntry`.
+        native_api::touch_inherited_origin(delegate_key);
+        native_api::prune_expired_inherited_origins();
         let mut context: Vec<u8> = self
             .delegate_contexts
             .get(delegate_key)
@@ -1858,6 +1863,31 @@ mod test {
 
         std::mem::drop(temp_dir);
         Ok(())
+    }
+
+    /// Checks that `inbound_app_message` calls `touch_inherited_origin` before
+    /// `prune_expired_inherited_origins`. The other tests verify the eviction
+    /// logic on its own, so without this one nobody would notice if those two
+    /// calls were removed or swapped — and the #3492 leak would come back. Reads
+    /// the source and asserts both calls are present and in that order.
+    #[test]
+    fn inbound_app_message_wires_inherited_origins_ttl_in_order() {
+        let src = include_str!("delegate.rs");
+        // The impl is the LAST occurrence; the first is the trait method signature.
+        let body = src
+            .rsplit("fn inbound_app_message(")
+            .next()
+            .expect("inbound_app_message impl must exist");
+        let touch = body
+            .find("touch_inherited_origin(delegate_key)")
+            .expect("inbound_app_message must refresh inherited-origin liveness (touch)");
+        let prune = body
+            .find("prune_expired_inherited_origins()")
+            .expect("inbound_app_message must run the inherited-origins TTL sweep (prune)");
+        assert!(
+            touch < prune,
+            "touch_inherited_origin must run BEFORE prune so a just-delivered message is not evicted"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/core/src/wasm_runtime/delegate_api.rs
+++ b/crates/core/src/wasm_runtime/delegate_api.rs
@@ -1158,7 +1158,7 @@ mod tests {
             inherited.is_some(),
             "child should have inherited attestations"
         );
-        assert_eq!(inherited.unwrap().value(), &vec![contract_id]);
+        assert_eq!(inherited.unwrap().value().origins, vec![contract_id]);
 
         // Cleanup
         DELEGATE_INHERITED_ORIGINS.remove(&child_key);
@@ -1200,5 +1200,225 @@ mod tests {
 
         // Cleanup
         CREATED_DELEGATES_COUNT.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    // These tests check the eviction rule directly. They build a small map by
+    // hand, set each entry's timestamps relative to `base`, then ask the pruner
+    // "if the time were `now`, what gets dropped?". Times are built forward
+    // (`base + offset`) because subtracting days from `Instant::now()` can
+    // underflow on a freshly-booted CI machine. A local map keeps them from
+    // interfering with other tests.
+
+    /// Regression (#3492): an entry left unused for longer than the TTL is
+    /// dropped, even though nobody called `UnregisterDelegate` — that is the
+    /// leak, since children created via `create_delegate` are never unregistered.
+    #[test]
+    fn test_inherited_origins_idle_ttl_evicts() {
+        use super::super::native_api::{
+            DELEGATE_INHERITED_ORIGINS_TTL, InheritedOriginsEntry, prune_inherited_origins_at,
+        };
+        use dashmap::DashMap;
+        use freenet_stdlib::prelude::CodeHash;
+
+        let base = tokio::time::Instant::now();
+        let map = DashMap::new();
+        let child = DelegateKey::new([0x71; 32], CodeHash::new([0x71; 32]));
+        map.insert(
+            child.clone(),
+            InheritedOriginsEntry {
+                origins: vec![ContractInstanceId::new([0x72; 32])],
+                created_at: base,
+                last_access: base,
+            },
+        );
+
+        // 1s past the idle TTL, nothing touched it.
+        let now = base + DELEGATE_INHERITED_ORIGINS_TTL + std::time::Duration::from_secs(1);
+        prune_inherited_origins_at(&map, now);
+
+        assert!(
+            !map.contains_key(&child),
+            "an entry idle past the TTL must be pruned even without UnregisterDelegate"
+        );
+    }
+
+    /// Even an entry refreshed right now (last_access = now) is dropped once it
+    /// is older than the cap. This is what stops a constantly-used entry from
+    /// living forever, as the AGENTS.md cleanup rule requires.
+    #[test]
+    fn test_inherited_origins_absolute_cap_overrides_refresh() {
+        use super::super::native_api::{
+            DELEGATE_INHERITED_ORIGINS_MAX_AGE, InheritedOriginsEntry, prune_inherited_origins_at,
+        };
+        use dashmap::DashMap;
+        use freenet_stdlib::prelude::CodeHash;
+
+        let base = tokio::time::Instant::now();
+        let map = DashMap::new();
+        let child = DelegateKey::new([0x73; 32], CodeHash::new([0x73; 32]));
+        // now is 1s past the cap; last_access == now (as if just refreshed).
+        let now = base + DELEGATE_INHERITED_ORIGINS_MAX_AGE + std::time::Duration::from_secs(1);
+        map.insert(
+            child.clone(),
+            InheritedOriginsEntry {
+                origins: vec![ContractInstanceId::new([0x74; 32])],
+                created_at: base,
+                last_access: now,
+            },
+        );
+
+        prune_inherited_origins_at(&map, now);
+
+        assert!(
+            !map.contains_key(&child),
+            "an entry older than MAX_AGE must be pruned despite a fresh last_access"
+        );
+    }
+
+    /// A delivered message refreshes the entry, so one that would otherwise be
+    /// dropped for being idle is kept. This is why an active child — even one
+    /// only ever reached by other delegates — keeps its origin.
+    #[test]
+    fn test_touch_inherited_origin_rescues_idle_entry() {
+        use super::super::native_api::{
+            DELEGATE_INHERITED_ORIGINS_TTL, InheritedOriginsEntry, prune_inherited_origins_at,
+            touch_inherited_origin_at,
+        };
+        use dashmap::DashMap;
+        use freenet_stdlib::prelude::CodeHash;
+
+        let base = tokio::time::Instant::now();
+        let map = DashMap::new();
+        let child = DelegateKey::new([0x77; 32], CodeHash::new([0x77; 32]));
+        map.insert(
+            child.clone(),
+            InheritedOriginsEntry {
+                origins: vec![ContractInstanceId::new([0x78; 32])],
+                created_at: base,
+                last_access: base,
+            },
+        );
+
+        // A message is delivered at the idle horizon, then the sweep runs 1s
+        // later: idle is now 1s (< TTL) and age is TTL+1s (< cap), so it stays.
+        let delivery = base + DELEGATE_INHERITED_ORIGINS_TTL;
+        touch_inherited_origin_at(&map, &child, delivery);
+        let now = delivery + std::time::Duration::from_secs(1);
+        prune_inherited_origins_at(&map, now);
+
+        assert!(
+            map.contains_key(&child),
+            "a touched (recently-delivered) entry must survive the idle sweep"
+        );
+    }
+
+    /// A brand-new entry is not dropped by a sweep (the opposite of the eviction
+    /// tests).
+    #[test]
+    fn test_inherited_origins_fresh_entry_survives() {
+        use super::super::native_api::{
+            DELEGATE_INHERITED_ORIGINS_TTL, InheritedOriginsEntry, prune_inherited_origins_at,
+        };
+        use dashmap::DashMap;
+        use freenet_stdlib::prelude::CodeHash;
+
+        let base = tokio::time::Instant::now();
+        let map = DashMap::new();
+        let child = DelegateKey::new([0x75; 32], CodeHash::new([0x75; 32]));
+        map.insert(
+            child.clone(),
+            InheritedOriginsEntry {
+                origins: vec![ContractInstanceId::new([0x76; 32])],
+                created_at: base,
+                last_access: base,
+            },
+        );
+
+        // Well within the idle window.
+        let now = base + DELEGATE_INHERITED_ORIGINS_TTL / 2;
+        prune_inherited_origins_at(&map, now);
+
+        assert!(
+            map.contains_key(&child),
+            "a fresh entry must survive the prune sweep"
+        );
+    }
+
+    /// Exactly at the TTL the entry is dropped; one second under, it is kept.
+    /// Catches an accidental `<` -> `<=` change in the comparison.
+    #[test]
+    fn test_inherited_origins_idle_ttl_boundary() {
+        use super::super::native_api::{
+            DELEGATE_INHERITED_ORIGINS_TTL, InheritedOriginsEntry, prune_inherited_origins_at,
+        };
+        use dashmap::DashMap;
+        use freenet_stdlib::prelude::CodeHash;
+
+        let base = tokio::time::Instant::now();
+        let child = DelegateKey::new([0x79; 32], CodeHash::new([0x79; 32]));
+        let make = || InheritedOriginsEntry {
+            origins: vec![ContractInstanceId::new([0x7a; 32])],
+            created_at: base,
+            last_access: base,
+        };
+
+        // idle == TTL -> evicted (strict `<`).
+        let at = DashMap::new();
+        at.insert(child.clone(), make());
+        prune_inherited_origins_at(&at, base + DELEGATE_INHERITED_ORIGINS_TTL);
+        assert!(
+            !at.contains_key(&child),
+            "idle == TTL must evict (strict <)"
+        );
+
+        // idle just under TTL -> retained.
+        let under = DashMap::new();
+        under.insert(child.clone(), make());
+        prune_inherited_origins_at(
+            &under,
+            base + DELEGATE_INHERITED_ORIGINS_TTL - std::time::Duration::from_secs(1),
+        );
+        assert!(
+            under.contains_key(&child),
+            "idle just under TTL must retain"
+        );
+    }
+
+    /// Runs the real `prune_expired_inherited_origins` / `touch_inherited_origin`
+    /// (the functions production calls; the other tests use the `_at` variants
+    /// with a hand-picked time). Checks that touching a delegate with no entry
+    /// does not create one, and that a fresh entry is kept. Uses its own keys so
+    /// it can't disturb other tests that share the global map.
+    #[test]
+    fn test_global_inherited_origin_wrappers_smoke() {
+        use super::super::native_api::{
+            DELEGATE_INHERITED_ORIGINS, InheritedOriginsEntry, prune_expired_inherited_origins,
+            touch_inherited_origin,
+        };
+        use freenet_stdlib::prelude::CodeHash;
+
+        let child = DelegateKey::new([0x7b; 32], CodeHash::new([0x7b; 32]));
+        let absent = DelegateKey::new([0x7c; 32], CodeHash::new([0x7c; 32]));
+        DELEGATE_INHERITED_ORIGINS.insert(
+            child.clone(),
+            InheritedOriginsEntry::new(vec![ContractInstanceId::new([0x7d; 32])]),
+        );
+
+        // touch must NOT create an entry for a delegate with no inherited origin.
+        touch_inherited_origin(&absent);
+        assert!(
+            !DELEGATE_INHERITED_ORIGINS.contains_key(&absent),
+            "touch must be a no-op (never insert) for a key with no entry"
+        );
+
+        // touch refreshes an existing entry; the global sweep keeps it fresh.
+        touch_inherited_origin(&child);
+        prune_expired_inherited_origins();
+        assert!(
+            DELEGATE_INHERITED_ORIGINS.contains_key(&child),
+            "global prune must keep a freshly-touched entry"
+        );
+
+        DELEGATE_INHERITED_ORIGINS.remove(&child);
     }
 }

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -109,13 +109,110 @@ pub(crate) fn prune_expired_contexts(cache: &DelegateContextCache) {
     cache.retain(|_, entry| now.duration_since(entry.last_write) < DELEGATE_CONTEXT_TTL);
 }
 
+/// One entry in [`DELEGATE_INHERITED_ORIGINS`]: a child delegate's inherited
+/// contracts plus TTL metadata.
+///
+/// Why a TTL: the map is cleaned only on `UnregisterDelegate`, which children
+/// created via `create_delegate` rarely receive — they are spawned inside the
+/// parent's WASM and have no lifecycle owner. Without a TTL their entries pin
+/// forever, which the AGENTS.md "cleanup must be time-bounded" rule forbids.
+///
+/// How it expires: `last_access` is refreshed on every message delivered to the
+/// delegate (a sliding idle TTL), so an active child keeps its origin. The
+/// `created_at` cap drops the entry at a fixed age regardless, so an always-busy
+/// entry can't be refreshed forever.
+///
+/// Dropping an entry never loses identity: secrets live in the SecretsStore
+/// keyed by delegate key (not here) and the DEK is re-derived from the node KEK.
+/// `tokio::time::Instant` mirrors [`DelegateContextEntry`].
+#[derive(Clone)]
+pub(crate) struct InheritedOriginsEntry {
+    pub origins: Vec<ContractInstanceId>,
+    /// Creation time — anchors the absolute `MAX_AGE` cap.
+    pub created_at: tokio::time::Instant,
+    /// Last message delivered to this delegate; drives the sliding idle TTL.
+    pub last_access: tokio::time::Instant,
+}
+
+impl InheritedOriginsEntry {
+    /// Fresh entry whose creation and last-access stamps are both "now".
+    pub(crate) fn new(origins: Vec<ContractInstanceId>) -> Self {
+        let now = tokio::time::Instant::now();
+        Self {
+            origins,
+            created_at: now,
+            last_access: now,
+        }
+    }
+}
+
+/// Idle TTL: drop an entry after this long with no message delivered to the
+/// child. 7 days — a child messaged daily keeps its origin; one idle a full week
+/// is reclaimed. The interactive WebSocket path supplies the origin fresh and
+/// never reads this map, so only autonomous child messaging is affected.
+pub(crate) const DELEGATE_INHERITED_ORIGINS_TTL: std::time::Duration =
+    std::time::Duration::from_secs(7 * 24 * 60 * 60);
+
+/// Absolute cap from `created_at`: drop the entry at this age no matter how
+/// active, so the sliding refresh can't keep it alive forever (AGENTS.md). 30
+/// days.
+pub(crate) const DELEGATE_INHERITED_ORIGINS_MAX_AGE: std::time::Duration =
+    std::time::Duration::from_secs(30 * 24 * 60 * 60);
+
 /// Tracks message origins inherited by child delegates from their parent.
 /// When a delegate with an origin contract creates a child, the child inherits
 /// the same origin so it can interact with the same app context.
-/// DelegateKey (child) → Vec<ContractInstanceId> (inherited origins)
+/// DelegateKey (child) → inherited origins + TTL metadata.
 pub(crate) static DELEGATE_INHERITED_ORIGINS: LazyLock<
-    DashMap<DelegateKey, Vec<ContractInstanceId>>,
+    DashMap<DelegateKey, InheritedOriginsEntry>,
 > = LazyLock::new(DashMap::default);
+
+/// Drop entries idle past `..._TTL` or older than `..._MAX_AGE`, measured
+/// against `now`. Kept separate from `prune_expired_inherited_origins` so tests
+/// can pass their own map and their own `now` — they build old timestamps by
+/// adding to a base time, rather than subtracting days from `Instant::now()`,
+/// which can fail on a machine that has only been running a short time (e.g. CI).
+pub(crate) fn prune_inherited_origins_at(
+    map: &DashMap<DelegateKey, InheritedOriginsEntry>,
+    now: tokio::time::Instant,
+) {
+    map.retain(|_, entry| {
+        now.duration_since(entry.last_access) < DELEGATE_INHERITED_ORIGINS_TTL
+            && now.duration_since(entry.created_at) < DELEGATE_INHERITED_ORIGINS_MAX_AGE
+    });
+}
+
+/// Sweep the global map. Called amortised from `inbound_app_message` (no
+/// background task). O(n) per call, but n ≤ `MAX_CREATED_DELEGATES_PER_NODE`.
+pub(crate) fn prune_expired_inherited_origins() {
+    prune_inherited_origins_at(&DELEGATE_INHERITED_ORIGINS, tokio::time::Instant::now());
+}
+
+/// Set one delegate's `last_access` to `now`, if it has an entry. Kept separate
+/// from the global wrapper for the same testing reason as
+/// [`prune_inherited_origins_at`] (a caller-supplied `now`).
+pub(crate) fn touch_inherited_origin_at(
+    map: &DashMap<DelegateKey, InheritedOriginsEntry>,
+    delegate_key: &DelegateKey,
+    now: tokio::time::Instant,
+) {
+    if let Some(mut entry) = map.get_mut(delegate_key) {
+        entry.last_access = now;
+    }
+}
+
+/// Refresh a delegate's inherited-origin liveness. Called from
+/// `inbound_app_message` for every delivered message — including inter-delegate
+/// calls that never read the inherited origin — so any still-alive child keeps
+/// its origin. No-op if the delegate has no entry; still bounded by the MAX_AGE
+/// cap.
+pub(crate) fn touch_inherited_origin(delegate_key: &DelegateKey) {
+    touch_inherited_origin_at(
+        &DELEGATE_INHERITED_ORIGINS,
+        delegate_key,
+        tokio::time::Instant::now(),
+    );
+}
 
 /// Global counter of all delegates created via the `create_delegate` host function.
 /// Used to enforce `MAX_CREATED_DELEGATES_PER_NODE` regardless of attestation status.
@@ -502,7 +599,10 @@ impl DelegateCallEnv {
 
         // Propagate app attestation to child
         if !self.origin_contracts.is_empty() {
-            DELEGATE_INHERITED_ORIGINS.insert(child_key.clone(), self.origin_contracts.clone());
+            DELEGATE_INHERITED_ORIGINS.insert(
+                child_key.clone(),
+                InheritedOriginsEntry::new(self.origin_contracts.clone()),
+            );
         }
 
         tracing::info!(


### PR DESCRIPTION
## Problem

`DELEGATE_INHERITED_ORIGINS` (`crates/core/src/wasm_runtime/native_api.rs`) holds the contract origins a child delegate inherited from its parent; `resolve_message_origin` reads it to attest the child's WebApp origin. Its only cleanup path is `UnregisterDelegate` — but children created via the `create_delegate` host function are spawned inside the parent's WASM and have no lifecycle owner, so they are rarely unregistered and their entries pin for the node's lifetime. This leaks and violates the AGENTS.md rule "cleanup exemptions MUST be time-bounded". (The issue's other half — the per-node creation cap — already shipped; only this TTL was left.)

## Approach

Give the map a sliding idle TTL plus an absolute cap, mirroring the existing `DelegateContextEntry` machinery in the same module.

- Map value becomes `InheritedOriginsEntry { origins, created_at, last_access }`.
- Idle TTL = 7d: an entry is dropped after 7 days with no message delivered to the child.
- Absolute cap = 30d: dropped at 30 days regardless of activity, so the refresh can't keep an entry alive forever (AGENTS.md).
- `prune_expired_inherited_origins()` runs amortised in `inbound_app_message`; `touch_inherited_origin()` refreshes liveness there too, before the sweep, so any delivered message — including inter-delegate calls that never read the origin — keeps an active child's entry. `resolve_message_origin` stays a pure read.

## Out of scope

Cascade-revoking a parent's children when the parent is unregistered (so a child can't keep acting for the parent's contract after the parent is gone) is deliberately **not** part of this PR, for three reasons: it would not fix this leak (the leak happens precisely when nobody unregisters), it would need a new parent→child index that would itself need a TTL, and whether a child should outlive its parent is a behaviour/security decision — children created via `create_delegate` are independent registered delegates. Tracked as a separate follow-up.

## Testing

- Eviction logic via the `prune`/`touch` `_at` cores against a local map with a synthetic `now` (built forward to avoid `Instant::now() - 30d` underflowing on CI): idle-evict, absolute-cap-beats-refresh, touch-rescues-active-child, exact TTL boundary, fresh-survives.
- Production wiring: a source-pin test fails if `inbound_app_message` stops calling `touch` + `prune` or reorders them; a smoke test exercises the real global functions.
- Existing `resolve_message_origin` / `create_delegate` tests updated for the new value type. `cargo fmt`, `cargo clippy -- -D warnings`, and the affected tests are green.

## Fixes

Closes #3492