### PR TITLE
fix: enforce public network port requirement for gateways ensures valid peer_id derivation

### DIFF
--- a/apps/freenet-ping/Cargo.lock
+++ b/apps/freenet-ping/Cargo.lock
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.2.74"
+version = "0.2.79"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1630,7 +1630,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite 0.27.0",
  "toml 1.1.2+spec-1.1.0",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-appender",
  "tracing-core",
@@ -1638,6 +1638,7 @@ dependencies = [
  "tray-icon",
  "turmoil",
  "ulid",
+ "wasmparser 0.248.0",
  "wasmtime",
  "winapi",
  "winreg",
@@ -4447,7 +4448,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5603,6 +5604,24 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
  "futures-core",
  "futures-util",
  "http",
@@ -5610,14 +5629,12 @@ dependencies = [
  "http-body-util",
  "http-range-header",
  "httpdate",
- "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1282,14 +1282,19 @@ fn parse_gateway(input: &str, secrets_dir: &Path) -> anyhow::Result<GatewayConfi
 impl NetworkArgs {
     pub(crate) fn validate(&self) -> anyhow::Result<()> {
         if self.is_gateway {
-            // For gateways, require both public address and port
+            // A gateway advertises its own identity (peer_id) from its public
+            // address + port and, unlike a NAT'd peer, can never learn or
+            // correct it later. Require both explicitly; otherwise peer_id is
+            // None and the gateway boots with no ring location. See #4324.
             if self.public_address.is_none() {
                 return Err(anyhow::anyhow!(
-                    "Gateway nodes must specify a public network address"
+                    "Gateway nodes must specify a public network address (--public-network-address)"
                 ));
             }
-            if self.public_port.is_none() && self.network_port.is_none() {
-                return Err(anyhow::anyhow!("Gateway nodes must specify a network port"));
+            if self.public_port.is_none() {
+                return Err(anyhow::anyhow!(
+                    "Gateway nodes must specify a public network port (--public-network-port)"
+                ));
             }
         }
         Ok(())
@@ -4234,25 +4239,25 @@ mod tests {
         (server, url)
     }
 
-    /// Regression test for #4268: an isolated gateway started with
-    /// `--is-gateway --public-network-address X --network-port Y` (and no
-    /// `--public-network-port`) has a `None` `peer_id`, because `peer_id` is
-    /// derived from `public_address.zip(public_port)`. On first boot — remote
-    /// index unreachable/empty, no on-disk `gateways.toml`, and no
-    /// `--gateway`/`--gateways` — the file-load fallback branch must still
-    /// allow the gateway to start with an empty bootstrap list.
+    /// Regression test for #4268: an isolated gateway — remote index
+    /// unreachable/empty, no on-disk `gateways.toml`, and no
+    /// `--gateway`/`--gateways` — must still be allowed to start with an empty
+    /// bootstrap list. Before the #4268 fix, the file-load fallback branch
+    /// guarded on `peer_id.is_none()` and wrongly rejected such a gateway with
+    /// "Cannot initialize node without gateways". This is the file-load
+    /// analogue of the `--skip-load-from-network` guard fixed in PR #4264.
     ///
-    /// Before the fix, the branch guarded on `peer_id.is_none()`, so this
-    /// configuration was wrongly rejected with "Cannot initialize node without
-    /// gateways". This is the file-load analogue of the
-    /// `--skip-load-from-network` guard fixed in PR #4264.
+    /// The gateway is configured with both `--public-network-address` and
+    /// `--public-network-port` (required for gateways since #4324), so it has a
+    /// valid `peer_id`. This test pins the *bootstrap* behavior, independent of
+    /// identity derivation.
     ///
     /// Note: `skip_load_from_network` is intentionally NOT set here — that flag
     /// would route an `is_gateway` node through the earlier
     /// `skip_load && is_gateway` branch and never reach the file-load guard
     /// this test exercises.
     #[tokio::test]
-    async fn test_file_load_branch_isolated_gateway_without_public_port_succeeds() {
+    async fn test_file_load_branch_isolated_gateway_succeeds() {
         let temp_dir = tempfile::tempdir().unwrap();
         let config_dir = temp_dir.path();
         // No gateways.toml is written: the config_dir is empty, so File::open
@@ -4270,11 +4275,9 @@ mod tests {
             },
             network_api: NetworkArgs {
                 is_gateway: true,
-                // public_address + network_port (NOT public_port) is the valid
-                // isolated-gateway configuration that yields peer_id == None.
                 public_address: Some("203.0.113.10".parse().unwrap()),
+                public_port: Some(31337),
                 network_port: Some(31337),
-                public_port: None,
                 ..Default::default()
             },
             ..Default::default()
@@ -4291,15 +4294,56 @@ mod tests {
             "isolated gateway should start with no bootstrap gateways, got {:?}",
             cfg.gateways
         );
-        // This PR intentionally does NOT change peer_id derivation: a gateway
-        // configured with --network-port but no --public-network-port still has
-        // peer_id == None (peer_id = public_address.zip(public_port)). That
-        // pre-existing behavior is out of scope here; whether such a gateway
-        // should derive peer_id from network_port is tracked separately. The
-        // fix only ensures build() no longer rejects this valid configuration.
         assert!(
-            cfg.peer_id.is_none(),
-            "expected peer_id to remain None for a gateway without --public-network-port"
+            cfg.peer_id.is_some(),
+            "expected peer_id to be derived from public address + port"
+        );
+    }
+
+    /// Regression test for #4324: a gateway started with
+    /// `--is-gateway --public-network-address X --network-port Y` but NO
+    /// `--public-network-port` must be rejected at config-build time.
+    ///
+    /// Such a gateway would otherwise derive `peer_id == None` (peer_id =
+    /// `public_address.zip(public_port)`) → `own_addr == None` → no ring
+    /// location. Unlike a NAT'd peer, a gateway has no upstream to learn or
+    /// correct its address later, so it would stay degraded permanently. The
+    /// agreed fix (maintainer consensus on the issue) is to fail fast and
+    /// require the public port explicitly, rather than silently falling back
+    /// to the local bind port.
+    #[tokio::test]
+    async fn test_gateway_without_public_port_is_rejected() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_dir = temp_dir.path();
+
+        let (_server, index_url) = empty_gateways_index_server();
+
+        let args = ConfigArgs {
+            mode: Some(OperationMode::Network),
+            config_paths: ConfigPathsArgs {
+                config_dir: Some(config_dir.to_path_buf()),
+                data_dir: Some(config_dir.to_path_buf()),
+                log_dir: Some(config_dir.to_path_buf()),
+            },
+            network_api: NetworkArgs {
+                is_gateway: true,
+                // network_port set but no public_port: it no longer substitutes
+                // for the public port, so this must be rejected.
+                public_address: Some("203.0.113.10".parse().unwrap()),
+                network_port: Some(31337),
+                public_port: None,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let err = args
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect_err("gateway without --public-network-port must be rejected");
+        assert!(
+            err.to_string().contains("public network port"),
+            "expected error to mention the missing public network port, got: {err}"
         );
     }
 


### PR DESCRIPTION
## Problem

A gateway started with `--is-gateway --public-network-address X --network-port Y` and **no** `--public-network-port` passed `NetworkArgs::validate()` but ended up with `peer_id == None`, because `peer_id` is derived strictly from `public_address.zip(public_port)`. That yields `own_addr == None` and no ring location: the gateway boots in a silently degraded state — it can't advertise its own address/key as a `PeerId`, and routing logs "no own_addr available".

Unlike a NAT'd peer (which learns its external address from a gateway via `try_set_own_addr`), a gateway has no upstream to learn or correct its address from, so this degraded state is **permanent**.

In practice no real gateway is started this way — every deployment and test harness passes both ports — so this only ever happens as an operator mistake that fails silently instead of loudly.

This is the follow-up to #4268 / PR #4323, which deliberately scoped itself to the no-gateways bootstrap guard and left `peer_id` derivation untouched (its test explicitly pinned `peer_id == None` as a known gap "tracked separately").

## Approach

Maintainer consensus on the issue was to **fail fast** rather than silently fall back: require `--public-network-port` explicitly for gateways and reject the config when it's missing.

Why reject instead of the originally-proposed `public_port.or(network_port)` fallback: a gateway's advertised identity is critical and can't be corrected later. Silently reusing the local bind port would advertise the wrong port to the whole network with no way to fix it if the gateway were ever behind NAT port-remapping. Rejecting up front turns a silent misconfiguration into a clear, actionable error.

The change is a one-line tightening of `NetworkArgs::validate()` (the gateway check now requires `public_port`, where it previously accepted `network_port` as a substitute), plus a clearer error message. `peer_id` derivation, ring location, routing, and transport are all untouched.

## Testing

- **New regression test** `test_gateway_without_public_port_is_rejected`: a gateway with `--network-port` but no `--public-network-port` now fails at `build()`. Verified it **fails without the fix** (build previously succeeded with `peer_id == None`) and **passes with the fix**.
- **Updated** the #4268 pin test (`test_file_load_branch_isolated_gateway_succeeds`, formerly `..._without_public_port_succeeds`): it now uses a valid gateway config (with `public_port`) and asserts `peer_id.is_some()`, while still exercising the isolated-bootstrap behavior it was written for.
- `config::tests`: 60 passed, 0 failed. `cargo fmt` clean.

**Why didn't CI catch this?** There was no test exercising an invalid gateway config through `validate()`; the #4268 pin test documented the gap explicitly ("tracked separately") rather than guarding against it. This PR adds that coverage.

No E2E run needed: this is config validation at startup, not runtime network behavior. The three integration tests that start gateways via `ConfigArgs` (`in_process_restart`, `operations_before_join`, `error_notification`) all pass both ports and are unaffected.

## Fixes

Closes #4324