### PR TITLE
feat(telemetry): add node fd-usage gauges to router_snapshot (#4440)

### DIFF
--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1061,11 +1061,20 @@ impl Ring {
                 snapshot.connect_forward_peer_adjustments = Some(adjustments);
             }
 
+            // Node-health gauges (#4440): make fd-exhaustion headroom observable
+            // on the existing snapshot cadence. Best-effort — `None` where the
+            // platform can't report it (see `read_fd_usage`).
+            let (open_fds, fd_soft_limit) = read_fd_usage();
+            snapshot.open_fds = open_fds;
+            snapshot.fd_soft_limit = fd_soft_limit;
+
             tracing::info!(
                 failure_events = snapshot.failure_events,
                 success_events = snapshot.success_events,
                 prediction_active = snapshot.prediction_active,
                 consider_n_closest_peers = snapshot.consider_n_closest_peers,
+                open_fds = ?snapshot.open_fds,
+                fd_soft_limit = ?snapshot.fd_soft_limit,
                 "router_snapshot"
             );
 
@@ -4020,6 +4029,91 @@ fn deferred_swap_drops_to_execute(
 #[inline]
 fn classify_suspend_jump(boot_elapsed: Duration, mono_elapsed: Duration) -> Duration {
     boot_elapsed.saturating_sub(mono_elapsed)
+}
+
+/// Best-effort snapshot of this process's open file-descriptor count and the
+/// `RLIMIT_NOFILE` soft limit, for the node-health telemetry gauges (#4440).
+///
+/// fd exhaustion (open fds reaching the soft limit → `EMFILE`) drove the
+/// v0.2.73 gateway crash-loop and was invisible to central telemetry at the
+/// time. Emitting these on the existing `router_snapshot` cadence makes the
+/// headroom observable to operators.
+///
+/// Returns `(open_fds, fd_soft_limit)`. Either element is `None` on a platform
+/// where it can't be read cheaply: the open-fd count is Linux-only (via
+/// `/proc/self/fd`); the soft limit is any-unix (via `getrlimit`).
+fn read_fd_usage() -> (Option<u64>, Option<u64>) {
+    (read_open_fd_count(), read_fd_soft_limit())
+}
+
+/// Count this process's open file descriptors by enumerating `/proc/self/fd`.
+///
+/// Returns `None` if the process is already at its fd limit — `read_dir` itself
+/// needs a descriptor and fails with `EMFILE` at the cliff. The companion
+/// [`read_fd_soft_limit`] still reports in that case, and the 5-minute cadence
+/// captures the *approach* to the limit, which is the actionable signal.
+#[cfg(target_os = "linux")]
+fn read_open_fd_count() -> Option<u64> {
+    // `read_dir` itself holds one descriptor open for the duration of the
+    // iteration, so it is included in the entry count; subtract it to report
+    // the steady-state number of descriptors the process actually holds.
+    let count = std::fs::read_dir("/proc/self/fd").ok()?.count() as u64;
+    Some(count.saturating_sub(1))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_open_fd_count() -> Option<u64> {
+    None
+}
+
+/// Read the current `RLIMIT_NOFILE` soft limit (the ceiling that triggers
+/// `EMFILE`). Mirrors the `getrlimit` read in `bin/freenet.rs::raise_fd_limit`.
+#[cfg(unix)]
+fn read_fd_soft_limit() -> Option<u64> {
+    let mut limits = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: `getrlimit` with a valid resource id and an exclusively-borrowed,
+    // initialized out-param is sound; the return code is checked before the
+    // struct is read.
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) } != 0 {
+        return None;
+    }
+    // `rlim_t` is `u64` on linux-gnu (CI target) but varies across unix targets;
+    // normalize to `u64`. The cast is redundant on linux-gnu, hence the scoped
+    // allow rather than a bare `as u64` that trips clippy.
+    #[allow(clippy::unnecessary_cast)]
+    Some(limits.rlim_cur as u64)
+}
+
+#[cfg(not(unix))]
+fn read_fd_soft_limit() -> Option<u64> {
+    None
+}
+
+#[cfg(test)]
+mod fd_usage_tests {
+    //! Validates the node-health fd gauges (#4440): the open-fd count and the
+    //! `RLIMIT_NOFILE` soft limit must report sane values on Linux so the
+    //! fd-exhaustion headroom signal that was missing during the v0.2.73
+    //! incident is trustworthy.
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn read_fd_usage_reports_sane_values_on_linux() {
+        let (open, soft) = super::read_fd_usage();
+        let open = open.expect("linux reports an open-fd count via /proc/self/fd");
+        let soft = soft.expect("unix reports the RLIMIT_NOFILE soft limit");
+        // A running process always holds at least stdin/stdout/stderr.
+        assert!(open > 0, "expected a positive open-fd count, got {open}");
+        // The kernel enforces open-fds <= soft limit, so this is invariant, not
+        // a heuristic — it pins that we read the two values the right way round.
+        assert!(
+            soft >= open,
+            "open fds ({open}) must not exceed the soft limit ({soft})"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -144,6 +144,18 @@ pub(crate) struct RouterSnapshotInfo {
     pub connect_forward_data_range: Option<(f64, f64)>,
     pub connect_forward_events: Option<usize>,
     pub connect_forward_peer_adjustments: Option<usize>,
+    /// Current number of open file descriptors held by this process, or `None`
+    /// where it can't be read cheaply (Linux-only, via `/proc/self/fd`).
+    ///
+    /// Populated by `Ring` on the `router_snapshot` cadence, not by the router
+    /// model. Paired with [`fd_soft_limit`](Self::fd_soft_limit) it makes
+    /// fd-exhaustion headroom observable in central telemetry: open fds reaching
+    /// the soft limit (`EMFILE`) drove the v0.2.73 gateway crash-loop and was
+    /// invisible to the collector at the time. See #4440.
+    pub open_fds: Option<u64>,
+    /// The `RLIMIT_NOFILE` soft limit (the ceiling that triggers `EMFILE`), or
+    /// `None` on non-unix. Populated by `Ring`; see [`open_fds`](Self::open_fds).
+    pub fd_soft_limit: Option<u64>,
     /// Per-operation-type estimator curves, keyed by op type name (e.g., "GET").
     pub per_op_curves: HashMap<String, PerOpCurves>,
     /// Renegade predictor diagnostics
@@ -888,6 +900,9 @@ impl Router {
             connect_forward_data_range: None,
             connect_forward_events: None,
             connect_forward_peer_adjustments: None,
+            // Node-health gauges populated by Ring on the snapshot cadence (#4440).
+            open_fds: None,
+            fd_soft_limit: None,
             // Renegade predictor diagnostics
             renegade_failure_events: self.renegade_predictor.len(),
             renegade_response_time_events: self.renegade_predictor.stage_sizes().1,

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -1839,6 +1839,12 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                 "connect_forward_data_range": snapshot.connect_forward_data_range,
                 "connect_forward_events": snapshot.connect_forward_events,
                 "connect_forward_peer_adjustments": snapshot.connect_forward_peer_adjustments,
+                // Node-health gauges (#4440). This body is a hand-mirrored
+                // `json!`, so new RouterSnapshotInfo fields must be added here or
+                // they never reach the collector — pinned by
+                // `router_snapshot_json_includes_fd_gauges`.
+                "open_fds": snapshot.open_fds,
+                "fd_soft_limit": snapshot.fd_soft_limit,
                 "per_op_curves": snapshot.per_op_curves,
             })
         }
@@ -1848,6 +1854,27 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pin: the manually-mirrored `router_snapshot` OTLP body
+    /// (`event_kind_to_json`) must forward the node-health fd gauges. The body
+    /// is a hand-written `json!` block, so a new `RouterSnapshotInfo` field is
+    /// silently dropped from central telemetry unless it is added there too
+    /// (the #4009/#4010 manually-mirrored-telemetry footgun). See #4440.
+    #[test]
+    fn router_snapshot_json_includes_fd_gauges() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.open_fds = Some(123);
+        info.fd_soft_limit = Some(4096);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(info));
+        assert_eq!(json["open_fds"], 123, "open_fds must reach the OTLP body");
+        assert_eq!(
+            json["fd_soft_limit"], 4096,
+            "fd_soft_limit must reach the OTLP body"
+        );
+    }
 
     #[test]
     fn test_backoff_calculation() {


### PR DESCRIPTION
## Problem

The v0.2.73 placement-migration incident drove a gateway crash-loop from **file-descriptor exhaustion** — the WASM module cache's memfds collided with systemd's 1024 `RLIMIT_NOFILE` soft limit, producing `EMFILE` and killing a monitored background task. The failure was **nearly invisible to central telemetry**: the fatal `os error 24` lived only in per-node file logs, so operators had no signal that fd pressure was building. #4440 tracks adding low-volume node-health gauges so this class of resource exhaustion is observable *before* it becomes fatal.

This is the single highest-value missing signal from that list.

## Approach

Emit two gauges on the **existing 5-minute `router_snapshot` cadence** (already forwarded to the OTLP collector, so no new event type, timer, or wiring):

- `open_fds` — this process's current open file-descriptor count (Linux, via `/proc/self/fd`).
- `fd_soft_limit` — the `RLIMIT_NOFILE` soft limit, i.e. the ceiling that triggers `EMFILE` (any-unix, via `getrlimit`).

Together they let an operator watch fd headroom (`open_fds / fd_soft_limit`) and alert before exhaustion. Both are best-effort and `None` on platforms that can't report them cheaply; the `getrlimit` read mirrors the already-vetted `bin/freenet.rs::raise_fd_limit`.

Design notes for reviewers:

- Values are populated by `Ring` on the snapshot cadence (like the existing `connect_forward_*` enrichment), not by the `Router` model.
- The `router_snapshot` OTLP body (`tracing/telemetry.rs::event_kind_to_json`) is a **hand-mirrored `json!` block**, so new `RouterSnapshotInfo` fields must be added there explicitly or they silently never reach the collector — the #4009/#4010 manually-mirrored-telemetry footgun. A regression test pins this.
- No new `NetMessageV1`/`EventKind` variant — fields are added to the existing `RouterSnapshot` payload, so there is no wire-format or match-arm churn.

## Testing

- `ring::fd_usage_tests::read_fd_usage_reports_sane_values_on_linux` — asserts the Linux path reports a positive open-fd count and `open_fds <= fd_soft_limit` (a kernel invariant, which also pins that the two values are read the right way round).
- `tracing::telemetry::tests::router_snapshot_json_includes_fd_gauges` — builds a `RouterSnapshot` event and asserts both gauges appear in the serialized OTLP body, guarding against the hand-mirror silently dropping them.
- `cargo fmt`, `cargo clippy --locked -- -D warnings` (CI parity), and the full lib test build are clean.

Part of #4440.

[AI-assisted - Claude]