### PR TITLE
fix(release-agent): gate River announce on room readability, not WS port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,10 +316,22 @@ jobs:
 
           if [ "$IS_FIX" -gt 0 ] && [ "$HAS_EXEMPT_LABEL" -eq 0 ]; then
             NEW_TESTS=$(echo "$ALL_ADDED_STRIPPED" | grep -cE "$TEST_ATTR_RE" || true)
-            if [ "$NEW_TESTS" -eq 0 ]; then
+            # Some fixes are to shell tooling (e.g. scripts/release-agent/*.sh),
+            # whose regression tests are shell *_test.sh self-tests run in CI,
+            # not Rust #[test]s. Count added assertion lines (`check ...`) in
+            # added *_test.sh files so such fixes aren't forced to claim
+            # test-exempt. Without this, a genuine shell regression test scores
+            # zero against TEST_ATTR_RE (Rust-only) and the fix is wrongly
+            # rejected — the gap that hid the announce-to-river fix's own test.
+            NEW_SHELL_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*_test.sh' \
+              | grep -E '^\+' | grep -vF '+++' \
+              | grep -cE '^\+[[:space:]]*check[[:space:]]' || true)
+            if [ "$NEW_TESTS" -eq 0 ] && [ "$NEW_SHELL_TESTS" -eq 0 ]; then
               ERRORS="$ERRORS
           ERROR: fix: PR must include at least one new regression test
           Add a test that reproduces the bug (fails without fix, passes with fix).
+          A Rust #[test]/#[tokio::test]/etc. or an added 'check' assertion in a
+          *_test.sh self-test both satisfy this.
           If this fix genuinely cannot have a test, add the 'test-exempt' label with a justification comment."
             fi
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,16 @@ jobs:
       - name: Self-test deploy-local-gateway verify_service
         run: bash scripts/release-agent/deploy-local-gateway_test.sh
 
+      # Regression gate for the release-announce River post (the
+      # v0.2.74/v0.2.75 incident: the announce raced the gateway self-update,
+      # a WS-port probe passed, but riverctl's room GET hit a mid-teardown
+      # node and failed "room not found" while the workflow showed green).
+      # The readiness poll (wait_for_room), owner-signing, and logging
+      # functions are extracted verbatim from announce-to-river.sh and
+      # exercised here, so the script and its test cannot drift.
+      - name: Self-test announce-to-river
+        run: bash scripts/release-agent/announce-to-river_test.sh
+
       - name: Check for old-style mod.rs files
         run: |
           # New modules must use foo.rs + foo/ style, not foo/mod.rs

--- a/scripts/release-agent/announce-to-river.sh
+++ b/scripts/release-agent/announce-to-river.sh
@@ -38,6 +38,10 @@ LOG_FILE="${LOG_FILE:-}"
 # the v0.2.61 release. Overridable (e.g. INTERVAL=0 in tests).
 NODE_WAIT_ATTEMPTS="${NODE_WAIT_ATTEMPTS:-60}"
 NODE_WAIT_INTERVAL="${NODE_WAIT_INTERVAL:-5}"
+# Set to any non-empty value to skip the post-send convergence re-read (the
+# read that confirms the message actually landed in room state). Off by
+# default; primarily a test hook.
+SKIP_POST_VERIFY="${SKIP_POST_VERIFY:-}"
 
 log() {
     local timestamp
@@ -58,32 +62,69 @@ EOF
     exit 1
 }
 
-# Poll FREENET_NODE_URL until it responds, or NODE_WAIT_ATTEMPTS is reached.
-# Returns 0 once reachable, 1 if it never became reachable.
+# Build riverctl ONCE, before the wait loop, so every subsequent
+# `cargo run -p riverctl` (the read probe AND the send) is a fast no-op
+# rebuild instead of a cold ~3min compile. Without this, each poll attempt
+# in wait_for_room() would re-pay the build cost and the ~5min budget would
+# only buy one or two real probes.
+build_riverctl() {
+    cd "$RIVER_DIR" || return 1
+    log "building riverctl once before the readiness probe"
+    cargo build --quiet -p riverctl
+}
+
+# Read room state via riverctl (the same owner-signed `message list` GET that
+# the post step relies on). Returns 0 iff riverctl exits 0, i.e. the room was
+# actually retrieved from the local node. stdout/stderr is discarded — callers
+# only care about reachability, not the message list.
+read_room_state() {
+    cd "$RIVER_DIR" || return 1
+    RIVER_SKIP_CONTRACT_CHECK=1 timeout 60 \
+        cargo run --quiet -p riverctl -- \
+            --signing-key-file "$SIGNING_KEY_FILE" \
+            message list "$ROOM_OWNER_VK" >/dev/null 2>&1
+}
+
+# Poll until the room is actually READABLE, or NODE_WAIT_ATTEMPTS is reached.
+# Returns 0 once a room GET succeeds, 1 if it never did.
 #
-# A release announcement runs concurrently with the gateway update that
-# restarts the local node (down ~90s), so a single probe routinely races
-# that window (issue #4208) — hence the polling.
+# A WS-port check is NOT sufficient. A release announcement runs concurrently
+# with the gateway update that restarts the local node (down ~90s, issue
+# #4208). The OLD node keeps answering the WS port right up until the update
+# stops the service, so a port probe passes, riverctl connects, and its room
+# GET then hits the node mid-teardown — returning empty, which riverctl
+# reports as "Room not found on the current contract or any of the 24 known
+# previous contract generations" and exits 1. The release workflow already
+# received its 202 by then, so the failure is silent: the v0.2.74 and
+# v0.2.75 announcements were both lost exactly this way (riverctl exited 1
+# in journald while the workflow showed green). The fix is to gate the post
+# on a real room READ succeeding, not on the WS port answering — that proves
+# the (restarted) node is up AND has the room state retrievable before we
+# attempt the send.
 #
 # The polling also keeps this script alive past the release-agent's
 # 1-second early-exit probe: the agent treats a sub-1s exit as a failure
 # (HTTP 500) but returns 202 for a still-running script and reaps it in the
 # background. So a node that is merely restarting still yields a completed
-# announcement. The flip side: a node that stays down for the whole budget
-# fails only in this script's journald log, not visibly to the release
-# workflow (which already received its 202). A prolonged gateway outage on
-# release day is independently visible, so that trade-off is acceptable;
-# surfacing late failures to the workflow would need a release-agent change.
-wait_for_node() {
+# announcement. The flip side: a node that stays unreadable for the whole
+# budget fails only in this script's journald log, not visibly to the
+# release workflow (which already received its 202). A prolonged gateway
+# outage on release day is independently visible, so that trade-off is
+# acceptable; surfacing late failures to the workflow would need a
+# release-agent change.
+wait_for_room() {
     local attempt
     for ((attempt = 1; attempt <= NODE_WAIT_ATTEMPTS; attempt++)); do
-        if curl -s --max-time 3 "$FREENET_NODE_URL" >/dev/null 2>&1; then
+        if read_room_state; then
+            if (( attempt > 1 )); then
+                log "room readable after $attempt attempts"
+            fi
             return 0
         fi
         if [[ "$attempt" -eq 1 ]]; then
-            log "Freenet node not reachable at $FREENET_NODE_URL yet — waiting (it is restarted by the concurrent gateway update)"
+            log "room not yet readable via $FREENET_NODE_URL — waiting (the node is restarted by the concurrent gateway update)"
         elif (( attempt % 12 == 0 )); then
-            log "still waiting for Freenet node ($attempt/$NODE_WAIT_ATTEMPTS)"
+            log "still waiting for room to become readable ($attempt/$NODE_WAIT_ATTEMPTS)"
         fi
         # No sleep after the final attempt — nothing follows it.
         if (( attempt < NODE_WAIT_ATTEMPTS )); then
@@ -157,11 +198,21 @@ if [[ ! -f "$ROOMS_JSON" ]]; then
     exit 1
 fi
 
-# Wait for the local Freenet node before invoking riverctl (it hangs
-# otherwise). See wait_for_node() above for why this polls rather than
-# probing once.
-if ! wait_for_node; then
-    log "ERROR: Freenet node still not reachable at $FREENET_NODE_URL after $NODE_WAIT_ATTEMPTS attempts"
+# Build riverctl once up front so the readiness probe and the send don't each
+# re-pay the cold-compile cost (see build_riverctl above). A build failure is
+# fatal — riverctl is required for everything below.
+if ! build_riverctl; then
+    log "ERROR: failed to build riverctl in $RIVER_DIR"
+    exit 1
+fi
+
+# Wait until the room is actually READABLE before posting. A WS-port probe is
+# not enough: the old node answers the port right up until the concurrent
+# gateway update stops it, so a port-only check lets riverctl issue a room GET
+# into a node mid-teardown and fail "room not found" (issue #4208 / the
+# v0.2.74+v0.2.75 lost announcements). See wait_for_room() for the full race.
+if ! wait_for_room; then
+    log "ERROR: room $ROOM_OWNER_VK still not readable via $FREENET_NODE_URL after $NODE_WAIT_ATTEMPTS attempts"
     exit 1
 fi
 
@@ -169,11 +220,32 @@ log "posting to River room $ROOM_OWNER_VK (msg ${#MESSAGE} bytes)"
 
 # Sign as the owner via the in-memory --signing-key-file override (see
 # post_message above for why pre-patching rooms.json does not work).
-if post_message; then
-    log "OK"
-    exit 0
-else
+if ! post_message; then
     rc=$?
     log "FAILED with rc=$rc"
     exit "$rc"
+fi
+
+# Post-send convergence check. riverctl prints "Message sent successfully" and
+# exits 0 even when the room contract silently drops the delta (e.g. a
+# non-owner signature — see post_message), so exit 0 alone does NOT prove the
+# message landed. Re-read room state and confirm the exact message text is
+# present; if it isn't, fail loudly so a future silent drop is visible in
+# journald instead of masquerading as success. Skippable via SKIP_POST_VERIFY.
+if [[ -n "$SKIP_POST_VERIFY" ]]; then
+    log "OK (post-send verification skipped via SKIP_POST_VERIFY)"
+    exit 0
+fi
+
+cd "$RIVER_DIR" || { log "ERROR: cannot cd to $RIVER_DIR for post-send verification"; exit 1; }
+if RIVER_SKIP_CONTRACT_CHECK=1 timeout 60 \
+        cargo run --quiet -p riverctl -- \
+            --signing-key-file "$SIGNING_KEY_FILE" \
+            message list "$ROOM_OWNER_VK" 2>/dev/null \
+        | grep -qF -- "$MESSAGE"; then
+    log "OK (verified message present in room state)"
+    exit 0
+else
+    log "ERROR: riverctl reported success but the message did NOT converge into room state (silent drop)"
+    exit 1
 fi

--- a/scripts/release-agent/announce-to-river.sh
+++ b/scripts/release-agent/announce-to-river.sh
@@ -25,19 +25,36 @@ RIVER_DIR="${RIVER_DIR:-$HOME/code/freenet/river/main}"
 ROOM_OWNER_VK="${ROOM_OWNER_VK:-4uNUKFzZQCnzo4K2ecZ16cMsYEEfoaRS35z6exEsbvm4}"
 SIGNING_KEY_FILE="${SIGNING_KEY_FILE:-$HOME/.config/freenet-river-official/room_owner_signing_key.bin}"
 ROOMS_JSON="${ROOMS_JSON:-$HOME/.local/share/river/rooms.json}"
+# Display-only since the readiness probe became a real room read: it appears
+# in log lines for context, but riverctl reaches the node via its OWN config,
+# not this URL. Changing FREENET_NODE_URL relabels the logs; it does NOT
+# redirect where the room read / send actually connect.
 FREENET_NODE_URL="${FREENET_NODE_URL:-http://127.0.0.1:7509/}"
 # Optional persistent log file. Empty by default — the release-agent already
 # captures this script's stderr to journald, and the old /var/log default
 # was not writable by the announce user, so every log() call emitted a
 # spurious "Permission denied" line (issue #4208).
 LOG_FILE="${LOG_FILE:-}"
-# Node-reachability polling budget. A release announcement runs concurrently
+# Room-readability polling budget. A release announcement runs concurrently
 # with the gateway update that restarts the local node, so it must wait that
-# restart out (issue #4208). ATTEMPTS * INTERVAL is the wall-clock budget —
-# default ~5 min, comfortably over the ~90s gateway down-window observed on
-# the v0.2.61 release. Overridable (e.g. INTERVAL=0 in tests).
+# restart out (issue #4208).
+#
+# The per-attempt wall-clock is bounded by READ_PROBE_TIMEOUT, NOT just
+# NODE_WAIT_INTERVAL: each probe is a real `riverctl message list` GET, and a
+# FAILING GET during the down-window is slow — riverctl walks all ~24 legacy
+# contract generations (~8s each) before giving up. Capping each probe at
+# READ_PROBE_TIMEOUT keeps the worst case bounded: roughly
+# ATTEMPTS * (READ_PROBE_TIMEOUT + INTERVAL). With the defaults that is
+# ~60 * (15s + 5s) = ~20 min worst case if the node never recovers, while the
+# happy path (room readable) returns in well under a second. The budget is
+# comfortably over the ~90s gateway down-window observed on the v0.2.61
+# release. Overridable (e.g. NODE_WAIT_INTERVAL=0 in tests).
 NODE_WAIT_ATTEMPTS="${NODE_WAIT_ATTEMPTS:-60}"
 NODE_WAIT_INTERVAL="${NODE_WAIT_INTERVAL:-5}"
+# Per-probe timeout for each room read (readiness probe and post-send verify).
+# Bounds the legacy-generation walk a failing GET performs during the
+# down-window; the happy-path read is far faster. Overridable in tests.
+READ_PROBE_TIMEOUT="${READ_PROBE_TIMEOUT:-15}"
 # Set to any non-empty value to skip the post-send convergence re-read (the
 # read that confirms the message actually landed in room state). Off by
 # default; primarily a test hook.
@@ -67,10 +84,21 @@ EOF
 # rebuild instead of a cold ~3min compile. Without this, each poll attempt
 # in wait_for_room() would re-pay the build cost and the ~5min budget would
 # only buy one or two real probes.
+#
+# RIVER_SKIP_CONTRACT_CHECK=1 matches every other riverctl invocation below
+# (read_room_state, post_message, the post-send verify). riverctl's
+# cli/build.rs panics ("room_contract.wasm out of date") when the flag is
+# unset and a stale wasm artifact happens to be present in the workspace.
+# Because this build is a *fatal* step (a failure aborts the whole announce),
+# omitting the flag here would introduce a brand-new failure mode the old
+# script never had — it only ever ran the skip-flagged `cargo run`. build.rs
+# declares rerun-if-changed, so cargo does NOT rebuild merely because the flag
+# toggles between this build and the later runs; the build-once optimization
+# still holds.
 build_riverctl() {
     cd "$RIVER_DIR" || return 1
     log "building riverctl once before the readiness probe"
-    cargo build --quiet -p riverctl
+    RIVER_SKIP_CONTRACT_CHECK=1 cargo build --quiet -p riverctl
 }
 
 # Read room state via riverctl (the same owner-signed `message list` GET that
@@ -79,10 +107,50 @@ build_riverctl() {
 # only care about reachability, not the message list.
 read_room_state() {
     cd "$RIVER_DIR" || return 1
-    RIVER_SKIP_CONTRACT_CHECK=1 timeout 60 \
+    RIVER_SKIP_CONTRACT_CHECK=1 timeout "$READ_PROBE_TIMEOUT" \
         cargo run --quiet -p riverctl -- \
             --signing-key-file "$SIGNING_KEY_FILE" \
             message list "$ROOM_OWNER_VK" >/dev/null 2>&1
+}
+
+# Emit the room's message list to stdout (the rendered text verify_converged
+# greps). Factored out from verify_converged so the test can stub it. stderr is
+# discarded; a riverctl failure yields empty output, which verify_converged
+# treats as "not converged".
+read_room_messages() {
+    cd "$RIVER_DIR" || return 1
+    RIVER_SKIP_CONTRACT_CHECK=1 timeout "$READ_PROBE_TIMEOUT" \
+        cargo run --quiet -p riverctl -- \
+            --signing-key-file "$SIGNING_KEY_FILE" \
+            message list "$ROOM_OWNER_VK" 2>/dev/null
+}
+
+# Confirm the just-sent message converged into room state. riverctl prints
+# "Message sent successfully" and exits 0 even when the room contract silently
+# drops the delta (e.g. a non-owner signature — see post_message), so exit 0
+# alone does NOT prove the message landed. Re-read the room and check the
+# message text is present.
+#
+# IMPORTANT: capture the listing into a variable FIRST, then grep it — do NOT
+# pipe `read_room_messages | grep`. Under `set -o pipefail`, `grep -q` exits as
+# soon as it matches and closes the pipe; the still-writing producer then gets
+# SIGPIPE (exit 141) and pipefail reports the whole pipeline as failed, so a
+# genuinely-converged message would be misreported as a silent drop (exit 1) —
+# the exact inverse of the bug this script fixes. Capturing first removes the
+# pipe and the SIGPIPE race entirely.
+#
+# `grep -F` (fixed-string) so a message containing regex metacharacters or a
+# leading `-` (guarded by `--`) still matches literally. The production
+# announcement is a single line ("Freenet vX.Y.Z released: <url>", see
+# release-announce.yml), so the whole text must appear contiguously. NOTE: for
+# a hypothetical MULTI-line message, `grep -F` matches each pattern line
+# independently (OR semantics), so this would pass if ANY one line converged —
+# acceptable as a smoke check, but switch to an exact match if multi-line
+# announcements are ever routed here.
+verify_converged() {
+    local listing
+    listing="$(read_room_messages)"
+    grep -qF -- "$MESSAGE" <<<"$listing"
 }
 
 # Poll until the room is actually READABLE, or NODE_WAIT_ATTEMPTS is reached.
@@ -167,6 +235,25 @@ post_message() {
             message send "$ROOM_OWNER_VK" "$MESSAGE"
 }
 
+# Run post_message and propagate riverctl's REAL exit code on failure.
+#
+# Capture the code with a trailing `|| rc=$?` rather than `if ! post_message`:
+# under `set -e` the `!`-negation resets `$?` to 0 inside the if-body, so a
+# genuine riverctl failure would be seen as rc=0 — masking the failed send and
+# letting the script fall through to the post-send verification as if it had
+# succeeded. `cmd || rc=$?` preserves riverctl's actual exit code. Returns 0 on
+# success and riverctl's non-zero code on failure; callers propagate it with
+# `send_message_checked || exit $?`.
+send_message_checked() {
+    local rc=0
+    post_message || rc=$?
+    if (( rc != 0 )); then
+        log "FAILED with rc=$rc"
+        return "$rc"
+    fi
+    return 0
+}
+
 if [[ $# -ne 1 ]]; then
     usage
 fi
@@ -219,30 +306,20 @@ fi
 log "posting to River room $ROOM_OWNER_VK (msg ${#MESSAGE} bytes)"
 
 # Sign as the owner via the in-memory --signing-key-file override (see
-# post_message above for why pre-patching rooms.json does not work).
-if ! post_message; then
-    rc=$?
-    log "FAILED with rc=$rc"
-    exit "$rc"
-fi
+# post_message above for why pre-patching rooms.json does not work), and
+# propagate riverctl's real exit code on failure (see send_message_checked
+# for why the naive `if ! post_message` masks it as rc=0).
+send_message_checked || exit $?
 
-# Post-send convergence check. riverctl prints "Message sent successfully" and
-# exits 0 even when the room contract silently drops the delta (e.g. a
-# non-owner signature — see post_message), so exit 0 alone does NOT prove the
-# message landed. Re-read room state and confirm the exact message text is
-# present; if it isn't, fail loudly so a future silent drop is visible in
-# journald instead of masquerading as success. Skippable via SKIP_POST_VERIFY.
+# Post-send convergence check (see verify_converged above): re-read room state
+# and confirm the message text is present, so a future silent drop is visible
+# in journald instead of masquerading as success. Skippable via SKIP_POST_VERIFY.
 if [[ -n "$SKIP_POST_VERIFY" ]]; then
     log "OK (post-send verification skipped via SKIP_POST_VERIFY)"
     exit 0
 fi
 
-cd "$RIVER_DIR" || { log "ERROR: cannot cd to $RIVER_DIR for post-send verification"; exit 1; }
-if RIVER_SKIP_CONTRACT_CHECK=1 timeout 60 \
-        cargo run --quiet -p riverctl -- \
-            --signing-key-file "$SIGNING_KEY_FILE" \
-            message list "$ROOM_OWNER_VK" 2>/dev/null \
-        | grep -qF -- "$MESSAGE"; then
+if verify_converged; then
     log "OK (verified message present in room state)"
     exit 0
 else

--- a/scripts/release-agent/announce-to-river_test.sh
+++ b/scripts/release-agent/announce-to-river_test.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034
-# ^ FREENET_NODE_URL / NODE_WAIT_* / LOG_FILE are read by the functions
+# shellcheck disable=SC2034,SC2317
+# ^ SC2034: FREENET_NODE_URL / NODE_WAIT_* / LOG_FILE are read by the functions
 #   extracted from announce-to-river.sh via `eval`; shellcheck cannot see
 #   into the eval and would otherwise flag them all as unused.
+#   SC2317: the stub functions (read_room_messages, post_message, curl) are
+#   invoked indirectly from those eval'd functions, so shellcheck wrongly
+#   reports their bodies as unreachable.
 #
 # Regression test for announce-to-river.sh (issues #4208 and the
 # v0.2.74/v0.2.75 lost-announcement race).
@@ -186,6 +189,80 @@ check "post_message runs riverctl from the source repo" \
     "$(printf '%s' "$cargo_args" | grep -cF -- "run --quiet -p riverctl" || true)" "1"
 check "post_message sets RIVER_SKIP_CONTRACT_CHECK for the riverctl run" \
     "$cargo_skip" "1"
+
+# ── verify_converged() ───────────────────────────────────────────────
+#
+# The post-send convergence check, the PR's SECOND silent-drop defense.
+# riverctl exits 0 even when the room contract silently drops the delta, so
+# the script re-reads room state and confirms the message text is present.
+# verify_converged is extracted verbatim; read_room_messages (the riverctl
+# `message list` GET) is stubbed so the test is hermetic.
+#
+# The load-bearing property: verify_converged must CAPTURE the listing into a
+# variable before grepping, NOT pipe `read_room_messages | grep -qF`. Under
+# `set -o pipefail`, a piped `grep -q` exits on first match and SIGPIPEs the
+# still-writing producer (exit 141), so pipefail would report a genuinely
+# converged message as a FAILURE — the inverse of the bug being fixed. The
+# large-output test below pins that: the match is EARLY in a big listing, so a
+# piped implementation gets SIGPIPE (rc=141) when grep exits before the
+# producer finishes, while capture-then-grep returns 0. (A last-line match
+# would NOT trigger it — grep must read all output — which is why the producer
+# emits the match first, then a large tail.)
+# shellcheck disable=SC2317  # stubs below are called indirectly via eval'd verify_converged
+eval "$(awk '/^verify_converged\(\) \{/,/^}/' "$ANNOUNCE_SH")"
+
+# Re-assert pipefail is on (matches the real script's `set -euo pipefail`), so
+# the SIGPIPE-resistance test below is meaningful.
+set -o pipefail
+
+MESSAGE="Freenet v0.2.75 released: https://example/v0.2.75"
+
+# Message present EARLY, followed by a large tail. A piped
+# read_room_messages|grep -qF would SIGPIPE the still-writing producer (rc=141)
+# under pipefail and report failure despite the match. Capture-then-grep
+# returns 0. Verified: against a piped impl this assertion fails (rc=141);
+# against capture-then-grep it passes.
+read_room_messages() {
+    echo "[15:23:44 - Room Owner]: $MESSAGE"
+    for i in $(seq 1 500000); do echo "[old line $i]: filler chatter to overrun the 64KB pipe buffer"; done
+}
+rc=0
+verify_converged || rc=$?
+check "verify_converged() returns 0 when present early in large output (no SIGPIPE false-failure)" "$rc" "0"
+
+# Message absent: the delta was silently dropped — must fail (exit nonzero).
+read_room_messages() {
+    echo "[15:00:00 - Room Owner]: Freenet v0.2.74 released: https://example/v0.2.74"
+}
+rc=0
+verify_converged || rc=$?
+check "verify_converged() returns nonzero when the message is absent" "$rc" "1"
+
+# riverctl read itself fails (empty output): must be treated as not-converged.
+read_room_messages() { return 1; }
+rc=0
+verify_converged || rc=$?
+check "verify_converged() returns nonzero when the room read fails" "$rc" "1"
+
+# grep -F literalness: a message with regex metacharacters / leading dash is
+# matched literally (the `--` and `-F` are load-bearing).
+MESSAGE="-n release [v1.2.3] (50%) a.b*c"
+read_room_messages() { echo "noise"; echo "x $MESSAGE y"; }
+rc=0
+verify_converged || rc=$?
+check "verify_converged() matches messages with regex/dash metacharacters literally" "$rc" "0"
+
+# ── send-failure exit-code preservation ──────────────────────────────
+#
+# Regression for the Codex finding: the success path used `if ! post_message`,
+# under which `set -e` resets `$?` to 0 inside the if-body, so a real riverctl
+# failure was logged and exited as rc=0 — masking the failed announcement and
+# skipping verification. The fix captures the code with `post_message || rc=$?`.
+# This asserts the surviving capture idiom preserves a nonzero exit code.
+post_message() { return 7; }
+rc=0
+post_message || rc=$?
+check "send-failure exit code is preserved (not masked to 0)" "$rc" "7"
 
 # ── result ───────────────────────────────────────────────────────────
 

--- a/scripts/release-agent/announce-to-river_test.sh
+++ b/scripts/release-agent/announce-to-river_test.sh
@@ -252,17 +252,28 @@ rc=0
 verify_converged || rc=$?
 check "verify_converged() matches messages with regex/dash metacharacters literally" "$rc" "0"
 
-# ── send-failure exit-code preservation ──────────────────────────────
+# ── send_message_checked() exit-code preservation ────────────────────
 #
-# Regression for the Codex finding: the success path used `if ! post_message`,
-# under which `set -e` resets `$?` to 0 inside the if-body, so a real riverctl
-# failure was logged and exited as rc=0 — masking the failed announcement and
-# skipping verification. The fix captures the code with `post_message || rc=$?`.
-# This asserts the surviving capture idiom preserves a nonzero exit code.
+# Regression for the Codex finding: the success path originally used
+# `if ! post_message`, under which `set -e` resets `$?` to 0 inside the
+# if-body, so a real riverctl failure was logged/exited as rc=0 — masking the
+# failed announcement and skipping verification. The fix wraps the send in
+# send_message_checked(), which captures the code with `post_message || rc=$?`
+# and returns it. send_message_checked is extracted VERBATIM here, so reverting
+# it to `if ! post_message` (which yields rc=0 on failure) fails this assertion.
+eval "$(awk '/^send_message_checked\(\) \{/,/^}/' "$ANNOUNCE_SH")"
+
+# riverctl send fails: send_message_checked must return riverctl's real code.
 post_message() { return 7; }
 rc=0
-post_message || rc=$?
-check "send-failure exit code is preserved (not masked to 0)" "$rc" "7"
+send_message_checked 2>/dev/null || rc=$?
+check "send_message_checked() preserves a send failure code (not masked to 0)" "$rc" "7"
+
+# riverctl send succeeds: send_message_checked returns 0.
+post_message() { return 0; }
+rc=0
+send_message_checked 2>/dev/null || rc=$?
+check "send_message_checked() returns 0 on a successful send" "$rc" "0"
 
 # ── result ───────────────────────────────────────────────────────────
 

--- a/scripts/release-agent/announce-to-river_test.sh
+++ b/scripts/release-agent/announce-to-river_test.sh
@@ -4,19 +4,25 @@
 #   extracted from announce-to-river.sh via `eval`; shellcheck cannot see
 #   into the eval and would otherwise flag them all as unused.
 #
-# Regression test for announce-to-river.sh (issue #4208).
+# Regression test for announce-to-river.sh (issues #4208 and the
+# v0.2.74/v0.2.75 lost-announcement race).
 #
-# Covers the two functions the #4208 fix touches:
-#   - wait_for_node(): the bounded node-reachability poll that lets the
-#     announce survive the gateway restarting the local node mid-release,
-#     instead of failing on a single probe that races the restart window.
+# Covers the functions the fixes touch:
+#   - wait_for_room(): the bounded readiness poll that gates the post on the
+#     room actually being READABLE (a riverctl room GET succeeding), not just
+#     on the WS port answering. The earlier wait_for_node() port probe passed
+#     while the old node was being torn down for the gateway self-update, so
+#     riverctl's room GET hit a mid-teardown node and failed "room not found"
+#     — the silent drop that lost v0.2.74 and v0.2.75. wait_for_room() rides
+#     out that window by retrying the real read.
 #   - log(): now writes a persistent log file only when LOG_FILE is set
 #     (the old unconditional /var/log default emitted "Permission denied"
 #     on every call because the announce user cannot write there).
+#   - post_message(): signs with the owner key via --signing-key-file.
 #
-# Both functions are extracted verbatim from announce-to-river.sh and
-# eval'd here, so the test exercises the real implementation and cannot
-# drift from it. curl is stubbed and NODE_WAIT_INTERVAL=0 keeps it instant.
+# All functions are extracted verbatim from announce-to-river.sh and eval'd
+# here, so the test exercises the real implementation and cannot drift from
+# it. read_room_state is stubbed and NODE_WAIT_INTERVAL=0 keeps it instant.
 #
 # Run manually with: bash scripts/release-agent/announce-to-river_test.sh
 
@@ -36,7 +42,7 @@ trap 'rm -rf "$TMP"' EXIT
 # Pull the two functions verbatim so the test runs the real code, not a
 # copy that could drift. Mirrors scripts/release_state_restore_test.sh.
 eval "$(awk '/^log\(\) \{/,/^}/' "$ANNOUNCE_SH")"
-eval "$(awk '/^wait_for_node\(\) \{/,/^}/' "$ANNOUNCE_SH")"
+eval "$(awk '/^wait_for_room\(\) \{/,/^}/' "$ANNOUNCE_SH")"
 
 FAILURES=0
 check() {
@@ -87,46 +93,61 @@ rc=0
 log "ignored" 2>/dev/null || rc=$?
 check "log() survives an unwritable LOG_FILE" "$rc" "0"
 
-# ── wait_for_node() ──────────────────────────────────────────────────
+# ── wait_for_room() ──────────────────────────────────────────────────
+#
+# The lost-announcement fix. The probe now gates on a real room READ
+# (read_room_state, a riverctl GET) succeeding rather than on a WS-port
+# answer, so it can't be fooled by the old node still answering the port
+# while it is being torn down for the gateway self-update. The crucial
+# difference from the old wait_for_node(): a node that is up at the port
+# layer but whose room GET fails counts as NOT ready, so the poll keeps
+# waiting through the restart instead of declaring success and letting the
+# post hit a mid-teardown node (the v0.2.74/v0.2.75 silent drop).
 
 FREENET_NODE_URL="http://stub/"
 NODE_WAIT_INTERVAL=0
 LOG_FILE=""
 
-# curl stub: fails for the first CURL_FAIL_COUNT calls, then succeeds.
-CURL_CALLS=0
-CURL_FAIL_COUNT=0
-curl() {
-    CURL_CALLS=$((CURL_CALLS + 1))
-    (( CURL_CALLS > CURL_FAIL_COUNT ))
+# read_room_state stub: fails for the first READ_FAIL_COUNT calls (room not
+# yet retrievable — node restarting / mid-teardown), then succeeds. This
+# stands in for the real riverctl `message list` GET. Stubbing the probe
+# function directly keeps the test independent of riverctl/cargo while still
+# exercising the genuine wait_for_room() loop body.
+READ_CALLS=0
+READ_FAIL_COUNT=0
+read_room_state() {
+    READ_CALLS=$((READ_CALLS + 1))
+    (( READ_CALLS > READ_FAIL_COUNT ))
 }
 
-# Node already up: succeeds on the first probe.
+# Room already readable: succeeds on the first probe.
 NODE_WAIT_ATTEMPTS=60
-CURL_CALLS=0
-CURL_FAIL_COUNT=0
+READ_CALLS=0
+READ_FAIL_COUNT=0
 rc=0
-wait_for_node 2>/dev/null || rc=$?
-check "wait_for_node() succeeds when the node is already up" "$rc" "0"
-check "wait_for_node() probes once when the node is up" "$CURL_CALLS" "1"
+wait_for_room 2>/dev/null || rc=$?
+check "wait_for_room() succeeds when the room is already readable" "$rc" "0"
+check "wait_for_room() probes once when the room is readable" "$READ_CALLS" "1"
 
-# Node down then up: the poll bridges the restart window (issue #4208).
+# Room unreadable then readable: the poll bridges the restart window. This is
+# the case the old port-only probe got wrong — the read fails while the node
+# is mid-teardown, and only succeeds once the restarted node has the room.
 NODE_WAIT_ATTEMPTS=60
-CURL_CALLS=0
-CURL_FAIL_COUNT=3
+READ_CALLS=0
+READ_FAIL_COUNT=3
 rc=0
-wait_for_node 2>/dev/null || rc=$?
-check "wait_for_node() succeeds once the node returns" "$rc" "0"
-check "wait_for_node() keeps probing across the down-window" "$CURL_CALLS" "4"
+wait_for_room 2>/dev/null || rc=$?
+check "wait_for_room() succeeds once the room becomes readable" "$rc" "0"
+check "wait_for_room() keeps probing across the down-window" "$READ_CALLS" "4"
 
-# Node never returns: the poll gives up after NODE_WAIT_ATTEMPTS.
+# Room never readable: the poll gives up after NODE_WAIT_ATTEMPTS.
 NODE_WAIT_ATTEMPTS=3
-CURL_CALLS=0
-CURL_FAIL_COUNT=9999
+READ_CALLS=0
+READ_FAIL_COUNT=9999
 rc=0
-wait_for_node 2>/dev/null || rc=$?
-check "wait_for_node() fails when the node never returns" "$rc" "1"
-check "wait_for_node() honours NODE_WAIT_ATTEMPTS as the bound" "$CURL_CALLS" "3"
+wait_for_room 2>/dev/null || rc=$?
+check "wait_for_room() fails when the room never becomes readable" "$rc" "1"
+check "wait_for_room() honours NODE_WAIT_ATTEMPTS as the bound" "$READ_CALLS" "3"
 
 # ── post_message() ───────────────────────────────────────────────────
 #


### PR DESCRIPTION
## Problem

The v0.2.74 and v0.2.75 release announcements posted to Matrix fine but were **silently dropped from the official River room**. The `release-announce.yml` "Post to River (via nova webhook)" job received HTTP 202 from nova and reported success, yet the message never converged into room state.

This is a **different** failure from the older non-owner-signature silent drop — the `--signing-key-file` owner-signing fix from #4318 is intact and correct. The real cause is a node-restart race:

`announce-to-river.sh`'s `wait_for_node()` only confirmed the **WS port answered**. But the announce runs concurrently with the gateway self-update that restarts the local node. The OLD node keeps answering the WS port right up until the update stops the service, so:

1. the port probe passes (old node still up at the port layer),
2. riverctl connects and issues its room GET,
3. the GET hits the node **mid-teardown** → returns empty,
4. riverctl reports `Room not found on the current contract or any of the 24 known previous contract generations` and exits 1,
5. nova already returned its 202, so the failure is visible only in journald while the workflow shows green.

Confirmed from nova journald for v0.2.75:

```
20:11:36  posting to River room 4uNUKFzZQCnzo4K2ecZ16cMsYEEfoaRS35z6exEsbvm4  (port probe passed; old v0.2.74 node still up)
20:11:38  Stopping systemd service (freenet-gateway)...            <- gateway-update
20:11:38  Error: Room not found ... 24 known previous contract generations
20:11:38  FAILED with rc=1
```

The room GET failed the same second the gateway was stopped for the self-update.

## Solution

Gate the post on a real room **READ** succeeding, not on the WS port:

- `wait_for_room()` replaces `wait_for_node()`. It retries the same owner-signed `riverctl message list` GET the post relies on, and only proceeds once it returns rc=0 — proving the (restarted) node is up **and** has the room state retrievable. This rides out the ~90s gateway-restart window within the existing ~5min budget.
- riverctl is built **once** up front (`cargo build -p riverctl`) before the poll, so each probe and the send are fast no-op rebuilds rather than cold ~3min compiles (otherwise the budget would buy only one or two real probes).
- Added a **post-send convergence check**: re-read room state and confirm the message text is present, failing loudly if it isn't — so any future silent drop is visible in journald instead of masquerading as success.

The owner-signing logic (`post_message`, `--signing-key-file`) is unchanged.

## Testing

- `announce-to-river_test.sh` updated: the readiness-poll tests now stub the room read (not curl) and assert the poll keeps probing across the down-window. **Verified the new "keeps probing across the down-window" assertion fails against the old port-only probe** (which never reads the room and returns success on the port answer) — the test reproduces the bug. `post_message` owner-signing and `log()` tests unchanged and pass (15/15).
- **Wired the test into CI** (`ci.yml`) alongside the existing `verify-version-decision_test.sh`; the announce test was **not run by CI before**, which is why this regression class could land. ("A bug that made it past CI is also a bug in CI.")
- `bash -n` + `shellcheck` clean on both scripts; CI YAML validates.
- Out of band: re-posted the genuine v0.2.75 announcement to the official room signed as owner and confirmed it converged into room state (visible as `[Room Owner]: Freenet v0.2.75 released: ...`).

## Deployment note

The live copy at `/usr/local/bin/announce-to-river.sh` on nova is a static copy installed by `scripts/release-agent/install.sh` (it is **not** auto-pulled from the repo). After this merges to main, the fix must be deployed to nova by re-running `install.sh` or copying the updated script. Deploy from main only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-assisted - Claude]