### PR TITLE
feat(dashboard): per-peer routing-predictor accuracy and outcomes-vs-distance panels

### DIFF
--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -113,7 +113,8 @@ pub(crate) struct PerOpCurves {
     pub transfer_rate_data_range: (f64, f64),
     pub transfer_rate_events: usize,
     /// Downsampled raw (distance, outcome) observations behind each isotonic fit,
-    /// for the scatter overlay. Defaulted so older serialized snapshots still load.
+    /// for the scatter overlay. `#[serde(default)]` keeps decode tolerant of
+    /// missing fields via self-describing formats (no-op under the bincode AOF).
     #[serde(default)]
     pub failure_points: Vec<(f64, f64)>,
     #[serde(default)]
@@ -147,7 +148,9 @@ pub(crate) struct RouterSnapshotInfo {
     /// X-range of actual regression data for the transfer rate estimator.
     pub transfer_rate_data_range: (f64, f64),
     /// Downsampled raw (distance, outcome) observations behind each aggregate
-    /// isotonic fit, for the scatter overlay. Defaulted for old snapshots.
+    /// isotonic fit, for the scatter overlay. `#[serde(default)]` keeps decode
+    /// tolerant of missing fields via self-describing formats; it is a no-op for
+    /// the positional bincode AOF (which skips records it can't decode).
     #[serde(default)]
     pub failure_points: Vec<(f64, f64)>,
     #[serde(default)]
@@ -189,7 +192,11 @@ pub(crate) struct RouterSnapshotInfo {
     pub delegate_module_cache_evictions_total: Option<u64>,
     /// Per-operation-type estimator curves, keyed by op type name (e.g., "GET").
     pub per_op_curves: HashMap<String, PerOpCurves>,
-    /// Renegade predictor diagnostics
+    /// Renegade predictor diagnostics. These (and `renegade_accuracy_pairs`) are
+    /// read by the in-process peer dashboard directly from this struct; they are
+    /// intentionally not mirrored into the hand-written OTLP `json!` block in
+    /// `tracing/telemetry.rs` (the dashboard is the only consumer). The per-op
+    /// scatter does reach OTLP, because `per_op_curves` is forwarded wholesale.
     pub renegade_failure_events: usize,
     pub renegade_response_time_events: usize,
     pub renegade_transfer_speed_events: usize,
@@ -203,12 +210,18 @@ pub(crate) struct RouterSnapshotInfo {
     /// Recent (predicted_failure, actual_outcome) pairs for accuracy visualization.
     pub renegade_accuracy_pairs: Vec<(f64, f64)>,
     /// Recent (predicted_secs, actual_secs) pairs for the response-time stage.
+    /// `#[serde(default)]` for decode consistency with the `*_points` fields
+    /// (no-op under the positional bincode AOF).
+    #[serde(default)]
     pub renegade_response_time_pairs: Vec<(f64, f64)>,
     /// Recent (predicted_bps, actual_bps) pairs for the transfer-speed stage.
+    #[serde(default)]
     pub renegade_transfer_speed_pairs: Vec<(f64, f64)>,
     /// Number of response-time predictions scored against actual outcomes.
+    #[serde(default)]
     pub renegade_response_time_evaluated: u64,
     /// Number of transfer-speed predictions scored against actual outcomes.
+    #[serde(default)]
     pub renegade_transfer_speed_evaluated: u64,
 }
 

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -186,6 +186,14 @@ pub(crate) struct RouterSnapshotInfo {
     pub renegade_predictions_evaluated: u64,
     /// Recent (predicted_failure, actual_outcome) pairs for accuracy visualization.
     pub renegade_accuracy_pairs: Vec<(f64, f64)>,
+    /// Recent (predicted_secs, actual_secs) pairs for the response-time stage.
+    pub renegade_response_time_pairs: Vec<(f64, f64)>,
+    /// Recent (predicted_bps, actual_bps) pairs for the transfer-speed stage.
+    pub renegade_transfer_speed_pairs: Vec<(f64, f64)>,
+    /// Number of response-time predictions scored against actual outcomes.
+    pub renegade_response_time_evaluated: u64,
+    /// Number of transfer-speed predictions scored against actual outcomes.
+    pub renegade_transfer_speed_evaluated: u64,
 }
 
 /// Per-peer routing data for the dashboard detail page.
@@ -940,6 +948,24 @@ impl Router {
                 .iter()
                 .copied()
                 .collect(),
+            renegade_response_time_pairs: self
+                .renegade_predictor
+                .response_time_accuracy_pairs()
+                .iter()
+                .copied()
+                .collect(),
+            renegade_transfer_speed_pairs: self
+                .renegade_predictor
+                .transfer_speed_accuracy_pairs()
+                .iter()
+                .copied()
+                .collect(),
+            renegade_response_time_evaluated: self
+                .renegade_predictor
+                .response_time_predictions_evaluated(),
+            renegade_transfer_speed_evaluated: self
+                .renegade_predictor
+                .transfer_speed_predictions_evaluated(),
         }
     }
 

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -112,6 +112,14 @@ pub(crate) struct PerOpCurves {
     pub transfer_rate_curve: Vec<(f64, f64)>,
     pub transfer_rate_data_range: (f64, f64),
     pub transfer_rate_events: usize,
+    /// Downsampled raw (distance, outcome) observations behind each isotonic fit,
+    /// for the scatter overlay. Defaulted so older serialized snapshots still load.
+    #[serde(default)]
+    pub failure_points: Vec<(f64, f64)>,
+    #[serde(default)]
+    pub response_time_points: Vec<(f64, f64)>,
+    #[serde(default)]
+    pub transfer_rate_points: Vec<(f64, f64)>,
 }
 
 /// Periodic snapshot of the router model state for telemetry.
@@ -138,6 +146,14 @@ pub(crate) struct RouterSnapshotInfo {
     pub transfer_rate_curve: Vec<(f64, f64)>,
     /// X-range of actual regression data for the transfer rate estimator.
     pub transfer_rate_data_range: (f64, f64),
+    /// Downsampled raw (distance, outcome) observations behind each aggregate
+    /// isotonic fit, for the scatter overlay. Defaulted for old snapshots.
+    #[serde(default)]
+    pub failure_points: Vec<(f64, f64)>,
+    #[serde(default)]
+    pub response_time_points: Vec<(f64, f64)>,
+    #[serde(default)]
+    pub transfer_rate_points: Vec<(f64, f64)>,
     /// Connect forward estimator curve sampled across [0, 0.5], clamped to [0, 1].
     pub connect_forward_curve: Option<Vec<(f64, f64)>>,
     /// X-range of actual regression data for the connect forward estimator.
@@ -885,6 +901,11 @@ impl Router {
                 .transfer_rate_estimator
                 .sampled_curve(0.0, f64::INFINITY, 50),
             transfer_rate_data_range: self.transfer_rate_estimator.data_x_range(),
+            // Downsampled raw observations for the scatter overlay (cap keeps the
+            // serialized snapshot small; estimators retain up to 500 each).
+            failure_points: self.failure_estimator.sampled_raw_points(100),
+            response_time_points: self.response_start_time_estimator.sampled_raw_points(100),
+            transfer_rate_points: self.transfer_rate_estimator.sampled_raw_points(100),
             per_op_curves: {
                 let mut curves = HashMap::new();
                 // Collect all op types that have any data
@@ -901,18 +922,21 @@ impl Router {
                         c.failure_curve = p;
                         c.failure_data_range = est.data_x_range();
                         c.failure_events = est.len();
+                        c.failure_points = est.sampled_raw_points(100);
                     }
                     if let Some(est) = self.per_op_response_time.get(&ot) {
                         let p = est.sampled_curve(0.0, f64::INFINITY, 50);
                         c.response_time_curve = p;
                         c.response_time_data_range = est.data_x_range();
                         c.response_time_events = est.len();
+                        c.response_time_points = est.sampled_raw_points(100);
                     }
                     if let Some(est) = self.per_op_transfer_rate.get(&ot) {
                         let p = est.sampled_curve(0.0, f64::INFINITY, 50);
                         c.transfer_rate_curve = p;
                         c.transfer_rate_data_range = est.data_x_range();
                         c.transfer_rate_events = est.len();
+                        c.transfer_rate_points = est.sampled_raw_points(100);
                     }
                     curves.insert(ot.as_str().to_string(), c);
                 }

--- a/crates/core/src/router/isotonic_estimator.rs
+++ b/crates/core/src/router/isotonic_estimator.rs
@@ -212,6 +212,28 @@ impl IsotonicEstimator {
 
         points
     }
+
+    /// Downsampled raw `(distance, outcome)` observations for visualization, in
+    /// insertion order, at most `max` points (evenly strided across the retained
+    /// window). These are the actual events the isotonic fit is computed from, so
+    /// the dashboard can show the scatter behind the curve. Empty when no data.
+    pub(crate) fn sampled_raw_points(&self, max: usize) -> Vec<(f64, f64)> {
+        let n = self.raw_points.len();
+        if n == 0 || max == 0 {
+            return Vec::new();
+        }
+        if n <= max {
+            return self.raw_points.iter().map(|p| (*p.x(), *p.y())).collect();
+        }
+        let stride = n as f64 / max as f64;
+        (0..max)
+            .map(|i| {
+                let idx = ((i as f64 * stride) as usize).min(n - 1);
+                let p = &self.raw_points[idx];
+                (*p.x(), *p.y())
+            })
+            .collect()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -448,6 +470,31 @@ mod tests {
             result.is_ok(),
             "Estimator should produce estimates after eviction"
         );
+    }
+
+    #[test]
+    fn sampled_raw_points_downsamples_and_bounds() {
+        let peer = PeerKeyLocation::random();
+        let contract = Location::random();
+        let mut estimator = IsotonicEstimator::new(std::iter::empty(), EstimatorType::Positive);
+
+        // No data yet.
+        assert!(estimator.sampled_raw_points(50).is_empty());
+
+        for i in 0..40 {
+            estimator.add_event(IsotonicEvent {
+                peer: peer.clone(),
+                contract_location: contract,
+                result: i as f64,
+            });
+        }
+
+        // Fewer than the cap -> every retained point is returned.
+        assert_eq!(estimator.sampled_raw_points(100).len(), 40);
+        // More than the cap -> downsampled to exactly the cap.
+        assert_eq!(estimator.sampled_raw_points(10).len(), 10);
+        // Degenerate cap.
+        assert!(estimator.sampled_raw_points(0).is_empty());
     }
 
     #[test]

--- a/crates/core/src/router/isotonic_estimator.rs
+++ b/crates/core/src/router/isotonic_estimator.rs
@@ -492,7 +492,15 @@ mod tests {
         // Fewer than the cap -> every retained point is returned.
         assert_eq!(estimator.sampled_raw_points(100).len(), 40);
         // More than the cap -> downsampled to exactly the cap.
-        assert_eq!(estimator.sampled_raw_points(10).len(), 10);
+        let strided = estimator.sampled_raw_points(10);
+        assert_eq!(strided.len(), 10);
+        // Striding preserves insertion order (outcomes were added monotonically
+        // 0..40), so a returned-first-before-returned-newest check catches a
+        // regression that returned the first N points or reversed the window.
+        assert!(
+            strided.first().unwrap().1 < strided.last().unwrap().1,
+            "downsample should span oldest..newest in order, got {strided:?}",
+        );
         // Degenerate cap.
         assert!(estimator.sampled_raw_points(0).is_empty());
     }

--- a/crates/core/src/router/routing_predictor.rs
+++ b/crates/core/src/router/routing_predictor.rs
@@ -587,10 +587,14 @@ impl RoutingPredictor {
         &self.transfer_speed_accuracy.recent_pairs
     }
 
+    /// Count of response-time predictions scored against an actual outcome
+    /// (finite (predicted, actual) pairs recorded on timed successes).
     pub fn response_time_predictions_evaluated(&self) -> u64 {
         self.response_time_accuracy.total
     }
 
+    /// Count of transfer-speed predictions scored against an actual outcome
+    /// (finite (predicted, actual) pairs recorded on timed successes).
     pub fn transfer_speed_predictions_evaluated(&self) -> u64 {
         self.transfer_speed_accuracy.total
     }
@@ -1087,5 +1091,35 @@ mod tests {
         assert_eq!(predictor.transfer_speed_predictions_evaluated(), 0);
         assert!(predictor.response_time_accuracy_pairs().is_empty());
         assert!(predictor.transfer_speed_accuracy_pairs().is_empty());
+    }
+
+    #[test]
+    fn regression_accuracy_skips_untimed_successes() {
+        let mut predictor = RoutingPredictor::new(10000);
+        let peer = make_peer();
+        let contract = Location::try_from(0.5).unwrap();
+
+        // Warm the timing stages with timed successes so predict() returns Some.
+        for i in 0..60 {
+            predictor.record_at_time(
+                &peer,
+                contract,
+                0.1,
+                success_timed(0.1, 1000.0),
+                i as f64 * 0.01,
+            );
+        }
+        let rt_before = predictor.response_time_predictions_evaluated();
+        let ts_before = predictor.transfer_speed_predictions_evaluated();
+        assert!(rt_before > 0 && ts_before > 0, "stages should be warmed");
+
+        // An untimed success carries no response-time/transfer-speed ground truth,
+        // so it must NOT be scored even though the stages can now predict (guards
+        // against recording a garbage/zero actual into the scatter).
+        for i in 60..70 {
+            predictor.record_at_time(&peer, contract, 0.1, success_untimed(), i as f64 * 0.01);
+        }
+        assert_eq!(predictor.response_time_predictions_evaluated(), rt_before);
+        assert_eq!(predictor.transfer_speed_predictions_evaluated(), ts_before);
     }
 }

--- a/crates/core/src/router/routing_predictor.rs
+++ b/crates/core/src/router/routing_predictor.rs
@@ -282,6 +282,10 @@ pub(crate) struct RoutingPredictor {
     next_peer_id: u64,
     /// Running prediction accuracy tracker for failure predictions.
     accuracy: PredictionAccuracy,
+    /// Accuracy tracker for the response-time regression stage.
+    response_time_accuracy: RegressionAccuracy,
+    /// Accuracy tracker for the transfer-speed regression stage.
+    transfer_speed_accuracy: RegressionAccuracy,
     /// When true, skip periodic training and accuracy tracking (batch loading).
     batch_mode: bool,
     /// Reference time (hours since epoch at predictor creation).
@@ -344,6 +348,38 @@ impl PredictionAccuracy {
     }
 }
 
+/// Tracks regression prediction accuracy (continuous targets such as response
+/// time and transfer speed). Unlike the binary failure stage there is no Brier
+/// score; quality is judged from the spread of (predicted, actual) pairs, which
+/// the dashboard renders as a predicted-vs-actual scatter and summarizes as a
+/// median absolute percentage error over the retained window.
+struct RegressionAccuracy {
+    total: u64,
+    /// Ring buffer of recent (predicted, actual) pairs for visualization.
+    recent_pairs: VecDeque<(f64, f64)>,
+}
+
+impl RegressionAccuracy {
+    fn new() -> Self {
+        RegressionAccuracy {
+            total: 0,
+            recent_pairs: VecDeque::new(),
+        }
+    }
+
+    fn record(&mut self, predicted: f64, actual: f64) {
+        // Drop non-finite samples so a single bad division can't poison the view.
+        if !predicted.is_finite() || !actual.is_finite() {
+            return;
+        }
+        self.total += 1;
+        if self.recent_pairs.len() >= MAX_ACCURACY_HISTORY {
+            self.recent_pairs.pop_front();
+        }
+        self.recent_pairs.push_back((predicted, actual));
+    }
+}
+
 impl std::fmt::Debug for RoutingPredictor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RoutingPredictor")
@@ -367,6 +403,8 @@ impl RoutingPredictor {
             lru_generation: 0,
             next_peer_id: 0,
             accuracy: PredictionAccuracy::new(),
+            response_time_accuracy: RegressionAccuracy::new(),
+            transfer_speed_accuracy: RegressionAccuracy::new(),
             batch_mode: false,
             reference_time_hours: wall_clock_hours(),
         }
@@ -404,13 +442,27 @@ impl RoutingPredictor {
     ) {
         let actual_failure = if outcome.success { 0.0 } else { 1.0 };
 
-        // Track prediction accuracy (skip in batch mode — no trained model yet)
+        // Track prediction accuracy (skip in batch mode — no trained model yet).
+        // Each stage is scored against the *current* model, i.e. before this
+        // event's own observation is added below, so a prediction is never graded
+        // against data that already contains its answer.
         if !self.batch_mode {
-            if let Some(predicted_failure) = self
-                .failure_stage
-                .predict(&self.make_observation_immutable(peer, contract_location, distance, time))
-            {
+            let query = self.make_observation_immutable(peer, contract_location, distance, time);
+            if let Some(predicted_failure) = self.failure_stage.predict(&query) {
                 self.accuracy.record(predicted_failure, actual_failure);
+            }
+            // Regression stages only have a ground-truth actual on timed successes.
+            if outcome.success {
+                if let Some(actual_rt) = outcome.time_to_response_start_secs {
+                    if let Some(predicted_rt) = self.response_time_stage.predict(&query) {
+                        self.response_time_accuracy.record(predicted_rt, actual_rt);
+                    }
+                }
+                if let Some(actual_ts) = outcome.transfer_speed_bps {
+                    if let Some(predicted_ts) = self.transfer_speed_stage.predict(&query) {
+                        self.transfer_speed_accuracy.record(predicted_ts, actual_ts);
+                    }
+                }
             }
         }
 
@@ -523,6 +575,24 @@ impl RoutingPredictor {
 
     pub fn recent_accuracy_pairs(&self) -> &VecDeque<(f64, f64)> {
         &self.accuracy.recent_pairs
+    }
+
+    /// Recent (predicted_secs, actual_secs) pairs for the response-time stage.
+    pub fn response_time_accuracy_pairs(&self) -> &VecDeque<(f64, f64)> {
+        &self.response_time_accuracy.recent_pairs
+    }
+
+    /// Recent (predicted_bps, actual_bps) pairs for the transfer-speed stage.
+    pub fn transfer_speed_accuracy_pairs(&self) -> &VecDeque<(f64, f64)> {
+        &self.transfer_speed_accuracy.recent_pairs
+    }
+
+    pub fn response_time_predictions_evaluated(&self) -> u64 {
+        self.response_time_accuracy.total
+    }
+
+    pub fn transfer_speed_predictions_evaluated(&self) -> u64 {
+        self.transfer_speed_accuracy.total
     }
 
     pub fn stage_sizes(&self) -> (usize, usize, usize) {
@@ -954,5 +1024,68 @@ mod tests {
             "Should have evaluated some predictions",
         );
         assert!(predictor.brier_score().is_some());
+    }
+
+    #[test]
+    fn regression_accuracy_tracked_for_timing_stages() {
+        let mut predictor = RoutingPredictor::new(10000);
+        let peer = make_peer();
+        let contract = Location::try_from(0.5).unwrap();
+
+        // Warm up the timing stages past MIN_OBSERVATIONS_FOR_PREDICTION so the
+        // next timed successes produce a prediction that gets scored.
+        for i in 0..50 {
+            predictor.record_at_time(
+                &peer,
+                contract,
+                0.1,
+                success_timed(0.1, 1000.0),
+                i as f64 * 0.01,
+            );
+        }
+        for i in 50..60 {
+            predictor.record_at_time(
+                &peer,
+                contract,
+                0.1,
+                success_timed(0.1, 1000.0),
+                i as f64 * 0.01,
+            );
+        }
+
+        assert!(
+            predictor.response_time_predictions_evaluated() > 0,
+            "response-time predictions should be scored once the stage is trained",
+        );
+        assert!(
+            predictor.transfer_speed_predictions_evaluated() > 0,
+            "transfer-speed predictions should be scored once the stage is trained",
+        );
+        assert!(
+            !predictor.response_time_accuracy_pairs().is_empty(),
+            "response-time accuracy pairs should be recorded for the scatter plot",
+        );
+        assert!(
+            !predictor.transfer_speed_accuracy_pairs().is_empty(),
+            "transfer-speed accuracy pairs should be recorded for the scatter plot",
+        );
+    }
+
+    #[test]
+    fn regression_accuracy_not_tracked_for_failures() {
+        let mut predictor = RoutingPredictor::new(10000);
+        let peer = make_peer();
+        let contract = Location::try_from(0.5).unwrap();
+
+        // Failures carry no timing ground truth, so the regression stages must
+        // never accumulate accuracy samples from them.
+        for i in 0..60 {
+            predictor.record_at_time(&peer, contract, 0.1, failure(), i as f64 * 0.01);
+        }
+
+        assert_eq!(predictor.response_time_predictions_evaluated(), 0);
+        assert_eq!(predictor.transfer_speed_predictions_evaluated(), 0);
+        assert!(predictor.response_time_accuracy_pairs().is_empty());
+        assert!(predictor.transfer_speed_accuracy_pairs().is_empty());
     }
 }

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2961,6 +2961,7 @@ fn peer_detail_html(address_str: &str) -> String {
                     <div class="info-label">This peer: transfer rate</div><div class="info-value">{pt} events</div>
                 </div>
                 <h3 style="margin-top: 1em;">Renegade ML Predictor</h3>
+                <p class="empty" style="font-size: 0.8em; margin-top: 0.25em;">Renegade is a k-nearest-neighbours predictor tuned for accurate estimates from small amounts of data, so routing improves after a handful of observations rather than thousands.</p>
                 <div class="info-grid">
                     <div class="info-label">Failure observations</div><div class="info-value">{rf}</div>
                     <div class="info-label">Response time observations</div><div class="info-value">{rr}</div>
@@ -3132,6 +3133,11 @@ fn peer_detail_html(address_str: &str) -> String {
         format!(
             r#"<div class="card">
                 <h2>Routing Predictions</h2>
+                <p style="font-size:0.8em;color:var(--text-muted);">
+                    What the model predicts for each outcome versus ring distance to the contract:
+                    the curves the router consults when choosing a next hop. The Prediction Accuracy
+                    panel below scores these predictions against what actually happened.
+                </p>
                 <p class="chart-legend">
                     <span class="chart-key"><span class="chart-dot chart-dot-global"></span> Global model</span>
                     <span class="chart-key"><span class="chart-dot chart-dot-peer"></span> Peer-adjusted</span>
@@ -3521,12 +3527,13 @@ fn build_estimator_chart(
         }
     };
 
-    // Global curve (blue)
+    // Global curve (teal, the brand accent)
     draw_curve(&mut svg, curve_points, 0.0, "var(--accent-primary)");
 
-    // Peer-adjusted curve (green)
+    // Peer-adjusted curve (violet — deliberately off the teal/green family so it
+    // is not confused with the teal global curve)
     if let Some(adj) = peer_adjustment {
-        draw_curve(&mut svg, curve_points, adj, "#34d399");
+        draw_curve(&mut svg, curve_points, adj, "#8b5cf6");
     }
 
     // Peer location marker (vertical dashed line)
@@ -3609,8 +3616,9 @@ fn build_renegade_accuracy_panel(
         r#"<div class="card">
         <h2>Prediction Accuracy</h2>
         <p style="font-size:0.8em;color:var(--text-muted);">
-            How well each routing model's recent predictions matched reality. Points on the
-            dashed diagonal are perfect: for failure, predicted probability equals the observed
+            How well each routing model's recent predictions matched reality (the Routing
+            Predictions panel above shows the predictions themselves). Points on the dashed
+            diagonal are perfect: for failure, predicted probability equals the observed
             failure rate (calibration); for the timing models, predicted equals actual.
         </p>
         <div style="display:flex;flex-wrap:wrap;gap:1rem;justify-content:flex-start;">
@@ -4055,7 +4063,7 @@ a.header-title {
     display: inline-block;
 }
 .chart-dot-global { background: var(--accent-primary); }
-.chart-dot-peer { background: #34d399; }
+.chart-dot-peer { background: #8b5cf6; }
 .chart-dot-loc { background: #fbbf24; }
 .chart-dot-ext {
     background: transparent;

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3147,8 +3147,11 @@ fn peer_detail_html(address_str: &str) -> String {
                     xfer_range,
                     if tab_name == "All" { xfer_adj } else { None },
                     ploc,
-                    "auto",
+                    // Transfer rate is a positive B/s value: floor at 0, auto-scale
+                    // the top. (Was "auto"/"0", which clamped the max to 0 and gave a
+                    // degenerate inverted range that also hid the scatter overlay.)
                     "0",
+                    "auto",
                     "No payload transfers have been observed from this peer yet.",
                 ));
             }
@@ -3939,11 +3942,20 @@ fn build_regression_chart(label: &str, kind: RegKind, pairs: &[(f64, f64)]) -> S
     )
     .ok();
 
-    // Power-of-ten gridlines + axis labels.
+    // Power-of-ten gridlines + axis labels. When all points fall within a single
+    // decade (the common steady-state case) there is no power-of-ten boundary in
+    // range, so fall back to labelling the axis endpoints rather than rendering an
+    // unlabelled axis.
     let first_decade = log_lo.ceil() as i32;
     let last_decade = log_hi.floor() as i32;
-    for d in first_decade..=last_decade {
-        let val = 10f64.powi(d);
+    let tick_vals: Vec<f64> = if first_decade <= last_decade {
+        (first_decade..=last_decade)
+            .map(|d| 10f64.powi(d))
+            .collect()
+    } else {
+        vec![10f64.powf(log_lo), 10f64.powf(log_hi)]
+    };
+    for val in tick_vals {
         let gx = to_x(val);
         let gy = to_y(val);
         write!(
@@ -4924,6 +4936,42 @@ mod tests {
     }
 
     #[test]
+    fn regression_chart_all_equal_points_render_finite() {
+        // Every point identical -> degenerate log range. Must pad the range and
+        // produce finite coordinates (no NaN) rather than dividing by a zero span.
+        let pairs = vec![(1000.0, 1000.0), (1000.0, 1000.0), (1000.0, 1000.0)];
+        let svg = build_regression_chart("Transfer speed", RegKind::Speed, &pairs);
+        assert!(svg.contains("<svg"));
+        assert!(
+            svg.contains("<circle"),
+            "should plot the overlapping points"
+        );
+        assert!(!svg.contains("NaN"), "no NaN coordinates, got: {svg}");
+        // Single-decade fallback must still produce axis labels.
+        assert!(svg.contains("B/s"), "endpoint axis labels should render");
+    }
+
+    #[test]
+    fn regression_chart_single_decade_labels_endpoints() {
+        // All points within one decade (no power-of-ten boundary lands in the
+        // padded range): the chart must fall back to labelling the axis endpoints
+        // rather than rendering an unlabelled axis.
+        let pairs: Vec<(f64, f64)> = (0..12)
+            .map(|i| {
+                let a = 0.16 + (i as f64) * 0.04; // 0.16..0.60 s, within one decade
+                (a, a)
+            })
+            .collect();
+        let svg = build_regression_chart("Response time", RegKind::Time, &pairs);
+        assert!(svg.contains("<svg"));
+        assert!(!svg.contains("NaN"), "no NaN coords, got: {svg}");
+        assert!(
+            svg.contains("ms"),
+            "endpoint axis labels should render in the single-decade case, got: {svg}"
+        );
+    }
+
+    #[test]
     fn accuracy_panel_empty_when_no_data() {
         assert_eq!(
             build_renegade_accuracy_panel(&[], None, &[], &[]),
@@ -5023,7 +5071,7 @@ mod tests {
         );
     }
 
-    /// Regression: the per-tab "Routing Predictions" panel must call
+    /// Regression: the per-tab "Outcomes vs Distance" panel must call
     /// `build_estimator_chart_or_placeholder` for all three
     /// prediction-component slots (Failure Probability, Response Time,
     /// Transfer Rate). Hiding empty slots previously masked the

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3150,13 +3150,14 @@ fn peer_detail_html(address_str: &str) -> String {
         String::new()
     };
 
-    // Build renegade accuracy chart
+    // Build the renegade prediction-accuracy panel (failure + timing models)
     let renegade_chart = if let Some(ref rs) = router_snapshot {
-        if rs.renegade_accuracy_pairs.is_empty() {
-            String::new()
-        } else {
-            build_renegade_accuracy_chart(&rs.renegade_accuracy_pairs)
-        }
+        build_renegade_accuracy_panel(
+            &rs.renegade_accuracy_pairs,
+            rs.renegade_brier_score,
+            &rs.renegade_response_time_pairs,
+            &rs.renegade_transfer_speed_pairs,
+        )
     } else {
         String::new()
     };
@@ -3576,73 +3577,116 @@ fn fmt_prediction_prob(v: f64) -> String {
     }
 }
 
-/// Build an SVG strip chart showing predicted failure probability vs actual outcome.
-/// X-axis: predicted probability [0, 1].
-/// Y-axis: actual outcome (0 = success at bottom, 1 = failure at top).
-/// Good calibration: successes cluster left, failures cluster right.
-fn build_renegade_accuracy_chart(pairs: &[(f64, f64)]) -> String {
+/// Which kind of regression model a scatter chart is rendering, controlling the
+/// axis unit formatting (durations vs throughput).
+#[derive(Clone, Copy)]
+enum RegKind {
+    Time,
+    Speed,
+}
+
+/// Build the renegade prediction-accuracy panel: one reliability diagram for the
+/// binary failure model plus predicted-vs-actual scatters for the two regression
+/// models (response time, transfer speed). Returns an empty string when no model
+/// has scored any predictions yet, so a fresh node shows nothing rather than an
+/// empty card.
+fn build_renegade_accuracy_panel(
+    failure_pairs: &[(f64, f64)],
+    brier: Option<f64>,
+    response_time_pairs: &[(f64, f64)],
+    transfer_speed_pairs: &[(f64, f64)],
+) -> String {
+    if failure_pairs.is_empty() && response_time_pairs.is_empty() && transfer_speed_pairs.is_empty()
+    {
+        return String::new();
+    }
+
+    let failure = build_reliability_chart(failure_pairs, brier);
+    let response = build_regression_chart("Response time", RegKind::Time, response_time_pairs);
+    let transfer = build_regression_chart("Transfer speed", RegKind::Speed, transfer_speed_pairs);
+
+    format!(
+        r#"<div class="card">
+        <h2>Prediction Accuracy</h2>
+        <p style="font-size:0.8em;color:var(--text-muted);">
+            How well each routing model's recent predictions matched reality. Points on the
+            dashed diagonal are perfect: for failure, predicted probability equals the observed
+            failure rate (calibration); for the timing models, predicted equals actual.
+        </p>
+        <div style="display:flex;flex-wrap:wrap;gap:1rem;justify-content:flex-start;">
+            {failure}
+            {response}
+            {transfer}
+        </div>
+    </div>"#,
+        failure = failure,
+        response = response,
+        transfer = transfer,
+    )
+}
+
+/// Reliability (calibration) diagram for the binary failure model.
+/// X = predicted failure probability, Y = observed failure rate within each
+/// predicted-probability bin. Dots on the diagonal mean the model is calibrated;
+/// above the line it under-predicts failure, below it over-predicts.
+fn build_reliability_chart(pairs: &[(f64, f64)], brier: Option<f64>) -> String {
     use std::fmt::Write;
 
-    // Filter out NaN/non-finite values before processing
-    let valid_pairs: Vec<(f64, f64)> = pairs
+    let valid: Vec<(f64, f64)> = pairs
         .iter()
         .copied()
         .filter(|(p, a)| p.is_finite() && a.is_finite())
-        .collect();
-    let total_count = valid_pairs.len();
-
-    let successes: Vec<f64> = valid_pairs
-        .iter()
-        .filter(|(_, a)| *a < 0.5)
-        .map(|(p, _)| p.clamp(0.0, 1.0))
-        .collect();
-    let failures: Vec<f64> = valid_pairs
-        .iter()
-        .filter(|(_, a)| *a >= 0.5)
-        .map(|(p, _)| p.clamp(0.0, 1.0))
+        .map(|(p, a)| (p.clamp(0.0, 1.0), a))
         .collect();
 
-    let w = 400.0_f64;
-    let h = 200.0_f64;
-    let pad_l = 50.0;
-    let pad_r = 20.0;
-    let pad_t = 30.0;
-    let pad_b = 30.0;
+    if valid.is_empty() {
+        return mini_chart_placeholder("Failure (calibration)", "predicted prob vs observed rate");
+    }
+
+    let n = valid.len();
+    let n_bins = 10usize;
+    let mut bin_pred_sum = vec![0.0f64; n_bins];
+    let mut bin_fail = vec![0usize; n_bins];
+    let mut bin_total = vec![0usize; n_bins];
+    for (p, a) in &valid {
+        let bin = ((p * n_bins as f64) as usize).min(n_bins - 1);
+        bin_pred_sum[bin] += p;
+        bin_total[bin] += 1;
+        if *a >= 0.5 {
+            bin_fail[bin] += 1;
+        }
+    }
+
+    let (w, h) = (260.0f64, 220.0f64);
+    let (pad_l, pad_r, pad_t, pad_b) = (38.0f64, 12.0f64, 30.0f64, 30.0f64);
     let plot_w = w - pad_l - pad_r;
     let plot_h = h - pad_t - pad_b;
-    let mid_y = pad_t + plot_h / 2.0; // dividing line between failure (top) and success (bottom)
-    let half_h = plot_h / 2.0;
-
-    // Use dots for very small datasets, bars for larger ones
-    let use_dots = total_count < 15;
-
-    // Adaptive bin count: fewer bins when less data
-    let n_bins = if total_count < 30 {
-        5
-    } else if total_count < 100 {
-        8
-    } else {
-        10
-    };
-    let bin_width = 1.0 / n_bins as f64;
-
-    let to_x = |v: f64| -> f64 { pad_l + v.clamp(0.0, 1.0) * plot_w };
+    let to_x = |v: f64| pad_l + v.clamp(0.0, 1.0) * plot_w;
+    let to_y = |v: f64| pad_t + (1.0 - v.clamp(0.0, 1.0)) * plot_h;
 
     let mut svg = format!(
-        r#"<div class="card">
-        <h2>Renegade Prediction Accuracy</h2>
-        <p style="font-size:0.8em;color:var(--text-muted);">
-            Distribution of predicted failure probability, split by outcome.
-            <span style="color:var(--accent-danger, #f85149);">Failures</span> above,
-            <span style="color:var(--accent-success, #3fb950);">successes</span> below.
-            Well-calibrated: failures skew right, successes skew left.
-        </p>
-        <svg viewBox="0 0 {w} {h}" width="{w}" height="{h}" class="chart-svg">"#,
+        r#"<svg viewBox="0 0 {w} {h}" width="{w}" height="{h}" class="accuracy-chart">"#,
         w = w as u32,
         h = h as u32,
     );
 
-    // Background
+    write!(
+        svg,
+        r#"<text x="{x}" y="14" font-size="10" font-weight="600" fill="var(--text-secondary)">Failure (calibration)</text>"#,
+        x = pad_l,
+    )
+    .ok();
+    let headline = match brier {
+        Some(b) if b.is_finite() => format!("Brier {b:.3} · n={n}"),
+        _ => format!("n={n}"),
+    };
+    write!(
+        svg,
+        r#"<text x="{x}" y="26" font-size="9" fill="var(--text-muted)">{headline}</text>"#,
+        x = pad_l,
+    )
+    .ok();
+
     write!(
         svg,
         r#"<rect x="{lx}" y="{ty}" width="{pw}" height="{ph}" fill="var(--bg-secondary)" rx="2"/>"#,
@@ -3653,233 +3697,274 @@ fn build_renegade_accuracy_chart(pairs: &[(f64, f64)]) -> String {
     )
     .ok();
 
-    // Center dividing line
+    // perfect-calibration diagonal
     write!(
         svg,
-        r#"<line x1="{lx}" y1="{my}" x2="{rx}" y2="{my}" stroke="var(--text-muted)" stroke-width="1"/>"#,
-        lx = pad_l,
-        my = mid_y,
-        rx = pad_l + plot_w,
+        r#"<line x1="{x1:.1}" y1="{y1:.1}" x2="{x2:.1}" y2="{y2:.1}" stroke="var(--text-muted)" stroke-width="1" stroke-dasharray="4"/>"#,
+        x1 = to_x(0.0),
+        y1 = to_y(0.0),
+        x2 = to_x(1.0),
+        y2 = to_y(1.0),
     )
     .ok();
 
-    // X-axis labels and grid
-    for &v in &[0.0, 0.25, 0.5, 0.75, 1.0] {
-        let x = to_x(v);
+    // axis ticks at 0 / 0.5 / 1 on both axes
+    for &v in &[0.0_f64, 0.5, 1.0] {
         write!(
             svg,
-            r#"<text x="{x}" y="{y}" text-anchor="middle" font-size="9" fill="var(--text-muted)">{v}</text>"#,
-            x = x,
-            y = pad_t + plot_h + 15.0,
-            v = v,
+            r#"<text x="{x:.1}" y="{y:.1}" text-anchor="middle" font-size="8" fill="var(--text-muted)">{v}</text>"#,
+            x = to_x(v),
+            y = pad_t + plot_h + 12.0,
         )
         .ok();
         write!(
             svg,
-            r#"<line x1="{x}" y1="{ty}" x2="{x}" y2="{by}" stroke="var(--text-muted)" stroke-width="0.3" stroke-dasharray="3"/>"#,
-            x = x,
+            r#"<text x="{x:.1}" y="{y:.1}" text-anchor="end" font-size="8" fill="var(--text-muted)">{v}</text>"#,
+            x = pad_l - 4.0,
+            y = to_y(v) + 3.0,
+        )
+        .ok();
+    }
+
+    // calibration curve through non-empty bins (in predicted-probability order)
+    let mut pts: Vec<(f64, f64, usize)> = Vec::new();
+    for b in 0..n_bins {
+        if bin_total[b] == 0 {
+            continue;
+        }
+        let mean_pred = bin_pred_sum[b] / bin_total[b] as f64;
+        let obs_rate = bin_fail[b] as f64 / bin_total[b] as f64;
+        pts.push((mean_pred, obs_rate, bin_total[b]));
+    }
+    if pts.len() >= 2 {
+        let path = pts
+            .iter()
+            .map(|(px, py, _)| format!("{:.1},{:.1}", to_x(*px), to_y(*py)))
+            .collect::<Vec<_>>()
+            .join(" ");
+        write!(
+            svg,
+            r#"<polyline points="{path}" fill="none" stroke="var(--accent-primary, #58a6ff)" stroke-width="1.5" opacity="0.8"/>"#,
+        )
+        .ok();
+    }
+    let max_bin = bin_total.iter().copied().max().unwrap_or(1).max(1);
+    for (px, py, count) in &pts {
+        let r = 2.5 + 3.5 * (*count as f64 / max_bin as f64).sqrt();
+        write!(
+            svg,
+            r#"<circle cx="{cx:.1}" cy="{cy:.1}" r="{r:.1}" fill="var(--accent-primary, #58a6ff)" opacity="0.85"/>"#,
+            cx = to_x(*px),
+            cy = to_y(*py),
+        )
+        .ok();
+    }
+
+    write!(
+        svg,
+        r#"<text x="{x:.1}" y="{y:.1}" text-anchor="middle" font-size="8" fill="var(--text-muted)">predicted fail prob</text>"#,
+        x = pad_l + plot_w / 2.0,
+        y = h - 1.0,
+    )
+    .ok();
+
+    svg.push_str("</svg>");
+    svg
+}
+
+/// Predicted-vs-actual scatter for a regression model (response time, transfer
+/// speed) on log-log axes, since both targets span orders of magnitude. Points
+/// on the dashed diagonal mean predicted == actual; the headline is the median
+/// absolute percentage error over the retained window.
+fn build_regression_chart(label: &str, kind: RegKind, pairs: &[(f64, f64)]) -> String {
+    use std::fmt::Write;
+
+    // Log axes require strictly-positive, finite values.
+    let valid: Vec<(f64, f64)> = pairs
+        .iter()
+        .copied()
+        .filter(|(p, a)| p.is_finite() && a.is_finite() && *p > 0.0 && *a > 0.0)
+        .collect();
+
+    if valid.len() < 2 {
+        return mini_chart_placeholder(label, "predicted vs actual");
+    }
+
+    let n = valid.len();
+
+    // Median absolute percentage error (robust to the heavy tails of latency /
+    // throughput) as the single headline number.
+    let mut apes: Vec<f64> = valid.iter().map(|(p, a)| ((p - a) / a).abs()).collect();
+    apes.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = apes.len() / 2;
+    let mdape = if apes.len() % 2 == 0 {
+        (apes[mid - 1] + apes[mid]) / 2.0
+    } else {
+        apes[mid]
+    };
+
+    // Shared log range across predicted and actual so the diagonal is 45°.
+    let mut lo = f64::INFINITY;
+    let mut hi = f64::NEG_INFINITY;
+    for (p, a) in &valid {
+        lo = lo.min(p.min(*a));
+        hi = hi.max(p.max(*a));
+    }
+    let mut log_lo = lo.log10();
+    let mut log_hi = hi.log10();
+    if (log_hi - log_lo) < 0.5 {
+        // Pad a near-flat range so points don't all sit on one edge.
+        let center = (log_hi + log_lo) / 2.0;
+        log_lo = center - 0.5;
+        log_hi = center + 0.5;
+    } else {
+        let pad = (log_hi - log_lo) * 0.08;
+        log_lo -= pad;
+        log_hi += pad;
+    }
+    let span = (log_hi - log_lo).max(1e-9);
+
+    let (w, h) = (260.0f64, 220.0f64);
+    let (pad_l, pad_r, pad_t, pad_b) = (38.0f64, 12.0f64, 30.0f64, 30.0f64);
+    let plot_w = w - pad_l - pad_r;
+    let plot_h = h - pad_t - pad_b;
+    let to_x = |v: f64| pad_l + ((v.log10() - log_lo) / span) * plot_w;
+    let to_y = |v: f64| pad_t + (1.0 - (v.log10() - log_lo) / span) * plot_h;
+
+    let mut svg = format!(
+        r#"<svg viewBox="0 0 {w} {h}" width="{w}" height="{h}" class="accuracy-chart">"#,
+        w = w as u32,
+        h = h as u32,
+    );
+    write!(
+        svg,
+        r#"<text x="{x}" y="14" font-size="10" font-weight="600" fill="var(--text-secondary)">{label}</text>"#,
+        x = pad_l,
+    )
+    .ok();
+    write!(
+        svg,
+        r#"<text x="{x}" y="26" font-size="9" fill="var(--text-muted)">median err {pct:.0}% · n={n}</text>"#,
+        x = pad_l,
+        pct = mdape * 100.0,
+    )
+    .ok();
+
+    write!(
+        svg,
+        r#"<rect x="{lx}" y="{ty}" width="{pw}" height="{ph}" fill="var(--bg-secondary)" rx="2"/>"#,
+        lx = pad_l,
+        ty = pad_t,
+        pw = plot_w,
+        ph = plot_h,
+    )
+    .ok();
+
+    // Power-of-ten gridlines + axis labels.
+    let first_decade = log_lo.ceil() as i32;
+    let last_decade = log_hi.floor() as i32;
+    for d in first_decade..=last_decade {
+        let val = 10f64.powi(d);
+        let gx = to_x(val);
+        let gy = to_y(val);
+        write!(
+            svg,
+            r#"<line x1="{gx:.1}" y1="{ty:.1}" x2="{gx:.1}" y2="{by:.1}" stroke="var(--text-muted)" stroke-width="0.3" stroke-dasharray="3"/>"#,
             ty = pad_t,
             by = pad_t + plot_h,
         )
         .ok();
+        write!(
+            svg,
+            r#"<text x="{gx:.1}" y="{y:.1}" text-anchor="middle" font-size="8" fill="var(--text-muted)">{lbl}</text>"#,
+            y = pad_t + plot_h + 12.0,
+            lbl = fmt_reg_axis(kind, val),
+        )
+        .ok();
+        write!(
+            svg,
+            r#"<text x="{x:.1}" y="{gy:.1}" text-anchor="end" font-size="8" fill="var(--text-muted)">{lbl}</text>"#,
+            x = pad_l - 4.0,
+            lbl = fmt_reg_axis(kind, val),
+        )
+        .ok();
     }
 
-    // Y-axis labels
+    // Perfect diagonal (predicted == actual).
     write!(
         svg,
-        r#"<text x="{x}" y="{y}" text-anchor="end" font-size="9" fill="var(--accent-danger, #f85149)">Fail</text>"#,
-        x = pad_l - 4.0,
-        y = pad_t + 14.0,
-    )
-    .ok();
-    write!(
-        svg,
-        r#"<text x="{x}" y="{y}" text-anchor="end" font-size="9" fill="var(--accent-success, #3fb950)">OK</text>"#,
-        x = pad_l - 4.0,
-        y = pad_t + plot_h - 6.0,
+        r#"<line x1="{x1:.1}" y1="{y1:.1}" x2="{x2:.1}" y2="{y2:.1}" stroke="var(--text-muted)" stroke-width="1" stroke-dasharray="4"/>"#,
+        x1 = to_x(10f64.powf(log_lo)),
+        y1 = to_y(10f64.powf(log_lo)),
+        x2 = to_x(10f64.powf(log_hi)),
+        y2 = to_y(10f64.powf(log_hi)),
     )
     .ok();
 
-    // X-axis title
+    for (p, a) in &valid {
+        write!(
+            svg,
+            r#"<circle cx="{cx:.1}" cy="{cy:.1}" r="2.2" fill="var(--accent-primary, #58a6ff)" opacity="0.45"/>"#,
+            cx = to_x(*p),
+            cy = to_y(*a),
+        )
+        .ok();
+    }
+
     write!(
         svg,
-        r#"<text x="{x}" y="{y}" text-anchor="middle" font-size="9" fill="var(--text-muted)">Predicted failure probability</text>"#,
+        r#"<text x="{x:.1}" y="{y:.1}" text-anchor="middle" font-size="8" fill="var(--text-muted)">predicted (x) vs actual (y)</text>"#,
         x = pad_l + plot_w / 2.0,
-        y = h - 2.0,
+        y = h - 1.0,
     )
     .ok();
 
-    if use_dots {
-        // Dot strip mode: stack dots vertically from the center line outward
-        let dot_r = 3.5;
-        let dot_spacing = dot_r * 2.2;
+    svg.push_str("</svg>");
+    svg
+}
 
-        // Bin dots to stack them
-        let mut fail_bins: Vec<Vec<f64>> = vec![Vec::new(); n_bins];
-        let mut ok_bins: Vec<Vec<f64>> = vec![Vec::new(); n_bins];
-
-        for &p in &failures {
-            let bin = ((p / bin_width) as usize).min(n_bins - 1);
-            fail_bins[bin].push(p);
-        }
-        for &p in &successes {
-            let bin = ((p / bin_width) as usize).min(n_bins - 1);
-            ok_bins[bin].push(p);
-        }
-
-        // Draw failure dots (grow upward from center), with overflow indicator
-        for (bin_idx, dots) in fail_bins.iter().enumerate() {
-            let cx = pad_l + (bin_idx as f64 + 0.5) * bin_width * plot_w;
-            let mut drawn = 0;
-            for (i, _) in dots.iter().enumerate() {
-                let cy = mid_y - dot_spacing * (i as f64 + 0.5);
-                if cy < pad_t + dot_r {
-                    break;
-                }
-                drawn += 1;
-                write!(
-                    svg,
-                    r#"<circle cx="{cx:.1}" cy="{cy:.1}" r="{r}" fill="var(--accent-danger, #f85149)" opacity="0.7"/>"#,
-                    cx = cx,
-                    cy = cy,
-                    r = dot_r,
-                )
-                .ok();
-            }
-            if drawn < dots.len() {
-                write!(
-                    svg,
-                    r#"<text x="{cx:.1}" y="{y:.1}" text-anchor="middle" font-size="8" fill="var(--accent-danger, #f85149)">+{n}</text>"#,
-                    cx = cx,
-                    y = pad_t - 1.0,
-                    n = dots.len() - drawn,
-                )
-                .ok();
+/// Compact axis label for a regression value: durations as s/ms/µs, throughput
+/// as B/KB/MB/GB per second.
+fn fmt_reg_axis(kind: RegKind, v: f64) -> String {
+    match kind {
+        RegKind::Time => {
+            if v >= 1.0 {
+                format!("{v:.0}s")
+            } else if v >= 0.001 {
+                format!("{:.0}ms", v * 1000.0)
+            } else {
+                format!("{:.0}µs", v * 1_000_000.0)
             }
         }
-
-        // Draw success dots (grow downward from center), with overflow indicator
-        for (bin_idx, dots) in ok_bins.iter().enumerate() {
-            let cx = pad_l + (bin_idx as f64 + 0.5) * bin_width * plot_w;
-            let mut drawn = 0;
-            for (i, _) in dots.iter().enumerate() {
-                let cy = mid_y + dot_spacing * (i as f64 + 0.5);
-                if cy > pad_t + plot_h - dot_r {
-                    break;
-                }
-                drawn += 1;
-                write!(
-                    svg,
-                    r#"<circle cx="{cx:.1}" cy="{cy:.1}" r="{r}" fill="var(--accent-success, #3fb950)" opacity="0.7"/>"#,
-                    cx = cx,
-                    cy = cy,
-                    r = dot_r,
-                )
-                .ok();
-            }
-            if drawn < dots.len() {
-                write!(
-                    svg,
-                    r#"<text x="{cx:.1}" y="{y:.1}" text-anchor="middle" font-size="8" fill="var(--accent-success, #3fb950)">+{n}</text>"#,
-                    cx = cx,
-                    y = pad_t + plot_h + 10.0,
-                    n = dots.len() - drawn,
-                )
-                .ok();
-            }
-        }
-    } else {
-        // Histogram bar mode
-        let mut fail_counts = vec![0usize; n_bins];
-        let mut ok_counts = vec![0usize; n_bins];
-
-        for &p in &failures {
-            let bin = ((p / bin_width) as usize).min(n_bins - 1);
-            fail_counts[bin] += 1;
-        }
-        for &p in &successes {
-            let bin = ((p / bin_width) as usize).min(n_bins - 1);
-            ok_counts[bin] += 1;
-        }
-
-        let max_count = fail_counts
-            .iter()
-            .chain(ok_counts.iter())
-            .copied()
-            .max()
-            .unwrap_or(1)
-            .max(1);
-
-        let bar_w = plot_w / n_bins as f64;
-        let bar_pad = bar_w * 0.1;
-
-        for i in 0..n_bins {
-            let x = pad_l + i as f64 * bar_w + bar_pad;
-            let bw = bar_w - 2.0 * bar_pad;
-
-            // Failure bars grow upward from center
-            if fail_counts[i] > 0 {
-                let bar_h = (fail_counts[i] as f64 / max_count as f64) * (half_h - 4.0);
-                let y = mid_y - bar_h;
-                write!(
-                    svg,
-                    r#"<rect x="{x:.1}" y="{y:.1}" width="{bw:.1}" height="{bh:.1}" fill="var(--accent-danger, #f85149)" opacity="0.7" rx="1"/>"#,
-                    x = x,
-                    y = y,
-                    bw = bw,
-                    bh = bar_h,
-                )
-                .ok();
-                // Count label on bar
-                write!(
-                    svg,
-                    r#"<text x="{tx:.1}" y="{ty:.1}" text-anchor="middle" font-size="8" fill="var(--text-muted)">{n}</text>"#,
-                    tx = x + bw / 2.0,
-                    ty = y - 2.0,
-                    n = fail_counts[i],
-                )
-                .ok();
-            }
-
-            // Success bars grow downward from center
-            if ok_counts[i] > 0 {
-                let bar_h = (ok_counts[i] as f64 / max_count as f64) * (half_h - 4.0);
-                write!(
-                    svg,
-                    r#"<rect x="{x:.1}" y="{my:.1}" width="{bw:.1}" height="{bh:.1}" fill="var(--accent-success, #3fb950)" opacity="0.7" rx="1"/>"#,
-                    x = x,
-                    my = mid_y,
-                    bw = bw,
-                    bh = bar_h,
-                )
-                .ok();
-                // Count label on bar
-                write!(
-                    svg,
-                    r#"<text x="{tx:.1}" y="{ty:.1}" text-anchor="middle" font-size="8" fill="var(--text-muted)">{n}</text>"#,
-                    tx = x + bw / 2.0,
-                    ty = mid_y + bar_h + 10.0,
-                    n = ok_counts[i],
-                )
-                .ok();
+        RegKind::Speed => {
+            if v >= 1e9 {
+                format!("{:.0}GB/s", v / 1e9)
+            } else if v >= 1e6 {
+                format!("{:.0}MB/s", v / 1e6)
+            } else if v >= 1e3 {
+                format!("{:.0}KB/s", v / 1e3)
+            } else {
+                format!("{v:.0}B/s")
             }
         }
     }
+}
 
-    // Stats summary
-    write!(
-        svg,
-        r#"<text x="{x}" y="{y}" text-anchor="start" font-size="9" fill="var(--text-muted)">{n} events ({s} ok, {f} fail)</text>"#,
-        x = pad_l + 2.0,
-        y = pad_t - 5.0,
-        n = total_count,
-        s = successes.len(),
-        f = failures.len(),
+/// A small placeholder chart shown while a model has too little data to plot.
+fn mini_chart_placeholder(label: &str, sub: &str) -> String {
+    let (w, h) = (260.0f64, 220.0f64);
+    format!(
+        r#"<svg viewBox="0 0 {w} {h}" width="{w}" height="{h}" class="accuracy-chart">
+        <text x="38" y="14" font-size="10" font-weight="600" fill="var(--text-secondary)">{label}</text>
+        <text x="{cx}" y="{cy}" text-anchor="middle" font-size="10" fill="var(--text-muted)">collecting data…</text>
+        <text x="{cx}" y="{cy2}" text-anchor="middle" font-size="8" fill="var(--text-muted)">{sub}</text>
+    </svg>"#,
+        w = w as u32,
+        h = h as u32,
+        cx = w / 2.0,
+        cy = h / 2.0,
+        cy2 = h / 2.0 + 14.0,
     )
-    .ok();
-
-    svg.push_str("</svg></div>");
-    svg
 }
 
 const PEER_CSS: &str = r##"
@@ -3936,6 +4021,15 @@ a.header-title {
     display: block;
     width: 100%;
     max-width: 600px;
+}
+/* Small-multiple accuracy charts: fixed width so the three sit side by side
+   in the flex row and wrap on narrow viewports (overridden global width:100%). */
+.accuracy-chart {
+    display: block;
+    width: 260px;
+    max-width: 100%;
+    height: auto;
+    flex: 0 0 auto;
 }
 .chart-svg .axis-label {
     font-family: var(--font-mono);
@@ -4656,63 +4750,118 @@ mod tests {
     }
 
     #[test]
-    fn renegade_chart_empty_input() {
-        let svg = build_renegade_accuracy_chart(&[]);
-        assert!(svg.contains("0 events (0 ok, 0 fail)"));
+    fn reliability_chart_empty_is_placeholder() {
+        let svg = build_reliability_chart(&[], None);
+        assert!(svg.contains("collecting data"));
         assert!(svg.contains("<svg"));
     }
 
     #[test]
-    fn renegade_chart_dot_mode_sparse_data() {
-        // < 15 points should use dot mode (circles, not rects for bars)
-        let pairs: Vec<(f64, f64)> = vec![
-            (0.1, 0.0), // success, low predicted
-            (0.9, 1.0), // failure, high predicted
-            (0.5, 0.0), // success, mid predicted
-        ];
-        let svg = build_renegade_accuracy_chart(&pairs);
-        assert!(svg.contains("<circle"), "dot mode should render circles");
-        assert!(svg.contains("3 events (2 ok, 1 fail)"));
-    }
-
-    #[test]
-    fn renegade_chart_bar_mode_dense_data() {
-        // >= 15 points should use histogram bars
+    fn reliability_chart_renders_points_and_brier() {
+        // Well-separated: low predicted -> success, high predicted -> failure.
         let pairs: Vec<(f64, f64)> = (0..20)
             .map(|i| (i as f64 / 20.0, if i > 10 { 1.0 } else { 0.0 }))
             .collect();
-        let svg = build_renegade_accuracy_chart(&pairs);
-        assert!(svg.contains("<rect"), "bar mode should render rects");
-        assert!(svg.contains("20 events"));
+        let svg = build_reliability_chart(&pairs, Some(0.042));
+        assert!(svg.contains("Failure (calibration)"));
+        assert!(svg.contains("Brier 0.042"));
+        assert!(svg.contains("n=20"));
+        assert!(svg.contains("<circle"), "bins should render as points");
     }
 
     #[test]
-    fn renegade_chart_filters_nan_values() {
+    fn reliability_chart_filters_nonfinite() {
         let pairs = vec![
-            (0.5, 0.0),           // valid success
-            (f64::NAN, 1.0),      // NaN predicted -- filtered
-            (0.3, f64::NAN),      // NaN actual -- filtered
-            (f64::INFINITY, 0.0), // infinite predicted -- filtered
-            (0.7, 1.0),           // valid failure
+            (0.5, 0.0),
+            (f64::NAN, 1.0),
+            (0.3, f64::NAN),
+            (f64::INFINITY, 0.0),
+            (0.7, 1.0),
         ];
-        let svg = build_renegade_accuracy_chart(&pairs);
-        // Only the 2 valid pairs should be counted
-        assert!(svg.contains("2 events (1 ok, 1 fail)"));
+        // Only 2 valid pairs survive the finite filter.
+        let svg = build_reliability_chart(&pairs, None);
+        assert!(svg.contains("n=2"));
     }
 
     #[test]
-    fn renegade_chart_all_successes() {
-        let pairs: Vec<(f64, f64)> = vec![(0.1, 0.0), (0.2, 0.0), (0.3, 0.0)];
-        let svg = build_renegade_accuracy_chart(&pairs);
-        assert!(svg.contains("3 events (3 ok, 0 fail)"));
+    fn reliability_chart_boundary_values_no_panic() {
+        // p == 1.0 and p == 0.0 must clamp into a bin without panicking.
+        let svg = build_reliability_chart(&[(1.0, 0.0), (0.0, 1.0)], Some(0.5));
+        assert!(svg.contains("<svg"));
+        assert!(svg.contains("n=2"));
     }
 
     #[test]
-    fn renegade_chart_boundary_predicted_value() {
-        // p=1.0 should not panic (bin clamping)
-        let pairs = vec![(1.0, 0.0), (0.0, 1.0)];
-        let svg = build_renegade_accuracy_chart(&pairs);
-        assert!(svg.contains("2 events"));
+    fn regression_chart_sparse_is_placeholder() {
+        // Fewer than 2 valid (positive, finite) points -> placeholder.
+        let svg = build_regression_chart("Response time", RegKind::Time, &[(0.5, 0.4)]);
+        assert!(svg.contains("collecting data"));
+        assert!(svg.contains("Response time"));
+    }
+
+    #[test]
+    fn regression_chart_time_renders_scatter_and_metric() {
+        // predicted ~= actual, sub-second range -> ms axis labels, low error.
+        let pairs: Vec<(f64, f64)> = (1..=20)
+            .map(|i| {
+                let actual = i as f64 * 0.01; // 10ms..200ms
+                (actual * 1.1, actual) // 10% over-prediction
+            })
+            .collect();
+        let svg = build_regression_chart("Response time", RegKind::Time, &pairs);
+        assert!(svg.contains("Response time"));
+        assert!(svg.contains("median err"));
+        assert!(svg.contains("<circle"));
+        assert!(
+            svg.contains("ms"),
+            "sub-second axis should be labelled in ms"
+        );
+    }
+
+    #[test]
+    fn regression_chart_speed_uses_byte_units() {
+        let pairs: Vec<(f64, f64)> = (1..=20)
+            .map(|i| {
+                let actual = i as f64 * 100_000.0; // up to ~2 MB/s
+                (actual, actual)
+            })
+            .collect();
+        let svg = build_regression_chart("Transfer speed", RegKind::Speed, &pairs);
+        assert!(svg.contains("Transfer speed"));
+        assert!(
+            svg.contains("KB/s") || svg.contains("MB/s"),
+            "throughput axis should use byte-rate units"
+        );
+    }
+
+    #[test]
+    fn regression_chart_filters_nonpositive() {
+        // Zero/negative/non-finite values can't be plotted on a log axis and are
+        // dropped, leaving too few points -> placeholder.
+        let pairs = vec![(0.0, 1.0), (-1.0, 2.0), (f64::NAN, 3.0), (5.0, 0.0)];
+        let svg = build_regression_chart("Response time", RegKind::Time, &pairs);
+        assert!(svg.contains("collecting data"));
+    }
+
+    #[test]
+    fn accuracy_panel_empty_when_no_data() {
+        assert_eq!(
+            build_renegade_accuracy_panel(&[], None, &[], &[]),
+            String::new()
+        );
+    }
+
+    #[test]
+    fn accuracy_panel_renders_all_three_models() {
+        let failure: Vec<(f64, f64)> = (0..20)
+            .map(|i| (i as f64 / 20.0, if i > 10 { 1.0 } else { 0.0 }))
+            .collect();
+        let svg = build_renegade_accuracy_panel(&failure, Some(0.05), &[], &[]);
+        assert!(svg.contains("Prediction Accuracy"));
+        assert!(svg.contains("Failure (calibration)"));
+        // Timing models have no data yet -> their placeholders still appear.
+        assert!(svg.contains("Response time"));
+        assert!(svg.contains("Transfer speed"));
     }
 
     #[test]

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3017,39 +3017,70 @@ fn peer_detail_html(address_str: &str) -> String {
         for (i, &tab_name) in tab_names.iter().enumerate() {
             let tab_id = tab_name.to_lowercase().replace(' ', "-");
 
-            // Get curves for this tab
-            let (f_curve, f_range, rt_curve, rt_range, xfer_curve, xfer_range, event_count) =
-                if tab_name == "All" {
-                    (
-                        rs.failure_curve.as_slice(),
-                        rs.failure_data_range,
-                        rs.response_time_curve.as_slice(),
-                        rs.response_time_data_range,
-                        rs.transfer_rate_curve.as_slice(),
-                        rs.transfer_rate_data_range,
-                        rs.failure_events,
-                    )
-                } else if let Some(c) = rs.per_op_curves.get(tab_name) {
-                    (
-                        c.failure_curve.as_slice(),
-                        c.failure_data_range,
-                        c.response_time_curve.as_slice(),
-                        c.response_time_data_range,
-                        c.transfer_rate_curve.as_slice(),
-                        c.transfer_rate_data_range,
-                        c.failure_events,
-                    )
-                } else {
-                    (
-                        &[][..],
-                        (0.0, 0.0),
-                        &[][..],
-                        (0.0, 0.0),
-                        &[][..],
-                        (0.0, 0.0),
-                        0,
-                    )
-                };
+            // Get curves + raw scatter points for this tab
+            #[allow(clippy::type_complexity)]
+            let (
+                f_curve,
+                f_range,
+                f_points,
+                rt_curve,
+                rt_range,
+                rt_points,
+                xfer_curve,
+                xfer_range,
+                xfer_points,
+                event_count,
+            ): (
+                &[(f64, f64)],
+                (f64, f64),
+                &[(f64, f64)],
+                &[(f64, f64)],
+                (f64, f64),
+                &[(f64, f64)],
+                &[(f64, f64)],
+                (f64, f64),
+                &[(f64, f64)],
+                usize,
+            ) = if tab_name == "All" {
+                (
+                    rs.failure_curve.as_slice(),
+                    rs.failure_data_range,
+                    rs.failure_points.as_slice(),
+                    rs.response_time_curve.as_slice(),
+                    rs.response_time_data_range,
+                    rs.response_time_points.as_slice(),
+                    rs.transfer_rate_curve.as_slice(),
+                    rs.transfer_rate_data_range,
+                    rs.transfer_rate_points.as_slice(),
+                    rs.failure_events,
+                )
+            } else if let Some(c) = rs.per_op_curves.get(tab_name) {
+                (
+                    c.failure_curve.as_slice(),
+                    c.failure_data_range,
+                    c.failure_points.as_slice(),
+                    c.response_time_curve.as_slice(),
+                    c.response_time_data_range,
+                    c.response_time_points.as_slice(),
+                    c.transfer_rate_curve.as_slice(),
+                    c.transfer_rate_data_range,
+                    c.transfer_rate_points.as_slice(),
+                    c.failure_events,
+                )
+            } else {
+                (
+                    &[][..],
+                    (0.0, 0.0),
+                    &[][..],
+                    &[][..],
+                    (0.0, 0.0),
+                    &[][..],
+                    &[][..],
+                    (0.0, 0.0),
+                    &[][..],
+                    0,
+                )
+            };
 
             // Tab label with event count badge
             let count_badge = if event_count > 0 {
@@ -3090,6 +3121,7 @@ fn peer_detail_html(address_str: &str) -> String {
                 panel_content.push_str(&build_estimator_chart_or_placeholder(
                     "Failure Probability",
                     f_curve,
+                    f_points,
                     f_range,
                     if tab_name == "All" { fail_adj } else { None },
                     ploc,
@@ -3100,6 +3132,7 @@ fn peer_detail_html(address_str: &str) -> String {
                 panel_content.push_str(&build_estimator_chart_or_placeholder(
                     "Response Time (s)",
                     rt_curve,
+                    rt_points,
                     rt_range,
                     if tab_name == "All" { rt_adj } else { None },
                     ploc,
@@ -3110,6 +3143,7 @@ fn peer_detail_html(address_str: &str) -> String {
                 panel_content.push_str(&build_estimator_chart_or_placeholder(
                     "Transfer Rate (B/s)",
                     xfer_curve,
+                    xfer_points,
                     xfer_range,
                     if tab_name == "All" { xfer_adj } else { None },
                     ploc,
@@ -3132,14 +3166,16 @@ fn peer_detail_html(address_str: &str) -> String {
 
         format!(
             r#"<div class="card">
-                <h2>Routing Predictions</h2>
+                <h2>Outcomes vs Distance</h2>
                 <p style="font-size:0.8em;color:var(--text-muted);">
-                    What the model predicts for each outcome versus ring distance to the contract:
-                    the curves the router consults when choosing a next hop. The Prediction Accuracy
-                    panel below scores these predictions against what actually happened.
+                    Actual observed outcomes (dots) plotted against ring distance to the contract,
+                    with the isotonic fit the router consults overlaid. How tightly the dots hug a
+                    monotonic curve shows how well distance actually predicts the outcome. The
+                    Prediction Accuracy panel below scores that fit against what happened.
                 </p>
                 <p class="chart-legend">
-                    <span class="chart-key"><span class="chart-dot chart-dot-global"></span> Global model</span>
+                    <span class="chart-key"><span class="chart-dot chart-dot-actual"></span> Actual outcomes</span>
+                    <span class="chart-key"><span class="chart-dot chart-dot-global"></span> Isotonic fit</span>
                     <span class="chart-key"><span class="chart-dot chart-dot-peer"></span> Peer-adjusted</span>
                     <span class="chart-key"><span class="chart-dot chart-dot-loc"></span> Peer location</span>
                     <span class="chart-key"><span class="chart-dot chart-dot-ext"></span> Extrapolated</span>
@@ -3255,6 +3291,7 @@ fn peer_detail_html(address_str: &str) -> String {
 fn build_estimator_chart_or_placeholder(
     title: &str,
     curve_points: &[(f64, f64)],
+    scatter_points: &[(f64, f64)],
     data_range: (f64, f64),
     peer_adjustment: Option<f64>,
     peer_location: Option<f64>,
@@ -3272,6 +3309,7 @@ fn build_estimator_chart_or_placeholder(
     build_estimator_chart(
         title,
         curve_points,
+        scatter_points,
         data_range,
         peer_adjustment,
         peer_location,
@@ -3284,9 +3322,11 @@ fn build_estimator_chart_or_placeholder(
 ///
 /// `data_range` is `(data_x_min, data_x_max)` -- the x-range of actual regression data.
 /// Points outside this range are extrapolated by the PAV crate and drawn as dashed lines.
+#[allow(clippy::too_many_arguments)]
 fn build_estimator_chart(
     title: &str,
     curve_points: &[(f64, f64)],
+    scatter_points: &[(f64, f64)],
     data_range: (f64, f64),
     peer_adjustment: Option<f64>,
     peer_location: Option<f64>,
@@ -3323,6 +3363,14 @@ fn build_estimator_chart(
         let y_vals: Vec<f64> = curve_points.iter().map(|(_, y)| *y).collect();
         y_min = y_vals.iter().cloned().fold(f64::INFINITY, f64::min);
         y_max = y_vals.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+
+        // Include the raw scatter so observed outliers aren't clipped.
+        for (_, y) in scatter_points {
+            if y.is_finite() {
+                y_min = y_min.min(*y);
+                y_max = y_max.max(*y);
+            }
+        }
 
         // Include peer-adjusted values in range if present
         if let Some(adj) = peer_adjustment {
@@ -3422,6 +3470,25 @@ fn build_estimator_chart(
             x = pad_l - 4.0,
             sy = sy,
             label = label,
+        )
+        .ok();
+    }
+
+    // Raw observed outcomes (drawn first, under the isotonic fit). Each dot is one
+    // actual event at its (distance, outcome); the spread shows how isotonic the
+    // relationship really is.
+    for &(x, y) in scatter_points {
+        if !(x.is_finite() && y.is_finite()) {
+            continue;
+        }
+        if !(x_min..=x_max).contains(&x) || !(y_min..=y_max).contains(&y) {
+            continue;
+        }
+        write!(
+            svg,
+            r#"<circle cx="{cx:.1}" cy="{cy:.1}" r="1.8" fill="var(--text-muted)" opacity="0.35"/>"#,
+            cx = to_svg_x(x),
+            cy = to_svg_y(y),
         )
         .ok();
     }
@@ -3616,9 +3683,9 @@ fn build_renegade_accuracy_panel(
         r#"<div class="card">
         <h2>Prediction Accuracy</h2>
         <p style="font-size:0.8em;color:var(--text-muted);">
-            How well each routing model's recent predictions matched reality (the Routing
-            Predictions panel above shows the predictions themselves). Points on the dashed
-            diagonal are perfect: for failure, predicted probability equals the observed
+            How well each routing model's recent predictions matched reality (the Outcomes
+            vs Distance panel above shows the observed outcomes and the fit). Points on the
+            dashed diagonal are perfect: for failure, predicted probability equals the observed
             failure rate (calibration); for the timing models, predicted equals actual.
         </p>
         <div style="display:flex;flex-wrap:wrap;gap:1rem;justify-content:flex-start;">
@@ -4062,6 +4129,7 @@ a.header-title {
     border-radius: 50%;
     display: inline-block;
 }
+.chart-dot-actual { background: var(--text-muted); opacity: 0.55; }
 .chart-dot-global { background: var(--accent-primary); }
 .chart-dot-peer { background: #8b5cf6; }
 .chart-dot-loc { background: #fbbf24; }
@@ -4905,6 +4973,7 @@ mod tests {
         let html = build_estimator_chart_or_placeholder(
             "Response Time (s)",
             &[],
+            &[],
             (0.0, 0.0),
             None,
             None,
@@ -4923,6 +4992,30 @@ mod tests {
         assert!(
             !html.contains("<svg"),
             "empty placeholder must not render an SVG, got: {html}"
+        );
+    }
+
+    #[test]
+    fn estimator_chart_overlays_raw_scatter() {
+        // A fit curve plus raw observations: the chart must draw the scatter dots
+        // (circles) behind the isotonic curve so the spread is visible.
+        let curve = vec![(0.0, 0.1), (0.25, 0.5), (0.5, 0.9)];
+        let scatter = vec![(0.05, 0.0), (0.1, 1.0), (0.3, 0.0), (0.4, 1.0)];
+        let html = build_estimator_chart_or_placeholder(
+            "Failure Probability",
+            &curve,
+            &scatter,
+            (0.0, 0.5),
+            None,
+            None,
+            "0.0",
+            "1.0",
+            "no data",
+        );
+        assert!(html.contains("<svg"), "should render an SVG, got: {html}");
+        assert!(
+            html.contains("<circle"),
+            "raw observations should render as scatter circles, got: {html}"
         );
     }
 
@@ -4982,6 +5075,7 @@ mod tests {
         let html = build_estimator_chart_or_placeholder(
             "Failure Probability",
             &curve,
+            &[],
             (0.0, 0.5),
             None,
             None,

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2961,7 +2961,7 @@ fn peer_detail_html(address_str: &str) -> String {
                     <div class="info-label">This peer: transfer rate</div><div class="info-value">{pt} events</div>
                 </div>
                 <h3 style="margin-top: 1em;">Renegade ML Predictor</h3>
-                <p class="empty" style="font-size: 0.8em; margin-top: 0.25em;">Renegade is a k-nearest-neighbours predictor tuned for accurate estimates from small amounts of data, so routing improves after a handful of observations rather than thousands.</p>
+                <p class="empty" style="font-size: 0.8em; margin-top: 0.25em;">Renegade is a zero-configuration k-nearest-neighbours model (it auto-selects K and learns which features matter). It predicts per-peer, per-contract outcomes from four features (peer, contract location, distance, time); the router blends its prediction with the distance-based estimate (a weighted average, Renegade's share growing with data up to half) to catch patterns distance alone misses, such as a peer that drops requests for specific contracts.</p>
                 <div class="info-grid">
                     <div class="info-label">Failure observations</div><div class="info-value">{rf}</div>
                     <div class="info-label">Response time observations</div><div class="info-value">{rr}</div>
@@ -3168,10 +3168,13 @@ fn peer_detail_html(address_str: &str) -> String {
             r#"<div class="card">
                 <h2>Outcomes vs Distance</h2>
                 <p style="font-size:0.8em;color:var(--text-muted);">
-                    Actual observed outcomes (dots) plotted against ring distance to the contract,
-                    with the isotonic fit the router consults overlaid. How tightly the dots hug a
-                    monotonic curve shows how well distance actually predicts the outcome. The
-                    Prediction Accuracy panel below scores that fit against what happened.
+                    Actual observed outcomes (dots) against ring distance to the contract, with the
+                    isotonic fit overlaid (the All tab is the aggregate the router uses; per-op tabs
+                    just break it down and are not consulted separately). "Peer-adjusted" adds this
+                    peer's running EWMA correction to that fit. How tightly the dots hug a monotonic
+                    curve shows how well distance alone predicts the outcome. A separate Renegade
+                    model is blended into the final estimate; its accuracy is in the Prediction
+                    Accuracy panel below.
                 </p>
                 <p class="chart-legend">
                     <span class="chart-key"><span class="chart-dot chart-dot-actual"></span> Actual outcomes</span>
@@ -3683,10 +3686,11 @@ fn build_renegade_accuracy_panel(
         r#"<div class="card">
         <h2>Prediction Accuracy</h2>
         <p style="font-size:0.8em;color:var(--text-muted);">
-            How well each routing model's recent predictions matched reality (the Outcomes
-            vs Distance panel above shows the observed outcomes and the fit). Points on the
-            dashed diagonal are perfect: for failure, predicted probability equals the observed
-            failure rate (calibration); for the timing models, predicted equals actual.
+            How well the Renegade predictor's recent predictions matched reality (this scores
+            the Renegade k-NN layer, not the distance-only fit in Outcomes vs Distance above).
+            On the dashed diagonal predictions are perfect: for failure, predicted probability
+            equals the observed failure rate (calibration); for the timing models, predicted
+            equals actual.
         </p>
         <div style="display:flex;flex-wrap:wrap;gap:1rem;justify-content:flex-start;">
             {failure}


### PR DESCRIPTION
## Problem

The peer dashboard's routing-predictor section was hard to read and incomplete:

- "Renegade Prediction Accuracy" was a mirrored back-to-back histogram of predicted failure probability: hard to compare, unlabelled relative-count y-axis, rare-failure side crushed by class imbalance, and captioned "calibration" when it showed discrimination.
- Only the **failure** model was covered; the response-time and transfer-speed Renegade stages had **no accuracy tracking**.
- The isotonic "Routing Predictions" curves were drawn with no raw observations behind them, so you couldn't see how isotonic the distance->outcome relationship actually is.
- "Routing Predictions" vs "Prediction Accuracy" were easy to confuse, and the global vs peer-adjusted curves shared a near-identical hue.

## Solution

Dashboard / telemetry only; routing algorithm untouched (follow-up on the blend itself: #4485).

- **Prediction Accuracy panel** for all three Renegade stages, each with the right metric: reliability/calibration diagram for failure (Brier headline), predicted-vs-actual log-log scatters for response time and transfer speed (median-abs-%-error headline). Adds `RegressionAccuracy` tracking for the two timing stages, scored on timed successes by predicting before the new observation is recorded (same discipline the failure stage already used).
- **Outcomes vs Distance** (renamed from "Routing Predictions"): overlays the raw observed-outcome scatter (downsampled via `IsotonicEstimator::sampled_raw_points`) under the isotonic fit, so monotonicity is visible. Snapshot carries the points with `#[serde(default)]` for backward-compatible deserialization.
- Recolour peer-adjusted curve to violet (was too close to the teal global curve); disambiguating captions; one-line Renegade description.
- All explanatory copy fact-checked against the routing code (e.g. Renegade is blended as a weighted average up to half, not a delta; the accuracy panel scores the Renegade k-NN layer, not the isotonic fit; the router routes from the aggregate isotonic fit, per-op tabs are breakdowns).

## Testing

- Renderer unit tests (reliability diagram, regression scatter incl. unit formatting and non-finite/non-positive filtering, the combined panel, scatter overlay).
- Estimator tests: `sampled_raw_points` downsampling/bounds; regression accuracy captured on timed successes and never on failures.
- `cargo test -p freenet --lib`, `cargo clippy -p freenet --lib -- -D warnings`, `cargo fmt` all clean.
- Validated live on a real peer (technic) with real routing data; panels render and populate as expected.

Closes #4486

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Bw7UBeJvqvH62Y6G98RjF
