### PR TITLE
feat(telemetry): add broadcast stream-assembly + bg-task health gauges (#4440)

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -51,6 +51,10 @@ use serde::{Deserialize, Serialize};
 pub(crate) use network_bridge::{
     ConnectionError, EventLoopNotificationsSender, NetworkBridge, OpExecutionPayload, WaiterReply,
 };
+// Re-export the UPDATE-broadcast stream-assembly telemetry global (#4440) so the
+// `Ring` snapshot task can read it (the broadcast queue lives behind the private
+// `network_bridge` module). Mirrors `crate::wasm_runtime::MODULE_CACHE_METRICS`.
+pub(crate) use network_bridge::broadcast_queue::BROADCAST_STREAM_METRICS;
 #[cfg(test)]
 pub(crate) use network_bridge::{EventLoopNotificationsReceiver, event_loop_notification_channel};
 // Re-export types for dev_tool and testing

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -32,13 +32,18 @@ const STREAM_COMPLETION_TIMEOUT: Duration = Duration::from_secs(120);
 /// Process-global UPDATE-broadcast stream-assembly telemetry (#4440).
 ///
 /// The streaming broadcast path (`broadcast_to_single_peer`'s `use_streaming`
-/// branch) sends a multi-fragment state transfer to one subscriber peer and
-/// awaits a `BroadcastDeliveryOutcome` completion signal. A non-`Delivered`
-/// outcome (explicit `Dropped`, a dropped completion oneshot, or a
-/// `STREAM_COMPLETION_TIMEOUT`) is a stream-assembly / transfer failure — the
-/// exact signal that flagged the v0.2.73 incident, where nova/vega saw
-/// ~1500-2300 broadcast stream-assembly failures/hr against a ~0 baseline and
-/// central telemetry had no gauge for it.
+/// branch) sends a multi-fragment state transfer to one subscriber peer. Each
+/// invocation records exactly one attempt, and a failure on any of its three
+/// exits is counted: the initial metadata send returning `Err` (the stream
+/// never landed), `send_stream_with_completion` returning `Err` (dispatch
+/// failed before any fragment), or a post-dispatch non-`Delivered`
+/// `BroadcastDeliveryOutcome` (explicit `Dropped`, a dropped completion oneshot,
+/// or a `STREAM_COMPLETION_TIMEOUT`). All three are stream-assembly / transfer
+/// failures — the exact signal that flagged the v0.2.73 incident, where
+/// nova/vega saw ~1500-2300 broadcast stream-assembly failures/hr against a ~0
+/// baseline and central telemetry had no gauge for it. (The two early-send
+/// exits are the congestion failure mode that would otherwise bias the gauge
+/// LOW precisely when it matters most.)
 ///
 /// These broadcast tasks are spawned per (contract, peer) from the global
 /// `BroadcastQueue` worker, unreachable from the `Ring` telemetry-snapshot task
@@ -50,6 +55,11 @@ const STREAM_COMPLETION_TIMEOUT: Duration = Duration::from_secs(120);
 /// Both counters are monotonic; the snapshot task differences them across the
 /// cadence to derive a per-window failure rate (see
 /// `Ring::emit_router_snapshot_telemetry`).
+///
+/// Per-node meaning holds only in single-node-per-process production. In a
+/// multi-node simulation every node shares this process-global, so the snapshot
+/// reads the aggregate across all in-process nodes (same caveat as
+/// [`MODULE_CACHE_METRICS`]).
 ///
 /// [`MODULE_CACHE_METRICS`]: crate::wasm_runtime::MODULE_CACHE_METRICS
 /// [`TRANSPORT_METRICS`]: crate::transport::metrics::TRANSPORT_METRICS
@@ -700,7 +710,13 @@ pub(super) async fn broadcast_to_single_peer(
         };
 
         let send_res = bridge.send(peer_addr, net_msg).await;
-        if send_res.is_ok() {
+        if send_res.is_err() {
+            // Telemetry gauge (#4440): the initial metadata send failed, so the
+            // streaming broadcast never landed. This is a real streaming-
+            // broadcast failure — and exactly the congestion failure mode that
+            // would otherwise bias the gauge LOW when it matters most.
+            BROADCAST_STREAM_METRICS.record_attempt(false);
+        } else {
             // Create completion channel for the broadcast queue to track
             // when the actual stream transfer finishes.
             let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
@@ -715,6 +731,10 @@ pub(super) async fn broadcast_to_single_peer(
                 )
                 .await
             {
+                // Telemetry gauge (#4440): stream dispatch failed before any
+                // fragment was handed to the transport — also a streaming-
+                // broadcast failure.
+                BROADCAST_STREAM_METRICS.record_attempt(false);
                 tracing::warn!(
                     tx = %update_tx,
                     peer = %peer_addr,
@@ -743,13 +763,16 @@ pub(super) async fn broadcast_to_single_peer(
                     new_state.size(),
                     payload_size,
                 );
-                // Telemetry gauge (#4440): count every completed streaming
-                // broadcast attempt, and (when !delivered) the stream-assembly /
-                // transfer failure. This is the single classification point that
-                // sees all failure modes uniformly (Dropped, dropped oneshot,
-                // timeout). Process-global counter, read on the router_snapshot
-                // cadence — NOT a per-failure event. This is the exact signal
-                // that flagged the v0.2.73 incident.
+                // Telemetry gauge (#4440): post-dispatch outcome — a drop,
+                // dropped completion oneshot, or completion timeout is the
+                // stream-assembly / transfer failure (`!delivered`). Together
+                // with the two earlier exits above, exactly one
+                // `record_attempt` fires per streaming broadcast invocation,
+                // covering initial-send failure, stream-dispatch failure, and
+                // post-dispatch drop/timeout/dropped-oneshot. Process-global
+                // counter, read on the router_snapshot cadence — NOT a
+                // per-failure event. This is the exact signal that flagged the
+                // v0.2.73 incident.
                 BROADCAST_STREAM_METRICS.record_attempt(delivered);
                 if delivered {
                     tracing::debug!(

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -1251,4 +1251,55 @@ mod tests {
              fires for every phantom contract before the gate can skip it"
         );
     }
+
+    /// Source-scrape pin: the streaming branch of `broadcast_to_single_peer`
+    /// must record the broadcast-stream gauge on ALL THREE of its exits (#4440),
+    /// not just the success arm. The two early-failure exits — initial metadata
+    /// `bridge.send(...)` returning Err, and `send_stream_with_completion(...)`
+    /// returning Err — are exactly the congestion failure mode the v0.2.73
+    /// incident exhibited. If a future edit drops one of those
+    /// `record_attempt(false)` calls, the gauge would silently undercount and
+    /// bias the incident signal LOW precisely when it matters most, with no
+    /// test failure otherwise. (The post-dispatch `record_attempt(delivered)` is
+    /// the third site.)
+    ///
+    /// Asserting against the process-global `BROADCAST_STREAM_METRICS` after
+    /// running the broadcast would be racy (concurrent tests share the global),
+    /// so this pins the call sites in source instead — mirroring the
+    /// `refresh_router` health-gauge pin in `ring.rs`.
+    #[test]
+    fn broadcast_to_single_peer_records_attempt_on_every_streaming_exit_pin() {
+        let src = include_str!("broadcast_queue.rs");
+        // Slice the `broadcast_to_single_peer` fn body so the unrelated
+        // `record_attempt` calls in the metrics unit test (and this test's own
+        // docs) don't count: from its signature to the start of the next fn.
+        let fn_start = src
+            .find("pub(super) async fn broadcast_to_single_peer(")
+            .expect("broadcast_to_single_peer not found");
+        let after = &src[fn_start..];
+        // The next item after the fn is the `#[cfg(test)] mod tests`.
+        let fn_end = after
+            .find("\nmod tests {")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .expect("end of broadcast_to_single_peer (start of tests module) not found");
+        let body = &after[..fn_end];
+
+        let record_calls = body.matches(".record_attempt(").count();
+        assert_eq!(
+            record_calls, 3,
+            "broadcast_to_single_peer's streaming branch must call record_attempt \
+             on all three exits (initial-send Err, dispatch Err, post-dispatch \
+             outcome) — got {record_calls}. A dropped early-exit record silently \
+             biases the v0.2.73 incident gauge LOW under congestion."
+        );
+        // Two of the three must be the explicit-failure form, so a refactor that
+        // collapses an early exit into the success path (losing the `false`)
+        // also trips this pin.
+        let failure_calls = body.matches(".record_attempt(false)").count();
+        assert_eq!(
+            failure_calls, 2,
+            "exactly the two early-failure exits must record record_attempt(false) \
+             (got {failure_calls}); the third exit records record_attempt(delivered)"
+        );
+    }
 }

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -11,6 +11,7 @@
 //! older entries with newer state when a duplicate is enqueued.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use freenet_stdlib::prelude::{ContractKey, WrappedState};
@@ -27,6 +28,79 @@ use super::p2p_protoc::P2pBridge;
 /// production, hence kept at module scope rather than inside the cfg-gated
 /// `queue` submodule.
 const STREAM_COMPLETION_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Process-global UPDATE-broadcast stream-assembly telemetry (#4440).
+///
+/// The streaming broadcast path (`broadcast_to_single_peer`'s `use_streaming`
+/// branch) sends a multi-fragment state transfer to one subscriber peer and
+/// awaits a `BroadcastDeliveryOutcome` completion signal. A non-`Delivered`
+/// outcome (explicit `Dropped`, a dropped completion oneshot, or a
+/// `STREAM_COMPLETION_TIMEOUT`) is a stream-assembly / transfer failure — the
+/// exact signal that flagged the v0.2.73 incident, where nova/vega saw
+/// ~1500-2300 broadcast stream-assembly failures/hr against a ~0 baseline and
+/// central telemetry had no gauge for it.
+///
+/// These broadcast tasks are spawned per (contract, peer) from the global
+/// `BroadcastQueue` worker, unreachable from the `Ring` telemetry-snapshot task
+/// that emits `router_snapshot`. Like [`MODULE_CACHE_METRICS`] /
+/// [`TRANSPORT_METRICS`], the failure site therefore *publishes* into this
+/// process-global and the snapshot task *reads* it on the existing ~5-minute
+/// cadence — no per-failure event is emitted.
+///
+/// Both counters are monotonic; the snapshot task differences them across the
+/// cadence to derive a per-window failure rate (see
+/// `Ring::emit_router_snapshot_telemetry`).
+///
+/// [`MODULE_CACHE_METRICS`]: crate::wasm_runtime::MODULE_CACHE_METRICS
+/// [`TRANSPORT_METRICS`]: crate::transport::metrics::TRANSPORT_METRICS
+pub(crate) static BROADCAST_STREAM_METRICS: BroadcastStreamMetrics = BroadcastStreamMetrics::new();
+
+/// Monotonic counters for UPDATE-broadcast streaming transfers. See
+/// [`BROADCAST_STREAM_METRICS`].
+pub(crate) struct BroadcastStreamMetrics {
+    /// Total streaming broadcast transfers attempted (one per peer that took the
+    /// streaming branch and reached the completion-await point).
+    streaming_attempts_total: AtomicU64,
+    /// Total streaming broadcast transfers that did NOT reach `Delivered`
+    /// (dropped, oneshot dropped, or completion timeout).
+    streaming_failures_total: AtomicU64,
+}
+
+/// A point-in-time read of [`BROADCAST_STREAM_METRICS`] for telemetry emission.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BroadcastStreamMetricsSnapshot {
+    pub streaming_attempts_total: u64,
+    pub streaming_failures_total: u64,
+}
+
+impl BroadcastStreamMetrics {
+    const fn new() -> Self {
+        Self {
+            streaming_attempts_total: AtomicU64::new(0),
+            streaming_failures_total: AtomicU64::new(0),
+        }
+    }
+
+    /// Record one completed streaming broadcast attempt. `delivered == false`
+    /// means a stream-assembly / transfer failure. Cheap `Relaxed` atomics — the
+    /// counters are summed/differenced by the collector, not used for ordering.
+    fn record_attempt(&self, delivered: bool) {
+        self.streaming_attempts_total
+            .fetch_add(1, Ordering::Relaxed);
+        if !delivered {
+            self.streaming_failures_total
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Read both counters for telemetry.
+    pub(crate) fn snapshot(&self) -> BroadcastStreamMetricsSnapshot {
+        BroadcastStreamMetricsSnapshot {
+            streaming_attempts_total: self.streaming_attempts_total.load(Ordering::Relaxed),
+            streaming_failures_total: self.streaming_failures_total.load(Ordering::Relaxed),
+        }
+    }
+}
 
 /// Whether we should broadcast a state change for `key` at all: only if we
 /// host it or are actively serving it (a live local-client or downstream
@@ -669,6 +743,14 @@ pub(super) async fn broadcast_to_single_peer(
                     new_state.size(),
                     payload_size,
                 );
+                // Telemetry gauge (#4440): count every completed streaming
+                // broadcast attempt, and (when !delivered) the stream-assembly /
+                // transfer failure. This is the single classification point that
+                // sees all failure modes uniformly (Dropped, dropped oneshot,
+                // timeout). Process-global counter, read on the router_snapshot
+                // cadence — NOT a per-failure event. This is the exact signal
+                // that flagged the v0.2.73 incident.
+                BROADCAST_STREAM_METRICS.record_attempt(delivered);
                 if delivered {
                     tracing::debug!(
                         tx = %update_tx,
@@ -748,7 +830,41 @@ mod tests {
     use crate::transport::{BroadcastDeliveryOutcome, TransportKeypair};
     use crate::util::time_source::SharedMockTimeSource;
 
-    use super::{record_streaming_delivery, streaming_completion_delivered};
+    use super::{
+        BroadcastStreamMetrics, record_streaming_delivery, streaming_completion_delivered,
+    };
+
+    /// `BroadcastStreamMetrics` counts every attempt and, separately, only the
+    /// non-`delivered` attempts (#4440). Tests a LOCAL instance so it stays
+    /// deterministic and never touches the concurrently-shared process-global
+    /// `BROADCAST_STREAM_METRICS`.
+    #[test]
+    fn broadcast_stream_metrics_counts_attempts_and_failures() {
+        let m = BroadcastStreamMetrics::new();
+        let s = m.snapshot();
+        assert_eq!(s.streaming_attempts_total, 0, "starts at zero");
+        assert_eq!(s.streaming_failures_total, 0, "starts at zero");
+
+        // A delivered attempt bumps attempts only.
+        m.record_attempt(true);
+        let s = m.snapshot();
+        assert_eq!(s.streaming_attempts_total, 1);
+        assert_eq!(s.streaming_failures_total, 0, "delivered is not a failure");
+
+        // A non-delivered attempt bumps both — this is the stream-assembly
+        // failure signal that flagged the v0.2.73 incident.
+        m.record_attempt(false);
+        let s = m.snapshot();
+        assert_eq!(s.streaming_attempts_total, 2, "every attempt counts");
+        assert_eq!(s.streaming_failures_total, 1, "the drop is counted");
+
+        // Counters are monotonic and accumulate.
+        m.record_attempt(false);
+        m.record_attempt(true);
+        let s = m.snapshot();
+        assert_eq!(s.streaming_attempts_total, 4);
+        assert_eq!(s.streaming_failures_total, 2);
+    }
 
     fn make_contract_key(seed: u8) -> ContractKey {
         ContractKey::from_id_and_code(

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -988,8 +988,15 @@ impl Ring {
         // Load routing history immediately on startup so the router doesn't
         // start cold — without this, peers route suboptimally for ~5 minutes
         // until the first periodic refresh.
+        //
+        // Health gauge (#4440): the startup read is recorded too, with the same
+        // semantics as the periodic loop (any Ok read = success, empty or not).
+        // Without this, a node whose startup read succeeds but whose every later
+        // periodic refresh fails would report `last_success_age_secs == null`
+        // forever — masking that it did succeed once.
         match register.get_router_events(Self::ROUTER_HISTORY_LIMIT).await {
             Ok(history) if !history.is_empty() => {
+                BACKGROUND_TASK_HEALTH.record_refresh_router_success();
                 tracing::info!(
                     events = history.len(),
                     "Restored routing history from event log"
@@ -997,9 +1004,11 @@ impl Ring {
                 *router.write() = Router::new(&history);
             }
             Ok(_) => {
+                BACKGROUND_TASK_HEALTH.record_refresh_router_success();
                 tracing::debug!("No routing history to restore on startup");
             }
             Err(error) => {
+                BACKGROUND_TASK_HEALTH.record_refresh_router_failure();
                 tracing::warn!(%error, "Failed to load routing history on startup, starting cold");
             }
         }
@@ -4390,6 +4399,50 @@ mod background_task_health_tests {
             s.last_success_age_secs,
             Some(100),
             "age unaffected by failures; still measured from last success"
+        );
+    }
+
+    /// Source-scrape pin: the startup read in `refresh_router` (the `match`
+    /// before the periodic loop) must record into the health gauge on every
+    /// arm, with the SAME semantics as the loop — both `Ok` arms record a
+    /// success, the `Err` arm records a failure. Without this, a node whose
+    /// startup read succeeds but whose later periodic refreshes all fail would
+    /// report `last_success_age_secs == null` forever, masking that it did
+    /// succeed once.
+    ///
+    /// Asserting against the process-global `BACKGROUND_TASK_HEALTH` after
+    /// running `refresh_router` would be racy (concurrent tests share the
+    /// global), so this pins the call sites in source instead — three startup
+    /// records plus two in the loop = five total.
+    #[test]
+    fn refresh_router_records_health_on_startup_and_in_loop() {
+        let src = include_str!("ring.rs");
+        // Restrict to the `refresh_router` fn body so unrelated mentions (this
+        // test, the rustdoc on the metrics struct) don't count. The body runs
+        // from its signature to the start of the next method.
+        let start = src
+            .find("async fn refresh_router")
+            .expect("refresh_router fn present");
+        let after = &src[start..];
+        let end = after
+            .find("async fn emit_router_snapshot_telemetry")
+            .expect("next method present");
+        let body = &after[..end];
+
+        let successes = body.matches(".record_refresh_router_success()").count();
+        let failures = body.matches(".record_refresh_router_failure()").count();
+        // Startup: 2 Ok arms (success) + 1 Err arm (failure). Loop: 1 Ok
+        // (success) + 1 Err (failure). Total 3 success + 2 failure.
+        assert_eq!(
+            successes, 3,
+            "refresh_router must record a success on both startup Ok arms and \
+             the loop Ok arm (got {successes}); a dropped startup record would \
+             mask a startup-only success in the health gauge"
+        );
+        assert_eq!(
+            failures, 2,
+            "refresh_router must record a failure on both the startup Err arm \
+             and the loop Err arm (got {failures})"
         );
     }
 }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1009,7 +1009,16 @@ impl Ring {
         loop {
             interval.tick().await;
             let history = match register.get_router_events(Self::ROUTER_HISTORY_LIMIT).await {
-                Ok(h) => h,
+                Ok(h) => {
+                    // Health gauge (#4440): a successful read clears the
+                    // consecutive-failure run and stamps the last-success time so
+                    // a *persistently* failing refresh (silent since the #4438
+                    // non-fatal hotfix) becomes observable on the snapshot
+                    // cadence. The read succeeded regardless of whether the
+                    // history is empty, so record success here, not below.
+                    BACKGROUND_TASK_HEALTH.record_refresh_router_success();
+                    h
+                }
                 Err(error) => {
                     // get_router_events errors are transient and recoverable —
                     // e.g. file-descriptor exhaustion ("os error 24") when the
@@ -1020,6 +1029,11 @@ impl Ring {
                     // panic inside this task is still caught by the
                     // BackgroundTaskMonitor — only this expected, transient read
                     // failure is swallowed here.)
+                    //
+                    // Health gauge (#4440): bump the consecutive-failure run so
+                    // the escalation #4438 deliberately left non-fatal is at
+                    // least visible in telemetry.
+                    BACKGROUND_TASK_HEALTH.record_refresh_router_failure();
                     tracing::error!(
                         error = %error,
                         "Failed to refresh routing history from event log; \
@@ -1042,6 +1056,14 @@ impl Ring {
         let mut interval = tokio::time::interval(interval_duration);
         // Skip the first immediate tick
         interval.tick().await;
+
+        // Previous lifetime broadcast-stream-failure count, so each snapshot can
+        // emit the per-window delta directly (#4440) without a stateful
+        // collector. Loop-local because this task is the sole reader; the
+        // monotonic totals are still emitted for collector-side differencing.
+        let mut prev_broadcast_stream_failures_total: u64 = crate::node::BROADCAST_STREAM_METRICS
+            .snapshot()
+            .streaming_failures_total;
 
         loop {
             interval.tick().await;
@@ -1081,6 +1103,27 @@ impl Ring {
             snapshot.delegate_module_cache_budget_bytes = Some(mc.delegate_budget_bytes);
             snapshot.delegate_module_cache_evictions_total = Some(mc.delegate_evictions_total);
 
+            // UPDATE-broadcast stream-assembly failure gauge (#4440): the exact
+            // signal that flagged the v0.2.73 incident. The broadcast queue
+            // publishes monotonic totals into the process-global; emit the totals
+            // (for collector-side differencing) plus the per-window failure delta
+            // sampled here.
+            let bs = crate::node::BROADCAST_STREAM_METRICS.snapshot();
+            let broadcast_stream_failures_delta = bs
+                .streaming_failures_total
+                .saturating_sub(prev_broadcast_stream_failures_total);
+            prev_broadcast_stream_failures_total = bs.streaming_failures_total;
+            snapshot.broadcast_stream_attempts_total = Some(bs.streaming_attempts_total);
+            snapshot.broadcast_stream_failures_total = Some(bs.streaming_failures_total);
+            snapshot.broadcast_stream_failures_last_snapshot =
+                Some(broadcast_stream_failures_delta);
+
+            // Background-task health gauges (#4440): make a persistently-failing
+            // (but non-fatal, post-#4438) `refresh_router` observable.
+            let rr_health = BACKGROUND_TASK_HEALTH.refresh_router_snapshot();
+            snapshot.refresh_router_last_success_age_secs = rr_health.last_success_age_secs;
+            snapshot.refresh_router_consecutive_failures = Some(rr_health.consecutive_failures);
+
             tracing::info!(
                 failure_events = snapshot.failure_events,
                 success_events = snapshot.success_events,
@@ -1091,6 +1134,11 @@ impl Ring {
                 contract_module_cache_entries = mc.contract_entries,
                 contract_module_cache_total_bytes = mc.contract_total_bytes,
                 contract_module_cache_evictions_total = mc.contract_evictions_total,
+                broadcast_stream_attempts_total = bs.streaming_attempts_total,
+                broadcast_stream_failures_total = bs.streaming_failures_total,
+                broadcast_stream_failures_last_snapshot = broadcast_stream_failures_delta,
+                refresh_router_last_success_age_secs = ?rr_health.last_success_age_secs,
+                refresh_router_consecutive_failures = rr_health.consecutive_failures,
                 "router_snapshot"
             );
 
@@ -4047,6 +4095,123 @@ fn classify_suspend_jump(boot_elapsed: Duration, mono_elapsed: Duration) -> Dura
     boot_elapsed.saturating_sub(mono_elapsed)
 }
 
+/// Process-global health gauges for monitored background tasks (#4440).
+///
+/// A task that the [`BackgroundTaskMonitor`](crate::node::background_task_monitor)
+/// only watches for *death* can still run for hours while every individual run
+/// fails — `refresh_router`'s `get_router_events` errors were made non-fatal by
+/// the v0.2.74 #4438 hotfix (a transient fd-exhaustion read failure must not
+/// kill the node), so a *persistent* failure is now completely silent. This
+/// records, per monitored task, the time of the last successful run and the
+/// current run of consecutive failures, so the snapshot task can emit
+/// `last_success_age` / `consecutive_failures` gauges on the existing
+/// `router_snapshot` cadence (partially addresses #4440 item (a)).
+///
+/// The task *publishes* (`record_success` / `record_failure`) and the `Ring`
+/// snapshot task *reads* (`refresh_router`), mirroring `MODULE_CACHE_METRICS` /
+/// `BROADCAST_STREAM_METRICS`. Currently scoped to `refresh_router`, the one
+/// monitored task with a non-fatal per-run failure mode; add fields here if
+/// another monitored task grows the same pattern.
+static BACKGROUND_TASK_HEALTH: std::sync::LazyLock<BackgroundTaskHealth> =
+    std::sync::LazyLock::new(BackgroundTaskHealth::new);
+
+/// Monotonic process clock for the background-task health gauges. `tokio::time`
+/// so the age respects `start_paused(true)` virtual time under simulation
+/// (a `std::time::Instant` would advance in real wall-clock and break
+/// deterministic tests). Sampled at publish time and at snapshot read time; the
+/// age is the difference, so the absolute epoch is irrelevant.
+static BACKGROUND_TASK_HEALTH_EPOCH: std::sync::LazyLock<Instant> =
+    std::sync::LazyLock::new(Instant::now);
+
+/// Health gauges for one monitored background task. See [`BACKGROUND_TASK_HEALTH`].
+struct TaskHealth {
+    /// Millis-since-[`BACKGROUND_TASK_HEALTH_EPOCH`] of the last successful run,
+    /// or [`NO_SUCCESS`](Self::NO_SUCCESS) if the task has never succeeded.
+    last_success_millis: AtomicU64,
+    /// Consecutive failures since the last success (reset to 0 on success).
+    consecutive_failures: AtomicU64,
+}
+
+impl TaskHealth {
+    /// Sentinel for "no successful run yet". `u64::MAX` millis is ~584 million
+    /// years of uptime, so it can never collide with a real elapsed value.
+    const NO_SUCCESS: u64 = u64::MAX;
+
+    const fn new() -> Self {
+        Self {
+            last_success_millis: AtomicU64::new(Self::NO_SUCCESS),
+            consecutive_failures: AtomicU64::new(0),
+        }
+    }
+}
+
+/// Per-task background-task health, currently just `refresh_router`. See
+/// [`BACKGROUND_TASK_HEALTH`].
+struct BackgroundTaskHealth {
+    refresh_router: TaskHealth,
+}
+
+/// A point-in-time read of one task's health for telemetry emission.
+#[derive(Debug, Clone, Copy)]
+struct TaskHealthSnapshot {
+    /// Seconds since the last successful run, or `None` if it never succeeded.
+    last_success_age_secs: Option<u64>,
+    /// Consecutive failures since the last success.
+    consecutive_failures: u64,
+}
+
+impl BackgroundTaskHealth {
+    fn new() -> Self {
+        Self {
+            refresh_router: TaskHealth::new(),
+        }
+    }
+
+    /// Record a successful run of `refresh_router`: stamp the last-success time
+    /// and clear the consecutive-failure run. Cheap `Relaxed` atomics.
+    fn record_refresh_router_success(&self) {
+        let elapsed_millis = BACKGROUND_TASK_HEALTH_EPOCH.elapsed().as_millis() as u64;
+        self.refresh_router
+            .last_success_millis
+            .store(elapsed_millis, std::sync::atomic::Ordering::Relaxed);
+        self.refresh_router
+            .consecutive_failures
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Record a failed run of `refresh_router` (transient `get_router_events`
+    /// error). Bumps the consecutive-failure run; does not touch last-success.
+    fn record_refresh_router_failure(&self) {
+        self.refresh_router
+            .consecutive_failures
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Read `refresh_router`'s health for telemetry.
+    fn refresh_router_snapshot(&self) -> TaskHealthSnapshot {
+        let last_success_millis = self
+            .refresh_router
+            .last_success_millis
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let consecutive_failures = self
+            .refresh_router
+            .consecutive_failures
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let last_success_age_secs = if last_success_millis == TaskHealth::NO_SUCCESS {
+            None
+        } else {
+            // saturating: if the clock and the stored stamp disagree (they
+            // shouldn't — same monotonic source), never underflow to a huge age.
+            let now_millis = BACKGROUND_TASK_HEALTH_EPOCH.elapsed().as_millis() as u64;
+            Some(now_millis.saturating_sub(last_success_millis) / 1000)
+        };
+        TaskHealthSnapshot {
+            last_success_age_secs,
+            consecutive_failures,
+        }
+    }
+}
+
 /// Best-effort snapshot of this process's open file-descriptor count and the
 /// `RLIMIT_NOFILE` soft limit, for the node-health telemetry gauges (#4440).
 ///
@@ -4128,6 +4293,81 @@ mod fd_usage_tests {
         assert!(
             soft >= open,
             "open fds ({open}) must not exceed the soft limit ({soft})"
+        );
+    }
+}
+
+#[cfg(test)]
+mod background_task_health_tests {
+    //! Validates the background-task health gauges (#4440): a persistently
+    //! failing `refresh_router` (non-fatal since the #4438 hotfix) must surface
+    //! as a rising `consecutive_failures` and a stale `last_success_age`, and a
+    //! task that has never succeeded must report `None` age (not a bogus zero).
+    //! Tests a LOCAL `BackgroundTaskHealth` so they never touch the shared
+    //! process-global.
+
+    use super::BackgroundTaskHealth;
+
+    /// Before any success, the age is `None` (the `NO_SUCCESS` sentinel), not a
+    /// misleading age of 0. Failures accumulate without touching last-success.
+    #[tokio::test(start_paused = true)]
+    async fn never_succeeded_reports_none_age_and_accumulates_failures() {
+        let h = BackgroundTaskHealth::new();
+        let s = h.refresh_router_snapshot();
+        assert_eq!(
+            s.last_success_age_secs, None,
+            "no success yet => None age, never a bogus 0"
+        );
+        assert_eq!(s.consecutive_failures, 0);
+
+        h.record_refresh_router_failure();
+        h.record_refresh_router_failure();
+        let s = h.refresh_router_snapshot();
+        assert_eq!(
+            s.last_success_age_secs, None,
+            "still never succeeded after failures"
+        );
+        assert_eq!(s.consecutive_failures, 2, "failures accumulate");
+    }
+
+    /// A success stamps the time (age starts at ~0 and grows with virtual time)
+    /// and clears the consecutive-failure run; a later failure run grows again
+    /// while the age keeps climbing from the last success.
+    #[tokio::test(start_paused = true)]
+    async fn success_resets_failures_and_stamps_age() {
+        let h = BackgroundTaskHealth::new();
+        h.record_refresh_router_failure();
+        h.record_refresh_router_failure();
+
+        h.record_refresh_router_success();
+        let s = h.refresh_router_snapshot();
+        assert_eq!(s.consecutive_failures, 0, "success clears the failure run");
+        assert_eq!(
+            s.last_success_age_secs,
+            Some(0),
+            "age is ~0 immediately after success"
+        );
+
+        // Advance virtual time; the age must reflect time since last success.
+        tokio::time::advance(std::time::Duration::from_secs(90)).await;
+        let s = h.refresh_router_snapshot();
+        assert_eq!(
+            s.last_success_age_secs,
+            Some(90),
+            "age grows with time since last success"
+        );
+
+        // A new failure run grows consecutive_failures but does NOT refresh the
+        // last-success stamp — the age keeps climbing, which is the signal that
+        // refresh is stuck.
+        h.record_refresh_router_failure();
+        tokio::time::advance(std::time::Duration::from_secs(10)).await;
+        let s = h.refresh_router_snapshot();
+        assert_eq!(s.consecutive_failures, 1);
+        assert_eq!(
+            s.last_success_age_secs,
+            Some(100),
+            "age unaffected by failures; still measured from last success"
         );
     }
 }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1109,10 +1109,10 @@ impl Ring {
             // (for collector-side differencing) plus the per-window failure delta
             // sampled here.
             let bs = crate::node::BROADCAST_STREAM_METRICS.snapshot();
-            let broadcast_stream_failures_delta = bs
-                .streaming_failures_total
-                .saturating_sub(prev_broadcast_stream_failures_total);
-            prev_broadcast_stream_failures_total = bs.streaming_failures_total;
+            let broadcast_stream_failures_delta = window_delta(
+                bs.streaming_failures_total,
+                &mut prev_broadcast_stream_failures_total,
+            );
             snapshot.broadcast_stream_attempts_total = Some(bs.streaming_attempts_total);
             snapshot.broadcast_stream_failures_total = Some(bs.streaming_failures_total);
             snapshot.broadcast_stream_failures_last_snapshot =
@@ -4095,6 +4095,22 @@ fn classify_suspend_jump(boot_elapsed: Duration, mono_elapsed: Duration) -> Dura
     boot_elapsed.saturating_sub(mono_elapsed)
 }
 
+/// Compute the per-snapshot window delta of a monotonic counter and advance the
+/// running previous-total in one step (#4440).
+///
+/// `current_total` is this snapshot's lifetime count; `prev_total` is the count
+/// at the previous snapshot. Returns `current_total - prev_total` (saturating,
+/// so a counter reset can never underflow to a huge bogus rate) and stores
+/// `current_total` into `*prev_total` for the next call. Extracted from the
+/// snapshot loop and unit-tested because a future reorder of the
+/// compute-then-advance steps would silently zero the broadcast-failure incident
+/// signal with no test failure otherwise.
+fn window_delta(current_total: u64, prev_total: &mut u64) -> u64 {
+    let delta = current_total.saturating_sub(*prev_total);
+    *prev_total = current_total;
+    delta
+}
+
 /// Process-global health gauges for monitored background tasks (#4440).
 ///
 /// A task that the [`BackgroundTaskMonitor`](crate::node::background_task_monitor)
@@ -4112,6 +4128,12 @@ fn classify_suspend_jump(boot_elapsed: Duration, mono_elapsed: Duration) -> Dura
 /// `BROADCAST_STREAM_METRICS`. Currently scoped to `refresh_router`, the one
 /// monitored task with a non-fatal per-run failure mode; add fields here if
 /// another monitored task grows the same pattern.
+///
+/// Per-node meaning holds only in single-node-per-process production. In a
+/// multi-node simulation every node's `refresh_router` shares this
+/// process-global, so the snapshot reads the aggregate (last-write-wins
+/// last-success across nodes; the consecutive-failure run is shared) — same
+/// caveat as `MODULE_CACHE_METRICS` / `BROADCAST_STREAM_METRICS`.
 static BACKGROUND_TASK_HEALTH: std::sync::LazyLock<BackgroundTaskHealth> =
     std::sync::LazyLock::new(BackgroundTaskHealth::new);
 
@@ -4369,6 +4391,37 @@ mod background_task_health_tests {
             Some(100),
             "age unaffected by failures; still measured from last success"
         );
+    }
+}
+
+#[cfg(test)]
+mod window_delta_tests {
+    //! Pins the per-snapshot window-delta of the monotonic broadcast-failure
+    //! counter (#4440): it must return `current - prev` AND advance `prev` to
+    //! `current`, so a reorder of those two steps (which would silently zero
+    //! the incident signal) fails CI.
+
+    use super::window_delta;
+
+    #[test]
+    fn broadcast_failure_window_delta_computes_and_advances_prev() {
+        let mut prev: u64 = 10;
+        // First window: 13 - 10 = 3, and prev advances to 13.
+        assert_eq!(window_delta(13, &mut prev), 3, "delta over the window");
+        assert_eq!(prev, 13, "prev advanced to current");
+        // No new failures: 13 - 13 = 0, prev stays 13.
+        assert_eq!(window_delta(13, &mut prev), 0, "no failures => zero delta");
+        assert_eq!(prev, 13);
+        // Next window: 20 - 13 = 7, prev advances to 20.
+        assert_eq!(window_delta(20, &mut prev), 7, "delta resumes from prev");
+        assert_eq!(prev, 20, "prev advanced to current again");
+        // Counter reset / restart must saturate to 0, never underflow.
+        assert_eq!(
+            window_delta(5, &mut prev),
+            0,
+            "reset saturates, no underflow"
+        );
+        assert_eq!(prev, 5, "prev tracks the reset value");
     }
 }
 

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -190,6 +190,31 @@ pub(crate) struct RouterSnapshotInfo {
     pub delegate_module_cache_total_bytes: Option<u64>,
     pub delegate_module_cache_budget_bytes: Option<u64>,
     pub delegate_module_cache_evictions_total: Option<u64>,
+    /// UPDATE-broadcast stream-assembly gauges (#4440), populated by `Ring` from
+    /// the process-global `BROADCAST_STREAM_METRICS` the broadcast queue
+    /// publishes into. A streaming broadcast that fails to reach `Delivered`
+    /// (dropped, oneshot dropped, or completion timeout) is a stream-assembly /
+    /// transfer failure — the exact signal that flagged the v0.2.73 incident
+    /// (nova/vega ~1500-2300 failures/hr vs ~0 baseline) and the one that would
+    /// catch a re-enable going wrong. `None` until the first streaming broadcast.
+    ///
+    /// `*_total` are monotonic lifetime counters (the collector differences them
+    /// across the cadence to derive a rate); `*_failures_last_snapshot` is the
+    /// per-snapshot delta `Ring` samples directly, so the incident signal is
+    /// legible without a stateful collector.
+    pub broadcast_stream_attempts_total: Option<u64>,
+    pub broadcast_stream_failures_total: Option<u64>,
+    pub broadcast_stream_failures_last_snapshot: Option<u64>,
+    /// Background-task health gauges (#4440), populated by `Ring` from the
+    /// process-global `BACKGROUND_TASK_HEALTH` the monitored tasks publish into.
+    /// `refresh_router`'s transient `get_router_events` errors were made
+    /// non-fatal by the v0.2.74 #4438 hotfix, so a persistently-failing refresh
+    /// is now silent; these make it observable (partially addresses #4440 (a)).
+    /// `last_success_age_secs` is seconds since the last successful run (`None`
+    /// until the first success); `consecutive_failures` is the current run of
+    /// failures since the last success.
+    pub refresh_router_last_success_age_secs: Option<u64>,
+    pub refresh_router_consecutive_failures: Option<u64>,
     /// Per-operation-type estimator curves, keyed by op type name (e.g., "GET").
     pub per_op_curves: HashMap<String, PerOpCurves>,
     /// Renegade predictor diagnostics. These (and `renegade_accuracy_pairs`) are
@@ -971,6 +996,13 @@ impl Router {
             delegate_module_cache_total_bytes: None,
             delegate_module_cache_budget_bytes: None,
             delegate_module_cache_evictions_total: None,
+            // Broadcast stream-assembly + background-task health gauges,
+            // populated by Ring on the snapshot cadence (#4440).
+            broadcast_stream_attempts_total: None,
+            broadcast_stream_failures_total: None,
+            broadcast_stream_failures_last_snapshot: None,
+            refresh_router_last_success_age_secs: None,
+            refresh_router_consecutive_failures: None,
             // Renegade predictor diagnostics
             renegade_failure_events: self.renegade_predictor.len(),
             renegade_response_time_events: self.renegade_predictor.stage_sizes().1,

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -1853,6 +1853,11 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                 "delegate_module_cache_total_bytes": snapshot.delegate_module_cache_total_bytes,
                 "delegate_module_cache_budget_bytes": snapshot.delegate_module_cache_budget_bytes,
                 "delegate_module_cache_evictions_total": snapshot.delegate_module_cache_evictions_total,
+                "broadcast_stream_attempts_total": snapshot.broadcast_stream_attempts_total,
+                "broadcast_stream_failures_total": snapshot.broadcast_stream_failures_total,
+                "broadcast_stream_failures_last_snapshot": snapshot.broadcast_stream_failures_last_snapshot,
+                "refresh_router_last_success_age_secs": snapshot.refresh_router_last_success_age_secs,
+                "refresh_router_consecutive_failures": snapshot.refresh_router_consecutive_failures,
                 "per_op_curves": snapshot.per_op_curves,
             })
         }
@@ -1910,6 +1915,35 @@ mod tests {
             ("delegate_module_cache_total_bytes", 23),
             ("delegate_module_cache_budget_bytes", 29),
             ("delegate_module_cache_evictions_total", 31),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
+    }
+
+    /// Pin: the UPDATE-broadcast stream-assembly gauges and the background-task
+    /// health gauges (#4440) must also reach the hand-mirrored OTLP body — same
+    /// footgun as the fd / module-cache gauges above. The broadcast
+    /// stream-assembly failure rate is the signal that flagged the v0.2.73
+    /// incident, so a silent drop here would re-blind us to a re-enable going
+    /// wrong.
+    #[test]
+    fn router_snapshot_json_includes_broadcast_and_bgtask_gauges() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.broadcast_stream_attempts_total = Some(37);
+        info.broadcast_stream_failures_total = Some(41);
+        info.broadcast_stream_failures_last_snapshot = Some(43);
+        info.refresh_router_last_success_age_secs = Some(47);
+        info.refresh_router_consecutive_failures = Some(53);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        for (key, want) in [
+            ("broadcast_stream_attempts_total", 37),
+            ("broadcast_stream_failures_total", 41),
+            ("broadcast_stream_failures_last_snapshot", 43),
+            ("refresh_router_last_success_age_secs", 47),
+            ("refresh_router_consecutive_failures", 53),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }


### PR DESCRIPTION
## What

Adds two **low-frequency observability gauges** to the existing `router_snapshot` telemetry event (~5 min/node cadence). No new event kinds, no per-op/per-message emission — this piggybacks the snapshot, so it adds negligible load to the telemetry collectors.

Part of #4440 (the deferred-work tracker from the v0.2.73 placement-migration incident).

### Gauge 1 — UPDATE-broadcast stream-assembly failure rate
The **single signal that flagged the v0.2.73 incident** (nova/vega ~1500–2300 stream-assembly failures/hr vs ~0 baseline) and the one that was missing — the incident was nearly invisible to central telemetry. Process-global atomic counters (attempts + failures) classified at `broadcast_to_single_peer` (the one point that observes all UPDATE-broadcast failure modes uniformly: explicit drop, dropped completion oneshot, completion timeout); GET/PUT/SUBSCRIBE never reach it. Emitted as a monotonic `*_total` plus a per-snapshot delta.

### Gauge 2 — background-task health (`refresh_router`)
`last_success_age_secs` + `consecutive_failures` for the `refresh_router` background task. The v0.2.74 hotfix (#4438) made transient `refresh_router` failures non-fatal — correct, but it meant a *persistent* failure now degrades routing silently forever. This makes that observable (partially addresses #4440 item (a)).

## Why now

A release is planned imminently. Shipping these gauges **with the placement migration still disabled** (the `SUBSCRIBE_HINT_MIN_VERSION` floor is untouched — verified) gives us a clean fleet-wide **baseline** of the incident metric *before* any re-enable. When the migration is eventually re-enabled (a later release, gated on #4145 + the #4233 fan-out validation test), this telemetry will already be deployed to watch it.

## Risk

Observability-only, additive. Does **not** touch the migration gate, routing logic, or broadcast behavior — only reads/counts. Hot-path cost is two relaxed atomic increments per broadcast attempt.

- Follows the established #4470/#4472 gauge pattern, including the hand-mirrored `event_kind_to_json` block (the #4009/#4010 footgun) with a pin test that genuinely guards it (verified by removing a mirror line → test fails).
- `cargo build` / `fmt` / `clippy -p freenet -- -D warnings` (CI gate) all clean. Telemetry pin tests + refresh_router + broadcast suite pass.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
