### PR TITLE
feat: list Atlas in Freenet Links on the node home page

### DIFF
--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -118,6 +118,10 @@ fn homepage_html() -> String {
             <h2>Freenet Links</h2>
             <ul class="app-list">
                 <li>
+                    <a href="/v1/contract/web/771DvtPMwt2PumPyrFvsz7fpvU1gogcmb5qtS1yYEEH9/">Atlas</a>
+                    <p class="note">Decentralized search and recommendation engine for Freenet.</p>
+                </li>
+                <li>
                     <a href="/v1/contract/web/raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv/">River Chat</a>
                     <p class="note">You'll need an <a href="https://freenet.org/quickstart#invite-form" target="_blank" rel="noopener noreferrer">invite</a> to join the "Freenet Official" room.</p>
                 </li>


### PR DESCRIPTION
## Problem

The node's local-peer dashboard (`/`) has a "Freenet Links" card listing apps you can reach on the network (River Chat, Freenet Mail, Delta, Ghostkey, freenet.org). Atlas, the new decentralized search and recommendation engine for Freenet, is live on the network but isn't listed, so operators have no in-dashboard pointer to it.

## Solution

Add an Atlas entry to the `Freenet Links` `<ul class="app-list">` in `home_page.rs`, linking to its web contract `771DvtPMwt2PumPyrFvsz7fpvU1gogcmb5qtS1yYEEH9`. Placed first in the list, since a search/recommendation engine is the natural "start here" / discovery front-door for everything else on Freenet. The new `<li>` reuses the existing `.app-list` styling, so no CSS change is needed.

## Testing

`cargo test -p freenet --lib server::home_page` — all 80 home-page render tests pass (1 pre-existing ignored). No test pins the link list, and the added markup is plain content inside the existing card.

Note: the home page is server-side rendered and baked in at compile time, so the live dashboard updates on the next release that ships this binary.

Requested by the maintainer (Ian Clarke / @sanity).

[AI-assisted - Claude]