### PR TITLE
perf(topology): bound attribution maps + swap meter to DashMap (#4276)

### DIFF
--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -92,7 +92,9 @@ pub(crate) mod running_average;
 pub(crate) mod small_world_rand;
 
 use crate::ring::{Connection, PeerKeyLocation};
-use crate::topology::meter::{AttributionSource, ResourceType};
+use crate::topology::meter::{
+    ATTRIBUTION_SOURCE_TTL, AttributionSource, MAX_ATTRIBUTION_SOURCES, ResourceType,
+};
 use crate::topology::rate::{Rate, RateProportion};
 use constants::*;
 use request_density_tracker::DensityMapError;
@@ -250,10 +252,14 @@ impl TopologyManager {
     ///
     /// Drops `source_creation_times` and meter entries for every
     /// `AttributionSource::Peer` whose `PeerKeyLocation` is not in `live`.
-    /// Contract/Delegate sources are untouched. Called once per maintenance
-    /// tick by the bandwidth bridge so neither `source_creation_times` (which
-    /// `extrapolated_usage` iterates every tick) nor the meter grows without
-    /// bound as peers churn (#3453 review).
+    /// Contract/Delegate sources are untouched HERE because their lifecycle
+    /// is not tied to the live-connection set; instead they (and any peer
+    /// entries that outlive a missed prune) are bounded at insertion time by
+    /// [`Self::bound_source_creation_times`], mirroring the meter's own
+    /// TTL + cap eviction. Called once per maintenance tick by the bandwidth
+    /// bridge so `source_creation_times` (which `extrapolated_usage`
+    /// iterates every tick) does not grow without bound as peers churn
+    /// (#3453 review).
     pub(crate) fn retain_peer_sources(
         &mut self,
         live: &std::collections::HashSet<PeerKeyLocation>,
@@ -262,9 +268,53 @@ impl TopologyManager {
             AttributionSource::Peer(peer) => live.contains(peer),
             // Enumerated explicitly (not `_`) so a future AttributionSource
             // variant must consciously decide its retention policy here.
+            // Non-peer sources are bounded by `bound_source_creation_times`,
+            // not by this live-set prune.
             AttributionSource::Delegate(_) | AttributionSource::Contract(_) => true,
         });
         self.meter.retain_peer_sources(live);
+    }
+
+    /// Size-bound `source_creation_times` before inserting a brand-new source.
+    ///
+    /// `source_creation_times` is keyed by `AttributionSource` — the same
+    /// externally-influenced keyspace as the meter's `attribution_meters` —
+    /// and `retain_peer_sources` only ever prunes `Peer` entries, so
+    /// Contract/Delegate sources would otherwise accumulate one entry per
+    /// distinct source ever reported (and `extrapolated_usage` iterates the
+    /// whole map every maintenance tick). Per `.claude/rules/code-style.md`
+    /// it must be size-bounded at insertion time, and per the AGENTS.md GC
+    /// rule the exemption from the live-peer prune must be time-bounded.
+    ///
+    /// Two phases, both bounded by an absolute-age threshold so no entry is
+    /// exempt from eviction indefinitely, sharing the meter's constants
+    /// since the two maps share a keyspace and lifecycle:
+    ///
+    /// 1. Drop every entry whose creation time is older than
+    ///    [`ATTRIBUTION_SOURCE_TTL`]. (`creation_time` only ever moves
+    ///    *earlier*, so age here is a strict lower bound on the entry's true
+    ///    age — never under-evicting.)
+    /// 2. If still at [`MAX_ATTRIBUTION_SOURCES`], evict the single oldest
+    ///    (lowest creation time) entry so the new source can be inserted.
+    fn bound_source_creation_times(&mut self, now: Instant) {
+        // Phase 1: TTL prune.
+        self.source_creation_times.retain(|_, creation_time| {
+            now.saturating_duration_since(*creation_time) < ATTRIBUTION_SOURCE_TTL
+        });
+
+        if self.source_creation_times.len() < MAX_ATTRIBUTION_SOURCES {
+            return;
+        }
+
+        // Phase 2: age-based eviction of the single oldest entry.
+        if let Some(oldest) = self
+            .source_creation_times
+            .iter()
+            .min_by_key(|(_, creation_time)| **creation_time)
+            .map(|(source, _)| source.clone())
+        {
+            self.source_creation_times.remove(&oldest);
+        }
     }
 
     pub(crate) fn report_resource_usage(
@@ -280,6 +330,11 @@ impl TopologyManager {
                     .insert(attribution.clone(), at_time);
             }
         } else {
+            // Bound the map BEFORE inserting a brand-new source so the cap is
+            // enforced at insertion time. Reporting against an existing
+            // source never grows the map, so this scan is skipped on the hot
+            // path (matching `Meter::report`).
+            self.bound_source_creation_times(at_time);
             self.source_creation_times
                 .insert(attribution.clone(), at_time);
         }
@@ -1149,6 +1204,77 @@ mod tests {
                 .per_second(),
             100.0
         );
+    }
+
+    fn test_limits() -> Limits {
+        Limits {
+            max_upstream_bandwidth: Rate::new_per_second(1000.0),
+            max_downstream_bandwidth: Rate::new_per_second(1000.0),
+            max_connections: 200,
+            min_connections: 5,
+        }
+    }
+
+    /// Encode a u32 into a distinct `ContractInstanceId` so we can mint more
+    /// than 256 distinct sources (a single `[byte; 32]` only yields 256).
+    fn contract_source_n(i: u32) -> AttributionSource {
+        use freenet_stdlib::prelude::ContractInstanceId;
+        let mut bytes = [0u8; 32];
+        bytes[0..4].copy_from_slice(&i.to_le_bytes());
+        AttributionSource::Contract(ContractInstanceId::new(bytes))
+    }
+
+    /// MAJOR #1 regression: `source_creation_times` must be size-bounded.
+    /// `retain_peer_sources` only prunes `Peer` entries, so without an
+    /// insertion-time bound Contract sources accumulate forever (and
+    /// `extrapolated_usage` iterates the whole map every tick). Filling past
+    /// the cap with fresh sources (TTL never fires) must hold the map at the
+    /// cap, evicting the oldest entry rather than growing.
+    #[test_log::test]
+    fn source_creation_times_bounded_by_cap() {
+        let mut topo = TopologyManager::new(test_limits());
+        let base = Instant::now();
+
+        for i in 0..MAX_ATTRIBUTION_SOURCES {
+            let at = base + Duration::from_millis(i as u64);
+            topo.report_resource_usage(
+                &contract_source_n(i as u32),
+                ResourceType::StateBytesWritten,
+                1.0,
+                at,
+            );
+        }
+        assert_eq!(topo.source_creation_times.len(), MAX_ATTRIBUTION_SOURCES);
+
+        // One more fresh source: oldest (i == 0) must be evicted, not grow.
+        let oldest = contract_source_n(0);
+        let newcomer = contract_source_n(MAX_ATTRIBUTION_SOURCES as u32);
+        let at = base + Duration::from_millis(MAX_ATTRIBUTION_SOURCES as u64);
+        topo.report_resource_usage(&newcomer, ResourceType::StateBytesWritten, 1.0, at);
+
+        assert_eq!(topo.source_creation_times.len(), MAX_ATTRIBUTION_SOURCES);
+        assert!(!topo.source_creation_times.contains_key(&oldest));
+        assert!(topo.source_creation_times.contains_key(&newcomer));
+    }
+
+    /// MAJOR #1 / combined-phase: an entry in `source_creation_times` older
+    /// than the TTL is dropped the next time a NEW source is inserted, even
+    /// when the map is nowhere near the cap.
+    #[test_log::test]
+    fn source_creation_times_ttl_evicts_stale_entry() {
+        let mut topo = TopologyManager::new(test_limits());
+        let t0 = Instant::now();
+        let stale = contract_source_n(1);
+        topo.report_resource_usage(&stale, ResourceType::StateBytesWritten, 1.0, t0);
+        assert_eq!(topo.source_creation_times.len(), 1);
+
+        let later = t0 + ATTRIBUTION_SOURCE_TTL + Duration::from_secs(1);
+        let fresh = contract_source_n(2);
+        topo.report_resource_usage(&fresh, ResourceType::StateBytesWritten, 1.0, later);
+
+        assert!(!topo.source_creation_times.contains_key(&stale));
+        assert!(topo.source_creation_times.contains_key(&fresh));
+        assert_eq!(topo.source_creation_times.len(), 1);
     }
 
     /// Regression test for the contract-hardening review (PR #4260):

--- a/crates/core/src/topology/meter.rs
+++ b/crates/core/src/topology/meter.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 use std::sync::RwLock;
 use std::time::Duration;
+
+use dashmap::DashMap;
 use tokio::time::Instant;
 
 use freenet_stdlib::prelude::*;
@@ -16,6 +18,44 @@ const DEFAULT_USAGE_PERCENTILE: f64 = 0.5;
 // Recache the estimated usage rate this often
 const ESTIMATED_USAGE_RATE_CACHE_TIME: Duration = Duration::from_secs(60);
 
+/// Hard ceiling on the number of distinct `AttributionSource` entries the
+/// meter will retain at once.
+///
+/// `attribution_meters` is keyed by data that external actors influence
+/// (peers we exchanged bytes with, contracts/delegates whose work we
+/// executed). Per `.claude/rules/code-style.md` "NEVER use unbounded
+/// per-key collections for data that external actors can influence" this
+/// map must be size-bounded at insertion time. Peer churn is already
+/// pruned by `retain_peer_sources`, but Contract/Delegate sources are
+/// deliberately retained across that prune and would otherwise accumulate
+/// one entry per distinct contract/delegate ever reported. The cap is the
+/// backstop that bounds the worst case regardless of source variant.
+///
+/// Sized generously relative to a node's realistic concurrent-source
+/// working set (live peers plus actively-executing contracts/delegates)
+/// so legitimate traffic is never evicted, while still capping the map at
+/// a few MB of running-average state.
+///
+/// Shared with [`crate::topology::TopologyManager::source_creation_times`],
+/// which is keyed by the same `AttributionSource` and shares this meter's
+/// lifecycle, so both bounded maps use one ceiling.
+pub(crate) const MAX_ATTRIBUTION_SOURCES: usize = 4096;
+
+/// Absolute age after which an attribution entry is eligible for eviction
+/// regardless of the live-peer prune.
+///
+/// Per the AGENTS.md GC rule ("cleanup exemptions MUST be time-bounded"),
+/// every entry carries an absolute-age threshold: an entry that has not
+/// been reported against for longer than this is stale and can be dropped
+/// on the next insertion that needs room. This is the TTL that keeps
+/// Contract/Delegate sources — which `retain_peer_sources` intentionally
+/// never prunes — from living forever after their last sample.
+///
+/// Shared with [`crate::topology::TopologyManager::source_creation_times`]
+/// (same keyspace, same lifecycle) so both bounded maps age entries out on
+/// the same schedule.
+pub(crate) const ATTRIBUTION_SOURCE_TTL: Duration = Duration::from_secs(15 * 60);
+
 /// A structure that keeps track of the usage of dynamic resources which are consumed over time.
 /// It provides methods to report and query resource usage, both total and attributed to specific
 /// sources.
@@ -29,7 +69,7 @@ impl Meter {
     /// Creates a new `Meter`.
     pub fn new_with_window_size(running_average_window_size: usize) -> Self {
         Meter {
-            attribution_meters: RwLock::new(BTreeMap::new()),
+            attribution_meters: DashMap::new(),
             running_average_window_size,
             cached_estimated_usage_rate: RwLock::new(BTreeMap::new()),
         }
@@ -42,8 +82,7 @@ impl Meter {
         resource: &ResourceType,
         at_time: Instant,
     ) -> Option<Rate> {
-        let meters = self.attribution_meters.read().unwrap();
-        match meters.get(attribution) {
+        match self.attribution_meters.get(attribution) {
             Some(attribution_meters) => {
                 match attribution_meters.map.get(resource) {
                     Some(meter) => {
@@ -104,12 +143,11 @@ impl Meter {
         at_time: Instant,
     ) -> BTreeMap<AttributionSource, Rate> {
         let mut rates = BTreeMap::new();
-        let meters = self.attribution_meters.read().unwrap();
 
-        for (attribution, attribution_meter) in meters.iter() {
-            if let Some(meter) = attribution_meter.map.get(resource) {
+        for entry in self.attribution_meters.iter() {
+            if let Some(meter) = entry.value().map.get(resource) {
                 if let Some(rate) = meter.get_rate_at_time(at_time) {
-                    rates.insert(attribution.clone(), rate);
+                    rates.insert(entry.key().clone(), rate);
                 }
             }
         }
@@ -142,12 +180,13 @@ impl Meter {
         resource: &ResourceType,
         at_time: Instant,
     ) -> Option<Rate> {
-        let meters = self.attribution_meters.read().unwrap();
-        let rates: Vec<Rate> = meters
-            .values()
+        let rates: Vec<Rate> = self
+            .attribution_meters
+            .iter()
             // Filter out resources with no Rate and collect their rates
             .filter_map(|t| {
-                t.map
+                t.value()
+                    .map
                     .get(resource)
                     .and_then(|m| m.get_rate_at_time(at_time))
             })
@@ -177,12 +216,8 @@ impl Meter {
     /// Without this, a peer that ever exchanged bytes leaves a permanent entry
     /// in `attribution_meters`, so under connection churn the map (and the
     /// per-tick work that iterates it) grows without bound. See #3453 review.
-    pub(crate) fn retain_peer_sources(
-        &mut self,
-        live: &std::collections::HashSet<PeerKeyLocation>,
-    ) {
-        let mut meters = self.attribution_meters.write().unwrap();
-        meters.retain(|source, _| match source {
+    pub(crate) fn retain_peer_sources(&self, live: &std::collections::HashSet<PeerKeyLocation>) {
+        self.attribution_meters.retain(|source, _| match source {
             AttributionSource::Peer(peer) => live.contains(peer),
             // Non-peer sources are not bounded by the live connection set;
             // enumerated explicitly (not `_`) so a future AttributionSource
@@ -194,23 +229,106 @@ impl Meter {
     /// Report the use of a resource. This should be done in the lowest-level
     /// functions that consume the resource, taking an AttributionMeter
     /// as a parameter.
+    ///
+    /// Takes `&self`: the underlying [`DashMap`] provides per-shard interior
+    /// mutability (per `.claude/rules/code-style.md` — DashMap over
+    /// `RwLock<HashMap>`).
+    ///
+    /// NOTE: this method does not yet deliver concurrent reporting in
+    /// production. The sole caller, `Ring::report_contract_resource_usage`,
+    /// still holds the outer `RwLock<TopologyManager>` write guard across
+    /// this call (see `ring.rs`), so reporters serialize on that coarse lock
+    /// regardless of the DashMap's per-shard locking. The DashMap swap is
+    /// groundwork; relieving that outer-lock contention requires decoupling
+    /// the contract meter from `TopologyManager` (the TopologyMeter /
+    /// GovernanceMeter split tracked in #4276) and is a separate change.
     pub(crate) fn report(
-        &mut self,
+        &self,
         attribution: &AttributionSource,
         resource: ResourceType,
         value: f64,
         at_time: Instant,
     ) {
-        // Report the usage for a specific attribution
-        let mut meters = self.attribution_meters.write().unwrap();
-        let resource_map = meters
+        // Hot path (existing source) is a SINGLE shard acquisition: take the
+        // `entry()` once and, when the source already exists, record the
+        // sample inline under that one guard. The eviction scan must NOT run
+        // while an entry guard is held (it `retain`s/`remove`s across keys on
+        // the same DashMap → self-deadlock), so for a brand-new source we
+        // drop the guard, run the bounded eviction, then re-acquire to insert.
+        //
+        // Bounding on the new-source path enforces the cap at insertion time
+        // (code-style.md: per-key collections influenced by external actors
+        // must be size-bounded at insertion). Reporting against an existing
+        // source never grows the map, so the scan is skipped on the hot path.
+        use dashmap::mapref::entry::Entry;
+        match self.attribution_meters.entry(attribution.clone()) {
+            Entry::Occupied(mut occupied) => {
+                let totals = occupied.get_mut();
+                totals.last_reported = totals.last_reported.max(at_time);
+                totals
+                    .map
+                    .entry(resource)
+                    .or_insert_with(|| RunningAverage::new(self.running_average_window_size))
+                    .insert_with_time(at_time, value);
+                return;
+            }
+            // Drop the vacant guard without inserting; eviction needs an
+            // unlocked map. We re-acquire the entry below after pruning.
+            Entry::Vacant(_) => {}
+        }
+
+        self.evict_if_full(at_time);
+
+        let mut totals = self
+            .attribution_meters
             .entry(attribution.clone())
-            .or_insert_with(ResourceTotals::new);
-        let resource_value = resource_map
+            .or_insert_with(|| ResourceTotals::new(at_time));
+        totals.last_reported = totals.last_reported.max(at_time);
+        totals
             .map
             .entry(resource)
-            .or_insert_with(|| RunningAverage::new(self.running_average_window_size));
-        resource_value.insert_with_time(at_time, value);
+            .or_insert_with(|| RunningAverage::new(self.running_average_window_size))
+            .insert_with_time(at_time, value);
+    }
+
+    /// Make room for a new attribution source when the map is at capacity.
+    ///
+    /// Two-phase, both phases bounded by an absolute-age threshold so no
+    /// entry can be exempted from eviction indefinitely (AGENTS.md GC rule):
+    ///
+    /// 1. Drop every entry whose last report is older than
+    ///    [`ATTRIBUTION_SOURCE_TTL`]. This alone usually keeps the map well
+    ///    under the cap for a healthy node.
+    /// 2. If still at [`MAX_ATTRIBUTION_SOURCES`], evict the single
+    ///    least-recently-reported entry (LRU) so the new source can be
+    ///    inserted. Bounding by recency means a flood of new sources cannot
+    ///    push the map past the cap.
+    ///
+    /// Note on the DashMap multi-key caveat (code-style.md): this is not an
+    /// atomic read-modify-write across keys — TTL pruning and LRU selection
+    /// only ever *remove* whole entries, and the subsequent insert in
+    /// `report` is independent. No entry guard is held across the scan, so
+    /// there is no self-deadlock risk.
+    fn evict_if_full(&self, now: Instant) {
+        // Phase 1: TTL prune.
+        self.attribution_meters.retain(|_, totals| {
+            now.saturating_duration_since(totals.last_reported) < ATTRIBUTION_SOURCE_TTL
+        });
+
+        if self.attribution_meters.len() < MAX_ATTRIBUTION_SOURCES {
+            return;
+        }
+
+        // Phase 2: LRU eviction. Find the least-recently-reported key
+        // without holding its guard across the removal.
+        let oldest = self
+            .attribution_meters
+            .iter()
+            .min_by_key(|entry| entry.value().last_reported)
+            .map(|entry| entry.key().clone());
+        if let Some(key) = oldest {
+            self.attribution_meters.remove(&key);
+        }
     }
 }
 
@@ -363,17 +481,22 @@ impl ResourceType {
     }
 }
 
-type AttributionMeters = RwLock<BTreeMap<AttributionSource, ResourceTotals>>;
+type AttributionMeters = DashMap<AttributionSource, ResourceTotals>;
 
 /// A structure that holds running averages of resource usage for different resource types.
 struct ResourceTotals {
     pub map: BTreeMap<ResourceType, RunningAverage>,
+    /// Most recent time this source was reported against. Drives the TTL +
+    /// LRU eviction in [`Meter::evict_if_full`] so a source that stops
+    /// producing samples eventually ages out of the bounded map.
+    last_reported: Instant,
 }
 
 impl ResourceTotals {
-    fn new() -> Self {
+    fn new(at_time: Instant) -> Self {
         ResourceTotals {
             map: BTreeMap::new(),
+            last_reported: at_time,
         }
     }
 }
@@ -397,12 +520,16 @@ mod tests {
                 )
                 .is_none()
         );
-        assert!(meter.attribution_meters.read().unwrap().is_empty());
+        assert!(meter.attribution_meters.is_empty());
+    }
+
+    fn contract_source(byte: u8) -> AttributionSource {
+        AttributionSource::Contract(ContractInstanceId::new([byte; 32]))
     }
 
     #[test]
     fn test_meter_attributed_usage() {
-        let mut meter = Meter::new_with_window_size(100);
+        let meter = Meter::new_with_window_size(100);
 
         // Test that the attributed usage is 0.0 for all resources
         let attribution = AttributionSource::Peer(PeerKeyLocation::random());
@@ -447,7 +574,7 @@ mod tests {
 
     #[test]
     fn test_meter_report() -> anyhow::Result<()> {
-        let mut meter = Meter::new_with_window_size(100);
+        let meter = Meter::new_with_window_size(100);
 
         // Report some usage and test that the total and attributed usage are updated
         let attribution = AttributionSource::Peer(PeerKeyLocation::random());
@@ -508,5 +635,155 @@ mod tests {
             150.0
         );
         Ok(())
+    }
+
+    #[test]
+    fn test_eviction_skipped_below_cap() {
+        // Boundary: a handful of distinct sources stays well under the cap,
+        // so nothing is ever evicted and every entry remains queryable.
+        let meter = Meter::new_with_window_size(100);
+        let now = Instant::now();
+        for i in 0..8u8 {
+            meter.report(
+                &contract_source(i),
+                ResourceType::StateBytesWritten,
+                1.0,
+                now,
+            );
+        }
+        assert_eq!(meter.attribution_meters.len(), 8);
+        for i in 0..8u8 {
+            assert!(
+                meter
+                    .attributed_usage_rate(
+                        &contract_source(i),
+                        &ResourceType::StateBytesWritten,
+                        now
+                    )
+                    .is_some()
+            );
+        }
+    }
+
+    #[test]
+    fn test_ttl_evicts_stale_source_on_insert() {
+        // An entry older than the TTL is dropped the next time a NEW source
+        // is inserted, even though the map is nowhere near the cap.
+        let meter = Meter::new_with_window_size(100);
+        let t0 = Instant::now();
+        let stale = contract_source(1);
+        meter.report(&stale, ResourceType::StateBytesWritten, 1.0, t0);
+        assert_eq!(meter.attribution_meters.len(), 1);
+
+        // Report a different source far enough in the future that `stale`
+        // has aged past ATTRIBUTION_SOURCE_TTL.
+        let later = t0 + ATTRIBUTION_SOURCE_TTL + Duration::from_secs(1);
+        let fresh = contract_source(2);
+        meter.report(&fresh, ResourceType::StateBytesWritten, 1.0, later);
+
+        assert!(!meter.attribution_meters.contains_key(&stale));
+        assert!(meter.attribution_meters.contains_key(&fresh));
+        assert_eq!(meter.attribution_meters.len(), 1);
+    }
+
+    #[test]
+    fn test_ttl_refreshed_by_repeated_reports() {
+        // A source reported against again resets its TTL, so it survives an
+        // insert that would otherwise have aged it out.
+        let meter = Meter::new_with_window_size(100);
+        let t0 = Instant::now();
+        let kept = contract_source(1);
+        meter.report(&kept, ResourceType::StateBytesWritten, 1.0, t0);
+
+        // Refresh just before the TTL would expire.
+        let refresh = t0 + ATTRIBUTION_SOURCE_TTL - Duration::from_secs(1);
+        meter.report(&kept, ResourceType::StateBytesWritten, 1.0, refresh);
+
+        // New source inserted slightly later: `kept` was last reported at
+        // `refresh`, which is still within the TTL window, so it stays.
+        let later = refresh + Duration::from_secs(2);
+        meter.report(
+            &contract_source(2),
+            ResourceType::StateBytesWritten,
+            1.0,
+            later,
+        );
+
+        assert!(meter.attribution_meters.contains_key(&kept));
+    }
+
+    #[test]
+    fn test_cap_enforced_via_lru_eviction() {
+        // Filling to the cap with fresh sources (so TTL never fires) and
+        // inserting one more must evict exactly the least-recently-reported
+        // entry, keeping the map at the cap rather than growing past it.
+        let meter = Meter::new_with_window_size(100);
+        let base = Instant::now();
+
+        // Use distinct, monotonically increasing timestamps so there's an
+        // unambiguous LRU victim. Keep within the TTL window so phase-1
+        // pruning is a no-op and we exercise phase-2 (LRU) deterministically.
+        for i in 0..MAX_ATTRIBUTION_SOURCES {
+            let src = AttributionSource::Contract(ContractInstanceId::new(id_bytes(i as u32)));
+            let at = base + Duration::from_millis(i as u64);
+            meter.report(&src, ResourceType::StateBytesWritten, 1.0, at);
+        }
+        assert_eq!(meter.attribution_meters.len(), MAX_ATTRIBUTION_SOURCES);
+
+        // The oldest (i == 0) is the LRU victim.
+        let oldest = AttributionSource::Contract(ContractInstanceId::new(id_bytes(0)));
+        let newcomer = AttributionSource::Contract(ContractInstanceId::new(id_bytes(
+            MAX_ATTRIBUTION_SOURCES as u32,
+        )));
+        let at = base + Duration::from_millis(MAX_ATTRIBUTION_SOURCES as u64);
+        meter.report(&newcomer, ResourceType::StateBytesWritten, 1.0, at);
+
+        assert_eq!(meter.attribution_meters.len(), MAX_ATTRIBUTION_SOURCES);
+        assert!(!meter.attribution_meters.contains_key(&oldest));
+        assert!(meter.attribution_meters.contains_key(&newcomer));
+    }
+
+    #[test]
+    fn test_combined_phase_ttl_prune_avoids_lru() {
+        // Combined-phase boundary: the map is AT the cap, but every existing
+        // entry is older than the TTL. Inserting a new source must drop the
+        // stale entries in phase 1 (TTL prune), bringing the map below the
+        // cap so phase 2 (LRU eviction of a live entry) is SKIPPED. The new
+        // entry is then inserted into the now-small map.
+        let meter = Meter::new_with_window_size(100);
+        let base = Instant::now();
+
+        // Fill exactly to the cap.
+        for i in 0..MAX_ATTRIBUTION_SOURCES {
+            let src = AttributionSource::Contract(ContractInstanceId::new(id_bytes(i as u32)));
+            meter.report(&src, ResourceType::StateBytesWritten, 1.0, base);
+        }
+        assert_eq!(meter.attribution_meters.len(), MAX_ATTRIBUTION_SOURCES);
+
+        // Report a new source far enough ahead that every existing entry is
+        // past the TTL. Phase 1 should evict ALL of them, so the map ends
+        // with just the newcomer — proving phase 2 did not run (it would
+        // have left the map at the cap).
+        let later = base + ATTRIBUTION_SOURCE_TTL + Duration::from_secs(1);
+        let newcomer = AttributionSource::Contract(ContractInstanceId::new(id_bytes(
+            MAX_ATTRIBUTION_SOURCES as u32,
+        )));
+        meter.report(&newcomer, ResourceType::StateBytesWritten, 1.0, later);
+
+        assert_eq!(
+            meter.attribution_meters.len(),
+            1,
+            "TTL prune should have dropped all stale entries before LRU ran"
+        );
+        assert!(meter.attribution_meters.contains_key(&newcomer));
+    }
+
+    /// Encode a u32 into a 32-byte contract-id array so each index maps to a
+    /// distinct `ContractInstanceId` (the single-byte `[byte; 32]` helper
+    /// only yields 256 distinct ids — not enough to reach the cap).
+    fn id_bytes(i: u32) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        bytes[0..4].copy_from_slice(&i.to_le_bytes());
+        bytes
     }
 }


### PR DESCRIPTION
## Problem

The topology meter (`crates/core/src/topology/meter.rs`) accumulated **two** unbounded per-source collections that external actors can influence — `Meter::attribution_meters` and `TopologyManager::source_creation_times` — with no eviction on peer disconnect or contract churn. `Contract`/`Delegate` sources churn fast and accumulated forever. Violates the code-style rule against unbounded per-key collections (an amplification vector).

## Solution

Bound **both** maps with a shared cap (`MAX_ATTRIBUTION_SOURCES`) and TTL/LRU eviction enforced at insertion time — TTL prune by entry age, then oldest-entry eviction at the cap — honoring the GC rule that exemptions must be time-bounded. `attribution_meters` also moves from `RwLock<BTreeMap>` to `DashMap` for per-shard locking, with the hot path collapsed to a single Entry-API acquisition (eviction runs only on the new-source path, after dropping the probe guard, to avoid DashMap self-deadlock).

### Scope notes
- The DashMap swap is **groundwork**. It does **not** yet relieve the `report_contract_resource_usage` writer-lock contention, because that call still runs inside the outer `Arc<RwLock<TopologyManager>>` write guard. Decoupling the meter from that lock is a tracked follow-up; no rustdoc/comment claims concurrent reporters proceed in parallel today.
- The `Meter` → `TopologyMeter`/`GovernanceMeter` type split is deferred per the issue's explicit option.

## Testing

New tests for cap-enforced LRU eviction, TTL eviction on insert, and the combined-phase case (map at cap, TTL prune drops entries, phase-2 LRU skipped). Mutation-tested: removing either map's bound-call fails the corresponding tests. 114/114 `topology` tests pass, fmt clean.

## Fixes

Fixes #4276

🤖 Reviewed by an adversarial xhigh-effort agent pass (which caught the second unbounded map + the contention overclaim, both fixed) before submission.