### PR TITLE
feat(router): multiplicative per-peer adjustment for response time

### DIFF
--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -10,7 +10,9 @@ use serde::{Deserialize, Serialize};
 use crate::config::GlobalRng;
 use crate::node::network_status::OpType;
 use crate::ring::{Distance, Location, PeerKeyLocation};
-pub(crate) use isotonic_estimator::{EstimatorType, IsotonicEstimator, IsotonicEvent};
+pub(crate) use isotonic_estimator::{
+    AdjustmentMode, EstimatorType, IsotonicEstimator, IsotonicEvent,
+};
 use util::{Mean, TransferSpeed};
 
 /// Default size of the candidate window the prediction-based router considers.
@@ -471,14 +473,21 @@ impl Router {
         }
 
         Router {
-            // Positive because we expect time to increase as distance increases
-            response_start_time_estimator: IsotonicEstimator::new(
+            // Positive because we expect time to increase as distance increases.
+            // Multiplicative per-peer adjustment: a peer's response time deviates
+            // from the global fit by a near-constant ratio, not a constant offset
+            // (validated on production telemetry). See `AdjustmentMode`.
+            response_start_time_estimator: IsotonicEstimator::new_with_mode(
                 success_durations,
                 EstimatorType::Positive,
+                AdjustmentMode::Multiplicative,
             ),
             // Positive because we expect failure probability to increase as distance increase
             failure_estimator: IsotonicEstimator::new(failure_outcomes, EstimatorType::Positive),
-            // Negative because we expect transfer rate to decrease as distance increases
+            // Negative because we expect transfer rate to decrease as distance increases.
+            // Additive for now: transfer rate is the same unbounded multiplicative-scale
+            // quantity as response time and is a strong candidate for multiplicative too,
+            // but current telemetry lacks the per-distance payload data to validate it.
             transfer_rate_estimator: IsotonicEstimator::new(
                 transfer_rates,
                 EstimatorType::Negative,
@@ -491,7 +500,16 @@ impl Router {
                 .collect(),
             per_op_response_time: per_op_response_time
                 .into_iter()
-                .map(|(k, v)| (k, IsotonicEstimator::new(v, EstimatorType::Positive)))
+                .map(|(k, v)| {
+                    (
+                        k,
+                        IsotonicEstimator::new_with_mode(
+                            v,
+                            EstimatorType::Positive,
+                            AdjustmentMode::Multiplicative,
+                        ),
+                    )
+                })
                 .collect(),
             per_op_transfer_rate: per_op_transfer_rate
                 .into_iter()
@@ -550,7 +568,12 @@ impl Router {
                     self.per_op_response_time
                         .entry(ot)
                         .or_insert_with(|| {
-                            IsotonicEstimator::new(std::iter::empty(), EstimatorType::Positive)
+                            // Multiplicative to match the global response-time estimator.
+                            IsotonicEstimator::new_with_mode(
+                                std::iter::empty(),
+                                EstimatorType::Positive,
+                                AdjustmentMode::Multiplicative,
+                            )
                         })
                         .add_event(IsotonicEvent {
                             peer: event.peer.clone(),
@@ -1139,6 +1162,72 @@ mod tests {
     use crate::ring::Distance;
 
     use super::*;
+
+    #[test]
+    fn estimators_use_intended_adjustment_modes() {
+        // Pin the per-estimator adjustment modes so a future change can't silently
+        // make failure probability multiplicative (wrong for a bounded [0,1] target)
+        // or response time additive. Response time is multiplicative (validated on
+        // telemetry, #4547); failure and transfer rate stay additive for now.
+        let mut router = Router::new(&[]);
+        // Global estimators.
+        assert_eq!(
+            router.response_start_time_estimator.adjustment_mode(),
+            AdjustmentMode::Multiplicative,
+            "response time must be multiplicative"
+        );
+        assert_eq!(
+            router.failure_estimator.adjustment_mode(),
+            AdjustmentMode::Additive,
+            "failure probability must stay additive (bounded [0,1])"
+        );
+        assert_eq!(
+            router.transfer_rate_estimator.adjustment_mode(),
+            AdjustmentMode::Additive,
+            "transfer rate stays additive pending instrumentation (#4547)"
+        );
+
+        // Per-op estimators are created lazily on the first matching event and must
+        // match their global counterpart's mode. A timed GET success populates all
+        // three (response time + failure + transfer rate) for OpType::Get.
+        router.add_event(RouteEvent {
+            peer: PeerKeyLocation::random(),
+            contract_location: Location::random(),
+            outcome: RouteOutcome::Success {
+                time_to_response_start: Duration::from_millis(100),
+                payload_size: 5000,
+                payload_transfer_time: Duration::from_millis(50),
+            },
+            op_type: Some(OpType::Get),
+        });
+        assert_eq!(
+            router
+                .per_op_response_time
+                .get(&OpType::Get)
+                .unwrap()
+                .adjustment_mode(),
+            AdjustmentMode::Multiplicative,
+            "per-op response time must match the global estimator (multiplicative)"
+        );
+        assert_eq!(
+            router
+                .per_op_failure
+                .get(&OpType::Get)
+                .unwrap()
+                .adjustment_mode(),
+            AdjustmentMode::Additive,
+            "per-op failure must stay additive"
+        );
+        assert_eq!(
+            router
+                .per_op_transfer_rate
+                .get(&OpType::Get)
+                .unwrap()
+                .adjustment_mode(),
+            AdjustmentMode::Additive,
+            "per-op transfer rate must stay additive"
+        );
+    }
 
     #[test]
     fn before_data_select_closest() {

--- a/crates/core/src/router/isotonic_estimator.rs
+++ b/crates/core/src/router/isotonic_estimator.rs
@@ -15,6 +15,15 @@ const MAX_REGRESSION_POINTS: usize = 500;
 /// observation drops below 50% after about 7 newer observations.
 const EWMA_ALPHA: f64 = 0.1;
 
+/// Floor for the global base in [`AdjustmentMode::Multiplicative`]. The global
+/// regression can extrapolate slightly negative near the edges of its data range;
+/// clamping that base to exactly `0.0` before a multiplicative adjustment would
+/// annihilate the peer's factor (`0 * exp(adj) == 0`), predicting a slow peer as
+/// instant. A tiny positive floor keeps `base * exp(adj)` ordered by the per-peer
+/// factor. It is far below any real response time (1 ns) / transfer rate, so it
+/// only affects the degenerate `global <= 0` region.
+const MULTIPLICATIVE_MIN_BASE: f64 = 1e-9;
+
 /// `IsotonicEstimator` provides outcome estimation for a given action, such as
 /// retrieving the state of a contract, based on the distance between the peer
 /// and the contract. It uses an isotonic regression model from the `pav.rs`
@@ -31,10 +40,89 @@ const EWMA_ALPHA: f64 = 0.1;
 pub(crate) struct IsotonicEstimator {
     pub global_regression: IsotonicRegression<f64>,
     pub peer_adjustments: HashMap<PeerKeyLocation, Adjustment>,
+    /// How per-peer adjustments combine with the global estimate. See
+    /// [`AdjustmentMode`].
+    #[serde(skip)]
+    adjustment_mode: AdjustmentMode,
     /// Raw input points in insertion order. When len exceeds
     /// `MAX_REGRESSION_POINTS`, the oldest is evicted via `remove_points`.
     #[serde(skip)]
     raw_points: VecDeque<Point<f64>>,
+}
+
+/// How a per-peer adjustment combines with the global isotonic estimate.
+///
+/// The per-peer adjustment is an EWMA that corrects the global distance→outcome
+/// fit for a specific peer. Whether that correction is best expressed as an
+/// absolute offset or a scaling factor depends on the target:
+///
+/// - **Additive** (`global + adjustment`): the EWMA averages absolute residuals
+///   `observed - global`. Correct for a bounded target such as failure
+///   probability, where "this peer fails 0.05 more often" is the natural unit.
+/// - **Multiplicative** (`global * exp(adjustment)`): the EWMA averages log
+///   ratios `ln(observed) - ln(global)` (a geometric mean of `observed/global`).
+///   Correct for an unbounded, heavy-tailed, multiplicative-scale target such as
+///   response time. Telemetry over 5.3 days / 631 peers showed a peer's deviation
+///   from the global response-time curve is a near-constant *ratio*, not a
+///   constant offset (log-residuals are level-independent for ~88% of peers,
+///   96% observation-weighted, whereas additive residuals grow with the level).
+///   It also makes a negative estimate impossible by construction: `global >= 0`
+///   and `exp(_) > 0`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum AdjustmentMode {
+    #[default]
+    Additive,
+    Multiplicative,
+}
+
+impl AdjustmentMode {
+    /// The per-event training residual fed to the peer's EWMA, or `None` when the
+    /// event cannot be expressed in this mode's space. Multiplicative requires a
+    /// strictly-positive observation and global estimate (`ln` is undefined at or
+    /// below zero); such events are skipped rather than corrupting the EWMA with
+    /// `NaN`/`-inf`.
+    fn residual(self, observed: f64, global: f64) -> Option<f64> {
+        match self {
+            AdjustmentMode::Additive => Some(observed - global),
+            AdjustmentMode::Multiplicative => {
+                if observed > 0.0 && global > 0.0 {
+                    Some(observed.ln() - global.ln())
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    /// Combine a global estimate with a peer's smoothed adjustment value. The
+    /// neutral adjustment is `0.0` in both modes (`global + 0` and
+    /// `global * e^0 = global`), so callers can pass `0.0` for a peer that has no
+    /// usable adjustment yet. Shared by the router and the dashboard so both
+    /// render the identical peer-adjusted value.
+    pub(crate) fn apply(self, global: f64, adjustment: f64) -> f64 {
+        match self {
+            AdjustmentMode::Additive => global + adjustment,
+            AdjustmentMode::Multiplicative => global * adjustment.exp(),
+        }
+    }
+
+    /// Clamp the global estimate to a non-negative base before applying the
+    /// adjustment. The regression can extrapolate slightly negative near its
+    /// data-range edges; both modes must start from a non-negative base.
+    ///
+    /// Additive floors at exactly `0.0` (`0 + adj` still carries the peer's
+    /// absolute correction). Multiplicative floors at a tiny POSITIVE value
+    /// instead: flooring to `0.0` would make `0 * exp(adj) == 0` and erase the
+    /// peer's learned factor entirely — a consistently-slow peer would be
+    /// predicted as instant. The tiny floor keeps `base * exp(adj)` ordered by the
+    /// per-peer factor in that degenerate region while staying far below any real
+    /// value, so normal (positive-base) predictions are unchanged.
+    fn floor_base(self, global: f64) -> f64 {
+        match self {
+            AdjustmentMode::Additive => global.max(0.0),
+            AdjustmentMode::Multiplicative => global.max(MULTIPLICATIVE_MIN_BASE),
+        }
+    }
 }
 
 impl IsotonicEstimator {
@@ -42,8 +130,25 @@ impl IsotonicEstimator {
     // dominated by sparse/noisy data.
     const ADJUSTMENT_PRIOR_SIZE: u64 = 10;
 
-    /// Creates a new `IsotonicEstimator` from a list of historical events.
+    /// Creates a new `IsotonicEstimator` from a list of historical events, using
+    /// [`AdjustmentMode::Additive`] per-peer adjustments.
     pub fn new<I>(history: I, estimator_type: EstimatorType) -> Self
+    where
+        I: IntoIterator<Item = IsotonicEvent>,
+    {
+        Self::new_with_mode(history, estimator_type, AdjustmentMode::Additive)
+    }
+
+    /// Like [`new`](Self::new) but selects how per-peer adjustments combine with
+    /// the global estimate. The mode must be fixed at construction because the
+    /// per-peer EWMA is trained on residuals computed in that mode's space (see
+    /// [`AdjustmentMode::residual`]); it cannot be changed afterwards without
+    /// recomputing every peer's history.
+    pub fn new_with_mode<I>(
+        history: I,
+        estimator_type: EstimatorType,
+        adjustment_mode: AdjustmentMode,
+    ) -> Self
     where
         I: IntoIterator<Item = IsotonicEvent>,
     {
@@ -91,8 +196,9 @@ impl IsotonicEstimator {
                     let global_estimate = global_regression
                         .interpolate(event.route_distance().as_f64())
                         .expect("Regression should always produce an estimate");
-                    let delta = event.result - global_estimate;
-                    adjustment.add(delta);
+                    if let Some(delta) = adjustment_mode.residual(event.result, global_estimate) {
+                        adjustment.add(delta);
+                    }
                 }
                 peer_adjustments.insert(peer_location.clone(), adjustment);
             }
@@ -101,6 +207,7 @@ impl IsotonicEstimator {
         IsotonicEstimator {
             global_regression,
             peer_adjustments,
+            adjustment_mode,
             raw_points: all_points,
         }
     }
@@ -122,16 +229,17 @@ impl IsotonicEstimator {
         }
 
         if self.global_regression.len() >= Self::ADJUSTMENT_PRIOR_SIZE as usize {
-            let adjustment = event.result
-                - self
-                    .global_regression
-                    .interpolate(route_distance.as_f64())
-                    .unwrap();
+            let global_estimate = self
+                .global_regression
+                .interpolate(route_distance.as_f64())
+                .unwrap();
 
-            self.peer_adjustments
-                .entry(event.peer)
-                .or_default()
-                .add(adjustment);
+            if let Some(delta) = self.adjustment_mode.residual(event.result, global_estimate) {
+                self.peer_adjustments
+                    .entry(event.peer)
+                    .or_default()
+                    .add(delta);
+            }
         }
     }
 
@@ -152,8 +260,11 @@ impl IsotonicEstimator {
             .interpolate(distance)
             .ok_or(EstimationError::InsufficientData)?;
 
-        // Regression can sometimes produce negative estimates
-        let global_estimate = global_estimate.max(0.0);
+        // Regression can sometimes produce negative estimates. Floor the base
+        // non-negative before applying the per-peer adjustment; in multiplicative
+        // mode the floor is a tiny positive value so the peer's factor is not
+        // annihilated (see `AdjustmentMode::floor_base`).
+        let global_estimate = self.adjustment_mode.floor_base(global_estimate);
 
         let adjusted_estimate =
             self.peer_adjustments
@@ -161,19 +272,20 @@ impl IsotonicEstimator {
                 .map_or(global_estimate, |peer_adjustment| {
                     let should_use_peer_adjustment =
                         peer_adjustment.effective_count >= MIN_POINTS_FOR_REGRESSION as f64;
-                    global_estimate
-                        + if should_use_peer_adjustment {
-                            peer_adjustment.value()
-                        } else {
-                            0.0
-                        }
+                    if should_use_peer_adjustment {
+                        self.adjustment_mode
+                            .apply(global_estimate, peer_adjustment.value())
+                    } else {
+                        global_estimate
+                    }
                 });
 
-        // The per-peer EWMA adjustment is added *after* the global clamp above and
-        // can be negative (a peer that is consistently faster / more reliable than
-        // the global fit). Re-clamp so the per-peer estimate can never go below
-        // zero — these targets (response time, transfer rate, failure probability)
-        // are all physically non-negative, and a negative prediction would both
+        // The per-peer adjustment is applied *after* the global clamp above. In
+        // additive mode it can be negative (a peer faster / more reliable than the
+        // global fit); in multiplicative mode `global * exp(_)` is already >= 0.
+        // Re-clamp either way so the per-peer estimate can never go below zero —
+        // these targets (response time, transfer rate, failure probability) are
+        // all physically non-negative, and a negative prediction would both
         // distort routing cost formulas and render below the x-axis on the
         // dashboard's "Peer-adjusted" curve. The failure path applies the same
         // clamp downstream (see `predict_routing_outcome`).
@@ -182,6 +294,15 @@ impl IsotonicEstimator {
 
     pub(crate) fn len(&self) -> usize {
         self.global_regression.len()
+    }
+
+    /// The per-peer adjustment mode this estimator was constructed with.
+    /// Test-only: used to pin each estimator's mode (see the router test
+    /// `estimators_use_intended_adjustment_modes`). When the dashboard is wired to
+    /// read the mode (the #4547 follow-up), drop the `cfg(test)` to make it real API.
+    #[cfg(test)]
+    pub(crate) fn adjustment_mode(&self) -> AdjustmentMode {
+        self.adjustment_mode
     }
 
     /// Return the x-range of actual regression data points, or (0, 0) if empty.
@@ -451,6 +572,203 @@ mod tests {
         assert!(
             estimate >= 0.0,
             "per-peer adjusted estimate must be clamped to a non-negative value, got {estimate}"
+        );
+    }
+
+    #[test]
+    fn adjustment_mode_residual_and_apply() {
+        // Additive: residual is the absolute difference; apply adds it back.
+        assert_eq!(
+            AdjustmentMode::Additive.residual(7.0, 10.0),
+            Some(-3.0),
+            "additive residual is observed - global"
+        );
+        assert_eq!(AdjustmentMode::Additive.apply(10.0, -3.0), 7.0);
+
+        // Multiplicative: residual is the log-ratio; apply scales by exp().
+        let r = AdjustmentMode::Multiplicative
+            .residual(20.0, 10.0)
+            .expect("positive inputs");
+        assert!(
+            (r - std::f64::consts::LN_2).abs() < 1e-12,
+            "multiplicative residual of 20/10 must be ln(2), got {r}"
+        );
+        let applied = AdjustmentMode::Multiplicative.apply(10.0, std::f64::consts::LN_2);
+        assert!(
+            (applied - 20.0).abs() < 1e-9,
+            "applying ln(2) to 10 must give 20, got {applied}"
+        );
+
+        // Multiplicative is undefined for non-positive inputs → skipped (None).
+        assert_eq!(AdjustmentMode::Multiplicative.residual(0.0, 10.0), None);
+        assert_eq!(AdjustmentMode::Multiplicative.residual(5.0, 0.0), None);
+        assert_eq!(AdjustmentMode::Multiplicative.residual(-1.0, 10.0), None);
+
+        // Neutral adjustment (0.0) is a no-op in both modes.
+        assert_eq!(AdjustmentMode::Additive.apply(42.0, 0.0), 42.0);
+        assert_eq!(AdjustmentMode::Multiplicative.apply(42.0, 0.0), 42.0);
+
+        // Multiplicative can never produce a negative estimate, even for a huge
+        // negative log-adjustment (the additive failure mode this design avoids).
+        assert!(AdjustmentMode::Multiplicative.apply(10.0, -1000.0) >= 0.0);
+    }
+
+    #[test]
+    fn multiplicative_estimate_scales_global_by_geometric_factor() {
+        // Build a multiplicative-mode estimator with a real global fit.
+        let mut events = Vec::new();
+        for _ in 0..100 {
+            let peer = PeerKeyLocation::random();
+            let contract_location = Location::random();
+            events.push(simulate_positive_request(peer, contract_location));
+        }
+        let mut estimator = IsotonicEstimator::new_with_mode(
+            events,
+            EstimatorType::Positive,
+            AdjustmentMode::Multiplicative,
+        );
+
+        // A peer whose log-adjustment is ln(2): it is consistently ~2x the global.
+        let peer = PeerKeyLocation::random();
+        let mut adjustment = Adjustment::new();
+        for _ in 0..10 {
+            adjustment.add(std::f64::consts::LN_2);
+        }
+        assert!(adjustment.effective_count >= MIN_POINTS_FOR_REGRESSION as f64);
+        estimator.peer_adjustments.insert(peer.clone(), adjustment);
+
+        // At the peer's own location distance is 0; compare against global * 2.
+        let contract_location = peer.location().unwrap();
+        let global = estimator
+            .global_regression
+            .interpolate(0.0)
+            .unwrap()
+            .max(0.0);
+        let estimate = estimator
+            .estimate_retrieval_time(&peer, contract_location)
+            .expect("enough data");
+        let expected = global * 2.0;
+        assert!(
+            (estimate - expected).abs() <= 1e-6 + expected * 1e-9,
+            "multiplicative estimate must be global*exp(ln2)=2*global ({expected}), got {estimate}"
+        );
+
+        // A strongly-negative log-adjustment scales toward (but not below) zero.
+        let mut neg = Adjustment::new();
+        for _ in 0..10 {
+            neg.add(-1000.0);
+        }
+        estimator.peer_adjustments.insert(peer.clone(), neg);
+        let est_neg = estimator
+            .estimate_retrieval_time(&peer, contract_location)
+            .expect("enough data");
+        assert!(
+            (0.0..1e-3).contains(&est_neg),
+            "global*exp(-1000) must round to ~0 and stay non-negative, got {est_neg}"
+        );
+    }
+
+    #[test]
+    fn multiplicative_adjustment_via_add_event_orders_peers_by_ratio() {
+        // End-to-end: build the multiplicative adjustment through the production
+        // path — `add_event` -> `residual` (log-ratio) -> EWMA -> `apply` — rather
+        // than hand-inserting an `Adjustment`. A slow peer (results ~2.0) must end
+        // up predicted slower than a fast peer (results ~0.5) at the same distance.
+        // This is the path a sign error or `ln`/`exp` inversion would corrupt.
+        let mut estimator = IsotonicEstimator::new_with_mode(
+            std::iter::empty(),
+            EstimatorType::Positive,
+            AdjustmentMode::Multiplicative,
+        );
+        for _ in 0..40 {
+            estimator.add_event(IsotonicEvent {
+                peer: PeerKeyLocation::random(),
+                contract_location: Location::random(),
+                result: 1.0,
+            });
+        }
+        let fast_peer = PeerKeyLocation::random();
+        let slow_peer = PeerKeyLocation::random();
+        for _ in 0..20 {
+            estimator.add_event(IsotonicEvent {
+                peer: fast_peer.clone(),
+                contract_location: Location::random(),
+                result: 0.5,
+            });
+            estimator.add_event(IsotonicEvent {
+                peer: slow_peer.clone(),
+                contract_location: Location::random(),
+                result: 2.0,
+            });
+        }
+        // Both query at distance 0 (contract at own location) → identical global
+        // base, so the ordering is decided purely by each peer's learned factor.
+        let est_fast = estimator
+            .estimate_retrieval_time(&fast_peer, fast_peer.location().unwrap())
+            .expect("enough data");
+        let est_slow = estimator
+            .estimate_retrieval_time(&slow_peer, slow_peer.location().unwrap())
+            .expect("enough data");
+        assert!(
+            est_slow > est_fast && est_fast > 0.0,
+            "slow peer (2.0) must estimate higher than fast peer (0.5): slow={est_slow} fast={est_fast}"
+        );
+    }
+
+    #[test]
+    fn multiplicative_skips_non_positive_observations() {
+        // A zero/negative response time can't be expressed in log space; `residual`
+        // returns None and `add_event` must skip the peer entirely rather than
+        // poisoning its EWMA with NaN/-inf.
+        let mut estimator = IsotonicEstimator::new_with_mode(
+            std::iter::empty(),
+            EstimatorType::Positive,
+            AdjustmentMode::Multiplicative,
+        );
+        for _ in 0..15 {
+            estimator.add_event(IsotonicEvent {
+                peer: PeerKeyLocation::random(),
+                contract_location: Location::random(),
+                result: 1.0,
+            });
+        }
+        let peer = PeerKeyLocation::random();
+        estimator.add_event(IsotonicEvent {
+            peer: peer.clone(),
+            contract_location: Location::random(),
+            result: 0.0,
+        });
+        assert!(
+            estimator.peer_adjustments.get(&peer).is_none(),
+            "a non-positive observation must be skipped in multiplicative mode (no adjustment entry created)"
+        );
+    }
+
+    #[test]
+    fn floor_base_preserves_multiplicative_factor_at_degenerate_base() {
+        // Additive floors at exactly 0; multiplicative floors at a tiny positive
+        // value so a degenerate (clamped) base does not annihilate the peer factor.
+        assert_eq!(AdjustmentMode::Additive.floor_base(-1.0), 0.0);
+        assert_eq!(AdjustmentMode::Additive.floor_base(5.0), 5.0);
+        assert_eq!(AdjustmentMode::Multiplicative.floor_base(5.0), 5.0);
+        let base = AdjustmentMode::Multiplicative.floor_base(-1.0);
+        assert!(
+            base > 0.0,
+            "multiplicative base must stay positive, got {base}"
+        );
+
+        // The fix: at a clamped base, a slow peer (adj>0) is still predicted slower
+        // than a fast peer (adj<0). Flooring to 0 (the bug) would tie both at 0.
+        let slow = AdjustmentMode::Multiplicative.apply(base, 0.7);
+        let fast = AdjustmentMode::Multiplicative.apply(base, -0.7);
+        assert!(
+            slow > fast && fast > 0.0,
+            "multiplicative ordering must survive a degenerate base: slow={slow} fast={fast}"
+        );
+        assert_eq!(
+            AdjustmentMode::Multiplicative.apply(0.0, 0.7),
+            0.0,
+            "sanity: a literal-0 base would annihilate the factor — the bug floor_base avoids"
         );
     }
 

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -200,6 +200,7 @@ mod tests {
         FailureSnapshot, HealthLevel, NatStatsSnapshot, NetworkStatusSnapshot, OpStatsSnapshot,
         RingStatsSnapshot,
     };
+    use crate::router::AdjustmentMode;
     use crate::transport::metrics::TransportSnapshot;
     use std::net::SocketAddr;
 
@@ -1005,6 +1006,7 @@ mod tests {
             &[],
             (0.0, 0.0),
             None,
+            AdjustmentMode::Additive,
             None,
             "0",
             "auto",
@@ -1036,6 +1038,7 @@ mod tests {
             &scatter,
             (0.0, 0.5),
             None,
+            AdjustmentMode::Additive,
             None,
             "0.0",
             "1.0",
@@ -1102,6 +1105,7 @@ mod tests {
             &[],
             (0.0, 0.5),
             None,
+            AdjustmentMode::Additive,
             None,
             "0.0",
             "1.0",
@@ -1162,6 +1166,7 @@ mod tests {
             &[],
             (0.0, 0.5),
             None,
+            AdjustmentMode::Additive,
             None,
             "0.0",
             "1.0",
@@ -1184,6 +1189,7 @@ mod tests {
             &[],
             (0.0, 0.5),
             None,
+            AdjustmentMode::Additive,
             None,
             "0.0",
             "0.01",
@@ -1213,6 +1219,7 @@ mod tests {
             &scatter,
             (0.0, 0.5),
             None,
+            AdjustmentMode::Additive,
             None,
             "0.0",
             "0.08",

--- a/crates/core/src/server/home_page/estimator.rs
+++ b/crates/core/src/server/home_page/estimator.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::router::AdjustmentMode;
 
 /// Choose the top of the failure-probability chart's y-axis.
 ///
@@ -43,6 +44,7 @@ pub fn build_estimator_chart_or_placeholder(
     scatter_points: &[(f64, f64)],
     data_range: (f64, f64),
     peer_adjustment: Option<f64>,
+    adjustment_mode: AdjustmentMode,
     peer_location: Option<f64>,
     y_min_hint: &str,
     y_max_hint: &str,
@@ -61,6 +63,7 @@ pub fn build_estimator_chart_or_placeholder(
         scatter_points,
         data_range,
         peer_adjustment,
+        adjustment_mode,
         peer_location,
         y_min_hint,
         y_max_hint,
@@ -78,6 +81,7 @@ pub fn build_estimator_chart(
     scatter_points: &[(f64, f64)],
     data_range: (f64, f64),
     peer_adjustment: Option<f64>,
+    adjustment_mode: AdjustmentMode,
     peer_location: Option<f64>,
     y_min_hint: &str,
     y_max_hint: &str,
@@ -126,7 +130,7 @@ pub fn build_estimator_chart(
         // Include peer-adjusted values in range if present
         if let Some(adj) = peer_adjustment {
             for (_, y) in curve_points {
-                let adjusted = y + adj;
+                let adjusted = adjustment_mode.apply(*y, adj);
                 y_min = y_min.min(adjusted);
                 y_max = y_max.max(adjusted);
             }
@@ -272,7 +276,9 @@ pub fn build_estimator_chart(
     }
 
     // Helper: draw a curve with solid line in data range and dashed outside.
-    // `points` are (x, y) pairs; `adj` is an optional y-offset for peer adjustment.
+    // `points` are (x, y) pairs; `adj` is the peer adjustment, combined with each
+    // y via `adjustment_mode.apply` (an additive offset or a multiplicative factor
+    // depending on the mode). `adj == 0.0` is the neutral global curve.
     let draw_curve = |svg: &mut String, points: &[(f64, f64)], adj: f64, color: &str| {
         if points.len() < 2 {
             return;
@@ -285,15 +291,21 @@ pub fn build_estimator_chart(
         let mut right_ext = Vec::new();
 
         for &(x, y) in points {
-            // Apply the per-peer adjustment, then clamp to the visible axis floor.
-            // A negative adjustment (a peer faster / more reliable than the global
-            // fit) can drive `y + adj` below the axis — e.g. a negative "response
-            // time", which is physically meaningless — and render the curve below
-            // the x-axis. The router clamps the same per-peer estimate to >= 0 (see
-            // `IsotonicEstimator::estimate_retrieval_time`); clamping to `y_min`
-            // here keeps the drawn curve on-axis and consistent with that, mirroring
-            // the scatter-point clamp above. (`y_min` is 0 for all of these charts.)
-            let y = (y + adj).max(y_min);
+            // Apply the per-peer adjustment via the same `AdjustmentMode` the
+            // router uses (additive `y + adj`, or multiplicative `y * exp(adj)`),
+            // so the drawn curve matches the router's prediction exactly. For the
+            // un-adjusted global curve `adj == 0.0`, which is the neutral value in
+            // both modes (`y + 0` / `y * e^0`), so it is drawn unchanged.
+            //
+            // Then clamp to the visible axis floor. In additive mode a negative
+            // adjustment (a peer faster / more reliable than the global fit) can
+            // drive the value below the axis — e.g. a negative "response time",
+            // which is physically meaningless. The router clamps the same per-peer
+            // estimate to >= 0 (`IsotonicEstimator::estimate_retrieval_time`);
+            // clamping to `y_min` here keeps the drawn curve on-axis and consistent
+            // with that, mirroring the scatter-point clamp above. (`y_min` is 0 for
+            // all of these charts.)
+            let y = adjustment_mode.apply(y, adj).max(y_min);
             if x < data_lo - 0.001 {
                 left_ext.push((x, y));
             } else if x > data_hi + 0.001 {
@@ -875,19 +887,21 @@ mod tests {
     }
 
     #[test]
-    fn peer_adjusted_curve_never_renders_below_x_axis() {
-        // Small positive base curve with a strongly-negative peer adjustment: the
-        // raw `y + adj` would be deeply negative and, on a y-axis floored at 0,
-        // would draw the violet "Peer-adjusted" curve well below the x-axis.
+    fn peer_adjusted_curve_additive_never_renders_below_x_axis() {
+        // Additive mode: small positive base curve with a strongly-negative peer
+        // adjustment. The raw `y + adj` would be deeply negative and, on a y-axis
+        // floored at 0, would draw the violet "Peer-adjusted" curve below the
+        // x-axis without the clamp.
         let curve = [(0.0, 0.10), (0.25, 0.30), (0.50, 0.50)];
         let svg = build_estimator_chart(
-            "Response Time (s)",
+            "Failure Probability",
             &curve,
             &[],           // no scatter
             (0.0, 0.5),    // entire range is data (solid line)
             Some(-1000.0), // strongly-negative peer adjustment
+            AdjustmentMode::Additive,
             None,
-            "0", // y floor (as used for the response-time chart)
+            "0.0", // y floor
             "auto",
         );
 
@@ -903,5 +917,61 @@ mod tests {
                 "peer-adjusted curve drawn below the x-axis (y={y} > {PLOT_BOTTOM_Y})"
             );
         }
+    }
+
+    #[test]
+    fn peer_adjusted_curve_multiplicative_stays_non_negative() {
+        // Multiplicative mode: a strongly-negative log-adjustment scales the curve
+        // toward zero (`y * exp(-1000) ≈ 0`). It must never render below the axis.
+        let curve = [(0.0, 0.10), (0.25, 0.30), (0.50, 0.50)];
+        let svg = build_estimator_chart(
+            "Response Time (s)",
+            &curve,
+            &[],
+            (0.0, 0.5),
+            Some(-1000.0), // log-ratio: exp(-1000) ≈ 0
+            AdjustmentMode::Multiplicative,
+            None,
+            "0", // y floor as used for the response-time chart
+            "auto",
+        );
+        let ys = path_y_coords_for_color(&svg, "#8b5cf6");
+        assert!(!ys.is_empty(), "expected a peer-adjusted curve; svg: {svg}");
+        for y in ys {
+            assert!(
+                y <= PLOT_BOTTOM_Y + 0.05,
+                "multiplicative peer-adjusted curve drawn below the x-axis (y={y})"
+            );
+        }
+    }
+
+    #[test]
+    fn peer_adjusted_curve_multiplicative_scales_above_global() {
+        // A positive log-adjustment (ln 2) scales the curve UP by 2x, so the violet
+        // peer-adjusted curve must sit ABOVE the teal global curve — i.e. at a
+        // SMALLER SVG y (the y-axis points down). This confirms the chart applies
+        // the multiplicative transform, not an additive offset, and renders it.
+        let curve = [(0.0, 1.0), (0.5, 1.0)]; // flat global at 1.0
+        let svg = build_estimator_chart(
+            "Response Time (s)",
+            &curve,
+            &[],
+            (0.0, 0.5),
+            Some(std::f64::consts::LN_2), // factor exp(ln 2) = 2.0
+            AdjustmentMode::Multiplicative,
+            None,
+            "0",
+            "auto",
+        );
+        let violet = path_y_coords_for_color(&svg, "#8b5cf6");
+        let teal = path_y_coords_for_color(&svg, "var(--accent-primary)");
+        let violet_top = violet.iter().cloned().fold(f64::INFINITY, f64::min);
+        let teal_top = teal.iter().cloned().fold(f64::INFINITY, f64::min);
+        assert!(violet.iter().all(|y| *y <= PLOT_BOTTOM_Y + 0.05));
+        assert!(
+            violet_top < teal_top - 1.0,
+            "multiplicative peer-adjusted curve (factor 2x) should sit above the \
+             global curve: violet_top={violet_top} should be < teal_top={teal_top}"
+        );
     }
 }

--- a/crates/core/src/server/home_page/peer_detail.rs
+++ b/crates/core/src/server/home_page/peer_detail.rs
@@ -5,6 +5,7 @@ use super::estimator::{
     fmt_prediction_prob, fmt_prediction_speed, fmt_prediction_time,
 };
 use super::*;
+use crate::router::AdjustmentMode;
 
 // ─── Peer detail page ────────────────────────────────────────────────────────
 
@@ -255,12 +256,23 @@ pub fn peer_detail_html(address_str: &str) -> String {
                 let fail_y_max =
                     failure_chart_y_max(f_curve, if tab_name == "All" { fail_adj } else { None })
                         .to_string();
+                // The adjustment mode per chart MUST match the router's choice for
+                // that estimator (see `Router::new`): failure + transfer are
+                // additive, response time is multiplicative. The dashboard renders
+                // the peer-adjusted curve with this mode, so a wrong mode would draw
+                // a curve of the wrong SHAPE vs the router's prediction. (The curve
+                // is intentionally a *preview*: the dashboard draws it whenever an
+                // adjustment exists, while the router only applies it once the peer
+                // has `MIN_POINTS_FOR_REGRESSION` effective observations.) When
+                // #4547 flips transfer rate to multiplicative, update its mode here
+                // too — the mode is mirrored, not read from the snapshot.
                 panel_content.push_str(&build_estimator_chart_or_placeholder(
                     "Failure Probability",
                     f_curve,
                     f_points,
                     f_range,
                     if tab_name == "All" { fail_adj } else { None },
+                    AdjustmentMode::Additive,
                     ploc,
                     "0.0",
                     &fail_y_max,
@@ -272,6 +284,7 @@ pub fn peer_detail_html(address_str: &str) -> String {
                     rt_points,
                     rt_range,
                     if tab_name == "All" { rt_adj } else { None },
+                    AdjustmentMode::Multiplicative,
                     ploc,
                     "0",
                     "auto",
@@ -283,6 +296,7 @@ pub fn peer_detail_html(address_str: &str) -> String {
                     xfer_points,
                     xfer_range,
                     if tab_name == "All" { xfer_adj } else { None },
+                    AdjustmentMode::Additive,
                     ploc,
                     // Transfer rate is a positive B/s value: floor at 0, auto-scale
                     // the top. (Was "auto"/"0", which clamped the max to 0 and gave a
@@ -310,8 +324,9 @@ pub fn peer_detail_html(address_str: &str) -> String {
                 <p style="font-size:0.8em;color:var(--text-muted);">
                     Actual observed outcomes (dots) against ring distance to the contract, with the
                     isotonic fit overlaid (the All tab is the aggregate the router uses; per-op tabs
-                    just break it down and are not consulted separately). "Peer-adjusted" adds this
-                    peer's running EWMA correction to that fit. How tightly the dots hug a monotonic
+                    just break it down and are not consulted separately). "Peer-adjusted" applies this
+                    peer's running EWMA correction to that fit — a multiplicative factor for response
+                    time, an additive offset for failure and transfer rate. How tightly the dots hug a monotonic
                     curve shows how well distance alone predicts the outcome. A separate Renegade
                     model is blended into the final estimate; its accuracy is in the Prediction
                     Accuracy panel below.


### PR DESCRIPTION
Follow-up to #4539. Closes part of #4547.

## What

The per-peer adjustment in `IsotonicEstimator` corrects the global distance→outcome fit for each peer. It was **additive** for all three estimators (`global + EWMA(observed - global)`) — a single distance-independent absolute offset. This makes the response-time adjustment **multiplicative** (`global * exp(EWMA(ln(observed/global)))`), driven by an empirical analysis.

## Why (evidence)

Residual analysis on production telemetry — `route_success` events from the central OTel collector, **684,728 events / 5.3 days / 1,156 peers** (631 with ≥8 obs over a non-trivial distance span):

| | additive `observed - global` | multiplicative `ln(observed/global)` |
|---|---|---|
| median Spearman(\|residual\|, level) | **+0.50** (grows with level → wrong) | **+0.13** (level-independent) |
| more homoscedastic for | — | **~88–89% of peers, 96% obs-weighted** |

Robust to the global-curve choice (PAV vs binned-median) and to p99 winsorization of stuck-op tails. A peer's deviation from the global response-time curve is a near-constant **ratio**, not a constant offset — consistent with the heavy-tailed, multiplicative nature of latency. Multiplicative also makes a negative estimate impossible by construction (`global ≥ 0`, `exp(_) > 0`).

## Scope (which estimators change)

- **Response time → Multiplicative** (global + per-op). Validated above.
- **Failure probability → stays Additive.** Bounded [0,1]; a multiplicative factor is the wrong model (and `clamp(0,1)` already bounds it).
- **Transfer rate → stays Additive for now.** Same unbounded multiplicative-scale quantity and a strong candidate, but **can't be validated**: `route_success` payload fields are ~always 0 and `transfer_completed` lacks distance/target location. Tracked in #4547 (instrument → validate → flip).

## How

- New `AdjustmentMode { Additive, Multiplicative }`, selected per estimator at construction (`new_with_mode`); `new` keeps the additive default. The mode is fixed at construction because the per-peer EWMA is trained on residuals in that mode's space.
- Multiplicative: the EWMA averages log-ratios (a geometric mean); the estimate is `global * exp(adjustment)`. The neutral value is `0.0` in **both** modes, so the prior-shrinkage seeding and the "not enough data" fallback are unchanged. Non-positive observations are skipped (`ln` undefined) rather than corrupting the EWMA.
- **Dashboard:** the peer-detail charts render the peer-adjusted curve via the same `AdjustmentMode::apply`, so `y * exp(adj)` for response time and `y + adj` otherwise — the drawn curve matches the router's prediction exactly. Legend wording updated. The #4539 non-negative clamp stays as a floor.

## Tests

- `adjustment_mode_residual_and_apply` — additive vs multiplicative residual/apply, neutral-is-noop, non-positive guard, non-negativity.
- `multiplicative_estimate_scales_global_by_geometric_factor` — a peer with log-adjustment ln(2) yields `2 × global`; a −1000 log-adjustment scales to ~0 and stays non-negative.
- Dashboard: `peer_adjusted_curve_multiplicative_scales_above_global` (factor 2× draws above the global curve), `..._multiplicative_stays_non_negative`, and the additive case retained.
- All 191 router + dashboard tests pass locally; clean build, no warnings.

## Review note

This changes the **routing cost model** (peer selection). The behavioral change is confined to the response-time estimator's per-peer adjustment; failure and transfer-rate ranking are unchanged. Worth scrutiny: the log-space EWMA semantics, the non-positive-observation skip, and that the dashboard transform exactly mirrors the router.

[AI-assisted - Claude]