### PR TITLE
test: add sanitization boundary and invalid-index handler tests for permission prompts

### DIFF
--- a/crates/core/src/contract/user_input.rs
+++ b/crates/core/src/contract/user_input.rs
@@ -494,6 +494,89 @@ mod tests {
         assert_eq!(labels, vec!["Valid", "Option 2"]);
     }
 
+    // ----- Sanitization-cap boundary tests (issue #3821) -----
+    //
+    // `parse_message` / `parse_button_labels` enforce the producer-side
+    // display caps MAX_MESSAGE_LEN (2048), MAX_LABEL_LEN (64) and
+    // MAX_LABELS (10). The existing tests above cover control-char
+    // stripping and invalid-UTF-8 fallback but never exercise the length
+    // caps at their boundaries. These tests pin the exact at-limit /
+    // over-limit behaviour so a future cap change (or a refactor that
+    // moves the `.take()` before/after the `.filter()`) is caught.
+
+    /// A message exactly at MAX_MESSAGE_LEN chars passes through untouched.
+    #[test]
+    fn test_parse_message_at_max_len_unchanged() {
+        let msg = "a".repeat(MAX_MESSAGE_LEN);
+        let req = make_test_request(&msg, vec![]);
+        let parsed = parse_message(&req);
+        assert_eq!(parsed.chars().count(), MAX_MESSAGE_LEN);
+        assert_eq!(parsed, msg);
+    }
+
+    /// A message one char over MAX_MESSAGE_LEN is truncated to the cap.
+    #[test]
+    fn test_parse_message_over_max_len_truncated() {
+        let msg = "a".repeat(MAX_MESSAGE_LEN + 1);
+        let req = make_test_request(&msg, vec![]);
+        let parsed = parse_message(&req);
+        assert_eq!(parsed.chars().count(), MAX_MESSAGE_LEN);
+    }
+
+    /// Truncation counts by `char`, not byte: a multi-byte message over the
+    /// cap must truncate at MAX_MESSAGE_LEN codepoints without splitting a
+    /// grapheme (which would otherwise risk a panic on a byte boundary).
+    #[test]
+    fn test_parse_message_over_max_len_char_based() {
+        let msg = "\u{1F525}".repeat(MAX_MESSAGE_LEN + 5);
+        let req = make_test_request(&msg, vec![]);
+        let parsed = parse_message(&req);
+        assert_eq!(parsed.chars().count(), MAX_MESSAGE_LEN);
+        assert!(parsed.chars().all(|c| c == '\u{1F525}'));
+    }
+
+    /// A button label exactly at MAX_LABEL_LEN chars passes through untouched.
+    #[test]
+    fn test_parse_button_labels_at_max_label_len_unchanged() {
+        let label = "x".repeat(MAX_LABEL_LEN);
+        let req = make_test_request("msg", vec![label.as_str()]);
+        let labels = parse_button_labels(&req);
+        assert_eq!(labels.len(), 1);
+        assert_eq!(labels[0].chars().count(), MAX_LABEL_LEN);
+        assert_eq!(labels[0], label);
+    }
+
+    /// A button label one char over MAX_LABEL_LEN is truncated to the cap.
+    #[test]
+    fn test_parse_button_labels_over_max_label_len_truncated() {
+        let label = "x".repeat(MAX_LABEL_LEN + 1);
+        let req = make_test_request("msg", vec![label.as_str()]);
+        let labels = parse_button_labels(&req);
+        assert_eq!(labels.len(), 1);
+        assert_eq!(labels[0].chars().count(), MAX_LABEL_LEN);
+    }
+
+    /// Exactly MAX_LABELS responses are all kept.
+    #[test]
+    fn test_parse_button_labels_at_max_labels_kept() {
+        let resp: Vec<String> = (0..MAX_LABELS).map(|i| format!("Option {i}")).collect();
+        let resp_refs: Vec<&str> = resp.iter().map(String::as_str).collect();
+        let req = make_test_request("msg", resp_refs);
+        let labels = parse_button_labels(&req);
+        assert_eq!(labels.len(), MAX_LABELS);
+    }
+
+    /// One response over MAX_LABELS drops the extra label(s): the rendered
+    /// button grid is capped so a delegate can't force an arbitrary count.
+    #[test]
+    fn test_parse_button_labels_over_max_labels_capped() {
+        let resp: Vec<String> = (0..MAX_LABELS + 1).map(|i| format!("Option {i}")).collect();
+        let resp_refs: Vec<&str> = resp.iter().map(String::as_str).collect();
+        let req = make_test_request("msg", resp_refs);
+        let labels = parse_button_labels(&req);
+        assert_eq!(labels.len(), MAX_LABELS);
+    }
+
     #[test]
     fn test_parse_message_raw_utf8() {
         use freenet_stdlib::prelude::NotificationMessage;

--- a/crates/core/src/server/client_api/permission_prompts.rs
+++ b/crates/core/src/server/client_api/permission_prompts.rs
@@ -1390,6 +1390,50 @@ mod tests {
         assert_eq!(resp.status(), axum::http::StatusCode::NOT_FOUND);
     }
 
+    // An out-of-range button index must return 400 BAD_REQUEST without
+    // consuming the prompt, so a user who fat-fingers (or a buggy client
+    // that posts a stale index) can still retry. The other respond error
+    // paths (missing/untrusted Origin -> 403, expired/unknown nonce -> 404)
+    // are covered above; this pins the remaining `index >= labels.len()`
+    // arm (issue #3821).
+    #[tokio::test]
+    async fn test_respond_invalid_index_returns_400_and_keeps_prompt() {
+        let pending = empty_pending();
+        // Two labels -> valid indices are 0 and 1; index 2 is out of range.
+        let _rx = insert_prompt(
+            &pending,
+            "n",
+            "m",
+            vec!["Allow", "Deny"],
+            "d",
+            webapp_caller("c"),
+        );
+
+        let resp = permission_respond(
+            Path("n".to_string()),
+            trusted_header(),
+            None,
+            None,
+            Extension(pending.clone()),
+            Json(PermissionResponse { index: 2 }),
+        )
+        .await
+        .into_response();
+        assert_eq!(resp.status(), axum::http::StatusCode::BAD_REQUEST);
+
+        use axum::body::to_bytes;
+        let body = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(value["error"], "invalid index");
+
+        // The prompt must still be pending so the user can retry with a
+        // valid index — a 400 must NOT consume the nonce.
+        assert!(
+            pending.get("n").is_some(),
+            "invalid index must not consume the prompt"
+        );
+    }
+
     // Regression tests for issue #3857 — behavioural assertions on the
     // standalone HTML page (no structural assertions, per codex review
     // point 7).


### PR DESCRIPTION
## Problem

The permission prompt system (#3818) has two test gaps flagged by rule review (acknowledged with `/ack` in #3818 to avoid blocking the security-critical sandbox fix, tracked in #3821):

1. **Sanitization-cap boundaries are untested.** The producer-side display caps in `contract/user_input.rs` — `MAX_MESSAGE_LEN` (2048), `MAX_LABEL_LEN` (64) and `MAX_LABELS` (10) — are enforced in production (`parse_message` / `parse_button_labels`) but never exercised at their boundaries. The existing `OVERLAY_*` cap tests live in `permission_prompts.rs` and cover a *different* layer (the JSON/HTML overlay-rendering boundary), so the producer-side caps had no coverage.

2. **The `permission_respond` invalid-index path was untested.** Of the handler's four error arms — missing Origin to 403, untrusted Origin to 403, expired/unknown nonce to 404, and out-of-range index to 400 — only the 400 (`index >= labels.len()`) arm lacked a handler-level test. The 403 and 404 arms are already covered.

## Approach

Test-only addition. **No production code changes.**

- `user_input.rs`: for each of the three caps, an at-limit test (passes through unchanged) and an over-limit test (truncated/dropped to the cap), plus a char-based truncation test for the message cap so a future refactor that moved `.take(MAX_MESSAGE_LEN)` past the control-char `.filter()` would be caught.
- `permission_prompts.rs`: `test_respond_invalid_index_returns_400_and_keeps_prompt` asserts an out-of-range index returns 400 with the `"invalid index"` body **and** leaves the prompt pending — pinning the validate-before-remove contract that lets a user retry after a bad index.

Tests follow the existing patterns in each module (`make_test_request`, `insert_prompt`, direct `permission_respond` invocation).

## Testing

- `cargo test -p freenet --lib user_input::tests` -> 25 passed (including the 7 new boundary tests).
- `test_respond_invalid_index_returns_400_and_keeps_prompt` -> passed.
- `cargo fmt` clean; clippy clean on the changed files.

Closes #3821

[AI-assisted - Claude]