### PR TITLE
feat: reject debug-compiled WASM contracts at PUT time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,6 +2072,7 @@ dependencies = [
  "turmoil",
  "ulid",
  "url",
+ "wasmparser 0.248.0",
  "wasmtime",
  "which",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,11 @@ wasmtime = { version = "45", default-features = false, features = [
     "gc", "gc-drc", "gc-null", "parallel-compilation", "pooling-allocator",
     "profiling", "runtime", "std", "threads", "wat",
 ] }
+# Lightweight WASM section parser used to reject debug-compiled contracts at
+# PUT time (see crates/core/src/client_events.rs::contains_debug_sections).
+# Pinned to the same minor wasmtime 45 already resolves transitively so cargo
+# reuses one copy rather than locking a second wasmparser build.
+wasmparser = "0.248"
 
 # Testing/simulation
 arbitrary = { version = "1", features = ["derive"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -83,6 +83,9 @@ tower-http = { workspace = true }
 ulid = { workspace = true }
 zeroize = { workspace = true }
 wasmtime = { workspace = true, optional = true }
+# Always enabled (not gated on wasmtime-backend): debug-section rejection at
+# PUT time must run regardless of which WASM execution backend is compiled in.
+wasmparser = { workspace = true }
 xz2 = { workspace = true }
 reqwest = { workspace = true }
 x25519-dalek = { workspace = true }

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -2571,6 +2571,28 @@ pub(crate) mod test {
             assert!(!contains_debug_sections(&truncated));
         }
 
+        /// A `.debug_*` section followed by a parse error must NOT leave the
+        /// scan reporting the already-collected debug section (Codex P3): a
+        /// module we can't fully parse is not trustworthy evidence of a
+        /// debug build, and rejecting it with "recompile with --release"
+        /// would mask the real malformed-WASM error. The whole scan must
+        /// void to empty on any parse error.
+        #[test]
+        fn debug_section_before_parse_error_is_not_flagged() {
+            // A complete, valid `.debug_info` custom section...
+            let mut wasm = wasm_with_custom_section(".debug_info", &[0xde, 0xad]);
+            // ...then a second custom section header that lies about its
+            // length, so the parser errors AFTER the debug section is seen.
+            wasm.push(0x00); // custom section id
+            wasm.push(0x40); // claims 64 bytes follow, but none do
+            assert!(
+                !contains_debug_sections(&wasm),
+                "a parse error after a debug section must void the scan, \
+                 not report the partial result"
+            );
+            assert!(debug_sections(&wasm).is_empty());
+        }
+
         /// The rejection maps through `report_op_init_error`'s
         /// `OpError::ContractError(_)` arm to a client-visible
         /// `ErrorKind::OperationError` whose cause carries the actionable

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -303,52 +303,7 @@ async fn register_subscription_listener(
     }
 }
 
-/// Names of the DWARF debug custom sections that mark a debug-compiled
-/// WASM module. Release builds (`--release`) emit none of these.
-const DEBUG_SECTION_PREFIX: &str = ".debug_";
-
-/// Scan a WASM module's custom sections and collect the names of any
-/// DWARF debug sections (`.debug_*`) it contains.
-///
-/// Debug-compiled contracts are typically 10-100x larger than release
-/// builds (e.g. ~12MB vs ~186KB for the ping contract) and can exceed
-/// WebSocket message-size limits, surfacing as a confusing "Message too
-/// long" transport error rather than an actionable one. We detect them
-/// at PUT time by looking for the `.debug_*` custom sections the Rust
-/// debug profile leaves in the module. See #2257.
-///
-/// Returns the matching section names in encounter order (empty when the
-/// module is a release build or cannot be parsed). A module that fails to
-/// parse is treated as "no debug sections": malformed-WASM rejection is a
-/// separate concern handled downstream by the executor, and we must not
-/// reject a contract here merely because this lightweight scan disagrees
-/// with the full validator.
-fn debug_sections(wasm: &[u8]) -> Vec<String> {
-    let mut found = Vec::new();
-    for payload in wasmparser::Parser::new(0).parse_all(wasm) {
-        match payload {
-            Ok(wasmparser::Payload::CustomSection(reader)) => {
-                let name = reader.name();
-                if name.starts_with(DEBUG_SECTION_PREFIX) {
-                    found.push(name.to_string());
-                }
-            }
-            // Stop scanning on the first parse error: we cannot trust
-            // section boundaries past it. Treat as "no debug sections"
-            // (see doc comment) rather than guessing.
-            Err(_) => break,
-            // Non-custom sections are irrelevant to debug detection.
-            Ok(_) => {}
-        }
-    }
-    found
-}
-
-/// Returns true if the WASM module contains any DWARF debug section,
-/// i.e. it was compiled in debug mode. See [`debug_sections`].
-fn contains_debug_sections(wasm: &[u8]) -> bool {
-    !debug_sections(wasm).is_empty()
-}
+use crate::contract::{contains_debug_sections, debug_sections};
 
 /// Report an operation init failure to the client via the result router.
 async fn report_op_init_error(
@@ -2493,7 +2448,7 @@ pub(crate) mod test {
     // would trip `dead_code` in a plain `cargo build`.
     #[cfg(test)]
     mod debug_wasm {
-        use super::super::{contains_debug_sections, debug_sections};
+        use crate::contract::{contains_debug_sections, debug_sections};
 
         /// Minimal unsigned-LEB128 encoder for building WASM section bytes by
         /// hand. Sufficient for the small lengths used in these fixtures.

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -303,6 +303,53 @@ async fn register_subscription_listener(
     }
 }
 
+/// Names of the DWARF debug custom sections that mark a debug-compiled
+/// WASM module. Release builds (`--release`) emit none of these.
+const DEBUG_SECTION_PREFIX: &str = ".debug_";
+
+/// Scan a WASM module's custom sections and collect the names of any
+/// DWARF debug sections (`.debug_*`) it contains.
+///
+/// Debug-compiled contracts are typically 10-100x larger than release
+/// builds (e.g. ~12MB vs ~186KB for the ping contract) and can exceed
+/// WebSocket message-size limits, surfacing as a confusing "Message too
+/// long" transport error rather than an actionable one. We detect them
+/// at PUT time by looking for the `.debug_*` custom sections the Rust
+/// debug profile leaves in the module. See #2257.
+///
+/// Returns the matching section names in encounter order (empty when the
+/// module is a release build or cannot be parsed). A module that fails to
+/// parse is treated as "no debug sections": malformed-WASM rejection is a
+/// separate concern handled downstream by the executor, and we must not
+/// reject a contract here merely because this lightweight scan disagrees
+/// with the full validator.
+fn debug_sections(wasm: &[u8]) -> Vec<String> {
+    let mut found = Vec::new();
+    for payload in wasmparser::Parser::new(0).parse_all(wasm) {
+        match payload {
+            Ok(wasmparser::Payload::CustomSection(reader)) => {
+                let name = reader.name();
+                if name.starts_with(DEBUG_SECTION_PREFIX) {
+                    found.push(name.to_string());
+                }
+            }
+            // Stop scanning on the first parse error: we cannot trust
+            // section boundaries past it. Treat as "no debug sections"
+            // (see doc comment) rather than guessing.
+            Err(_) => break,
+            // Non-custom sections are irrelevant to debug detection.
+            Ok(_) => {}
+        }
+    }
+    found
+}
+
+/// Returns true if the WASM module contains any DWARF debug section,
+/// i.e. it was compiled in debug mode. See [`debug_sections`].
+fn contains_debug_sections(wasm: &[u8]) -> bool {
+    !debug_sections(wasm).is_empty()
+}
+
 /// Report an operation init failure to the client via the result router.
 async fn report_op_init_error(
     op_manager: &OpManager,
@@ -693,6 +740,36 @@ async fn process_open_request(
                                     "Error waiting for transaction result"
                                 )
                             })?;
+
+                        // Reject debug-compiled contracts BEFORE routing
+                        // (#2257). Debug WASM carries DWARF `.debug_*`
+                        // custom sections and is typically 10-100x larger
+                        // than release builds, which can blow past
+                        // WebSocket message-size limits and surface as a
+                        // confusing "Message too long" transport error.
+                        // Failing here gives the client an actionable
+                        // "recompile with --release" message instead.
+                        if contains_debug_sections(contract.data()) {
+                            // Re-scan only on the (rare) rejection path to
+                            // name the offending sections in the error.
+                            let detected = debug_sections(contract.data());
+                            let err = OpError::ContractError(
+                                crate::contract::ContractError::DebugWasmRejected {
+                                    sections: detected.join(", "),
+                                },
+                            );
+                            report_op_init_error(
+                                &op_manager,
+                                client_tx,
+                                &contract_key,
+                                "PUT",
+                                &err,
+                                client_id,
+                                request_id,
+                            )
+                            .await;
+                            return Ok(None);
+                        }
 
                         if subscribe {
                             if let Some(sl) = subscription_listener {
@@ -2408,4 +2485,174 @@ pub(crate) mod test {
             ),
         }
     }
+
+    // Debug-WASM rejection (#2257). Nested in its own `#[cfg(test)]`
+    // module because the enclosing `mod test` is `pub(crate)` (it exports
+    // `MemoryEventsGen` to non-test simulation code) and so is compiled in
+    // non-test builds; without this gate the byte-builder helpers below
+    // would trip `dead_code` in a plain `cargo build`.
+    #[cfg(test)]
+    mod debug_wasm {
+        use super::super::{contains_debug_sections, debug_sections};
+
+        /// Minimal unsigned-LEB128 encoder for building WASM section bytes by
+        /// hand. Sufficient for the small lengths used in these fixtures.
+        fn leb128_u32(mut value: u32, out: &mut Vec<u8>) {
+            loop {
+                let mut byte = (value & 0x7f) as u8;
+                value >>= 7;
+                if value != 0 {
+                    byte |= 0x80;
+                }
+                out.push(byte);
+                if value == 0 {
+                    break;
+                }
+            }
+        }
+
+        /// Build a minimal valid WASM module (just the 8-byte header) plus a
+        /// single custom section with `name`. A WASM custom section is:
+        /// `0x00` (section id) | `section_len` (LEB128) | `name_len` (LEB128) |
+        /// `name` bytes | payload bytes.
+        fn wasm_with_custom_section(name: &str, payload: &[u8]) -> Vec<u8> {
+            let mut name_field = Vec::new();
+            leb128_u32(name.len() as u32, &mut name_field);
+            name_field.extend_from_slice(name.as_bytes());
+
+            let mut section_body = name_field;
+            section_body.extend_from_slice(payload);
+
+            // WASM magic + version 1.
+            let mut module = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+            module.push(0x00); // custom section id
+            leb128_u32(section_body.len() as u32, &mut module);
+            module.extend_from_slice(&section_body);
+            module
+        }
+
+        /// A release-style module: valid header, no custom sections at all.
+        fn release_wasm() -> Vec<u8> {
+            vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]
+        }
+
+        /// A debug WASM module is rejected: at least one `.debug_*` custom
+        /// section is detected. This is the core guarantee of #2257 — without
+        /// the fix, `debug_sections` would return empty and the 12MB debug
+        /// contract would be routed and then fail with an opaque transport
+        /// error.
+        #[test]
+        fn debug_wasm_is_detected() {
+            let wasm = wasm_with_custom_section(".debug_info", &[0xde, 0xad, 0xbe, 0xef]);
+            assert!(
+                contains_debug_sections(&wasm),
+                "a module carrying a .debug_info custom section must be flagged as debug"
+            );
+            let sections = debug_sections(&wasm);
+            assert_eq!(sections, vec![".debug_info".to_string()]);
+        }
+
+        /// Every DWARF section the issue enumerates is detected (not just
+        /// `.debug_info`), and multiple sections are all reported.
+        #[test]
+        fn all_dwarf_sections_are_detected() {
+            for name in [
+                ".debug_abbrev",
+                ".debug_info",
+                ".debug_ranges",
+                ".debug_str",
+                ".debug_line",
+                ".debug_loc",
+            ] {
+                let wasm = wasm_with_custom_section(name, &[0x00]);
+                assert!(
+                    contains_debug_sections(&wasm),
+                    "{name} must be detected as a debug section"
+                );
+            }
+        }
+
+        /// A release WASM module (no custom sections) passes the check.
+        #[test]
+        fn release_wasm_passes() {
+            let wasm = release_wasm();
+            assert!(
+                !contains_debug_sections(&wasm),
+                "a release build with no custom sections must not be flagged as debug"
+            );
+            assert!(debug_sections(&wasm).is_empty());
+        }
+
+        /// A non-debug custom section (e.g. the conventional `name` section, or
+        /// a producers section) must NOT be misclassified as debug. Release
+        /// builds routinely carry these; flagging them would reject valid
+        /// contracts.
+        #[test]
+        fn non_debug_custom_sections_pass() {
+            for name in ["name", "producers", "target_features", ".llvmcmd"] {
+                let wasm = wasm_with_custom_section(name, &[0x01, 0x02]);
+                assert!(
+                    !contains_debug_sections(&wasm),
+                    "custom section {name:?} is not a .debug_* section and must pass"
+                );
+            }
+        }
+
+        /// Unparseable / truncated input is treated as "no debug sections":
+        /// malformed-WASM rejection is the executor's job, not this scan's.
+        /// We must not reject a contract here just because the lightweight
+        /// parser tripped.
+        #[test]
+        fn malformed_wasm_is_not_flagged_as_debug() {
+            // Empty input.
+            assert!(!contains_debug_sections(&[]));
+            // Garbage that is not a WASM module.
+            assert!(!contains_debug_sections(b"not a wasm module at all"));
+            // Valid header followed by a truncated custom section (declares a
+            // length longer than the bytes that follow).
+            let mut truncated = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+            truncated.push(0x00); // custom section id
+            truncated.push(0x20); // claims 32 bytes follow, but none do
+            assert!(!contains_debug_sections(&truncated));
+        }
+
+        /// The rejection maps through `report_op_init_error`'s
+        /// `OpError::ContractError(_)` arm to a client-visible
+        /// `ErrorKind::OperationError` whose cause carries the actionable
+        /// "recompile with --release" guidance. Replicates the relevant arm
+        /// (same fixture-avoidance approach as the pins above).
+        #[test]
+        fn debug_wasm_rejection_yields_actionable_client_error() {
+            use crate::operations::OpError;
+            use freenet_stdlib::client_api::ErrorKind;
+
+            let err = OpError::ContractError(crate::contract::ContractError::DebugWasmRejected {
+                sections: ".debug_info, .debug_str".to_string(),
+            });
+            let op_name = "PUT";
+            #[allow(clippy::wildcard_enum_match_arm)]
+            let kind = match err {
+                OpError::ContractError(_) => ErrorKind::OperationError {
+                    cause: format!("{op_name} operation failed: {err}").into(),
+                },
+                _ => ErrorKind::Unhandled {
+                    cause: "irrelevant for this test".to_string().into(),
+                },
+            };
+            #[allow(clippy::wildcard_enum_match_arm)]
+            match kind {
+                ErrorKind::OperationError { cause } => {
+                    assert!(
+                        cause.contains("debug mode"),
+                        "cause must explain the contract is debug-compiled; got: {cause}"
+                    );
+                    assert!(
+                        cause.contains("--release"),
+                        "cause must tell the user to recompile with --release; got: {cause}"
+                    );
+                }
+                other => panic!("DebugWasmRejected must map to OperationError, got {other:?}"),
+            }
+        }
+    } // mod debug_wasm
 }

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -2209,6 +2209,53 @@ where
     Ok(())
 }
 
+/// Prefix shared by all DWARF debug custom sections (`.debug_info`,
+/// `.debug_str`, ...). Release builds (`--release`) emit none of these.
+const DEBUG_SECTION_PREFIX: &str = ".debug_";
+
+/// Scan a WASM module's custom sections and collect the names of any
+/// DWARF debug sections (`.debug_*`) it contains.
+///
+/// Debug-compiled contracts are typically 10-100x larger than release
+/// builds (e.g. ~12MB vs ~186KB for the ping contract) and can exceed
+/// WebSocket message-size limits, surfacing as a confusing "Message too
+/// long" transport error rather than an actionable one. We detect them
+/// at PUT time by looking for the `.debug_*` custom sections the Rust
+/// debug profile leaves in the module. See #2257.
+///
+/// Returns the matching section names in encounter order (empty when the
+/// module is a release build or cannot be parsed). A module that fails to
+/// parse is treated as "no debug sections": malformed-WASM rejection is a
+/// separate concern handled downstream by the WASM runtime, and we must
+/// not reject a contract here merely because this lightweight scan
+/// disagrees with the full validator.
+pub(crate) fn debug_sections(wasm: &[u8]) -> Vec<String> {
+    let mut found = Vec::new();
+    for payload in wasmparser::Parser::new(0).parse_all(wasm) {
+        match payload {
+            Ok(wasmparser::Payload::CustomSection(reader)) => {
+                let name = reader.name();
+                if name.starts_with(DEBUG_SECTION_PREFIX) {
+                    found.push(name.to_string());
+                }
+            }
+            // Stop scanning on the first parse error: we cannot trust
+            // section boundaries past it. Treat as "no debug sections"
+            // (see doc comment) rather than guessing.
+            Err(_) => break,
+            // Non-custom sections are irrelevant to debug detection.
+            Ok(_) => {}
+        }
+    }
+    found
+}
+
+/// Returns true if the WASM module contains any DWARF debug section,
+/// i.e. it was compiled in debug mode. See [`debug_sections`].
+pub(crate) fn contains_debug_sections(wasm: &[u8]) -> bool {
+    !debug_sections(wasm).is_empty()
+}
+
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ContractError {
     #[error("handler channel dropped")]

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -2223,12 +2223,18 @@ const DEBUG_SECTION_PREFIX: &str = ".debug_";
 /// at PUT time by looking for the `.debug_*` custom sections the Rust
 /// debug profile leaves in the module. See #2257.
 ///
-/// Returns the matching section names in encounter order (empty when the
-/// module is a release build or cannot be parsed). A module that fails to
-/// parse is treated as "no debug sections": malformed-WASM rejection is a
-/// separate concern handled downstream by the WASM runtime, and we must
-/// not reject a contract here merely because this lightweight scan
-/// disagrees with the full validator.
+/// Returns the matching section names in encounter order, or an empty
+/// vec when the module is a release build OR cannot be fully parsed.
+///
+/// A module that fails to parse is treated as "no debug sections" —
+/// including the case where some `.debug_*` sections were collected
+/// before the parse error: we discard the partial result and return
+/// empty. Malformed-WASM rejection is a separate concern handled
+/// downstream by the WASM runtime with a precise error; we must not
+/// short-circuit it here with a misleading "recompile with --release"
+/// message, and a partial scan of a module we can't fully parse is not
+/// trustworthy evidence of a debug build. We only trust the `.debug_*`
+/// signal on a module that parses cleanly end to end.
 pub(crate) fn debug_sections(wasm: &[u8]) -> Vec<String> {
     let mut found = Vec::new();
     for payload in wasmparser::Parser::new(0).parse_all(wasm) {
@@ -2239,10 +2245,13 @@ pub(crate) fn debug_sections(wasm: &[u8]) -> Vec<String> {
                     found.push(name.to_string());
                 }
             }
-            // Stop scanning on the first parse error: we cannot trust
-            // section boundaries past it. Treat as "no debug sections"
-            // (see doc comment) rather than guessing.
-            Err(_) => break,
+            // A parse error anywhere voids the whole scan: section
+            // boundaries past it can't be trusted, and any `.debug_*`
+            // names collected BEFORE it are not reliable evidence on a
+            // module we can't fully parse. Treat the module as "no debug
+            // sections" (see doc comment) so the runtime surfaces the real
+            // malformed-WASM error instead of "recompile with --release".
+            Err(_) => return Vec::new(),
             // Non-custom sections are irrelevant to debug detection.
             Ok(_) => {}
         }

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -2222,6 +2222,19 @@ pub(crate) enum ContractError {
         key: ContractKey,
         error: ExecutorError,
     },
+    /// The contract WASM contains DWARF debug sections (`.debug_*`),
+    /// indicating it was compiled in debug mode. Debug builds are
+    /// typically 10-100x larger than release builds and can exceed
+    /// WebSocket message-size limits, producing confusing "Message too
+    /// long" errors. Rejected at PUT time so the problem surfaces with
+    /// an actionable message instead of a transport failure. See #2257.
+    #[error(
+        "contract appears to be compiled in debug mode \
+         (contains {sections} section(s)). Debug WASM is typically \
+         10-100x larger than release builds and may exceed message-size \
+         limits. Recompile the contract with `--release` before publishing."
+    )]
+    DebugWasmRejected { sections: String },
 }
 
 #[cfg(test)]

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -3520,6 +3520,30 @@ impl Executor<Runtime> {
                     state_size = state.as_ref().len(),
                     "putting contract"
                 );
+                // Reject debug-compiled contracts (#2257). The network
+                // client path guards this in `process_open_request`, but
+                // local-node mode (`run_local_node`, the local server
+                // loop, `preload`, `handle_request`) PUTs straight through
+                // here — and local development is the most likely place to
+                // hand the node a debug build. Debug WASM carries DWARF
+                // `.debug_*` sections and is 10-100x larger than release,
+                // so without this guard it surfaces as an opaque
+                // "Message too long" error instead of an actionable one.
+                let key = contract.key();
+                if crate::contract::contains_debug_sections(contract.data()) {
+                    let sections = crate::contract::debug_sections(contract.data()).join(", ");
+                    return Err(ExecutorError::request(StdContractError::Put {
+                        key,
+                        cause: format!(
+                            "contract appears to be compiled in debug mode \
+                             (contains {sections} section(s)). Debug WASM is \
+                             typically 10-100x larger than release builds and \
+                             may exceed message-size limits. Recompile the \
+                             contract with `--release` before publishing."
+                        )
+                        .into(),
+                    }));
+                }
                 self.perform_contract_put(contract, state, related_contracts)
                     .await
             }
@@ -4966,6 +4990,39 @@ mod executor_pin_tests {
         assert!(
             !body.contains("DEFAULT_MODULE_CACHE_CAPACITY"),
             "RuntimePool::new must no longer reference the removed count cap"
+        );
+    }
+
+    /// Pin (#2257): the `ContractRequest::Put` arm of `contract_requests`
+    /// MUST reject debug-compiled WASM (`contains_debug_sections`) BEFORE
+    /// delegating to `perform_contract_put`. This is the only debug-WASM
+    /// guard on the local-node PUT path (`run_local_node`, the local
+    /// server loop, `preload`, `handle_request`), which never touches
+    /// `process_open_request`. A migration that drops this call would
+    /// silently restore the opaque "Message too long" symptom for local
+    /// development — exactly the case #2257 targets. Source-scrape pin per
+    /// `.claude/rules/bug-prevention-patterns.md` (cheaper and more robust
+    /// than standing up a full `Executor<Runtime>` fixture for a one-line
+    /// guard).
+    #[test]
+    fn contract_requests_put_rejects_debug_wasm_before_perform_put() {
+        let src = include_str!("runtime.rs");
+        // Isolate the `contract_requests` function body.
+        let body = src
+            .split("pub async fn contract_requests(")
+            .nth(1)
+            .expect("contract_requests must exist");
+        let guard_pos = body
+            .find("contains_debug_sections")
+            .expect("contract_requests Put arm must call contains_debug_sections");
+        let put_pos = body
+            .find("self.perform_contract_put(")
+            .expect("contract_requests must call perform_contract_put");
+        assert!(
+            guard_pos < put_pos,
+            "the debug-WASM guard (contains_debug_sections) must run BEFORE \
+             perform_contract_put, so a debug build is rejected before any \
+             local storage/validation work"
         );
     }
 }

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -181,6 +181,25 @@ pub(super) async fn put_contract(
     related_contracts: RelatedContracts<'static>,
     contract: &ContractContainer,
 ) -> Result<(WrappedState, bool), OpError> {
+    // Reject debug-compiled contracts before storing (#2257). This is the
+    // shared storage chokepoint for the network/relay PUT path
+    // (`relay_put_store_locally` → here), which does NOT pass through the
+    // originator's `process_open_request` / `contract_requests` guards.
+    // Without this, a debug contract from a malicious or mixed-version
+    // peer could still be stored and re-forwarded by this node. Debug WASM
+    // carries DWARF `.debug_*` sections and is 10-100x larger than release.
+    if crate::contract::contains_debug_sections(contract.data()) {
+        let sections = crate::contract::debug_sections(contract.data()).join(", ");
+        tracing::warn!(
+            contract = %key,
+            sections = %sections,
+            "Rejecting debug-compiled contract at storage time (#2257)"
+        );
+        return Err(OpError::ContractError(
+            crate::contract::ContractError::DebugWasmRejected { sections },
+        ));
+    }
+
     match op_manager
         .notify_contract_handler(ContractHandlerEvent::PutQuery {
             key,
@@ -946,6 +965,50 @@ mod tests {
              freenet-stdlib mirror demo 180s cold-GET timeout (2026-05-14) \
              returns. See contracts_needing_renewal at hosting.rs:971-991 \
              for the downstream gate that depends on this flag."
+        );
+    }
+
+    /// Pin (#2257): `put_contract` — the shared storage chokepoint for the
+    /// network/relay PUT path — MUST reject debug-compiled WASM
+    /// (`contains_debug_sections`) before notifying the contract handler
+    /// to store it. This is the only debug-WASM guard for contracts
+    /// arriving via relay/forwarding (`relay_put_store_locally`), which
+    /// bypasses the originator-side `process_open_request` /
+    /// `contract_requests` guards. Without it a malicious or
+    /// mixed-version peer could still get this node to store and
+    /// re-forward a debug build. Matches on executable code (line comments
+    /// stripped) so the doc comment above the call can't false-pass.
+    #[test]
+    fn put_contract_rejects_debug_wasm_before_storing() {
+        const SOURCE: &str = include_str!("put.rs");
+        let fn_start = SOURCE
+            .find("pub(super) async fn put_contract(")
+            .expect("put_contract definition not found");
+        let body_start = SOURCE[fn_start..]
+            .find('{')
+            .map(|p| fn_start + p)
+            .expect("put_contract body opening brace not found");
+        let body_end = SOURCE[body_start..]
+            .find("\n}\n")
+            .map(|p| body_start + p)
+            .expect("put_contract body closing brace not found");
+        let body = &SOURCE[body_start..body_end];
+        let executable: String = body
+            .lines()
+            .map(|line| line.split("//").next().unwrap_or(""))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let guard_pos = executable
+            .find("contains_debug_sections")
+            .expect("put_contract must call contains_debug_sections (executable code)");
+        let store_pos = executable
+            .find("notify_contract_handler")
+            .expect("put_contract must call notify_contract_handler");
+        assert!(
+            guard_pos < store_pos,
+            "the debug-WASM guard MUST run BEFORE notify_contract_handler so a \
+             relayed debug contract is rejected before this node stores it"
         );
     }
 }


### PR DESCRIPTION
## Problem

Debug-compiled WASM contracts are ~65x larger than release builds (e.g.
~12MB vs ~186KB for the ping contract). When a client PUTs one of these,
the serialized message can exceed WebSocket size limits and surface as a
confusing "Message too long" transport error rather than something
actionable. PR #2252 raised the WS limit to 100MB as a workaround and
PR #2254 fixed tests to use release builds, but nothing prevented the
problem at the source.

## Approach

Reject debug-compiled contracts at PUT time, before the contract is
routed, with an actionable error.

- Add `contains_debug_sections(wasm: &[u8]) -> bool` (and the underlying
  `debug_sections` helper) in `client_events.rs`. It scans the WASM
  custom sections with `wasmparser` and flags any section whose name
  starts with `.debug_` (the DWARF sections the Rust debug profile
  leaves behind: `.debug_info`, `.debug_str`, `.debug_line`, etc.).
- In the `ContractRequest::Put` arm of `process_open_request`, run the
  check right after the transaction is registered with the result router
  and before `start_client_put`. On a hit, surface the rejection through
  the existing `report_op_init_error` path so the client receives a
  typed `ErrorKind::OperationError` whose cause tells the user to
  recompile with `--release`.
- The error is carried by a new `ContractError::DebugWasmRejected`
  variant, which flows through `report_op_init_error`'s existing
  `OpError::ContractError(_)` arm with no other match changes.

Design choices:
- A module that fails to parse is treated as "no debug sections" — this
  scan must not reject a contract merely because the lightweight parser
  disagrees with the full validator; malformed-WASM rejection remains
  the executor's job.
- `wasmparser` is added as a direct dependency (not gated on the
  `wasmtime-backend` feature) so the check runs regardless of which WASM
  execution backend is compiled in. It pins to `0.248`, the version
  wasmtime 45 already resolves transitively, so cargo reuses one copy.

## Testing

New unit tests in `client_events::test`:
- `debug_wasm_is_detected` — a module carrying `.debug_info` is flagged.
- `all_dwarf_sections_are_detected` — every DWARF section the issue
  enumerates (`.debug_abbrev/info/ranges/str/line/loc`) is caught.
- `release_wasm_passes` — a release build (no custom sections) is
  accepted.
- `non_debug_custom_sections_pass` — non-debug custom sections (`name`,
  `producers`, `target_features`, `.llvmcmd`) are not misclassified.
- `malformed_wasm_is_not_flagged_as_debug` — empty/garbage/truncated
  input is treated as "no debug sections", not rejected.
- `debug_wasm_rejection_yields_actionable_client_error` — the rejection
  maps to a client error whose cause mentions "debug mode" and
  "--release".

All 6 pass; the full `client_events` suite (96 tests) is green.
`cargo fmt` and `cargo clippy -- -D warnings` are clean.

Closes #2257

[AI-assisted - Claude]
