### PR TITLE
fix(service): repair Windows-target compilation after submodule split

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -364,7 +364,7 @@ pub use launch_at_login::{
 pub use macos::generate_plist;
 
 #[cfg(target_os = "windows")]
-pub use windows::kill_freenet_service_processes;
+pub(crate) use windows::kill_freenet_service_processes;
 #[cfg(target_os = "windows")]
 pub use windows::stop_and_remove_service;
 
@@ -412,6 +412,33 @@ fn service_logs(_error_only: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression guard for the service.rs submodule split: it dropped
+    /// `spawn_first_run_dashboard_opener` entirely (only the call site
+    /// survived) and left several Windows-only items unimported, breaking the
+    /// Windows build. Linux CI compiles none of those `#[cfg(windows)]` paths,
+    /// so the breakage shipped to `main` silently. These source-scrape pins run
+    /// on every platform and fail fast if the Windows-critical wiring is
+    /// dropped again.
+    #[test]
+    fn windows_first_run_wiring_is_present() {
+        let wrapper = include_str!("service/wrapper.rs");
+        assert!(
+            wrapper.contains("fn spawn_first_run_dashboard_opener("),
+            "wrapper.rs must define spawn_first_run_dashboard_opener — the split \
+             dropped it, breaking the Windows build."
+        );
+        assert!(
+            wrapper.contains("use super::single_instance::FIRST_RUN_OPENER_SPAWNED;"),
+            "wrapper.rs must import FIRST_RUN_OPENER_SPAWNED from single_instance."
+        );
+        let windows = include_str!("service/windows.rs");
+        assert!(
+            windows.contains("use super::log_utils::find_latest_log_file;"),
+            "windows.rs must import find_latest_log_file from log_utils."
+        );
+    }
+
     // Pull test-helper functions from submodules that are not re-exported at the
     // service.rs level (they are pub(super) in their submodule, making them
     // visible here via explicit `use`).

--- a/crates/core/src/bin/commands/service/single_instance.rs
+++ b/crates/core/src/bin/commands/service/single_instance.rs
@@ -134,5 +134,5 @@ pub(super) struct WrapperSingleInstanceLock;
 /// Checking a real wall-clock Instant plus polling a TCP port means we
 /// also can't reuse the per-launch marker file itself as a latch.
 #[cfg(any(target_os = "windows", target_os = "macos"))]
-static FIRST_RUN_OPENER_SPAWNED: std::sync::atomic::AtomicBool =
+pub(super) static FIRST_RUN_OPENER_SPAWNED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);

--- a/crates/core/src/bin/commands/service/windows.rs
+++ b/crates/core/src/bin/commands/service/windows.rs
@@ -1,4 +1,6 @@
 #[cfg(target_os = "windows")]
+use super::log_utils::find_latest_log_file;
+#[cfg(target_os = "windows")]
 use anyhow::Context;
 #[cfg(target_os = "windows")]
 use anyhow::Result;

--- a/crates/core/src/bin/commands/service/wrapper.rs
+++ b/crates/core/src/bin/commands/service/wrapper.rs
@@ -10,11 +10,62 @@ use super::single_instance::{AcquireWrapperLockOutcome, acquire_wrapper_single_i
 use super::DASHBOARD_URL;
 #[cfg(any(target_os = "windows", target_os = "macos"))]
 use super::open_url_in_browser;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+use super::single_instance::FIRST_RUN_OPENER_SPAWNED;
 use super::{
     SENTINEL_RESTART, SENTINEL_STOP, WRAPPER_EXIT_ALREADY_RUNNING, WRAPPER_EXIT_UPDATE_NEEDED,
     WRAPPER_INITIAL_BACKOFF_SECS, WRAPPER_MAX_BACKOFF_SECS, WRAPPER_MAX_CONSECUTIVE_FAILURES,
     WRAPPER_MAX_PORT_CONFLICT_KILLS,
 };
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+use super::{
+    dashboard_port_is_listening, first_run_marker_path, is_first_run_at, mark_first_run_complete_at,
+};
+
+/// Spawn a short-lived thread that waits for the dashboard HTTP server to
+/// come up, then opens it in the browser and writes the first-run marker.
+/// The thread gives up after a generous timeout. If the daemon is crashing
+/// repeatedly we'd rather skip first-run and retry next launch than open
+/// a "connection refused" page in the user's browser.
+///
+/// Caller is responsible for gating on `FIRST_RUN_OPENER_SPAWNED` so we
+/// don't start more than one opener per process lifetime.
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+fn spawn_first_run_dashboard_opener(log_dir: &Path) {
+    // Import locally so we use the unqualified `Instant::now()` form. Wall-
+    // clock time is correct here: this is tray/CLI onboarding, not sim-
+    // reachable core code, and the deadline is about what the user's
+    // patience will tolerate. See `crates/core/src/bin/freenet.rs` for
+    // similar bin-side wall-clock usage.
+    use std::time::{Duration, Instant};
+
+    let log_dir = log_dir.to_path_buf();
+    std::thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while Instant::now() < deadline {
+            if dashboard_port_is_listening() {
+                open_url_in_browser(DASHBOARD_URL);
+                if let Some(marker) = first_run_marker_path() {
+                    match mark_first_run_complete_at(&marker) {
+                        Ok(()) => {
+                            log_wrapper_event(&log_dir, "First-run onboarding: dashboard opened")
+                        }
+                        Err(e) => log_wrapper_event(
+                            &log_dir,
+                            &format!("Failed to write first-run marker: {e}"),
+                        ),
+                    }
+                }
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(500));
+        }
+        log_wrapper_event(
+            &log_dir,
+            "First-run dashboard open skipped: dashboard never became reachable",
+        );
+    });
+}
 
 /// State for the wrapper backoff state machine.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Problem

PR #4517 split `commands/service.rs` into submodules, but the agent's
pre-merge checks only built the Linux default target. The split broke the
**Windows** build, and #4517 was merged in that state — so `main`'s
Windows target currently does not compile (12 errors).

Failure modes:

- **E0364** — `service.rs` re-exported `kill_freenet_service_processes`
  with `pub use`, but the item is `pub(crate)`, which a `pub` re-export
  cannot widen.
- **E0425 ×3 / E0282 ×4** — `windows.rs` used `find_latest_log_file`
  without importing it (it now lives in the sibling `log_utils` module),
  which also cascaded into type-inference failures.
- **E0425 ×4** — `wrapper.rs` lost the `spawn_first_run_dashboard_opener`
  function entirely during the split (only its call site survived), plus
  the first-run-marker helpers and `FIRST_RUN_OPENER_SPAWNED` were no
  longer in scope.

## Solution

- `service.rs`: re-export with `pub(crate) use` to match the item's
  visibility.
- `single_instance.rs`: make `FIRST_RUN_OPENER_SPAWNED` `pub(super)` so
  the sibling `wrapper` module can reach it.
- `windows.rs`: `#[cfg(target_os = "windows")] use super::log_utils::find_latest_log_file;`.
- `wrapper.rs`: cfg-gated imports of the first-run-marker helpers and
  `FIRST_RUN_OPENER_SPAWNED`, and restore `spawn_first_run_dashboard_opener`
  verbatim from the pre-split source.

All new imports are `#[cfg(...)]`-matched to their use sites so they do
not become unused on other targets (Linux `clippy -D warnings` stays
clean).

## Testing

- `cargo check -p freenet --bins --target x86_64-pc-windows-gnu` →
  Finished, 0 errors (was 12 errors on `main`).
- `cargo check -p freenet --bins` (Linux) → 0 errors.
- `cargo test -p freenet --bins commands::service` → 69 passed.
- `cargo clippy -p freenet --bins -- -D warnings` → clean.

Adds a source-scrape regression pin,
`commands::service::tests::windows_first_run_wiring_is_present`, that
fails if the `spawn_first_run_dashboard_opener` definition, the
`FIRST_RUN_OPENER_SPAWNED` import in `wrapper.rs`, or the
`find_latest_log_file` import in `windows.rs` is dropped again — so a
future re-split cannot silently re-break the Windows target the way #4517
did.

## Fixes

Repairs the broken Windows build introduced by #4517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ut4suySidCWRKUV7ZAT5Lr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ut4suySidCWRKUV7ZAT5Lr)_