### PR TITLE
fix(contract): gate auto-fetch + overlap-sync on legitimate interest

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1621,6 +1621,44 @@ where
                     );
                     continue;
                 }
+                // Skip the per-contract state fetch — a `GetQuery` that opens
+                // the `fetch_contract` span on the single-threaded
+                // contract-handling loop — for contracts we neither actively
+                // serve nor owe a deferred broadcast. A node carrying phantom
+                // interest (e.g. the #4404 placement migration left hundreds
+                // of not-held contracts) otherwise fetched state for EVERY
+                // overlapping contract on EVERY inbound NeighborHosting
+                // announce, only to discard it at the
+                // `is_receiving_updates() || has_downstream_subscribers()`
+                // gate below. That fetch-then-discard was the residual #4473
+                // `fetch_contract` churn on technic (the fetch-path sibling of
+                // the #4475 / #4482 summarize gates).
+                //
+                // The gate reuses the existing discard predicate
+                // (`is_receiving_updates || has_downstream_subscribers`), so it
+                // changes nothing for served contracts, and adds a
+                // `pending_broadcasts` clause so the #4359 fresh-PUT flush at
+                // the matching arm still runs for any contract that owes one.
+                // Skipping is safe for the flush because a deferred broadcast
+                // is only ever stashed for a contract THIS node originated
+                // (broadcast give-up), so the flush is a guaranteed no-op for
+                // every contract this gate skips. The predicates take a
+                // synthetic key with a zero code hash: `ContractKey` equality
+                // and hashing are instance-only (freenet-stdlib `key.rs`), so
+                // the hosting / subscription maps resolve correctly from the
+                // instance id alone — `get_contract_state_by_id` is the only
+                // path that recovers the full key here, and that is exactly the
+                // round-trip we are avoiding.
+                let probe_key = freenet_stdlib::prelude::ContractKey::from_id_and_code(
+                    instance_id,
+                    freenet_stdlib::prelude::CodeHash::new([0u8; 32]),
+                );
+                if !op_manager.ring.is_receiving_updates(&probe_key)
+                    && !op_manager.ring.has_downstream_subscribers(&probe_key)
+                    && !op_manager.pending_broadcasts.contains(&instance_id)
+                {
+                    continue;
+                }
                 if let Some((key, state)) =
                     get_contract_state_by_id(&op_manager, &instance_id).await
                 {
@@ -3019,6 +3057,55 @@ mod tests {
             gated_calls >= 3,
             "expected the 3 periodic interest-sync arms to call \
              summary_if_hosted_or_in_use, found {gated_calls}"
+        );
+    }
+
+    /// Regression pin for the #4473 residual `fetch_contract` churn (the
+    /// fetch-path sibling of the summarize gate pinned above).
+    ///
+    /// The NeighborHosting overlap-sync loop fetched `get_contract_state_by_id`
+    /// for EVERY overlapping contract on EVERY inbound announce, only to discard
+    /// the result at the `is_receiving_updates || has_downstream_subscribers`
+    /// gate for contracts we don't actively serve — a `fetch_contract` span
+    /// burst on the serial `contract_handling` loop driven by phantom interest.
+    /// The activity gate (plus a `pending_broadcasts` clause that preserves the
+    /// #4359 fresh-PUT flush) MUST precede the `get_contract_state_by_id` fetch
+    /// so the span is never opened for a skipped contract. If a refactor moves
+    /// the gate after the fetch, the churn regresses silently, so pin the
+    /// ordering at the source level.
+    #[test]
+    fn neighbor_hosting_overlap_sync_gates_before_state_fetch_pin() {
+        let src = include_str!("node.rs");
+
+        // Bound the slice to the NeighborHosting overlap-sync loop so the
+        // ordering check can't false-pass on a neighbouring handler. The loop
+        // is the only site that iterates `result.overlapping_contracts`.
+        let loop_start = src
+            .find("for instance_id in result.overlapping_contracts {")
+            .expect("NeighborHosting overlap-sync loop not found");
+        let loop_src = &src[loop_start..];
+
+        let gate_pos = loop_src
+            .find("op_manager.pending_broadcasts.contains(&instance_id)")
+            .expect(
+                "overlap-sync loop MUST gate on the activity predicate + \
+                 pending_broadcasts.contains before fetching state (#4473)",
+            );
+        let recv_pos = loop_src
+            .find("is_receiving_updates(&probe_key)")
+            .expect("overlap-sync gate MUST check is_receiving_updates on the probe key");
+        let downstream_pos = loop_src
+            .find("has_downstream_subscribers(&probe_key)")
+            .expect("overlap-sync gate MUST check has_downstream_subscribers on the probe key");
+        let fetch_pos = loop_src
+            .find("get_contract_state_by_id(&op_manager, &instance_id)")
+            .expect("overlap-sync loop must still fetch state on the served path");
+
+        assert!(
+            recv_pos < fetch_pos && downstream_pos < fetch_pos && gate_pos < fetch_pos,
+            "the activity gate (is_receiving_updates || has_downstream_subscribers \
+             || pending_broadcasts.contains) MUST precede get_contract_state_by_id, \
+             or the #4473 fetch_contract churn regresses for phantom contracts"
         );
     }
 

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -137,45 +137,83 @@ pub(crate) struct UpdateExecution {
 /// transient routing failure.
 pub(crate) const CONTRACT_FETCH_COOLDOWN_MS: u64 = 300_000;
 
+/// Why a `try_auto_fetch_contract` call was made — decides whether the
+/// phantom-interest gate applies.
+///
+/// The auto-fetch helper is reached from two kinds of site, and only one of
+/// them is the #4473 churn:
+///
+/// * [`AutoFetchReason::Originator`] — a *local client* submitted an UPDATE for
+///   a contract whose code/params we lack, and the driver is self-healing so
+///   the client's retry can succeed (the `phase = "auto_fetch_originator"`
+///   site). This is demand-driven: a real client is waiting on it, exactly
+///   like a subscribe-driven fetch, so it must NOT be gated even when no
+///   subscription exists yet (a one-shot updater need not be subscribed).
+///   Suppressing it would strand the client's UPDATE behind a contract that
+///   never gets fetched (Codex review on PR #4489).
+/// * [`AutoFetchReason::InboundRelay`] — an *inbound* relayed UPDATE / broadcast
+///   failed its merge because we lack the contract. A node carrying phantom
+///   interest (the #4404 placement-migration after-effect) hits this on every
+///   such message and would spawn a `fetch_contract` sub-op for state nothing
+///   on this node depends on — the residual #4473 churn. This is the path the
+///   `contract_in_use` gate suppresses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AutoFetchReason {
+    /// Local-client UPDATE self-heal — demand-driven, never gated.
+    Originator,
+    /// Inbound relay/broadcast self-heal — gated on `contract_in_use`.
+    InboundRelay,
+}
+
 impl OpManager {
     /// Trigger a background GET when an UPDATE broadcast fails because the node
     /// doesn't have the contract's parameters (code + params). This self-heals
     /// the node by fetching the contract directly from the UPDATE sender, who
     /// is known to have the contract.
     ///
-    /// Gated to contracts we actually have a reason to hold: skipped unless a
-    /// local client or a downstream peer is subscribed (`contract_in_use`).
+    /// For [`AutoFetchReason::InboundRelay`] calls this is gated to contracts we
+    /// actually have a reason to hold: skipped unless a local client or a
+    /// downstream peer is subscribed (`contract_in_use`).
+    /// [`AutoFetchReason::Originator`] calls are demand-driven (a local client
+    /// is waiting on the retry) and bypass the gate.
     /// Rate-limited: at most one fetch attempt per contract per 5 minutes.
-    pub(crate) fn try_auto_fetch_contract(&self, key: &ContractKey, sender_addr: SocketAddr) {
+    pub(crate) fn try_auto_fetch_contract(
+        &self,
+        key: &ContractKey,
+        sender_addr: SocketAddr,
+        reason: AutoFetchReason,
+    ) {
         use crate::config::GlobalSimulationTime;
 
         let instance_id = *key.id();
 
-        // Don't self-heal-fetch a contract nothing on this node depends on.
-        // An UPDATE/broadcast for a contract we carry only phantom interest in
-        // (e.g. the #4404 placement migration left stale interest with no
-        // subscriber) reaches this path and would spawn a sub-op GET — a
-        // `fetch_contract` span burst against state we have no client or
-        // downstream subscriber to serve. The existing 5-minute cooldown only
-        // *throttles* that to one burst per contract per window; gating on
-        // `contract_in_use` (a live local-client subscription or a downstream
-        // peer subscriber) stops it at the source. This is the fetch-path
-        // analogue of the #4475 / #4482 `is_hosting_contract || contract_in_use`
-        // summarize gates. We intentionally do NOT also accept
-        // `is_hosting_contract` here: on this path the merge already failed
-        // because we lack the contract, so hosting is moot; nor a bare upstream
-        // network subscription, which `contract_in_use` deliberately excludes
-        // (an orphaned upstream sub renews its lease unboundedly and is meant to
-        // be torn down, not kept alive by self-heal fetches — see
-        // `HostingManager::contract_in_use`). A contract that gains a real
-        // local client or downstream subscriber becomes `contract_in_use` and
-        // its next inbound UPDATE re-arms this fetch.
-        if !self.ring.contract_in_use(key) {
+        // Don't self-heal-fetch a contract nothing on this node depends on —
+        // but ONLY for inbound relay/broadcast self-heal, never for the
+        // originator path (see `AutoFetchReason`). An inbound UPDATE/broadcast
+        // for a contract we carry only phantom interest in (e.g. the #4404
+        // placement migration left stale interest with no subscriber) reaches
+        // this path and would spawn a sub-op GET — a `fetch_contract` span
+        // burst against state we have no client or downstream subscriber to
+        // serve. The existing 5-minute cooldown only *throttles* that to one
+        // burst per contract per window; gating on `contract_in_use` (a live
+        // local-client subscription or a downstream peer subscriber) stops it
+        // at the source. This is the fetch-path analogue of the #4475 / #4482
+        // `is_hosting_contract || contract_in_use` summarize gates. We
+        // intentionally do NOT also accept `is_hosting_contract` here: on this
+        // path the merge already failed because we lack the contract, so
+        // hosting is moot; nor a bare upstream network subscription, which
+        // `contract_in_use` deliberately excludes (an orphaned upstream sub
+        // renews its lease unboundedly and is meant to be torn down, not kept
+        // alive by self-heal fetches — see `HostingManager::contract_in_use`).
+        // A contract that gains a real local client or downstream subscriber
+        // becomes `contract_in_use` and its next inbound UPDATE re-arms this
+        // fetch.
+        if reason == AutoFetchReason::InboundRelay && !self.ring.contract_in_use(key) {
             tracing::debug!(
                 contract = %key,
                 sender = %sender_addr,
-                "Skipping auto-fetch: no local client or downstream subscriber \
-                 depends on this contract (phantom interest)"
+                "Skipping inbound-relay auto-fetch: no local client or downstream \
+                 subscriber depends on this contract (phantom interest)"
             );
             return;
         }
@@ -1425,14 +1463,21 @@ mod tests {
 
     /// Pin (#4473): `try_auto_fetch_contract` MUST gate on
     /// `self.ring.contract_in_use(...)` and early-return BEFORE it spawns a
-    /// sub-op GET (`start_targeted_sub_op_get`). Without the gate, an UPDATE
-    /// for a contract this node carries only phantom interest in (no client,
-    /// no downstream subscriber) spawns a `fetch_contract` sub-op every time
-    /// the per-contract cooldown lapses — the residual #4473 churn the gate
-    /// stops at the source. The existing 5-minute cooldown only throttles
-    /// that; it does not prevent it. If a refactor drops this gate or moves it
-    /// after the spawn, the storm regresses silently (all behavioural tests
-    /// still pass), so pin the ordering at the source level.
+    /// sub-op GET (`start_targeted_sub_op_get`) — but ONLY for the
+    /// `AutoFetchReason::InboundRelay` path. Without the gate, an inbound
+    /// relayed UPDATE for a contract this node carries only phantom interest in
+    /// (no client, no downstream subscriber) spawns a `fetch_contract` sub-op
+    /// every time the per-contract cooldown lapses — the residual #4473 churn
+    /// the gate stops at the source. The existing 5-minute cooldown only
+    /// throttles that; it does not prevent it. If a refactor drops this gate or
+    /// moves it after the spawn, the storm regresses silently (all behavioural
+    /// tests still pass), so pin the ordering at the source level.
+    ///
+    /// Equally important (Codex review on #4489): the gate MUST stay scoped to
+    /// `InboundRelay`, never unconditional. Making it unconditional again would
+    /// re-suppress the `Originator` self-heal path, stranding a local client's
+    /// UPDATE behind a contract that never gets fetched. Pin that the gate
+    /// condition mentions `AutoFetchReason::InboundRelay`.
     #[test]
     fn try_auto_fetch_contract_gates_on_contract_in_use_before_spawn() {
         let src = include_str!("update.rs");
@@ -1445,6 +1490,12 @@ mod tests {
             "try_auto_fetch_contract MUST gate on self.ring.contract_in_use(key) \
              so phantom-interest contracts are not auto-fetched (#4473)",
         );
+        // The gate condition must be scoped to the inbound-relay reason so the
+        // originator self-heal path is never suppressed (#4489).
+        let reason_pos = fn_src.find("AutoFetchReason::InboundRelay").expect(
+            "the contract_in_use gate MUST be conditioned on \
+             AutoFetchReason::InboundRelay so Originator self-heal bypasses it (#4489)",
+        );
         let return_pos = fn_src[gate_pos..]
             .find("return;")
             .map(|p| gate_pos + p)
@@ -1454,10 +1505,55 @@ mod tests {
             .expect("try_auto_fetch_contract must still spawn the sub-op GET on the in-use path");
 
         assert!(
+            reason_pos < gate_pos,
+            "the AutoFetchReason::InboundRelay guard MUST precede the \
+             contract_in_use check, or the gate becomes unconditional and \
+             re-suppresses the Originator self-heal path (#4489)"
+        );
+        assert!(
             gate_pos < return_pos && return_pos < spawn_pos,
             "the contract_in_use gate + early return MUST precede the \
              start_targeted_sub_op_get spawn, or phantom-interest contracts \
              regress the #4473 fetch_contract churn"
+        );
+    }
+
+    /// Pin (#4489): the originator self-heal site MUST call
+    /// `try_auto_fetch_contract` with `AutoFetchReason::Originator`, and every
+    /// inbound relay/broadcast site MUST use `AutoFetchReason::InboundRelay`.
+    /// If a refactor flips the originator site to `InboundRelay`, a one-shot
+    /// client UPDATE for a contract we lack would be silently suppressed by the
+    /// phantom-interest gate (the Codex finding on #4489); if it flips a relay
+    /// site to `Originator`, the #4473 churn regresses. Pin both at the source.
+    #[test]
+    fn auto_fetch_call_sites_use_correct_reason() {
+        let driver_src = include_str!("update/op_ctx_task.rs");
+
+        // The originator site is the one paired with the `auto_fetch_originator`
+        // tracing phase; it must use the Originator (ungated) reason.
+        let originator_anchor = driver_src
+            .find("phase = \"auto_fetch_originator\"")
+            .expect("originator auto-fetch site (auto_fetch_originator phase) not found");
+        let originator_call = driver_src[originator_anchor..]
+            .find("try_auto_fetch_contract(")
+            .map(|p| originator_anchor + p)
+            .expect("originator site must still call try_auto_fetch_contract");
+        let originator_reason = driver_src[originator_call..]
+            .find("AutoFetchReason::")
+            .map(|p| originator_call + p)
+            .expect("originator try_auto_fetch_contract call must pass an AutoFetchReason");
+        assert!(
+            driver_src[originator_reason..].starts_with("AutoFetchReason::Originator"),
+            "the auto_fetch_originator site MUST pass AutoFetchReason::Originator \
+             so a local client's UPDATE self-heal is never gated (#4489)"
+        );
+
+        // No inbound relay/broadcast site may use Originator: those are the
+        // #4473 churn paths and must stay gated.
+        assert!(
+            !driver_src.contains("sender_addr, AutoFetchReason::Originator"),
+            "inbound relay/broadcast auto-fetch sites (keyed on sender_addr) MUST \
+             use AutoFetchReason::InboundRelay, not Originator, or #4473 regresses"
         );
     }
 }

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -143,11 +143,43 @@ impl OpManager {
     /// the node by fetching the contract directly from the UPDATE sender, who
     /// is known to have the contract.
     ///
+    /// Gated to contracts we actually have a reason to hold: skipped unless a
+    /// local client or a downstream peer is subscribed (`contract_in_use`).
     /// Rate-limited: at most one fetch attempt per contract per 5 minutes.
     pub(crate) fn try_auto_fetch_contract(&self, key: &ContractKey, sender_addr: SocketAddr) {
         use crate::config::GlobalSimulationTime;
 
         let instance_id = *key.id();
+
+        // Don't self-heal-fetch a contract nothing on this node depends on.
+        // An UPDATE/broadcast for a contract we carry only phantom interest in
+        // (e.g. the #4404 placement migration left stale interest with no
+        // subscriber) reaches this path and would spawn a sub-op GET — a
+        // `fetch_contract` span burst against state we have no client or
+        // downstream subscriber to serve. The existing 5-minute cooldown only
+        // *throttles* that to one burst per contract per window; gating on
+        // `contract_in_use` (a live local-client subscription or a downstream
+        // peer subscriber) stops it at the source. This is the fetch-path
+        // analogue of the #4475 / #4482 `is_hosting_contract || contract_in_use`
+        // summarize gates. We intentionally do NOT also accept
+        // `is_hosting_contract` here: on this path the merge already failed
+        // because we lack the contract, so hosting is moot; nor a bare upstream
+        // network subscription, which `contract_in_use` deliberately excludes
+        // (an orphaned upstream sub renews its lease unboundedly and is meant to
+        // be torn down, not kept alive by self-heal fetches — see
+        // `HostingManager::contract_in_use`). A contract that gains a real
+        // local client or downstream subscriber becomes `contract_in_use` and
+        // its next inbound UPDATE re-arms this fetch.
+        if !self.ring.contract_in_use(key) {
+            tracing::debug!(
+                contract = %key,
+                sender = %sender_addr,
+                "Skipping auto-fetch: no local client or downstream subscriber \
+                 depends on this contract (phantom interest)"
+            );
+            return;
+        }
+
         let now_ms = GlobalSimulationTime::read_time_ms();
 
         // Atomic rate-limit: try to insert a new entry. If one exists and hasn't
@@ -1388,6 +1420,44 @@ mod tests {
             return_pos < notify_pos,
             "early return on inequality MUST precede the notify_node_event \
              send — otherwise mismatched summaries would still be transmitted"
+        );
+    }
+
+    /// Pin (#4473): `try_auto_fetch_contract` MUST gate on
+    /// `self.ring.contract_in_use(...)` and early-return BEFORE it spawns a
+    /// sub-op GET (`start_targeted_sub_op_get`). Without the gate, an UPDATE
+    /// for a contract this node carries only phantom interest in (no client,
+    /// no downstream subscriber) spawns a `fetch_contract` sub-op every time
+    /// the per-contract cooldown lapses — the residual #4473 churn the gate
+    /// stops at the source. The existing 5-minute cooldown only throttles
+    /// that; it does not prevent it. If a refactor drops this gate or moves it
+    /// after the spawn, the storm regresses silently (all behavioural tests
+    /// still pass), so pin the ordering at the source level.
+    #[test]
+    fn try_auto_fetch_contract_gates_on_contract_in_use_before_spawn() {
+        let src = include_str!("update.rs");
+        let fn_start = src
+            .find("pub(crate) fn try_auto_fetch_contract(")
+            .expect("try_auto_fetch_contract not found");
+        let fn_src = &src[fn_start..];
+
+        let gate_pos = fn_src.find("self.ring.contract_in_use(key)").expect(
+            "try_auto_fetch_contract MUST gate on self.ring.contract_in_use(key) \
+             so phantom-interest contracts are not auto-fetched (#4473)",
+        );
+        let return_pos = fn_src[gate_pos..]
+            .find("return;")
+            .map(|p| gate_pos + p)
+            .expect("the contract_in_use gate must early-return when not in use");
+        let spawn_pos = fn_src
+            .find("start_targeted_sub_op_get")
+            .expect("try_auto_fetch_contract must still spawn the sub-op GET on the in-use path");
+
+        assert!(
+            gate_pos < return_pos && return_pos < spawn_pos,
+            "the contract_in_use gate + early return MUST precede the \
+             start_targeted_sub_op_get spawn, or phantom-interest contracts \
+             regress the #4473 fetch_contract churn"
         );
     }
 }

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1183,7 +1183,11 @@ async fn drive_relay_broadcast_to(
                 // Full state failed and the merge function did NOT reject it
                 // (so contract code is missing). Trigger self-healing GET.
                 // Inbound relay path → gated on `contract_in_use` (#4473).
-                op_manager.try_auto_fetch_contract(&key, sender_addr, AutoFetchReason::InboundRelay);
+                op_manager.try_auto_fetch_contract(
+                    &key,
+                    sender_addr,
+                    AutoFetchReason::InboundRelay,
+                );
             } else if queue_full {
                 tracing::debug!(
                     tx = %incoming_tx,
@@ -1827,7 +1831,11 @@ async fn drive_relay_broadcast_to_streaming(
             // update.rs:1336-1361.
             if super::log_broadcast_to_streaming_failure(&incoming_tx, &key, &err) {
                 // Inbound broadcast relay path → gated on `contract_in_use` (#4473).
-                op_manager.try_auto_fetch_contract(&key, sender_addr, AutoFetchReason::InboundRelay);
+                op_manager.try_auto_fetch_contract(
+                    &key,
+                    sender_addr,
+                    AutoFetchReason::InboundRelay,
+                );
             } else if err.is_invalid_update_rejection() {
                 let op_mgr = op_manager.clone();
                 let contract_key = key;

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -26,7 +26,9 @@ use crate::operations::OpError;
 use crate::ring::{PeerKeyLocation, RingError};
 use crate::tracing::{NetEventLog, OperationFailure, state_hash_full};
 
-use super::{BroadcastStreamingPayload, UpdateExecution, UpdateMsg, UpdateStreamingPayload};
+use super::{
+    AutoFetchReason, BroadcastStreamingPayload, UpdateExecution, UpdateMsg, UpdateStreamingPayload,
+};
 use crate::transport::peer_connection::StreamId;
 
 /// Counter: number of times `start_relay_request_update` or
@@ -389,7 +391,14 @@ async fn drive_client_update(
                              code/params for this contract; triggering \
                              auto-fetch from target and asking client to retry"
                         );
-                        op_manager.try_auto_fetch_contract(&key, target_addr);
+                        // Originator self-heal: a local client is waiting on
+                        // the retry, so this is demand-driven and bypasses the
+                        // #4473 phantom-interest gate (Codex review on #4489).
+                        op_manager.try_auto_fetch_contract(
+                            &key,
+                            target_addr,
+                            AutoFetchReason::Originator,
+                        );
                         return Ok(DriverOutcome::Publish(Err(ErrorKind::OperationError {
                             cause: format!(
                                 "originator missing contract code/params for {key}; \
@@ -1173,7 +1182,8 @@ async fn drive_relay_broadcast_to(
             } else if !is_delta && !err.is_contract_exec_rejection() && !queue_full {
                 // Full state failed and the merge function did NOT reject it
                 // (so contract code is missing). Trigger self-healing GET.
-                op_manager.try_auto_fetch_contract(&key, sender_addr);
+                // Inbound relay path → gated on `contract_in_use` (#4473).
+                op_manager.try_auto_fetch_contract(&key, sender_addr, AutoFetchReason::InboundRelay);
             } else if queue_full {
                 tracing::debug!(
                     tx = %incoming_tx,
@@ -1816,7 +1826,8 @@ async fn drive_relay_broadcast_to_streaming(
             // send_summary_back_on_rejection. Mirrors legacy at
             // update.rs:1336-1361.
             if super::log_broadcast_to_streaming_failure(&incoming_tx, &key, &err) {
-                op_manager.try_auto_fetch_contract(&key, sender_addr);
+                // Inbound broadcast relay path → gated on `contract_in_use` (#4473).
+                op_manager.try_auto_fetch_contract(&key, sender_addr, AutoFetchReason::InboundRelay);
             } else if err.is_invalid_update_rejection() {
                 let op_mgr = op_manager.clone();
                 let contract_key = key;

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -3108,6 +3108,82 @@ mod tests {
         assert!(!manager.contract_in_use(&contract));
     }
 
+    /// Behavioural regression for the #4473 UPDATE auto-fetch gate.
+    ///
+    /// `OpManager::try_auto_fetch_contract` self-heal-fetches a contract only
+    /// when `self.ring.contract_in_use(key)` — i.e. a local client or a
+    /// downstream peer subscriber depends on it. Before the gate, an inbound
+    /// UPDATE/broadcast for a phantom-interest contract (the #4404
+    /// placement-migration after-effect: stale interest with no subscriber)
+    /// spawned a `fetch_contract` sub-op every time the 5-minute cooldown
+    /// lapsed — the residual #4473 churn. This drives the predicate the gate
+    /// keys on through real subscription registration/teardown and asserts the
+    /// decision the gate makes at each step:
+    ///   phantom (no subscriber)            → gate skips  (would NOT auto-fetch)
+    ///   live local client                  → gate passes (WOULD auto-fetch)
+    ///   live downstream subscriber         → gate passes (WOULD auto-fetch)
+    ///   upstream network subscription only → gate skips  (would NOT auto-fetch)
+    /// and that teardown returns the decision to "skip", so the gate re-arms
+    /// only while a real subscriber exists.
+    #[test]
+    fn auto_fetch_gate_skips_phantom_contracts_and_passes_served_ones() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+
+        // Phantom: interest carried with no subscriber of any kind. The gate
+        // (`!contract_in_use`) skips it — no auto-fetch sub-op spawned, which is
+        // the whole point of the #4473 fix.
+        let phantom = make_contract_key(40);
+        assert!(
+            !manager.contract_in_use(&phantom),
+            "phantom contract (no subscriber) MUST be gated out of auto-fetch (#4473)"
+        );
+
+        // A live local client makes the contract genuinely needed → gate passes.
+        let client_served = make_contract_key(41);
+        let client = crate::client_events::ClientId::next();
+        manager.add_client_subscription(client_served.id(), client);
+        assert!(
+            manager.contract_in_use(&client_served),
+            "a contract with a live local-client subscription MUST pass the \
+             auto-fetch gate so genuinely-needed state still self-heals"
+        );
+        // Teardown re-arms the skip: once the client leaves, the contract is
+        // phantom again and must NOT keep auto-fetching.
+        manager.remove_client_subscription(client_served.id(), client);
+        assert!(
+            !manager.contract_in_use(&client_served),
+            "auto-fetch gate must re-close once the last client unsubscribes"
+        );
+
+        // A downstream peer subscriber likewise makes the fetch legitimate.
+        let downstream_served = make_contract_key(42);
+        let peer = make_peer_key(9);
+        manager.add_downstream_subscriber(&downstream_served, peer.clone());
+        assert!(
+            manager.contract_in_use(&downstream_served),
+            "a contract with a downstream subscriber MUST pass the auto-fetch gate"
+        );
+        manager.remove_downstream_subscriber(&downstream_served, &peer);
+        assert!(
+            !manager.contract_in_use(&downstream_served),
+            "auto-fetch gate must re-close once the last downstream subscriber leaves"
+        );
+
+        // An upstream network subscription ALONE is deliberately excluded: it
+        // renews its lease unboundedly (see `contract_in_use` rustdoc) and is
+        // meant to be torn down, not kept alive by self-heal fetches. So a
+        // contract we are merely network-subscribed to stays gated out.
+        let upstream_only = make_contract_key(43);
+        manager.subscribe(upstream_only);
+        assert!(manager.is_subscribed(&upstream_only));
+        assert!(
+            !manager.contract_in_use(&upstream_only),
+            "an upstream-network-subscription-only contract MUST stay gated out \
+             of auto-fetch (#4473): keeping it would re-introduce the phantom churn"
+        );
+        manager.unsubscribe(&upstream_only);
+    }
+
     /// Generation flow through `HostingManager`: bumping the state
     /// generation BEFORE `record_contract_access` makes the captured
     /// generation match; subsequently bumping the generation simulates

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -3110,15 +3110,17 @@ mod tests {
 
     /// Behavioural regression for the #4473 UPDATE auto-fetch gate.
     ///
+    /// On the `AutoFetchReason::InboundRelay` path,
     /// `OpManager::try_auto_fetch_contract` self-heal-fetches a contract only
     /// when `self.ring.contract_in_use(key)` — i.e. a local client or a
-    /// downstream peer subscriber depends on it. Before the gate, an inbound
-    /// UPDATE/broadcast for a phantom-interest contract (the #4404
-    /// placement-migration after-effect: stale interest with no subscriber)
-    /// spawned a `fetch_contract` sub-op every time the 5-minute cooldown
-    /// lapsed — the residual #4473 churn. This drives the predicate the gate
-    /// keys on through real subscription registration/teardown and asserts the
-    /// decision the gate makes at each step:
+    /// downstream peer subscriber depends on it. (The `Originator` path is
+    /// demand-driven and bypasses this gate; see `AutoFetchReason`.) Before the
+    /// gate, an inbound UPDATE/broadcast for a phantom-interest contract (the
+    /// #4404 placement-migration after-effect: stale interest with no
+    /// subscriber) spawned a `fetch_contract` sub-op every time the 5-minute
+    /// cooldown lapsed — the residual #4473 churn. This drives the predicate
+    /// the gate keys on through real subscription registration/teardown and
+    /// asserts the decision the gate makes at each step:
     ///   phantom (no subscriber)            → gate skips  (would NOT auto-fetch)
     ///   live local client                  → gate passes (WOULD auto-fetch)
     ///   live downstream subscriber         → gate passes (WOULD auto-fetch)


### PR DESCRIPTION
## Problem

After the #4404 placement migration, several production peers (notably technic and the nova gateway) carry **phantom contract interest**: stale interest in hundreds of contracts they neither host nor have any client/downstream subscriber for. Two code paths turn that phantom interest into a sustained `fetch_contract` storm on the single-threaded contract-handling loop:

1. **NeighborHosting overlap-sync (`node.rs`)** — on *every* inbound `NeighborHosting` announce, the loop called `get_contract_state_by_id` (which opens a `fetch_contract` span on the serial contract-handling loop) for *every* overlapping contract, only to throw the result away at the existing `is_receiving_updates() || has_downstream_subscribers()` discard gate. Fetch-then-discard, once per overlapping phantom contract per announce.

2. **UPDATE auto-fetch (`update.rs::try_auto_fetch_contract`)** — an inbound UPDATE/broadcast for a phantom-interest contract spawned a sub-op GET (`fetch_contract`) every time the per-contract 5-minute cooldown lapsed. The cooldown only *throttles* the storm; it does not stop it.

This is the residual #4473 `fetch_contract` churn — the fetch-path sibling of the already-merged summarize gates #4475 / #4482. On technic the per-callsite rate limiter is currently dropping 700-1000+ `fetch_contract` calls per 30s in bursts (cumulative counter climbing ~1500/4.5min).

## Approach

Gate both paths on *legitimate interest*, mirroring the #4475 / #4482 `is_hosting_contract || contract_in_use` summarize gates:

1. **`node.rs` overlap-sync:** before fetching, check `is_receiving_updates(probe) || has_downstream_subscribers(probe) || pending_broadcasts.contains(instance_id)` and `continue` if none hold. The gate **reuses the existing discard predicate**, so served contracts are unaffected; the `pending_broadcasts` clause preserves the #4359 fresh-PUT flush. The predicates take a synthetic `ContractKey` with a zero code hash — safe because `ContractKey` equality and hashing are *instance-only* in freenet-stdlib (`key.rs`), so the hosting/subscription maps resolve from the instance id alone (and `get_contract_state_by_id` is the very round-trip we are avoiding).

2. **`update.rs::try_auto_fetch_contract`:** early-return `if !self.ring.contract_in_use(key)` — no local client and no downstream subscriber means nothing on this node depends on the contract, so don't self-heal-fetch it. Deliberately *not* gated on `is_hosting_contract` (the merge already failed because we lack the contract) nor on a bare upstream network subscription (which `contract_in_use` excludes by design — an orphaned upstream sub is meant to be torn down, not kept alive by self-heal fetches).

No subscribe-path cooldown is added: subscribe-driven fetch is legitimate demand and intentionally left alone.

## Testing

- **Behavioural regression** (`hosting.rs::auto_fetch_gate_skips_phantom_contracts_and_passes_served_ones`): drives the `contract_in_use` predicate the gate keys on through real subscription registration/teardown and asserts the decision at each step — phantom skips, live local client passes, live downstream subscriber passes, upstream-network-sub-only skips, and teardown re-closes the gate.
- **Source-scrape pins** (one per gated path): assert the gate precedes the fetch/spawn at the source level so a future refactor that reorders them fails CI rather than silently regressing the churn.
- Build clean (`cargo build -p freenet`), `cargo clippy --locked -- -D warnings` clean, changed-module test suites green (`ring::hosting`, `operations::update`: 163 passed).
- Deploy-validated on technic (real NATed peer): `fetch_contract` rate-limiter drop bursts vs. the live 0.2.77 baseline.

This is the fetch-path sibling of #4475 / #4482. Recovered from a borg backup after the original worktree was deleted before commit.

Refs #4473 #4440

[AI-assisted - Claude]
