### PR TITLE
feat(telemetry): observe placement-migration effect via router_snapshot gauges

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1758,6 +1758,13 @@ where
             return Ok(());
         }
         NetMessageV1::SubscribeHint(hint) => {
+            // Placement-migration telemetry (#4404 follow-up): count every inbound
+            // hint, before any admission gate, so `received` is the true arrival
+            // rate and `received - acted` is the gated/dropped fraction.
+            op_manager
+                .ring
+                .placement_migration_metrics()
+                .record_received();
             // Placement-migration version gate. The migration is re-enabled at
             // floor `(0, 2, 80)` (#4499 made it load-safe). The SEND side
             // (`p2p_protoc::peer_supports_subscribe_hint`) gates emission on the
@@ -1865,6 +1872,11 @@ where
                 ?source_addr,
                 "Received SubscribeHint — starting directed subscribe to holder"
             );
+            // Placement-migration telemetry (#4404 follow-up): count only the
+            // hints we actually act on (all gates passed), i.e. the migrations
+            // that actually start a directed subscribe and thereby host the
+            // contract closer to its key.
+            op_manager.ring.placement_migration_metrics().record_acted();
             subscribe::start_directed_subscribe(op_manager.clone(), hint.key, hint.holder);
             return Ok(());
         }

--- a/crates/core/src/node/network_bridge/p2p_protoc/migration.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/migration.rs
@@ -140,6 +140,15 @@ impl P2pConnManager {
         let msg = NetMessage::V1(NetMessageV1::SubscribeHint(
             crate::message::SubscribeHintMsg { key, holder: me },
         ));
+        // Placement-migration telemetry (#4404 follow-up): count the dispatch of
+        // this nudge. Counted here, at the point we commit to sending, so the
+        // `sent` total reflects nudges we attempted to dispatch (a bridge-full
+        // drop below is self-healing and re-tried on the next migration trigger).
+        self.bridge
+            .op_manager
+            .ring
+            .placement_migration_metrics()
+            .record_sent();
         self.bridge
             .op_manager
             .sending_transaction(&target_pkl, &msg);

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1365,15 +1365,21 @@ impl Ring {
                     .iter()
                     .map(|key| Location::from(key).as_f64())
                     .collect();
-                snapshot.hosted_contracts_count = Some(contract_locations.len() as u64);
                 if let Some(stats) =
                     placement_migration_metrics::placement_quality(node_loc, &contract_locations)
                 {
+                    // `stats.count` equals `contract_locations.len()`; read it here
+                    // (rather than the Vec len) so the field stays live in
+                    // non-test builds.
+                    snapshot.hosted_contracts_count = Some(stats.count);
                     snapshot.hosted_key_distance_median = Some(stats.median);
                     snapshot.hosted_key_distance_p90 = Some(stats.p90);
                     snapshot.hosted_key_distance_min = Some(stats.min);
                     snapshot.hosted_key_distance_mean = Some(stats.mean);
                     snapshot.hosted_key_distance_frac_within_0_1 = Some(stats.frac_within_0_1);
+                } else {
+                    // Node hosts nothing: count is 0, distance gauges absent.
+                    snapshot.hosted_contracts_count = Some(0);
                 }
             }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -99,6 +99,7 @@ mod location;
 pub(crate) mod peer_cache;
 mod peer_connection_backoff;
 mod peer_key_location;
+mod placement_migration_metrics;
 pub mod topology_registry;
 pub(crate) mod update_rate_limit;
 
@@ -205,6 +206,16 @@ pub(crate) struct Ring {
     /// task *reads* it. Threading the `Arc` (rather than a process-global)
     /// keeps the gauges per-node so unit tests stay isolated (#4488).
     module_cache_metrics: Arc<crate::wasm_runtime::ModuleCacheMetrics>,
+    /// Per-node placement-migration activity counters (#4404 follow-up).
+    /// Constructed once here and shared via `Arc`: the migration SEND site
+    /// (`p2p_protoc::migration`) and the two RECEIVE sites (`node::process_message`)
+    /// increment it through `op_manager.ring`, while
+    /// `emit_router_snapshot_telemetry` reads it on the snapshot cadence. Threading
+    /// the `Arc` (rather than a process-global) keeps the counters per-node so unit
+    /// tests stay isolated. Together with the placement-quality gauge it lets us
+    /// observe whether the placement migration is firing and whether it actually
+    /// pulls hosting closer to each contract's key.
+    placement_migration_metrics: Arc<placement_migration_metrics::PlacementMigrationMetrics>,
     /// Shutdown signal for the long-lived background tasks spawned in
     /// [`Ring::new`]. Triggered once on node teardown (via
     /// [`Ring::trigger_shutdown`], fired from `ShutdownTeardown::drop`).
@@ -448,6 +459,12 @@ impl Ring {
             // (the `RuntimePool` reaches it through `op_manager.ring`). See
             // the field docs and #4488.
             module_cache_metrics: Arc::new(crate::wasm_runtime::ModuleCacheMetrics::new()),
+            // One placement-migration counter sink per node, shared with the
+            // migration send/receive sites via the `Arc` (reached through
+            // `op_manager.ring`). See the field docs.
+            placement_migration_metrics: Arc::new(
+                placement_migration_metrics::PlacementMigrationMetrics::default(),
+            ),
             shutdown,
         };
 
@@ -578,6 +595,15 @@ impl Ring {
     /// this `Arc` is what replaced the old `MODULE_CACHE_METRICS` process-global.
     pub(crate) fn module_cache_metrics(&self) -> Arc<crate::wasm_runtime::ModuleCacheMetrics> {
         self.module_cache_metrics.clone()
+    }
+
+    /// Shared per-node placement-migration counter sink (#4404 follow-up). The
+    /// migration send/receive sites clone this to increment `sent` / `received`
+    /// / `acted`; the snapshot task reads it on the `router_snapshot` cadence.
+    pub(crate) fn placement_migration_metrics(
+        &self,
+    ) -> Arc<placement_migration_metrics::PlacementMigrationMetrics> {
+        self.placement_migration_metrics.clone()
     }
 
     /// Signal the long-lived background tasks (spawned in [`Ring::new`]) to
@@ -1319,6 +1345,46 @@ impl Ring {
             snapshot.refresh_router_last_success_age_secs = rr_health.last_success_age_secs;
             snapshot.refresh_router_consecutive_failures = Some(rr_health.consecutive_failures);
 
+            // Placement-quality gauge (#4404 follow-up): host-to-hosted-key
+            // ring-distance distribution. If the SubscribeHint placement
+            // migration is working, hosting drifts toward each contract's key,
+            // so this distribution tightens over time. Cheap — a few thousand
+            // distance computations at most, every 5 minutes. Skip gracefully if
+            // the node has no ring location yet (emit nothing) or hosts nothing
+            // (emit count=0, distances absent). No lock is held across an await:
+            // `hosting_contract_keys()` returns an owned `Vec` and the distance
+            // math is pure.
+            let own_location = ring
+                .connection_manager
+                .own_location()
+                .location()
+                .map(|loc| loc.as_f64());
+            if let Some(node_loc) = own_location {
+                let hosted_keys = ring.hosting_contract_keys();
+                let contract_locations: Vec<f64> = hosted_keys
+                    .iter()
+                    .map(|key| Location::from(key).as_f64())
+                    .collect();
+                snapshot.hosted_contracts_count = Some(contract_locations.len() as u64);
+                if let Some(stats) =
+                    placement_migration_metrics::placement_quality(node_loc, &contract_locations)
+                {
+                    snapshot.hosted_key_distance_median = Some(stats.median);
+                    snapshot.hosted_key_distance_p90 = Some(stats.p90);
+                    snapshot.hosted_key_distance_min = Some(stats.min);
+                    snapshot.hosted_key_distance_mean = Some(stats.mean);
+                    snapshot.hosted_key_distance_frac_within_0_1 = Some(stats.frac_within_0_1);
+                }
+            }
+
+            // Placement-migration activity counters (#4404 follow-up): is the
+            // migration firing, and at what rate? Monotonic lifetime totals read
+            // from the per-node counter sink the send/receive sites publish into.
+            let pm = ring.placement_migration_metrics.snapshot();
+            snapshot.subscribe_hint_sent = Some(pm.sent);
+            snapshot.subscribe_hint_received = Some(pm.received);
+            snapshot.subscribe_hint_acted = Some(pm.acted);
+
             tracing::info!(
                 failure_events = snapshot.failure_events,
                 success_events = snapshot.success_events,
@@ -1334,6 +1400,13 @@ impl Ring {
                 broadcast_stream_failures_last_snapshot = broadcast_stream_failures_delta,
                 refresh_router_last_success_age_secs = ?rr_health.last_success_age_secs,
                 refresh_router_consecutive_failures = rr_health.consecutive_failures,
+                hosted_contracts_count = ?snapshot.hosted_contracts_count,
+                hosted_key_distance_median = ?snapshot.hosted_key_distance_median,
+                hosted_key_distance_p90 = ?snapshot.hosted_key_distance_p90,
+                hosted_key_distance_frac_within_0_1 = ?snapshot.hosted_key_distance_frac_within_0_1,
+                subscribe_hint_sent = pm.sent,
+                subscribe_hint_received = pm.received,
+                subscribe_hint_acted = pm.acted,
                 "router_snapshot"
             );
 

--- a/crates/core/src/ring/placement_migration_metrics.rs
+++ b/crates/core/src/ring/placement_migration_metrics.rs
@@ -1,0 +1,345 @@
+//! Placement-migration observability (#4404 follow-up).
+//!
+//! The SubscribeHint placement migration nudges a closer-to-the-key neighbor to
+//! subscribe-and-host a contract, so hosting drifts toward each contract's ideal
+//! ring location over time. That effect was previously invisible to telemetry
+//! (SubscribeHint is `EventKind::Ignored`), so this module adds two cheap,
+//! low-overhead observability primitives that piggyback on the existing 5-minute
+//! `router_snapshot` gauge cadence — no new per-message events:
+//!
+//! 1. [`PlacementMigrationMetrics`] — three cumulative `AtomicU64` counters
+//!    (`sent` / `received` / `acted`) incremented at the three migration sites,
+//!    read once per snapshot. Lets us trend whether the migration is firing and
+//!    at what rate.
+//! 2. [`placement_quality`] — a pure function over this node's ring location and
+//!    the locations of the contracts it hosts. Produces the host-to-hosted-key
+//!    ring-distance distribution (median / p90 / fraction within 0.1 / min /
+//!    mean). If the migration works, that distribution tightens over time.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Three cumulative lifetime counters tracking placement-migration activity.
+///
+/// Constructed once per node in `Ring::new` and shared via `Arc`: the migration
+/// SEND site (`p2p_protoc::migration::consider_contract_migration`) and the two
+/// RECEIVE sites (`node::process_message`) reach it through `op_manager.ring`,
+/// while `emit_router_snapshot_telemetry` reads it. Counters are monotonic
+/// lifetime totals — the collector differences them across the snapshot cadence
+/// to derive a rate. Cheap `Relaxed` atomics; never blocks.
+#[derive(Debug, Default)]
+pub(crate) struct PlacementMigrationMetrics {
+    /// Incremented each time this node dispatches a `SubscribeHint` nudge to a
+    /// closer-to-the-key neighbor.
+    sent: AtomicU64,
+    /// Incremented for every inbound `SubscribeHint` this node receives, counted
+    /// before any admission gate (version / already-hosted / holder / cache).
+    received: AtomicU64,
+    /// Incremented only when an inbound `SubscribeHint` actually triggers a
+    /// directed subscribe (the migration is acted upon, not dropped by a gate).
+    acted: AtomicU64,
+}
+
+/// A point-in-time read of [`PlacementMigrationMetrics`] for telemetry emission.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PlacementMigrationSnapshot {
+    pub sent: u64,
+    pub received: u64,
+    pub acted: u64,
+}
+
+impl PlacementMigrationMetrics {
+    /// Record that this node dispatched a `SubscribeHint` nudge.
+    #[inline]
+    pub(crate) fn record_sent(&self) {
+        self.sent.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record that this node received an inbound `SubscribeHint` (any inbound
+    /// hint, counted before the admission gates).
+    #[inline]
+    pub(crate) fn record_received(&self) {
+        self.received.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record that an inbound `SubscribeHint` was acted on (a directed subscribe
+    /// was started).
+    #[inline]
+    pub(crate) fn record_acted(&self) {
+        self.acted.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Read all three counters for telemetry.
+    pub(crate) fn snapshot(&self) -> PlacementMigrationSnapshot {
+        PlacementMigrationSnapshot {
+            sent: self.sent.load(Ordering::Relaxed),
+            received: self.received.load(Ordering::Relaxed),
+            acted: self.acted.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Ring-distance threshold below which a hosted contract is considered "close"
+/// to this node, for the `frac_within_0_1` summary statistic. Chosen as the
+/// clearest single "are hosted contracts near their host" number: 0.1 is 20% of
+/// the maximum possible ring distance (0.5), so a tightening fraction-within-0.1
+/// over time is direct evidence the placement migration is working.
+pub(crate) const CLOSE_RING_DISTANCE: f64 = 0.1;
+
+/// Summary of the distribution of ring distances between this node's location
+/// and the ring locations of the contracts it currently hosts.
+///
+/// All distances are ring distances in `[0.0, 0.5]` (the maximum distance on the
+/// unit ring). Emitted as gauge fields on the 5-minute `router_snapshot`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct HostedKeyDistanceStats {
+    /// Number of hosted contracts the distribution was computed over.
+    pub count: u64,
+    /// Median host-to-hosted-key ring distance.
+    pub median: f64,
+    /// 90th-percentile host-to-hosted-key ring distance.
+    pub p90: f64,
+    /// Smallest host-to-hosted-key ring distance.
+    pub min: f64,
+    /// Mean host-to-hosted-key ring distance.
+    pub mean: f64,
+    /// Fraction of hosted contracts within [`CLOSE_RING_DISTANCE`] of this node.
+    pub frac_within_0_1: f64,
+}
+
+/// Compute the host-to-hosted-key ring-distance distribution.
+///
+/// `node_location` is this node's own ring location in `[0.0, 1.0]`.
+/// `contract_locations` are the ring locations (also in `[0.0, 1.0]`) of the
+/// contracts this node currently hosts. Returns `None` when the node hosts
+/// nothing (no distribution to summarize) — the caller emits `count = 0` and
+/// leaves the distance gauges absent.
+///
+/// Distances use the same wrap-around ring metric as the rest of the crate
+/// (`Location::distance`), so the result is in `[0.0, 0.5]`.
+///
+/// # Example
+///
+/// ```ignore
+/// let stats = placement_quality(0.5, &[0.5, 0.55, 0.9]).unwrap();
+/// assert_eq!(stats.count, 3);
+/// ```
+pub(crate) fn placement_quality(
+    node_location: f64,
+    contract_locations: &[f64],
+) -> Option<HostedKeyDistanceStats> {
+    if contract_locations.is_empty() {
+        return None;
+    }
+
+    let node = crate::ring::Location::new_rounded(node_location);
+    let mut distances: Vec<f64> = contract_locations
+        .iter()
+        .map(|&loc| {
+            node.distance(crate::ring::Location::new_rounded(loc))
+                .as_f64()
+        })
+        .collect();
+
+    // Sort for percentile extraction. NaN is impossible here: ring distances
+    // are finite values in [0.0, 0.5], so `total_cmp` gives a total order.
+    distances.sort_by(|a, b| a.total_cmp(b));
+
+    let count = distances.len();
+    let sum: f64 = distances.iter().sum();
+    let mean = sum / count as f64;
+    let min = distances[0];
+    let within = distances
+        .iter()
+        .filter(|&&d| d <= CLOSE_RING_DISTANCE)
+        .count();
+    let frac_within_0_1 = within as f64 / count as f64;
+
+    Some(HostedKeyDistanceStats {
+        count: count as u64,
+        median: percentile(&distances, 0.5),
+        p90: percentile(&distances, 0.9),
+        min,
+        mean,
+        frac_within_0_1,
+    })
+}
+
+/// Nearest-rank percentile of an already-sorted, non-empty slice.
+///
+/// `q` is in `[0.0, 1.0]`. Uses the nearest-rank method (rank = ceil(q * n),
+/// clamped to `[1, n]`), which is exact for the small distributions this is used
+/// on and avoids interpolation ambiguity. The slice MUST be sorted ascending and
+/// non-empty (callers guarantee both).
+fn percentile(sorted: &[f64], q: f64) -> f64 {
+    debug_assert!(!sorted.is_empty(), "percentile of empty slice");
+    debug_assert!((0.0..=1.0).contains(&q), "percentile q out of range");
+    let n = sorted.len();
+    // Nearest-rank: smallest index whose cumulative share is >= q.
+    let rank = (q * n as f64).ceil() as usize;
+    let idx = rank.clamp(1, n) - 1;
+    sorted[idx]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn placement_quality_empty_is_none() {
+        assert!(placement_quality(0.5, &[]).is_none());
+    }
+
+    #[test]
+    fn placement_quality_single_contract_at_node() {
+        // A single contract exactly at the node's location: distance 0.
+        let stats = placement_quality(0.5, &[0.5]).expect("non-empty");
+        assert_eq!(stats.count, 1);
+        assert!((stats.median - 0.0).abs() < 1e-12);
+        assert!((stats.p90 - 0.0).abs() < 1e-12);
+        assert!((stats.min - 0.0).abs() < 1e-12);
+        assert!((stats.mean - 0.0).abs() < 1e-12);
+        assert!((stats.frac_within_0_1 - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn placement_quality_known_distribution() {
+        // Node at 0.5. Contracts at distances 0.0, 0.05, 0.1, 0.2, 0.4 from it.
+        // Place them on the +side so the wrap-around picks the direct arc.
+        let node = 0.5;
+        let contracts = [0.5, 0.55, 0.6, 0.7, 0.9];
+        let stats = placement_quality(node, &contracts).expect("non-empty");
+
+        assert_eq!(stats.count, 5);
+        // Sorted distances: [0.0, 0.05, 0.1, 0.2, 0.4]
+        // Nearest-rank median (q=0.5): rank=ceil(2.5)=3 → idx 2 → 0.1
+        assert!((stats.median - 0.1).abs() < 1e-9, "median={}", stats.median);
+        // p90 (q=0.9): rank=ceil(4.5)=5 → idx 4 → 0.4
+        assert!((stats.p90 - 0.4).abs() < 1e-9, "p90={}", stats.p90);
+        assert!((stats.min - 0.0).abs() < 1e-12, "min={}", stats.min);
+        // mean = (0.0+0.05+0.1+0.2+0.4)/5 = 0.15
+        assert!((stats.mean - 0.15).abs() < 1e-9, "mean={}", stats.mean);
+        // within 0.1 (inclusive): 0.0, 0.05, 0.1 → 3 of 5 = 0.6
+        assert!(
+            (stats.frac_within_0_1 - 0.6).abs() < 1e-9,
+            "frac_within_0_1={}",
+            stats.frac_within_0_1
+        );
+    }
+
+    #[test]
+    fn placement_quality_uses_wrap_around_distance() {
+        // Node near the top of the ring; a contract just past 1.0 wrap.
+        // Node 0.95, contract 0.02 → direct arc would be 0.93, wrap arc 0.07.
+        let stats = placement_quality(0.95, &[0.02]).expect("non-empty");
+        assert!(
+            (stats.median - 0.07).abs() < 1e-9,
+            "wrap distance median={}",
+            stats.median
+        );
+        assert!(stats.median <= 0.5, "ring distance must be <= 0.5");
+    }
+
+    #[test]
+    fn placement_quality_far_contracts_low_close_fraction() {
+        // All contracts at the antipode region: none within 0.1.
+        let stats = placement_quality(0.0, &[0.4, 0.45, 0.5]).expect("non-empty");
+        assert_eq!(stats.count, 3);
+        assert!(
+            (stats.frac_within_0_1 - 0.0).abs() < 1e-12,
+            "no contract should be within 0.1, frac={}",
+            stats.frac_within_0_1
+        );
+        assert!(stats.min >= CLOSE_RING_DISTANCE);
+    }
+
+    #[test]
+    fn percentile_nearest_rank_endpoints() {
+        let sorted = [0.0, 0.1, 0.2, 0.3, 0.4];
+        // q=0.0 → rank=ceil(0)=0 → clamp to 1 → idx 0
+        assert_eq!(percentile(&sorted, 0.0), 0.0);
+        // q=1.0 → rank=5 → idx 4
+        assert_eq!(percentile(&sorted, 1.0), 0.4);
+    }
+
+    #[test]
+    fn metrics_counters_increment_independently() {
+        let m = PlacementMigrationMetrics::default();
+        let s0 = m.snapshot();
+        assert_eq!((s0.sent, s0.received, s0.acted), (0, 0, 0));
+
+        m.record_sent();
+        m.record_sent();
+        m.record_received();
+        m.record_acted();
+        m.record_received();
+        m.record_received();
+
+        let s1 = m.snapshot();
+        assert_eq!(s1.sent, 2, "sent");
+        assert_eq!(s1.received, 3, "received");
+        assert_eq!(s1.acted, 1, "acted");
+    }
+
+    /// Source-pin the three migration counter sites so a refactor that drops a
+    /// `record_*` call (or moves an `acted` increment onto a gated branch) fails
+    /// the build. The three sites live in different files and on different
+    /// control-flow branches, so an integration test would need a full multi-node
+    /// migration to exercise them; pinning the call sites in source is the cheap,
+    /// deterministic guard (same approach as
+    /// `refresh_router_records_health_on_startup_and_in_loop` in `ring.rs`).
+    #[test]
+    fn migration_counter_sites_present() {
+        // SEND: exactly one `record_sent()` in the migration helper module.
+        let migration_src = include_str!("../node/network_bridge/p2p_protoc/migration.rs");
+        assert_eq!(
+            migration_src
+                .matches(".placement_migration_metrics()")
+                .count(),
+            1,
+            "the SubscribeHint SEND site must reach the placement-migration metrics exactly once"
+        );
+        assert_eq!(
+            migration_src.matches(".record_sent()").count(),
+            1,
+            "the SubscribeHint SEND site must increment `sent` exactly once"
+        );
+
+        // RECEIVE + ACTED: both live in the `SubscribeHint` arm of
+        // `node::process_message`. Scope to that arm so unrelated mentions don't
+        // count. `received` is at the top (before the gates); `acted` is on the
+        // branch that starts the directed subscribe.
+        let node_src = include_str!("../node.rs");
+        let arm_start = node_src
+            .find("NetMessageV1::SubscribeHint(hint) =>")
+            .expect("SubscribeHint arm present in node.rs");
+        let after = &node_src[arm_start..];
+        // The arm ends at the next top-level match arm (`Aborted`).
+        let arm_end = after
+            .find("NetMessageV1::Aborted(tx) =>")
+            .expect("Aborted arm follows SubscribeHint arm");
+        let arm = &after[..arm_end];
+        assert_eq!(
+            arm.matches(".record_received()").count(),
+            1,
+            "the SubscribeHint RECEIVE site must increment `received` exactly once \
+             (counted before the admission gates)"
+        );
+        assert_eq!(
+            arm.matches(".record_acted()").count(),
+            1,
+            "the SubscribeHint ACTED site must increment `acted` exactly once \
+             (only on the branch that starts the directed subscribe)"
+        );
+        // The `acted` increment must come AFTER the directed-subscribe log line,
+        // i.e. on the act branch past all gates — not at the top with `received`.
+        let acted_at = arm.find(".record_acted()").expect("acted present");
+        let act_log_at = arm
+            .find("Received SubscribeHint — starting directed subscribe to holder")
+            .expect("act-branch log present");
+        assert!(
+            acted_at > act_log_at,
+            "`record_acted()` must sit on the act branch (after the directed-subscribe \
+             log), so gated/dropped hints are not counted as acted"
+        );
+    }
+}

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -218,6 +218,33 @@ pub(crate) struct RouterSnapshotInfo {
     /// failures since the last success.
     pub refresh_router_last_success_age_secs: Option<u64>,
     pub refresh_router_consecutive_failures: Option<u64>,
+    /// Placement-quality gauges (#4404 follow-up), populated by `Ring` on the
+    /// snapshot cadence from the contracts this node hosts. They make the
+    /// effect of the SubscribeHint placement migration observable: the migration
+    /// nudges hosting toward each contract's key, so the host-to-hosted-key
+    /// ring-distance distribution should tighten over time. `hosted_contracts_count`
+    /// is the number of contracts hosted at snapshot time; the distance fields are
+    /// the distribution of `ring_distance(this_node_location, contract_location)`
+    /// in `[0.0, 0.5]`. `hosted_key_distance_frac_within_0_1` (fraction within ring
+    /// distance 0.1) is the clearest single "are hosted contracts close" number.
+    /// The distance fields are `None` when the node hosts nothing or has no ring
+    /// location yet (`hosted_contracts_count` is then `0` / absent respectively).
+    pub hosted_contracts_count: Option<u64>,
+    pub hosted_key_distance_median: Option<f64>,
+    pub hosted_key_distance_p90: Option<f64>,
+    pub hosted_key_distance_min: Option<f64>,
+    pub hosted_key_distance_mean: Option<f64>,
+    pub hosted_key_distance_frac_within_0_1: Option<f64>,
+    /// Placement-migration activity counters (#4404 follow-up), populated by
+    /// `Ring` from the per-node `PlacementMigrationMetrics`. Monotonic lifetime
+    /// totals (the collector differences them across the cadence to derive a
+    /// rate): `sent` is hints this node dispatched, `received` is all inbound
+    /// hints (counted before the admission gates), and `acted` is the subset that
+    /// actually triggered a directed subscribe. `None` until the snapshot task
+    /// has populated them (i.e. always populated in production snapshots).
+    pub subscribe_hint_sent: Option<u64>,
+    pub subscribe_hint_received: Option<u64>,
+    pub subscribe_hint_acted: Option<u64>,
     /// Per-operation-type estimator curves, keyed by op type name (e.g., "GET").
     pub per_op_curves: HashMap<String, PerOpCurves>,
     /// Renegade predictor diagnostics. These (and `renegade_accuracy_pairs`) are
@@ -1027,6 +1054,17 @@ impl Router {
             broadcast_stream_failures_last_snapshot: None,
             refresh_router_last_success_age_secs: None,
             refresh_router_consecutive_failures: None,
+            // Placement-quality + placement-migration gauges populated by Ring on
+            // the snapshot cadence (#4404 follow-up).
+            hosted_contracts_count: None,
+            hosted_key_distance_median: None,
+            hosted_key_distance_p90: None,
+            hosted_key_distance_min: None,
+            hosted_key_distance_mean: None,
+            hosted_key_distance_frac_within_0_1: None,
+            subscribe_hint_sent: None,
+            subscribe_hint_received: None,
+            subscribe_hint_acted: None,
             // Renegade predictor diagnostics
             renegade_failure_events: self.renegade_predictor.len(),
             renegade_response_time_events: self.renegade_predictor.stage_sizes().1,

--- a/crates/core/src/router/isotonic_estimator.rs
+++ b/crates/core/src/router/isotonic_estimator.rs
@@ -739,7 +739,7 @@ mod tests {
             result: 0.0,
         });
         assert!(
-            estimator.peer_adjustments.get(&peer).is_none(),
+            !estimator.peer_adjustments.contains_key(&peer),
             "a non-positive observation must be skipped in multiplicative mode (no adjustment entry created)"
         );
     }

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -1878,7 +1878,7 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
             })
         }
         EventKind::RouterSnapshot(snapshot) => {
-            serde_json::json!({
+            let mut body = serde_json::json!({
                 "type": "router_snapshot",
                 "failure_events": snapshot.failure_events,
                 "success_events": snapshot.success_events,
@@ -1918,7 +1918,52 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                 "refresh_router_last_success_age_secs": snapshot.refresh_router_last_success_age_secs,
                 "refresh_router_consecutive_failures": snapshot.refresh_router_consecutive_failures,
                 "per_op_curves": snapshot.per_op_curves,
-            })
+            });
+            // Placement-quality + placement-migration gauges (#4404 follow-up).
+            // Inserted AFTER the `json!` (not as inline keys) only to keep the
+            // macro under its expansion recursion limit — this body is still
+            // hand-mirrored, so a new `RouterSnapshotInfo` field is invisible to
+            // the collector unless added here. Pinned by
+            // `router_snapshot_json_includes_placement_gauges`.
+            if let Some(obj) = body.as_object_mut() {
+                obj.insert(
+                    "hosted_contracts_count".to_string(),
+                    serde_json::json!(snapshot.hosted_contracts_count),
+                );
+                obj.insert(
+                    "hosted_key_distance_median".to_string(),
+                    serde_json::json!(snapshot.hosted_key_distance_median),
+                );
+                obj.insert(
+                    "hosted_key_distance_p90".to_string(),
+                    serde_json::json!(snapshot.hosted_key_distance_p90),
+                );
+                obj.insert(
+                    "hosted_key_distance_min".to_string(),
+                    serde_json::json!(snapshot.hosted_key_distance_min),
+                );
+                obj.insert(
+                    "hosted_key_distance_mean".to_string(),
+                    serde_json::json!(snapshot.hosted_key_distance_mean),
+                );
+                obj.insert(
+                    "hosted_key_distance_frac_within_0_1".to_string(),
+                    serde_json::json!(snapshot.hosted_key_distance_frac_within_0_1),
+                );
+                obj.insert(
+                    "subscribe_hint_sent".to_string(),
+                    serde_json::json!(snapshot.subscribe_hint_sent),
+                );
+                obj.insert(
+                    "subscribe_hint_received".to_string(),
+                    serde_json::json!(snapshot.subscribe_hint_received),
+                );
+                obj.insert(
+                    "subscribe_hint_acted".to_string(),
+                    serde_json::json!(snapshot.subscribe_hint_acted),
+                );
+            }
+            body
         }
     }
 }
@@ -2047,6 +2092,47 @@ mod tests {
             ("broadcast_stream_failures_last_snapshot", 43),
             ("refresh_router_last_success_age_secs", 47),
             ("refresh_router_consecutive_failures", 53),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
+    }
+
+    /// The placement-quality + placement-migration gauges (#4404 follow-up) must
+    /// reach the hand-mirrored OTLP `json!` body, same footgun as the gauges
+    /// above: a new `RouterSnapshotInfo` field is invisible to the collector
+    /// unless it is added to that block. These fields are exactly how we observe
+    /// whether the placement migration pulls hosting closer to each contract's
+    /// key, so a silent drop would re-blind us to it.
+    #[test]
+    fn router_snapshot_json_includes_placement_gauges() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.hosted_contracts_count = Some(5);
+        info.hosted_key_distance_median = Some(0.1);
+        info.hosted_key_distance_p90 = Some(0.4);
+        info.hosted_key_distance_min = Some(0.0);
+        info.hosted_key_distance_mean = Some(0.15);
+        info.hosted_key_distance_frac_within_0_1 = Some(0.6);
+        info.subscribe_hint_sent = Some(11);
+        info.subscribe_hint_received = Some(13);
+        info.subscribe_hint_acted = Some(7);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        for (key, want) in [
+            ("hosted_contracts_count", 5u64),
+            ("subscribe_hint_sent", 11),
+            ("subscribe_hint_received", 13),
+            ("subscribe_hint_acted", 7),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
+        for (key, want) in [
+            ("hosted_key_distance_median", 0.1),
+            ("hosted_key_distance_p90", 0.4),
+            ("hosted_key_distance_min", 0.0),
+            ("hosted_key_distance_mean", 0.15),
+            ("hosted_key_distance_frac_within_0_1", 0.6),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }

--- a/crates/core/tests/hosted_mode_export.rs
+++ b/crates/core/tests/hosted_mode_export.rs
@@ -623,6 +623,7 @@ impl PoolSizeEnv {
 }
 impl Drop for PoolSizeEnv {
     fn drop(&mut self) {
+        // SAFETY: serialized tests; no concurrent node start reads this var.
         unsafe { std::env::remove_var("FREENET_RUNTIME_POOL_SIZE") };
     }
 }


### PR DESCRIPTION
## Problem

The SubscribeHint placement migration (#4404) nudges a closer-to-the-key neighbor to subscribe-and-host a contract, so hosting should drift toward each contract's ideal ring location over time. But that effect is **invisible to telemetry** — inbound `SubscribeHint` is classified `EventKind::Ignored` (`tracing/register.rs`), and nothing reports whether hosting is actually getting closer to contract keys. So we can verify the migration is *safe* (broadcast-failure metrics) but not whether it's *working*.

## Approach

Two cheap, low-overhead observability primitives, both **piggybacked on the existing 5-minute `router_snapshot`** so collector volume stays flat (no new per-message events):

1. **Placement-quality gauge** — per node, the distribution of ring-distance from this node to the keys of the contracts it hosts: `hosted_contracts_count`, `hosted_key_distance_{median,p90,min,mean}`, and `hosted_key_distance_frac_within_0_1` (fraction within 0.1 — the clearest single "are hosted contracts near their host" number). If the migration works, this distribution **tightens over time**, network-wide.
2. **Migration-activity counters** — `subscribe_hint_{sent,received,acted}` cumulative counters, incremented at the three migration sites (send in `migration.rs`; received before the gates and acted on the directed-subscribe branch in `node.rs`).

Purely additive observability: **no change to the wire protocol, the `SubscribeHint` type, the migration logic, or the version floor.** The distance computation runs over an owned `Vec` of hosted keys (no lock held across it), uses the in-tree wrap-aware `Location::distance`, and skips gracefully when the node has no location yet.

No collector/extractor change: the `router_snapshot` OTLP body is a hand-mirrored `json!` block that the collector stores raw, so the nine new fields flow through and are queryable directly from `logs.jsonl` (pinned by a test, matching the existing fd/module-cache gauge convention).

## Testing

- New `placement_migration_metrics` module: 8 unit tests — placement-quality math (empty / single / known distribution / wrap-around / far-contracts), nearest-rank percentile endpoints, counter increments, and a **source-pin test** asserting the three `record_*` sites exist exactly once and that `record_acted` sits on the act branch (not at the top with `received`), so a refactor that miscounts fails the build.
- `router_snapshot_json_includes_placement_gauges` pins the nine fields into the OTLP body.
- `cargo clippy -p freenet --tests -- -D warnings` clean; affected module suites green (location/router/telemetry/hosting).

Two tiny drive-by clippy fixes (`isotonic_estimator.rs`, `tests/hosted_mode_export.rs`) for pre-existing Rust 1.94 lints that blocked `clippy --tests` — included rather than left as landmines.

Observability follow-up to #4404 / the SubscribeHint re-enable.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
