### PR TITLE
fix(service): restore macOS + Windows binary build after #4517 split (#4526)

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -187,17 +187,17 @@ fn open_url_in_browser(url: &str) {
 
 /// Path of the first-run marker file, if we can determine a data directory.
 #[allow(dead_code)] // Used by the tray wrapper on Windows/macOS only
-fn first_run_marker_path() -> Option<PathBuf> {
+pub(super) fn first_run_marker_path() -> Option<PathBuf> {
     dirs::data_local_dir().map(|d| d.join("freenet").join(".first-run-complete"))
 }
 
 #[allow(dead_code)]
-fn is_first_run_at(marker: &Path) -> bool {
+pub(super) fn is_first_run_at(marker: &Path) -> bool {
     !marker.exists()
 }
 
 #[allow(dead_code)]
-fn mark_first_run_complete_at(marker: &Path) -> std::io::Result<()> {
+pub(super) fn mark_first_run_complete_at(marker: &Path) -> std::io::Result<()> {
     if let Some(parent) = marker.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -211,12 +211,12 @@ fn mark_first_run_complete_at(marker: &Path) -> std::io::Result<()> {
 /// onboarding state. The migration is its own one-shot, tracked by its own
 /// marker, so it runs once for existing DMG users too.
 #[allow(dead_code)]
-fn legacy_migration_marker_path() -> Option<PathBuf> {
+pub(super) fn legacy_migration_marker_path() -> Option<PathBuf> {
     dirs::data_local_dir().map(|d| d.join("freenet").join(".legacy-migration-complete"))
 }
 
 #[cfg(any(target_os = "windows", target_os = "macos"))]
-fn dashboard_port_is_listening() -> bool {
+pub(super) fn dashboard_port_is_listening() -> bool {
     use std::net::TcpStream;
     use std::time::Duration;
     let Ok(addr) = DASHBOARD_ADDR.parse::<std::net::SocketAddr>() else {
@@ -354,14 +354,14 @@ pub use macos::stop_and_remove_service;
 
 // Re-exports for tray.rs (Launch at Login toggle and state query).
 #[cfg(target_os = "macos")]
-pub use launch_at_login::{
+pub(crate) use launch_at_login::{
     ToggleLaunchAtLoginOutcome, disable_launch_at_login, enable_launch_at_login,
     is_launch_at_login_enabled, macos_app_bundle_path, toggle_launch_at_login_outcome,
 };
 
 // Re-exports for update.rs (macOS plist generation).
 #[cfg(target_os = "macos")]
-pub use macos::generate_plist;
+pub(crate) use macos::generate_plist;
 
 #[cfg(target_os = "windows")]
 pub(crate) use windows::kill_freenet_service_processes;
@@ -2882,7 +2882,7 @@ echo "RC=$?"
         let plist_path = home.join("org.freenet.node.plist");
 
         for path in [&wrapper_path, &hash_path, &bak_path, &plist_path] {
-            fs::write(path, b"x").expect("write fixture file");
+            fs::write(path, b"x" as &[u8]).expect("write fixture file");
             assert!(path.exists(), "fixture {} should exist", path.display());
         }
 

--- a/crates/core/src/bin/commands/service/launch_at_login.rs
+++ b/crates/core/src/bin/commands/service/launch_at_login.rs
@@ -5,6 +5,15 @@ use std::path::{Path, PathBuf};
 #[cfg(target_os = "macos")]
 use super::wrapper::log_wrapper_event;
 
+// First-run / legacy-migration marker helpers live in the parent `service`
+// module (platform-independent so they can be unit-tested on Linux CI); the
+// macOS startup self-heal path below references them.
+#[cfg(target_os = "macos")]
+use super::{
+    first_run_marker_path, is_first_run_at, legacy_migration_marker_path,
+    mark_first_run_complete_at,
+};
+
 // ── Launch at Login (macOS) ──
 //
 // On macOS, the DMG-installed Freenet.app does not auto-start on login by
@@ -59,7 +68,7 @@ pub(super) fn is_launch_at_login_enabled_at(plist: &Path) -> bool {
 /// Exposed at `pub(super)` so `update.rs` can detect bundle context for
 /// its DMG-swap auto-update path.
 #[allow(dead_code)]
-pub(super) fn macos_app_bundle_path(exe: &Path) -> Option<PathBuf> {
+pub(crate) fn macos_app_bundle_path(exe: &Path) -> Option<PathBuf> {
     for ancestor in exe.ancestors() {
         if ancestor
             .file_name()
@@ -269,7 +278,7 @@ fn launchctl_bootout(_plist: &Path) {}
 
 /// Enable launch-at-login: write the plist and ask launchd to load it.
 #[allow(dead_code)]
-pub(super) fn enable_launch_at_login(executable: &Path) -> std::io::Result<()> {
+pub(crate) fn enable_launch_at_login(executable: &Path) -> std::io::Result<()> {
     let Some(plist) = launch_agent_plist_path() else {
         return Err(std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -289,7 +298,7 @@ pub(super) fn enable_launch_at_login(executable: &Path) -> std::io::Result<()> {
 }
 
 #[allow(dead_code)]
-pub(super) fn disable_launch_at_login() -> std::io::Result<()> {
+pub(crate) fn disable_launch_at_login() -> std::io::Result<()> {
     let Some(plist) = launch_agent_plist_path() else {
         return Ok(());
     };
@@ -299,7 +308,7 @@ pub(super) fn disable_launch_at_login() -> std::io::Result<()> {
 
 /// User-facing query: is launch-at-login currently on?
 #[allow(dead_code)]
-pub(super) fn is_launch_at_login_enabled() -> bool {
+pub(crate) fn is_launch_at_login_enabled() -> bool {
     launch_agent_plist_path()
         .map(|p| is_launch_at_login_enabled_at(&p))
         .unwrap_or(false)
@@ -340,13 +349,13 @@ pub(super) fn first_run_launch_at_login_action(
 /// rationale as `first_run_launch_at_login_action`.
 #[derive(Debug, PartialEq, Eq)]
 #[allow(dead_code)]
-pub(super) enum ToggleLaunchAtLoginOutcome {
+pub(crate) enum ToggleLaunchAtLoginOutcome {
     Enable,
     Disable,
 }
 
 #[allow(dead_code)]
-pub(super) fn toggle_launch_at_login_outcome(
+pub(crate) fn toggle_launch_at_login_outcome(
     currently_enabled: bool,
 ) -> ToggleLaunchAtLoginOutcome {
     if currently_enabled {

--- a/crates/core/src/bin/commands/service/macos.rs
+++ b/crates/core/src/bin/commands/service/macos.rs
@@ -23,7 +23,7 @@ pub(super) fn install_service(system: bool) -> Result<()> {
 /// writes the script), the update path, and the uninstall path (which
 /// removes it). Keep this in sync with `update.rs`'s wrapper derivation.
 #[cfg(target_os = "macos")]
-fn wrapper_script_path(home_dir: &Path) -> PathBuf {
+pub(super) fn wrapper_script_path(home_dir: &Path) -> PathBuf {
     home_dir.join(".local/bin/freenet-service-wrapper.sh")
 }
 
@@ -37,7 +37,7 @@ fn wrapper_script_path(home_dir: &Path) -> PathBuf {
 /// Regression target for #4290: install wrote three files, uninstall
 /// removed zero, leaving stale wrapper artifacts in `~/.local/bin`.
 #[cfg(target_os = "macos")]
-fn remove_wrapper_files(wrapper_path: &Path) -> Result<()> {
+pub(super) fn remove_wrapper_files(wrapper_path: &Path) -> Result<()> {
     use std::fs;
 
     // `.sh` itself, plus the `.sh.hash` sidecar (#4286) and any `.sh.bak`
@@ -352,7 +352,7 @@ done
 }
 
 #[cfg(target_os = "macos")]
-pub(super) fn generate_plist(wrapper_path: &Path, log_dir: &Path) -> String {
+pub(crate) fn generate_plist(wrapper_path: &Path, log_dir: &Path) -> String {
     // Note: wrapper_path is the auto-update wrapper script, not the freenet binary directly.
     // The wrapper handles the loop: run freenet, check exit code, update if needed.
     format!(
@@ -433,7 +433,7 @@ pub fn stop_and_remove_service(_system: bool) -> Result<bool> {
 /// `$HOME` or shelling out to `launchctl` (which only runs when the plist is
 /// present).
 #[cfg(target_os = "macos")]
-fn stop_and_remove_service_at(home_dir: &Path) -> Result<bool> {
+pub(super) fn stop_and_remove_service_at(home_dir: &Path) -> Result<bool> {
     use std::fs;
 
     let plist_path = home_dir.join("Library/LaunchAgents/org.freenet.node.plist");

--- a/crates/core/src/bin/commands/service/wrapper.rs
+++ b/crates/core/src/bin/commands/service/wrapper.rs
@@ -7,11 +7,14 @@ use super::launch_at_login::macos_launch_at_login_startup;
 use super::single_instance::{AcquireWrapperLockOutcome, acquire_wrapper_single_instance_lock};
 
 #[cfg(any(target_os = "windows", target_os = "macos"))]
+use super::single_instance::FIRST_RUN_OPENER_SPAWNED;
+
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use super::DASHBOARD_URL;
 #[cfg(any(target_os = "windows", target_os = "macos"))]
 use super::open_url_in_browser;
-#[cfg(any(target_os = "windows", target_os = "macos"))]
-use super::single_instance::FIRST_RUN_OPENER_SPAWNED;
+// First-run marker helpers + dashboard reachability probe live in the parent
+// `service` module; the first-run onboarding opener below references them.
 use super::{
     SENTINEL_RESTART, SENTINEL_STOP, WRAPPER_EXIT_ALREADY_RUNNING, WRAPPER_EXIT_UPDATE_NEEDED,
     WRAPPER_INITIAL_BACKOFF_SECS, WRAPPER_MAX_BACKOFF_SECS, WRAPPER_MAX_CONSECUTIVE_FAILURES,


### PR DESCRIPTION
## Problem

PR #4517 (`refactor(service): split service.rs into submodules`) broke the **macOS** and **Windows** binary builds on `main`. Pristine `origin/main` fails to compile both targets — 30 errors on macOS, the same class on the Windows Check CI job:

```
E0364 / E0365 / E0603  re-export / access of private split-out items
                       (generate_plist, *_launch_at_login, macos_app_bundle_path,
                        ToggleLaunchAtLoginOutcome, kill_freenet_service_processes, ...)
E0425                  unqualified calls to moved helpers
                       (find_latest_log_file, first_run_marker_path, is_first_run_at,
                        legacy_migration_marker_path, FIRST_RUN_OPENER_SPAWNED, ...)
E0282                  type annotation needed (test fixture write)
```

Every broken symbol is behind `#[cfg(target_os = "macos")]` / `#[cfg(target_os = "windows")]`, so #4517's **Linux-only** build never compiled them and the regression merged green. This blocks all local non-Linux development and any natively-compiled release path.

## Solution

Pure visibility/scope cleanup — **no behavior change**:
- Raise the split-out helpers/types to `pub(super)` / `pub(crate)` so the parent module's re-exports and cross-submodule references resolve (E0364/E0365/E0603).
- Add the missing `use` imports at the moved call sites (E0425).
- One type annotation on a test fixture write (E0282).

## Testing

macOS native: `cargo build -p freenet --bin freenet` → 30 errors → **0**; `cargo test -p freenet --bin freenet commands::service` → **72 passed**; bin clippy clean (the lone remaining lint is the pre-existing `module_cache.rs:520` undocumented-unsafe on an untouched file under rust-1.94, which CI's pinned toolchain passes). The durable regression guard is a non-Linux CI build job — tracked as a follow-up in the issue (the exact `deployment.md` "cfg'd path CI doesn't build = unverified" failure mode).

## Fixes

Fixes #4526

🤖 Found incidentally while rebasing #4382 onto the post-#4517 layout; root-caused and fixed.