### PR TITLE
fix(release-agent): fail gateway update when the service is not running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,15 @@ jobs:
       - name: Self-test gateway-update verify decision
         run: bash scripts/release-agent/verify-version-decision_test.sh
 
+      # Regression gate for the independent post-deploy service-health check in
+      # gateway-auto-update.sh (the 2026-06-18 v0.2.78 nova incident, #4492: a
+      # stale deploy-local-gateway.sh exited 0 on a DEAD service and the wrapper
+      # reported the update successful). The load-bearing case: a deploy script
+      # that lies (exits 0 while the service is down) must still fail the update
+      # via the independent `systemctl is-active` gate.
+      - name: Self-test gateway-auto-update service-health gate
+        run: bash scripts/release-agent/gateway-auto-update_test.sh
+
       - name: Check for old-style mod.rs files
         run: |
           # New modules must use foo.rs + foo/ style, not foo/mod.rs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,13 @@ jobs:
       - name: Self-test gateway-auto-update service-health gate
         run: bash scripts/release-agent/gateway-auto-update_test.sh
 
+      # Regression gate for deploy-local-gateway.sh::verify_service — the
+      # function that actually regressed on nova (#4492). Pins that a dead
+      # service, a missing unit, and an active-but-no-process unit each cause a
+      # non-zero exit, and that a healthy deploy exits 0.
+      - name: Self-test deploy-local-gateway verify_service
+        run: bash scripts/release-agent/deploy-local-gateway_test.sh
+
       - name: Check for old-style mod.rs files
         run: |
           # New modules must use foo.rs + foo/ style, not foo/mod.rs

--- a/.github/workflows/gateway-update.yml
+++ b/.github/workflows/gateway-update.yml
@@ -284,7 +284,9 @@ jobs:
                 # like `wait` (keep polling, fail at the deadline) and tell the
                 # operator to update the agent. Only the explicit
                 # allow_binary_only_fallback opt-in restores the old behaviour.
-                if [[ "${ALLOW_BINARY_ONLY_FALLBACK:-false}" == "true" ]]; then
+                # The accept/hold policy lives in fallback_decision() (sourced
+                # above) so it is unit-tested rather than inline-untested.
+                if [[ "$(fallback_decision "$DECISION" "${ALLOW_BINARY_ONLY_FALLBACK:-false}")" == "accept" ]]; then
                   echo "::warning::Gateway ${{ matrix.gateway.name }} agent predates the service-health check (no 'service_active' in /version); allow_binary_only_fallback=true, so accepting binary-only verification. Update the release-agent on this gateway to enable the stronger check."
                   echo "✓ Gateway ${{ matrix.gateway.name }} now reports version $INSTALLED (binary-only check)"
                   exit 0

--- a/.github/workflows/gateway-update.yml
+++ b/.github/workflows/gateway-update.yml
@@ -29,6 +29,18 @@ on:
         required: false
         type: boolean
         default: false
+      allow_binary_only_fallback:
+        description: >-
+          Accept a gateway whose release-agent predates the service_active
+          field (binary-version-only verification). OFF by default: without
+          service_active we cannot tell a running gateway from one whose binary
+          was swapped but whose service is dead (the 2026-06-18 nova incident,
+          #4492), so a missing field is treated as not-yet-converged and the
+          rollout fails at the deadline. Turn this on ONLY for a deliberate
+          rollout to a gateway you know runs an old agent.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -223,6 +235,9 @@ jobs:
         env:
           GATEWAY_URL: ${{ matrix.gateway.url }}
           VERSION: ${{ needs.plan.outputs.version }}
+          # Empty on the release-trigger path (no inputs) → defaults to the
+          # safe "false". See the allow_binary_only_fallback input docs.
+          ALLOW_BINARY_ONLY_FALLBACK: ${{ inputs.allow_binary_only_fallback }}
         run: |
           set -euo pipefail
           # The agent restarts the freenet service after the script
@@ -245,6 +260,9 @@ jobs:
           source scripts/release-agent/verify-version-decision.sh
 
           DEADLINE=$(( $(date +%s) + 120 ))
+          # Remember if we ever saw the old-agent (no service_active) response,
+          # so the deadline error can point at the real cause.
+          SAW_FALLBACK=false
           while (( $(date +%s) < DEADLINE )); do
             RESPONSE=$(curl -sS --max-time 5 "$GATEWAY_URL/version" || true)
             INSTALLED=$(printf '%s' "$RESPONSE" | jq -r '.version // empty' 2>/dev/null || echo "")
@@ -257,9 +275,23 @@ jobs:
                 exit 0
                 ;;
               success-fallback)
-                echo "::warning::Gateway ${{ matrix.gateway.name }} agent predates the service-health check (no 'service_active' in /version); falling back to binary-only verification. Update the release-agent on this gateway to enable the stronger check."
-                echo "✓ Gateway ${{ matrix.gateway.name }} now reports version $INSTALLED (binary-only check)"
-                exit 0
+                # The agent predates the service_active field, so we cannot
+                # confirm the SERVICE is up — only that the binary on disk is
+                # the new version. On 2026-06-18 (#4492) nova hit exactly this:
+                # binary swapped to the target but the gateway service was
+                # dead, and this branch reported the rollout green. So by
+                # default we DO NOT accept binary-only as success: treat it
+                # like `wait` (keep polling, fail at the deadline) and tell the
+                # operator to update the agent. Only the explicit
+                # allow_binary_only_fallback opt-in restores the old behaviour.
+                if [[ "${ALLOW_BINARY_ONLY_FALLBACK:-false}" == "true" ]]; then
+                  echo "::warning::Gateway ${{ matrix.gateway.name }} agent predates the service-health check (no 'service_active' in /version); allow_binary_only_fallback=true, so accepting binary-only verification. Update the release-agent on this gateway to enable the stronger check."
+                  echo "✓ Gateway ${{ matrix.gateway.name }} now reports version $INSTALLED (binary-only check)"
+                  exit 0
+                fi
+                SAW_FALLBACK=true
+                echo "::warning::Gateway ${{ matrix.gateway.name }} agent predates the service-health check (no 'service_active' in /version); cannot confirm the service is actually running. Update the release-agent (>= the #4378 build) to enable the service-health gate, or re-run with allow_binary_only_fallback=true to accept binary-only verification."
+                echo "Binary is $INSTALLED but service health is UNVERIFIABLE on this agent; treating as not-yet-converged…"
                 ;;
               wait)
                 if [[ "$INSTALLED" == "$VERSION" ]]; then
@@ -275,5 +307,9 @@ jobs:
             esac
             sleep 5
           done
+          if [[ "$SAW_FALLBACK" == "true" ]]; then
+            echo "::error::Gateway ${{ matrix.gateway.name }} reported version $VERSION but its release-agent predates the service_active field, so service health could not be confirmed (binary-only). Failing closed (#4492). Update the release-agent on ${{ matrix.gateway.name }}, or re-run with allow_binary_only_fallback=true if you accept binary-only verification."
+            exit 1
+          fi
           echo "::error::Gateway ${{ matrix.gateway.name }} did not converge on $VERSION with an active service within 120s"
           exit 1

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -226,9 +226,14 @@ converge timeout now has two possible meanings:
   `inactive` unit with the new binary on disk is this failure mode.
 
 (Note: against a gateway running an OLD release-agent that predates the
-`service_active` field, the workflow logs a `::warning::` and falls back to the
-binary-only check, so the stronger signal is only enforced once the agent
-itself has been updated.)
+`service_active` field, the workflow can no longer confirm the service is
+running. As of #4492 it **fails closed** by default — the rollout step errors
+at the deadline telling you to update that gateway's release-agent. The old
+binary-only behaviour is available only via the explicit
+`allow_binary_only_fallback=true` `workflow_dispatch` input, for a deliberate
+rollout to a gateway you know runs an old agent. So on the normal
+release-triggered path, a gateway with an outdated agent will fail the rollout
+until its agent is upgraded.)
 
 Recovery:
 

--- a/scripts/deploy-local-gateway.sh
+++ b/scripts/deploy-local-gateway.sh
@@ -342,8 +342,11 @@ verify_service() {
                 # Fall back to the global pgrep only when MainPID is
                 # unavailable/0 (e.g. an ExecStart wrapper whose MainPID points
                 # at the shell rather than the freenet child).
+                # `|| true`: a non-zero exit (systemctl error / no MainPID)
+                # must yield an empty result, NOT abort the function via
+                # `set -e`. We handle "no PID" explicitly below.
                 local freenet_pid
-                freenet_pid=$(systemctl show -p MainPID --value "$service_arg.service" 2>/dev/null)
+                freenet_pid=$(systemctl show -p MainPID --value "$service_arg.service" 2>/dev/null || true)
 
                 if [[ -z "$freenet_pid" ]] || [[ "$freenet_pid" == "0" ]]; then
                     # Fallback: locate the freenet process by command line. This
@@ -356,11 +359,20 @@ verify_service() {
                     # unit. If we can't read the cgroup, we conservatively drop
                     # the candidate (fail closed) rather than risk a cross-unit
                     # false success.
+                    # `|| true`: pgrep exits non-zero when it finds no match,
+                    # which under `set -euo pipefail` would otherwise abort the
+                    # function here (skipping the active-but-no-process handling
+                    # below). An empty candidate_pid is the intended "not found".
                     local candidate_pid
-                    candidate_pid=$(pgrep -f "freenet.*--is-gateway\|freenet.*network" | head -1)
+                    candidate_pid=$(pgrep -f "freenet.*--is-gateway\|freenet.*network" | head -1 || true)
+                    # Fixed-string match (`-F`): the unit token is matched
+                    # literally so the `.` in `<unit>.service` is not a regex
+                    # wildcard, and `freenet-gateway.service` does not match a
+                    # sibling like `freenet-gateway-hector.service` (the `-` vs
+                    # `.` boundary differs).
                     if [[ -n "$candidate_pid" ]] \
                         && sudo cat "/proc/$candidate_pid/cgroup" 2>/dev/null \
-                            | grep -q "$service_arg.service"; then
+                            | grep -qF "$service_arg.service"; then
                         freenet_pid="$candidate_pid"
                     else
                         freenet_pid=""

--- a/scripts/deploy-local-gateway.sh
+++ b/scripts/deploy-local-gateway.sh
@@ -351,30 +351,44 @@ verify_service() {
                 if [[ -z "$freenet_pid" ]] || [[ "$freenet_pid" == "0" ]]; then
                     # Fallback: locate the freenet process by command line. This
                     # is global, so on a multi-instance host it can match a
-                    # process belonging to a DIFFERENT unit. Attribute the match
-                    # to THIS unit via its cgroup (systemd places each unit's
-                    # processes under .../<unit>.service/...) before trusting it;
-                    # a match that isn't in $service_arg's cgroup is discarded so
-                    # a sibling instance can't bless this (active-but-exited)
-                    # unit. If we can't read the cgroup, we conservatively drop
-                    # the candidate (fail closed) rather than risk a cross-unit
-                    # false success.
+                    # process belonging to a DIFFERENT unit. We therefore
+                    # attribute each candidate to THIS unit via its cgroup
+                    # (systemd places each unit's processes under
+                    # .../<unit>.service/...) and pick the FIRST candidate that
+                    # belongs to $service_arg. Iterating all matches (not just
+                    # the first) matters on multi-instance hosts: if the first
+                    # pgrep hit is a sibling's process, a later hit may still be
+                    # this unit's. If none belongs to this unit (or the cgroup
+                    # can't be read), freenet_pid stays empty → fail closed,
+                    # rather than blessing this (active-but-exited) unit with a
+                    # sibling's live process.
+                    #
+                    # The pattern uses ERE alternation `(A|B)` (pgrep -f uses
+                    # ERE). It matches the freenet gateway command line, which is
+                    # `freenet network ... --is-gateway ...`.
+                    #
                     # `|| true`: pgrep exits non-zero when it finds no match,
                     # which under `set -euo pipefail` would otherwise abort the
                     # function here (skipping the active-but-no-process handling
-                    # below). An empty candidate_pid is the intended "not found".
+                    # below). An empty match list is the intended "not found".
                     local candidate_pid
-                    candidate_pid=$(pgrep -f "freenet.*--is-gateway\|freenet.*network" | head -1 || true)
-                    # Fixed-string match (`-F`): the unit token is matched
-                    # literally so the `.` in `<unit>.service` is not a regex
-                    # wildcard, and `freenet-gateway.service` does not match a
-                    # sibling like `freenet-gateway-hector.service` (the `-` vs
-                    # `.` boundary differs).
-                    if [[ -n "$candidate_pid" ]] \
-                        && sudo cat "/proc/$candidate_pid/cgroup" 2>/dev/null \
+                    while IFS= read -r candidate_pid; do
+                        [[ -z "$candidate_pid" ]] && continue
+                        # Fixed-string match (`-F`): the unit token is matched
+                        # literally so the `.` in `<unit>.service` is not a regex
+                        # wildcard, and `freenet-gateway.service` does not match
+                        # a sibling like `freenet-gateway-hector.service` (the
+                        # `-` vs `.` boundary differs).
+                        if sudo cat "/proc/$candidate_pid/cgroup" 2>/dev/null \
                             | grep -qF "$service_arg.service"; then
-                        freenet_pid="$candidate_pid"
-                    else
+                            freenet_pid="$candidate_pid"
+                            break
+                        fi
+                    done < <(pgrep -f "freenet.*network|freenet.*--is-gateway" || true)
+                    # If no candidate was attributed to this unit, clear the
+                    # leftover MainPID "0"/"" so the active-but-no-process branch
+                    # below fires.
+                    if [[ "$freenet_pid" == "0" ]]; then
                         freenet_pid=""
                     fi
                 fi

--- a/scripts/deploy-local-gateway.sh
+++ b/scripts/deploy-local-gateway.sh
@@ -308,102 +308,136 @@ verify_service() {
 
     case "$SERVICE_MANAGER" in
         systemd)
-            # Check if unit file exists by querying systemctl directly
-            if systemctl list-unit-files "$service_arg.service" 2>/dev/null | grep -q "$service_arg.service"; then
-                echo -n "  Verifying service status ($service_arg)... "
-                sleep 3  # Give service time to start
+            # Check if unit file exists by querying systemctl directly.
+            #
+            # If the unit file is NOT found we must treat that as a verification
+            # FAILURE (return 1), not silently fall through to a 0 exit. A
+            # missing unit means the service this deploy is supposed to manage
+            # cannot be confirmed running — reporting success here is exactly
+            # the false-success class that left nova "deployed" with a dead
+            # gateway on 2026-06-18 (#4492).
+            if ! systemctl list-unit-files "$service_arg.service" 2>/dev/null | grep -q "$service_arg.service"; then
+                echo "  ⚠️  Service unit file not found for $service_arg; cannot verify it is running"
+                echo "     This deploy CANNOT be confirmed — treating as a verification failure."
+                return 1
+            fi
+            echo -n "  Verifying service status ($service_arg)... "
+            sleep 3  # Give service time to start
 
-                if systemctl is-active --quiet "$service_arg.service"; then
-                    # Find the actual freenet process, not the wrapper
-                    # MainPID may point to bash if service uses ExecStart with shell
-                    local freenet_pid=$(pgrep -f "freenet.*--is-gateway\|freenet.*network" | head -1)
+            if systemctl is-active --quiet "$service_arg.service"; then
+                # Declared up front (default "unknown") so the success
+                # summary's `✓ Binary: $running_binary` never trips
+                # `set -u` on the path where no freenet PID is found (e.g.
+                # MainPID 0, or pgrep misses the process). Previously this
+                # was only assigned inside the freenet_pid block, so that
+                # path aborted the whole deploy with an "unbound variable"
+                # error.
+                local running_binary="unknown"
+                # Find the actual freenet process, not the wrapper
+                # MainPID may point to bash if service uses ExecStart with shell
+                local freenet_pid=$(pgrep -f "freenet.*--is-gateway\|freenet.*network" | head -1)
 
-                    if [[ -z "$freenet_pid" ]]; then
-                        # Fallback to MainPID
-                        freenet_pid=$(systemctl show -p MainPID --value "$service_arg.service" 2>/dev/null)
-                    fi
+                if [[ -z "$freenet_pid" ]]; then
+                    # Fallback to MainPID
+                    freenet_pid=$(systemctl show -p MainPID --value "$service_arg.service" 2>/dev/null)
+                fi
 
-                    if [[ -n "$freenet_pid" ]] && [[ "$freenet_pid" != "0" ]]; then
-                        # CRITICAL: Verify the RUNNING process is using the correct binary
-                        local running_binary=$(sudo readlink -f /proc/$freenet_pid/exe 2>/dev/null || echo "unknown")
-                        local expected_binary=$(readlink -f "$INSTALL_PATH" 2>/dev/null || echo "$INSTALL_PATH")
+                if [[ -n "$freenet_pid" ]] && [[ "$freenet_pid" != "0" ]]; then
+                    # CRITICAL: Verify the RUNNING process is using the correct
+                    # binary. running_binary is already declared above; just
+                    # reassign it here.
+                    running_binary=$(sudo readlink -f /proc/$freenet_pid/exe 2>/dev/null || echo "unknown")
+                    local expected_binary=$(readlink -f "$INSTALL_PATH" 2>/dev/null || echo "$INSTALL_PATH")
 
-                        # Handle case where binary is bash (wrapper script) - look for freenet specifically
-                        if [[ "$running_binary" == *"/bash"* ]] || [[ "$running_binary" == *"/sh"* ]]; then
-                            # Find the actual freenet process spawned by the wrapper
-                            local child_pid=$(pgrep -P "$freenet_pid" -f freenet 2>/dev/null | head -1)
-                            if [[ -n "$child_pid" ]]; then
-                                running_binary=$(sudo readlink -f /proc/$child_pid/exe 2>/dev/null || echo "unknown")
-                                freenet_pid="$child_pid"
-                            else
-                                # Try to find any freenet process
-                                local any_freenet=$(pgrep -f "$INSTALL_PATH" | head -1)
-                                if [[ -n "$any_freenet" ]]; then
-                                    running_binary=$(sudo readlink -f /proc/$any_freenet/exe 2>/dev/null || echo "unknown")
-                                    freenet_pid="$any_freenet"
-                                fi
+                    # Handle case where binary is bash (wrapper script) - look for freenet specifically
+                    if [[ "$running_binary" == *"/bash"* ]] || [[ "$running_binary" == *"/sh"* ]]; then
+                        # Find the actual freenet process spawned by the wrapper
+                        local child_pid=$(pgrep -P "$freenet_pid" -f freenet 2>/dev/null | head -1)
+                        if [[ -n "$child_pid" ]]; then
+                            running_binary=$(sudo readlink -f /proc/$child_pid/exe 2>/dev/null || echo "unknown")
+                            freenet_pid="$child_pid"
+                        else
+                            # Try to find any freenet process
+                            local any_freenet=$(pgrep -f "$INSTALL_PATH" | head -1)
+                            if [[ -n "$any_freenet" ]]; then
+                                running_binary=$(sudo readlink -f /proc/$any_freenet/exe 2>/dev/null || echo "unknown")
+                                freenet_pid="$any_freenet"
                             fi
                         fi
-
-                        if [[ "$running_binary" != "unknown" ]] && [[ "$running_binary" != "$expected_binary" ]]; then
-                            echo "✗"
-                            echo "  ⚠️  CRITICAL: Running process using DIFFERENT binary!"
-                            echo "     Running process (PID $freenet_pid) uses: $running_binary"
-                            echo "     Expected (installed at):                 $expected_binary"
-
-                            if [[ $retry_count -lt $max_retries ]]; then
-                                echo "  🔄 Auto-restarting service to fix..."
-                                sudo systemctl restart "$service_arg.service"
-                                sleep 2
-                                # Recursive retry
-                                verify_service "$service_arg" "$expected_version" $((retry_count + 1))
-                                return $?
-                            else
-                                echo "  ❌ Failed after $max_retries restart attempts"
-                                echo "     Manual intervention required."
-                                return 1
-                            fi
-                        fi
                     fi
 
-                    # Verify the binary version on disk matches expected
-                    local disk_version=$("$INSTALL_PATH" --version 2>&1 | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1 || echo "unknown")
-
-                    # Verify version matches
-                    if [[ "$VERIFY_VERSION" == "true" ]] && [[ "$expected_version" != "unknown" ]] && [[ "$disk_version" != "$expected_version" ]]; then
+                    if [[ "$running_binary" != "unknown" ]] && [[ "$running_binary" != "$expected_binary" ]]; then
                         echo "✗"
-                        echo "  ⚠️  Version mismatch!"
-                        echo "     Expected: $expected_version"
-                        echo "     Got:      $disk_version"
-                        return 1
-                    fi
+                        echo "  ⚠️  CRITICAL: Running process using DIFFERENT binary!"
+                        echo "     Running process (PID $freenet_pid) uses: $running_binary"
+                        echo "     Expected (installed at):                 $expected_binary"
 
-                    echo "✓"
-                    echo "  ✓ Version: $disk_version"
-                    echo "  ✓ Service: Running (PID ${freenet_pid:-unknown})"
-                    echo "  ✓ Binary:  $running_binary"
-                else
+                        if [[ $retry_count -lt $max_retries ]]; then
+                            echo "  🔄 Auto-restarting service to fix..."
+                            sudo systemctl restart "$service_arg.service"
+                            sleep 2
+                            # Recursive retry
+                            verify_service "$service_arg" "$expected_version" $((retry_count + 1))
+                            return $?
+                        else
+                            echo "  ❌ Failed after $max_retries restart attempts"
+                            echo "     Manual intervention required."
+                            return 1
+                        fi
+                    fi
+                fi
+
+                # Verify the binary version on disk matches expected
+                local disk_version=$("$INSTALL_PATH" --version 2>&1 | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1 || echo "unknown")
+
+                # Verify version matches
+                if [[ "$VERIFY_VERSION" == "true" ]] && [[ "$expected_version" != "unknown" ]] && [[ "$disk_version" != "$expected_version" ]]; then
                     echo "✗"
-                    echo "  ⚠️  Service failed to start"
-                    echo "     Check logs with: sudo journalctl -u $service_arg.service -n 50"
-
-                    if [[ $retry_count -lt $max_retries ]]; then
-                        echo "  🔄 Retrying start..."
-                        sudo systemctl start "$service_arg.service"
-                        sleep 2
-                        verify_service "$service_arg" "$expected_version" $((retry_count + 1))
-                        return $?
-                    fi
+                    echo "  ⚠️  Version mismatch!"
+                    echo "     Expected: $expected_version"
+                    echo "     Got:      $disk_version"
                     return 1
                 fi
+
+                echo "✓"
+                echo "  ✓ Version: $disk_version"
+                echo "  ✓ Service: Running (PID ${freenet_pid:-unknown})"
+                echo "  ✓ Binary:  $running_binary"
+                # Positively confirmed: service active, correct binary,
+                # matching version. This is the ONLY success path — make
+                # the 0 exit explicit so a future edit can't accidentally
+                # fall through to it.
+                return 0
+            else
+                echo "✗"
+                echo "  ⚠️  Service failed to start"
+                echo "     Check logs with: sudo journalctl -u $service_arg.service -n 50"
+
+                if [[ $retry_count -lt $max_retries ]]; then
+                    echo "  🔄 Retrying start..."
+                    sudo systemctl start "$service_arg.service"
+                    sleep 2
+                    verify_service "$service_arg" "$expected_version" $((retry_count + 1))
+                    return $?
+                fi
+                return 1
             fi
             ;;
         launchd)
+            # launchd verification is not automated; we cannot positively
+            # confirm the service is running the new binary. Return success to
+            # preserve the existing manual-deploy behaviour on macOS, but make
+            # the lack of verification explicit. The automated release-agent
+            # path is systemd-only (nova/vega), and gateway-auto-update.sh adds
+            # an independent is-active gate on top of this (#4492), so the
+            # unverified launchd path is not on the automated update chain.
             echo "  ℹ️  Manual verification required for launchd"
             echo "     Check with: launchctl list | grep $SERVICE_NAME"
+            return 0
             ;;
         none)
-            echo "  ℹ️  Manual verification required"
+            echo "  ℹ️  Manual verification required (no service manager detected)"
+            return 0
             ;;
     esac
 }

--- a/scripts/deploy-local-gateway.sh
+++ b/scripts/deploy-local-gateway.sh
@@ -325,13 +325,14 @@ verify_service() {
             sleep 3  # Give service time to start
 
             if systemctl is-active --quiet "$service_arg.service"; then
-                # Declared up front (default "unknown") so the success
-                # summary's `✓ Binary: $running_binary` never trips
-                # `set -u` on the path where no freenet PID is found (e.g.
-                # MainPID 0, or pgrep misses the process). Previously this
-                # was only assigned inside the freenet_pid block, so that
-                # path aborted the whole deploy with an "unbound variable"
-                # error.
+                # Declared up front (default "unknown") for two reasons:
+                # (1) the success summary's `✓ Binary: $running_binary` no
+                #     longer trips `set -u` when no freenet PID is found
+                #     (previously this aborted the deploy with an "unbound
+                #     variable" error from inside the success path), and
+                # (2) "unknown" is the sentinel for "could not identify a live
+                #     freenet process", which the check below treats as a
+                #     verification FAILURE rather than success.
                 local running_binary="unknown"
                 # Find the actual freenet process, not the wrapper
                 # MainPID may point to bash if service uses ExecStart with shell
@@ -387,6 +388,31 @@ verify_service() {
                     fi
                 fi
 
+                # The unit is `active`, but `active` alone is NOT proof the
+                # gateway is actually running the new binary: a `Type=oneshot`
+                # / `RemainAfterExit` misconfig, or a unit whose ExecStart
+                # forked and exited, reads as `active (exited)` with no live
+                # process. We must positively identify a running freenet
+                # process (above) before blessing the deploy — otherwise we'd
+                # reproduce the very false-success this fix exists to close,
+                # just one rung up (#4492). If neither pgrep nor MainPID found
+                # a non-zero PID, running_binary is still "unknown": fail.
+                if [[ "$running_binary" == "unknown" ]]; then
+                    echo "✗"
+                    echo "  ⚠️  Service unit is active but no running freenet process could be found"
+                    echo "     (active-but-no-process, e.g. a unit that forked-and-exited)."
+                    echo "     Cannot confirm the gateway is running the new binary."
+
+                    if [[ $retry_count -lt $max_retries ]]; then
+                        echo "  🔄 Restarting and re-checking..."
+                        sudo systemctl restart "$service_arg.service"
+                        sleep 2
+                        verify_service "$service_arg" "$expected_version" $((retry_count + 1))
+                        return $?
+                    fi
+                    return 1
+                fi
+
                 # Verify the binary version on disk matches expected
                 local disk_version=$("$INSTALL_PATH" --version 2>&1 | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1 || echo "unknown")
 
@@ -403,10 +429,10 @@ verify_service() {
                 echo "  ✓ Version: $disk_version"
                 echo "  ✓ Service: Running (PID ${freenet_pid:-unknown})"
                 echo "  ✓ Binary:  $running_binary"
-                # Positively confirmed: service active, correct binary,
-                # matching version. This is the ONLY success path — make
-                # the 0 exit explicit so a future edit can't accidentally
-                # fall through to it.
+                # Positively confirmed: service active, a live freenet process
+                # on the correct binary, matching version. This is the ONLY
+                # success path — make the 0 exit explicit so a future edit
+                # can't accidentally fall through to it.
                 return 0
             else
                 echo "✗"

--- a/scripts/deploy-local-gateway.sh
+++ b/scripts/deploy-local-gateway.sh
@@ -334,13 +334,37 @@ verify_service() {
                 #     freenet process", which the check below treats as a
                 #     verification FAILURE rather than success.
                 local running_binary="unknown"
-                # Find the actual freenet process, not the wrapper
-                # MainPID may point to bash if service uses ExecStart with shell
-                local freenet_pid=$(pgrep -f "freenet.*--is-gateway\|freenet.*network" | head -1)
+                # Identify the running process for THIS unit. Prefer the unit's
+                # own MainPID (authoritative and scoped to $service_arg) so a
+                # live process from a DIFFERENT instance can't bless this unit
+                # when it is active-but-exited — a real risk on multi-instance
+                # hosts, where a global `pgrep` would match the wrong process.
+                # Fall back to the global pgrep only when MainPID is
+                # unavailable/0 (e.g. an ExecStart wrapper whose MainPID points
+                # at the shell rather than the freenet child).
+                local freenet_pid
+                freenet_pid=$(systemctl show -p MainPID --value "$service_arg.service" 2>/dev/null)
 
-                if [[ -z "$freenet_pid" ]]; then
-                    # Fallback to MainPID
-                    freenet_pid=$(systemctl show -p MainPID --value "$service_arg.service" 2>/dev/null)
+                if [[ -z "$freenet_pid" ]] || [[ "$freenet_pid" == "0" ]]; then
+                    # Fallback: locate the freenet process by command line. This
+                    # is global, so on a multi-instance host it can match a
+                    # process belonging to a DIFFERENT unit. Attribute the match
+                    # to THIS unit via its cgroup (systemd places each unit's
+                    # processes under .../<unit>.service/...) before trusting it;
+                    # a match that isn't in $service_arg's cgroup is discarded so
+                    # a sibling instance can't bless this (active-but-exited)
+                    # unit. If we can't read the cgroup, we conservatively drop
+                    # the candidate (fail closed) rather than risk a cross-unit
+                    # false success.
+                    local candidate_pid
+                    candidate_pid=$(pgrep -f "freenet.*--is-gateway\|freenet.*network" | head -1)
+                    if [[ -n "$candidate_pid" ]] \
+                        && sudo cat "/proc/$candidate_pid/cgroup" 2>/dev/null \
+                            | grep -q "$service_arg.service"; then
+                        freenet_pid="$candidate_pid"
+                    else
+                        freenet_pid=""
+                    fi
                 fi
 
                 if [[ -n "$freenet_pid" ]] && [[ "$freenet_pid" != "0" ]]; then

--- a/scripts/gateway-auto-update.sh
+++ b/scripts/gateway-auto-update.sh
@@ -26,10 +26,18 @@ INSTALL_PATH="${INSTALL_PATH:-/usr/local/bin/freenet}"
 GITHUB_REPO="${GITHUB_REPO:-freenet/freenet-core}"
 DOWNLOAD_DIR="${DOWNLOAD_DIR:-/tmp/freenet-update}"
 LOG_FILE="${LOG_FILE:-/var/log/freenet-auto-update.log}"
-# systemd unit (without .service) whose health we independently confirm after
-# deploy. Must match deploy-local-gateway.sh's --service default. Overridable
-# so a non-standard instance (e.g. vega's freenet-gateway-hector) can be
-# verified. See verify_service_active / #4492.
+# systemd unit (without .service) this run deploys to AND independently
+# confirms is active afterwards. Used both as deploy-local-gateway.sh's
+# --service and by verify_service_active so the two always target the same
+# unit (#4492).
+#
+# Defaults to freenet-gateway. A non-default instance (e.g. vega's
+# freenet-gateway-hector) MUST set SERVICE_NAME in this script's environment.
+# The release-agent does not yet forward its `managed_service` config as
+# SERVICE_NAME, so on such an instance both the deploy and the gate currently
+# fall back to freenet-gateway — tracked as a follow-up to thread
+# managed_service through (see #4492). Setting SERVICE_NAME in the agent's
+# systemd unit Environment= is the interim fix.
 SERVICE_NAME="${SERVICE_NAME:-freenet-gateway}"
 
 # Flags
@@ -140,7 +148,10 @@ Security:
 EOF
 }
 
-# Parse arguments
+# Parse arguments. In a function (called only on direct execution, from the
+# guard at the bottom) so that `source`-ing this script for unit tests does not
+# consume the test harness's positional args or exit it on an unknown option.
+parse_args() {
 while [[ $# -gt 0 ]]; do
     case $1 in
         --force)
@@ -192,6 +203,7 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+}
 
 # Check dependencies
 check_dependencies() {
@@ -366,6 +378,14 @@ deploy_update() {
 
     if [[ "$ALL_INSTANCES" == "true" ]]; then
         deploy_args+=("--all-instances")
+    else
+        # Deploy (stop/swap/start/verify) the SAME unit the post-deploy gate
+        # below checks. Without this, a non-default instance (e.g. vega's
+        # freenet-gateway-hector) would deploy the default freenet-gateway
+        # while verify_service_active checks freenet-gateway-hector — two
+        # different units, defeating the gate (#4492). --all-instances has its
+        # own fixed unit list, so --service does not apply there.
+        deploy_args+=("--service" "$SERVICE_NAME")
     fi
 
     if [[ "$DRY_RUN" == "true" ]]; then
@@ -529,10 +549,12 @@ main() {
     log INFO "Auto-update check complete"
 }
 
-# Only run main when executed directly, not when sourced. Sourcing is how the
-# regression test (gateway-auto-update_test.sh) exercises verify_service_active
-# and deploy_update in isolation without going through the network download
-# path. `${BASH_SOURCE[0]} == ${0}` is true only on direct execution.
+# Only parse args and run main when executed directly, not when sourced.
+# Sourcing is how the regression test (gateway-auto-update_test.sh) exercises
+# verify_service_active and deploy_update in isolation without going through the
+# network download path; it must not have its own args parsed or be exited by
+# this script. `${BASH_SOURCE[0]} == ${0}` is true only on direct execution.
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    parse_args "$@"
     main "$@"
 fi

--- a/scripts/gateway-auto-update.sh
+++ b/scripts/gateway-auto-update.sh
@@ -31,13 +31,20 @@ LOG_FILE="${LOG_FILE:-/var/log/freenet-auto-update.log}"
 # --service and by verify_service_active so the two always target the same
 # unit (#4492).
 #
-# Defaults to freenet-gateway. A non-default instance (e.g. vega's
-# freenet-gateway-hector) MUST set SERVICE_NAME in this script's environment.
-# The release-agent does not yet forward its `managed_service` config as
-# SERVICE_NAME, so on such an instance both the deploy and the gate currently
-# fall back to freenet-gateway — tracked as a follow-up to thread
-# managed_service through (see #4492). Setting SERVICE_NAME in the agent's
-# systemd unit Environment= is the interim fix.
+# Defaults to freenet-gateway (nova's unit, and the deploy-script default).
+#
+# A non-default instance (e.g. vega's freenet-gateway-hector) needs SERVICE_NAME
+# set, but the release-agent does NOT yet forward its `managed_service` config:
+# it spawns this script via `sudo --non-interactive <cmd> --force
+# --target-version vX.Y.Z` (updater.rs), and sudo strips the environment, so an
+# `Environment=SERVICE_NAME=...` on the agent's unit would NOT reach here unless
+# the sudoers policy also `env_keep`s it (it does not). The robust fix is to
+# forward `managed_service` as an argv flag the agent already passes through the
+# sudoers wildcard (like --target-version), then have the agent invoke this
+# script with `--service`/SERVICE_NAME. Until that lands, both the deploy and
+# the gate fall back to freenet-gateway on a non-default instance — tracked as a
+# follow-up to #4492. (nova, the host in the #4492 incident, IS freenet-gateway,
+# so the default path is correctly covered.)
 SERVICE_NAME="${SERVICE_NAME:-freenet-gateway}"
 
 # Flags

--- a/scripts/gateway-auto-update.sh
+++ b/scripts/gateway-auto-update.sh
@@ -26,6 +26,11 @@ INSTALL_PATH="${INSTALL_PATH:-/usr/local/bin/freenet}"
 GITHUB_REPO="${GITHUB_REPO:-freenet/freenet-core}"
 DOWNLOAD_DIR="${DOWNLOAD_DIR:-/tmp/freenet-update}"
 LOG_FILE="${LOG_FILE:-/var/log/freenet-auto-update.log}"
+# systemd unit (without .service) whose health we independently confirm after
+# deploy. Must match deploy-local-gateway.sh's --service default. Overridable
+# so a non-standard instance (e.g. vega's freenet-gateway-hector) can be
+# verified. See verify_service_active / #4492.
+SERVICE_NAME="${SERVICE_NAME:-freenet-gateway}"
 
 # Flags
 FORCE_UPDATE=false
@@ -374,7 +379,59 @@ deploy_update() {
         return 1
     fi
 
+    # Independent post-deploy service-health gate.
+    #
+    # WHY this is here even though deploy-local-gateway.sh already verifies:
+    # the release-agent spawns whatever deploy-local-gateway.sh is INSTALLED on
+    # the gateway, which can lag the repo. On 2026-06-18 nova ran a months-old
+    # deploy script that swallowed its own verify failure (`verify_service ...
+    # || true`) and printed "Deployment complete!" + exit 0 while the gateway
+    # service was dead — so this wrapper logged "Deployment successful" and the
+    # release was reported green for a down gateway (#4492). This gate does NOT
+    # trust the deploy script's exit code for liveness: it independently asks
+    # systemd whether the managed unit is active, and fails the update if it is
+    # not. That makes the wrapper robust regardless of which deploy script is
+    # installed. (Skipped on --all-instances, where the unit set is dynamic and
+    # the per-instance verification is the deploy script's job.)
+    if [[ "$ALL_INSTANCES" != "true" ]]; then
+        if ! verify_service_active "$SERVICE_NAME"; then
+            log ERROR "Deploy script exited 0 but service '$SERVICE_NAME' is NOT active after update; treating as a failed update"
+            return 1
+        fi
+    fi
+
     log INFO "Deployment successful"
+}
+
+# Independently confirm the managed systemd unit is `active`. Returns 0 only
+# when systemd reports `active`; any other state (inactive/failed/activating),
+# a missing unit, or a non-systemd host returns non-zero. `systemctl is-active`
+# is a read-only query and needs no root. Mirrors the release-agent's
+# version.rs::query_service_active so the script-side and HTTP-side gates agree.
+verify_service_active() {
+    local service_arg="$1"
+
+    # Only systemd is supported by the automated update path (nova/vega). On a
+    # host without systemctl we cannot confirm liveness; fail closed so a
+    # non-systemd gateway is never silently reported as a healthy update.
+    if ! command -v systemctl &> /dev/null; then
+        log ERROR "systemctl not found; cannot confirm '$service_arg' is running"
+        return 1
+    fi
+
+    # Give the unit a moment to settle after the deploy script's own start.
+    sleep 2
+
+    local state
+    state=$(systemctl is-active "$service_arg.service" 2>/dev/null || true)
+    if [[ "$state" == "active" ]]; then
+        log INFO "Service '$service_arg' is active"
+        return 0
+    fi
+
+    log ERROR "Service '$service_arg' is '${state:-unknown}' (expected 'active')"
+    log ERROR "Check logs with: sudo journalctl -u $service_arg.service -n 50"
+    return 1
 }
 
 # Cleanup temporary files
@@ -450,13 +507,17 @@ main() {
                 exit 1
             fi
 
-            # Verify update
+            # Verify update. A version mismatch here means the new binary did
+            # NOT actually land on disk — that is a FAILED update, not a
+            # warning. Previously this only WARNed, so an install that left the
+            # old binary in place still exited 0 and was reported as success.
             local new_version
             new_version=$(get_current_version)
             if [[ "$new_version" == "$latest_version" ]]; then
                 log INFO "Successfully updated to v$latest_version"
             else
-                log WARN "Update completed but version mismatch: expected $latest_version, got $new_version"
+                log ERROR "Update failed: expected v$latest_version on disk but found v$new_version"
+                exit 1
             fi
         else
             log INFO "[DRY RUN] Would deploy v$latest_version"
@@ -468,4 +529,10 @@ main() {
     log INFO "Auto-update check complete"
 }
 
-main "$@"
+# Only run main when executed directly, not when sourced. Sourcing is how the
+# regression test (gateway-auto-update_test.sh) exercises verify_service_active
+# and deploy_update in isolation without going through the network download
+# path. `${BASH_SOURCE[0]} == ${0}` is true only on direct execution.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/release-agent/README.md
+++ b/scripts/release-agent/README.md
@@ -83,9 +83,12 @@ will show a `dry-run: would invoke …` line. No update is actually performed.
   service failed to restart (the vega v0.2.71 incident, where `/version`
   reported the new version while the gateway was down for ~5 minutes).
   Consumers polling for a successful update MUST require `service_active == true`.
-  **Backward compatibility:** agents built before this field omit it entirely —
-  treat its ABSENCE as "agent predates the check" and fall back to the
-  binary-only check, not as a failure.
+  **Backward compatibility:** agents built before this field omit it entirely.
+  Its ABSENCE means "this agent cannot confirm service health", which is NOT the
+  same as success. As of #4492 the `gateway-update.yml` consumer **fails closed**
+  when the field is absent (the binary may have swapped while the service stayed
+  dead — the 2026-06-18 nova incident); accepting a binary-only check is now an
+  explicit, opt-in choice (`allow_binary_only_fallback=true`), not the default.
 - **`managed_service`** — the systemd unit name whose state `service_active`
   reflects.
 

--- a/scripts/release-agent/deploy-local-gateway_test.sh
+++ b/scripts/release-agent/deploy-local-gateway_test.sh
@@ -32,9 +32,14 @@ FAILURES=0
 pass() { echo "ok   - $1"; }
 fail() { echo "FAIL - $1" >&2; FAILURES=$((FAILURES + 1)); }
 
-TMP="$(mktemp -d)"
+# Hard-fail on any fixture-setup error (e.g. a read-only /tmp where mktemp/mkdir
+# fail). The body intentionally avoids `set -e` (assertions run in `if`
+# conditions and must keep going after a failure), so a broken harness could
+# otherwise let a negative-case assertion pass vacuously — guard setup
+# explicitly.
+TMP="$(mktemp -d)" || { echo "FAIL: mktemp -d failed (is /tmp writable?)" >&2; exit 1; }
 trap 'rm -rf "$TMP"' EXIT
-mkdir -p "$TMP/bin" "$TMP/install"
+mkdir -p "$TMP/bin" "$TMP/install" || { echo "FAIL: could not create $TMP dirs" >&2; exit 1; }
 
 # Fake freenet binary that reports the target version. Used both as the source
 # --binary and (after the script copies it) as the installed binary.
@@ -46,17 +51,28 @@ chmod +x "$TMP/source-binary"
 
 # Stub `sudo`: chown is a no-op (we are not root and INSTALL_PATH is in tmp);
 # `readlink` is intercepted to report the installed path so the running-binary
-# check matches; everything else execs through.
+# check matches; `cat /proc/<pid>/cgroup` is answered from $TMP/cgroup-content
+# so a test can control whether the pgrep-fallback candidate is attributed to
+# the target unit; everything else execs through.
 cat > "$TMP/bin/sudo" <<EOF
 #!/bin/bash
 [[ "\$1" == "-n" || "\$1" == "--non-interactive" ]] && shift
 case "\$1" in
   chown) exit 0 ;;
   readlink) echo "$TMP/install/freenet"; exit 0 ;;
+  cat)
+    # Only the cgroup read is modelled; echo whatever the test configured.
+    cat "$TMP/cgroup-content" 2>/dev/null || true
+    exit 0
+    ;;
   *) exec "\$@" ;;
 esac
 EOF
 chmod +x "$TMP/bin/sudo"
+# Default cgroup content: belongs to the target unit (so the fallback-path
+# candidate, if used, is attributed to this unit). Tests that exercise a
+# foreign process overwrite this.
+echo "0::/system.slice/freenet-gateway.service" > "$TMP/cgroup-content"
 
 # `lsof` stub: binary is never busy.
 printf '#!/bin/bash\nexit 1\n' > "$TMP/bin/lsof"
@@ -147,6 +163,36 @@ if [[ "$rc" != "0" ]]; then
     pass "verify_service: active-but-no-process → non-zero exit"
 else
     fail "verify_service: active-but-no-process must NOT exit 0 (got $rc)"
+fi
+
+# ── active-but-no-process for THIS unit, but ANOTHER freenet process is
+#    alive → still failure. Pins the MainPID-first + cgroup-attribution: a live
+#    process from a DIFFERENT instance (its cgroup names another unit) must NOT
+#    bless this unit's empty MainPID.
+write_systemctl 0 true 0      # THIS unit: active, MainPID 0 (no process)
+write_pgrep found             # a global pgrep WOULD find some freenet process
+# ...but that process belongs to a different unit's cgroup.
+echo "0::/system.slice/freenet-gateway-hector.service" > "$TMP/cgroup-content"
+rc=$(run_deploy)
+if [[ "$rc" != "0" ]]; then
+    pass "verify_service: MainPID 0 + foreign-cgroup freenet process → non-zero exit (no cross-unit bless)"
+else
+    fail "verify_service: a foreign-cgroup freenet process must NOT bless this unit's empty MainPID (got $rc)"
+fi
+# Restore the default (this-unit) cgroup for any later cases.
+echo "0::/system.slice/freenet-gateway.service" > "$TMP/cgroup-content"
+
+# ── MainPID 0 (wrapper ExecStart) but pgrep finds the unit's OWN freenet
+#    child (cgroup matches) → success. Pins that the cgroup-attributed
+#    fallback still blesses a legitimately-running wrapper-launched gateway.
+write_systemctl 0 true 0      # active, MainPID 0 (wrapper points MainPID at shell)
+write_pgrep found             # freenet child found by command line
+echo "0::/system.slice/freenet-gateway.service" > "$TMP/cgroup-content"  # belongs to this unit
+rc=$(run_deploy)
+if [[ "$rc" == "0" ]]; then
+    pass "verify_service: MainPID 0 + this-unit-cgroup freenet child → exit 0 (wrapper ExecStart still verifies)"
+else
+    fail "verify_service: a this-unit freenet child should verify even when MainPID is 0 (got $rc)"
 fi
 
 # ── result ────────────────────────────────────────────────────────────

--- a/scripts/release-agent/deploy-local-gateway_test.sh
+++ b/scripts/release-agent/deploy-local-gateway_test.sh
@@ -61,8 +61,17 @@ case "\$1" in
   chown) exit 0 ;;
   readlink) echo "$TMP/install/freenet"; exit 0 ;;
   cat)
-    # Only the cgroup read is modelled; echo whatever the test configured.
-    cat "$TMP/cgroup-content" 2>/dev/null || true
+    # Only the cgroup read is modelled: "/proc/<pid>/cgroup". Return per-PID
+    # content from \$TMP/cgroup-<pid> if the test set it, else the default
+    # \$TMP/cgroup-content. Lets a multi-candidate test give each PID a
+    # different unit cgroup.
+    proc_path="\$2"
+    pid=\$(printf '%s' "\$proc_path" | sed -n 's#^/proc/\([0-9]*\)/cgroup\$#\1#p')
+    if [[ -n "\$pid" && -f "$TMP/cgroup-\$pid" ]]; then
+        cat "$TMP/cgroup-\$pid"
+    else
+        cat "$TMP/cgroup-content" 2>/dev/null || true
+    fi
     exit 0
     ;;
   *) exec "\$@" ;;
@@ -104,13 +113,36 @@ EOF
     chmod +x "$TMP/bin/systemctl"
 }
 
-# `pgrep` stub: $1 controls whether a freenet process is "found".
+# `pgrep` stub: $1 controls whether a freenet process is "running" on the box.
+#
+# FAITHFUL to `pgrep -f`: it applies the caller's regex (ERE, last argument)
+# against a REALISTIC freenet gateway command line, so a broken production
+# pattern (e.g. a literal `\|` that matches nothing) makes this stub return no
+# match — the test then catches it instead of masking it. Emits PID 4242 only
+# when "running" AND the pattern matches the fake cmdline; exits 1 otherwise
+# (matching real pgrep's no-match exit).
 write_pgrep() {
-    if [[ "$1" == "found" ]]; then
-        printf '#!/bin/bash\necho 4242\n' > "$TMP/bin/pgrep"
-    else
-        printf '#!/bin/bash\nexit 1\n' > "$TMP/bin/pgrep"
-    fi
+    local running="$1"
+    # "multi" mode emits TWO matching PIDs (4241 a sibling, 4242 this unit) to
+    # exercise the iterate-all-candidates path; "found" emits one (4242).
+    cat > "$TMP/bin/pgrep" <<EOF
+#!/bin/bash
+running="$running"
+# A representative running freenet gateway command line.
+cmdline="/usr/local/bin/freenet network --is-gateway --skip-load-from-network"
+# The regex pgrep -f matches against is the LAST argument.
+pat="\${@: -1}"
+if [[ "\$running" == "multi" ]] && printf '%s' "\$cmdline" | grep -Eq "\$pat"; then
+    echo 4241
+    echo 4242
+    exit 0
+fi
+if [[ "\$running" == "found" ]] && printf '%s' "\$cmdline" | grep -Eq "\$pat"; then
+    echo 4242
+    exit 0
+fi
+exit 1
+EOF
     chmod +x "$TMP/bin/pgrep"
 }
 
@@ -204,6 +236,22 @@ if [[ "$rc" == "0" ]]; then
 else
     fail "verify_service: a this-unit freenet child should verify even when MainPID is 0 (got $rc)"
 fi
+
+# ── MainPID 0, TWO pgrep matches: the first (4241) is a sibling, the second
+#    (4242) belongs to this unit → must iterate past the sibling and verify.
+#    Pins the iterate-all-candidates behaviour (not just the first pgrep hit).
+write_systemctl 0 true 0      # active, MainPID 0
+write_pgrep multi             # pgrep returns 4241 then 4242
+echo "0::/system.slice/freenet-gateway-hector.service" > "$TMP/cgroup-4241"  # sibling
+echo "0::/system.slice/freenet-gateway.service"        > "$TMP/cgroup-4242"  # this unit
+echo "0::/system.slice/freenet-gateway.service" > "$TMP/cgroup-content"      # default fallback
+rc=$(run_deploy)
+if [[ "$rc" == "0" ]]; then
+    pass "verify_service: iterates past a sibling pgrep match to this unit's process → exit 0"
+else
+    fail "verify_service: should iterate past the first (sibling) pgrep match to this unit's (got $rc)"
+fi
+rm -f "$TMP/cgroup-4241" "$TMP/cgroup-4242"
 
 # ── result ────────────────────────────────────────────────────────────
 if (( FAILURES > 0 )); then

--- a/scripts/release-agent/deploy-local-gateway_test.sh
+++ b/scripts/release-agent/deploy-local-gateway_test.sh
@@ -115,11 +115,13 @@ write_pgrep() {
 }
 
 run_deploy() {
+    # Capture combined output to $TMP/last-output so assertions can inspect
+    # WHICH path was taken (not just the exit code), then echo the exit code.
     bash "$DEPLOY_SH" \
         --binary "$TMP/source-binary" \
         --service freenet-gateway \
         --install-path "$TMP/install/freenet" \
-        >/dev/null 2>&1
+        >"$TMP/last-output" 2>&1
     echo $?
 }
 
@@ -163,6 +165,14 @@ if [[ "$rc" != "0" ]]; then
     pass "verify_service: active-but-no-process → non-zero exit"
 else
     fail "verify_service: active-but-no-process must NOT exit 0 (got $rc)"
+fi
+# It must reach the GRACEFUL active-but-no-process branch, not abort via set -e
+# on the pgrep-not-found command substitution (which would also exit non-zero,
+# but at the wrong place, skipping the retry). Assert the branch's message.
+if grep -q "no running freenet process could be found" "$TMP/last-output"; then
+    pass "verify_service: active-but-no-process reaches graceful branch (no set -e abort on pgrep)"
+else
+    fail "verify_service: active-but-no-process did not reach its graceful branch (likely set -e abort)"
 fi
 
 # ── active-but-no-process for THIS unit, but ANOTHER freenet process is

--- a/scripts/release-agent/deploy-local-gateway_test.sh
+++ b/scripts/release-agent/deploy-local-gateway_test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Regression test for deploy-local-gateway.sh::verify_service (#4492).
+#
+# This is the function that actually regressed in production on 2026-06-18: a
+# stale copy on nova swallowed its verify failure and exited 0 while the
+# gateway service was dead. The repo copy is fixed, but verify_service had
+# several return-0 fall-throughs worth pinning so they don't come back:
+#   - service NOT active                       → exit 1
+#   - systemd unit file not found              → exit 1
+#   - active but NO running freenet process    → exit 1 (active-but-exited)
+#   - active + correct binary + version match  → exit 0  (the only success)
+#
+# Strategy: run the REAL deploy-local-gateway.sh end-to-end with stub
+# systemctl/sudo/pgrep/lsof on PATH and a throwaway --install-path, then assert
+# the script's overall exit code (verify_service's result propagates to it via
+# VERIFICATION_FAILED → exit 1). No real systemd, no root, no network.
+#
+# Run manually: bash scripts/release-agent/deploy-local-gateway_test.sh
+# Also wired into CI (the Fmt job in .github/workflows/ci.yml).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_SH="$SCRIPT_DIR/../deploy-local-gateway.sh"
+
+if [[ ! -x "$DEPLOY_SH" ]]; then
+    echo "FAIL: $DEPLOY_SH not found or not executable" >&2
+    exit 1
+fi
+
+FAILURES=0
+pass() { echo "ok   - $1"; }
+fail() { echo "FAIL - $1" >&2; FAILURES=$((FAILURES + 1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin" "$TMP/install"
+
+# Fake freenet binary that reports the target version. Used both as the source
+# --binary and (after the script copies it) as the installed binary.
+cat > "$TMP/source-binary" <<'EOF'
+#!/bin/bash
+echo "freenet 0.2.78"
+EOF
+chmod +x "$TMP/source-binary"
+
+# Stub `sudo`: chown is a no-op (we are not root and INSTALL_PATH is in tmp);
+# `readlink` is intercepted to report the installed path so the running-binary
+# check matches; everything else execs through.
+cat > "$TMP/bin/sudo" <<EOF
+#!/bin/bash
+[[ "\$1" == "-n" || "\$1" == "--non-interactive" ]] && shift
+case "\$1" in
+  chown) exit 0 ;;
+  readlink) echo "$TMP/install/freenet"; exit 0 ;;
+  *) exec "\$@" ;;
+esac
+EOF
+chmod +x "$TMP/bin/sudo"
+
+# `lsof` stub: binary is never busy.
+printf '#!/bin/bash\nexit 1\n' > "$TMP/bin/lsof"
+chmod +x "$TMP/bin/lsof"
+
+export PATH="$TMP/bin:$PATH"
+
+# Write a systemctl stub for a given is-active state, unit-file presence, and
+# MainPID. $1=is-active-exit (0=active), $2=unit-found (true/false),
+# $3=mainpid.
+write_systemctl() {
+    local active_exit="$1" unit_found="$2" mainpid="$3"
+    local unit_line=""
+    [[ "$unit_found" == "true" ]] && unit_line='echo "freenet-gateway.service enabled"'
+    cat > "$TMP/bin/systemctl" <<EOF
+#!/bin/bash
+case "\$1" in
+  is-active)
+    [[ "\$*" == *"--quiet"* ]] || echo "active"
+    exit $active_exit
+    ;;
+  list-unit-files) $unit_line ; exit 0 ;;
+  is-enabled) exit 1 ;;
+  show) echo "$mainpid" ;;
+  start|stop|restart|disable|enable|daemon-reload) exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+    chmod +x "$TMP/bin/systemctl"
+}
+
+# `pgrep` stub: $1 controls whether a freenet process is "found".
+write_pgrep() {
+    if [[ "$1" == "found" ]]; then
+        printf '#!/bin/bash\necho 4242\n' > "$TMP/bin/pgrep"
+    else
+        printf '#!/bin/bash\nexit 1\n' > "$TMP/bin/pgrep"
+    fi
+    chmod +x "$TMP/bin/pgrep"
+}
+
+run_deploy() {
+    bash "$DEPLOY_SH" \
+        --binary "$TMP/source-binary" \
+        --service freenet-gateway \
+        --install-path "$TMP/install/freenet" \
+        >/dev/null 2>&1
+    echo $?
+}
+
+# ── active + correct binary + matching version → success (exit 0) ────
+write_systemctl 0 true 4242   # active, unit found, MainPID 4242
+write_pgrep found
+rc=$(run_deploy)
+if [[ "$rc" == "0" ]]; then
+    pass "verify_service: active + running process + version match → exit 0"
+else
+    fail "verify_service: healthy deploy should exit 0 (got $rc)"
+fi
+
+# ── service NOT active → failure (exit 1) — THE incident class ────────
+write_systemctl 3 true 4242   # is-active exits non-zero
+write_pgrep found
+rc=$(run_deploy)
+if [[ "$rc" != "0" ]]; then
+    pass "verify_service: dead service → non-zero exit (#4492)"
+else
+    fail "verify_service: dead service must NOT exit 0 (got $rc)"
+fi
+
+# ── systemd unit file not found → failure (exit 1) ───────────────────
+write_systemctl 0 false 4242  # active reported, but no unit file listed
+write_pgrep found
+rc=$(run_deploy)
+if [[ "$rc" != "0" ]]; then
+    pass "verify_service: unit file not found → non-zero exit"
+else
+    fail "verify_service: missing unit must NOT exit 0 (got $rc)"
+fi
+
+# ── active but no running freenet process → failure (exit 1) ─────────
+# active (exited) / oneshot misconfig: the unit reads active but there is no
+# live process to confirm the new binary. Must fail, not bless.
+write_systemctl 0 true 0      # active, unit found, MainPID 0
+write_pgrep notfound          # pgrep finds nothing either
+rc=$(run_deploy)
+if [[ "$rc" != "0" ]]; then
+    pass "verify_service: active-but-no-process → non-zero exit"
+else
+    fail "verify_service: active-but-no-process must NOT exit 0 (got $rc)"
+fi
+
+# ── result ────────────────────────────────────────────────────────────
+if (( FAILURES > 0 )); then
+    echo "$FAILURES deploy-local-gateway.sh test(s) failed" >&2
+    exit 1
+fi
+echo "All deploy-local-gateway.sh tests passed."

--- a/scripts/release-agent/gateway-auto-update_test.sh
+++ b/scripts/release-agent/gateway-auto-update_test.sh
@@ -137,6 +137,19 @@ else
     fail "deploy_update: active service should succeed"
 fi
 
+# --all-instances deliberately skips the single-unit gate (the unit set is
+# dynamic there; deploy-local-gateway.sh verifies each instance and its exit
+# code is still checked). Pin the skip so a future edit can't accidentally
+# invert the condition and drop the gate on the common single-instance path.
+echo "failed" > "$TMP/service-state"
+ALL_INSTANCES=true
+if deploy_update "$TMP/fake-binary" 2>/dev/null; then
+    pass "deploy_update: --all-instances skips the single-unit gate (deploy exit code still gates)"
+else
+    fail "deploy_update: --all-instances should not be blocked by the single-unit gate"
+fi
+ALL_INSTANCES=false
+
 # ── result ────────────────────────────────────────────────────────────
 
 if (( FAILURES > 0 )); then

--- a/scripts/release-agent/gateway-auto-update_test.sh
+++ b/scripts/release-agent/gateway-auto-update_test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Regression test for the independent service-health gate in
+# gateway-auto-update.sh (#4492).
+#
+# THE incident this pins: on 2026-06-18 (v0.2.78) nova ran a stale
+# deploy-local-gateway.sh that swallowed its own verify failure and exited 0
+# while the gateway service was DEAD. gateway-auto-update.sh trusted that exit
+# code, logged "Deployment successful", and the release was reported green for
+# a down gateway.
+#
+# The fix added verify_service_active(), an independent `systemctl is-active`
+# gate that deploy_update() applies AFTER the deploy script — so a deploy
+# script that lies (exits 0 on a dead service) is still caught.
+#
+# Strategy: source the script (its `main` is guarded by a
+# BASH_SOURCE==$0 check, so sourcing does NOT run the update) and drive the two
+# functions directly with a stub `systemctl`/`sudo` on PATH. No network, no
+# real systemd, no root.
+#
+# Run manually: bash scripts/release-agent/gateway-auto-update_test.sh
+# Also wired into CI (the Fmt job in .github/workflows/ci.yml).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUTO_UPDATE_SH="$SCRIPT_DIR/../gateway-auto-update.sh"
+
+if [[ ! -f "$AUTO_UPDATE_SH" ]]; then
+    echo "FAIL: $AUTO_UPDATE_SH not found" >&2
+    exit 1
+fi
+
+FAILURES=0
+pass() { echo "ok   - $1"; }
+fail() { echo "FAIL - $1" >&2; FAILURES=$((FAILURES + 1)); }
+
+# A throwaway tempdir holding stub binaries and the fake deploy script.
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+# Stub `systemctl`: its `is-active` answer is whatever is written to the
+# SERVICE_STATE file. Everything else (start/stop/etc.) is a no-op success.
+cat > "$TMP/bin/systemctl" <<EOF
+#!/bin/bash
+case "\$1" in
+  is-active)
+    state="\$(cat "$TMP/service-state" 2>/dev/null || echo unknown)"
+    echo "\$state"
+    [[ "\$state" == "active" ]] && exit 0 || exit 3
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$TMP/bin/systemctl"
+
+# Stub `sudo`: drop a leading -n/--non-interactive and exec the rest, so
+# `sudo "$deploy_script"` just runs the (fake) deploy script.
+cat > "$TMP/bin/sudo" <<'EOF'
+#!/bin/bash
+[[ "$1" == "-n" || "$1" == "--non-interactive" ]] && shift
+exec "$@"
+EOF
+chmod +x "$TMP/bin/sudo"
+
+export PATH="$TMP/bin:$PATH"
+
+# Quiet the script's logger and avoid writing to /var/log during the test.
+export LOG_FILE="$TMP/auto-update.log"
+
+# Source the script. `main` is guarded, so this only defines functions.
+# shellcheck source=scripts/gateway-auto-update.sh
+source "$AUTO_UPDATE_SH"
+
+# Functions log to stderr; keep the test output readable by routing there.
+exec 3>&2
+
+# ── verify_service_active ────────────────────────────────────────────
+
+echo "active" > "$TMP/service-state"
+if verify_service_active "freenet-gateway" 2>/dev/null; then
+    pass "verify_service_active: active service → 0"
+else
+    fail "verify_service_active: active service should return 0"
+fi
+
+echo "failed" > "$TMP/service-state"
+if verify_service_active "freenet-gateway" 2>/dev/null; then
+    fail "verify_service_active: failed service must NOT return 0 (vega/nova case)"
+else
+    pass "verify_service_active: failed service → non-zero"
+fi
+
+echo "inactive" > "$TMP/service-state"
+if verify_service_active "freenet-gateway" 2>/dev/null; then
+    fail "verify_service_active: inactive service must NOT return 0"
+else
+    pass "verify_service_active: inactive service → non-zero"
+fi
+
+# ── deploy_update: the lying deploy script (the actual incident) ──────
+
+# A deploy script that prints success and exits 0 EVEN THOUGH the service is
+# dead — exactly nova's stale script on 2026-06-18.
+LYING_DEPLOY="$TMP/scriptdir/deploy-local-gateway.sh"
+mkdir -p "$TMP/scriptdir"
+cat > "$LYING_DEPLOY" <<'EOF'
+#!/bin/bash
+echo "  Verifying service status (freenet-gateway)... ✗"
+echo "  ⚠️  Service failed to start"
+echo "✅ Deployment complete!"
+exit 0
+EOF
+chmod +x "$LYING_DEPLOY"
+
+# deploy_update resolves the deploy script via SCRIPT_DIR; point it at the dir
+# holding our lying script. ALL_INSTANCES/DRY_RUN are read by deploy_update.
+SCRIPT_DIR="$TMP/scriptdir"
+ALL_INSTANCES=false
+DRY_RUN=false
+SERVICE_NAME="freenet-gateway"
+
+# Service is DEAD. The deploy script exits 0, but the independent gate must
+# still fail deploy_update — this is the regression: pre-fix it returned 0.
+echo "failed" > "$TMP/service-state"
+if deploy_update "$TMP/fake-binary" 2>/dev/null; then
+    fail "deploy_update: lying deploy script + dead service must NOT succeed (#4492)"
+else
+    pass "deploy_update: dead service caught despite deploy script exiting 0"
+fi
+
+# Same deploy script, but now the service is genuinely active → success.
+echo "active" > "$TMP/service-state"
+if deploy_update "$TMP/fake-binary" 2>/dev/null; then
+    pass "deploy_update: active service → success"
+else
+    fail "deploy_update: active service should succeed"
+fi
+
+# ── result ────────────────────────────────────────────────────────────
+
+if (( FAILURES > 0 )); then
+    echo "$FAILURES gateway-auto-update.sh test(s) failed" >&2
+    exit 1
+fi
+echo "All gateway-auto-update.sh tests passed."

--- a/scripts/release-agent/gateway-auto-update_test.sh
+++ b/scripts/release-agent/gateway-auto-update_test.sh
@@ -34,10 +34,15 @@ FAILURES=0
 pass() { echo "ok   - $1"; }
 fail() { echo "FAIL - $1" >&2; FAILURES=$((FAILURES + 1)); }
 
-# A throwaway tempdir holding stub binaries and the fake deploy script.
-TMP="$(mktemp -d)"
+# A throwaway tempdir holding stub binaries and the fake deploy script. Hard-
+# fail on any fixture-setup error (e.g. a read-only /tmp where mktemp/mkdir
+# fail) so a broken harness can NEVER let a negative-case assertion pass
+# vacuously. We deliberately do NOT `set -e` for the body (assertions run in
+# `if` conditions and must keep going after a failure), so guard setup
+# explicitly.
+TMP="$(mktemp -d)" || { echo "FAIL: mktemp -d failed (is /tmp writable?)" >&2; exit 1; }
 trap 'rm -rf "$TMP"' EXIT
-mkdir -p "$TMP/bin"
+mkdir -p "$TMP/bin" || { echo "FAIL: could not create $TMP/bin" >&2; exit 1; }
 
 # Stub `systemctl`: its `is-active` answer is whatever is written to the
 # SERVICE_STATE file. Everything else (start/stop/etc.) is a no-op success.

--- a/scripts/release-agent/verify-version-decision.sh
+++ b/scripts/release-agent/verify-version-decision.sh
@@ -15,8 +15,13 @@
 #   success           binary is on the target version AND the service is active
 #                     (new-agent path) — the update is confirmed.
 #   success-fallback  binary is on the target version but the agent predates
-#                     the `service_active` field — fall back to binary-only
-#                     verification (with a warning). Backward compatibility.
+#                     the `service_active` field, so service health is
+#                     UNVERIFIABLE. This is a classification only — it does NOT
+#                     mean "accept". As of #4492 the consumer (gateway-update.yml)
+#                     fails closed on this token by default and accepts a
+#                     binary-only check only when explicitly opted in via the
+#                     `allow_binary_only_fallback` input. The policy lives in the
+#                     workflow, not here.
 #   wait              not yet converged: binary not on target, OR binary on
 #                     target but service not active (the vega case), OR the
 #                     gateway is unreachable / returned malformed JSON. The
@@ -58,7 +63,37 @@ verify_version_decision() {
             echo "wait"
         fi
     else
-        # Old agent without the field: fall back to binary-only verification.
+        # Old agent without the field: service health is unverifiable here.
+        # Emit the token; the consumer decides whether to accept binary-only
+        # (off by default since #4492 — see the header).
         echo "success-fallback"
+    fi
+}
+
+# Consumer-side policy for the `success-fallback` token (#4492). Extracted here
+# (rather than inline in gateway-update.yml) so the fail-closed default is unit-
+# tested and cannot silently regress — the inline-in-YAML version is exactly the
+# kind of untested logic this file exists to replace.
+#
+# Usage:
+#   decision=$(fallback_decision "$DECISION_TOKEN" "$ALLOW_BINARY_ONLY_FALLBACK")
+#
+# Echoes one token on stdout:
+#   accept  the workflow may treat this as a successful update. ONLY for
+#           `success-fallback` WHEN `allow` is exactly "true" (the explicit
+#           opt-in). A genuine `success` is the workflow's own concern and is
+#           NOT routed through here.
+#   hold    do NOT accept: keep polling and fail closed at the deadline. This is
+#           the default for `success-fallback` (missing service_active → service
+#           health unverifiable → must not be reported as success).
+#
+# `allow` is treated as opt-in: anything other than the exact string "true"
+# (empty on the release-trigger path, "false", garbage) yields `hold`.
+fallback_decision() {
+    local token="$1" allow="$2"
+    if [[ "$token" == "success-fallback" && "$allow" == "true" ]]; then
+        echo "accept"
+    else
+        echo "hold"
     fi
 }

--- a/scripts/release-agent/verify-version-decision_test.sh
+++ b/scripts/release-agent/verify-version-decision_test.sh
@@ -5,8 +5,10 @@
 # This is the exact vega v0.2.71 incident path:
 #   - present `service_active:false` MUST NOT report success (the load-bearing
 #     assertion: that is what let the down gateway look healthy);
-#   - an ABSENT field MUST fall back to binary-only success (backward compat
-#     with agents that predate the field);
+#   - an ABSENT field classifies as `success-fallback` (backward-compat token
+#     for agents predating the field). NOTE: the token is not itself an
+#     "accept" — since #4492 the consumer workflow fails closed on it by
+#     default; this test pins the classifier, not the consumer's policy;
 #   - present `service_active:true` + matching version MUST report success.
 #
 # The real function is sourced (not copied) so the test cannot drift from the
@@ -99,6 +101,38 @@ check "malformed JSON response → wait" \
 check "new agent: service_active null + binary on target → wait" \
     '{"version":"0.2.71","service_active":null}' \
     "$TARGET" "wait"
+
+# ── fallback_decision: consumer policy for the success-fallback token (#4492) ──
+#
+# This is the load-bearing fail-closed default: a missing service_active field
+# must NOT be accepted as success unless the operator explicitly opts in.
+
+check_fallback() {
+    # check_fallback <description> <token> <allow> <expected>
+    local desc="$1" token="$2" allow="$3" expected="$4" actual
+    actual=$(fallback_decision "$token" "$allow")
+    if [[ "$actual" == "$expected" ]]; then
+        echo "ok   - $desc"
+    else
+        echo "FAIL - $desc (got '$actual', expected '$expected')" >&2
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# Default (no opt-in): fall back is NOT accepted — fail closed. The empty
+# string is what the release-trigger path passes (no workflow input).
+check_fallback "success-fallback + allow empty → hold (fail closed, release path)" \
+    "success-fallback" "" "hold"
+check_fallback "success-fallback + allow=false → hold (fail closed)" \
+    "success-fallback" "false" "hold"
+check_fallback "success-fallback + allow=garbage → hold (only exact 'true' opts in)" \
+    "success-fallback" "yes" "hold"
+# Explicit opt-in: accepted.
+check_fallback "success-fallback + allow=true → accept (explicit opt-in)" \
+    "success-fallback" "true" "accept"
+# Any non-fallback token never routes through here as accept.
+check_fallback "wait token + allow=true → hold (only success-fallback can accept)" \
+    "wait" "true" "hold"
 
 # ── result ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

A gateway update that leaves the systemd service **not running** can still be reported as a **successful update**, so the release workflow and the release-agent's `/version` show green while the gateway is actually down.

This bit us on 2026-06-18 (v0.2.78): nova's binary was swapped to 0.2.78 but its service was left dead (a separate racing updater stopped it — fixed separately). The release-agent journal on nova shows the false success directly:

```
Verifying service status (freenet-gateway)... ✗
⚠️  Service failed to start
✅ Deployment complete!                              <-- script still exits 0
[INFO] Deployment successful
[INFO] Successfully updated to v0.2.78
update command exited status=exit status: 0          <-- release-agent: success
```

and the `gateway-update.yml` run for v0.2.78 (`27770490034`) reported success via:

```
✓ Gateway nova now reports version 0.2.78 (binary-only check)   <-- success-fallback
```

nova was down ~4.5 min and nothing flagged it.

### Root cause: three converging stale-deployment links

Tracing the chain (`gateway-update.yml` → release-agent `updater.rs` → `gateway-auto-update.sh` → `deploy-local-gateway.sh`), three independent links each let a dead service look healthy:

1. **Stale `deploy-local-gateway.sh` on nova** (mtime 2025-12-21) predated commit `9540abf8`, so it still had `verify_service "$service" "$BINARY_VERSION" || true` (exit code swallowed) and printed `✅ Deployment complete!` + `exit 0` unconditionally. The repo copy was already fixed — but the script also still had two **return-0 fall-throughs** in the current code: unit-file-not-found, and a latent `set -u` "unbound variable" crash on the success path when no freenet PID is found.

2. **Stale release-agent binary on nova** predates #4378, so `/version` omits `service_active`.

3. **Workflow `success-fallback`**: when `service_active` is absent, the workflow treated a binary-version match alone as success — exactly the dead-service-but-binary-swapped case #4378 set out to catch.

Even after redeploying current scripts to nova, links 2/3 mean any gateway running an old agent silently bypasses the service-health gate.

## Approach

Make the failure non-silent at every layer, so it is caught regardless of which deploy script / agent version is installed on a given gateway:

1. **`deploy-local-gateway.sh`** — `verify_service` now returns non-zero on every path that does not positively confirm the service is `active` on the correct binary (unit-file-not-found is a failure; the success path returns 0 explicitly). Also fixes the pre-existing `set -u` crash by declaring `running_binary` up front.

2. **`gateway-auto-update.sh`** — add an **independent** post-deploy `systemctl is-active` gate (`verify_service_active`) that does **not** trust the deploy script's exit code for liveness, so even a stale/buggy deploy script that exits 0 on a dead service fails the update. Also makes the on-disk version-mismatch check fatal instead of a warning.

3. **`gateway-update.yml`** — new `allow_binary_only_fallback` input (default **off**). When the agent omits `service_active`, the workflow no longer silently passes on binary version alone: by default it treats the response as not-yet-converged and **fails closed** at the deadline with an actionable error. The old binary-only behaviour is available via the explicit opt-in.

The release-agent's `/version` already reports `service_active` (PR #4378) and the workflow already polls it; this PR closes the remaining links that let the gate be bypassed.

### Operational note (please read before the next release)

Until nova/vega release-agents are upgraded past the #4378 build, the next release's `gateway-update.yml` will **fail closed** for them (or require `allow_binary_only_fallback=true`), because their `/version` still omits `service_active`. That is the **intended, loud** behaviour — it surfaces the same dead-gateway risk this PR closes rather than hiding it. This PR does **not** touch nova/vega; redeploying the updated scripts and upgrading the agents is an ops follow-up.

## Testing

- New `scripts/release-agent/gateway-auto-update_test.sh` (wired into the CI Fmt job, alongside the existing `verify-version-decision_test.sh`): sources the wrapper and proves a **lying deploy script** (prints "Deployment complete!" and exits 0 while the service is dead — the exact incident) is still caught by the independent `is-active` gate, and that it passes when the service is active. Verified the test **fails without** the gate (reproduces the bug) and **passes with** it.
- `deploy-local-gateway.sh` active / dead / unit-not-found paths verified by hand against a stub `systemctl`: active → exit 0, dead → exit 1, unit-not-found → exit 1.
- Existing `verify-version-decision_test.sh` still passes unchanged (the decision script is an unchanged pure classifier; the workflow owns the policy).

## Risk tier

Release/deploy infra = high-risk surface → Full multi-model review.

Refs #4492
