### PR TITLE
test: bound test_interest_renewal so it can't time out on non-convergence

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,8 +9,14 @@ fail-fast = false
 # Terminate tests that hang (2 periods of 120s = 4 min max per test).
 slow-timeout = { period = "120s", terminate-after = 2 }
 
-# Interest renewal runs a full simulation with contract operations and needs
-# extra time when competing with parallel fdev tests for CPU (#3792).
+# Interest renewal drives a 6-node / 8-contract simulation for ~1200s of virtual
+# time (paused-time direct runner, advanced in ~1ms quanta), so its wall-clock
+# scales with runner CPU and can be 2-3x slower under load. The original CI
+# timeout (#3792) was a 1800s convergence-polling tail stacked on top of that
+# whenever the network didn't fully converge; that tail is now skipped for this
+# test (it never asserts convergence — see test_interest_renewal's
+# no_convergence_wait()). This generous timeout remains as headroom for the fixed
+# event-phase cost on slow/contended runners.
 [[profile.ci.overrides]]
 filter = "test(test_interest_renewal)"
 slow-timeout = { period = "300s", terminate-after = 2 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,8 +9,8 @@ fail-fast = false
 # Terminate tests that hang (2 periods of 120s = 4 min max per test).
 slow-timeout = { period = "120s", terminate-after = 2 }
 
-# Interest renewal drives a 6-node / 8-contract simulation for ~1200s of virtual
-# time (paused-time direct runner, advanced in ~1ms quanta), so its wall-clock
+# Interest renewal drives a 2-gateway / 4-node / 8-contract simulation for ~1200s
+# of virtual time (paused-time direct runner, advanced in ~1ms quanta), so its wall-clock
 # scales with runner CPU and can be 2-3x slower under load. The original CI
 # timeout (#3792) was a 1800s convergence-polling tail stacked on top of that
 # whenever the network didn't fully converge; that tail is now skipped for this

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -947,6 +947,20 @@ pub struct SimNetwork {
     /// When true, use `MockWasmRuntime` (production `ContractExecutor` code path)
     /// instead of `MockRuntime` (simplified hash-based merge).
     pub use_mock_wasm: bool,
+    /// When true, the direct runner skips the long post-event convergence-polling
+    /// loop and does only a brief fixed propagation settle instead.
+    ///
+    /// The direct runner normally polls for full state convergence for up to
+    /// ~1800s of virtual time after the event phase (30 rounds × 60s, early-exit
+    /// on convergence). That tail is advisory — the runner only logs a warning if
+    /// convergence is never reached, it does not fail the simulation. For tests
+    /// that analyze events produced *during* the event phase and never assert
+    /// convergence (e.g. `test_interest_renewal`), running the full polling tail
+    /// when the network happens not to converge adds up to 1800s of virtual time
+    /// for no benefit, blowing the wall-clock budget and making the test time out
+    /// in CI. Set this (via `TestConfig::require_convergence(false)`) so such tests
+    /// stay bounded regardless of whether the network converges. See #3792.
+    pub skip_convergence_wait: bool,
     /// Optional churn (crash/restart) configuration for the chaos driver.
     churn_config: Option<ChurnConfig>,
     /// Optional governance-manager config override applied to every node
@@ -1111,6 +1125,7 @@ impl SimNetwork {
             streaming_threshold: None,
             connection_managers: HashMap::new(),
             use_mock_wasm: false,
+            skip_convergence_wait: false,
             churn_config: None,
             governance_config_override: None,
             subscribe_hint_floor_override: None,
@@ -4419,6 +4434,7 @@ impl SimNetwork {
         // non-deterministic convergence failures even in small networks.
         SimulationTransportOpt::enable();
         let use_mock_wasm = self.use_mock_wasm;
+        let skip_convergence_wait = self.skip_convergence_wait;
 
         let result: anyhow::Result<()> = rt.block_on(async {
             // Time driver: bridges tokio's paused time → VirtualTime
@@ -4727,34 +4743,48 @@ impl SimNetwork {
             // compete across multi-hop topologies.
             //
             // Early exit: if all contracts converge, we break immediately.
+            //
+            // When `skip_convergence_wait` is set (TestConfig::require_convergence(false)),
+            // we do only a brief fixed settle and skip the polling loop entirely. The
+            // polling tail is advisory — it only logs on failure, never fails the
+            // simulation — so a test that never asserts convergence gains nothing from
+            // it but pays up to 1800s of virtual time when the network happens not to
+            // converge, which is exactly how test_interest_renewal timed out in CI (#3792).
             tokio::time::sleep(Duration::from_secs(15)).await;
 
-            let converged = 'convergence: {
-                for round in 0..30u32 {
-                    let result = check_convergence_from_logs(&event_logs).await;
-                    let total = result.converged.len() + result.diverged.len();
-                    if total > 0 && result.diverged.is_empty() {
-                        tracing::info!(
-                            converged = result.converged.len(),
-                            round,
-                            "Convergence achieved during propagation"
-                        );
-                        break 'convergence true;
-                    }
-                    tracing::debug!(
-                        converged = result.converged.len(),
-                        diverged = result.diverged.len(),
-                        round,
-                        "Convergence not yet achieved, waiting..."
-                    );
-                    tokio::time::sleep(Duration::from_secs(60)).await;
-                }
-                false
-            };
-            if !converged {
-                tracing::warn!(
-                    "Propagation timeout — convergence not achieved after 30 rounds (1800s)"
+            if skip_convergence_wait {
+                tracing::info!(
+                    "Skipping convergence-polling tail (require_convergence = false); \
+                     brief settle only"
                 );
+            } else {
+                let converged = 'convergence: {
+                    for round in 0..30u32 {
+                        let result = check_convergence_from_logs(&event_logs).await;
+                        let total = result.converged.len() + result.diverged.len();
+                        if total > 0 && result.diverged.is_empty() {
+                            tracing::info!(
+                                converged = result.converged.len(),
+                                round,
+                                "Convergence achieved during propagation"
+                            );
+                            break 'convergence true;
+                        }
+                        tracing::debug!(
+                            converged = result.converged.len(),
+                            diverged = result.diverged.len(),
+                            round,
+                            "Convergence not yet achieved, waiting..."
+                        );
+                        tokio::time::sleep(Duration::from_secs(60)).await;
+                    }
+                    false
+                };
+                if !converged {
+                    tracing::warn!(
+                        "Propagation timeout — convergence not achieved after 30 rounds (1800s)"
+                    );
+                }
             }
 
             // Shutdown: abort chaos driver, time driver, then check node tasks

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -958,8 +958,9 @@ pub struct SimNetwork {
     /// convergence (e.g. `test_interest_renewal`), running the full polling tail
     /// when the network happens not to converge adds up to 1800s of virtual time
     /// for no benefit, blowing the wall-clock budget and making the test time out
-    /// in CI. Set this (via `TestConfig::require_convergence(false)`) so such tests
-    /// stay bounded regardless of whether the network converges. See #3792.
+    /// in CI. The test crate sets this via `TestConfig::no_convergence_wait()` so
+    /// such tests stay bounded regardless of whether the network converges.
+    /// See #3792.
     pub skip_convergence_wait: bool,
     /// Optional churn (crash/restart) configuration for the chaos driver.
     churn_config: Option<ChurnConfig>,
@@ -4744,7 +4745,7 @@ impl SimNetwork {
             //
             // Early exit: if all contracts converge, we break immediately.
             //
-            // When `skip_convergence_wait` is set (TestConfig::require_convergence(false)),
+            // When `skip_convergence_wait` is set (TestConfig::no_convergence_wait()),
             // we do only a brief fixed settle and skip the polling loop entirely. The
             // polling tail is advisory — it only logs on failure, never fails the
             // simulation — so a test that never asserts convergence gains nothing from

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -230,6 +230,20 @@ impl TestConfig {
         self
     }
 
+    /// Opt out of asserting convergence.
+    ///
+    /// For `run_direct()` tests this ALSO tells the runner to skip its
+    /// up-to-1800s post-event convergence-polling tail and do only a brief
+    /// settle instead. Use this for tests that analyze events produced during
+    /// the event phase and never assert final-state convergence — running the
+    /// advisory polling tail (which only warns, never fails) when the network
+    /// happens not to converge just burns wall-clock and risks a CI timeout.
+    /// See #3792.
+    fn no_convergence_wait(mut self) -> Self {
+        self.require_convergence = false;
+        self
+    }
+
     /// Add latency jitter simulation.
     #[allow(dead_code)]
     fn with_latency(mut self, min: Duration, max: Duration) -> Self {
@@ -345,6 +359,12 @@ impl TestConfig {
         let rt = create_runtime();
 
         let use_mock_wasm = self.use_mock_wasm;
+        // Tests that never assert convergence (require_convergence = false) skip the
+        // direct runner's up-to-1800s convergence-polling tail and do a brief settle
+        // instead. The tail is advisory (it only warns on failure), so skipping it
+        // changes no assertion but keeps wall-clock bounded when the network does not
+        // converge — the failure mode that timed out test_interest_renewal in CI (#3792).
+        let skip_convergence_wait = !self.require_convergence;
         let (sim, logs_handle) = rt.block_on(async {
             let mut sim = SimNetwork::new(
                 self.name,
@@ -358,6 +378,7 @@ impl TestConfig {
             )
             .await;
             sim.use_mock_wasm = use_mock_wasm;
+            sim.skip_convergence_wait = skip_convergence_wait;
 
             // Apply fault injection if configured (latency and/or message loss)
             let has_latency = self.latency_range.is_some();
@@ -6267,6 +6288,13 @@ fn test_router_learning() {
 /// Uses `run_direct()` (paused-time single-thread runtime) for efficiency.
 /// Virtual time is controlled by iterations * event_wait, not `with_duration()`.
 ///
+/// `no_convergence_wait()`: this test asserts only on broadcast-received events
+/// produced during the 1200s event phase, never on final-state convergence, so
+/// it skips the direct runner's advisory up-to-1800s convergence-polling tail.
+/// When the network happens not to converge, that tail would add 1800s of virtual
+/// time (processed in ~1ms quanta) on top of the event phase for no benefit — the
+/// exact failure mode that made this test consistently time out in CI (#3792).
+///
 /// Catches #3093 (interest TTL not refreshed on broadcast send).
 #[test_log::test]
 fn test_interest_renewal() {
@@ -6278,6 +6306,7 @@ fn test_interest_renewal() {
         .with_nodes(4)
         .with_iterations(400)
         .with_event_wait(Duration::from_secs(3))
+        .no_convergence_wait()
         .run_direct()
         .assert_ok();
 


### PR DESCRIPTION
## Problem

`test_interest_renewal` consistently timed out in CI (240s, both retries), blocking the merge queue (#3792).

It is a `run_direct()` paused-time simulation: 2 gateways + 4 nodes, 8 contracts, 400 iterations × 3s = **1200s of event-phase virtual time**, which the direct runner advances in ~1ms quanta. Wall-clock therefore scales with total virtual time × node count × contract count and is very sensitive to runner CPU.

After the event phase the runner appends an **unconditional convergence-polling tail**: `sleep(15s)` then up to 30 rounds of `sleep(60s)` = **up to 1800s of additional virtual time**, early-exiting only when every contract converges. That tail is *advisory* — it only logs a warning if convergence is never reached; it never fails the simulation. `test_interest_renewal` only inspects broadcast-received events produced **during** the event phase and never asserts convergence, so the tail buys it nothing.

Two factors stacked to produce the timeout:
1. The test ran concurrently with the fdev load sims, starving it of CPU (since fixed by running the nextest sim tests uncontended first, #4301).
2. The `InvalidStateTransition` errors cited in the issue prevented convergence, so the polling tail ran all 30 rounds — adding 1800s on top of the 1200s event phase and blowing the budget.

The earlier "fix" (the #3792 nextest override added in #3790) only bumped the per-test timeout 240s → 300s; it never removed the 1800s landmine, so the issue stayed open. On current `main` the interest-renewal reworks (#3886, #3979, #4133, #4201) let the network converge immediately, so the test passes again — **but the landmine remains**: any future regression that breaks convergence makes this test time out again, even though it doesn't depend on convergence.

## Approach

Make the test's wall-clock independent of whether the network converges — the correct invariant for a test that never asserts convergence — instead of bumping the timeout again.

- Add `SimNetwork::skip_convergence_wait`. When set, the direct runner does only the brief 15s settle and skips the up-to-1800s polling loop. The loop is advisory, so skipping it changes no assertion.
- Thread it from `TestConfig` via a new `no_convergence_wait()` builder that sets `require_convergence = false` (the field already existed; `run_direct` now honors it). Other direct-runner tests keep the full tail unchanged.
- Apply `no_convergence_wait()` to `test_interest_renewal`.
- Keep the 300s nextest override as headroom for the fixed event-phase cost on slow/contended runners, with an accurate comment.

No production code path changes — edits are confined to test-only harness code (`testing_impl.rs`, compiled under `testing`/`simulation_tests`), the integration test, and CI test config. (Hence `test:`, not `fix:`.)

## Testing

Ran `test_interest_renewal` repeatedly under the `ci` nextest profile while other agents loaded the machine; it passed every time (23.7s / 53.2s / 64.7s / 68.3s / 23.2s) — the spread shows the CPU sensitivity that originally caused the timeout. Verified the new path executes (the runner logs `Skipping convergence-polling tail`) and the test still asserts a healthy late/early broadcast ratio (0.87, threshold 0.2), so the #3093 regression guard is intact. `cargo fmt --check` clean.

Closes #3792

[AI-assisted - Claude]
