### PR TITLE
test: add Playwright smoke-test harness for shell + iframe postMessage contract

### DIFF
--- a/.github/workflows/playwright-shell.yml
+++ b/.github/workflows/playwright-shell.yml
@@ -27,12 +27,16 @@ on:
       - 'crates/core/src/server/**'
       - 'crates/core/tests/playwright/**'
       - 'crates/core/tests/playwright_shell.rs'
+      # fdev is the publish path the harness shells out to; a regression in
+      # `fdev website publish` would break the harness, so run on fdev changes.
+      - 'crates/fdev/**'
       - '.github/workflows/playwright-shell.yml'
   pull_request:
     paths:
       - 'crates/core/src/server/**'
       - 'crates/core/tests/playwright/**'
       - 'crates/core/tests/playwright_shell.rs'
+      - 'crates/fdev/**'
       - '.github/workflows/playwright-shell.yml'
 
 concurrency:

--- a/.github/workflows/playwright-shell.yml
+++ b/.github/workflows/playwright-shell.yml
@@ -1,0 +1,135 @@
+name: Shell Playwright E2E
+
+# Browser smoke tests for the gateway shell + sandboxed iframe postMessage
+# contract (freenet/freenet-core#3856).
+#
+# Why a separate workflow: the shell bridge, navigation interceptor, and CSP
+# are JavaScript strings injected by crates/core/src/server/path_handlers.rs +
+# client_api.rs. Every other CI job only ever asserts substrings of that JS at
+# the Rust level; nothing executes it in a real browser. Four regressions
+# (#3842, #3852, #3853, #3854) shipped to production through that gap. This job
+# boots a node (via the #[freenet_test] harness in
+# crates/core/tests/playwright_shell.rs), publishes a fixture webapp, and drives
+# the injected JS against headless Chromium with Playwright.
+#
+# NOT a required check (yet): it is path-filtered to the server JS + the test
+# harness, so it does not run on every PR. A path-filtered workflow does not
+# reliably produce a check context for branch protection, so do NOT mark this
+# required without first restructuring it into an always-green gate + a
+# conditional real job (see the note in macos-dmg-swap-e2e.yml). Until then it
+# runs as an informational gate on PRs that touch the relevant surface and on
+# main.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/core/src/server/**'
+      - 'crates/core/tests/playwright/**'
+      - 'crates/core/tests/playwright_shell.rs'
+      - '.github/workflows/playwright-shell.yml'
+  pull_request:
+    paths:
+      - 'crates/core/src/server/**'
+      - 'crates/core/tests/playwright/**'
+      - 'crates/core/tests/playwright_shell.rs'
+      - '.github/workflows/playwright-shell.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  shell-e2e:
+    name: Shell Playwright E2E
+    runs-on: ubicloud-standard-8
+    timeout-minutes: 30
+
+    env:
+      # Quiet logs; the harness emits its own progress at INFO via tracing only
+      # when something is wrong. A full DEBUG run produces GBs for a node boot.
+      RUST_LOG: warn
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      RUST_MIN_STACK: 268435456
+      FREENET_PLAYWRIGHT: "1"
+      # Reduce gateway connection backoff for CI (default 30s is too aggressive
+      # for localhost tests under CI resource pressure). See issue #3078.
+      FREENET_BACKOFF_BASE_SECS: "5"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install mold linker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mold
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.0
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
+      # fdev is the publish path the harness shells out to. Build it (and the
+      # test's own crate deps) before the test step so the binary is on disk.
+      - name: Build fdev
+        env:
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
+        run: cargo build --bin fdev --locked
+
+      - name: Install Playwright deps
+        working-directory: crates/core/tests/playwright
+        run: npm ci
+
+      # Cache the downloaded browser binaries keyed on the pinned Playwright
+      # version so we only re-download when the version in package.json changes.
+      - name: Resolve Playwright version
+        id: pw
+        working-directory: crates/core/tests/playwright
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: pw-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      - name: Install Playwright browsers
+        working-directory: crates/core/tests/playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Clean test directories
+        run: rm -rf /tmp/freenet /tmp/freenet-* 2>/dev/null || true
+
+      - name: Run shell Playwright E2E
+        env:
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
+        run: |
+          cargo nextest run -p freenet \
+            --no-default-features \
+            --features trace,websocket,redb,wasmtime-backend,testing \
+            --test playwright_shell --no-capture
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            crates/core/tests/playwright/playwright-report
+            crates/core/tests/playwright/test-results
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/playwright-shell.yml
+++ b/.github/workflows/playwright-shell.yml
@@ -7,7 +7,7 @@ name: Shell Playwright E2E
 # are JavaScript strings injected by crates/core/src/server/path_handlers.rs +
 # client_api.rs. Every other CI job only ever asserts substrings of that JS at
 # the Rust level; nothing executes it in a real browser. Four regressions
-# (#3842, #3852, #3853, #3854) shipped to production through that gap. This job
+# (#3842, #3849, #3852, #3854) shipped to production through that gap. This job
 # boots a node (via the #[freenet_test] harness in
 # crates/core/tests/playwright_shell.rs), publishes a fixture webapp, and drives
 # the injected JS against headless Chromium with Playwright.

--- a/crates/core/tests/playwright/.gitignore
+++ b/crates/core/tests/playwright/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+playwright-report/
+test-results/

--- a/crates/core/tests/playwright/README.md
+++ b/crates/core/tests/playwright/README.md
@@ -57,3 +57,16 @@ To iterate on the specs alone against an already-running node, point
 > Linux-only: the harness binds the node to a varied `127.x.y.1` loopback for
 > test isolation. The full `127.0.0.0/8` range is loopback on Linux but not on
 > macOS, where only `127.0.0.1` is reachable by default.
+
+## Why the fixture's external link targets `example.com`, not localhost
+
+The shell's `open_url` bridge deliberately **refuses** to open `localhost`,
+`127.0.0.1`, `::1`, and `0.0.0.0` URLs — it must not be usable as a proxy from
+a sandboxed contract to other services on the operator's machine
+(`path_handlers.rs` `open_url` handler). So the cross-origin fixture link uses
+`https://example.com/external` (RFC 2606 documentation domain), which clears
+that blocklist and is intercepted *before* any network request is made — the
+test never actually reaches example.com. A side effect of the same blocklist:
+you cannot use the Freenet shell to open links to your own local dev servers
+(e.g. `http://localhost:3000`); that is an accepted security trade-off, not a
+bug.

--- a/crates/core/tests/playwright/README.md
+++ b/crates/core/tests/playwright/README.md
@@ -1,0 +1,59 @@
+# Shell Playwright smoke tests
+
+Browser smoke tests for the Freenet gateway **shell + sandboxed iframe
+postMessage contract** (freenet/freenet-core#3856).
+
+These exercise, against a real headless Chromium, the JavaScript the node
+injects into the shell page and the sandboxed iframe — `SHELL_BRIDGE_JS`,
+`WEBSOCKET_SHIM_JS`, `NAVIGATION_INTERCEPTOR_JS` in
+`crates/core/src/server/path_handlers.rs` — and the CSP headers it serves
+(`SHELL_PAGE_CSP`, `sandbox_csp_for_origin` in
+`crates/core/src/server/client_api.rs`). Before this suite, that code was only
+guarded by Rust-level substring assertions on the emitted JS; four regressions
+(#3842, #3852, #3853, #3854) shipped to production through that gap.
+
+## How it runs
+
+The Rust harness `crates/core/tests/playwright_shell.rs` owns the node
+lifecycle. It:
+
+1. boots a single in-process gateway node via `#[freenet_test]`,
+2. publishes `fixture-webapp/` as a Freenet **website contract** using the real
+   `fdev website publish` path (with an isolated `XDG_CONFIG_HOME` so it never
+   touches your `~/.config/freenet`),
+3. waits until the shell route serves over HTTP, then
+4. runs this Playwright project with the shell URL in `FREENET_SHELL_URL`.
+
+The Playwright step is opt-in: the harness only launches the browser when
+`FREENET_PLAYWRIGHT=1`. A plain `cargo test`/`cargo nextest` run publishes the
+fixture, confirms the shell serves, and returns early — so a checkout without
+Node/browsers never fails. The dedicated `.github/workflows/playwright-shell.yml`
+job installs the browsers and sets the flag.
+
+### Fixture WASM
+
+The fixture is published with the **prebuilt** website-container WASM embedded
+in `fdev` (`crates/fdev/resources/website_contract.wasm`). That keeps the test
+free of a `wasm32-unknown-unknown` build step and makes the contract key
+deterministic per fdev version. See `crates/website-contract/README.md` for the
+(rare) procedure to rebuild that committed binary.
+
+## Running locally
+
+```bash
+# one-time, from this directory:
+npm ci
+npx playwright install --with-deps chromium
+
+# from the workspace root:
+cargo build --bin fdev
+FREENET_PLAYWRIGHT=1 cargo nextest run -p freenet \
+  --features testing --test playwright_shell --no-capture
+```
+
+To iterate on the specs alone against an already-running node, point
+`FREENET_SHELL_URL` at its shell route and run `npx playwright test` directly.
+
+> Linux-only: the harness binds the node to a varied `127.x.y.1` loopback for
+> test isolation. The full `127.0.0.0/8` range is loopback on Linux but not on
+> macOS, where only `127.0.0.1` is reachable by default.

--- a/crates/core/tests/playwright/README.md
+++ b/crates/core/tests/playwright/README.md
@@ -10,7 +10,7 @@ injects into the shell page and the sandboxed iframe — `SHELL_BRIDGE_JS`,
 (`SHELL_PAGE_CSP`, `sandbox_csp_for_origin` in
 `crates/core/src/server/client_api.rs`). Before this suite, that code was only
 guarded by Rust-level substring assertions on the emitted JS; four regressions
-(#3842, #3852, #3853, #3854) shipped to production through that gap.
+(#3842, #3849, #3852, #3854) shipped to production through that gap.
 
 ## How it runs
 

--- a/crates/core/tests/playwright/fixture-webapp/index.html
+++ b/crates/core/tests/playwright/fixture-webapp/index.html
@@ -44,10 +44,20 @@
 
 <!--
   Download link. The interceptor must NOT intercept links carrying a
-  `download` attribute; they fall through to the browser/shell download path
-  (path_handlers.rs handleAnchorClick early-return on `download`).
+  `download` attribute; `handleAnchorClick` early-returns on `download`
+  (path_handlers.rs:2013), so no open_url / navigate postMessage is sent and
+  the link keeps its native (download) behaviour.
+
+  The href is SAME-ORIGIN (a data URL would be skipped earlier by the
+  javascript:/data: protocol check at path_handlers.rs:2011, which would NOT
+  isolate the `download` guard). Without the `download` attribute this exact
+  same-origin link would be intercepted as a `navigate` (see #same-origin-link);
+  the `download` attribute is what makes the early-return fire instead, so the
+  absence of a `navigate` postMessage on click is attributable to the
+  `download` guard specifically. The test reads `#download-link` directly and
+  does not rely on what the browser does natively after the early-return.
 -->
-<a id="download-link" href="data:text/plain,hello" download="hello.txt">Download</a>
+<a id="download-link" href="page2.html" download="hello.txt">Download</a>
 
 <!-- Result sink the Playwright tests read via page.evaluate. -->
 <pre id="poll-result">pending</pre>

--- a/crates/core/tests/playwright/fixture-webapp/index.html
+++ b/crates/core/tests/playwright/fixture-webapp/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Freenet shell smoke-test fixture</title>
+</head>
+<body>
+<!--
+  This page is published as a Freenet website contract and loaded inside the
+  shell's sandboxed iframe by the Playwright smoke tests
+  (crates/core/tests/playwright/tests/shell.spec.ts).
+
+  It deliberately does NOT include the shell bridge, the WebSocket shim, or the
+  navigation interceptor: the freenet node injects those into the served HTML
+  (see crates/core/src/server/path_handlers.rs::sandbox_content_body). The
+  point of the test is to exercise that injected code against a real browser,
+  so the fixture only provides the DOM the injected code acts on.
+
+  Stable element ids are the test contract — keep them in sync with
+  shell.spec.ts.
+-->
+<h1 id="title">Freenet shell fixture</h1>
+
+<!--
+  Cross-origin link. The navigation interceptor must intercept clicks on this
+  (left, middle, and shift) and forward them to the shell as an `open_url`
+  postMessage rather than letting the sandboxed iframe open a null-origin
+  popup (freenet/freenet-core#3852, #3853, #3854). example.com is a reserved
+  documentation domain (RFC 2606) that is never actually navigated to in the
+  tests — the click is intercepted before any network request.
+-->
+<a id="cross-origin-link" href="https://example.com/external" target="_blank" rel="noopener">
+  External cross-origin link
+</a>
+
+<!--
+  Same-origin, in-contract link. The interceptor must turn this into a
+  `navigate` postMessage so the shell performs an in-place iframe hop instead
+  of a full reload. The href is relative so it resolves under this contract's
+  web prefix regardless of the contract key.
+-->
+<a id="same-origin-link" href="page2.html">In-contract page 2</a>
+
+<!--
+  Download link. The interceptor must NOT intercept links carrying a
+  `download` attribute; they fall through to the browser/shell download path
+  (path_handlers.rs handleAnchorClick early-return on `download`).
+-->
+<a id="download-link" href="data:text/plain,hello" download="hello.txt">Download</a>
+
+<!-- Result sink the Playwright tests read via page.evaluate. -->
+<pre id="poll-result">pending</pre>
+
+<script>
+  // Exercise the CSP `connect-src 'self'` directive that #3842 fixed: a
+  // same-origin fetch to the permission poller endpoint. If the shell CSP
+  // regresses to `ws: wss:` only, the browser blocks this fetch and emits a
+  // "Content-Security-Policy: blocked ... (connect-src)" console error, which
+  // the Playwright test asserts is absent.
+  //
+  // We surface the outcome in #poll-result so the test can also confirm the
+  // fetch actually ran (a CSP block rejects the promise rather than returning
+  // a response).
+  (function () {
+    var sink = document.getElementById('poll-result');
+    fetch('/permission/pending', { headers: { 'accept': 'application/json' } })
+      .then(function (resp) { sink.textContent = 'fetched:' + resp.status; })
+      .catch(function (err) { sink.textContent = 'error:' + (err && err.message); });
+  })();
+</script>
+</body>
+</html>

--- a/crates/core/tests/playwright/fixture-webapp/index.html
+++ b/crates/core/tests/playwright/fixture-webapp/index.html
@@ -26,7 +26,7 @@
   Cross-origin link. The navigation interceptor must intercept clicks on this
   (left, middle, and shift) and forward them to the shell as an `open_url`
   postMessage rather than letting the sandboxed iframe open a null-origin
-  popup (freenet/freenet-core#3852, #3853, #3854). example.com is a reserved
+  popup (freenet/freenet-core#3852, #3854). example.com is a reserved
   documentation domain (RFC 2606) that is never actually navigated to in the
   tests — the click is intercepted before any network request.
 -->

--- a/crates/core/tests/playwright/fixture-webapp/page2.html
+++ b/crates/core/tests/playwright/fixture-webapp/page2.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Freenet shell fixture - page 2</title>
+</head>
+<body>
+<!--
+  Destination of the same-origin in-contract link on index.html. A successful
+  in-place `navigate` hop swaps the iframe to this page; the Playwright test
+  asserts #page2-title becomes visible inside the iframe.
+-->
+<h1 id="page2-title">Fixture page 2</h1>
+<a id="back-link" href="index.html">Back to index</a>
+</body>
+</html>

--- a/crates/core/tests/playwright/package-lock.json
+++ b/crates/core/tests/playwright/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "freenet-shell-smoke-tests",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "freenet-shell-smoke-tests",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "1.61.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/crates/core/tests/playwright/package.json
+++ b/crates/core/tests/playwright/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "freenet-shell-smoke-tests",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Playwright smoke tests for the Freenet gateway shell + sandboxed iframe postMessage contract (freenet/freenet-core#3856).",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.61.0"
+  }
+}

--- a/crates/core/tests/playwright/playwright.config.ts
+++ b/crates/core/tests/playwright/playwright.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Playwright configuration for the Freenet shell smoke tests
+// (freenet/freenet-core#3856).
+//
+// The freenet node is NOT started by Playwright. The Rust harness
+// (crates/core/tests/playwright_shell.rs) boots an in-process node, publishes
+// the fixture website contract, and passes the ready-to-load shell URL via the
+// FREENET_SHELL_URL environment variable before invoking `npx playwright
+// test`. This keeps node lifecycle on the well-tested `#[freenet_test]` path
+// and leaves Playwright as a thin browser-driver layer.
+//
+// To run these tests standalone (without the Rust harness) point
+// FREENET_SHELL_URL at a running node's shell URL, e.g.:
+//   FREENET_SHELL_URL=http://127.0.0.1:50001/v1/contract/web/<key>/ \
+//     npx playwright test
+
+const shellUrl = process.env.FREENET_SHELL_URL;
+
+export default defineConfig({
+  testDir: "./tests",
+  // Generous, CI-friendly timeouts: the first iframe load fetches and unpacks
+  // the contract bundle, which can be slow on a cold/contended CI runner.
+  timeout: 60_000,
+  expect: { timeout: 20_000 },
+  // The shell is a single node; running specs in parallel against one node
+  // only adds contention without coverage. Keep it serial and deterministic.
+  fullyParallel: false,
+  workers: 1,
+  // Never silently pass on an accidentally-skipped suite in CI.
+  forbidOnly: !!process.env.CI,
+  // No automatic retries — a flaky shell test is a real bug to investigate,
+  // not something to paper over (project "flaky tests are broken tests" rule).
+  retries: 0,
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  use: {
+    baseURL: shellUrl,
+    headless: true,
+    trace: "retain-on-failure",
+    // Capture console + page errors for the CSP-violation assertions.
+    ignoreHTTPSErrors: true,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -227,6 +227,50 @@ test("same-origin in-contract link performs an in-place navigate hop", async ({ 
   await expect(page).not.toHaveURL(/__sandbox/);
 });
 
+test("a link carrying a download attribute is NOT intercepted", async ({ page }) => {
+  await page.goto(shellUrl!);
+  await captureShellMessages(page);
+  const frame = await fixtureFrame(page);
+
+  // `#download-link` is a SAME-ORIGIN href (page2.html) that, WITHOUT the
+  // `download` attribute, would be intercepted as a `navigate` (proven by the
+  // same-origin test above). `handleAnchorClick` early-returns on the
+  // `download` attribute (path_handlers.rs:2013), so clicking it must send NO
+  // interception postMessage (no `navigate`, no `open_url`). A regression that
+  // dropped the `if (target.hasAttribute('download')) return;` guard would turn
+  // this back into a `navigate`.
+  //
+  // Ordering matters: we assert on the *delta* of captured messages around the
+  // click, because the click may (natively) cause the iframe to load page2 —
+  // which would tear down the in-iframe listeners and make a post-click control
+  // click impossible. So we (1) prove the interceptor is live with a control
+  // click on the SAME element with its `download` attribute removed, expecting
+  // a `navigate`; then (2) reload, re-arm capture, click the unmodified
+  // download link, and assert it adds NO message.
+
+  // (1) Control: same element minus `download` IS intercepted → listener live,
+  // and the element/selector themselves are wired correctly.
+  await frame.locator("#download-link").evaluate((el) => el.removeAttribute("download"));
+  await frame.locator("#download-link").click();
+  await expect
+    .poll(async () => (await shellMessages(page)).map((m) => m.type))
+    .toContain("navigate");
+
+  // (2) Reload to restore the original DOM (with the `download` attribute) and
+  // a fresh, empty capture buffer, then click the real download link.
+  await page.goto(shellUrl!);
+  await captureShellMessages(page);
+  const frame2 = await fixtureFrame(page);
+  await frame2.locator("#download-link").click();
+  // Give any (erroneous) interception postMessage a tick to arrive.
+  await page.waitForTimeout(300);
+  const types = (await shellMessages(page)).map((m) => m.type);
+  expect(
+    types,
+    `a download link must not be intercepted, but got messages: ${types.join(", ")}`,
+  ).toEqual([]);
+});
+
 test("browser Back restores the previous subpage via the popstate handler (#3839)", async ({
   page,
 }) => {

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -217,8 +217,40 @@ test("same-origin in-contract link performs an in-place navigate hop", async ({ 
   expect(navigate?.href, `navigate href: ${navigate?.href}`).toContain("page2.html");
 
   // The shell performs the hop in place: the iframe now shows page 2 and the
-  // top-level URL no longer carries __sandbox (issue #3839).
+  // top-level URL no longer carries __sandbox (issue #3839). Use Playwright's
+  // polling toHaveURL (not a synchronous page.url() snapshot) because the
+  // pushState that updates the address bar runs in the bridge's message
+  // handler, which can settle a tick after the iframe content loads.
   await expect(page.frameLocator("iframe#app").locator("#page2-title")).toBeVisible();
-  expect(page.url()).toContain("page2.html");
-  expect(page.url()).not.toContain("__sandbox");
+  await expect(page).toHaveURL(/page2\.html/);
+  await expect(page).not.toHaveURL(/__sandbox/);
+});
+
+test("browser Back restores the previous subpage via the popstate handler (#3839)", async ({
+  page,
+}) => {
+  await page.goto(shellUrl!);
+  const frame = await fixtureFrame(page);
+
+  // Navigate forward to page 2 (in-place hop, pushes a history entry).
+  await frame.locator("#same-origin-link").click();
+  await expect(page.frameLocator("iframe#app").locator("#page2-title")).toBeVisible();
+  await expect(page).toHaveURL(/page2\.html/);
+
+  // Browser Back must fire the bridge's popstate handler, which restores the
+  // iframe to the PREVIOUS subpage (index) rather than leaving it on page 2 or
+  // blanking it. Restoring iframe.src is exactly the behaviour the popstate
+  // handler owns (path_handlers.rs SHELL_BRIDGE_JS popstate listener), so we
+  // assert on the iframe content — the observable effect of that handler.
+  //
+  // We deliberately do NOT assert on the top-level address-bar URL here: the
+  // forward hop used history.pushState, so going back is a popstate event that
+  // only swaps iframe.src and never triggers a document load. Whether/when the
+  // browser's address bar reverts on a scripted history.back() is a browser
+  // history detail, not part of the bridge's contract, and asserting it is
+  // flaky under headless automation. The forward-navigate test above already
+  // pins the address-bar behaviour for the push direction.
+  await page.evaluate(() => window.history.back());
+  await expect(page.frameLocator("iframe#app").locator("#title")).toBeVisible();
+  await expect(page.frameLocator("iframe#app").locator("#page2-title")).toHaveCount(0);
 });

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -1,0 +1,224 @@
+import { test, expect, type Page, type ConsoleMessage } from "@playwright/test";
+
+// Smoke tests for the Freenet gateway shell + sandboxed iframe postMessage
+// contract (freenet/freenet-core#3856).
+//
+// These exercise, against a real headless Chromium, the JavaScript the node
+// injects into the shell page and the sandboxed iframe
+// (crates/core/src/server/path_handlers.rs: SHELL_BRIDGE_JS,
+// WEBSOCKET_SHIM_JS, NAVIGATION_INTERCEPTOR_JS) and the CSP headers it serves
+// (crates/core/src/server/client_api.rs: SHELL_PAGE_CSP, sandbox_csp_for_origin).
+//
+// Each test below maps to a regression that previously shipped to production
+// with only a Rust-level HTML-string assertion guarding it:
+//   - #3842 — shell CSP must allow same-origin fetches (connect-src 'self').
+//   - #3852 — cross-origin target="_blank" links must not open null-origin
+//             sandboxed popups; they go through the shell's open_url bridge.
+//   - #3853 / #3854 — middle-click (auxclick) and shift-click must also be
+//             intercepted, not just primary-button click.
+
+const shellUrl = process.env.FREENET_SHELL_URL;
+
+test.beforeAll(() => {
+  if (!shellUrl) {
+    throw new Error(
+      "FREENET_SHELL_URL is not set. These tests are normally driven by the " +
+        "Rust harness (crates/core/tests/playwright_shell.rs), which boots a " +
+        "node, publishes the fixture, and exports the shell URL.",
+    );
+  }
+});
+
+// Collector for browser console messages so individual tests can assert the
+// absence of CSP violations. Chromium reports a CSP block as a console error
+// whose text contains "Content Security Policy".
+function trackConsole(page: Page): ConsoleMessage[] {
+  const messages: ConsoleMessage[] = [];
+  page.on("console", (msg) => messages.push(msg));
+  return messages;
+}
+
+function cspViolations(messages: ConsoleMessage[]): string[] {
+  return messages
+    .map((m) => m.text())
+    .filter((t) => /content security policy/i.test(t));
+}
+
+// Install a capturing listener on the SHELL (top) window that records every
+// `__freenet_shell__` postMessage the iframe sends up. This lets us assert the
+// exact payload shape of the open_url / navigate contract, not just its
+// side effects. Must run before any interaction.
+async function captureShellMessages(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as unknown as { __freenetMessages: unknown[] }).__freenetMessages = [];
+    window.addEventListener(
+      "message",
+      (e) => {
+        const d = e.data;
+        if (d && typeof d === "object" && (d as { __freenet_shell__?: boolean }).__freenet_shell__) {
+          (window as unknown as { __freenetMessages: unknown[] }).__freenetMessages.push(d);
+        }
+      },
+      true,
+    );
+  });
+}
+
+type ShellMessage = { type: string; url?: string; href?: string; shiftKey?: boolean };
+
+async function shellMessages(page: Page): Promise<ShellMessage[]> {
+  return page.evaluate(
+    () => (window as unknown as { __freenetMessages: ShellMessage[] }).__freenetMessages,
+  );
+}
+
+// Override window.open on the shell page so an open_url that the bridge
+// honours is observable (and so the test never actually launches a popup to
+// example.com). Returns nothing; read the calls via openCalls().
+async function stubWindowOpen(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as unknown as { __openCalls: string[] }).__openCalls = [];
+    window.open = ((url?: string | URL) => {
+      (window as unknown as { __openCalls: string[] }).__openCalls.push(String(url ?? ""));
+      return null;
+    }) as typeof window.open;
+  });
+}
+
+async function openCalls(page: Page): Promise<string[]> {
+  return page.evaluate(() => (window as unknown as { __openCalls: string[] }).__openCalls);
+}
+
+// The shell wraps the contract in an iframe#app. Wait for the iframe to load
+// the fixture (its #title) and return a handle to that frame.
+async function fixtureFrame(page: Page) {
+  const frameElement = page.locator("iframe#app");
+  await expect(frameElement).toBeAttached();
+  const frame = page.frameLocator("iframe#app");
+  await expect(frame.locator("#title")).toBeVisible();
+  return frame;
+}
+
+test("shell page loads and embeds the sandboxed iframe", async ({ page }) => {
+  const consoleMessages = trackConsole(page);
+  const resp = await page.goto(shellUrl!);
+  expect(resp?.ok()).toBeTruthy();
+
+  // The shell serves its strict CSP on the outer page.
+  const csp = resp?.headers()["content-security-policy"] ?? "";
+  expect(csp, `shell CSP header missing: ${csp}`).toContain("frame-src 'self'");
+  // connect-src must include BOTH same-origin fetch (#3842) and ws/wss.
+  expect(csp).toMatch(/connect-src[^;]*'self'/);
+  expect(csp).toMatch(/connect-src[^;]*ws:/);
+
+  // The sandbox attribute must NOT grant allow-same-origin (origin isolation,
+  // GHSA-824h-7x5x-wfmf) but must allow scripts + popups.
+  const sandbox = await page.locator("iframe#app").getAttribute("sandbox");
+  expect(sandbox, `iframe sandbox: ${sandbox}`).toContain("allow-scripts");
+  expect(sandbox).toContain("allow-popups");
+  expect(sandbox).not.toContain("allow-same-origin");
+  expect(sandbox).not.toContain("allow-popups-to-escape-sandbox");
+
+  await fixtureFrame(page);
+  expect(
+    cspViolations(consoleMessages),
+    `unexpected CSP violations on initial load: ${cspViolations(consoleMessages).join(" | ")}`,
+  ).toEqual([]);
+});
+
+test("same-origin permission poll fetch is allowed by the shell CSP (#3842)", async ({ page }) => {
+  const consoleMessages = trackConsole(page);
+  await page.goto(shellUrl!);
+  const frame = await fixtureFrame(page);
+
+  // The fixture fires `fetch('/permission/pending')` on load. Under the fixed
+  // CSP (connect-src 'self') it resolves; under the #3842 regression
+  // (connect-src ws: wss:) it would be blocked and the result would start with
+  // "error:". The endpoint exists on the node, so a non-error result confirms
+  // the fetch reached the server.
+  const result = frame.locator("#poll-result");
+  await expect(result).not.toHaveText("pending");
+  await expect(result).toHaveText(/^fetched:/);
+
+  expect(
+    cspViolations(consoleMessages),
+    `permission poll triggered a CSP violation (regression of #3842): ${cspViolations(consoleMessages).join(" | ")}`,
+  ).toEqual([]);
+});
+
+test("left-click on a cross-origin link routes through the open_url bridge (#3852)", async ({
+  page,
+}) => {
+  await page.goto(shellUrl!);
+  await captureShellMessages(page);
+  await stubWindowOpen(page);
+  const frame = await fixtureFrame(page);
+
+  await frame.locator("#cross-origin-link").click();
+
+  // The interceptor must postMessage open_url to the shell ...
+  await expect
+    .poll(async () => (await shellMessages(page)).map((m) => m.type))
+    .toContain("open_url");
+  const msgs = await shellMessages(page);
+  const openUrl = msgs.find((m) => m.type === "open_url");
+  expect(openUrl?.url).toBe("https://example.com/external");
+  expect(openUrl?.shiftKey).toBe(false);
+
+  // ... and the shell must honour it via window.open with the real origin
+  // (not a sandboxed null-origin popup).
+  await expect.poll(async () => await openCalls(page)).toContain("https://example.com/external");
+});
+
+test("middle-click (auxclick) on a cross-origin link is also intercepted (#3853/#3854)", async ({
+  page,
+}) => {
+  await page.goto(shellUrl!);
+  await captureShellMessages(page);
+  await stubWindowOpen(page);
+  const frame = await fixtureFrame(page);
+
+  // Middle-click dispatches `auxclick`, not `click`. Pre-#3854 only `click`
+  // was listened for, so the browser opened a null-origin sandboxed popup.
+  await frame.locator("#cross-origin-link").click({ button: "middle" });
+
+  await expect
+    .poll(async () => (await shellMessages(page)).map((m) => m.type))
+    .toContain("open_url");
+  const openUrl = (await shellMessages(page)).find((m) => m.type === "open_url");
+  expect(openUrl?.url).toBe("https://example.com/external");
+});
+
+test("shift-click on a cross-origin link forwards shiftKey (#3853)", async ({ page }) => {
+  await page.goto(shellUrl!);
+  await captureShellMessages(page);
+  await stubWindowOpen(page);
+  const frame = await fixtureFrame(page);
+
+  await frame.locator("#cross-origin-link").click({ modifiers: ["Shift"] });
+
+  await expect
+    .poll(async () => (await shellMessages(page)).some((m) => m.type === "open_url" && m.shiftKey === true))
+    .toBeTruthy();
+});
+
+test("same-origin in-contract link performs an in-place navigate hop", async ({ page }) => {
+  await page.goto(shellUrl!);
+  await captureShellMessages(page);
+  const frame = await fixtureFrame(page);
+
+  await frame.locator("#same-origin-link").click();
+
+  // Interceptor sends a `navigate` (not `open_url`) for a same-origin link.
+  await expect
+    .poll(async () => (await shellMessages(page)).map((m) => m.type))
+    .toContain("navigate");
+  const navigate = (await shellMessages(page)).find((m) => m.type === "navigate");
+  expect(navigate?.href, `navigate href: ${navigate?.href}`).toContain("page2.html");
+
+  // The shell performs the hop in place: the iframe now shows page 2 and the
+  // top-level URL no longer carries __sandbox (issue #3839).
+  await expect(page.frameLocator("iframe#app").locator("#page2-title")).toBeVisible();
+  expect(page.url()).toContain("page2.html");
+  expect(page.url()).not.toContain("__sandbox");
+});

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -14,8 +14,9 @@ import { test, expect, type Page, type ConsoleMessage } from "@playwright/test";
 //   - #3842 — shell CSP must allow same-origin fetches (connect-src 'self').
 //   - #3852 — cross-origin target="_blank" links must not open null-origin
 //             sandboxed popups; they go through the shell's open_url bridge.
-//   - #3853 / #3854 — middle-click (auxclick) and shift-click must also be
-//             intercepted, not just primary-button click.
+//   - #3854 — middle-click (auxclick) and shift-click must also be
+//             intercepted, not just primary-button click (the merged fix;
+//             #3853 was the closed predecessor PR for the same work).
 
 const shellUrl = process.env.FREENET_SHELL_URL;
 
@@ -170,7 +171,7 @@ test("left-click on a cross-origin link routes through the open_url bridge (#385
   await expect.poll(async () => await openCalls(page)).toContain("https://example.com/external");
 });
 
-test("middle-click (auxclick) on a cross-origin link is also intercepted (#3853/#3854)", async ({
+test("middle-click (auxclick) on a cross-origin link is also intercepted (#3854)", async ({
   page,
 }) => {
   await page.goto(shellUrl!);
@@ -189,7 +190,7 @@ test("middle-click (auxclick) on a cross-origin link is also intercepted (#3853/
   expect(openUrl?.url).toBe("https://example.com/external");
 });
 
-test("shift-click on a cross-origin link forwards shiftKey (#3853)", async ({ page }) => {
+test("shift-click on a cross-origin link forwards shiftKey (#3854)", async ({ page }) => {
   await page.goto(shellUrl!);
   await captureShellMessages(page);
   await stubWindowOpen(page);

--- a/crates/core/tests/playwright_shell.rs
+++ b/crates/core/tests/playwright_shell.rs
@@ -55,7 +55,11 @@ use std::time::Duration;
 
 use freenet::test_utils::TestContext;
 use freenet_macros::freenet_test;
-use testresult::TestResult;
+// NOTE: the `#[freenet_test]` macro rewrites the wrapped function's return type
+// to `freenet::test_utils::TestResult`, so the `-> TestResult` annotation below
+// is parsed but discarded — no `TestResult` import is needed (and importing one
+// trips `unused_imports`). This matches the other `#[freenet_test]` suites
+// (e.g. error_notification.rs), which also write `-> TestResult` with no import.
 
 /// Name of the website signing key created in the temp config dir.
 const FIXTURE_KEY_NAME: &str = "smoke-fixture";
@@ -109,6 +113,31 @@ fn fixture_webapp_dir() -> PathBuf {
     playwright_dir().join("fixture-webapp")
 }
 
+/// Strip ANSI CSI escape sequences (`ESC [ ... <final byte>`) from a line.
+/// Small hand-rolled stripper so the harness needs no extra dependency; it
+/// only has to handle the colour/SGR sequences a CLI might emit.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' {
+            // ESC: skip an optional '[' then everything up to and including the
+            // final byte in the range 0x40..=0x7e.
+            if chars.peek() == Some(&'[') {
+                chars.next();
+            }
+            for d in chars.by_ref() {
+                if ('\u{40}'..='\u{7e}').contains(&d) {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 // ---------------------------------------------------------------------------
 // fdev website publish helpers
 // ---------------------------------------------------------------------------
@@ -129,12 +158,29 @@ fn website_init(config_home: &Path) -> anyhow::Result<String> {
             String::from_utf8_lossy(&output.stderr),
         );
     }
+    // Parse the "Your website contract key: <key>" line. `fdev` writes it with
+    // a plain `println!` and we capture its stdout via a pipe (not a TTY), so
+    // no ANSI colouring is emitted; we still strip CSI escape sequences and any
+    // trailing CR/whitespace defensively so a future colourised fdev, or a
+    // Windows CRLF, doesn't silently corrupt the key.
     let key = stdout
         .lines()
-        .find_map(|l| l.strip_prefix("Your website contract key: "))
-        .map(|k| k.trim().to_string())
-        .ok_or_else(|| anyhow::anyhow!("could not parse contract key from fdev output:\n{stdout}"))?;
-    anyhow::ensure!(!key.is_empty(), "fdev printed an empty contract key");
+        .find_map(|l| {
+            let stripped = strip_ansi(l);
+            stripped
+                .strip_prefix("Your website contract key: ")
+                .map(|k| k.trim().to_string())
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!("could not parse contract key from fdev output:\n{stdout}")
+        })?;
+    // Contract keys are base58 (alphanumeric, no punctuation/whitespace). A
+    // value that fails this shape check means our parse picked up the wrong
+    // text — fail loudly rather than feed garbage into the shell URL.
+    anyhow::ensure!(
+        !key.is_empty() && key.chars().all(|c| c.is_ascii_alphanumeric()),
+        "parsed contract key has unexpected shape (ANSI/format drift?): {key:?}"
+    );
     Ok(key)
 }
 
@@ -228,7 +274,10 @@ fn run_playwright(shell_url: &str) -> anyhow::Result<()> {
         .args(["playwright", "test"])
         .status()
         .map_err(|e| anyhow::anyhow!("failed to spawn `npx playwright test` in {dir:?}: {e}"))?;
-    anyhow::ensure!(status.success(), "Playwright suite failed (exit {status:?})");
+    anyhow::ensure!(
+        status.success(),
+        "Playwright suite failed (exit {status:?})"
+    );
     Ok(())
 }
 
@@ -243,10 +292,17 @@ fn run_playwright(shell_url: &str) -> anyhow::Result<()> {
 /// A single gateway node suffices: it stores its own published contract, so
 /// `contract_home` fetches it locally and renders the shell without needing
 /// network propagation.
+// Budget: the harness times the WHOLE test, including the `fdev website
+// publish` step (which can burn its full ~90s single-shot Put timeout before
+// the insert lands — see `website_publish_observed`), the shell-readiness poll
+// (up to 120s), and the Playwright suite (~70s for 7 specs). An observed local
+// run finished in ~282s, so 300s left almost no slack on a contended runner;
+// 600s gives comfortable headroom without masking a genuine hang (the
+// individual sub-steps have their own tighter internal deadlines).
 #[freenet_test(
     health_check_readiness = true,
     nodes = ["gateway"],
-    timeout_secs = 300,
+    timeout_secs = 600,
     startup_wait_secs = 30,
     tokio_flavor = "multi_thread",
     tokio_worker_threads = 4,

--- a/crates/core/tests/playwright_shell.rs
+++ b/crates/core/tests/playwright_shell.rs
@@ -1,0 +1,295 @@
+//! Rust harness that drives the Playwright shell smoke tests
+//! (freenet/freenet-core#3856).
+//!
+//! ## Why this exists
+//!
+//! Four PRs (#3842, #3849, #3852, #3854) fixed bugs in the shell bridge, the
+//! navigation interceptor, and the CSP — code that lives as JavaScript strings
+//! in `crates/core/src/server/path_handlers.rs` and `client_api.rs`. Each was
+//! only guarded by a Rust-level substring assertion on the emitted JS, and
+//! each review note said "this should really be a browser test". This harness
+//! closes that gap: it boots a real node, publishes a fixture webapp, and runs
+//! the injected shell/iframe JavaScript against a headless Chromium via
+//! Playwright.
+//!
+//! ## Architecture
+//!
+//! - Node lifecycle stays on the well-tested `#[freenet_test]` in-process path
+//!   (same model as `fdev_publish_e2e.rs`). A single gateway node is enough:
+//!   it stores the contract it publishes locally, so serving the shell needs
+//!   no network propagation.
+//! - The fixture webapp (`tests/playwright/fixture-webapp/`) is published as a
+//!   Freenet *website contract* using the same `fdev website` path real users
+//!   take. We drive `fdev` as a child process with a temp `XDG_CONFIG_HOME`,
+//!   so the signing key never touches the developer's real config dir.
+//! - Fixture WASM choice: we reuse the **prebuilt** website-container WASM that
+//!   ships embedded in `fdev` (`crates/fdev/resources/website_contract.wasm`).
+//!   That keeps the test free of a `wasm32-unknown-unknown` build step and
+//!   makes the contract key deterministic per fdev version. The tradeoff (the
+//!   WASM is a committed binary that must be rebuilt by hand when its source
+//!   changes) is already accepted project-wide — see
+//!   `crates/website-contract/README.md`.
+//! - The browser layer (`tests/playwright/`) is a thin Playwright project; the
+//!   Rust side passes it the ready-to-load shell URL via `FREENET_SHELL_URL`.
+//!
+//! ## Running
+//!
+//! The Playwright step is opt-in via `FREENET_PLAYWRIGHT=1` so the default
+//! `cargo nextest` run (and the unit-test CI job) does not require Node /
+//! browsers and never goes red for a missing toolchain. The dedicated
+//! `.github/workflows/playwright-shell.yml` job installs the browsers and sets
+//! the flag.
+//!
+//! ```text
+//! # one-time, in crates/core/tests/playwright/:
+//! npm ci && npx playwright install --with-deps chromium
+//! # then, from the workspace root:
+//! cargo build --bin fdev
+//! FREENET_PLAYWRIGHT=1 cargo nextest run -p freenet \
+//!   --features testing --test playwright_shell
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use freenet::test_utils::TestContext;
+use freenet_macros::freenet_test;
+use testresult::TestResult;
+
+/// Name of the website signing key created in the temp config dir.
+const FIXTURE_KEY_NAME: &str = "smoke-fixture";
+
+/// Env flag that opts in to actually launching Playwright. Unset (the default,
+/// including a plain `cargo test`) makes the test publish + reach the shell and
+/// then return early, so the absence of Node/browsers is never a failure.
+const PLAYWRIGHT_ENV: &str = "FREENET_PLAYWRIGHT";
+
+// ---------------------------------------------------------------------------
+// Path resolution (mirrors fdev_publish_e2e.rs)
+// ---------------------------------------------------------------------------
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace layout: crates/core/../../ should resolve")
+        .to_path_buf()
+}
+
+fn target_dir() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target"))
+}
+
+/// Path to the `fdev` binary. CI builds it with `cargo build` before tests;
+/// local devs need `cargo build --bin fdev` first.
+fn fdev_bin() -> PathBuf {
+    let debug = target_dir().join("debug").join("fdev");
+    if debug.exists() {
+        return debug;
+    }
+    let release = target_dir().join("release").join("fdev");
+    assert!(
+        release.exists(),
+        "fdev binary not found at {debug:?} or {release:?}. Build it first: \
+         `cargo build --bin fdev`."
+    );
+    release
+}
+
+fn playwright_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("playwright")
+}
+
+fn fixture_webapp_dir() -> PathBuf {
+    playwright_dir().join("fixture-webapp")
+}
+
+// ---------------------------------------------------------------------------
+// fdev website publish helpers
+// ---------------------------------------------------------------------------
+
+/// Run `fdev website init <FIXTURE_KEY_NAME>` against an isolated config dir
+/// (`XDG_CONFIG_HOME = config_home`) and return the contract key printed on the
+/// "Your website contract key: <key>" line.
+fn website_init(config_home: &Path) -> anyhow::Result<String> {
+    let output = Command::new(fdev_bin())
+        .env("XDG_CONFIG_HOME", config_home)
+        .args(["website", "init", FIXTURE_KEY_NAME])
+        .output()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if !output.status.success() {
+        anyhow::bail!(
+            "fdev website init failed: {:?}\nstdout: {stdout}\nstderr: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+    let key = stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("Your website contract key: "))
+        .map(|k| k.trim().to_string())
+        .ok_or_else(|| anyhow::anyhow!("could not parse contract key from fdev output:\n{stdout}"))?;
+    anyhow::ensure!(!key.is_empty(), "fdev printed an empty contract key");
+    Ok(key)
+}
+
+/// Run `fdev --node-url <ws_url> website publish <fixture> --key <name>`.
+///
+/// Like `fdev_publish_observed` in `fdev_publish_e2e.rs`, a non-zero exit is
+/// not treated as fatal: the freshly-spun fixture's Put driver can report a
+/// timeout while the insert still lands. We confirm the real outcome by
+/// polling the HTTP shell route instead.
+fn website_publish_observed(config_home: &Path, ws_url: &str) {
+    let output = Command::new(fdev_bin())
+        .env("XDG_CONFIG_HOME", config_home)
+        .args(["--node-url", ws_url, "website", "publish"])
+        .arg(fixture_webapp_dir())
+        .args(["--key", FIXTURE_KEY_NAME])
+        .output()
+        .expect("spawn fdev website publish");
+    if output.status.success() {
+        tracing::info!(
+            "fdev website publish exited 0: {}",
+            String::from_utf8_lossy(&output.stdout).trim_end()
+        );
+    } else {
+        tracing::warn!(
+            "fdev website publish reported error (may still have landed): exit={:?}\nstderr: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr).trim_end(),
+        );
+    }
+}
+
+/// Poll the shell route (`GET /v1/contract/web/{key}/`) until it returns 200
+/// and the body looks like the shell (contains the sandboxed iframe), or the
+/// deadline expires. A 200 shell means the node fetched + unpacked the contract
+/// it stored locally and `shell_page` rendered — exactly what the browser test
+/// then loads.
+async fn wait_for_shell(shell_url: &str, within: Duration) -> anyhow::Result<bool> {
+    let deadline = std::time::Instant::now() + within;
+    // reqwest is already a (non-dev) dependency of the freenet crate, so this
+    // adds no new dependency. Short per-request timeout so a hung connection
+    // doesn't eat the whole budget on one attempt.
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()?;
+    while std::time::Instant::now() < deadline {
+        match client.get(shell_url).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                let body = resp.text().await.unwrap_or_default();
+                if body.contains("id=\"app\"") && body.contains("freenetBridge") {
+                    return Ok(true);
+                }
+                tracing::debug!("shell 200 but body not ready yet ({} bytes)", body.len());
+            }
+            Ok(resp) => {
+                tracing::debug!("shell not ready: HTTP {}", resp.status());
+            }
+            Err(e) => {
+                tracing::debug!("shell request errored (node still warming?): {e}");
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    Ok(false)
+}
+
+// ---------------------------------------------------------------------------
+// Playwright invocation
+// ---------------------------------------------------------------------------
+
+/// Whether the caller asked us to actually launch the browser suite.
+fn playwright_enabled() -> bool {
+    matches!(
+        std::env::var(PLAYWRIGHT_ENV).ok().as_deref(),
+        Some("1") | Some("true")
+    )
+}
+
+/// Run `npx playwright test` against the shell URL. Assumes deps + browsers are
+/// already installed (the CI workflow / local README handle that). Returns an
+/// error if the suite fails so the Rust test fails too.
+fn run_playwright(shell_url: &str) -> anyhow::Result<()> {
+    let dir = playwright_dir();
+    anyhow::ensure!(
+        dir.join("node_modules").exists(),
+        "Playwright deps not installed. Run `npm ci` in {dir:?} (CI does this) \
+         before setting {PLAYWRIGHT_ENV}=1."
+    );
+    let status = Command::new("npx")
+        .current_dir(&dir)
+        .env("FREENET_SHELL_URL", shell_url)
+        .args(["playwright", "test"])
+        .status()
+        .map_err(|e| anyhow::anyhow!("failed to spawn `npx playwright test` in {dir:?}: {e}"))?;
+    anyhow::ensure!(status.success(), "Playwright suite failed (exit {status:?})");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+/// Boot a node, publish the fixture webapp, confirm the shell serves over HTTP,
+/// then (when `FREENET_PLAYWRIGHT=1`) run the Playwright browser suite against
+/// it.
+///
+/// A single gateway node suffices: it stores its own published contract, so
+/// `contract_home` fetches it locally and renders the shell without needing
+/// network propagation.
+#[freenet_test(
+    health_check_readiness = true,
+    nodes = ["gateway"],
+    timeout_secs = 300,
+    startup_wait_secs = 30,
+    tokio_flavor = "multi_thread",
+    tokio_worker_threads = 4,
+)]
+async fn shell_smoke_via_playwright(ctx: &mut TestContext) -> TestResult {
+    let node = ctx.node("gateway")?;
+
+    // Isolate the website signing key in a temp config dir so we never touch
+    // the developer's real ~/.config/freenet.
+    let config_home = tempfile::tempdir()?;
+    let key = website_init(config_home.path())?;
+    tracing::info!("fixture website contract key: {key}");
+
+    // Publish the fixture via the real `fdev website publish` path.
+    let ws_url = node.ws_url();
+    website_publish_observed(config_home.path(), &ws_url);
+
+    // The HTTP API server shares the node's WS port. Build the shell route.
+    let shell_url = format!(
+        "http://{}:{}/v1/contract/web/{}/",
+        node.ip, node.ws_port, key
+    );
+
+    assert!(
+        wait_for_shell(&shell_url, Duration::from_secs(120)).await?,
+        "shell never became ready at {shell_url} — the fixture contract did not \
+         publish + unpack within the deadline"
+    );
+    tracing::info!("shell ready at {shell_url}");
+
+    if !playwright_enabled() {
+        tracing::warn!(
+            "{PLAYWRIGHT_ENV} not set: published the fixture and confirmed the \
+             shell serves, but skipping the browser suite. Set {PLAYWRIGHT_ENV}=1 \
+             (and install Playwright deps) to run it."
+        );
+        return Ok(());
+    }
+
+    // tokio is multi-threaded here; the blocking `npx` child is fine on a
+    // worker thread for a one-shot suite run.
+    let shell_url_for_pw = shell_url.clone();
+    tokio::task::spawn_blocking(move || run_playwright(&shell_url_for_pw)).await??;
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

The gateway shell bridge, navigation interceptor, and CSP are JavaScript
strings injected by `crates/core/src/server/path_handlers.rs` and
`client_api.rs`. Nothing in CI executes that JS in a real browser — every
existing test only substring-matches the emitted strings at the Rust level.
Four regressions shipped to production through that gap, each with a review
note saying "this should really be a browser test":

- **#3842** — shell CSP missing `connect-src 'self'` blocked the
  `/permission/pending` poller in every webapp (fix pinned by #3849).
- **#3852** — cross-origin `target="_blank"` links opened null-origin
  sandboxed popups and broke CORS on destination sites (freenet/river#208).
- **#3854** — middle-click (`auxclick`) and shift/modifier-key semantics on
  cross-origin links were silently dropped; middle-click wasn't intercepted
  at all (#3853 was the closed predecessor of this merged fix).

## Approach

Add a Playwright smoke-test harness that drives the injected shell/iframe JS
against headless Chromium:

- `crates/core/tests/playwright_shell.rs` — a `#[freenet_test]` harness that
  boots a single in-process gateway, publishes a fixture webapp via the real
  `fdev website publish` path (isolated `XDG_CONFIG_HOME`), waits for the
  shell route to serve, then runs the Playwright suite with the shell URL in
  `FREENET_SHELL_URL`. Node lifecycle stays on the well-tested in-process path,
  mirroring `fdev_publish_e2e.rs`. A single node suffices: it stores its own
  published contract, so the shell renders with no network propagation.
- `crates/core/tests/playwright/` — the browser layer: a minimal fixture
  webapp (cross-origin / same-origin / download links + a permission-poll
  fetch) and specs that assert the shell CSP, the sandbox attribute, the
  `open_url` bridge for left/middle/shift cross-origin clicks, the in-place
  navigate hop for same-origin links, browser-Back restoration (#3839), and
  the absence of CSP violations.
- `.github/workflows/playwright-shell.yml` — a path-filtered job
  (`crates/core/src/server/**`, the test files, and `crates/fdev/**` since the
  harness shells out to `fdev website publish`) that installs cached Playwright
  browsers and runs the harness with `FREENET_PLAYWRIGHT=1`.

The browser step is opt-in via `FREENET_PLAYWRIGHT=1`, so the default
`cargo nextest` run publishes the fixture and confirms the shell serves but
skips the browser suite — a checkout without Node/browsers never goes red.

Fixture WASM reuses the prebuilt website-container WASM embedded in fdev
(`crates/fdev/resources/website_contract.wasm`); no `wasm32-unknown-unknown`
build step, deterministic contract key per fdev version.

## Testing

Purely additive test infrastructure; no production code changes. Validated
end-to-end: 7/7 specs pass against a live node. The new workflow is
informational (not a required check) and path-filtered, so it does not run on
unrelated PRs. A plain `cargo nextest` run (without `FREENET_PLAYWRIGHT=1`)
still publishes the fixture and confirms the shell serves, so the Rust side
exercises `fdev website publish` even when browsers are absent.

Closes #3856

[AI-assisted - Claude]