### PR TITLE
fix(broadcast): gate summarize on hosted-or-in-use in broadcast fan-out

### DIFF
--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -28,6 +28,39 @@ use super::p2p_protoc::P2pBridge;
 /// `queue` submodule.
 const STREAM_COMPLETION_TIMEOUT: Duration = Duration::from_secs(120);
 
+/// Whether we should broadcast a state change for `key` at all: only if we
+/// host it or are actively serving it (a live local-client or downstream
+/// subscriber). Mirrors `node.rs::summary_if_hosted_or_in_use` (#4475) for the
+/// broadcast fan-out path.
+///
+/// A node can be driven into `broadcast_state_to_peers` /
+/// `broadcast_to_single_peer` for a contract it neither hosts nor serves —
+/// "phantom" contracts it holds no local state for. For such a contract the
+/// per-peer body would call `get_contract_summary` (→
+/// `InterestManager::summarize_contract_state`), which issues a
+/// `GetSummaryQuery` round-trip on the single-threaded contract-handling loop
+/// that returns "Contract state not found in store" every time, and would then
+/// fall through to "send full state" with nothing real to send. #4475 gated the
+/// interest-sync summarize sites (path A); this is the residual path-B caller
+/// that drove the plateaued ~100k/hr summarize WARNs observed on nova after the
+/// #4475 rollout (#4473). With no local state there is nothing to broadcast to
+/// the peer, so skipping is the correct behavior, not just a throttle.
+///
+/// Gating on `is_hosting_contract || contract_in_use` is correct, not merely a
+/// heuristic — same reasoning as #4475: a phantom contract is neither hosted
+/// nor in use (skipped); a contract whose state we evicted from the hosting
+/// cache is only reachable while NOT in use, and has no live subscriber whose
+/// broadcast we'd be dropping; the moment a contract gains a live subscriber it
+/// is `contract_in_use`, so we resume broadcasting it.
+///
+/// NOTE: it is surprising the broadcast path runs at all for a contract we hold
+/// no state for — that points at a routing/subscription leak upstream of
+/// `broadcast_state_to_peers` (tracked separately on #4473). This gate stops the
+/// storm symptom; it does not fix that upstream question.
+pub(super) fn should_broadcast_contract(op_manager: &Arc<OpManager>, key: &ContractKey) -> bool {
+    op_manager.ring.is_hosting_contract(key) || op_manager.ring.contract_in_use(key)
+}
+
 // The `BroadcastQueue` struct (constants, types, impl) is only used in the
 // production `p2p_protoc` path. Under `simulation_tests` the code routes
 // through `broadcast_to_single_peer` directly (see p2p_protoc.rs), so the
@@ -444,6 +477,19 @@ pub(super) async fn broadcast_to_single_peer(
     let Some(peer_addr) = target.socket_addr() else {
         return;
     };
+
+    // Skip the summary/delta computation (and the per-peer send) entirely when
+    // we hold no local state for `key`. The expensive `get_contract_summary`
+    // call below is what drove the residual #4473 summarize storm on this
+    // path-B caller. See `should_broadcast_contract`.
+    if !should_broadcast_contract(op_manager, &key) {
+        tracing::trace!(
+            contract = %key,
+            peer = %peer_addr,
+            "Skipping broadcast - contract not hosted or in use"
+        );
+        return;
+    }
 
     let peer_key = PeerKey::from(target.pub_key().clone());
 
@@ -1002,5 +1048,68 @@ mod tests {
                  the state), or the next summary-mismatch resend is suppressed"
             );
         }
+    }
+
+    /// Regression pin for the #4473 path-B summarize storm (counterpart to
+    /// #4475's `interest_sync_periodic_arms_summarize_only_hosted_or_in_use_pin`).
+    ///
+    /// #4475 gated the interest-sync summarize sites (path A) but left the
+    /// broadcast fan-out caller ungated: `broadcast_to_single_peer` called
+    /// `get_contract_summary` (→ `summarize_contract_state`) once per
+    /// (broadcast × target) with NO hosting/in-use gate, driving the residual
+    /// ~100k/hr "Contract state not found in store" WARNs observed on nova for a
+    /// small phantom set of contracts the node holds no state for. The fix gates
+    /// the expensive summarize on `should_broadcast_contract`
+    /// (`is_hosting_contract || contract_in_use`) BEFORE the
+    /// `get_contract_summary` call.
+    ///
+    /// This pin fails on the pre-fix code (an ungated `get_contract_summary` in
+    /// `broadcast_to_single_peer`) and guards against a future migration
+    /// hand-inlining the per-peer body and dropping the gate again.
+    #[test]
+    fn broadcast_single_peer_gates_summarize_on_hosted_or_in_use_pin() {
+        let src = include_str!("broadcast_queue.rs");
+
+        // 1. The gate helper must check BOTH predicates: gating on hosting alone
+        //    wrongly drops the broadcast for an evicted-but-in-use stateful
+        //    contract (the #4475 Codex-P1 lesson, applied to this path).
+        let helper_start = src
+            .find("pub(super) fn should_broadcast_contract(")
+            .expect("should_broadcast_contract helper not found");
+        let helper_end = helper_start
+            + src[helper_start..]
+                .find("\n}\n")
+                .expect("should_broadcast_contract body end not found");
+        let helper_src = &src[helper_start..helper_end];
+        assert!(
+            helper_src.contains("is_hosting_contract"),
+            "should_broadcast_contract must gate on is_hosting_contract"
+        );
+        assert!(
+            helper_src.contains("contract_in_use"),
+            "should_broadcast_contract must ALSO gate on contract_in_use so an \
+             evicted-but-in-use stateful contract keeps being broadcast"
+        );
+
+        // 2. `broadcast_to_single_peer` must call the gate BEFORE the expensive
+        //    `get_contract_summary`. Slice the function body and assert the gate
+        //    call precedes the first `get_contract_summary(` in it.
+        let fn_start = src
+            .find("pub(super) async fn broadcast_to_single_peer(")
+            .expect("broadcast_to_single_peer not found");
+        let fn_src = &src[fn_start..];
+        let gate_off = fn_src.find("should_broadcast_contract(op_manager").expect(
+            "broadcast_to_single_peer must call should_broadcast_contract — a bare \
+             get_contract_summary here reintroduces the #4473 storm",
+        );
+        let summarize_off = fn_src
+            .find("get_contract_summary(")
+            .expect("broadcast_to_single_peer get_contract_summary call not found");
+        assert!(
+            gate_off < summarize_off,
+            "broadcast_to_single_peer must gate on should_broadcast_contract BEFORE \
+             calling get_contract_summary (#4473) — otherwise the summarize storm \
+             fires for every phantom contract before the gate can skip it"
+        );
     }
 }

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -5143,6 +5143,19 @@ impl P2pConnManager {
         new_state: freenet_stdlib::prelude::WrappedState,
         target_result: crate::operations::update::BroadcastTargetResult,
     ) {
+        // Skip the whole fan-out when we hold no local state for `key`: there is
+        // nothing to broadcast, and the per-target `get_contract_summary` calls
+        // below are the residual #4473 summarize storm on this path. Mirrors the
+        // production `broadcast_to_single_peer` gate. See
+        // `broadcast_queue::should_broadcast_contract`.
+        if !super::broadcast_queue::should_broadcast_contract(op_manager, &key) {
+            tracing::trace!(
+                contract = %key,
+                "Skipping broadcast fan-out - contract not hosted or in use"
+            );
+            return;
+        }
+
         // Get our summary once for all targets
         let our_summary = op_manager
             .interest_manager
@@ -7058,6 +7071,47 @@ mod tests {
             send_pos > remove_pos,
             "the PeerDisconnected send must happen on the sender taken out by \
              pending_op_results.remove (send-before-drop). Arm body:\n{body}"
+        );
+    }
+
+    /// #4473 path-B summarize-storm pin (sim-inline counterpart of
+    /// `broadcast_queue::broadcast_single_peer_gates_summarize_on_hosted_or_in_use_pin`).
+    ///
+    /// The simulation-only `broadcast_state_to_peers` has its own inline
+    /// `get_contract_summary` (computed once for all targets). It must skip the
+    /// whole fan-out via `should_broadcast_contract` BEFORE that call, so the
+    /// sim path mirrors the production `broadcast_to_single_peer` gate and the
+    /// behavioral broadcast simulation tests can't silently regress the storm.
+    #[test]
+    fn broadcast_state_to_peers_gates_summarize_on_hosted_or_in_use() {
+        const SOURCE: &str = include_str!("p2p_protoc.rs");
+
+        let fn_anchor = "async fn broadcast_state_to_peers(";
+        let fn_start = SOURCE
+            .find(fn_anchor)
+            .expect("broadcast_state_to_peers renamed or removed");
+        // Bound the slice at the next `async fn ` so the assertion can't match a
+        // later function's body.
+        let after_header = &SOURCE[fn_start + fn_anchor.len()..];
+        let body_end = after_header
+            .find("\n    async fn ")
+            .map(|p| fn_start + fn_anchor.len() + p)
+            .unwrap_or(SOURCE.len());
+        let body = &SOURCE[fn_start..body_end];
+
+        let gate_pos = body.find("should_broadcast_contract(op_manager").expect(
+            "broadcast_state_to_peers must gate on should_broadcast_contract — a \
+             bare get_contract_summary here reintroduces the #4473 summarize storm \
+             on the sim-inline broadcast path",
+        );
+        let summarize_pos = body
+            .find("get_contract_summary(")
+            .expect("broadcast_state_to_peers get_contract_summary call not found");
+        assert!(
+            gate_pos < summarize_pos,
+            "broadcast_state_to_peers must call should_broadcast_contract (offset \
+             {gate_pos}) BEFORE get_contract_summary (offset {summarize_pos}) so the \
+             fan-out is skipped for a contract we hold no state for. Body:\n{body}"
         );
     }
 


### PR DESCRIPTION
## Problem

PR #4475 (shipped in 0.2.76) gated the interest-sync summarize sites (path A) on `is_hosting_contract || contract_in_use` and stopped that arm of the #4473 summarize storm. But a **second, ungated caller** kept the residual storm alive on nova — plateaued ~100k/hr `summarize_contract_state` "Contract state not found in store" WARNs, still not decaying hours after a restart:

- **`broadcast_to_single_peer`** (`broadcast_queue.rs`) — the production per-(broadcast × target) body driven by the broadcast queue worker — called `op_manager.interest_manager.get_contract_summary(...)` (→ `summarize_contract_state`) with **no** hosting/in-use gate. For a small phantom set of contracts the node holds no local state for, each call is a pointless `GetSummaryQuery` round-trip on the single-threaded contract-handling loop that returns "state not found" every time, then falls through to "send full state" with nothing real to send.
- The simulation-only inline `broadcast_state_to_peers` (`p2p_protoc.rs`) has the same ungated `get_contract_summary`.

This is the **path-B counterpart to #4475** (which fixed path A).

## Approach

Mirror #4475's predicate (`is_hosting_contract || contract_in_use`) as a shared `should_broadcast_contract` helper in `broadcast_queue.rs`, and gate both broadcast callers on it **before** the expensive summarize:

- `broadcast_to_single_peer`: skip the per-peer summary/delta/send when we hold no local state for `key`.
- `broadcast_state_to_peers` (sim-inline): skip the whole fan-out before computing the shared `our_summary`.

With no local state there is nothing to broadcast to the peer, so skipping is the **correct behavior, not just a throttle**. The predicate passes for any contract we host or actively serve, so legitimate broadcasts are unaffected (tested both directions).

The secondary `update.rs::send_summary_back_on_rejection` caller was **assessed and left as-is**: it is already throttled to ~10/sec/contract by `should_send_summary_notification` AND returns early when the summary is `None`, so it is not the storm and gating it would be scope creep into a different path.

### Upstream caveat (not fixed here — see #4473)

It is surprising the broadcast path runs at all for a contract we hold no state for. That points at a routing/subscription leak **upstream** of `broadcast_state_to_peers` — we're being asked to relay UPDATEs for contracts whose state we never stored. This gate stops the storm symptom correctly and is the must-have; it does **not** fix that upstream question. Noted on #4473 for follow-up.

## Testing

Two source-scrape pin tests (the regression class here is a callsite that forgot to gate; the predicate's truth table is already covered by the `hosting.rs` unit tests for `is_hosting_contract` / `contract_in_use`):

- `broadcast_single_peer_gates_summarize_on_hosted_or_in_use_pin` (`broadcast_queue.rs`): the gate helper checks **both** predicates (the #4475 Codex-P1 lesson: gating on hosting alone wrongly drops an evicted-but-in-use stateful contract), and `broadcast_to_single_peer` calls it **before** `get_contract_summary`.
- `broadcast_state_to_peers_gates_summarize_on_hosted_or_in_use` (`p2p_protoc.rs`): same ordering pin for the sim-inline path.

Both verified to **FAIL** on the pre-fix code (ungated `get_contract_summary`) and **pass** with the gate. Mirrors #4475's `interest_sync_periodic_arms_summarize_only_hosted_or_in_use_pin`.

Existing `broadcast_queue` (5) and `p2p_protoc` (40) test modules pass; `cargo clippy --locked -- -D warnings` (the CI invocation) is clean.

Refs #4473 #4145 #4440

[AI-assisted - Claude]