### PR TITLE
refactor: thread ModuleCacheMetrics as Arc instead of process-global static

### DIFF
--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -978,19 +978,32 @@ mod executor_pin_tests {
             .split("pub async fn new(")
             .nth(1)
             .expect("RuntimePool::new must exist")
+            // Take the first chunk of the function body. Whitespace is collapsed
+            // so the assertions below survive line-wrapping / reformatting of the
+            // (now multi-line, metrics-threaded) cache construction.
             .split("\n    ")
-            .take(60)
-            .collect::<String>();
+            .take(80)
+            .collect::<String>()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
         assert!(
             body.contains("config.module_cache_budget_bytes"),
             "RuntimePool::new must size caches from config.module_cache_budget_bytes"
         );
+        // The contract cache is built from `contract_cache_budget` with the
+        // "contract" label; the delegate cache from `delegate_cache_budget` with
+        // the "delegate" label. We assert each piece independently (rather than a
+        // single literal call string) so threading the metrics `Arc` through
+        // `with_label` (#4488) doesn't make this pin brittle.
         assert!(
-            body.contains("ModuleCache::with_label(contract_cache_budget, \"contract\")"),
+            body.contains("ModuleCache::with_label( contract_cache_budget, \"contract\"")
+                || body.contains("ModuleCache::with_label(contract_cache_budget, \"contract\""),
             "RuntimePool::new must build the contract cache from the contract byte budget"
         );
         assert!(
-            body.contains("ModuleCache::with_label(delegate_cache_budget, \"delegate\")"),
+            body.contains("ModuleCache::with_label( delegate_cache_budget, \"delegate\"")
+                || body.contains("ModuleCache::with_label(delegate_cache_budget, \"delegate\""),
             "RuntimePool::new must build the delegate cache from its own (smaller) budget"
         );
         assert!(

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -148,12 +148,24 @@ impl RuntimePool {
         let delegate_cache_budget = (contract_cache_budget
             / crate::wasm_runtime::DELEGATE_MODULE_CACHE_BUDGET_DIVISOR)
             .max(1);
-        let shared_contract_modules: SharedModuleCache<ContractKey> = Arc::new(Mutex::new(
-            ModuleCache::with_label(contract_cache_budget, "contract"),
-        ));
-        let shared_delegate_modules: SharedModuleCache<DelegateKey> = Arc::new(Mutex::new(
-            ModuleCache::with_label(delegate_cache_budget, "delegate"),
-        ));
+        // Per-node telemetry sink shared with the `Ring` snapshot task (#4440 /
+        // #4488). The caches publish occupancy/eviction into it; the snapshot
+        // task reads the same `Arc` via `Ring`. Threading it (rather than a
+        // process-global) keeps the gauges per-node. Both caches share one sink;
+        // they're routed apart by their `"contract"` / `"delegate"` label.
+        let module_cache_metrics = op_manager.ring.module_cache_metrics();
+        let shared_contract_modules: SharedModuleCache<ContractKey> =
+            Arc::new(Mutex::new(ModuleCache::with_label(
+                contract_cache_budget,
+                "contract",
+                Some(module_cache_metrics.clone()),
+            )));
+        let shared_delegate_modules: SharedModuleCache<DelegateKey> =
+            Arc::new(Mutex::new(ModuleCache::with_label(
+                delegate_cache_budget,
+                "delegate",
+                Some(module_cache_metrics),
+            )));
         // Shared delegate-context cache so a prompt round-trip routed to a
         // different pool executor still finds its `ctx.write()` blob.
         let shared_delegate_contexts = crate::wasm_runtime::new_delegate_context_cache();

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -53,7 +53,9 @@ pub(crate) use network_bridge::{
 };
 // Re-export the UPDATE-broadcast stream-assembly telemetry global (#4440) so the
 // `Ring` snapshot task can read it (the broadcast queue lives behind the private
-// `network_bridge` module). Mirrors `crate::wasm_runtime::MODULE_CACHE_METRICS`.
+// `network_bridge` module). Mirrors `crate::transport::metrics::TRANSPORT_METRICS`.
+// (The module-cache metrics were a sibling process-global until #4488 made them
+// a per-node `Arc`.)
 pub(crate) use network_bridge::broadcast_queue::BROADCAST_STREAM_METRICS;
 #[cfg(test)]
 pub(crate) use network_bridge::{EventLoopNotificationsReceiver, event_loop_notification_channel};
@@ -1837,7 +1839,11 @@ where
             // subscribes/GETs are never gated here. The hint is dropped silently
             // and the holder re-proposes it on its next migration trigger once
             // headroom returns.
-            let contract_cache_occupancy = crate::wasm_runtime::contract_cache_occupancy_pct();
+            // Read the per-node module-cache occupancy off the same `Ring` the
+            // caches publish into (a process-global until #4488).
+            let contract_cache_occupancy = crate::wasm_runtime::contract_cache_occupancy_pct(
+                &op_manager.ring.module_cache_metrics(),
+            );
             if !migration_admission_allowed(contract_cache_occupancy) {
                 tracing::debug!(
                     key = %hint.key,

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -47,10 +47,11 @@ const STREAM_COMPLETION_TIMEOUT: Duration = Duration::from_secs(120);
 ///
 /// These broadcast tasks are spawned per (contract, peer) from the global
 /// `BroadcastQueue` worker, unreachable from the `Ring` telemetry-snapshot task
-/// that emits `router_snapshot`. Like [`MODULE_CACHE_METRICS`] /
-/// [`TRANSPORT_METRICS`], the failure site therefore *publishes* into this
-/// process-global and the snapshot task *reads* it on the existing ~5-minute
-/// cadence — no per-failure event is emitted.
+/// that emits `router_snapshot`. Like [`TRANSPORT_METRICS`], the failure site
+/// therefore *publishes* into this process-global and the snapshot task *reads*
+/// it on the existing ~5-minute cadence — no per-failure event is emitted. (The
+/// analogous module-cache telemetry was likewise a process-global until #4488
+/// threaded it as a per-node `Arc`; this static still mirrors `TRANSPORT_METRICS`.)
 ///
 /// Both counters are monotonic; the snapshot task differences them across the
 /// cadence to derive a per-window failure rate (see
@@ -58,10 +59,9 @@ const STREAM_COMPLETION_TIMEOUT: Duration = Duration::from_secs(120);
 ///
 /// Per-node meaning holds only in single-node-per-process production. In a
 /// multi-node simulation every node shares this process-global, so the snapshot
-/// reads the aggregate across all in-process nodes (same caveat as
-/// [`MODULE_CACHE_METRICS`]).
+/// reads the aggregate across all in-process nodes (the same caveat that drove
+/// #4488 for the module-cache metrics).
 ///
-/// [`MODULE_CACHE_METRICS`]: crate::wasm_runtime::MODULE_CACHE_METRICS
 /// [`TRANSPORT_METRICS`]: crate::transport::metrics::TRANSPORT_METRICS
 pub(crate) static BROADCAST_STREAM_METRICS: BroadcastStreamMetrics = BroadcastStreamMetrics::new();
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -160,6 +160,13 @@ pub(crate) struct Ring {
     /// Directory for persisting the peer address cache. When set, the peer cache
     /// is periodically saved here and loaded on startup for fast reconnection.
     pub(crate) peer_cache_dir: Option<std::path::PathBuf>,
+    /// Per-node compiled-WASM module-cache occupancy + eviction telemetry
+    /// (#4440). Constructed once here and threaded as an `Arc`: the
+    /// `RuntimePool` clones it (via `op_manager.ring`) into its labeled module
+    /// caches, which *publish* into it; the `emit_router_snapshot_telemetry`
+    /// task *reads* it. Threading the `Arc` (rather than a process-global)
+    /// keeps the gauges per-node so unit tests stay isolated (#4488).
+    module_cache_metrics: Arc<crate::wasm_runtime::ModuleCacheMetrics>,
 }
 
 // /// A data type that represents the fact that a peer has been blacklisted
@@ -339,6 +346,10 @@ impl Ring {
             contract_connect_backoff: Mutex::new(HashMap::new()),
             time_source,
             peer_cache_dir,
+            // One sink per node, shared with the module caches via the `Arc`
+            // (the `RuntimePool` reaches it through `op_manager.ring`). See
+            // the field docs and #4488.
+            module_cache_metrics: Arc::new(crate::wasm_runtime::ModuleCacheMetrics::new()),
         };
 
         if let Some(loc) = config.location {
@@ -460,6 +471,14 @@ impl Ring {
 
     pub fn attach_op_manager(&self, op_manager: &Arc<OpManager>) {
         self.op_manager.write().replace(Arc::downgrade(op_manager));
+    }
+
+    /// Shared per-node module-cache telemetry sink (#4440 / #4488). The
+    /// `RuntimePool` clones this into its labeled module caches (which publish
+    /// occupancy/eviction into it) while the snapshot task reads it; threading
+    /// this `Arc` is what replaced the old `MODULE_CACHE_METRICS` process-global.
+    pub(crate) fn module_cache_metrics(&self) -> Arc<crate::wasm_runtime::ModuleCacheMetrics> {
+        self.module_cache_metrics.clone()
     }
 
     fn upgrade_op_manager(&self) -> Option<Arc<OpManager>> {
@@ -1100,9 +1119,10 @@ impl Ring {
             snapshot.fd_soft_limit = fd_soft_limit;
 
             // Compiled-WASM module-cache occupancy + eviction gauges (#4440),
-            // read from the process-global the caches publish into (they live
-            // behind the contract-handler channel, unreachable from here).
-            let mc = crate::wasm_runtime::MODULE_CACHE_METRICS.snapshot();
+            // read from the per-node `Arc` the caches publish into (they live
+            // behind the contract-handler channel, unreachable from here; the
+            // `RuntimePool` shares this `Arc` via `op_manager.ring`).
+            let mc = ring.module_cache_metrics.snapshot();
             snapshot.contract_module_cache_entries = Some(mc.contract_entries);
             snapshot.contract_module_cache_total_bytes = Some(mc.contract_total_bytes);
             snapshot.contract_module_cache_budget_bytes = Some(mc.contract_budget_bytes);
@@ -4133,16 +4153,17 @@ fn window_delta(current_total: u64, prev_total: &mut u64) -> u64 {
 /// `router_snapshot` cadence (partially addresses #4440 item (a)).
 ///
 /// The task *publishes* (`record_success` / `record_failure`) and the `Ring`
-/// snapshot task *reads* (`refresh_router`), mirroring `MODULE_CACHE_METRICS` /
-/// `BROADCAST_STREAM_METRICS`. Currently scoped to `refresh_router`, the one
-/// monitored task with a non-fatal per-run failure mode; add fields here if
-/// another monitored task grows the same pattern.
+/// snapshot task *reads* (`refresh_router`), mirroring `BROADCAST_STREAM_METRICS`
+/// (and the module-cache metrics, which were a sibling process-global until
+/// #4488 threaded them as a per-node `Arc`). Currently scoped to
+/// `refresh_router`, the one monitored task with a non-fatal per-run failure
+/// mode; add fields here if another monitored task grows the same pattern.
 ///
 /// Per-node meaning holds only in single-node-per-process production. In a
 /// multi-node simulation every node's `refresh_router` shares this
 /// process-global, so the snapshot reads the aggregate (last-write-wins
-/// last-success across nodes; the consecutive-failure run is shared) — same
-/// caveat as `MODULE_CACHE_METRICS` / `BROADCAST_STREAM_METRICS`.
+/// last-success across nodes; the consecutive-failure run is shared) — the same
+/// caveat that drove #4488 for the module-cache metrics.
 static BACKGROUND_TASK_HEALTH: std::sync::LazyLock<BackgroundTaskHealth> =
     std::sync::LazyLock::new(BackgroundTaskHealth::new);
 

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -176,7 +176,8 @@ pub(crate) struct RouterSnapshotInfo {
     /// `None` on non-unix. Populated by `Ring`; see [`open_fds`](Self::open_fds).
     pub fd_soft_limit: Option<u64>,
     /// Compiled-WASM module-cache gauges (#4440), populated by `Ring` from the
-    /// process-global `MODULE_CACHE_METRICS`. `None` until the WASM runtime has
+    /// per-node `ModuleCacheMetrics` `Arc` the caches publish into (a
+    /// process-global until #4488). `None` until the WASM runtime has
     /// touched the cache. The contract-cache thrash (eviction → recompile) that
     /// drove the #4441 incident was invisible to central telemetry; these make
     /// occupancy and eviction pressure observable on the snapshot cadence. The

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -26,7 +26,7 @@ pub(crate) use error::{ContractError, RuntimeInnerError, RuntimeResult};
 pub use mock_state_storage::MockStateStorage;
 pub use module_cache::default_module_cache_budget_bytes;
 pub(crate) use module_cache::{
-    DELEGATE_MODULE_CACHE_BUDGET_DIVISOR, MODULE_CACHE_METRICS, ModuleCache,
+    DELEGATE_MODULE_CACHE_BUDGET_DIVISOR, ModuleCache, ModuleCacheMetrics,
     contract_cache_occupancy_pct,
 };
 // Clamp bounds are referenced only by the config-default round-trip test, which

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -1749,7 +1749,7 @@ mod test {
         let budget = per_module + per_module / 2; // between 1x and 2x
         {
             let mut cache = runtime.delegate_modules.lock().unwrap();
-            *cache = super::super::ModuleCache::with_label(budget, "delegate");
+            *cache = super::super::ModuleCache::with_label(budget, "delegate", None);
         }
 
         // Load all 6 distinct delegates; the cache must stay within budget.

--- a/crates/core/src/wasm_runtime/module_cache.rs
+++ b/crates/core/src/wasm_runtime/module_cache.rs
@@ -39,7 +39,7 @@
 
 use std::borrow::Borrow;
 use std::hash::Hash;
-use std::sync::LazyLock;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
@@ -84,31 +84,39 @@ pub(crate) struct ModuleCache<K: Hash + Eq, V> {
     /// operator log line, not simulated node behavior, so it must advance in
     /// real time regardless of any paused test clock.
     window_started_at: Option<Instant>,
+    /// Shared occupancy/eviction telemetry sink this cache publishes into, or
+    /// `None` for unlabeled / test caches that don't report metrics. The `Arc`
+    /// is constructed once at node startup (`Ring::new`) and threaded through
+    /// `RuntimePool::new`; the `Ring` snapshot task reads from the same `Arc`.
+    /// See [`ModuleCacheMetrics`].
+    metrics: Option<Arc<ModuleCacheMetrics>>,
 }
 
 impl<K: Hash + Eq, V> ModuleCache<K, V> {
-    /// Create an empty cache with the given byte budget and an unlabeled
-    /// ("module") operator-warning tag. Prefer [`Self::with_label`] in
-    /// production so the eviction warning identifies the cache.
+    /// Create an empty cache with the given byte budget, an unlabeled
+    /// ("module") operator-warning tag, and no metrics sink. Prefer
+    /// [`Self::with_label`] in production so the eviction warning identifies
+    /// the cache and so occupancy/eviction telemetry is published.
     ///
     /// `budget_bytes` is clamped to at least 1 so a degenerate budget of 0
     /// still permits exactly one (most-recently-used) entry to be resident,
     /// keeping the cache functional rather than evicting on every insert.
     pub(crate) fn new(budget_bytes: usize) -> Self {
-        Self::with_label(budget_bytes, "module")
+        Self::with_label(budget_bytes, "module", None)
     }
 
     /// Like [`Self::new`] but with a label ("contract" / "delegate") used in the
-    /// rate-limited "cache is evicting at budget" operator warning.
-    pub(crate) fn with_label(budget_bytes: usize, label: &'static str) -> Self {
+    /// rate-limited "cache is evicting at budget" operator warning, and an
+    /// optional shared [`ModuleCacheMetrics`] sink. Production passes
+    /// `Some(metrics)` (the per-node `Arc` threaded from `Ring::new` through
+    /// `RuntimePool::new`); tests that don't care about telemetry pass `None`.
+    pub(crate) fn with_label(
+        budget_bytes: usize,
+        label: &'static str,
+        metrics: Option<Arc<ModuleCacheMetrics>>,
+    ) -> Self {
         let budget_bytes = budget_bytes.max(1);
-        // Publish the budget immediately, so an idle cache (a node that hasn't
-        // compiled a module yet, or a delegate cache that's never used) reports
-        // its configured budget instead of the atomic default 0. Otherwise the
-        // collector's occupancy-% denominator is 0 until the first insert/remove
-        // (#4440 — flagged by both PR reviewers).
-        MODULE_CACHE_METRICS.record_occupancy(label, 0, 0, budget_bytes);
-        Self {
+        let cache = Self {
             // The LRU is unbounded by count; the byte budget is the only
             // bound. `usize::MAX` capacity means `LruCache` never evicts on
             // its own — we drive all eviction via the byte budget below.
@@ -118,7 +126,15 @@ impl<K: Hash + Eq, V> ModuleCache<K, V> {
             label,
             evictions_in_window: 0,
             window_started_at: None,
-        }
+            metrics,
+        };
+        // Publish the budget immediately, so an idle cache (a node that hasn't
+        // compiled a module yet, or a delegate cache that's never used) reports
+        // its configured budget instead of the atomic default 0. Otherwise the
+        // collector's occupancy-% denominator is 0 until the first insert/remove
+        // (#4440 — flagged by both PR reviewers).
+        cache.record_occupancy(0, 0, budget_bytes);
+        cache
     }
 
     /// Look up a key, marking it most-recently-used on a hit. Returns a
@@ -145,12 +161,23 @@ impl<K: Hash + Eq, V> ModuleCache<K, V> {
         }
         self.total_bytes = self.total_bytes.saturating_add(size_bytes);
         self.evict_to_budget();
-        MODULE_CACHE_METRICS.record_occupancy(
-            self.label,
-            self.inner.len(),
-            self.total_bytes,
-            self.budget_bytes,
-        );
+        self.record_occupancy(self.inner.len(), self.total_bytes, self.budget_bytes);
+    }
+
+    /// Publish current occupancy into the metrics sink (no-op when this cache
+    /// has no sink — unlabeled / test caches). Routed by this cache's `label`.
+    fn record_occupancy(&self, entries: usize, total_bytes: usize, budget_bytes: usize) {
+        if let Some(metrics) = &self.metrics {
+            metrics.record_occupancy(self.label, entries, total_bytes, budget_bytes);
+        }
+    }
+
+    /// Add to this cache's monotonic lifetime eviction counter in the metrics
+    /// sink (no-op when this cache has no sink). Routed by this cache's `label`.
+    fn add_evictions(&self, count: u64) {
+        if let Some(metrics) = &self.metrics {
+            metrics.add_evictions(self.label, count);
+        }
     }
 
     /// Evict least-recently-used entries until `total_bytes <= budget_bytes`,
@@ -171,7 +198,7 @@ impl<K: Hash + Eq, V> ModuleCache<K, V> {
             // Monotonic lifetime counter for telemetry; the collector differences
             // it across the snapshot cadence to derive an eviction rate. Distinct
             // from `evictions_in_window`, which resets per warn window (#4440).
-            MODULE_CACHE_METRICS.add_evictions(self.label, evicted_this_insert);
+            self.add_evictions(evicted_this_insert);
         }
     }
 
@@ -222,12 +249,7 @@ impl<K: Hash + Eq, V> ModuleCache<K, V> {
     {
         let (value, size) = self.inner.pop(key)?;
         self.total_bytes = self.total_bytes.saturating_sub(size);
-        MODULE_CACHE_METRICS.record_occupancy(
-            self.label,
-            self.inner.len(),
-            self.total_bytes,
-            self.budget_bytes,
-        );
+        self.record_occupancy(self.inner.len(), self.total_bytes, self.budget_bytes);
         Some(value)
     }
 
@@ -252,21 +274,6 @@ impl<K: Hash + Eq, V> ModuleCache<K, V> {
     }
 }
 
-/// Process-global compiled-WASM module-cache occupancy + eviction telemetry
-/// (#4440).
-///
-/// The module caches live behind the contract-handler channel, unreachable from
-/// the `Ring` telemetry-snapshot task that emits `router_snapshot`. Like
-/// [`TRANSPORT_METRICS`](crate::transport::metrics::TRANSPORT_METRICS), the
-/// caches therefore *publish* into this process-global and the snapshot task
-/// *reads* it. A node builds exactly one contract cache and one delegate cache
-/// (`RuntimePool::new`), so one global pair of gauges is correct; this assumes a
-/// single runtime pool per process (the production invariant). The cache-thrash
-/// that drove the #4441 incident was invisible to central telemetry — these
-/// gauges make occupancy and eviction pressure observable.
-pub(crate) static MODULE_CACHE_METRICS: LazyLock<ModuleCacheMetrics> =
-    LazyLock::new(ModuleCacheMetrics::new);
-
 /// Atomic occupancy gauges plus a monotonic eviction counter for one cache.
 #[derive(Default)]
 struct CacheGauges {
@@ -282,14 +289,30 @@ struct CacheGauges {
     evictions_total: AtomicU64,
 }
 
-/// Per-cache module-cache telemetry, routed by the cache's `"contract"` /
-/// `"delegate"` label. See [`MODULE_CACHE_METRICS`].
+/// Per-node compiled-WASM module-cache occupancy + eviction telemetry (#4440),
+/// routed by the cache's `"contract"` / `"delegate"` label.
+///
+/// The module caches live behind the contract-handler channel, unreachable from
+/// the `Ring` telemetry-snapshot task that emits `router_snapshot`. The caches
+/// therefore *publish* into this shared sink and the snapshot task *reads* it.
+/// A node builds exactly one contract cache and one delegate cache
+/// (`RuntimePool::new`), so one shared pair of gauges is correct.
+///
+/// Unlike the [`TRANSPORT_METRICS`](crate::transport::metrics::TRANSPORT_METRICS)
+/// process-global it used to mirror, this is constructed once at node startup
+/// (`Ring::new`) and threaded as an `Arc`: `Ring` keeps a clone for the snapshot
+/// reader and `RuntimePool::new` clones it into each labeled `ModuleCache`. That
+/// keeps the gauges per-node (so unit tests get isolated instances with no
+/// cross-talk) while preserving the single-runtime-pool-per-process production
+/// behavior. The cache-thrash that drove the #4441 incident was invisible to
+/// central telemetry — these gauges make occupancy and eviction pressure
+/// observable.
 pub(crate) struct ModuleCacheMetrics {
     contract: CacheGauges,
     delegate: CacheGauges,
 }
 
-/// A point-in-time read of [`MODULE_CACHE_METRICS`] for telemetry emission.
+/// A point-in-time read of [`ModuleCacheMetrics`] for telemetry emission.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ModuleCacheMetricsSnapshot {
     pub contract_entries: u64,
@@ -303,7 +326,9 @@ pub(crate) struct ModuleCacheMetricsSnapshot {
 }
 
 impl ModuleCacheMetrics {
-    fn new() -> Self {
+    /// Construct an empty metrics sink. Called once per node at startup
+    /// (`Ring::new`) and shared via `Arc`; see the type-level docs.
+    pub(crate) fn new() -> Self {
         Self {
             contract: CacheGauges::default(),
             delegate: CacheGauges::default(),
@@ -369,10 +394,11 @@ impl ModuleCacheMetrics {
 }
 
 /// Contract-module-cache occupancy as a percentage of the configured byte
-/// budget, read lock-free from the process-global [`MODULE_CACHE_METRICS`].
+/// budget, read lock-free from the per-node [`ModuleCacheMetrics`] sink (reach it
+/// off `op_manager.ring.module_cache_metrics()`; a process-global until #4488).
 ///
 /// Returns `None` when the budget gauge has not been published yet — i.e. no
-/// runtime pool has been built in this process (early startup, or a test / tool
+/// runtime pool has been built on this node (early startup, or a test / tool
 /// binary with no WASM runtime). Callers treat `None` as "no pressure signal".
 ///
 /// Used by the placement-migration admission gate (#4534): once occupancy is at
@@ -392,8 +418,8 @@ impl ModuleCacheMetrics {
 /// new load — the failure mode of a stale read is at worst deferring one
 /// migration that would have fit, never accepting one it should have refused
 /// once occupancy has caught up.
-pub(crate) fn contract_cache_occupancy_pct() -> Option<u64> {
-    let snapshot = MODULE_CACHE_METRICS.snapshot();
+pub(crate) fn contract_cache_occupancy_pct(metrics: &ModuleCacheMetrics) -> Option<u64> {
+    let snapshot = metrics.snapshot();
     occupancy_pct(
         snapshot.contract_total_bytes,
         snapshot.contract_budget_bytes,
@@ -1211,24 +1237,55 @@ mod tests {
         assert_eq!(s.delegate_entries, 1, "unknown label is a no-op");
     }
 
-    /// A `"contract"`-labeled cache that evicts publishes to the process-global
-    /// monotonic eviction counter. Asserts only the strict increase, which is
-    /// race-safe under concurrent tests (the counter is `fetch_add`-only and
-    /// never resets), unlike the last-write-wins occupancy gauges.
+    /// A `"contract"`-labeled cache that evicts publishes occupancy + the
+    /// monotonic eviction counter into its *injected* metrics `Arc`.
+    ///
+    /// Because the sink is constructed locally and passed in (rather than a
+    /// process-global), this test is fully isolated — it can assert exact
+    /// absolute values with no cross-talk from concurrent tests, which proves
+    /// the old `MODULE_CACHE_METRICS` static is gone. (#4488)
     #[test]
-    fn evicting_contract_cache_increments_global_eviction_counter() {
-        let before = MODULE_CACHE_METRICS.snapshot().contract_evictions_total;
+    fn evicting_contract_cache_publishes_to_injected_metrics() {
+        let metrics = Arc::new(ModuleCacheMetrics::new());
+        // Constructing the cache publishes the budget immediately (occupancy 0).
         // 10-byte budget, 8-byte entries → the 2nd insert evicts the 1st.
-        let mut cache: ModuleCache<u64, ()> = ModuleCache::with_label(10, "contract");
+        let mut cache: ModuleCache<u64, ()> =
+            ModuleCache::with_label(10, "contract", Some(metrics.clone()));
+        assert_eq!(
+            metrics.snapshot().contract_evictions_total,
+            0,
+            "a fresh injected sink starts at zero — no global cross-talk"
+        );
+        assert_eq!(
+            metrics.snapshot().contract_budget_bytes,
+            10,
+            "construction publishes the configured budget"
+        );
+
         cache.insert(0, (), 8);
         cache.insert(1, (), 8); // total 16 > 10, len 2 > 1 → evict LRU (key 0)
         assert_eq!(cache.len(), 1, "the test setup must actually evict");
-        let after = MODULE_CACHE_METRICS.snapshot().contract_evictions_total;
-        assert!(
-            after > before,
-            "eviction on a contract-labeled cache must bump the global counter \
-             (before={before}, after={after})"
+
+        let s = metrics.snapshot();
+        assert_eq!(
+            s.contract_evictions_total, 1,
+            "exactly one eviction recorded in this isolated sink"
         );
+        assert_eq!(s.contract_entries, 1, "occupancy is last-write-wins");
+        assert_eq!(
+            s.delegate_evictions_total, 0,
+            "the delegate gauges must not bleed from the contract cache"
+        );
+    }
+
+    /// A cache built without a metrics sink (`None`) records nothing and never
+    /// panics — the unlabeled / test-runtime path.
+    #[test]
+    fn cache_without_metrics_sink_is_a_no_op() {
+        let mut cache: ModuleCache<u64, ()> = ModuleCache::with_label(10, "contract", None);
+        cache.insert(0, (), 8);
+        cache.insert(1, (), 8);
+        assert_eq!(cache.len(), 1, "eviction still happens without a sink");
     }
 
     /// An uninitialized budget gauge yields no occupancy signal (the


### PR DESCRIPTION
## Problem

`MODULE_CACHE_METRICS` (introduced in #4472) was a process-global `static` used to share compiled-WASM module-cache occupancy/eviction telemetry between two components on opposite sides of the contract-handler channel boundary: the **writers** (`ModuleCache` methods, owned by `RuntimePool`) and the **reader** (the `Ring` snapshot task at `ring.rs`).

Process-global statics make test isolation harder — labeled caches in different unit tests share the same gauge pair, so parallel tests can observe each other's metric state. This is the same problem class as `TRANSPORT_METRICS`. (#4488)

## Approach

Replace the static with a per-node `Arc<ModuleCacheMetrics>` threaded through the call graph, exactly as the issue proposed:

- Construct the `Arc` **once** in `Ring::new` (one sink per node).
- `RuntimePool::new` reaches it via the already-available `op_manager.ring` and clones it into both labeled `ModuleCache`s.
- The `emit_router_snapshot_telemetry` task reads the same `Arc` off `Ring`.

Key insight: `RuntimePool::new` already receives `op_manager: Arc<OpManager>`, and `op_manager.ring` is exactly where the snapshot task lives — so the `Arc` is shared through the existing object graph with **no new `RuntimePool::new` parameter** and no channel crossing. `Ring` is constructed before `RuntimePool`, so it's the natural owner.

`ModuleCache` now stores `Option<Arc<ModuleCacheMetrics>>` (`None` for unlabeled / test caches, which never published anyway) and routes publishing through two small `record_occupancy`/`add_evictions` helpers; `with_label` takes the optional sink.

**No behavior change:** metric values, Prometheus labels, and snapshot fields are identical. This is purely a wiring change. Both labeled caches share one sink and are routed apart by their `"contract"` / `"delegate"` label, exactly as before.

## Testing

- Rewrote the existing eviction test (`evicting_contract_cache_publishes_to_injected_metrics`): it now constructs its own metrics `Arc` and asserts **exact absolute values** (`contract_evictions_total == 1`, budget published on construction, delegate gauges stay zero). Previously it could only assert a strict increase against the shared global because concurrent tests polluted it — the new isolation is the whole point of the refactor, and the test demonstrates the global is gone.
- Added `cache_without_metrics_sink_is_a_no_op` covering the `None` path.
- Updated the `runtime_pool_sizes_caches_by_byte_budget` source-pinning test for the new multi-line `with_label(..., Some(metrics))` call shape (collapses whitespace; asserts budget + label independently so it isn't brittle to the `Arc` arg).
- `cargo build -p freenet`, `cargo clippy -p freenet --lib` (default features), and the full `wasm_runtime::module_cache::tests` + `wasm_runtime::tests::cache` modules all pass.

Note on CI gap: this is a developer-experience hygiene refactor with no user-visible behavior change, so no production bug to reproduce. The acceptance criterion ("unit tests create isolated metric instances without cross-talk") is met by the injected-`Arc` test above.

Updated doc comments that referenced the removed static (broadcast-queue / background-task-health "mirror" notes, `RouterSnapshotInfo`, the re-export in `node.rs`) to point at `TRANSPORT_METRICS` and note the #4488 change.

## Fixes

Closes #4488

[AI-assisted - Claude]