### PR TITLE
fix(hosted): keep the export endpoint from blocking the contract loop (#4531 P5)

### DIFF
--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -2154,9 +2154,14 @@ where
         } => {
             // Hosted-mode export (P3-live of #4381). Runs on the executor (which
             // owns the SecretsStore) and returns the encrypted bundle bytes.
-            // `user_context` is the forge-proof per-user namespace derived at the
-            // connection boundary; the export reads ONLY that user's scope. Log
-            // only the non-secret user_id — never the token or bundle bytes.
+            // The executor's `export_user_secrets` offloads the synchronous
+            // enumerate+decrypt+re-encrypt to a blocking thread
+            // (`RuntimePool::export_user_secrets`), so awaiting it here does NOT
+            // stall this single-threaded loop for the export's duration (#4381
+            // P5). `user_context` is the forge-proof per-user namespace derived
+            // at the connection boundary; the export reads ONLY that user's
+            // scope. Log only the non-secret user_id — never the token or
+            // bundle bytes.
             tracing::debug!(
                 user_id = ?user_context.user_id(),
                 "Processing hosted-mode secret export request"

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -2360,7 +2360,6 @@ where
             match contract_handler
                 .executor()
                 .try_begin_export(&user_context, token.expose())
-                .await
             {
                 executor::runtime::ExportAdmission::Admitted(job) => {
                     // Park the client responder so the off-loop task can answer it

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -16,7 +16,7 @@ pub mod storages;
 pub(crate) mod user_input;
 
 pub(crate) use executor::{
-    ContractExecutor, ExecutorTransactionStream, MAX_CREATED_DELEGATES_PER_NODE,
+    ContractExecutor, ExecutorTransactionStream, ExportBusy, MAX_CREATED_DELEGATES_PER_NODE,
     MAX_DELEGATE_CREATION_DEPTH, MAX_DELEGATE_CREATIONS_PER_CALL,
     SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE, UpsertOutcome, UpsertResult, mock_runtime::MockRuntime,
 };
@@ -231,6 +231,101 @@ impl Drop for ResumeGuard {
     }
 }
 
+/// A hosted-mode export that ran OFF the contract loop, carrying its result
+/// (and the executor to return to the pool) back to the loop (#4531 / #4381 P5).
+///
+/// Built by the off-loop export task and sent back to the `contract_handling`
+/// loop via the export-resume channel; the loop returns/replaces the executor
+/// (`finish_export`) and answers the stashed client responder. Mirrors the
+/// #4391 [`DeferredResume`] flow, but the work is the export itself (not a
+/// network wait), so there is nothing to re-run on the loop — just deliver the
+/// precomputed result and reclaim the executor.
+struct ExportResume {
+    /// The completed export: the executor to return (or `None` if the export
+    /// task panicked) and the result for the client.
+    done: crate::contract::executor::runtime::ExportDone,
+    /// The parked client responder (the HTTP export handler's oneshot). `None`
+    /// only if the client disconnected before the export finished.
+    responder: Option<StashedResponder>,
+}
+
+/// RAII guard guaranteeing the off-loop export task delivers EXACTLY ONE
+/// [`ExportResume`] — whether the export completes, or the task is
+/// dropped/panics/cancelled before sending.
+///
+/// Same load-bearing invariant as the #4391 [`ResumeGuard`]: every admitted
+/// export is answered exactly once, so the parked client responder never hangs
+/// and the checked-out executor is always reclaimed. On the success path
+/// [`send`](Self::send) takes the payload (Drop becomes a no-op); on any early
+/// exit, `Drop` delivers an `ExportResume` carrying a panicked-style
+/// [`ExportDone`] (`executor: None`) so the loop replaces the lost executor and
+/// answers the client with an error.
+struct ExportGuard {
+    payload: Option<ExportGuardPayload>,
+}
+
+struct ExportGuardPayload {
+    export_resume_tx: tokio::sync::mpsc::UnboundedSender<ExportResume>,
+    responder: Option<StashedResponder>,
+}
+
+impl ExportGuard {
+    fn new(
+        export_resume_tx: tokio::sync::mpsc::UnboundedSender<ExportResume>,
+        responder: Option<StashedResponder>,
+    ) -> Self {
+        Self {
+            payload: Some(ExportGuardPayload {
+                export_resume_tx,
+                responder,
+            }),
+        }
+    }
+
+    /// Deliver the completed export. Consumes the payload so a subsequent `Drop`
+    /// is a no-op (exactly-once).
+    fn send(mut self, done: crate::contract::executor::runtime::ExportDone) {
+        if let Some(p) = self.payload.take() {
+            Self::deliver(p, done);
+        }
+    }
+
+    fn deliver(p: ExportGuardPayload, done: crate::contract::executor::runtime::ExportDone) {
+        let ExportGuardPayload {
+            export_resume_tx,
+            responder,
+        } = p;
+        // Unbounded channel, non-blocking send (channel-safety.md carve-out: the
+        // producer count is bounded by MAX_CONCURRENT_EXPORTS, the receiver is
+        // this loop which drains every iteration, and the waiter never reads what
+        // the loop produces — no cycle). A send failure means the loop is gone.
+        if export_resume_tx
+            .send(ExportResume { done, responder })
+            .is_err()
+        {
+            tracing::debug!("export resume channel closed; contract-handling loop gone");
+        }
+    }
+}
+
+impl Drop for ExportGuard {
+    fn drop(&mut self) {
+        if let Some(p) = self.payload.take() {
+            // Early exit before `send` (task dropped / panicked / cancelled).
+            // Deliver a panicked-style ExportDone so the loop replaces the lost
+            // executor and answers the parked client exactly once.
+            tracing::warn!(
+                "Off-loop export task dropped before sending — delivering an error \
+                 resume so the export terminates and the client is answered (#4531)"
+            );
+            Self::deliver(
+                p,
+                crate::contract::executor::runtime::ExportDone::lost_to_drop(),
+            );
+        }
+    }
+}
+
 /// Loop-side state for off-loading deferred related-contract fetches (#4391).
 ///
 /// Owned by `contract_handling`; passed by `&mut` into `handle_contract_event`
@@ -256,14 +351,22 @@ struct DeferralCtx {
     stashed: std::collections::HashMap<u64, StashedResponder>,
     /// Monotonic id generator for `deferral_id`.
     next_deferral_id: u64,
+    /// Off-loop export tasks send their completed [`ExportResume`]s back to the
+    /// loop here (#4531 / #4381 P5). Separate from `resume_tx` because the export
+    /// resume carries an executor + precomputed bytes, not an upsert to re-run.
+    export_resume_tx: tokio::sync::mpsc::UnboundedSender<ExportResume>,
 }
 
 impl DeferralCtx {
-    fn new(resume_tx: tokio::sync::mpsc::UnboundedSender<DeferredResume>) -> Self {
+    fn new(
+        resume_tx: tokio::sync::mpsc::UnboundedSender<DeferredResume>,
+        export_resume_tx: tokio::sync::mpsc::UnboundedSender<ExportResume>,
+    ) -> Self {
         Self {
             resume_tx,
             stashed: std::collections::HashMap::new(),
             next_deferral_id: 0,
+            export_resume_tx,
         }
     }
 
@@ -1025,7 +1128,15 @@ where
     // non-blocking `unbounded_send` (no `.await`), so it can never back-pressure
     // anything.
     let (resume_tx, mut resume_rx) = tokio::sync::mpsc::unbounded_channel::<DeferredResume>();
-    let mut deferral_ctx = DeferralCtx::new(resume_tx);
+    // Resume channel for hosted-mode EXPORTS off-loaded from this serial loop
+    // (#4531 / #4381 P5). The off-loop export task sends back the executor (to
+    // return to the pool) + the result (for the client). Unbounded for the same
+    // channel-safety carve-out as `resume_tx`: producers bounded by
+    // MAX_CONCURRENT_EXPORTS, the receiver is this loop (drains every iteration),
+    // no cycle, non-blocking `unbounded_send`.
+    let (export_resume_tx, mut export_resume_rx) =
+        tokio::sync::mpsc::unbounded_channel::<ExportResume>();
+    let mut deferral_ctx = DeferralCtx::new(resume_tx, export_resume_tx);
 
     loop {
         // Drain resumed (deferred) upserts so a completed off-loop fetch is
@@ -1037,6 +1148,19 @@ where
                 Ok(resume) => {
                     handle_deferred_resume(&mut contract_handler, &mut deferral_ctx, resume)
                         .await?;
+                }
+                Err(_) => break,
+            }
+        }
+
+        // Drain completed off-loop EXPORTS (#4531 / #4381 P5): return/replace the
+        // executor and answer the parked client. Bounded by MAX_CONCURRENT_EXPORTS
+        // (the export semaphore), so this batch is tiny; each iteration is a pool
+        // return + a oneshot send (microseconds).
+        for _ in 0..executor::runtime::MAX_CONCURRENT_EXPORTS {
+            match export_resume_rx.try_recv() {
+                Ok(resume) => {
+                    handle_export_resume(&mut contract_handler, resume).await;
                 }
                 Err(_) => break,
             }
@@ -1122,6 +1246,9 @@ where
             Some(resume) = resume_rx.recv() => {
                 handle_deferred_resume(&mut contract_handler, &mut deferral_ctx, resume).await?;
             }
+            Some(export_resume) = export_resume_rx.recv() => {
+                handle_export_resume(&mut contract_handler, export_resume).await;
+            }
             notification = recv_delegate_notification(&mut delegate_rx) => {
                 handle_delegate_notification(&mut contract_handler, notification, &prompter).await;
             }
@@ -1144,6 +1271,53 @@ where
 /// contract's CRDT merge — there is no lost update. The client is answered
 /// exactly once via its stashed responder (the `ResumeGuard` guarantees this
 /// resume runs exactly once per deferral, even if the waiter was dropped).
+/// Send an `ExportUserSecretsResponse` to a still-waiting client inline (the
+/// rejection paths: no deferral ctx, busy, unsupported). Logs at debug if the
+/// client already disconnected.
+async fn send_export_response_inline<CH>(
+    contract_handler: &mut CH,
+    id: handler::EventId,
+    result: Result<Vec<u8>, ExecutorError>,
+) where
+    CH: ContractHandler + Send + 'static,
+{
+    if let Err(error) = contract_handler
+        .channel()
+        .send_to_sender(id, ContractHandlerEvent::ExportUserSecretsResponse(result))
+        .await
+    {
+        tracing::debug!(
+            error = %error,
+            "Failed to send EXPORT response (client may have disconnected)"
+        );
+    }
+}
+
+/// Handle a completed off-loop export (#4531 / #4381 P5): return/replace the
+/// executor in the pool and answer the parked client. Runs ON the loop (the
+/// pool return needs `&mut contract_handler`), but the work is just a pool
+/// slot-return + a oneshot send — microseconds, never the export itself.
+async fn handle_export_resume<CH>(contract_handler: &mut CH, resume: ExportResume)
+where
+    CH: ContractHandler + Send + 'static,
+{
+    let ExportResume { done, responder } = resume;
+    // Return/replace the executor and recover the result for the client.
+    let result = contract_handler.executor().finish_export(done).await;
+    // Answer the parked client. `responder` is `None` only if the client
+    // disconnected before the export finished (we still reclaimed the executor).
+    if let Some(responder) = responder {
+        if let Err(error) =
+            responder.respond(ContractHandlerEvent::ExportUserSecretsResponse(result))
+        {
+            tracing::debug!(
+                error = %error,
+                "Failed to deliver EXPORT resume response (client may have disconnected)"
+            );
+        }
+    }
+}
+
 async fn handle_deferred_resume<CH>(
     contract_handler: &mut CH,
     deferral_ctx: &mut DeferralCtx,
@@ -2152,33 +2326,69 @@ where
             user_context,
             token,
         } => {
-            // Hosted-mode export (P3-live of #4381). Runs on the executor (which
-            // owns the SecretsStore) and returns the encrypted bundle bytes.
-            // The executor's `export_user_secrets` offloads the synchronous
-            // enumerate+decrypt+re-encrypt to a blocking thread
-            // (`RuntimePool::export_user_secrets`), so awaiting it here does NOT
-            // stall this single-threaded loop for the export's duration (#4381
-            // P5). `user_context` is the forge-proof per-user namespace derived
-            // at the connection boundary; the export reads ONLY that user's
-            // scope. Log only the non-secret user_id — never the token or
-            // bundle bytes.
+            // Hosted-mode export (P3-live of #4381). DEFERRED OFF this serial loop
+            // (#4531 / #4381 P5): the enumerate+decrypt+seal is potentially long,
+            // so running it inline would park the loop for its whole duration and
+            // make every queued GET/PUT/UPDATE/delegate event wait behind it —
+            // the authenticated DoS. Instead we check out a pooled executor
+            // (`try_begin_export`) and run the export on a SPAWNED background task,
+            // returning from this arm IMMEDIATELY so the loop drains the next
+            // event. The task sends its result + the executor back via the
+            // export-resume channel; the loop returns/replaces the executor and
+            // answers the client (`handle_export_resume`).
+            //
+            // `user_context` is the forge-proof per-user namespace derived at the
+            // connection boundary; the export reads ONLY that user's scope. Log
+            // only the non-secret user_id — never the token or bundle bytes.
             tracing::debug!(
                 user_id = ?user_context.user_id(),
                 "Processing hosted-mode secret export request"
             );
-            let result = contract_handler
+
+            // Without a DeferralCtx (delegate-driven path / direct unit-test
+            // calls) there is no export-resume channel to off-load onto. The
+            // production hosted HTTP path always provides one; anything else
+            // cannot export. Answer with the not-supported error inline.
+            let Some(deferral) = deferral else {
+                let err = ExecutorError::other(anyhow::anyhow!(
+                    "secret export is not supported in this context"
+                ));
+                send_export_response_inline(contract_handler, id, Err(err)).await;
+                return Ok(());
+            };
+
+            match contract_handler
                 .executor()
-                .export_user_secrets(&user_context, token.expose())
-                .await;
-            if let Err(error) = contract_handler
-                .channel()
-                .send_to_sender(id, ContractHandlerEvent::ExportUserSecretsResponse(result))
+                .try_begin_export(&user_context, token.expose())
                 .await
             {
-                tracing::debug!(
-                    error = %error,
-                    "Failed to send EXPORT response (client may have disconnected)"
-                );
+                executor::runtime::ExportAdmission::Admitted(job) => {
+                    // Park the client responder so the off-loop task can answer it
+                    // later via the resume channel; the arm returns now.
+                    let responder = contract_handler.channel().take_waiting_response(&id);
+                    let guard = ExportGuard::new(deferral.export_resume_tx.clone(), responder);
+                    // Fire-and-forget background task. Bounded by
+                    // MAX_CONCURRENT_EXPORTS (the export semaphore the job holds);
+                    // the ExportGuard guarantees exactly-one resume even if the
+                    // task is dropped/panics, so the executor is always reclaimed
+                    // and the client always answered. (Same fire-and-forget shape
+                    // as the #4391 deferral spawn — short-lived, capacity-bounded.)
+                    GlobalExecutor::spawn(async move {
+                        let done = job.run().await;
+                        guard.send(done);
+                    });
+                }
+                executor::runtime::ExportAdmission::Busy => {
+                    // At MAX_CONCURRENT_EXPORTS already; do not queue on the loop.
+                    let err = ExecutorError::other(ExportBusy);
+                    send_export_response_inline(contract_handler, id, Err(err)).await;
+                }
+                executor::runtime::ExportAdmission::Unsupported => {
+                    let err = ExecutorError::other(anyhow::anyhow!(
+                        "secret export is not supported by this executor"
+                    ));
+                    send_export_response_inline(contract_handler, id, Err(err)).await;
+                }
             }
         }
         ContractHandlerEvent::RegisterSubscriberListener {
@@ -4314,7 +4524,10 @@ mod hol_4391_tests {
     #[tokio::test]
     async fn dropped_waiter_guard_answers_client_missing_related() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<DeferredResume>();
-        let mut ctx = DeferralCtx::new(tx.clone());
+        // This test exercises the related-fetch resume path only; the export
+        // resume channel is unused here.
+        let (export_tx, _export_rx) = tokio::sync::mpsc::unbounded_channel::<ExportResume>();
+        let mut ctx = DeferralCtx::new(tx.clone(), export_tx);
         let mut handler =
             MockWasmContractHandler::new_test(handler::contract_handler_channel().1, None, "drop")
                 .await;

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -117,6 +117,29 @@ impl std::fmt::Display for ContractQueueFull {
 
 impl std::error::Error for ContractQueueFull {}
 
+/// Typed marker carried by an [`ExecutorError`] when a hosted-mode secret
+/// export was rejected for exceeding the per-user export bound (too many
+/// secrets, or too much total plaintext). Lets the hosted-export HTTP layer
+/// downcast and return a 413 (Payload Too Large) instead of a generic 500.
+///
+/// Constructed by `Executor::export_user_secrets` from a
+/// [`crate::wasm_runtime::secret_export::ExportError::TooLarge`]; recognized by
+/// [`ExecutorError::is_export_too_large`]. The `Display` text is non-secret
+/// (sizes only, no token / secret bytes), so it is safe to log/return. See
+/// #4381 P5.
+#[derive(Debug, Clone)]
+pub struct ExportTooLarge {
+    pub message: String,
+}
+
+impl std::fmt::Display for ExportTooLarge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ExportTooLarge {}
+
 /// Typed marker carried by an [`ExecutorError`] when an upsert was invoked
 /// in *deferrable* mode (see [`ContractExecutor::upsert_contract_state_deferrable`])
 /// and discovered it needs to fetch related contracts from the network to
@@ -340,6 +363,16 @@ impl ExecutorError {
         match &self.inner {
             Either::Left(_) => false,
             Either::Right(err) => err.downcast_ref::<ContractQueueFull>().is_some(),
+        }
+    }
+
+    /// Returns true if this error is the typed [`ExportTooLarge`] marker (a
+    /// hosted-mode export rejected for exceeding the per-user export bound).
+    /// The hosted-export HTTP handler gates a 413 response on this. See #4381 P5.
+    pub fn is_export_too_large(&self) -> bool {
+        match &self.inner {
+            Either::Left(_) => false,
+            Either::Right(err) => err.downcast_ref::<ExportTooLarge>().is_some(),
         }
     }
 

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -140,6 +140,22 @@ impl std::fmt::Display for ExportTooLarge {
 
 impl std::error::Error for ExportTooLarge {}
 
+/// Typed marker carried by an [`ExecutorError`] when a hosted-mode export was
+/// rejected because `MAX_CONCURRENT_EXPORTS` exports are already running
+/// off-loop. Lets the hosted-export HTTP layer downcast and return a 503
+/// (Service Unavailable, "retry later") rather than a generic 500 — the export
+/// was not attempted and is not queued. See #4531 / #4381 P5.
+#[derive(Debug, Clone, Copy)]
+pub struct ExportBusy;
+
+impl std::fmt::Display for ExportBusy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("too many concurrent exports, try again later")
+    }
+}
+
+impl std::error::Error for ExportBusy {}
+
 /// Typed marker carried by an [`ExecutorError`] when an upsert was invoked
 /// in *deferrable* mode (see [`ContractExecutor::upsert_contract_state_deferrable`])
 /// and discovered it needs to fetch related contracts from the network to
@@ -373,6 +389,17 @@ impl ExecutorError {
         match &self.inner {
             Either::Left(_) => false,
             Either::Right(err) => err.downcast_ref::<ExportTooLarge>().is_some(),
+        }
+    }
+
+    /// Returns true if this error is the typed [`ExportBusy`] marker (a
+    /// hosted-mode export rejected because the node is at its concurrent-export
+    /// cap). The hosted-export HTTP handler gates a 503 response on this so the
+    /// caller can distinguish "retry later" from a real failure. See #4531 P5.
+    pub fn is_export_busy(&self) -> bool {
+        match &self.inner {
+            Either::Left(_) => false,
+            Either::Right(err) => err.downcast_ref::<ExportBusy>().is_some(),
         }
     }
 
@@ -642,19 +669,45 @@ pub(crate) trait ContractExecutor: Send + 'static {
     /// ([`crate::wasm_runtime::SecretScope::User`]), never the node-local
     /// (`Local`) namespace.
     ///
-    /// The default implementation rejects: only the production
-    /// `RuntimePool` / `Executor<Runtime>` (which owns a real `SecretsStore`)
-    /// supports export. Mock executors keep no on-disk secrets.
-    fn export_user_secrets(
+    /// Admit a hosted-mode export to run OFF the contract loop (#4531 / #4381
+    /// P5). Instead of running the (potentially long) enumerate+decrypt+seal
+    /// inline — which would park the single-threaded contract loop for its whole
+    /// duration, so queued GET/PUT/UPDATE/delegate events wait behind it — this
+    /// checks out a pooled executor and returns an opaque
+    /// `ExportJob`. The caller (the contract loop) moves the job into
+    /// a background task, calls `ExportJob::run` there, and hands the
+    /// resulting [`runtime::ExportDone`] back to [`Self::finish_export`] on the
+    /// loop to return/replace the executor.
+    ///
+    /// Concurrency is bounded ([`runtime::MAX_CONCURRENT_EXPORTS`]); over the cap
+    /// returns [`runtime::ExportAdmission::Busy`]. `user_context` MUST come from
+    /// the connection boundary (the forge-proof per-user namespace), never a
+    /// request body; the export reads only `user_context.scope()`, never `Local`.
+    ///
+    /// The default implementation returns
+    /// [`runtime::ExportAdmission::Unsupported`]: only the production
+    /// `RuntimePool` (which owns real `SecretsStore`-backed executors) supports
+    /// export. Mock executors keep no on-disk secrets.
+    fn try_begin_export(
         &mut self,
         _user_context: &UserSecretContext,
         _token: &[u8],
+    ) -> impl Future<Output = runtime::ExportAdmission> + Send {
+        async { runtime::ExportAdmission::Unsupported }
+    }
+
+    /// Return (or, on a panicked export task, replace) the executor an
+    /// `ExportJob` borrowed, and yield the export RESULT for the
+    /// client. Called on the contract loop once the background export task
+    /// delivers its [`runtime::ExportDone`]. Default returns the carried result
+    /// without touching a pool (mock executors never admit, so this is only
+    /// reached via the `ExportDone` carried in an [`runtime::ExportDone`] the
+    /// default path never builds).
+    fn finish_export(
+        &mut self,
+        done: runtime::ExportDone,
     ) -> impl Future<Output = Result<Vec<u8>, ExecutorError>> + Send {
-        async {
-            Err(ExecutorError::other(anyhow::anyhow!(
-                "secret export is not supported by this executor"
-            )))
-        }
+        async move { done.into_result() }
     }
 
     fn get_subscription_info(&self) -> Vec<crate::message::SubscriptionInfo>;

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -688,12 +688,16 @@ pub(crate) trait ContractExecutor: Send + 'static {
     /// [`runtime::ExportAdmission::Unsupported`]: only the production
     /// `RuntimePool` (which owns real `SecretsStore`-backed executors) supports
     /// export. Mock executors keep no on-disk secrets.
+    /// NON-BLOCKING: runs on the contract loop, so it must never await/park (a
+    /// blocking executor checkout here is the #4531 deadlock). Returns `Busy`
+    /// when the node is at its export-concurrency cap OR no executor is
+    /// immediately free; the loop answers a 503 and never queues the export.
     fn try_begin_export(
         &mut self,
         _user_context: &UserSecretContext,
         _token: &[u8],
-    ) -> impl Future<Output = runtime::ExportAdmission> + Send {
-        async { runtime::ExportAdmission::Unsupported }
+    ) -> runtime::ExportAdmission {
+        runtime::ExportAdmission::Unsupported
     }
 
     /// Return (or, on a panicked export task, replace) the executor an

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -11,6 +11,7 @@ use super::{
 };
 pub(crate) use contract_ops::ReclaimOutcome;
 pub use pool::RuntimePool;
+pub(crate) use pool::{ExportAdmission, ExportDone, MAX_CONCURRENT_EXPORTS};
 
 /// Maximum number of related contracts a single validation can request.
 /// Bounds worst-case first-time cost: N GETs of up to 50MB each.
@@ -101,6 +102,21 @@ fn production_offload_compilation() -> bool {
     true
 }
 
+/// Outcome of [`run_blocking_offloaded`].
+///
+/// Distinguishes the normal case (work completed, the moved-in value `T` came
+/// back) from a panic inside the offloaded closure. On panic the `spawn_blocking`
+/// thread unwound while owning `value`, so it is GONE and cannot be returned —
+/// the caller must reconcile a lost resource (for the export path: replace the
+/// lost pool executor so the permit is restored, and fail just that one export).
+pub(crate) enum OffloadOutcome<T, R> {
+    /// The closure ran to completion; `value` is returned alongside the result.
+    Completed(T, R),
+    /// The offloaded closure PANICKED. `value` was owned by the unwinding
+    /// blocking thread and is unrecoverable.
+    Panicked,
+}
+
 /// Run a synchronous, potentially-long CPU/IO closure OFF the contract-handling
 /// loop when we're on a multi-threaded runtime, or INLINE otherwise.
 ///
@@ -109,26 +125,31 @@ fn production_offload_compilation() -> bool {
 /// other contract op (GET/PUT/UPDATE/delegate) for its full duration. The
 /// hosted-mode secret export (`export_user_secrets`) enumerates, decrypts, and
 /// re-encrypts every secret in a user's scope synchronously, so an authenticated
-/// token-holder with a large secret set — or one who simply repeats the request
-/// — could otherwise wedge the loop (the #4381 P5 DoS). Moving that work onto a
-/// blocking thread keeps the loop free to drain other events.
+/// token-holder with a large secret set could otherwise wedge the loop (the
+/// #4381 P5 DoS). Moving that work onto a blocking thread keeps the loop free.
 ///
 /// `f` takes ownership of `value` (the checked-out executor) and returns it
 /// alongside the result, so the caller can return the executor to the pool
-/// afterwards. `value` is exclusively checked out for the whole call, so this
-/// does NOT break the redb single-writer model or the pool's executor checkout:
-/// the executor simply runs on a blocking thread instead of the loop thread.
+/// afterwards. `value` is exclusively checked out for the whole call.
 ///
-/// Mirrors the runtime-flavor gate in `wasmtime_engine::compile_offloaded` /
-/// `block_on_async` (#4441): `block_in_place` + `spawn_blocking` is only legal
-/// on a multi-threaded runtime and PANICS on a `current_thread` runtime, which
-/// the simulation runner and `current_thread` integration tests use — so those
-/// (and the no-runtime case) run `f` inline. Production is always multi-threaded
-/// and offloads.
+/// PANIC SAFETY: mirrors `wasmtime_engine::compile_offloaded` (#4441) — a panic
+/// inside the offloaded closure is CAUGHT (`JoinError::is_panic()`) and reported
+/// as [`OffloadOutcome::Panicked`], NOT re-raised. Re-raising would propagate the
+/// panic onto the *caller's* task; for the export caller (the contract-handling
+/// loop / a loop-spawned task) that would abort the loop and, via the node's
+/// top-level `select!`, shut down the WHOLE node — and leak the executor's pool
+/// slot. Catching it lets the caller fail just that one export and reconcile the
+/// lost slot.
+///
+/// Runtime-flavor gate: offload (multi-thread) vs inline (`current_thread` / no
+/// runtime, where `spawn_blocking` + a blocking `await` is unnecessary and the
+/// sim/test runners want a deterministic inline run). On the inline path a panic
+/// propagates normally (there is no thread boundary to catch it at), exactly as
+/// it would have without this helper.
 async fn run_blocking_offloaded<T, R>(
     value: T,
     f: impl FnOnce(T) -> (T, R) + Send + 'static,
-) -> (T, R)
+) -> OffloadOutcome<T, R>
 where
     T: Send + 'static,
     R: Send + 'static,
@@ -136,18 +157,30 @@ where
     use tokio::runtime::RuntimeFlavor;
     match tokio::runtime::Handle::try_current() {
         Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::MultiThread => {
-            tokio::task::spawn_blocking(move || f(value))
-                .await
-                // A panic inside `f` propagates as a JoinError; re-raise it so it
-                // surfaces the same way an inline panic would (the pool's
-                // post-op health check then replaces the executor). This cannot
-                // happen for the export path (no panics), but keeping the
-                // failure mode identical to inline avoids a silent divergence.
-                .expect("export offload task panicked")
+            match tokio::task::spawn_blocking(move || f(value)).await {
+                Ok((value, result)) => OffloadOutcome::Completed(value, result),
+                Err(e) if e.is_panic() => {
+                    // The blocking thread unwound while owning `value`; it is
+                    // lost. Report Panicked so the caller replaces the slot and
+                    // fails this one operation, rather than crashing the node.
+                    tracing::error!("offloaded export task panicked");
+                    OffloadOutcome::Panicked
+                }
+                // Cancellation: the runtime is shutting down. Treat like a panic
+                // (value gone), but this only happens at teardown.
+                Err(e) => {
+                    tracing::error!(error = %e, "offloaded export task failed (cancelled)");
+                    OffloadOutcome::Panicked
+                }
+            }
         }
         // current_thread runtime (sim / current_thread integration tests) or no
-        // tokio runtime: run inline. `block_in_place` would panic here.
-        _ => f(value),
+        // tokio runtime: run inline. There is no thread boundary, so a panic
+        // here propagates exactly as it would without the offload.
+        _ => {
+            let (value, result) = f(value);
+            OffloadOutcome::Completed(value, result)
+        }
     }
 }
 use std::num::NonZeroUsize;
@@ -249,13 +282,14 @@ impl ContractExecutor for Executor<Runtime> {
         self.delegate_request(req, origin_contract, caller_delegate, user_context)
     }
 
-    async fn export_user_secrets(
-        &mut self,
-        user_context: &UserSecretContext,
-        token: &[u8],
-    ) -> Result<Vec<u8>, ExecutorError> {
-        Executor::export_user_secrets(self, user_context, token)
-    }
+    // NOTE: `ContractExecutor::try_begin_export` / `finish_export` are NOT
+    // overridden for a bare `Executor<Runtime>` — only the pooled `RuntimePool`
+    // can admit a deferred export (it owns the executor pool + the export
+    // concurrency semaphore needed to check one out and return it). A bare
+    // executor (tests / direct use, never the production hosted path) falls
+    // through to the trait default (`ExportAdmission::Unsupported`). The inherent
+    // `Executor::export_user_secrets` (delegates.rs) remains as the work
+    // function the pool's `ExportJob::run` calls.
 
     fn get_subscription_info(&self) -> Vec<crate::message::SubscriptionInfo> {
         self.get_subscription_info()
@@ -995,9 +1029,12 @@ mod executor_pin_tests {
     async fn run_blocking_offloaded_runs_off_thread_under_multithread() {
         let caller_thread = std::thread::current().id();
         // Move a value in, return it alongside the result.
-        let (value, (result, ran_on)) =
+        let outcome =
             super::run_blocking_offloaded(41u64, |v| (v + 1, (v * 2, std::thread::current().id())))
                 .await;
+        let super::OffloadOutcome::Completed(value, (result, ran_on)) = outcome else {
+            panic!("a non-panicking closure must complete");
+        };
         assert_eq!(
             value, 42,
             "moved-in value is returned (mutated by the closure)"
@@ -1010,14 +1047,18 @@ mod executor_pin_tests {
     }
 
     /// `run_blocking_offloaded` under a CURRENT-THREAD runtime must run INLINE
-    /// (same thread) — `block_in_place`/`spawn_blocking` offload would panic on
-    /// a current_thread runtime, which the simulation runner and current_thread
-    /// integration tests use. This pins the runtime-flavor fallback.
+    /// (same thread). `spawn_blocking` real threads break the simulation
+    /// runner's paused-time determinism (and the current_thread integration
+    /// tests), so the helper runs the closure inline there instead. This pins
+    /// the runtime-flavor fallback.
     #[tokio::test(flavor = "current_thread")]
     async fn run_blocking_offloaded_runs_inline_under_current_thread() {
         let caller_thread = std::thread::current().id();
-        let (value, ran_on) =
+        let outcome =
             super::run_blocking_offloaded(7u64, |v| (v, std::thread::current().id())).await;
+        let super::OffloadOutcome::Completed(value, ran_on) = outcome else {
+            panic!("inline run must complete");
+        };
         assert_eq!(value, 7);
         assert_eq!(
             ran_on, caller_thread,
@@ -1025,25 +1066,100 @@ mod executor_pin_tests {
         );
     }
 
-    /// Pin (#4381 P5): `RuntimePool::export_user_secrets` MUST route the
-    /// synchronous export through `run_blocking_offloaded` so it does not run on
-    /// the single-threaded contract-handling loop. A future refactor that drops
-    /// the offload (calling `executor.export_user_secrets` directly on the loop)
-    /// re-introduces the head-of-line-blocking DoS and must fail CI here.
+    /// PANIC SAFETY (#4531): a panic inside the offloaded closure on a
+    /// multi-thread runtime must be CAUGHT and reported as
+    /// `OffloadOutcome::Panicked` — NOT re-raised onto the caller's task (which
+    /// for the export path is the contract loop, whose abort would shut the node
+    /// down). The moved-in value is lost (the blocking thread owned it).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_blocking_offloaded_catches_panic_under_multithread() {
+        let outcome = super::run_blocking_offloaded(1u64, |_v| -> (u64, ()) {
+            panic!("boom inside the offloaded closure");
+        })
+        .await;
+        assert!(
+            matches!(outcome, super::OffloadOutcome::Panicked),
+            "a panicking offload must surface as Panicked, not unwind the caller"
+        );
+    }
+
+    /// Pin (#4531 / #4381 P5): the off-loop export MUST route the synchronous
+    /// enumerate+decrypt+seal through `run_blocking_offloaded` (so the CPU work
+    /// lands on a blocking thread, not the contract loop). A future refactor that
+    /// drops the offload re-introduces the head-of-line-blocking DoS and must
+    /// fail CI here. Anchored on `ExportJob::run`, the off-loop entry point.
     #[test]
-    fn pool_export_user_secrets_offloads_off_loop() {
+    fn export_job_run_offloads_blocking_work() {
         let src = include_str!("runtime/pool.rs");
         let body = src
-            .split("async fn export_user_secrets(")
+            .split("pub(crate) async fn run(self) -> ExportDone {")
             .nth(1)
-            .expect("RuntimePool::export_user_secrets must exist")
-            .split("\n    fn get_subscription_info(")
+            .expect("ExportJob::run must exist")
+            .split("\n    }\n")
             .next()
-            .expect("end of export_user_secrets");
+            .expect("end of ExportJob::run");
         assert!(
             body.contains("run_blocking_offloaded("),
-            "export_user_secrets must offload the synchronous export off the \
-             contract loop via run_blocking_offloaded (#4381 P5)"
+            "ExportJob::run must offload the synchronous export off the contract \
+             loop via run_blocking_offloaded (#4531 / #4381 P5)"
+        );
+    }
+
+    /// Pin (#4531): when the offloaded export task PANICS, the executor is lost
+    /// with the unwinding thread, so `RuntimePool::finish_export` MUST reconcile
+    /// the missing pool slot — build a replacement (restoring the permit) rather
+    /// than leaving the pool one short or, worse, leaking the permit. A refactor
+    /// that drops the replacement re-introduces a slow capacity leak (and risks
+    /// the `pop_executor` `unreachable!` from a permit/slot mismatch).
+    #[test]
+    fn finish_export_replaces_panicked_executor() {
+        let src = include_str!("runtime/pool.rs");
+        let body = src
+            .split("async fn finish_export(&mut self, done: ExportDone)")
+            .nth(1)
+            .expect("RuntimePool::finish_export must exist")
+            .split("\n    fn get_subscription_info(")
+            .next()
+            .expect("end of finish_export");
+        // The None (panicked) arm must build a replacement executor.
+        assert!(
+            body.contains("create_replacement_executor("),
+            "finish_export must replace a panic-lost executor (create_replacement_executor)"
+        );
+        // ...and on a successful export, return the executor to the pool.
+        assert!(
+            body.contains("return_checked("),
+            "finish_export must return a healthy executor to the pool"
+        );
+    }
+
+    /// Pin (#4531 / #4381 P5): the `ExportUserSecrets` dispatch arm MUST defer
+    /// the export onto a spawned background task (so the loop returns
+    /// immediately) rather than awaiting it inline. Anchored on the arm spawning
+    /// the job via `GlobalExecutor::spawn` and routing through `try_begin_export`
+    /// — awaiting the export inline (the previous design) re-introduces #4531.
+    #[test]
+    fn export_dispatch_arm_defers_off_loop() {
+        let src = include_str!("../../contract.rs");
+        let arm = src
+            .split("ContractHandlerEvent::ExportUserSecrets {\n            user_context,\n            token,\n        } => {")
+            .nth(1)
+            .expect("ExportUserSecrets dispatch arm must exist")
+            .split("ContractHandlerEvent::RegisterSubscriberListener")
+            .next()
+            .expect("end of ExportUserSecrets arm");
+        assert!(
+            arm.contains("try_begin_export("),
+            "the export arm must admit via try_begin_export (off-loop deferral)"
+        );
+        assert!(
+            arm.contains("GlobalExecutor::spawn("),
+            "the export arm must run the export on a spawned background task, \
+             not await it inline on the contract loop (#4531)"
+        );
+        assert!(
+            !arm.contains(".export_user_secrets("),
+            "the export arm must NOT call export_user_secrets inline on the loop"
         );
     }
 

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -100,6 +100,56 @@ use std::collections::{HashMap, HashSet};
 fn production_offload_compilation() -> bool {
     true
 }
+
+/// Run a synchronous, potentially-long CPU/IO closure OFF the contract-handling
+/// loop when we're on a multi-threaded runtime, or INLINE otherwise.
+///
+/// The contract-handling loop is single-threaded and processes one event at a
+/// time, so any synchronous work done inside an event handler blocks every
+/// other contract op (GET/PUT/UPDATE/delegate) for its full duration. The
+/// hosted-mode secret export (`export_user_secrets`) enumerates, decrypts, and
+/// re-encrypts every secret in a user's scope synchronously, so an authenticated
+/// token-holder with a large secret set — or one who simply repeats the request
+/// — could otherwise wedge the loop (the #4381 P5 DoS). Moving that work onto a
+/// blocking thread keeps the loop free to drain other events.
+///
+/// `f` takes ownership of `value` (the checked-out executor) and returns it
+/// alongside the result, so the caller can return the executor to the pool
+/// afterwards. `value` is exclusively checked out for the whole call, so this
+/// does NOT break the redb single-writer model or the pool's executor checkout:
+/// the executor simply runs on a blocking thread instead of the loop thread.
+///
+/// Mirrors the runtime-flavor gate in `wasmtime_engine::compile_offloaded` /
+/// `block_on_async` (#4441): `block_in_place` + `spawn_blocking` is only legal
+/// on a multi-threaded runtime and PANICS on a `current_thread` runtime, which
+/// the simulation runner and `current_thread` integration tests use — so those
+/// (and the no-runtime case) run `f` inline. Production is always multi-threaded
+/// and offloads.
+async fn run_blocking_offloaded<T, R>(
+    value: T,
+    f: impl FnOnce(T) -> (T, R) + Send + 'static,
+) -> (T, R)
+where
+    T: Send + 'static,
+    R: Send + 'static,
+{
+    use tokio::runtime::RuntimeFlavor;
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::MultiThread => {
+            tokio::task::spawn_blocking(move || f(value))
+                .await
+                // A panic inside `f` propagates as a JoinError; re-raise it so it
+                // surfaces the same way an inline panic would (the pool's
+                // post-op health check then replaces the executor). This cannot
+                // happen for the export path (no panics), but keeping the
+                // failure mode identical to inline avoids a silent divergence.
+                .expect("export offload task panicked")
+        }
+        // current_thread runtime (sim / current_thread integration tests) or no
+        // tokio runtime: run inline. `block_in_place` would panic here.
+        _ => f(value),
+    }
+}
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -934,6 +984,66 @@ mod executor_pin_tests {
             super::production_offload_compilation(),
             "production pool must opt in to offload; the runtime-flavor check in \
              compile_offloaded keeps it safe/deterministic everywhere else"
+        );
+    }
+
+    /// `run_blocking_offloaded` under a MULTI-THREAD runtime must run the
+    /// closure on a DIFFERENT thread (the offload actually happens, so a long
+    /// export does not occupy the calling/loop thread) and round-trip both the
+    /// moved-in value and the closure's result.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_blocking_offloaded_runs_off_thread_under_multithread() {
+        let caller_thread = std::thread::current().id();
+        // Move a value in, return it alongside the result.
+        let (value, (result, ran_on)) =
+            super::run_blocking_offloaded(41u64, |v| (v + 1, (v * 2, std::thread::current().id())))
+                .await;
+        assert_eq!(
+            value, 42,
+            "moved-in value is returned (mutated by the closure)"
+        );
+        assert_eq!(result, 82, "closure result is returned");
+        assert_ne!(
+            ran_on, caller_thread,
+            "multi-thread runtime must offload the closure to a blocking thread"
+        );
+    }
+
+    /// `run_blocking_offloaded` under a CURRENT-THREAD runtime must run INLINE
+    /// (same thread) — `block_in_place`/`spawn_blocking` offload would panic on
+    /// a current_thread runtime, which the simulation runner and current_thread
+    /// integration tests use. This pins the runtime-flavor fallback.
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_blocking_offloaded_runs_inline_under_current_thread() {
+        let caller_thread = std::thread::current().id();
+        let (value, ran_on) =
+            super::run_blocking_offloaded(7u64, |v| (v, std::thread::current().id())).await;
+        assert_eq!(value, 7);
+        assert_eq!(
+            ran_on, caller_thread,
+            "current_thread runtime must run the closure inline (no offload)"
+        );
+    }
+
+    /// Pin (#4381 P5): `RuntimePool::export_user_secrets` MUST route the
+    /// synchronous export through `run_blocking_offloaded` so it does not run on
+    /// the single-threaded contract-handling loop. A future refactor that drops
+    /// the offload (calling `executor.export_user_secrets` directly on the loop)
+    /// re-introduces the head-of-line-blocking DoS and must fail CI here.
+    #[test]
+    fn pool_export_user_secrets_offloads_off_loop() {
+        let src = include_str!("runtime/pool.rs");
+        let body = src
+            .split("async fn export_user_secrets(")
+            .nth(1)
+            .expect("RuntimePool::export_user_secrets must exist")
+            .split("\n    fn get_subscription_info(")
+            .next()
+            .expect("end of export_user_secrets");
+        assert!(
+            body.contains("run_blocking_offloaded("),
+            "export_user_secrets must offload the synchronous export off the \
+             contract loop via run_blocking_offloaded (#4381 P5)"
         );
     }
 

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1105,6 +1105,34 @@ mod executor_pin_tests {
         );
     }
 
+    /// The anti-deadlock invariant (#4531): off-loop export concurrency is
+    /// `min(MAX_CONCURRENT_EXPORTS, pool_size - 1)`, so at least one executor is
+    /// ALWAYS reserved for normal contract ops — exports can never hold every
+    /// executor and wedge the loop. On a 1-executor pool this is 0 (exports
+    /// disabled → Busy/503). Pure-function guard for the math.
+    #[test]
+    fn effective_export_permits_always_reserves_one_executor() {
+        use super::pool::{MAX_CONCURRENT_EXPORTS, effective_export_permits};
+        // 1-executor pool: exports DISABLED (no spare executor to lend).
+        assert_eq!(effective_export_permits(1), 0);
+        // 2-executor pool: exactly one export, one executor reserved for ops.
+        assert_eq!(effective_export_permits(2), 1);
+        // Below the MAX_CONCURRENT_EXPORTS ceiling, scales with pool_size - 1.
+        assert_eq!(effective_export_permits(3), MAX_CONCURRENT_EXPORTS.min(2));
+        // Large pool: clamped to MAX_CONCURRENT_EXPORTS, never more.
+        assert_eq!(effective_export_permits(64), MAX_CONCURRENT_EXPORTS);
+        // The invariant: for any pool_size >= 1, permits <= pool_size - 1, so a
+        // spare executor always remains for normal ops.
+        for n in 1..=64usize {
+            assert!(
+                effective_export_permits(n) <= n.saturating_sub(1),
+                "must always reserve >=1 executor for normal ops (pool_size={n})"
+            );
+        }
+        // Degenerate pool_size == 0 must not panic (saturating).
+        assert_eq!(effective_export_permits(0), 0);
+    }
+
     /// Pin (#4531): when the offloaded export task PANICS, the executor is lost
     /// with the unwinding thread, so `RuntimePool::finish_export` MUST reconcile
     /// the missing pool slot — build a replacement (restoring the permit) rather

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -13,7 +13,14 @@ impl Executor<Runtime> {
     /// #4381).
     ///
     /// Runs entirely on the executor (which owns the `SecretsStore` via its
-    /// `Runtime`), so the on-disk redb is touched only by its single writer.
+    /// `Runtime`). This is a READ-ONLY walk: it enumerates the in-memory secret
+    /// index and reads + AEAD-decrypts each on-disk secret BLOB (one file per
+    /// `(delegate, secret_hash)` under the shared `secrets_dir`); it opens no
+    /// redb write transaction and mutates nothing. So it is safe to run on a
+    /// blocking thread (or concurrently with other read-only walks): a secret
+    /// file racing a concurrent write is protected by per-file FS semantics and
+    /// AEAD authentication — a torn read fails authentication and surfaces a
+    /// clean export error, never silent corruption.
     /// The bundle is scoped to `user_context.scope()` — strictly the per-user
     /// namespace, never `Local`. The `token` is the bundle-key material so the
     /// user re-imports on their own peer with the token they already hold.

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -25,10 +25,24 @@ impl Executor<Runtime> {
         user_context: &UserSecretContext,
         token: &[u8],
     ) -> Result<Vec<u8>, ExecutorError> {
-        use crate::wasm_runtime::secret_export::BundleKeyMaterial;
+        use crate::wasm_runtime::secret_export::{BundleKeyMaterial, ExportError};
         self.runtime
             .export_secret_bundle(user_context.scope(), &BundleKeyMaterial::Token(token))
-            .map_err(|e| ExecutorError::other(anyhow::anyhow!("secret export failed: {e}")))
+            .map_err(|e| {
+                // Preserve the over-limit case as a typed marker so the HTTP
+                // layer can map it to a 413 rather than a generic 500. The
+                // Display text is non-secret (sizes only). Everything else stays
+                // an opaque executor error. See #4381 P5. (An `if let` rather
+                // than a `match` with a wildcard arm: `ExportError` is large and
+                // a catch-all trips `clippy::wildcard_enum_match_arm`.)
+                if let ExportError::TooLarge { .. } = &e {
+                    ExecutorError::other(ExportTooLarge {
+                        message: e.to_string(),
+                    })
+                } else {
+                    ExecutorError::other(anyhow::anyhow!("secret export failed: {e}"))
+                }
+            })
     }
 
     pub fn delegate_request(

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -99,6 +99,130 @@ pub struct RuntimePool {
     /// `lookup_key`, `get_subscription_info`, `remove_client`
     /// (read-only / no executor checkout).
     in_flight_contracts: HashMap<ContractKey, usize>,
+    /// Bounds how many hosted-mode secret exports may run OFF-LOOP concurrently
+    /// (#4381 P5). Each admitted export holds one permit (in its `ExportJob`)
+    /// AND one pool executor for its duration. Capping at
+    /// `MAX_CONCURRENT_EXPORTS` (< pool_size) ensures exports can never drain the
+    /// whole executor pool and starve normal contract ops, and bounds the
+    /// node-wide concurrent export work regardless of how many users request at
+    /// once. `Arc` so an admitted `ExportJob` can hold an owned permit across the
+    /// spawned background task without borrowing the pool.
+    export_semaphore: Arc<Semaphore>,
+}
+
+/// Max hosted-mode secret exports allowed to run off-loop at once (#4381 P5).
+///
+/// Small and fixed: exports are an occasional self-host-migration action, not a
+/// hot path, and each one holds a pool executor for its duration. Keeping this
+/// well below a typical `pool_size` (CPU count) guarantees normal contract ops
+/// always have executors available. A request that arrives while this many
+/// exports are in flight is rejected with a typed busy error (HTTP 503), not
+/// queued on the contract loop.
+pub(crate) const MAX_CONCURRENT_EXPORTS: usize = 2;
+
+/// Result of [`RuntimePool::try_begin_export`]: an admitted off-loop export job,
+/// or a rejection because too many exports are already in flight, or because
+/// this executor kind does not support export (mock executors).
+pub(crate) enum ExportAdmission {
+    /// Admitted. The contract-handling loop moves this `ExportJob` into a
+    /// background task and calls [`ExportJob::run`] there; the resulting
+    /// [`ExportDone`] comes back to the loop, which calls
+    /// [`RuntimePool::finish_export`] to return/replace the executor. Boxed: an
+    /// `ExportJob` owns a whole `Executor<Runtime>`, so keeping it inline would
+    /// make every `ExportAdmission` (incl. the zero-size `Busy`/`Unsupported`)
+    /// that large.
+    Admitted(Box<ExportJob>),
+    /// `MAX_CONCURRENT_EXPORTS` exports are already running. The caller answers
+    /// the client with a typed busy error (HTTP 503); the export is NOT queued.
+    Busy,
+    /// This executor kind keeps no on-disk secrets and cannot export (mock /
+    /// test executors). The caller answers with the not-supported error.
+    Unsupported,
+}
+
+/// An admitted hosted-mode export, owning everything it needs to run OFF the
+/// contract loop: an exclusively-checked-out pool executor, the export-
+/// concurrency permit (released when the job is consumed by `run`), and the
+/// owned inputs. Opaque to the loop, which just moves it into a background task.
+pub(crate) struct ExportJob {
+    executor: Executor<Runtime>,
+    /// Held for the lifetime of the job so the export-concurrency slot is
+    /// occupied until the work finishes; dropped at the end of `run`.
+    _permit: tokio::sync::OwnedSemaphorePermit,
+    user_context: UserSecretContext,
+    /// Zeroized when the job drops, so the high-value token isn't left in memory.
+    token: zeroize::Zeroizing<Vec<u8>>,
+}
+
+impl ExportJob {
+    /// Run the export off the contract loop and produce an [`ExportDone`] to hand
+    /// back to the loop. The CPU/IO work (enumerate + decrypt + AEAD-seal) runs
+    /// via [`run_blocking_offloaded`], so on the production multi-thread runtime
+    /// it lands on a blocking thread; a panic there is caught and surfaced as a
+    /// lost executor (`ExportDone { executor: None, .. }`) rather than crashing.
+    ///
+    /// This is intended to be called from a spawned background task, NOT on the
+    /// contract loop — that is the whole point of the deferral (#4531/#4381 P5).
+    pub(crate) async fn run(self) -> ExportDone {
+        let ExportJob {
+            executor,
+            _permit,
+            user_context,
+            token,
+        } = self;
+        match super::run_blocking_offloaded(executor, move |executor| {
+            let result = executor.export_user_secrets(&user_context, token.as_slice());
+            (executor, result)
+        })
+        .await
+        {
+            super::OffloadOutcome::Completed(executor, result) => ExportDone {
+                executor: Some(executor),
+                result,
+            },
+            super::OffloadOutcome::Panicked => ExportDone {
+                executor: None,
+                result: Err(ExecutorError::other(anyhow::anyhow!(
+                    "secret export task panicked"
+                ))),
+            },
+        }
+        // `_permit` drops here, freeing the export-concurrency slot for the next
+        // request. The executor (when `Some`) is returned to the pool by the loop
+        // via `finish_export`.
+    }
+}
+
+/// The completed export, handed back to the contract loop. Carries the result
+/// for the client and the executor to return to the pool (`None` if the export
+/// task panicked, in which case the loop replaces the lost executor).
+pub(crate) struct ExportDone {
+    executor: Option<Executor<Runtime>>,
+    pub(crate) result: Result<Vec<u8>, ExecutorError>,
+}
+
+impl ExportDone {
+    /// An `ExportDone` for the case where the off-loop export task was dropped /
+    /// cancelled before producing a result (e.g. runtime teardown). Carries no
+    /// executor — the job owned it and is gone — so the loop's `finish_export`
+    /// treats it like the panic path (replace the lost slot) and answers the
+    /// client with an error. Delivered by `ExportGuard::drop`.
+    pub(crate) fn lost_to_drop() -> Self {
+        Self {
+            executor: None,
+            result: Err(ExecutorError::other(anyhow::anyhow!(
+                "secret export task was dropped before completion"
+            ))),
+        }
+    }
+
+    /// Consume the `ExportDone`, dropping any carried executor and returning just
+    /// the result. Used by the trait default `finish_export` (no pool to return
+    /// the executor to); the real `RuntimePool::finish_export` returns the
+    /// executor to the pool instead of dropping it.
+    pub(crate) fn into_result(self) -> Result<Vec<u8>, ExecutorError> {
+        self.result
+    }
 }
 
 impl RuntimePool {
@@ -250,6 +374,7 @@ impl RuntimePool {
             delegate_notification_tx,
             delegate_notification_rx: Some(delegate_notification_rx),
             in_flight_contracts: HashMap::new(),
+            export_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_EXPORTS)),
         })
     }
 
@@ -840,35 +965,77 @@ impl ContractExecutor for RuntimePool {
         result
     }
 
-    async fn export_user_secrets(
+    async fn try_begin_export(
         &mut self,
         user_context: &UserSecretContext,
         token: &[u8],
-    ) -> Result<Vec<u8>, ExecutorError> {
-        // Run on a pooled executor so the on-disk secrets redb is touched only
-        // by its single writer (all pool executors point at the same
-        // `secrets_dir`, but `pop_executor` serializes the checkout).
-        let executor = self.pop_executor().await;
+    ) -> ExportAdmission {
+        // Bound concurrent exports FIRST (cheap, no executor taken on rejection).
+        // `try_acquire_owned` never blocks the caller (the contract loop): if
+        // MAX_CONCURRENT_EXPORTS are already in flight, reject with Busy so the
+        // HTTP layer returns 503 — we do NOT queue exports on the loop.
+        let Ok(permit) = self.export_semaphore.clone().try_acquire_owned() else {
+            return ExportAdmission::Busy;
+        };
 
-        // Offload the synchronous enumerate+decrypt+re-encrypt OFF the
-        // single-threaded contract-handling loop (#4381 P5). The export is a
-        // read-only `&SecretsStore` walk (no redb write txn), and the executor
-        // is exclusively checked out for the whole call, so moving it onto a
-        // blocking thread preserves the redb single-writer model and the pool
-        // checkout — the loop is just free to drain other events meanwhile.
+        // Take an executor for the export to own off-loop. `pop_executor` awaits
+        // a pool permit; the export semaphore (< pool_size) guarantees exports
+        // alone can never exhaust the pool, so this only waits if normal contract
+        // ops momentarily hold every executor (brief, legitimate backpressure —
+        // those ops don't run unbounded work). The executor is exclusively owned
+        // by the returned job until `finish_export` returns it.
         //
-        // Own the inputs so the closure is `'static`. The token is copied into
-        // a Zeroizing buffer that is wiped when the closure drops it, so the
-        // high-value credential is not left lying in an un-zeroized Vec.
-        let owned_ctx = user_context.clone();
-        let owned_token = zeroize::Zeroizing::new(token.to_vec());
-        let (executor, result) = super::run_blocking_offloaded(executor, move |executor| {
-            let result = executor.export_user_secrets(&owned_ctx, owned_token.as_slice());
-            (executor, result)
-        })
-        .await;
+        // Own the inputs so the spawned task's closure is `'static`. The token is
+        // copied into a Zeroizing buffer wiped when the job drops it, so the
+        // high-value credential is not left in an un-zeroized Vec.
+        let executor = self.pop_executor().await;
+        ExportAdmission::Admitted(Box::new(ExportJob {
+            executor,
+            _permit: permit,
+            user_context: user_context.clone(),
+            token: zeroize::Zeroizing::new(token.to_vec()),
+        }))
+    }
 
-        self.return_checked(executor, "export_user_secrets").await;
+    async fn finish_export(&mut self, done: ExportDone) -> Result<Vec<u8>, ExecutorError> {
+        let ExportDone { executor, result } = done;
+        match executor {
+            // Normal path: the export ran (success or a clean export error) and
+            // handed the executor back. Return it through the health-checked path
+            // (it stays healthy — a read-only walk runs no WASM — but this keeps
+            // the accounting identical to every other op).
+            Some(executor) => {
+                self.return_checked(executor, "export_user_secrets").await;
+            }
+            // The offloaded export task PANICKED: the executor was owned by the
+            // unwinding blocking thread and is gone. Build a replacement and
+            // return THAT so the pool's permit is restored and capacity is not
+            // permanently leaked — exactly the "health check replaces a broken
+            // executor" semantic, here for a lost-to-panic executor.
+            None => {
+                tracing::error!("export offload task panicked; replacing the lost pool executor");
+                match self.create_replacement_executor().await {
+                    // `return_executor` fills the slot the lost executor vacated
+                    // and restores the pool permit (sub checked_out, add_permits).
+                    Ok(replacement) => self.return_executor(replacement),
+                    Err(e) => {
+                        // Could not build a replacement (a serious node problem on
+                        // its own). Do NOT restore the permit: leaving the slot
+                        // empty WITHOUT a matching permit keeps the pool invariant
+                        // `available permits == count of Some(executor) slots`, so
+                        // `pop_executor` can never acquire a permit and then find
+                        // no executor (its `unreachable!`). The pool is one
+                        // executor smaller until restart; that's the safe choice
+                        // versus a latent slot/permit mismatch.
+                        tracing::error!(
+                            error = %e,
+                            "failed to replace export-panicked executor; pool capacity reduced by one"
+                        );
+                        self.checked_out.fetch_sub(1, Ordering::SeqCst);
+                    }
+                }
+            }
+        }
         result
     }
 

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -849,7 +849,25 @@ impl ContractExecutor for RuntimePool {
         // by its single writer (all pool executors point at the same
         // `secrets_dir`, but `pop_executor` serializes the checkout).
         let executor = self.pop_executor().await;
-        let result = executor.export_user_secrets(user_context, token);
+
+        // Offload the synchronous enumerate+decrypt+re-encrypt OFF the
+        // single-threaded contract-handling loop (#4381 P5). The export is a
+        // read-only `&SecretsStore` walk (no redb write txn), and the executor
+        // is exclusively checked out for the whole call, so moving it onto a
+        // blocking thread preserves the redb single-writer model and the pool
+        // checkout — the loop is just free to drain other events meanwhile.
+        //
+        // Own the inputs so the closure is `'static`. The token is copied into
+        // a Zeroizing buffer that is wiped when the closure drops it, so the
+        // high-value credential is not left lying in an un-zeroized Vec.
+        let owned_ctx = user_context.clone();
+        let owned_token = zeroize::Zeroizing::new(token.to_vec());
+        let (executor, result) = super::run_blocking_offloaded(executor, move |executor| {
+            let result = executor.export_user_secrets(&owned_ctx, owned_token.as_slice());
+            (executor, result)
+        })
+        .await;
+
         self.return_checked(executor, "export_user_secrets").await;
         result
     }

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -101,24 +101,44 @@ pub struct RuntimePool {
     in_flight_contracts: HashMap<ContractKey, usize>,
     /// Bounds how many hosted-mode secret exports may run OFF-LOOP concurrently
     /// (#4381 P5). Each admitted export holds one permit (in its `ExportJob`)
-    /// AND one pool executor for its duration. Capping at
-    /// `MAX_CONCURRENT_EXPORTS` (< pool_size) ensures exports can never drain the
-    /// whole executor pool and starve normal contract ops, and bounds the
-    /// node-wide concurrent export work regardless of how many users request at
-    /// once. `Arc` so an admitted `ExportJob` can hold an owned permit across the
-    /// spawned background task without borrowing the pool.
+    /// AND one pool executor for its duration. Sized to
+    /// [`effective_export_permits`] (`min(MAX_CONCURRENT_EXPORTS, pool_size-1)`)
+    /// so >=1 executor is ALWAYS reserved for normal contract ops — this is the
+    /// enforced anti-deadlock invariant (see `effective_export_permits`), not a
+    /// prose hope. `Arc` so an admitted `ExportJob` can hold an owned permit
+    /// across the spawned background task without borrowing the pool.
     export_semaphore: Arc<Semaphore>,
 }
 
-/// Max hosted-mode secret exports allowed to run off-loop at once (#4381 P5).
+/// Max hosted-mode secret exports allowed to run off-loop at once (#4381 P5),
+/// BEFORE the pool-size clamp in [`effective_export_permits`].
 ///
 /// Small and fixed: exports are an occasional self-host-migration action, not a
-/// hot path, and each one holds a pool executor for its duration. Keeping this
-/// well below a typical `pool_size` (CPU count) guarantees normal contract ops
-/// always have executors available. A request that arrives while this many
-/// exports are in flight is rejected with a typed busy error (HTTP 503), not
-/// queued on the contract loop.
+/// hot path, and each one holds a pool executor for its duration. The real cap
+/// is `min(this, pool_size - 1)` so >=1 executor is ALWAYS free for normal ops.
+/// A request that arrives while that many exports are in flight (or that can't
+/// immediately reserve an executor) is rejected with a typed busy error (HTTP
+/// 503), never queued on the contract loop.
 pub(crate) const MAX_CONCURRENT_EXPORTS: usize = 2;
+
+/// Effective off-loop export concurrency for a pool of `pool_size` executors.
+///
+/// `min(MAX_CONCURRENT_EXPORTS, pool_size - 1)` — this is the load-bearing
+/// anti-deadlock invariant, ENFORCED in code (not prose): an admitted export
+/// holds one pool executor off-loop, and the only executor-return path
+/// (`finish_export`) runs ON the contract loop. If exports could hold EVERY
+/// executor, a normal contract op would park the loop waiting for an executor
+/// that only the (now-parked) loop can return — a permanent self-deadlock.
+/// Reserving at least one executor for normal ops makes that impossible.
+///
+/// `pool_size == 1` → 0: exports are DISABLED on a single-executor node (they
+/// return the typed Busy → 503). That is correct, not a regression — a tiny
+/// 1-executor node has no spare executor to lend a deferred export anyway, and
+/// the alternative (running it on the sole executor) is exactly the inline
+/// blocking this whole change removes.
+pub(crate) fn effective_export_permits(pool_size: usize) -> usize {
+    MAX_CONCURRENT_EXPORTS.min(pool_size.saturating_sub(1))
+}
 
 /// Result of [`RuntimePool::try_begin_export`]: an admitted off-loop export job,
 /// or a rejection because too many exports are already in flight, or because
@@ -374,7 +394,7 @@ impl RuntimePool {
             delegate_notification_tx,
             delegate_notification_rx: Some(delegate_notification_rx),
             in_flight_contracts: HashMap::new(),
-            export_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_EXPORTS)),
+            export_semaphore: Arc::new(Semaphore::new(effective_export_permits(pool_size_usize))),
         })
     }
 
@@ -480,6 +500,36 @@ impl RuntimePool {
         // But if it does, we need to restore the checked_out count
         self.checked_out.fetch_sub(1, Ordering::SeqCst);
         unreachable!("No executors available despite semaphore permit")
+    }
+
+    /// Non-blocking executor checkout: returns `Some(executor)` only if one is
+    /// immediately available, `None` otherwise (NEVER awaits/parks the caller).
+    ///
+    /// Used by the off-loop export admission path (`try_begin_export`), which
+    /// runs ON the contract loop and therefore must not block: if no executor is
+    /// free right now, the export is rejected (Busy → 503) rather than parking
+    /// the loop. Mirrors `pop_executor`'s permit/slot accounting exactly, just
+    /// with a non-blocking `try_acquire`.
+    fn try_pop_executor(&mut self) -> Option<Executor<Runtime>> {
+        let permit = self.available.try_acquire().ok()?;
+        // Take the slot BEFORE forgetting the permit: if (impossibly, given the
+        // permit==Some-slot-count invariant) no slot is found, dropping `permit`
+        // here restores it, so we never leak a permit on the unreachable path.
+        let executor = self
+            .runtimes
+            .iter_mut()
+            .find_map(|slot| slot.take())
+            .or_else(|| {
+                tracing::error!(
+                    "try_pop_executor acquired a permit but found no executor slot \
+                     (pool invariant violated)"
+                );
+                None
+            })?;
+        // Found a slot: now consume the permit (restored in `return_executor`).
+        permit.forget();
+        self.checked_out.fetch_add(1, Ordering::SeqCst);
+        Some(executor)
     }
 
     /// Return an executor to the pool after use.
@@ -965,30 +1015,34 @@ impl ContractExecutor for RuntimePool {
         result
     }
 
-    async fn try_begin_export(
+    fn try_begin_export(
         &mut self,
         user_context: &UserSecretContext,
         token: &[u8],
     ) -> ExportAdmission {
-        // Bound concurrent exports FIRST (cheap, no executor taken on rejection).
-        // `try_acquire_owned` never blocks the caller (the contract loop): if
-        // MAX_CONCURRENT_EXPORTS are already in flight, reject with Busy so the
-        // HTTP layer returns 503 — we do NOT queue exports on the loop.
+        // FULLY NON-BLOCKING admission — this runs ON the contract loop, so it
+        // must never await/park. Two non-blocking gates, in order:
+        //
+        // 1. Export-concurrency permit. Sized to `min(MAX_CONCURRENT_EXPORTS,
+        //    pool_size-1)` so admitted exports can never hold every executor. On
+        //    a 1-executor pool this is 0, so exports are disabled here. Over the
+        //    cap → Busy (HTTP 503), never queued.
         let Ok(permit) = self.export_semaphore.clone().try_acquire_owned() else {
             return ExportAdmission::Busy;
         };
+        // 2. A pool executor, taken NON-BLOCKING. If every executor is momentarily
+        //    busy with normal ops, we do NOT await (that would park the loop, the
+        //    whole #4531 deadlock) — we reject with Busy and the permit drops
+        //    here (restoring the export slot). The pool-size-1 invariant means
+        //    this only happens under genuine concurrent normal-op load, where a
+        //    "retry shortly" 503 is the correct answer.
+        let Some(executor) = self.try_pop_executor() else {
+            return ExportAdmission::Busy;
+        };
 
-        // Take an executor for the export to own off-loop. `pop_executor` awaits
-        // a pool permit; the export semaphore (< pool_size) guarantees exports
-        // alone can never exhaust the pool, so this only waits if normal contract
-        // ops momentarily hold every executor (brief, legitimate backpressure —
-        // those ops don't run unbounded work). The executor is exclusively owned
-        // by the returned job until `finish_export` returns it.
-        //
         // Own the inputs so the spawned task's closure is `'static`. The token is
         // copied into a Zeroizing buffer wiped when the job drops it, so the
         // high-value credential is not left in an un-zeroized Vec.
-        let executor = self.pop_executor().await;
         ExportAdmission::Admitted(Box::new(ExportJob {
             executor,
             _permit: permit,

--- a/crates/core/src/server/client_api/hosted_export.rs
+++ b/crates/core/src/server/client_api/hosted_export.rs
@@ -331,6 +331,15 @@ async fn run_export(
                     "export exceeds the per-user size limit",
                 ));
             }
+            // The node is at its concurrent-export cap: a transient "retry
+            // later", not a failure. 503 so the caller can distinguish it.
+            if e.is_export_busy() {
+                tracing::warn!(error = %e, "Rejected hosted export: node busy (concurrent-export cap)");
+                return Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "node is busy with other exports; retry shortly",
+                ));
+            }
             // Executor-side failure (e.g. a secret failed to decrypt). Do not
             // leak internals to the client; log the detail, return a generic 500.
             tracing::error!(error = %e, "Hosted export failed on the executor");

--- a/crates/core/src/server/client_api/hosted_export.rs
+++ b/crates/core/src/server/client_api/hosted_export.rs
@@ -41,24 +41,31 @@
 //! derives the storage DEK), but it means token confidentiality is the whole
 //! ballgame — hence the strict refuse-plaintext-token gate above.
 //!
-//! ## Known limitation — loop-blocking DoS (P5 follow-up)
+//! ## DoS hardening — off-loop execution + per-user bound (#4381 P5)
 //!
-//! An export enumerates AND AEAD-decrypts EVERY secret in the user's scope
-//! SYNCHRONOUSLY on the single-threaded contract-handling loop (the export runs
-//! inside the `ContractHandlerEvent::ExportUserSecrets` handler, same loop as
-//! every PUT/GET/UPDATE/delegate op), with NO per-user secret-count or
-//! bundle-size cap. So a token-holder with a large per-user secret set — or one
-//! who simply repeats the request — can block ALL other contract operations on
-//! the node for the duration of each export. The request is AUTHENTICATED (a
-//! valid token + secure connection), so this is an authenticated-DoS, not an
-//! anonymous one.
+//! An export enumerates AND AEAD-decrypts EVERY secret in the user's scope. To
+//! keep an AUTHENTICATED token-holder (valid token + secure connection) from
+//! using a large or repeated export to wedge the node, two guards are in place:
 //!
-//! This is acceptable ONLY because the endpoint ships behind the DEFAULT-OFF
-//! hosted flag and is not yet exposed on shared/public infrastructure. Before
-//! it is, a P5 (abuse/quotas) follow-up MUST add: (1) a per-user export quota
-//! (secret-count / bundle-size / rate cap), and (2) off-loop execution
-//! (`spawn_blocking` or a dedicated worker) so a single user's export cannot
-//! stall the node's contract loop. Tracked as part of P5 (#4381).
+//! 1. **Off-loop execution.** The export no longer runs synchronously on the
+//!    single-threaded contract-handling loop. The handler arm
+//!    (`ContractHandlerEvent::ExportUserSecrets`) hands off to
+//!    `RuntimePool::export_user_secrets`, which runs the synchronous
+//!    enumerate+decrypt+re-encrypt on a blocking thread (`spawn_blocking`,
+//!    runtime-flavor-gated like the WASM-compile offload of #4441). The loop is
+//!    free to drain other PUT/GET/UPDATE/delegate ops while an export runs, so a
+//!    single user's export can no longer block the node's contract loop.
+//!
+//! 2. **Per-user bound.** `secret_export::export_bundle` rejects — BEFORE the
+//!    heavy work — any export exceeding `MAX_EXPORT_SECRET_COUNT` or
+//!    `MAX_EXPORT_TOTAL_PLAINTEXT_BYTES`, bounding the worst-case work of a
+//!    single export. The rejection surfaces here as HTTP 413.
+//!
+//! What remains for the broader P5 abuse work (#4381): per-user RATE limiting
+//! across many requests over time (e.g. N exports/minute) and node-wide export
+//! concurrency caps. The two guards above remove the head-of-line blocking and
+//! bound a single request; a full quota/rate-limiting system is tracked
+//! separately and is not required for the endpoint behind the default-off flag.
 
 use axum::{
     Router,
@@ -206,12 +213,11 @@ pub(crate) fn export_user_context_or_reject(
 /// uses, and necessary because this crate builds `axum` without the feature
 /// that provides the `ConnectInfo` extractor.
 ///
-/// PERFORMANCE / DoS: the export runs SYNCHRONOUSLY on the contract-handling
-/// loop and decrypts every secret in the user's scope with no per-user cap, so
-/// an authenticated token-holder can block the node for the export's duration.
-/// Acceptable only behind the default-off hosted flag; a per-user quota +
-/// off-loop execution is a required P5 follow-up before public exposure. See the
-/// module-level "Known limitation" section.
+/// PERFORMANCE / DoS (#4381 P5): the export is bounded (per-user secret-count /
+/// byte cap, returned here as 413) AND runs OFF the contract-handling loop on a
+/// blocking thread, so a single authenticated token-holder's export can neither
+/// do unbounded work nor stall other contract ops. See the module-level
+/// "DoS hardening" section for what remains (cross-request rate limiting).
 async fn export_handler(req: axum::extract::Request) -> Response {
     // Tolerant: the standalone `as_router` composition path has no `HostedMode`
     // layer, so a missing extension means hosted-off ⇒ the gate below 403s (it
@@ -314,6 +320,17 @@ async fn run_export(
     {
         Ok(ContractHandlerEvent::ExportUserSecretsResponse(Ok(bundle))) => Ok(bundle),
         Ok(ContractHandlerEvent::ExportUserSecretsResponse(Err(e))) => {
+            // An over-limit export is a client condition, not a node fault:
+            // surface it as 413 (Payload Too Large) so the caller can tell it
+            // apart from a genuine 500. The message is non-secret (sizes only).
+            // See the per-user export bound in `secret_export` (#4381 P5).
+            if e.is_export_too_large() {
+                tracing::warn!(error = %e, "Rejected hosted export: over per-user limit");
+                return Err((
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    "export exceeds the per-user size limit",
+                ));
+            }
             // Executor-side failure (e.g. a secret failed to decrypt). Do not
             // leak internals to the client; log the detail, return a generic 500.
             tracing::error!(error = %e, "Hosted export failed on the executor");

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -284,16 +284,19 @@ impl Runtime {
     /// Plaintext exists only in the `Zeroizing` buffers inside `export_bundle`;
     /// the returned bytes are encrypted at rest.
     ///
-    /// PERFORMANCE / DoS: this enumerates AND AEAD-decrypts EVERY secret in
-    /// `scope`, synchronously, and the hosted-export caller invokes it on the
-    /// single-threaded contract-handling loop with no per-user secret-count or
-    /// bundle-size cap. A large or repeated export by an authenticated
-    /// token-holder therefore blocks all other contract ops for its duration.
-    /// Acceptable only behind the default-off hosted flag; a per-user quota +
-    /// off-loop execution (`spawn_blocking`) is a required P5 follow-up before
-    /// the export endpoint is exposed on shared/public infrastructure. See the
-    /// "Known limitation" section in
-    /// `server::client_api::hosted_export`.
+    /// PERFORMANCE / DoS (#4381 P5, addressed): this enumerates AND
+    /// AEAD-decrypts EVERY secret in `scope`, synchronously. Two guards keep an
+    /// authenticated token-holder from wedging the node with it:
+    /// - **Per-user bound**: `export_bundle` rejects (before the heavy work) an
+    ///   export exceeding `MAX_EXPORT_SECRET_COUNT` /
+    ///   `MAX_EXPORT_TOTAL_PLAINTEXT_BYTES`, bounding the worst-case work.
+    /// - **Off-loop execution**: the hosted-export caller
+    ///   (`RuntimePool::export_user_secrets`) runs this on a blocking thread
+    ///   (`spawn_blocking`, runtime-flavor-gated), so it does NOT stall the
+    ///   single-threaded contract-handling loop while it runs.
+    ///
+    /// Broader per-user rate/quota limiting (repeated exports over time) remains
+    /// part of the wider P5 abuse work tracked under #4381.
     pub(crate) fn export_secret_bundle(
         &self,
         scope: super::secrets_store::SecretScope<'_>,

--- a/crates/core/src/wasm_runtime/secret_export.rs
+++ b/crates/core/src/wasm_runtime/secret_export.rs
@@ -467,8 +467,9 @@ fn export_bundle_with_limits(
     // Defense-in-depth bound (#4381 P5): reject an over-large export so an
     // authenticated token-holder cannot coerce the node into unbounded crypto/IO
     // or memory. BOTH checks happen BEFORE/DURING the heavy work, never after:
-    //   - The count check is a cheap in-memory metadata walk (no decrypt) and
-    //     short-circuits before a single secret is read.
+    //   - The count check STREAMS the on-disk walk and stops the instant it has
+    //     seen max_count + 1 entries (no full traversal, no allocation of the
+    //     attacker-controlled entry list) — see `scope_count_exceeds`.
     //   - The byte check is enforced INCREMENTALLY inside
     //     `export_scope_entries_bounded`, which aborts the decrypt loop the
     //     instant the running plaintext total crosses the cap and drops the
@@ -476,12 +477,14 @@ fn export_bundle_with_limits(
     //     never gets multi-GiB decrypted+buffered before the rejection.
     // Both are hard rejections (never silent truncation), so no user data is
     // lost — the caller surfaces a 413 and an operator can raise the limit if a
-    // real workload ever needs it.
-    let count = store.scope_entry_count(&scope);
-    if count > max_count {
+    // real workload ever needs it. A disk I/O failure during the count
+    // propagates (fail-loud) rather than passing the cap on a partial walk.
+    if store.scope_count_exceeds(&scope, max_count)? {
         return Err(ExportError::TooLarge {
             what: "secret count",
-            actual: count,
+            // The streaming count stops at max_count + 1, so we report that as a
+            // lower bound on the true (over-cap) count rather than a full count.
+            actual: max_count + 1,
             limit: max_count,
         });
     }
@@ -1216,10 +1219,112 @@ mod test {
 
         // The count cap (scope_entry_count) must also see BOTH (it walks disk).
         assert_eq!(
-            store_b.scope_entry_count(&ctx.scope()),
+            store_b.scope_entry_count(&ctx.scope()).unwrap(),
             2,
             "scope_entry_count must count both on-disk secrets, not just B's index"
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn export_fails_loud_on_unexpected_io_error() {
+        // FAIL-LOUD (#4563 P2): an unexpected I/O error during enumeration must
+        // make the export FAIL, not seal a silently-partial/empty bundle. We
+        // make the user's on-disk scope dir UNREADABLE (chmod 000) so read_dir
+        // returns PermissionDenied (not NotFound) — the export must return Err.
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = new_store(tmp.path()).await;
+        let token = b"io-error-user";
+        let ctx = UserSecretContext::from_token(token);
+        let d = delegate(1);
+        let s = SecretsId::new(b"k".to_vec());
+        let _ = put_user(&mut store, &d, &ctx, &s, b"v");
+
+        // The scope dir that now holds the secret: base/<delegate>/users/<id>.
+        let scope_dir = tmp
+            .path()
+            .join("secrets")
+            .join(d.key().encode())
+            .join("users")
+            .join(ctx.user_id().encode());
+        assert!(scope_dir.is_dir(), "scope dir must exist after the write");
+
+        // Make it unreadable. If running as root (chmod 000 is bypassed), skip —
+        // the branch is also covered by the count path's identical fail-loud.
+        std::fs::set_permissions(&scope_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let still_readable = std::fs::read_dir(&scope_dir).is_ok();
+        if still_readable {
+            // root or a permissive FS: restore and skip the assertion.
+            std::fs::set_permissions(&scope_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+            return;
+        }
+
+        let material = BundleKeyMaterial::Token(token);
+        let result = export_bundle(&store, ctx.scope(), &material);
+        // Restore perms so tempdir cleanup works regardless of the assertion.
+        std::fs::set_permissions(&scope_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(
+            result.is_err(),
+            "an unreadable scope dir must make the export FAIL, not seal a partial bundle"
+        );
+    }
+
+    #[tokio::test]
+    async fn export_of_absent_scope_is_clean_empty_not_error() {
+        // A user with NO stored secrets has no on-disk users/<id> dir → read_dir
+        // NotFound, which is EXPECTED-absent → a clean EMPTY bundle, NOT an error
+        // (must not be conflated with the fail-loud I/O-error path).
+        let tmp = tempfile::tempdir().unwrap();
+        let store = new_store(tmp.path()).await;
+        let token = b"never-stored-anything";
+        let ctx = UserSecretContext::from_token(token);
+        let material = BundleKeyMaterial::Token(token);
+        let bundle = export_bundle(&store, ctx.scope(), &material)
+            .expect("absent user scope must export a clean empty bundle, not error");
+        let payload = open_bundle(&bundle, &material).expect("open empty");
+        assert!(payload.entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn count_cap_check_streams_and_stops_early() {
+        // The count-cap check must decide "over the cap" WITHOUT enumerating the
+        // whole (attacker-controlled) scope. We store 5 secrets and assert
+        // scope_count_exceeds(cap=2) is true. The streaming counter stops after
+        // seeing 3 (cap+1), so it never materializes all 5 — the gather
+        // (export_scope_entries_bounded) is never reached for an over-cap scope.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = new_store(tmp.path()).await;
+        let token = b"count-stream-user";
+        let ctx = UserSecretContext::from_token(token);
+        let d = delegate(1);
+        for i in 0..5u8 {
+            let s = SecretsId::new(vec![b'k', i]);
+            put_user(&mut store, &d, &ctx, &s, b"v");
+        }
+        // Over the cap of 2.
+        assert!(
+            store.scope_count_exceeds(&ctx.scope(), 2).unwrap(),
+            "5 secrets must exceed a cap of 2"
+        );
+        // At/under the cap is NOT exceeded (boundary: 5 with cap 5 → not over).
+        assert!(
+            !store.scope_count_exceeds(&ctx.scope(), 5).unwrap(),
+            "exactly-at-cap must NOT be flagged as exceeding"
+        );
+        assert!(
+            !store.scope_count_exceeds(&ctx.scope(), 10).unwrap(),
+            "under-cap must NOT be flagged as exceeding"
+        );
+        // And the full export of an over-cap scope is rejected as TooLarge.
+        let material = BundleKeyMaterial::Token(token);
+        let err = export_bundle_with_limits(&store, ctx.scope(), &material, 2, usize::MAX)
+            .expect_err("over-count export must be rejected");
+        let ExportError::TooLarge { what, limit, .. } = err else {
+            panic!("expected TooLarge(secret count), got {err:?}");
+        };
+        assert_eq!(what, "secret count");
+        assert_eq!(limit, 2);
     }
 
     fn read_local(store: &SecretsStore, d: &Delegate<'static>, hash: &[u8; 32]) -> Vec<u8> {

--- a/crates/core/src/wasm_runtime/secret_export.rs
+++ b/crates/core/src/wasm_runtime/secret_export.rs
@@ -640,6 +640,20 @@ mod test {
         SecretsStore::new(secrets_dir, Default::default(), db).expect("store")
     }
 
+    /// Build a `SecretsStore` over a SPECIFIC, SHARED `secrets_dir` but with its
+    /// OWN ReDb (in `db_dir`). Two such stores model two pooled executors: they
+    /// write to the same on-disk `secrets_dir` but each keeps its own in-memory
+    /// index — exactly the cross-executor divergence the disk-enumeration export
+    /// fix must tolerate.
+    async fn new_store_sharing(
+        secrets_dir: &std::path::Path,
+        db_dir: &std::path::Path,
+    ) -> SecretsStore {
+        std::fs::create_dir_all(secrets_dir).unwrap();
+        let db = Storage::new(db_dir).await.expect("db");
+        SecretsStore::new(secrets_dir.to_path_buf(), Default::default(), db).expect("store")
+    }
+
     fn delegate(code: u8) -> Delegate<'static> {
         Delegate::from((&vec![code].into(), &vec![].into()))
     }
@@ -1147,6 +1161,64 @@ mod test {
         let payload = open_bundle(&bundle, &material).expect("open");
         assert_eq!(payload.entries.len(), 1);
         assert_eq!(payload.entries[0].secret_hash.as_slice(), h.as_slice());
+    }
+
+    #[tokio::test]
+    async fn export_includes_secret_written_by_a_different_executor() {
+        // THE #4 REGRESSION (cross-executor staleness): under the pooled-executor
+        // model two executors share one on-disk `secrets_dir` but each keeps its
+        // OWN in-memory index. A secret stored via executor A is NOT in executor
+        // B's index. The export — which may run on B — must still include A's
+        // secret, because it enumerates from DISK (the shared source of truth),
+        // not from B's stale in-memory index. With the old in-memory enumeration
+        // this export would silently OMIT the secret → incomplete backup.
+        let tmp = tempfile::tempdir().unwrap();
+        let shared_secrets = tmp.path().join("shared-secrets");
+        let token = b"cross-executor-user";
+        let ctx = UserSecretContext::from_token(token);
+        let d = delegate(1);
+        let s_a = SecretsId::new(b"written-by-A".to_vec());
+        let s_b = SecretsId::new(b"written-by-B".to_vec());
+
+        // Executor A's store: writes secret A to the shared dir.
+        let mut store_a = new_store_sharing(&shared_secrets, &tmp.path().join("db-a")).await;
+        let h_a = put_user(&mut store_a, &d, &ctx, &s_a, b"value-A");
+
+        // Executor B's store: a SEPARATE in-memory index over the SAME secrets
+        // dir. It only knows about the secret IT writes (B); it has never seen A.
+        let mut store_b = new_store_sharing(&shared_secrets, &tmp.path().join("db-b")).await;
+        let h_b = put_user(&mut store_b, &d, &ctx, &s_b, b"value-B");
+
+        // Export via executor B. The bundle MUST contain BOTH secrets — A's
+        // (written by the other executor, absent from B's in-memory index) and
+        // B's own. Pre-fix, A's secret would be missing.
+        let material = BundleKeyMaterial::Token(token);
+        let bundle =
+            export_bundle(&store_b, ctx.scope(), &material).expect("export via B succeeds");
+        let payload = open_bundle(&bundle, &material).expect("open");
+
+        let exported: std::collections::HashSet<Vec<u8>> = payload
+            .entries
+            .iter()
+            .map(|e| e.secret_hash.clone())
+            .collect();
+        assert!(
+            exported.contains(h_a.as_slice()),
+            "export run on executor B MUST include the secret written by executor A \
+             (disk is the source of truth, not B's stale in-memory index) — #4531/#4 fix"
+        );
+        assert!(
+            exported.contains(h_b.as_slice()),
+            "export must also include B's own secret"
+        );
+        assert_eq!(payload.entries.len(), 2, "exactly the two stored secrets");
+
+        // The count cap (scope_entry_count) must also see BOTH (it walks disk).
+        assert_eq!(
+            store_b.scope_entry_count(&ctx.scope()),
+            2,
+            "scope_entry_count must count both on-disk secrets, not just B's index"
+        );
     }
 
     fn read_local(store: &SecretsStore, d: &Delegate<'static>, hash: &[u8; 32]) -> Vec<u8> {

--- a/crates/core/src/wasm_runtime/secret_export.rs
+++ b/crates/core/src/wasm_runtime/secret_export.rs
@@ -650,6 +650,7 @@ mod test {
         db_dir: &std::path::Path,
     ) -> SecretsStore {
         std::fs::create_dir_all(secrets_dir).unwrap();
+        std::fs::create_dir_all(db_dir).unwrap();
         let db = Storage::new(db_dir).await.expect("db");
         SecretsStore::new(secrets_dir.to_path_buf(), Default::default(), db).expect("store")
     }

--- a/crates/core/src/wasm_runtime/secret_export.rs
+++ b/crates/core/src/wasm_runtime/secret_export.rs
@@ -94,6 +94,36 @@ const HEADER_LEN: usize = 4 + 1 + 1 + SALT_LEN + 24;
 /// same token.
 const TOKEN_BUNDLE_HKDF_INFO: &[u8] = b"freenet-secret-bundle-token-v1";
 
+/// Upper bound on the number of secrets a single [`export_bundle`] call will
+/// gather, checked BEFORE any secret is read/decrypted.
+///
+/// This is a defense-in-depth cap on the worst-case work of one export — even
+/// though the hosted path now runs the export off the contract loop (see
+/// `RuntimePool::export_user_secrets`), an unbounded enumerate+decrypt is still
+/// CPU/IO the node shouldn't be coerced into doing without limit by an
+/// authenticated token-holder (the hosted-export DoS surface of #4381 P5).
+///
+/// 10,000 is deliberately far above any legitimate per-user delegate-secret
+/// set: a hosted user accumulates a handful of secrets per delegate they
+/// interact with, so a real export is tens to low-hundreds of entries. A user
+/// who genuinely exceeds this is not a normal hosted user, and the request is
+/// rejected (HTTP 413) rather than silently truncated, so no data is lost — the
+/// limit can be raised by an operator follow-up if a real workload ever needs
+/// it.
+pub const MAX_EXPORT_SECRET_COUNT: usize = 10_000;
+
+/// Upper bound on the cumulative DECRYPTED plaintext bytes a single
+/// [`export_bundle`] call will gather, checked incrementally as secrets are
+/// read so the loop bails early instead of buffering an unbounded amount of
+/// plaintext in memory.
+///
+/// 256 MiB is far above any legitimate per-user secret payload (delegate
+/// secrets are keys/tokens/small blobs, kilobytes each), but bounds the
+/// in-memory `Zeroizing` plaintext buffers and the resulting bundle so a
+/// single export cannot be used to exhaust node memory. Like the count cap,
+/// exceeding it is a hard 413, never a silent truncation.
+pub const MAX_EXPORT_TOTAL_PLAINTEXT_BYTES: usize = 256 * 1024 * 1024;
+
 /// Which key-derivation function produced the bundle key. Recorded in the
 /// header so `import` derives the matching key without the user having to
 /// re-specify the method.
@@ -186,6 +216,17 @@ const PAYLOAD_SCHEMA_V1: u32 = 1;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ExportError {
+    /// The export would gather more than [`MAX_EXPORT_SECRET_COUNT`] secrets or
+    /// more than [`MAX_EXPORT_TOTAL_PLAINTEXT_BYTES`] of decrypted plaintext.
+    /// Distinct from the other variants so the hosted-export HTTP layer can map
+    /// it to a 413 (Payload Too Large) rather than a generic 500. The `limit`
+    /// and `actual` are non-secret sizes (counts/bytes), safe to surface.
+    #[error("export too large: {what} {actual} exceeds limit {limit}")]
+    TooLarge {
+        what: &'static str,
+        actual: usize,
+        limit: usize,
+    },
     #[error("secrets store error: {0}")]
     Store(#[from] super::secrets_store::SecretStoreError),
     #[error("runtime error: {0}")]
@@ -398,11 +439,60 @@ pub fn export_bundle(
     scope: SecretScope<'_>,
     material: &BundleKeyMaterial<'_>,
 ) -> Result<Vec<u8>, ExportError> {
+    export_bundle_with_limits(
+        store,
+        scope,
+        material,
+        MAX_EXPORT_SECRET_COUNT,
+        MAX_EXPORT_TOTAL_PLAINTEXT_BYTES,
+    )
+}
+
+/// [`export_bundle`] with the per-user bound made explicit, so tests can
+/// exercise the cap at small limits deterministically (the public entry point
+/// passes the production [`MAX_EXPORT_SECRET_COUNT`] /
+/// [`MAX_EXPORT_TOTAL_PLAINTEXT_BYTES`]).
+fn export_bundle_with_limits(
+    store: &SecretsStore,
+    scope: SecretScope<'_>,
+    material: &BundleKeyMaterial<'_>,
+    max_count: usize,
+    max_total_bytes: usize,
+) -> Result<Vec<u8>, ExportError> {
     let scope_label = match &scope {
         SecretScope::Local => "local",
         SecretScope::User { .. } => "user",
     };
+
+    // Defense-in-depth bound (#4381 P5): reject an over-large export BEFORE
+    // doing the heavy enumerate+decrypt+re-encrypt work, so an authenticated
+    // token-holder cannot coerce the node into unbounded crypto/IO. The count
+    // check is a cheap in-memory metadata walk (no decrypt). The byte check is
+    // applied AFTER the gather but BEFORE the expensive whole-bundle AEAD seal,
+    // bounding the in-memory plaintext and the resulting bundle size. Both are
+    // hard rejections (never silent truncation), so no user data is lost — the
+    // caller surfaces a 413 and an operator can raise the limit if a real
+    // workload ever needs it.
+    let count = store.scope_entry_count(&scope);
+    if count > max_count {
+        return Err(ExportError::TooLarge {
+            what: "secret count",
+            actual: count,
+            limit: max_count,
+        });
+    }
+
     let entries = store.export_scope_entries(scope)?;
+
+    let total_bytes: usize = entries.iter().map(|e| e.plaintext.len()).sum();
+    if total_bytes > max_total_bytes {
+        return Err(ExportError::TooLarge {
+            what: "total plaintext bytes",
+            actual: total_bytes,
+            limit: max_total_bytes,
+        });
+    }
+
     seal_bundle(&entries, scope_label, material)
 }
 
@@ -913,6 +1003,107 @@ mod test {
             Err(ExportError::AuthFailed) => {}
             other => panic!("ciphertext tamper must fail auth, got {:?}", other.err()),
         }
+    }
+
+    #[tokio::test]
+    async fn export_over_count_limit_rejected_before_decrypt() {
+        // An export gathering more secrets than the count cap is rejected with a
+        // typed `TooLarge` error (mapped to a 413 at the HTTP layer), and the
+        // check happens on the cheap metadata walk before any decrypt. Uses a
+        // tiny limit so the test is deterministic without storing 10k secrets.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = new_store(tmp.path()).await;
+        let token = b"count-limit-user";
+        let ctx = UserSecretContext::from_token(token);
+        let d = delegate(1);
+        // Three secrets for the same user; cap at 2.
+        for i in 0..3u8 {
+            let s = SecretsId::new(vec![b'k', i]);
+            put_user(&mut store, &d, &ctx, &s, b"v");
+        }
+        let material = BundleKeyMaterial::Token(token);
+        let err = export_bundle_with_limits(&store, ctx.scope(), &material, 2, usize::MAX)
+            .expect_err("over-count export must be rejected");
+        match err {
+            ExportError::TooLarge {
+                what,
+                actual,
+                limit,
+            } => {
+                assert_eq!(what, "secret count");
+                assert_eq!(actual, 3);
+                assert_eq!(limit, 2);
+            }
+            other => panic!("expected TooLarge(secret count), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn export_at_count_limit_succeeds() {
+        // Boundary: count exactly AT the limit still exports (the check is `>`,
+        // not `>=`), so the cap never rejects a legitimate at-capacity user.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = new_store(tmp.path()).await;
+        let token = b"at-limit-user";
+        let ctx = UserSecretContext::from_token(token);
+        let d = delegate(2);
+        for i in 0..2u8 {
+            let s = SecretsId::new(vec![b'k', i]);
+            put_user(&mut store, &d, &ctx, &s, b"v");
+        }
+        let material = BundleKeyMaterial::Token(token);
+        let bundle = export_bundle_with_limits(&store, ctx.scope(), &material, 2, usize::MAX)
+            .expect("export at the count limit must succeed");
+        let payload = open_bundle(&bundle, &material).expect("open");
+        assert_eq!(payload.entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn export_over_byte_limit_rejected() {
+        // An export whose total decrypted plaintext exceeds the byte cap is
+        // rejected with a typed `TooLarge` error. Uses a tiny byte limit and a
+        // payload that exceeds it.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = new_store(tmp.path()).await;
+        let token = b"byte-limit-user";
+        let ctx = UserSecretContext::from_token(token);
+        let d = delegate(3);
+        let s = SecretsId::new(b"big".to_vec());
+        // 100 bytes of plaintext, cap at 50.
+        put_user(&mut store, &d, &ctx, &s, &[7u8; 100]);
+        let material = BundleKeyMaterial::Token(token);
+        let err = export_bundle_with_limits(&store, ctx.scope(), &material, usize::MAX, 50)
+            .expect_err("over-byte export must be rejected");
+        match err {
+            ExportError::TooLarge {
+                what,
+                actual,
+                limit,
+            } => {
+                assert_eq!(what, "total plaintext bytes");
+                assert_eq!(actual, 100);
+                assert_eq!(limit, 50);
+            }
+            other => panic!("expected TooLarge(total plaintext bytes), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn export_under_production_limits_succeeds() {
+        // A normal small export goes through the PUBLIC entry point (which uses
+        // the production caps), so the cap never regresses a real user.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = new_store(tmp.path()).await;
+        let token = b"normal-user";
+        let ctx = UserSecretContext::from_token(token);
+        let d = delegate(4);
+        let s = SecretsId::new(b"ordinary".to_vec());
+        let h = put_user(&mut store, &d, &ctx, &s, b"ordinary-value");
+        let material = BundleKeyMaterial::Token(token);
+        let bundle = export_bundle(&store, ctx.scope(), &material).expect("normal export succeeds");
+        let payload = open_bundle(&bundle, &material).expect("open");
+        assert_eq!(payload.entries.len(), 1);
+        assert_eq!(payload.entries[0].secret_hash.as_slice(), h.as_slice());
     }
 
     fn read_local(store: &SecretsStore, d: &Delegate<'static>, hash: &[u8; 32]) -> Vec<u8> {

--- a/crates/core/src/wasm_runtime/secret_export.rs
+++ b/crates/core/src/wasm_runtime/secret_export.rs
@@ -1032,18 +1032,17 @@ mod test {
         let material = BundleKeyMaterial::Token(token);
         let err = export_bundle_with_limits(&store, ctx.scope(), &material, 2, usize::MAX)
             .expect_err("over-count export must be rejected");
-        match err {
-            ExportError::TooLarge {
-                what,
-                actual,
-                limit,
-            } => {
-                assert_eq!(what, "secret count");
-                assert_eq!(actual, 3);
-                assert_eq!(limit, 2);
-            }
-            other => panic!("expected TooLarge(secret count), got {other:?}"),
-        }
+        let ExportError::TooLarge {
+            what,
+            actual,
+            limit,
+        } = err
+        else {
+            panic!("expected TooLarge(secret count), got {err:?}");
+        };
+        assert_eq!(what, "secret count");
+        assert_eq!(actual, 3);
+        assert_eq!(limit, 2);
     }
 
     #[tokio::test]
@@ -1082,18 +1081,17 @@ mod test {
         let material = BundleKeyMaterial::Token(token);
         let err = export_bundle_with_limits(&store, ctx.scope(), &material, usize::MAX, 50)
             .expect_err("over-byte export must be rejected");
-        match err {
-            ExportError::TooLarge {
-                what,
-                actual,
-                limit,
-            } => {
-                assert_eq!(what, "total plaintext bytes");
-                assert_eq!(actual, 100);
-                assert_eq!(limit, 50);
-            }
-            other => panic!("expected TooLarge(total plaintext bytes), got {other:?}"),
-        }
+        let ExportError::TooLarge {
+            what,
+            actual,
+            limit,
+        } = err
+        else {
+            panic!("expected TooLarge(total plaintext bytes), got {err:?}");
+        };
+        assert_eq!(what, "total plaintext bytes");
+        assert_eq!(actual, 100);
+        assert_eq!(limit, 50);
     }
 
     #[tokio::test]
@@ -1119,20 +1117,18 @@ mod test {
             Ok(_) => panic!("over-byte gather must bail, not succeed"),
             Err(e) => e,
         };
-        match err {
-            ExportScopeError::TooLarge { actual, limit } => {
-                assert_eq!(limit, 50);
-                // Bailed at the SECOND secret (40 + 40 = 80 > 50), NOT after
-                // buffering all three (which would be 120). This is the proof
-                // that the partial buffer was dropped mid-loop.
-                assert_eq!(
-                    actual, 80,
-                    "must bail the instant the running total crosses the cap, \
-                     not after gathering the whole scope"
-                );
-            }
-            other => panic!("expected ExportScopeError::TooLarge, got {other:?}"),
-        }
+        let ExportScopeError::TooLarge { actual, limit } = err else {
+            panic!("expected ExportScopeError::TooLarge, got {err:?}");
+        };
+        assert_eq!(limit, 50);
+        // Bailed at the SECOND secret (40 + 40 = 80 > 50), NOT after buffering
+        // all three (which would be 120). This is the proof that the partial
+        // buffer was dropped mid-loop.
+        assert_eq!(
+            actual, 80,
+            "must bail the instant the running total crosses the cap, \
+             not after gathering the whole scope"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/wasm_runtime/secret_export.rs
+++ b/crates/core/src/wasm_runtime/secret_export.rs
@@ -489,8 +489,12 @@ fn export_bundle_with_limits(
         });
     }
 
+    // The gather re-enforces BOTH caps incrementally (the count cap here is the
+    // AUTHORITATIVE one — the pre-check above is only an early-out, and a
+    // concurrent store_secret can push the scope over the cap between the two,
+    // a TOCTOU the gather closes). See `export_scope_entries_bounded`.
     let entries = store
-        .export_scope_entries_bounded(scope, max_total_bytes)
+        .export_scope_entries_bounded(scope, max_count, max_total_bytes)
         .map_err(|e| match e {
             super::secrets_store::ExportScopeError::Store(store_err) => {
                 ExportError::Store(store_err)
@@ -498,6 +502,13 @@ fn export_bundle_with_limits(
             super::secrets_store::ExportScopeError::TooLarge { actual, limit } => {
                 ExportError::TooLarge {
                     what: "total plaintext bytes",
+                    actual,
+                    limit,
+                }
+            }
+            super::secrets_store::ExportScopeError::CountTooLarge { actual, limit } => {
+                ExportError::TooLarge {
+                    what: "secret count",
                     actual,
                     limit,
                 }
@@ -1130,8 +1141,9 @@ mod test {
             put_user(&mut store, &d, &ctx, &s, &[1u8; 40]);
         }
         // `ExportSecretEntry` deliberately has no `Debug` (it holds decrypted
-        // plaintext), so match on the result rather than `expect_err`.
-        let err = match store.export_scope_entries_bounded(ctx.scope(), 50) {
+        // plaintext), so match on the result rather than `expect_err`. No count
+        // cap here (usize::MAX) — exercise the byte bail specifically.
+        let err = match store.export_scope_entries_bounded(ctx.scope(), usize::MAX, 50) {
             Ok(_) => panic!("over-byte gather must bail, not succeed"),
             Err(e) => e,
         };
@@ -1325,6 +1337,46 @@ mod test {
         };
         assert_eq!(what, "secret count");
         assert_eq!(limit, 2);
+    }
+
+    #[tokio::test]
+    async fn gather_enforces_count_cap_authoritatively() {
+        // TOCTOU (#4563 final): the count cap MUST be enforced DURING the gather,
+        // not only by the cheap pre-check — because the export runs off-loop
+        // while the loop keeps serving store_secret, so a concurrent writer can
+        // push a just-under-cap scope OVER the cap between the pre-check and the
+        // gather. We simulate "the scope crossed the cap by the time the gather
+        // ran" by driving export_scope_entries_bounded DIRECTLY (bypassing the
+        // pre-check) with a 5-secret scope and max_count = 2: the gather itself
+        // must abort with CountTooLarge, NOT seal all 5.
+        use crate::wasm_runtime::secrets_store::ExportScopeError;
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = new_store(tmp.path()).await;
+        let token = b"toctou-count-user";
+        let ctx = UserSecretContext::from_token(token);
+        let d = delegate(1);
+        for i in 0..5u8 {
+            let s = SecretsId::new(vec![b'k', i]);
+            put_user(&mut store, &d, &ctx, &s, b"v");
+        }
+        // No count cap (usize::MAX) succeeds and gathers all 5 — sanity.
+        let all = store
+            .export_scope_entries_bounded(ctx.scope(), usize::MAX, usize::MAX)
+            .expect("uncapped gather succeeds");
+        assert_eq!(all.len(), 5);
+
+        // With max_count = 2 the gather ABORTS — the count is enforced in the
+        // gather pass itself, closing the TOCTOU window.
+        let err = match store.export_scope_entries_bounded(ctx.scope(), 2, usize::MAX) {
+            Ok(_) => panic!("over-count gather must abort, not seal all 5"),
+            Err(e) => e,
+        };
+        let ExportScopeError::CountTooLarge { actual, limit } = err else {
+            panic!("expected CountTooLarge, got {err:?}");
+        };
+        assert_eq!(limit, 2);
+        // Bailed at the 3rd entry (count crossed the cap), not after all 5.
+        assert_eq!(actual, 3, "must abort the instant count crosses the cap");
     }
 
     fn read_local(store: &SecretsStore, d: &Delegate<'static>, hash: &[u8; 32]) -> Vec<u8> {

--- a/crates/core/src/wasm_runtime/secret_export.rs
+++ b/crates/core/src/wasm_runtime/secret_export.rs
@@ -464,15 +464,19 @@ fn export_bundle_with_limits(
         SecretScope::User { .. } => "user",
     };
 
-    // Defense-in-depth bound (#4381 P5): reject an over-large export BEFORE
-    // doing the heavy enumerate+decrypt+re-encrypt work, so an authenticated
-    // token-holder cannot coerce the node into unbounded crypto/IO. The count
-    // check is a cheap in-memory metadata walk (no decrypt). The byte check is
-    // applied AFTER the gather but BEFORE the expensive whole-bundle AEAD seal,
-    // bounding the in-memory plaintext and the resulting bundle size. Both are
-    // hard rejections (never silent truncation), so no user data is lost — the
-    // caller surfaces a 413 and an operator can raise the limit if a real
-    // workload ever needs it.
+    // Defense-in-depth bound (#4381 P5): reject an over-large export so an
+    // authenticated token-holder cannot coerce the node into unbounded crypto/IO
+    // or memory. BOTH checks happen BEFORE/DURING the heavy work, never after:
+    //   - The count check is a cheap in-memory metadata walk (no decrypt) and
+    //     short-circuits before a single secret is read.
+    //   - The byte check is enforced INCREMENTALLY inside
+    //     `export_scope_entries_bounded`, which aborts the decrypt loop the
+    //     instant the running plaintext total crosses the cap and drops the
+    //     partial buffer — so a user under the count cap but with huge secrets
+    //     never gets multi-GiB decrypted+buffered before the rejection.
+    // Both are hard rejections (never silent truncation), so no user data is
+    // lost — the caller surfaces a 413 and an operator can raise the limit if a
+    // real workload ever needs it.
     let count = store.scope_entry_count(&scope);
     if count > max_count {
         return Err(ExportError::TooLarge {
@@ -482,16 +486,20 @@ fn export_bundle_with_limits(
         });
     }
 
-    let entries = store.export_scope_entries(scope)?;
-
-    let total_bytes: usize = entries.iter().map(|e| e.plaintext.len()).sum();
-    if total_bytes > max_total_bytes {
-        return Err(ExportError::TooLarge {
-            what: "total plaintext bytes",
-            actual: total_bytes,
-            limit: max_total_bytes,
-        });
-    }
+    let entries = store
+        .export_scope_entries_bounded(scope, max_total_bytes)
+        .map_err(|e| match e {
+            super::secrets_store::ExportScopeError::Store(store_err) => {
+                ExportError::Store(store_err)
+            }
+            super::secrets_store::ExportScopeError::TooLarge { actual, limit } => {
+                ExportError::TooLarge {
+                    what: "total plaintext bytes",
+                    actual,
+                    limit,
+                }
+            }
+        })?;
 
     seal_bundle(&entries, scope_label, material)
 }
@@ -1085,6 +1093,45 @@ mod test {
                 assert_eq!(limit, 50);
             }
             other => panic!("expected TooLarge(total plaintext bytes), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn export_scope_entries_bounded_bails_incrementally() {
+        // INCREMENTAL bail (#4531 P5): the byte cap aborts the decrypt loop the
+        // instant the running total crosses the limit, WITHOUT decrypting and
+        // buffering the whole scope. With three 40-byte secrets and a 50-byte
+        // cap, the bail must fire at total=80 (after the SECOND secret), i.e.
+        // before the third is ever read — the reported `actual` is 80, not 120.
+        use crate::wasm_runtime::secrets_store::ExportScopeError;
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = new_store(tmp.path()).await;
+        let token = b"incremental-user";
+        let ctx = UserSecretContext::from_token(token);
+        let d = delegate(9);
+        for i in 0..3u8 {
+            let s = SecretsId::new(vec![b'b', i]);
+            put_user(&mut store, &d, &ctx, &s, &[1u8; 40]);
+        }
+        // `ExportSecretEntry` deliberately has no `Debug` (it holds decrypted
+        // plaintext), so match on the result rather than `expect_err`.
+        let err = match store.export_scope_entries_bounded(ctx.scope(), 50) {
+            Ok(_) => panic!("over-byte gather must bail, not succeed"),
+            Err(e) => e,
+        };
+        match err {
+            ExportScopeError::TooLarge { actual, limit } => {
+                assert_eq!(limit, 50);
+                // Bailed at the SECOND secret (40 + 40 = 80 > 50), NOT after
+                // buffering all three (which would be 120). This is the proof
+                // that the partial buffer was dropped mid-loop.
+                assert_eq!(
+                    actual, 80,
+                    "must bail the instant the running total crosses the cap, \
+                     not after gathering the whole scope"
+                );
+            }
+            other => panic!("expected ExportScopeError::TooLarge, got {other:?}"),
         }
     }
 

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -1605,6 +1605,36 @@ impl SecretsStore {
     // from the delegate's wasm+params), so a re-installed webapp shipping the
     // same delegate yields the same key and the imported secrets line up.
 
+    /// Map `delegate-key-bytes (32) -> real CodeHash` from this store's in-memory
+    /// index for `scope`, so the on-disk enumeration can recover the real
+    /// `code_hash` of a delegate the dir name (key-only) can't carry. Best-effort:
+    /// a delegate this executor never registered simply isn't in the map (the
+    /// caller falls back to a placeholder code_hash, which is inert).
+    fn index_code_hashes_by_key(
+        &self,
+        scope: &SecretScope<'_>,
+    ) -> std::collections::HashMap<[u8; 32], CodeHash> {
+        let mut out = std::collections::HashMap::new();
+        match scope {
+            SecretScope::Local => {
+                for entry in self.key_to_secret_part.iter() {
+                    let dk = entry.key();
+                    // `DelegateKey` derefs to its 32-byte key.
+                    out.insert(**dk, *dk.code_hash());
+                }
+            }
+            SecretScope::User { id, .. } => {
+                for entry in self.user_key_to_secret_part.iter() {
+                    let (dk, user) = entry.key();
+                    if user == *id {
+                        out.insert(**dk, *dk.code_hash());
+                    }
+                }
+            }
+        }
+        out
+    }
+
     /// Enumerate every `(DelegateKey, secret_hash)` for `scope` by walking the
     /// on-disk `secrets_dir` (the shared source of truth) instead of this
     /// store's per-instance in-memory index.
@@ -1651,6 +1681,19 @@ impl SecretsStore {
             // base_path missing/unreadable ⇒ no secrets to export.
             return out;
         };
+        // Recover each delegate's real `code_hash` from the in-memory index when
+        // this executor knows it. The on-disk delegate dir name encodes only the
+        // 32-byte key (`DelegateKey::encode()`), NOT the code_hash — but the
+        // bundle records `code_hash`, and `DelegateKey`'s `Eq`/`Hash` cover both
+        // fields, so a placeholder would make the exported key `!=` the real one.
+        // code_hash is otherwise inert (path/DEK/read are key-only), so a secret
+        // written by ANOTHER executor for a delegate THIS executor never
+        // registered still exports + decrypts correctly under the zero
+        // placeholder; it just carries a placeholder code_hash in the bundle
+        // (inert for import). The exporting executor has almost always
+        // registered the delegate, so the real code_hash is recovered in
+        // practice.
+        let code_hashes = self.index_code_hashes_by_key(scope);
         for delegate_entry in delegate_dirs.flatten() {
             let delegate_path = delegate_entry.path();
             if !delegate_path.is_dir() {
@@ -1662,8 +1705,11 @@ impl SecretsStore {
             let Some(delegate_key_bytes) = decode_bs58_32(&delegate_name) else {
                 continue; // not a delegate dir (e.g. a stray non-bs58 name)
             };
-            // code_hash is inert for path/DEK/read; use a zero placeholder.
-            let delegate = DelegateKey::new(delegate_key_bytes, CodeHash::from(&[0u8; 32]));
+            let code_hash = code_hashes
+                .get(&delegate_key_bytes)
+                .copied()
+                .unwrap_or_else(|| CodeHash::from(&[0u8; 32]));
+            let delegate = DelegateKey::new(delegate_key_bytes, code_hash);
 
             // The directory that actually holds this scope's secret files.
             let scope_path = match scope {
@@ -5324,14 +5370,25 @@ mod test {
         store.db.store_secrets_index(delegate.key(), &[])?;
         store.key_to_secret_part.remove(delegate.key());
 
-        // Pre-condition: file present, index empty → invisible to enumeration.
+        // Pre-condition: file present, in-memory index empty.
         let file_path = secrets_dir
             .join(delegate.key().encode())
             .join(secret_id.encode());
         assert!(file_path.exists(), "secret file should still be on disk");
         assert!(
-            store.export_scope_entries(SecretScope::Local)?.is_empty(),
-            "pre-condition: unindexed secret must be invisible to enumeration"
+            store.key_to_secret_part.get(delegate.key()).is_none(),
+            "pre-condition: the in-memory index entry was dropped (crash window)"
+        );
+        // Since the export now enumerates from DISK (the shared source of truth,
+        // for cross-executor consistency — see `enumerate_scope_on_disk`), the
+        // completed on-disk secret IS already visible to export even before the
+        // index is repaired. This is the intended improvement: a backup includes
+        // every completed write regardless of in-memory index state. (It was
+        // "invisible" only under the OLD in-memory-index enumeration.)
+        assert_eq!(
+            store.export_scope_entries(SecretScope::Local)?.len(),
+            1,
+            "disk-based export sees the completed on-disk secret pre-repair"
         );
 
         // Retry the import WITHOUT overwrite. It must skip the rewrite
@@ -5403,9 +5460,21 @@ mod test {
             .user_key_to_secret_part
             .remove(&(delegate.key().clone(), *ctx.user_id()));
 
+        // In-memory index row dropped, but the disk-based export (the source of
+        // truth, for cross-executor consistency) still sees the completed
+        // on-disk secret pre-repair — the intended improvement (was "invisible"
+        // only under the OLD in-memory-index enumeration).
         assert!(
-            store.export_scope_entries(ctx.scope())?.is_empty(),
-            "pre-condition: unindexed user secret invisible"
+            store
+                .user_key_to_secret_part
+                .get(&(delegate.key().clone(), *ctx.user_id()))
+                .is_none(),
+            "pre-condition: the in-memory user-index entry was dropped"
+        );
+        assert_eq!(
+            store.export_scope_entries(ctx.scope())?.len(),
+            1,
+            "disk-based export sees the completed on-disk user secret pre-repair"
         );
 
         let wrote = store.import_secret_by_hash(
@@ -5417,6 +5486,17 @@ mod test {
         )?;
         assert!(!wrote);
 
+        // Post-condition: import repaired the ReDb + in-memory user index (for
+        // index consumers other than export, e.g. the `.keys` registry / ReDb
+        // consistency), and export still enumerates the secret.
+        assert!(
+            store
+                .user_key_to_secret_part
+                .get(&(delegate.key().clone(), *ctx.user_id()))
+                .map(|e| e.value().contains(&secret_hash))
+                .unwrap_or(false),
+            "in-memory user index must be repaired"
+        );
         let entries = store.export_scope_entries(ctx.scope())?;
         assert_eq!(
             entries.len(),

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -1635,9 +1635,35 @@ impl SecretsStore {
         out
     }
 
-    /// Enumerate every `(DelegateKey, secret_hash)` for `scope` by walking the
-    /// on-disk `secrets_dir` (the shared source of truth) instead of this
-    /// store's per-instance in-memory index.
+    /// Count the secrets under `scope` on disk, STOPPING as soon as the count
+    /// reaches `stop_at`. Used for the export count-cap pre-check so an
+    /// over-limit (attacker-controlled) scope is rejected without materializing
+    /// — or even fully traversing past `stop_at` — its entries. Same disk walk /
+    /// filter as the gather, and the same fail-loud I/O semantics.
+    fn count_scope_secrets_on_disk(
+        &self,
+        scope: &SecretScope<'_>,
+        stop_at: usize,
+    ) -> Result<usize, SecretStoreError> {
+        let mut count = 0usize;
+        self.walk_scope_secrets_on_disk(scope, |_delegate, _secret_hash| {
+            count += 1;
+            if count >= stop_at {
+                std::ops::ControlFlow::Break(())
+            } else {
+                std::ops::ControlFlow::Continue(())
+            }
+        })?;
+        Ok(count)
+    }
+
+    /// Shared on-disk scope walk: invoke `visit` once per secret blob under
+    /// `scope` by walking the on-disk `secrets_dir` (the shared source of truth)
+    /// instead of this store's per-instance in-memory index. `visit` returns
+    /// [`ControlFlow::Break`](std::ops::ControlFlow) to stop early. The gather
+    /// ([`Self::export_scope_entries_bounded`]) and the count
+    /// ([`Self::count_scope_secrets_on_disk`]) both stream through this one
+    /// walker, so they can never diverge in filter / scope / error handling.
     ///
     /// WHY (the cross-executor correctness fix): each pooled `Executor` owns its
     /// OWN `SecretsStore` with its own in-memory index, but ALL of them write to
@@ -1665,12 +1691,13 @@ impl SecretsStore {
     /// skipped explicitly as belt-and-suspenders.
     ///
     /// The reconstructed `DelegateKey` carries the real 32-byte key (the
-    /// directory name) and a ZERO `code_hash` placeholder. `code_hash` is never
-    /// consulted by [`Self::scope_dir`], [`Self::derive_user_dek`],
-    /// [`Self::cipher_for_read`], or `read_secret_by_hash` (all key only via
-    /// `delegate.encode()`), so the placeholder reads and decrypts the secret
-    /// identically; it only ends up as a (functionally inert) 32-byte value in
-    /// the exported bundle's `code_hash` field.
+    /// directory name) and the real `code_hash` recovered from the in-memory
+    /// index when known (see [`Self::index_code_hashes_by_key`]), or a ZERO
+    /// placeholder otherwise. `code_hash` is never consulted by
+    /// [`Self::scope_dir`], [`Self::derive_user_dek`], [`Self::cipher_for_read`],
+    /// or `read_secret_by_hash` (all key-only via `delegate.encode()`), so the
+    /// placeholder reads and decrypts the secret identically; it only ends up as
+    /// a (functionally inert) 32-byte value in the exported bundle's `code_hash`.
     ///
     /// FAIL-LOUD: an UNEXPECTED I/O error (permission denied, EIO, a vanished
     /// mount — anything other than `NotFound`) is PROPAGATED, not swallowed.
@@ -1679,46 +1706,6 @@ impl SecretsStore {
     /// removes, via a different door. `NotFound` is the one expected-absent case
     /// (base_path or a user-scope dir simply doesn't exist ⇒ that scope has no
     /// secrets) and is treated as empty/skip.
-    fn enumerate_scope_on_disk(
-        &self,
-        scope: &SecretScope<'_>,
-    ) -> Result<Vec<(DelegateKey, SecretKey)>, SecretStoreError> {
-        let mut out = Vec::new();
-        self.walk_scope_secrets_on_disk(scope, |delegate, secret_hash| {
-            out.push((delegate, secret_hash));
-            std::ops::ControlFlow::Continue(())
-        })?;
-        Ok(out)
-    }
-
-    /// Count the secrets under `scope` on disk, STOPPING as soon as the count
-    /// reaches `stop_at`. Used for the export count-cap pre-check so an
-    /// over-limit (attacker-controlled) scope is rejected without materializing
-    /// — or even fully traversing past `stop_at` — its entries. Same disk walk /
-    /// filter as the gather, and the same fail-loud I/O semantics.
-    fn count_scope_secrets_on_disk(
-        &self,
-        scope: &SecretScope<'_>,
-        stop_at: usize,
-    ) -> Result<usize, SecretStoreError> {
-        let mut count = 0usize;
-        self.walk_scope_secrets_on_disk(scope, |_delegate, _secret_hash| {
-            count += 1;
-            if count >= stop_at {
-                std::ops::ControlFlow::Break(())
-            } else {
-                std::ops::ControlFlow::Continue(())
-            }
-        })?;
-        Ok(count)
-    }
-
-    /// Shared on-disk scope walk: invoke `visit` once per secret blob under
-    /// `scope`, recovering the real `code_hash` for known delegates (see
-    /// [`Self::index_code_hashes_by_key`]). `visit` returns
-    /// [`ControlFlow::Break`](std::ops::ControlFlow) to stop early (the count
-    /// cap uses this). Returns `Err` on any unexpected I/O error (fail-loud);
-    /// `NotFound` is treated as empty/skip.
     fn walk_scope_secrets_on_disk(
         &self,
         scope: &SecretScope<'_>,
@@ -1856,7 +1843,7 @@ impl SecretsStore {
     /// instant it has seen `max_count + 1` matching entries, so an over-limit
     /// scope is rejected without a full traversal/allocation. Counts from disk
     /// (the shared source of truth) for the same cross-executor-consistency
-    /// reason as [`Self::enumerate_scope_on_disk`], using the same walk/filter,
+    /// reason as [`Self::walk_scope_secrets_on_disk`], using the same walk/filter,
     /// so the cap is checked against the SAME set the gather will materialize.
     /// Returns `Err` on an unexpected I/O error (fail-loud, same as the gather).
     pub fn scope_count_exceeds(
@@ -1893,57 +1880,98 @@ impl SecretsStore {
         // Unbounded gather (CLI backup / tests). The hosted-export path uses
         // `export_scope_entries_bounded` so an authenticated token-holder cannot
         // make the node buffer an unbounded amount of decrypted plaintext.
-        match self.export_scope_entries_bounded(scope, usize::MAX) {
+        match self.export_scope_entries_bounded(scope, usize::MAX, usize::MAX) {
             Ok(entries) => Ok(entries),
             Err(ExportScopeError::Store(e)) => Err(e),
-            // usize::MAX cap is never exceeded.
-            Err(ExportScopeError::TooLarge { .. }) => unreachable!("cap is usize::MAX"),
+            // usize::MAX caps are never exceeded.
+            Err(ExportScopeError::TooLarge { .. } | ExportScopeError::CountTooLarge { .. }) => {
+                unreachable!("count/byte caps are usize::MAX")
+            }
         }
     }
 
     /// Like [`Self::export_scope_entries`] but ABORTS the instant the running
-    /// plaintext total would exceed `max_total_bytes`.
+    /// secret COUNT would exceed `max_count` OR the running plaintext total
+    /// would exceed `max_total_bytes`.
     ///
-    /// The byte cap is checked INCREMENTALLY, per entry, as each plaintext is
-    /// decrypted — so an over-limit export bails after reading only enough to
-    /// cross the threshold and drops the partial buffer, rather than decrypting
-    /// and buffering the user's entire (potentially multi-GiB) scope and only
-    /// then rejecting. On overflow it returns [`ExportScopeError::TooLarge`]
-    /// carrying the running total at the bail point (`> max_total_bytes`) and
-    /// the limit. Used by the hosted-mode export DoS bound (#4381 P5).
+    /// BOTH caps are enforced INCREMENTALLY, per entry, as the scope is walked
+    /// and each plaintext decrypted:
+    /// - Count: checked BEFORE reading each entry, so an over-cap scope aborts
+    ///   without reading/decrypting past `max_count + 1` entries. This is the
+    ///   AUTHORITATIVE count enforcement: the cheap `scope_count_exceeds`
+    ///   pre-check rejects the common case before any decrypt, but the export
+    ///   runs off-loop while the contract loop keeps serving `store_secret`, so
+    ///   a concurrent writer could push a just-under-cap scope over the cap
+    ///   between the pre-check and here — enforcing it again during the gather
+    ///   closes that TOCTOU window.
+    /// - Bytes: checked after each decrypt, so an over-limit export bails after
+    ///   reading only enough to cross the threshold and drops the partial
+    ///   buffer, rather than buffering the user's entire scope first.
+    ///
+    /// On overflow returns [`ExportScopeError::CountTooLarge`] /
+    /// [`ExportScopeError::TooLarge`] carrying the running value at the bail
+    /// point (`>` the limit) and the limit. Used by the hosted-mode export DoS
+    /// bound (#4381 P5). Pass `usize::MAX` to disable either cap.
     pub fn export_scope_entries_bounded(
         &self,
         scope: SecretScope<'_>,
+        max_count: usize,
         max_total_bytes: usize,
     ) -> Result<Vec<ExportSecretEntry>, ExportScopeError> {
-        // Enumerate from DISK (the shared `secrets_dir`), NOT this store's
-        // per-instance in-memory index: under the pooled-executor model the
-        // export may run on a different executor than the one that wrote a
-        // secret, so the in-memory index can be stale and miss completed
-        // on-disk writes. The disk walk is the source of truth and includes
-        // every committed secret regardless of which executor stored it.
-        // A disk I/O failure here aborts the export (fail-loud) rather than
-        // sealing a silently-partial bundle. See `enumerate_scope_on_disk`.
-        let refs = self.enumerate_scope_on_disk(&scope)?;
-        let mut entries = Vec::with_capacity(refs.len());
+        // STREAM the shared on-disk walk (the same walk_scope_secrets_on_disk
+        // the count pre-check uses) and read+decrypt each secret in one pass —
+        // so we never materialize the full (attacker-controlled) ref list, and
+        // both caps are enforced inline. Enumerating from DISK (not this store's
+        // per-instance in-memory index) is the cross-executor correctness fix;
+        // a disk I/O failure aborts the export (fail-loud). See
+        // `walk_scope_secrets_on_disk`.
+        use std::ops::ControlFlow;
+        let mut entries: Vec<ExportSecretEntry> = Vec::new();
         let mut total_bytes: usize = 0;
-        for (delegate, secret_hash) in refs {
-            let plaintext = self.read_secret_by_hash(&delegate, &secret_hash, &scope)?;
-            // Check BEFORE pushing, so we never retain a buffer that crosses the
-            // cap. `plaintext` is dropped here (its `Zeroizing` wipes it) on the
-            // bail path.
+        let mut count: usize = 0;
+        // The visit closure can't return a Result, so it stashes a terminal
+        // outcome here and Breaks; we surface it after the walk.
+        let mut bail: Option<ExportScopeError> = None;
+        self.walk_scope_secrets_on_disk(&scope, |delegate, secret_hash| {
+            // Count cap: check BEFORE reading/decrypting this entry so an
+            // over-cap scope never decrypts more than max_count + 1 entries.
+            // This is the AUTHORITATIVE count enforcement (closes the TOCTOU
+            // window vs. the cheap pre-check, since a concurrent store_secret
+            // can push the scope over the cap after that pre-check passed).
+            count += 1;
+            if count > max_count {
+                bail = Some(ExportScopeError::CountTooLarge {
+                    actual: count,
+                    limit: max_count,
+                });
+                return ControlFlow::Break(());
+            }
+            let plaintext = match self.read_secret_by_hash(&delegate, &secret_hash, &scope) {
+                Ok(p) => p,
+                Err(e) => {
+                    bail = Some(ExportScopeError::Store(e));
+                    return ControlFlow::Break(());
+                }
+            };
+            // Byte cap: check BEFORE pushing, so we never retain a buffer that
+            // crosses the cap. `plaintext` is dropped here on the bail path.
             total_bytes = total_bytes.saturating_add(plaintext.len());
             if total_bytes > max_total_bytes {
-                return Err(ExportScopeError::TooLarge {
+                bail = Some(ExportScopeError::TooLarge {
                     actual: total_bytes,
                     limit: max_total_bytes,
                 });
+                return ControlFlow::Break(());
             }
             entries.push(ExportSecretEntry {
                 delegate_key: delegate,
                 secret_hash,
                 plaintext,
             });
+            ControlFlow::Continue(())
+        })?; // a disk I/O error during the walk itself is fail-loud.
+        if let Some(err) = bail {
+            return Err(err);
         }
         Ok(entries)
     }
@@ -2057,8 +2085,8 @@ pub struct ExportSecretEntry {
     pub plaintext: Zeroizing<Vec<u8>>,
 }
 
-/// Error from [`SecretsStore::export_scope_entries_bounded`]: either an
-/// underlying store/IO failure, or the incremental byte cap was exceeded.
+/// Error from [`SecretsStore::export_scope_entries_bounded`]: an underlying
+/// store/IO failure, or the gather hit the byte cap or the count cap.
 #[derive(Debug, thiserror::Error)]
 pub enum ExportScopeError {
     #[error(transparent)]
@@ -2068,6 +2096,13 @@ pub enum ExportScopeError {
     /// non-secret, safe to surface.
     #[error("export plaintext total {actual} exceeds limit {limit}")]
     TooLarge { actual: usize, limit: usize },
+    /// The running SECRET COUNT crossed `limit` mid-gather (a concurrent writer
+    /// pushed the scope over the cap after the cheap pre-check passed). The
+    /// gather aborts authoritatively here so the count cap can't be bypassed by
+    /// a TOCTOU race. `actual` is the count at the bail point (`> limit`).
+    /// Counts only — non-secret, safe to surface.
+    #[error("export secret count {actual} exceeds limit {limit}")]
+    CountTooLarge { actual: usize, limit: usize },
 }
 
 /// Decrypt an on-disk secret blob, transparently supporting every
@@ -5462,7 +5497,7 @@ mod test {
             "pre-condition: the in-memory index entry was dropped (crash window)"
         );
         // Since the export now enumerates from DISK (the shared source of truth,
-        // for cross-executor consistency — see `enumerate_scope_on_disk`), the
+        // for cross-executor consistency — see `walk_scope_secrets_on_disk`), the
         // completed on-disk secret IS already visible to export even before the
         // index is repaired. This is the intended improvement: a backup includes
         // every completed write regardless of in-memory index state. (It was

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -29,8 +29,8 @@ use crate::contract::storages::Storage;
 
 use super::RuntimeResult;
 use super::secret_snapshots::{
-    RestoreError, RetentionPolicy, SnapshotMetadata, list_snapshots, restore_snapshot_file,
-    snapshot_active_value, snapshot_dir_for, thin_snapshots,
+    RestoreError, RetentionPolicy, SNAPSHOTS_DIR, SnapshotMetadata, list_snapshots,
+    restore_snapshot_file, snapshot_active_value, snapshot_dir_for, thin_snapshots,
 };
 
 /// Environment variable that disables snapshot-on-write for delegate secrets.
@@ -460,6 +460,24 @@ pub(super) fn ensure_owner_only_dir(_path: &Path) -> std::io::Result<()> {
 /// unchanged. `base` itself is never touched here (it is tightened once in
 /// [`SecretsStore::new`]). Best-effort by contract of its callers: they log
 /// and continue on a chmod error rather than failing the primary write.
+/// Decode a base58 (BITCOIN alphabet) name into exactly 32 bytes, or `None` if
+/// it isn't a valid 32-byte bs58 string. Used by the on-disk export enumeration
+/// to recognize delegate-dir names and secret-blob filenames (both are
+/// `bs58(<32-byte hash>)`) while rejecting every non-secret entry (`.keys`,
+/// `*.tmp`, `node_kek`, `kek_backend`, ...), none of which decode to 32 bytes.
+fn decode_bs58_32(name: &str) -> Option<[u8; 32]> {
+    let mut out = [0u8; 32];
+    match bs58::decode(name)
+        .with_alphabet(bs58::Alphabet::BITCOIN)
+        .onto(&mut out)
+    {
+        // `onto` fills `out` and returns the number of bytes written; require
+        // EXACTLY 32 so a shorter/longer bs58 string is rejected.
+        Ok(32) => Some(out),
+        _ => None,
+    }
+}
+
 fn ensure_owner_only_tree(base: &Path, full: &Path) -> std::io::Result<()> {
     // The relative path from base to full names exactly the segments we
     // must tighten. If `full` is not under `base` (should never happen —
@@ -1587,33 +1605,90 @@ impl SecretsStore {
     // from the delegate's wasm+params), so a re-installed webapp shipping the
     // same delegate yields the same key and the imported secrets line up.
 
-    /// Enumerate every `(DelegateKey, secret_hash)` held for `scope`.
+    /// Enumerate every `(DelegateKey, secret_hash)` for `scope` by walking the
+    /// on-disk `secrets_dir` (the shared source of truth) instead of this
+    /// store's per-instance in-memory index.
     ///
-    /// Reads from the in-memory index maps (kept in lock-step with ReDb), so
-    /// it reflects exactly what `get_secret` could read. For `User` scope only
-    /// the `id` field of the scope is consulted (the `dek_secret` is unused
-    /// here — enumeration is a metadata walk, not a decrypt).
-    fn enumerate_scope(&self, scope: &SecretScope<'_>) -> Vec<(DelegateKey, SecretKey)> {
+    /// WHY (the cross-executor correctness fix): each pooled `Executor` owns its
+    /// OWN `SecretsStore` with its own in-memory index, but ALL of them write to
+    /// the SAME `secrets_dir`. A `store_secret` on executor A updates only A's
+    /// index; an export running on executor B would miss A's just-written secret
+    /// if it enumerated B's in-memory index — a silently incomplete backup once
+    /// the export runs off-loop concurrently with normal ops. Walking the disk
+    /// includes EVERY committed write regardless of which executor made it.
+    ///
+    /// Consistency: `store_secret`/`import_secret_by_hash` write each secret blob
+    /// via tmp-file + fsync + atomic `rename` into place, so a concurrent walk
+    /// only ever sees a fully-written active file (a torn read is impossible at
+    /// the active path; even so, a bad blob fails AEAD on read → a clean export
+    /// error, never silent corruption).
+    ///
+    /// On-disk layout (see [`Self::scope_dir`]):
+    /// - `Local` => `base_path/<delegate>/<bs58(secret_hash)>`
+    /// - `User`  => `base_path/<delegate>/users/<user_id>/<bs58(secret_hash)>`
+    ///
+    /// A "secret blob" is a REGULAR FILE whose name bs58-decodes to exactly 32
+    /// bytes. That positive filter inherently rejects every non-secret entry
+    /// (`.keys`, `.keys.tmp`, `<hash>.tmp`, `node_kek`, `kek_backend*` — none
+    /// bs58-decode to 32 bytes) and every directory (`.snapshots/`, `users/`,
+    /// and the delegate dirs themselves); the known non-secret names are also
+    /// skipped explicitly as belt-and-suspenders.
+    ///
+    /// The reconstructed `DelegateKey` carries the real 32-byte key (the
+    /// directory name) and a ZERO `code_hash` placeholder. `code_hash` is never
+    /// consulted by [`Self::scope_dir`], [`Self::derive_user_dek`],
+    /// [`Self::cipher_for_read`], or `read_secret_by_hash` (all key only via
+    /// `delegate.encode()`), so the placeholder reads and decrypts the secret
+    /// identically; it only ends up as a (functionally inert) 32-byte value in
+    /// the exported bundle's `code_hash` field.
+    fn enumerate_scope_on_disk(&self, scope: &SecretScope<'_>) -> Vec<(DelegateKey, SecretKey)> {
         let mut out = Vec::new();
-        match scope {
-            SecretScope::Local => {
-                for entry in self.key_to_secret_part.iter() {
-                    let delegate = entry.key().clone();
-                    for hash in entry.value() {
-                        out.push((delegate.clone(), *hash));
-                    }
-                }
+        // Iterate the delegate directories under base_path. Each is named
+        // `bs58(delegate_key)`; non-directory / non-bs58 root entries
+        // (`node_kek`, `kek_backend`, `kek_backend.tmp`) are skipped by the
+        // 32-byte-bs58 decode below.
+        let Ok(delegate_dirs) = fs::read_dir(&self.base_path) else {
+            // base_path missing/unreadable ⇒ no secrets to export.
+            return out;
+        };
+        for delegate_entry in delegate_dirs.flatten() {
+            let delegate_path = delegate_entry.path();
+            if !delegate_path.is_dir() {
+                continue;
             }
-            SecretScope::User { id, .. } => {
-                for entry in self.user_key_to_secret_part.iter() {
-                    let (delegate, user) = entry.key();
-                    if user != *id {
-                        continue;
-                    }
-                    for hash in entry.value() {
-                        out.push((delegate.clone(), *hash));
-                    }
+            let Some(delegate_name) = delegate_entry.file_name().to_str().map(str::to_owned) else {
+                continue;
+            };
+            let Some(delegate_key_bytes) = decode_bs58_32(&delegate_name) else {
+                continue; // not a delegate dir (e.g. a stray non-bs58 name)
+            };
+            // code_hash is inert for path/DEK/read; use a zero placeholder.
+            let delegate = DelegateKey::new(delegate_key_bytes, CodeHash::from(&[0u8; 32]));
+
+            // The directory that actually holds this scope's secret files.
+            let scope_path = match scope {
+                SecretScope::Local => delegate_path.clone(),
+                SecretScope::User { id, .. } => delegate_path.join("users").join(id.encode()),
+            };
+            let Ok(files) = fs::read_dir(&scope_path) else {
+                continue; // this delegate has no secrets for this scope
+            };
+            for file_entry in files.flatten() {
+                // Only regular files whose name bs58-decodes to a 32-byte hash.
+                let name = file_entry.file_name();
+                let Some(name) = name.to_str() else { continue };
+                if name == KEY_REGISTRY_FILE || name == SNAPSHOTS_DIR || name.ends_with(".tmp") {
+                    continue;
                 }
+                let Some(secret_hash) = decode_bs58_32(name) else {
+                    continue;
+                };
+                // Confirm it is a regular file (not a dir like `users/`).
+                match file_entry.file_type() {
+                    Ok(ft) if ft.is_file() => {}
+                    _ => continue,
+                }
+                out.push((delegate.clone(), secret_hash));
             }
         }
         out
@@ -1665,11 +1740,14 @@ impl SecretsStore {
 
     /// Number of secrets currently held under `scope`.
     ///
-    /// A cheap metadata walk of the in-memory index (no decrypt, no disk read),
-    /// used by [`super::secret_export::export_bundle`] to enforce the export
-    /// count cap BEFORE any secret is read/decrypted.
+    /// A metadata-only DISK walk (no decrypt), used by
+    /// [`super::secret_export::export_bundle`] to enforce the export count cap
+    /// BEFORE any secret is read/decrypted. Counts from disk (the shared source
+    /// of truth) for the same cross-executor-consistency reason as
+    /// [`Self::enumerate_scope_on_disk`] — so the cap is checked against the
+    /// SAME set the export will actually gather.
     pub fn scope_entry_count(&self, scope: &SecretScope<'_>) -> usize {
-        self.enumerate_scope(scope).len()
+        self.enumerate_scope_on_disk(scope).len()
     }
 
     /// Gather every secret under `scope`, decrypted, as portable export
@@ -1711,7 +1789,14 @@ impl SecretsStore {
         scope: SecretScope<'_>,
         max_total_bytes: usize,
     ) -> Result<Vec<ExportSecretEntry>, ExportScopeError> {
-        let refs = self.enumerate_scope(&scope);
+        // Enumerate from DISK (the shared `secrets_dir`), NOT this store's
+        // per-instance in-memory index: under the pooled-executor model the
+        // export may run on a different executor than the one that wrote a
+        // secret, so the in-memory index can be stale and miss completed
+        // on-disk writes. The disk walk is the source of truth and includes
+        // every committed secret regardless of which executor stored it.
+        // See `enumerate_scope_on_disk`.
+        let refs = self.enumerate_scope_on_disk(&scope);
         let mut entries = Vec::with_capacity(refs.len());
         let mut total_bytes: usize = 0;
         for (delegate, secret_hash) in refs {

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -1685,10 +1685,47 @@ impl SecretsStore {
         &self,
         scope: SecretScope<'_>,
     ) -> Result<Vec<ExportSecretEntry>, SecretStoreError> {
+        // Unbounded gather (CLI backup / tests). The hosted-export path uses
+        // `export_scope_entries_bounded` so an authenticated token-holder cannot
+        // make the node buffer an unbounded amount of decrypted plaintext.
+        match self.export_scope_entries_bounded(scope, usize::MAX) {
+            Ok(entries) => Ok(entries),
+            Err(ExportScopeError::Store(e)) => Err(e),
+            // usize::MAX cap is never exceeded.
+            Err(ExportScopeError::TooLarge { .. }) => unreachable!("cap is usize::MAX"),
+        }
+    }
+
+    /// Like [`Self::export_scope_entries`] but ABORTS the instant the running
+    /// plaintext total would exceed `max_total_bytes`.
+    ///
+    /// The byte cap is checked INCREMENTALLY, per entry, as each plaintext is
+    /// decrypted — so an over-limit export bails after reading only enough to
+    /// cross the threshold and drops the partial buffer, rather than decrypting
+    /// and buffering the user's entire (potentially multi-GiB) scope and only
+    /// then rejecting. On overflow it returns [`ExportScopeError::TooLarge`]
+    /// carrying the running total at the bail point (`> max_total_bytes`) and
+    /// the limit. Used by the hosted-mode export DoS bound (#4381 P5).
+    pub fn export_scope_entries_bounded(
+        &self,
+        scope: SecretScope<'_>,
+        max_total_bytes: usize,
+    ) -> Result<Vec<ExportSecretEntry>, ExportScopeError> {
         let refs = self.enumerate_scope(&scope);
         let mut entries = Vec::with_capacity(refs.len());
+        let mut total_bytes: usize = 0;
         for (delegate, secret_hash) in refs {
             let plaintext = self.read_secret_by_hash(&delegate, &secret_hash, &scope)?;
+            // Check BEFORE pushing, so we never retain a buffer that crosses the
+            // cap. `plaintext` is dropped here (its `Zeroizing` wipes it) on the
+            // bail path.
+            total_bytes = total_bytes.saturating_add(plaintext.len());
+            if total_bytes > max_total_bytes {
+                return Err(ExportScopeError::TooLarge {
+                    actual: total_bytes,
+                    limit: max_total_bytes,
+                });
+            }
             entries.push(ExportSecretEntry {
                 delegate_key: delegate,
                 secret_hash,
@@ -1805,6 +1842,19 @@ pub struct ExportSecretEntry {
     pub delegate_key: DelegateKey,
     pub secret_hash: [u8; 32],
     pub plaintext: Zeroizing<Vec<u8>>,
+}
+
+/// Error from [`SecretsStore::export_scope_entries_bounded`]: either an
+/// underlying store/IO failure, or the incremental byte cap was exceeded.
+#[derive(Debug, thiserror::Error)]
+pub enum ExportScopeError {
+    #[error(transparent)]
+    Store(#[from] SecretStoreError),
+    /// The running decrypted-plaintext total crossed `limit` (the gather
+    /// aborted at `actual`, having dropped the partial buffer). Sizes only —
+    /// non-secret, safe to surface.
+    #[error("export plaintext total {actual} exceeds limit {limit}")]
+    TooLarge { actual: usize, limit: usize },
 }
 
 /// Decrypt an on-disk secret blob, transparently supporting every

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -1671,15 +1671,69 @@ impl SecretsStore {
     /// `delegate.encode()`), so the placeholder reads and decrypts the secret
     /// identically; it only ends up as a (functionally inert) 32-byte value in
     /// the exported bundle's `code_hash` field.
-    fn enumerate_scope_on_disk(&self, scope: &SecretScope<'_>) -> Vec<(DelegateKey, SecretKey)> {
+    ///
+    /// FAIL-LOUD: an UNEXPECTED I/O error (permission denied, EIO, a vanished
+    /// mount — anything other than `NotFound`) is PROPAGATED, not swallowed.
+    /// Swallowing it would let the export seal a SUCCESSFUL but silently
+    /// INCOMPLETE bundle — the same silent-incompleteness class this whole fix
+    /// removes, via a different door. `NotFound` is the one expected-absent case
+    /// (base_path or a user-scope dir simply doesn't exist ⇒ that scope has no
+    /// secrets) and is treated as empty/skip.
+    fn enumerate_scope_on_disk(
+        &self,
+        scope: &SecretScope<'_>,
+    ) -> Result<Vec<(DelegateKey, SecretKey)>, SecretStoreError> {
         let mut out = Vec::new();
+        self.walk_scope_secrets_on_disk(scope, |delegate, secret_hash| {
+            out.push((delegate, secret_hash));
+            std::ops::ControlFlow::Continue(())
+        })?;
+        Ok(out)
+    }
+
+    /// Count the secrets under `scope` on disk, STOPPING as soon as the count
+    /// reaches `stop_at`. Used for the export count-cap pre-check so an
+    /// over-limit (attacker-controlled) scope is rejected without materializing
+    /// — or even fully traversing past `stop_at` — its entries. Same disk walk /
+    /// filter as the gather, and the same fail-loud I/O semantics.
+    fn count_scope_secrets_on_disk(
+        &self,
+        scope: &SecretScope<'_>,
+        stop_at: usize,
+    ) -> Result<usize, SecretStoreError> {
+        let mut count = 0usize;
+        self.walk_scope_secrets_on_disk(scope, |_delegate, _secret_hash| {
+            count += 1;
+            if count >= stop_at {
+                std::ops::ControlFlow::Break(())
+            } else {
+                std::ops::ControlFlow::Continue(())
+            }
+        })?;
+        Ok(count)
+    }
+
+    /// Shared on-disk scope walk: invoke `visit` once per secret blob under
+    /// `scope`, recovering the real `code_hash` for known delegates (see
+    /// [`Self::index_code_hashes_by_key`]). `visit` returns
+    /// [`ControlFlow::Break`](std::ops::ControlFlow) to stop early (the count
+    /// cap uses this). Returns `Err` on any unexpected I/O error (fail-loud);
+    /// `NotFound` is treated as empty/skip.
+    fn walk_scope_secrets_on_disk(
+        &self,
+        scope: &SecretScope<'_>,
+        mut visit: impl FnMut(DelegateKey, SecretKey) -> std::ops::ControlFlow<()>,
+    ) -> Result<(), SecretStoreError> {
+        use std::ops::ControlFlow;
         // Iterate the delegate directories under base_path. Each is named
         // `bs58(delegate_key)`; non-directory / non-bs58 root entries
         // (`node_kek`, `kek_backend`, `kek_backend.tmp`) are skipped by the
-        // 32-byte-bs58 decode below.
-        let Ok(delegate_dirs) = fs::read_dir(&self.base_path) else {
-            // base_path missing/unreadable ⇒ no secrets to export.
-            return out;
+        // 32-byte-bs58 decode below. A missing base_path ⇒ no secrets; any other
+        // read error is unexpected ⇒ fail loud.
+        let delegate_dirs = match fs::read_dir(&self.base_path) {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(SecretStoreError::IO(e)),
         };
         // Recover each delegate's real `code_hash` from the in-memory index when
         // this executor knows it. The on-disk delegate dir name encodes only the
@@ -1694,7 +1748,9 @@ impl SecretsStore {
         // registered the delegate, so the real code_hash is recovered in
         // practice.
         let code_hashes = self.index_code_hashes_by_key(scope);
-        for delegate_entry in delegate_dirs.flatten() {
+        for delegate_entry in delegate_dirs {
+            // A per-entry read error mid-iteration is unexpected ⇒ fail loud.
+            let delegate_entry = delegate_entry.map_err(SecretStoreError::IO)?;
             let delegate_path = delegate_entry.path();
             if !delegate_path.is_dir() {
                 continue;
@@ -1716,10 +1772,15 @@ impl SecretsStore {
                 SecretScope::Local => delegate_path.clone(),
                 SecretScope::User { id, .. } => delegate_path.join("users").join(id.encode()),
             };
-            let Ok(files) = fs::read_dir(&scope_path) else {
-                continue; // this delegate has no secrets for this scope
+            // A missing scope dir ⇒ this delegate has no secrets for this scope
+            // (expected). Any other read error is unexpected ⇒ fail loud.
+            let files = match fs::read_dir(&scope_path) {
+                Ok(rd) => rd,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(SecretStoreError::IO(e)),
             };
-            for file_entry in files.flatten() {
+            for file_entry in files {
+                let file_entry = file_entry.map_err(SecretStoreError::IO)?;
                 // Only regular files whose name bs58-decodes to a 32-byte hash.
                 let name = file_entry.file_name();
                 let Some(name) = name.to_str() else { continue };
@@ -1734,10 +1795,12 @@ impl SecretsStore {
                     Ok(ft) if ft.is_file() => {}
                     _ => continue,
                 }
-                out.push((delegate.clone(), secret_hash));
+                if let ControlFlow::Break(()) = visit(delegate.clone(), secret_hash) {
+                    return Ok(());
+                }
             }
         }
-        out
+        Ok(())
     }
 
     /// Read + decrypt the active secret blob named `bs58(secret_hash)` under
@@ -1784,16 +1847,34 @@ impl SecretsStore {
         }
     }
 
-    /// Number of secrets currently held under `scope`.
+    /// `true` if `scope` holds MORE than `max_count` secrets on disk, decided
+    /// WITHOUT enumerating beyond `max_count + 1` entries.
     ///
-    /// A metadata-only DISK walk (no decrypt), used by
-    /// [`super::secret_export::export_bundle`] to enforce the export count cap
-    /// BEFORE any secret is read/decrypted. Counts from disk (the shared source
-    /// of truth) for the same cross-executor-consistency reason as
-    /// [`Self::enumerate_scope_on_disk`] — so the cap is checked against the
-    /// SAME set the export will actually gather.
-    pub fn scope_entry_count(&self, scope: &SecretScope<'_>) -> usize {
-        self.enumerate_scope_on_disk(scope).len()
+    /// Used by [`super::secret_export::export_bundle`] to enforce the export
+    /// count cap BEFORE any secret is read/decrypted AND before materializing
+    /// the (attacker-controlled) entry list: the streaming count stops the
+    /// instant it has seen `max_count + 1` matching entries, so an over-limit
+    /// scope is rejected without a full traversal/allocation. Counts from disk
+    /// (the shared source of truth) for the same cross-executor-consistency
+    /// reason as [`Self::enumerate_scope_on_disk`], using the same walk/filter,
+    /// so the cap is checked against the SAME set the gather will materialize.
+    /// Returns `Err` on an unexpected I/O error (fail-loud, same as the gather).
+    pub fn scope_count_exceeds(
+        &self,
+        scope: &SecretScope<'_>,
+        max_count: usize,
+    ) -> Result<bool, SecretStoreError> {
+        // Stop after seeing max_count + 1 — enough to know we're over the cap.
+        let stop_at = max_count.saturating_add(1);
+        Ok(self.count_scope_secrets_on_disk(scope, stop_at)? > max_count)
+    }
+
+    /// Number of secrets currently held under `scope` on disk (full count, no
+    /// decrypt). Used by tests / callers that need the exact count; the export
+    /// count cap uses the streaming [`Self::scope_count_exceeds`] instead so an
+    /// over-limit scope is never fully traversed.
+    pub fn scope_entry_count(&self, scope: &SecretScope<'_>) -> Result<usize, SecretStoreError> {
+        self.count_scope_secrets_on_disk(scope, usize::MAX)
     }
 
     /// Gather every secret under `scope`, decrypted, as portable export
@@ -1841,8 +1922,9 @@ impl SecretsStore {
         // secret, so the in-memory index can be stale and miss completed
         // on-disk writes. The disk walk is the source of truth and includes
         // every committed secret regardless of which executor stored it.
-        // See `enumerate_scope_on_disk`.
-        let refs = self.enumerate_scope_on_disk(&scope);
+        // A disk I/O failure here aborts the export (fail-loud) rather than
+        // sealing a silently-partial bundle. See `enumerate_scope_on_disk`.
+        let refs = self.enumerate_scope_on_disk(&scope)?;
         let mut entries = Vec::with_capacity(refs.len());
         let mut total_bytes: usize = 0;
         for (delegate, secret_hash) in refs {

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -1663,6 +1663,15 @@ impl SecretsStore {
         }
     }
 
+    /// Number of secrets currently held under `scope`.
+    ///
+    /// A cheap metadata walk of the in-memory index (no decrypt, no disk read),
+    /// used by [`super::secret_export::export_bundle`] to enforce the export
+    /// count cap BEFORE any secret is read/decrypted.
+    pub fn scope_entry_count(&self, scope: &SecretScope<'_>) -> usize {
+        self.enumerate_scope(scope).len()
+    }
+
     /// Gather every secret under `scope`, decrypted, as portable export
     /// entries. The returned plaintexts live in `Zeroizing` buffers so they
     /// are wiped when the caller drops them.

--- a/crates/core/tests/hosted_mode_export.rs
+++ b/crates/core/tests/hosted_mode_export.rs
@@ -409,6 +409,84 @@ async fn hosted_export_secure_round_trip() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// DEFER (#4531 / #4381 P5): an in-flight export must NOT block the contract
+/// loop. We store several secrets (so the export does real enumerate+decrypt+
+/// seal work), then fire the HTTP export CONCURRENTLY with a WS delegate
+/// store-secret op that goes through the SAME contract loop, and require BOTH to
+/// complete. With the previous inline design the export ran ON the loop, so the
+/// concurrent delegate op could not even start until the export finished; with
+/// the deferral the loop stays free and both make progress together. Generous
+/// timeouts (this asserts non-blocking liveness + correctness, not tight
+/// timing — the strict "arm defers off-loop" guarantee is pinned by the
+/// source-scrape unit tests `export_dispatch_arm_defers_off_loop` /
+/// `export_job_run_offloads_blocking_work`).
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn export_does_not_block_concurrent_contract_ops() -> anyhow::Result<()> {
+    let node = TestNode::start(/* hosted_mode */ true).await?;
+    let port = node.ws_port;
+
+    let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
+    let delegate_key = delegate.key().clone();
+
+    const TOKEN: &str = "user-token-for-defer-bbbbbbbbbbbbbbbb";
+
+    let mut conn = connect_hosted(port, Some(TOKEN), true).await?;
+    register_delegate(&mut conn, &delegate, &delegate_key).await?;
+    // Store enough secrets that the export has real work to do.
+    for i in 0..64u32 {
+        let key = format!("defer-secret-{i}");
+        let value = vec![b'v'; 256];
+        store_secret(&mut conn, &delegate_key, key.as_bytes(), &value).await?;
+    }
+
+    // Open a SECOND connection for the concurrent op so it doesn't serialize
+    // behind the first connection's WS request/response framing.
+    let mut conn2 = connect_hosted(port, Some(TOKEN), true).await?;
+    register_delegate(&mut conn2, &delegate, &delegate_key).await?;
+
+    // Fire the export and a concurrent delegate store-secret op at the same
+    // time. Both route through the single contract-handling loop; both must
+    // complete. The concurrent op must NOT be starved for the export's duration.
+    let export_fut = http_export(port, Some(TOKEN), true);
+    let concurrent_op_fut = store_secret(
+        &mut conn2,
+        &delegate_key,
+        b"stored-while-export-runs",
+        b"concurrent-value",
+    );
+
+    let (export_resp, concurrent_op) = tokio::join!(
+        async { timeout(Duration::from_secs(30), export_fut).await },
+        async { timeout(Duration::from_secs(30), concurrent_op_fut).await },
+    );
+
+    // The concurrent contract op completed (was not blocked behind the export).
+    concurrent_op
+        .expect("a contract op concurrent with an export must not be starved (#4531)")
+        .expect("the concurrent store-secret op must succeed");
+
+    // The export also completed and returned a valid bundle.
+    let export_resp = export_resp
+        .expect("export must complete")
+        .expect("export HTTP request must not error");
+    assert_eq!(
+        export_resp.status(),
+        reqwest::StatusCode::OK,
+        "export must be 200 OK"
+    );
+    let bundle = export_resp.bytes().await?.to_vec();
+    assert_eq!(
+        &bundle[0..4],
+        b"FNSX",
+        "export must return a valid FNSX bundle"
+    );
+
+    drop(conn);
+    drop(conn2);
+    node.shutdown().await;
+    Ok(())
+}
+
 /// A wrong token cannot decrypt a bundle exported under the real token —
 /// confirms the bundle key is genuinely the user's token (not a fixed key).
 #[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]

--- a/crates/core/tests/hosted_mode_export.rs
+++ b/crates/core/tests/hosted_mode_export.rs
@@ -335,8 +335,12 @@ async fn import_into_fresh_store(
 /// Headline: a secure export (hosted on + loopback + XFP:https + a valid token
 /// that has stored secrets) returns a non-empty FNSX bundle that round-trips
 /// via `import_bundle` back to the original secret.
+#[serial_test::serial]
 #[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
 async fn hosted_export_secure_round_trip() -> anyhow::Result<()> {
+    // Pin a multi-executor pool so the export is admitted regardless of the CI
+    // runner's core count (a 1-core runner's default pool of 1 disables exports).
+    let _pool = PoolSizeEnv::set(4);
     let node = TestNode::start(/* hosted_mode */ true).await?;
     let port = node.ws_port;
 
@@ -420,8 +424,13 @@ async fn hosted_export_secure_round_trip() -> anyhow::Result<()> {
 /// timing — the strict "arm defers off-loop" guarantee is pinned by the
 /// source-scrape unit tests `export_dispatch_arm_defers_off_loop` /
 /// `export_job_run_offloads_blocking_work`).
+#[serial_test::serial]
 #[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
 async fn export_does_not_block_concurrent_contract_ops() -> anyhow::Result<()> {
+    // Pin a multi-executor pool so the export is admitted (200) deterministically
+    // regardless of the CI runner's core count — on a 1-core runner the default
+    // pool would be 1, which disables exports (covered separately).
+    let _pool = PoolSizeEnv::set(4);
     let node = TestNode::start(/* hosted_mode */ true).await?;
     let port = node.ws_port;
 
@@ -489,8 +498,12 @@ async fn export_does_not_block_concurrent_contract_ops() -> anyhow::Result<()> {
 
 /// A wrong token cannot decrypt a bundle exported under the real token —
 /// confirms the bundle key is genuinely the user's token (not a fixed key).
+#[serial_test::serial]
 #[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
 async fn hosted_export_bundle_rejects_wrong_token() -> anyhow::Result<()> {
+    // Pin a multi-executor pool so the export is admitted (this test needs a real
+    // bundle to then prove a wrong token can't decrypt it).
+    let _pool = PoolSizeEnv::set(4);
     let node = TestNode::start(true).await?;
     let port = node.ws_port;
 
@@ -525,6 +538,7 @@ async fn hosted_export_bundle_rejects_wrong_token() -> anyhow::Result<()> {
 }
 
 /// Insecure variants on a hosted node: every one must 403 and return NO bundle.
+#[serial_test::serial]
 #[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
 async fn hosted_export_rejects_insecure_requests() -> anyhow::Result<()> {
     let node = TestNode::start(/* hosted_mode */ true).await?;
@@ -572,6 +586,7 @@ async fn hosted_export_rejects_insecure_requests() -> anyhow::Result<()> {
 
 /// Flag gate: with `hosted_mode = false`, a token + XFP export is still 403 —
 /// the whole feature is inert unless the flag is on (no user namespaces exist).
+#[serial_test::serial]
 #[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
 async fn hosted_export_flag_off_rejects() -> anyhow::Result<()> {
     let node = TestNode::start(/* hosted_mode */ false).await?;
@@ -590,6 +605,135 @@ async fn hosted_export_flag_off_rejects() -> anyhow::Result<()> {
         "must not return a bundle"
     );
 
+    node.shutdown().await;
+    Ok(())
+}
+
+/// RAII guard that sets `FREENET_RUNTIME_POOL_SIZE` for the duration of a
+/// (serialized) test and restores it on drop, so a specific pool size can be
+/// forced when the node builds its `RuntimePool`. Safe only because these tests
+/// are `#[serial]` — no other node start overlaps the env-var window.
+struct PoolSizeEnv;
+impl PoolSizeEnv {
+    fn set(n: usize) -> Self {
+        // SAFETY: serialized tests; no concurrent node start reads this var.
+        unsafe { std::env::set_var("FREENET_RUNTIME_POOL_SIZE", n.to_string()) };
+        Self
+    }
+}
+impl Drop for PoolSizeEnv {
+    fn drop(&mut self) {
+        unsafe { std::env::remove_var("FREENET_RUNTIME_POOL_SIZE") };
+    }
+}
+
+/// DEADLOCK REGRESSION (#4531, #4563 re-review): on a 2-executor pool, an export
+/// in flight must NOT wedge the contract loop. The effective export-concurrency
+/// cap is `min(MAX_CONCURRENT_EXPORTS, pool_size-1) == 1`, so an admitted export
+/// holds exactly ONE of the two executors; the loop keeps the other free for
+/// normal ops. We fire an HTTP export and a concurrent WS delegate op together
+/// and require BOTH to complete — the previous design (blocking executor
+/// checkout on the loop, no pool-size clamp) could deadlock here. Exercises the
+/// real node loop + pool, not a mock.
+#[serial_test::serial]
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn export_on_small_pool_does_not_deadlock_the_loop() -> anyhow::Result<()> {
+    let _pool = PoolSizeEnv::set(2);
+    let node = TestNode::start(/* hosted_mode */ true).await?;
+    let port = node.ws_port;
+
+    let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
+    let delegate_key = delegate.key().clone();
+    const TOKEN: &str = "user-token-small-pool-cccccccccccccccc";
+
+    let mut conn = connect_hosted(port, Some(TOKEN), true).await?;
+    register_delegate(&mut conn, &delegate, &delegate_key).await?;
+    for i in 0..32u32 {
+        store_secret(
+            &mut conn,
+            &delegate_key,
+            format!("sp-secret-{i}").as_bytes(),
+            &vec![b'v'; 256],
+        )
+        .await?;
+    }
+
+    // Second connection for the concurrent op (independent WS framing).
+    let mut conn2 = connect_hosted(port, Some(TOKEN), true).await?;
+    register_delegate(&mut conn2, &delegate, &delegate_key).await?;
+
+    // Export (holds 1 of 2 executors off-loop) + a concurrent contract op. With
+    // pool_size=2 the loop must keep the second executor free; both must finish.
+    let export_fut = http_export(port, Some(TOKEN), true);
+    let op_fut = store_secret(
+        &mut conn2,
+        &delegate_key,
+        b"sp-stored-while-export-runs",
+        b"sp-concurrent-value",
+    );
+    let (export_resp, op) = tokio::join!(
+        async { timeout(Duration::from_secs(30), export_fut).await },
+        async { timeout(Duration::from_secs(30), op_fut).await },
+    );
+
+    op.expect("concurrent op must not be wedged behind the export on a 2-pool (#4531)")
+        .expect("the concurrent store-secret op must succeed");
+    let export_resp = export_resp
+        .expect("export must complete")
+        .expect("export HTTP request must not error");
+    // On a 2-executor pool exactly one export permit exists, so this single
+    // export is admitted and succeeds (200).
+    assert_eq!(
+        export_resp.status(),
+        reqwest::StatusCode::OK,
+        "the single export on a 2-pool must be admitted and succeed"
+    );
+
+    drop(conn);
+    drop(conn2);
+    node.shutdown().await;
+    Ok(())
+}
+
+/// On a 1-executor pool the effective export concurrency is 0, so an export is
+/// DISABLED — it returns 503 (Busy) rather than running on the sole executor
+/// (which would be the inline-blocking this change removes) or deadlocking. The
+/// node must otherwise function normally. Exercises the real node loop + pool.
+#[serial_test::serial]
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn export_disabled_on_single_executor_pool() -> anyhow::Result<()> {
+    let _pool = PoolSizeEnv::set(1);
+    let node = TestNode::start(/* hosted_mode */ true).await?;
+    let port = node.ws_port;
+
+    let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
+    let delegate_key = delegate.key().clone();
+    const TOKEN: &str = "user-token-single-pool-dddddddddddddddd";
+
+    // The node still works on a 1-executor pool: store a secret normally.
+    let mut conn = connect_hosted(port, Some(TOKEN), true).await?;
+    register_delegate(&mut conn, &delegate, &delegate_key).await?;
+    store_secret(&mut conn, &delegate_key, b"sole-secret", b"sole-value").await?;
+
+    // The export is disabled (0 export permits) → 503, NOT a hang and NOT a 200.
+    let resp = timeout(
+        Duration::from_secs(30),
+        http_export(port, Some(TOKEN), true),
+    )
+    .await
+    .expect("export request must return promptly (disabled, not hung)")?;
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "export must be 503 (disabled) on a single-executor pool"
+    );
+
+    // And the node still serves normal ops afterwards (loop not wedged).
+    store_secret(&mut conn, &delegate_key, b"after-export", b"after-value")
+        .await
+        .expect("node must still serve contract ops after a rejected export");
+
+    drop(conn);
     node.shutdown().await;
     Ok(())
 }


### PR DESCRIPTION
## Problem

The hosted-mode "export my data" endpoint (`GET /v{1,2}/hosted/export`, P3-live of #4381) ran the secret export **synchronously on the single-threaded contract-handling loop**. The export enumerates AND AEAD-decrypts **every** secret in a user's scope, with no per-user cap. So an authenticated token-holder with a large secret set — or one who repeats the request — could block **all** other contract operations (GET/PUT/UPDATE/delegate) on the node for each export's duration. The documented #4531 / #4381 P5 blocker.

## Solution (reworked after the first review — see #4563 history)

The first revision offloaded the CPU to `spawn_blocking` but still **awaited it inline** on the loop, so the loop stayed parked and queued events still waited (the offload alone did **not** fix #4531). This revision fixes that and two other issues the review surfaced:

**1. DEFER off-loop (the real fix).** The `ExportUserSecrets` dispatch arm now checks out a pooled executor (`RuntimePool::try_begin_export`) and runs the export on a `GlobalExecutor::spawn` background task, **returning from the arm immediately** so the contract loop drains the next event. The task sends the executor + result back over a new unbounded export-resume channel; the loop returns/replaces the executor (`finish_export`) and answers the parked client (`StashedResponder`) — mirroring the #4391 related-fetch deferral. Concurrency is bounded by `MAX_CONCURRENT_EXPORTS` (=2, below pool size) so exports can never drain the executor pool; over the cap → typed `ExportBusy` → **HTTP 503**. An `ExportGuard` RAII guarantees exactly-once resume (and executor reclaim) even if the task is dropped/cancelled.

**2. PANIC-SAFE offload (was a node-crash bug).** `run_blocking_offloaded` now **catches** a `JoinError` panic (mirroring `compile_offloaded`) and returns `OffloadOutcome::Panicked` instead of re-raising via `.expect()`. The old `.expect()` would have propagated the panic onto the loop task → the node's top-level `select!` → **whole-node shutdown**, and leaked the executor slot. On panic the executor is gone, so `finish_export` builds a replacement to restore the pool permit; the one export fails, the node lives.

**3. INCREMENTAL byte cap (was enforced too late).** The 256 MiB plaintext cap is now enforced **inside** the decrypt loop (`SecretsStore::export_scope_entries_bounded`), aborting the instant the running total crosses the limit and dropping the partial buffer — instead of decrypting+buffering the user's **whole** scope and only then rejecting. The 10,000-secret count cap still short-circuits before any decrypt. Over either cap → typed `ExportTooLarge` → **HTTP 413**.

**4. Fixed misleading comments** flagged in review: the export is a read-only **filesystem-blob** walk over a per-executor `SecretsStore` on a shared `secrets_dir` (not "redb single-writer"; `pop_executor` does not serialize other executors). Concurrency safety is per-file FS semantics + AEAD authentication (a torn read fails AEAD → clean error, never corruption).

## Why defer rather than refactor the pool

A background task cannot check out a pool executor today (`pop_executor`/`return_checked` are `&mut self`). Rather than make the pool `&self`-shareable (a concurrency-model change on a high-risk surface), the loop pops the executor (fast slot-take) and **moves the owned `Executor<Runtime>` into the task**, which returns it via the resume channel. This keeps the pool's sequential invariant intact — only the loop ever touches the pool — while the export work runs on an exclusively-owned executor off-loop.

## Testing

- **Incremental bail** unit test: three 40-byte secrets, 50-byte cap → bails at total=80 (after the 2nd secret), proving it does NOT buffer the whole scope (would be 120).
- **Panic-catch** unit test: a panicking offload surfaces as `OffloadOutcome::Panicked`, not a re-raise onto the caller (no node crash).
- **Defer** integration test (`export_does_not_block_concurrent_contract_ops`): with secrets stored, an HTTP export and a concurrent WS delegate op fire together; the concurrent op completes (was not starved). The previous inline design would have serialized it behind the export.
- **Source-scrape pins**: the export arm defers via `GlobalExecutor::spawn`/`try_begin_export` with no inline `export_user_secrets`; `ExportJob::run` routes through `run_blocking_offloaded`; `finish_export` replaces a panic-lost executor.
- Existing cap + round-trip + isolation tests stay green: `hosted_mode_export` 5/5, `hosted_mode_isolation` 3/3, cap units 16/16, offload/pin 14/14.
- `cargo fmt`; `cargo clippy -p freenet --lib -- -D warnings` clean; `cargo test --workspace --no-run` compiles.

## Residual risk (for the P5 tracking issue, #4561)

- No **cross-request rate limiting** (N exports/minute per user). `MAX_CONCURRENT_EXPORTS` now bounds *node-wide concurrency* (excess → 503), which closes the aggregate-concurrency gap from the first revision, but a user can still issue exports back-to-back over time.
- The caps and concurrency limit are fixed consts (not operator-configurable yet).

Refs #4531, #4381 (P5).

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
