### PR TITLE
feat(p2p): re-enable SubscribeHint placement migration at floor (0,2,80) (#4404)

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3371,9 +3371,8 @@ mod tests {
         /// 0.2.79 until the re-enable release bumps it to the floor version).
         #[test]
         fn receive_gate_active_at_reenable_floor() {
-            // Pin the re-enable floor value: an accidental change here moves the
-            // migration's activation set.
-            assert_eq!(SUBSCRIBE_HINT_MIN_VERSION, (0, 2, 80));
+            // The `supported(0,2,80)` + `!supported(0,2,79)` pair pins the floor
+            // to exactly `(0, 2, 80)`; an accidental change trips these asserts.
             // Peers at or above the floor are acted on.
             assert!(version_supports_subscribe_hint(
                 Some((0, 2, 80)),

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1755,23 +1755,19 @@ where
             return Ok(());
         }
         NetMessageV1::SubscribeHint(hint) => {
-            // Placement-migration deactivation gate (v0.2.74 hotfix). The
-            // placement migration was disabled after the v0.2.73 UPDATE-broadcast
-            // degradation by parking the SubscribeHint version floor at
-            // `(0, 3, 0)`, above every shipped 0.2.x release. The SEND side
-            // (`p2p_protoc::peer_supports_subscribe_hint`) already respects this
-            // floor, but the floor bump alone only stops US from emitting hints —
-            // a 0.2.74 node receiving a hint from a not-yet-upgraded 0.2.73 peer
-            // would still ACT on it and keep the migration load alive throughout
-            // the multi-hour staggered rollout.
+            // Placement-migration version gate. The migration is re-enabled at
+            // floor `(0, 2, 80)` (#4499 made it load-safe). The SEND side
+            // (`p2p_protoc::peer_supports_subscribe_hint`) gates emission on the
+            // remote peer's version; the RECEIVE path must gate too, so a node on
+            // an older release does not ACT on a hint from an upgraded peer and
+            // keep migration load alive on a peer that predates the load-safe fix.
             //
-            // So gate the RECEIVE path too. The symmetric (sender-version) gate is
-            // not cleanly reachable here — the per-connection remote version lives
-            // in `P2pConnManager.connections` and is not exposed through the
-            // `NetworkBridge` trait — so use this node's OWN version against the
-            // SAME floor the send side uses. With the floor parked at `(0, 3, 0)`
-            // and our own version on the 0.2.x line this evaluates to "migration
-            // off → ignore"; lowering the floor re-activates both sides together.
+            // The symmetric (sender-version) gate is not cleanly reachable here:
+            // the per-connection remote version lives in `P2pConnManager.connections`
+            // and is not exposed through the `NetworkBridge` trait, so use this
+            // node's OWN version against the SAME floor the send side uses. A node
+            // on `>= 0.2.80` acts on inbound hints; a pre-floor node ignores them.
+            // Lowering the floor (sim override) re-activates both sides together.
             //
             // Read the floor via `subscribe_hint_floor_override().unwrap_or(...)`,
             // identical to the send side, so a simulation that opts into the
@@ -1792,8 +1788,8 @@ where
                     ?own_version,
                     ?floor,
                     ?source_addr,
-                    "Ignoring inbound SubscribeHint — placement migration deactivated \
-                     (own version below the SubscribeHint floor)"
+                    "Ignoring inbound SubscribeHint: own version is below the \
+                     SubscribeHint re-enable floor (pre-floor peer, wire-compat)"
                 );
                 return Ok(());
             }
@@ -3330,40 +3326,51 @@ mod tests {
         assert_eq!(init_peer.location, location);
     }
 
-    // Tests for the INBOUND `SubscribeHint` receive gate (v0.2.74 hotfix).
+    // Tests for the INBOUND `SubscribeHint` receive gate.
     //
-    // FIX 1: the floor bump to `(0, 3, 0)` only gates the SEND side; the
-    // receive handler must ALSO ignore inbound hints while the placement
-    // migration is deactivated, so a 0.2.74 node does not act on hints sent
-    // by a not-yet-upgraded 0.2.73 peer during the staggered rollout.
+    // The placement migration is RE-ENABLED at floor `(0, 2, 80)` (#4499 made it
+    // load-safe). The receive handler shares this floor with the send side, so a
+    // node acts on an inbound hint only when both it and the producing peer are at
+    // or above the floor; it still ignores hints from pre-floor peers, which
+    // preserves wire-compat during the staggered rollout.
     mod inbound_subscribe_hint_gate {
         use crate::node::network_bridge::p2p_protoc::{
             SUBSCRIBE_HINT_MIN_VERSION, own_crate_version, version_supports_subscribe_hint,
         };
 
-        /// The gate predicate ignores an inbound hint while the migration is
-        /// deactivated: for THIS node's own (0.2.x) version against the parked
-        /// production floor, `version_supports_subscribe_hint` returns `false`,
-        /// which is the "ignore the hint" branch in the receive handler.
+        /// At the re-enable floor the receive gate ACTS on hints from peers at or
+        /// above the floor and IGNORES hints from pre-floor peers (wire-compat).
+        /// Uses explicit versions rather than `own_crate_version` so the assertion
+        /// is stable across the 0.2.79 -> 0.2.80 boundary (the crate is still
+        /// 0.2.79 until the re-enable release bumps it to the floor version).
         #[test]
-        fn receive_gate_ignores_hint_while_deactivated() {
-            let own = own_crate_version();
-            // Sanity: this hotfix ships on the 0.2.x line, strictly below the
-            // parked floor. If the crate ever crosses the floor this guard
-            // (and the deactivation it pins) must be revisited.
-            assert!(
-                own < SUBSCRIBE_HINT_MIN_VERSION,
-                "own version {own:?} must be below the parked floor \
-                 {SUBSCRIBE_HINT_MIN_VERSION:?} for the migration to stay off"
-            );
-            assert!(
-                !version_supports_subscribe_hint(Some(own), SUBSCRIBE_HINT_MIN_VERSION),
-                "while deactivated, the receive gate must IGNORE inbound hints \
-                 (own version below the floor)"
-            );
-            // A concrete 0.2.73 sender's own-version analogue is likewise ignored.
+        fn receive_gate_active_at_reenable_floor() {
+            // Pin the re-enable floor value: an accidental change here moves the
+            // migration's activation set.
+            assert_eq!(SUBSCRIBE_HINT_MIN_VERSION, (0, 2, 80));
+            // Peers at or above the floor are acted on.
+            assert!(version_supports_subscribe_hint(
+                Some((0, 2, 80)),
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
+            assert!(version_supports_subscribe_hint(
+                Some((0, 3, 0)),
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
+            // Pre-floor peers are still ignored: older 0.2.x peers, and the
+            // original 0.2.73 sender from the staggered rollout.
+            assert!(!version_supports_subscribe_hint(
+                Some((0, 2, 79)),
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
             assert!(!version_supports_subscribe_hint(
                 Some((0, 2, 73)),
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
+            // Unknown remote version fails closed (the migration's send/receive
+            // gate must never act on a peer whose version we could not determine).
+            assert!(!version_supports_subscribe_hint(
+                None,
                 SUBSCRIBE_HINT_MIN_VERSION
             ));
         }
@@ -3409,7 +3416,7 @@ mod tests {
                 .expect("receive arm must still call start_directed_subscribe");
             assert!(
                 gate_idx < directed_idx,
-                "the deactivation gate must run BEFORE start_directed_subscribe"
+                "the version gate must run BEFORE start_directed_subscribe"
             );
             assert!(
                 arm.contains("subscribe_hint_floor_override()"),

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3338,6 +3338,32 @@ mod tests {
             SUBSCRIBE_HINT_MIN_VERSION, own_crate_version, version_supports_subscribe_hint,
         };
 
+        // Superseded: the placement migration was RE-ENABLED at `(0, 2, 80)` by
+        // PR #4511 (#4145 fixed in #4499). This test pinned the v0.2.74
+        // deactivation (own version below the parked floor, so all inbound hints
+        // ignored) and now documents that prior behavior; its `own < floor`
+        // assert no longer holds once the crate reaches the floor. Replaced by
+        // `receive_gate_active_at_reenable_floor` below.
+        #[ignore]
+        #[test]
+        fn receive_gate_ignores_hint_while_deactivated() {
+            let own = own_crate_version();
+            assert!(
+                own < SUBSCRIBE_HINT_MIN_VERSION,
+                "own version {own:?} must be below the parked floor \
+                 {SUBSCRIBE_HINT_MIN_VERSION:?} for the migration to stay off"
+            );
+            assert!(
+                !version_supports_subscribe_hint(Some(own), SUBSCRIBE_HINT_MIN_VERSION),
+                "while deactivated, the receive gate must IGNORE inbound hints \
+                 (own version below the floor)"
+            );
+            assert!(!version_supports_subscribe_hint(
+                Some((0, 2, 73)),
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
+        }
+
         /// At the re-enable floor the receive gate ACTS on hints from peers at or
         /// above the floor and IGNORES hints from pre-floor peers (wire-compat).
         /// Uses explicit versions rather than `own_crate_version` so the assertion

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -648,29 +648,31 @@ pub(in crate::node) struct P2pConnManager {
 /// Minimum negotiated protocol version a peer must report before we send it a
 /// [`SubscribeHint`](crate::message::NetMessageV1::SubscribeHint).
 ///
-/// DEACTIVATED after the v0.2.73 UPDATE-broadcast-degradation incident. Set to
-/// `(0, 3, 0)`, which is ABOVE every shipped 0.2.x release, so the gate
-/// (`remote.is_some_and(|v| v >= floor)`, fail-closed on unknown) evaluates to
-/// `false` for all 0.2.x peers and the placement-migration wire behavior never
-/// fires in production. The placement-migration path (directed subscribes plus
-/// the `ConsiderContractMigration` emits) amplified the #4145/#4231
-/// broadcast-backpressure surface and drove a network-wide UPDATE-broadcast
-/// degradation on 0.2.73. The migration code is intentionally left in place;
-/// re-enable it by LOWERING this floor back to the release that first ships a
-/// load-safe SubscribeHint once the broadcast-backpressure load issue is fixed.
+/// RE-ENABLED at `(0, 2, 80)` after the #4145 event-loop fix (#4499) made the
+/// migration load-safe. 0.2.80 is the first release that ships SubscribeHint with
+/// that fix, so the floor follows the standard "set to the first-shipping release
+/// version, then FREEZE" rule. The gate (`remote.is_some_and(|v| v >= floor)`,
+/// fail-closed on unknown) sends a hint only to peers on `>= 0.2.80`, so the
+/// migration activates among upgraded peers and ramps with fleet upgrade rather
+/// than switching on everywhere at once.
 ///
-/// Original (pre-deactivation) contract, still true mechanically: a peer is only
-/// sent SubscribeHint if its negotiated version is >= this; older peers cannot
-/// deserialize the new wire variant and would drop the connection. None (unknown,
-/// e.g. joiner->gateway) is treated as unsupported.
+/// History: the migration first shipped in v0.2.73, where the placement-migration
+/// path (directed subscribes plus the `ConsiderContractMigration` emits) amplified
+/// the #4145/#4231 broadcast-backpressure surface and drove a network-wide
+/// UPDATE-broadcast degradation. v0.2.74 disabled it by raising this floor to
+/// `(0, 3, 0)`, above every shipped 0.2.x peer. It was re-enabled at `(0, 2, 80)`
+/// only after #4145 was fixed (#4499), validated at incident-scale fan-out, and
+/// the broadcast-assembly-failure telemetry (#4498) was deployed.
 ///
-/// WHEN RE-ENABLING — UPDATE AT RELEASE TIME, then FREEZE: set this to the exact
-/// release version that first ships the load-safe SubscribeHint and do NOT keep
-/// bumping it afterward to track the crate version. Once shipped in release R,
-/// peers running R can deserialize the variant, so the floor must stay at R
-/// forever — raising it above R would silently stop sending hints to
-/// fully-capable R peers. (This is why there is no `floor` vs `CARGO_PKG_VERSION`
-/// unit test; see docs/RELEASING.md.)
+/// Wire-compat contract: a peer is only sent SubscribeHint if its negotiated
+/// version is `>=` this floor; older peers cannot deserialize the wire variant and
+/// would drop the connection. None (unknown, e.g. joiner->gateway) is treated as
+/// unsupported.
+///
+/// DO NOT bump this floor on later releases. Once shipped in 0.2.80, peers running
+/// 0.2.80+ can deserialize the variant, so the floor must stay at 0.2.80 forever;
+/// raising it would silently stop sending hints to fully-capable peers. (This is
+/// why there is no `floor` vs `CARGO_PKG_VERSION` unit test; see docs/RELEASING.md.)
 ///
 /// This is a single non-cfg constant: deliberately NOT lowered under any test
 /// feature, because `testing` is pulled into the SHIPPED release binary (`fdev`
@@ -686,17 +688,23 @@ pub(in crate::node) struct P2pConnManager {
 /// enough, because a 0.2.74 node would otherwise still ACT on hints sent by a
 /// pre-floor 0.2.73 peer and keep the (deactivated) migration load alive during
 /// the staggered rollout.
-pub(crate) const SUBSCRIBE_HINT_MIN_VERSION: (u8, u8, u16) = (0, 3, 0);
+///
+/// Set to `(0, 2, 80)`: the first release that ships SubscribeHint together with
+/// the #4145 event-loop fix (#4499) that makes the migration load-safe. The
+/// migration is RE-ENABLED at this floor, and the value is now FROZEN per the
+/// general wire-gated-floor rule in `docs/RELEASING.md` (do NOT bump it on later
+/// releases). Only peer pairs both on `>= 0.2.80` exchange hints, so activation
+/// ramps with fleet upgrade rather than switching on everywhere at once.
+pub(crate) const SUBSCRIBE_HINT_MIN_VERSION: (u8, u8, u16) = (0, 2, 80);
 
 /// This node's own crate version as a `(major, minor, patch)` tuple, parsed at
 /// compile time from `CARGO_PKG_VERSION`.
 ///
 /// Used by the INBOUND `SubscribeHint` receive gate (see [`crate::node`]) to ask
 /// "is the placement migration active for a node running THIS version?" via
-/// [`version_supports_subscribe_hint`]. With the floor parked at `(0, 3, 0)` and
-/// our own version on the 0.2.x line, the gate evaluates to "migration off →
-/// ignore inbound hints"; lowering the floor re-activates both the send and the
-/// receive side together.
+/// [`version_supports_subscribe_hint`]. With the floor at `(0, 2, 80)`, a node on
+/// `>= 0.2.80` acts on inbound hints and a pre-floor node ignores them; the send
+/// and receive sides share this floor so they activate together.
 pub(crate) const fn own_crate_version() -> (u8, u8, u16) {
     parse_crate_version(env!("CARGO_PKG_VERSION"))
 }
@@ -3379,23 +3387,35 @@ mod tests {
             assert!(!version_supports_subscribe_hint(None, (0, 0, 0)));
         }
 
-        /// Pin the PRODUCTION constant (not the local `FLOOR`): with
-        /// `SUBSCRIBE_HINT_MIN_VERSION` parked at `(0, 3, 0)` the placement
-        /// migration is dormant for EVERY shipped 0.2.x peer — both the lowest
-        /// shipped patch and any conceivable future 0.2.x — and stays fail-closed
-        /// on an unknown version. If someone lowers the floor to a 0.2.x release
-        /// (silently re-enabling the migration disabled in v0.2.74), this test
-        /// fails. See docs/RELEASING.md and issue #4145.
+        /// Pin the PRODUCTION constant (not the local `FLOOR`): the placement
+        /// migration is RE-ENABLED at `(0, 2, 80)` (#4499 made it load-safe), so
+        /// peers at or above that floor participate while pre-floor 0.2.x peers
+        /// and unknown versions stay gated off (wire-compat with the staggered
+        /// rollout). An accidental change to the floor moves the activation set
+        /// and trips the pinned value below. See docs/RELEASING.md and issues
+        /// #4145 / #4499.
         #[test]
-        fn placement_migration_deactivated_for_all_0_2_x() {
+        fn placement_migration_active_at_reenable_floor() {
+            assert_eq!(SUBSCRIBE_HINT_MIN_VERSION, (0, 2, 80));
+            // At or above the floor: active.
+            assert!(version_supports_subscribe_hint(
+                Some((0, 2, 80)),
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
+            assert!(version_supports_subscribe_hint(
+                Some((0, 2, 255)),
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
+            // Below the floor: still gated off.
+            assert!(!version_supports_subscribe_hint(
+                Some((0, 2, 79)),
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
             assert!(!version_supports_subscribe_hint(
                 Some((0, 2, 73)),
                 SUBSCRIBE_HINT_MIN_VERSION
             ));
-            assert!(!version_supports_subscribe_hint(
-                Some((0, 2, 255)),
-                SUBSCRIBE_HINT_MIN_VERSION
-            ));
+            // Unknown version fails closed.
             assert!(!version_supports_subscribe_hint(
                 None,
                 SUBSCRIBE_HINT_MIN_VERSION

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -3418,7 +3418,9 @@ mod tests {
         /// #4145 / #4499.
         #[test]
         fn placement_migration_active_at_reenable_floor() {
-            assert_eq!(SUBSCRIBE_HINT_MIN_VERSION, (0, 2, 80));
+            // The `supported(0,2,80)` + `!supported(0,2,79)` pair below pins the
+            // floor to exactly `(0, 2, 80)`: an accidental change moves the
+            // activation set and trips these asserts.
             // At or above the floor: active.
             assert!(version_supports_subscribe_hint(
                 Some((0, 2, 80)),

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -3387,6 +3387,28 @@ mod tests {
             assert!(!version_supports_subscribe_hint(None, (0, 0, 0)));
         }
 
+        // Superseded: the placement migration was RE-ENABLED at `(0, 2, 80)` by
+        // PR #4511 (#4145 fixed in #4499). This test pinned the v0.2.74
+        // deactivation (dormant for every 0.2.x peer) and now documents that
+        // prior behavior; its asserts no longer hold against the lowered floor.
+        // Replaced by `placement_migration_active_at_reenable_floor` below.
+        #[ignore]
+        #[test]
+        fn placement_migration_deactivated_for_all_0_2_x() {
+            assert!(!version_supports_subscribe_hint(
+                Some((0, 2, 73)),
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
+            assert!(!version_supports_subscribe_hint(
+                Some((0, 2, 255)),
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
+            assert!(!version_supports_subscribe_hint(
+                None,
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
+        }
+
         /// Pin the PRODUCTION constant (not the local `FLOOR`): the placement
         /// migration is RE-ENABLED at `(0, 2, 80)` (#4499 made it load-safe), so
         /// peers at or above that floor participate while pre-floor 0.2.x peers

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -89,12 +89,17 @@ Current wire-gated floors:
   Set to **`(0, 2, 80)`** and FROZEN. 0.2.80 is the first release that ships
   SubscribeHint together with the #4145 event-loop fix (#4499) that makes the
   migration load-safe, so this floor now follows the general "set to the
-  first-shipping release version, then freeze" rule above. Both the SEND gate
-  and the inbound-hint RECEIVE gate in `node.rs` read this floor, so only peer
-  pairs both on `>= 0.2.80` exchange hints, and activation ramps with fleet
-  upgrade rather than switching on everywhere at once. **DO NOT bump this floor
-  on later releases** (raising it above the first-shipping version would silently
-  stop sending to fully-capable peers).
+  first-shipping release version, then freeze" rule above. The SEND gate emits a
+  hint only to peers reported at `>= 0.2.80`; the inbound-hint RECEIVE gate (in
+  `node.rs`) acts on a hint only if THIS node is itself `>= 0.2.80` (a proxy: the
+  per-connection sender version is not exposed at the receive handler, so the
+  load-bearing receiver gates on its own version, which guarantees the node that
+  takes on migration load always has the #4145 fix). Because pre-0.2.80 releases
+  have parked floors and emit no hints, in practice hints flow only between
+  `>= 0.2.80` peers, so activation ramps with fleet upgrade rather than switching
+  on everywhere at once. **DO NOT bump this floor on later releases** (raising it
+  above the first-shipping version would silently stop sending to fully-capable
+  peers).
 
   History: the migration first shipped in v0.2.73 and its directed-subscribe /
   hint-broadcast load drove a network-wide UPDATE-broadcast degradation by

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -86,21 +86,23 @@ Current wire-gated floors:
 - `SUBSCRIBE_HINT_MIN_VERSION` in `crates/core/src/node/network_bridge/p2p_protoc.rs`
   (SubscribeHint placement migration, #4404).
 
-  **DO NOT lower this to the release version.** It is intentionally **parked at
-  `(0, 3, 0)`** — above every shipped 0.2.x release — to keep the placement
-  migration **DEACTIVATED**. The migration's directed-subscribe / hint-broadcast
-  load drove a network-wide UPDATE-broadcast degradation after the v0.2.73
-  release, and v0.2.74 disabled it by raising this floor above all live peers
-  (the SEND side **and** the inbound-hint RECEIVE gate in `node.rs` both read
-  this floor, so the migration is dormant in both directions). This is the one
-  wire-gated floor that does **NOT** follow the "set to the first-shipping
-  release version" rule above.
+  Set to **`(0, 2, 80)`** and FROZEN. 0.2.80 is the first release that ships
+  SubscribeHint together with the #4145 event-loop fix (#4499) that makes the
+  migration load-safe, so this floor now follows the general "set to the
+  first-shipping release version, then freeze" rule above. Both the SEND gate
+  and the inbound-hint RECEIVE gate in `node.rs` read this floor, so only peer
+  pairs both on `>= 0.2.80` exchange hints, and activation ramps with fleet
+  upgrade rather than switching on everywhere at once. **DO NOT bump this floor
+  on later releases** (raising it above the first-shipping version would silently
+  stop sending to fully-capable peers).
 
-  Lowering it to the release version would **silently re-enable** the migration
-  and reproduce the degradation. Leave it at `(0, 3, 0)` until the
-  broadcast-backpressure load issue (#4145) is fixed; only then drop it to the
-  release that first ships a load-safe SubscribeHint and freeze it there per the
-  general rule.
+  History: the migration first shipped in v0.2.73 and its directed-subscribe /
+  hint-broadcast load drove a network-wide UPDATE-broadcast degradation by
+  amplifying the latent #4145 event-loop wedge. v0.2.74 disabled it by parking
+  this floor at `(0, 3, 0)`, above all live peers. It was re-enabled at
+  `(0, 2, 80)` only after #4145 was fixed (#4499), the fix was validated at
+  incident-scale fan-out, and the broadcast-assembly-failure telemetry (#4498)
+  was deployed to record a baseline and watch the rollout.
 
 When a NEW wire-gated feature first ships (not this one), set its floor to
 **exactly that release version** and freeze it, as described above.


### PR DESCRIPTION
## Problem

The SubscribeHint placement migration (#4404) was disabled in v0.2.74 after its v0.2.73 deployment caused a network-wide UPDATE-broadcast degradation by amplifying the latent #4145 event-loop wedge. It has been parked at floor `(0, 3, 0)` (above all shipped versions) ever since.

The preconditions to re-enable are now met:
- **#4145 root fixed** (#4499): the blocking event-loop sends are non-blocking, so the wedge can't form under fan-out. Validated at 40-80-subscriber fan-out (converges, no connectivity loss, bounded backlog).
- **Telemetry deployed** (#4498, shipped in 0.2.79): the broadcast-assembly-failure gauge is collecting a clean baseline on the live network (~0 failures per 5-min window vs the incident's ~125-190).

## Solution

Lower `SUBSCRIBE_HINT_MIN_VERSION` from `(0, 3, 0)` to **`(0, 2, 80)`**, the first release that ships SubscribeHint with the #4145 fix. The gate sends a hint only to peers on `>= 0.2.80`, so the migration activates **gateway-first** (gateways auto-update first) and **ramps with fleet upgrade** rather than switching on everywhere at once. This is the staged, version-gated canary; rollback is re-parking the floor in a hotfix release.

Also flips the two **deactivation guard tests** to the re-enabled semantics (`placement_migration_active_at_reenable_floor`, `receive_gate_active_at_reenable_floor`). These previously asserted the migration is off for all 0.2.x and would **fail in the release build** once the crate crosses the floor at 0.2.80. Updates `docs/RELEASING.md` (parked -> frozen-at-first-shipping-version) and the stale "parked/deactivated" doc comments, receive-gate log message, and one source-pin assertion.

## Testing

- Gate unit tests pass at a temp 0.2.80 bump (8/8), including both rewrites.
- **Full simulation suite verified at a temp 0.2.80 bump** (migration cascade **on** by default, exactly as the release's merge_group CI will run it): `streaming_e2e` + `simulation_integration` = **123/123 passed**, including `test_streaming_get_retries_after_assembly_failure` (the most placement-sensitive). The #4435 placement-robustness hardening holds after the #4145 fix and the #4507 refactor.
- `cargo clippy --locked -p freenet -- -D warnings` clean.

Note: this PR keeps the crate at 0.2.79, so its own CI runs with the migration off (0.2.79 < floor); the cascade-on behavior is exercised by the release build (crate 0.2.80) and was pre-verified above.

Re-enables #4404. Tracking: #4440.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
