### PR TITLE
fix: guard trace-ot feature build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,16 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
         run: cargo clippy --locked -- -D warnings
 
+      # Guards the opt-in `trace-ot` OpenTelemetry feature against silent
+      # rot: it is excluded from the default build, so a refactor can break
+      # its #[cfg(feature = "trace-ot")] code paths without any other CI job
+      # noticing. See #4225.
+      - name: clippy (trace-ot feature)
+        env:
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
+        run: cargo clippy --locked -p freenet --features trace-ot -- -D warnings
+
   # Windows compile check - catches missing imports, feature flags, and
   # platform-specific errors that Linux CI misses. Added after #3685 where
   # PRs #3669/#3680 introduced Windows-only code that failed to compile,

--- a/crates/core/src/tracing/metrics_client.rs
+++ b/crates/core/src/tracing/metrics_client.rs
@@ -644,5 +644,9 @@ mod opentelemetry_tracer {
     }
 }
 
+// `pub(crate)` (not `pub(super)`): `OTEventRegister` is re-exported again as
+// `pub(crate)` from `tracing.rs` and constructed in `node.rs` / `testing_impl`,
+// so it must be visible crate-wide. The narrower `pub(super)` broke the
+// `trace-ot` build after the tracing module split (see #4225).
 #[cfg(feature = "trace-ot")]
-pub(super) use opentelemetry_tracer::OTEventRegister;
+pub(crate) use opentelemetry_tracer::OTEventRegister;

--- a/crates/core/src/tracing/register.rs
+++ b/crates/core/src/tracing/register.rs
@@ -1553,8 +1553,14 @@ impl NetLogMessage {
     /// Signals whether this message closes a transaction span.
     ///
     /// In case of isolated events where the span is not being tracked it should return true.
+    // Terminal variants above complete a span; the wildcard is deliberate so
+    // non-span events (and any future variant) are treated as not-completing.
+    // `pub(crate)`: called from the sibling `metrics_client` module's
+    // OpenTelemetry span processing. Was private, which broke the `trace-ot`
+    // build after the tracing module split (see #4225).
     #[cfg(feature = "trace-ot")]
-    fn span_completed(&self) -> bool {
+    #[allow(clippy::wildcard_enum_match_arm)]
+    pub(crate) fn span_completed(&self) -> bool {
         match &self.kind {
             EventKind::Connect(ConnectEvent::Finished { .. }) => true,
             EventKind::Connect(_) => false,
@@ -1568,6 +1574,10 @@ impl NetLogMessage {
                 | SubscribeEvent::SubscribeTimeout { .. },
             ) => true,
             EventKind::Subscribe(_) => false,
+            EventKind::Update(
+                UpdateEvent::UpdateSuccess { .. } | UpdateEvent::UpdateFailure { .. },
+            ) => true,
+            EventKind::Update(_) => false,
             _ => false,
         }
     }
@@ -1586,6 +1596,9 @@ impl<'a> From<NetEventLog<'a>> for NetLogMessage {
 
 #[cfg(feature = "trace-ot")]
 impl<'a> From<&'a NetLogMessage> for Option<Vec<opentelemetry::KeyValue>> {
+    // Wildcard is deliberate: only the event kinds mapped above carry
+    // span attributes; every other event (and any new variant) maps to None.
+    #[allow(clippy::wildcard_enum_match_arm)]
     fn from(msg: &'a NetLogMessage) -> Self {
         use opentelemetry::KeyValue;
         let map: Option<Vec<KeyValue>> = match &msg.kind {
@@ -2054,5 +2067,81 @@ mod eventlog_backpressure_tests {
         )
         .await
         .expect("register_events must return promptly on a closed channel");
+    }
+}
+
+#[cfg(all(test, feature = "trace-ot"))]
+mod span_completed_tests {
+    use super::*;
+
+    fn msg(kind: EventKind) -> NetLogMessage {
+        NetLogMessage {
+            datetime: Utc::now(),
+            tx: *Transaction::NULL,
+            peer_id: PeerId::random(),
+            kind,
+        }
+    }
+
+    fn contract_key() -> ContractKey {
+        ContractKey::from_id_and_code(ContractInstanceId::new([1u8; 32]), CodeHash::new([2u8; 32]))
+    }
+
+    // Regression for #4225: UpdateSuccess / UpdateFailure are terminal UPDATE
+    // events that close their OpenTelemetry span. They previously fell through
+    // the `_ => false` arm of `span_completed`, so their spans were never
+    // marked complete and leaked under the `trace-ot` feature.
+    #[test]
+    fn update_terminal_events_complete_span() {
+        let tx = Transaction::new::<crate::operations::update::UpdateMsg>();
+        let key = contract_key();
+
+        let success = msg(EventKind::Update(UpdateEvent::UpdateSuccess {
+            id: tx,
+            requester: PeerKeyLocation::random(),
+            target: PeerKeyLocation::random(),
+            key,
+            timestamp: 0,
+            state_hash_before: None,
+            state_hash_after: None,
+            state_size: None,
+        }));
+        assert!(
+            success.span_completed(),
+            "UpdateSuccess must close its span"
+        );
+
+        let failure = msg(EventKind::Update(UpdateEvent::UpdateFailure {
+            id: tx,
+            requester: PeerKeyLocation::random(),
+            target: PeerKeyLocation::random(),
+            key,
+            reason: OperationFailure::Timeout,
+            elapsed_ms: 0,
+            timestamp: 0,
+        }));
+        assert!(
+            failure.span_completed(),
+            "UpdateFailure must close its span"
+        );
+    }
+
+    // A non-terminal UPDATE event must NOT close the span — guards against
+    // over-broadly classifying the whole `Update` group as span-completing.
+    #[test]
+    fn non_terminal_update_event_does_not_complete_span() {
+        let tx = Transaction::new::<crate::operations::update::UpdateMsg>();
+
+        let request = msg(EventKind::Update(UpdateEvent::Request {
+            id: tx,
+            requester: PeerKeyLocation::random(),
+            key: contract_key(),
+            target: PeerKeyLocation::random(),
+            timestamp: 0,
+        }));
+        assert!(
+            !request.span_completed(),
+            "UpdateEvent::Request is not terminal and must not close the span"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds a CI step that builds the optional `trace-ot` feature through clippy, so the OpenTelemetry tracing path cannot silently break again. Also resolves the two clippy errors that surface only when that feature is enabled.

## Why this matters

The default Clippy job runs `cargo clippy --locked -- -D warnings`, which does not enable `trace-ot`. After the workspace bumped to `opentelemetry = "0.32"`, the feature-gated tracing code broke and the break was invisible to CI. The `SpanBuilder` construction was already repaired on `main` (#4385), but the feature is still not exercised in CI, so it can rot again. Two `wildcard_enum_match_arm` errors in feature-gated match arms also fail `cargo clippy -p freenet --features trace-ot -- -D warnings`.

This wires that exact command into the Clippy job and clears the remaining feature-gated lint failures. See #4225.

## Changes

- `.github/workflows/ci.yml`: new `clippy (trace-ot feature)` step running `cargo clippy --locked -p freenet --features trace-ot -- -D warnings`, using the same linker env as the existing clippy step.
- `crates/core/src/tracing.rs`:
  - `span_completed`: classify the terminal `UpdateEvent::UpdateSuccess` / `UpdateFailure` variants as span-completing. They previously fell through `_ => false`, so UPDATE transaction spans were never removed under `trace-ot`. The remaining wildcard keeps a deliberate `#[allow(clippy::wildcard_enum_match_arm)]`.
  - `From<&NetLogMessage> for Option<Vec<KeyValue>>`: add the same narrow `#[allow]` with a comment, matching the existing pattern in this file.

## Testing

- `cargo clippy -p freenet --features trace-ot -- -D warnings` passes (failed before this change). Verified on Linux; the only residual error in a local macOS run is a pre-existing `undocumented_unsafe_blocks` in `module_cache.rs` gated behind `cfg(all(unix, not(target_os = "linux")))`, which compiles out on the Linux CI runner.
- `cargo build -p freenet --features trace-ot --lib` succeeds.

Fixes #4225

AI was used for assistance.
