### PR TITLE
fix: stop gateway death-spiral wedge under contract-executor backpressure (#4549)

### DIFF
--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -223,6 +223,12 @@ async fn run_network_node_with_signals(
     use freenet::transport::{clear_urgent_update, get_highest_seen_version, is_urgent_update};
     use tokio::signal;
 
+    // #4549: this is the real node process (not a test / embedded use), so enable the
+    // fast-exit watchdog — a fatal network-event-listener exit will abort the process
+    // (code 42) for a prompt systemd restart + auto-update, instead of risking a hang
+    // in teardown that leaves the node network-dead and spinning.
+    freenet::enable_abort_on_fatal_listener_exit();
+
     // Set up SIGTERM handler for Unix systems
     #[cfg(unix)]
     let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -19,7 +19,10 @@ mod message;
 
 /// Node configuration, implementations and execution (entry points for the binaries).
 mod node;
-pub use node::{EventLoopExitReason, Node, ShutdownHandle, run_local_node, run_network_node};
+pub use node::{
+    EventLoopExitReason, Node, ShutdownHandle, enable_abort_on_fatal_listener_exit, run_local_node,
+    run_network_node,
+};
 
 /// Network operation/transaction state machines.
 mod operations;

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -80,6 +80,7 @@ mod p2p_impl;
 mod request_router;
 pub(crate) mod testing_impl;
 
+pub use p2p_impl::enable_abort_on_fatal_listener_exit;
 pub use request_router::{DeduplicatedRequest, RequestRouter};
 
 /// Handle to trigger graceful shutdown of the node.

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -38,7 +38,7 @@ use crate::transport::{
 use crate::{
     client_events::ClientId,
     config::GlobalExecutor,
-    contract::{ContractHandlerChannel, ExecutorTransactionStream, WaitingResolution},
+    contract::{ContractHandlerChannel, ExecutorTransactionStream, SenderHalve, WaitingResolution},
     message::{MessageStats, NetMessage, NodeEvent, Transaction, TransactionType},
     node::{
         NetEventRegister, NodeConfig, OpManager, PeerId, WaiterReply, process_message_decoupled,
@@ -109,6 +109,53 @@ impl std::error::Error for EventLoopExitReason {}
 /// poll. A diagnostics query is best-effort, so cap the wait and serve an empty
 /// result on timeout rather than freezing (or, previously, killing) the listener.
 const QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Best-effort, bounded query to the contract handler for application-level
+/// subscriptions, used by the diagnostics arms of the network event loop (#4549).
+///
+/// This runs INLINE on the network event loop, so it must be both bounded and
+/// non-fatal: a saturated contract handler previously made the bare
+/// `notify_contract_handler(QuerySubscriptions ...).await?` return
+/// `NoEvHandlerResponse` only after the 300s handler timeout, which killed the
+/// whole network event listener ("Network event listener exited: no response
+/// received from handler") and took the gateway network-dead. Here the wait is
+/// capped at [`QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT`] and ANY failure (timeout,
+/// channel error, missing response) yields an empty list. A genuinely-dead
+/// contract handler causes the `contract_executor_task` to exit, which the
+/// `run_node` supervisor observes via its `deterministic_select!` and brings the
+/// node down — so de-fatalizing this diagnostics query does not mask a dead
+/// handler.
+async fn query_app_subscriptions_bounded(
+    ch_outbound: &ContractHandlerChannel<SenderHalve>,
+) -> Vec<crate::message::SubscriptionInfo> {
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    match timeout(
+        QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT,
+        ch_outbound.send_to_handler(ContractHandlerEvent::QuerySubscriptions { callback: tx }),
+    )
+    .await
+    {
+        Ok(Ok(_)) => match timeout(Duration::from_secs(1), rx.recv()).await {
+            Ok(Some(QueryResult::NetworkDebug(info))) => info.application_subscriptions,
+            _ => Vec::new(),
+        },
+        Ok(Err(err)) => {
+            tracing::warn!(
+                error = %err,
+                "QuerySubscriptions diagnostics: contract handler error; \
+                 serving empty app subscriptions"
+            );
+            Vec::new()
+        }
+        Err(_elapsed) => {
+            tracing::warn!(
+                "QuerySubscriptions diagnostics: contract handler did not respond within \
+                 timeout; serving empty app subscriptions"
+            );
+            Vec::new()
+        }
+    }
+}
 
 pub(crate) enum P2pBridgeEvent {
     Message(PeerKeyLocation, Box<NetMessage>),
@@ -1401,7 +1448,7 @@ impl P2pConnManager {
                                     )
                                     .await
                                     {
-                                        Ok(Ok(_)) => {
+                                        Ok(Ok(())) => {
                                             tracing::trace!(
                                                 tx = %msg.id(),
                                                 peer_addr = %target_addr,
@@ -2058,7 +2105,7 @@ impl P2pConnManager {
                                 )
                                 .await
                                 {
-                                    Ok(Ok(_)) => {}
+                                    Ok(Ok(())) => {}
                                     Ok(Err(send_error)) => {
                                         tracing::error!(
                                             error = ?send_error,
@@ -2093,54 +2140,12 @@ impl P2pConnManager {
                                     })
                                     .collect();
 
-                                // Get application subscriptions from contract executor
-                                // For now, we'll send a query to the contract handler.
-                                //
-                                // #4549: this is a best-effort diagnostics query. It must
-                                // NOT be fatal to the network event listener, and must not
-                                // stall it: a saturated contract handler previously made
-                                // this `.await?` return `NoEvHandlerResponse` after the
-                                // 300s handler timeout, which killed the whole listener
-                                // ("Network event listener exited: no response received
-                                // from handler") and took the gateway network-dead. Bound
-                                // the wait and serve an empty list on any failure. A
-                                // genuinely-dead contract handler is detected separately by
-                                // the `contract_executor_task` supervisor in `run_node`.
-                                let (tx, mut rx) = tokio::sync::mpsc::channel(1);
-
-                                let app_subscriptions = match timeout(
-                                    QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT,
-                                    op_manager.notify_contract_handler(
-                                        ContractHandlerEvent::QuerySubscriptions { callback: tx },
-                                    ),
-                                )
-                                .await
-                                {
-                                    Ok(Ok(_)) => {
-                                        match timeout(Duration::from_secs(1), rx.recv()).await {
-                                            Ok(Some(QueryResult::NetworkDebug(info))) => {
-                                                info.application_subscriptions
-                                            }
-                                            _ => Vec::new(),
-                                        }
-                                    }
-                                    Ok(Err(err)) => {
-                                        tracing::warn!(
-                                            error = %err,
-                                            "QuerySubscriptions diagnostics: contract handler \
-                                             error; serving empty app subscriptions"
-                                        );
-                                        Vec::new()
-                                    }
-                                    Err(_elapsed) => {
-                                        tracing::warn!(
-                                            "QuerySubscriptions diagnostics: contract handler did \
-                                             not respond within timeout; serving empty app \
-                                             subscriptions"
-                                        );
-                                        Vec::new()
-                                    }
-                                };
+                                // Get application subscriptions from the contract handler.
+                                // #4549: bounded + non-fatal (see
+                                // `query_app_subscriptions_bounded`) — a saturated handler
+                                // must never stall or kill the network event listener.
+                                let app_subscriptions =
+                                    query_app_subscriptions_bounded(&op_manager.ch_outbound).await;
 
                                 // Log network subscription details for debugging
                                 for (contract_key, peers) in &network_subs {
@@ -2177,7 +2182,7 @@ impl P2pConnManager {
                                 )
                                 .await
                                 {
-                                    Ok(Ok(_)) => {}
+                                    Ok(Ok(())) => {}
                                     Ok(Err(send_error)) => {
                                         tracing::error!(
                                             error = ?send_error,
@@ -2261,36 +2266,14 @@ impl P2pConnManager {
                                     // Get network subscriptions from OpManager
                                     let _network_subs = op_manager.get_network_subscriptions();
 
-                                    // Get application subscriptions from contract executor.
-                                    // #4549: bounded + best-effort, same rationale as the
-                                    // QuerySubscriptions arm above — a saturated handler must
-                                    // not stall (or kill) the network event listener.
-                                    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
-                                    if matches!(
-                                        timeout(
-                                            QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT,
-                                            op_manager.notify_contract_handler(
-                                                ContractHandlerEvent::QuerySubscriptions {
-                                                    callback: tx,
-                                                },
-                                            ),
-                                        )
-                                        .await,
-                                        Ok(Ok(_))
-                                    ) {
-                                        let app_subscriptions = match timeout(
-                                            Duration::from_secs(1),
-                                            rx.recv(),
-                                        )
-                                        .await
-                                        {
-                                            Ok(Some(QueryResult::NetworkDebug(info))) => {
-                                                info.application_subscriptions
-                                            }
-                                            _ => Vec::new(),
-                                        };
-
-                                        response.subscriptions = app_subscriptions
+                                    // Get application subscriptions from the contract handler.
+                                    // #4549: bounded + non-fatal (see
+                                    // `query_app_subscriptions_bounded`). On any failure this
+                                    // serves an empty list rather than stalling or killing the
+                                    // network event listener.
+                                    response.subscriptions =
+                                        query_app_subscriptions_bounded(&op_manager.ch_outbound)
+                                            .await
                                             .into_iter()
                                             .map(|sub| {
                                                 freenet_stdlib::client_api::SubscriptionInfo {
@@ -2299,7 +2282,6 @@ impl P2pConnManager {
                                                 }
                                             })
                                             .collect();
-                                    }
                                 }
 
                                 // Collect contract states.
@@ -2380,7 +2362,7 @@ impl P2pConnManager {
                                 )
                                 .await
                                 {
-                                    Ok(Ok(_)) => {}
+                                    Ok(Ok(())) => {}
                                     Ok(Err(send_error)) => {
                                         tracing::error!(
                                             error = ?send_error,
@@ -4326,36 +4308,79 @@ mod tests {
         // Built at runtime so this test's own source can't self-match the needle.
         let needle = concat!("ContractHandlerEvent::", "QuerySubscriptions {");
         let sites: Vec<usize> = src.match_indices(needle).map(|(i, _)| i).collect();
-        // Two on-loop dispatch arms: NodeEvent::QuerySubscriptions and
-        // NodeEvent::QueryNodeDiagnostics both query the handler for app subs.
-        assert!(
-            sites.len() >= 2,
-            "expected >=2 on-loop QuerySubscriptions dispatch sites, found {}",
+        // The handler query now lives in exactly ONE place — the bounded helper
+        // `query_app_subscriptions_bounded`. Re-inlining it into an event-loop arm
+        // (the #4549 regression shape) would add a site and fail this assert.
+        assert_eq!(
+            sites.len(),
+            1,
+            "the QuerySubscriptions handler query must live only in \
+             query_app_subscriptions_bounded, found {} sites",
             sites.len()
         );
-        for idx in sites {
-            // Forward window (char-based, so a multi-byte char in nearby comments
-            // can't panic the slice): must not use the fatal `.await?`.
-            let forward: String = src[idx..].chars().take(220).collect();
-            assert!(
-                !forward.contains(".await?"),
-                "QuerySubscriptions diagnostics query must not use the fatal `.await?` — a \
-                 per-op handler timeout must never kill the network event listener (#4549). \
-                 Near:\n{forward}"
-            );
-            // Each call must be wrapped in `timeout(QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT, ..)`
-            // — confirm the nearest preceding `timeout(` carries the bound constant.
-            let before = &src[..idx];
-            let bounded = before
-                .rfind("timeout(")
-                .is_some_and(|tp| src[tp..idx].contains("QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT"));
-            assert!(
-                bounded,
-                "QuerySubscriptions diagnostics query must be wrapped in \
-                 timeout(QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT, ..) so a saturated contract handler \
-                 can neither stall nor kill the network event loop (#4549)."
-            );
-        }
+        let idx = sites[0];
+        // Non-fatal: no `?`-propagation on the handler result (char-based window so
+        // a multi-byte char in nearby comments can't panic the slice).
+        let forward: String = src[idx..].chars().take(220).collect();
+        assert!(
+            !forward.contains(".await?"),
+            "the QuerySubscriptions handler query must not use the fatal `.await?` — a per-op \
+             handler timeout must never kill the network event listener (#4549). Near:\n{forward}"
+        );
+        // Bounded: wrapped in `timeout(QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT, ..)`.
+        let before = &src[..idx];
+        let bounded = before
+            .rfind("timeout(")
+            .is_some_and(|tp| src[tp..idx].contains("QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT"));
+        assert!(
+            bounded,
+            "the QuerySubscriptions handler query must be wrapped in \
+             timeout(QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT, ..) so a saturated contract handler \
+             can neither stall nor kill the network event loop (#4549)."
+        );
+        // Both diagnostics arms (and the helper definition) must reference the helper.
+        assert!(
+            src.matches("query_app_subscriptions_bounded(").count() >= 3,
+            "both diagnostics arms must delegate to query_app_subscriptions_bounded (#4549)"
+        );
+        // Keep the bound small so a future bump can't reopen the event-loop stall window.
+        assert!(
+            super::QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT <= Duration::from_secs(30),
+            "QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT must stay small to bound the loop stall (#4549)"
+        );
+    }
+
+    /// Behavioral pin for #4549: a stalled contract handler must make the bounded
+    /// diagnostics query return an EMPTY list within the timeout — never error (the
+    /// old fatal `.await?`) and never stall for the handler's 300s response timeout.
+    /// This exercises the production `query_app_subscriptions_bounded` directly, so
+    /// it fails if the stall-survival behavior regresses by ANY route, not just the
+    /// one syntactic revert the source-scrape pin catches.
+    #[tokio::test(start_paused = true)]
+    async fn query_app_subscriptions_bounded_yields_empty_when_handler_stalls() {
+        // Keep the handler (receiver) half alive but NEVER respond — the saturation
+        // condition that killed the listener pre-#4549. The unbounded send succeeds;
+        // the response oneshot never resolves, so the outer bound must fire.
+        let (sender, _handler_half, _waiting) = crate::contract::contract_handler_channel();
+        let bound = super::QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT;
+        let start = Instant::now();
+        let subs = super::query_app_subscriptions_bounded(&sender).await;
+        let elapsed = start.elapsed();
+        assert!(
+            subs.is_empty(),
+            "a stalled handler must yield empty app subscriptions, got {} entries",
+            subs.len()
+        );
+        // start_paused advances the clock deterministically: we wait the bound but
+        // NOT the handler's full 300s CH_EV_RESPONSE_TIME_OUT.
+        assert!(
+            elapsed >= bound,
+            "must wait the bounded timeout ({elapsed:?} < {bound:?})"
+        );
+        assert!(
+            elapsed < Duration::from_secs(60),
+            "must not stall for the 300s handler timeout ({elapsed:?})"
+        );
     }
 
     /// Pin: the `TransactionOrphaned` handler must deliver the cause

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -100,6 +100,16 @@ impl std::fmt::Display for EventLoopExitReason {
 
 impl std::error::Error for EventLoopExitReason {}
 
+/// Upper bound on how long the network event listener will wait for the contract
+/// handler to answer a *diagnostics* `QuerySubscriptions` query (#4549).
+///
+/// These queries run inline on the event loop. The handler's own response timeout
+/// is `CH_EV_RESPONSE_TIME_OUT` (300s); without an outer bound a saturated handler
+/// would stall the entire network event loop for up to 5 minutes per diagnostics
+/// poll. A diagnostics query is best-effort, so cap the wait and serve an empty
+/// result on timeout rather than freezing (or, previously, killing) the listener.
+const QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT: Duration = Duration::from_secs(5);
+
 pub(crate) enum P2pBridgeEvent {
     Message(PeerKeyLocation, Box<NetMessage>),
     NodeAction(NodeEvent),
@@ -1391,7 +1401,7 @@ impl P2pConnManager {
                                     )
                                     .await
                                     {
-                                        Ok(Ok(())) => {
+                                        Ok(Ok(_)) => {
                                             tracing::trace!(
                                                 tx = %msg.id(),
                                                 peer_addr = %target_addr,
@@ -2048,7 +2058,7 @@ impl P2pConnManager {
                                 )
                                 .await
                                 {
-                                    Ok(Ok(())) => {}
+                                    Ok(Ok(_)) => {}
                                     Ok(Err(send_error)) => {
                                         tracing::error!(
                                             error = ?send_error,
@@ -2084,22 +2094,53 @@ impl P2pConnManager {
                                     .collect();
 
                                 // Get application subscriptions from contract executor
-                                // For now, we'll send a query to the contract handler
+                                // For now, we'll send a query to the contract handler.
+                                //
+                                // #4549: this is a best-effort diagnostics query. It must
+                                // NOT be fatal to the network event listener, and must not
+                                // stall it: a saturated contract handler previously made
+                                // this `.await?` return `NoEvHandlerResponse` after the
+                                // 300s handler timeout, which killed the whole listener
+                                // ("Network event listener exited: no response received
+                                // from handler") and took the gateway network-dead. Bound
+                                // the wait and serve an empty list on any failure. A
+                                // genuinely-dead contract handler is detected separately by
+                                // the `contract_executor_task` supervisor in `run_node`.
                                 let (tx, mut rx) = tokio::sync::mpsc::channel(1);
 
-                                op_manager
-                                    .notify_contract_handler(
+                                let app_subscriptions = match timeout(
+                                    QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT,
+                                    op_manager.notify_contract_handler(
                                         ContractHandlerEvent::QuerySubscriptions { callback: tx },
-                                    )
-                                    .await?;
-
-                                let app_subscriptions =
-                                    match timeout(Duration::from_secs(1), rx.recv()).await {
-                                        Ok(Some(QueryResult::NetworkDebug(info))) => {
-                                            info.application_subscriptions
+                                    ),
+                                )
+                                .await
+                                {
+                                    Ok(Ok(_)) => {
+                                        match timeout(Duration::from_secs(1), rx.recv()).await {
+                                            Ok(Some(QueryResult::NetworkDebug(info))) => {
+                                                info.application_subscriptions
+                                            }
+                                            _ => Vec::new(),
                                         }
-                                        _ => Vec::new(),
-                                    };
+                                    }
+                                    Ok(Err(err)) => {
+                                        tracing::warn!(
+                                            error = %err,
+                                            "QuerySubscriptions diagnostics: contract handler \
+                                             error; serving empty app subscriptions"
+                                        );
+                                        Vec::new()
+                                    }
+                                    Err(_elapsed) => {
+                                        tracing::warn!(
+                                            "QuerySubscriptions diagnostics: contract handler did \
+                                             not respond within timeout; serving empty app \
+                                             subscriptions"
+                                        );
+                                        Vec::new()
+                                    }
+                                };
 
                                 // Log network subscription details for debugging
                                 for (contract_key, peers) in &network_subs {
@@ -2136,7 +2177,7 @@ impl P2pConnManager {
                                 )
                                 .await
                                 {
-                                    Ok(Ok(())) => {}
+                                    Ok(Ok(_)) => {}
                                     Ok(Err(send_error)) => {
                                         tracing::error!(
                                             error = ?send_error,
@@ -2220,17 +2261,23 @@ impl P2pConnManager {
                                     // Get network subscriptions from OpManager
                                     let _network_subs = op_manager.get_network_subscriptions();
 
-                                    // Get application subscriptions from contract executor
+                                    // Get application subscriptions from contract executor.
+                                    // #4549: bounded + best-effort, same rationale as the
+                                    // QuerySubscriptions arm above — a saturated handler must
+                                    // not stall (or kill) the network event listener.
                                     let (tx, mut rx) = tokio::sync::mpsc::channel(1);
-                                    if op_manager
-                                        .notify_contract_handler(
-                                            ContractHandlerEvent::QuerySubscriptions {
-                                                callback: tx,
-                                            },
+                                    if matches!(
+                                        timeout(
+                                            QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT,
+                                            op_manager.notify_contract_handler(
+                                                ContractHandlerEvent::QuerySubscriptions {
+                                                    callback: tx,
+                                                },
+                                            ),
                                         )
-                                        .await
-                                        .is_ok()
-                                    {
+                                        .await,
+                                        Ok(Ok(_))
+                                    ) {
                                         let app_subscriptions = match timeout(
                                             Duration::from_secs(1),
                                             rx.recv(),
@@ -2333,7 +2380,7 @@ impl P2pConnManager {
                                 )
                                 .await
                                 {
-                                    Ok(Ok(())) => {}
+                                    Ok(Ok(_)) => {}
                                     Ok(Err(send_error)) => {
                                         tracing::error!(
                                             error = ?send_error,
@@ -4262,6 +4309,53 @@ mod tests {
             "PipeStream dispatch must use `reserve()` instead of `send().await` — \
              see #4145. Body:\n{body}"
         );
+    }
+
+    /// Source-scrape regression guard for #4549. The inline diagnostics
+    /// `QuerySubscriptions` queries on the network event loop must be BOUNDED by
+    /// `QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT` and must NOT propagate the contract
+    /// handler's result with `?`. The original bug was a bare
+    /// `notify_contract_handler(QuerySubscriptions ...).await?`: under
+    /// contract-executor saturation it returned `NoEvHandlerResponse` after the
+    /// 300s handler timeout, which killed the entire network event listener
+    /// ("Network event listener exited: no response received from handler") and
+    /// took the gateway network-dead with no self-recovery.
+    #[test]
+    fn query_subscriptions_diagnostics_bounded_and_non_fatal() {
+        let src = include_str!("p2p_protoc.rs");
+        // Built at runtime so this test's own source can't self-match the needle.
+        let needle = concat!("ContractHandlerEvent::", "QuerySubscriptions {");
+        let sites: Vec<usize> = src.match_indices(needle).map(|(i, _)| i).collect();
+        // Two on-loop dispatch arms: NodeEvent::QuerySubscriptions and
+        // NodeEvent::QueryNodeDiagnostics both query the handler for app subs.
+        assert!(
+            sites.len() >= 2,
+            "expected >=2 on-loop QuerySubscriptions dispatch sites, found {}",
+            sites.len()
+        );
+        for idx in sites {
+            // Forward window (char-based, so a multi-byte char in nearby comments
+            // can't panic the slice): must not use the fatal `.await?`.
+            let forward: String = src[idx..].chars().take(220).collect();
+            assert!(
+                !forward.contains(".await?"),
+                "QuerySubscriptions diagnostics query must not use the fatal `.await?` — a \
+                 per-op handler timeout must never kill the network event listener (#4549). \
+                 Near:\n{forward}"
+            );
+            // Each call must be wrapped in `timeout(QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT, ..)`
+            // — confirm the nearest preceding `timeout(` carries the bound constant.
+            let before = &src[..idx];
+            let bounded = before
+                .rfind("timeout(")
+                .is_some_and(|tp| src[tp..idx].contains("QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT"));
+            assert!(
+                bounded,
+                "QuerySubscriptions diagnostics query must be wrapped in \
+                 timeout(QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT, ..) so a saturated contract handler \
+                 can neither stall nor kill the network event loop (#4549)."
+            );
+        }
     }
 
     /// Pin: the `TransactionOrphaned` handler must deliver the cause

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -7,8 +7,8 @@ use tracing::Instrument;
 use super::{
     NetEventRegister, PeerId,
     network_bridge::{
-        EventLoopNotificationsReceiver, event_loop_notification_channel_with_capacity,
-        p2p_protoc::P2pConnManager,
+        EventLoopExitReason, EventLoopNotificationsReceiver,
+        event_loop_notification_channel_with_capacity, p2p_protoc::P2pConnManager,
     },
 };
 use crate::{
@@ -25,6 +25,49 @@ use crate::{
 };
 
 use super::{OpManager, background_task_monitor::BackgroundTaskMonitor};
+
+/// Exit code requested when the network event loop dies on a fatal (non-graceful)
+/// condition (#4549). `42` == `EXIT_CODE_UPDATE_NEEDED` (see
+/// `crates/core/src/bin/commands/auto_update.rs`) and is also hard-coded in the
+/// systemd unit templates (`[ "$EXIT_STATUS" = "42" ]`). It is listed in the unit's
+/// `SuccessExitStatus`, so a repeating wedge-restart cannot trip `StartLimitBurst`
+/// and brick the unit; its `ExecStopPost` hook runs `freenet update`, so a wedged
+/// old binary can auto-upgrade to a fixed version.
+const FATAL_LISTENER_EXIT_CODE: i32 = 42;
+
+/// When `true`, a fatal (non-graceful) exit of the network event listener aborts
+/// the whole process with [`FATAL_LISTENER_EXIT_CODE`] instead of unwinding through
+/// the normal teardown/return path (#4549).
+///
+/// In production that unwind path could hang for tens of minutes while the node sat
+/// network-dead (the listener had already logged its exit), so systemd never
+/// restarted it and the auto-update hook never fired — the node just spun. A prompt
+/// `process::exit` converts that dark window into a quick restart.
+///
+/// **Off by default.** It is enabled only by the real `freenet` binary
+/// ([`enable_abort_on_fatal_listener_exit`]) so that simulation / integration tests
+/// and library embedders never have a fatal listener exit kill their host process.
+static ABORT_ON_FATAL_LISTENER_EXIT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Enable the #4549 fast-exit behaviour: a fatal (non-graceful) network event
+/// listener exit will abort the process with [`FATAL_LISTENER_EXIT_CODE`] for a
+/// prompt service-manager restart, rather than risk hanging in teardown. Call once
+/// from the production node entry point. See [`ABORT_ON_FATAL_LISTENER_EXIT`].
+pub fn enable_abort_on_fatal_listener_exit() {
+    ABORT_ON_FATAL_LISTENER_EXIT.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Whether a network-event-listener exit error is a *graceful* shutdown (a clean,
+/// intended exit) rather than a fatal wedge that warrants a process restart.
+///
+/// Graceful shutdown (`NodeEvent::Disconnect`, e.g. SIGTERM or auto-update) returns
+/// [`EventLoopExitReason::GracefulShutdown`]; every other listener-exit error
+/// (UDP-listener death, unexpected stream end, a handler/transport error) is fatal.
+fn listener_exit_is_graceful(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<EventLoopExitReason>()
+        .is_some_and(|reason| matches!(reason, EventLoopExitReason::GracefulShutdown))
+}
 
 pub(crate) struct NodeP2P {
     pub(crate) op_manager: Arc<OpManager>,
@@ -400,6 +443,25 @@ impl NodeP2P {
         let result = crate::deterministic_select! {
             r = f => {
                let Err(e) = r;
+               // #4549: on a fatal (non-graceful) listener exit, abort the process
+               // immediately rather than risk hanging in the teardown/return path
+               // below (in production the node sat network-dead and spun for ~37min
+               // before finally exiting, so systemd never restarted it). A graceful
+               // shutdown (Disconnect / SIGTERM / auto-update) must still fall through
+               // to the clean teardown. Gated so only the real binary force-exits.
+               if !listener_exit_is_graceful(&e)
+                   && ABORT_ON_FATAL_LISTENER_EXIT.load(std::sync::atomic::Ordering::Relaxed)
+               {
+                   eprintln!("CRITICAL: Network event listener exited (fatal): {e}");
+                   tracing::error!(
+                       error = %e,
+                       exit_code = FATAL_LISTENER_EXIT_CODE,
+                       "Network event listener exited unexpectedly; forcing immediate process \
+                        exit so the service manager restarts the node promptly and the \
+                        auto-update hook can fire (avoids the wedged-but-alive dark window, #4549)"
+                   );
+                   std::process::exit(FATAL_LISTENER_EXIT_CODE);
+               }
                eprintln!("CRITICAL: Network event listener exited: {e}");
                tracing::error!("Network event listener exited: {}", e);
                Err(e)
@@ -725,6 +787,54 @@ impl NodeP2P {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #4549: the fast-exit watchdog (`process::exit(42)` on a fatal listener exit)
+    /// is gated by `listener_exit_is_graceful`. A regression in this predicate is
+    /// dangerous in BOTH directions: classifying a graceful shutdown as fatal would
+    /// force-exit the process on every clean SIGTERM / auto-update (turning exit 0
+    /// into a spurious exit-42 + auto-update on every stop); classifying a real
+    /// wedge as graceful would leave the node spinning network-dead (the bug we are
+    /// fixing). Pin both directions.
+    #[test]
+    fn listener_exit_graceful_classification() {
+        // Graceful shutdown (NodeEvent::Disconnect via SIGTERM / auto-update).
+        assert!(
+            listener_exit_is_graceful(&EventLoopExitReason::GracefulShutdown.into()),
+            "GracefulShutdown must be treated as a clean exit (no force-exit)"
+        );
+
+        // Unexpected stream end is fatal — the node must fast-exit and restart.
+        assert!(
+            !listener_exit_is_graceful(&EventLoopExitReason::UnexpectedStreamEnd.into()),
+            "UnexpectedStreamEnd must be treated as a fatal wedge"
+        );
+
+        // Arbitrary listener errors (UDP-listener death, handler/transport errors,
+        // the #4549 'no response received from handler') are all fatal.
+        assert!(!listener_exit_is_graceful(&anyhow::anyhow!(
+            "UDP listen task exited unexpectedly — transport layer is dead"
+        )));
+        assert!(!listener_exit_is_graceful(&anyhow::anyhow!(
+            "no response received from handler"
+        )));
+    }
+
+    /// The fast-exit flag must be OFF by default so simulation / integration tests
+    /// and library embedders never have a fatal listener exit kill their process.
+    /// Only the real binary opts in via `enable_abort_on_fatal_listener_exit`.
+    #[test]
+    fn fatal_listener_fast_exit_is_opt_in() {
+        // NOTE: deliberately does NOT call `enable_abort_on_fatal_listener_exit()`
+        // (a process-global flip would affect other tests in the same binary).
+        assert!(
+            !ABORT_ON_FATAL_LISTENER_EXIT.load(std::sync::atomic::Ordering::Relaxed),
+            "fatal-listener fast-exit must be opt-in (off unless the binary enables it)"
+        );
+        assert_eq!(
+            FATAL_LISTENER_EXIT_CODE, 42,
+            "must match EXIT_CODE_UPDATE_NEEDED"
+        );
+    }
 
     /// Verify that a spawned task that panics is detected via JoinHandle.
     #[tokio::test]

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -29,10 +29,21 @@ use super::{OpManager, background_task_monitor::BackgroundTaskMonitor};
 /// Exit code requested when the network event loop dies on a fatal (non-graceful)
 /// condition (#4549). `42` == `EXIT_CODE_UPDATE_NEEDED` (see
 /// `crates/core/src/bin/commands/auto_update.rs`) and is also hard-coded in the
-/// systemd unit templates (`[ "$EXIT_STATUS" = "42" ]`). It is listed in the unit's
-/// `SuccessExitStatus`, so a repeating wedge-restart cannot trip `StartLimitBurst`
-/// and brick the unit; its `ExecStopPost` hook runs `freenet update`, so a wedged
-/// old binary can auto-upgrade to a fixed version.
+/// GENERATED systemd unit template (`crates/core/src/bin/commands/service/linux.rs`,
+/// `[ "$EXIT_STATUS" = "42" ]`). Its `ExecStopPost` hook runs `freenet update`, so a
+/// wedged OLD binary auto-upgrades to a fixed version (the self-heal path that rolls
+/// this fix out), and `Restart=always` (`RestartSec=10`) restarts it.
+///
+/// The restart loop is bounded by `RestartSec` and is visible (a `CRITICAL` log per
+/// exit + climbing `NRestarts`) — strictly better than the #4549 dark wedge. NOTE:
+/// the unit's `StartLimitBurst`/`StartLimitIntervalSec` are currently emitted in the
+/// `[Service]` section, where systemd ignores them, so they do NOT rate-limit a
+/// repeating wedge today; moving them to `[Unit]` (and then a min-uptime exit-code
+/// guard) is tracked in #4551 and is out of scope for this hotfix.
+///
+/// Caveat (macOS): the macOS service wrapper treats a non-zero `freenet update`
+/// result (the no-op "already up to date" exit) as a failure and applies restart
+/// backoff. Production gateways are Linux, so this only slows restart on macOS.
 const FATAL_LISTENER_EXIT_CODE: i32 = 42;
 
 /// When `true`, a fatal (non-graceful) exit of the network event listener aborts
@@ -456,6 +467,7 @@ impl NodeP2P {
                    tracing::error!(
                        error = %e,
                        exit_code = FATAL_LISTENER_EXIT_CODE,
+                       uptime_secs = start_time.elapsed().as_secs(),
                        "Network event listener exited unexpectedly; forcing immediate process \
                         exit so the service manager restarts the node promptly and the \
                         auto-update hook can fire (avoids the wedged-but-alive dark window, #4549)"
@@ -809,14 +821,18 @@ mod tests {
             "UnexpectedStreamEnd must be treated as a fatal wedge"
         );
 
-        // Arbitrary listener errors (UDP-listener death, handler/transport errors,
-        // the #4549 'no response received from handler') are all fatal.
+        // Arbitrary listener errors (UDP-listener death, handler/transport errors)
+        // are all fatal.
         assert!(!listener_exit_is_graceful(&anyhow::anyhow!(
             "UDP listen task exited unexpectedly — transport layer is dead"
         )));
-        assert!(!listener_exit_is_graceful(&anyhow::anyhow!(
-            "no response received from handler"
-        )));
+
+        // The real #4549 production error is the TYPED
+        // `ContractError::NoEvHandlerResponse` (not a string stand-in) — it must
+        // also classify as fatal so the wedge triggers a restart.
+        assert!(!listener_exit_is_graceful(
+            &crate::contract::ContractError::NoEvHandlerResponse.into()
+        ));
     }
 
     /// The fast-exit flag must be OFF by default so simulation / integration tests
@@ -832,7 +848,8 @@ mod tests {
         );
         assert_eq!(
             FATAL_LISTENER_EXIT_CODE, 42,
-            "must match EXIT_CODE_UPDATE_NEEDED"
+            "must match EXIT_CODE_UPDATE_NEEDED so the systemd ExecStopPost auto-update \
+             hook fires on a wedge"
         );
     }
 

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -998,6 +998,31 @@ impl WasmtimeEngine {
         // Memory benefits come from pooling and proper cleanup, not optimizations
         wasmtime_config.cranelift_opt_level(OptLevel::None);
 
+        // Disable native (DWARF) unwind-info registration (#4549).
+        //
+        // Wasmtime registers per-module FDE (frame description entry) unwind info
+        // with the *system* libunwind so a host stack-capture / OS unwinder can
+        // walk THROUGH JIT'd wasm frames. libunwind's FDE cache invalidation
+        // (`DwarfFDECache::removeAllIn`) is O(n) in the number of registered
+        // ranges, so under heavy module load/unload churn (cache eviction +
+        // recompilation under contract-executor backpressure) registration becomes
+        // quadratic. A production gateway death-spiralled at ~100% CPU entirely
+        // inside `DwarfFDECache::removeAllIn`. Wasmtime's own docs explicitly
+        // recommend disabling this on "systems loading many modules".
+        //
+        // Safety: this does NOT affect wasmtime's own Wasm-trap backtraces (those
+        // are governed by `wasm_backtrace*` and are independent), so contract
+        // trap / out-of-fuel error reporting is unchanged. The only thing lost is
+        // a third-party unwinder's ability to walk through wasm frames — which
+        // Freenet never does: contract WASM runs via `spawn_blocking` on a
+        // dedicated thread and panics are caught as `BlockingResult::Panic`, never
+        // unwound across the wasm boundary.
+        //
+        // Windows forbids disabling native unwind info (wasmtime returns an error
+        // from `Engine::new`), so leave it at its default there.
+        #[cfg(not(target_os = "windows"))]
+        wasmtime_config.native_unwind_info(false);
+
         // Enable disk-based compilation cache (#3456). Wasmtime caches compiled
         // modules keyed by (engine config + WASM bytes hash). On cache hit,
         // Module::new() skips compilation entirely and deserializes — ~100x faster.


### PR DESCRIPTION
## Problem

Both production gateways (nova, vega) crash on a ~21.5h cadence under the #4404/#4534 placement-migration load. On the big box (nova) it manifests as the death-spiral in #4549:

1. The WASM contract executor is globally saturated → ops cross the 5s timeout → wasmtime "Recovering engine store after timeout/panic" churns module register/unregister.
2. Wasmtime registers per-module DWARF unwind info (FDEs) with the **system** libunwind. libunwind's FDE-cache invalidation (`DwarfFDECache::removeAllIn`) is **O(n)**, so under heavy module load/unload it goes quadratic and pins the box at ~100% CPU (perf showed 99.8% there). Stolen CPU slows the executor → more timeouts → more churn (positive feedback).
3. A client diagnostics query (`NodeQuery::SubscriptionInfo`) runs **inline on the network event loop** and `await?`s the contract handler. Under saturation it returns `NoEvHandlerResponse` after the 300s handler timeout — which was **fatal**: it killed the whole network event listener ("Network event listener exited: no response received from handler"), taking the node network-dead.
4. The wedged process then **never exited promptly** — it spun network-dead for ~37 min before the normal teardown path finally returned (exit 1). systemd never restarted it in a useful window and the exit-42 auto-update hook never fired.

This addresses the three **root causes** of the unrecoverable wedge. The upstream executor *load* itself (chronic queue-full backpressure) is the #4534/#4537 migration-throughput workstream and is intentionally **out of scope** here — its queue bounds and the 300s handler timeout are load-bearing and unchanged.

## Approach (three root-cause fixes, one per stage of the spiral)

**A — Disable native (DWARF) unwind-info registration (`wasm_runtime/engine/wasmtime_engine.rs`).**
`wasmtime_config.native_unwind_info(false)` (gated `cfg(not(windows))`, where wasmtime forbids it). This is the root of the CPU pin: it removes the per-module `__register_frame`/`__deregister_frame` calls that feed libunwind's quadratic FDE cache. Wasmtime's own docs explicitly recommend disabling it for "systems loading many modules". **Safety:** it does not affect wasmtime's own Wasm-trap backtraces (governed by `wasm_backtrace*`), so contract trap / out-of-fuel reporting is unchanged; the only thing lost is a third-party/OS unwinder's ability to walk *through* JIT'd wasm frames, which Freenet never does (contract WASM runs via `spawn_blocking` and panics are caught as `BlockingResult::Panic`, never unwound across the wasm boundary). Freeing the pinned CPU also lets the executor keep up, attacking the spiral at its source.

**B — Fast-exit on a fatal network-listener death (`node/p2p_impl.rs`, `bin/freenet.rs`).**
On a *non-graceful* listener exit, `process::exit(42)` immediately instead of unwinding through the teardown/return path that hung for ~37 min in production. `42` = `EXIT_CODE_UPDATE_NEEDED`: it is `SuccessExitStatus` (burst-exempt, so a repeating wedge can't trip `StartLimitBurst` and brick the unit) and its `ExecStopPost` runs `freenet update` (so a wedged old binary auto-upgrades to a fixed one). Graceful shutdown (`NodeEvent::Disconnect` via SIGTERM / auto-update → `EventLoopExitReason::GracefulShutdown`) still falls through to the clean teardown. The force-exit is **off by default** and enabled only by the real `freenet` binary, so simulation / integration tests and library embedders never have a listener exit kill their process.

**C — Make the on-loop diagnostics `QuerySubscriptions` non-fatal and bounded (`node/network_bridge/p2p_protoc.rs`).**
Both diagnostics arms (`QuerySubscriptions`, `QueryNodeDiagnostics`) now wrap the inline `notify_contract_handler(QuerySubscriptions ...)` in `timeout(QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT = 5s, ..)` and treat any failure as "serve empty app subscriptions". A per-op handler timeout can no longer kill the listener, nor stall the event loop for up to 300s. A genuinely-dead contract handler is still detected by the separate `contract_executor_task` supervisor in `run_node`.

## Testing

- `cargo fmt`, `cargo clippy --all-targets --all-features`, `cargo test -p freenet`.
- New regression tests:
  - `p2p_impl::tests::listener_exit_graceful_classification` — pins that the force-exit predicate fires only on a fatal exit and never on `GracefulShutdown` (a regression either way is dangerous: spurious exit-42 on every clean stop, or failure to recover a real wedge).
  - `p2p_impl::tests::fatal_listener_fast_exit_is_opt_in` — the force-exit flag is off by default (tests/embedders never self-kill) and the exit code is 42.
  - `p2p_protoc::tests::query_subscriptions_diagnostics_bounded_and_non_fatal` — source-scrape pin (same pattern as the #4145 guards) that both diagnostics `QuerySubscriptions` calls are wrapped in the bounded timeout and never use the fatal `.await?`.
- Fix A's no-regression is covered by the existing wasm_runtime tests (`test_wasmtime_engine_creation`, `wasm_runtime/tests/execution_handling.rs`, `contract_metering.rs`) continuing to pass — FDE registration is internal to wasmtime and not unit-testable from our side.

## Why one PR

All three are tightly-coupled root-cause fixes for the single death-spiral in #4549 (the issue frames them as sub-problems of one bug). Per the finish-the-fix principle, the user-visible "unrecoverable wedge" symptom only goes away when all three land together — A stops the CPU pin, C keeps the listener alive through transient saturation, B guarantees a prompt restart if anything else wedges it.

Closes #4549

[AI-assisted - Claude]
