### PR TITLE
feat(hosted): wire the shell export button to the node export endpoint

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -2503,6 +2503,12 @@ mod tests {
             "access-key backup/restore controls missing"
         );
         assert!(hosted.contains("Export data"), "export control missing");
+        // The export button must be wired to the node export endpoint, not a
+        // placeholder. Pin the route so a refactor cannot silently revert it.
+        assert!(
+            hosted.contains("/v1/hosted/export"),
+            "export button is not wired to the export endpoint"
+        );
         // The access key is read from the shell-only token global; it is never
         // injected into the sandboxed iframe.
         assert!(

--- a/crates/core/src/server/path_handlers/assets/hosted_bar.js
+++ b/crates/core/src/server/path_handlers/assets/hosted_bar.js
@@ -54,8 +54,36 @@
     }
   });
   document.getElementById('fnexport').addEventListener('click', function () {
-    alert(
-      'Export your delegate data to your own Freenet peer.\n\nThis downloads an encrypted bundle you can import on your own node with: freenet secrets import\n\n(Coming soon.)',
-    );
+    var t =
+      typeof __freenet_user_token !== 'undefined' ? __freenet_user_token : null;
+    if (!t) {
+      setOk('No key on this connection');
+      return;
+    }
+    setOk('Preparing download...');
+    // Read the token from the shell-only global and send it in the header the
+    // export endpoint requires (never a query param, so it stays out of logs).
+    // fetch->blob->download because a plain navigation cannot set the header.
+    fetch('/v1/hosted/export', { headers: { 'X-Freenet-User-Token': t } })
+      .then(function (r) {
+        if (!r.ok) {
+          throw new Error('HTTP ' + r.status);
+        }
+        return r.blob();
+      })
+      .then(function (blob) {
+        var url = URL.createObjectURL(blob);
+        var a = document.createElement('a');
+        a.href = url;
+        a.download = 'freenet-data.fnsx';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+        setOk('Downloaded freenet-data.fnsx');
+      })
+      .catch(function (e) {
+        setOk('Export failed (' + e.message + ')');
+      });
   });
 })();


### PR DESCRIPTION
## Problem

The hosted shell-chrome "Export data" button (#4530) was a placeholder `alert`. The node export endpoint (#4531) has since merged, so the button can do the real thing: let a hosted user download their per-user delegate data to take to their own peer.

## Solution

On click, the bar reads the durable user token from the shell-only `__freenet_user_token` global and does `fetch` → `blob` → download of `GET /v1/hosted/export`, sending the token in the `X-Freenet-User-Token` **header** (a plain navigation can't set a header, and the endpoint deliberately refuses the token as a query param to keep it out of logs). The download saves the encrypted `freenet-data.fnsx` bundle, importable on the user's own peer with `freenet secrets import`. Inline feedback reuses the existing `setOk` status line ("Preparing download..." → "Downloaded freenet-data.fnsx", or a failure message).

The token is read only in the shell document and never enters the sandboxed app iframe, consistent with the rest of the bar. The change is confined to the shell-chrome JS asset plus a test assertion.

## Testing

- Extended `shell_page_hosted_mode_renders_proxy_chrome_bar` to pin that the rendered hosted shell wires `/v1/hosted/export` (so a refactor can't silently revert it to a placeholder).
- Verified live on `try.freenet.org` (0.2.82, hosted node behind a TLS proxy): clicking **Export data** in a real browser downloads a valid `FNSX` bundle (`freenet-data.fnsx`); the endpoint returns **403** without a token.

Part of #4381. Frontend follow-up to #4530 (strip) and #4531 (endpoint).

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
