### PR TITLE
fix(node): gate placement-migration admission on module-cache headroom (#4534)

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -22,7 +22,7 @@ Driver entry points:
 | GET | `get/op_ctx_task.rs::start_client_get`, `start_relay_get`, `start_sub_op_get`, `start_targeted_sub_op_get` |
 | PUT | `put/op_ctx_task.rs::start_client_put`, `start_relay_put`, `start_relay_put_streaming` |
 | UPDATE | `update/op_ctx_task.rs::start_client_update`, `start_relay_request_update`, `start_relay_broadcast_to`, `start_relay_request_update_streaming`, `start_relay_broadcast_to_streaming` |
-| SUBSCRIBE | `subscribe/op_ctx_task.rs::start_client_subscribe`, `start_directed_subscribe` (SubscribeHint placement nudge, #4404), `run_executor_subscribe`, `run_renewal_subscribe`, `start_relay_subscribe`; `subscribe.rs::handle_unsubscribe_inbound` for `Unsubscribe` |
+| SUBSCRIBE | `subscribe/op_ctx_task.rs::start_client_subscribe`, `start_directed_subscribe` (SubscribeHint placement nudge, #4404 — the inbound-hint receive arm in `node.rs` now refuses it above the module-cache occupancy ceiling, `migration_admission_allowed`, #4534), `run_executor_subscribe`, `run_renewal_subscribe`, `start_relay_subscribe`; `subscribe.rs::handle_unsubscribe_inbound` for `Unsubscribe` |
 
 The shared retry-loop driver lives in `op_ctx.rs` (`RetryDriver` trait
 + `drive_retry_loop`). UPDATE is fire-and-forget (no retry loop, no

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1827,6 +1827,31 @@ where
                 );
                 return Ok(());
             }
+            // Backpressure-aware migration admission (#4534): refuse to take on
+            // a NEW migrated contract when the contract module cache is already
+            // at/above its occupancy ceiling. Accepting more would push the
+            // hosted working set past cache capacity, forcing recompile-on-
+            // access thrash that fills the fair queue ("contract queue full")
+            // and OOMs memory-bound gateways. This gates ONLY the directed-
+            // subscribe placement nudge; the node's own local client
+            // subscribes/GETs are never gated here. The hint is dropped silently
+            // and the holder re-proposes it on its next migration trigger once
+            // headroom returns.
+            let contract_cache_occupancy = crate::wasm_runtime::contract_cache_occupancy_pct();
+            if !migration_admission_allowed(contract_cache_occupancy) {
+                tracing::debug!(
+                    key = %hint.key,
+                    holder = %hint.holder,
+                    ?source_addr,
+                    occupancy_pct = ?contract_cache_occupancy,
+                    ceiling_pct = MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT,
+                    "Refusing inbound SubscribeHint: contract module cache at/above \
+                     the migration-admission occupancy ceiling — deferring placement \
+                     migration to bound the hosted working set and avoid cache thrash \
+                     (#4534)"
+                );
+                return Ok(());
+            }
             tracing::debug!(
                 key = %hint.key,
                 holder = %hint.holder,
@@ -1895,6 +1920,68 @@ const MAX_STALE_SYNCS_PER_SUMMARIES: usize = 32;
 /// [`MAX_STALE_SYNCS_PER_SUMMARIES`] regardless of `stale_contracts_len`.
 fn stale_sync_emit_budget(stale_contracts_len: usize) -> usize {
     stale_contracts_len.min(MAX_STALE_SYNCS_PER_SUMMARIES)
+}
+
+/// Maximum contract-module-cache occupancy (percent of budget) at which this
+/// node still accepts an inbound placement-migration `SubscribeHint` (#4534).
+///
+/// Above this ceiling, inbound hints are refused so the hosted working set
+/// cannot grow past cache capacity and thrash (module recompile-on-access),
+/// which had filled the contract fair queue and produced client-facing
+/// "contract queue full" outages and gateway OOMs on 0.2.80. The ~10% headroom
+/// below 100% is reserved for the node's own locally-requested contracts, whose
+/// directed subscribes are NOT gated here. Refusal is silent and best-effort:
+/// the holder re-proposes the migration on its next trigger once headroom
+/// returns, so placement migration otherwise stays enabled (#4404).
+const MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT: u64 = 90;
+
+/// Whether to accept an inbound placement-migration hint given the current
+/// contract-module-cache occupancy. `None` (budget gauge not yet published — no
+/// runtime pool built) admits, since there is no pressure signal to act on.
+///
+/// Split out as a pure function so the threshold logic is unit-testable without
+/// constructing an `OpManager` or touching the global cache gauges (#4534).
+fn migration_admission_allowed(contract_cache_occupancy_pct: Option<u64>) -> bool {
+    match contract_cache_occupancy_pct {
+        Some(pct) => pct < MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT,
+        None => true,
+    }
+}
+
+#[cfg(test)]
+mod migration_admission_tests {
+    use super::{
+        MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT, migration_admission_allowed,
+    };
+
+    /// No runtime pool / budget gauge yet → no pressure signal → admit.
+    #[test]
+    fn admits_when_cache_budget_uninitialized() {
+        assert!(migration_admission_allowed(None));
+    }
+
+    /// Below the ceiling the node keeps accepting migration (the #4404 feature
+    /// is not crippled on healthy nodes).
+    #[test]
+    fn admits_below_occupancy_ceiling() {
+        assert!(migration_admission_allowed(Some(0)));
+        assert!(migration_admission_allowed(Some(
+            MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT - 1
+        )));
+    }
+
+    /// At or above the ceiling the node sheds inbound migration — this is the
+    /// #4534 fix. The over-budget transient (> 100%) is refused too.
+    #[test]
+    fn refuses_at_or_above_occupancy_ceiling() {
+        assert!(!migration_admission_allowed(Some(
+            MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT
+        )));
+        assert!(!migration_admission_allowed(Some(
+            MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT + 5
+        )));
+        assert!(!migration_admission_allowed(Some(150)));
+    }
 }
 
 /// Per-contract disposition in the stale-sync emission loop, used to model the

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1931,8 +1931,20 @@ fn stale_sync_emit_budget(stale_contracts_len: usize) -> usize {
 /// "contract queue full" outages and gateway OOMs on 0.2.80. The ~10% headroom
 /// below 100% is reserved for the node's own locally-requested contracts, whose
 /// directed subscribes are NOT gated here. Refusal is silent and best-effort:
-/// the holder re-proposes the migration on its next trigger once headroom
-/// returns, so placement migration otherwise stays enabled (#4404).
+/// the holder re-proposes the migration on its next trigger, so placement
+/// migration resumes automatically once occupancy falls back below the ceiling.
+///
+/// Recovery is real but NOT guaranteed: occupancy only drops when cold modules
+/// age out of the LRU faster than new ones compile (the recent distinct-module
+/// byte-sum falls below the ceiling). On a node whose hosted working set
+/// genuinely exceeds the cache budget — the exact #4534 scenario — occupancy
+/// stays pinned near 100% and migration is refused INDEFINITELY by design. That
+/// is the correct conservative behavior (it stops the thrash), but it means this
+/// gate is a stopgap, not a complete fix: on such a node the operator must raise
+/// `FREENET_MODULE_CACHE_BUDGET_BYTES` to actually re-enable placement. #4534
+/// stays open for the cache-sizing / offload-compilation / interest-weighted-
+/// retention directions; this constant implements only the "couple migration
+/// acceptance to cache headroom" one.
 const MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT: u64 = 90;
 
 /// Whether to accept an inbound placement-migration hint given the current

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -464,3 +464,38 @@ fn test_subscribe_msg_response_hop_count_roundtrip() {
         }
     }
 }
+
+/// Pin: the inbound `SubscribeHint` arm in `node.rs` MUST consult the
+/// backpressure-aware migration-admission gate (`migration_admission_allowed`)
+/// BEFORE calling `start_directed_subscribe`. Without this gate the node accepts
+/// unbounded placement migration, overruns the module cache, and reproduces the
+/// #4534 "contract queue full" outage / gateway OOM. Anchored from this side so
+/// removing or reordering the gate trips the build.
+#[test]
+fn subscribe_hint_arm_gates_migration_on_cache_backpressure() {
+    const SOURCE: &str = include_str!("../../node.rs");
+    let anchor = "NetMessageV1::SubscribeHint(hint) => {";
+    let branch_start = SOURCE
+        .find(anchor)
+        .expect("SubscribeHint arm not found in node.rs");
+    let next_variant = "NetMessageV1::Aborted(tx) => {";
+    let window_end = SOURCE[branch_start..]
+        .find(next_variant)
+        .expect("could not find end of SubscribeHint arm")
+        + branch_start;
+    let window = &SOURCE[branch_start..window_end];
+
+    let gate = window.find("migration_admission_allowed(").expect(
+        "SubscribeHint arm must call `migration_admission_allowed` to gate \
+         placement migration on module-cache backpressure (#4534)",
+    );
+    let subscribe = window
+        .find("start_directed_subscribe(")
+        .expect("SubscribeHint arm must call `start_directed_subscribe` to act on the hint");
+    assert!(
+        gate < subscribe,
+        "the migration-admission gate must run BEFORE start_directed_subscribe, \
+         else the node starts hosting the migrated contract before checking cache \
+         headroom (#4534)"
+    );
+}

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -27,6 +27,7 @@ pub use mock_state_storage::MockStateStorage;
 pub use module_cache::default_module_cache_budget_bytes;
 pub(crate) use module_cache::{
     DELEGATE_MODULE_CACHE_BUDGET_DIVISOR, MODULE_CACHE_METRICS, ModuleCache,
+    contract_cache_occupancy_pct,
 };
 // Clamp bounds are referenced only by the config-default round-trip test, which
 // asserts the resolved default lands within [MIN, MAX] without hardcoding the

--- a/crates/core/src/wasm_runtime/module_cache.rs
+++ b/crates/core/src/wasm_runtime/module_cache.rs
@@ -381,6 +381,17 @@ impl ModuleCacheMetrics {
 /// capacity and thrash (recompile-on-access), which had filled the contract fair
 /// queue and produced client-facing "contract queue full" outages and gateway
 /// OOMs on 0.2.80.
+///
+/// This is a deliberate PROXY for hosting pressure, not a direct measure of the
+/// hosted set: it reflects *compiled-module-cache bytes*, which a module only
+/// joins when it is first executed (summarize / GET / UPDATE), so it LAGS the
+/// hosted set after a directed subscribe makes the node a holder. The lag is
+/// acceptable here because (a) the hosted set is independently bounded by the
+/// hosting cache's own byte budget and the node's ring-responsibility region, so
+/// a burst cannot grow it without bound, and (b) the gate only ever *refuses*
+/// new load — the failure mode of a stale read is at worst deferring one
+/// migration that would have fit, never accepting one it should have refused
+/// once occupancy has caught up.
 pub(crate) fn contract_cache_occupancy_pct() -> Option<u64> {
     let snapshot = MODULE_CACHE_METRICS.snapshot();
     occupancy_pct(
@@ -1248,5 +1259,17 @@ mod tests {
         // Cleanly-divisible large budget to assert the 90% boundary exactly
         // (avoids integer-truncation noise from a non-divisible GiB budget).
         assert_eq!(occupancy_pct(900_000_000, 1_000_000_000), Some(90));
+    }
+
+    /// Floor-division must land 89.x% occupancy on the admit side of the 90%
+    /// decision boundary and exactly-90% on the refuse side — the truncation
+    /// edge the whole gate hinges on (#4534). 899/1000 = 89.9% → 89 (admit);
+    /// 900/1000 = 90.0% → 90 (refuse).
+    #[test]
+    fn occupancy_pct_truncates_below_the_decision_boundary() {
+        assert_eq!(occupancy_pct(899, 1_000), Some(89));
+        assert_eq!(occupancy_pct(900, 1_000), Some(90));
+        // Just over the boundary stays refused.
+        assert_eq!(occupancy_pct(901, 1_000), Some(90));
     }
 }

--- a/crates/core/src/wasm_runtime/module_cache.rs
+++ b/crates/core/src/wasm_runtime/module_cache.rs
@@ -368,6 +368,40 @@ impl ModuleCacheMetrics {
     }
 }
 
+/// Contract-module-cache occupancy as a percentage of the configured byte
+/// budget, read lock-free from the process-global [`MODULE_CACHE_METRICS`].
+///
+/// Returns `None` when the budget gauge has not been published yet — i.e. no
+/// runtime pool has been built in this process (early startup, or a test / tool
+/// binary with no WASM runtime). Callers treat `None` as "no pressure signal".
+///
+/// Used by the placement-migration admission gate (#4534): once occupancy is at
+/// or above the admission ceiling, the node stops accepting inbound
+/// `SubscribeHint` migrations so the hosted working set cannot grow past cache
+/// capacity and thrash (recompile-on-access), which had filled the contract fair
+/// queue and produced client-facing "contract queue full" outages and gateway
+/// OOMs on 0.2.80.
+pub(crate) fn contract_cache_occupancy_pct() -> Option<u64> {
+    let snapshot = MODULE_CACHE_METRICS.snapshot();
+    occupancy_pct(
+        snapshot.contract_total_bytes,
+        snapshot.contract_budget_bytes,
+    )
+}
+
+/// Pure occupancy-percent computation, split out so the threshold arithmetic is
+/// unit-testable without touching the process-global gauges. `None` when
+/// `budget_bytes == 0` (gauge uninitialized): with no known budget there is no
+/// meaningful occupancy, so callers must not infer pressure from it.
+fn occupancy_pct(total_bytes: u64, budget_bytes: u64) -> Option<u64> {
+    if budget_bytes == 0 {
+        return None;
+    }
+    // `saturating_mul` guards the (practically impossible) overflow of
+    // `total_bytes * 100`; at realistic cache sizes (a few GiB) it never trips.
+    Some(total_bytes.saturating_mul(100) / budget_bytes)
+}
+
 /// Lower clamp for the default contract-module cache budget (64 MiB).
 ///
 /// Even a tiny VPS should be able to hold a healthy working set of compiled
@@ -1184,5 +1218,35 @@ mod tests {
             "eviction on a contract-labeled cache must bump the global counter \
              (before={before}, after={after})"
         );
+    }
+
+    /// An uninitialized budget gauge yields no occupancy signal (the
+    /// placement-migration gate treats `None` as "no backpressure" — #4534).
+    #[test]
+    fn occupancy_pct_is_none_when_budget_uninitialized() {
+        assert_eq!(occupancy_pct(0, 0), None);
+        assert_eq!(occupancy_pct(1_000, 0), None);
+    }
+
+    /// Occupancy is `total * 100 / budget`, including the over-budget transient
+    /// (> 100%) the cache shows between an insert and the eviction that follows.
+    #[test]
+    fn occupancy_pct_computes_percentage_of_budget() {
+        assert_eq!(occupancy_pct(0, 1_000), Some(0));
+        assert_eq!(occupancy_pct(500, 1_000), Some(50));
+        assert_eq!(occupancy_pct(900, 1_000), Some(90));
+        assert_eq!(occupancy_pct(1_000, 1_000), Some(100));
+        assert_eq!(occupancy_pct(1_500, 1_000), Some(150));
+    }
+
+    /// A fully-occupied 1.5 GiB budget must not overflow `total * 100`.
+    #[test]
+    fn occupancy_pct_handles_gib_scale_without_overflow() {
+        // `1.5 GiB * 100` is ~1.6e11, well within u64; assert no overflow panic.
+        let budget = 1_536u64 * 1024 * 1024;
+        assert_eq!(occupancy_pct(budget, budget), Some(100));
+        // Cleanly-divisible large budget to assert the 90% boundary exactly
+        // (avoids integer-truncation noise from a non-divisible GiB budget).
+        assert_eq!(occupancy_pct(900_000_000, 1_000_000_000), Some(90));
     }
 }


### PR DESCRIPTION
## Problem

Inbound `SubscribeHint` placement migration (#4404, re-enabled in 0.2.80) had no coupling to module-cache capacity. A node kept accepting contracts migrated toward its key until the hosted working set overran the WASM module cache (`MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES`, 1.5 GiB; `total_ram / 8` binds first). Past that point every access recompiles an evicted module (Cranelift), pinning the single-threaded `contract_handling` loop, filling the fair queue to `MAX_TOTAL_FAIR_QUEUE`, and rejecting the node's own client requests with `contract queue full, try again later`. On memory-bound gateways the same growth OOM-kills the process (vega: anon-rss 6.96 GB, OOM at ~21h uptime — see #4534).

## Approach

Gate the **receive** side of placement migration on module-cache headroom. In the `SubscribeHint` arm of `handle_pure_network_message_v1`, after the existing version-floor / already-hosting / holder-validity checks and before `start_directed_subscribe`, refuse the hint when contract-module-cache occupancy is at or above a 90% ceiling.

- **No new pressure signal.** Occupancy is read from the existing lock-free `MODULE_CACHE_METRICS` gauges (`contract_total_bytes / contract_budget_bytes`), the same telemetry already emitted for #4440. `None` (gauge not yet published, i.e. no runtime pool built) admits, so there is no behavior change in test/sim or early-startup contexts.
- **Migration stays on.** Only the directed-subscribe placement nudge is gated; the node's own local client subscribes/GETs are never gated here. Refusal is silent and best-effort — the holder re-proposes on its next migration trigger once headroom returns.
- **~10% headroom** below 100% is reserved for the node's own locally-requested contracts.
- **Send side unchanged** — a node keeps proposing migrations to others; only its own acceptance is throttled by its own capacity.

This is the migration-acceptance half of #4534. It complements the queue-scheduling / priority-tiering fix in #4535 (@iduartgomez): #4535 stops client requests from being starved; this PR stops the hosted set from growing past cache capacity in the first place (the OOM / thrash root cause). Neither alone resolves both symptoms. Cache-retention pinning by local interest remains a tracked follow-up on #4534.

## Testing

- `occupancy_pct` unit tests: boundary math (0 / 50 / 90 / 100 / over-budget), uninitialized-budget → `None`, and GiB-scale no-overflow.
- `migration_admission_allowed` unit tests: admit when occupancy is `None` or below the ceiling; refuse at/above (including the over-budget transient).
- Source-scrape pin (`subscribe_hint_arm_gates_migration_on_cache_backpressure`): the `SubscribeHint` arm must call the admission gate before `start_directed_subscribe`, so removing or reordering the gate trips the build.

`cargo fmt`, `cargo clippy --locked -- -D warnings`, and the `wasm_runtime::module_cache` + `operations::subscribe::tests` suites pass locally.

Part of #4534 (paired with #4535).

[AI-assisted - Claude]
