### PR TITLE
ci: restore fork PR checkout for Claude Rule Review under checkout v7

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -139,6 +139,15 @@ jobs:
           # .git/config under prompt injection. The trusted git steps here
           # need no credentials, so persisting them buys nothing.
           persist-credentials: false
+          # actions/checkout v7 refuses to check out a fork PR head from a
+          # pull_request_target workflow unless this is set (the "pwn request"
+          # guard). It is safe HERE specifically because, per the reasoning
+          # above, this job never executes the fork's code (no cargo/npm/bash,
+          # Claude has no Bash tool) and does not persist credentials — it only
+          # reads the fork diff to review it against base-repo-trusted rules.
+          # Without this, every fork PR fails the required "Claude Rule Review"
+          # check and cannot merge.
+          allow-unsafe-pr-checkout: true
 
       - name: Check review-override label
         id: override


### PR DESCRIPTION
## Problem

#4495 bumped \`actions/checkout\` 6→7. v7 **refuses to check out a fork PR head from a \`pull_request_target\` workflow** by default (the "pwn request" guard, opt-in via \`allow-unsafe-pr-checkout\`). \`claude-pr-review.yml\` does exactly that, so its job now fails at the checkout step on **every fork PR** with:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow. … set 'allow-unsafe-pr-checkout: true'

"Claude Rule Review" is a **required** check (ruleset "Ensure CI passes before merge"), so no external contribution can merge. #4495 passed CI because dependabot PRs run from same-repo branches, not forks — the breakage only surfaces on forks (e.g. #4304).

## Fix

Set \`allow-unsafe-pr-checkout: true\` on the one affected checkout step, keeping checkout v7.

This is safe **here specifically**, and the workflow was already hardened for exactly this threat model (see the existing comments on the step):
- it **never executes the fork's code** — no cargo/npm/bash build or test;
- the Claude action has **no Bash tool** (Read/Glob/Grep only);
- it reviews the diff against **base-repo-trusted rules** snapshotted before checkout ("Fork PR content cannot change it");
- \`persist-credentials: false\`, so no token is written to \`.git/config\`.

The v7 default guards workflows that run untrusted code with secrets; this one doesn't.

## Alternative considered

Pinning this workflow back to \`checkout@v6\` works too, but dependabot would re-open the v7 bump and someone would re-merge it and re-break this. Opting in on v7 is the durable fix. A longer-term hardening (compute the diff via API without checking out fork code at all) is worth a follow-up but out of scope here.

[AI-assisted - Claude]