### PR TITLE
fix: deflake delegate node-limit tests under parallel cargo test --lib

### DIFF
--- a/crates/core/src/wasm_runtime/delegate_api.rs
+++ b/crates/core/src/wasm_runtime/delegate_api.rs
@@ -1013,6 +1013,7 @@ mod tests {
 
     /// create_delegate_sync rejects creation when depth limit is exceeded.
     #[tokio::test]
+    #[serial_test::serial(created_delegates_count)]
     async fn test_create_delegate_depth_exceeded() {
         let mut env_holder = TestEnv::new().await;
 
@@ -1033,6 +1034,7 @@ mod tests {
 
     /// create_delegate_sync allows creation at depth just below the limit.
     #[tokio::test]
+    #[serial_test::serial(created_delegates_count)]
     async fn test_create_delegate_depth_just_under_limit() {
         let mut env_holder = TestEnv::new().await;
 
@@ -1053,6 +1055,7 @@ mod tests {
 
     /// create_delegate_sync rejects creation when per-call limit is exceeded.
     #[tokio::test]
+    #[serial_test::serial(created_delegates_count)]
     async fn test_create_delegate_per_call_limit_exceeded() {
         let mut env_holder = TestEnv::new().await;
 
@@ -1082,6 +1085,7 @@ mod tests {
     /// Superseded: WASM validation moved from creation to execution time.
     /// Replaced test_create_delegate_invalid_wasm which expected InvalidWasm error.
     #[tokio::test]
+    #[serial_test::serial(created_delegates_count)]
     async fn test_create_delegate_accepts_any_bytes_at_creation() {
         let mut env_holder = TestEnv::new().await;
 
@@ -1101,6 +1105,7 @@ mod tests {
 
     /// create_delegate_sync rejects WASM bytes exceeding the size limit.
     #[tokio::test]
+    #[serial_test::serial(created_delegates_count)]
     async fn test_create_delegate_rejects_oversized_wasm() {
         let mut env_holder = TestEnv::new().await;
 
@@ -1120,6 +1125,7 @@ mod tests {
 
     /// create_delegate_sync tracks per-call count correctly via Cell.
     #[tokio::test]
+    #[serial_test::serial(created_delegates_count)]
     async fn test_create_delegate_counter_tracks_correctly() {
         let mut env_holder = TestEnv::new().await;
 
@@ -1142,6 +1148,7 @@ mod tests {
 
     /// Child delegate inherits parent's attested contracts in DELEGATE_INHERITED_ORIGINS.
     #[tokio::test]
+    #[serial_test::serial(created_delegates_count)]
     async fn test_create_delegate_inherits_attestations() {
         use super::super::native_api::DELEGATE_INHERITED_ORIGINS;
 
@@ -1173,6 +1180,7 @@ mod tests {
     /// Child created by non-attested parent does NOT appear in DELEGATE_INHERITED_ORIGINS
     /// but still counts toward the per-node limit via CREATED_DELEGATES_COUNT.
     #[tokio::test]
+    #[serial_test::serial(created_delegates_count)]
     async fn test_create_delegate_non_attested_still_counts_toward_node_limit() {
         use super::super::native_api::{CREATED_DELEGATES_COUNT, DELEGATE_INHERITED_ORIGINS};
         use std::sync::atomic::Ordering;


### PR DESCRIPTION
## What

Deflakes `test_create_delegate_non_attested_still_counts_toward_node_limit` (and its sibling delegate-creation tests) under a threaded `cargo test -p freenet --lib` run.

## Why

`test_create_delegate_non_attested_still_counts_toward_node_limit` snapshots the process-global `CREATED_DELEGATES_COUNT` atomic into `before`, creates a delegate, asserts `after > before`, then restores the counter with `fetch_sub(1)`. Because the counter is a process-global static, other delegate-creation tests in the same binary run concurrently on other threads and call `CREATED_DELEGATES_COUNT.fetch_add(1)` inside `create_delegate_sync`, perturbing the `before`/`after` snapshot and racing the cleanup. The test passes in isolation but fails intermittently under the full parallel `--lib` run.

CI uses nextest per-process isolation, so each test gets its own process and never observes the race; only a threaded `cargo test --lib` exercises it.

## How

Group the delegate-creation tests that read or mutate the shared `CREATED_DELEGATES_COUNT` global into a single named serial group via `#[serial_test::serial(created_delegates_count)]`, so they cannot run concurrently with one another. The named group serializes only these tests against each other; it does not globally serialize the rest of the suite, keeping the wall-clock impact minimal. `serial_test` is already a workspace dev-dependency.

No production code changes — the fix is confined to the test module in `crates/core/src/wasm_runtime/delegate_api.rs`.

## Verification

- `cargo build -p freenet --lib` — passes
- `cargo test -p freenet --lib wasm_runtime::delegate_api` — 43 passed, 0 failed
- `cargo fmt -p freenet --check` — clean

Fixes #4418
