### PR TITLE
fix: route standalone LocalSubscribeComplete through consistent terminal cleanup (#3099)

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -2633,6 +2633,37 @@ impl P2pConnManager {
                                         );
                                     }
                                 }
+
+                                // Invariant hardening (#3099): this is the one
+                                // terminal path that publishes its result directly
+                                // via `result_router_tx` instead of routing through
+                                // `OpManager::send_client_result`, so it never emits
+                                // `NodeEvent::TransactionCompleted` and never reaches
+                                // the `TransactionCompleted` handler that prunes
+                                // `pending_op_results`.
+                                //
+                                // Today `tx` here is always the client/parent tx,
+                                // which is NEVER inserted into `pending_op_results`:
+                                // the SUBSCRIBE driver only registers per-attempt
+                                // `attempt_tx` slots (see subscribe/op_ctx_task.rs
+                                // module docs — "`client_tx` ... never passed to
+                                // `send_and_await`"), and each `attempt_tx` slot is
+                                // released via `release_pending_op_slot`. So this call
+                                // is a no-op on every currently-reachable case and is
+                                // purely defensive. We keep it — pinned by
+                                // `local_subscribe_complete_reclaims_pending_op_result`
+                                // — so that if a future refactor ever routes a
+                                // `pending_op_results`-bearing tx through this arm, the
+                                // entry is freed immediately instead of lingering until
+                                // the 60s periodic sweep. `reclaim_pending_op_result`
+                                // is idempotent and records the matching
+                                // `pending_op_remove` metric so the accounting behind
+                                // `test_pending_op_results_bounded` (#3100) stays
+                                // balanced. `live_tx_tracker`/`under_progress` are
+                                // already cleaned by the `op_manager.completed(tx)`
+                                // that `complete_local_subscription` ran, so they are
+                                // not touched again here.
+                                state.reclaim_pending_op_result(tx);
                             }
                             NodeEvent::BroadcastHostingUpdate { message } => {
                                 ctx.handle_hosting_broadcast(message).await;
@@ -5449,6 +5480,28 @@ impl EventListenerState {
             last_backoff_cleanup: Instant::now(),
         }
     }
+
+    /// Reclaim the executor callback sender for a transaction that has
+    /// reached a terminal state, recording the matching `pending_op_remove`
+    /// metric so the `inserts - removes` balance that backs
+    /// `test_pending_op_results_bounded` (#3100) stays accurate.
+    ///
+    /// Returns `true` if an entry was actually removed. Idempotent: calling
+    /// it again for the same `tx` is a no-op and records nothing. This is
+    /// the same `pending_op_results` cleanup the `TransactionCompleted`
+    /// handler performs for the common terminal path. The standalone-parent
+    /// `LocalSubscribeComplete` arm calls it directly because that arm
+    /// publishes its result via `result_router_tx` without emitting
+    /// `TransactionCompleted` (#3099) — see that arm for why the call is
+    /// defensive (the parent tx is not a `pending_op_results` key today).
+    fn reclaim_pending_op_result(&mut self, tx: Transaction) -> bool {
+        if self.pending_op_results.remove(&tx).is_some() {
+            crate::config::GlobalTestMetrics::record_pending_op_remove();
+            true
+        } else {
+            false
+        }
+    }
 }
 
 impl Drop for EventListenerState {
@@ -6546,6 +6599,97 @@ mod tests {
             ExpectedInboundTracker::empty_for_test(),
         ));
         assert_eq!(GlobalTestMetrics::pending_op_removes(), removes_before);
+    }
+
+    /// Behavioral guard for #3099's `reclaim_pending_op_result` helper, which
+    /// the `LocalSubscribeComplete` arm calls so the bypass path participates
+    /// in the same `pending_op_results` cleanup as the `TransactionCompleted`
+    /// handler. When an entry is present it MUST be dropped and record exactly
+    /// one `pending_op_remove`; a second call MUST be idempotent (so layering
+    /// it on top of the `op_manager.completed(tx)` that
+    /// `complete_local_subscription` already ran cannot double-count or panic),
+    /// and a subsequent `Drop` MUST NOT re-count the already-reclaimed entry.
+    #[test]
+    fn reclaim_pending_op_result_drops_entry_and_records_remove() {
+        use crate::config::GlobalTestMetrics;
+        use crate::message::Transaction;
+        use crate::transport::ExpectedInboundTracker;
+
+        let mut state = super::EventListenerState::new(ExpectedInboundTracker::empty_for_test());
+        let tx = Transaction::ttl_transaction();
+        let (callback, _rx) = mpsc::channel(1);
+        state.pending_op_results.insert(tx, callback);
+
+        let removes_before = GlobalTestMetrics::pending_op_removes();
+
+        // First call: removes the resident entry and records one remove.
+        assert!(
+            state.reclaim_pending_op_result(tx),
+            "reclaim must remove a resident pending_op_results entry (#3099)"
+        );
+        assert!(
+            !state.pending_op_results.contains_key(&tx),
+            "pending_op_results entry must be gone after reclaim (#3099)"
+        );
+        assert_eq!(
+            GlobalTestMetrics::pending_op_removes() - removes_before,
+            1,
+            "reclaim must record exactly one pending_op_remove so test_pending_op_results_bounded (#3100) stays balanced"
+        );
+
+        // Second call: idempotent — no entry, no spurious metric.
+        assert!(
+            !state.reclaim_pending_op_result(tx),
+            "reclaim must be idempotent: a second call on the same tx removes nothing"
+        );
+        assert_eq!(
+            GlobalTestMetrics::pending_op_removes() - removes_before,
+            1,
+            "idempotent reclaim must not record a second pending_op_remove"
+        );
+
+        // Drop must not record a spurious remove for the already-reclaimed tx.
+        drop(state);
+        assert_eq!(
+            GlobalTestMetrics::pending_op_removes() - removes_before,
+            1,
+            "Drop must not re-count an entry that reclaim already removed"
+        );
+    }
+
+    /// Pin for #3099: the standalone-parent branch of the
+    /// `LocalSubscribeComplete` arm MUST reclaim its `pending_op_results`
+    /// entry. This arm is the one terminal path that bypasses
+    /// `OpManager::send_client_result` (it pushes directly to
+    /// `result_router_tx`), so it never emits `NodeEvent::TransactionCompleted`
+    /// and never reaches the handler that prunes `pending_op_results`. The
+    /// call is defensive today (the parent tx is not a `pending_op_results`
+    /// key — see the arm comment), but pinning it guarantees that if a future
+    /// refactor ever routes a `pending_op_results`-bearing tx through this arm
+    /// the entry is freed immediately instead of lingering until the 60s sweep.
+    #[test]
+    fn local_subscribe_complete_reclaims_pending_op_result() {
+        const SOURCE: &str = include_str!("p2p_protoc.rs");
+
+        let arm_anchor = "NodeEvent::LocalSubscribeComplete {";
+        let arm_start = SOURCE
+            .find(arm_anchor)
+            .expect("LocalSubscribeComplete handler renamed or removed");
+        // The arm closes at the next `BroadcastHostingUpdate` arm — bound the
+        // slice there so the assertion can't match a later arm's body.
+        let arm_end = SOURCE[arm_start..]
+            .find("NodeEvent::BroadcastHostingUpdate")
+            .map(|p| arm_start + p)
+            .expect("LocalSubscribeComplete arm closer not found");
+        let body = &SOURCE[arm_start..arm_end];
+
+        assert!(
+            body.contains("reclaim_pending_op_result(tx)"),
+            "LocalSubscribeComplete's standalone-parent path must call \
+             state.reclaim_pending_op_result(tx) so the executor callback \
+             sender is freed immediately instead of leaking until the 60s \
+             sweep (#3099). Arm body:\n{body}"
+        );
     }
 
     /// Test that connection_id generation produces unique, monotonically increasing IDs.


### PR DESCRIPTION
## Problem

#3099 asked why some transactions reach a terminal state without emitting `TransactionCompleted`/`TransactionTimedOut`. @iduartgomez re-scoped it (the three original paths were eliminated by the #1454 op refactor) to the one remaining path: the standalone-parent branch of the `LocalSubscribeComplete` arm in `crates/core/src/node/network_bridge/p2p_protoc.rs` publishes its result directly via `op_manager.result_router_tx` instead of `OpManager::send_client_result`, so it never emits `TransactionCompleted` and never reaches the handler that prunes `pending_op_results`.

## Investigation finding (please read before merging)

**The feared `pending_op_results` leak does NOT actually occur on this path.** While implementing the fix I traced the path end-to-end and found:

- The tx carried by `LocalSubscribeComplete` for the standalone parent is the **client/parent tx**, which the SUBSCRIBE driver **never inserts into `pending_op_results`** — it only registers per-attempt `attempt_tx` slots, each released via `release_pending_op_slot`. The module docs say so explicitly: *"`client_tx` ... never passed to `send_and_await`"* (`subscribe/op_ctx_task.rs`).
- `live_tx_tracker` and `under_progress` are already cleaned by the `op_manager.completed(tx)` that `complete_local_subscription` runs (`subscribe.rs`).
- `tx_to_client` / `client_waiting_transaction` are already cleaned by the existing arm.
- The existing `test_pending_op_results_bounded` (#3100) already asserts a **zero** leak at shutdown and passes on `main`, corroborating that there's no active leak on this path.

So the prioritizer/triage premise (an active transient `pending_op_results` leak per standalone subscribe) is not supported by the current code.

## What this PR does

Given that, this is **invariant hardening, not an active leak fix**. It makes the one terminal path that bypasses `send_client_result` participate in the same `pending_op_results` cleanup every other terminal path gets, via a new idempotent `EventListenerState::reclaim_pending_op_result` helper (which also records the matching `pending_op_remove` metric so #3100's accounting stays balanced). The call is a no-op on every currently-reachable case; it exists so a future refactor that routes a `pending_op_results`-bearing tx through this arm frees the entry immediately rather than leaving it for the 60s sweep, and it adds a pin test so that wiring can't silently regress. The redundant `live_tx_tracker` removal is intentionally **not** added (already done by `op_manager.completed`).

**Maintainer decision needed:** is this forward-looking hardening worth carrying, or should #3099 simply be closed as "no active leak, the #1454 refactor already fixed the originally-reported paths"? I did not auto-merge for this reason.

## Testing

- `reclaim_pending_op_result_drops_entry_and_records_remove` — behavioral unit test: removes a resident entry, records exactly one `pending_op_remove`, is idempotent on a second call, and a subsequent `Drop` does not re-count.
- `local_subscribe_complete_reclaims_pending_op_result` — source-scrape pin test asserting the arm calls the helper (matches the existing `transaction_orphaned_handler_*` pin convention). **Verified to FAIL on the pre-fix arm and PASS with the fix.**

`cargo fmt` + `cargo clippy -p freenet --lib --features testing -- -D warnings` clean. External review: `codex review --base origin/main` found no regressions introduced by the patch.

## Fixes

Closes #3099

[AI-assisted - Claude]