### PR TITLE
feat(telemetry): shadow event sub-budget so shadow streams can't starve operational telemetry

### DIFF
--- a/.claude/rules/transport.md
+++ b/.claude/rules/transport.md
@@ -138,9 +138,12 @@ populated by `RollingRttStatsHandle` in every `RemoteConnection`. A
 mirror; visible via `RUST_LOG=…=debug` in debug builds, compiled
 out entirely in release builds via the `release_max_level_info`
 feature in `crates/core/Cargo.toml`) and via
-`send_standalone_event_with_peer_id` so it reaches the OTLP
+`send_standalone_shadow_event_with_peer_id` so it reaches the OTLP
 collector regardless of log level, tagged with the local node id
-so the collector can disaggregate samples per reporting node.
+so the collector can disaggregate samples per reporting node. All
+five shadow emitters use the `_shadow_` variant so the telemetry
+rate limiter admits them under a low-priority sub-budget and they
+cannot starve operational telemetry (#4380).
 
 `transport/reference_ping.rs` runs an analogous 1Hz loop
 (`reference_ping` background task) that probes a fixed external

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -7,7 +7,9 @@
 //! Features:
 //! - Exponential backoff on connection failures (1s → 2s → 4s → ... → 5min max)
 //! - Event batching (send every 10 seconds or when buffer reaches 100 events)
-//! - Rate limiting (max 10 events/second aggregate)
+//! - Rate limiting (max 10 events/second aggregate), with a separate shadow
+//!   sub-budget (max 4/second) so always-on low-priority shadow telemetry
+//!   cannot starve operational telemetry (#4380)
 //! - Priority-based dropping when buffer is full
 //!
 //! ## Design Notes
@@ -48,6 +50,35 @@ use super::{EventKind, NetEventLog, NetEventRegister, NetLogMessage};
 /// silently drops events.
 static TELEMETRY_SENDER: OnceLock<mpsc::Sender<TelemetryCommand>> = OnceLock::new();
 
+/// Admission priority for a telemetry event.
+///
+/// The per-second rate limiter ([`TelemetryWorker::handle_event`]) enforces a
+/// flat aggregate cap shared by every event. Without a priority distinction,
+/// always-on background "shadow" telemetry (the #4074 floor-analysis emitters)
+/// competes for the same slots as operational net-events (GET/PUT/SUBSCRIBE
+/// results, routing decisions, connection state). On a busy node the shadow
+/// stream (3–5 events/sec) deterministically consumed 30–50% of the budget,
+/// crowding out exactly the operational telemetry an operator needs when the
+/// network is busiest (#4380).
+///
+/// `Shadow` events are admitted under a *separate, smaller* sub-budget
+/// ([`MAX_SHADOW_EVENTS_PER_SECOND`]) carved out of the aggregate cap, so they
+/// can never starve `Operational` telemetry. The sub-budget is best-effort:
+/// excess shadow events are dropped silently, same as any other rate-limited
+/// event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EventPriority {
+    /// Operational net-events and node telemetry. Admitted up to the full
+    /// aggregate cap. This is the default for everything except the
+    /// always-on shadow emitters.
+    #[default]
+    Operational,
+    /// Always-on background "shadow" telemetry (#4074 Phase 1.x floor
+    /// analysis). Admitted only under the shadow sub-budget so it yields to
+    /// `Operational` events under load.
+    Shadow,
+}
+
 /// Send a standalone telemetry event from any context.
 ///
 /// This is a non-blocking, best-effort send. Events are dropped silently if:
@@ -57,25 +88,52 @@ static TELEMETRY_SENDER: OnceLock<mpsc::Sender<TelemetryCommand>> = OnceLock::ne
 /// The `peer_id` OTLP attribute is left empty. For events that originate
 /// from a specific node and should be filterable by that node in the
 /// collector, use [`send_standalone_event_with_peer_id`] instead.
+///
+/// Emitted at [`EventPriority::Operational`]. For always-on background
+/// "shadow" telemetry, use [`send_standalone_shadow_event_with_peer_id`].
 pub fn send_standalone_event(event_type: &str, event_data: serde_json::Value) {
-    send_standalone_event_inner(event_type, "", event_data);
+    send_standalone_event_inner(event_type, "", event_data, EventPriority::Operational);
 }
 
 /// Send a standalone telemetry event tagged with the local node's peer id.
 ///
-/// Used by node-level periodic emitters (e.g. shadow RTT aggregator) whose
-/// output is only meaningful when the collector can disaggregate samples
-/// by source node. The `peer_id` is set as the OTLP record attribute so
-/// the collector can group/filter without parsing the event body.
+/// Used by node-level periodic emitters whose output is only meaningful when
+/// the collector can disaggregate samples by source node. The `peer_id` is
+/// set as the OTLP record attribute so the collector can group/filter without
+/// parsing the event body.
+///
+/// Emitted at [`EventPriority::Operational`]. For always-on background
+/// "shadow" telemetry, use [`send_standalone_shadow_event_with_peer_id`].
 pub fn send_standalone_event_with_peer_id(
     event_type: &str,
     peer_id: &str,
     event_data: serde_json::Value,
 ) {
-    send_standalone_event_inner(event_type, peer_id, event_data);
+    send_standalone_event_inner(event_type, peer_id, event_data, EventPriority::Operational);
 }
 
-fn send_standalone_event_inner(event_type: &str, peer_id: &str, event_data: serde_json::Value) {
+/// Send a low-priority "shadow" telemetry event tagged with the local node's
+/// peer id.
+///
+/// Used by the always-on #4074 floor-analysis emitters (`shadow_rtt_aggregate`,
+/// `shadow_reference_ping`, `shadow_rate_demand`, `shadow_outbound_class`,
+/// `shadow_iface_tx`). Emitted at [`EventPriority::Shadow`] so the rate limiter
+/// admits them only under the shadow sub-budget and they cannot starve
+/// operational telemetry (#4380).
+pub fn send_standalone_shadow_event_with_peer_id(
+    event_type: &str,
+    peer_id: &str,
+    event_data: serde_json::Value,
+) {
+    send_standalone_event_inner(event_type, peer_id, event_data, EventPriority::Shadow);
+}
+
+fn send_standalone_event_inner(
+    event_type: &str,
+    peer_id: &str,
+    event_data: serde_json::Value,
+    priority: EventPriority,
+) {
     if let Some(sender) = TELEMETRY_SENDER.get() {
         let event = TelemetryEvent {
             timestamp: current_timestamp_ms(),
@@ -83,6 +141,7 @@ fn send_standalone_event_inner(event_type: &str, peer_id: &str, event_data: serd
             transaction_id: String::new(),
             event_type: event_type.to_string(),
             event_data,
+            priority,
         };
         // Fire-and-forget: channel full means telemetry event is dropped
         #[allow(clippy::let_underscore_must_use)]
@@ -96,8 +155,23 @@ const MAX_BUFFER_SIZE: usize = 100;
 /// How often to send batched events (in seconds)
 const BATCH_INTERVAL_SECS: u64 = 10;
 
-/// Maximum events per second (rate limiting)
+/// Maximum events per second (aggregate rate limiting across all priorities)
 const MAX_EVENTS_PER_SECOND: usize = 10;
+
+/// Maximum *shadow* (low-priority) events per second.
+///
+/// Shadow telemetry is admitted under this sub-budget, carved out of the
+/// aggregate [`MAX_EVENTS_PER_SECOND`] cap, so that always-on background
+/// emitters cannot starve operational telemetry (#4380). With the current
+/// always-on baseline of 3 shadow events/sec (`shadow_rtt_aggregate` +
+/// `shadow_rate_demand` + `shadow_outbound_class`), rising to 5/sec on a
+/// gateway that also enables reference-ping and iface-tx, a cap of 4 admits
+/// the always-on set while still reserving at least
+/// `MAX_EVENTS_PER_SECOND - MAX_SHADOW_EVENTS_PER_SECOND` (= 6) slots/sec for
+/// operational events even when shadow demand spikes (e.g. Phase 2 adds the
+/// shadow controller decision log). Shadow events still also count against the
+/// aggregate cap.
+const MAX_SHADOW_EVENTS_PER_SECOND: usize = 4;
 
 /// Initial backoff duration on failure
 const INITIAL_BACKOFF_MS: u64 = 1000;
@@ -151,6 +225,12 @@ struct TelemetryEvent {
     transaction_id: String,
     event_type: String,
     event_data: serde_json::Value,
+    /// Admission priority. Not serialized to OTLP — it only steers the
+    /// in-process rate limiter (#4380). `#[serde(skip)]` keeps the wire
+    /// payload byte-identical to pre-#4380 so the collector schema is
+    /// unchanged.
+    #[serde(skip)]
+    priority: EventPriority,
 }
 
 impl TelemetryReporter {
@@ -231,6 +311,7 @@ impl NetEventRegister for TelemetryReporter {
                     transaction_id: log_msg.tx.to_string(),
                     event_type: event_kind_to_string(&log_msg.kind),
                     event_data: event_kind_to_json(&log_msg.kind),
+                    priority: EventPriority::Operational,
                 };
                 self.send_event(event).await;
             }
@@ -262,6 +343,7 @@ impl NetEventRegister for TelemetryReporter {
                     "op_type": op_type,
                     "target_peer": target_peer,
                 }),
+                priority: EventPriority::Operational,
             };
             // Fire-and-forget: channel full means telemetry event is dropped
             #[allow(clippy::let_underscore_must_use)]
@@ -285,6 +367,11 @@ struct TelemetryWorker {
     backoff_ms: u64,
     last_send: Instant,
     events_this_second: usize,
+    /// Shadow (low-priority) events admitted in the current 1s window.
+    /// Bounded by [`MAX_SHADOW_EVENTS_PER_SECOND`] so shadow telemetry cannot
+    /// starve operational telemetry (#4380). Reset alongside
+    /// `events_this_second` when the window rolls over.
+    shadow_events_this_second: usize,
     rate_limit_window_start: Instant,
     /// Interval for transport snapshots (0 = disabled)
     transport_snapshot_interval_secs: u64,
@@ -313,6 +400,7 @@ impl TelemetryWorker {
             backoff_ms: 0,
             last_send: Instant::now(),
             events_this_second: 0,
+            shadow_events_this_second: 0,
             rate_limit_window_start: Instant::now(),
             transport_snapshot_interval_secs,
             transfer_event_receiver,
@@ -333,6 +421,7 @@ impl TelemetryWorker {
             transaction_id: String::new(), // Not tied to a transaction
             event_type: "transport_snapshot".to_string(),
             event_data: serde_json::to_value(snapshot).unwrap_or_default(),
+            priority: EventPriority::Operational,
         }
     }
 
@@ -353,6 +442,7 @@ impl TelemetryWorker {
             transaction_id: String::new(), // Not available at transport layer
             event_type: event_type.to_string(),
             event_data: event_kind_to_json(&super::EventKind::Transfer(transfer_event)),
+            priority: EventPriority::Operational,
         }
     }
 
@@ -414,19 +504,56 @@ impl TelemetryWorker {
         }
     }
 
-    async fn handle_event(&mut self, event: TelemetryEvent) {
-        // Rate limiting
-        let now = Instant::now();
+    /// Decide whether an event of the given priority is admitted under the
+    /// per-second rate limit, updating the window counters as a side effect.
+    ///
+    /// Pulled out of [`Self::handle_event`] so the admission policy (the
+    /// #4380 shadow sub-budget) is unit-testable without driving the async
+    /// buffer/backoff/HTTP machinery. Returns `true` if the event is admitted.
+    ///
+    /// Policy:
+    /// - The window rolls over once `now` is >= 1s past its start, resetting
+    ///   both counters.
+    /// - `Operational` events are admitted while the aggregate count is below
+    ///   [`MAX_EVENTS_PER_SECOND`] — unchanged from the pre-#4380 behavior.
+    /// - `Shadow` events are admitted only while BOTH the shadow sub-budget
+    ///   ([`MAX_SHADOW_EVENTS_PER_SECOND`]) AND the aggregate cap have room.
+    ///   Because the sub-budget (4) is strictly below the aggregate cap (10),
+    ///   shadow events can occupy at most `MAX_SHADOW_EVENTS_PER_SECOND` of
+    ///   the slots, always leaving
+    ///   `MAX_EVENTS_PER_SECOND - MAX_SHADOW_EVENTS_PER_SECOND` for
+    ///   operational telemetry.
+    fn admit_event(&mut self, priority: EventPriority, now: Instant) -> bool {
         if now.duration_since(self.rate_limit_window_start) >= Duration::from_secs(1) {
             self.rate_limit_window_start = now;
             self.events_this_second = 0;
+            self.shadow_events_this_second = 0;
         }
 
+        // Aggregate cap applies to every event regardless of priority.
         if self.events_this_second >= MAX_EVENTS_PER_SECOND {
+            return false;
+        }
+
+        // Shadow events additionally yield to the sub-budget so they cannot
+        // crowd out operational telemetry (#4380).
+        if priority == EventPriority::Shadow {
+            if self.shadow_events_this_second >= MAX_SHADOW_EVENTS_PER_SECOND {
+                return false;
+            }
+            self.shadow_events_this_second += 1;
+        }
+
+        self.events_this_second += 1;
+        true
+    }
+
+    async fn handle_event(&mut self, event: TelemetryEvent) {
+        // Rate limiting (#4380: shadow events admitted under a sub-budget)
+        if !self.admit_event(event.priority, Instant::now()) {
             // Drop event due to rate limiting
             return;
         }
-        self.events_this_second += 1;
 
         // Drop events if buffer is full and we're in backoff (prevents unbounded memory growth)
         if self.buffer.len() >= MAX_BUFFER_SIZE && self.backoff_ms > 0 {
@@ -1881,6 +2008,7 @@ mod tests {
             transaction_id: String::new(),
             event_type: "shadow_rtt_aggregate".to_string(),
             event_data: serde_json::json!({"active_peers": 3}),
+            priority: EventPriority::Shadow,
         };
         let otlp = to_otlp_logs(std::slice::from_ref(&event));
         let attrs = &otlp["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]["attributes"];
@@ -1959,6 +2087,7 @@ mod tests {
             transaction_id: String::new(),
             event_type: "transfer_failed".to_string(),
             event_data: serde_json::json!({}),
+            priority: EventPriority::Operational,
         };
         let otlp = to_otlp_logs(std::slice::from_ref(&event));
         let resource_attrs = &otlp["resourceLogs"][0]["resource"]["attributes"];
@@ -2018,6 +2147,7 @@ mod tests {
             transaction_id: String::new(),
             event_type: "other_event".to_string(),
             event_data: serde_json::json!({}),
+            priority: EventPriority::Operational,
         };
         let otlp = to_otlp_logs(std::slice::from_ref(&event));
         let attrs = &otlp["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]["attributes"];
@@ -2088,5 +2218,202 @@ mod tests {
         assert_eq!(json["reason"], "htl_exhausted");
         assert_eq!(json["elapsed_ms"], 1234);
         assert_eq!(json["timestamp"], 99999);
+    }
+
+    // ----- #4380: shadow sub-budget rate limiting -----
+
+    /// Build a worker purely to exercise the admission policy. The endpoint
+    /// and channels are inert; only the rate-limit counters are touched.
+    fn rate_limit_test_worker() -> TelemetryWorker {
+        let (_cmd_tx, cmd_rx) = mpsc::channel(1);
+        let (_transfer_tx, transfer_rx) = mpsc::channel(1);
+        TelemetryWorker::new(
+            "http://localhost:4318".to_string(),
+            cmd_rx,
+            0,
+            transfer_rx,
+            "rate-limit-test-peer".to_string(),
+        )
+    }
+
+    /// Admit `count` events of `priority` at instant `now`, returning how many
+    /// were admitted.
+    fn admit_n(
+        worker: &mut TelemetryWorker,
+        priority: EventPriority,
+        count: usize,
+        now: Instant,
+    ) -> usize {
+        (0..count)
+            .filter(|_| worker.admit_event(priority, now))
+            .count()
+    }
+
+    #[test]
+    fn test_shadow_subbudget_caps_shadow_events() {
+        // Sanity-check the constants the policy depends on: the sub-budget
+        // must be strictly below the aggregate cap, otherwise shadow events
+        // could consume the whole budget and the carve-out is meaningless.
+        assert!(
+            MAX_SHADOW_EVENTS_PER_SECOND < MAX_EVENTS_PER_SECOND,
+            "shadow sub-budget must leave room for operational events"
+        );
+
+        let mut worker = rate_limit_test_worker();
+        let now = Instant::now();
+
+        // A flood of shadow-only events is capped at the sub-budget, never the
+        // full aggregate cap.
+        let admitted = admit_n(&mut worker, EventPriority::Shadow, 100, now);
+        assert_eq!(
+            admitted, MAX_SHADOW_EVENTS_PER_SECOND,
+            "shadow events must be capped at the sub-budget within a window"
+        );
+    }
+
+    #[test]
+    fn test_shadow_flood_cannot_starve_operational() {
+        // Regression for #4380: before the sub-budget, a burst of shadow
+        // events arriving first in a window could consume the entire flat cap,
+        // dropping operational telemetry. Now shadow is capped at the
+        // sub-budget, leaving (cap - sub-budget) slots for operational events.
+        let mut worker = rate_limit_test_worker();
+        let now = Instant::now();
+
+        // Shadow events arrive first and try to grab everything.
+        let shadow_admitted = admit_n(&mut worker, EventPriority::Shadow, 50, now);
+        assert_eq!(shadow_admitted, MAX_SHADOW_EVENTS_PER_SECOND);
+
+        // Operational events arriving afterwards still get the slots the
+        // shadow sub-budget reserved for them.
+        let expected_operational = MAX_EVENTS_PER_SECOND - MAX_SHADOW_EVENTS_PER_SECOND;
+        let op_admitted = admit_n(&mut worker, EventPriority::Operational, 50, now);
+        assert_eq!(
+            op_admitted, expected_operational,
+            "operational events must keep (aggregate cap - shadow sub-budget) \
+             slots even when shadow floods first (#4380)"
+        );
+    }
+
+    #[test]
+    fn test_operational_can_use_full_aggregate_cap() {
+        // Operational telemetry is unchanged from pre-#4380: it may use the
+        // entire aggregate cap when there are no shadow events.
+        let mut worker = rate_limit_test_worker();
+        let now = Instant::now();
+
+        let admitted = admit_n(&mut worker, EventPriority::Operational, 100, now);
+        assert_eq!(
+            admitted, MAX_EVENTS_PER_SECOND,
+            "operational events alone must be able to fill the aggregate cap"
+        );
+    }
+
+    #[test]
+    fn test_shadow_still_bounded_by_aggregate_cap() {
+        // The aggregate cap is the hard ceiling: if operational events have
+        // already filled it, no shadow event is admitted even though the
+        // shadow sub-budget still nominally has room.
+        let mut worker = rate_limit_test_worker();
+        let now = Instant::now();
+
+        let op_admitted = admit_n(
+            &mut worker,
+            EventPriority::Operational,
+            MAX_EVENTS_PER_SECOND,
+            now,
+        );
+        assert_eq!(op_admitted, MAX_EVENTS_PER_SECOND);
+
+        // Sub-budget untouched, but the aggregate cap is exhausted.
+        let shadow_admitted = admit_n(&mut worker, EventPriority::Shadow, 10, now);
+        assert_eq!(
+            shadow_admitted, 0,
+            "shadow events must still respect the aggregate cap, not just the \
+             sub-budget"
+        );
+    }
+
+    #[test]
+    fn test_rate_limit_window_resets_both_counters() {
+        // After the 1s window rolls over, both the aggregate and shadow
+        // counters reset, so a new window admits a fresh budget of each.
+        let mut worker = rate_limit_test_worker();
+        let t0 = Instant::now();
+
+        // Fill the aggregate cap (some shadow, some operational) in window 0.
+        assert_eq!(
+            admit_n(&mut worker, EventPriority::Shadow, 10, t0),
+            MAX_SHADOW_EVENTS_PER_SECOND
+        );
+        assert_eq!(
+            admit_n(&mut worker, EventPriority::Operational, 10, t0),
+            MAX_EVENTS_PER_SECOND - MAX_SHADOW_EVENTS_PER_SECOND
+        );
+        // Window 0 is now full.
+        assert!(!worker.admit_event(EventPriority::Operational, t0));
+
+        // Roll the window over (exactly 1s is the boundary: >= 1s resets).
+        let t1 = t0 + Duration::from_secs(1);
+        assert_eq!(
+            admit_n(&mut worker, EventPriority::Shadow, 10, t1),
+            MAX_SHADOW_EVENTS_PER_SECOND,
+            "shadow sub-budget must refresh on window rollover"
+        );
+        assert_eq!(
+            admit_n(&mut worker, EventPriority::Operational, 10, t1),
+            MAX_EVENTS_PER_SECOND - MAX_SHADOW_EVENTS_PER_SECOND,
+            "aggregate cap must refresh on window rollover"
+        );
+    }
+
+    #[test]
+    fn test_window_does_not_reset_before_one_second() {
+        // Just under 1s must NOT roll the window over: counters persist.
+        let mut worker = rate_limit_test_worker();
+        let t0 = Instant::now();
+
+        assert_eq!(
+            admit_n(
+                &mut worker,
+                EventPriority::Operational,
+                MAX_EVENTS_PER_SECOND,
+                t0
+            ),
+            MAX_EVENTS_PER_SECOND
+        );
+
+        let almost = t0 + Duration::from_millis(999);
+        assert!(
+            !worker.admit_event(EventPriority::Operational, almost),
+            "window must not reset before a full second elapses"
+        );
+    }
+
+    #[test]
+    fn test_priority_default_is_operational() {
+        // The default priority must be Operational so any event constructed
+        // without explicitly opting into Shadow keeps the full budget.
+        assert_eq!(EventPriority::default(), EventPriority::Operational);
+    }
+
+    #[test]
+    fn test_priority_not_serialized_to_otlp() {
+        // The priority field steers the in-process rate limiter only; it must
+        // not change the OTLP wire payload (the collector schema is unchanged
+        // from pre-#4380). Verify it is absent from the serialized event.
+        let event = TelemetryEvent {
+            timestamp: 1,
+            peer_id: "p".to_string(),
+            transaction_id: String::new(),
+            event_type: "shadow_rtt_aggregate".to_string(),
+            event_data: serde_json::json!({"k": "v"}),
+            priority: EventPriority::Shadow,
+        };
+        let serialized = serde_json::to_value(&event).expect("serialize");
+        assert!(
+            serialized.get("priority").is_none(),
+            "priority must be #[serde(skip)] so the OTLP payload is unchanged"
+        );
     }
 }

--- a/crates/core/src/transport/reference_ping.rs
+++ b/crates/core/src/transport/reference_ping.rs
@@ -213,7 +213,7 @@ fn emit_snapshot(local_peer_id: &str, target: SocketAddr, stats: &RollingRttStat
         recent_samples,
         "shadow_reference_ping"
     );
-    crate::tracing::telemetry::send_standalone_event_with_peer_id(
+    crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
         "shadow_reference_ping",
         local_peer_id,
         serde_json::json!({

--- a/crates/core/src/transport/rolling_rtt_stats.rs
+++ b/crates/core/src/transport/rolling_rtt_stats.rs
@@ -331,19 +331,21 @@ pub(crate) fn spawn_aggregator(
 /// mirror at INFO was the third-largest contributor to the
 /// #4251 / #4272 log-volume regression at ~3,600 lines/hour per
 /// node. Production telemetry reaches the OTLP collector via the
-/// `send_standalone_event_with_peer_id` call below, which is
+/// `send_standalone_shadow_event_with_peer_id` call below, which is
 /// independent of the tracing level, so the dashboard's 1 Hz feed
 /// survives.
 ///
-/// `send_standalone_event_with_peer_id` pushes a structured event
-/// through the global telemetry sender
-/// (`crate::tracing::telemetry::send_standalone_event_with_peer_id`)
+/// `send_standalone_shadow_event_with_peer_id` pushes a structured
+/// event through the global telemetry sender
+/// (`crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id`)
 /// so it reaches the central OTLP collector (per the `NetEventLog`
 /// path that `TelemetryReporter` consumes). Without that, the
 /// aggregate would land only in per-node file logs and the 2-4 week
 /// observation the RFC calls for would require manual log scraping.
 /// The `local_peer_id` argument is attached as an OTLP attribute so
-/// the collector can disaggregate per reporting node.
+/// the collector can disaggregate per reporting node. The shadow
+/// variant tags the event as low-priority so it yields to operational
+/// telemetry under the rate-limiter sub-budget (#4380).
 fn emit_aggregate_snapshot(local_peer_id: &str) {
     let snap = registry_snapshot();
     let active_peers = snap.len();
@@ -382,7 +384,7 @@ fn emit_aggregate_snapshot(local_peer_id: &str) {
     // call surfaces the same numbers in the freenet telemetry
     // dashboard so the 2-4 week observation horizon is queryable
     // without manual log scraping.
-    crate::tracing::telemetry::send_standalone_event_with_peer_id(
+    crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
         "shadow_rtt_aggregate",
         local_peer_id,
         serde_json::json!({

--- a/crates/core/src/transport/shadow_demand.rs
+++ b/crates/core/src/transport/shadow_demand.rs
@@ -298,8 +298,9 @@ pub(crate) fn spawn_demand_aggregator(local_peer_id: String, monitor: &Backgroun
 /// Emit one `shadow_rate_demand` event. See the module-level rustdoc for
 /// why the OTLP send is independent of the `tracing::debug!` level: the
 /// local mirror is at DEBUG (compiled out of release builds via
-/// `release_max_level_info`), while `send_standalone_event_with_peer_id`
-/// reaches the collector regardless of log level.
+/// `release_max_level_info`), while `send_standalone_shadow_event_with_peer_id`
+/// reaches the collector regardless of log level (tagged low-priority so it
+/// yields to operational telemetry under the rate-limiter sub-budget, #4380).
 fn emit_demand_snapshot(local_peer_id: &str, sent_bytes_last_interval: u64) {
     let active_connections = active_connections();
     let broadcast_queue_depth = BROADCAST_QUEUE_DEPTH.load(Ordering::Relaxed);
@@ -318,7 +319,7 @@ fn emit_demand_snapshot(local_peer_id: &str, sent_bytes_last_interval: u64) {
         global_per_connection_rate_bytes,
         "shadow_rate_demand"
     );
-    crate::tracing::telemetry::send_standalone_event_with_peer_id(
+    crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
         "shadow_rate_demand",
         local_peer_id,
         serde_json::json!({
@@ -377,7 +378,7 @@ fn emit_class_snapshot(
         bulk_bytes,
         "shadow_outbound_class"
     );
-    crate::tracing::telemetry::send_standalone_event_with_peer_id(
+    crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
         "shadow_outbound_class",
         local_peer_id,
         serde_json::json!({

--- a/crates/core/src/transport/shadow_iface_tx.rs
+++ b/crates/core/src/transport/shadow_iface_tx.rs
@@ -172,7 +172,7 @@ fn emit_iface_snapshot(
         op_tx_bytes,
         "shadow_iface_tx"
     );
-    crate::tracing::telemetry::send_standalone_event_with_peer_id(
+    crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
         "shadow_iface_tx",
         local_peer_id,
         serde_json::json!({


### PR DESCRIPTION
## Problem

The OTLP telemetry pipe is rate-limited at a flat `MAX_EVENTS_PER_SECOND = 10`
with **no priority ordering** (`crates/core/src/tracing/telemetry.rs`,
`handle_event`): once 10 events are admitted in a 1-second window, every further
event that second is dropped, regardless of whether it is an operational
net-event (GET/PUT/SUBSCRIBE results, routing decisions, connection state) or a
low-value, always-on shadow-telemetry event.

Phase 1.6 (#4379) raised the always-on shadow baseline to ~3 events/sec
(`shadow_rtt_aggregate` + `shadow_rate_demand` + `shadow_outbound_class`), up to
~5/sec on a gateway that also enables reference-ping and iface-tx. On a busy
gateway emitting >10 operational events/sec, the always-on shadow stream
deterministically consumed 30–50% of the budget, crowding out operational
telemetry exactly when the network is busiest and most needs observation. Phase 2
will add more always-on shadow emitters (the shadow controller decision log),
making this worse. This was surfaced by the skeptical reviewer during the #4379
review and deferred as out of scope for that observation-only PR.

## Solution

Give shadow telemetry a lower priority and enforce a **separate sub-budget** so
it can never starve operational telemetry.

- Add `EventPriority { Operational, Shadow }` (default `Operational`) and a
  `priority` field on `TelemetryEvent`. The field is `#[serde(skip)]` — it only
  steers the in-process rate limiter, so the OTLP wire payload is byte-identical
  to pre-#4380 and the collector schema is unchanged.
- Tag the five always-on shadow emitters (`shadow_rtt_aggregate`,
  `shadow_reference_ping`, `shadow_rate_demand`, `shadow_outbound_class`,
  `shadow_iface_tx`) as `Shadow` via a new
  `send_standalone_shadow_event_with_peer_id` helper. Everything else stays
  `Operational`.
- The rate limiter (`admit_event`, extracted from `handle_event` so the policy
  is unit-testable) now enforces:
  - Operational events: admitted up to `MAX_EVENTS_PER_SECOND` (10) — unchanged.
  - Shadow events: admitted only while BOTH the shadow sub-budget AND the
    aggregate cap have room.

**Chosen budget split:** `MAX_SHADOW_EVENTS_PER_SECOND = 4`. Because the
sub-budget (4) is strictly below the aggregate cap (10), shadow events can
occupy at most 4 of the 10 slots, always reserving at least 6/sec for
operational telemetry — even when shadow demand spikes (e.g. Phase 2). The
chosen 4 admits the current always-on set (3, rising to 5 with the gated
emitters) while keeping a comfortable operational reserve. Shadow events still
also count against the aggregate cap, so the limiter never exceeds 10/sec total.

This is a best-effort telemetry subsystem (events already drop silently on
rate-limit or channel-full); there is no wire/protocol path involved.

## Testing

Added unit tests for the admission policy (`tracing::telemetry::tests`):
- `test_shadow_subbudget_caps_shadow_events` — shadow flood capped at 4, not 10.
- `test_shadow_flood_cannot_starve_operational` — the #4380 regression: shadow
  events arriving first leave the reserved 6 operational slots intact (before the
  fix this would be 0).
- `test_operational_can_use_full_aggregate_cap` — operational behaviour unchanged.
- `test_shadow_still_bounded_by_aggregate_cap` — aggregate cap is the hard ceiling.
- `test_rate_limit_window_resets_both_counters` / `test_window_does_not_reset_before_one_second`
  — window rollover boundary for both counters.
- `test_priority_default_is_operational`, `test_priority_not_serialized_to_otlp`.

Both `test_shadow_subbudget_caps_shadow_events` and
`test_shadow_flood_cannot_starve_operational` fail against the pre-fix flat
counter (shadow would admit 10 / operational would admit 0), so they genuinely
reproduce the regression.

## Fixes

Closes #4380

[AI-assisted - Claude]
