### PR TITLE
perf(contract): raise module-cache default ceiling so large gateways stop thrashing (#4441)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -120,12 +120,15 @@ pub struct ConfigArgs {
     #[arg(long, env = "MAX_HOSTING_STORAGE")]
     pub max_hosting_storage: Option<u64>,
 
-    /// Byte budget for each compiled-WASM module cache (the contract cache and
-    /// the delegate cache each get this budget). When a cache's tracked
-    /// compiled-byte total would exceed this on insert, least-recently-used
-    /// modules are evicted until it fits. Bounding by bytes (not entry count)
-    /// stops a node hosting many contracts from thrashing the cache and
-    /// recompiling on every access (issue #4441). Default: 384 MiB.
+    /// Byte budget for the compiled-WASM **contract** module cache. The
+    /// **delegate** cache gets a fraction of this value
+    /// (`DELEGATE_MODULE_CACHE_BUDGET_DIVISOR`, currently 1/4), so the combined
+    /// ceiling is ~1.25× this. When a cache's tracked compiled-byte total would
+    /// exceed its budget on insert, least-recently-used modules are evicted
+    /// until it fits. Bounding by bytes (not entry count) stops a node hosting
+    /// many contracts from thrashing the cache and recompiling on every access
+    /// (issue #4441). When unset, the default scales with system RAM
+    /// (`clamp(total_ram / 8, 64 MiB, 1.5 GiB)`); set this to override.
     #[arg(long, env = "FREENET_MODULE_CACHE_BUDGET_BYTES")]
     pub module_cache_budget_bytes: Option<usize>,
 
@@ -935,7 +938,7 @@ pub struct Config {
     /// ~1.25× this value. Bounds the cache by total compiled bytes rather than
     /// entry count, so a node hosting many contracts doesn't thrash (issue
     /// #4441). When unset, the default scales with system RAM
-    /// (`clamp(total_ram / 8, 64 MiB, 384 MiB)`) so a small VPS doesn't OOM and
+    /// (`clamp(total_ram / 8, 64 MiB, 1.5 GiB)`) so a small VPS doesn't OOM and
     /// a big gateway still caches a large working set.
     #[serde(
         default = "default_module_cache_budget_bytes",
@@ -992,7 +995,7 @@ fn default_max_hosting_storage() -> u64 {
 }
 
 /// Default contract-module cache byte budget, scaled to system RAM
-/// (`clamp(total_ram / 8, 64 MiB, 384 MiB)`).
+/// (`clamp(total_ram / 8, 64 MiB, 1.5 GiB)`).
 ///
 /// Resolves to [`crate::wasm_runtime::default_module_cache_budget_bytes`], the
 /// single source of truth, so the operator-facing default and the in-code
@@ -3147,9 +3150,12 @@ mod tests {
             ..Default::default()
         };
         let cfg = args.build().await.unwrap();
-        // The default is RAM-scaled and clamped to [64 MiB, 384 MiB]. It must
-        // resolve to the wasm_runtime single-source-of-truth default and land
-        // within the documented clamp range on any host.
+        // The default is RAM-scaled and clamped to [MIN, MAX]. It must resolve to
+        // the wasm_runtime single-source-of-truth default and land within the
+        // documented clamp range on any host. Reference the constants rather than
+        // hardcoded byte values so this test never drifts from the clamp.
+        let min = crate::wasm_runtime::MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES;
+        let max = crate::wasm_runtime::MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES;
         assert_eq!(
             cfg.module_cache_budget_bytes,
             crate::wasm_runtime::default_module_cache_budget_bytes(),
@@ -3157,8 +3163,8 @@ mod tests {
              single-source-of-truth default"
         );
         assert!(
-            (64 * 1024 * 1024..=384 * 1024 * 1024).contains(&cfg.module_cache_budget_bytes),
-            "default budget {} must be within the [64 MiB, 384 MiB] clamp",
+            (min..=max).contains(&cfg.module_cache_budget_bytes),
+            "default budget {} must be within the [{min}, {max}] clamp",
             cfg.module_cache_budget_bytes
         );
     }

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -27,6 +27,14 @@ pub use module_cache::default_module_cache_budget_bytes;
 pub(crate) use module_cache::{
     DELEGATE_MODULE_CACHE_BUDGET_DIVISOR, MODULE_CACHE_METRICS, ModuleCache,
 };
+// Clamp bounds are referenced only by the config-default round-trip test, which
+// asserts the resolved default lands within [MIN, MAX] without hardcoding the
+// byte values (so the test can't drift from the clamp). Gated to test builds so
+// the re-export isn't an unused import under `-D warnings` in release.
+#[cfg(test)]
+pub(crate) use module_cache::{
+    MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES, MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES,
+};
 pub(crate) use native_api::{
     CREATED_DELEGATES_COUNT, DELEGATE_INHERITED_ORIGINS, DELEGATE_SUBSCRIPTIONS,
     DelegateContextCache, new_delegate_context_cache,

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -1823,13 +1823,30 @@ mod tests {
         // the self-satisfying-pin failure mode. Splitting on the function
         // signature and the next fn restricts the scrape to production code.
         let src = include_str!("wasmtime_engine.rs");
-        let body = src
+        let after_sig = src
             .split("fn create_backend_engine(config: &RuntimeConfig) -> Result<Engine, ContractError> {")
             .nth(1)
-            .expect("create_backend_engine must exist")
-            .split("\n    fn recover_store(")
-            .next()
-            .expect("end of create_backend_engine");
+            .expect("create_backend_engine must exist");
+        // Truncate at the NEXT function so the scrape sees only production code,
+        // never this test's own assertion strings. `split().next()` always
+        // returns `Some` even when the delimiter is absent, so an `.expect()`
+        // here would NOT catch a renamed/removed `recover_store` — the body
+        // would silently extend to EOF and the test would self-satisfy. Assert
+        // the delimiter was actually present instead, so the safety is real.
+        const END_ANCHOR: &str = "\n    fn recover_store(";
+        assert!(
+            after_sig.contains(END_ANCHOR),
+            "end-of-function anchor `{END_ANCHOR}` not found — if recover_store \
+             was renamed/removed, re-point this anchor so the scrape stays \
+             scoped to create_backend_engine and can't self-satisfy"
+        );
+        let body = after_sig.split(END_ANCHOR).next().unwrap();
+        // Defense in depth: the scoped body must not contain this test's own
+        // function name, proving the scrape really excludes the test module.
+        assert!(
+            !body.contains("engine_enables_wasmtime_disk_compilation_cache"),
+            "scraped body leaked into the test module — the scope is not isolated"
+        );
         // The build path that constructs the wasmtime Config must install a
         // disk cache via `wasmtime_config.cache(Some(...))`.
         assert!(

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -1803,6 +1803,34 @@ mod tests {
         );
     }
 
+    /// Pin (issue #4441): the wasmtime disk **compilation** cache MUST stay
+    /// enabled on the engine config. This is the second half of the #4441 fix:
+    /// when a module is evicted from the in-memory `ModuleCache` and accessed
+    /// again, the recompile path (`prepare_contract_call` → `engine.compile` →
+    /// `compile_coalesced` → `Module::new`) hits this disk cache and
+    /// *deserializes* the already-compiled artifact (~100x faster) instead of
+    /// running Cranelift from scratch. Without it, eviction-reload would pay the
+    /// full compile cost every time, re-creating the thrash the byte budget is
+    /// meant to bound. A source-scrape pin (not a behavioral test) because the
+    /// disk cache writes to a shared user cache dir and its hit/miss timing is
+    /// not deterministic enough to assert on in CI.
+    #[test]
+    fn engine_enables_wasmtime_disk_compilation_cache() {
+        let src = include_str!("wasmtime_engine.rs");
+        // The build path that constructs the wasmtime Config must install a
+        // disk cache via `wasmtime_config.cache(Some(...))`.
+        assert!(
+            src.contains("Cache::new(CacheConfig::new())"),
+            "engine config must construct the wasmtime disk compilation cache"
+        );
+        assert!(
+            src.contains("wasmtime_config.cache(Some(cache))"),
+            "engine config must install the disk compilation cache so an \
+             evicted module deserializes from disk on reload instead of \
+             recompiling (issue #4441 fix #2)"
+        );
+    }
+
     /// Regression test for Report 2RDXTD: wasmtime's per-Store instance counter is
     /// monotonic (never decremented) with a default limit of 10,000. Our ResourceLimiter
     /// override sets instances() to usize::MAX so long-running gateways don't exhaust.

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -1816,16 +1816,29 @@ mod tests {
     /// not deterministic enough to assert on in CI.
     #[test]
     fn engine_enables_wasmtime_disk_compilation_cache() {
+        // Isolate ONLY the production `create_backend_engine` body before
+        // scraping. `include_str!` pulls in this test's own assertion strings,
+        // so a whole-file `contains` would be satisfied by the literals below
+        // and pass even if the real cache-enabling lines were deleted — exactly
+        // the self-satisfying-pin failure mode. Splitting on the function
+        // signature and the next fn restricts the scrape to production code.
         let src = include_str!("wasmtime_engine.rs");
+        let body = src
+            .split("fn create_backend_engine(config: &RuntimeConfig) -> Result<Engine, ContractError> {")
+            .nth(1)
+            .expect("create_backend_engine must exist")
+            .split("\n    fn recover_store(")
+            .next()
+            .expect("end of create_backend_engine");
         // The build path that constructs the wasmtime Config must install a
         // disk cache via `wasmtime_config.cache(Some(...))`.
         assert!(
-            src.contains("Cache::new(CacheConfig::new())"),
-            "engine config must construct the wasmtime disk compilation cache"
+            body.contains("Cache::new(CacheConfig::new())"),
+            "create_backend_engine must construct the wasmtime disk compilation cache"
         );
         assert!(
-            src.contains("wasmtime_config.cache(Some(cache))"),
-            "engine config must install the disk compilation cache so an \
+            body.contains("wasmtime_config.cache(Some(cache))"),
+            "create_backend_engine must install the disk compilation cache so an \
              evicted module deserializes from disk on reload instead of \
              recompiling (issue #4441 fix #2)"
         );

--- a/crates/core/src/wasm_runtime/module_cache.rs
+++ b/crates/core/src/wasm_runtime/module_cache.rs
@@ -437,7 +437,9 @@ pub const DELEGATE_MODULE_CACHE_BUDGET_DIVISOR: usize = 4;
 const FALLBACK_TOTAL_RAM_BYTES: usize = 1024 * 1024 * 1024;
 
 /// Default per-cache byte budget for the **contract** compiled-module cache,
-/// scaled to the host's physical RAM and clamped to a sane floor/ceiling.
+/// scaled to the memory the node may use (host RAM, or a smaller cgroup limit
+/// when containerized — see [`read_total_ram_bytes`]) and clamped to a sane
+/// floor/ceiling.
 ///
 /// Returns `clamp(total_ram / DEFAULT_MODULE_CACHE_RAM_DIVISOR,
 /// MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES, MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES)`
@@ -475,41 +477,41 @@ fn budget_for_ram(total_ram: usize) -> usize {
     )
 }
 
-/// Best-effort read of the host's total physical RAM in bytes.
+/// Best-effort read of the memory the node may actually use, in bytes.
 ///
-/// Portable and dependency-free:
-/// - On Linux, parse `MemTotal` from `/proc/meminfo` (reported in KiB).
-/// - On other unix, fall back to `sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE)`.
+/// This is the **minimum** of the host's physical RAM and any cgroup memory
+/// limit applied to the process. Using the cgroup limit matters because raising
+/// the cache clamp to 1.5 GiB would otherwise let a node inside a small
+/// container (say a 2 GiB limit on a 128 GiB host) default to a ~1.5 GiB cache
+/// sized from the *host* total and OOM the container. Taking the min means a
+/// constrained container gets a budget scaled to its real limit, while a host
+/// systemd service (the production gateways) sees no cgroup limit and uses
+/// `MemTotal` as before.
+///
+/// Sources, in order:
+/// - On Linux, physical RAM from `MemTotal` in `/proc/meminfo` (reported in
+///   KiB), then min'd with the cgroup memory limit (cgroup v2 `memory.max`, or
+///   v1 `memory.limit_in_bytes`) when one is present and is a real limit (not
+///   the "unlimited" sentinel).
+/// - On other unix, `sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE)` (no cgroup
+///   notion).
 /// - Otherwise return `None` so the caller uses `FALLBACK_TOTAL_RAM_BYTES`.
 ///
 /// Never panics; any failure (missing file, parse error, non-positive sysconf)
-/// yields `None`.
-///
-/// # Containers / cgroups
-///
-/// This reports the **host's** physical RAM, not a cgroup memory limit. A node
-/// run inside a container with a memory limit far below host RAM (e.g. a 2 GiB
-/// limit on a 128 GiB host) will size its default cache from the host total, so
-/// the `total_ram / 8` divisor (and the MAX clamp) can land above the container
-/// limit. The Freenet production gateways run as host systemd services, not in
-/// constrained containers, so this is not a concern for them; a containerized
-/// deployment with a tight memory limit should set the explicit
-/// `--module-cache-budget-bytes` / `FREENET_MODULE_CACHE_BUDGET_BYTES` override
-/// sized to its limit. Making this cgroup-aware (min of `MemTotal` and
-/// `memory.max`) is a possible future improvement if containerized nodes become
-/// common.
+/// yields `None` for that source and falls back.
 fn read_total_ram_bytes() -> Option<usize> {
     #[cfg(target_os = "linux")]
     {
-        // /proc/meminfo line: "MemTotal:       16331752 kB"
-        let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
-        for line in meminfo.lines() {
-            if let Some(rest) = line.strip_prefix("MemTotal:") {
-                let kib: usize = rest.split_whitespace().next()?.parse().ok()?;
-                return kib.checked_mul(1024);
-            }
+        let phys = read_proc_meminfo_total_bytes();
+        // Clamp to the cgroup limit when one applies. If we can read physical
+        // RAM, take the min; if not, fall back to the cgroup limit alone (a
+        // container with no readable /proc/meminfo still gets a sane bound).
+        match (phys, read_cgroup_memory_limit_bytes()) {
+            (Some(p), Some(c)) => Some(p.min(c)),
+            (Some(p), None) => Some(p),
+            (None, Some(c)) => Some(c),
+            (None, None) => None,
         }
-        None
     }
     #[cfg(all(unix, not(target_os = "linux")))]
     {
@@ -526,6 +528,80 @@ fn read_total_ram_bytes() -> Option<usize> {
     {
         None
     }
+}
+
+/// Parse physical RAM (bytes) from `/proc/meminfo`'s `MemTotal:` line.
+#[cfg(target_os = "linux")]
+fn read_proc_meminfo_total_bytes() -> Option<usize> {
+    // /proc/meminfo line: "MemTotal:       16331752 kB"
+    let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+    parse_meminfo_total_bytes(&meminfo)
+}
+
+/// Pure parse of `MemTotal` (KiB) from `/proc/meminfo` contents into bytes.
+#[cfg(target_os = "linux")]
+fn parse_meminfo_total_bytes(meminfo: &str) -> Option<usize> {
+    for line in meminfo.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            let kib: usize = rest.split_whitespace().next()?.parse().ok()?;
+            return kib.checked_mul(1024);
+        }
+    }
+    None
+}
+
+/// Best-effort read of the process's cgroup memory limit in bytes, or `None`
+/// when there is no readable limit (or the limit is the "unlimited" sentinel).
+///
+/// Tries cgroup v2 (`/sys/fs/cgroup/memory.max`) first, then cgroup v1
+/// (`/sys/fs/cgroup/memory/memory.limit_in_bytes`). Both files contain a single
+/// integer of bytes, except v2 uses the literal `max` for "no limit" and v1 uses
+/// a near-`u64::MAX` sentinel (e.g. `9223372036854771712`). We treat anything at
+/// or above [`CGROUP_UNLIMITED_THRESHOLD_BYTES`] as "no limit" so a host-level
+/// (effectively unlimited) cgroup doesn't pin the budget to a meaningless huge
+/// number.
+#[cfg(target_os = "linux")]
+fn read_cgroup_memory_limit_bytes() -> Option<usize> {
+    // cgroup v2 unified hierarchy.
+    if let Ok(s) = std::fs::read_to_string("/sys/fs/cgroup/memory.max") {
+        if let Some(v) = parse_cgroup_limit(&s) {
+            return Some(v);
+        }
+        // Present but "max" / unparseable → no v2 limit; fall through to v1 in
+        // case of a hybrid mount, then to None.
+    }
+    // cgroup v1.
+    if let Ok(s) = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes") {
+        if let Some(v) = parse_cgroup_limit(&s) {
+            return Some(v);
+        }
+    }
+    None
+}
+
+/// Above this, a cgroup limit is treated as "unlimited" rather than a real
+/// bound. Covers cgroup v1's `~u64::MAX` sentinel and a host-root cgroup whose
+/// limit equals (or rounds to) all of physical RAM. Far above any budget we'd
+/// ever want, so clamping the cache to it would be a no-op anyway.
+#[cfg(target_os = "linux")]
+const CGROUP_UNLIMITED_THRESHOLD_BYTES: usize = 1 << 60; // 1 EiB
+
+/// Parse a single cgroup memory-limit file value (bytes) into a real limit, or
+/// `None` for the literal `max`, an unparseable value, zero, or an "unlimited"
+/// sentinel at/above [`CGROUP_UNLIMITED_THRESHOLD_BYTES`].
+#[cfg(target_os = "linux")]
+fn parse_cgroup_limit(contents: &str) -> Option<usize> {
+    let trimmed = contents.trim();
+    if trimmed == "max" {
+        return None;
+    }
+    let bytes: usize = trimmed.parse().ok()?;
+    // Zero is not a meaningful budget bound; treat as absent. Sentinels at/above
+    // the threshold mean "unlimited".
+    if bytes == 0 || bytes >= CGROUP_UNLIMITED_THRESHOLD_BYTES {
+        return None;
+    }
+    Some(bytes)
 }
 
 #[cfg(test)]
@@ -701,7 +777,17 @@ mod tests {
             let contract = budget_for_ram(total_ram);
             let delegate = contract / DELEGATE_MODULE_CACHE_BUDGET_DIVISOR;
             let combined = contract + delegate;
-            // The combined default must never exceed 1/4 of physical RAM, so the
+            // Hard floor that must hold at EVERY RAM size, including the tiniest
+            // box where the MIN clamp binds: the combined default must never
+            // exceed total RAM. This catches an unsafe MIN raise (e.g. a MIN
+            // larger than a small box's RAM), which the fractional bound below
+            // would skip because its guard scales with MIN.
+            assert!(
+                combined <= total_ram,
+                "combined default {combined} must never exceed total RAM \
+                 ({total_ram}) — a MIN raise above a small box's RAM would OOM it"
+            );
+            // The combined default must also stay within 1/4 of RAM, so the
             // node always has at least 3/4 of RAM for everything else (state
             // store, transport buffers, WASM instance arenas, the OS). Below the
             // MIN clamp a very small box gets a fixed 64+16 MiB floor, which is
@@ -718,6 +804,30 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Upper-bound guard (the other side of the net): the COMBINED default
+    /// ceiling at the MAX clamp must stay a safe fraction of the smallest host
+    /// where the MAX binds (`MAX × DEFAULT_MODULE_CACHE_RAM_DIVISOR` of RAM), so
+    /// a future MAX raise can't silently hand a just-large-enough box a cache
+    /// that crowds out the rest of the node. Without this, every other test in
+    /// the suite would still pass if MAX were bumped to, say, 12 GiB (which would
+    /// give a 12-16 GiB box a ~15 GiB combined cache → OOM).
+    #[test]
+    fn max_clamp_combined_ceiling_is_safe_at_binding_host() {
+        let contract = MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES;
+        let delegate = contract / DELEGATE_MODULE_CACHE_BUDGET_DIVISOR;
+        let combined = contract + delegate;
+        // The smallest host at which the MAX clamp binds (below this the divisor
+        // binds first and the small-box test covers it).
+        let binding_host_ram =
+            MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES * DEFAULT_MODULE_CACHE_RAM_DIVISOR;
+        assert!(
+            combined <= binding_host_ram / 4,
+            "combined default at the MAX clamp ({combined}) must stay within 1/4 \
+             of the smallest host where MAX binds ({binding_host_ram}); a MAX \
+             raise that breaks this would OOM a just-large-enough box"
+        );
     }
 
     /// Regression for issue #4441: a large gateway (nova has 125 GiB RAM) must
@@ -753,6 +863,41 @@ mod tests {
             "the default ceiling must hold a realistic gateway working set \
              (~1000 modules at ~1.5 MiB each); holds {modules_held}"
         );
+    }
+
+    /// cgroup limit parsing: a real byte value is a limit; the v2 `max`
+    /// sentinel, the v1 near-`u64::MAX` sentinel, zero, and garbage are all
+    /// "no limit" (`None`). This is what keeps a containerized node from
+    /// defaulting its cache to host RAM and OOMing its cgroup (#4481 review).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_cgroup_limit_distinguishes_real_limits_from_sentinels() {
+        // Real limits (with surrounding whitespace/newline as the kernel emits).
+        assert_eq!(
+            parse_cgroup_limit("2147483648\n"),
+            Some(2 * 1024 * 1024 * 1024)
+        );
+        assert_eq!(parse_cgroup_limit("  536870912  "), Some(512 * 1024 * 1024));
+        // cgroup v2 "no limit".
+        assert_eq!(parse_cgroup_limit("max\n"), None);
+        // cgroup v1 unlimited sentinel (~u64::MAX rounded to page size).
+        assert_eq!(parse_cgroup_limit("9223372036854771712"), None);
+        // A host-root cgroup whose "limit" is enormous → treated as unlimited.
+        assert_eq!(parse_cgroup_limit(&format!("{}", 1usize << 61)), None);
+        // Degenerate / unparseable values.
+        assert_eq!(parse_cgroup_limit("0"), None);
+        assert_eq!(parse_cgroup_limit(""), None);
+        assert_eq!(parse_cgroup_limit("not-a-number"), None);
+    }
+
+    /// `MemTotal` parsing pulls the KiB value and converts to bytes; a file
+    /// without the line yields `None` (caller falls back).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_meminfo_total_reads_kib_as_bytes() {
+        let sample = "MemFree:  100 kB\nMemTotal:       16331752 kB\nBuffers:  1 kB\n";
+        assert_eq!(parse_meminfo_total_bytes(sample), Some(16331752 * 1024));
+        assert_eq!(parse_meminfo_total_bytes("SwapTotal: 0 kB\n"), None);
     }
 
     /// A zero budget still keeps exactly one most-recently-used entry resident

--- a/crates/core/src/wasm_runtime/module_cache.rs
+++ b/crates/core/src/wasm_runtime/module_cache.rs
@@ -554,15 +554,22 @@ fn parse_meminfo_total_bytes(meminfo: &str) -> Option<usize> {
 /// when there is no readable limit (or the limit is the "unlimited" sentinel).
 ///
 /// Crucially, this resolves the **process's own** cgroup from
-/// `/proc/self/cgroup` rather than only reading the mount-root files. A process
-/// in a non-root cgroup *without* a private cgroup namespace — e.g. a systemd
-/// service with `MemoryMax=`, or a Docker/Kubernetes container sharing the host
-/// cgroup namespace — has its limit at `/sys/fs/cgroup<path>/memory.max`
-/// (v2) or `/sys/fs/cgroup/memory<path>/memory.limit_in_bytes` (v1), where
-/// `<path>` comes from `/proc/self/cgroup`. Reading only the mount root would
-/// miss that limit and size the cache from host RAM (Codex #4481 review). We try
-/// the resolved sub-path first, then fall back to the mount root (the
-/// private-namespace case, where `/proc/self/cgroup` reads `/`).
+/// `/proc/self/cgroup` rather than only reading the mount-root files, AND walks
+/// its ancestors. A process in a non-root cgroup *without* a private cgroup
+/// namespace — e.g. a systemd service with `MemoryMax=`, or a Docker/Kubernetes
+/// container sharing the host cgroup namespace — has its limit at
+/// `/sys/fs/cgroup<path>/memory.max` (v2) or
+/// `/sys/fs/cgroup/memory<path>/memory.limit_in_bytes` (v1), where `<path>`
+/// comes from `/proc/self/cgroup`. Reading only the mount root would miss that
+/// limit and size the cache from host RAM (Codex #4481 review).
+///
+/// cgroup memory limits are **hierarchical**: the effective cap is the tightest
+/// `memory.max` over the process's own cgroup and every ancestor up to the root.
+/// A child whose own `memory.max` is `max` can still be bounded by an ancestor
+/// (the common Docker/k8s/systemd-slice shape). So we walk leaf→root and take
+/// the MINIMUM real limit found (also covers the private-namespace case, where
+/// `/proc/self/cgroup` reads `/` and the walk is just the root). If both the v2
+/// and v1 hierarchies report a real limit (hybrid mount), the smaller binds.
 ///
 /// v2 (`memory.max`) uses the literal `max` for "no limit"; v1
 /// (`memory.limit_in_bytes`) uses a near-`u64::MAX` sentinel (e.g.
@@ -574,40 +581,66 @@ fn parse_meminfo_total_bytes(meminfo: &str) -> Option<usize> {
 fn read_cgroup_memory_limit_bytes() -> Option<usize> {
     let (v2_rel, v1_rel) = cgroup_relative_paths();
 
-    // cgroup v2 unified hierarchy: /sys/fs/cgroup<rel>/memory.max, where <rel>
-    // is the process's cgroup path (or "" at the root).
-    let v2_path = format!("/sys/fs/cgroup{v2_rel}/memory.max");
-    if let Ok(s) = std::fs::read_to_string(&v2_path) {
-        if let Some(v) = parse_cgroup_limit(&s) {
-            return Some(v);
-        }
-        // Present but "max"/unparseable → no v2 limit at this path; fall through.
-    }
-    // Fallback: mount root, for a private-cgroup-namespace process whose
-    // /proc/self/cgroup reads "/" but whose limit lives at the visible root.
-    if v2_rel != "/"
-        && !v2_rel.is_empty()
-        && let Ok(s) = std::fs::read_to_string("/sys/fs/cgroup/memory.max")
-        && let Some(v) = parse_cgroup_limit(&s)
-    {
-        return Some(v);
-    }
+    // cgroup v2 limits are HIERARCHICAL: a process is bound by the tightest
+    // `memory.max` among its own cgroup AND every ancestor. A child whose own
+    // `memory.max` is `max` can still be capped by an ancestor (a Docker/k8s
+    // container or systemd slice limit). Walk leaf→root under
+    // /sys/fs/cgroup<path> and take the MIN real limit found (Codex #4481).
+    let v2 = min_cgroup_limit_over_ancestors("/sys/fs/cgroup", "memory.max", &v2_rel);
 
-    // cgroup v1: /sys/fs/cgroup/memory<rel>/memory.limit_in_bytes.
-    let v1_path = format!("/sys/fs/cgroup/memory{v1_rel}/memory.limit_in_bytes");
-    if let Ok(s) = std::fs::read_to_string(&v1_path) {
-        if let Some(v) = parse_cgroup_limit(&s) {
-            return Some(v);
+    // cgroup v1 (memory controller): /sys/fs/cgroup/memory<path>/...; also
+    // hierarchical, so walk ancestors the same way.
+    let v1 =
+        min_cgroup_limit_over_ancestors("/sys/fs/cgroup/memory", "memory.limit_in_bytes", &v1_rel);
+
+    // A node is bound by whichever hierarchy actually applies; if both report a
+    // real limit (hybrid mount), the smaller binds.
+    match (v2, v1) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
+/// Walk the cgroup path `rel` (e.g. `/system.slice/x`) from leaf to root under
+/// `mount` (e.g. `/sys/fs/cgroup`), reading `file` (e.g. `memory.max`) at each
+/// level, and return the **minimum** real limit found, or `None` if no level
+/// carries a real limit. This implements the hierarchical-min semantics of
+/// cgroup memory limits: the effective cap is the tightest limit on the chain.
+#[cfg(target_os = "linux")]
+fn min_cgroup_limit_over_ancestors(mount: &str, file: &str, rel: &str) -> Option<usize> {
+    let mut best: Option<usize> = None;
+    for path in cgroup_ancestor_limit_paths(mount, file, rel) {
+        if let Ok(s) = std::fs::read_to_string(&path) {
+            if let Some(v) = parse_cgroup_limit(&s) {
+                best = Some(best.map_or(v, |b: usize| b.min(v)));
+            }
         }
     }
-    if v1_rel != "/"
-        && !v1_rel.is_empty()
-        && let Ok(s) = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes")
-        && let Some(v) = parse_cgroup_limit(&s)
-    {
-        return Some(v);
+    best
+}
+
+/// Build the leaf→root list of limit-file paths to check for a cgroup at `rel`
+/// under `mount`, reading `file` at each level. For `rel = "/a/b"` this yields
+/// `["{mount}/a/b/{file}", "{mount}/a/{file}", "{mount}/{file}"]` (own cgroup,
+/// then each ancestor up to the mount root). Pure (no I/O) so the ancestor walk
+/// is unit-testable.
+#[cfg(target_os = "linux")]
+fn cgroup_ancestor_limit_paths(mount: &str, file: &str, rel: &str) -> Vec<String> {
+    let mut paths = Vec::new();
+    let mut current = rel.trim_end_matches('/').to_string();
+    loop {
+        paths.push(format!("{mount}{current}/{file}"));
+        if current.is_empty() {
+            break; // reached the mount root
+        }
+        match current.rfind('/') {
+            Some(idx) => current.truncate(idx),
+            None => current.clear(),
+        }
     }
-    None
+    paths
 }
 
 /// Resolve the process's cgroup paths (relative to the controller mount) for the
@@ -882,6 +915,30 @@ mod tests {
         }
     }
 
+    // Superseded: the combined default ceiling at the MAX clamp is no longer
+    // bounded by an absolute 512 MiB. PR #4481 raised
+    // MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES from 384 MiB to 1.5 GiB (so large
+    // gateways stop module-cache thrashing), making the combined ceiling
+    // 1.5 GiB + 384 MiB ≈ 1.9 GiB. The OLD invariant below (combined < 512 MiB)
+    // mistakenly pinned the MAX clamp as the small-box protection; the actual
+    // protection is the `total_ram / 8` divisor. Replaced by
+    // `combined_default_ceiling_is_safe_on_small_box` (divisor-relative, swept
+    // across RAM sizes) and `max_clamp_combined_ceiling_is_safe_at_binding_host`
+    // (upper bound at the smallest host where MAX binds). Kept as historical
+    // documentation of the old (incorrect) invariant per git-workflow.md.
+    #[ignore = "superseded by #4481: MAX raised 384 MiB -> 1.5 GiB; see replacement tests"]
+    #[test]
+    fn combined_default_ceiling_is_safe() {
+        let contract = MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES;
+        let delegate = contract / DELEGATE_MODULE_CACHE_BUDGET_DIVISOR;
+        let combined = contract + delegate;
+        assert!(
+            combined < 512 * 1024 * 1024,
+            "combined default ceiling {combined} must stay under 512 MiB so the \
+             #4441 OOM fix doesn't itself OOM a small box (was 768 MiB pre-fix)"
+        );
+    }
+
     /// Upper-bound guard (the other side of the net): the COMBINED default
     /// ceiling at the MAX clamp must stay a safe fraction of the smallest host
     /// where the MAX binds (`MAX × DEFAULT_MODULE_CACHE_RAM_DIVISOR` of RAM), so
@@ -1022,6 +1079,41 @@ mod tests {
         assert_eq!(
             parse_proc_self_cgroup(weird),
             ("/odd:name/x".to_string(), "/".to_string())
+        );
+    }
+
+    /// The cgroup ancestor walk yields the own cgroup's limit file first, then
+    /// each ancestor up to the mount root — so `min_cgroup_limit_over_ancestors`
+    /// honors the HIERARCHICAL nature of cgroup memory limits (a `max` leaf under
+    /// a limited ancestor is still bounded). Codex #4481 finding.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn cgroup_ancestor_paths_walk_leaf_to_root() {
+        assert_eq!(
+            cgroup_ancestor_limit_paths("/sys/fs/cgroup", "memory.max", "/a/b/c"),
+            vec![
+                "/sys/fs/cgroup/a/b/c/memory.max".to_string(),
+                "/sys/fs/cgroup/a/b/memory.max".to_string(),
+                "/sys/fs/cgroup/a/memory.max".to_string(),
+                "/sys/fs/cgroup/memory.max".to_string(),
+            ]
+        );
+        // Root cgroup → only the mount-root file.
+        assert_eq!(
+            cgroup_ancestor_limit_paths("/sys/fs/cgroup", "memory.max", "/"),
+            vec!["/sys/fs/cgroup/memory.max".to_string()]
+        );
+        // A single-level cgroup → own file then root.
+        assert_eq!(
+            cgroup_ancestor_limit_paths(
+                "/sys/fs/cgroup/memory",
+                "memory.limit_in_bytes",
+                "/system.slice"
+            ),
+            vec![
+                "/sys/fs/cgroup/memory/system.slice/memory.limit_in_bytes".to_string(),
+                "/sys/fs/cgroup/memory/memory.limit_in_bytes".to_string(),
+            ]
         );
     }
 

--- a/crates/core/src/wasm_runtime/module_cache.rs
+++ b/crates/core/src/wasm_runtime/module_cache.rs
@@ -375,14 +375,37 @@ impl ModuleCacheMetrics {
 /// contracts. Below this the cache would thrash on a normal node.
 pub const MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES: usize = 64 * 1024 * 1024;
 
-/// Upper clamp for the default contract-module cache budget (384 MiB).
+/// Upper clamp for the default contract-module cache budget (1.5 GiB).
 ///
-/// A big gateway hosts well over 1024 contracts, but past a few hundred
-/// resident modules the working-set benefit flattens while the absolute memory
-/// cost keeps rising. 384 MiB holds ~256-512 modules at the measured per-module
-/// size — comfortably above a healthy gateway's hot set. Operators who truly
-/// need more raise it explicitly via the config override below.
-pub const MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES: usize = 384 * 1024 * 1024;
+/// Two competing pressures set this ceiling:
+///
+/// - **Too low → large gateways thrash.** A production gateway hosts hundreds
+///   of contracts and, post-#4404 placement migration, also carries a sizeable
+///   *interest* set on contracts it doesn't hold (the #4441 incident saw ~85
+///   such phantom-interest contracts on technic). At the measured ~1.5 MiB per
+///   compiled module, the previous 384 MiB ceiling held only ~256 modules — so
+///   the cache permanently evicts-and-recompiles a working set it can't fit,
+///   pinning the single-threaded contract loop. nova (125 GiB RAM) is the
+///   canonical case: `total_ram / 8` is ~15 GiB, so the *only* thing capping
+///   its default cache was this clamp, and 384 MiB was well below its working
+///   set. 1.5 GiB holds ~1000 modules at the measured size — comfortably above
+///   a healthy gateway's hot set — and matches the 1 GiB default hosted-*state*
+///   budget (`ring::DEFAULT_HOSTING_BUDGET_BYTES`): a node allowed ~1 GiB of
+///   contract state should be able to cache the corresponding compiled code.
+/// - **Too high → wasted memory on huge hosts.** Past ~1000 resident modules
+///   the working-set benefit flattens while absolute memory cost keeps rising.
+///   Without a ceiling, `total_ram / 8` would default a 125 GiB box to a
+///   ~15 GiB compiled-module cache it can't benefit from. The clamp keeps the
+///   default a bounded, defensible commitment.
+///
+/// This clamp only binds on hosts with more than
+/// `MAX * DEFAULT_MODULE_CACHE_RAM_DIVISOR` (= 12 GiB) of RAM; below that the
+/// `total_ram / 8` divisor binds first, so raising this ceiling does **not**
+/// change the default on small/medium hosts (see
+/// `default_module_cache_budget_bytes`). Operators who truly need more raise it
+/// explicitly via the config override below (the explicit override is
+/// unclamped).
+pub const MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES: usize = 1536 * 1024 * 1024;
 
 /// Fraction of total system RAM used to size the default contract cache budget.
 ///
@@ -398,10 +421,12 @@ const DEFAULT_MODULE_CACHE_RAM_DIVISOR: usize = 8;
 /// The delegate-module cache's default budget is the contract budget divided by
 /// this. Delegates are far fewer and smaller than contracts on a typical node,
 /// so a quarter share is generous. This keeps the COMBINED default ceiling at
-/// `contract_budget * (1 + 1/4) = 1.25 × contract_budget` — at the MAX clamp
-/// that is 480 MiB total, vs. the previous 768 MiB (384 MiB × 2) that applied
-/// the full budget to BOTH caches and could OOM a small VPS (issue #4441 was
-/// "OOM on a small box"; the fix must not itself OOM that box).
+/// `contract_budget * (1 + 1/4) = 1.25 × contract_budget`. The key small-box
+/// safety property is that BOTH caches scale from the same RAM-derived contract
+/// budget, so the combined default is `1.25 × clamp(total_ram / 8, …)` — a 1 GiB
+/// VPS gets `1.25 × 128 MiB = 160 MiB` combined, nowhere near OOM. (The original
+/// pre-#4452 code applied the full budget to BOTH caches; this divisor is what
+/// keeps the combined default safe regardless of where the MAX clamp sits.)
 pub const DELEGATE_MODULE_CACHE_BUDGET_DIVISOR: usize = 4;
 
 /// Fallback total-RAM estimate (1 GiB) when the OS query fails.
@@ -414,14 +439,17 @@ const FALLBACK_TOTAL_RAM_BYTES: usize = 1024 * 1024 * 1024;
 /// Default per-cache byte budget for the **contract** compiled-module cache,
 /// scaled to the host's physical RAM and clamped to a sane floor/ceiling.
 ///
-/// Returns `clamp(total_ram / 8, 64 MiB, 384 MiB)`. The same fix for issue
+/// Returns `clamp(total_ram / DEFAULT_MODULE_CACHE_RAM_DIVISOR,
+/// MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES, MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES)`
+/// (currently `clamp(total_ram / 8, 64 MiB, 1.5 GiB)`). The same fix for issue
 /// #4441 (a node hosting >1024 contracts thrashed/OOM'd the old count cap) must
-/// not itself OOM a small box: a fixed 384-MiB-per-cache default applied to
-/// both the contract AND delegate caches meant a ~768 MiB compiled-code ceiling
-/// regardless of host size. Scaling the contract budget to RAM and giving the
-/// delegate cache only a fraction (`DELEGATE_MODULE_CACHE_BUDGET_DIVISOR`) keeps
-/// the COMBINED default ceiling safe on small hosts while still letting big
-/// gateways cache a large working set.
+/// not itself OOM a small box: the `total_ram / 8` divisor — not the absolute
+/// MAX clamp — is the small-box protection, and giving the delegate cache only a
+/// fraction (`DELEGATE_MODULE_CACHE_BUDGET_DIVISOR`) keeps the COMBINED default
+/// ceiling safe on small hosts. The MAX clamp only binds on large hosts (>12 GiB
+/// RAM); it exists to stop the divisor from handing a huge box a cache far
+/// larger than any useful working set, not to protect small boxes. See
+/// `MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES` for why 1.5 GiB.
 ///
 /// The explicit `--module-cache-budget-bytes` flag /
 /// `FREENET_MODULE_CACHE_BUDGET_BYTES` env / `module-cache-budget-bytes` config
@@ -433,6 +461,14 @@ const FALLBACK_TOTAL_RAM_BYTES: usize = 1024 * 1024 * 1024;
 /// `wasm_runtime/tests/cache.rs`, which measures and logs the real size.
 pub fn default_module_cache_budget_bytes() -> usize {
     let total_ram = read_total_ram_bytes().unwrap_or(FALLBACK_TOTAL_RAM_BYTES);
+    budget_for_ram(total_ram)
+}
+
+/// Pure clamp math behind [`default_module_cache_budget_bytes`], split out so the
+/// small-box / large-box boundary behavior is unit-testable without depending on
+/// the test host's real RAM. Returns the contract-cache byte budget for a host
+/// with `total_ram` bytes of physical RAM.
+fn budget_for_ram(total_ram: usize) -> usize {
     (total_ram / DEFAULT_MODULE_CACHE_RAM_DIVISOR).clamp(
         MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES,
         MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES,
@@ -448,6 +484,20 @@ pub fn default_module_cache_budget_bytes() -> usize {
 ///
 /// Never panics; any failure (missing file, parse error, non-positive sysconf)
 /// yields `None`.
+///
+/// # Containers / cgroups
+///
+/// This reports the **host's** physical RAM, not a cgroup memory limit. A node
+/// run inside a container with a memory limit far below host RAM (e.g. a 2 GiB
+/// limit on a 128 GiB host) will size its default cache from the host total, so
+/// the `total_ram / 8` divisor (and the MAX clamp) can land above the container
+/// limit. The Freenet production gateways run as host systemd services, not in
+/// constrained containers, so this is not a concern for them; a containerized
+/// deployment with a tight memory limit should set the explicit
+/// `--module-cache-budget-bytes` / `FREENET_MODULE_CACHE_BUDGET_BYTES` override
+/// sized to its limit. Making this cgroup-aware (min of `MemTotal` and
+/// `memory.max`) is a possible future improvement if containerized nodes become
+/// common.
 fn read_total_ram_bytes() -> Option<usize> {
     #[cfg(target_os = "linux")]
     {
@@ -622,8 +672,8 @@ mod tests {
     }
 
     /// The RAM-scaled default budget is always within the documented clamp
-    /// `[64 MiB, 384 MiB]`, on any host (the `/proc/meminfo` read or its
-    /// fallback both feed through the clamp).
+    /// `[MIN, MAX]`, on any host (the `/proc/meminfo` read or its fallback both
+    /// feed through the clamp).
     #[test]
     fn default_budget_is_within_clamp() {
         let b = default_module_cache_budget_bytes();
@@ -635,19 +685,73 @@ mod tests {
         );
     }
 
-    /// The COMBINED default ceiling (contract budget + delegate budget) stays
-    /// well under what would OOM a small box. With the delegate cache at
-    /// `1/DELEGATE_MODULE_CACHE_BUDGET_DIVISOR` of the contract budget, the
-    /// combined max is `MAX * (1 + 1/divisor)` — must be < 512 MiB.
+    /// Small-box safety: on a constrained VPS the COMBINED default (contract +
+    /// delegate cache) stays a small fraction of RAM and never OOMs. This is the
+    /// invariant the #4441 fix must preserve — the `total_ram / 8` divisor, not
+    /// the absolute MAX clamp, is what protects small hosts, so raising the MAX
+    /// clamp must not change this. Checked across a sweep of small/medium RAM
+    /// sizes where the divisor (not the MAX clamp) binds.
     #[test]
-    fn combined_default_ceiling_is_safe() {
-        let contract = MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES;
-        let delegate = contract / DELEGATE_MODULE_CACHE_BUDGET_DIVISOR;
-        let combined = contract + delegate;
+    fn combined_default_ceiling_is_safe_on_small_box() {
+        // RAM sizes from a tiny 512 MiB VPS up to 12 GiB — the largest host at
+        // which the divisor still binds below the MAX clamp.
+        for total_ram_gib_eighths in 1..=96u64 {
+            // step in 1/8-GiB increments so we cover sub-GiB hosts too.
+            let total_ram = (total_ram_gib_eighths as usize) * (128 * 1024 * 1024);
+            let contract = budget_for_ram(total_ram);
+            let delegate = contract / DELEGATE_MODULE_CACHE_BUDGET_DIVISOR;
+            let combined = contract + delegate;
+            // The combined default must never exceed 1/4 of physical RAM, so the
+            // node always has at least 3/4 of RAM for everything else (state
+            // store, transport buffers, WASM instance arenas, the OS). Below the
+            // MIN clamp a very small box gets a fixed 64+16 MiB floor, which is
+            // still tiny in absolute terms; only enforce the fraction bound once
+            // RAM is large enough that the fixed floor isn't the binding term.
+            if total_ram
+                >= 4 * (MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES
+                    + MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES / DELEGATE_MODULE_CACHE_BUDGET_DIVISOR)
+            {
+                assert!(
+                    combined <= total_ram / 4,
+                    "combined default {combined} must stay within 1/4 of RAM \
+                     ({total_ram}); the divisor, not the MAX clamp, protects small boxes"
+                );
+            }
+        }
+    }
+
+    /// Regression for issue #4441: a large gateway (nova has 125 GiB RAM) must
+    /// get a default contract-cache budget far above the old 384 MiB ceiling, so
+    /// its working set (hundreds of hosted contracts plus the post-#4404
+    /// phantom-interest set) fits without permanent evict-and-recompile thrash.
+    ///
+    /// At `total_ram / 8`, any host with >12 GiB RAM lands on the MAX clamp, so
+    /// the budget equals the MAX. This test pins that the MAX is high enough to
+    /// hold a realistic gateway working set (~1000 modules at the measured
+    /// ~1.5 MiB) and is strictly larger than the pre-fix 384 MiB that caused the
+    /// thrash.
+    #[test]
+    fn large_gateway_default_exceeds_old_clamp() {
+        const OLD_MAX: usize = 384 * 1024 * 1024;
+        const MEASURED_MODULE_SIZE: usize = 1536 * 1024; // ~1.5 MiB, per #4452
+
+        // nova-sized host: 125 GiB.
+        let nova_ram = 125 * 1024 * 1024 * 1024usize;
+        let budget = budget_for_ram(nova_ram);
+        assert_eq!(
+            budget, MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES,
+            "a >12 GiB host lands on the MAX clamp"
+        );
         assert!(
-            combined < 512 * 1024 * 1024,
-            "combined default ceiling {combined} must stay under 512 MiB so the \
-             #4441 OOM fix doesn't itself OOM a small box (was 768 MiB pre-fix)"
+            budget > OLD_MAX,
+            "the new default ceiling {budget} must exceed the pre-#4441 384 MiB \
+             clamp that caused gateway module-cache thrash"
+        );
+        let modules_held = budget / MEASURED_MODULE_SIZE;
+        assert!(
+            modules_held >= 900,
+            "the default ceiling must hold a realistic gateway working set \
+             (~1000 modules at ~1.5 MiB each); holds {modules_held}"
         );
     }
 

--- a/crates/core/src/wasm_runtime/module_cache.rs
+++ b/crates/core/src/wasm_runtime/module_cache.rs
@@ -553,36 +553,112 @@ fn parse_meminfo_total_bytes(meminfo: &str) -> Option<usize> {
 /// Best-effort read of the process's cgroup memory limit in bytes, or `None`
 /// when there is no readable limit (or the limit is the "unlimited" sentinel).
 ///
-/// Tries cgroup v2 (`/sys/fs/cgroup/memory.max`) first, then cgroup v1
-/// (`/sys/fs/cgroup/memory/memory.limit_in_bytes`). Both files contain a single
-/// integer of bytes, except v2 uses the literal `max` for "no limit" and v1 uses
-/// a near-`u64::MAX` sentinel (e.g. `9223372036854771712`). We treat anything at
-/// or above [`CGROUP_UNLIMITED_THRESHOLD_BYTES`] as "no limit" so a host-level
+/// Crucially, this resolves the **process's own** cgroup from
+/// `/proc/self/cgroup` rather than only reading the mount-root files. A process
+/// in a non-root cgroup *without* a private cgroup namespace — e.g. a systemd
+/// service with `MemoryMax=`, or a Docker/Kubernetes container sharing the host
+/// cgroup namespace — has its limit at `/sys/fs/cgroup<path>/memory.max`
+/// (v2) or `/sys/fs/cgroup/memory<path>/memory.limit_in_bytes` (v1), where
+/// `<path>` comes from `/proc/self/cgroup`. Reading only the mount root would
+/// miss that limit and size the cache from host RAM (Codex #4481 review). We try
+/// the resolved sub-path first, then fall back to the mount root (the
+/// private-namespace case, where `/proc/self/cgroup` reads `/`).
+///
+/// v2 (`memory.max`) uses the literal `max` for "no limit"; v1
+/// (`memory.limit_in_bytes`) uses a near-`u64::MAX` sentinel (e.g.
+/// `9223372036854771712`). Anything at or above
+/// [`CGROUP_UNLIMITED_THRESHOLD_BYTES`] is treated as "no limit" so a host-level
 /// (effectively unlimited) cgroup doesn't pin the budget to a meaningless huge
 /// number.
 #[cfg(target_os = "linux")]
 fn read_cgroup_memory_limit_bytes() -> Option<usize> {
-    // cgroup v2 unified hierarchy.
-    if let Ok(s) = std::fs::read_to_string("/sys/fs/cgroup/memory.max") {
+    let (v2_rel, v1_rel) = cgroup_relative_paths();
+
+    // cgroup v2 unified hierarchy: /sys/fs/cgroup<rel>/memory.max, where <rel>
+    // is the process's cgroup path (or "" at the root).
+    let v2_path = format!("/sys/fs/cgroup{v2_rel}/memory.max");
+    if let Ok(s) = std::fs::read_to_string(&v2_path) {
         if let Some(v) = parse_cgroup_limit(&s) {
             return Some(v);
         }
-        // Present but "max" / unparseable → no v2 limit; fall through to v1 in
-        // case of a hybrid mount, then to None.
+        // Present but "max"/unparseable → no v2 limit at this path; fall through.
     }
-    // cgroup v1.
-    if let Ok(s) = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes") {
+    // Fallback: mount root, for a private-cgroup-namespace process whose
+    // /proc/self/cgroup reads "/" but whose limit lives at the visible root.
+    if v2_rel != "/"
+        && !v2_rel.is_empty()
+        && let Ok(s) = std::fs::read_to_string("/sys/fs/cgroup/memory.max")
+        && let Some(v) = parse_cgroup_limit(&s)
+    {
+        return Some(v);
+    }
+
+    // cgroup v1: /sys/fs/cgroup/memory<rel>/memory.limit_in_bytes.
+    let v1_path = format!("/sys/fs/cgroup/memory{v1_rel}/memory.limit_in_bytes");
+    if let Ok(s) = std::fs::read_to_string(&v1_path) {
         if let Some(v) = parse_cgroup_limit(&s) {
             return Some(v);
         }
+    }
+    if v1_rel != "/"
+        && !v1_rel.is_empty()
+        && let Ok(s) = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+        && let Some(v) = parse_cgroup_limit(&s)
+    {
+        return Some(v);
     }
     None
+}
+
+/// Resolve the process's cgroup paths (relative to the controller mount) for the
+/// v2 unified hierarchy and the v1 `memory` controller, from `/proc/self/cgroup`.
+///
+/// Returns `(v2_rel, v1_rel)`, each a leading-slash path like `/system.slice/x`
+/// or `/` (root). On any read/parse failure both default to `/` (mount root), so
+/// the caller still attempts the root files. See [`parse_proc_self_cgroup`].
+#[cfg(target_os = "linux")]
+fn cgroup_relative_paths() -> (String, String) {
+    match std::fs::read_to_string("/proc/self/cgroup") {
+        Ok(s) => parse_proc_self_cgroup(&s),
+        Err(_) => ("/".to_string(), "/".to_string()),
+    }
+}
+
+/// Pure parse of `/proc/self/cgroup` contents into `(v2_rel, v1_rel)` cgroup
+/// paths. Lines are `hierarchy-id:controllers:path`. The v2 line has an empty
+/// controller field and hierarchy id `0` (`0::/path`); the v1 `memory` line
+/// lists `memory` among its controllers (`N:memory:/path` or
+/// `N:cpu,memory:/path`). Missing entries default to `/`.
+#[cfg(target_os = "linux")]
+fn parse_proc_self_cgroup(contents: &str) -> (String, String) {
+    let mut v2 = "/".to_string();
+    let mut v1 = "/".to_string();
+    for line in contents.lines() {
+        // splitn(3) because the path itself may contain ':'.
+        let mut parts = line.splitn(3, ':');
+        let (Some(_id), Some(controllers), Some(path)) = (parts.next(), parts.next(), parts.next())
+        else {
+            continue;
+        };
+        if controllers.is_empty() {
+            // cgroup v2 unified line ("0::/path").
+            v2 = path.to_string();
+        } else if controllers.split(',').any(|c| c == "memory") {
+            // cgroup v1 memory controller.
+            v1 = path.to_string();
+        }
+    }
+    (v2, v1)
 }
 
 /// Above this, a cgroup limit is treated as "unlimited" rather than a real
 /// bound. Covers cgroup v1's `~u64::MAX` sentinel and a host-root cgroup whose
 /// limit equals (or rounds to) all of physical RAM. Far above any budget we'd
 /// ever want, so clamping the cache to it would be a no-op anyway.
+///
+/// NOTE: 64-bit-only. `1 << 60` overflows a 32-bit `usize`; the project targets
+/// only 64-bit platforms (see cross-compile.yml). If a 32-bit target is ever
+/// added, switch this and `parse_cgroup_limit` to `u64`.
 #[cfg(target_os = "linux")]
 const CGROUP_UNLIMITED_THRESHOLD_BYTES: usize = 1 << 60; // 1 EiB
 
@@ -898,6 +974,55 @@ mod tests {
         let sample = "MemFree:  100 kB\nMemTotal:       16331752 kB\nBuffers:  1 kB\n";
         assert_eq!(parse_meminfo_total_bytes(sample), Some(16331752 * 1024));
         assert_eq!(parse_meminfo_total_bytes("SwapTotal: 0 kB\n"), None);
+    }
+
+    /// `/proc/self/cgroup` parsing resolves the process's OWN cgroup sub-path for
+    /// both the v2 unified line (`0::/path`) and the v1 `memory` controller line,
+    /// so a non-root cgroup's limit file is found at the right place rather than
+    /// only the mount root (Codex #4481 review). Defaults to `/` when absent.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_proc_self_cgroup_resolves_own_path() {
+        // Pure cgroup v2 (systemd service with MemoryMax=, host cgroup ns).
+        let v2_only = "0::/system.slice/freenet-gateway.service\n";
+        assert_eq!(
+            parse_proc_self_cgroup(v2_only),
+            (
+                "/system.slice/freenet-gateway.service".to_string(),
+                "/".to_string()
+            )
+        );
+
+        // Hybrid / v1 with the memory controller grouped among several.
+        let hybrid = "12:cpu,memory:/docker/abc123\n0::/docker/abc123\n";
+        assert_eq!(
+            parse_proc_self_cgroup(hybrid),
+            ("/docker/abc123".to_string(), "/docker/abc123".to_string())
+        );
+
+        // v1 memory controller alone, plus an unrelated controller line.
+        let v1 = "8:memory:/kubepods/pod1\n9:cpuset:/elsewhere\n";
+        assert_eq!(
+            parse_proc_self_cgroup(v1),
+            ("/".to_string(), "/kubepods/pod1".to_string())
+        );
+
+        // Root cgroup / empty input → defaults to "/".
+        assert_eq!(
+            parse_proc_self_cgroup("0::/\n"),
+            ("/".to_string(), "/".to_string())
+        );
+        assert_eq!(
+            parse_proc_self_cgroup(""),
+            ("/".to_string(), "/".to_string())
+        );
+
+        // A path containing ':' must survive splitn(3).
+        let weird = "0::/odd:name/x\n";
+        assert_eq!(
+            parse_proc_self_cgroup(weird),
+            ("/odd:name/x".to_string(), "/".to_string())
+        );
     }
 
     /// A zero budget still keeps exactly one most-recently-used entry resident


### PR DESCRIPTION
## Problem

A node hosting a large working set of contracts thrashes its compiled-WASM module cache: every cold contract evicts a warm one, and the evicted module must be recompiled on its next access, pinning the single-threaded `contract_handling` loop and (on resource-constrained hosts) growing RSS until OOM. This is issue #4441, observed in the broadcast-storm incident cluster (#4440): technic recompiled the River web container ~15× in 16h and intermittently 30s-timed-out GETs.

PR #4452 already did the bulk of #4441: it replaced the old hardcoded 1024-**entry** LRU with a **byte-budget** cache (default `clamp(total_ram / 8, 64 MiB, 384 MiB)`, delegate cache = 1/4 of that), wired it to `--module-cache-budget-bytes` / `FREENET_MODULE_CACHE_BUDGET_BYTES` / a config field, and offloaded cold compiles off the contract loop. The wasmtime **disk** compilation cache (#3456) is also already enabled, so an evicted module **deserializes** from disk on reload rather than recompiling from source.

The remaining gap is the **384 MiB MAX clamp**. The `total_ram / 8` divisor is what protects small boxes from OOM; the absolute MAX clamp is a separate ceiling that only binds on large hosts. On a production gateway (nova has 125 GiB RAM), `total_ram / 8` is ~15.6 GiB, so the MAX clamp is the *only* thing sizing the default cache — and 384 MiB holds only ~256 modules at the measured ~1.5 MiB each. A gateway's working set (hundreds of hosted contracts plus, post-#4404, an ~85-contract phantom-interest set) exceeds that, so the cache permanently evicts-and-recompiles. The operator *could* set the override, but the out-of-the-box default thrashes on exactly the nodes #4441 is about.

## Approach

Raise `MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES` from 384 MiB to **1.5 GiB**.

- **Small/medium hosts are unchanged.** The MAX clamp only binds above `MAX × 8 = 12 GiB` of RAM; below that the `total_ram / 8` divisor binds first. A 1 GiB VPS still defaults to 128 MiB; a 512 MiB box still gets the 64 MiB MIN. Raising MAX does not touch them.
- **Large gateways stop thrashing.** 1.5 GiB holds ~1000 modules at the measured ~1.5 MiB — comfortably above a real gateway working set — and matches the 1 GiB default hosted-*state* budget (`ring::DEFAULT_HOSTING_BUDGET_BYTES`): a node allowed ~1 GiB of state should be able to cache the corresponding compiled code.
- **Still bounded — not removed.** An unbounded `total_ram / 8` would default a 125 GiB box to a ~15 GiB cache it can't benefit from (working-set benefit flattens past ~1000 modules). The clamp keeps the default a bounded, defensible commitment; the explicit override remains unclamped for operators who genuinely need more.
- **cgroup-aware sizing (review hardening).** Raising the ceiling to 1.5 GiB widened a latent risk: a node in a small container (e.g. a 2 GiB cgroup limit on a 128 GiB host) would size its default from *host* RAM and could OOM the container. `read_total_ram_bytes` now takes the **min** of `/proc/meminfo` `MemTotal` and the cgroup memory limit (cgroup v2 `memory.max`, falling back to v1 `memory.limit_in_bytes`), treating the `max`/`~u64::MAX` "unlimited" sentinels as no-limit. A host systemd service (the production gateways) sees no limit and behaves exactly as before; a constrained container now gets a budget scaled to its real limit.

The wasmtime disk-cache "deserialize on eviction-reload" behavior (the other half originally scoped for this work) is **already in place** (`wasmtime_engine.rs` enables `Cache::new(CacheConfig::new())`; the reload path goes `prepare_contract_call` → `engine.compile` → `Module::new`, which deserializes on a `(config + WASM-hash)` hit). No code change needed; this PR adds a source-scrape pin test (isolated to the `create_backend_engine` body so it can't self-satisfy) so the behavior can't silently regress.

## Testing

- `large_gateway_default_exceeds_old_clamp` — regression for #4441: a nova-sized (125 GiB) host now defaults above the old 384 MiB ceiling and holds ≥900 modules. Fails on the old 384 MiB MAX.
- `combined_default_ceiling_is_safe_on_small_box` — sweeps 128 MiB…12 GiB RAM, asserts the combined default never exceeds total RAM (catches an unsafe MIN raise) and stays ≤ 1/4 of RAM, pinning that the divisor (not the MAX clamp) protects small boxes. Rewritten from the old `combined_default_ceiling_is_safe` (which asserted `< 512 MiB`, no longer the invariant).
- `max_clamp_combined_ceiling_is_safe_at_binding_host` — upper-bound guard: the combined ceiling at MAX stays ≤ 1/4 of the smallest host where MAX binds (12 GiB), so a future unsafe MAX raise fails CI.
- `parse_cgroup_limit_distinguishes_real_limits_from_sentinels` / `parse_meminfo_total_reads_kib_as_bytes` — unit tests for the new memory-limit parsing (real limits vs `max`/`~u64::MAX`/zero/garbage).
- `engine_enables_wasmtime_disk_compilation_cache` — source-scrape pin (isolated to `create_backend_engine`) that the wasmtime disk compilation cache stays enabled.
- Extracted a pure `budget_for_ram(total_ram)` helper so the small-box / large-box boundary is deterministically testable without depending on the test host's RAM.
- Updated `default_budget_is_within_clamp` and the config round-trip test to reference the MIN/MAX constants instead of hardcoded byte values, so they can't drift from the clamp.
- Fixed config.rs docstrings (clamp range; also corrected a wrong "both caches get the full budget" claim — the delegate cache gets 1/4).

`cargo fmt` + `clippy -D warnings` clean; wasm_runtime + config module-cache tests pass.

Refs #4441, #4440.

[AI-assisted - Claude]
