### PR TITLE
fix(telemetry): suppress test-build telemetry to prod collector (#4366)

### DIFF
--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -233,6 +233,35 @@ struct TelemetryEvent {
     priority: EventPriority,
 }
 
+/// Best-effort runtime detection of a cargo test/bench harness.
+///
+/// Cargo builds every unit-test, integration-test and bench binary into a
+/// `deps/` directory (e.g. `target/debug/deps/operations_before_join-<hash>`)
+/// and runs it from there. The real node binary is run as `…/freenet` (from a
+/// `bin/` install dir, or `target/<profile>/freenet` under `cargo run`), whose
+/// parent directory is never `deps`. So "the current executable's parent dir is
+/// named `deps`" cleanly distinguishes a cargo test harness from a production
+/// node, regardless of which Cargo features were enabled.
+///
+/// This is the only signal that catches the documented local dev command
+/// `cargo test -p freenet` run WITHOUT `--features testing`: there the library
+/// is a plain dependency (so `cfg!(test)` is false) and the integration tests
+/// build `ConfigArgs::default()` (so `is_test_environment` is false). See
+/// issue #4366.
+///
+/// Best-effort: if `current_exe()` fails we return `false` and fall back to the
+/// compile-time guards, which already cover unit tests and CI.
+fn running_under_cargo_test() -> bool {
+    std::env::current_exe()
+        .ok()
+        .and_then(|exe| {
+            exe.parent()
+                .and_then(|dir| dir.file_name())
+                .map(|name| name == "deps")
+        })
+        .unwrap_or(false)
+}
+
 impl TelemetryReporter {
     /// Create a new telemetry reporter.
     ///
@@ -240,7 +269,9 @@ impl TelemetryReporter {
     /// best-effort address), used to attribute transport-level events
     /// that have no `NetLogMessage` context.
     ///
-    /// Returns None if telemetry is disabled or in a test environment.
+    /// Returns None if telemetry is disabled, in a `--id` test environment,
+    /// or in a test build/harness (`cfg(test)` / `feature = "testing"` /
+    /// running under cargo test — see `running_under_cargo_test`).
     pub fn new(config: &TelemetryConfig, local_peer_id: String) -> Option<Self> {
         if !config.enabled {
             tracing::info!("Telemetry reporting is disabled");
@@ -248,9 +279,37 @@ impl TelemetryReporter {
         }
 
         // Disable telemetry in test environments (detected via --id flag) to avoid
-        // flooding the collector with CI/integration test data.
+        // flooding the production collector with CI/integration test data.
         if config.is_test_environment {
             tracing::info!("Telemetry disabled in test environment (--id flag detected)");
+            return None;
+        }
+
+        // Belt-and-suspenders guard for test binaries that build `NodeConfig`
+        // directly without going through the `--id` CLI path, so
+        // `is_test_environment` stays false (the integration tests under
+        // `crates/core/tests/*.rs`, e.g. operations_before_join /
+        // hosted_mode_* / in_process_restart / error_notification). Without
+        // this, those tests shipped events — including simulation-loopback
+        // `get_not_found` and one-shot synthetic "gateway" peers — to the
+        // production OTLP collector at `DEFAULT_TELEMETRY_ENDPOINT`,
+        // contaminating network metrics (issue #4366).
+        //
+        // Three overlapping signals, none of which the real node binary
+        // matches, so production telemetry is unaffected:
+        //   - `cfg!(test)`: the library's own unit tests.
+        //   - `cfg!(feature = "testing")`: integration/simulation tests as
+        //     CI compiles them (`--features ...,testing`, see ci.yml /
+        //     simulation-nightly.yml).
+        //   - `running_under_cargo_test()`: a runtime check that also covers
+        //     the *documented* local dev path `cargo test -p freenet` WITHOUT
+        //     `--features testing` (AGENTS.md), where the library links as a
+        //     normal dependency so `cfg!(test)` is false and the integration
+        //     tests build `ConfigArgs::default()` (no `--id`). The real
+        //     `freenet` binary never runs from a cargo `deps/` test harness,
+        //     so it never trips this.
+        if cfg!(test) || cfg!(feature = "testing") || running_under_cargo_test() {
+            tracing::info!("Telemetry disabled in test build/harness");
             return None;
         }
 
@@ -1866,7 +1925,51 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
+    // `TelemetryConfig` and `TelemetryReporter` come in via `super::*`.
     use super::*;
+
+    /// Regression for #4366: a test build must NOT initialize a
+    /// `TelemetryReporter` (and thus must not ship events to the production
+    /// OTLP collector) even when the config looks like a real production
+    /// node — `enabled: true`, the production `DEFAULT_TELEMETRY_ENDPOINT`,
+    /// and `is_test_environment: false`. That is exactly the config the
+    /// integration tests under `crates/core/tests/*.rs` build (via
+    /// `ConfigArgs { ..Default::default() }`, which leaves `--id` unset).
+    /// Before the fix they leaked synthetic peers / simulation-loopback
+    /// `get_not_found` events to `nova.locut.us:4318`.
+    ///
+    /// This test runs under `cfg(test)` (and via the cargo `deps/` harness),
+    /// so it pins the shared early-return that all three signals trigger —
+    /// `cfg!(test)`, `cfg!(feature = "testing")` (CI integration/sim runs),
+    /// and `running_under_cargo_test()` (the no-feature `cargo test -p freenet`
+    /// dev path). The production binary trips none of them and is unaffected.
+    #[test]
+    fn telemetry_reporter_suppressed_in_test_build() {
+        let prod_like = TelemetryConfig {
+            enabled: true,
+            endpoint: crate::config::DEFAULT_TELEMETRY_ENDPOINT.to_string(),
+            transport_snapshot_interval_secs: 30,
+            is_test_environment: false,
+            reference_ping_enabled: false,
+            iface_tx_enabled: false,
+        };
+        assert!(
+            TelemetryReporter::new(&prod_like, "peer-under-test".to_string()).is_none(),
+            "test builds must not ship telemetry to the production collector (#4366)"
+        );
+    }
+
+    /// The runtime harness detector must fire for this test binary: cargo
+    /// always runs test binaries from a `deps/` directory. This is the signal
+    /// that covers the documented `cargo test -p freenet` path run without
+    /// `--features testing`, where the compile-time guards don't apply.
+    #[test]
+    fn detects_running_under_cargo_test() {
+        assert!(
+            running_under_cargo_test(),
+            "test binaries run from a cargo deps/ dir and must be detected (#4366)"
+        );
+    }
 
     /// Pin: the manually-mirrored `router_snapshot` OTLP body
     /// (`event_kind_to_json`) must forward the node-health gauges. The body is a


### PR DESCRIPTION
## Problem

Simulation/integration test peers were shipping telemetry to the **production** OTLP
collector (`DEFAULT_TELEMETRY_ENDPOINT = http://nova.locut.us:4318`), contaminating
network metrics (issue #4366). Symptoms observed on nova: bursts of one-shot synthetic
"gateway" peer IDs, `get_not_found` events with simulation-loopback requester addresses
(e.g. `…@127.1.2.1:…`), and bogus version strings — all making per-version GET / transfer
analysis unusable without manual filtering.

Earlier work added an `is_test_environment` flag (set when the `--id` CLI flag is present)
that makes `TelemetryReporter::new` return `None`. The `SimNetwork` harness
(`testing_impl.rs`) sets `id: Some(label)`, so it was already suppressed. **The residual
gap**: the integration tests under `crates/core/tests/*.rs` (`operations_before_join`,
`hosted_mode_export`, `hosted_mode_isolation`, `in_process_restart`, `error_notification`)
build `NodeConfig` directly via `ConfigArgs { ..Default::default() }`, which leaves
`id: None` → `is_test_environment: false` and `telemetry.enabled: true` pointing at the
production endpoint. Those tests therefore still initialized a real reporter and shipped to
prod.

## Approach

Add a belt-and-suspenders guard in `TelemetryReporter::new`: in addition to the existing
`is_test_environment` (`--id`) check, return `None` when the binary is a test build —
`cfg!(test) || cfg!(feature = "testing")`.

Three overlapping signals, none of which the production node binary matches:

- `cfg!(test)` — the library's own unit tests.
- `cfg!(feature = "testing")` — integration/simulation tests as CI compiles them
  (`--features ...,testing`, see `ci.yml` / `simulation-nightly.yml`).
- `running_under_cargo_test()` — a best-effort runtime check (current exe's parent dir is
  `deps/`) that also covers the **documented local dev path** `cargo test -p freenet`
  run WITHOUT `--features testing` (AGENTS.md:122), where the library links as a normal
  dependency so `cfg!(test)` is false and the integration tests build `ConfigArgs::default()`
  (no `--id`). This was raised by the Codex review (see below) and is the realistic
  developer-laptop leak vector.

Why not `cfg!(test)` alone: integration tests in `crates/core/tests/*.rs` link the
`freenet` library as a normal dependency, so `#[cfg(test)]` is **not** set in the library
when those tests run.

This is **test-infrastructure-only**: the production `freenet` binary is built with default
features (`cargo install --path .` in the node/gateway Dockerfiles; the release workflow
sets no `testing` feature), so neither `cfg(test)` nor `feature = "testing"` is active and
real-node telemetry is completely unchanged.

`TelemetryReporter::new` is the single chokepoint — the global `TELEMETRY_SENDER` used by
standalone-event emission is only populated inside `new`, so returning `None` also drops
standalone/transport events. No other emission path bypasses it.

## Testing

- `telemetry_reporter_suppressed_in_test_build`: constructs a production-shaped
  `TelemetryConfig` (`enabled: true`, prod endpoint, `is_test_environment: false`) — exactly
  what the integration tests pass — and asserts `TelemetryReporter::new(...).is_none()`.
  Fails without the guard, passes with it.
- `detects_running_under_cargo_test`: pins that the runtime harness detector fires for a
  cargo test binary (the signal covering the no-feature `cargo test` path).
- `cargo fmt`, `cargo clippy --features testing`, existing telemetry unit tests.

## Review

- **Codex** (`codex review --base origin/main`): raised one P2 — the original
  `cfg!(test) || cfg!(feature = "testing")` guard left the documented `cargo test -p freenet`
  (no `--features testing`) path able to leak. Addressed by adding the runtime
  `running_under_cargo_test()` signal. Re-reviewed after the change.
- **Gemini**: unavailable (`IneligibleTierError` — account tier no longer supported, not a
  transient outage), so the external pass is Codex only. Supplemented with the four-lens
  Claude review (code-first, testing, skeptical, big-picture); the skeptical lens caught a
  redundant `use crate::config::TelemetryConfig;` import (already in scope via `super::*`),
  now removed.

## Fixes

Closes #4366

[AI-assisted - Claude]
