### PR TITLE
fix(telemetry): emit subscribe_timeout event when a client subscribe gives up

### DIFF
--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -3210,7 +3210,8 @@ impl SimNetwork {
                     match sub_event {
                         SubscribeEvent::Request { .. } => summary.subscribe.requested += 1,
                         SubscribeEvent::SubscribeSuccess { .. } => summary.subscribe.succeeded += 1,
-                        SubscribeEvent::SubscribeNotFound { .. } => summary.subscribe.failed += 1,
+                        SubscribeEvent::SubscribeNotFound { .. }
+                        | SubscribeEvent::SubscribeTimeout { .. } => summary.subscribe.failed += 1,
                         SubscribeEvent::ResponseSent { .. }
                         | SubscribeEvent::HostingStarted { .. }
                         | SubscribeEvent::HostingStopped { .. }

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -811,6 +811,22 @@ async fn drive_client_subscribe_inner(
                         continue;
                     }
                     None => {
+                        // #3445: emit a terminal telemetry event so a
+                        // timed-out client subscribe is no longer invisible
+                        // on the dashboard. Keyed on `client_tx` (the same
+                        // tx the originating `subscribe_request` was keyed
+                        // on) so the request pairs with this outcome.
+                        if let Some(event) = crate::tracing::NetEventLog::subscribe_timeout(
+                            &client_tx,
+                            &op_manager.ring,
+                            instance_id,
+                            retries + 1,
+                        ) {
+                            op_manager
+                                .ring
+                                .register_events(either::Either::Left(event))
+                                .await;
+                        }
                         return Ok(DriverOutcome::Publish(Err(ErrorKind::OperationError {
                             cause: format!(
                                 "subscribe to {instance_id} timed out after {} rounds",
@@ -3027,6 +3043,49 @@ mod tests {
             after.contains("op_manager.ring.routing_finished("),
             "Subscribed branch must hand the RouteEvent to \
              `routing_finished` so the router actually learns from it."
+        );
+    }
+
+    /// #3445 regression (source-scrape pin): the client-initiated SUBSCRIBE
+    /// driver must emit a `NetEventLog::subscribe_timeout` telemetry event on
+    /// the branch where every candidate peer timed out without a terminal
+    /// reply. Before the fix this branch returned an `OperationError` with no
+    /// telemetry, so a timed-out subscribe left a `subscribe_request` on the
+    /// dashboard with no paired outcome (the River container contract showed
+    /// 196 requests and 0 outcomes — all silent timeouts).
+    ///
+    /// This guards against a future migration silently dropping the call, the
+    /// telemetry-counter-rot failure mode from
+    /// `.claude/rules/bug-prevention-patterns.md`.
+    #[test]
+    fn drive_client_subscribe_inner_emits_timeout_telemetry_on_exhaustion() {
+        const SOURCE: &str = include_str!("op_ctx_task.rs");
+        let prod = production_source(SOURCE);
+        let body = extract_fn_body(prod, "async fn drive_client_subscribe_inner(");
+
+        // The timeout-exhausted branch is identified by its terminal cause
+        // string; the telemetry emission must appear before that return.
+        let timeout_return = body
+            .find("timed out after {} rounds")
+            .expect("timeout-exhausted branch must exist");
+        let before_timeout_return = &body[..timeout_return];
+        assert!(
+            before_timeout_return.contains("NetEventLog::subscribe_timeout("),
+            "the subscribe timeout-exhausted branch must emit \
+             NetEventLog::subscribe_timeout(..) before returning the \
+             OperationError; otherwise a timed-out subscribe is invisible on \
+             the telemetry dashboard (#3445)."
+        );
+        // It must actually be registered into the event pipeline, not built
+        // and dropped.
+        let emit_pos = before_timeout_return
+            .rfind("NetEventLog::subscribe_timeout(")
+            .unwrap();
+        assert!(
+            before_timeout_return[emit_pos..].contains("register_events("),
+            "the subscribe_timeout event must be handed to \
+             op_manager.ring.register_events(..) so it reaches the telemetry \
+             pipeline (#3445)."
         );
     }
 

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -698,6 +698,35 @@ impl<'a> NetEventLog<'a> {
         })
     }
 
+    /// Create a Subscribe timeout event (#3445).
+    ///
+    /// Emitted from the client-initiated subscribe driver when it exhausts
+    /// all candidate peers without ever receiving a terminal reply (every
+    /// attempt timed out or errored). Mirrors [`Self::subscribe_not_found`]
+    /// but records the timeout outcome so the dashboard pairs every
+    /// `subscribe_request` with an outcome instead of leaving it dangling.
+    pub fn subscribe_timeout(
+        tx: &'a Transaction,
+        ring: &'a Ring,
+        instance_id: ContractInstanceId,
+        retries: usize,
+    ) -> Option<Self> {
+        let peer_id = Self::get_own_peer_id(ring)?;
+        let own_loc = ring.connection_manager.own_location();
+        Some(NetEventLog {
+            tx,
+            peer_id,
+            kind: EventKind::Subscribe(SubscribeEvent::SubscribeTimeout {
+                id: *tx,
+                requester: own_loc,
+                instance_id,
+                retries,
+                elapsed_ms: tx.elapsed().as_millis() as u64,
+                timestamp: chrono::Utc::now().timestamp() as u64,
+            }),
+        })
+    }
+
     // ==================== UPDATE Operation Helpers ====================
 
     /// Create an Update request event.
@@ -1590,7 +1619,9 @@ impl NetLogMessage {
             EventKind::Get(GetEvent::GetSuccess { .. } | GetEvent::GetNotFound { .. }) => true,
             EventKind::Get(_) => false,
             EventKind::Subscribe(
-                SubscribeEvent::SubscribeSuccess { .. } | SubscribeEvent::SubscribeNotFound { .. },
+                SubscribeEvent::SubscribeSuccess { .. }
+                | SubscribeEvent::SubscribeNotFound { .. }
+                | SubscribeEvent::SubscribeTimeout { .. },
             ) => true,
             EventKind::Subscribe(_) => false,
             _ => false,
@@ -2846,14 +2877,16 @@ impl EventKind {
         }
     }
 
-    /// Returns whether this is a subscribe outcome event (success or not-found).
+    /// Returns whether this is a subscribe outcome event (success or failure).
     ///
-    /// Returns `Some(true)` for `SubscribeSuccess`, `Some(false)` for `SubscribeNotFound`,
+    /// Returns `Some(true)` for `SubscribeSuccess`, `Some(false)` for the
+    /// failure outcomes `SubscribeNotFound` and `SubscribeTimeout` (#3445),
     /// `None` for all other events (including subscribe requests/responses).
     pub fn subscribe_outcome(&self) -> Option<bool> {
         match self {
             EventKind::Subscribe(SubscribeEvent::SubscribeSuccess { .. }) => Some(true),
-            EventKind::Subscribe(SubscribeEvent::SubscribeNotFound { .. }) => Some(false),
+            EventKind::Subscribe(SubscribeEvent::SubscribeNotFound { .. })
+            | EventKind::Subscribe(SubscribeEvent::SubscribeTimeout { .. }) => Some(false),
             EventKind::Connect(_)
             | EventKind::Put(_)
             | EventKind::Get(_)
@@ -3825,6 +3858,29 @@ pub(crate) enum SubscribeEvent {
         at: PeerKeyLocation,
         timestamp: u64,
     },
+    /// A client-initiated Subscribe operation gave up without a terminal
+    /// reply (every candidate peer timed out / errored before any of them
+    /// returned Subscribed or NotFound). This is a terminal outcome, like
+    /// `SubscribeSuccess`/`SubscribeNotFound`, but distinct because the
+    /// originator never heard back from the network at all.
+    ///
+    /// Issue #3445: without this event a timed-out subscribe left a
+    /// `subscribe_request` on the dashboard with no paired outcome, making
+    /// the failure invisible (the River container contract showed 196
+    /// requests and 0 outcomes — all silent timeouts).
+    SubscribeTimeout {
+        id: Transaction,
+        /// The peer that initiated the subscribe (this node).
+        requester: PeerKeyLocation,
+        /// Contract instance that was being subscribed to (the full key is
+        /// not known on the originator until a successful Subscribed reply).
+        instance_id: ContractInstanceId,
+        /// Number of routing rounds attempted before giving up.
+        retries: usize,
+        /// Time elapsed since the operation started (milliseconds).
+        elapsed_ms: u64,
+        timestamp: u64,
+    },
 }
 
 impl SubscribeEvent {
@@ -3844,7 +3900,8 @@ impl SubscribeEvent {
             | SubscribeEvent::_Reserved9
             | SubscribeEvent::_Reserved10
             | SubscribeEvent::UnsubscribeSent { .. }
-            | SubscribeEvent::UnsubscribeReceived { .. } => None,
+            | SubscribeEvent::UnsubscribeReceived { .. }
+            | SubscribeEvent::SubscribeTimeout { .. } => None,
         }
     }
 }

--- a/crates/core/src/tracing/state_verifier/detectors.rs
+++ b/crates/core/src/tracing/state_verifier/detectors.rs
@@ -661,7 +661,8 @@ impl super::StateVerifier {
                     ));
                 }
                 EventKind::Subscribe(SubscribeEvent::SubscribeSuccess { id, .. })
-                | EventKind::Subscribe(SubscribeEvent::SubscribeNotFound { id, .. }) => {
+                | EventKind::Subscribe(SubscribeEvent::SubscribeNotFound { id, .. })
+                | EventKind::Subscribe(SubscribeEvent::SubscribeTimeout { id, .. }) => {
                     if let Some(entry) = tx_states.get_mut(id) {
                         entry.3 = true;
                     }

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -745,6 +745,7 @@ fn event_kind_to_string(kind: &EventKind) -> String {
                 SubscribeEvent::Request { .. } => "subscribe_request".to_string(),
                 SubscribeEvent::SubscribeSuccess { .. } => "subscribe_success".to_string(),
                 SubscribeEvent::SubscribeNotFound { .. } => "subscribe_not_found".to_string(),
+                SubscribeEvent::SubscribeTimeout { .. } => "subscribe_timeout".to_string(),
                 SubscribeEvent::ResponseSent { .. } => "subscribe_response_sent".to_string(),
                 SubscribeEvent::HostingStarted { .. } => "hosting_started".to_string(),
                 SubscribeEvent::HostingStopped { .. } => "hosting_stopped".to_string(),
@@ -1273,6 +1274,24 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                         "instance_id": instance_id.to_string(),
                         "target": target.to_string(),
                         "hop_count": hop_count,
+                        "elapsed_ms": elapsed_ms,
+                        "timestamp": timestamp,
+                    })
+                }
+                SubscribeEvent::SubscribeTimeout {
+                    id,
+                    requester,
+                    instance_id,
+                    retries,
+                    elapsed_ms,
+                    timestamp,
+                } => {
+                    serde_json::json!({
+                        "type": "subscribe_timeout",
+                        "id": id.to_string(),
+                        "requester": requester.to_string(),
+                        "instance_id": instance_id.to_string(),
+                        "retries": retries,
                         "elapsed_ms": elapsed_ms,
                         "timestamp": timestamp,
                     })
@@ -2415,5 +2434,49 @@ mod tests {
             serialized.get("priority").is_none(),
             "priority must be #[serde(skip)] so the OTLP payload is unchanged"
         );
+    }
+
+    /// #3445: a client subscribe that exhausts every candidate without a
+    /// terminal reply must emit a `subscribe_timeout` outcome event so the
+    /// dashboard pairs the original `subscribe_request` with an outcome
+    /// instead of leaving it dangling. Without the new `SubscribeTimeout`
+    /// variant + its name-mapping and JSON arms this test does not compile,
+    /// and before they were wired in the timeout was completely invisible.
+    #[test]
+    fn test_event_kind_to_json_subscribe_timeout() {
+        use crate::message::Transaction;
+        use crate::ring::PeerKeyLocation;
+        use crate::tracing::SubscribeEvent;
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let tx = Transaction::new::<crate::operations::subscribe::SubscribeMsg>();
+        let requester = PeerKeyLocation::random();
+        let instance_id = ContractInstanceId::new([7u8; 32]);
+
+        let event = EventKind::Subscribe(SubscribeEvent::SubscribeTimeout {
+            id: tx,
+            requester: requester.clone(),
+            instance_id,
+            retries: 4,
+            elapsed_ms: 60000,
+            timestamp: 12345,
+        });
+
+        // Name-mapping (OTLP event_type): must be a dedicated, queryable name.
+        assert_eq!(event_kind_to_string(&event), "subscribe_timeout");
+
+        // JSON serialization (dashboard payload): every field round-trips.
+        let json = event_kind_to_json(&event);
+        assert_eq!(json["type"], "subscribe_timeout");
+        assert_eq!(json["id"], tx.to_string());
+        assert_eq!(json["requester"], requester.to_string());
+        assert_eq!(json["instance_id"], instance_id.to_string());
+        assert_eq!(json["retries"], 4);
+        assert_eq!(json["elapsed_ms"], 60000);
+        assert_eq!(json["timestamp"], 12345);
+
+        // It is classified as a (failure) subscribe outcome so dashboards
+        // counting paired outcomes recognize it, unlike non-terminal events.
+        assert_eq!(event.subscribe_outcome(), Some(false));
     }
 }


### PR DESCRIPTION
## Problem

When a client-initiated SUBSCRIBE exhausts every candidate peer without ever receiving a terminal reply (every attempt timed out), the driver returned an `OperationError` but emitted **no telemetry**. The dashboard had `subscribe_request` / `subscribe_success` / `subscribe_not_found` events but no timeout outcome, so a timed-out subscribe left a `subscribe_request` with no paired outcome and the failure was invisible. The River container contract (`raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv`) showed 196 `subscribe_request` events and 0 outcomes — all silent timeouts.

Issue #3445 originally pointed at `remove_subscribe_and_notify_timeout` in the old GC path. **That path no longer exists**: SUBSCRIBE now runs on a task-per-tx driver (`subscribe/op_ctx_task.rs`) that owns its own timeout reporting, and the GC sweep no longer removes per-op state. The timeout give-up therefore now lives in the originator driver's retry loop, which is where the new event is emitted.

## Solution

Add a `SubscribeTimeout` variant to the `SubscribeEvent` telemetry enum (appended after the existing variants, well past the reserved-discriminant range, so the change is wire-format additive). It carries the transaction id, requester, contract instance id, retry-round count, and elapsed time — the same shape as the existing `SubscribeNotFound` outcome.

Emit it from `drive_client_subscribe_inner`'s timeout-exhausted branch, keyed on `client_tx` (the same tx the originating `subscribe_request` was keyed on) so the request pairs with this outcome on the dashboard. Wire it through the telemetry name-mapping (`"subscribe_timeout"`) and JSON serialization so it is recorded like the other `SubscribeEvent` variants, and classify it as a (failure) subscribe outcome in `subscribe_outcome()`, `span_completed()`, the state-verifier terminal-resolution detector, and the simulation summary's failed counter.

## Testing

- `test_event_kind_to_json_subscribe_timeout` (`tracing/telemetry.rs`): asserts the event maps to the `subscribe_timeout` name, serializes every field, and is classified as a subscribe outcome. Without the new variant + arms this test does not compile.
- `drive_client_subscribe_inner_emits_timeout_telemetry_on_exhaustion` (`subscribe/op_ctx_task.rs`): source-scrape pin test asserting the timeout branch emits `NetEventLog::subscribe_timeout` and registers it into the event pipeline before returning. **Verified it FAILS when the emission is removed and PASSES with it.** This guards against the telemetry-counter-rot failure mode in `.claude/rules/bug-prevention-patterns.md`.

`cargo fmt` clean; `cargo clippy --locked -- -D warnings` clean.

Closes #3445

[AI-assisted - Claude]
