### PR TITLE
feat(hosted): hosted-mode flag + per-user token threading (P2 backend of #4381)

### DIFF
--- a/apps/freenet-ping/app/tests/common/mod.rs
+++ b/apps/freenet-ping/app/tests/common/mod.rs
@@ -155,6 +155,7 @@ pub async fn base_node_test_config_with_rng<R: Rng>(
             token_cleanup_interval_seconds: None,
             allowed_host: None,
             allowed_source_cidrs: None,
+            hosted_mode: None,
         },
         network_api: NetworkArgs {
             // Use varied IP for network socket to get unique ring locations

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -22,6 +22,7 @@ use tokio::sync::mpsc;
 use crate::contract::{ClientResponsesReceiver, ContractHandlerEvent};
 use crate::message::{NodeEvent, QueryResult};
 use crate::node::OpManager;
+use crate::wasm_runtime::UserSecretContext;
 use crate::operations::{OpError, get, put, update};
 use crate::ring::KnownPeerKeyLocation;
 use crate::tracing::NetEventLog;
@@ -179,6 +180,12 @@ pub struct OpenRequest<'a> {
     pub notification_channel: Option<mpsc::Sender<HostResult>>,
     pub token: Option<AuthToken>,
     pub origin_contract: Option<ContractInstanceId>,
+    /// Per-connection per-user secret namespace (hosted mode, P2 of #4381),
+    /// derived once at the WS connection boundary from the connection's user
+    /// token. `None` outside hosted mode or when no token was presented. This
+    /// is carried alongside the request — never read from the request body —
+    /// so it cannot be forged by a client.
+    pub user_context: Option<UserSecretContext>,
 }
 
 impl Display for OpenRequest<'_> {
@@ -207,6 +214,7 @@ impl<'a> OpenRequest<'a> {
             notification_channel: None,
             token: None,
             origin_contract: None,
+            user_context: None,
         }
     }
 
@@ -222,6 +230,11 @@ impl<'a> OpenRequest<'a> {
 
     pub fn with_origin_contract(mut self, contract: Option<ContractInstanceId>) -> Self {
         self.origin_contract = contract;
+        self
+    }
+
+    pub fn with_user_context(mut self, user_context: Option<UserSecretContext>) -> Self {
+        self.user_context = user_context;
         self
     }
 }
@@ -1626,11 +1639,17 @@ async fn process_open_request(
                     );
                 }
                 let origin_contract = request.origin_contract;
+                // Per-connection user secret namespace (hosted mode). Taken from
+                // the OpenRequest, which received it from the connection layer —
+                // NOT from anything inside `req`. Moving it into the event keeps
+                // it on a channel the delegate/client cannot reach.
+                let user_context = request.user_context;
 
                 let res = match op_manager
                     .notify_contract_handler(ContractHandlerEvent::DelegateRequest {
                         req,
                         origin_contract,
+                        user_context,
                     })
                     .await
                 {
@@ -1987,6 +2006,7 @@ pub(crate) mod test {
                 notification_channel,
                 token: None,
                 origin_contract: None,
+                user_context: None,
             }
             .into_owned()
         }

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -22,10 +22,10 @@ use tokio::sync::mpsc;
 use crate::contract::{ClientResponsesReceiver, ContractHandlerEvent};
 use crate::message::{NodeEvent, QueryResult};
 use crate::node::OpManager;
-use crate::wasm_runtime::UserSecretContext;
 use crate::operations::{OpError, get, put, update};
 use crate::ring::KnownPeerKeyLocation;
 use crate::tracing::NetEventLog;
+use crate::wasm_runtime::UserSecretContext;
 use crate::{
     config::{GlobalExecutor, GlobalRng},
     contract::StoreResponse,

--- a/crates/core/src/client_events/combinator.rs
+++ b/crates/core/src/client_events/combinator.rs
@@ -135,6 +135,7 @@ impl<const N: usize> super::ClientEventsProxy for ClientEventsCombinator<N> {
                                 notification_channel,
                                 token,
                                 origin_contract,
+                                user_context,
                             }) => {
                                 let id = *self.external_clients[idx]
                                     .entry(external)
@@ -151,6 +152,9 @@ impl<const N: usize> super::ClientEventsProxy for ClientEventsCombinator<N> {
                                     notification_channel,
                                     token,
                                     origin_contract,
+                                    // Preserve the connection's user context through
+                                    // the ID-remapping proxy combinator unchanged.
+                                    user_context,
                                 })
                             }
                             err @ Err(_) => err,
@@ -291,6 +295,7 @@ async fn client_fn(
                         notification_channel,
                         token,
                         origin_contract,
+                        user_context,
                     }) => {
                         tracing::debug!(
                             "received msg @ combinator from external id {client_id}, msg: {request}"
@@ -303,6 +308,8 @@ async fn client_fn(
                                 notification_channel,
                                 token,
                                 origin_contract,
+                                // Forward the connection's user context unchanged.
+                                user_context,
                             }))
                             .await
                             .is_err()

--- a/crates/core/src/client_events/test_correlation.rs
+++ b/crates/core/src/client_events/test_correlation.rs
@@ -34,6 +34,7 @@ mod tests {
             notification_channel: None,
             token: None,
             origin_contract: None,
+            user_context: None,
         };
 
         assert_eq!(req.request_id, request_id);

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -724,7 +724,6 @@ async fn connection_info(
     }): Query<ConnectionInfo>,
     Extension(allowed_hosts): Extension<crate::server::AllowedHosts>,
     Extension(allowed_source_cidrs): Extension<crate::server::AllowedSourceCidrs>,
-    Extension(hosted_mode): Extension<crate::server::HostedMode>,
     mut req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> Response {
@@ -831,6 +830,18 @@ async fn connection_info(
     // which, if present, takes precedence (mirrors how a Bearer `auth_token`
     // header overrides its query form). The token is sensitive: we derive the
     // context and then drop the raw bytes — they are never stored or logged.
+    // Read the hosted-mode flag tolerantly: an absent `HostedMode` extension
+    // defaults to OFF. The production local path
+    // (node::run_local_node -> serve_client_api_in) always injects it, but a
+    // required `Extension<HostedMode>` extractor would make any embedded /
+    // library / secondary server that mounts this middleware without the layer
+    // 500 on every WS upgrade. Defaulting to false = hosted-off = inert/secure,
+    // which is the correct posture for any non-hosted server.
+    let hosted_mode = req
+        .extensions()
+        .get::<crate::server::HostedMode>()
+        .copied()
+        .unwrap_or_default();
     let user_token = req
         .headers()
         .get("x-freenet-user-token")
@@ -839,15 +850,19 @@ async fn connection_info(
         .or(user_token_q);
     let user_context = derive_user_context(hosted_mode.0, user_token.as_deref());
 
+    // Do NOT log credentials. The auth token, the user token, and the full
+    // request URI are all sensitive: the URI query string carries
+    // `?auth_token=<raw>` and `?userToken=<raw>` verbatim, and the user token
+    // is an especially high-value credential (durable, node-independent, names
+    // a per-user secret namespace). Log only the URI PATH and non-secret
+    // presence/derived flags. `?user_context` is safe — its `Debug` redacts the
+    // dek_secret and prints only the non-secret user_id (or `None`).
     tracing::debug!(
-        ?auth_token_q,
-        ?auth_token,
+        auth_token_present = auth_token.is_some(),
         hosted_mode = hosted_mode.0,
-        // `UserSecretContext`'s Debug redacts the dek_secret; only the
-        // non-secret user_id (or `None`) is logged. The raw token never is.
         ?user_context,
-        request_uri = ?req.uri(),
-        "connection_info middleware extracting auth token and encoding protocol",
+        request_path = req.uri().path(),
+        "connection_info middleware: resolved auth token, hosted-mode context, and encoding protocol",
     );
     req.extensions_mut().insert(encoding_protoc);
     req.extensions_mut().insert(auth_token);

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -130,6 +130,7 @@ use crate::{
 
 use super::{ClientError, ClientEventsProxy, ClientId, HostResult, OpenRequest};
 use crate::server::client_api::OriginContractMap;
+use crate::wasm_runtime::UserSecretContext;
 
 /// Checks if a WebSocket Origin header value refers to localhost.
 ///
@@ -528,6 +529,7 @@ impl WebSocketProxy {
     /// Returns `None` if the client has already disconnected (response channel
     /// closed or missing). Returning `None` instead of an error prevents
     /// transient disconnects from killing `client_fn` (#3479).
+    #[allow(clippy::too_many_arguments)]
     fn setup_subscription(
         &self,
         client_id: ClientId,
@@ -535,6 +537,7 @@ impl WebSocketProxy {
         req: Box<ClientRequest<'static>>,
         auth_token: Option<AuthToken>,
         origin_contract: Option<ContractInstanceId>,
+        user_context: Option<UserSecretContext>,
     ) -> Option<OpenRequest<'static>> {
         let (tx, rx) =
             tokio::sync::mpsc::channel(crate::contract::SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE);
@@ -554,7 +557,8 @@ impl WebSocketProxy {
             OpenRequest::new(client_id, req)
                 .with_notification(tx)
                 .with_token(auth_token)
-                .with_origin_contract(origin_contract),
+                .with_origin_contract(origin_contract)
+                .with_user_context(user_context),
         )
     }
 
@@ -584,6 +588,7 @@ impl WebSocketProxy {
                 req,
                 auth_token,
                 origin_contract,
+                user_context,
                 ..
             } => {
                 // Extract the subscription key if this request needs a notification channel.
@@ -610,8 +615,14 @@ impl WebSocketProxy {
 
                 let open_req = if let Some(key) = sub_key {
                     tracing::debug!(%client_id, contract = %key, "setting up subscription channel");
-                    match self.setup_subscription(client_id, key, req, auth_token, origin_contract)
-                    {
+                    match self.setup_subscription(
+                        client_id,
+                        key,
+                        req,
+                        auth_token,
+                        origin_contract,
+                        user_context,
+                    ) {
                         Some(r) => r,
                         None => return Ok(None),
                     }
@@ -619,6 +630,7 @@ impl WebSocketProxy {
                     OpenRequest::new(client_id, req)
                         .with_token(auth_token)
                         .with_origin_contract(origin_contract)
+                        .with_user_context(user_context)
                 };
                 Ok(Some(open_req))
             }
@@ -666,6 +678,16 @@ struct ConnectionInfo {
     /// Accepted for backward compatibility but ignored — streaming is always enabled.
     #[allow(dead_code)]
     streaming: Option<bool>,
+    /// Durable per-user token for hosted mode (P2 of #4381). This is a SEPARATE
+    /// credential from `auth_token` (the per-app session token minted by the
+    /// HTTP attestation flow): `auth_token` identifies which app-contract a
+    /// connection is acting for, whereas `user_token` identifies WHICH USER's
+    /// secret namespace the connection's delegate secret operations bind to.
+    /// The browser shell page supplies it as the `userToken` query parameter on
+    /// the WS upgrade URL (the P2-frontend follow-up mints/stores/presents it).
+    /// It is honored ONLY when the node runs in hosted mode; otherwise it is
+    /// ignored entirely and every connection stays single-user.
+    user_token: Option<String>,
 }
 
 async fn connection_info(
@@ -673,9 +695,11 @@ async fn connection_info(
         auth_token: auth_token_q,
         encoding_protocol,
         streaming: _,
+        user_token: user_token_q,
     }): Query<ConnectionInfo>,
     Extension(allowed_hosts): Extension<crate::server::AllowedHosts>,
     Extension(allowed_source_cidrs): Extension<crate::server::AllowedSourceCidrs>,
+    Extension(hosted_mode): Extension<crate::server::HostedMode>,
     mut req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> Response {
@@ -769,11 +793,52 @@ async fn connection_info(
         }
     }
 
+    // Derive the per-connection user secret context (hosted mode, P2 of #4381).
+    //
+    // SECURITY-CRITICAL boundary: this is the ONE place a `UserSecretContext` is
+    // constructed. It happens here, at connection establishment, from the user
+    // token presented on the upgrade request — never from a `ClientRequest`, a
+    // delegate message, or anything reachable from WASM. Downstream the context
+    // is immutable and travels with the connection.
+    //
+    // Token source: the `userToken` query parameter (canonical, supplied by the
+    // browser shell page on the WS URL), OR an `X-Freenet-User-Token` header
+    // which, if present, takes precedence (mirrors how a Bearer `auth_token`
+    // header overrides its query form). The token is sensitive: we derive the
+    // context and then drop the raw bytes — they are never stored or logged.
+    let user_token = req
+        .headers()
+        .get("x-freenet-user-token")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_owned())
+        .or(user_token_q);
+    // Only honor the token in hosted mode. With the flag off the token is
+    // ignored entirely: `None` flows through and every connection is
+    // single-user (byte-for-byte the pre-#4381 behavior).
+    let user_context: Option<UserSecretContext> = match (hosted_mode.0, user_token) {
+        (true, Some(token)) if !token.is_empty() => {
+            // Derived solely from the token bytes via domain-separated hashes.
+            Some(UserSecretContext::from_token(token.as_bytes()))
+        }
+        // hosted mode on but no/empty token => single-user for this connection.
+        (true, _) => None,
+        // hosted mode off => token ignored regardless of presence.
+        (false, _) => None,
+    };
+
     tracing::debug!(
-        ?auth_token_q, ?auth_token, request_uri = ?req.uri(), "connection_info middleware extracting auth token and encoding protocol",
+        ?auth_token_q,
+        ?auth_token,
+        hosted_mode = hosted_mode.0,
+        // `UserSecretContext`'s Debug redacts the dek_secret; only the
+        // non-secret user_id (or `None`) is logged. The raw token never is.
+        ?user_context,
+        request_uri = ?req.uri(),
+        "connection_info middleware extracting auth token and encoding protocol",
     );
     req.extensions_mut().insert(encoding_protoc);
     req.extensions_mut().insert(auth_token);
+    req.extensions_mut().insert(user_context);
     // `streaming` query parameter is accepted but ignored — streaming is now
     // always enabled for payloads exceeding CHUNK_THRESHOLD (512 KiB).
 
@@ -787,6 +852,10 @@ async fn websocket_commands(
     Extension(rs): Extension<WebSocketRequest>,
     Extension(origin_contracts): Extension<OriginContractMap>,
     Extension(api_version): Extension<ApiVersion>,
+    // The per-connection user secret context derived in `connection_info`
+    // (hosted mode). `None` outside hosted mode or when no user token was
+    // presented. Owned and moved into the connection task below.
+    Extension(user_context): Extension<Option<UserSecretContext>>,
 ) -> Response {
     let on_upgrade = move |ws: WebSocket| async move {
         // Get the data we need from the DashMap
@@ -844,6 +913,7 @@ async fn websocket_commands(
         if let Err(error) = websocket_interface(
             rs.clone(),
             auth_and_instance,
+            user_context,
             token_is_invalid,
             encoding_protoc,
             api_version,
@@ -883,6 +953,8 @@ async fn notify_disconnect(
             req: Box::new(ClientRequest::Disconnect { cause: None }),
             auth_token: auth_token.as_ref().map(|t| t.0.clone()),
             origin_contract: auth_token.as_ref().map(|t| t.1),
+            // Synthetic disconnect: no secret operations, so no user context.
+            user_context: None,
             api_version,
         })
         .await
@@ -894,6 +966,11 @@ async fn notify_disconnect(
 async fn websocket_interface(
     request_sender: WebSocketRequest,
     mut auth_token: Option<(AuthToken, ContractInstanceId)>,
+    // Per-connection user secret context (hosted mode). Derived once at upgrade
+    // and immutable for the life of this connection; cloned into each
+    // `ClientConnection::Request` so every request from this connection (and
+    // only this connection) binds to the same user namespace.
+    user_context: Option<UserSecretContext>,
     token_is_invalid: bool,
     encoding_protoc: EncodingProtocol,
     api_version: ApiVersion,
@@ -1016,6 +1093,7 @@ async fn websocket_interface(
                     &request_sender,
                     &mut auth_token.as_mut().map(|t| t.0.clone()),
                     auth_token.as_mut().map(|t| t.1),
+                    user_context.as_ref(),
                     api_version,
                     &mut delegate_rate_limiter,
                     &mut conn_state,
@@ -1280,6 +1358,7 @@ async fn process_client_request(
     request_sender: &mpsc::Sender<ClientConnection>,
     auth_token: &mut Option<AuthToken>,
     origin_contract: Option<ContractInstanceId>,
+    user_context: Option<&UserSecretContext>,
     api_version: ApiVersion,
     rate_limiter: &mut DelegateRateLimiter,
     conn_state: &mut ConnectionState,
@@ -1454,6 +1533,10 @@ async fn process_client_request(
             req: Box::new(req),
             auth_token: auth_token.clone(),
             origin_contract,
+            // Clone the connection's user context into this request. Every
+            // request from this connection carries the SAME context, derived
+            // once at upgrade; a client cannot vary it per-request.
+            user_context: user_context.cloned(),
             api_version,
         })
         .await

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -690,6 +690,31 @@ struct ConnectionInfo {
     user_token: Option<String>,
 }
 
+/// Decide a connection's per-user secret namespace from the hosted-mode flag
+/// and the presented user token (P2 of #4381).
+///
+/// This is the security-critical gate, factored out of the `connection_info`
+/// middleware so it can be unit-tested in isolation:
+///
+/// - hosted mode OFF => always `None` (token ignored entirely; single-user).
+/// - hosted mode ON, non-empty token => `Some` context derived solely from the
+///   token bytes.
+/// - hosted mode ON, no token or empty token => `None` (this connection is
+///   single-user, just like a non-hosted node).
+///
+/// `None` everywhere means [`crate::wasm_runtime::SecretScope::Local`]
+/// downstream — byte-for-byte the pre-#4381 behavior — so the flag-off path is
+/// provably inert.
+fn derive_user_context(hosted_mode: bool, user_token: Option<&str>) -> Option<UserSecretContext> {
+    match (hosted_mode, user_token) {
+        (true, Some(token)) if !token.is_empty() => {
+            Some(UserSecretContext::from_token(token.as_bytes()))
+        }
+        // hosted on but no/empty token, or hosted off (token ignored): Local.
+        (true, _) | (false, _) => None,
+    }
+}
+
 async fn connection_info(
     Query(ConnectionInfo {
         auth_token: auth_token_q,
@@ -812,19 +837,7 @@ async fn connection_info(
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_owned())
         .or(user_token_q);
-    // Only honor the token in hosted mode. With the flag off the token is
-    // ignored entirely: `None` flows through and every connection is
-    // single-user (byte-for-byte the pre-#4381 behavior).
-    let user_context: Option<UserSecretContext> = match (hosted_mode.0, user_token) {
-        (true, Some(token)) if !token.is_empty() => {
-            // Derived solely from the token bytes via domain-separated hashes.
-            Some(UserSecretContext::from_token(token.as_bytes()))
-        }
-        // hosted mode on but no/empty token => single-user for this connection.
-        (true, _) => None,
-        // hosted mode off => token ignored regardless of presence.
-        (false, _) => None,
-    };
+    let user_context = derive_user_context(hosted_mode.0, user_token.as_deref());
 
     tracing::debug!(
         ?auth_token_q,
@@ -1885,6 +1898,49 @@ mod tests {
     use freenet_stdlib::client_api::streaming::{
         CHUNK_SIZE, CHUNK_THRESHOLD, ReassemblyBuffer, chunk_request,
     };
+
+    /// The hosted-mode flag is the gate: with it OFF, a presented user token is
+    /// ignored entirely and no per-user context is derived (single-user).
+    #[test]
+    fn hosted_mode_off_ignores_user_token() {
+        assert!(
+            derive_user_context(false, Some("some-user-token")).is_none(),
+            "flag off must ignore the token entirely"
+        );
+        assert!(derive_user_context(false, None).is_none());
+        assert!(derive_user_context(false, Some("")).is_none());
+    }
+
+    /// With hosted mode ON, a non-empty token yields a context; absent/empty
+    /// token still means single-user (no context).
+    #[test]
+    fn hosted_mode_on_honors_only_a_nonempty_token() {
+        assert!(
+            derive_user_context(true, Some("alice")).is_some(),
+            "flag on + token must derive a context"
+        );
+        assert!(
+            derive_user_context(true, None).is_none(),
+            "flag on + no token => single-user"
+        );
+        assert!(
+            derive_user_context(true, Some("")).is_none(),
+            "flag on + empty token => single-user (not an empty-token namespace)"
+        );
+    }
+
+    /// The derived namespace depends only on the token bytes: same token =>
+    /// same UserId; different tokens => different UserId. This pins that the
+    /// flag-gated boundary feeds the token straight into the (deterministic)
+    /// derivation with no other inputs.
+    #[test]
+    fn derived_context_namespace_tracks_only_the_token() {
+        let a = derive_user_context(true, Some("alice")).unwrap();
+        let a_again = derive_user_context(true, Some("alice")).unwrap();
+        let b = derive_user_context(true, Some("bob")).unwrap();
+        assert_eq!(a.user_id(), a_again.user_id());
+        assert_ne!(a.user_id(), b.user_id());
+    }
 
     fn test_conn_state(encoding: EncodingProtocol) -> ConnectionState {
         ConnectionState {

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -724,6 +724,7 @@ async fn connection_info(
     }): Query<ConnectionInfo>,
     Extension(allowed_hosts): Extension<crate::server::AllowedHosts>,
     Extension(allowed_source_cidrs): Extension<crate::server::AllowedSourceCidrs>,
+    Extension(hosted_mode): Extension<crate::server::HostedMode>,
     mut req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> Response {
@@ -830,18 +831,15 @@ async fn connection_info(
     // which, if present, takes precedence (mirrors how a Bearer `auth_token`
     // header overrides its query form). The token is sensitive: we derive the
     // context and then drop the raw bytes — they are never stored or logged.
-    // Read the hosted-mode flag tolerantly: an absent `HostedMode` extension
-    // defaults to OFF. The production local path
-    // (node::run_local_node -> serve_client_api_in) always injects it, but a
-    // required `Extension<HostedMode>` extractor would make any embedded /
-    // library / secondary server that mounts this middleware without the layer
-    // 500 on every WS upgrade. Defaulting to false = hosted-off = inert/secure,
-    // which is the correct posture for any non-hosted server.
-    let hosted_mode = req
-        .extensions()
-        .get::<crate::server::HostedMode>()
-        .copied()
-        .unwrap_or_default();
+    // `hosted_mode` is a REQUIRED `Extension<HostedMode>` extractor (above), not
+    // read tolerantly: it is a security-isolation flag, so a missing injection
+    // must fail loud (500) rather than silently default to hosted-off. The single
+    // bring-up choke point `server::serve_client_api_in_impl` injects it on both
+    // router branches (loopback and LAN), so production always has it; a 500 here
+    // means a misconfiguration to surface, not to paper over. A silent
+    // default-to-false in a real hosted deployment that lost the injection would
+    // disable per-user isolation (all users -> Local shared namespace ->
+    // cross-user clobber) — for a security flag, fail-loud beats fail-silent.
     let user_token = req
         .headers()
         .get("x-freenet-user-token")

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1586,7 +1586,19 @@ pub struct WebsocketApiArgs {
     /// OFF by default. When off, `userToken` is ignored and every connection is
     /// single-user, byte-for-byte today's behavior. Enable only on a node you
     /// intend to operate as a shared public proxy for untrusted users.
-    #[arg(long = "hosted-mode", env = "FREENET_HOSTED_MODE")]
+    ///
+    /// `--hosted-mode` is THE operator switch, so it works as a BARE flag:
+    /// `--hosted-mode` => `Some(true)`; `--hosted-mode=false` (or
+    /// `--hosted-mode false`) => `Some(false)`; absent => `None`. Kept as
+    /// `Option<bool>` (not a plain `bool` with `default_value`) so config-file /
+    /// env layering can still leave it unset (`None`) and the CLI only overrides
+    /// when actually present — `None` is then resolved to `false` in `build`.
+    #[arg(
+        long = "hosted-mode",
+        env = "FREENET_HOSTED_MODE",
+        num_args = 0..=1,
+        default_missing_value = "true"
+    )]
     #[serde(rename = "hosted-mode", skip_serializing_if = "Option::is_none")]
     pub hosted_mode: Option<bool>,
 }
@@ -3195,6 +3207,69 @@ mod tests {
             reparsed.ws_api.hosted_mode,
             "hosted_mode=true must survive a TOML serialize/deserialize round-trip"
         );
+    }
+
+    /// `--hosted-mode` is the operator switch for the feature, so it MUST work as
+    /// a BARE flag (clap optional-value form), while staying `Option<bool>` so
+    /// config-file/env layering can leave it unset. Asserts the three forms:
+    ///   bare `--hosted-mode`        => Some(true)
+    ///   `--hosted-mode=false`       => Some(false)
+    ///   absent                      => None
+    #[test]
+    fn hosted_mode_cli_accepts_bare_flag_and_explicit_value() {
+        use clap::Parser;
+
+        // The arg also reads FREENET_HOSTED_MODE via clap's `env`. Clear it for
+        // the duration of this test so the env of the test runner can't mask the
+        // CLI-form assertions, then restore it. SAFETY: this is the only test
+        // that touches FREENET_HOSTED_MODE.
+        let saved = std::env::var_os("FREENET_HOSTED_MODE");
+        unsafe {
+            std::env::remove_var("FREENET_HOSTED_MODE");
+        }
+
+        // Bare `--hosted-mode` => Some(true) (default_missing_value).
+        let bare = ConfigArgs::try_parse_from(["freenet", "--hosted-mode"])
+            .expect("bare --hosted-mode should parse");
+        assert_eq!(
+            bare.ws_api.hosted_mode,
+            Some(true),
+            "bare --hosted-mode must mean Some(true)"
+        );
+
+        // `--hosted-mode=false` => Some(false) (explicit override off).
+        let explicit_false = ConfigArgs::try_parse_from(["freenet", "--hosted-mode=false"])
+            .expect("--hosted-mode=false should parse");
+        assert_eq!(
+            explicit_false.ws_api.hosted_mode,
+            Some(false),
+            "--hosted-mode=false must mean Some(false)"
+        );
+
+        // `--hosted-mode true` (space-separated value) => Some(true).
+        let explicit_true = ConfigArgs::try_parse_from(["freenet", "--hosted-mode", "true"])
+            .expect("--hosted-mode true should parse");
+        assert_eq!(
+            explicit_true.ws_api.hosted_mode,
+            Some(true),
+            "--hosted-mode true must mean Some(true)"
+        );
+
+        // Absent => None (so config-file/env can still supply the value, and
+        // `build()` resolves None to false).
+        let absent =
+            ConfigArgs::try_parse_from(["freenet"]).expect("no hosted-mode flag should parse");
+        assert_eq!(
+            absent.ws_api.hosted_mode, None,
+            "absent --hosted-mode must leave it None for config/env layering"
+        );
+
+        // Restore the env var for any other test in this process.
+        unsafe {
+            if let Some(v) = saved {
+                std::env::set_var("FREENET_HOSTED_MODE", v);
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -179,6 +179,7 @@ impl Default for ConfigArgs {
                 token_cleanup_interval_seconds: None,
                 allowed_host: None,
                 allowed_source_cidrs: None,
+                hosted_mode: None,
             },
             secrets: Default::default(),
             log_level: Some(tracing::log::LevelFilter::Info),
@@ -351,6 +352,7 @@ impl ConfigArgs {
                         .collect(),
                 );
             }
+            self.ws_api.hosted_mode.get_or_insert(cfg.ws_api.hosted_mode);
             self.network_api
                 .address
                 .get_or_insert(cfg.network_api.address);
@@ -796,6 +798,7 @@ impl ConfigArgs {
                     })
                     .transpose()?
                     .unwrap_or_default(),
+                hosted_mode: self.ws_api.hosted_mode.unwrap_or(false),
             },
             secrets,
             log_level: self.log_level.unwrap_or(tracing::log::LevelFilter::Info),
@@ -1573,6 +1576,17 @@ pub struct WebsocketApiArgs {
         skip_serializing_if = "Option::is_none"
     )]
     pub allowed_source_cidrs: Option<Vec<String>>,
+
+    /// Opt-in hosted mode (P2 of #4381): honor a per-connection durable user
+    /// token (the `userToken` query parameter on the WebSocket upgrade) and
+    /// give that connection its own per-user delegate-secret namespace.
+    ///
+    /// OFF by default. When off, `userToken` is ignored and every connection is
+    /// single-user, byte-for-byte today's behavior. Enable only on a node you
+    /// intend to operate as a shared public proxy for untrusted users.
+    #[arg(long = "hosted-mode", env = "FREENET_HOSTED_MODE")]
+    #[serde(rename = "hosted-mode", skip_serializing_if = "Option::is_none")]
+    pub hosted_mode: Option<bool>,
 }
 
 /// Default telemetry endpoint (nova.locut.us OTLP collector).
@@ -1758,6 +1772,18 @@ pub struct WebsocketApiConfig {
     /// Empty means only loopback + RFC1918 / IPv6 ULA are accepted.
     #[serde(default, rename = "allowed-source-cidrs")]
     pub allowed_source_cidrs: Vec<ipnet::IpNet>,
+
+    /// Opt-in hosted mode (P2 of #4381). When `true`, a WebSocket connection
+    /// that presents a durable per-user token (the `userToken` query parameter)
+    /// gets a per-user delegate-secret namespace derived from that token; when
+    /// `false` (the default), the `userToken` parameter is ignored entirely and
+    /// every connection is single-user — byte-for-byte the pre-#4381 behavior.
+    ///
+    /// This flag ONLY governs whether the WS boundary derives a per-user
+    /// context; everything downstream is driven by whether a context was
+    /// derived, so with the flag off the entire feature is inert.
+    #[serde(default, rename = "hosted-mode")]
+    pub hosted_mode: bool,
 }
 
 #[inline]
@@ -1779,6 +1805,7 @@ impl From<SocketAddr> for WebsocketApiConfig {
             token_cleanup_interval_seconds: default_token_cleanup_interval_seconds(),
             allowed_hosts: Vec::new(),
             allowed_source_cidrs: Vec::new(),
+            hosted_mode: false,
         }
     }
 }
@@ -1793,6 +1820,7 @@ impl Default for WebsocketApiConfig {
             token_cleanup_interval_seconds: default_token_cleanup_interval_seconds(),
             allowed_hosts: Vec::new(),
             allowed_source_cidrs: Vec::new(),
+            hosted_mode: false,
         }
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3143,6 +3143,60 @@ mod tests {
         );
     }
 
+    /// Hosted mode (P2 of #4381) is OFF unless explicitly enabled. This is the
+    /// inert-by-default guarantee: a node built with no hosted-mode flag never
+    /// honors a user token and stays single-user.
+    #[tokio::test]
+    async fn hosted_mode_defaults_to_off() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let args = ConfigArgs {
+            mode: Some(OperationMode::Local),
+            config_paths: ConfigPathsArgs {
+                config_dir: Some(temp_dir.path().to_path_buf()),
+                data_dir: Some(temp_dir.path().to_path_buf()),
+                log_dir: Some(temp_dir.path().to_path_buf()),
+            },
+            ..Default::default()
+        };
+        let cfg = args.build().await.unwrap();
+        assert!(
+            !cfg.ws_api.hosted_mode,
+            "hosted_mode must default to false (inert unless explicitly enabled)"
+        );
+    }
+
+    /// When explicitly enabled, hosted mode resolves to `true` and survives a
+    /// TOML round-trip (so it works from a config file, not just the CLI flag).
+    #[tokio::test]
+    async fn hosted_mode_explicit_true_round_trips() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let args = ConfigArgs {
+            mode: Some(OperationMode::Local),
+            config_paths: ConfigPathsArgs {
+                config_dir: Some(temp_dir.path().to_path_buf()),
+                data_dir: Some(temp_dir.path().to_path_buf()),
+                log_dir: Some(temp_dir.path().to_path_buf()),
+            },
+            ws_api: WebsocketApiArgs {
+                hosted_mode: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let cfg = args.build().await.unwrap();
+        assert!(
+            cfg.ws_api.hosted_mode,
+            "explicit --hosted-mode should resolve to true"
+        );
+
+        let serialized = toml::to_string(&cfg).unwrap();
+        let reparsed: Config = toml::from_str(&serialized).unwrap();
+        assert!(
+            reparsed.ws_api.hosted_mode,
+            "hosted_mode=true must survive a TOML serialize/deserialize round-trip"
+        );
+    }
+
     #[tokio::test]
     async fn max_hosting_storage_explicit_value_round_trips() {
         let temp_dir = tempfile::tempdir().unwrap();

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -352,7 +352,9 @@ impl ConfigArgs {
                         .collect(),
                 );
             }
-            self.ws_api.hosted_mode.get_or_insert(cfg.ws_api.hosted_mode);
+            self.ws_api
+                .hosted_mode
+                .get_or_insert(cfg.ws_api.hosted_mode);
             self.network_api
                 .address
                 .get_or_insert(cfg.network_api.address);

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -42,6 +42,7 @@ use tracing::Instrument;
 use self::executor::DelegateNotificationReceiver;
 use self::user_input::{CallerIdentity, UserInputPrompter};
 use crate::config::GlobalExecutor;
+use crate::wasm_runtime::UserSecretContext;
 
 /// Maximum iterations when handling contract requests to prevent infinite loops
 const MAX_CONTRACT_REQUEST_ITERATIONS: usize = 100;
@@ -405,6 +406,7 @@ async fn handle_delegate_with_contract_requests<CH, P>(
     contract_handler: &mut CH,
     initial_req: DelegateRequest<'static>,
     origin_contract: Option<&ContractInstanceId>,
+    user_context: Option<&UserSecretContext>,
     delegate_key: &DelegateKey,
     prompter: &P,
 ) -> Vec<OutboundDelegateMsg>
@@ -441,7 +443,7 @@ where
         // Execute the delegate request
         let values = match contract_handler
             .executor()
-            .execute_delegate_request(current_req, origin_contract, None)
+            .execute_delegate_request(current_req, origin_contract, None, user_context)
             .await
         {
             Ok(freenet_stdlib::client_api::HostResponse::DelegateResponse { key: _, values }) => {
@@ -822,7 +824,15 @@ where
                 };
                 match contract_handler
                     .executor()
-                    .execute_delegate_request(target_req, None, Some(delegate_key))
+                    // Inter-delegate hop: `user_context = None`. A
+                    // delegate-to-delegate message does NOT carry the
+                    // originating connection's per-user secret namespace — the
+                    // target delegate's secrets are its own, scoped to whatever
+                    // (if any) user context its own connections present. This
+                    // keeps the per-user namespace bound to the connection
+                    // boundary, not propagated transitively through delegate
+                    // messages (part of the #4381 unforgeability invariant).
+                    .execute_delegate_request(target_req, None, Some(delegate_key), None)
                     .await
                 {
                     Ok(freenet_stdlib::client_api::HostResponse::DelegateResponse {
@@ -1654,6 +1664,10 @@ async fn handle_delegate_notification<CH, P>(
         contract_handler,
         req,
         None,
+        // Contract-state-change notification: not driven by a client
+        // connection, so there is no user token and no per-user secret
+        // namespace. Secrets stay `SecretScope::Local`.
+        None,
         &delegate_key,
         prompter,
     )
@@ -2023,11 +2037,16 @@ where
         ContractHandlerEvent::DelegateRequest {
             req,
             origin_contract,
+            user_context,
         } => {
             let delegate_key = req.key().clone();
             tracing::debug!(
                 delegate_key = %delegate_key,
                 ?origin_contract,
+                // `user_context`'s Debug redacts the dek_secret; logging the
+                // (non-secret) user_id here is safe and useful for tracing
+                // which namespace a hosted-mode request touched.
+                ?user_context,
                 "Processing delegate request"
             );
 
@@ -2036,6 +2055,7 @@ where
                 contract_handler,
                 req,
                 origin_contract.as_ref(),
+                user_context.as_ref(),
                 &delegate_key,
                 prompter,
             )

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -29,7 +29,7 @@ use crate::node::OpManager;
 use crate::operations::get::GetResult;
 use crate::wasm_runtime::{
     ContractRuntimeInterface, ContractStore, DelegateRuntimeInterface, DelegateStore, Runtime,
-    SecretsStore, StateStorage, StateStore, StateStoreError,
+    SecretsStore, StateStorage, StateStore, StateStoreError, UserSecretContext,
 };
 use crate::{
     client_events::{ClientId, HostResult},
@@ -575,11 +575,24 @@ pub(crate) trait ContractExecutor: Send + 'static {
     /// the receiver's `MessageOrigin`. At most one of these two arguments is
     /// expected to be `Some` at a given call site, and only `caller_delegate`
     /// is used for inter-delegate dispatch (issue #3860).
+    ///
+    /// `user_context` carries the per-connection per-user secret namespace
+    /// (hosted mode, P2 of #4381). It is derived ONCE at the WS connection
+    /// boundary from the connection's user token and is `None` outside hosted
+    /// mode or when no token was presented. When `Some`, the delegate's secret
+    /// host functions operate on that user's namespace; when `None` they use
+    /// the single-user [`crate::wasm_runtime::SecretScope::Local`] path,
+    /// byte-for-byte today's behavior. Crucially this is a SEPARATE channel
+    /// from `origin_contract`/`caller_delegate` and the request body: nothing
+    /// the delegate or client can put in a message can set or forge it. The
+    /// inter-delegate dispatch path passes `None` (a delegate-to-delegate hop
+    /// does not inherit the originating connection's user namespace).
     fn execute_delegate_request(
         &mut self,
         req: DelegateRequest<'_>,
         origin_contract: Option<&ContractInstanceId>,
         caller_delegate: Option<&DelegateKey>,
+        user_context: Option<&UserSecretContext>,
     ) -> impl Future<Output = Response> + Send;
 
     fn get_subscription_info(&self) -> Vec<crate::message::SubscriptionInfo>;

--- a/crates/core/src/contract/executor/mock_runtime.rs
+++ b/crates/core/src/contract/executor/mock_runtime.rs
@@ -1,7 +1,9 @@
 use super::*;
 use crate::message::NodeEvent;
 use crate::node::OpManager;
-use crate::wasm_runtime::{InMemoryContractStore, MockStateStorage, StateStorage};
+use crate::wasm_runtime::{
+    InMemoryContractStore, MockStateStorage, StateStorage, UserSecretContext,
+};
 use dashmap::DashSet;
 use std::sync::Arc;
 
@@ -706,6 +708,7 @@ where
         _req: DelegateRequest<'_>,
         _origin_contract: Option<&ContractInstanceId>,
         _caller_delegate: Option<&DelegateKey>,
+        _user_context: Option<&UserSecretContext>,
     ) -> Response {
         Err(ExecutorError::other(anyhow::anyhow!(
             "not supported in mock runtime"

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::wasm_runtime::{
     ContractRuntimeInterface, ContractStoreBridge, InMemoryContractStore, MockStateStorage,
+    UserSecretContext,
 };
 use std::collections::HashMap;
 
@@ -325,6 +326,7 @@ impl ContractExecutor for Executor<MockWasmRuntime, MockStateStorage> {
         _req: DelegateRequest<'_>,
         _origin_contract: Option<&ContractInstanceId>,
         _caller_delegate: Option<&DelegateKey>,
+        _user_context: Option<&UserSecretContext>,
     ) -> Response {
         Err(ExecutorError::other(anyhow::anyhow!(
             "delegates not supported in MockWasmRuntime"

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -65,6 +65,7 @@ fn byte_multiset_eq(a: &[u8], b: &[u8]) -> bool {
 use crate::node::OpManager;
 use crate::wasm_runtime::{
     BackendEngine, MAX_STATE_SIZE, ModuleCache, RuntimeConfig, SharedModuleCache,
+    UserSecretContext,
 };
 
 use dashmap::DashMap;
@@ -945,9 +946,11 @@ impl ContractExecutor for RuntimePool {
         req: DelegateRequest<'_>,
         origin_contract: Option<&ContractInstanceId>,
         caller_delegate: Option<&DelegateKey>,
+        user_context: Option<&UserSecretContext>,
     ) -> Response {
         let mut executor = self.pop_executor().await;
-        let result = executor.delegate_request(req, origin_contract, caller_delegate);
+        let result =
+            executor.delegate_request(req, origin_contract, caller_delegate, user_context);
         self.return_checked(executor, "execute_delegate_request")
             .await;
         result
@@ -3278,8 +3281,9 @@ impl ContractExecutor for Executor<Runtime> {
         req: DelegateRequest<'_>,
         origin_contract: Option<&ContractInstanceId>,
         caller_delegate: Option<&DelegateKey>,
+        user_context: Option<&UserSecretContext>,
     ) -> Response {
-        self.delegate_request(req, origin_contract, caller_delegate)
+        self.delegate_request(req, origin_contract, caller_delegate, user_context)
     }
 
     fn get_subscription_info(&self) -> Vec<crate::message::SubscriptionInfo> {
@@ -3475,7 +3479,9 @@ impl Executor<Runtime> {
     ) -> Response {
         match req {
             ClientRequest::ContractOp(op) => self.contract_requests(op, id, updates).await,
-            ClientRequest::DelegateOp(op) => self.delegate_request(op, None, None),
+            // Local-node path (no hosted-mode connection): always single-user
+            // (`user_context = None`), so secrets stay `SecretScope::Local`.
+            ClientRequest::DelegateOp(op) => self.delegate_request(op, None, None, None),
             ClientRequest::Disconnect { cause } => {
                 if let Some(cause) = cause {
                     tracing::info!("disconnecting cause: {cause}");
@@ -3648,6 +3654,7 @@ impl Executor<Runtime> {
         req: DelegateRequest<'_>,
         origin_contract: Option<&ContractInstanceId>,
         caller_delegate: Option<&DelegateKey>,
+        user_context: Option<&UserSecretContext>,
     ) -> Response {
         // Mutual exclusion invariant: a single inbound delegate request is
         // either dispatched on behalf of a contract-backed web app
@@ -3748,6 +3755,12 @@ impl Executor<Runtime> {
                     &key,
                     &params,
                     origin.as_ref(),
+                    // The per-user secret scope, present only in hosted mode and
+                    // derived solely from the connection token. It is delivered
+                    // here on a SEPARATE channel from `origin`/the request body,
+                    // so neither WASM nor any delegate-message content can set or
+                    // change which user's namespace a secret op touches.
+                    user_context,
                     inbound
                         .into_iter()
                         .map(InboundDelegateMsg::into_owned)

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -64,8 +64,7 @@ fn byte_multiset_eq(a: &[u8], b: &[u8]) -> bool {
 
 use crate::node::OpManager;
 use crate::wasm_runtime::{
-    BackendEngine, MAX_STATE_SIZE, ModuleCache, RuntimeConfig, SharedModuleCache,
-    UserSecretContext,
+    BackendEngine, MAX_STATE_SIZE, ModuleCache, RuntimeConfig, SharedModuleCache, UserSecretContext,
 };
 
 use dashmap::DashMap;
@@ -949,8 +948,7 @@ impl ContractExecutor for RuntimePool {
         user_context: Option<&UserSecretContext>,
     ) -> Response {
         let mut executor = self.pop_executor().await;
-        let result =
-            executor.delegate_request(req, origin_contract, caller_delegate, user_context);
+        let result = executor.delegate_request(req, origin_contract, caller_delegate, user_context);
         self.return_checked(executor, "execute_delegate_request")
             .await;
         result

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -778,6 +778,7 @@ mod tests {
                         inbound: vec![],
                     },
                     origin_contract: None,
+                    user_context: None,
                 },
             ),
             (

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -30,6 +30,7 @@ use crate::client_events::{AuthToken, HostResult, RequestId};
 use crate::config::Config;
 use crate::message::{QueryResult, Transaction};
 use crate::node::OpManager;
+use crate::wasm_runtime::UserSecretContext;
 use std::num::NonZeroUsize;
 
 pub(crate) struct ClientResponsesReceiver(UnboundedReceiver<(ClientId, RequestId, HostResult)>);
@@ -663,6 +664,14 @@ pub(crate) enum ContractHandlerEvent {
     DelegateRequest {
         req: DelegateRequest<'static>,
         origin_contract: Option<ContractInstanceId>,
+        /// Per-connection per-user secret namespace (hosted mode, P2 of #4381),
+        /// derived once at the WS connection boundary from the connection's
+        /// user token. `None` outside hosted mode or when no token was
+        /// presented. Carried here on a separate channel from `req`/`origin_contract`
+        /// so nothing in the request body can forge it. The owned
+        /// `UserSecretContext` holds the `dek_secret` in `Zeroizing`; its
+        /// `Debug` impl redacts the secret, so logging this event is safe.
+        user_context: Option<UserSecretContext>,
     },
     DelegateResponse(Vec<OutboundDelegateMsg>),
     /// Try to push/put a new value into the contract
@@ -767,6 +776,10 @@ impl std::fmt::Display for ContractHandlerEvent {
             ContractHandlerEvent::DelegateRequest {
                 req,
                 origin_contract,
+                // `user_context` deliberately omitted from Display: it names a
+                // per-user namespace and carries a (redacted-in-Debug) secret;
+                // it has no place in a human-facing event description.
+                ..
             } => {
                 write!(
                     f,

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2761,6 +2761,7 @@ pub async fn run_local_node(
             notification_channel,
             token,
             origin_contract,
+            user_context,
             ..
         } = req;
         tracing::debug!(client_id = %id, ?token, "Received OpenRequest -> {request}");
@@ -2786,7 +2787,14 @@ pub async fn run_local_node(
                     ?origin_contract,
                     "Handling ClientRequest::DelegateOp"
                 );
-                executor.delegate_request(op, origin_contract.as_ref(), None)
+                // `user_context` is `Some` only in hosted mode with a user token;
+                // `None` keeps secrets on the single-user `SecretScope::Local`.
+                executor.delegate_request(
+                    op,
+                    origin_contract.as_ref(),
+                    None,
+                    user_context.as_ref(),
+                )
             }
             ClientRequest::Disconnect { cause } => {
                 if let Some(cause) = cause {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2789,12 +2789,7 @@ pub async fn run_local_node(
                 );
                 // `user_context` is `Some` only in hosted mode with a user token;
                 // `None` keeps secrets on the single-user `SecretScope::Local`.
-                executor.delegate_request(
-                    op,
-                    origin_contract.as_ref(),
-                    None,
-                    user_context.as_ref(),
-                )
+                executor.delegate_request(op, origin_contract.as_ref(), None, user_context.as_ref())
             }
             ClientRequest::Disconnect { cause } => {
                 if let Some(cause) = cause {

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -32,6 +32,7 @@ use tower_http::trace::TraceLayer;
 use crate::{
     client_events::{AuthToken, BoxedClient, ClientId, HostResult, websocket::WebSocketProxy},
     config::{GlobalExecutor, WebsocketApiConfig},
+    wasm_runtime::UserSecretContext,
 };
 
 pub use app_packaging::WebApp;
@@ -80,6 +81,11 @@ pub(crate) enum ClientConnection {
         req: Box<ClientRequest<'static>>,
         auth_token: Option<AuthToken>,
         origin_contract: Option<ContractInstanceId>,
+        /// Per-connection per-user secret namespace (hosted mode, P2 of #4381),
+        /// derived once at WS upgrade from the connection's user token. `None`
+        /// outside hosted mode. Carried on the connection, never from the
+        /// request body, so a client cannot forge another user's namespace.
+        user_context: Option<UserSecretContext>,
         /// Plumbing for future V2-specific dispatch; not yet read.
         #[allow(dead_code)]
         api_version: ApiVersion,
@@ -307,6 +313,7 @@ pub mod local_node {
                 request,
                 notification_channel,
                 token,
+                user_context,
                 ..
             } = req;
             tracing::trace!(cli_id = %id, "got request -> {request}");
@@ -323,7 +330,14 @@ pub mod local_node {
                             .get(&token)
                             .map(|entry| entry.contract_id)
                     });
-                    executor.delegate_request(op, origin_contract.as_ref(), None)
+                    // `user_context` is `Some` only in hosted mode with a user
+                    // token; otherwise `None` keeps secrets `SecretScope::Local`.
+                    executor.delegate_request(
+                        op,
+                        origin_contract.as_ref(),
+                        None,
+                        user_context.as_ref(),
+                    )
                 }
                 ClientRequest::Disconnect { cause } => {
                     if let Some(cause) = cause {
@@ -435,6 +449,13 @@ pub(crate) async fn serve_client_api_in(
 
 /// Hostnames and IPs accepted in the HTTP `Host` header for WebSocket connections.
 pub(crate) type AllowedHosts = Arc<HashSet<String>>;
+
+/// Whether this node runs in hosted mode (P2 of #4381). Injected as an axum
+/// `Extension` so the `connection_info` middleware can decide whether to honor
+/// a connection's `userToken` and derive a per-user secret namespace. Defaults
+/// to `false`; only `--hosted-mode` / `hosted-mode = true` turns it on.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct HostedMode(pub bool);
 
 /// User-supplied source CIDRs that extend the built-in private-IP allowlist.
 ///
@@ -646,6 +667,18 @@ async fn serve_client_api_in_impl(
     // When bound to a non-loopback address, reject connections from non-private
     // source IPs. Users may extend the allowlist with --allowed-source-cidrs
     // (e.g. for a Tailscale tailnet range).
+    let hosted_mode = HostedMode(config.hosted_mode);
+    if hosted_mode.0 {
+        // Posture change the operator should see on every boot: hosted mode
+        // lets untrusted connections claim per-user secret namespaces via the
+        // `userToken` parameter. warn! (not info!) so it stands out in logs.
+        tracing::warn!(
+            "Hosted mode ENABLED: WebSocket connections presenting a `userToken` \
+             get a per-user delegate-secret namespace. Only run this on a node \
+             intended as a shared public proxy."
+        );
+    }
+
     let needs_lan_filter = !config.address.is_loopback();
     let router = if needs_lan_filter {
         // Layer ordering matters: axum executes layers bottom-to-top per
@@ -661,6 +694,7 @@ async fn serve_client_api_in_impl(
         // `connection_info` (inside the WebSocket router) also extracts
         // `Extension<AllowedSourceCidrs>` for the Host-header CIDR check.
         ws_router
+            .layer(Extension(hosted_mode))
             .layer(Extension(allowed_hosts))
             .layer(axum::middleware::from_fn(private_network_filter))
             .layer(Extension(allowed_source_cidrs))
@@ -670,6 +704,7 @@ async fn serve_client_api_in_impl(
         // `connection_info` always finds the extractor; missing it would
         // 500 every WS upgrade.
         ws_router
+            .layer(Extension(hosted_mode))
             .layer(Extension(allowed_hosts))
             .layer(Extension(allowed_source_cidrs))
             .layer(TraceLayer::new_for_http())

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -565,11 +565,13 @@ impl ClientEventsProxy for HttpClientApi {
                         req,
                         auth_token,
                         origin_contract,
+                        user_context,
                         ..
                     } => {
                         return Ok(OpenRequest::new(client_id, req)
                             .with_token(auth_token)
-                            .with_origin_contract(origin_contract));
+                            .with_origin_contract(origin_contract)
+                            .with_user_context(user_context));
                     }
                 }
             }

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -224,6 +224,8 @@ async fn is_locally_known(
             })),
             auth_token: None,
             origin_contract: None,
+            // Internal node-query request: no delegate secrets, no user context.
+            user_context: None,
             api_version: Default::default(),
         })
         .await
@@ -253,6 +255,8 @@ async fn is_locally_known(
             req: Box::new(ClientRequest::Disconnect { cause: None }),
             auth_token: None,
             origin_contract: None,
+            // Internal node-query request: no delegate secrets, no user context.
+            user_context: None,
             api_version: Default::default(),
         })
         .await
@@ -459,6 +463,8 @@ async fn ensure_contract_cached(
             ),
             auth_token: None,
             origin_contract: None,
+            // Internal node-query request: no delegate secrets, no user context.
+            user_context: None,
             api_version: Default::default(),
         })
         .await
@@ -481,6 +487,8 @@ async fn ensure_contract_cached(
             req: Box::new(ClientRequest::Disconnect { cause: None }),
             auth_token: None,
             origin_contract: None,
+            // Internal node-query request: no delegate secrets, no user context.
+            user_context: None,
             api_version: Default::default(),
         })
         .await

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -46,7 +46,7 @@ pub(crate) use native_api::{
 pub(crate) use native_api::InheritedOriginsEntry;
 pub use runtime::{ContractExecError, Runtime};
 pub(crate) use runtime::{RuntimeConfig, SharedModuleCache};
-pub use secrets_store::{SecretStoreError, SecretsStore};
+pub use secrets_store::{SecretStoreError, SecretsStore, UserSecretContext};
 // NOTE: InMemoryContractStore and SimulationStores are available but currently unused
 // They provide infrastructure for more sophisticated simulation scenarios
 #[allow(unused_imports)]

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -4999,5 +4999,91 @@ mod test {
                 "user_id should appear in Debug"
             );
         }
+
+        /// The per-user namespace does NOT propagate across a delegate-to-delegate
+        /// hop. When delegate A (running under user X's connection) sends a
+        /// `SendDelegateMessage` to delegate B, the executor delivers it to B with
+        /// `user_context = None` and `origin = Some(MessageOrigin::Delegate(A))`
+        /// (see `contract.rs::handle_delegate_with_contract_requests`, the
+        /// `execute_delegate_request(target_req, None, Some(delegate_key), None)`
+        /// call). So B's secret op MUST land in B's `Local` namespace, never under
+        /// user X — the user namespace is bound to the originating connection, not
+        /// transitively inherited through the inter-delegate hop.
+        ///
+        /// This test drives B exactly the way the executor drives it for that hop:
+        /// `origin = Delegate(A)`, `user_context = None`. It is parameterised over
+        /// the user X whose namespace must stay untouched.
+        #[tokio::test(flavor = "multi_thread")]
+        async fn user_namespace_does_not_propagate_across_inter_delegate_hop()
+        -> Result<(), Box<dyn std::error::Error>> {
+            // Register two distinct delegates (A the sender, B the target). Only B
+            // performs the secret op; A's key is used solely to attest the
+            // inter-delegate origin the executor would inject.
+            let (delegate_b, mut runtime, temp_dir) = setup_runtime(TEST_DELEGATE_2).await?;
+            let key_b = delegate_b.key().clone();
+            // Synthetic sender delegate A (key only — its WASM is irrelevant here;
+            // we are testing what B's secrets bind to, given the hop's arguments).
+            let key_a = DelegateKey::new([0xA1u8; 32], CodeHash::new([0xA2u8; 32]));
+
+            // User X's connection: a secret B stores DIRECTLY under X's context.
+            let ctx_x = UserSecretContext::from_token(b"user-X");
+            let sk = vec![0xEE, 0xEE];
+            let x_value = vec![0x58; 8]; // 'X'
+            store(
+                &mut runtime,
+                &key_b,
+                Some(&ctx_x),
+                sk.clone(),
+                x_value.clone(),
+            );
+
+            // Now deliver to B the way the executor delivers an inter-delegate hop
+            // that originated from A (which was itself invoked under user X):
+            //   origin = Some(MessageOrigin::Delegate(A)),  user_context = None.
+            // B stores under the SAME secret key but a different value.
+            let hop_value = vec![0x42; 8]; // 'B' — the inter-delegate write
+            let origin = MessageOrigin::Delegate(key_a.clone());
+            let payload = bincode::serialize(&InboundAppMessage::StoreSecret {
+                key: sk.clone(),
+                value: hop_value.clone(),
+            })
+            .expect("serialize");
+            let app_msg = ApplicationMessage::new(payload);
+            let outbound = runtime
+                .inbound_app_message(
+                    &key_b,
+                    &vec![].into(),
+                    Some(&origin), // attested inter-delegate origin (A)
+                    None,          // user_context = None: the hop does NOT carry X
+                    vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
+                )
+                .expect("inbound_app_message");
+            let OutboundDelegateMsg::ApplicationMessage(m) = &outbound[0] else {
+                panic!("Expected ApplicationMessage reply, got {:?}", &outbound[0]);
+            };
+            let resp: OutboundAppMessage = bincode::deserialize(&m.payload).expect("decode");
+            assert!(
+                matches!(resp, OutboundAppMessage::SecretStored),
+                "inter-delegate-hop store should succeed, got {resp:?}"
+            );
+
+            // The hop's write landed in B's Local namespace...
+            assert_eq!(
+                get(&mut runtime, &key_b, None, sk.clone()),
+                Some(hop_value),
+                "inter-delegate-hop secret must be in B's Local namespace"
+            );
+            // ...and user X's namespace is UNTOUCHED — it still holds X's value,
+            // NOT the value written during the A->B hop. This is the property:
+            // the hop did not write into (or read from) X's namespace.
+            assert_eq!(
+                get(&mut runtime, &key_b, Some(&ctx_x), sk),
+                Some(x_value),
+                "user X's secret must be unchanged by the inter-delegate hop"
+            );
+
+            std::mem::drop(temp_dir);
+            Ok(())
+        }
     }
 }

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -13,6 +13,7 @@ use super::native_api::{
     self, CURRENT_DELEGATE_INSTANCE, DELEGATE_ENV, DelegateCallEnv, DelegateContextEntry,
     InstanceId,
 };
+use super::secrets_store::UserSecretContext;
 use super::{Runtime, RuntimeResult};
 use crate::wasm_runtime::delegate_api::DelegateApiVersion;
 
@@ -59,6 +60,7 @@ pub(crate) trait DelegateRuntimeInterface {
         key: &DelegateKey,
         params: &Parameters,
         origin: Option<&MessageOrigin>,
+        user_context: Option<&UserSecretContext>,
         inbound: Vec<InboundDelegateMsg>,
     ) -> RuntimeResult<Vec<OutboundDelegateMsg>>;
 
@@ -83,6 +85,7 @@ impl Runtime {
         delegate_key: &DelegateKey,
         params: &Parameters<'_>,
         origin: Option<&MessageOrigin>,
+        user_context: Option<&UserSecretContext>,
         msg: &InboundDelegateMsg,
         context: Vec<u8>,
         handle: &InstanceHandle,
@@ -134,6 +137,12 @@ impl Runtime {
                 &mut self.delegate_store,
                 0, // creation_depth: always 0 for top-level calls
                 origin_contracts,
+                // Clone the connection's user context into the env so the
+                // owned `dek_secret` outlives every secret call during this
+                // `process()` invocation. The context is read-only here; the
+                // delegate cannot mutate or forge it. `None` outside hosted
+                // mode keeps secret ops on `SecretScope::Local`.
+                user_context.cloned(),
             )
         };
 
@@ -500,6 +509,7 @@ impl DelegateRuntimeInterface for Runtime {
         delegate_key: &DelegateKey,
         params: &Parameters,
         origin: Option<&MessageOrigin>,
+        user_context: Option<&UserSecretContext>,
         inbound: Vec<InboundDelegateMsg>,
     ) -> RuntimeResult<Vec<OutboundDelegateMsg>> {
         let mut results = Vec::with_capacity(inbound.len());
@@ -570,6 +580,7 @@ impl DelegateRuntimeInterface for Runtime {
                             delegate_key,
                             params,
                             origin,
+                            user_context,
                             &app_msg,
                             std::mem::take(&mut context),
                             &running.handle,
@@ -595,6 +606,7 @@ impl DelegateRuntimeInterface for Runtime {
                             delegate_key,
                             params,
                             origin,
+                            user_context,
                             &InboundDelegateMsg::UserResponse(response),
                             std::mem::take(&mut context),
                             &running.handle,
@@ -620,6 +632,7 @@ impl DelegateRuntimeInterface for Runtime {
                             delegate_key,
                             params,
                             origin,
+                            user_context,
                             &InboundDelegateMsg::GetContractResponse(response),
                             std::mem::take(&mut context),
                             &running.handle,
@@ -649,6 +662,7 @@ impl DelegateRuntimeInterface for Runtime {
                             delegate_key,
                             params,
                             origin,
+                            user_context,
                             &msg,
                             std::mem::take(&mut context),
                             &running.handle,
@@ -679,6 +693,7 @@ impl DelegateRuntimeInterface for Runtime {
                             delegate_key,
                             params,
                             origin,
+                            user_context,
                             &other,
                             std::mem::take(&mut context),
                             &running.handle,

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -4750,41 +4750,68 @@ mod test {
                     vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
                 )
                 .expect("inbound_app_message");
-            match &outbound[0] {
-                OutboundDelegateMsg::ApplicationMessage(m) => {
-                    bincode::deserialize(&m.payload).expect("decode outbound")
-                }
-                other => panic!("Expected ApplicationMessage reply, got {other:?}"),
-            }
+            let OutboundDelegateMsg::ApplicationMessage(m) = &outbound[0] else {
+                panic!("Expected ApplicationMessage reply, got {:?}", &outbound[0]);
+            };
+            bincode::deserialize(&m.payload).expect("decode outbound")
         }
 
-        fn store(runtime: &mut Runtime, key: &DelegateKey, ctx: Option<&UserSecretContext>, sk: Vec<u8>, sv: Vec<u8>) {
-            let resp = run(runtime, key, ctx, InboundAppMessage::StoreSecret { key: sk, value: sv });
+        fn store(
+            runtime: &mut Runtime,
+            key: &DelegateKey,
+            ctx: Option<&UserSecretContext>,
+            sk: Vec<u8>,
+            sv: Vec<u8>,
+        ) {
+            let resp = run(
+                runtime,
+                key,
+                ctx,
+                InboundAppMessage::StoreSecret { key: sk, value: sv },
+            );
             assert!(
                 matches!(resp, OutboundAppMessage::SecretStored),
                 "store should succeed, got {resp:?}"
             );
         }
 
-        fn get(runtime: &mut Runtime, key: &DelegateKey, ctx: Option<&UserSecretContext>, sk: Vec<u8>) -> Option<Vec<u8>> {
-            match run(runtime, key, ctx, InboundAppMessage::GetNonExistentSecret(sk)) {
-                OutboundAppMessage::SecretResult(v) => v,
-                other => panic!("Expected SecretResult, got {other:?}"),
-            }
+        fn get(
+            runtime: &mut Runtime,
+            key: &DelegateKey,
+            ctx: Option<&UserSecretContext>,
+            sk: Vec<u8>,
+        ) -> Option<Vec<u8>> {
+            let resp = run(
+                runtime,
+                key,
+                ctx,
+                InboundAppMessage::GetNonExistentSecret(sk),
+            );
+            let OutboundAppMessage::SecretResult(v) = resp else {
+                panic!("Expected SecretResult, got {resp:?}");
+            };
+            v
         }
 
-        fn has(runtime: &mut Runtime, key: &DelegateKey, ctx: Option<&UserSecretContext>, sk: Vec<u8>) -> bool {
-            match run(runtime, key, ctx, InboundAppMessage::HasSecret(sk)) {
-                OutboundAppMessage::SecretExists(b) => b,
-                other => panic!("Expected SecretExists, got {other:?}"),
-            }
+        fn has(
+            runtime: &mut Runtime,
+            key: &DelegateKey,
+            ctx: Option<&UserSecretContext>,
+            sk: Vec<u8>,
+        ) -> bool {
+            let resp = run(runtime, key, ctx, InboundAppMessage::HasSecret(sk));
+            let OutboundAppMessage::SecretExists(b) = resp else {
+                panic!("Expected SecretExists, got {resp:?}");
+            };
+            b
         }
 
         /// Two different user tokens get disjoint secret namespaces under the
         /// SAME delegate: A's secret is invisible to B, B's to A, and each can
         /// read only its own — even though the secret KEY is identical.
         #[tokio::test(flavor = "multi_thread")]
-        async fn two_users_have_disjoint_secret_namespaces() -> Result<(), Box<dyn std::error::Error>> {
+        async fn two_users_have_disjoint_secret_namespaces()
+        -> Result<(), Box<dyn std::error::Error>> {
             let (delegate, mut runtime, temp_dir) = setup_runtime(TEST_DELEGATE_2).await?;
             let key = delegate.key().clone();
 
@@ -4800,8 +4827,14 @@ mod test {
             store(&mut runtime, &key, Some(&ctx_b), sk.clone(), val_b.clone());
 
             // Each user reads back ONLY its own value.
-            assert_eq!(get(&mut runtime, &key, Some(&ctx_a), sk.clone()), Some(val_a));
-            assert_eq!(get(&mut runtime, &key, Some(&ctx_b), sk.clone()), Some(val_b));
+            assert_eq!(
+                get(&mut runtime, &key, Some(&ctx_a), sk.clone()),
+                Some(val_a)
+            );
+            assert_eq!(
+                get(&mut runtime, &key, Some(&ctx_b), sk.clone()),
+                Some(val_b)
+            );
 
             // A cannot read B's namespace and vice-versa is implied by the
             // distinct values above; assert existence is per-namespace too.
@@ -4809,10 +4842,21 @@ mod test {
             assert!(has(&mut runtime, &key, Some(&ctx_b), sk.clone()));
 
             // Removing A's secret leaves B's intact (independent namespaces).
-            let resp = run(&mut runtime, &key, Some(&ctx_a), InboundAppMessage::RemoveSecret(sk.clone()));
+            let resp = run(
+                &mut runtime,
+                &key,
+                Some(&ctx_a),
+                InboundAppMessage::RemoveSecret(sk.clone()),
+            );
             assert!(matches!(resp, OutboundAppMessage::SecretRemoved));
-            assert!(!has(&mut runtime, &key, Some(&ctx_a), sk.clone()), "A's secret should be gone");
-            assert!(has(&mut runtime, &key, Some(&ctx_b), sk.clone()), "B's secret must survive A's removal");
+            assert!(
+                !has(&mut runtime, &key, Some(&ctx_a), sk.clone()),
+                "A's secret should be gone"
+            );
+            assert!(
+                has(&mut runtime, &key, Some(&ctx_b), sk.clone()),
+                "B's secret must survive A's removal"
+            );
 
             std::mem::drop(temp_dir);
             Ok(())
@@ -4825,7 +4869,8 @@ mod test {
         /// expose — or collide with — the node's pre-existing single-user
         /// secrets, so the flag-off behavior is preserved byte-for-byte.
         #[tokio::test(flavor = "multi_thread")]
-        async fn local_and_user_namespaces_are_disjoint() -> Result<(), Box<dyn std::error::Error>> {
+        async fn local_and_user_namespaces_are_disjoint() -> Result<(), Box<dyn std::error::Error>>
+        {
             let (delegate, mut runtime, temp_dir) = setup_runtime(TEST_DELEGATE_2).await?;
             let key = delegate.key().clone();
             let ctx_a = UserSecretContext::from_token(b"token-A");
@@ -4837,21 +4882,36 @@ mod test {
             // Write under Local (no token).
             store(&mut runtime, &key, None, sk.clone(), local_val.clone());
             // Same key under user A.
-            store(&mut runtime, &key, Some(&ctx_a), sk.clone(), user_val.clone());
+            store(
+                &mut runtime,
+                &key,
+                Some(&ctx_a),
+                sk.clone(),
+                user_val.clone(),
+            );
 
             // Each side sees only its own.
             assert_eq!(get(&mut runtime, &key, None, sk.clone()), Some(local_val));
-            assert_eq!(get(&mut runtime, &key, Some(&ctx_a), sk.clone()), Some(user_val));
+            assert_eq!(
+                get(&mut runtime, &key, Some(&ctx_a), sk.clone()),
+                Some(user_val)
+            );
 
             // A key written only under Local is invisible to a user, and a
             // key written only under a user is invisible to Local.
             let local_only = vec![1u8];
             store(&mut runtime, &key, None, local_only.clone(), vec![1]);
-            assert!(!has(&mut runtime, &key, Some(&ctx_a), local_only.clone()), "Local-only secret must be invisible to a user");
+            assert!(
+                !has(&mut runtime, &key, Some(&ctx_a), local_only.clone()),
+                "Local-only secret must be invisible to a user"
+            );
 
             let user_only = vec![2u8];
             store(&mut runtime, &key, Some(&ctx_a), user_only.clone(), vec![2]);
-            assert!(!has(&mut runtime, &key, None, user_only), "User-only secret must be invisible to Local");
+            assert!(
+                !has(&mut runtime, &key, None, user_only),
+                "User-only secret must be invisible to Local"
+            );
 
             std::mem::drop(temp_dir);
             Ok(())
@@ -4866,7 +4926,8 @@ mod test {
         /// namespace it operates on, because that choice is carried entirely by
         /// the out-of-band `user_context` argument.
         #[tokio::test(flavor = "multi_thread")]
-        async fn namespace_is_determined_solely_by_user_context() -> Result<(), Box<dyn std::error::Error>> {
+        async fn namespace_is_determined_solely_by_user_context()
+        -> Result<(), Box<dyn std::error::Error>> {
             let (delegate, mut runtime, temp_dir) = setup_runtime(TEST_DELEGATE_2).await?;
             let key = delegate.key().clone();
 
@@ -4885,12 +4946,18 @@ mod test {
                 "A different user_context must NOT see user A's secret, even with an identical request body"
             );
             // And re-reading under A's context still finds it.
-            assert_eq!(get(&mut runtime, &key, Some(&ctx_a), sk.clone()), Some(vec![0xA1]));
+            assert_eq!(
+                get(&mut runtime, &key, Some(&ctx_a), sk.clone()),
+                Some(vec![0xA1])
+            );
 
             // Re-deriving the context from the same token reproduces the same
             // namespace (the derivation is deterministic in the token alone).
             let ctx_a_again = UserSecretContext::from_token(b"alice");
-            assert_eq!(get(&mut runtime, &key, Some(&ctx_a_again), sk), Some(vec![0xA1]));
+            assert_eq!(
+                get(&mut runtime, &key, Some(&ctx_a_again), sk),
+                Some(vec![0xA1])
+            );
 
             std::mem::drop(temp_dir);
             Ok(())
@@ -4907,7 +4974,11 @@ mod test {
             let a2 = UserSecretContext::from_token(b"token-A");
             let b = UserSecretContext::from_token(b"token-B");
             assert_eq!(a1.user_id(), a2.user_id(), "same token => same UserId");
-            assert_ne!(a1.user_id(), b.user_id(), "different tokens => different UserId");
+            assert_ne!(
+                a1.user_id(),
+                b.user_id(),
+                "different tokens => different UserId"
+            );
         }
 
         /// The `Debug` impl must never leak the `dek_secret`. A struct that
@@ -4918,9 +4989,15 @@ mod test {
         fn debug_redacts_the_dek_secret() {
             let ctx = UserSecretContext::from_token(b"super-secret-token");
             let rendered = format!("{ctx:?}");
-            assert!(rendered.contains("redacted"), "dek_secret must be redacted in Debug, got: {rendered}");
+            assert!(
+                rendered.contains("redacted"),
+                "dek_secret must be redacted in Debug, got: {rendered}"
+            );
             // The non-secret user_id is fine to show.
-            assert!(rendered.contains(&ctx.user_id().encode()), "user_id should appear in Debug");
+            assert!(
+                rendered.contains(&ctx.user_id().encode()),
+                "user_id should appear in Debug"
+            );
         }
     }
 }

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -4713,4 +4713,214 @@ mod test {
 
         Ok(())
     }
+
+    /// Hosted-mode per-user secret namespace tests (P2 of #4381).
+    ///
+    /// These drive the real secret host functions (`set_secret`/`get_secret`/
+    /// `has_secret`/`remove_secret`) through `inbound_app_message` with varying
+    /// `user_context` values, and assert that the namespace a delegate's secret
+    /// operations land in is determined SOLELY by the `user_context` argument —
+    /// the connection-boundary credential — and never by the message body, the
+    /// delegate key, or the origin.
+    mod hosted_user_secrets {
+        use super::delegate2_messages::{InboundAppMessage, OutboundAppMessage};
+        use super::*;
+        use crate::wasm_runtime::UserSecretContext;
+
+        /// Drive a single `delegate2` app message through `inbound_app_message`
+        /// under the given `user_context` and decode the single outbound
+        /// `OutboundAppMessage` reply. This is the one place the test exercises
+        /// the secret scope: `user_context` is the ONLY thing that varies the
+        /// namespace; `key`, `params`, `origin`, and the message body are held
+        /// identical across users by the callers below.
+        fn run(
+            runtime: &mut Runtime,
+            delegate_key: &DelegateKey,
+            user_context: Option<&UserSecretContext>,
+            msg: InboundAppMessage,
+        ) -> OutboundAppMessage {
+            let payload = bincode::serialize(&msg).expect("serialize inbound");
+            let app_msg = ApplicationMessage::new(payload);
+            let outbound = runtime
+                .inbound_app_message(
+                    delegate_key,
+                    &vec![].into(),
+                    None, // origin: identical for every user — not the scope source
+                    user_context,
+                    vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
+                )
+                .expect("inbound_app_message");
+            match &outbound[0] {
+                OutboundDelegateMsg::ApplicationMessage(m) => {
+                    bincode::deserialize(&m.payload).expect("decode outbound")
+                }
+                other => panic!("Expected ApplicationMessage reply, got {other:?}"),
+            }
+        }
+
+        fn store(runtime: &mut Runtime, key: &DelegateKey, ctx: Option<&UserSecretContext>, sk: Vec<u8>, sv: Vec<u8>) {
+            let resp = run(runtime, key, ctx, InboundAppMessage::StoreSecret { key: sk, value: sv });
+            assert!(
+                matches!(resp, OutboundAppMessage::SecretStored),
+                "store should succeed, got {resp:?}"
+            );
+        }
+
+        fn get(runtime: &mut Runtime, key: &DelegateKey, ctx: Option<&UserSecretContext>, sk: Vec<u8>) -> Option<Vec<u8>> {
+            match run(runtime, key, ctx, InboundAppMessage::GetNonExistentSecret(sk)) {
+                OutboundAppMessage::SecretResult(v) => v,
+                other => panic!("Expected SecretResult, got {other:?}"),
+            }
+        }
+
+        fn has(runtime: &mut Runtime, key: &DelegateKey, ctx: Option<&UserSecretContext>, sk: Vec<u8>) -> bool {
+            match run(runtime, key, ctx, InboundAppMessage::HasSecret(sk)) {
+                OutboundAppMessage::SecretExists(b) => b,
+                other => panic!("Expected SecretExists, got {other:?}"),
+            }
+        }
+
+        /// Two different user tokens get disjoint secret namespaces under the
+        /// SAME delegate: A's secret is invisible to B, B's to A, and each can
+        /// read only its own — even though the secret KEY is identical.
+        #[tokio::test(flavor = "multi_thread")]
+        async fn two_users_have_disjoint_secret_namespaces() -> Result<(), Box<dyn std::error::Error>> {
+            let (delegate, mut runtime, temp_dir) = setup_runtime(TEST_DELEGATE_2).await?;
+            let key = delegate.key().clone();
+
+            let ctx_a = UserSecretContext::from_token(b"token-A");
+            let ctx_b = UserSecretContext::from_token(b"token-B");
+
+            // Same secret KEY for both users; different values.
+            let sk = vec![7u8, 7, 7];
+            let val_a = vec![0xAA; 16];
+            let val_b = vec![0xBB; 16];
+
+            store(&mut runtime, &key, Some(&ctx_a), sk.clone(), val_a.clone());
+            store(&mut runtime, &key, Some(&ctx_b), sk.clone(), val_b.clone());
+
+            // Each user reads back ONLY its own value.
+            assert_eq!(get(&mut runtime, &key, Some(&ctx_a), sk.clone()), Some(val_a));
+            assert_eq!(get(&mut runtime, &key, Some(&ctx_b), sk.clone()), Some(val_b));
+
+            // A cannot read B's namespace and vice-versa is implied by the
+            // distinct values above; assert existence is per-namespace too.
+            assert!(has(&mut runtime, &key, Some(&ctx_a), sk.clone()));
+            assert!(has(&mut runtime, &key, Some(&ctx_b), sk.clone()));
+
+            // Removing A's secret leaves B's intact (independent namespaces).
+            let resp = run(&mut runtime, &key, Some(&ctx_a), InboundAppMessage::RemoveSecret(sk.clone()));
+            assert!(matches!(resp, OutboundAppMessage::SecretRemoved));
+            assert!(!has(&mut runtime, &key, Some(&ctx_a), sk.clone()), "A's secret should be gone");
+            assert!(has(&mut runtime, &key, Some(&ctx_b), sk.clone()), "B's secret must survive A's removal");
+
+            std::mem::drop(temp_dir);
+            Ok(())
+        }
+
+        /// A secret written with NO user context (single-user `Local`) is NOT
+        /// visible under any user token, and vice-versa: the Local namespace
+        /// and every User namespace are mutually disjoint. This proves that
+        /// turning hosted mode on for a connection (token present) does not
+        /// expose — or collide with — the node's pre-existing single-user
+        /// secrets, so the flag-off behavior is preserved byte-for-byte.
+        #[tokio::test(flavor = "multi_thread")]
+        async fn local_and_user_namespaces_are_disjoint() -> Result<(), Box<dyn std::error::Error>> {
+            let (delegate, mut runtime, temp_dir) = setup_runtime(TEST_DELEGATE_2).await?;
+            let key = delegate.key().clone();
+            let ctx_a = UserSecretContext::from_token(b"token-A");
+
+            let sk = vec![9u8, 9, 9];
+            let local_val = vec![0x11; 8];
+            let user_val = vec![0x22; 8];
+
+            // Write under Local (no token).
+            store(&mut runtime, &key, None, sk.clone(), local_val.clone());
+            // Same key under user A.
+            store(&mut runtime, &key, Some(&ctx_a), sk.clone(), user_val.clone());
+
+            // Each side sees only its own.
+            assert_eq!(get(&mut runtime, &key, None, sk.clone()), Some(local_val));
+            assert_eq!(get(&mut runtime, &key, Some(&ctx_a), sk.clone()), Some(user_val));
+
+            // A key written only under Local is invisible to a user, and a
+            // key written only under a user is invisible to Local.
+            let local_only = vec![1u8];
+            store(&mut runtime, &key, None, local_only.clone(), vec![1]);
+            assert!(!has(&mut runtime, &key, Some(&ctx_a), local_only.clone()), "Local-only secret must be invisible to a user");
+
+            let user_only = vec![2u8];
+            store(&mut runtime, &key, Some(&ctx_a), user_only.clone(), vec![2]);
+            assert!(!has(&mut runtime, &key, None, user_only), "User-only secret must be invisible to Local");
+
+            std::mem::drop(temp_dir);
+            Ok(())
+        }
+
+        /// INVARIANT: the secret namespace is a pure function of `user_context`.
+        /// Holding the delegate key, params, origin, and message body byte-for-byte
+        /// identical, swapping ONLY the `user_context` swaps the namespace —
+        /// nothing in the message body can reach across to another user's
+        /// secrets. This is the core unforgeability property: a delegate (or a
+        /// client crafting the message body) cannot select WHICH user's
+        /// namespace it operates on, because that choice is carried entirely by
+        /// the out-of-band `user_context` argument.
+        #[tokio::test(flavor = "multi_thread")]
+        async fn namespace_is_determined_solely_by_user_context() -> Result<(), Box<dyn std::error::Error>> {
+            let (delegate, mut runtime, temp_dir) = setup_runtime(TEST_DELEGATE_2).await?;
+            let key = delegate.key().clone();
+
+            let ctx_a = UserSecretContext::from_token(b"alice");
+            let ctx_b = UserSecretContext::from_token(b"bob");
+
+            // IDENTICAL message body for the write — only the context differs.
+            let sk = vec![5u8, 5];
+            store(&mut runtime, &key, Some(&ctx_a), sk.clone(), vec![0xA1]);
+
+            // Reading the SAME key, with the SAME body, under a DIFFERENT
+            // context yields nothing: the body did not carry the namespace.
+            assert_eq!(
+                get(&mut runtime, &key, Some(&ctx_b), sk.clone()),
+                None,
+                "A different user_context must NOT see user A's secret, even with an identical request body"
+            );
+            // And re-reading under A's context still finds it.
+            assert_eq!(get(&mut runtime, &key, Some(&ctx_a), sk.clone()), Some(vec![0xA1]));
+
+            // Re-deriving the context from the same token reproduces the same
+            // namespace (the derivation is deterministic in the token alone).
+            let ctx_a_again = UserSecretContext::from_token(b"alice");
+            assert_eq!(get(&mut runtime, &key, Some(&ctx_a_again), sk), Some(vec![0xA1]));
+
+            std::mem::drop(temp_dir);
+            Ok(())
+        }
+
+        /// The same token always maps to the same `UserId`, and two different
+        /// tokens map to different `UserId`s — pinned here so the connection
+        /// boundary's identity derivation can't silently change and re-key every
+        /// hosted user's secrets. (The dek_secret is never asserted on directly;
+        /// it is exercised end-to-end by the namespace tests above.)
+        #[test]
+        fn user_id_is_a_stable_function_of_the_token() {
+            let a1 = UserSecretContext::from_token(b"token-A");
+            let a2 = UserSecretContext::from_token(b"token-A");
+            let b = UserSecretContext::from_token(b"token-B");
+            assert_eq!(a1.user_id(), a2.user_id(), "same token => same UserId");
+            assert_ne!(a1.user_id(), b.user_id(), "different tokens => different UserId");
+        }
+
+        /// The `Debug` impl must never leak the `dek_secret`. A struct that
+        /// transitively holds a `UserSecretContext` (e.g. the delegate-request
+        /// contract-handler event) is logged with `{:?}`, so a non-redacting
+        /// Debug would write key material to the logs.
+        #[test]
+        fn debug_redacts_the_dek_secret() {
+            let ctx = UserSecretContext::from_token(b"super-secret-token");
+            let rendered = format!("{ctx:?}");
+            assert!(rendered.contains("redacted"), "dek_secret must be redacted in Debug, got: {rendered}");
+            // The non-secret user_id is fine to show.
+            assert!(rendered.contains(&ctx.user_id().encode()), "user_id should appear in Debug");
+        }
+    }
 }

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -964,6 +964,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
         )?;
 
@@ -990,8 +991,13 @@ mod test {
             context: contract_request.context.clone(),
         });
 
-        let final_outbound =
-            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, vec![response])?;
+        let final_outbound = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![response],
+        )?;
 
         assert_eq!(final_outbound.len(), 1);
         let final_msg = match &final_outbound[0] {
@@ -1047,6 +1053,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
         )?;
 
@@ -1069,8 +1076,13 @@ mod test {
             context: contract_request.context.clone(),
         });
 
-        let final_outbound =
-            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, vec![response])?;
+        let final_outbound = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![response],
+        )?;
 
         let final_msg = match &final_outbound[0] {
             OutboundDelegateMsg::ApplicationMessage(msg) => msg,
@@ -1126,6 +1138,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
         )?;
 
@@ -1150,8 +1163,13 @@ mod test {
             context: req1.context,
         });
 
-        let outbound2 =
-            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, vec![response1])?;
+        let outbound2 = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![response1],
+        )?;
 
         assert_eq!(outbound2.len(), 1);
         let req2 = match &outbound2[0] {
@@ -1174,8 +1192,13 @@ mod test {
             context: req2.context,
         });
 
-        let outbound3 =
-            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, vec![response2])?;
+        let outbound3 = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![response2],
+        )?;
 
         assert_eq!(outbound3.len(), 1);
         let req3 = match &outbound3[0] {
@@ -1198,8 +1221,13 @@ mod test {
             context: req3.context,
         });
 
-        let final_outbound =
-            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, vec![response3])?;
+        let final_outbound = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![response3],
+        )?;
 
         assert_eq!(final_outbound.len(), 1);
         let final_msg = match &final_outbound[0] {
@@ -1263,6 +1291,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
         )?;
 
@@ -1324,6 +1353,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![contract_response],
         )?;
 
@@ -1379,8 +1409,13 @@ mod test {
         let payload: Vec<u8> = bincode::serialize(&InboundAppMessage::CreateInboxRequest).unwrap();
         let create_msg = ApplicationMessage::new(payload);
         let inbound = InboundDelegateMsg::ApplicationMessage(create_msg);
-        let outbound =
-            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, vec![inbound])?;
+        let outbound = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![inbound],
+        )?;
 
         let expected_payload =
             bincode::serialize(&OutboundAppMessage::CreateInboxResponse(vec![1])).unwrap();
@@ -1394,8 +1429,13 @@ mod test {
             bincode::serialize(&InboundAppMessage::PleaseSignMessage(vec![1, 2, 3])).unwrap();
         let sign_msg = ApplicationMessage::new(payload);
         let inbound = InboundDelegateMsg::ApplicationMessage(sign_msg);
-        let outbound =
-            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, vec![inbound])?;
+        let outbound = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![inbound],
+        )?;
 
         let expected_payload =
             bincode::serialize(&OutboundAppMessage::MessageSigned(vec![4, 5, 2])).unwrap();
@@ -1432,7 +1472,7 @@ mod test {
         ];
 
         let outbound =
-            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, messages)?;
+            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, None, messages)?;
 
         assert_eq!(outbound.len(), 2);
 
@@ -1516,6 +1556,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
 
@@ -1541,6 +1582,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
@@ -1596,6 +1638,7 @@ mod test {
         let _outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
@@ -1672,6 +1715,7 @@ mod test {
             runtime.inbound_app_message(
                 d.key(),
                 &vec![].into(),
+                None,
                 None,
                 vec![InboundDelegateMsg::ApplicationMessage(msg)],
             )?;
@@ -1767,6 +1811,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(
                 ApplicationMessage::new(payload),
             )],
@@ -1789,6 +1834,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![InboundDelegateMsg::ApplicationMessage(
                 ApplicationMessage::new(payload),
@@ -1864,6 +1910,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(
                 ApplicationMessage::new(payload),
             )],
@@ -1925,6 +1972,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
 
@@ -1951,6 +1999,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
 
@@ -1959,6 +2008,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
@@ -1999,6 +2049,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
@@ -2044,6 +2095,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
 
@@ -2067,6 +2119,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
@@ -2133,6 +2186,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
 
@@ -2176,6 +2230,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
@@ -2234,6 +2289,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
 
@@ -2242,6 +2298,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
@@ -2265,6 +2322,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
@@ -2324,7 +2382,7 @@ mod test {
             .collect();
 
         let outbound =
-            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, messages)?;
+            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, None, messages)?;
 
         assert_eq!(outbound.len(), 3);
 
@@ -2389,6 +2447,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
 
@@ -2397,6 +2456,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
@@ -2420,6 +2480,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
         let response: OutboundAppMessage = match &outbound[0] {
@@ -2441,6 +2502,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
@@ -2487,6 +2549,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
         let response: OutboundAppMessage = match &outbound[0] {
@@ -2526,6 +2589,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
@@ -2595,7 +2659,7 @@ mod test {
         ];
 
         let outbound =
-            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, messages)?;
+            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, None, messages)?;
 
         assert_eq!(outbound.len(), 2);
 
@@ -2668,6 +2732,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
         let response: OutboundAppMessage = match &outbound[0] {
@@ -2708,6 +2773,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![InboundDelegateMsg::ApplicationMessage(msg)],
         )?;
@@ -2795,6 +2861,7 @@ mod test {
                         delegate1_clone.key(),
                         &vec![].into(),
                         None,
+                        None,
                         vec![InboundDelegateMsg::ApplicationMessage(msg)],
                     )
                     .unwrap();
@@ -2810,6 +2877,7 @@ mod test {
                     .inbound_app_message(
                         delegate1_clone.key(),
                         &vec![].into(),
+                        None,
                         None,
                         vec![InboundDelegateMsg::ApplicationMessage(msg)],
                     )
@@ -2875,6 +2943,7 @@ mod test {
                         delegate2_clone.key(),
                         &vec![].into(),
                         None,
+                        None,
                         vec![InboundDelegateMsg::ApplicationMessage(msg)],
                     )
                     .unwrap();
@@ -2890,6 +2959,7 @@ mod test {
                     .inbound_app_message(
                         delegate2_clone.key(),
                         &vec![].into(),
+                        None,
                         None,
                         vec![InboundDelegateMsg::ApplicationMessage(msg)],
                     )
@@ -3003,8 +3073,13 @@ mod test {
         let payload: Vec<u8> = bincode::serialize(&InboundAppMessage::CreateInboxRequest).unwrap();
         let create_msg = ApplicationMessage::new(payload);
         let inbound = InboundDelegateMsg::ApplicationMessage(create_msg);
-        let outbound =
-            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, vec![inbound])?;
+        let outbound = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![inbound],
+        )?;
 
         let expected_payload =
             bincode::serialize(&OutboundAppMessage::CreateInboxResponse(vec![1])).unwrap();
@@ -3141,6 +3216,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
         )?;
 
@@ -3228,6 +3304,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
         )?;
@@ -3341,6 +3418,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
         )?;
@@ -3550,6 +3628,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
         )?;
 
@@ -3575,8 +3654,13 @@ mod test {
             context: put_request.context.clone(),
         });
 
-        let final_outbound =
-            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, vec![response])?;
+        let final_outbound = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![response],
+        )?;
 
         assert_eq!(
             final_outbound.len(),
@@ -3638,6 +3722,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
         )?;
 
@@ -3663,8 +3748,13 @@ mod test {
             context: update_request.context.clone(),
         });
 
-        let final_outbound =
-            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, vec![response])?;
+        let final_outbound = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![response],
+        )?;
 
         assert_eq!(
             final_outbound.len(),
@@ -3728,6 +3818,7 @@ mod test {
             delegate.key(),
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
         )?;
 
@@ -3753,8 +3844,13 @@ mod test {
             context: subscribe_request.context.clone(),
         });
 
-        let final_outbound =
-            runtime.inbound_app_message(delegate.key(), &vec![].into(), None, vec![response])?;
+        let final_outbound = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![response],
+        )?;
 
         assert_eq!(
             final_outbound.len(),
@@ -3819,6 +3915,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             delegate.key(),
             &vec![].into(),
+            None,
             None,
             vec![notification],
         )?;
@@ -3931,6 +4028,7 @@ mod test {
             &delegate_key,
             &vec![].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
         )?;
 
@@ -3980,6 +4078,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             &delegate_key,
             &vec![].into(),
+            None,
             None,
             vec![subscribe_response],
         )?;
@@ -4040,8 +4139,13 @@ mod test {
             context: DelegateContext::default(),
         });
 
-        let outbound =
-            runtime.inbound_app_message(&delegate_key, &vec![].into(), None, vec![notification])?;
+        let outbound = runtime.inbound_app_message(
+            &delegate_key,
+            &vec![].into(),
+            None,
+            None,
+            vec![notification],
+        )?;
 
         // --- Step 4: Verify delegate responds correctly ---
         assert_eq!(outbound.len(), 1, "Expected one outbound from notification");
@@ -4258,6 +4362,7 @@ mod test {
             &key_a,
             &vec![1u8].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
         )?;
 
@@ -4320,6 +4425,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             &key_b,
             &vec![2u8].into(),
+            None,
             None,
             vec![InboundDelegateMsg::DelegateMessage(delegate_msg)],
         )?;
@@ -4391,6 +4497,7 @@ mod test {
             &key_b,
             &vec![2u8].into(),
             Some(&origin),
+            None,
             vec![InboundDelegateMsg::DelegateMessage(delegate_msg)],
         )?;
 
@@ -4452,6 +4559,7 @@ mod test {
             &key_a,
             &vec![1u8].into(),
             None,
+            None,
             vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
         )?;
 
@@ -4477,6 +4585,7 @@ mod test {
         let outbound_b = runtime_b.inbound_app_message(
             &key_b,
             &vec![2u8].into(),
+            None,
             None,
             vec![InboundDelegateMsg::DelegateMessage(send_msg)],
         )?;
@@ -4562,6 +4671,7 @@ mod test {
         let outbound = runtime.inbound_app_message(
             &key_a,
             &vec![1u8].into(),
+            None,
             None,
             vec![
                 InboundDelegateMsg::ApplicationMessage(ApplicationMessage::new(payload1)),

--- a/crates/core/src/wasm_runtime/delegate_api.rs
+++ b/crates/core/src/wasm_runtime/delegate_api.rs
@@ -395,6 +395,7 @@ mod tests {
                     &mut self.delegate_store,
                     depth,
                     vec![],
+                    None,
                 )
             }
         }
@@ -421,6 +422,7 @@ mod tests {
                     &mut self.delegate_store,
                     0,
                     vec![],
+                    None,
                 )
             }
         }
@@ -447,6 +449,7 @@ mod tests {
                     &mut self.delegate_store,
                     0,
                     attestations,
+                    None,
                 )
             }
         }
@@ -540,6 +543,7 @@ mod tests {
                 &mut env_holder.delegate_store,
                 0,
                 vec![],
+                None,
             )
         };
 
@@ -621,6 +625,7 @@ mod tests {
                 &mut env_holder.delegate_store,
                 0,
                 vec![],
+                None,
             )
         };
 
@@ -648,6 +653,7 @@ mod tests {
                 &mut env_holder.delegate_store,
                 0,
                 vec![],
+                None,
             )
         };
 

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use super::contract_store::ContractStore;
 use super::delegate_store::DelegateStore;
 use super::runtime::InstanceInfo;
-use super::secrets_store::{SecretScope, SecretsStore};
+use super::secrets_store::{SecretScope, SecretsStore, UserSecretContext};
 use crate::contract::storages::Storage;
 
 /// This is a map of starting addresses of the instance memory space.
@@ -367,6 +367,19 @@ pub(super) struct DelegateCallEnv {
     secret_store: std::cell::UnsafeCell<*mut SecretsStore>,
     /// The delegate key, needed to scope secret access.
     pub delegate_key: DelegateKey,
+    /// Optional per-user secret namespace for this call, derived ONCE at the
+    /// WS connection boundary from the connection's user token (hosted mode,
+    /// P2 of #4381). When `Some`, the secret host functions
+    /// (`get_secret`/`set_secret`/`remove_secret`/`get_secret_len`) operate on
+    /// [`SecretScope::User`] keyed by this context; when `None` they use
+    /// [`SecretScope::Local`] — byte-for-byte the single-user behavior.
+    ///
+    /// This is OWNED (not a borrow) so the `dek_secret` it holds outlives every
+    /// secret call made during this `process()` invocation. It is supplied by
+    /// the runtime from the connection context and is NEVER settable from
+    /// inside the WASM sandbox, a delegate message, or any request body — that
+    /// is the unforgeability invariant of the per-user namespace.
+    user_context: Option<UserSecretContext>,
     /// Read-only pointer to the ContractStore for index lookups
     /// (ContractInstanceId → CodeHash). Valid only during synchronous process().
     contract_store: *const ContractStore,
@@ -455,11 +468,13 @@ impl DelegateCallEnv {
         delegate_store: &mut DelegateStore,
         creation_depth: u32,
         origin_contracts: Vec<ContractInstanceId>,
+        user_context: Option<UserSecretContext>,
     ) -> Self {
         Self {
             context,
             secret_store: std::cell::UnsafeCell::new(secret_store as *mut SecretsStore),
             delegate_key,
+            user_context,
             contract_store: contract_store as *const ContractStore,
             state_store_db,
             state_write_callback,
@@ -467,6 +482,19 @@ impl DelegateCallEnv {
             creation_depth,
             creations_this_call: std::cell::Cell::new(0),
             origin_contracts,
+        }
+    }
+
+    /// The [`SecretScope`] for this call's secret operations.
+    ///
+    /// Returns [`SecretScope::User`] (borrowing the connection's
+    /// [`UserSecretContext`]) when this call runs under a hosted-mode user
+    /// token, else [`SecretScope::Local`]. The borrow is tied to `&self`, so
+    /// the `dek_secret` is never copied out of the owned context.
+    fn secret_scope(&self) -> SecretScope<'_> {
+        match &self.user_context {
+            Some(ctx) => ctx.scope(),
+            None => SecretScope::Local,
         }
     }
 
@@ -1105,11 +1133,13 @@ pub(super) mod delegate_secrets {
         let key_bytes = unsafe { std::slice::from_raw_parts(key_src, key_len as usize) };
         let secret_id = SecretsId::new(key_bytes.to_vec());
 
-        // Look up the secret. P1 of #4381 added an optional per-user scope;
-        // the delegate host ABI is still single-user, so always Local here.
+        // Look up the secret. The scope is `Local` for single-user nodes and
+        // `User` when this call runs under a hosted-mode user token (P2 of
+        // #4381). The scope comes solely from the connection-derived
+        // `user_context`, never from anything the delegate can influence.
         match env
             .secret_store()
-            .get_secret(&env.delegate_key, &secret_id, SecretScope::Local)
+            .get_secret(&env.delegate_key, &secret_id, env.secret_scope())
         {
             Ok(plaintext) => {
                 let len = plaintext.len();
@@ -1177,10 +1207,11 @@ pub(super) mod delegate_secrets {
         let key_bytes = unsafe { std::slice::from_raw_parts(key_src, key_len as usize) };
         let secret_id = SecretsId::new(key_bytes.to_vec());
 
-        // Look up the secret (single-user Local scope; see get_secret_len).
+        // Look up the secret (scope per the connection's user_context; see
+        // get_secret_len).
         match env
             .secret_store()
-            .get_secret(&env.delegate_key, &secret_id, SecretScope::Local)
+            .get_secret(&env.delegate_key, &secret_id, env.secret_scope())
         {
             Ok(plaintext) => {
                 let secret_len = plaintext.len();
@@ -1296,12 +1327,11 @@ pub(super) mod delegate_secrets {
             unsafe { std::slice::from_raw_parts(val_src, val_len as usize) }.to_vec(),
         );
 
-        match env.secret_store_mut().store_secret(
-            &env.delegate_key,
-            &secret_id,
-            SecretScope::Local,
-            value,
-        ) {
+        let scope = env.secret_scope();
+        match env
+            .secret_store_mut()
+            .store_secret(&env.delegate_key, &secret_id, scope, value)
+        {
             Ok(()) => error_codes::SUCCESS,
             Err(e) => {
                 tracing::error!("delegate set_secret failed: {e}");
@@ -1352,7 +1382,7 @@ pub(super) mod delegate_secrets {
 
         match env
             .secret_store()
-            .get_secret(&env.delegate_key, &secret_id, SecretScope::Local)
+            .get_secret(&env.delegate_key, &secret_id, env.secret_scope())
         {
             Ok(_) => 1,
             Err(e) => {
@@ -1408,11 +1438,11 @@ pub(super) mod delegate_secrets {
         let key_bytes = unsafe { std::slice::from_raw_parts(key_src, key_len as usize) };
         let secret_id = SecretsId::new(key_bytes.to_vec());
 
-        match env.secret_store_mut().remove_secret(
-            &env.delegate_key,
-            &secret_id,
-            SecretScope::Local,
-        ) {
+        let scope = env.secret_scope();
+        match env
+            .secret_store_mut()
+            .remove_secret(&env.delegate_key, &secret_id, scope)
+        {
             Ok(()) => error_codes::SUCCESS,
             Err(e) => {
                 tracing::debug!(

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -60,10 +60,10 @@ type SecretKey = [u8; 32];
 /// Identifier for a per-user secret namespace.
 ///
 /// A `UserId` is a 32-byte opaque tag that partitions a delegate's secret
-/// storage into independent per-user namespaces. It is INERT in this release:
-/// no production caller constructs one yet (the WS/token plumbing that will
-/// feed it lands in P2 of #4381). It exists so the storage layer can carry the
-/// per-user dimension end-to-end and be exercised by tests.
+/// storage into independent per-user namespaces. In hosted mode (P2 of #4381)
+/// it is derived from a connection's user token via [`user_id`] and carried in
+/// a [`UserSecretContext`]; outside hosted mode no `UserId` is constructed and
+/// every secret operation stays [`SecretScope::Local`].
 ///
 /// The bytes are not secret on their own (they only name a namespace), so
 /// `UserId` does NOT zeroize — unlike the `dek_secret` that travels alongside
@@ -109,7 +109,9 @@ impl std::fmt::Debug for UserId {
 /// DEK, same ReDb table). `User` adds an optional per-user dimension whose
 /// DEK is derived purely from a caller-provided `dek_secret` (NOT the node
 /// KEK), making per-user secrets portable by design (P3 export). The `User`
-/// scope is INERT in this release — only tests construct it.
+/// scope is selected only in hosted mode (P2 of #4381), when a connection
+/// presents a user token; the borrowed `id`/`dek_secret` come from that
+/// connection's [`UserSecretContext`].
 ///
 /// The `dek_secret` is borrowed as `&Zeroizing<[u8; 32]>` so the caller
 /// retains ownership and the value is wiped when the caller drops it; the
@@ -125,20 +127,83 @@ pub enum SecretScope<'a> {
     },
 }
 
+/// A per-connection user secret namespace, derived ONCE at the WebSocket
+/// connection boundary from a durable user token (P2 of #4381, hosted mode).
+///
+/// This is the owned counterpart to [`SecretScope::User`]: it holds the
+/// `user_id` tag and the `dek_secret` (the latter in `Zeroizing` so it is
+/// wiped on drop), and lends them out as a borrowed [`SecretScope::User`] via
+/// [`Self::scope`] for the duration of a single secret operation.
+///
+/// # Security invariant
+///
+/// A `UserSecretContext` is constructed in EXACTLY ONE place — at WS
+/// connection establishment, from the connection's user token (see
+/// [`UserSecretContext::from_token`]). It then travels immutably with the
+/// connection. Nothing reachable from a delegate's WASM, a delegate message
+/// body, a `ClientRequest`, or the app contract id can construct, mutate, or
+/// substitute it: the only public constructor takes the raw token bytes and
+/// derives both fields deterministically via the domain-separated [`user_id`]
+/// / [`user_dek_secret`] hashes. This is what makes the per-user namespace
+/// unforgeable from inside the sandbox.
+#[derive(Clone)]
+pub struct UserSecretContext {
+    user_id: UserId,
+    dek_secret: Zeroizing<[u8; 32]>,
+}
+
+impl UserSecretContext {
+    /// Derive a `UserSecretContext` from a connection's opaque user token.
+    ///
+    /// This is the ONLY constructor. Both the namespace tag and the DEK
+    /// secret come solely from `token` via the domain-separated derivations,
+    /// so the resulting scope cannot be influenced by anything other than the
+    /// token presented at the connection boundary.
+    ///
+    /// The token is sensitive; this never logs it or the derived secret.
+    pub fn from_token(token: &[u8]) -> Self {
+        Self {
+            user_id: user_id(token),
+            dek_secret: user_dek_secret(token),
+        }
+    }
+
+    /// The non-secret namespace tag for this user. Safe to log.
+    pub fn user_id(&self) -> &UserId {
+        &self.user_id
+    }
+
+    /// Borrow this context as a [`SecretScope::User`] for one secret call.
+    ///
+    /// The returned scope borrows `self`, so the `dek_secret` is never copied
+    /// into a longer-lived buffer — it lives exactly as long as `self`.
+    pub fn scope(&self) -> SecretScope<'_> {
+        SecretScope::User {
+            id: &self.user_id,
+            dek_secret: &self.dek_secret,
+        }
+    }
+}
+
+impl std::fmt::Debug for UserSecretContext {
+    /// Render only the non-secret `user_id`. The `dek_secret` is NEVER
+    /// included so that `{:?}` on any struct that transitively holds a
+    /// `UserSecretContext` (e.g. the `DelegateRequest` contract-handler event)
+    /// cannot leak key material into logs.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UserSecretContext")
+            .field("user_id", &self.user_id)
+            .field("dek_secret", &"<redacted>")
+            .finish()
+    }
+}
+
 /// Domain-separation prefix for [`user_id`]. Distinct from
 /// [`USER_DEK_SECRET_DOMAIN`] so the same token cannot yield a user id that
 /// collides with a dek-secret (and vice-versa).
-///
-/// `allow(dead_code)` in non-test builds: these are landed INERT for P2 of
-/// #4381 (the token threading that consumes them is a later phase). Tests
-/// exercise them now so the derivation is pinned before any caller depends on
-/// it.
-#[cfg_attr(not(test), allow(dead_code))]
 const USER_ID_DOMAIN: &[u8] = b"freenet-user-id";
 
-/// Domain-separation prefix for [`user_dek_secret`]. See [`USER_ID_DOMAIN`]
-/// for the inert-until-P2 rationale.
-#[cfg_attr(not(test), allow(dead_code))]
+/// Domain-separation prefix for [`user_dek_secret`].
 const USER_DEK_SECRET_DOMAIN: &[u8] = b"freenet-user-dek";
 
 /// Derive a [`UserId`] from an opaque bearer token.
@@ -147,13 +212,11 @@ const USER_DEK_SECRET_DOMAIN: &[u8] = b"freenet-user-dek";
 /// distinct from [`user_dek_secret`]'s so the two derivations are
 /// independent: knowing a user's id reveals nothing about their dek-secret.
 ///
-/// INERT in this release: the token threading that will call this lands in
-/// P2 of #4381. Provided now (with tests) so the derivation is pinned before
-/// any caller depends on it.
+/// Consumed by [`UserSecretContext::from_token`] at the WS connection boundary
+/// (P2 of #4381, hosted mode).
 ///
 /// The token is sensitive; this function never logs it. The returned id is a
 /// non-secret namespace tag, so it is not wrapped in `Zeroizing`.
-#[cfg_attr(not(test), allow(dead_code))]
 pub fn user_id(token: &[u8]) -> UserId {
     let mut hasher = blake3::Hasher::new();
     hasher.update(USER_ID_DOMAIN);
@@ -168,9 +231,8 @@ pub fn user_id(token: &[u8]) -> UserId {
 /// from [`user_id`] guarantees `user_id(token) != user_dek_secret(token)`
 /// as byte strings for every token.
 ///
-/// INERT in this release (see [`user_id`]). The token is sensitive; this
-/// function never logs it or the derived secret.
-#[cfg_attr(not(test), allow(dead_code))]
+/// Consumed by [`UserSecretContext::from_token`] (see [`user_id`]). The token
+/// is sensitive; this function never logs it or the derived secret.
 pub fn user_dek_secret(token: &[u8]) -> Zeroizing<[u8; 32]> {
     let mut hasher = blake3::Hasher::new();
     hasher.update(USER_DEK_SECRET_DOMAIN);

--- a/crates/core/tests/error_notification.rs
+++ b/crates/core/tests/error_notification.rs
@@ -580,6 +580,7 @@ async fn test_connection_drop_error_notification() -> anyhow::Result<()> {
             token_cleanup_interval_seconds: None,
             allowed_host: None,
             allowed_source_cidrs: None,
+            hosted_mode: None,
         },
         network_api: freenet::config::NetworkArgs {
             public_address: Some(Ipv4Addr::LOCALHOST.into()),
@@ -639,6 +640,7 @@ async fn test_connection_drop_error_notification() -> anyhow::Result<()> {
             token_cleanup_interval_seconds: None,
             allowed_host: None,
             allowed_source_cidrs: None,
+            hosted_mode: None,
         },
         network_api: freenet::config::NetworkArgs {
             public_address: Some(Ipv4Addr::LOCALHOST.into()),

--- a/crates/core/tests/operations_before_join.rs
+++ b/crates/core/tests/operations_before_join.rs
@@ -96,6 +96,7 @@ async fn test_operations_blocked_before_join() -> anyhow::Result<()> {
             token_cleanup_interval_seconds: None,
             allowed_host: None,
             allowed_source_cidrs: None,
+            hosted_mode: None,
         },
         network_api: freenet::config::NetworkArgs {
             public_address: Some(Ipv4Addr::LOCALHOST.into()),
@@ -154,6 +155,7 @@ async fn test_operations_blocked_before_join() -> anyhow::Result<()> {
             token_cleanup_interval_seconds: None,
             allowed_host: None,
             allowed_source_cidrs: None,
+            hosted_mode: None,
         },
         network_api: freenet::config::NetworkArgs {
             public_address: Some(Ipv4Addr::LOCALHOST.into()),

--- a/crates/core/tests/token_expiration.rs
+++ b/crates/core/tests/token_expiration.rs
@@ -36,6 +36,7 @@ async fn create_test_config(
             token_cleanup_interval_seconds: Some(cleanup_interval_seconds),
             allowed_host: None,
             allowed_source_cidrs: None,
+            hosted_mode: None,
         },
         network_api: NetworkArgs {
             address: Some(Ipv4Addr::LOCALHOST.into()),
@@ -133,6 +134,7 @@ async fn test_default_token_configuration() -> TestResult {
                 token_cleanup_interval_seconds: None,
                 allowed_host: None,
                 allowed_source_cidrs: None,
+                hosted_mode: None,
             },
             network_api: NetworkArgs {
                 address: Some(Ipv4Addr::LOCALHOST.into()),

--- a/crates/core/tests/token_expiration.rs
+++ b/crates/core/tests/token_expiration.rs
@@ -214,6 +214,7 @@ async fn test_token_cleanup_removes_expired_tokens() -> TestResult {
             token_cleanup_interval_seconds: CLEANUP_INTERVAL_SECS,
             allowed_hosts: Vec::new(),
             allowed_source_cidrs: Vec::new(),
+            hosted_mode: false,
         };
 
         // Start the client API server (which spawns the cleanup task)

--- a/crates/freenet-macros/src/codegen.rs
+++ b/crates/freenet-macros/src/codegen.rs
@@ -280,6 +280,7 @@ fn generate_node_setup(args: &FreenetTestArgs) -> TokenStream {
                             token_cleanup_interval_seconds: None,
                             allowed_host: None,
                             allowed_source_cidrs: None,
+                            hosted_mode: None,
                         },
                         network_api: freenet::config::NetworkArgs {
                             // Use varied IP for public_address (affects location calculation)
@@ -420,6 +421,7 @@ fn generate_node_setup(args: &FreenetTestArgs) -> TokenStream {
                             token_cleanup_interval_seconds: None,
                             allowed_host: None,
                             allowed_source_cidrs: None,
+                            hosted_mode: None,
                         },
                         network_api: freenet::config::NetworkArgs {
                             // Use varied IP for public_address (affects location calculation)


### PR DESCRIPTION
## Problem

P2 backend of #4381 (hosted public proxy). A Freenet node is single-user today: a delegate's secrets live in one namespace (`SecretScope::Local`). To run a node as a shared public proxy for untrusted users, each user's delegate secrets must live in their own isolated namespace, and that per-user identity must be impossible to forge from inside the sandbox.

P1 (#4502) landed the storage layer: `SecretScope::{Local, User{id, dek_secret}}`, a per-user DEK derived purely from a token (`secrets_store::user_id` / `user_dek_secret`), and the disjoint on-disk/ReDb layout. P1 was inert: nothing constructed a `User` scope outside tests.

This PR makes it live, behind an opt-in flag, and threads a per-connection user context from the WebSocket boundary all the way to the delegate secret host functions.

## Approach

**Flag-gated, inert by default.** A new `--hosted-mode` / `hosted-mode = true` flag (`WebsocketApiConfig`, default **false**). With it off, the new `userToken` channel is ignored entirely and every secret op stays `SecretScope::Local`, byte-for-byte today's behavior. The flag's only job is to decide whether the WS boundary derives a per-user context; everything downstream is driven by *whether a context was derived*, so the whole feature is provably inert when off.

**The connection-boundary invariant (the part that matters).** A `UserSecretContext` (owns the `UserId` plus the `dek_secret` in `Zeroizing`) is constructed in **exactly one place**: the `connection_info` WS middleware, from the connection's user token, via the deterministic P1 derivations. It then travels immutably with the connection. Nothing reachable from delegate WASM, a delegate message body, a `ClientRequest`, or the app contract id can construct, mutate, or substitute it. It rides a **separate channel** from `origin_contract`/`caller_delegate`/the request body the whole way down. The raw token is never persisted or logged; `dek_secret` stays `Zeroizing` and is redacted in `Debug`.

**Token channel.** The browser shell page (P2-frontend follow-up) supplies the token as the `userToken` query parameter on the WS upgrade URL, chosen to mirror the existing `auth_token` query form, which is the simplest thing for the shell page to put on the WS URL. An `X-Freenet-User-Token` header is also accepted and takes precedence when present (mirrors how a Bearer `auth_token` header overrides its query form), for non-browser clients / proxies.

**Threading path** (`Option<UserSecretContext>` alongside, never inside, the request):

`connection_info` (derive once) -> `Extension<Option<UserSecretContext>>` -> `ClientConnection::Request.user_context` -> `OpenRequest.user_context` -> `ContractHandlerEvent::DelegateRequest.user_context` -> `handle_delegate_with_contract_requests` -> `execute_delegate_request` -> `delegate_request` -> `inbound_app_message` -> `exec_inbound_with_env` -> `DelegateCallEnv.user_context` (owned, `Zeroizing` lives for the call) -> the secret host fns (`get_secret`/`get_secret_len`/`set_secret`/`remove_secret`), which call `env.secret_scope()` -> `SecretScope::User{..}` when present, else `Local`.

Inter-delegate dispatch (`SendDelegateMessage`) and contract-state-change notifications pass `None`: a delegate-to-delegate hop does **not** inherit the originating connection's user namespace. The namespace binds to the connection boundary, not transitively through delegate messages.

**`DelegateCallEnv` ownership.** The env stores an **owned** `Option<UserSecretContext>` (cloned from the borrowed connection context), so the `dek_secret` outlives every secret call during the synchronous `process()` invocation. `secret_scope()` borrows from it (`&self`), so the secret is never copied into a longer-lived buffer.

## Testing (the gate)

New tests, all green; the full `freenet` lib suite passes (3301 passed, 0 failed):

- **Namespace isolation** (`two_users_have_disjoint_secret_namespaces`): tokens A and B store the *same* secret key under the same delegate; each reads back only its own value; removing A's leaves B's intact.
- **Local <-> User disjoint** (`local_and_user_namespaces_are_disjoint`): a `None`-context (Local) secret is invisible under any token and vice-versa, so flag-off single-user behavior is preserved and hosted connections never collide with the node's existing secrets.
- **The invariant** (`namespace_is_determined_solely_by_user_context`): identical delegate key + params + origin + message body, only `user_context` swapped => namespace swaps; the message body cannot reach another user's secrets. Proves the user id cannot be set by WASM / the client body.
- **Derivation pinned** (`user_id_is_a_stable_function_of_the_token`, `debug_redacts_the_dek_secret`).
- **Flag gating** (`derive_user_context` unit tests): flag off => token ignored; flag on => only a non-empty token derives a context.
- **Config** (`hosted_mode_defaults_to_off`, `hosted_mode_explicit_true_round_trips`): default false; round-trips through TOML when enabled.
- **Regression**: all pre-existing secret/delegate tests (91 secret-related) pass unchanged.

`cargo build -p freenet` ok, `cargo fmt` ok, `cargo clippy -p freenet --lib` clean.

## Out of scope (P2-frontend follow-up)

Browser shell-page JS (minting / storing / presenting the token in localStorage), the export button, and disclosure UI. Here the token arrives via the `userToken` channel and is exercised by tests.

Refs #4381

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
