### PR TITLE
fix: persist and reload node settings across restarts

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -344,6 +344,25 @@ Do not add new `OsRng` call sites outside of crypto key/nonce
 generation. Every other "I need randomness" urge in `crates/core/`
 should still go through `GlobalRng`.
 
+### WHEN adding a persisted config field
+
+A field serialized into `config.toml` MUST also be merged back from the
+file into `ConfigArgs` in `ConfigArgs::build()`. Forgetting this is a
+recurring, silent bug: the value is written but ignored on the next
+flag-less restart and reverts to its default. This caused #3890
+(allowed-host/CIDR) and #4275 (is_gateway, bandwidth limits, ...).
+
+The guard test
+`config::tests::all_persisted_config_fields_round_trip_through_build`
+destructures every persisted config struct with no `..`, so a new field
+fails to COMPILE there until you classify it:
+
+  - operator-configurable → add a `get_or_insert` merge line in
+    `build()`, plus a non-default seed value and an `assert_eq!` in the
+    guard (so the round-trip is actually exercised).
+  - not config (peer_id, gateways, secret key material, derived/runtime
+    fields) → bind it to `_` in the guard with a one-line reason.
+
 ### WHEN writing documentation
 
 ```

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -285,9 +285,6 @@ impl ConfigArgs {
     /// URL so the remote-fetch path is exercised deterministically without
     /// reaching out to `freenet.org` (which would be slow and flaky in CI).
     async fn build_with_gateways_index(mut self, gateways_index: &str) -> anyhow::Result<Config> {
-        // Validate gateway configuration
-        self.network_api.validate()?;
-
         let cfg = if let Some(path) = self.config_paths.config_dir.as_ref() {
             if !path.exists() {
                 return Err(anyhow::Error::new(std::io::Error::new(
@@ -407,6 +404,33 @@ impl ConfigArgs {
             if self.network_api.bbr_startup_rate.is_none() {
                 self.network_api.bbr_startup_rate = cfg.network_api.bbr_startup_rate;
             }
+            if let Some(limit) = cfg.network_api.total_bandwidth_limit {
+                self.network_api.total_bandwidth_limit.get_or_insert(limit);
+            }
+            if let Some(min_bw) = cfg.network_api.min_bandwidth_per_connection {
+                self.network_api
+                    .min_bandwidth_per_connection
+                    .get_or_insert(min_bw);
+            }
+            self.network_api
+                .event_loop_channel_capacity
+                .get_or_insert(cfg.network_api.event_loop_channel_capacity);
+            // `--is-gateway` is a plain on/off flag: when absent we can't tell
+            // "not a gateway" from "flag not passed", so only let the file turn
+            // it ON. A saved gateway then stays a gateway on a bare restart (the
+            // telemetry flags below have the same limitation).
+            if cfg.is_gateway {
+                self.network_api.is_gateway = true;
+            }
+            // Same on/off-flag limitation: only let the file turn this ON, so a
+            // node set up to run isolated stays isolated on a bare restart
+            // instead of going back to fetching the public gateway list.
+            if cfg.network_api.skip_load_from_network {
+                self.network_api.skip_load_from_network = true;
+            }
+            if let Some(loc) = cfg.location {
+                self.network_api.location.get_or_insert(loc);
+            }
             self.log_level.get_or_insert(cfg.log_level);
             self.max_hosting_storage
                 .get_or_insert(cfg.max_hosting_storage);
@@ -414,6 +438,8 @@ impl ConfigArgs {
                 .get_or_insert(cfg.module_cache_budget_bytes);
             self.shutdown_drain_secs
                 .get_or_insert(cfg.shutdown_drain_secs);
+            self.max_blocking_threads
+                .get_or_insert(cfg.max_blocking_threads);
             self.config_paths.merge(cfg.config_paths.as_ref().clone());
             // Merge telemetry config - CLI args override file config
             // Note: enabled defaults to true via clap, so we only override
@@ -426,6 +452,9 @@ impl ConfigArgs {
                     .endpoint
                     .get_or_insert(cfg.telemetry.endpoint);
             }
+            self.telemetry
+                .transport_snapshot_interval_secs
+                .get_or_insert(cfg.telemetry.transport_snapshot_interval_secs);
             // reference-ping-enabled defaults to false via clap; override
             // if the config file sets it to true. The inverse direction
             // doesn't need handling — the clap default is already false.
@@ -438,6 +467,11 @@ impl ConfigArgs {
                 self.telemetry.iface_tx_enabled = true;
             }
         }
+
+        // Validate the effective config (CLI + values merged from config.toml).
+        // After the merge so a gateway role restored from the file is still
+        // checked for its public address/port, not silently armed (#4275).
+        self.network_api.validate()?;
 
         let mode = self.mode.unwrap_or(OperationMode::Network);
         let config_paths = self.config_paths.build(self.id.as_deref())?;
@@ -509,6 +543,31 @@ impl ConfigArgs {
             // When we successfully fetch gateways from the network, replace local ones entirely
             // This ensures users always use the current active gateways
             // TODO: This behavior will likely change once we release a stable version
+
+            // #4275: warn about locally-cached gateways the remote index no
+            // longer lists (e.g. a peer pinned via --gateway) before discarding
+            // them. The remote index still wins; --skip-load-from-network keeps
+            // a custom peer set.
+            if let Ok(content) = fs::read_to_string(&gateways_file) {
+                if let Ok(local_cache) = toml::from_str::<Gateways>(&content) {
+                    let dropped = gateways_dropped_by_remote_replace(
+                        &local_cache.gateways,
+                        &remotely_loaded_gateways.gateways,
+                    );
+                    if !dropped.is_empty() {
+                        tracing::warn!(
+                            dropped = ?dropped,
+                            file = ?gateways_file,
+                            "Remote gateway index does not list {} locally-cached \
+                             gateway(s); they will be discarded. If you pinned them \
+                             manually, run with --skip-load-from-network to keep a \
+                             custom peer set.",
+                            dropped.len()
+                        );
+                    }
+                }
+            }
+
             tracing::info!(
                 gateway_count = remotely_loaded_gateways.gateways.len(),
                 "Replacing local gateways with gateways from remote index"
@@ -2261,6 +2320,22 @@ impl Gateways {
     }
 }
 
+/// Gateway addresses in `local` (the on-disk `gateways.toml` cache) absent
+/// from `remote` (the freshly fetched index) — the entries the remote-index
+/// replacement is about to drop. Surfaced as a warning so an operator-pinned
+/// `--gateway` peer is never discarded silently (#4275).
+fn gateways_dropped_by_remote_replace(
+    local: &[GatewayConfig],
+    remote: &[GatewayConfig],
+) -> Vec<Address> {
+    let remote_addrs: HashSet<&Address> = remote.iter().map(|g| &g.address).collect();
+    local
+        .iter()
+        .filter(|g| !remote_addrs.contains(&g.address))
+        .map(|g| g.address.clone())
+        .collect()
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct GatewayConfig {
     /// Address of the gateway. It can be either a hostname or an IP address and port.
@@ -3553,6 +3628,426 @@ mod tests {
             cfg.ws_api.allowed_hosts,
             vec!["my-tailscale-host".to_string()],
             "allowed-host from config.toml must be present in built config"
+        );
+    }
+
+    /// A local-mode `ConfigArgs` pointing every path at `dir`. Used to seed a
+    /// `config.toml` (first `build()` persists it) and to read it back on a
+    /// later bare build — the real persistence round-trip.
+    fn local_args(dir: &Path) -> ConfigArgs {
+        ConfigArgs {
+            mode: Some(OperationMode::Local),
+            config_paths: ConfigPathsArgs {
+                config_dir: Some(dir.to_path_buf()),
+                data_dir: Some(dir.to_path_buf()),
+                log_dir: Some(dir.to_path_buf()),
+            },
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn gateway_role_and_total_bandwidth_round_trip_through_build() {
+        // Regression for #4275: is_gateway/location/total_bandwidth_limit are
+        // written to config.toml but build()'s merge never read them back, so a
+        // bare `freenet network` demoted the gateway and dropped its bandwidth
+        // cap. Exercises the real round-trip: first build persists, bare build
+        // reads back.
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let mut first = local_args(temp_dir.path());
+        first.network_api.is_gateway = true;
+        first.network_api.public_address = Some("1.2.3.4".parse().unwrap());
+        first.network_api.public_port = Some(31337);
+        first.network_api.location = Some(0.5);
+        first.network_api.total_bandwidth_limit = Some(100_000_000);
+        first.network_api.max_connections = Some(2000);
+        first.build().await.unwrap();
+        assert!(
+            temp_dir.path().join("config.toml").exists(),
+            "first build with flags must persist config.toml"
+        );
+
+        let cfg = local_args(temp_dir.path()).build().await.unwrap();
+
+        assert!(
+            cfg.is_gateway,
+            "is_gateway from config.toml must survive a bare build (node must stay a gateway)"
+        );
+        assert_eq!(
+            cfg.location,
+            Some(0.5),
+            "location from config.toml must survive a bare build"
+        );
+        assert_eq!(
+            cfg.network_api.total_bandwidth_limit,
+            Some(100_000_000),
+            "total_bandwidth_limit from config.toml must survive a bare build"
+        );
+        assert_eq!(
+            cfg.network_api.max_connections, 2000,
+            "max_connections from config.toml must survive a bare build"
+        );
+        assert!(
+            cfg.peer_id.is_some(),
+            "peer_id must be reconstructed from the restored public address/port"
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_in_config_without_public_address_fails_validation() {
+        // A config.toml claiming is_gateway=true with no public address must be
+        // rejected, not silently armed — which only holds if validate() runs
+        // after the merge. The normal flow can't produce such a file (validate
+        // rejects it up front), so hand-craft it: seed a valid non-gateway
+        // config.toml, then flip is_gateway on with no public address.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut seeded = local_args(temp_dir.path()).build().await.unwrap();
+        seeded.is_gateway = true;
+        seeded.network_api.public_address = None;
+        seeded.network_api.public_port = None;
+        std::fs::write(
+            temp_dir.path().join("config.toml"),
+            toml::to_string(&seeded).unwrap(),
+        )
+        .unwrap();
+
+        let err = local_args(temp_dir.path()).build().await.unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("public network address"),
+            "an is_gateway=true config without a public address must fail validation: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cli_total_bandwidth_limit_overrides_file_config() {
+        // CLI args still take precedence over the file value: the new merge
+        // must use get_or_insert (fill-if-empty), not a blind overwrite.
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let mut first = local_args(temp_dir.path());
+        first.network_api.total_bandwidth_limit = Some(100_000_000);
+        first.build().await.unwrap();
+
+        let mut second = local_args(temp_dir.path());
+        second.network_api.total_bandwidth_limit = Some(50_000_000);
+        let cfg = second.build().await.unwrap();
+
+        assert_eq!(
+            cfg.network_api.total_bandwidth_limit,
+            Some(50_000_000),
+            "CLI --total-bandwidth-limit must override the config.toml value"
+        );
+    }
+
+    #[test]
+    fn warns_only_about_cached_gateways_absent_from_remote_index() {
+        // #4275 (A2): the remote-index replacement must surface — but only —
+        // the locally-cached gateways that the index no longer lists, so a
+        // manually pinned peer is not dropped silently.
+        fn gw(host: &str) -> GatewayConfig {
+            GatewayConfig {
+                address: Address::Host {
+                    host: host.to_string(),
+                    port: 31337,
+                },
+                public_key_path: PathBuf::from("/dev/null"),
+                location: None,
+            }
+        }
+
+        let local = vec![gw("a"), gw("b"), gw("c")];
+        let remote = vec![gw("b"), gw("c"), gw("d")];
+
+        // Only "a" is in the local cache but missing from the remote index.
+        assert_eq!(
+            gateways_dropped_by_remote_replace(&local, &remote),
+            vec![Address::Host {
+                host: "a".to_string(),
+                port: 31337
+            }],
+        );
+
+        // Remote is a superset / identical → nothing is dropped → no warning.
+        assert!(gateways_dropped_by_remote_replace(&local, &local).is_empty());
+        assert!(gateways_dropped_by_remote_replace(&[], &remote).is_empty());
+    }
+
+    /// A `ConfigArgs` mirroring a real bare `freenet network` parse: every
+    /// optional field unset (None), pointed at `dir` in Local mode. Avoids
+    /// `ConfigArgs::default()`, which pre-fills some fields with `Some(..)` that
+    /// would MASK the file value on merge and give the guard below a false pass.
+    fn clap_bare_args(dir: &Path) -> ConfigArgs {
+        ConfigArgs {
+            mode: Some(OperationMode::Local),
+            network_api: NetworkArgs::default(),
+            ws_api: WebsocketApiArgs::default(),
+            secrets: Default::default(),
+            log_level: None,
+            config_paths: ConfigPathsArgs {
+                config_dir: Some(dir.to_path_buf()),
+                data_dir: Some(dir.to_path_buf()),
+                log_dir: Some(dir.to_path_buf()),
+            },
+            id: None,
+            version: false,
+            max_blocking_threads: None,
+            max_hosting_storage: None,
+            module_cache_budget_bytes: None,
+            shutdown_drain_secs: None,
+            telemetry: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn all_persisted_config_fields_round_trip_through_build() {
+        // #4275 guard against the recurring bug class (#3890, #4275): build()'s
+        // field-by-field merge silently drops any persisted field it doesn't
+        // list. Seeds a non-default value for EVERY persisted field, writes it,
+        // rebuilds from a clap-bare ConfigArgs, and asserts each one survives.
+        //
+        // The destructuring below has NO `..`: adding a field to any of these
+        // structs fails to COMPILE until the author classifies it (round-trips
+        // -> merge + assert; skip-by-design -> bind to `_`). Keeps it honest.
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        // Valid base build: creates the on-disk secret files (and gives us real
+        // secrets + resolved paths) that the rebuild will read back.
+        let base = clap_bare_args(temp_dir.path()).build().await.unwrap();
+
+        let seed = Config {
+            mode: OperationMode::Local,
+            network_api: NetworkApiConfig {
+                address: "10.1.2.3".parse().unwrap(),
+                port: 40001,
+                public_address: Some("1.2.3.4".parse().unwrap()),
+                public_port: Some(40002),
+                ignore_protocol_version: false, // #[serde(skip)] — not persisted
+                bandwidth_limit: Some(7_000_000),
+                total_bandwidth_limit: Some(123_000_000),
+                min_bandwidth_per_connection: Some(2_000_000),
+                blocked_addresses: Some(
+                    std::iter::once("9.9.9.9:1234".parse::<SocketAddr>().unwrap()).collect(),
+                ),
+                event_loop_channel_capacity: 4096,
+                transient_budget: 4097,
+                transient_ttl_secs: 61,
+                min_connections: 11,
+                max_connections: 222,
+                streaming_threshold: 131_072,
+                ledbat_min_ssthresh: Some(200_000),
+                congestion_control: "bbr".to_string(),
+                bbr_startup_rate: Some(5_000),
+                skip_load_from_network: true,
+            },
+            ws_api: WebsocketApiConfig {
+                address: "10.1.2.4".parse().unwrap(),
+                port: 8123,
+                token_ttl_seconds: 4321,
+                token_cleanup_interval_seconds: 321,
+                allowed_hosts: vec!["my-host".to_string()],
+                allowed_source_cidrs: vec!["10.0.0.0/8".parse().unwrap()],
+            },
+            secrets: base.secrets.clone(),
+            log_level: tracing::log::LevelFilter::Debug,
+            config_paths: base.config_paths.clone(),
+            peer_id: None,
+            gateways: vec![],
+            is_gateway: true,
+            location: Some(0.5),
+            max_blocking_threads: 7,
+            max_hosting_storage: 123_456_789,
+            module_cache_budget_bytes: 987_654_321,
+            telemetry: TelemetryConfig {
+                enabled: false,
+                endpoint: "http://example.invalid:4318".to_string(),
+                transport_snapshot_interval_secs: 45,
+                is_test_environment: false, // #[serde(skip)] — derived from --id
+                reference_ping_enabled: true,
+                iface_tx_enabled: true,
+            },
+            shutdown_drain_secs: 77,
+        };
+
+        std::fs::write(
+            temp_dir.path().join("config.toml"),
+            toml::to_string(&seed).unwrap(),
+        )
+        .unwrap();
+
+        let rebuilt = clap_bare_args(temp_dir.path()).build().await.unwrap();
+
+        // Exhaustive destructure — NO `..`. A new Config field must be handled here.
+        let Config {
+            mode,
+            network_api,
+            ws_api,
+            secrets: _, // key material, not config
+            log_level,
+            config_paths: _, // re-resolved per process (temp dir)
+            peer_id: _,      // derived from public addr/port
+            gateways: _,     // lives in gateways.toml
+            is_gateway,
+            location,
+            max_blocking_threads,
+            max_hosting_storage,
+            module_cache_budget_bytes,
+            telemetry,
+            shutdown_drain_secs,
+        } = rebuilt;
+
+        assert_eq!(mode, seed.mode, "mode");
+        assert_eq!(log_level, seed.log_level, "log_level");
+        assert_eq!(is_gateway, seed.is_gateway, "is_gateway");
+        assert_eq!(location, seed.location, "location");
+        assert_eq!(
+            max_blocking_threads, seed.max_blocking_threads,
+            "max_blocking_threads"
+        );
+        assert_eq!(
+            max_hosting_storage, seed.max_hosting_storage,
+            "max_hosting_storage"
+        );
+        assert_eq!(
+            module_cache_budget_bytes, seed.module_cache_budget_bytes,
+            "module_cache_budget_bytes"
+        );
+        assert_eq!(
+            shutdown_drain_secs, seed.shutdown_drain_secs,
+            "shutdown_drain_secs"
+        );
+
+        let NetworkApiConfig {
+            address,
+            port,
+            public_address,
+            public_port,
+            ignore_protocol_version: _, // serde-skip
+            bandwidth_limit,
+            total_bandwidth_limit,
+            min_bandwidth_per_connection,
+            blocked_addresses,
+            event_loop_channel_capacity,
+            transient_budget,
+            transient_ttl_secs,
+            min_connections,
+            max_connections,
+            streaming_threshold,
+            ledbat_min_ssthresh,
+            congestion_control,
+            bbr_startup_rate,
+            skip_load_from_network,
+        } = network_api;
+        assert_eq!(address, seed.network_api.address, "network_api.address");
+        assert_eq!(port, seed.network_api.port, "network_api.port");
+        assert_eq!(
+            public_address, seed.network_api.public_address,
+            "public_address"
+        );
+        assert_eq!(public_port, seed.network_api.public_port, "public_port");
+        assert_eq!(
+            bandwidth_limit, seed.network_api.bandwidth_limit,
+            "bandwidth_limit"
+        );
+        assert_eq!(
+            total_bandwidth_limit, seed.network_api.total_bandwidth_limit,
+            "total_bandwidth_limit"
+        );
+        assert_eq!(
+            min_bandwidth_per_connection, seed.network_api.min_bandwidth_per_connection,
+            "min_bandwidth_per_connection"
+        );
+        assert_eq!(
+            blocked_addresses, seed.network_api.blocked_addresses,
+            "blocked_addresses"
+        );
+        assert_eq!(
+            event_loop_channel_capacity, seed.network_api.event_loop_channel_capacity,
+            "event_loop_channel_capacity"
+        );
+        assert_eq!(
+            transient_budget, seed.network_api.transient_budget,
+            "transient_budget"
+        );
+        assert_eq!(
+            transient_ttl_secs, seed.network_api.transient_ttl_secs,
+            "transient_ttl_secs"
+        );
+        assert_eq!(
+            min_connections, seed.network_api.min_connections,
+            "min_connections"
+        );
+        assert_eq!(
+            max_connections, seed.network_api.max_connections,
+            "max_connections"
+        );
+        assert_eq!(
+            streaming_threshold, seed.network_api.streaming_threshold,
+            "streaming_threshold"
+        );
+        assert_eq!(
+            ledbat_min_ssthresh, seed.network_api.ledbat_min_ssthresh,
+            "ledbat_min_ssthresh"
+        );
+        assert_eq!(
+            congestion_control, seed.network_api.congestion_control,
+            "congestion_control"
+        );
+        assert_eq!(
+            bbr_startup_rate, seed.network_api.bbr_startup_rate,
+            "bbr_startup_rate"
+        );
+        assert_eq!(
+            skip_load_from_network, seed.network_api.skip_load_from_network,
+            "skip_load_from_network"
+        );
+
+        let WebsocketApiConfig {
+            address: ws_address,
+            port: ws_port,
+            token_ttl_seconds,
+            token_cleanup_interval_seconds,
+            allowed_hosts,
+            allowed_source_cidrs,
+        } = ws_api;
+        assert_eq!(ws_address, seed.ws_api.address, "ws_api.address");
+        assert_eq!(ws_port, seed.ws_api.port, "ws_api.port");
+        assert_eq!(
+            token_ttl_seconds, seed.ws_api.token_ttl_seconds,
+            "token_ttl_seconds"
+        );
+        assert_eq!(
+            token_cleanup_interval_seconds, seed.ws_api.token_cleanup_interval_seconds,
+            "token_cleanup_interval_seconds"
+        );
+        assert_eq!(allowed_hosts, seed.ws_api.allowed_hosts, "allowed_hosts");
+        assert_eq!(
+            allowed_source_cidrs, seed.ws_api.allowed_source_cidrs,
+            "allowed_source_cidrs"
+        );
+
+        let TelemetryConfig {
+            enabled,
+            endpoint,
+            transport_snapshot_interval_secs,
+            is_test_environment: _, // serde-skip, derived from --id
+            reference_ping_enabled,
+            iface_tx_enabled,
+        } = telemetry;
+        assert_eq!(enabled, seed.telemetry.enabled, "telemetry.enabled");
+        assert_eq!(endpoint, seed.telemetry.endpoint, "telemetry.endpoint");
+        assert_eq!(
+            transport_snapshot_interval_secs, seed.telemetry.transport_snapshot_interval_secs,
+            "transport_snapshot_interval_secs"
+        );
+        assert_eq!(
+            reference_ping_enabled, seed.telemetry.reference_ping_enabled,
+            "reference_ping_enabled"
+        );
+        assert_eq!(
+            iface_tx_enabled, seed.telemetry.iface_tx_enabled,
+            "iface_tx_enabled"
         );
     }
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3895,6 +3895,7 @@ mod tests {
                 token_cleanup_interval_seconds: 321,
                 allowed_hosts: vec!["my-host".to_string()],
                 allowed_source_cidrs: vec!["10.0.0.0/8".parse().unwrap()],
+                hosted_mode: true,
             },
             secrets: base.secrets.clone(),
             log_level: tracing::log::LevelFilter::Debug,
@@ -4057,6 +4058,7 @@ mod tests {
             token_cleanup_interval_seconds,
             allowed_hosts,
             allowed_source_cidrs,
+            hosted_mode,
         } = ws_api;
         assert_eq!(ws_address, seed.ws_api.address, "ws_api.address");
         assert_eq!(ws_port, seed.ws_api.port, "ws_api.port");
@@ -4073,6 +4075,7 @@ mod tests {
             allowed_source_cidrs, seed.ws_api.allowed_source_cidrs,
             "allowed_source_cidrs"
         );
+        assert_eq!(hosted_mode, seed.ws_api.hosted_mode, "ws_api.hosted_mode");
 
         let TelemetryConfig {
             enabled,

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -321,8 +321,6 @@ impl ConfigArgs {
             }
         };
 
-        let should_persist = cfg.is_none();
-
         // merge the configuration from the file with the command line arguments
         if let Some(cfg) = cfg {
             self.secrets.merge(cfg.secrets);
@@ -906,15 +904,19 @@ impl ConfigArgs {
             gateways.save_to_file(&gateways_file)?;
         }
 
-        if should_persist {
-            let path = this.config_dir().join("config.toml");
-            tracing::info!(path = ?path, "Persisting configuration");
-            let mut file = File::create(path)?;
-            file.write_all(
-                toml::to_string(&this)
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?
-                    .as_bytes(),
-            )?;
+        // Persist on first run (no file yet) or when the effective config
+        // changed — e.g. the operator passed a new CLI flag — so config.toml
+        // stays the source of truth (#4275). Comparing against the file's
+        // current contents (written by the same serializer) keeps an unchanged
+        // restart a no-op, so operator hand-edits survive.
+        let config_path = this.config_dir().join("config.toml");
+        let new_config_toml = toml::to_string(&this)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        let current = std::fs::read_to_string(&config_path).ok();
+        if current.as_deref() != Some(new_config_toml.as_str()) {
+            tracing::info!(path = ?config_path, "Persisting configuration");
+            let mut file = File::create(&config_path)?;
+            file.write_all(new_config_toml.as_bytes())?;
         }
 
         Ok(this)
@@ -3738,6 +3740,51 @@ mod tests {
             cfg.network_api.total_bandwidth_limit,
             Some(50_000_000),
             "CLI --total-bandwidth-limit must override the config.toml value"
+        );
+    }
+
+    #[tokio::test]
+    async fn cli_flag_set_on_a_later_run_is_persisted_to_config() {
+        // #4275 (B2): config.toml was only written on the first run, so a value
+        // passed on the CLI when the file already existed applied for that run
+        // but was lost on the next bare restart. It must be persisted instead.
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        // First run creates config.toml (no total_bandwidth_limit).
+        clap_bare_args(temp_dir.path()).build().await.unwrap();
+
+        // Later run passes a new value on the CLI.
+        let mut args = clap_bare_args(temp_dir.path());
+        args.network_api.total_bandwidth_limit = Some(50_000_000);
+        args.build().await.unwrap();
+
+        // A subsequent bare run must see the persisted value.
+        let cfg = clap_bare_args(temp_dir.path()).build().await.unwrap();
+        assert_eq!(
+            cfg.network_api.total_bandwidth_limit,
+            Some(50_000_000),
+            "a CLI flag set on a later run must be written back to config.toml"
+        );
+    }
+
+    #[tokio::test]
+    async fn bare_restart_does_not_rewrite_unchanged_config() {
+        // The re-persist must only fire when something changed: a no-op restart
+        // must leave config.toml byte-identical, so operator hand-edits survive.
+        // Uses clap_bare_args (all-None) so the rebuild reads every value back
+        // from the file; local_args would re-pick a random network port each
+        // build (ConfigArgs::default) and look like a spurious change.
+        let temp_dir = tempfile::tempdir().unwrap();
+        clap_bare_args(temp_dir.path()).build().await.unwrap();
+
+        let path = temp_dir.path().join("config.toml");
+        let before = std::fs::read_to_string(&path).unwrap();
+        clap_bare_args(temp_dir.path()).build().await.unwrap();
+        let after = std::fs::read_to_string(&path).unwrap();
+
+        assert_eq!(
+            before, after,
+            "a no-op restart must not rewrite config.toml"
         );
     }
 


### PR DESCRIPTION
## Problem

`config.toml` was not a reliable source of truth for a node's configuration, so settings could silently revert on restart. There were two distinct issues:

1. **Settings were written but not read back.** `ConfigArgs::build()` merged only a subset of the persisted fields from `config.toml` into the effective config. `is_gateway`, `location`, `total_bandwidth_limit`, `min_bandwidth_per_connection`, `event_loop_channel_capacity`, `max_blocking_threads`, `transport_snapshot_interval_secs` and `skip_load_from_network` were serialized to the file but ignored on load. Any flag-less start (the systemd unit, the tray wrapper, or a plain `freenet network`) reverted them to their defaults. For a gateway this was severe: it lost its `is_gateway` role and, with the empty bootstrap list a top-level gateway typically has, failed to start with *"At least one remote gateway is required ... for non-gateway nodes"*. This is exactly what `freenet service install` (or an auto-update) triggers by regenerating the bare unit.

2. **CLI changes were not persisted.** `config.toml` was only written on the very first run (when no file existed yet). A flag passed on a later run applied for that session but was never written back, so it was lost on the next restart.

## Solution

- **Read path:** the file→CLI merge now copies every persisted setting back into the effective config (CLI still takes precedence). `is_gateway` and `skip_load_from_network` are merged one-directionally — a plain on/off flag cannot express "explicitly false", so the file may only turn them on, which keeps a saved gateway a gateway across a bare restart. Gateway validation now runs *after* the merge, so a role restored from the file is validated against the effective config instead of being armed invalid.

- **Write path:** `config.toml` is re-persisted after the merge when the effective config differs from what is on disk (e.g. the operator passed a new CLI flag), so an override sticks across restarts. An unchanged restart is a no-op — the new content is compared against the file's current contents, so the file (and any hand-edits) is never rewritten needlessly.

- **Guard against regressions:** a round-trip test checks that every persisted setting survives a restart. It is written so that adding a new config field fails to compile until the author wires it up (the config structs are destructured with no `..`), preventing the same silent-drop bug (#3890, #4275) from recurring as new settings are added.

## Testing

- Unit tests in `config.rs`: per-field round-trip, post-merge gateway validation (an `is_gateway=true` file with no public address is rejected), CLI-over-file precedence, override persistence on a later run, no-op restart not rewriting the file, and the exhaustive round-trip guard. `cargo fmt` and `cargo clippy -- -D warnings` are clean.
- Manual: an isolated gateway keeps its role and limits across a flag-less restart; a `--total-bandwidth-limit` override set on a later run is persisted to `config.toml`.

## Out of scope (possible follow-ups)

This change is confined to `config.rs` (making `config.toml` the source of truth, the agreed approach); it does not touch `service.rs`. Regenerating the unit on `service install`/update is now harmless because the unit's `ExecStart` is bare and `config.toml` carries the configuration. Two items from the issue remain as optional follow-ups:

- Migrating existing deployments whose settings live only in the systemd unit's `ExecStart` (those nodes need their configuration written to `config.toml` once).
- Letting `freenet service install` accept network flags and write them to `config.toml`, and/or warning + backing up the unit before regenerating it.

## Fixes

Closes #4275
