### PR TITLE
feat(dashboard): add contract ban-list panel to local peer dashboard

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -39,6 +39,14 @@ pub type GovernanceProvider = Arc<dyn Fn() -> GovernanceSnapshot + Send + Sync +
 /// Same provider pattern as `SubscriptionProvider`/`GovernanceProvider`.
 pub type RingStatsProvider = Arc<dyn Fn() -> RingStatsSnapshot + Send + Sync + 'static>;
 
+/// Provider for the contract ban-list snapshot (#4302). Same pattern as
+/// `GovernanceProvider`: registered at node startup, replaceable for
+/// multi-node test harnesses, read by `get_snapshot` on every dashboard
+/// request. In production the closure captures `Arc<Ring>` and calls
+/// `Ring::dashboard_ban_list_snapshot()`, which reads the canonical
+/// `Ring::contract_ban_list` directly — no mirrored counter to rot.
+pub type BanListProvider = Arc<dyn Fn() -> BanListSnapshot + Send + Sync + 'static>;
+
 /// Snapshot of ring-level statistics exposed to the dashboard.
 #[derive(Debug, Clone, Default)]
 pub struct RingStatsSnapshot {
@@ -91,6 +99,16 @@ pub(crate) fn clear_ring_stats_provider() {
 #[allow(dead_code)] // consumed by Phase 4.5 dashboard tests
 pub(crate) fn clear_governance_provider() {
     *GOVERNANCE_PROVIDER.write() = None;
+}
+
+static BAN_LIST_PROVIDER: parking_lot::RwLock<Option<BanListProvider>> =
+    parking_lot::RwLock::new(None);
+
+/// Register the dashboard's contract-ban-list data source (#4302).
+/// Replaces any previously-registered provider so multi-node in-process
+/// harnesses can re-wire to the current node.
+pub fn set_ban_list_provider(provider: BanListProvider) {
+    *BAN_LIST_PROVIDER.write() = Some(provider);
 }
 
 /// Replaceable storage for the subscription provider. Wrapped in a
@@ -542,6 +560,55 @@ pub struct NetworkStatusSnapshot {
     /// we silence it here too with the same justification.
     #[allow(dead_code)] // consumed by the dashboard renderer (Phase 4.5)
     pub governance: GovernanceSnapshot,
+    /// Contract ban list (Phase 7, #4302). Drives the "N contracts on
+    /// ban list" tile and the per-entry list in the dashboard's ban-list
+    /// card. Read from the canonical `Ring::contract_ban_list` via the
+    /// provider closure — no mirrored counter to rot. Empty when nothing
+    /// is banned (the common case).
+    pub ban_list: BanListSnapshot,
+}
+
+/// Snapshot of the contract ban list for the dashboard (#4302).
+///
+/// Carries only data the canonical `Ring::contract_ban_list` already
+/// exposes: the live count, the per-entry list (key + reason + time
+/// remaining), and the cumulative capacity-rejection counter. There is
+/// no mirrored state — `get_snapshot` rebuilds this on every dashboard
+/// request from the provider closure.
+#[derive(Debug, Clone, Default)]
+pub struct BanListSnapshot {
+    /// Number of currently-banned contracts (`ContractBanList::len`).
+    /// Drives the count tile.
+    pub count: usize,
+    /// Total bans rejected because the list was at `MAX_BANNED_CONTRACTS`
+    /// capacity. A non-zero value tells operators the cap is being hit.
+    pub capacity_rejected_total: u64,
+    /// One entry per currently-banned contract.
+    pub entries: Vec<BanListEntry>,
+}
+
+/// One row of [`BanListSnapshot`]: a banned contract, why it was banned,
+/// and how long until the ban lifts.
+#[derive(Debug, Clone)]
+pub struct BanListEntry {
+    /// `ContractInstanceId.to_string()` — the same string the dashboard's
+    /// other contract panels render.
+    pub instance_id: String,
+    /// Why the contract is banned: governance-automatic vs operator-driven.
+    pub reason: BanReasonSnapshot,
+    /// Seconds until the ban automatically lifts (`expires_at - now`,
+    /// clamped at zero). Rendered as a human-readable "Ns" / "Nm" string.
+    pub expires_in_secs: u64,
+}
+
+/// Public mirror of the `pub(crate)` `ring::contract_ban_list::BanReason`,
+/// so the snapshot stays decoupled from the ring-internal enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BanReasonSnapshot {
+    /// Auto-flipped by the governance reaper after `BanTriggered`.
+    AutoMad,
+    /// Operator-driven via the CLI / config flag (#4274).
+    Operator,
 }
 
 /// Snapshot of the governance system's state, mirrored from
@@ -919,6 +986,11 @@ pub fn get_snapshot() -> Option<NetworkStatusSnapshot> {
         ring_stats,
         transport_snapshot,
         governance: GOVERNANCE_PROVIDER
+            .read()
+            .as_ref()
+            .map(|provider| provider())
+            .unwrap_or_default(),
+        ban_list: BAN_LIST_PROVIDER
             .read()
             .as_ref()
             .map(|provider| provider())

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -256,6 +256,13 @@ impl NodeP2P {
         super::network_status::set_governance_provider(std::sync::Arc::new(move || {
             ring.dashboard_governance_snapshot()
         }));
+        // Same pattern for the contract ban list (#4302) — dashboard
+        // reads the canonical `Ring::contract_ban_list` so the count
+        // tile + entry list can't drift from a mirrored counter.
+        let ban_list_ring = self.op_manager.ring.clone();
+        super::network_status::set_ban_list_provider(std::sync::Arc::new(move || {
+            ban_list_ring.dashboard_ban_list_snapshot()
+        }));
 
         // Wire live ring stats for the dashboard: connection count +
         // hosted contracts + own public key, read on every homepage

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2429,8 +2429,16 @@ impl Ring {
                 .then_with(|| a.instance_id.cmp(&b.instance_id))
         });
 
+        // Count LIVE entries — derive from the filtered snapshot, not
+        // `ContractBanList::len()`. `len()` includes entries that have
+        // expired but not yet been swept by `cleanup()`/`unban()`;
+        // `snapshot()` filters those out with the same `now < expires_at`
+        // predicate as `is_banned`. Using `len()` here would let the
+        // count tile read "1 contract banned" while the entry list (and
+        // the wire boundary) show zero — an inconsistency in the
+        // expiry-before-sweep window. (Codex review on #4464.)
         ns::BanListSnapshot {
-            count: self.contract_ban_list.len(),
+            count: entries.len(),
             capacity_rejected_total: self.contract_ban_list.capacity_rejected_total(),
             entries,
         }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2395,6 +2395,47 @@ impl Ring {
         }
     }
 
+    /// Snapshot of the contract ban list for the local-peer dashboard
+    /// (#4302). Reads directly from the canonical `contract_ban_list` —
+    /// no mirror, no cache. The count, capacity-rejection counter, and
+    /// per-entry list (key + reason + time remaining) all come from the
+    /// list's own accessors, so the panel can't drift the way a mirrored
+    /// counter would.
+    pub fn dashboard_ban_list_snapshot(&self) -> crate::node::network_status::BanListSnapshot {
+        use crate::node::network_status as ns;
+        use crate::ring::contract_ban_list::BanReason;
+
+        let map_reason = |r: BanReason| match r {
+            BanReason::AutoMad => ns::BanReasonSnapshot::AutoMad,
+            BanReason::Operator => ns::BanReasonSnapshot::Operator,
+        };
+
+        let mut entries: Vec<ns::BanListEntry> = self
+            .contract_ban_list
+            .snapshot()
+            .into_iter()
+            .map(|e| ns::BanListEntry {
+                instance_id: e.contract.to_string(),
+                reason: map_reason(e.reason),
+                expires_in_secs: e.remaining.as_secs(),
+            })
+            .collect();
+        // Stable display order: soonest-to-lift first, then by id so the
+        // dashboard doesn't reshuffle rows between refreshes (DashMap
+        // iteration order is unspecified).
+        entries.sort_by(|a, b| {
+            a.expires_in_secs
+                .cmp(&b.expires_in_secs)
+                .then_with(|| a.instance_id.cmp(&b.instance_id))
+        });
+
+        ns::BanListSnapshot {
+            count: self.contract_ban_list.len(),
+            capacity_rejected_total: self.contract_ban_list.capacity_rejected_total(),
+            entries,
+        }
+    }
+
     /// Record that a state update was observed for `contract`.
     /// No-op if the contract is not currently subscribed.
     pub fn record_contract_update(&self, contract: &ContractKey) {

--- a/crates/core/src/ring/contract_ban_list.rs
+++ b/crates/core/src/ring/contract_ban_list.rs
@@ -394,6 +394,45 @@ impl ContractBanList {
     pub fn capacity_rejected_total(&self) -> u64 {
         self.capacity_rejected_total.load(Ordering::Relaxed)
     }
+
+    /// Read-only view of every currently-banned contract, for the
+    /// local-peer dashboard's ban-list panel (#4302).
+    ///
+    /// Returns one [`BanListEntry`] per live entry: the contract id, why
+    /// it was banned, and how long until the ban automatically lifts
+    /// (`expires_at - now`, clamped at zero). Already-expired entries
+    /// that haven't been swept yet are skipped so the panel never shows a
+    /// "banned" row that `is_banned` would already treat as lifted — the
+    /// same `now < expires_at` predicate as [`Self::is_banned`].
+    ///
+    /// This is a snapshot, not a structure the list maintains: it
+    /// collects the values already stored in each entry at call time. The
+    /// returned `Vec` has no guaranteed order (it follows `DashMap`
+    /// iteration order); the renderer sorts for stable display.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn snapshot(&self) -> Vec<BanListEntry> {
+        let now = self.time_source.now();
+        self.entries
+            .iter()
+            .filter(|e| now < e.value().expires_at)
+            .map(|e| BanListEntry {
+                contract: *e.key(),
+                reason: e.value().reason,
+                remaining: e.value().expires_at.saturating_duration_since(now),
+            })
+            .collect()
+    }
+}
+
+/// One row of [`ContractBanList::snapshot`]: a currently-banned contract,
+/// the reason it was banned, and the time remaining before the ban lifts.
+/// Carries only data the ban list already stores per entry.
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct BanListEntry {
+    pub contract: ContractInstanceId,
+    pub reason: BanReason,
+    pub remaining: std::time::Duration,
 }
 
 #[cfg(test)]
@@ -1153,4 +1192,84 @@ mod tests {
     // unit tests, where the test helpers for the state-machine setup
     // (mk_mgr_shared, etc.) already exist. See
     // `governance_to_ban_list_end_to_end` in that module.
+
+    // ─── snapshot() — dashboard data source (#4302) ────────────────
+
+    #[test]
+    fn snapshot_of_empty_list_is_empty() {
+        let (bl, _ts) = mk_ban_list();
+        assert!(bl.snapshot().is_empty());
+    }
+
+    #[test]
+    fn snapshot_reports_key_reason_and_remaining() {
+        let (bl, ts) = mk_ban_list();
+        let auto = mk_contract(1);
+        let operator = mk_contract(2);
+        let now = ts.now();
+        bl.ban(auto, now + Duration::from_secs(120), BanReason::AutoMad);
+        bl.ban(
+            operator,
+            now + Duration::from_secs(300),
+            BanReason::Operator,
+        );
+
+        let snap = bl.snapshot();
+        assert_eq!(snap.len(), 2, "both bans must appear in the snapshot");
+
+        let auto_row = snap
+            .iter()
+            .find(|e| e.contract == auto)
+            .expect("auto-banned contract must be in snapshot");
+        assert_eq!(auto_row.reason, BanReason::AutoMad);
+        assert_eq!(auto_row.remaining, Duration::from_secs(120));
+
+        let op_row = snap
+            .iter()
+            .find(|e| e.contract == operator)
+            .expect("operator-banned contract must be in snapshot");
+        assert_eq!(op_row.reason, BanReason::Operator);
+        assert_eq!(op_row.remaining, Duration::from_secs(300));
+    }
+
+    #[test]
+    fn snapshot_remaining_shrinks_as_time_advances() {
+        let (bl, ts) = mk_ban_list();
+        let contract = mk_contract(1);
+        let now = ts.now();
+        bl.ban(contract, now + Duration::from_secs(100), BanReason::AutoMad);
+
+        ts.advance_time(Duration::from_secs(40));
+        let snap = bl.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(
+            snap[0].remaining,
+            Duration::from_secs(60),
+            "remaining must reflect elapsed time"
+        );
+    }
+
+    #[test]
+    fn snapshot_excludes_expired_but_unswept_entries() {
+        // A ban can sit in `entries` past its expiry until the next
+        // `cleanup()` sweep or explicit `unban()`. The snapshot must use
+        // the same `now < expires_at` predicate as `is_banned`, so the
+        // dashboard never shows a row the wire boundary would already
+        // treat as lifted.
+        let (bl, ts) = mk_ban_list();
+        let contract = mk_contract(1);
+        let now = ts.now();
+        bl.ban(contract, now + Duration::from_secs(30), BanReason::AutoMad);
+
+        // Advance past expiry WITHOUT calling cleanup/unban.
+        ts.advance_time(Duration::from_secs(31));
+        assert!(
+            !bl.is_banned(&contract),
+            "guard: entry is logically expired"
+        );
+        assert!(
+            bl.snapshot().is_empty(),
+            "expired-but-unswept entry must not appear in the snapshot"
+        );
+    }
 }

--- a/crates/core/src/ring/contract_ban_list.rs
+++ b/crates/core/src/ring/contract_ban_list.rs
@@ -379,8 +379,12 @@ impl ContractBanList {
         }
     }
 
-    /// Number of currently-banned contracts. Used by tests and the
-    /// dashboard's governance card for "N contracts on ban list."
+    /// Raw number of entries in the map, including any that have expired
+    /// but not yet been swept by [`Self::cleanup`] / [`Self::unban`].
+    /// Test-only: the dashboard count tile uses [`Self::snapshot`]`.len()`
+    /// instead, which filters to LIVE entries (the same `now <
+    /// expires_at` predicate as [`Self::is_banned`]) so the count agrees
+    /// with the rendered entry list and the wire boundary.
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn len(&self) -> usize {
         self.entries.len()
@@ -388,7 +392,7 @@ impl ContractBanList {
 
     /// Total bans rejected because the list was at capacity. A non-zero
     /// value tells operators the cap is being hit — surfaced on the
-    /// dashboard's governance card alongside the ban count. Mirrors
+    /// dashboard's ban-list card (#4302) alongside the ban count. Mirrors
     /// [`crate::ring::update_rate_limit::UpdateRateLimiter::capacity_rejected_total`].
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn capacity_rejected_total(&self) -> u64 {
@@ -1270,6 +1274,36 @@ mod tests {
         assert!(
             bl.snapshot().is_empty(),
             "expired-but-unswept entry must not appear in the snapshot"
+        );
+    }
+
+    /// Source-scrape pin (Codex review on #4464): the dashboard count
+    /// tile MUST be derived from the LIVE filtered `entries`, not from
+    /// `ContractBanList::len()`. `len()` includes expired-but-unswept
+    /// entries, so using it would let the count tile read "1 banned"
+    /// while the entry list (and the wire boundary) show zero during the
+    /// expiry-before-sweep window. Building a full `Ring` for this is
+    /// overkill, so pin the wiring at the source level the same way the
+    /// dispatch-gate tests above do.
+    #[test]
+    fn dashboard_count_derives_from_live_entries_not_len() {
+        const RING_SRC: &str = include_str!("../ring.rs");
+        let fn_pos = RING_SRC
+            .find("pub fn dashboard_ban_list_snapshot")
+            .expect("dashboard_ban_list_snapshot must exist in ring.rs");
+        // Scope the scan to the function body so an unrelated `len()`
+        // elsewhere in ring.rs can't satisfy or break this pin.
+        let body = &RING_SRC[fn_pos..fn_pos.saturating_add(2_000).min(RING_SRC.len())];
+        assert!(
+            body.contains("count: entries.len()"),
+            "dashboard count must be derived from the filtered live \
+             `entries`, not the raw ban-list `len()` — see Codex review \
+             on #4464:\n{body}"
+        );
+        assert!(
+            !body.contains("count: self.contract_ban_list.len()"),
+            "dashboard count must NOT use `contract_ban_list.len()` — it \
+             includes expired-but-unswept entries the entry list omits"
         );
     }
 }

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -33,6 +33,7 @@ fn homepage_html() -> String {
     let status_card = build_status_card(&snap);
     let peers_card = build_peers_card(&snap);
     let governance_card = build_governance_card(&snap);
+    let ban_list_card = build_ban_list_card(&snap);
     let contracts_card = build_contracts_card(&snap);
     let ops_card = build_ops_card(&snap);
     let transfer_card = build_transfer_card(&snap);
@@ -109,6 +110,7 @@ fn homepage_html() -> String {
         {peers_card}
         {transfer_card}
         {governance_card}
+        {ban_list_card}
         {contracts_card}
         {ops_card}
 
@@ -1359,6 +1361,99 @@ fn build_governance_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
         mad = mad_txt,
         threshold = threshold_txt,
         rows = rows,
+    )
+}
+
+/// Contract ban-list card (#4302). Surfaces the canonical
+/// `Ring::contract_ban_list` so operators can see whether the Phase 7
+/// hardening mechanism is catching abusers or sitting idle.
+///
+/// Two concrete asks from the issue: a count tile ("N contracts on ban
+/// list") and a per-entry list (key, reason, time remaining). The
+/// governance-state-machine drill-down is deferred (the ban list stores
+/// only the current entry, not the transition history that led to it).
+///
+/// The card is rendered whenever a snapshot exists — including when the
+/// list is empty — so an idle-but-active mechanism is distinguishable
+/// from one that isn't wired. Every value here comes from the ban list's
+/// own accessors via the provider closure; nothing is invented at render
+/// time.
+fn build_ban_list_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> String {
+    let Some(snap) = snap else {
+        return String::new();
+    };
+    let b = &snap.ban_list;
+
+    let plural = |n: usize| if n == 1 { "contract" } else { "contracts" };
+
+    // Capacity-rejection note: only shown when non-zero, so the common
+    // case stays uncluttered. A non-zero value is the operator's signal
+    // that the bounded list (MAX_BANNED_CONTRACTS) is overflowing.
+    let capacity_note = if b.capacity_rejected_total > 0 {
+        format!(
+            r#"<p class="empty" style="margin: 0 0.9rem 0.6rem; font-size: 0.82rem; color: var(--danger, #c0392b);">{n} ban{s} rejected — list at capacity.</p>"#,
+            n = b.capacity_rejected_total,
+            s = if b.capacity_rejected_total == 1 {
+                ""
+            } else {
+                "s"
+            },
+        )
+    } else {
+        String::new()
+    };
+
+    let body = if b.entries.is_empty() {
+        r#"<p class="empty" style="margin: 0.6rem 0.9rem;">No contracts banned. The mechanism is active and currently idle.</p>"#
+            .to_string()
+    } else {
+        let mut rows = String::new();
+        for e in &b.entries {
+            let reason_txt = match e.reason {
+                network_status::BanReasonSnapshot::AutoMad => "auto (governance)",
+                network_status::BanReasonSnapshot::Operator => "operator",
+            };
+            let remaining = if e.expires_in_secs == 0 {
+                "lifting".to_string()
+            } else {
+                format!("{} left", format_duration(e.expires_in_secs))
+            };
+            // html_escape the contract id even though instance ids are
+            // base58 (no HTML metacharacters today): defense-in-depth so
+            // the row stays safe if the id format ever changes.
+            write!(
+                rows,
+                r#"<tr><td class="mono">{id}</td><td>{reason}</td><td>{remaining}</td></tr>"#,
+                id = html_escape(&e.instance_id),
+                reason = reason_txt,
+                remaining = html_escape(&remaining),
+            )
+            .ok();
+        }
+        format!(
+            r#"<table class="data-table">
+                <thead><tr><th>Contract</th><th>Reason</th><th>Expires</th></tr></thead>
+                <tbody>{rows}</tbody>
+            </table>"#
+        )
+    };
+
+    format!(
+        r##"<div class="card">
+            <div class="card-header"><h2>Contract Ban List</h2></div>
+            <div class="g-verdict-row">
+                <div class="g-norms">
+                    <div class="g-norm"><div class="g-norm-label">On ban list</div><div class="g-norm-value">{count}</div></div>
+                </div>
+                <p class="empty" style="margin: 0; padding: 0.4rem 0.9rem; font-size: 0.9rem;">{count} {n_word} currently banned at this node.</p>
+            </div>
+            {capacity_note}
+            {body}
+        </div>"##,
+        count = b.count,
+        n_word = plural(b.count),
+        capacity_note = capacity_note,
+        body = body,
     )
 }
 
@@ -3962,6 +4057,7 @@ mod tests {
             ring_stats: RingStatsSnapshot::default(),
             transport_snapshot: TransportSnapshot::default(),
             governance: Default::default(),
+            ban_list: Default::default(),
         }
     }
 
@@ -5505,6 +5601,160 @@ mod tests {
     #[test]
     fn governance_card_omits_when_snap_is_none() {
         let html = build_governance_card(&None);
+        assert!(html.is_empty());
+    }
+
+    // ─── Contract ban-list card (#4302) ────────────────────────────
+
+    use crate::node::network_status::{BanListEntry, BanListSnapshot, BanReasonSnapshot};
+
+    fn mk_ban_entry(id: &str, reason: BanReasonSnapshot, expires_in_secs: u64) -> BanListEntry {
+        BanListEntry {
+            instance_id: id.to_string(),
+            reason,
+            expires_in_secs,
+        }
+    }
+
+    #[test]
+    fn ban_list_card_empty_state_renders_count_zero_and_idle_message() {
+        // Empty list still renders the card so operators can tell the
+        // mechanism is active-but-idle (the issue's core motivation),
+        // not unwired. Count tile shows 0.
+        let snap = base_snapshot();
+        let html = build_ban_list_card(&Some(snap));
+        assert!(
+            html.contains("Contract Ban List"),
+            "card must render its heading even when empty — got:\n{html}"
+        );
+        assert!(
+            html.contains(
+                r#"<div class="g-norm-label">On ban list</div><div class="g-norm-value">0</div>"#
+            ),
+            "empty state must show a 0 count tile — got:\n{html}"
+        );
+        assert!(
+            html.contains("0 contracts currently banned"),
+            "empty state must say 0 contracts banned — got:\n{html}"
+        );
+        assert!(
+            html.contains("active and currently idle"),
+            "empty state must distinguish idle-but-active from unwired — got:\n{html}"
+        );
+        assert!(
+            !html.contains("<table"),
+            "empty state must not render an entry table — got:\n{html}"
+        );
+    }
+
+    #[test]
+    fn ban_list_card_lists_entries_with_key_reason_and_expiry() {
+        // The two concrete asks: count tile + entry list (key, reason,
+        // expiry remaining). Pin all three columns for both reasons.
+        let mut snap = base_snapshot();
+        snap.ban_list = BanListSnapshot {
+            count: 2,
+            capacity_rejected_total: 0,
+            entries: vec![
+                mk_ban_entry("AutoBannedContract11111", BanReasonSnapshot::AutoMad, 1800),
+                mk_ban_entry("OperatorBannedContract22", BanReasonSnapshot::Operator, 90),
+            ],
+        };
+        let html = build_ban_list_card(&Some(snap));
+        // Count tile.
+        assert!(
+            html.contains(r#"<div class="g-norm-value">2</div>"#),
+            "count tile must show 2 — got:\n{html}"
+        );
+        // Keys appear.
+        assert!(
+            html.contains("AutoBannedContract11111"),
+            "auto-banned contract id must appear — got:\n{html}"
+        );
+        assert!(
+            html.contains("OperatorBannedContract22"),
+            "operator-banned contract id must appear — got:\n{html}"
+        );
+        // Reasons distinguish AutoMad vs Operator.
+        assert!(
+            html.contains("auto (governance)"),
+            "AutoMad ban must render an 'auto (governance)' reason — got:\n{html}"
+        );
+        assert!(
+            html.contains(">operator<"),
+            "Operator ban must render an 'operator' reason — got:\n{html}"
+        );
+        // Expiry remaining: 90s formatted, and 1800s as 30m.
+        assert!(
+            html.contains("30m left") || html.contains("30m 0s left"),
+            "expiry remaining must render the 1800s ban as ~30m — got:\n{html}"
+        );
+        assert!(
+            html.contains("1m 30s left") || html.contains("90s left"),
+            "expiry remaining must render the 90s ban — got:\n{html}"
+        );
+    }
+
+    #[test]
+    fn ban_list_card_singular_count_pluralization() {
+        // Boundary: count == 1 must read "1 contract", not "1 contracts".
+        let mut snap = base_snapshot();
+        snap.ban_list = BanListSnapshot {
+            count: 1,
+            capacity_rejected_total: 0,
+            entries: vec![mk_ban_entry("OnlyBanned1", BanReasonSnapshot::AutoMad, 600)],
+        };
+        let html = build_ban_list_card(&Some(snap));
+        assert!(
+            html.contains("1 contract currently banned"),
+            "count==1 must use singular 'contract' — got:\n{html}"
+        );
+        assert!(
+            !html.contains("1 contracts currently banned"),
+            "count==1 must not say '1 contracts' — got:\n{html}"
+        );
+    }
+
+    #[test]
+    fn ban_list_card_shows_capacity_rejection_note_when_nonzero() {
+        // The capacity-rejection counter is the operator's signal that
+        // the bounded list is overflowing — surface it only when > 0.
+        let mut snap = base_snapshot();
+        snap.ban_list = BanListSnapshot {
+            count: 1,
+            capacity_rejected_total: 5,
+            entries: vec![mk_ban_entry("AtCapacity1", BanReasonSnapshot::AutoMad, 300)],
+        };
+        let html = build_ban_list_card(&Some(snap));
+        assert!(
+            html.contains("5 bans rejected"),
+            "non-zero capacity rejection must surface a note — got:\n{html}"
+        );
+        assert!(
+            html.contains("list at capacity"),
+            "capacity note must explain the cause — got:\n{html}"
+        );
+    }
+
+    #[test]
+    fn ban_list_card_hides_capacity_note_when_zero() {
+        // Common case: no capacity pressure → no clutter.
+        let mut snap = base_snapshot();
+        snap.ban_list = BanListSnapshot {
+            count: 1,
+            capacity_rejected_total: 0,
+            entries: vec![mk_ban_entry("Normal1", BanReasonSnapshot::Operator, 300)],
+        };
+        let html = build_ban_list_card(&Some(snap));
+        assert!(
+            !html.contains("rejected"),
+            "zero capacity rejections must not render the note — got:\n{html}"
+        );
+    }
+
+    #[test]
+    fn ban_list_card_omits_when_snap_is_none() {
+        let html = build_ban_list_card(&None);
         assert!(html.is_empty());
     }
 }


### PR DESCRIPTION
## Problem

PR #4299 landed the `ContractBanList` (Phase 7 contract hardening) but never surfaced it on the local peer dashboard. Operators had no way to tell whether the ban mechanism is catching abusers or sitting idle — the per-contract governance table only shows a "Banned" badge, not the ban list itself, its size, or per-entry reason/expiry.

## Solution

Follow the established provider-closure pattern (same shape as the governance / subscription / ring-stats providers) so the panel reads from the canonical `Ring::contract_ban_list` on every dashboard request — no manually-mirrored counter to rot (the failure mode called out in `AGENTS.md` bug-prevention-patterns).

- **`ContractBanList::snapshot()`** — read-only view of each live entry (contract id, reason, time remaining), using the same `now < expires_at` predicate as `is_banned` so expired-but-unswept entries never appear. Exposes only data the list already stores; no new persisted structure.
- **`network_status::BanListSnapshot` / `BanListEntry` / `BanReasonSnapshot`** + `BanListProvider` static, wired into `get_snapshot()`.
- **`Ring::dashboard_ban_list_snapshot()`** maps the ring-internal types to the public snapshot and sorts entries (soonest-to-lift, then id) for stable display across refreshes (DashMap iteration order is unspecified).
- Provider registered in `p2p_impl.rs` capturing `Arc<Ring>`.
- **`build_ban_list_card()`** in `home_page.rs`: a count tile + per-entry list (key, reason, expiry remaining), plus a capacity-rejection note when non-zero. Rendered even when empty so an idle-but-active mechanism is distinguishable from an unwired one (the issue's core motivation).

Scope follows the issue's two concrete asks (count tile + entry list). The governance-state-machine **drill-down is deferred**: the ban list stores only the current entry, not the transition history that led to `BanTriggered`. Per the issue ("Don't add new data structures the ban list doesn't already expose"), no history threading was added.

## Testing

- `contract_ban_list.rs`: 4 `snapshot()` unit tests — empty list, key/reason/remaining reported, remaining shrinks as virtual time advances (via `SharedMockTimeSource`), and expired-but-unswept entries excluded (same predicate as `is_banned`).
- `home_page.rs`: 6 `build_ban_list_card()` HTML-assertion tests — empty state (count-0 tile + idle message, no table), entry list with both `AutoMad`/`Operator` reasons + expiry rendering, singular pluralization at count==1, capacity note shown/hidden, omit-when-None.

All new tests reference symbols that did not exist before this change, so they fail to compile without the fix and pass with it (the fails-before/passes-after requirement). `cargo fmt` and CI-equivalent `cargo clippy --locked -- -D warnings` are clean.

## Note for reviewers

`cargo clippy --all-targets` surfaces one **pre-existing** `assertions_on_constants` warning in `crates/core/src/tracing/telemetry.rs` (test `test_shadow_subbudget_caps_shadow_events`, from #4456). It is unrelated to this PR and does not break CI (CI runs clippy without `--all-targets`), so it was left out to keep this PR to one logical change.

Closes #4302

[AI-assisted - Claude]