### PR TITLE
feat(telemetry): add module-cache occupancy + eviction gauges (#4440)

### DIFF
--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1068,6 +1068,19 @@ impl Ring {
             snapshot.open_fds = open_fds;
             snapshot.fd_soft_limit = fd_soft_limit;
 
+            // Compiled-WASM module-cache occupancy + eviction gauges (#4440),
+            // read from the process-global the caches publish into (they live
+            // behind the contract-handler channel, unreachable from here).
+            let mc = crate::wasm_runtime::MODULE_CACHE_METRICS.snapshot();
+            snapshot.contract_module_cache_entries = Some(mc.contract_entries);
+            snapshot.contract_module_cache_total_bytes = Some(mc.contract_total_bytes);
+            snapshot.contract_module_cache_budget_bytes = Some(mc.contract_budget_bytes);
+            snapshot.contract_module_cache_evictions_total = Some(mc.contract_evictions_total);
+            snapshot.delegate_module_cache_entries = Some(mc.delegate_entries);
+            snapshot.delegate_module_cache_total_bytes = Some(mc.delegate_total_bytes);
+            snapshot.delegate_module_cache_budget_bytes = Some(mc.delegate_budget_bytes);
+            snapshot.delegate_module_cache_evictions_total = Some(mc.delegate_evictions_total);
+
             tracing::info!(
                 failure_events = snapshot.failure_events,
                 success_events = snapshot.success_events,
@@ -1075,6 +1088,9 @@ impl Ring {
                 consider_n_closest_peers = snapshot.consider_n_closest_peers,
                 open_fds = ?snapshot.open_fds,
                 fd_soft_limit = ?snapshot.fd_soft_limit,
+                contract_module_cache_entries = mc.contract_entries,
+                contract_module_cache_total_bytes = mc.contract_total_bytes,
+                contract_module_cache_evictions_total = mc.contract_evictions_total,
                 "router_snapshot"
             );
 

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -156,6 +156,21 @@ pub(crate) struct RouterSnapshotInfo {
     /// The `RLIMIT_NOFILE` soft limit (the ceiling that triggers `EMFILE`), or
     /// `None` on non-unix. Populated by `Ring`; see [`open_fds`](Self::open_fds).
     pub fd_soft_limit: Option<u64>,
+    /// Compiled-WASM module-cache gauges (#4440), populated by `Ring` from the
+    /// process-global `MODULE_CACHE_METRICS`. `None` until the WASM runtime has
+    /// touched the cache. The contract-cache thrash (eviction → recompile) that
+    /// drove the #4441 incident was invisible to central telemetry; these make
+    /// occupancy and eviction pressure observable on the snapshot cadence. The
+    /// `*_evictions_total` fields are monotonic counters — the collector
+    /// differences them across the cadence to derive an eviction rate.
+    pub contract_module_cache_entries: Option<u64>,
+    pub contract_module_cache_total_bytes: Option<u64>,
+    pub contract_module_cache_budget_bytes: Option<u64>,
+    pub contract_module_cache_evictions_total: Option<u64>,
+    pub delegate_module_cache_entries: Option<u64>,
+    pub delegate_module_cache_total_bytes: Option<u64>,
+    pub delegate_module_cache_budget_bytes: Option<u64>,
+    pub delegate_module_cache_evictions_total: Option<u64>,
     /// Per-operation-type estimator curves, keyed by op type name (e.g., "GET").
     pub per_op_curves: HashMap<String, PerOpCurves>,
     /// Renegade predictor diagnostics
@@ -903,6 +918,14 @@ impl Router {
             // Node-health gauges populated by Ring on the snapshot cadence (#4440).
             open_fds: None,
             fd_soft_limit: None,
+            contract_module_cache_entries: None,
+            contract_module_cache_total_bytes: None,
+            contract_module_cache_budget_bytes: None,
+            contract_module_cache_evictions_total: None,
+            delegate_module_cache_entries: None,
+            delegate_module_cache_total_bytes: None,
+            delegate_module_cache_budget_bytes: None,
+            delegate_module_cache_evictions_total: None,
             // Renegade predictor diagnostics
             renegade_failure_events: self.renegade_predictor.len(),
             renegade_response_time_events: self.renegade_predictor.stage_sizes().1,

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -1106,7 +1106,7 @@ impl<'a> NetEventLog<'a> {
         Some(NetEventLog {
             tx: Transaction::NULL,
             peer_id,
-            kind: EventKind::RouterSnapshot(snapshot),
+            kind: EventKind::RouterSnapshot(Box::new(snapshot)),
         })
     }
 
@@ -2803,7 +2803,12 @@ pub enum EventKind {
     /// that want to emit routing decisions through OTLP with sampling.
     RoutingDecision(crate::router::RoutingDecisionInfo),
     /// Periodic snapshot of the router model (isotonic regression curves, event counts).
-    RouterSnapshot(crate::router::RouterSnapshotInfo),
+    ///
+    /// Boxed because `RouterSnapshotInfo` is by far the largest `EventKind`
+    /// payload (regression curves + per-op maps + the #4440 node-health gauges);
+    /// inlining it would bloat every other variant (`clippy::large_enum_variant`).
+    /// `Box` serializes transparently, so the AOF/OTLP wire format is unchanged.
+    RouterSnapshot(Box<crate::router::RouterSnapshotInfo>),
 }
 
 impl EventKind {

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -1845,6 +1845,14 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                 // `router_snapshot_json_includes_fd_gauges`.
                 "open_fds": snapshot.open_fds,
                 "fd_soft_limit": snapshot.fd_soft_limit,
+                "contract_module_cache_entries": snapshot.contract_module_cache_entries,
+                "contract_module_cache_total_bytes": snapshot.contract_module_cache_total_bytes,
+                "contract_module_cache_budget_bytes": snapshot.contract_module_cache_budget_bytes,
+                "contract_module_cache_evictions_total": snapshot.contract_module_cache_evictions_total,
+                "delegate_module_cache_entries": snapshot.delegate_module_cache_entries,
+                "delegate_module_cache_total_bytes": snapshot.delegate_module_cache_total_bytes,
+                "delegate_module_cache_budget_bytes": snapshot.delegate_module_cache_budget_bytes,
+                "delegate_module_cache_evictions_total": snapshot.delegate_module_cache_evictions_total,
                 "per_op_curves": snapshot.per_op_curves,
             })
         }
@@ -1856,8 +1864,8 @@ mod tests {
     use super::*;
 
     /// Pin: the manually-mirrored `router_snapshot` OTLP body
-    /// (`event_kind_to_json`) must forward the node-health fd gauges. The body
-    /// is a hand-written `json!` block, so a new `RouterSnapshotInfo` field is
+    /// (`event_kind_to_json`) must forward the node-health gauges. The body is a
+    /// hand-written `json!` block, so a new `RouterSnapshotInfo` field is
     /// silently dropped from central telemetry unless it is added there too
     /// (the #4009/#4010 manually-mirrored-telemetry footgun). See #4440.
     #[test]
@@ -1868,12 +1876,43 @@ mod tests {
             .expect("construct RouterSnapshotInfo for test");
         info.open_fds = Some(123);
         info.fd_soft_limit = Some(4096);
-        let json = event_kind_to_json(&EventKind::RouterSnapshot(info));
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
         assert_eq!(json["open_fds"], 123, "open_fds must reach the OTLP body");
         assert_eq!(
             json["fd_soft_limit"], 4096,
             "fd_soft_limit must reach the OTLP body"
         );
+    }
+
+    /// Pin: the module-cache gauges (#4440) must also reach the hand-mirrored
+    /// OTLP body — same footgun as the fd gauges above.
+    #[test]
+    fn router_snapshot_json_includes_module_cache_gauges() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.contract_module_cache_entries = Some(7);
+        info.contract_module_cache_total_bytes = Some(11);
+        info.contract_module_cache_budget_bytes = Some(13);
+        info.contract_module_cache_evictions_total = Some(17);
+        info.delegate_module_cache_entries = Some(19);
+        info.delegate_module_cache_total_bytes = Some(23);
+        info.delegate_module_cache_budget_bytes = Some(29);
+        info.delegate_module_cache_evictions_total = Some(31);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        for (key, want) in [
+            ("contract_module_cache_entries", 7),
+            ("contract_module_cache_total_bytes", 11),
+            ("contract_module_cache_budget_bytes", 13),
+            ("contract_module_cache_evictions_total", 17),
+            ("delegate_module_cache_entries", 19),
+            ("delegate_module_cache_total_bytes", 23),
+            ("delegate_module_cache_budget_bytes", 29),
+            ("delegate_module_cache_evictions_total", 31),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
     }
 
     #[test]

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -24,7 +24,9 @@ pub(crate) use engine::BackendEngine;
 pub(crate) use error::{ContractError, RuntimeInnerError, RuntimeResult};
 pub use mock_state_storage::MockStateStorage;
 pub use module_cache::default_module_cache_budget_bytes;
-pub(crate) use module_cache::{DELEGATE_MODULE_CACHE_BUDGET_DIVISOR, ModuleCache};
+pub(crate) use module_cache::{
+    DELEGATE_MODULE_CACHE_BUDGET_DIVISOR, MODULE_CACHE_METRICS, ModuleCache,
+};
 pub(crate) use native_api::{
     CREATED_DELEGATES_COUNT, DELEGATE_INHERITED_ORIGINS, DELEGATE_SUBSCRIPTIONS,
     DelegateContextCache, new_delegate_context_cache,

--- a/crates/core/src/wasm_runtime/module_cache.rs
+++ b/crates/core/src/wasm_runtime/module_cache.rs
@@ -39,6 +39,8 @@
 
 use std::borrow::Borrow;
 use std::hash::Hash;
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use lru::LruCache;
@@ -99,13 +101,20 @@ impl<K: Hash + Eq, V> ModuleCache<K, V> {
     /// Like [`Self::new`] but with a label ("contract" / "delegate") used in the
     /// rate-limited "cache is evicting at budget" operator warning.
     pub(crate) fn with_label(budget_bytes: usize, label: &'static str) -> Self {
+        let budget_bytes = budget_bytes.max(1);
+        // Publish the budget immediately, so an idle cache (a node that hasn't
+        // compiled a module yet, or a delegate cache that's never used) reports
+        // its configured budget instead of the atomic default 0. Otherwise the
+        // collector's occupancy-% denominator is 0 until the first insert/remove
+        // (#4440 — flagged by both PR reviewers).
+        MODULE_CACHE_METRICS.record_occupancy(label, 0, 0, budget_bytes);
         Self {
             // The LRU is unbounded by count; the byte budget is the only
             // bound. `usize::MAX` capacity means `LruCache` never evicts on
             // its own — we drive all eviction via the byte budget below.
             inner: LruCache::unbounded(),
             total_bytes: 0,
-            budget_bytes: budget_bytes.max(1),
+            budget_bytes,
             label,
             evictions_in_window: 0,
             window_started_at: None,
@@ -136,6 +145,12 @@ impl<K: Hash + Eq, V> ModuleCache<K, V> {
         }
         self.total_bytes = self.total_bytes.saturating_add(size_bytes);
         self.evict_to_budget();
+        MODULE_CACHE_METRICS.record_occupancy(
+            self.label,
+            self.inner.len(),
+            self.total_bytes,
+            self.budget_bytes,
+        );
     }
 
     /// Evict least-recently-used entries until `total_bytes <= budget_bytes`,
@@ -153,6 +168,10 @@ impl<K: Hash + Eq, V> ModuleCache<K, V> {
         }
         if evicted_this_insert > 0 {
             self.note_evictions(evicted_this_insert);
+            // Monotonic lifetime counter for telemetry; the collector differences
+            // it across the snapshot cadence to derive an eviction rate. Distinct
+            // from `evictions_in_window`, which resets per warn window (#4440).
+            MODULE_CACHE_METRICS.add_evictions(self.label, evicted_this_insert);
         }
     }
 
@@ -203,6 +222,12 @@ impl<K: Hash + Eq, V> ModuleCache<K, V> {
     {
         let (value, size) = self.inner.pop(key)?;
         self.total_bytes = self.total_bytes.saturating_sub(size);
+        MODULE_CACHE_METRICS.record_occupancy(
+            self.label,
+            self.inner.len(),
+            self.total_bytes,
+            self.budget_bytes,
+        );
         Some(value)
     }
 
@@ -224,6 +249,122 @@ impl<K: Hash + Eq, V> ModuleCache<K, V> {
     #[cfg(test)]
     pub(crate) fn budget_bytes(&self) -> usize {
         self.budget_bytes
+    }
+}
+
+/// Process-global compiled-WASM module-cache occupancy + eviction telemetry
+/// (#4440).
+///
+/// The module caches live behind the contract-handler channel, unreachable from
+/// the `Ring` telemetry-snapshot task that emits `router_snapshot`. Like
+/// [`TRANSPORT_METRICS`](crate::transport::metrics::TRANSPORT_METRICS), the
+/// caches therefore *publish* into this process-global and the snapshot task
+/// *reads* it. A node builds exactly one contract cache and one delegate cache
+/// (`RuntimePool::new`), so one global pair of gauges is correct; this assumes a
+/// single runtime pool per process (the production invariant). The cache-thrash
+/// that drove the #4441 incident was invisible to central telemetry — these
+/// gauges make occupancy and eviction pressure observable.
+pub(crate) static MODULE_CACHE_METRICS: LazyLock<ModuleCacheMetrics> =
+    LazyLock::new(ModuleCacheMetrics::new);
+
+/// Atomic occupancy gauges plus a monotonic eviction counter for one cache.
+#[derive(Default)]
+struct CacheGauges {
+    /// Resident entry count (last-write-wins gauge).
+    entries: AtomicU64,
+    /// Total compiled bytes resident (last-write-wins gauge).
+    total_bytes: AtomicU64,
+    /// Configured byte budget (effectively constant per run; reported so the
+    /// collector can compute occupancy % without hardcoding the budget).
+    budget_bytes: AtomicU64,
+    /// Lifetime evictions (monotonic; the collector differences it across the
+    /// snapshot cadence to derive an eviction rate).
+    evictions_total: AtomicU64,
+}
+
+/// Per-cache module-cache telemetry, routed by the cache's `"contract"` /
+/// `"delegate"` label. See [`MODULE_CACHE_METRICS`].
+pub(crate) struct ModuleCacheMetrics {
+    contract: CacheGauges,
+    delegate: CacheGauges,
+}
+
+/// A point-in-time read of [`MODULE_CACHE_METRICS`] for telemetry emission.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ModuleCacheMetricsSnapshot {
+    pub contract_entries: u64,
+    pub contract_total_bytes: u64,
+    pub contract_budget_bytes: u64,
+    pub contract_evictions_total: u64,
+    pub delegate_entries: u64,
+    pub delegate_total_bytes: u64,
+    pub delegate_budget_bytes: u64,
+    pub delegate_evictions_total: u64,
+}
+
+impl ModuleCacheMetrics {
+    fn new() -> Self {
+        Self {
+            contract: CacheGauges::default(),
+            delegate: CacheGauges::default(),
+        }
+    }
+
+    /// Route to the gauges for a labeled cache. Unlabeled / test caches
+    /// (`ModuleCache::new`, label `"module"`) don't publish.
+    fn gauges_for(&self, label: &str) -> Option<&CacheGauges> {
+        match label {
+            "contract" => Some(&self.contract),
+            "delegate" => Some(&self.delegate),
+            _ => None,
+        }
+    }
+
+    /// Publish current occupancy for the named cache (last-write-wins). Cheap
+    /// `Relaxed` atomics; the caller already holds the cache `Mutex`.
+    fn record_occupancy(
+        &self,
+        label: &str,
+        entries: usize,
+        total_bytes: usize,
+        budget_bytes: usize,
+    ) {
+        if let Some(g) = self.gauges_for(label) {
+            g.entries.store(entries as u64, Ordering::Relaxed);
+            g.total_bytes.store(total_bytes as u64, Ordering::Relaxed);
+            g.budget_bytes.store(budget_bytes as u64, Ordering::Relaxed);
+        }
+    }
+
+    /// Add to the named cache's monotonic lifetime eviction counter.
+    fn add_evictions(&self, label: &str, count: u64) {
+        if let Some(g) = self.gauges_for(label) {
+            g.evictions_total.fetch_add(count, Ordering::Relaxed);
+        }
+    }
+
+    /// Read all gauges for telemetry.
+    pub(crate) fn snapshot(&self) -> ModuleCacheMetricsSnapshot {
+        let load = |g: &CacheGauges| {
+            (
+                g.entries.load(Ordering::Relaxed),
+                g.total_bytes.load(Ordering::Relaxed),
+                g.budget_bytes.load(Ordering::Relaxed),
+                g.evictions_total.load(Ordering::Relaxed),
+            )
+        };
+        let (ce, ctb, cbb, cev) = load(&self.contract);
+        let (de, dtb, dbb, dev) = load(&self.delegate);
+        ModuleCacheMetricsSnapshot {
+            contract_entries: ce,
+            contract_total_bytes: ctb,
+            contract_budget_bytes: cbb,
+            contract_evictions_total: cev,
+            delegate_entries: de,
+            delegate_total_bytes: dtb,
+            delegate_budget_bytes: dbb,
+            delegate_evictions_total: dev,
+        }
     }
 }
 
@@ -521,5 +662,61 @@ mod tests {
         assert_eq!(cache.len(), 1, "at most one entry survives a zero budget");
         assert!(cache.get(&1).is_some(), "most-recent entry kept");
         assert!(cache.get(&0).is_none());
+    }
+
+    /// `ModuleCacheMetrics` routes by label, isolates contract vs delegate, and
+    /// treats unknown labels as no-ops. Tests the publishing logic on a LOCAL
+    /// instance so it stays deterministic and never touches the process-global.
+    #[test]
+    fn module_cache_metrics_routing_and_isolation() {
+        let m = ModuleCacheMetrics::new();
+        m.record_occupancy("contract", 3, 300, 1000);
+        m.add_evictions("contract", 2);
+        // Delegate stays zero — the two caches must not bleed into each other.
+        let s = m.snapshot();
+        assert_eq!(s.contract_entries, 3);
+        assert_eq!(s.contract_total_bytes, 300);
+        assert_eq!(s.contract_budget_bytes, 1000);
+        assert_eq!(s.contract_evictions_total, 2);
+        assert_eq!(s.delegate_entries, 0);
+        assert_eq!(s.delegate_evictions_total, 0);
+
+        m.record_occupancy("delegate", 1, 50, 250);
+        m.add_evictions("delegate", 5);
+        // Evictions are monotonic (accumulate); occupancy is last-write-wins.
+        m.add_evictions("contract", 4);
+        m.record_occupancy("contract", 1, 100, 1000);
+        let s = m.snapshot();
+        assert_eq!(s.contract_evictions_total, 6, "evictions accumulate");
+        assert_eq!(s.contract_entries, 1, "occupancy is last-write-wins");
+        assert_eq!(s.delegate_entries, 1);
+        assert_eq!(s.delegate_evictions_total, 5);
+
+        // An unlabeled / test cache ("module") must not publish anywhere.
+        m.record_occupancy("module", 999, 999, 999);
+        m.add_evictions("module", 999);
+        let s = m.snapshot();
+        assert_eq!(s.contract_entries, 1, "unknown label is a no-op");
+        assert_eq!(s.delegate_entries, 1, "unknown label is a no-op");
+    }
+
+    /// A `"contract"`-labeled cache that evicts publishes to the process-global
+    /// monotonic eviction counter. Asserts only the strict increase, which is
+    /// race-safe under concurrent tests (the counter is `fetch_add`-only and
+    /// never resets), unlike the last-write-wins occupancy gauges.
+    #[test]
+    fn evicting_contract_cache_increments_global_eviction_counter() {
+        let before = MODULE_CACHE_METRICS.snapshot().contract_evictions_total;
+        // 10-byte budget, 8-byte entries → the 2nd insert evicts the 1st.
+        let mut cache: ModuleCache<u64, ()> = ModuleCache::with_label(10, "contract");
+        cache.insert(0, (), 8);
+        cache.insert(1, (), 8); // total 16 > 10, len 2 > 1 → evict LRU (key 0)
+        assert_eq!(cache.len(), 1, "the test setup must actually evict");
+        let after = MODULE_CACHE_METRICS.snapshot().contract_evictions_total;
+        assert!(
+            after > before,
+            "eviction on a contract-labeled cache must bump the global counter \
+             (before={before}, after={after})"
+        );
     }
 }


### PR DESCRIPTION
## Problem

The v0.2.73 / #4441 incident was a compiled-WASM **module-cache thrash**: on nodes hosting >1024 contracts every cold contract evicted a warm one and forced a Cranelift recompile, pinning CPU and (on small hosts) OOM-spiraling. #4452 fixed the *bound* (byte-budget instead of a 1024 count cap), but the cache *pressure* stayed invisible to central telemetry — an operator had no way to see a node thrashing until it fell over. This is the next gauge on the #4440 observability checklist (after the #4470 fd gauges).

## Approach

Emit per-cache occupancy + eviction gauges on the **existing 5-minute `router_snapshot` cadence** (the same OTLP-forwarded vehicle the fd gauges use):

- `contract_module_cache_*` and `delegate_module_cache_*`: `entries`, `total_bytes`, `budget_bytes`, `evictions_total`.
- `evictions_total` is a **monotonic lifetime counter** — the collector differences it across the cadence to derive an eviction *rate*. It is deliberately distinct from `ModuleCache::evictions_in_window`, which resets every warn window and so can't serve as a cumulative signal.

The caches live behind the contract-handler channel, unreachable from the `Ring` snapshot task, so — exactly like `TRANSPORT_METRICS` — they **publish** into a process-global (`MODULE_CACHE_METRICS`) via lock-free `Relaxed` atomics in `insert`/`evict_to_budget`/`remove` (the caller already holds the cache `Mutex`), and the snapshot task **reads** it. Routing is by the cache's existing `"contract"`/`"delegate"` label; unlabeled/test caches don't publish. Contract and delegate are reported **separately** so a delegate-cache thrash can't hide behind a healthy contract cache. Assumes one runtime pool per process (the production invariant), same as `TRANSPORT_METRICS`.

Notes for reviewers:

- Adding the fields tipped `EventKind::RouterSnapshot` over clippy's `large_enum_variant` threshold, so that variant is now **boxed**. `Box` serializes transparently, so the AOF/OTLP wire format is unchanged, and boxing also shrinks every other `EventKind` variant.
- The `router_snapshot` OTLP body (`event_kind_to_json`) is a **hand-mirrored `json!` block** — new fields must be added there or they never reach the collector (the #4009/#4010 footgun). A regression test pins it.

## Testing

- `module_cache_metrics_routing_and_isolation` — label routing, contract/delegate isolation, monotonic-eviction vs last-write-wins-occupancy semantics, unknown-label no-op (deterministic, on a local instance).
- `evicting_contract_cache_increments_global_eviction_counter` — a `"contract"`-labeled cache that evicts bumps the process-global counter; asserts only the strict increase, which is race-safe (monotonic `fetch_add`, never resets) under concurrent tests.
- `router_snapshot_json_includes_module_cache_gauges` — all 8 fields reach the hand-mirrored OTLP body.
- `cargo fmt`, `cargo clippy --locked -- -D warnings` (CI parity), and the touched test suites are clean.

Part of #4440.

[AI-assisted - Claude]