### PR TITLE
test: re-seed test_get_retry_with_alternatives_sparse_topology for current stdlib

### DIFF
--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -8031,17 +8031,29 @@ fn test_relay_route_events_multihop() {
 ///
 /// Exercises: `get.rs` alternative retry (line ~1521) and k_closest re-query (line ~1569)
 ///
-/// Ignored: freenet-stdlib 0.2.2 adds the StreamChunk variant to ClientRequest,
-/// changing bincode serialization sizes and altering RNG-dependent topology formation.
-/// The test's fixed seed produces a different topology under 0.2.2 where node-10 cannot
-/// reach caching nodes. The GET retry logic itself is unchanged and covered by
-/// test_get_routing_coverage_low_htl. See PR #3488.
-#[ignore]
+/// Seed history: this test was `#[ignore]`d in PR #3488 because the original
+/// seed (`0xBEEF_CAFE_0001`) stopped producing a sparse-but-reachable topology
+/// after a freenet-stdlib bump shifted RNG-dependent topology formation (the
+/// stdlib's enum layout changes bincode serialization sizes, which perturbs the
+/// seeded RNG stream). #3506 re-seeded it for the current stdlib: with
+/// `SEED = 0x3506_000B_0001` the gateway PUT at HTL=2 caches the contract at
+/// exactly 2 of the 10 nodes (verified with a PUT-only run of this same
+/// topology), so 8 of the 10 GET requesters must use the retry-with-alternatives
+/// path to reach a cacher, and all 10 do, deterministically across repeated
+/// runs. Like every seed-coupled topology test, a future stdlib/topology change
+/// could perturb the RNG stream again and require another re-seed; that is
+/// expected maintenance rather than a regression in the GET retry logic itself
+/// (which is also covered by `test_get_routing_coverage_low_htl`).
 #[test_log::test]
 fn test_get_retry_with_alternatives_sparse_topology() {
     use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
 
-    const SEED: u64 = 0xBEEF_CAFE_0001;
+    // Seed reselected for the current freenet-stdlib layout (see #3506). Under
+    // this seed the gateway PUT at HTL=2 caches the contract at exactly 2 of the
+    // 10 nodes, and all 10 GET requesters reach one of those 2 cachers via the
+    // GET retry-with-alternatives path. Verified sparse + reachable + deterministic
+    // before un-ignoring; see the doc comment above for the full rationale.
+    const SEED: u64 = 0x3506_000B_0001;
     const NETWORK_NAME: &str = "get-retry-sparse";
 
     GlobalTestMetrics::reset();


### PR DESCRIPTION
## Problem

`test_get_retry_with_alternatives_sparse_topology` (in
`crates/core/tests/simulation_integration.rs`) has been `#[ignore]`d since
PR #3488. Its hardcoded seed (`0xBEEF_CAFE_0001`) no longer produces the
intended **sparse-but-reachable** topology under the current `freenet-stdlib`:
the stdlib's enum layout changes bincode serialization sizes, which perturbs
the seeded RNG stream and shifts topology formation. Under the current stdlib
that seed leaves one GET requester (node-6 today; the issue originally observed
node-10/node-3) unable to reach any contract-caching node within HTL=2, so the
test's all-nodes-reachable assertion fails. While ignored, the test provides
zero coverage of the GET retry-with-alternatives path in a sparse topology.

## Solution

Re-seed the test for the current stdlib layout and remove `#[ignore]`. The new
seed `0x3506_000B_0001` was found by an empirical search over the test's own
topology parameters (10 nodes, HTL=2, max_connections=6) and verified to
satisfy both constraints the test depends on:

- **Sparse** — a PUT-only run of this exact topology caches the contract at
  *exactly 2 of the 10 nodes* (nodes 4 and 5), matching the issue's "2-3
  caching nodes" premise. So 8 of the 10 GET requesters genuinely have to use
  the retry-with-alternatives / k_closest re-query path.
- **Reachable + deterministic** — all 10 GET requesters reach a caching node;
  confirmed 10/10 across repeated runs. Live logs show the expected
  `get: attempt timed out; advancing` retry events firing for the distant
  requesters.

The GET retry logic itself is unchanged. This is purely a seed/topology repair
in a single test function; no production code is touched.

Note: like every seed-coupled topology test, a future stdlib/topology change
could perturb the RNG stream again and require another re-seed. That is the
expected maintenance for these tests, not a regression in the retry logic
(which is also covered by `test_get_routing_coverage_low_htl`).

## Testing

```
cargo nextest run -p freenet --features "simulation_tests,testing" \
  --test simulation_integration \
  -E 'test(test_get_retry_with_alternatives_sparse_topology)'
```

now passes (the test is no longer ignored). Sparseness was verified
out-of-band with a temporary PUT-only variant of the same network (PUT caches
at 2/10 nodes), and the full test was run multiple times with the chosen seed
to confirm 10/10 reachability every time. The temporary instrumentation used
for the seed search is not part of this diff.

Closes #3506

[AI-assisted - Claude]