### PR TITLE
chore: fix clippy::assertions_on_constants in telemetry.rs

### DIFF
--- a/crates/core/src/bin/commands/secrets_cmd.rs
+++ b/crates/core/src/bin/commands/secrets_cmd.rs
@@ -1846,6 +1846,8 @@ mod tests {
         let got = resolve_secret(Some("from-flag"), Some(env_name), "thing", false)
             .expect("env source must resolve");
         assert_eq!(&*got, "from-env", "env must win over the flag");
+        // SAFETY: test-private env var name removed within this test; nextest
+        // runs each test in its own process.
         unsafe {
             std::env::remove_var(env_name);
         }

--- a/crates/core/src/server/client_api/hosted_export.rs
+++ b/crates/core/src/server/client_api/hosted_export.rs
@@ -422,8 +422,9 @@ mod tests {
     fn gate_honors_ipv4_mapped_loopback() {
         // `::ffff:127.0.0.1` from a dual-stack socket normalizes to loopback.
         let headers = headers_with(Some("tok-abc"), Some("https"));
-        let mapped = Some(IpAddr::V6(Ipv4Addr::LOCALHOST.to_ipv6_mapped()));
-        assert!(is_loopback_source(mapped.unwrap()));
+        let addr = IpAddr::V6(Ipv4Addr::LOCALHOST.to_ipv6_mapped());
+        let mapped = Some(addr);
+        assert!(is_loopback_source(addr));
         let (_, token) =
             export_user_context_or_reject(&headers, mapped, true).expect("mapped loopback honored");
         assert_eq!(token, b"tok-abc");

--- a/crates/core/src/topology/rate.rs
+++ b/crates/core/src/topology/rate.rs
@@ -129,7 +129,7 @@ mod tests {
 
         // Sorting is the exact production trigger (sort_unstable in
         // calculate_estimated_usage_rate).
-        let mut rates = vec![
+        let mut rates = [
             Rate::new_per_second(3.0),
             Rate::new_per_second(1.0),
             Rate::new_per_second(2.0),

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2373,10 +2373,12 @@ mod tests {
         // Sanity-check the constants the policy depends on: the sub-budget
         // must be strictly below the aggregate cap, otherwise shadow events
         // could consume the whole budget and the carve-out is meaningless.
-        assert!(
-            MAX_SHADOW_EVENTS_PER_SECOND < MAX_EVENTS_PER_SECOND,
-            "shadow sub-budget must leave room for operational events"
-        );
+        const {
+            assert!(
+                MAX_SHADOW_EVENTS_PER_SECOND < MAX_EVENTS_PER_SECOND,
+                "shadow sub-budget must leave room for operational events"
+            );
+        }
 
         let mut worker = rate_limit_test_worker();
         let now = Instant::now();


### PR DESCRIPTION
## Problem
`cargo clippy --all-targets` fails on a pre-existing test-only constant assertion at `crates/core/src/tracing/telemetry.rs` (`clippy::assertions_on_constants`), surfaced by the rustc 1.94 / v0.2.75 toolchain bump on main. CI's clippy job runs `cargo clippy --locked -- -D warnings` **without** `--all-targets`, so CI stays green — but it breaks local `cargo clippy --all-targets` runs for everyone.

## Approach
The assertion compares two compile-time constants (`MAX_SHADOW_EVENTS_PER_SECOND < MAX_EVENTS_PER_SECOND`), which is exactly what `assertions_on_constants` flags. Wrapping it in `const { assert!(..) }` is the lint's recommended fix and is strictly stronger: the invariant is now enforced at **compile time** rather than at test runtime.

### Incidental fixes (clearly noted — not part of #4465)
With the primary lint fixed, `cargo clippy --all-targets` *still* failed on three other **pre-existing, test-only** lints surfaced by the same toolchain bump. They are unrelated to #4465, but each is trivial and the issue's stated goal is a clean `--all-targets` run, so they are fixed in the same PR rather than deferred:

- **`crates/core/src/bin/commands/secrets_cmd.rs:1849`** — `undocumented_unsafe_blocks` (this one is **deny-level**, i.e. a hard `error`, so `--all-targets` does not even compile without it). Added a `// SAFETY:` comment to the `remove_var` unsafe block, matching the style of the sibling blocks.
- **`crates/core/src/server/client_api/hosted_export.rs:426`** — `unnecessary_literal_unwrap`. Bind the address once (`let addr = ...; let mapped = Some(addr);`) and pass `addr` directly instead of `.unwrap()`-ing a literal `Some`. `mapped` is still needed as an `Option` two lines later.
- **`crates/core/src/topology/rate.rs:132`** — `useless_vec`. Use an array literal instead of `vec!` (the value is only sorted in place via `sort_unstable`).

All four edits are in test code; there is **no production behavior change**.

## Testing
- `cargo clippy --all-targets` — now finishes clean (0 warnings, 0 errors); previously failed.
- `cargo fmt` — no changes.
- Affected unit tests pass: `tracing::telemetry::tests::test_shadow_subbudget_caps_shadow_events`, `server::client_api::hosted_export::tests::gate_honors_ipv4_mapped_loopback`, `topology::rate::tests::*`, `commands::secrets_cmd::tests::resolve_secret_*`.

**Why CI didn't catch this:** the clippy gate intentionally omits `--all-targets` (test targets aren't linted in CI), which is why these test-only lints never blocked a CI run. This PR does not change that gate; it just makes the local `--all-targets` developer workflow clean again, per the issue.

## Fixes
Closes #4465

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)