### PR TITLE
fix(ring): feed per-peer bandwidth into the topology resource meter

### DIFF
--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2566,12 +2566,25 @@ fn resource_weight(resource: crate::topology::meter::ResourceType) -> f64 {
 ///
 /// `TRANSPORT_METRICS.per_peer_snapshot()` exposes *cumulative* sent/received
 /// byte counts per peer socket address. The topology meter, by contrast,
-/// expects per-sample byte counts that it accumulates into a rate over a
-/// sliding window. We therefore diff the current snapshot against the
-/// previous tick's counts (`prev`) to recover the bytes transferred during
-/// the tick, and feed that delta as one sample per direction:
+/// accumulates each reported sample into a sliding-window sum and divides by
+/// the elapsed wall-time (`now − oldest_sample`) to produce a rate. We diff
+/// the current snapshot against the previous tick's counts (`prev`) to recover
+/// the bytes transferred *during the interval*, and feed that delta as one
+/// sample per direction:
 ///   - received bytes → `InboundBandwidthBytes`
 ///   - sent bytes     → `OutboundBandwidthBytes`
+///
+/// `interval_start` MUST be the time of the *previous* maintenance tick, not
+/// the current one. The meter divides the windowed byte sum by
+/// `query_time − oldest_sample_time` with a 1-second floor
+/// (`RunningAverage::get_rate_at_time`). `adjust_topology` queries the meter at
+/// the current tick time immediately after this call, so timestamping the
+/// interval's whole byte delta at the interval START makes the very first
+/// sample divide by the real interval length (e.g. ~60s) instead of flooring
+/// to 1s. Timestamping at the interval END would treat a full interval's bytes
+/// as if they were transferred in a single second, overstating the rate by up
+/// to the tick interval (~60×) and triggering spurious connection removals
+/// under ordinary traffic (#3453 review).
 ///
 /// Only deltas with a resolvable `PeerKeyLocation` are reported: an address
 /// that doesn't (yet) map to a ring peer — e.g. a transient handshake
@@ -2579,21 +2592,31 @@ fn resource_weight(resource: crate::topology::meter::ResourceType) -> f64 {
 /// don't pollute the meter with samples that can't be matched against the
 /// node's actual neighbors.
 ///
-/// `prev` is updated in place to the current cumulative counts, and entries
-/// for peers no longer present in `snapshot` are dropped. This keeps `prev`
-/// bounded by the transport metrics table size (`MAX_TRACKED_PEERS`) rather
-/// than growing without limit as peers churn.
+/// Three things are bounded as peers churn (#3453 review):
+///   - `prev` is pruned of peers absent from `snapshot`, so it stays bounded
+///     by the transport metrics table size (`MAX_TRACKED_PEERS`).
+///   - The topology meter's per-source bandwidth meters AND
+///     `source_creation_times` are pruned to the set of peers resolved this
+///     tick via `retain_peer_sources`, so neither grows without bound (and
+///     `adjust_topology`, which iterates `source_creation_times` every tick,
+///     stays O(live peers)).
 ///
-/// This takes the topology manager's write lock once per reported delta. It
-/// performs no channel sends and no `.await`, so it is safe to call inline on
-/// the `connection_maintenance` tick (cf. `.claude/rules/channel-safety.md`).
+/// This takes the topology manager's write lock once per reported delta plus
+/// once for the retain. It performs no channel sends and no `.await`, so it is
+/// safe to call inline on the `connection_maintenance` tick
+/// (cf. `.claude/rules/channel-safety.md`).
 fn feed_peer_bandwidth_to_meter(
     connection_manager: &ConnectionManager,
     snapshot: &[(SocketAddr, u64, u64)],
     prev: &mut HashMap<SocketAddr, (u64, u64)>,
-    at_time: Instant,
+    interval_start: Instant,
 ) {
     use crate::topology::meter::{AttributionSource, ResourceType};
+
+    // Peers resolved to a ring `PeerKeyLocation` this tick. Used to bound the
+    // meter / source_creation_times to the live connection set below.
+    let mut live_peers: std::collections::HashSet<PeerKeyLocation> =
+        std::collections::HashSet::new();
 
     for &(addr, cum_sent, cum_recv) in snapshot {
         // Cumulative counters only ever increase, but use saturating
@@ -2608,15 +2631,19 @@ fn feed_peer_bandwidth_to_meter(
         // against them, even when this tick produced no usable delta.
         prev.insert(addr, (cum_sent, cum_recv));
 
-        if sent_delta == 0 && recv_delta == 0 {
-            continue;
-        }
-
         let Some(peer) = connection_manager.get_peer_by_addr(addr) else {
             // No ring peer for this address (transient/handshake connection,
             // or just-torn-down). Skip rather than attribute to a phantom.
             continue;
         };
+        // Track every resolvable peer (even with a zero delta this tick) as
+        // live so retain below doesn't evict a currently-connected, currently
+        // idle peer's accumulated samples.
+        live_peers.insert(peer.clone());
+
+        if sent_delta == 0 && recv_delta == 0 {
+            continue;
+        }
 
         let source = AttributionSource::Peer(peer);
         let mut topo = connection_manager.topology_manager.write();
@@ -2625,7 +2652,7 @@ fn feed_peer_bandwidth_to_meter(
                 &source,
                 ResourceType::InboundBandwidthBytes,
                 recv_delta as f64,
-                at_time,
+                interval_start,
             );
         }
         if sent_delta > 0 {
@@ -2633,10 +2660,18 @@ fn feed_peer_bandwidth_to_meter(
                 &source,
                 ResourceType::OutboundBandwidthBytes,
                 sent_delta as f64,
-                at_time,
+                interval_start,
             );
         }
     }
+
+    // Bound the meter / source_creation_times to the live peer set so they
+    // don't accumulate departed peers forever (#3453 review). Non-Peer
+    // (Contract/Delegate) sources are retained by `retain_peer_sources`.
+    connection_manager
+        .topology_manager
+        .write()
+        .retain_peer_sources(&live_peers);
 
     // Drop prior-tick entries for peers that vanished from the snapshot so
     // `prev` stays bounded as peers churn (#3453). After the loop above,
@@ -2863,6 +2898,12 @@ impl Ring {
                 .into_iter()
                 .map(|(addr, sent, recv)| (addr, (sent, recv)))
                 .collect();
+        // Time of the previous bandwidth feed (the start of the interval whose
+        // byte delta the next feed reports). Seeded with "now" so the first
+        // feed's delta is divided by the real first-interval length rather than
+        // flooring to the meter's 1s minimum (#3453 review — see
+        // `feed_peer_bandwidth_to_meter`).
+        let mut prev_bandwidth_tick = self.time_source.now();
 
         // Gateway version probe: random initial delay to prevent thundering herd.
         // The loop guard (`!is_gateway`) ensures gateways never probe themselves.
@@ -3379,12 +3420,17 @@ impl Ring {
             // so `calculate_usage_proportion` always reports ~0% usage and
             // `adjust_topology` perpetually takes the "add connections" branch —
             // the load-aware add/hold/remove logic never engages (#3453).
+            let bandwidth_tick_now = self.time_source.now();
             feed_peer_bandwidth_to_meter(
                 &self.connection_manager,
                 &crate::transport::metrics::TRANSPORT_METRICS.per_peer_snapshot(),
                 &mut prev_peer_bandwidth,
-                self.time_source.now(),
+                // Timestamp this interval's byte delta at the PREVIOUS tick
+                // (interval start) so the meter divides by the real interval
+                // length, not the 1s floor. See feed_peer_bandwidth_to_meter.
+                prev_bandwidth_tick,
             );
+            prev_bandwidth_tick = bandwidth_tick_now;
 
             let adjustment = self
                 .connection_manager
@@ -4223,6 +4269,110 @@ mod resource_meter_bridge_tests {
         );
         assert_eq!(prev.len(), 1, "departed peers must be pruned from prev");
         assert!(prev.contains_key(&addrs[0]));
+    }
+
+    /// #3453 review (P1): the per-interval byte delta must be timestamped at
+    /// the interval START so the meter divides it by the real interval length,
+    /// not the 1-second floor in `RunningAverage::get_rate_at_time`. A single
+    /// tick reporting one interval's worth of bytes must yield
+    /// `bytes / interval`, NOT `bytes / 1s` (which would overstate the rate by
+    /// the interval length and trigger spurious removals).
+    #[test_log::test]
+    fn bridge_timestamps_delta_at_interval_start_no_inflation() {
+        let cm = ConnectionManager::test_default();
+        let addrs = add_connections(&cm, 1);
+        let peer = cm.get_peer_by_addr(addrs[0]).unwrap();
+        let source = AttributionSource::Peer(peer);
+
+        // 60_000 bytes transferred over a 60s interval = 1000 B/s. Production
+        // passes the PREVIOUS tick time as `interval_start`.
+        let interval = Duration::from_secs(60);
+        let interval_start = Instant::now();
+        let query_time = interval_start + interval;
+
+        let mut prev = HashMap::new();
+        feed_peer_bandwidth_to_meter(&cm, &[(addrs[0], 0, 60_000)], &mut prev, interval_start);
+
+        let rate = cm
+            .topology_manager
+            .write()
+            .attributed_usage_rate(&source, &ResourceType::InboundBandwidthBytes, query_time)
+            .expect("inbound recorded")
+            .per_second();
+
+        // Correct: 60_000 / 60s = 1000 B/s. The interval-END bug would give
+        // 60_000 / 1s = 60_000 B/s (60× inflation).
+        assert!(
+            (rate - 1000.0).abs() < 1.0,
+            "interval delta must be divided by the real interval, got {rate} B/s (expected ~1000)"
+        );
+        assert!(
+            rate < 2000.0,
+            "rate must not be inflated toward the 1s-floor (delta/1s = 60000), got {rate}"
+        );
+    }
+
+    /// #3453 review (P2): peers that leave the live set must be pruned from the
+    /// topology meter (and `source_creation_times`), not accumulate forever.
+    /// After a peer departs, a subsequent bridge tick that no longer resolves
+    /// it must drop its meter samples.
+    #[test_log::test]
+    fn bridge_prunes_departed_peer_from_meter() {
+        let cm = ConnectionManager::test_default();
+        let addrs = add_connections(&cm, 2);
+        let peer0 = cm.get_peer_by_addr(addrs[0]).unwrap();
+        let peer1 = cm.get_peer_by_addr(addrs[1]).unwrap();
+        let src0 = AttributionSource::Peer(peer0);
+        let src1 = AttributionSource::Peer(peer1);
+
+        let t0 = Instant::now();
+        let mut prev = HashMap::new();
+        // Tick 1: both peers transfer bytes — both get meter entries.
+        feed_peer_bandwidth_to_meter(
+            &cm,
+            &[(addrs[0], 0, 10_000), (addrs[1], 0, 10_000)],
+            &mut prev,
+            t0,
+        );
+        let q = t0 + Duration::from_secs(60);
+        {
+            let mut topo = cm.topology_manager.write();
+            assert!(
+                topo.attributed_usage_rate(&src0, &ResourceType::InboundBandwidthBytes, q)
+                    .is_some(),
+                "peer0 should have a meter entry after tick 1"
+            );
+            assert!(
+                topo.attributed_usage_rate(&src1, &ResourceType::InboundBandwidthBytes, q)
+                    .is_some(),
+                "peer1 should have a meter entry after tick 1"
+            );
+        }
+
+        // peer1 disconnects from the ring; only peer0 remains a resolvable
+        // connection. The transport snapshot drops the departed peer too.
+        cm.prune_alive_connection(addrs[1]);
+        assert!(
+            cm.get_peer_by_addr(addrs[1]).is_none(),
+            "peer1 must no longer resolve after prune"
+        );
+
+        // Tick 2: only peer0 present in the snapshot. peer1 is no longer in the
+        // live set, so its meter samples must be pruned.
+        feed_peer_bandwidth_to_meter(&cm, &[(addrs[0], 0, 20_000)], &mut prev, t0);
+        {
+            let mut topo = cm.topology_manager.write();
+            assert!(
+                topo.attributed_usage_rate(&src0, &ResourceType::InboundBandwidthBytes, q)
+                    .is_some(),
+                "live peer0 must keep its meter entry"
+            );
+            assert!(
+                topo.attributed_usage_rate(&src1, &ResourceType::InboundBandwidthBytes, q)
+                    .is_none(),
+                "departed peer1 must be pruned from the meter"
+            );
+        }
     }
 }
 
@@ -5181,16 +5331,24 @@ mod deferred_swap_drop_tests {
 ///     needs real wall-clock time (see `.claude/rules/code-style.md`).
 ///     These carry a type prefix, so they don't match a *bare* `Instant::now()`.
 ///
-/// The only remaining bare `Instant::now()` call sites live in the
-/// `#[cfg(test)]` `gateway_version_probe_predicate_tests` module, where they
-/// construct inputs for the pure `should_probe_gateway` predicate (no
-/// production time is read there). If you add a new production time read,
-/// route it through `self.time_source.now()` rather than bumping this count.
+/// The only remaining bare `Instant::now()` call sites live in two
+/// `#[cfg(test)]` modules:
+///   * `gateway_version_probe_predicate_tests` (6 sites) — constructs inputs
+///     for the pure `should_probe_gateway` predicate (no production time read).
+///   * `resource_meter_bridge_tests` (8 sites) — drives the #3453 bandwidth
+///     bridge directly with synthetic timestamps; `feed_peer_bandwidth_to_meter`
+///     itself takes the time as a parameter, and the production caller in
+///     `connection_maintenance` supplies `self.time_source.now()`.
+///
+/// If you add a new production time read, route it through
+/// `self.time_source.now()` rather than bumping this count.
 #[cfg(test)]
 mod instant_now_pin_test {
     /// Number of bare `Instant::now()` call sites expected in this file, all
     /// in test code. Production code must use `self.time_source.now()`.
-    const EXPECTED_BARE_INSTANT_NOW: usize = 6;
+    /// 6 in `gateway_version_probe_predicate_tests` + 8 in
+    /// `resource_meter_bridge_tests` (#3453).
+    const EXPECTED_BARE_INSTANT_NOW: usize = 14;
 
     #[test]
     fn no_unexpected_bare_instant_now_call_sites() {

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2560,6 +2560,96 @@ fn resource_weight(resource: crate::topology::meter::ResourceType) -> f64 {
     }
 }
 
+/// Bridge the transport layer's per-peer wire-byte counters into the
+/// topology meter so `TopologyManager::adjust_topology` can make load-aware
+/// connection decisions in production (#3453).
+///
+/// `TRANSPORT_METRICS.per_peer_snapshot()` exposes *cumulative* sent/received
+/// byte counts per peer socket address. The topology meter, by contrast,
+/// expects per-sample byte counts that it accumulates into a rate over a
+/// sliding window. We therefore diff the current snapshot against the
+/// previous tick's counts (`prev`) to recover the bytes transferred during
+/// the tick, and feed that delta as one sample per direction:
+///   - received bytes → `InboundBandwidthBytes`
+///   - sent bytes     → `OutboundBandwidthBytes`
+///
+/// Only deltas with a resolvable `PeerKeyLocation` are reported: an address
+/// that doesn't (yet) map to a ring peer — e.g. a transient handshake
+/// connection — is skipped rather than attributed to a phantom source, so we
+/// don't pollute the meter with samples that can't be matched against the
+/// node's actual neighbors.
+///
+/// `prev` is updated in place to the current cumulative counts, and entries
+/// for peers no longer present in `snapshot` are dropped. This keeps `prev`
+/// bounded by the transport metrics table size (`MAX_TRACKED_PEERS`) rather
+/// than growing without limit as peers churn.
+///
+/// This takes the topology manager's write lock once per reported delta. It
+/// performs no channel sends and no `.await`, so it is safe to call inline on
+/// the `connection_maintenance` tick (cf. `.claude/rules/channel-safety.md`).
+fn feed_peer_bandwidth_to_meter(
+    connection_manager: &ConnectionManager,
+    snapshot: &[(SocketAddr, u64, u64)],
+    prev: &mut HashMap<SocketAddr, (u64, u64)>,
+    at_time: Instant,
+) {
+    use crate::topology::meter::{AttributionSource, ResourceType};
+
+    for &(addr, cum_sent, cum_recv) in snapshot {
+        // Cumulative counters only ever increase, but use saturating
+        // subtraction so a counter reset (e.g. the per-peer slot was evicted
+        // and re-created since the last tick) can never underflow into a
+        // huge bogus delta.
+        let (prev_sent, prev_recv) = prev.get(&addr).copied().unwrap_or((0, 0));
+        let sent_delta = cum_sent.saturating_sub(prev_sent);
+        let recv_delta = cum_recv.saturating_sub(prev_recv);
+
+        // Always record the latest cumulative counts so the next tick diffs
+        // against them, even when this tick produced no usable delta.
+        prev.insert(addr, (cum_sent, cum_recv));
+
+        if sent_delta == 0 && recv_delta == 0 {
+            continue;
+        }
+
+        let Some(peer) = connection_manager.get_peer_by_addr(addr) else {
+            // No ring peer for this address (transient/handshake connection,
+            // or just-torn-down). Skip rather than attribute to a phantom.
+            continue;
+        };
+
+        let source = AttributionSource::Peer(peer);
+        let mut topo = connection_manager.topology_manager.write();
+        if recv_delta > 0 {
+            topo.report_resource_usage(
+                &source,
+                ResourceType::InboundBandwidthBytes,
+                recv_delta as f64,
+                at_time,
+            );
+        }
+        if sent_delta > 0 {
+            topo.report_resource_usage(
+                &source,
+                ResourceType::OutboundBandwidthBytes,
+                sent_delta as f64,
+                at_time,
+            );
+        }
+    }
+
+    // Drop prior-tick entries for peers that vanished from the snapshot so
+    // `prev` stays bounded as peers churn (#3453). After the loop above,
+    // every snapshot address is present in `prev`, so `prev.len() >
+    // snapshot.len()` holds exactly when some prior peer is no longer in the
+    // snapshot — the only case where a prune is needed.
+    if prev.len() > snapshot.len() {
+        let live: std::collections::HashSet<SocketAddr> =
+            snapshot.iter().map(|&(addr, _, _)| addr).collect();
+        prev.retain(|addr, _| live.contains(addr));
+    }
+}
+
 impl Ring {
     // ==================== Subscription Retry Spam Prevention ====================
 
@@ -2752,6 +2842,27 @@ impl Ring {
         // successful connection, use a shorter isolation escalation threshold
         // for faster recovery from cold-start failures (#3737).
         let mut ever_had_connections = false;
+
+        // Prior-tick cumulative per-peer wire-byte counts, keyed by the
+        // transport socket address. Each maintenance tick we diff the current
+        // `TRANSPORT_METRICS.per_peer_snapshot()` against this to derive the
+        // bytes transferred *during the tick*, then feed that delta into the
+        // topology meter so `adjust_topology` can make load-aware decisions
+        // (#3453). Bounded: entries for peers absent from the latest snapshot
+        // are pruned each tick, so this never outgrows the transport metrics
+        // table (capped at `MAX_TRACKED_PEERS`).
+        //
+        // Seed with the current cumulative counts so the first maintenance
+        // tick attributes only the bytes transferred *during* that first
+        // interval, not the entire history accumulated before the loop
+        // started (which would over-count any pre-maintenance bootstrap
+        // traffic into a single inflated first sample).
+        let mut prev_peer_bandwidth: HashMap<SocketAddr, (u64, u64)> =
+            crate::transport::metrics::TRANSPORT_METRICS
+                .per_peer_snapshot()
+                .into_iter()
+                .map(|(addr, sent, recv)| (addr, (sent, recv)))
+                .collect();
 
         // Gateway version probe: random initial delay to prevent thundering herd.
         // The loop guard (`!is_gateway`) ensures gateways never probe themselves.
@@ -3260,6 +3371,19 @@ impl Ring {
                 candidates = peers.len(),
                 live_tx_peers = live_tx_tracker.len(),
                 "Evaluating topology maintenance"
+            );
+
+            // Feed the per-peer bandwidth measured since the previous tick into
+            // the topology meter BEFORE adjust_topology reads it. Without this
+            // the meter sees no peer-attributed bandwidth samples in production,
+            // so `calculate_usage_proportion` always reports ~0% usage and
+            // `adjust_topology` perpetually takes the "add connections" branch —
+            // the load-aware add/hold/remove logic never engages (#3453).
+            feed_peer_bandwidth_to_meter(
+                &self.connection_manager,
+                &crate::transport::metrics::TRANSPORT_METRICS.per_peer_snapshot(),
+                &mut prev_peer_bandwidth,
+                self.time_source.now(),
             );
 
             let adjustment = self
@@ -3801,6 +3925,305 @@ fn deferred_swap_drops_to_execute(
 #[inline]
 fn classify_suspend_jump(boot_elapsed: Duration, mono_elapsed: Duration) -> Duration {
     boot_elapsed.saturating_sub(mono_elapsed)
+}
+
+#[cfg(test)]
+mod resource_meter_bridge_tests {
+    //! Regression tests for #3453: the topology resource meter was never fed
+    //! per-peer bandwidth data in production, so `adjust_topology` always saw
+    //! ~0% usage and perpetually took the "add connections" branch. These
+    //! tests drive `feed_peer_bandwidth_to_meter` — the production bridge from
+    //! `TRANSPORT_METRICS.per_peer_snapshot()` into the meter — and assert the
+    //! meter actually receives the samples, exercising the load-aware
+    //! remove/hold/add decision logic that was previously dead in production.
+
+    // `super::*` brings in ConnectionManager, TopologyAdjustment, Location,
+    // SocketAddr, HashMap, BTreeMap, Duration, and tokio's Instant.
+    use super::*;
+    use crate::topology::meter::{AttributionSource, ResourceType};
+    use crate::transport::TransportKeypair;
+
+    /// Mirror of `topology::constants::SOURCE_RAMP_UP_DURATION` (5 min). That
+    /// constant is `pub(super)` to the topology module, so we restate it here.
+    /// Samples reported older than this window use their measured attributed
+    /// rate rather than the P50 ramp-up extrapolation.
+    const SOURCE_RAMP_UP_DURATION: Duration = Duration::from_secs(5 * 60);
+
+    /// Add `n` ring connections to `cm`, returning their socket addresses in
+    /// the order added. Each gets a distinct loopback address and location.
+    fn add_connections(cm: &ConnectionManager, n: usize) -> Vec<SocketAddr> {
+        let mut addrs = Vec::with_capacity(n);
+        for i in 0..n {
+            let addr: SocketAddr = format!("127.0.0.1:{}", 9000 + i).parse().unwrap();
+            // Spread locations across the ring so each peer is a distinct
+            // neighbor location (adjust_topology keys neighbors by location).
+            let loc = Location::new((i as f64 + 0.5) / n as f64);
+            let keypair = TransportKeypair::new();
+            assert!(cm.add_connection(loc, addr, keypair.public().clone(), false));
+            addrs.push(addr);
+        }
+        addrs
+    }
+
+    /// Drive the bridge once per simulated second, placing the first sample at
+    /// `first_sample` and one sample per second thereafter for `ticks` seconds.
+    /// `per_sec_recv[i]` is the bytes-received delta attributed to `addrs[i]`
+    /// each second; cumulative counters are simulated by accumulating the
+    /// per-second deltas (mirrors production, where each maintenance tick feeds
+    /// one delta per peer). Returns the final `prev` map for inspection.
+    ///
+    /// Callers that want the meter to report a *measured* rate (rather than the
+    /// ramp-up P50 estimate) must arrange two things, both governed by the
+    /// sample timestamps relative to the eventual `adjust_topology` query time
+    /// `q`:
+    ///   1. The first sample (the source's creation time) must be older than
+    ///      `SOURCE_RAMP_UP_DURATION` before `q`, or `extrapolated_usage`
+    ///      treats the source as ramping up and substitutes the network P50.
+    ///   2. The samples must extend up to just before `q`, because the meter's
+    ///      rate is `sum(retained samples) / (q − oldest_retained_sample)`.
+    ///      A window that ends far in the past inflates the denominator and
+    ///      dilutes the rate toward zero. The meter retains only the most
+    ///      recent `RUNNING_AVERAGE_WINDOW` (100) samples.
+    fn drive_bridge(
+        cm: &ConnectionManager,
+        addrs: &[SocketAddr],
+        per_sec_recv: &[u64],
+        first_sample: Instant,
+        ticks: u64,
+    ) -> HashMap<SocketAddr, (u64, u64)> {
+        let mut prev: HashMap<SocketAddr, (u64, u64)> = HashMap::new();
+        let mut cumulative: Vec<u64> = vec![0; addrs.len()];
+        for t in 0..ticks {
+            for (i, c) in cumulative.iter_mut().enumerate() {
+                *c += per_sec_recv[i];
+            }
+            let snapshot: Vec<(SocketAddr, u64, u64)> = addrs
+                .iter()
+                .zip(cumulative.iter())
+                .map(|(&addr, &recv)| (addr, 0u64, recv))
+                .collect();
+            let at = first_sample + Duration::from_secs(t);
+            feed_peer_bandwidth_to_meter(cm, &snapshot, &mut prev, at);
+        }
+        prev
+    }
+
+    /// The core regression: with the bridge feeding high per-peer bandwidth,
+    /// `adjust_topology` reaches the resource-overload "remove" branch. Before
+    /// the fix nothing fed the meter, so this path was unreachable in
+    /// production and the node would instead always try to ADD connections.
+    #[test_log::test]
+    fn bridge_feeds_meter_so_overloaded_node_removes() {
+        // test_default: min_connections=4, max_connections=10,
+        // max_upstream/downstream = 1_000_000 bytes/sec.
+        let cm = ConnectionManager::test_default();
+        let addrs = add_connections(&cm, 6);
+
+        // `extrapolated_usage` SUMS the per-source rates across all peers, so
+        // 200_000 B/s inbound per peer × 6 peers = 1_200_000 B/s = 1.2× the
+        // 1_000_000 downstream limit → usage proportion 1.2 > 0.9 → remove.
+        let per_sec_recv = vec![200_000u64; 6];
+
+        // Choose the query time `now`, then lay samples from
+        // (now − RAMP_UP − 30s) up to (now − 1s): the first sample is older
+        // than the ramp-up window (so the source reports its measured rate),
+        // and the retained 100-sample tail ends ~1s before `now` (so the rate
+        // isn't diluted by a stale denominator). See `drive_bridge` docs.
+        let now = Instant::now();
+        let first_sample = now - SOURCE_RAMP_UP_DURATION - Duration::from_secs(30);
+        let ticks = SOURCE_RAMP_UP_DURATION.as_secs() + 29; // last sample ≈ now − 1s
+        drive_bridge(&cm, &addrs, &per_sec_recv, first_sample, ticks);
+
+        let mut neighbor_locations = BTreeMap::new();
+        let conns = cm.get_connections_by_location();
+        for (loc, c) in &conns {
+            neighbor_locations.insert(*loc, c.clone());
+        }
+
+        let adjustment =
+            cm.topology_manager
+                .write()
+                .adjust_topology(&neighbor_locations, &None, now, 6);
+
+        assert!(
+            matches!(adjustment, TopologyAdjustment::RemoveConnections(_)),
+            "overloaded node fed via the bridge must remove a connection, got {adjustment:?}"
+        );
+    }
+
+    /// Demonstrates the bug: with NO bridge call (the production state before
+    /// this fix), the meter is empty and `adjust_topology` on a node above
+    /// min_connections takes the low-usage "add" branch. This is the symptom
+    /// #3453 describes; the test above proves the bridge cures it.
+    #[test_log::test]
+    fn empty_meter_never_removes() {
+        let cm = ConnectionManager::test_default();
+        let _addrs = add_connections(&cm, 6);
+
+        let mut neighbor_locations = BTreeMap::new();
+        let conns = cm.get_connections_by_location();
+        for (loc, c) in &conns {
+            neighbor_locations.insert(*loc, c.clone());
+        }
+
+        let adjustment = cm.topology_manager.write().adjust_topology(
+            &neighbor_locations,
+            &None,
+            Instant::now(),
+            6,
+        );
+
+        assert!(
+            !matches!(adjustment, TopologyAdjustment::RemoveConnections(_)),
+            "with an unfed meter the remove branch must be unreachable (the #3453 bug), got {adjustment:?}"
+        );
+    }
+
+    /// The bridge must attribute samples to the right `ResourceType` and only
+    /// for peers that resolve to a ring `PeerKeyLocation`.
+    #[test_log::test]
+    fn bridge_records_inbound_and_outbound_for_known_peer() {
+        let cm = ConnectionManager::test_default();
+        let addrs = add_connections(&cm, 1);
+        let peer = cm
+            .get_peer_by_addr(addrs[0])
+            .expect("peer is a ring connection");
+
+        let at = Instant::now();
+        let mut prev = HashMap::new();
+        // First snapshot establishes the baseline; cumulative counts start here.
+        feed_peer_bandwidth_to_meter(&cm, &[(addrs[0], 1_000, 2_000)], &mut prev, at);
+
+        let source = AttributionSource::Peer(peer);
+        // `attributed_usage_rate` takes `&mut self` (it can refresh the
+        // meter's cached estimate), so a write guard is required.
+        let mut topo = cm.topology_manager.write();
+        // First tick: delta == cumulative (prev was 0), so both directions get
+        // a sample equal to the cumulative count.
+        let outbound = topo.attributed_usage_rate(
+            &source,
+            &ResourceType::OutboundBandwidthBytes,
+            at + Duration::from_secs(1),
+        );
+        let inbound = topo.attributed_usage_rate(
+            &source,
+            &ResourceType::InboundBandwidthBytes,
+            at + Duration::from_secs(1),
+        );
+        drop(topo);
+
+        assert_eq!(outbound.expect("outbound recorded").per_second(), 1_000.0);
+        assert_eq!(inbound.expect("inbound recorded").per_second(), 2_000.0);
+    }
+
+    /// An address with no ring connection (e.g. a transient handshake) must be
+    /// skipped, not attributed to a phantom source. `prev` is still updated so
+    /// the next tick diffs correctly if the peer later resolves.
+    #[test_log::test]
+    fn bridge_skips_unresolvable_address() {
+        let cm = ConnectionManager::test_default();
+        // Six real peers above min_connections so the only thing that could
+        // push usage into the remove branch is bandwidth attribution.
+        let _addrs = add_connections(&cm, 6);
+        // An address that is NOT a ring connection.
+        let unknown: SocketAddr = "127.0.0.1:55555".parse().unwrap();
+
+        // Feed enormous traffic for the unknown address across a full window.
+        let now = Instant::now();
+        let window_end = now - SOURCE_RAMP_UP_DURATION - Duration::from_secs(30);
+        let mut prev = HashMap::new();
+        let mut cum = 0u64;
+        for t in 0..120u64 {
+            cum += 10_000_000; // far above any limit, IF it were attributed
+            feed_peer_bandwidth_to_meter(
+                &cm,
+                &[(unknown, 0, cum)],
+                &mut prev,
+                window_end - Duration::from_secs(120 - t),
+            );
+        }
+
+        let mut neighbor_locations = BTreeMap::new();
+        for (loc, c) in &cm.get_connections_by_location() {
+            neighbor_locations.insert(*loc, c.clone());
+        }
+        let adjustment =
+            cm.topology_manager
+                .write()
+                .adjust_topology(&neighbor_locations, &None, now, 6);
+
+        // The unknown address contributed no meter sample, so usage stays ~0
+        // and the node must NOT remove — proving the skip.
+        assert!(
+            !matches!(adjustment, TopologyAdjustment::RemoveConnections(_)),
+            "traffic for an unresolvable address must not be attributed, got {adjustment:?}"
+        );
+        // But prev is still updated so a future tick computes the delta from here.
+        assert_eq!(prev.get(&unknown).copied(), Some((0, cum)));
+    }
+
+    /// A counter that goes backwards (per-peer slot evicted then re-created,
+    /// resetting cumulative counts) must not underflow into a giant bogus
+    /// delta. saturating_sub clamps it to zero.
+    #[test_log::test]
+    fn bridge_handles_counter_reset_without_underflow() {
+        let cm = ConnectionManager::test_default();
+        let addrs = add_connections(&cm, 1);
+        let peer = cm.get_peer_by_addr(addrs[0]).unwrap();
+        let source = AttributionSource::Peer(peer);
+
+        let t0 = Instant::now();
+        let mut prev = HashMap::new();
+        // Establish a high cumulative count.
+        feed_peer_bandwidth_to_meter(&cm, &[(addrs[0], 0, 1_000_000)], &mut prev, t0);
+        // Counter reset: cumulative drops to a small value. Delta must be 0,
+        // not u64::MAX - something.
+        let t1 = t0 + Duration::from_secs(1);
+        feed_peer_bandwidth_to_meter(&cm, &[(addrs[0], 0, 10)], &mut prev, t1);
+
+        let rate = cm
+            .topology_manager
+            .write()
+            .attributed_usage_rate(
+                &source,
+                &ResourceType::InboundBandwidthBytes,
+                t1 + Duration::from_secs(1),
+            )
+            .unwrap()
+            .per_second();
+        // Only the first tick's 1_000_000 sample is present; the reset tick
+        // contributed a 0 delta (no sample). Sum=1_000_000 over a ~2s window.
+        assert!(
+            rate > 0.0 && rate.is_finite(),
+            "counter reset must clamp to a finite, non-underflowed rate, got {rate}"
+        );
+    }
+
+    /// `prev` must stay bounded as peers churn: entries for peers absent from
+    /// the latest snapshot are pruned so it never outgrows the transport
+    /// metrics table.
+    #[test_log::test]
+    fn bridge_prunes_departed_peers_from_prev() {
+        let cm = ConnectionManager::test_default();
+        let addrs = add_connections(&cm, 3);
+
+        let at = Instant::now();
+        let mut prev = HashMap::new();
+        let full: Vec<_> = addrs.iter().map(|&a| (a, 1u64, 1u64)).collect();
+        feed_peer_bandwidth_to_meter(&cm, &full, &mut prev, at);
+        assert_eq!(prev.len(), 3);
+
+        // Next tick: only one peer remains in the snapshot. The other two must
+        // be pruned from prev.
+        feed_peer_bandwidth_to_meter(
+            &cm,
+            &[(addrs[0], 2, 2)],
+            &mut prev,
+            at + Duration::from_secs(1),
+        );
+        assert_eq!(prev.len(), 1, "departed peers must be pruned from prev");
+        assert!(prev.contains_key(&addrs[0]));
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -246,6 +246,27 @@ impl TopologyManager {
         }
     }
 
+    /// Bound peer-attributed resource state to the set of live peers.
+    ///
+    /// Drops `source_creation_times` and meter entries for every
+    /// `AttributionSource::Peer` whose `PeerKeyLocation` is not in `live`.
+    /// Contract/Delegate sources are untouched. Called once per maintenance
+    /// tick by the bandwidth bridge so neither `source_creation_times` (which
+    /// `extrapolated_usage` iterates every tick) nor the meter grows without
+    /// bound as peers churn (#3453 review).
+    pub(crate) fn retain_peer_sources(
+        &mut self,
+        live: &std::collections::HashSet<PeerKeyLocation>,
+    ) {
+        self.source_creation_times.retain(|source, _| match source {
+            AttributionSource::Peer(peer) => live.contains(peer),
+            // Enumerated explicitly (not `_`) so a future AttributionSource
+            // variant must consciously decide its retention policy here.
+            AttributionSource::Delegate(_) | AttributionSource::Contract(_) => true,
+        });
+        self.meter.retain_peer_sources(live);
+    }
+
     pub(crate) fn report_resource_usage(
         &mut self,
         attribution: &AttributionSource,

--- a/crates/core/src/topology/meter.rs
+++ b/crates/core/src/topology/meter.rs
@@ -169,6 +169,28 @@ impl Meter {
         sorted_rates.get(estimated_index).cloned()
     }
 
+    /// Drop the per-source meters for every `AttributionSource::Peer` whose
+    /// inner `PeerKeyLocation` is NOT in `live`. Non-`Peer` sources (Contract,
+    /// Delegate) are always retained — only the peer-attributed bandwidth
+    /// samples are bounded by the live connection set.
+    ///
+    /// Without this, a peer that ever exchanged bytes leaves a permanent entry
+    /// in `attribution_meters`, so under connection churn the map (and the
+    /// per-tick work that iterates it) grows without bound. See #3453 review.
+    pub(crate) fn retain_peer_sources(
+        &mut self,
+        live: &std::collections::HashSet<PeerKeyLocation>,
+    ) {
+        let mut meters = self.attribution_meters.write().unwrap();
+        meters.retain(|source, _| match source {
+            AttributionSource::Peer(peer) => live.contains(peer),
+            // Non-peer sources are not bounded by the live connection set;
+            // enumerated explicitly (not `_`) so a future AttributionSource
+            // variant must consciously decide its retention policy here.
+            AttributionSource::Delegate(_) | AttributionSource::Contract(_) => true,
+        });
+    }
+
     /// Report the use of a resource. This should be done in the lowest-level
     /// functions that consume the resource, taking an AttributionMeter
     /// as a parameter.

--- a/crates/core/src/topology/rate.rs
+++ b/crates/core/src/topology/rate.rs
@@ -11,7 +11,18 @@ impl Eq for Rate {}
 
 impl Ord for Rate {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap_or(Ordering::Equal)
+        // Compare the underlying value directly. `total_cmp` gives a total
+        // order over all f64 (including NaN), which is required for the `Eq`
+        // + `Ord` impls to be consistent and is relied upon by
+        // `calculate_estimated_usage_rate`'s `sort_unstable`.
+        //
+        // NOTE: `cmp` MUST NOT delegate to `partial_cmp` here — `partial_cmp`
+        // delegates back to `cmp`, so any mutual delegation infinite-loops
+        // into a stack overflow. This was a latent bug that only surfaced
+        // once the topology meter started being fed real samples in
+        // production (#3453): the first `Rate` comparison (via `sort_unstable`)
+        // recursed until the stack overflowed.
+        self.value.total_cmp(&other.value)
     }
 }
 
@@ -91,6 +102,41 @@ mod tests {
         let rate2 = Rate::new(200.0, Duration::from_secs(2));
         let rate3 = rate2 - rate1;
         assert_eq!(rate3.per_second(), 50.0);
+    }
+
+    /// Regression for #3453: `Rate::cmp` and `Rate::partial_cmp` used to
+    /// delegate to each other, infinite-looping into a stack overflow on the
+    /// FIRST comparison. This was latent until the topology meter started
+    /// being fed real samples in production, at which point
+    /// `calculate_estimated_usage_rate`'s `sort_unstable` over `Vec<Rate>`
+    /// triggered the overflow and aborted every node. These comparisons must
+    /// terminate and return the correct ordering.
+    #[test]
+    fn test_ord_does_not_recurse() {
+        use std::cmp::Ordering;
+
+        let lo = Rate::new_per_second(1.0);
+        let hi = Rate::new_per_second(2.0);
+
+        // Each of these would stack-overflow (SIGABRT, not a test failure)
+        // under the old mutually-recursive impls.
+        assert_eq!(lo.cmp(&hi), Ordering::Less);
+        assert_eq!(hi.cmp(&lo), Ordering::Greater);
+        assert_eq!(lo.cmp(&lo), Ordering::Equal);
+        assert_eq!(lo.partial_cmp(&hi), Some(Ordering::Less));
+        assert!(lo < hi);
+        assert!(hi > lo);
+
+        // Sorting is the exact production trigger (sort_unstable in
+        // calculate_estimated_usage_rate).
+        let mut rates = vec![
+            Rate::new_per_second(3.0),
+            Rate::new_per_second(1.0),
+            Rate::new_per_second(2.0),
+        ];
+        rates.sort_unstable();
+        let sorted: Vec<f64> = rates.iter().map(|r| r.per_second()).collect();
+        assert_eq!(sorted, vec![1.0, 2.0, 3.0]);
     }
 }
 


### PR DESCRIPTION
## Problem

`TopologyManager`'s resource-usage `Meter` is never fed per-peer bandwidth
data in production. `report_resource_usage` was only ever called with
`AttributionSource::Contract` (governance scoring) and from test code — never
with `AttributionSource::Peer` for the two bandwidth resource types
(`InboundBandwidthBytes` / `OutboundBandwidthBytes`) that the topology
manager actually uses.

`calculate_usage_proportion` iterates `ResourceType::all()` (exactly those two
bandwidth types). With no peer-attributed samples, `extrapolated_usage`
iterates an empty set and reports ~0% usage. So at/above `min_connections`,
`adjust_topology` always took the "usage below 50% → add connections" branch.
The load-aware hold (50–90%) and remove (>90%) paths — and
`select_connections_to_remove` — were effectively dead in production. An
overloaded node would keep adding connections instead of shedding load.

## Solution

Bridge the transport layer's existing per-peer wire-byte counters into the
topology meter on each `connection_maintenance` tick, just before
`adjust_topology` reads it (#3453):

- New free function `feed_peer_bandwidth_to_meter` in `ring.rs`.
- It snapshots `TRANSPORT_METRICS.per_peer_snapshot()` (cumulative
  sent/received bytes per peer `SocketAddr`), diffs against the previous
  tick's counts held in a `HashMap<SocketAddr, (u64, u64)>`, and feeds the
  per-tick byte delta to `report_resource_usage` as a `Peer` sample
  (received → `InboundBandwidthBytes`, sent → `OutboundBandwidthBytes`).
- Addresses that don't resolve to a ring `PeerKeyLocation` via
  `get_peer_by_addr` (transient/handshake connections) are skipped rather than
  attributed to a phantom source.
- `saturating_sub` guards against counter resets (per-peer slot eviction +
  re-creation) producing a bogus huge delta.
- The prior-tick map is pruned of peers absent from the latest snapshot, so it
  stays bounded by the transport metrics table (`MAX_TRACKED_PEERS`).

The diff/feed is a lock-only, non-blocking, no-`await` operation safe to run
inline on the maintenance tick (cf. `.claude/rules/channel-safety.md`). Uses
the injectable `TimeSource` so deterministic simulation is unaffected.

## Testing

New regression tests in `ring.rs` (`resource_meter_bridge_tests`):

- `bridge_feeds_meter_so_overloaded_node_removes` — drives the bridge with
  high per-peer bandwidth across a full sample window and asserts
  `adjust_topology` reaches `RemoveConnections`. This path was unreachable
  before the fix.
- `empty_meter_never_removes` — documents the bug: with an unfed meter, a node
  above `min_connections` never reaches the remove branch.
- `bridge_records_inbound_and_outbound_for_known_peer` — asserts the bridge
  attributes received bytes to `InboundBandwidthBytes` and sent bytes to
  `OutboundBandwidthBytes` for a resolvable peer.
- `bridge_skips_unresolvable_address` — traffic for a non-ring address is not
  attributed (no spurious removal), but the prior-tick map is still updated.
- `bridge_handles_counter_reset_without_underflow` — a backwards counter
  clamps to a finite rate.
- `bridge_prunes_departed_peers_from_prev` — the prior-tick map drops peers
  that leave the snapshot.

Verified the meter-feed remove test fails without the bridge wiring and passes
with it.

Closes #3453

[AI-assisted - Claude]
