### PR TITLE
fix(router): clamp per-peer adjusted estimate to non-negative

### DIFF
--- a/crates/core/src/router/isotonic_estimator.rs
+++ b/crates/core/src/router/isotonic_estimator.rs
@@ -155,19 +155,29 @@ impl IsotonicEstimator {
         // Regression can sometimes produce negative estimates
         let global_estimate = global_estimate.max(0.0);
 
-        Ok(self
-            .peer_adjustments
-            .get(peer)
-            .map_or(global_estimate, |peer_adjustment| {
-                let should_use_peer_adjustment =
-                    peer_adjustment.effective_count >= MIN_POINTS_FOR_REGRESSION as f64;
-                global_estimate
-                    + if should_use_peer_adjustment {
-                        peer_adjustment.value()
-                    } else {
-                        0.0
-                    }
-            }))
+        let adjusted_estimate =
+            self.peer_adjustments
+                .get(peer)
+                .map_or(global_estimate, |peer_adjustment| {
+                    let should_use_peer_adjustment =
+                        peer_adjustment.effective_count >= MIN_POINTS_FOR_REGRESSION as f64;
+                    global_estimate
+                        + if should_use_peer_adjustment {
+                            peer_adjustment.value()
+                        } else {
+                            0.0
+                        }
+                });
+
+        // The per-peer EWMA adjustment is added *after* the global clamp above and
+        // can be negative (a peer that is consistently faster / more reliable than
+        // the global fit). Re-clamp so the per-peer estimate can never go below
+        // zero — these targets (response time, transfer rate, failure probability)
+        // are all physically non-negative, and a negative prediction would both
+        // distort routing cost formulas and render below the x-axis on the
+        // dashboard's "Peer-adjusted" curve. The failure path applies the same
+        // clamp downstream (see `predict_routing_outcome`).
+        Ok(adjusted_estimate.max(0.0))
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -397,6 +407,51 @@ mod tests {
         debug!("Average error: {average_error}");
         // Threshold 0.02 to avoid flaky failures from random seed variation
         assert!(average_error < 0.02);
+    }
+
+    #[test]
+    fn test_peer_adjustment_cannot_produce_negative_estimate() {
+        // A strongly-negative per-peer EWMA adjustment (a peer far faster / more
+        // reliable than the global fit) must not drive the estimate below zero:
+        // these targets are physically non-negative, and a negative estimate both
+        // distorts routing and renders below the x-axis on the dashboard chart.
+        let mut events = Vec::new();
+        for _ in 0..100 {
+            let peer = PeerKeyLocation::random();
+            let contract_location = Location::random();
+            events.push(simulate_positive_request(peer, contract_location));
+        }
+        let mut estimator = IsotonicEstimator::new(events, EstimatorType::Positive);
+
+        // Overwrite one peer's adjustment with a large negative value and enough
+        // effective observations that it is actually applied.
+        let fast_peer = PeerKeyLocation::random();
+        let mut adjustment = Adjustment::new();
+        for _ in 0..10 {
+            adjustment.add(-1000.0);
+        }
+        assert!(
+            adjustment.effective_count >= MIN_POINTS_FOR_REGRESSION as f64,
+            "adjustment must have enough effective observations to be applied"
+        );
+        assert!(
+            adjustment.value() < -1.0,
+            "adjustment must be strongly negative"
+        );
+        estimator
+            .peer_adjustments
+            .insert(fast_peer.clone(), adjustment);
+
+        // Estimate at the peer's own location (distance 0 → smallest global value).
+        let contract_location = fast_peer.location().unwrap();
+        let estimate = estimator
+            .estimate_retrieval_time(&fast_peer, contract_location)
+            .expect("estimator has enough data to produce an estimate");
+
+        assert!(
+            estimate >= 0.0,
+            "per-peer adjusted estimate must be clamped to a non-negative value, got {estimate}"
+        );
     }
 
     #[test]

--- a/crates/core/src/server/home_page/estimator.rs
+++ b/crates/core/src/server/home_page/estimator.rs
@@ -285,7 +285,15 @@ pub fn build_estimator_chart(
         let mut right_ext = Vec::new();
 
         for &(x, y) in points {
-            let y = y + adj;
+            // Apply the per-peer adjustment, then clamp to the visible axis floor.
+            // A negative adjustment (a peer faster / more reliable than the global
+            // fit) can drive `y + adj` below the axis — e.g. a negative "response
+            // time", which is physically meaningless — and render the curve below
+            // the x-axis. The router clamps the same per-peer estimate to >= 0 (see
+            // `IsotonicEstimator::estimate_retrieval_time`); clamping to `y_min`
+            // here keeps the drawn curve on-axis and consistent with that, mirroring
+            // the scatter-point clamp above. (`y_min` is 0 for all of these charts.)
+            let y = (y + adj).max(y_min);
             if x < data_lo - 0.001 {
                 left_ext.push((x, y));
             } else if x > data_hi + 0.001 {
@@ -828,4 +836,72 @@ fn mini_chart_placeholder(label: &str, sub: &str) -> String {
         cy = h / 2.0,
         cy2 = h / 2.0 + 14.0,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The plot's bottom edge (x-axis) in SVG user units, matching the geometry in
+    // `build_estimator_chart`: pad_t (10) + plot_h (h 210 - pad_t 10 - pad_b 40 = 160).
+    const PLOT_BOTTOM_Y: f64 = 170.0;
+
+    // Extract the y-coordinates from every path drawn in the given stroke color.
+    fn path_y_coords_for_color(svg: &str, color: &str) -> Vec<f64> {
+        let mut ys = Vec::new();
+        for seg in svg.split("<path") {
+            if !seg.contains(color) {
+                continue;
+            }
+            // The `d="..."` attribute precedes the stroke color in the same element.
+            let Some(start) = seg.find("d=\"") else {
+                continue;
+            };
+            let rest = &seg[start + 3..];
+            let Some(end) = rest.find('"') else {
+                continue;
+            };
+            for token in rest[..end].split_whitespace() {
+                // Tokens look like `M50.0,170.0` or `L256.0,131.4`.
+                let cleaned = token.trim_start_matches(['M', 'L']);
+                if let Some((_, y)) = cleaned.split_once(',') {
+                    if let Ok(v) = y.parse::<f64>() {
+                        ys.push(v);
+                    }
+                }
+            }
+        }
+        ys
+    }
+
+    #[test]
+    fn peer_adjusted_curve_never_renders_below_x_axis() {
+        // Small positive base curve with a strongly-negative peer adjustment: the
+        // raw `y + adj` would be deeply negative and, on a y-axis floored at 0,
+        // would draw the violet "Peer-adjusted" curve well below the x-axis.
+        let curve = [(0.0, 0.10), (0.25, 0.30), (0.50, 0.50)];
+        let svg = build_estimator_chart(
+            "Response Time (s)",
+            &curve,
+            &[],           // no scatter
+            (0.0, 0.5),    // entire range is data (solid line)
+            Some(-1000.0), // strongly-negative peer adjustment
+            None,
+            "0", // y floor (as used for the response-time chart)
+            "auto",
+        );
+
+        // "#8b5cf6" is the violet stroke used only for the peer-adjusted curve.
+        let ys = path_y_coords_for_color(&svg, "#8b5cf6");
+        assert!(
+            !ys.is_empty(),
+            "expected a peer-adjusted curve to be drawn; svg: {svg}"
+        );
+        for y in ys {
+            assert!(
+                y <= PLOT_BOTTOM_Y + 0.05,
+                "peer-adjusted curve drawn below the x-axis (y={y} > {PLOT_BOTTOM_Y})"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Symptom

On the node dashboard's peer detail page (`/peer/<addr>`), the **Response Time** chart's violet **"Peer-adjusted"** curve renders **below the x-axis** — i.e. a *negative* response time, which is physically meaningless.

## Root cause

`IsotonicEstimator::estimate_retrieval_time` clamps the **global** isotonic estimate to `>= 0` (regression can produce small negatives), but then **adds the per-peer EWMA adjustment _after_ that clamp**:

```rust
let global_estimate = global_estimate.max(0.0);   // clamped
... global_estimate + peer_adjustment.value()     // adjustment NOT re-clamped
```

A peer that is consistently faster / more reliable than the global fit has a **negative** adjustment. When its magnitude exceeds the (small) global estimate — most likely near distance 0, the left edge of the chart — the result goes negative. The targets here (response time, transfer rate, failure probability) are all physically non-negative.

This surfaces in two places, one cause:

- **Routing:** a negative `time_to_response_start` flows *unclamped* into `expected_total_time` in `predict_routing_outcome` (`router.rs`), making such a peer look impossibly fast and biasing selection toward it. Note the **failure** path right beside it *is* already clamped (`failure_estimate.clamp(0.0, 1.0)`) — the timing path simply missed the analogous clamp.
- **Dashboard:** the peer detail chart draws the peer-adjusted curve as `global_curve_y + adjustment` with no lower bound, so the line dips below the plot floor.

## Fix

1. **Root cause** (`isotonic_estimator.rs`): re-clamp the adjusted estimate to `>= 0` in `estimate_retrieval_time`. Harmless for the failure estimator (already clamped to `[0,1]` downstream); corrects the timing/rate paths.
2. **Display** (`server/home_page/estimator.rs`): clamp the drawn curve to the visible axis floor (`y_min`, which is `0` for these charts), mirroring the existing scatter-point clamp, so the curve never renders below the x-axis even though the chart computes `y + adj` independently of the router.

## Tests

- `test_peer_adjustment_cannot_produce_negative_estimate` — a strongly-negative per-peer adjustment no longer yields a negative estimate.
- `peer_adjusted_curve_never_renders_below_x_axis` — the violet curve's SVG y-coordinates stay at/above the plot floor.

All 26 tests in the touched modules pass; clean build, no warnings.

## Review note

This touches the **routing** surface (peer selection cost formula), so it warrants careful review of the behavioral change: peers with strong negative timing adjustments now have `time_to_response_start` floored at 0 (best possible) rather than negative (impossibly good).

[AI-assisted - Claude]