### PR TITLE
fix(tracing): make event-log registration non-blocking to prevent node deadlock

### DIFF
--- a/.claude/rules/channel-safety.md
+++ b/.claude/rules/channel-safety.md
@@ -1,5 +1,5 @@
 ---
-description: Prevent bounded channel deadlocks — cascading backpressure from .send().await in event loops has caused 4+ production incidents
+description: Prevent bounded channel deadlocks — cascading backpressure from .send().await in event loops has caused 5+ production incidents
 paths:
   - "crates/core/src/node/**"
   - "crates/core/src/transport/**"
@@ -13,7 +13,7 @@ paths:
 
 `.send().await` on a bounded channel inside an event loop or recv loop.
 When the receiver is slow or blocked on another channel, the sender blocks,
-stalling the entire event loop. This has caused 5+ production deadlocks:
+stalling the entire event loop. This has caused 6+ production deadlocks:
 
 - **StreamRegistry** (Mar 2026): `mpsc::channel(64)` whose receiver was never
   consumed. After 64 streams, `.send().await` blocked forever, deadlocking
@@ -78,6 +78,22 @@ stalling the entire event loop. This has caused 5+ production deadlocks:
   receiver ack) is corrected by the periodic InterestSync summary
   exchange and by the delta-apply-failure → ResyncRequest path that
   clears the sender's cached summary.
+
+- **Event-log channel send** (#4466, Jun 2026): `EventRegister::register_events`
+  and `notify_of_time_out` (`tracing.rs`) did an untimed `.send().await` on the
+  bounded event-log `mpsc::channel(1000)`, awaited from the network event loop's
+  hot outbound path (`p2p_protoc.rs` `OutboundMessageWithTarget` and disconnect
+  handlers). The sole consumer `record_logs` blocks on its metrics-server
+  WebSocket send (`ws://127.0.0.1:55010`, present on peers running the fdev
+  metrics server) and its AOF write; when that sink stalled, the channel filled
+  and the event loop blocked forever, parking every runtime thread on a futex at
+  0% CPU — a silent freeze (process alive, API port open, logging frozen
+  mid-activity, no crash so systemd never restarts). This is the sibling send
+  the #4145/#4231 fix missed, three lines above the peer-send it *did* wrap.
+  Fixed (#4467) by switching both sends to `try_send` with drop-on-full
+  (best-effort telemetry) plus a `DROPPED_EVENT_LOGS` counter; the `trace-ot`
+  `OTEventRegister` siblings were converted too. Observed on a 0.2.75 peer and
+  corroborated by a real-user diagnostic report on 0.2.74.
 
 ## Exception: same-runtime internal consumers
 

--- a/.claude/rules/channel-safety.md
+++ b/.claude/rules/channel-safety.md
@@ -1,5 +1,5 @@
 ---
-description: Prevent bounded channel deadlocks — cascading backpressure from .send().await in event loops has caused 5+ production incidents
+description: Prevent bounded channel deadlocks — cascading backpressure from .send().await in event loops has caused 6+ production incidents
 paths:
   - "crates/core/src/node/**"
   - "crates/core/src/transport/**"

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -1717,6 +1717,12 @@ impl EventFlushHandle {
     /// Request a flush and wait for completion
     pub async fn flush(&self) {
         let (tx, rx) = tokio::sync::oneshot::channel();
+        // DELIBERATE blocking send (channel-safety.md "same-runtime internal
+        // consumer" exception): `flush` is a shutdown/test synchronization
+        // barrier — it MUST wait for `record_logs` to drain, not drop. It is
+        // never called from the network event loop (only shutdown/test paths),
+        // and the reply wait below is timeout-bounded. This is intentionally
+        // NOT converted to `try_send` like the hot-path event-log sends.
         if self.sender.send(EventLogCommand::Flush(tx)).await.is_ok() {
             // Best-effort flush: timeout or channel error is acceptable
             let _flush_result = tokio::time::timeout(std::time::Duration::from_secs(2), rx).await;
@@ -1913,6 +1919,11 @@ fn note_dropped_event_log() {
     }
 }
 
+#[cfg(test)]
+fn dropped_event_log_count() -> u64 {
+    DROPPED_EVENT_LOGS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 impl NetEventRegister for EventRegister {
     fn register_events<'a>(
         &'a self,
@@ -1987,40 +1998,55 @@ impl NetEventRegister for EventRegister {
 mod eventlog_backpressure_tests {
     use super::*;
 
+    /// A self-contained `Disconnected` event for backpressure tests. It borrows
+    /// nothing: `Transaction::NULL` is a `&'static Transaction` and the other
+    /// fields are owned, so the log is `NetEventLog<'static>`.
+    fn dummy_event() -> NetEventLog<'static> {
+        NetEventLog {
+            tx: Transaction::NULL,
+            peer_id: PeerId::random(),
+            kind: EventKind::Disconnected {
+                from: PeerId::random(),
+                reason: DisconnectReason::RemoteDropped,
+                connection_duration_ms: None,
+                bytes_sent: None,
+                bytes_received: None,
+            },
+        }
+    }
+
+    /// A capacity-1 log channel that is full but still OPEN: the single slot is
+    /// pre-filled and the receiver is returned so the caller can keep it alive
+    /// (dropping it would close the channel and mask the deadlock as an early
+    /// `Closed` return). Returns `(register, rx_guard, filler_guard)`.
+    fn saturated_register() -> (
+        EventRegister,
+        mpsc::Receiver<EventLogCommand>,
+        tokio::sync::oneshot::Receiver<()>,
+    ) {
+        let (tx, rx) = mpsc::channel::<EventLogCommand>(1);
+        let (filler_tx, filler_rx) = tokio::sync::oneshot::channel::<()>();
+        tx.try_send(EventLogCommand::Flush(filler_tx))
+            .expect("first slot accepts the filler");
+        (EventRegister::from_sender_for_test(tx), rx, filler_rx)
+    }
+
     /// Regression: the network event loop awaits `register_events` on the hot
     /// outbound path (`p2p_protoc.rs` `OutboundMessageWithTarget`). When
     /// `record_logs` stalled on its metrics WebSocket or AOF write, a blocking
     /// `.send().await` on the bounded log channel filled the buffer and wedged
     /// the entire node — every thread parked on a futex at 0% CPU. The send
-    /// must drop on full instead of blocking. Without the fix this test hangs
-    /// (caught by the timeout); with it, it completes instantly.
+    /// must drop on full instead of blocking. Without the fix the loop parks on
+    /// the full channel; under `start_paused` the runtime then auto-advances
+    /// virtual time to the 5s timeout, so the test fails deterministically
+    /// (`Elapsed`) in ~0ms rather than hanging in wall-clock time.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn register_events_does_not_block_when_log_channel_full() {
-        // Capacity-1 channel whose receiver is never drained. Keep `_rx` alive
-        // so the channel stays OPEN (a closed channel would make `send` return
-        // immediately and hide the deadlock), and pre-fill the single slot so
-        // every subsequent send hits a full channel.
-        let (tx, _rx) = mpsc::channel::<EventLogCommand>(1);
-        let (filler_tx, _filler_rx) = tokio::sync::oneshot::channel::<()>();
-        tx.try_send(EventLogCommand::Flush(filler_tx))
-            .expect("first slot accepts the filler");
-
-        let register = EventRegister::from_sender_for_test(tx);
+        let (register, _rx, _filler) = saturated_register();
 
         let fire_many = async {
             for _ in 0..2_000 {
-                let event = NetEventLog {
-                    tx: Transaction::NULL,
-                    peer_id: PeerId::random(),
-                    kind: EventKind::Disconnected {
-                        from: PeerId::random(),
-                        reason: DisconnectReason::RemoteDropped,
-                        connection_duration_ms: None,
-                        bytes_sent: None,
-                        bytes_received: None,
-                    },
-                };
-                register.register_events(Either::Left(event)).await;
+                register.register_events(Either::Left(dummy_event())).await;
             }
         };
 
@@ -2033,12 +2059,7 @@ mod eventlog_backpressure_tests {
     /// reachable from hot paths, so it must drop on full rather than block.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn notify_of_time_out_does_not_block_when_log_channel_full() {
-        let (tx, _rx) = mpsc::channel::<EventLogCommand>(1);
-        let (filler_tx, _filler_rx) = tokio::sync::oneshot::channel::<()>();
-        tx.try_send(EventLogCommand::Flush(filler_tx))
-            .expect("first slot accepts the filler");
-
-        let mut register = EventRegister::from_sender_for_test(tx);
+        let (mut register, _rx, _filler) = saturated_register();
 
         let fire_many = async {
             for _ in 0..2_000 {
@@ -2051,6 +2072,46 @@ mod eventlog_backpressure_tests {
         tokio::time::timeout(std::time::Duration::from_secs(5), fire_many)
             .await
             .expect("notify_of_time_out must never block when the log channel is full");
+    }
+
+    /// The `Full` arm must count the drop so a persistent stall is observable.
+    /// `DROPPED_EVENT_LOGS` is a process-global counter, so other tests in the
+    /// same binary may also increment it concurrently; assert a lower bound
+    /// (our K drops are always counted; concurrent drops only add to it) so the
+    /// test stays order-independent under parallel execution.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn register_events_counts_dropped_messages_when_full() {
+        let (register, _rx, _filler) = saturated_register();
+
+        const K: u64 = 16;
+        let before = dropped_event_log_count();
+        for _ in 0..K {
+            register.register_events(Either::Left(dummy_event())).await;
+        }
+        let after = dropped_event_log_count();
+        assert!(
+            after >= before + K,
+            "expected >= {K} new drops counted, saw {}",
+            after.saturating_sub(before)
+        );
+    }
+
+    /// A closed channel must not block or panic: `register_events` returns
+    /// promptly (its loop `break`s on `Closed`), exercising the non-`Full`
+    /// error arm over a multi-event batch.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn register_events_handles_closed_channel() {
+        let (tx, rx) = mpsc::channel::<EventLogCommand>(4);
+        drop(rx); // channel now closed
+        let register = EventRegister::from_sender_for_test(tx);
+
+        let batch = vec![dummy_event(), dummy_event(), dummy_event()];
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            register.register_events(Either::Right(batch)),
+        )
+        .await
+        .expect("register_events must return promptly on a closed channel");
     }
 }
 
@@ -2635,7 +2696,13 @@ mod opentelemetry_tracer {
         ) -> BoxFuture<'a, ()> {
             async {
                 for log_msg in NetLogMessage::to_log_message(logs) {
-                    let _sent = self.log_sender.send(log_msg).await;
+                    // Non-blocking, same rationale as `EventRegister`: this is
+                    // awaited from the network event loop's hot path via
+                    // `DynamicRegister`, so a blocking `.send().await` here would
+                    // wedge the loop if the consumer stalls. Drop on full
+                    // (channel-safety.md). Best-effort OT telemetry; `trace-ot`
+                    // is a non-default debug build.
+                    let _ = self.log_sender.try_send(log_msg);
                 }
             }
             .boxed()
@@ -2653,7 +2720,8 @@ mod opentelemetry_tracer {
         ) -> BoxFuture<'_, ()> {
             async move {
                 if cfg!(test) {
-                    let _sent = self.finished_tx_notifier.send(tx).await;
+                    // Non-blocking, same rationale as `register_events` above.
+                    let _ = self.finished_tx_notifier.try_send(tx);
                 }
             }
             .boxed()

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -2701,8 +2701,13 @@ mod opentelemetry_tracer {
                     // `DynamicRegister`, so a blocking `.send().await` here would
                     // wedge the loop if the consumer stalls. Drop on full
                     // (channel-safety.md). Best-effort OT telemetry; `trace-ot`
-                    // is a non-default debug build.
-                    let _ = self.log_sender.try_send(log_msg);
+                    // is a non-default debug build. `match` (not `let _ =`)
+                    // satisfies the crate's `let_underscore_must_use` deny lint.
+                    match self.log_sender.try_send(log_msg) {
+                        Ok(()) => {}
+                        Err(mpsc::error::TrySendError::Full(_)) => {}
+                        Err(mpsc::error::TrySendError::Closed(_)) => break,
+                    }
                 }
             }
             .boxed()
@@ -2721,6 +2726,10 @@ mod opentelemetry_tracer {
             async move {
                 if cfg!(test) {
                     // Non-blocking, same rationale as `register_events` above.
+                    // Best-effort; intentionally discard the result (drop on
+                    // full or closed). `#[allow]` per the crate convention for
+                    // deliberate `must_use` discards (e.g. tracing.rs:1831).
+                    #[allow(clippy::let_underscore_must_use)]
                     let _ = self.finished_tx_notifier.try_send(tx);
                 }
             }

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -1762,6 +1762,23 @@ impl EventRegister {
         self.flush_handle.clone()
     }
 
+    /// Build a register around an existing sender WITHOUT spawning the
+    /// `record_logs` drain task. Tests use this to saturate the bounded log
+    /// channel and assert `register_events` never blocks the caller (the
+    /// event-log backpressure deadlock regression).
+    #[cfg(test)]
+    fn from_sender_for_test(log_sender: mpsc::Sender<EventLogCommand>) -> Self {
+        let flush_handle = EventFlushHandle {
+            sender: log_sender.clone(),
+        };
+        Self {
+            log_sender,
+            log_file: Arc::new(PathBuf::from("event-log-no-drain-test")),
+            clone_count: Arc::new(std::sync::atomic::AtomicUsize::new(1)),
+            flush_handle,
+        }
+    }
+
     async fn record_logs(
         mut log_recv: mpsc::Receiver<EventLogCommand>,
         event_log_path: Arc<PathBuf>,
@@ -1875,6 +1892,27 @@ impl Drop for EventRegister {
     }
 }
 
+/// Count of telemetry event-log messages dropped because the bounded
+/// `record_logs` channel was full. Telemetry is best-effort: dropping under
+/// load keeps the node alive, whereas blocking the event loop on a stalled log
+/// consumer deadlocked the entire node (every thread parked on a futex at 0%
+/// CPU). Logged at power-of-two milestones so a persistent stall stays visible
+/// without spamming the log.
+static DROPPED_EVENT_LOGS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+fn note_dropped_event_log() {
+    use std::sync::atomic::Ordering;
+    let dropped = DROPPED_EVENT_LOGS.fetch_add(1, Ordering::Relaxed) + 1;
+    if dropped.is_power_of_two() {
+        tracing::warn!(
+            dropped_total = dropped,
+            "event log channel full; dropping telemetry event(s). The node is \
+             healthy — telemetry is intentionally lossy under load rather than \
+             blocking the event loop (see .claude/rules/channel-safety.md)."
+        );
+    }
+}
+
 impl NetEventRegister for EventRegister {
     fn register_events<'a>(
         &'a self,
@@ -1882,9 +1920,21 @@ impl NetEventRegister for EventRegister {
     ) -> BoxFuture<'a, ()> {
         async {
             for log_msg in NetLogMessage::to_log_message(logs) {
-                if let Err(e) = self.log_sender.send(EventLogCommand::Log(log_msg)).await {
-                    tracing::debug!(error = %e, "event log channel closed");
-                    break;
+                // Best-effort telemetry MUST NOT block the caller. This future is
+                // awaited from the network event loop's hot outbound path (see the
+                // `OutboundMessageWithTarget` and disconnect handlers in
+                // p2p_protoc.rs). A blocking `.send().await` on the bounded log
+                // channel wedged the whole node when `record_logs` stalled on its
+                // metrics WebSocket or AOF write: the channel filled, the event
+                // loop blocked here forever, and every thread parked on a futex at
+                // 0% CPU. Drop on full instead (see channel-safety.md).
+                match self.log_sender.try_send(EventLogCommand::Log(log_msg)) {
+                    Ok(()) => {}
+                    Err(mpsc::error::TrySendError::Full(_)) => note_dropped_event_log(),
+                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                        tracing::debug!("event log channel closed");
+                        break;
+                    }
                 }
             }
         }
@@ -1914,8 +1964,15 @@ impl NetEventRegister for EventRegister {
         };
         let sender = self.log_sender.clone();
         async move {
-            if let Err(e) = sender.send(EventLogCommand::Log(log_msg)).await {
-                tracing::debug!(error = %e, "event log channel closed during timeout notification");
+            // Non-blocking for the same reason as `register_events`: a stalled
+            // log consumer must never wedge a caller on the bounded log channel
+            // (see channel-safety.md). Best-effort telemetry — drop on full.
+            match sender.try_send(EventLogCommand::Log(log_msg)) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => note_dropped_event_log(),
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    tracing::debug!("event log channel closed during timeout notification");
+                }
             }
         }
         .boxed()
@@ -1923,6 +1980,77 @@ impl NetEventRegister for EventRegister {
 
     fn get_router_events(&self, number: usize) -> BoxFuture<'_, anyhow::Result<Vec<RouteEvent>>> {
         async move { aof::LogFile::get_router_events(number, &self.log_file).await }.boxed()
+    }
+}
+
+#[cfg(test)]
+mod eventlog_backpressure_tests {
+    use super::*;
+
+    /// Regression: the network event loop awaits `register_events` on the hot
+    /// outbound path (`p2p_protoc.rs` `OutboundMessageWithTarget`). When
+    /// `record_logs` stalled on its metrics WebSocket or AOF write, a blocking
+    /// `.send().await` on the bounded log channel filled the buffer and wedged
+    /// the entire node — every thread parked on a futex at 0% CPU. The send
+    /// must drop on full instead of blocking. Without the fix this test hangs
+    /// (caught by the timeout); with it, it completes instantly.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn register_events_does_not_block_when_log_channel_full() {
+        // Capacity-1 channel whose receiver is never drained. Keep `_rx` alive
+        // so the channel stays OPEN (a closed channel would make `send` return
+        // immediately and hide the deadlock), and pre-fill the single slot so
+        // every subsequent send hits a full channel.
+        let (tx, _rx) = mpsc::channel::<EventLogCommand>(1);
+        let (filler_tx, _filler_rx) = tokio::sync::oneshot::channel::<()>();
+        tx.try_send(EventLogCommand::Flush(filler_tx))
+            .expect("first slot accepts the filler");
+
+        let register = EventRegister::from_sender_for_test(tx);
+
+        let fire_many = async {
+            for _ in 0..2_000 {
+                let event = NetEventLog {
+                    tx: Transaction::NULL,
+                    peer_id: PeerId::random(),
+                    kind: EventKind::Disconnected {
+                        from: PeerId::random(),
+                        reason: DisconnectReason::RemoteDropped,
+                        connection_duration_ms: None,
+                        bytes_sent: None,
+                        bytes_received: None,
+                    },
+                };
+                register.register_events(Either::Left(event)).await;
+            }
+        };
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), fire_many)
+            .await
+            .expect("register_events must never block when the log channel is full");
+    }
+
+    /// `notify_of_time_out` writes to the same bounded log channel and is also
+    /// reachable from hot paths, so it must drop on full rather than block.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn notify_of_time_out_does_not_block_when_log_channel_full() {
+        let (tx, _rx) = mpsc::channel::<EventLogCommand>(1);
+        let (filler_tx, _filler_rx) = tokio::sync::oneshot::channel::<()>();
+        tx.try_send(EventLogCommand::Flush(filler_tx))
+            .expect("first slot accepts the filler");
+
+        let mut register = EventRegister::from_sender_for_test(tx);
+
+        let fire_many = async {
+            for _ in 0..2_000 {
+                register
+                    .notify_of_time_out(*Transaction::NULL, "get", None)
+                    .await;
+            }
+        };
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), fire_many)
+            .await
+            .expect("notify_of_time_out must never block when the log channel is full");
     }
 }
 


### PR DESCRIPTION
## Problem

A Freenet node can **silently deadlock**: the process stays alive with its API port open, but every runtime thread parks on a futex at 0% CPU, all logging stops mid-activity, and the node serves nothing until it is manually restarted (no crash, so systemd never restarts it).

The production `EventRegister::register_events` (and `notify_of_time_out`) did an untimed `.send().await` on the bounded event-log `mpsc::channel(1000)`. That future is awaited from the network event loop's hot outbound path (`p2p_protoc.rs` `OutboundMessageWithTarget` and disconnect handlers). The sole consumer, `record_logs`, blocks on its metrics-server WebSocket send (`ws://127.0.0.1:55010`, present on peers running the fdev metrics server) **or** its AOF write. When the consumer stalls, the channel fills, the event loop blocks here forever, and the whole runtime cascades to all-threads-parked — even the tracing-appender, which is why logging freezes instantly.

This is the exact pattern `.claude/rules/channel-safety.md` bans, and a sibling of #4145/#4231: that fix made the `event_loop_notification` channel non-blocking and wrapped the per-peer send three lines below in a 500ms timeout, but missed this event-log channel send directly above it.

Observed on a 0.2.75 peer (silent freeze, all threads `futex_wait_queue`, 0% CPU, port open) and corroborated by a real-user diagnostic report on 0.2.74 ("Node stalling or restarting"). Full evidence in #4466.

## Solution

Make `register_events` and `notify_of_time_out` use `try_send` with **drop-on-full** — best-effort telemetry per channel-safety.md ("drop messages when full rather than blocking"). The single impl change covers all five event-loop call sites (they all route through `EventRegister::register_events`). The `trace-ot` `OTEventRegister` siblings (same hot path via `DynamicRegister`) are converted too, so the class is fully closed for every build.

Observability: a `DROPPED_EVENT_LOGS` counter emits a `tracing::warn!` at power-of-two milestones, so a persistent stall surfaces in the node's own logs — and therefore in a captured `freenet service report` — without log spam. (A structured `event_log_dropped_total` gauge on `NodeDiagnostics` is deliberately left as a follow-up; see below.)

An audit of every event-loop-reachable bounded `.send().await` confirmed this was the **last** unprotected instance of the class; all others are timeout-wrapped, spawned off the critical path, unbounded, or a documented same-runtime exception. The remaining `EventFlushHandle::flush` send is intentionally left blocking (a shutdown/test sync barrier, timeout-bounded, never on the event loop) and now carries an inline exception comment. `.claude/rules/channel-safety.md` is updated with this incident per repo convention.

## Testing

Four deterministic unit tests (`eventlog_backpressure_tests`, `current_thread` + `start_paused`):
- `register_events` / `notify_of_time_out` complete under a timeout when the log channel is saturated. **Verified these FAIL without the fix** — the old blocking `.send().await` parks the task; under paused virtual time the runtime auto-advances to the 5s timeout, so the test fails deterministically (`Elapsed`) in ~0ms rather than hanging in wall-clock.
- The `Full` arm increments `DROPPED_EVENT_LOGS` (lower-bound assertion, order-independent under parallel test execution).
- A closed channel returns promptly without panicking (exercises the `Closed` arm over a batch).

`cargo fmt` clean; `cargo clippy --locked -- -D warnings` clean; `--features trace-ot` compiles.

## Defense in depth / follow-ups (separate issue, per one-change-per-PR)

- Out-of-band event-loop **liveness watchdog** (dedicated OS thread; detect any full freeze → log + abort → systemd restart). Cause-agnostic backstop; relates to #4233.
- Consumer-side timeouts on `record_logs` (WS + AOF) so a stalled sink can't keep telemetry dead until restart.
- Low-rate pull-based `event_log_dropped_total` gauge on `NodeDiagnostics`.
- Minor: under drop, the offline `StateVerifier` can report spurious `ZombieTransaction` anomalies (a paired start event persists while its outcome drops) — a diagnostics-quality caveat to note there.

## Fixes

Closes #4466

[AI-assisted - Claude]
