### PR TITLE
test(governance): run the ban-chain e2e simulation tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,7 +545,19 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
         run: |
+          # `--lib` is included so the in-crate simulation tests gated behind
+          # `#[cfg(all(test, feature = "simulation_tests"))]` (e.g. the
+          # governance ban-chain e2e module in
+          # crates/core/src/contract/governance.rs) are built and run. They use
+          # `pub(crate)` accessors (Ring::governance, Ring::contract_ban_list,
+          # the test-only hosting_manager_* counters) that an external
+          # tests/ integration binary cannot reach, so they MUST live in the
+          # lib. Without `--lib` here this whole class of tests was compiled
+          # out of the workspace test step (no simulation_tests feature) AND
+          # excluded from this simulation step (only --test binaries), so it
+          # never ran in CI. See issue #4301.
           cargo nextest run -p freenet --locked --no-run \
+            --lib \
             --test simulation_integration \
             --test simulation_smoke \
             --test streaming_e2e \
@@ -577,11 +589,21 @@ jobs:
           NEXTEST_FAILED=0
           (
             echo "== $(date -u +%H:%M:%S) nextest starting"
+            # `--lib` makes the in-crate simulation_tests-gated tests (see the
+            # build step above and issue #4301) available to run alongside the
+            # integration binaries. The filterset then restricts execution to
+            # ALL integration tests (`kind(test)`) PLUS only the simulation
+            # e2e lib tests (`kind(lib) & test(sim_e2e_tests)`) — so the ~3000
+            # ordinary freenet lib unit tests (already covered by the
+            # workspace test job) are NOT re-run here. They were all built with
+            # --no-run above.
             cargo nextest run -p freenet --locked \
+              --lib \
               --test simulation_integration \
               --test simulation_smoke \
               --test streaming_e2e \
               --test state_verification \
+              -E 'kind(test) | (kind(lib) & test(sim_e2e_tests))' \
               --features simulation_tests,testing --profile ci 2>&1
             rc=$?
             echo "== $(date -u +%H:%M:%S) nextest done rc=${rc}"


### PR DESCRIPTION
## Problem

Issue #4301 asks for an end-to-end simulation-network test of the governance ban chain (rate-limit reject → MAD flag → `Normal → … → Evicted → Banned` → wire-traffic drop), as the **required behavioral gate before flipping governance into Enforce mode** on gateways.

The tests themselves **already exist**: the `sim_e2e_tests` module in `crates/core/src/contract/governance.rs` (added in PR #4309) contains `governance_ban_chain_end_to_end` and `popular_contract_with_subscribers_not_evicted`. They drive the full production wiring inside a `run_controlled_simulation` network (1 gateway + 5 nodes):

- `governance_ban_chain_end_to_end` — floods an abuser contract with heavy UPDATEs (cost flows through the real `Executor → Ring::commit_state_write → report_contract_resource_usage → GovernanceManager::ingest_cost` path, driven by the per-node `governance_reaper_loop` on virtual time), asserts the abuser lands on the per-node `ContractBanList` (the wire-boundary enforcement signal that `node.rs` consults to drop banned traffic) and reaches the terminal `Banned` state, and asserts every honest contract is NOT banned (no collateral damage).
- `popular_contract_with_subscribers_not_evicted` — the #4296 false-positive control: a same-cost contract with many live downstream subscribers is NOT banned on its host, while the zero-beneficiary abuser IS.

**The gap this PR closes:** those tests never actually ran in CI, so the gate was not enforced and the tests could silently rot. The module is gated behind `#[cfg(all(test, feature = "simulation_tests"))]` and lives in the lib — it must, because it uses `pub(crate)` accessors (`Ring::governance`, `Ring::contract_ban_list`, the test-only `hosting_manager_*` counters) that an external `tests/` integration binary cannot reach. But:

- the workspace test job runs the lib tests **without** `simulation_tests`, so the module is compiled out there; and
- the Simulation job enables `simulation_tests` but only runs specific `--test <integration_binary>` targets, which **excludes lib tests**.

So the module fell through the crack between the two jobs and was dead in CI.

## Solution

Add `--lib` to the Simulation job's build (`--no-run`) and run steps so the lib test binary is compiled and executed alongside the integration binaries. To avoid re-running the ~3000 ordinary freenet lib unit tests (already covered by the workspace test job), the run step restricts execution with a nextest filterset:

```
kind(test) | (kind(lib) & test(sim_e2e_tests))
```

i.e. all integration tests **plus only** the governance sim e2e lib tests.

**No production code changes** — this is a CI/test wiring fix only.

## Testing

Ran the two tests locally under the CI feature set; both pass deterministically:

```
cargo nextest run -p freenet --no-default-features \
  --features "trace,websocket,redb,wasmtime-backend,testing,simulation_tests" \
  --lib -E 'test(sim_e2e_tests)'
# 2 tests run: 2 passed
#   governance_ban_chain_end_to_end            115.5s
#   popular_contract_with_subscribers_not_evicted  88.3s
```

Verified via `cargo nextest list` that the filterset selects exactly the integration tests plus the two sim e2e lib tests (not the other lib unit tests).

Closes #4301

[AI-assisted - Claude]