### PR TITLE
fix(subscribe): bound renewal attempts by budget below a cleanup-safe outer cancel (#4350)

### DIFF
--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -597,7 +597,11 @@ impl OpManager {
 
     /// Timeout for sending notifications to the event loop.
     /// If the channel is full for this long, the event loop is stuck and sending will never succeed.
-    const NOTIFICATION_SEND_TIMEOUT: Duration = Duration::from_secs(30);
+    ///
+    /// `pub(crate)` so the renewal outer-cancel deadline in
+    /// [`crate::ring::Ring`] can reserve enough headroom for a worst-case
+    /// backpressured `release_pending_op_slot` cleanup (issue #4350).
+    pub(crate) const NOTIFICATION_SEND_TIMEOUT: Duration = Duration::from_secs(30);
 
     // `notify_op_change` (legacy state-machine re-entry primitive)
     // is gone: every op routes outbound messages through

--- a/crates/core/src/operations/op_ctx.rs
+++ b/crates/core/src/operations/op_ctx.rs
@@ -875,6 +875,249 @@ mod tests {
             .expect("executor task should complete without panicking");
     }
 
+    /// Regression for issue #4350. The renewal driver wraps each
+    /// `send_to_and_await` attempt in a per-attempt timeout, and
+    /// `recover_orphaned_subscriptions` wraps the whole renewal future in an
+    /// **outer** cancel deadline. Before the fix the per-attempt wait was the
+    /// global `OPERATION_TTL` (60 s) while the outer deadline was only 25 s, so
+    /// a peer that replied between 25 s and 60 s tripped the OUTER cancel first
+    /// — dropping the future (and its capacity-1 reply receiver) mid-`await`,
+    /// so the in-flight reply landed on a closed receiver.
+    ///
+    /// This pins the corrected nesting at the timeout layer where the bug
+    /// lives, in virtual time (`start_paused = true`): with a per-attempt
+    /// timeout strictly *below* the outer deadline, a slow peer makes the INNER
+    /// per-attempt timeout fire first, returning a clean `Elapsed` to the
+    /// renewal task while the outer deadline still has budget left — so the
+    /// task records its own failure instead of being cancelled mid-flight.
+    ///
+    /// It also asserts the inverse to prove the test actually discriminates:
+    /// the pre-fix shape (per-attempt wait > outer deadline) is killed by the
+    /// outer cancel, which is exactly the discarded-reply path #4350 removes.
+    #[tokio::test(start_paused = true)]
+    async fn renewal_per_attempt_timeout_fires_before_outer_cancel() {
+        use crate::ring::Ring;
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        // Current production constants/relationship from #4350.
+        let per_attempt = Ring::RENEWAL_PER_ATTEMPT_TIMEOUT; // 20 s
+        let outer = Ring::renewal_outer_cancel(); // 55 s (budget + cleanup + margin)
+        assert!(
+            per_attempt < outer,
+            "test precondition: per-attempt ({per_attempt:?}) must be below the \
+             outer cancel deadline ({outer:?}) — the #4350 invariant"
+        );
+
+        let target = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 7)), 31337);
+
+        // --- Fixed shape: outer(per_attempt(send_to_and_await)) ---
+        // A slow peer that never replies within the 20 s per-attempt window.
+        // With the fix the inner per-attempt timeout fires first, well before
+        // the 55 s outer cancel; the task gets a clean Elapsed to classify.
+        {
+            let (receiver, sender) = event_loop_notification_channel();
+            let EventLoopNotificationsReceiver {
+                mut op_execution_receiver,
+                ..
+            } = receiver;
+            let tx = Transaction::new::<ConnectMsg>();
+            let mut ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+
+            // Slow peer holds the reply sender well past the per-attempt
+            // timeout (but `peer.abort()` removes the timer so it can't advance
+            // virtual time past the deadline).
+            let peer = tokio::spawn(async move {
+                let (reply_sender, _outbound, _target) = op_execution_receiver
+                    .recv()
+                    .await
+                    .expect("outbound msg should be delivered");
+                tokio::time::sleep(outer * 100).await;
+                drop(reply_sender);
+            });
+
+            let outbound = dummy_reply_with_tx(tx);
+            let outer_result = tokio::time::timeout(
+                outer,
+                tokio::time::timeout(per_attempt, ctx.send_to_and_await(target, outbound)),
+            )
+            .await;
+
+            // The OUTER deadline must NOT fire: the inner per-attempt timeout
+            // resolves first, so `tokio::time::timeout(outer, ..)` returns Ok.
+            let inner_result = outer_result.expect(
+                "outer cancel deadline must NOT fire — the per-attempt timeout \
+                 resolves first (issue #4350); an outer Err here means the \
+                 future was cancelled mid-await, discarding the in-flight reply",
+            );
+            // The inner per-attempt timeout DID fire (slow peer exceeded it),
+            // returning a clean Elapsed the renewal task can classify.
+            assert!(
+                inner_result.is_err(),
+                "the per-attempt timeout should elapse for a slow peer, yielding \
+                 a clean in-task failure rather than an outer-cancel drop"
+            );
+            peer.abort();
+        }
+
+        // --- Pre-fix shape (historical bug, literal values) ---
+        // Proves the test discriminates: the original bug was a 25 s outer
+        // deadline wrapping a 60 s `OPERATION_TTL` per-attempt wait. A peer
+        // replying between 25 s and 60 s tripped the outer cancel first,
+        // dropping the future (and its receiver) mid-await. Modelled with
+        // literal values so it stays a faithful record of the pre-fix shape
+        // even as the production constants evolve.
+        {
+            let old_outer = Duration::from_secs(25);
+            let old_per_attempt = OPERATION_TTL; // 60 s
+            let reply_delay = Duration::from_secs(40); // in (25 s, 60 s)
+            assert!(old_outer < reply_delay && reply_delay < old_per_attempt);
+
+            let (receiver, sender) = event_loop_notification_channel();
+            let EventLoopNotificationsReceiver {
+                mut op_execution_receiver,
+                ..
+            } = receiver;
+            let tx = Transaction::new::<ConnectMsg>();
+            let mut ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+
+            let peer = tokio::spawn(async move {
+                let (reply_sender, _outbound, _target) = op_execution_receiver
+                    .recv()
+                    .await
+                    .expect("outbound msg should be delivered");
+                tokio::time::sleep(reply_delay).await;
+                // Expected to fail: the receiver is dropped by the outer cancel
+                // in this buggy pre-fix shape. Swallow it deliberately.
+                drop(reply_sender.try_send(WaiterReply::Reply(dummy_reply_with_tx(tx))));
+            });
+
+            let outbound = dummy_reply_with_tx(tx);
+            let outer_result = tokio::time::timeout(
+                old_outer,
+                tokio::time::timeout(old_per_attempt, ctx.send_to_and_await(target, outbound)),
+            )
+            .await;
+
+            assert!(
+                outer_result.is_err(),
+                "pre-fix shape (per-attempt wait > outer deadline) MUST be \
+                 killed by the outer cancel — this is the discarded-reply path \
+                 #4350 removes; if this passes the test no longer discriminates"
+            );
+            peer.await.expect("peer task should not panic");
+        }
+    }
+
+    /// Regression for issue #4350, **multi-attempt** case (Codex review P2).
+    /// A single shorter per-attempt timeout is not enough on its own: when a
+    /// renewal advances to a second peer (e.g. after a fast NotFound from the
+    /// first), a fresh full-length per-attempt timeout on that second attempt
+    /// could still outlive the outer cancel, so its reply would be dropped
+    /// mid-await — the #4350 bug, just on the retry.
+    ///
+    /// The driver closes this by clamping EACH attempt to the budget remaining
+    /// until its task deadline (`Ring::RENEWAL_TASK_BUDGET`, kept below the
+    /// outer cancel). This pins that behaviour at the timeout layer in virtual
+    /// time: attempt 1 replies fast (consuming little budget) and attempt 2 is
+    /// a slow peer clamped to the *remaining* budget. Both resolve inside the
+    /// task deadline, so the outer cancel never fires even across the retry.
+    #[tokio::test(start_paused = true)]
+    async fn renewal_clamps_retry_attempt_to_remaining_budget() {
+        use crate::ring::Ring;
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        let outer = Ring::renewal_outer_cancel(); // 55 s
+        let budget = Ring::RENEWAL_TASK_BUDGET; // 20 s, < outer
+        let per_attempt_cap = Ring::RENEWAL_PER_ATTEMPT_TIMEOUT;
+        let min_attempt = Ring::RENEWAL_MIN_ATTEMPT_BUDGET;
+        assert!(budget < outer, "task budget must be below the outer cancel");
+
+        let target = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 9)), 31337);
+
+        // Model the driver's loop: a single task deadline, each attempt's
+        // timeout clamped to the remaining budget. Attempt 1's peer replies
+        // fast; attempt 2's peer never replies (slow peer) and must be cut by
+        // the clamped per-attempt timeout, NOT the outer cancel.
+        let deadline = tokio::time::Instant::now() + budget;
+
+        let sequence = async {
+            let mut rounds = 0u32;
+            let mut last_attempt_timed_out = false;
+            loop {
+                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                if remaining < min_attempt {
+                    break (rounds, last_attempt_timed_out);
+                }
+                let attempt_timeout = remaining.min(per_attempt_cap);
+
+                let (receiver, sender) = event_loop_notification_channel();
+                let EventLoopNotificationsReceiver {
+                    mut op_execution_receiver,
+                    ..
+                } = receiver;
+                let tx = Transaction::new::<ConnectMsg>();
+                let mut ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+
+                // Round 0: peer replies fast (1 s). Later rounds: slow peer
+                // that never replies within the clamped window.
+                let fast = rounds == 0;
+                let peer = tokio::spawn(async move {
+                    let (reply_sender, _outbound, _target) = op_execution_receiver
+                        .recv()
+                        .await
+                        .expect("outbound msg should be delivered");
+                    if fast {
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        drop(reply_sender.try_send(WaiterReply::Reply(dummy_reply_with_tx(tx))));
+                    } else {
+                        // Slow peer: hold the reply sender (so the driver's
+                        // recv() doesn't see a hang-up and actually waits) far
+                        // beyond any deadline. `peer.abort()` below removes this
+                        // timer so it can't advance virtual time. The clamped
+                        // per-attempt timeout must cut the driver's await first.
+                        tokio::time::sleep(outer * 100).await;
+                        drop(reply_sender);
+                    }
+                });
+
+                let outbound = dummy_reply_with_tx(tx);
+                let attempt =
+                    tokio::time::timeout(attempt_timeout, ctx.send_to_and_await(target, outbound))
+                        .await;
+                last_attempt_timed_out = attempt.is_err();
+                rounds += 1;
+                // Drop (don't await) the slow peer so its indefinite hold can't
+                // advance virtual time past the deadline. The fast peer has
+                // already replied by here.
+                peer.abort();
+
+                // After a fast reply, keep retrying (models advance_to_next_peer);
+                // after a slow-peer timeout we've demonstrated the clamp held.
+                if last_attempt_timed_out || rounds >= 10 {
+                    break (rounds, last_attempt_timed_out);
+                }
+            }
+        };
+
+        let outer_result = tokio::time::timeout(outer, sequence).await;
+        assert!(
+            outer_result.is_ok(),
+            "the outer cancel deadline must NOT fire — every clamped attempt \
+             completes within the task budget, so retries can't be killed \
+             mid-await (issue #4350, Codex P2)"
+        );
+        let (rounds, last_timed_out) = outer_result.unwrap();
+        assert!(
+            rounds >= 2,
+            "expected at least two attempts (fast reply then clamped slow retry), got {rounds}"
+        );
+        assert!(
+            last_timed_out,
+            "the slow second attempt must be cut by its own clamped timeout \
+             inside the task budget, not left awaiting the outer cancel"
+        );
+    }
+
     #[tokio::test]
     async fn send_and_await_errors_on_dropped_receiver() {
         let (receiver, sender) = event_loop_notification_channel();

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -647,7 +647,60 @@ async fn drive_client_subscribe_inner(
     let mut current_target_addr: std::net::SocketAddr = target_addr;
     let mut is_first_attempt = true;
 
+    // Renewal task budget (issue #4350). `recover_orphaned_subscriptions`
+    // wraps each renewal task in an outer cancel deadline
+    // (`Ring::renewal_outer_cancel`); before this fix the driver's per-attempt
+    // wait used the global `OPERATION_TTL` (60 s) while the outer deadline was
+    // only 25 s, so a peer replying between 25 s and 60 s was killed by the
+    // outer cancel mid-`await`, discarding the in-flight reply onto the
+    // already-dropped renewal receiver.
+    //
+    // The renewal path now gives itself a total budget
+    // (`Ring::RENEWAL_TASK_BUDGET`, 20 s) and clamps EACH attempt's timeout to
+    // the budget remaining until that deadline. This bounds not just the first
+    // attempt but every retry: no attempt can still be awaiting when the outer
+    // cancel fires, so a slow peer produces at most one clean, in-task timeout
+    // per cycle (clean failure + telemetry on the exhaustion branch below)
+    // instead of a mid-await cancellation that discards an in-flight reply. The
+    // outer cancel is sized (in `renewal_outer_cancel`) to also clear the
+    // driver's post-loop `release_pending_op_slot` cleanup. Client / executor /
+    // directed subscribes have no outer cancel deadline and keep `OPERATION_TTL`
+    // with no budget (`renewal_deadline = None`).
+    let renewal_deadline =
+        is_renewal.then(|| tokio::time::Instant::now() + crate::ring::Ring::RENEWAL_TASK_BUDGET);
+
     loop {
+        // For renewals, clamp this attempt's wait to the budget remaining until
+        // the task deadline (capped at `RENEWAL_PER_ATTEMPT_TIMEOUT`). When the
+        // remaining budget is too small to complete a useful round-trip, stop
+        // cleanly and let the next recovery cycle retry rather than starting an
+        // attempt that the outer cancel would cut short. Non-renewal paths use
+        // the global `OPERATION_TTL`.
+        let attempt_timeout = match renewal_deadline {
+            Some(deadline) => {
+                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                if remaining < crate::ring::Ring::RENEWAL_MIN_ATTEMPT_BUDGET {
+                    tracing::debug!(
+                        tx = %client_tx,
+                        contract = %instance_id,
+                        retries,
+                        remaining_ms = remaining.as_millis() as u64,
+                        "subscribe renewal: task budget exhausted; stopping before outer cancel"
+                    );
+                    return Ok(DriverOutcome::Publish(Err(ErrorKind::OperationError {
+                        cause: format!(
+                            "renewal to {instance_id} ran out of task budget after {} rounds",
+                            retries + 1
+                        )
+                        .into(),
+                    }
+                    .into())));
+                }
+                remaining.min(crate::ring::Ring::RENEWAL_PER_ATTEMPT_TIMEOUT)
+            }
+            None => OPERATION_TTL,
+        };
+
         // Fresh attempt tx: single-use-per-tx for send_and_await.
         let attempt_tx = Transaction::new::<SubscribeMsg>();
 
@@ -707,7 +760,7 @@ async fn drive_client_subscribe_inner(
         // `crates/core/`'s timing primitives.
         let request_sent_at = tokio::time::Instant::now();
         let round_trip = tokio::time::timeout(
-            OPERATION_TTL,
+            attempt_timeout,
             ctx.send_to_and_await(current_target_addr, NetMessage::from(request)),
         )
         .await;
@@ -786,8 +839,11 @@ async fn drive_client_subscribe_inner(
                 }
             }
             Err(_) => {
-                // OPERATION_TTL elapsed without the peer producing a
-                // terminal reply. Distinct from `wire_error` (which is
+                // `attempt_timeout` elapsed without the peer producing a
+                // terminal reply (`OPERATION_TTL` for client/executor/directed
+                // subscribes; for renewals, the remaining task budget clamped
+                // at `RENEWAL_PER_ATTEMPT_TIMEOUT` — see #4350). Distinct from
+                // `wire_error` (which is
                 // an infrastructure failure on the executor/send side)
                 // and from `not_found` (a legitimate wire-level
                 // response). `outcome=timeout` (review finding T-4).
@@ -798,7 +854,8 @@ async fn drive_client_subscribe_inner(
                     retries,
                     attempts_at_hop,
                     outcome = "timeout",
-                    timeout_secs = OPERATION_TTL.as_secs(),
+                    timeout_secs = attempt_timeout.as_secs(),
+                    is_renewal,
                     "subscribe: attempt timed out; advancing to next peer"
                 );
                 match advance_to_next_peer(
@@ -3135,6 +3192,64 @@ mod tests {
             "the subscribe_timeout event must be handed to \
              op_manager.ring.register_events(..) so it reaches the telemetry \
              pipeline (#3445)."
+        );
+    }
+
+    /// Issue #4350 pin: the renewal driver must (a) establish a task budget
+    /// (`renewal_deadline`) from `Ring::RENEWAL_TASK_BUDGET` on the renewal
+    /// path, (b) clamp EACH attempt's timeout to the budget remaining until
+    /// that deadline (so retries — not just the first attempt — can't outlive
+    /// the outer cancel), and (c) feed that per-attempt `attempt_timeout` into
+    /// the `tokio::time::timeout` wrapping `send_to_and_await`. Non-renewal
+    /// paths keep `OPERATION_TTL`. A regression that hardcoded `OPERATION_TTL`
+    /// for renewals, or that used a fixed per-attempt timeout instead of the
+    /// remaining budget, would let a slow peer's reply be killed by the 25 s
+    /// outer cancel in `recover_orphaned_subscriptions`, re-introducing the
+    /// discarded-reply drops. The behavioural effect is covered by
+    /// `op_ctx::tests::renewal_per_attempt_timeout_fires_before_outer_cancel`.
+    #[test]
+    fn renewal_driver_clamps_attempt_timeout_to_remaining_budget() {
+        const SOURCE: &str = include_str!("op_ctx_task.rs");
+        let prod = production_source(SOURCE);
+        let body = extract_fn_body(prod, "async fn drive_client_subscribe_inner(");
+
+        // (a) The renewal task budget is established from the config-tied
+        // constant and gated on the renewal path.
+        assert!(
+            body.contains("let renewal_deadline =")
+                && body.contains("is_renewal.then(")
+                && body.contains("crate::ring::Ring::RENEWAL_TASK_BUDGET"),
+            "drive_client_subscribe_inner must establish a renewal task \
+             deadline from Ring::RENEWAL_TASK_BUDGET on the is_renewal path \
+             (issue #4350)."
+        );
+        // (b) Each attempt's timeout is the remaining budget, capped at the
+        // per-attempt ceiling — not a fixed constant — and non-renewal keeps
+        // OPERATION_TTL.
+        assert!(
+            body.contains("saturating_duration_since")
+                && body.contains("crate::ring::Ring::RENEWAL_PER_ATTEMPT_TIMEOUT")
+                && body.contains("crate::ring::Ring::RENEWAL_MIN_ATTEMPT_BUDGET")
+                && body.contains("None => OPERATION_TTL"),
+            "each renewal attempt must clamp its timeout to the remaining \
+             budget (min RENEWAL_PER_ATTEMPT_TIMEOUT, floor \
+             RENEWAL_MIN_ATTEMPT_BUDGET), with OPERATION_TTL on the non-renewal \
+             path (issue #4350)."
+        );
+        // (c) The per-attempt round-trip must be wrapped in the computed
+        // `attempt_timeout`, not a hardcoded constant.
+        let timeout_pos = body
+            .find("ctx.send_to_and_await(current_target_addr")
+            .expect("send_to_and_await call site must exist");
+        let before = &body[..timeout_pos];
+        let wrap_pos = before
+            .rfind("tokio::time::timeout(")
+            .expect("send_to_and_await must be wrapped in tokio::time::timeout");
+        assert!(
+            before[wrap_pos..].contains("attempt_timeout"),
+            "the per-attempt send_to_and_await must be wrapped in \
+             tokio::time::timeout(attempt_timeout, ..), not a hardcoded \
+             OPERATION_TTL (issue #4350)."
         );
     }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -36,10 +36,47 @@ use crate::tracing::{NetEventLog, NetEventRegister};
 use crate::transport::TransportPublicKey;
 use crate::util::{Contains, time_source::InstantTimeSrc};
 use crate::{
-    config::{GlobalExecutor, GlobalRng},
+    config::{GlobalExecutor, GlobalRng, OPERATION_TTL},
     message::Transaction,
     node::{self, EventLoopNotificationsSender, NodeConfig, OpManager, PeerId},
     router::Router,
+};
+
+// Issue #4350 invariants, pinned at compile time so a future edit to any of the
+// renewal-timing constants can't silently reopen the discarded-reply bug. The
+// outer cancel deadline is defined in `renewal_outer_cancel` as exactly
+// `RENEWAL_TASK_BUDGET + NOTIFICATION_SEND_TIMEOUT + RENEWAL_OUTER_DEADLINE_MARGIN`,
+// so it clears the driver's worst case (a full-budget slow attempt plus a fully
+// backpressured `release_pending_op_slot` cleanup) by exactly the margin. These
+// asserts pin the surrounding relationships that definition depends on.
+const _: () = {
+    let budget = Ring::RENEWAL_TASK_BUDGET.as_secs();
+    // The cleanup-headroom margin must be non-zero: the outer cancel
+    // (= budget + cleanup + margin) has to be STRICTLY greater than the
+    // worst-case self-termination time (budget + cleanup), or it could fire
+    // exactly as cleanup completes (issue #4350, Codex review).
+    assert!(
+        Ring::RENEWAL_OUTER_DEADLINE_MARGIN.as_secs() > 0,
+        "RENEWAL_OUTER_DEADLINE_MARGIN must be > 0 so the outer cancel strictly \
+         exceeds BUDGET + cleanup timeout (issue #4350)"
+    );
+    // A renewal must be allowed at least one real attempt: the no-start floor
+    // has to sit below the total budget.
+    assert!(
+        Ring::RENEWAL_MIN_ATTEMPT_BUDGET.as_secs() < budget,
+        "RENEWAL_MIN_ATTEMPT_BUDGET must be < RENEWAL_TASK_BUDGET (issue #4350)"
+    );
+    // No single attempt may exceed the total budget.
+    assert!(
+        Ring::RENEWAL_PER_ATTEMPT_TIMEOUT.as_secs() <= budget,
+        "RENEWAL_PER_ATTEMPT_TIMEOUT must be <= RENEWAL_TASK_BUDGET (issue #4350)"
+    );
+    // The per-attempt renewal wait stays below the global operation TTL so a
+    // renewal never out-waits a normal client subscribe attempt.
+    assert!(
+        Ring::RENEWAL_PER_ATTEMPT_TIMEOUT.as_secs() < OPERATION_TTL.as_secs(),
+        "RENEWAL_PER_ATTEMPT_TIMEOUT must be < OPERATION_TTL (issue #4350)"
+    );
 };
 
 mod broken_invariants;
@@ -1222,6 +1259,75 @@ impl Ring {
     /// but failed to establish subscription (no upstream in subscription tree).
     pub(crate) const SUBSCRIPTION_RECOVERY_INTERVAL: Duration = Duration::from_secs(30);
 
+    /// Total wall-clock budget the renewal driver gives **itself** across all
+    /// of a renewal's network attempts.
+    ///
+    /// Issue #4350: `recover_orphaned_subscriptions` wraps each renewal task in
+    /// an outer cancel deadline ([`Self::renewal_outer_cancel`]), but the
+    /// renewal driver's per-attempt network wait used the global
+    /// [`OPERATION_TTL`] (60 s) while the old outer deadline was only 25 s. A
+    /// peer answering between 25 s and 60 s was killed by the outer cancel
+    /// *mid-await* — the in-flight reply then landed on the renewal task's
+    /// already-dropped capacity-1 receiver (the dominant source of
+    /// `try_forward_driver_reply` closed-receiver drops; log-level fixed in
+    /// PR #4351). The driver now clamps **each** attempt's timeout to the budget
+    /// remaining until this deadline, so no attempt — first or retry — can still
+    /// be awaiting when the outer cancel fires.
+    ///
+    /// Derived from the config interval (most of one recovery cycle) rather than
+    /// independently hardcoded. 20 s.
+    pub(crate) const RENEWAL_TASK_BUDGET: Duration =
+        Duration::from_secs(Self::SUBSCRIPTION_RECOVERY_INTERVAL.as_secs() - 10);
+
+    /// Maximum single-attempt network wait on the renewal path. Each attempt is
+    /// actually capped at `min(this, remaining task budget)` (see
+    /// [`Self::RENEWAL_TASK_BUDGET`]); this is the ceiling for the first
+    /// attempt when the full budget is available. Set equal to the total budget
+    /// so a single slow peer may consume the whole budget in one attempt;
+    /// multi-peer renewals naturally get shorter per-attempt waits as the
+    /// remaining budget shrinks.
+    pub(crate) const RENEWAL_PER_ATTEMPT_TIMEOUT: Duration = Self::RENEWAL_TASK_BUDGET;
+
+    /// Slack between a renewal task's worst-case self-termination time
+    /// (`RENEWAL_TASK_BUDGET` + a fully backpressured `release_pending_op_slot`
+    /// cleanup) and the hard outer cancel deadline. Gives the driver room to
+    /// finish its own cleanup and telemetry before the outer cancel could fire.
+    /// 5 s.
+    pub(crate) const RENEWAL_OUTER_DEADLINE_MARGIN: Duration = Duration::from_secs(5);
+
+    /// Hard outer cancel deadline wrapping each spawned renewal task in
+    /// `recover_orphaned_subscriptions`. Pure backstop for a *genuinely wedged*
+    /// driver: in normal operation the driver self-terminates within
+    /// [`Self::RENEWAL_TASK_BUDGET`] (slow peer) and then runs cleanup, so this
+    /// deadline never fires.
+    ///
+    /// Issue #4350 (Codex review): it must clear the driver's worst case —
+    /// `RENEWAL_TASK_BUDGET` (a full slow attempt) **plus** a fully
+    /// backpressured `release_pending_op_slot`, which awaits up to
+    /// [`OpManager::NOTIFICATION_SEND_TIMEOUT`] (30 s) — or the outer cancel
+    /// could interrupt cleanup, leaving the per-attempt waiter in
+    /// `pending_op_results` (the very closed-receiver drop this change removes).
+    /// Deadline = `BUDGET (20 s) + NOTIFICATION_SEND_TIMEOUT (30 s) +
+    /// RENEWAL_OUTER_DEADLINE_MARGIN (5 s) = 55 s`.
+    ///
+    /// Outliving the 30 s recovery interval is safe: `mark_subscription_pending`
+    /// (released via `SubscriptionRecoveryGuard` on completion **or** cancel)
+    /// blocks a second concurrent renewal for the same contract, and the
+    /// per-cycle spawn count is bounded by `MAX_RECOVERY_ATTEMPTS_PER_INTERVAL`
+    /// and the channel-capacity gates — so a long-running task can't accumulate.
+    pub(crate) fn renewal_outer_cancel() -> Duration {
+        Self::RENEWAL_TASK_BUDGET
+            + crate::node::OpManager::NOTIFICATION_SEND_TIMEOUT
+            + Self::RENEWAL_OUTER_DEADLINE_MARGIN
+    }
+
+    /// Floor below which the renewal driver will **not** start another attempt:
+    /// a remaining budget this small can't complete a useful network round-trip
+    /// before the task budget (and then the outer cancel) elapses, so the
+    /// driver stops cleanly and lets the next 30 s recovery cycle retry rather
+    /// than starting an attempt doomed to be cut short. 2 s.
+    pub(crate) const RENEWAL_MIN_ATTEMPT_BUDGET: Duration = Duration::from_secs(2);
+
     /// Interval for periodic GET subscription cache sweep.
     pub(crate) const GET_SUBSCRIPTION_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
 
@@ -1464,22 +1570,29 @@ impl Ring {
                         // `result_router_tx`. `is_renewal=true` so
                         // the responder skips sending state.
                         //
-                        // Outer renewal-cycle timeout: cap each renewal task at
-                        // a fraction of the renewal interval so a stuck driver
-                        // (slow peer, blocked op_execution_sender) self-cancels
-                        // within one cycle instead of leaking past
-                        // `mark_subscription_pending` semantics. The driver's
-                        // per-attempt `OPERATION_TTL` (60 s) bounds individual
-                        // peer waits; this outer timeout bounds total task
-                        // lifetime. Without it, sustained slow-peer load could
-                        // accumulate background renewal tasks faster than they
-                        // complete (90+ contracts × multi-attempt ×
-                        // OPERATION_TTL on a gateway).
+                        // Outer renewal cancel deadline: a pure backstop for a
+                        // *genuinely wedged* driver. In normal operation the
+                        // renewal driver self-terminates within
+                        // `RENEWAL_TASK_BUDGET` (slow peer) and then runs its
+                        // cleanup, so this deadline never fires.
+                        //
+                        // Issue #4350: the driver clamps each attempt's wait to
+                        // the budget remaining until its own task deadline
+                        // (`RENEWAL_TASK_BUDGET`, 20 s), so no attempt — first
+                        // or retry — is still awaiting when this outer cancel
+                        // fires; and the deadline is sized
+                        // (`renewal_outer_cancel`, 55 s) to clear the driver's
+                        // worst case (full-budget attempt + a fully
+                        // backpressured `release_pending_op_slot` cleanup, up to
+                        // `NOTIFICATION_SEND_TIMEOUT`). A task outliving the 30 s
+                        // recovery interval is safe: `mark_subscription_pending`
+                        // (released by `SubscriptionRecoveryGuard` on completion
+                        // or cancel) blocks a second concurrent renewal for the
+                        // same contract.
                         let renewal_tx = crate::message::Transaction::new::<
                             crate::operations::subscribe::SubscribeMsg,
                         >();
-                        let renewal_deadline = Self::SUBSCRIPTION_RECOVERY_INTERVAL
-                            .saturating_sub(Duration::from_secs(5));
+                        let renewal_deadline = Self::renewal_outer_cancel();
                         let outcome_enum = match tokio::time::timeout(
                             renewal_deadline,
                             crate::operations::subscribe::run_renewal_subscribe(


### PR DESCRIPTION
## Problem

SUBSCRIBE renewals were structurally guaranteed to be cancelled mid-flight whenever a peer took longer than ~25s to reply, wasting the in-flight attempt and producing a steady stream of "late reply on a closed receiver" drops.

`recover_orphaned_subscriptions` wraps each spawned renewal task in an **outer** cancel deadline, but the renewal driver's per-attempt network wait used the global `OPERATION_TTL = 60s` while the old outer deadline was only `SUBSCRIPTION_RECOVERY_INTERVAL - 5s = 25s`. Because the outer 25s deadline was shorter than the inner 60s wait, a renewal whose peer hadn't answered within 25s was killed by the outer cancel while its `Subscribe::Response` was still in flight; the reply then landed on the renewal task's already-dropped capacity-1 receiver — the dominant source of the `try_forward_driver_reply` closed-receiver drops whose log level was lowered in PR #4351. On the busiest gateway (nova) this ran ~30/hr, spiking after a restart when hundreds of hosted contracts re-subscribe at once.

## Approach

Two parts (the second was surfaced by review — see below):

1. **Budget-bounded attempts.** On the renewal path (`is_renewal=true`), the driver gives itself a total task budget (`Ring::RENEWAL_TASK_BUDGET = 20s`) and clamps **each** attempt's timeout to the budget remaining until that deadline (capped at `RENEWAL_PER_ATTEMPT_TIMEOUT`). When the remaining budget falls below `RENEWAL_MIN_ATTEMPT_BUDGET` it stops cleanly and lets the next 30s cycle retry. This bounds not just the first attempt but every retry after `advance_to_next_peer`, so no attempt is still awaiting when the outer cancel fires. A slow peer now produces at most one clean, in-task timeout (emitting timeout telemetry and proactively releasing its `pending_op_results` slot via `release_pending_op_slot`); the late reply then finds no slot and is a clean no-op rather than a closed-receiver drop, and the wasted full attempt is eliminated. Client / executor / directed subscribes have no outer cancel deadline and keep `OPERATION_TTL`.

2. **Cleanup-safe outer cancel.** The outer cancel deadline is now sized as `RENEWAL_TASK_BUDGET + OpManager::NOTIFICATION_SEND_TIMEOUT + RENEWAL_OUTER_DEADLINE_MARGIN = 55s` (`Ring::renewal_outer_cancel`) so it clears the driver's worst case: a full-budget slow attempt **plus** a fully backpressured `release_pending_op_slot` cleanup (which awaits up to the 30s notification-send timeout). With the old 25s deadline the outer cancel could still interrupt cleanup and leave a stale waiter — the very drop this change removes. The outer cancel is now a pure backstop for a genuinely wedged driver. Outliving the 30s recovery interval is safe: `mark_subscription_pending` (released by `SubscriptionRecoveryGuard` on completion or cancel) blocks a second concurrent renewal for the same contract, and per-cycle spawns are bounded by `MAX_RECOVERY_ATTEMPTS_PER_INTERVAL` and the channel-capacity gates.

The renewal constants are derived from `SUBSCRIPTION_RECOVERY_INTERVAL` / `NOTIFICATION_SEND_TIMEOUT` (not independently hardcoded) so they cannot drift, per the code-style rule on config-tied thresholds. A compile-time assertion pins `BUDGET + cleanup < outer` and `RENEWAL_PER_ATTEMPT_TIMEOUT < OPERATION_TTL`.

## Testing

- `op_ctx::tests::renewal_per_attempt_timeout_fires_before_outer_cancel` — virtual-time (`start_paused`) regression: a slow peer's per-attempt timeout fires before the outer cancel; a discriminator block models the historical pre-fix shape (25s outer wrapping 60s wait) and proves it WAS killed by the outer cancel (so the test discriminates).
- `op_ctx::tests::renewal_clamps_retry_attempt_to_remaining_budget` — multi-attempt regression (fast reply then a slow clamped retry) proving the retry is cut by its own budget-clamped timeout, never the outer cancel.
- `op_ctx_task::tests::renewal_driver_clamps_attempt_timeout_to_remaining_budget` — source pin that the renewal driver establishes the task deadline and clamps each attempt to the remaining budget.

All touched-module tests pass (`operations::op_ctx` 22, `operations::subscribe::op_ctx_task` 51, renewal-related ring tests 21). `cargo clippy -p freenet --bins` clean; `cargo fmt --check` clean.

## Review

External pass: `codex review --base origin/main` (run 3×). It raised two findings during development, both real and both addressed in this PR: (P2) multi-peer retries could still be outer-cancelled mid-await → fixed by clamping every attempt to remaining budget; (P2) backpressured cleanup could be interrupted by the outer cancel → fixed by sizing the outer cancel to clear budget + cleanup timeout. The final codex pass found no actionable regressions. (Gemini was reported down by the batch coordinator; a local Gemini pass was also run as a second perspective.)

This touches the SUBSCRIBE timing/renewal path (high-risk surface) and was reviewed accordingly.

Closes #4350

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)