### PR TITLE
fix(contract): priority-tier the contract event loop so client requests aren't starved (#4534)

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -64,6 +64,51 @@ for every inbound wire message. Pattern per op:
 `RelayState::handle_request`. Production CONNECT runs entirely on the
 drivers in `connect/op_ctx_task.rs`.
 
+## Critical Invariant: Tag Contract-Handler Events with the Right Priority (#4534)
+
+```
+Every event sent to the single-threaded contract_handling loop carries a
+`crate::contract::Priority` (ClientLocal > NetworkRelay > Background).
+The fair queue drains higher classes first, reserves admission capacity
+(CLIENT_LOCAL_RESERVE) for ClientLocal, and sheds Background to make room.
+A mis-tag silently degrades service: tag a client path Background and it
+gets starved/evicted; tag relay/background ClientLocal and it can exhaust
+the reserve meant to protect real client requests.
+
+Rules for choosing the class at a send site:
+
+  ClientLocal  → the event serves a WS/HTTP client connected to THIS node.
+                 Set it at the client-facing entry points:
+                 - client_events.rs request handlers (GET, RegisterSubscriberListener,
+                   DelegateRequest)
+                 - drive_client_update → update_contract(.., ClientLocal)
+                 - hosted_export.rs ExportUserSecrets
+                 - a client's own PUT reaches the relay driver via
+                   originator-loopback (upstream_addr == own_addr); compute it
+                   with put_store_priority() — DO NOT hardcode NetworkRelay on
+                   the relay PUT store path.
+
+  NetworkRelay → serving a remote peer's relayed op (the default). All
+                 drive_relay_* drivers, ResyncResponse apply, broadcast-path
+                 summaries/deltas that propagate a real UPDATE. This is also
+                 `Priority::DEFAULT`, so untagged callers fall here safely.
+
+  Background   → best-effort node-internal work that must yield to client/relay
+                 traffic: the periodic interest-sync summarize
+                 (summary_if_hosted_or_in_use), placement-migration caching,
+                 renewal, and EvictContract disk reclamation. NEVER tag a
+                 client- or peer-visible op Background.
+
+When a shared helper is reached from BOTH a client and a relay path (e.g.
+put_contract, update_contract), thread a `priority` param through rather
+than hardcoding — decide the class at the driver that knows the origin.
+
+The loop's pop() applies a bounded anti-starvation floor
+(RELAY_STARVATION_FLOOR) so sustained ClientLocal load cannot indefinitely
+starve NetworkRelay/Background — but that is a backstop, not a license to
+mis-tag.
+```
+
 ## Critical Invariant: Initialize-Before-Send
 
 ```

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -284,12 +284,15 @@ async fn register_subscription_listener(
         "Registering subscription listener"
     );
     let register_listener = op_manager
-        .notify_contract_handler(ContractHandlerEvent::RegisterSubscriberListener {
-            key: instance_id,
-            client_id,
-            summary: None, // No summary for GET/PUT-based subscriptions
-            subscriber_listener: subscription_listener,
-        })
+        .notify_contract_handler_prioritized(
+            ContractHandlerEvent::RegisterSubscriberListener {
+                key: instance_id,
+                client_id,
+                summary: None, // No summary for GET/PUT-based subscriptions
+                subscriber_listener: subscription_listener,
+            },
+            crate::contract::Priority::ClientLocal,
+        )
         .await
         .inspect_err(|err| {
             tracing::error!(
@@ -1049,10 +1052,13 @@ async fn process_open_request(
                             Err(err) if !subscribe => {
                                 // Not joined yet — check if we can serve from local cache
                                 let local_result = op_manager
-                                    .notify_contract_handler(ContractHandlerEvent::GetQuery {
-                                        instance_id: key,
-                                        return_contract_code,
-                                    })
+                                    .notify_contract_handler_prioritized(
+                                        ContractHandlerEvent::GetQuery {
+                                            instance_id: key,
+                                            return_contract_code,
+                                        },
+                                        crate::contract::Priority::ClientLocal,
+                                    )
                                     .await;
                                 if let Ok(ContractHandlerEvent::GetResponse {
                                     key: Some(full_key),
@@ -1091,10 +1097,13 @@ async fn process_open_request(
                         // if subscribed (cache is fresh), otherwise fetch from network.
                         // See PR #2388 for why always-local-first was problematic.
                         let (full_key, state, contract) = match op_manager
-                            .notify_contract_handler(ContractHandlerEvent::GetQuery {
-                                instance_id: key,
-                                return_contract_code,
-                            })
+                            .notify_contract_handler_prioritized(
+                                ContractHandlerEvent::GetQuery {
+                                    instance_id: key,
+                                    return_contract_code,
+                                },
+                                crate::contract::Priority::ClientLocal,
+                            )
                             .await
                         {
                             Ok(ContractHandlerEvent::GetResponse {
@@ -1338,11 +1347,12 @@ async fn process_open_request(
                         // GET+subscribe=true and PUT+subscribe=true bypass this check
                         // because those operations inherently fetch/provide the WASM.
                         match op_manager
-                            .notify_contract_handler(
+                            .notify_contract_handler_prioritized(
                                 crate::contract::ContractHandlerEvent::GetQuery {
                                     instance_id: key,
                                     return_contract_code: true,
                                 },
+                                crate::contract::Priority::ClientLocal,
                             )
                             .await
                         {
@@ -1408,13 +1418,14 @@ async fn process_open_request(
                         };
 
                         let register_listener = op_manager
-                            .notify_contract_handler(
+                            .notify_contract_handler_prioritized(
                                 ContractHandlerEvent::RegisterSubscriberListener {
                                     key,
                                     client_id,
                                     summary,
                                     subscriber_listener,
                                 },
+                                crate::contract::Priority::ClientLocal,
                             )
                             .await
                             .inspect_err(|err| {
@@ -1663,11 +1674,14 @@ async fn process_open_request(
                 let user_context = request.user_context;
 
                 let res = match op_manager
-                    .notify_contract_handler(ContractHandlerEvent::DelegateRequest {
-                        req,
-                        origin_contract,
-                        user_context,
-                    })
+                    .notify_contract_handler_prioritized(
+                        ContractHandlerEvent::DelegateRequest {
+                            req,
+                            origin_contract,
+                            user_context,
+                        },
+                        crate::contract::Priority::ClientLocal,
+                    )
                     .await
                 {
                     Ok(ContractHandlerEvent::DelegateResponse(res)) => {

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -9,6 +9,7 @@ use freenet_stdlib::prelude::*;
 
 mod executor;
 mod fair_queue;
+pub(crate) use fair_queue::Priority;
 pub(crate) mod governance;
 mod handler;
 pub mod storages;
@@ -1048,7 +1049,7 @@ where
         // single-digit microseconds even at peak load.
         for _ in 0..fair_queue::MAX_DRAIN_BATCH {
             match contract_handler.channel().try_recv_from_sender()? {
-                Some((id, event)) => {
+                Some((id, event, priority)) => {
                     // Process ClientDisconnect inline — it's a lightweight cleanup
                     // operation that should never be delayed or compete with
                     // DelegateRequest events for the default queue's limited capacity.
@@ -1058,10 +1059,14 @@ where
                         contract_handler.channel().drop_waiting_response(id);
                         continue;
                     }
-                    if let Err(rejected) = fair_queue.try_push(id, event) {
-                        track_pending_reclamation_if_evict(&mut contract_handler, &rejected);
-                        send_queue_full_response(contract_handler.channel(), rejected).await;
-                    }
+                    push_with_background_eviction(
+                        &mut contract_handler,
+                        &mut fair_queue,
+                        id,
+                        event,
+                        priority,
+                    )
+                    .await;
                 }
                 None => break,
             }
@@ -1104,11 +1109,15 @@ where
         // or a delegate notification.
         tokio::select! {
             result = contract_handler.channel().recv_from_sender() => {
-                let (id, event) = result?;
-                if let Err(rejected) = fair_queue.try_push(id, event) {
-                    track_pending_reclamation_if_evict(&mut contract_handler, &rejected);
-                    send_queue_full_response(contract_handler.channel(), rejected).await;
-                }
+                let (id, event, priority) = result?;
+                push_with_background_eviction(
+                    &mut contract_handler,
+                    &mut fair_queue,
+                    id,
+                    event,
+                    priority,
+                )
+                .await;
             }
             Some(resume) = resume_rx.recv() => {
                 handle_deferred_resume(&mut contract_handler, &mut deferral_ctx, resume).await?;
@@ -1531,6 +1540,54 @@ where
 ///
 /// This closes disk-leak edge case #1 in PR #4212 review round 7
 /// (other variants are no-ops here — they have their own error paths).
+/// Push an event into the fair queue, shedding queued `Background` work to make
+/// room when a higher-priority (foreground) event would otherwise be rejected
+/// (#4534).
+///
+/// A `ClientLocal`/`NetworkRelay` event that hits the soft admission cap first
+/// triggers [`FairEventQueue::evict_background`]; the evicted background events
+/// get best-effort queue-full responses (they re-emit on their next cycle), and
+/// the foreground event is retried once. If it still cannot be admitted (or it
+/// was itself `Background`), it gets the normal queue-full response.
+async fn push_with_background_eviction<CH>(
+    contract_handler: &mut CH,
+    fair_queue: &mut fair_queue::FairEventQueue,
+    id: handler::EventId,
+    event: ContractHandlerEvent,
+    priority: fair_queue::Priority,
+) where
+    CH: ContractHandler + Send + 'static,
+{
+    let rejected = match fair_queue.try_push(id, event, priority) {
+        Ok(()) => return,
+        Err(rejected) => rejected,
+    };
+
+    // Only foreground work earns an eviction attempt; a rejected Background
+    // event is simply shed (it must not displace other Background work).
+    if priority > fair_queue::Priority::Background && fair_queue.background_queued() > 0 {
+        // Reclaim at most the reserve's worth of slots in one shot — enough to
+        // admit a burst of client work without unbounded eviction churn.
+        let evicted = fair_queue.evict_background(fair_queue::CLIENT_LOCAL_RESERVE);
+        for shed in evicted {
+            track_pending_reclamation_if_evict(contract_handler, &shed);
+            send_queue_full_response(contract_handler.channel(), Box::new(shed)).await;
+        }
+        // Retry the foreground push now that space was freed.
+        match fair_queue.try_push(rejected.id, rejected.event, rejected.priority) {
+            Ok(()) => return,
+            Err(still_rejected) => {
+                track_pending_reclamation_if_evict(contract_handler, &still_rejected);
+                send_queue_full_response(contract_handler.channel(), still_rejected).await;
+                return;
+            }
+        }
+    }
+
+    track_pending_reclamation_if_evict(contract_handler, &rejected);
+    send_queue_full_response(contract_handler.channel(), rejected).await;
+}
+
 fn track_pending_reclamation_if_evict<CH>(
     contract_handler: &mut CH,
     rejected: &fair_queue::RejectedEvent,
@@ -2573,7 +2630,7 @@ mod tests {
         });
 
         // Receive on the handler side (populates waiting_response)
-        let (id, received_event) =
+        let (id, received_event, priority) =
             tokio::time::timeout(Duration::from_millis(200), rcv_halve.recv_from_sender())
                 .await
                 .expect("timeout waiting for event")
@@ -2582,6 +2639,7 @@ mod tests {
         let rejected = Box::new(fair_queue::RejectedEvent {
             id,
             event: received_event,
+            priority,
         });
 
         (rejected, handle)
@@ -2894,7 +2952,7 @@ mod tests {
         // so the two futures make progress cooperatively to completion.
         let send_fut = send_halve.send_to_handler(event);
         let recv_fut = async {
-            let (id, received) = handler
+            let (id, received, _priority) = handler
                 .channel()
                 .recv_from_sender()
                 .await
@@ -2931,7 +2989,7 @@ mod tests {
         };
         let send_fut = send_halve.send_to_handler(event);
         let recv_fut = async {
-            let (id, received) = handler
+            let (id, received, _priority) = handler
                 .channel()
                 .recv_from_sender()
                 .await

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1533,22 +1533,22 @@ where
     })
 }
 
-/// When the fair queue rejects an `EvictContract` event (queue-full),
-/// the hosting-cache entry is already gone — no later sweep would
-/// re-emit on its own. Record the key in the pending-reclamation retry
-/// queue so the periodic sweep retries via `reclaim_evicted_contract`.
-///
-/// This closes disk-leak edge case #1 in PR #4212 review round 7
-/// (other variants are no-ops here — they have their own error paths).
 /// Push an event into the fair queue, shedding queued `Background` work to make
-/// room when a higher-priority (foreground) event would otherwise be rejected
-/// (#4534).
+/// room when a higher-priority (foreground) event is rejected *for lack of
+/// global capacity* (#4534).
 ///
-/// A `ClientLocal`/`NetworkRelay` event that hits the soft admission cap first
-/// triggers [`FairEventQueue::evict_background`]; the evicted background events
-/// get best-effort queue-full responses (they re-emit on their next cycle), and
-/// the foreground event is retried once. If it still cannot be admitted (or it
-/// was itself `Background`), it gets the normal queue-full response.
+/// Eviction is attempted ONLY when ALL of:
+/// - the rejected event is foreground (`> Background`), and
+/// - the rejection reason is [`RejectReason::GlobalCapacity`] — a
+///   [`RejectReason::PerContract`] rejection cannot be helped by evicting
+///   Background (a different tier/contract), so we skip the wasted shed and the
+///   identical-failure retry (review of #4534), and
+/// - there is queued `Background` to shed.
+///
+/// The evicted background events get best-effort queue-full responses (they
+/// re-emit on their next cycle), then the foreground event is retried once. If
+/// it still cannot be admitted (or eviction did not apply), it gets the normal
+/// queue-full response.
 async fn push_with_background_eviction<CH>(
     contract_handler: &mut CH,
     fair_queue: &mut fair_queue::FairEventQueue,
@@ -1563,9 +1563,11 @@ async fn push_with_background_eviction<CH>(
         Err(rejected) => rejected,
     };
 
-    // Only foreground work earns an eviction attempt; a rejected Background
-    // event is simply shed (it must not displace other Background work).
-    if priority > fair_queue::Priority::Background && fair_queue.background_queued() > 0 {
+    let eviction_can_help = priority > fair_queue::Priority::Background
+        && rejected.reason == fair_queue::RejectReason::GlobalCapacity
+        && fair_queue.background_queued() > 0;
+
+    if eviction_can_help {
         // Reclaim at most the reserve's worth of slots in one shot — enough to
         // admit a burst of client work without unbounded eviction churn.
         let evicted = fair_queue.evict_background(fair_queue::CLIENT_LOCAL_RESERVE);
@@ -1588,6 +1590,13 @@ async fn push_with_background_eviction<CH>(
     send_queue_full_response(contract_handler.channel(), rejected).await;
 }
 
+/// When the fair queue rejects an `EvictContract` event (queue-full),
+/// the hosting-cache entry is already gone — no later sweep would
+/// re-emit on its own. Record the key in the pending-reclamation retry
+/// queue so the periodic sweep retries via `reclaim_evicted_contract`.
+///
+/// This closes disk-leak edge case #1 in PR #4212 review round 7
+/// (other variants are no-ops here — they have their own error paths).
 fn track_pending_reclamation_if_evict<CH>(
     contract_handler: &mut CH,
     rejected: &fair_queue::RejectedEvent,
@@ -2640,6 +2649,7 @@ mod tests {
             id,
             event: received_event,
             priority,
+            reason: fair_queue::RejectReason::GlobalCapacity,
         });
 
         (rejected, handle)

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -1,24 +1,34 @@
-//! Per-contract fair queuing for the WASM executor event loop.
+//! Priority-tiered, per-contract fair queuing for the WASM executor event loop.
 //!
-//! Provides round-robin scheduling across contracts to prevent a single contract
-//! from monopolizing the sequential event loop. Events for each contract are
-//! bucketed into per-contract queues, and the scheduler rotates through contracts
-//! in round-robin order, processing one event per contract per turn.
+//! Prevents a single contract from monopolizing the sequential event loop, AND
+//! prevents best-effort background work (placement-migration caching,
+//! interest-sync summaries, renewal) from starving a node's own client requests
+//! (issue #4534).
 //!
 //! # Design
 //!
-//! The fair queue maintains:
-//! - A `HashMap` of per-contract event queues (keyed by `ContractInstanceId`)
-//! - A default queue for events with no contract identity (delegates, disconnects)
-//! - A `VecDeque<QueueKey>` tracking the round-robin order
-//! - A total event count for global backpressure
+//! Two layers of fairness:
 //!
-//! Events are rejected with a `RejectedEvent` if either:
-//! - The per-contract queue has reached `MAX_QUEUED_PER_CONTRACT`
-//! - The total queue across all contracts has reached `MAX_TOTAL_FAIR_QUEUE`
+//! 1. **Across priority classes** ([`Priority`]) — events are bucketed into one
+//!    [`PriorityTier`] per class. [`FairEventQueue::pop`] drains `ClientLocal`
+//!    fully before `NetworkRelay`, which drains before `Background`. Admission
+//!    ([`FairEventQueue::try_push`]) reserves `CLIENT_LOCAL_RESERVE` slots that
+//!    only `ClientLocal` may use, and [`FairEventQueue::evict_background`] sheds
+//!    queued background work to make room for higher-priority events.
+//! 2. **Within a class** — each tier keeps the original per-contract round-robin:
+//!    a `HashMap` of per-contract queues, a default queue for events with no
+//!    contract identity (delegates, disconnects), and a `VecDeque<QueueKey>`
+//!    round-robin order.
+//!
+//! Events are rejected with a [`RejectedEvent`] when:
+//! - the per-contract-per-tier queue has reached `MAX_QUEUED_PER_CONTRACT`,
+//! - a sub-`ClientLocal` push would cross the soft cap
+//!   (`MAX_TOTAL_FAIR_QUEUE - CLIENT_LOCAL_RESERVE`), or
+//! - any push would cross the hard `MAX_TOTAL_FAIR_QUEUE` cap.
 //!
 //! The caller is responsible for sending an appropriate error response for
-//! rejected events (see `send_queue_full_response` in `contract.rs`).
+//! rejected events (see `send_queue_full_response` in `contract.rs`); a shed
+//! `Background` event is a best-effort drop that re-emits on its next cycle.
 
 use std::collections::{HashMap, VecDeque};
 
@@ -37,9 +47,53 @@ pub(super) const MAX_QUEUED_PER_CONTRACT: usize = 100;
 /// before the mediator hits its limit.
 pub(super) const MAX_TOTAL_FAIR_QUEUE: usize = 5_000;
 
+/// Admission capacity reserved for [`Priority::ClientLocal`] events.
+///
+/// Once `total_queued` reaches `MAX_TOTAL_FAIR_QUEUE - CLIENT_LOCAL_RESERVE`,
+/// `NetworkRelay` and `Background` pushes are refused (after a Background-shed
+/// attempt), but `ClientLocal` pushes keep being admitted into the reserve up
+/// to the hard `MAX_TOTAL_FAIR_QUEUE` cap. This guarantees a locally-originated
+/// client request on THIS node is never rejected with "contract queue full"
+/// merely because background placement-migration / summarize churn (issue
+/// #4534) has filled the queue. Sized to comfortably hold an interactive
+/// client's in-flight working set without materially shrinking the shared cap.
+pub(super) const CLIENT_LOCAL_RESERVE: usize = 256;
+
 /// Maximum events to drain from channel per iteration.
 /// Prevents the drain loop from blocking delegate notifications too long.
 pub(super) const MAX_DRAIN_BATCH: usize = 256;
+
+/// Scheduling/admission priority class for a contract-handler event (#4534).
+///
+/// The contract event loop is single-threaded, so a flood of best-effort
+/// background work (placement-migration caching, interest-sync summaries,
+/// renewal) can starve a node's own client requests. Tagging events with a
+/// priority class lets [`FairEventQueue`] (a) drain higher classes first,
+/// (b) reserve admission capacity for client requests, and (c) shed/evict
+/// background work to make room.
+///
+/// Ordered low → high so `>=`/`cmp` reflect precedence
+/// (`ClientLocal > NetworkRelay > Background`).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub(crate) enum Priority {
+    /// Best-effort, node-internal background work (summarize for interest-sync,
+    /// placement-migration caching, renewal, contract eviction). Shed FIRST
+    /// under pressure; never surfaces a client-facing error when dropped.
+    Background,
+    /// Serving a remote peer's relayed operation. Normal precedence.
+    NetworkRelay,
+    /// Originated by a WS/HTTP client connected to THIS node. Highest
+    /// precedence; admitted into the reserved lane so it is never rejected
+    /// because background/relay work filled the queue.
+    ClientLocal,
+}
+
+impl Priority {
+    /// The class that untagged / legacy callers default to. `NetworkRelay` is
+    /// the safe middle: it never starves clients more than today's flat queue
+    /// did, and it is not silently sheddable like `Background`.
+    pub(crate) const DEFAULT: Priority = Priority::NetworkRelay;
+}
 
 /// Key identifying which queue an event belongs to.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -50,10 +104,15 @@ enum QueueKey {
     Default,
 }
 
-/// An event that was rejected because its queue was full.
+/// An event that was rejected (admission refused) or evicted (dropped after
+/// being queued) to protect higher-priority capacity.
 pub(super) struct RejectedEvent {
     pub id: EventId,
     pub event: ContractHandlerEvent,
+    /// Priority class of the rejected/evicted event — lets the caller log the
+    /// shed tier and decide whether a client-facing error is warranted
+    /// (`Background` sheds are silent best-effort drops).
+    pub priority: Priority,
 }
 
 impl std::fmt::Debug for RejectedEvent {
@@ -61,22 +120,106 @@ impl std::fmt::Debug for RejectedEvent {
         f.debug_struct("RejectedEvent")
             .field("id", &self.id.id)
             .field("event", &self.event)
+            .field("priority", &self.priority)
             .finish()
     }
 }
 
-/// Per-contract fair event queue providing round-robin scheduling.
+/// One queued event together with its priority class.
+type QueuedItem = (EventId, ContractHandlerEvent, Priority);
+
+/// A single priority tier: per-contract round-robin scheduling within the tier.
 ///
-/// Prevents a single contract from monopolizing the sequential executor event
-/// loop by bucketing events by contract and rotating through them in order.
-pub(super) struct FairEventQueue {
-    /// Per-contract event queues.
-    contract_queues: HashMap<ContractInstanceId, VecDeque<(EventId, ContractHandlerEvent)>>,
-    /// Queue for events with no contract identity.
-    default_queue: VecDeque<(EventId, ContractHandlerEvent)>,
-    /// Round-robin ordering of queue keys.
+/// Each tier is self-contained — its own per-contract queues, default queue,
+/// round-robin order, and count — so the parent [`FairEventQueue`] can drain
+/// higher tiers to exhaustion before lower ones and evict a whole tier without
+/// disturbing the others.
+#[derive(Default)]
+struct PriorityTier {
+    contract_queues: HashMap<ContractInstanceId, VecDeque<QueuedItem>>,
+    default_queue: VecDeque<QueuedItem>,
     round_robin: VecDeque<QueueKey>,
-    /// Total number of queued events across all queues.
+    queued: usize,
+}
+
+impl PriorityTier {
+    /// Per-contract (or default) length for the routing key of `event`.
+    fn len_for(&self, event: &ContractHandlerEvent) -> usize {
+        match extract_contract_id(event) {
+            Some(cid) => self.contract_queues.get(&cid).map_or(0, VecDeque::len),
+            None => self.default_queue.len(),
+        }
+    }
+
+    /// Enqueue, registering the routing key in the round-robin when its queue
+    /// transitions from empty. Caller has already enforced capacity.
+    fn push(&mut self, item: QueuedItem) {
+        match extract_contract_id(&item.1) {
+            Some(cid) => {
+                let queue = self.contract_queues.entry(cid).or_default();
+                if queue.is_empty() {
+                    self.round_robin.push_back(QueueKey::Contract(cid));
+                }
+                queue.push_back(item);
+            }
+            None => {
+                if self.default_queue.is_empty() {
+                    self.round_robin.push_back(QueueKey::Default);
+                }
+                self.default_queue.push_back(item);
+            }
+        }
+        self.queued += 1;
+    }
+
+    /// Pop one event in round-robin order across this tier's contracts.
+    fn pop(&mut self) -> Option<QueuedItem> {
+        loop {
+            let key = self.round_robin.pop_front()?;
+            match key {
+                QueueKey::Contract(cid) => {
+                    if let Some(queue) = self.contract_queues.get_mut(&cid) {
+                        if let Some(item) = queue.pop_front() {
+                            self.queued = self.queued.saturating_sub(1);
+                            if queue.is_empty() {
+                                self.contract_queues.remove(&cid);
+                            } else {
+                                self.round_robin.push_back(key);
+                            }
+                            return Some(item);
+                        }
+                        self.contract_queues.remove(&cid);
+                    }
+                }
+                QueueKey::Default => {
+                    if let Some(item) = self.default_queue.pop_front() {
+                        self.queued = self.queued.saturating_sub(1);
+                        if !self.default_queue.is_empty() {
+                            self.round_robin.push_back(QueueKey::Default);
+                        }
+                        return Some(item);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Per-contract fair event queue with priority tiering (#4534).
+///
+/// Two layers of fairness:
+/// 1. **Across priority classes** — [`Priority::ClientLocal`] drains before
+///    `NetworkRelay`, which drains before `Background`. A locally-originated
+///    client request is never head-of-line-blocked by background migration /
+///    summarize churn, and gets a reserved admission lane plus the ability to
+///    evict queued `Background` work to make room.
+/// 2. **Within a class** — the original per-contract round-robin, so no single
+///    contract monopolizes the sequential executor loop.
+pub(super) struct FairEventQueue {
+    /// One tier per `Priority`, indexed by `priority as usize`
+    /// (`Background`=0, `NetworkRelay`=1, `ClientLocal`=2).
+    tiers: [PriorityTier; 3],
+    /// Total events across all tiers (global backpressure bound).
     total_queued: usize,
 }
 
@@ -84,66 +227,98 @@ impl FairEventQueue {
     /// Create a new, empty fair event queue.
     pub(super) fn new() -> Self {
         Self {
-            contract_queues: HashMap::new(),
-            default_queue: VecDeque::new(),
-            round_robin: VecDeque::new(),
+            tiers: Default::default(),
             total_queued: 0,
         }
     }
 
-    /// Attempt to enqueue an event.
+    fn tier(&mut self, priority: Priority) -> &mut PriorityTier {
+        &mut self.tiers[priority as usize]
+    }
+
+    /// Attempt to enqueue an event at the given priority.
     ///
-    /// Extracts the contract identity from the event and places it in the
-    /// appropriate per-contract queue. If the event has no contract identity
-    /// (delegates, disconnects, etc.), it is placed in the default queue.
+    /// Admission rules (issue #4534):
+    /// - The per-contract-per-tier cap `MAX_QUEUED_PER_CONTRACT` always applies.
+    /// - `ClientLocal` is admitted up to the hard `MAX_TOTAL_FAIR_QUEUE` cap —
+    ///   it may use the `CLIENT_LOCAL_RESERVE` headroom that lower classes
+    ///   cannot, so a client request is never refused because background/relay
+    ///   work filled the queue.
+    /// - `NetworkRelay` / `Background` are refused once
+    ///   `total_queued >= MAX_TOTAL_FAIR_QUEUE - CLIENT_LOCAL_RESERVE`. Before
+    ///   refusing, the caller-facing [`try_push`] first tries to evict queued
+    ///   `Background` to make room (see [`evict_background`]).
     ///
-    /// Returns `Err(Box<RejectedEvent>)` if:
-    /// - The per-contract queue has reached `MAX_QUEUED_PER_CONTRACT`, or
-    /// - The total queue has reached `MAX_TOTAL_FAIR_QUEUE`.
+    /// Returns `Err(Box<RejectedEvent>)` (tagged with `priority`) when the event
+    /// cannot be admitted.
     pub(super) fn try_push(
         &mut self,
         id: EventId,
         event: ContractHandlerEvent,
+        priority: Priority,
     ) -> Result<(), Box<RejectedEvent>> {
-        // Check global limit first (avoids per-contract map lookup)
+        // Hard global cap — never exceeded by any class.
         if self.total_queued >= MAX_TOTAL_FAIR_QUEUE {
-            return Err(Box::new(RejectedEvent { id, event }));
+            return Err(Box::new(RejectedEvent {
+                id,
+                event,
+                priority,
+            }));
         }
 
-        match extract_contract_id(&event) {
-            Some(contract_id) => {
-                let queue = self.contract_queues.entry(contract_id).or_default();
-
-                // Check per-contract limit
-                if queue.len() >= MAX_QUEUED_PER_CONTRACT {
-                    return Err(Box::new(RejectedEvent { id, event }));
-                }
-
-                // If this is a new contract, add it to the round-robin
-                if queue.is_empty() {
-                    self.round_robin.push_back(QueueKey::Contract(contract_id));
-                }
-
-                queue.push_back((id, event));
-                self.total_queued += 1;
-            }
-            None => {
-                // Default queue also respects the per-slot limit
-                if self.default_queue.len() >= MAX_QUEUED_PER_CONTRACT {
-                    return Err(Box::new(RejectedEvent { id, event }));
-                }
-
-                // Add the default key to round-robin only if queue is currently empty
-                if self.default_queue.is_empty() {
-                    self.round_robin.push_back(QueueKey::Default);
-                }
-
-                self.default_queue.push_back((id, event));
-                self.total_queued += 1;
-            }
+        // Soft cap: classes below ClientLocal must leave the reserve free. If a
+        // foreground push (ClientLocal/NetworkRelay) would cross the soft cap,
+        // first try to reclaim space by shedding already-queued Background.
+        let soft_cap = MAX_TOTAL_FAIR_QUEUE - CLIENT_LOCAL_RESERVE;
+        if priority < Priority::ClientLocal && self.total_queued >= soft_cap {
+            return Err(Box::new(RejectedEvent {
+                id,
+                event,
+                priority,
+            }));
         }
 
+        // Per-contract-per-tier cap (DoS protection, preserved from the
+        // original flat queue but now scoped to the tier).
+        if self.tier(priority).len_for(&event) >= MAX_QUEUED_PER_CONTRACT {
+            return Err(Box::new(RejectedEvent {
+                id,
+                event,
+                priority,
+            }));
+        }
+
+        self.tier(priority).push((id, event, priority));
+        self.total_queued += 1;
         Ok(())
+    }
+
+    /// Evict up to `max` oldest `Background` events to free admission capacity
+    /// for higher-priority work (#4534). Returns the evicted events so the
+    /// caller can fire best-effort "queue full" responses for them — a shed
+    /// `Background` task (summarize / migration caching / renewal) is
+    /// re-emitted on its next cycle, so dropping it is non-fatal.
+    pub(super) fn evict_background(&mut self, max: usize) -> Vec<RejectedEvent> {
+        let mut evicted = Vec::new();
+        for _ in 0..max {
+            match self.tiers[Priority::Background as usize].pop() {
+                Some((id, event, priority)) => {
+                    self.total_queued = self.total_queued.saturating_sub(1);
+                    evicted.push(RejectedEvent {
+                        id,
+                        event,
+                        priority,
+                    });
+                }
+                None => break,
+            }
+        }
+        evicted
+    }
+
+    /// Number of queued `Background`-tier events (for shed/admission decisions).
+    pub(super) fn background_queued(&self) -> usize {
+        self.tiers[Priority::Background as usize].queued
     }
 
     /// Pop one event in round-robin order.
@@ -152,46 +327,24 @@ impl FairEventQueue {
     /// If the queue still has items, the key is moved to the back (round-robin).
     /// If the queue is now empty, the key is removed.
     ///
-    /// Returns `None` if all queues are empty.
+    /// Pop the next event, highest priority class first, round-robin within the
+    /// class (#4534). `ClientLocal` drains fully before `NetworkRelay`, which
+    /// drains fully before `Background` — so newly-arrived background work never
+    /// head-of-line-blocks a pending client request (this is the "don't START
+    /// new background ahead of a client" guarantee; an already-running WASM
+    /// compile still finishes, see issue #4534).
+    ///
+    /// Returns `None` if all tiers are empty.
     pub(super) fn pop(&mut self) -> Option<(EventId, ContractHandlerEvent)> {
-        loop {
-            let key = self.round_robin.pop_front()?;
-
-            match key {
-                QueueKey::Contract(contract_id) => {
-                    if let Some(queue) = self.contract_queues.get_mut(&contract_id) {
-                        if let Some(item) = queue.pop_front() {
-                            debug_assert!(self.total_queued > 0);
-                            self.total_queued = self.total_queued.saturating_sub(1);
-
-                            if queue.is_empty() {
-                                self.contract_queues.remove(&contract_id);
-                            } else {
-                                self.round_robin.push_back(key);
-                            }
-
-                            return Some(item);
-                        }
-                        // Queue existed but was empty — invariant violated, clean up
-                        self.contract_queues.remove(&contract_id);
-                    }
-                    // Contract not in map or empty — skip, try next key in round_robin
-                }
-                QueueKey::Default => {
-                    if let Some(item) = self.default_queue.pop_front() {
-                        debug_assert!(self.total_queued > 0);
-                        self.total_queued = self.total_queued.saturating_sub(1);
-
-                        if !self.default_queue.is_empty() {
-                            self.round_robin.push_back(QueueKey::Default);
-                        }
-
-                        return Some(item);
-                    }
-                    // Default queue was somehow empty — skip and try next
-                }
+        // Highest index = highest priority (ClientLocal=2 → NetworkRelay=1 → Background=0).
+        for tier in self.tiers.iter_mut().rev() {
+            if let Some((id, event, _priority)) = tier.pop() {
+                debug_assert!(self.total_queued > 0);
+                self.total_queued = self.total_queued.saturating_sub(1);
+                return Some((id, event));
             }
         }
+        None
     }
 
     /// Returns `true` if all queues are empty.
@@ -253,8 +406,13 @@ mod tests {
     use crate::contract::handler::EventId;
 
     fn make_contract_id(seed: u8) -> ContractInstanceId {
-        let code = ContractCode::from(vec![seed; 32]);
-        let params = Parameters::from(vec![seed; 8]);
+        make_contract_id_u32(seed as u32)
+    }
+
+    fn make_contract_id_u32(seed: u32) -> ContractInstanceId {
+        let bytes = seed.to_le_bytes();
+        let code = ContractCode::from(bytes.repeat(8)); // 32 bytes
+        let params = Parameters::from(bytes.repeat(2)); // 8 bytes
         let key = ContractKey::from_params_and_code(&params, &code);
         *key.id()
     }
@@ -270,9 +428,33 @@ mod tests {
         }
     }
 
+    /// Extract the routed contract id from a `GetQuery` test event.
+    fn get_cid(event: ContractHandlerEvent) -> ContractInstanceId {
+        let ContractHandlerEvent::GetQuery { instance_id, .. } = event else {
+            panic!("expected GetQuery event");
+        };
+        instance_id
+    }
+
     fn make_delegate_event() -> ContractHandlerEvent {
         ContractHandlerEvent::ClientDisconnect {
             client_id: crate::client_events::ClientId::next(),
+        }
+    }
+
+    impl FairEventQueue {
+        /// Test shim: push at the default (`NetworkRelay`) priority.
+        fn try_push_default(
+            &mut self,
+            id: EventId,
+            event: ContractHandlerEvent,
+        ) -> Result<(), Box<RejectedEvent>> {
+            self.try_push(id, event, Priority::DEFAULT)
+        }
+
+        /// Test helper: total events queued in the given tier.
+        fn tier_queued(&self, priority: Priority) -> usize {
+            self.tiers[priority as usize].queued
         }
     }
 
@@ -285,12 +467,12 @@ mod tests {
         // Push 10 events for A, then 10 for B
         for i in 0..10u64 {
             queue
-                .try_push(make_event_id(i), make_get_event(a))
+                .try_push_default(make_event_id(i), make_get_event(a))
                 .expect("push should succeed");
         }
         for i in 10..20u64 {
             queue
-                .try_push(make_event_id(i), make_get_event(b))
+                .try_push_default(make_event_id(i), make_get_event(b))
                 .expect("push should succeed");
         }
 
@@ -323,12 +505,12 @@ mod tests {
         // Fill to the limit
         for i in 0..MAX_QUEUED_PER_CONTRACT as u64 {
             queue
-                .try_push(make_event_id(i), make_get_event(contract_id))
+                .try_push_default(make_event_id(i), make_get_event(contract_id))
                 .expect("should succeed within limit");
         }
 
         // One more should be rejected
-        let result = queue.try_push(
+        let result = queue.try_push_default(
             make_event_id(MAX_QUEUED_PER_CONTRACT as u64),
             make_get_event(contract_id),
         );
@@ -338,37 +520,67 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_global_limit() {
-        let mut queue = FairEventQueue::new();
-
-        // Push events across many contracts until global limit
-        let mut pushed = 0usize;
-        let mut contract_seed = 0u8;
+    /// Fill the queue with `priority` events across many contracts up to `target`
+    /// total. Each contract holds at most `MAX_QUEUED_PER_CONTRACT`. Returns the
+    /// next unused event id.
+    fn fill_to(queue: &mut FairEventQueue, priority: Priority, target: usize) -> u64 {
+        let mut pushed = queue.total_queued();
+        let mut contract_seed = 0u32;
         let mut event_id = 0u64;
-
-        while pushed < MAX_TOTAL_FAIR_QUEUE {
-            let remaining = MAX_TOTAL_FAIR_QUEUE - pushed;
-            let batch = remaining.min(MAX_QUEUED_PER_CONTRACT);
-            let contract_id = make_contract_id(contract_seed);
-
+        while pushed < target {
+            let batch = (target - pushed).min(MAX_QUEUED_PER_CONTRACT);
+            // Vary the contract id by seed so we never hit the per-contract cap.
+            let contract_id = make_contract_id_u32(contract_seed);
             for _ in 0..batch {
                 queue
-                    .try_push(make_event_id(event_id), make_get_event(contract_id))
-                    .expect("should succeed within limits");
+                    .try_push(
+                        make_event_id(event_id),
+                        make_get_event(contract_id),
+                        priority,
+                    )
+                    .expect("should succeed below the relevant cap");
                 event_id += 1;
                 pushed += 1;
             }
-
             contract_seed = contract_seed.wrapping_add(1);
         }
+        event_id
+    }
 
+    #[test]
+    fn test_foreground_soft_cap_then_client_reserve_then_hard_cap() {
+        let mut queue = FairEventQueue::new();
+        let soft_cap = MAX_TOTAL_FAIR_QUEUE - CLIENT_LOCAL_RESERVE;
+
+        // Foreground (NetworkRelay) fills to the soft cap, then is refused —
+        // the CLIENT_LOCAL_RESERVE headroom stays free for client work.
+        let mut event_id = fill_to(&mut queue, Priority::NetworkRelay, soft_cap);
+        assert_eq!(queue.total_queued(), soft_cap);
+        let relay_over = queue.try_push(
+            make_event_id(event_id),
+            make_get_event(make_contract_id_u32(9_999)),
+            Priority::NetworkRelay,
+        );
+        assert!(
+            relay_over.is_err(),
+            "NetworkRelay must be refused once the soft cap (reserve) is reached"
+        );
+        event_id += 1;
+
+        // ClientLocal keeps being admitted into the reserve, up to the hard cap.
+        event_id = fill_to(&mut queue, Priority::ClientLocal, MAX_TOTAL_FAIR_QUEUE).max(event_id);
         assert_eq!(queue.total_queued(), MAX_TOTAL_FAIR_QUEUE);
 
-        // Next push should be rejected
-        let contract_id = make_contract_id(contract_seed.wrapping_add(1));
-        let result = queue.try_push(make_event_id(event_id), make_get_event(contract_id));
-        assert!(result.is_err(), "should reject when global limit exceeded");
+        // Even ClientLocal is refused at the hard cap.
+        let client_over = queue.try_push(
+            make_event_id(event_id),
+            make_get_event(make_contract_id_u32(8_888)),
+            Priority::ClientLocal,
+        );
+        assert!(
+            client_over.is_err(),
+            "ClientLocal must still be refused at the hard MAX_TOTAL_FAIR_QUEUE cap"
+        );
     }
 
     #[test]
@@ -378,10 +590,10 @@ mod tests {
 
         // Push one delegate (default) event and one contract event
         queue
-            .try_push(make_event_id(0), make_delegate_event())
+            .try_push_default(make_event_id(0), make_delegate_event())
             .expect("push should succeed");
         queue
-            .try_push(make_event_id(1), make_get_event(contract_id))
+            .try_push_default(make_event_id(1), make_get_event(contract_id))
             .expect("push should succeed");
 
         assert_eq!(queue.total_queued(), 2);
@@ -402,23 +614,26 @@ mod tests {
         let contract_id = make_contract_id(1);
 
         queue
-            .try_push(make_event_id(0), make_get_event(contract_id))
+            .try_push_default(make_event_id(0), make_get_event(contract_id))
             .expect("push should succeed");
         queue
-            .try_push(make_event_id(1), make_get_event(contract_id))
+            .try_push_default(make_event_id(1), make_get_event(contract_id))
             .expect("push should succeed");
 
         // Pop both events
         queue.pop().expect("first pop should succeed");
         queue.pop().expect("second pop should succeed");
 
-        // Queue should be empty
+        // Queue should be empty, and every tier's internal maps fully drained.
         assert!(queue.is_empty());
-        assert!(
-            queue.contract_queues.is_empty(),
-            "contract queue map should be empty"
-        );
-        assert!(queue.round_robin.is_empty(), "round_robin should be empty");
+        for tier in &queue.tiers {
+            assert!(
+                tier.contract_queues.is_empty(),
+                "contract queue map should be empty"
+            );
+            assert!(tier.round_robin.is_empty(), "round_robin should be empty");
+            assert_eq!(tier.queued, 0, "tier count should be zero");
+        }
     }
 
     #[test]
@@ -429,7 +644,7 @@ mod tests {
         // Push events with distinct IDs to track ordering
         for i in 0..5u64 {
             queue
-                .try_push(make_event_id(i), make_get_event(contract_id))
+                .try_push_default(make_event_id(i), make_get_event(contract_id))
                 .expect("push should succeed");
         }
 
@@ -445,7 +660,9 @@ mod tests {
     #[test]
     fn test_stress_many_contracts() {
         let mut queue = FairEventQueue::new();
-        let num_contracts = 50usize; // Stay within limits: 50 * 100 = 5000
+        // Stay within the NetworkRelay soft cap (MAX_TOTAL - reserve = 4744):
+        // 47 * 100 = 4700 fits; the reserve stays free for ClientLocal.
+        let num_contracts = 47usize;
         let events_per_contract = MAX_QUEUED_PER_CONTRACT;
 
         // Push exactly events_per_contract events for each of num_contracts contracts
@@ -454,7 +671,7 @@ mod tests {
             let contract_id = make_contract_id(seed);
             for _ in 0..events_per_contract {
                 queue
-                    .try_push(make_event_id(event_id), make_get_event(contract_id))
+                    .try_push_default(make_event_id(event_id), make_get_event(contract_id))
                     .expect("push should succeed");
                 event_id += 1;
             }
@@ -489,7 +706,7 @@ mod tests {
         // Push MAX_QUEUED_PER_CONTRACT events for hot contract
         for i in 0..MAX_QUEUED_PER_CONTRACT as u64 {
             queue
-                .try_push(make_event_id(i), make_get_event(hot_contract))
+                .try_push_default(make_event_id(i), make_get_event(hot_contract))
                 .expect("push should succeed");
         }
 
@@ -498,7 +715,7 @@ mod tests {
         for seed in 1..=num_cold as u8 {
             let contract_id = make_contract_id(seed);
             queue
-                .try_push(make_event_id(event_id), make_get_event(contract_id))
+                .try_push_default(make_event_id(event_id), make_get_event(contract_id))
                 .expect("push should succeed");
             event_id += 1;
         }
@@ -554,7 +771,7 @@ mod tests {
 
         let contract_id = make_contract_id(1);
         queue
-            .try_push(make_event_id(0), make_get_event(contract_id))
+            .try_push_default(make_event_id(0), make_get_event(contract_id))
             .expect("push should succeed");
         assert!(!queue.is_empty());
 
@@ -579,11 +796,16 @@ mod tests {
         };
 
         queue
-            .try_push(make_event_id(0), event)
+            .try_push_default(make_event_id(0), event)
             .expect("push should succeed");
 
         assert_eq!(queue.total_queued(), 1);
-        assert!(queue.contract_queues.contains_key(&contract_id));
+        // Default tier (NetworkRelay) holds it under the routed contract key.
+        assert!(
+            queue.tiers[Priority::DEFAULT as usize]
+                .contract_queues
+                .contains_key(&contract_id)
+        );
     }
 
     #[test]
@@ -593,12 +815,12 @@ mod tests {
         // Fill default queue to per-slot limit with ClientDisconnect events
         for i in 0..MAX_QUEUED_PER_CONTRACT as u64 {
             queue
-                .try_push(make_event_id(i), make_delegate_event())
+                .try_push_default(make_event_id(i), make_delegate_event())
                 .expect("should succeed within limit");
         }
 
         // One more should be rejected
-        let result = queue.try_push(
+        let result = queue.try_push_default(
             make_event_id(MAX_QUEUED_PER_CONTRACT as u64),
             make_delegate_event(),
         );
@@ -615,13 +837,19 @@ mod tests {
         let b = make_contract_id(2);
 
         // Push event for A, pop (gets A)
-        queue.try_push(make_event_id(0), make_get_event(a)).unwrap();
+        queue
+            .try_push_default(make_event_id(0), make_get_event(a))
+            .unwrap();
         let (id0, _) = queue.pop().expect("should pop A");
         assert_eq!(id0.id, 0);
 
         // Push events for B and A
-        queue.try_push(make_event_id(1), make_get_event(b)).unwrap();
-        queue.try_push(make_event_id(2), make_get_event(a)).unwrap();
+        queue
+            .try_push_default(make_event_id(1), make_get_event(b))
+            .unwrap();
+        queue
+            .try_push_default(make_event_id(2), make_get_event(a))
+            .unwrap();
 
         // Round-robin should give B first (B was added after A was drained,
         // so B is at front of round_robin)
@@ -650,12 +878,18 @@ mod tests {
 
         // Fill: A(3), B(2), C(1)
         for i in 0..3u64 {
-            queue.try_push(make_event_id(i), make_get_event(a)).unwrap();
+            queue
+                .try_push_default(make_event_id(i), make_get_event(a))
+                .unwrap();
         }
         for i in 3..5u64 {
-            queue.try_push(make_event_id(i), make_get_event(b)).unwrap();
+            queue
+                .try_push_default(make_event_id(i), make_get_event(b))
+                .unwrap();
         }
-        queue.try_push(make_event_id(5), make_get_event(c)).unwrap();
+        queue
+            .try_push_default(make_event_id(5), make_get_event(c))
+            .unwrap();
 
         // Pop 3 — should be one from each (A, B, C in round-robin)
         let mut first_round = Vec::new();
@@ -855,5 +1089,183 @@ mod tests {
             let result = extract_contract_id(event);
             assert_eq!(result, None, "{name} should route to default queue");
         }
+    }
+
+    // ── Priority tiering (#4534) ──────────────────────────────────────────
+
+    #[test]
+    fn pop_drains_higher_priority_first() {
+        let mut queue = FairEventQueue::new();
+        let bg = make_contract_id_u32(1);
+        let relay = make_contract_id_u32(2);
+        let client = make_contract_id_u32(3);
+
+        // Interleave the push order so ordering can't come from insertion order.
+        queue
+            .try_push(make_event_id(0), make_get_event(bg), Priority::Background)
+            .unwrap();
+        queue
+            .try_push(
+                make_event_id(1),
+                make_get_event(relay),
+                Priority::NetworkRelay,
+            )
+            .unwrap();
+        queue
+            .try_push(
+                make_event_id(2),
+                make_get_event(client),
+                Priority::ClientLocal,
+            )
+            .unwrap();
+
+        let order: Vec<ContractInstanceId> = std::iter::from_fn(|| queue.pop())
+            .map(|(_, ev)| get_cid(ev))
+            .collect();
+        assert_eq!(
+            order,
+            vec![client, relay, bg],
+            "must drain ClientLocal, then NetworkRelay, then Background"
+        );
+    }
+
+    #[test]
+    fn client_local_admitted_when_queue_full_of_background() {
+        let mut queue = FairEventQueue::new();
+        // Background, like any sub-ClientLocal class, is admission-capped at the
+        // soft cap (it must leave the reserve free). So the most Background the
+        // queue can hold is `soft_cap`.
+        let soft_cap = MAX_TOTAL_FAIR_QUEUE - CLIENT_LOCAL_RESERVE;
+        fill_to(&mut queue, Priority::Background, soft_cap);
+        assert_eq!(queue.total_queued(), soft_cap);
+
+        // ClientLocal is admitted straight into the reserve even with the queue
+        // full of background — no eviction needed below the hard cap. Spread
+        // across several contracts to stay under the per-contract-per-tier cap.
+        for i in 0..CLIENT_LOCAL_RESERVE as u64 {
+            let client = make_contract_id_u32(7000 + (i / MAX_QUEUED_PER_CONTRACT as u64) as u32);
+            queue
+                .try_push(
+                    make_event_id(100_000 + i),
+                    make_get_event(client),
+                    Priority::ClientLocal,
+                )
+                .expect("ClientLocal must use the reserved lane past the soft cap");
+        }
+        assert_eq!(queue.total_queued(), MAX_TOTAL_FAIR_QUEUE);
+
+        // Now the reserve is exhausted: a further ClientLocal needs room, which
+        // eviction of Background provides (the loop's helper does evict→retry).
+        let evicted = queue.evict_background(CLIENT_LOCAL_RESERVE);
+        assert_eq!(evicted.len(), CLIENT_LOCAL_RESERVE);
+        assert!(evicted.iter().all(|e| e.priority == Priority::Background));
+        queue
+            .try_push(
+                make_event_id(999_999),
+                make_get_event(make_contract_id_u32(7777)),
+                Priority::ClientLocal,
+            )
+            .expect("ClientLocal admitted after Background eviction frees space");
+    }
+
+    #[test]
+    fn evict_background_only_touches_background_tier() {
+        let mut queue = FairEventQueue::new();
+        let relay = make_contract_id_u32(2);
+        let client = make_contract_id_u32(3);
+        queue
+            .try_push(
+                make_event_id(0),
+                make_get_event(relay),
+                Priority::NetworkRelay,
+            )
+            .unwrap();
+        queue
+            .try_push(
+                make_event_id(1),
+                make_get_event(client),
+                Priority::ClientLocal,
+            )
+            .unwrap();
+        // 5 background events.
+        for i in 0..5u64 {
+            queue
+                .try_push(
+                    make_event_id(10 + i),
+                    make_get_event(make_contract_id_u32(100 + i as u32)),
+                    Priority::Background,
+                )
+                .unwrap();
+        }
+        assert_eq!(queue.background_queued(), 5);
+
+        // Evicting more than present drains only background; foreground untouched.
+        let evicted = queue.evict_background(100);
+        assert_eq!(evicted.len(), 5);
+        assert_eq!(queue.background_queued(), 0);
+        assert_eq!(
+            queue.tier_queued(Priority::NetworkRelay),
+            1,
+            "relay event must survive background eviction"
+        );
+        assert_eq!(
+            queue.tier_queued(Priority::ClientLocal),
+            1,
+            "client event must survive background eviction"
+        );
+        assert_eq!(queue.total_queued(), 2);
+    }
+
+    #[test]
+    fn per_contract_cap_is_per_tier() {
+        // A contract saturated with Background must not block a ClientLocal op
+        // on the SAME contract — the per-contract cap is scoped to the tier.
+        let mut queue = FairEventQueue::new();
+        let key = make_contract_id_u32(42);
+        for i in 0..MAX_QUEUED_PER_CONTRACT as u64 {
+            queue
+                .try_push(make_event_id(i), make_get_event(key), Priority::Background)
+                .expect("background fills its own per-contract slot");
+        }
+        // Same contract, ClientLocal tier — still has its own fresh slot.
+        queue
+            .try_push(
+                make_event_id(9999),
+                make_get_event(key),
+                Priority::ClientLocal,
+            )
+            .expect("ClientLocal on a Background-saturated contract must still be admitted");
+
+        // And ClientLocal drains first despite being pushed last.
+        let (_, ev) = queue.pop().unwrap();
+        assert_eq!(get_cid(ev), key);
+        assert_eq!(queue.tier_queued(Priority::ClientLocal), 0);
+        assert_eq!(
+            queue.tier_queued(Priority::Background),
+            MAX_QUEUED_PER_CONTRACT
+        );
+    }
+
+    #[test]
+    fn within_tier_round_robin_preserved() {
+        // Two contracts in the SAME tier interleave fairly (the original
+        // guarantee, now scoped per tier).
+        let mut queue = FairEventQueue::new();
+        let a = make_contract_id_u32(1);
+        let b = make_contract_id_u32(2);
+        for i in 0..4u64 {
+            queue
+                .try_push(make_event_id(i), make_get_event(a), Priority::NetworkRelay)
+                .unwrap();
+        }
+        for i in 4..8u64 {
+            queue
+                .try_push(make_event_id(i), make_get_event(b), Priority::NetworkRelay)
+                .unwrap();
+        }
+        let order: Vec<ContractInstanceId> = std::iter::from_fn(|| queue.pop())
+            .map(|(_, ev)| get_cid(ev))
+            .collect();
+        assert_eq!(order, vec![a, b, a, b, a, b, a, b]);
     }
 }

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -104,6 +104,24 @@ enum QueueKey {
     Default,
 }
 
+/// Why an event was refused admission. Lets the caller decide whether shedding
+/// `Background` could help: it can only free space for a *global-capacity*
+/// rejection, never a *per-contract* one (#4534 review).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum RejectReason {
+    /// The hard `MAX_TOTAL_FAIR_QUEUE` cap, or the soft
+    /// `MAX_TOTAL_FAIR_QUEUE - CLIENT_LOCAL_RESERVE` cap for a sub-`ClientLocal`
+    /// class. Evicting `Background` can free a slot and let a retry succeed.
+    GlobalCapacity,
+    /// This event's own per-contract-per-tier queue is at
+    /// `MAX_QUEUED_PER_CONTRACT`. Evicting `Background` (a different tier and/or
+    /// contract) cannot help; a retry would fail identically.
+    PerContract,
+    /// An event evicted from the queue (not an admission failure). Carried so a
+    /// shed `Background` event flows through the same response path.
+    Evicted,
+}
+
 /// An event that was rejected (admission refused) or evicted (dropped after
 /// being queued) to protect higher-priority capacity.
 pub(super) struct RejectedEvent {
@@ -113,6 +131,8 @@ pub(super) struct RejectedEvent {
     /// shed tier and decide whether a client-facing error is warranted
     /// (`Background` sheds are silent best-effort drops).
     pub priority: Priority,
+    /// Why this event was rejected (or that it was evicted).
+    pub reason: RejectReason,
 }
 
 impl std::fmt::Debug for RejectedEvent {
@@ -121,6 +141,7 @@ impl std::fmt::Debug for RejectedEvent {
             .field("id", &self.id.id)
             .field("event", &self.event)
             .field("priority", &self.priority)
+            .field("reason", &self.reason)
             .finish()
     }
 }
@@ -221,7 +242,19 @@ pub(super) struct FairEventQueue {
     tiers: [PriorityTier; 3],
     /// Total events across all tiers (global backpressure bound).
     total_queued: usize,
+    /// Consecutive `pop()`s that served `ClientLocal` while a lower tier had
+    /// work waiting. Drives the anti-starvation floor (see `pop`): once this
+    /// reaches `RELAY_STARVATION_FLOOR`, the next `pop` force-serves the highest
+    /// non-empty lower tier so sustained client load cannot indefinitely starve
+    /// remote relay / background execution (#4534 review).
+    client_streak: usize,
 }
+
+/// After this many consecutive `ClientLocal` pops (while lower-tier work is
+/// waiting), `pop()` serves one lower-tier event regardless of pending
+/// `ClientLocal`. Bounds relay/background starvation latency to roughly one in
+/// `RELAY_STARVATION_FLOOR + 1` pops while still strongly favouring client work.
+pub(super) const RELAY_STARVATION_FLOOR: usize = 16;
 
 impl FairEventQueue {
     /// Create a new, empty fair event queue.
@@ -229,6 +262,7 @@ impl FairEventQueue {
         Self {
             tiers: Default::default(),
             total_queued: 0,
+            client_streak: 0,
         }
     }
 
@@ -263,28 +297,33 @@ impl FairEventQueue {
                 id,
                 event,
                 priority,
+                reason: RejectReason::GlobalCapacity,
             }));
         }
 
         // Soft cap: classes below ClientLocal must leave the reserve free. If a
         // foreground push (ClientLocal/NetworkRelay) would cross the soft cap,
-        // first try to reclaim space by shedding already-queued Background.
+        // the caller can first try to reclaim space by shedding already-queued
+        // Background (a GlobalCapacity rejection is eviction-recoverable).
         let soft_cap = MAX_TOTAL_FAIR_QUEUE - CLIENT_LOCAL_RESERVE;
         if priority < Priority::ClientLocal && self.total_queued >= soft_cap {
             return Err(Box::new(RejectedEvent {
                 id,
                 event,
                 priority,
+                reason: RejectReason::GlobalCapacity,
             }));
         }
 
         // Per-contract-per-tier cap (DoS protection, preserved from the
-        // original flat queue but now scoped to the tier).
+        // original flat queue but now scoped to the tier). Evicting Background
+        // cannot help here, so this is flagged PerContract.
         if self.tier(priority).len_for(&event) >= MAX_QUEUED_PER_CONTRACT {
             return Err(Box::new(RejectedEvent {
                 id,
                 event,
                 priority,
+                reason: RejectReason::PerContract,
             }));
         }
 
@@ -308,6 +347,7 @@ impl FairEventQueue {
                         id,
                         event,
                         priority,
+                        reason: RejectReason::Evicted,
                     });
                 }
                 None => break,
@@ -327,20 +367,62 @@ impl FairEventQueue {
     /// If the queue still has items, the key is moved to the back (round-robin).
     /// If the queue is now empty, the key is removed.
     ///
-    /// Pop the next event, highest priority class first, round-robin within the
-    /// class (#4534). `ClientLocal` drains fully before `NetworkRelay`, which
-    /// drains fully before `Background` — so newly-arrived background work never
-    /// head-of-line-blocks a pending client request (this is the "don't START
-    /// new background ahead of a client" guarantee; an already-running WASM
-    /// compile still finishes, see issue #4534).
+    /// Pop the next event, strongly favouring higher priority classes but with a
+    /// bounded anti-starvation floor (#4534 + review).
+    ///
+    /// Normally serves the highest non-empty tier (`ClientLocal` → `NetworkRelay`
+    /// → `Background`), round-robin within the tier — so newly-arrived background
+    /// work never head-of-line-blocks a pending client request ("don't START new
+    /// background ahead of a client"; an already-running WASM compile still
+    /// finishes).
+    ///
+    /// To avoid the strict-priority failure mode where sustained `ClientLocal`
+    /// load indefinitely starves remote relay/background execution, after
+    /// `RELAY_STARVATION_FLOOR` consecutive `ClientLocal` pops *with lower-tier
+    /// work waiting*, one lower-tier event is served instead. This bounds
+    /// relay/background latency while keeping the overwhelming majority of slots
+    /// for client work.
     ///
     /// Returns `None` if all tiers are empty.
     pub(super) fn pop(&mut self) -> Option<(EventId, ContractHandlerEvent)> {
-        // Highest index = highest priority (ClientLocal=2 → NetworkRelay=1 → Background=0).
-        for tier in self.tiers.iter_mut().rev() {
-            if let Some((id, event, _priority)) = tier.pop() {
+        let client_nonempty = self.tiers[Priority::ClientLocal as usize].queued > 0;
+        let lower_nonempty = self.tiers[Priority::NetworkRelay as usize].queued > 0
+            || self.tiers[Priority::Background as usize].queued > 0;
+
+        // Anti-starvation: if ClientLocal has monopolized the last
+        // RELAY_STARVATION_FLOOR pops and a lower tier is waiting, serve the
+        // highest non-empty lower tier this round and reset the streak.
+        let force_lower =
+            client_nonempty && lower_nonempty && self.client_streak >= RELAY_STARVATION_FLOOR;
+
+        let order: [Priority; 3] = if force_lower {
+            // Skip ClientLocal this round; drain NetworkRelay then Background.
+            [
+                Priority::NetworkRelay,
+                Priority::Background,
+                // ClientLocal last as a safety net (only reached if both lower
+                // tiers raced to empty between the check and the pop).
+                Priority::ClientLocal,
+            ]
+        } else {
+            [
+                Priority::ClientLocal,
+                Priority::NetworkRelay,
+                Priority::Background,
+            ]
+        };
+
+        for priority in order {
+            if let Some((id, event, _)) = self.tiers[priority as usize].pop() {
                 debug_assert!(self.total_queued > 0);
                 self.total_queued = self.total_queued.saturating_sub(1);
+                // Track the ClientLocal streak only while lower work waits — an
+                // uncontested client burst should not trip the floor.
+                if priority == Priority::ClientLocal && lower_nonempty {
+                    self.client_streak += 1;
+                } else {
+                    self.client_streak = 0;
+                }
                 return Some((id, event));
             }
         }
@@ -525,8 +607,10 @@ mod tests {
     /// next unused event id.
     fn fill_to(queue: &mut FairEventQueue, priority: Priority, target: usize) -> u64 {
         let mut pushed = queue.total_queued();
-        let mut contract_seed = 0u32;
-        let mut event_id = 0u64;
+        // Start high so fill_to's synthetic contracts never collide with the
+        // small hand-picked seeds individual tests use.
+        let mut contract_seed = 1_000_000u32;
+        let mut event_id = 1_000_000u64;
         while pushed < target {
             let batch = (target - pushed).min(MAX_QUEUED_PER_CONTRACT);
             // Vary the contract id by seed so we never hit the per-contract cap.
@@ -1267,5 +1351,126 @@ mod tests {
             .map(|(_, ev)| get_cid(ev))
             .collect();
         assert_eq!(order, vec![a, b, a, b, a, b, a, b]);
+    }
+
+    #[test]
+    fn relay_not_starved_by_sustained_client_load() {
+        // With a permanent backlog of both ClientLocal and NetworkRelay work,
+        // the anti-starvation floor must serve a NetworkRelay event at least
+        // once every (RELAY_STARVATION_FLOOR + 1) pops (#4534 review).
+        let mut queue = FairEventQueue::new();
+        let client = make_contract_id_u32(1);
+        let relay = make_contract_id_u32(2);
+
+        // Saturate both tiers (spread across contracts to dodge per-contract cap).
+        for i in 0..1000u64 {
+            queue
+                .try_push(
+                    make_event_id(i),
+                    make_get_event(make_contract_id_u32(1000 + (i / 50) as u32)),
+                    Priority::ClientLocal,
+                )
+                .unwrap();
+        }
+        for i in 0..1000u64 {
+            queue
+                .try_push(
+                    make_event_id(10_000 + i),
+                    make_get_event(make_contract_id_u32(2000 + (i / 50) as u32)),
+                    Priority::NetworkRelay,
+                )
+                .unwrap();
+        }
+        let _ = (client, relay);
+
+        // Pop a long run and assert NetworkRelay is served on a bounded cadence:
+        // no window of (FLOOR + 1) consecutive pops is all-ClientLocal.
+        let mut gap = 0usize; // pops since last NetworkRelay
+        let mut max_gap = 0usize;
+        let mut relay_served = 0usize;
+        for _ in 0..400 {
+            let (_, ev) = queue.pop().unwrap();
+            let cid = get_cid(ev);
+            // relay contracts are the 2000.. series
+            let is_relay = (2000..3000).any(|s| make_contract_id_u32(s) == cid);
+            if is_relay {
+                relay_served += 1;
+                max_gap = max_gap.max(gap);
+                gap = 0;
+            } else {
+                gap += 1;
+            }
+        }
+        max_gap = max_gap.max(gap);
+        assert!(relay_served > 0, "NetworkRelay must not be fully starved");
+        assert!(
+            max_gap <= RELAY_STARVATION_FLOOR,
+            "gap between relay pops ({max_gap}) must not exceed the floor ({RELAY_STARVATION_FLOOR})"
+        );
+        // Client work still dominates: vastly more client than relay served.
+        assert!(
+            relay_served < 400 / 2,
+            "client work should still dominate scheduling"
+        );
+    }
+
+    #[test]
+    fn uncontested_client_burst_does_not_trip_floor() {
+        // With NO lower-tier work waiting, a long ClientLocal burst is served
+        // back-to-back — the floor only applies when lower work is starved.
+        let mut queue = FairEventQueue::new();
+        for i in 0..200u64 {
+            queue
+                .try_push(
+                    make_event_id(i),
+                    make_get_event(make_contract_id_u32(1000 + (i / 50) as u32)),
+                    Priority::ClientLocal,
+                )
+                .unwrap();
+        }
+        // All 200 pops are ClientLocal (no relay/background to divert to).
+        for _ in 0..200 {
+            assert!(queue.pop().is_some());
+        }
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn per_contract_rejection_keeps_reason() {
+        // A per-contract-cap rejection is flagged PerContract (so the loop skips
+        // the futile Background eviction); a global-cap rejection is
+        // GlobalCapacity.
+        let mut queue = FairEventQueue::new();
+        let key = make_contract_id_u32(1);
+        for i in 0..MAX_QUEUED_PER_CONTRACT as u64 {
+            queue
+                .try_push(
+                    make_event_id(i),
+                    make_get_event(key),
+                    Priority::NetworkRelay,
+                )
+                .unwrap();
+        }
+        let rejected = queue
+            .try_push(
+                make_event_id(999),
+                make_get_event(key),
+                Priority::NetworkRelay,
+            )
+            .expect_err("should reject at per-contract cap");
+        assert_eq!(rejected.reason, RejectReason::PerContract);
+
+        // Fill the rest of the queue to the soft cap with other contracts, then
+        // a NetworkRelay push is refused for GlobalCapacity.
+        let soft_cap = MAX_TOTAL_FAIR_QUEUE - CLIENT_LOCAL_RESERVE;
+        fill_to(&mut queue, Priority::NetworkRelay, soft_cap);
+        let rejected = queue
+            .try_push(
+                make_event_id(1000),
+                make_get_event(make_contract_id_u32(55555)),
+                Priority::NetworkRelay,
+            )
+            .expect_err("should reject at soft cap");
+        assert_eq!(rejected.reason, RejectReason::GlobalCapacity);
     }
 }

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -1473,4 +1473,52 @@ mod tests {
             .expect_err("should reject at soft cap");
         assert_eq!(rejected.reason, RejectReason::GlobalCapacity);
     }
+
+    #[test]
+    fn evict_then_retry_can_still_fail_per_contract() {
+        // Models the `still_rejected` arm of `push_with_background_eviction`:
+        // even after Background is evicted (freeing GLOBAL capacity), a
+        // ClientLocal push to a key whose ClientLocal tier is already at the
+        // per-contract cap still fails — and is flagged PerContract, NOT
+        // GlobalCapacity, so the loop does not loop on a futile re-evict.
+        let mut queue = FairEventQueue::new();
+        let hot = make_contract_id_u32(1);
+
+        // Saturate the hot key's ClientLocal per-contract queue.
+        for i in 0..MAX_QUEUED_PER_CONTRACT as u64 {
+            queue
+                .try_push(make_event_id(i), make_get_event(hot), Priority::ClientLocal)
+                .unwrap();
+        }
+        // Add some evictable Background on other contracts.
+        for i in 0..10u64 {
+            queue
+                .try_push(
+                    make_event_id(1000 + i),
+                    make_get_event(make_contract_id_u32(2000 + i as u32)),
+                    Priority::Background,
+                )
+                .unwrap();
+        }
+
+        // Evicting Background frees global slots...
+        let before = queue.total_queued();
+        let evicted = queue.evict_background(CLIENT_LOCAL_RESERVE);
+        assert_eq!(evicted.len(), 10);
+        assert_eq!(queue.total_queued(), before - 10);
+
+        // ...but a retry on the hot key still fails on the per-contract cap.
+        let rejected = queue
+            .try_push(
+                make_event_id(9999),
+                make_get_event(hot),
+                Priority::ClientLocal,
+            )
+            .expect_err("hot key is at its ClientLocal per-contract cap");
+        assert_eq!(
+            rejected.reason,
+            RejectReason::PerContract,
+            "post-eviction retry failure must be PerContract, not GlobalCapacity"
+        );
+    }
 }

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -382,11 +382,25 @@ impl ContractHandlerChannel<SenderHalve> {
     const CH_EV_RESPONSE_TIME_OUT: Duration = Duration::from_secs(300);
 
     /// Send an event to the contract handler and receive a response event if successful.
+    ///
+    /// Defaults to [`Priority::DEFAULT`] (`NetworkRelay`). Callers on a
+    /// local-client path should use [`send_to_handler_prioritized`] with
+    /// [`Priority::ClientLocal`] (#4534).
     pub async fn send_to_handler(
         &self,
         ev: ContractHandlerEvent,
     ) -> Result<ContractHandlerEvent, ContractError> {
-        self.send_to_handler_with_timeout(ev, Self::CH_EV_RESPONSE_TIME_OUT)
+        self.send_to_handler_prioritized(ev, super::fair_queue::Priority::DEFAULT)
+            .await
+    }
+
+    /// Send an event at an explicit priority class and await its response.
+    pub async fn send_to_handler_prioritized(
+        &self,
+        ev: ContractHandlerEvent,
+        priority: super::fair_queue::Priority,
+    ) -> Result<ContractHandlerEvent, ContractError> {
+        self.send_to_handler_with_timeout(ev, Self::CH_EV_RESPONSE_TIME_OUT, priority)
             .await
     }
 
@@ -398,6 +412,7 @@ impl ContractHandlerChannel<SenderHalve> {
         &self,
         ev: ContractHandlerEvent,
         timeout: Duration,
+        priority: super::fair_queue::Priority,
     ) -> Result<ContractHandlerEvent, ContractError> {
         let id = EV_ID.with(|c| {
             let v = c.get();
@@ -407,7 +422,12 @@ impl ContractHandlerChannel<SenderHalve> {
         let (result, result_receiver) = tokio::sync::oneshot::channel();
         self.end
             .event_sender
-            .send(InternalCHEvent { ev, id, result })
+            .send(InternalCHEvent {
+                ev,
+                id,
+                priority,
+                result,
+            })
             .map_err(|err| ContractError::ChannelDropped(Box::new(err.0.ev)))?;
         match tokio::time::timeout(timeout, result_receiver).await {
             Ok(Ok((_, res))) => Ok(res),
@@ -418,10 +438,19 @@ impl ContractHandlerChannel<SenderHalve> {
     /// Send an event to the contract handler without waiting for a response.
     ///
     /// Used for fire-and-forget events like `ClientDisconnect` that don't
-    /// produce a response.
+    /// produce a response. Defaults to [`Priority::DEFAULT`].
     pub fn send_to_handler_fire_and_forget(
         &self,
         ev: ContractHandlerEvent,
+    ) -> Result<(), ContractError> {
+        self.send_to_handler_fire_and_forget_prioritized(ev, super::fair_queue::Priority::DEFAULT)
+    }
+
+    /// Fire-and-forget send at an explicit priority class.
+    pub fn send_to_handler_fire_and_forget_prioritized(
+        &self,
+        ev: ContractHandlerEvent,
+        priority: super::fair_queue::Priority,
     ) -> Result<(), ContractError> {
         let id = EV_ID.with(|c| {
             let v = c.get();
@@ -433,7 +462,12 @@ impl ContractHandlerChannel<SenderHalve> {
         let (result, _) = tokio::sync::oneshot::channel();
         self.end
             .event_sender
-            .send(InternalCHEvent { ev, id, result })
+            .send(InternalCHEvent {
+                ev,
+                id,
+                priority,
+                result,
+            })
             .map_err(|err| ContractError::ChannelDropped(Box::new(err.0.ev)))?;
         Ok(())
     }
@@ -618,10 +652,16 @@ impl ContractHandlerChannel<ContractHandlerHalve> {
 
     pub async fn recv_from_sender(
         &mut self,
-    ) -> Result<(EventId, ContractHandlerEvent), ContractError> {
-        if let Some(InternalCHEvent { ev, id, result }) = self.end.event_receiver.recv().await {
+    ) -> Result<(EventId, ContractHandlerEvent, super::fair_queue::Priority), ContractError> {
+        if let Some(InternalCHEvent {
+            ev,
+            id,
+            priority,
+            result,
+        }) = self.end.event_receiver.recv().await
+        {
             self.end.waiting_response.insert(id, result);
-            return Ok((EventId { id }, ev));
+            return Ok((EventId { id }, ev, priority));
         }
         Err(ContractError::NoEvHandlerResponse)
     }
@@ -630,13 +670,20 @@ impl ContractHandlerChannel<ContractHandlerHalve> {
     ///
     /// Returns `Ok(None)` if the channel is empty, `Err` if the channel is closed.
     /// Used by the fair-queue drain loop to batch-fill the fair queue before processing.
+    #[allow(clippy::type_complexity)]
     pub fn try_recv_from_sender(
         &mut self,
-    ) -> Result<Option<(EventId, ContractHandlerEvent)>, ContractError> {
+    ) -> Result<Option<(EventId, ContractHandlerEvent, super::fair_queue::Priority)>, ContractError>
+    {
         match self.end.event_receiver.try_recv() {
-            Ok(InternalCHEvent { ev, id, result }) => {
+            Ok(InternalCHEvent {
+                ev,
+                id,
+                priority,
+                result,
+            }) => {
                 self.end.waiting_response.insert(id, result);
-                Ok(Some((EventId { id }, ev)))
+                Ok(Some((EventId { id }, ev, priority)))
             }
             Err(tokio::sync::mpsc::error::TryRecvError::Empty) => Ok(None),
             Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
@@ -656,6 +703,8 @@ struct InternalCHEvent {
     ev: ContractHandlerEvent,
     id: u64,
     // client_id: Option<ClientId>,
+    /// Scheduling/admission priority class for the fair queue (#4534).
+    priority: super::fair_queue::Priority,
     result: tokio::sync::oneshot::Sender<(EventId, ContractHandlerEvent)>,
 }
 
@@ -982,7 +1031,7 @@ pub mod test {
                 })
                 .await
         });
-        let (id, ev) =
+        let (id, ev, _priority) =
             tokio::time::timeout(Duration::from_millis(100), rcv_halve.recv_from_sender())
                 .await??;
 
@@ -1049,7 +1098,7 @@ pub mod test {
         });
 
         // Receive the event from the handler side
-        let (id, ev) =
+        let (id, ev, _priority) =
             tokio::time::timeout(Duration::from_millis(100), rcv_halve.recv_from_sender())
                 .await??;
 
@@ -1238,7 +1287,7 @@ pub mod test {
         // try_recv should succeed
         let result = rcv_halve.try_recv_from_sender();
         assert!(result.is_ok());
-        let (id, event) = result.unwrap().expect("should have received an event");
+        let (id, event, _priority) = result.unwrap().expect("should have received an event");
         // Verify we got a valid EventId (any u64 is valid)
 
         let ContractHandlerEvent::PutQuery { state, .. } = event else {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2376,8 +2376,10 @@ async fn handle_interest_sync_message(
                 return None;
             };
 
-            // Fetch our summary
-            let summary = get_contract_summary(op_manager, &key).await;
+            // Fetch our summary (serving a peer's ResyncRequest — relay-tier).
+            let summary =
+                get_contract_summary(op_manager, &key, crate::contract::Priority::NetworkRelay)
+                    .await;
             let Some(summary) = summary else {
                 tracing::warn!(
                     contract = %key,
@@ -2555,14 +2557,23 @@ async fn get_contract_state_by_id(
 }
 
 /// Get the contract state summary using the contract's summarize_state method.
+///
+/// `priority` lets the periodic interest-sync path issue the summarize at
+/// [`Priority::Background`](crate::contract::Priority::Background) so the
+/// post-#4473 residual summarize load never starves client work (#4534), while
+/// relay/resync callers keep the default `NetworkRelay` precedence.
 async fn get_contract_summary(
     op_manager: &Arc<OpManager>,
     key: &freenet_stdlib::prelude::ContractKey,
+    priority: crate::contract::Priority,
 ) -> Option<freenet_stdlib::prelude::StateSummary<'static>> {
     use crate::contract::ContractHandlerEvent;
 
     match op_manager
-        .notify_contract_handler(ContractHandlerEvent::GetSummaryQuery { key: *key })
+        .notify_contract_handler_prioritized(
+            ContractHandlerEvent::GetSummaryQuery { key: *key },
+            priority,
+        )
         .await
     {
         Ok(ContractHandlerEvent::GetSummaryResponse {
@@ -2620,7 +2631,9 @@ async fn summary_if_hosted_or_in_use(
     key: &freenet_stdlib::prelude::ContractKey,
 ) -> Option<freenet_stdlib::prelude::StateSummary<'static>> {
     if op_manager.ring.is_hosting_contract(key) || op_manager.ring.contract_in_use(key) {
-        get_contract_summary(op_manager, key).await
+        // Periodic interest-sync summarize: best-effort background work, so it
+        // yields the contract loop to client/relay traffic (#4534 / #4473).
+        get_contract_summary(op_manager, key, crate::contract::Priority::Background).await
     } else {
         None
     }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -846,11 +846,28 @@ impl OpManager {
     }
 
     /// Send an event to the contract handler and await a response event from it if successful.
+    ///
+    /// Defaults to [`Priority::DEFAULT`] (`NetworkRelay`). Local-client callers
+    /// should use [`notify_contract_handler_prioritized`] with
+    /// [`Priority::ClientLocal`], and background callers with
+    /// [`Priority::Background`] (#4534).
     pub async fn notify_contract_handler(
         &self,
         msg: ContractHandlerEvent,
     ) -> Result<ContractHandlerEvent, ContractError> {
         self.ch_outbound.send_to_handler(msg).await
+    }
+
+    /// Send an event to the contract handler at an explicit priority class and
+    /// await its response (#4534).
+    pub async fn notify_contract_handler_prioritized(
+        &self,
+        msg: ContractHandlerEvent,
+        priority: crate::contract::Priority,
+    ) -> Result<ContractHandlerEvent, ContractError> {
+        self.ch_outbound
+            .send_to_handler_prioritized(msg, priority)
+            .await
     }
 
     /// Send an event to the contract handler with a custom timeout.
@@ -863,15 +880,22 @@ impl OpManager {
         timeout: std::time::Duration,
     ) -> Result<ContractHandlerEvent, ContractError> {
         self.ch_outbound
-            .send_to_handler_with_timeout(msg, timeout)
+            .send_to_handler_with_timeout(msg, timeout, crate::contract::Priority::DEFAULT)
             .await
     }
 
-    /// Fire-and-forget notification to the contract handler. Used for
-    /// maintenance events (e.g. EvictContract) where no response is needed
-    /// and the caller must not block.
-    pub fn notify_contract_handler_fire_and_forget(&self, ev: ContractHandlerEvent) {
-        if let Err(e) = self.ch_outbound.send_to_handler_fire_and_forget(ev) {
+    /// Fire-and-forget notification to the contract handler at an explicit
+    /// priority class (#4534). Used for maintenance events (e.g. EvictContract)
+    /// where no response is needed and the caller must not block.
+    pub fn notify_contract_handler_fire_and_forget_prioritized(
+        &self,
+        ev: ContractHandlerEvent,
+        priority: crate::contract::Priority,
+    ) {
+        if let Err(e) = self
+            .ch_outbound
+            .send_to_handler_fire_and_forget_prioritized(ev, priority)
+        {
             tracing::warn!(error = %e, "failed to send fire-and-forget event to contract handler");
         }
     }

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -333,11 +333,14 @@ pub(crate) fn reclaim_evicted_contract(
             .pending_reclamation_add(key, expected_generation);
         return;
     }
-    op_manager.notify_contract_handler_fire_and_forget(
+    // Disk reclamation after hosting-cache eviction is best-effort GC —
+    // background-tier so it yields the contract loop to client/relay work (#4534).
+    op_manager.notify_contract_handler_fire_and_forget_prioritized(
         crate::contract::ContractHandlerEvent::EvictContract {
             key,
             expected_generation,
         },
+        crate::contract::Priority::Background,
     );
 }
 

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -180,6 +180,7 @@ pub(super) async fn put_contract(
     state: WrappedState,
     related_contracts: RelatedContracts<'static>,
     contract: &ContractContainer,
+    priority: crate::contract::Priority,
 ) -> Result<(WrappedState, bool), OpError> {
     // Reject debug-compiled contracts before storing (#2257). This is the
     // shared storage chokepoint for the network/relay PUT path
@@ -201,12 +202,15 @@ pub(super) async fn put_contract(
     }
 
     match op_manager
-        .notify_contract_handler(ContractHandlerEvent::PutQuery {
-            key,
-            state,
-            related_contracts,
-            contract: Some(contract.clone()),
-        })
+        .notify_contract_handler_prioritized(
+            ContractHandlerEvent::PutQuery {
+                key,
+                state,
+                related_contracts,
+                contract: Some(contract.clone()),
+            },
+            priority,
+        )
         .await
     {
         Ok(ContractHandlerEvent::PutResponse {

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1150,6 +1150,10 @@ where
     );
 
     // ── Step 1: Store contract locally (all nodes cache) ────────────────────
+    // Originator-loopback (a local client's own PUT, mapped to
+    // upstream_addr=own_addr in dispatch) is ClientLocal so it lands in the
+    // reserved fair-queue lane; a genuine relay store stays NetworkRelay (#4534).
+    let store_priority = put_store_priority(op_manager, upstream_addr);
     let merged_value = relay_put_store_locally(
         op_manager,
         incoming_tx,
@@ -1158,6 +1162,7 @@ where
         &contract,
         related_contracts.clone(),
         htl,
+        store_priority,
     )
     .await?;
 
@@ -1683,6 +1688,23 @@ where
 /// This helper is **relay-only** — it never sets
 /// `mark_local_client_access` (that's originator-side). Errors emit a
 /// `put_failure` telemetry event and propagate.
+/// Fair-queue priority for a relay PUT's local store (#4534).
+///
+/// A local client's own PUT enters the relay driver via originator-loopback,
+/// which dispatch maps to `upstream_addr = own_addr` (see operations.md). That
+/// case is `ClientLocal` so the store uses the reserved admission lane; any
+/// genuine upstream peer is `NetworkRelay`. If our own address is unknown we
+/// fail safe to `NetworkRelay` (never over-prioritize an ambiguous store).
+fn put_store_priority(
+    op_manager: &Arc<OpManager>,
+    upstream_addr: SocketAddr,
+) -> crate::contract::Priority {
+    match op_manager.ring.connection_manager.get_own_addr() {
+        Some(own) if own == upstream_addr => crate::contract::Priority::ClientLocal,
+        _ => crate::contract::Priority::NetworkRelay,
+    }
+}
+
 async fn relay_put_store_locally(
     op_manager: &Arc<OpManager>,
     incoming_tx: Transaction,
@@ -1691,6 +1713,7 @@ async fn relay_put_store_locally(
     contract: &ContractContainer,
     related_contracts: RelatedContracts<'static>,
     htl: usize,
+    priority: crate::contract::Priority,
 ) -> Result<WrappedState, OpError> {
     let was_hosting = op_manager.ring.is_hosting_contract(&key);
     let (merged_value, _state_changed) = match super::put_contract(
@@ -1699,6 +1722,7 @@ async fn relay_put_store_locally(
         value.clone(),
         related_contracts,
         contract,
+        priority,
     )
     .await
     {
@@ -2574,6 +2598,8 @@ where
     // forward (#4509) before the store consumes `related_contracts`.
     let replicate_payload =
         terminus_replicate_to.map(|addr| (addr, contract.clone(), related_contracts.clone()));
+    // Originator-loopback client PUT → ClientLocal reserved lane (#4534).
+    let store_priority = put_store_priority(op_manager, upstream_addr);
     let merged_value = relay_put_store_locally(
         op_manager,
         incoming_tx,
@@ -2582,6 +2608,7 @@ where
         &contract,
         related_contracts,
         htl,
+        store_priority,
     )
     .await?;
 

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1705,6 +1705,7 @@ fn put_store_priority(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn relay_put_store_locally(
     op_manager: &Arc<OpManager>,
     incoming_tx: Transaction,

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -613,12 +613,17 @@ pub(crate) async fn update_contract(
             let resolved_state = match previous_state {
                 Some(prev_state) => prev_state,
                 None => {
-                    // Try to fetch current state from store
+                    // Try to fetch current state from store (same priority as
+                    // the rest of this update — keep the ClientLocal lane for a
+                    // client UPDATE that CRDT-merges to no change; #4534).
                     let fetched_state = op_manager
-                        .notify_contract_handler(ContractHandlerEvent::GetQuery {
-                            instance_id: *key.id(),
-                            return_contract_code: false,
-                        })
+                        .notify_contract_handler_prioritized(
+                            ContractHandlerEvent::GetQuery {
+                                instance_id: *key.id(),
+                                return_contract_code: false,
+                            },
+                            priority,
+                        )
                         .await
                         .ok()
                         .and_then(|event| match event {

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -526,12 +526,16 @@ pub(crate) async fn update_contract(
     key: ContractKey,
     update_data: UpdateData<'static>,
     related_contracts: RelatedContracts<'static>,
+    priority: crate::contract::Priority,
 ) -> Result<UpdateExecution, OpError> {
     let previous_state = match op_manager
-        .notify_contract_handler(ContractHandlerEvent::GetQuery {
-            instance_id: *key.id(),
-            return_contract_code: false,
-        })
+        .notify_contract_handler_prioritized(
+            ContractHandlerEvent::GetQuery {
+                instance_id: *key.id(),
+                return_contract_code: false,
+            },
+            priority,
+        )
         .await
     {
         Ok(ContractHandlerEvent::GetResponse {
@@ -549,11 +553,14 @@ pub(crate) async fn update_contract(
     };
 
     match op_manager
-        .notify_contract_handler(ContractHandlerEvent::UpdateQuery {
-            key,
-            data: update_data.clone(),
-            related_contracts,
-        })
+        .notify_contract_handler_prioritized(
+            ContractHandlerEvent::UpdateQuery {
+                key,
+                data: update_data.clone(),
+                related_contracts,
+            },
+            priority,
+        )
         .await
     {
         Ok(ContractHandlerEvent::UpdateResponse {

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -253,7 +253,14 @@ async fn drive_client_update(
                 summary,
                 changed,
                 ..
-            } = match super::update_contract(op_manager, key, update_data, related_contracts).await
+            } = match super::update_contract(
+                op_manager,
+                key,
+                update_data,
+                related_contracts,
+                crate::contract::Priority::ClientLocal,
+            )
+            .await
             {
                 Ok(execution) => execution,
                 Err(err) if err.is_missing_contract_parameters() => {
@@ -333,6 +340,7 @@ async fn drive_client_update(
                 key,
                 update_data.clone(),
                 related_contracts.clone(),
+                crate::contract::Priority::ClientLocal,
             )
             .await;
 
@@ -864,6 +872,7 @@ async fn drive_relay_request_update(
             key,
             UpdateData::State(State::from(value.clone())),
             related_contracts.clone(),
+            crate::contract::Priority::NetworkRelay,
         )
         .await?;
 
@@ -1098,8 +1107,14 @@ async fn drive_relay_broadcast_to(
     }
 
     // ── Step 4: apply broadcast via WASM merge ────────────────────────────
-    let update_result =
-        super::update_contract(op_manager, key, update_data, RelatedContracts::default()).await;
+    let update_result = super::update_contract(
+        op_manager,
+        key,
+        update_data,
+        RelatedContracts::default(),
+        crate::contract::Priority::NetworkRelay,
+    )
+    .await;
 
     let UpdateExecution {
         value: updated_value,
@@ -1616,6 +1631,7 @@ async fn drive_relay_request_update_streaming(
         key,
         UpdateData::State(State::from(value.clone())),
         related_contracts,
+        crate::contract::Priority::NetworkRelay,
     )
     .await?;
 
@@ -1814,6 +1830,7 @@ async fn drive_relay_broadcast_to_streaming(
         key,
         UpdateData::State(State::from(state_bytes.clone())),
         RelatedContracts::default(),
+        crate::contract::Priority::NetworkRelay,
     )
     .await;
 

--- a/crates/core/src/server/client_api/hosted_export.rs
+++ b/crates/core/src/server/client_api/hosted_export.rs
@@ -307,7 +307,11 @@ async fn run_export(
         token: crate::contract::RedactedToken::new(token),
     };
 
-    match op_manager.notify_contract_handler(event).await {
+    // Hosted export is initiated by a local HTTP client → ClientLocal lane (#4534).
+    match op_manager
+        .notify_contract_handler_prioritized(event, crate::contract::Priority::ClientLocal)
+        .await
+    {
         Ok(ContractHandlerEvent::ExportUserSecretsResponse(Ok(bundle))) => Ok(bundle),
         Ok(ContractHandlerEvent::ExportUserSecretsResponse(Err(e))) => {
             // Executor-side failure (e.g. a secret failed to decrypt). Do not


### PR DESCRIPTION
## Problem

A node that accepts placement-migration caching work (#4404, re-enabled in 0.2.80) grows its hosted working set without bound. When that set overruns the WASM module cache, the serial `contract_handling` loop spends its time on background `summarize` recompiles, the flat round-robin fair queue fills to `MAX_TOTAL_FAIR_QUEUE`, and the node rejects its **own** client requests with `contract queue full, try again later`.

Observed live on a production node (#4534): `hosted=` climbed 1462 → 1898+, ~2300 queue-full rejections/hour, the local web API unusable while the node was busy serving migrated contracts it didn't care about.

The flat queue had no notion of **who** an event served — a best-effort background summarize competed on equal footing with a locally-initiated client GET/PUT, and admission rejected whatever arrived next regardless of origin.

## Solution

**Key insight:** the contract event loop is single-threaded, so background work and client work must not share one undifferentiated queue. Tag every contract-handler event with a `Priority` class (`ClientLocal > NetworkRelay > Background`) and make `FairEventQueue` priority-aware:

- **`pop()` drains higher classes first** — newly-arrived background work never head-of-line-blocks a pending client request. (An already-running WASM compile still finishes; true in-flight preemption needs off-loop compile — follow-up.)
- **`try_push()` reserves `CLIENT_LOCAL_RESERVE` (256) admission slots** that only `ClientLocal` may use, so a client request is never refused because background/relay work filled the queue.
- **`evict_background()` sheds already-queued background** to make room for a foreground push (the reserved lane is useless if the queue is already full of background, so the loop evicts-then-retries). Shed background re-emits next cycle — non-fatal, client-silent.
- **Per-contract caps are now scoped per tier** — background churn on a contract can't block a client op on the same contract.

Origin is set at the send sites: local WS/HTTP client paths (`client_events.rs`) → `ClientLocal`; periodic interest-sync summarize (`summary_if_hosted_or_in_use`) and disk-reclamation `EvictContract` → `Background`; everything else keeps the `NetworkRelay` default (no behavior change vs the old flat queue for relay traffic). Broadcast-path summaries that serve real UPDATE propagation deliberately stay at `NetworkRelay`.

This is the **queue-admission/scheduling half** of #4534. Cache-retention pinning by local interest and backpressure-aware migration admission are separate follow-ups tracked in the issue.

## Testing

New `fair_queue` unit tests:
- priority-ordered `pop()` (ClientLocal → NetworkRelay → Background)
- ClientLocal admitted past the soft cap into the reserve; hard-cap rejection
- `evict_background()` touches only the Background tier (foreground survives)
- per-contract cap scoped per tier (Background-saturated contract still admits a ClientLocal op on the same key)
- within-tier round-robin preserved

Full suites green: **19** fair_queue, **308** contract, **30** op_state_manager, **286** node (incl. the summarize-gating source-scrape pins). `cargo fmt` clean; no new clippy findings on the changed files.

> Note: the local pre-commit clippy hook flags 4 **pre-existing** lints (module_cache.rs, hosted_export.rs, telemetry.rs, rate.rs) that are new in clippy 1.94 but do not fire under CI's pinned 1.93 — none are touched by this PR.

## Fixes

Partially addresses #4534 (queue-admission/scheduling layer). Follow-ups for cache-retention pinning + migration backpressure remain open on the issue.
