### PR TITLE
perf(contract): off-load Background summarize from the serial contract loop

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -107,6 +107,18 @@ The loop's pop() applies a bounded anti-starvation floor
 (RELAY_STARVATION_FLOOR) so sustained ClientLocal load cannot indefinitely
 starve NetworkRelay/Background — but that is a backstop, not a license to
 mis-tag.
+
+Beyond reordering, a Background GetSummaryQuery (the periodic interest-sync
+summarize) also runs OFF the serial loop on a spawned task when a pooled
+executor is free (#4534, contract.rs GetSummaryQuery arm → pool
+try_begin_summarize/finish_summarize), so a burst of them can't head-of-line
+block client work even once popped. Foreground summaries
+(NetworkRelay/ClientLocal — resync / a direct client ask) stay inline for
+latency. This is the same off-load idiom as the hosted-export deferral (#4531
+/ #4381 P5) and the related-fetch deferral (#4391, contracts.md); all
+off-loop classes share ONE pool-executor budget (effective_offload_permits =
+min(exports+summaries, pool_size-1)) so they can never jointly hold every
+executor and wedge the loop.
 ```
 
 ## Critical Invariant: Initialize-Before-Send

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -326,6 +326,98 @@ impl Drop for ExportGuard {
     }
 }
 
+/// Loop-side payload for a completed off-loop `Background` summary (#4534).
+/// Mirrors [`ExportResume`]: the executor + precomputed summary come back to the
+/// loop, which returns/replaces the executor (`finish_summarize`) and answers
+/// the parked client. Nothing to re-run on the loop — just deliver and reclaim.
+struct SummaryResume {
+    /// The contract whose summary was computed (needed both for the
+    /// `GetSummaryResponse` and for `finish_summarize`'s per-contract accounting).
+    key: ContractKey,
+    /// The completed summary: the executor to return (or `None` if the task
+    /// panicked/was dropped) and the result for the client.
+    done: crate::contract::executor::runtime::SummaryDone,
+    /// The parked client responder. `None` only if the client disconnected
+    /// before the summary finished.
+    responder: Option<StashedResponder>,
+}
+
+/// RAII guard guaranteeing the off-loop summary task delivers EXACTLY ONE
+/// [`SummaryResume`] — whether the summary completes or the task is
+/// dropped/panics/cancelled before sending. Same load-bearing invariant as
+/// [`ExportGuard`]: the parked client responder never hangs and the
+/// checked-out executor is always reclaimed.
+struct SummaryGuard {
+    payload: Option<SummaryGuardPayload>,
+}
+
+struct SummaryGuardPayload {
+    summary_resume_tx: tokio::sync::mpsc::UnboundedSender<SummaryResume>,
+    key: ContractKey,
+    responder: Option<StashedResponder>,
+}
+
+impl SummaryGuard {
+    fn new(
+        summary_resume_tx: tokio::sync::mpsc::UnboundedSender<SummaryResume>,
+        key: ContractKey,
+        responder: Option<StashedResponder>,
+    ) -> Self {
+        Self {
+            payload: Some(SummaryGuardPayload {
+                summary_resume_tx,
+                key,
+                responder,
+            }),
+        }
+    }
+
+    /// Deliver the completed summary. Consumes the payload so a subsequent `Drop`
+    /// is a no-op (exactly-once).
+    fn send(mut self, done: crate::contract::executor::runtime::SummaryDone) {
+        if let Some(p) = self.payload.take() {
+            Self::deliver(p, done);
+        }
+    }
+
+    fn deliver(p: SummaryGuardPayload, done: crate::contract::executor::runtime::SummaryDone) {
+        let SummaryGuardPayload {
+            summary_resume_tx,
+            key,
+            responder,
+        } = p;
+        // Unbounded channel, non-blocking send (channel-safety.md carve-out: the
+        // producer count is bounded by MAX_CONCURRENT_SUMMARIES, the receiver is
+        // this loop which drains every iteration, and the waiter never reads what
+        // the loop produces — no cycle). A send failure means the loop is gone.
+        if summary_resume_tx
+            .send(SummaryResume {
+                key,
+                done,
+                responder,
+            })
+            .is_err()
+        {
+            tracing::debug!("summary resume channel closed; contract-handling loop gone");
+        }
+    }
+}
+
+impl Drop for SummaryGuard {
+    fn drop(&mut self) {
+        if let Some(p) = self.payload.take() {
+            tracing::warn!(
+                "Off-loop summary task dropped before sending — delivering an error \
+                 resume so the summary terminates and the client is answered (#4534)"
+            );
+            Self::deliver(
+                p,
+                crate::contract::executor::runtime::SummaryDone::lost_to_drop(),
+            );
+        }
+    }
+}
+
 /// Loop-side state for off-loading deferred related-contract fetches (#4391).
 ///
 /// Owned by `contract_handling`; passed by `&mut` into `handle_contract_event`
@@ -355,18 +447,24 @@ struct DeferralCtx {
     /// loop here (#4531 / #4381 P5). Separate from `resume_tx` because the export
     /// resume carries an executor + precomputed bytes, not an upsert to re-run.
     export_resume_tx: tokio::sync::mpsc::UnboundedSender<ExportResume>,
+    /// Off-loop `Background` summary tasks send their completed [`SummaryResume`]s
+    /// back to the loop here (#4534). Separate channel for the same reason as
+    /// `export_resume_tx`: it carries an executor + precomputed summary.
+    summary_resume_tx: tokio::sync::mpsc::UnboundedSender<SummaryResume>,
 }
 
 impl DeferralCtx {
     fn new(
         resume_tx: tokio::sync::mpsc::UnboundedSender<DeferredResume>,
         export_resume_tx: tokio::sync::mpsc::UnboundedSender<ExportResume>,
+        summary_resume_tx: tokio::sync::mpsc::UnboundedSender<SummaryResume>,
     ) -> Self {
         Self {
             resume_tx,
             stashed: std::collections::HashMap::new(),
             next_deferral_id: 0,
             export_resume_tx,
+            summary_resume_tx,
         }
     }
 
@@ -1136,7 +1234,13 @@ where
     // no cycle, non-blocking `unbounded_send`.
     let (export_resume_tx, mut export_resume_rx) =
         tokio::sync::mpsc::unbounded_channel::<ExportResume>();
-    let mut deferral_ctx = DeferralCtx::new(resume_tx, export_resume_tx);
+    // Off-loop Background summary resume channel (#4534). Same channel-safety
+    // carve-out as the export channel: producers bounded by
+    // MAX_CONCURRENT_SUMMARIES, receiver is this loop (drains every iteration),
+    // no cycle, non-blocking `unbounded_send`.
+    let (summary_resume_tx, mut summary_resume_rx) =
+        tokio::sync::mpsc::unbounded_channel::<SummaryResume>();
+    let mut deferral_ctx = DeferralCtx::new(resume_tx, export_resume_tx, summary_resume_tx);
 
     loop {
         // Drain resumed (deferred) upserts so a completed off-loop fetch is
@@ -1161,6 +1265,18 @@ where
             match export_resume_rx.try_recv() {
                 Ok(resume) => {
                     handle_export_resume(&mut contract_handler, resume).await;
+                }
+                Err(_) => break,
+            }
+        }
+
+        // Drain completed off-loop SUMMARIES (#4534): return/replace the executor
+        // and answer the parked client. Bounded by MAX_CONCURRENT_SUMMARIES, so
+        // this batch is tiny; each iteration is a pool return + a oneshot send.
+        for _ in 0..executor::runtime::MAX_CONCURRENT_SUMMARIES {
+            match summary_resume_rx.try_recv() {
+                Ok(resume) => {
+                    handle_summary_resume(&mut contract_handler, resume).await;
                 }
                 Err(_) => break,
             }
@@ -1217,11 +1333,12 @@ where
         // only on commit (its responder is parked in `deferral_ctx.stashed`), so
         // its causality is preserved; concurrent same-key ops reconcile via the
         // contract's CRDT merge on resume. This reordering is intended (#4391).
-        if let Some((id, event)) = fair_queue.pop() {
+        if let Some((id, event, priority)) = fair_queue.pop() {
             handle_contract_event(
                 &mut contract_handler,
                 id,
                 event,
+                priority,
                 &prompter,
                 Some(&mut deferral_ctx),
             )
@@ -1248,6 +1365,9 @@ where
             }
             Some(export_resume) = export_resume_rx.recv() => {
                 handle_export_resume(&mut contract_handler, export_resume).await;
+            }
+            Some(summary_resume) = summary_resume_rx.recv() => {
+                handle_summary_resume(&mut contract_handler, summary_resume).await;
             }
             notification = recv_delegate_notification(&mut delegate_rx) => {
                 handle_delegate_notification(&mut contract_handler, notification, &prompter).await;
@@ -1313,6 +1433,35 @@ where
             tracing::debug!(
                 error = %error,
                 "Failed to deliver EXPORT resume response (client may have disconnected)"
+            );
+        }
+    }
+}
+
+/// Reconcile a completed off-loop `Background` summary back onto the loop
+/// (#4534): return/replace the executor and answer the parked client with the
+/// `GetSummaryResponse`. Mirrors [`handle_export_resume`].
+async fn handle_summary_resume<CH>(contract_handler: &mut CH, resume: SummaryResume)
+where
+    CH: ContractHandler + Send + 'static,
+{
+    let SummaryResume {
+        key,
+        done,
+        responder,
+    } = resume;
+    let summary = contract_handler
+        .executor()
+        .finish_summarize(key, done)
+        .await;
+    if let Some(responder) = responder {
+        if let Err(error) =
+            responder.respond(ContractHandlerEvent::GetSummaryResponse { key, summary })
+        {
+            tracing::debug!(
+                error = %error,
+                contract = %key,
+                "Failed to deliver SUMMARY resume response (client may have disconnected)"
             );
         }
     }
@@ -1958,6 +2107,7 @@ async fn handle_contract_event<CH, P>(
     contract_handler: &mut CH,
     id: handler::EventId,
     event: ContractHandlerEvent,
+    priority: fair_queue::Priority,
     prompter: &P,
     deferral: Option<&mut DeferralCtx>,
 ) -> Result<(), ContractError>
@@ -2454,6 +2604,47 @@ where
             }
         }
         ContractHandlerEvent::GetSummaryQuery { key } => {
+            // Background summaries (the periodic InterestSync interest-exchange,
+            // by far the highest-volume summarize source) are OFF-LOADED off the
+            // serial loop when a pooled executor is free (#4534): a burst of them
+            // serializing inline is what starved client GET/PUT/UPDATE in the
+            // "contract queue full" incident. Foreground summaries
+            // (NetworkRelay/ClientLocal — resync / a client asking directly) stay
+            // INLINE for latency. Off-loading needs a DeferralCtx (the production
+            // path always has one; delegate-driven / direct unit-test calls do
+            // not) to carry the summary-resume channel; without it, run inline.
+            if priority == fair_queue::Priority::Background {
+                if let Some(deferral) = deferral.as_ref() {
+                    match contract_handler.executor().try_begin_summarize(key) {
+                        executor::runtime::SummaryAdmission::Admitted(job) => {
+                            // Park the responder so the off-loop task answers it
+                            // later via the summary-resume channel; return now so
+                            // the loop keeps draining while the summary computes.
+                            let responder = contract_handler.channel().take_waiting_response(&id);
+                            let guard = SummaryGuard::new(
+                                deferral.summary_resume_tx.clone(),
+                                key,
+                                responder,
+                            );
+                            // Fire-and-forget, bounded by MAX_CONCURRENT_SUMMARIES
+                            // (the semaphore the job holds); the SummaryGuard
+                            // guarantees exactly-one resume even if the task is
+                            // dropped/panics, so the executor is always reclaimed
+                            // and the client always answered.
+                            GlobalExecutor::spawn(async move {
+                                let done = job.run().await;
+                                guard.send(done);
+                            });
+                            return Ok(());
+                        }
+                        // At the off-loop cap, no executor free, or this executor
+                        // kind can't off-load: fall through to the inline summary.
+                        executor::runtime::SummaryAdmission::Busy
+                        | executor::runtime::SummaryAdmission::Unsupported => {}
+                    }
+                }
+            }
+
             let summary = contract_handler
                 .executor()
                 .summarize_contract_state(key)
@@ -3176,7 +3367,7 @@ mod tests {
         // so the two futures make progress cooperatively to completion.
         let send_fut = send_halve.send_to_handler(event);
         let recv_fut = async {
-            let (id, received, _priority) = handler
+            let (id, received, priority) = handler
                 .channel()
                 .recv_from_sender()
                 .await
@@ -3185,6 +3376,7 @@ mod tests {
                 handler,
                 id,
                 received,
+                priority,
                 &user_input::AutoApprovePrompter,
                 None,
             )
@@ -3213,7 +3405,7 @@ mod tests {
         };
         let send_fut = send_halve.send_to_handler(event);
         let recv_fut = async {
-            let (id, received, _priority) = handler
+            let (id, received, priority) = handler
                 .channel()
                 .recv_from_sender()
                 .await
@@ -3222,6 +3414,7 @@ mod tests {
                 handler,
                 id,
                 received,
+                priority,
                 &user_input::AutoApprovePrompter,
                 None,
             )
@@ -4524,9 +4717,10 @@ mod hol_4391_tests {
     async fn dropped_waiter_guard_answers_client_missing_related() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<DeferredResume>();
         // This test exercises the related-fetch resume path only; the export
-        // resume channel is unused here.
+        // and summary resume channels are unused here.
         let (export_tx, _export_rx) = tokio::sync::mpsc::unbounded_channel::<ExportResume>();
-        let mut ctx = DeferralCtx::new(tx.clone(), export_tx);
+        let (summary_tx, _summary_rx) = tokio::sync::mpsc::unbounded_channel::<SummaryResume>();
+        let mut ctx = DeferralCtx::new(tx.clone(), export_tx, summary_tx);
         let mut handler =
             MockWasmContractHandler::new_test(handler::contract_handler_channel().1, None, "drop")
                 .await;
@@ -4613,6 +4807,93 @@ mod hol_4391_tests {
         );
         assert!(
             rx.try_recv().is_err(),
+            "exactly one resume — Drop must NOT send again after a success send"
+        );
+    }
+
+    /// (#4534, unit): the `SummaryGuard` delivers a terminal ERROR resume when the
+    /// off-loop summary task is DROPPED before sending (task cancelled / panicked).
+    /// Driving that resume through `handle_summary_resume` must answer the parked
+    /// client with a `GetSummaryResponse` error — the wedge-prevention (parked
+    /// client never hangs, executor always reclaimed) is the drop-guard's
+    /// exactly-once delivery. Mirrors `dropped_waiter_guard_answers_client_missing_related`.
+    #[tokio::test]
+    async fn dropped_summary_guard_answers_client_with_error() {
+        let (summary_tx, mut summary_rx) = tokio::sync::mpsc::unbounded_channel::<SummaryResume>();
+        let mut handler = MockWasmContractHandler::new_test(
+            handler::contract_handler_channel().1,
+            None,
+            "drop_summary",
+        )
+        .await;
+
+        let key = make_contract(b"drop_summary_k").key();
+        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+        let responder = StashedResponder::for_test(9, resp_tx);
+
+        // Build the off-loop summary guard and DROP it WITHOUT `send` (the task was
+        // cancelled/dropped before the summary computed).
+        {
+            let guard = SummaryGuard::new(summary_tx, key, Some(responder));
+            drop(guard);
+        }
+
+        // The guard's Drop must have delivered exactly one terminal resume,
+        // carrying a lost-to-drop SummaryDone (executor None, result Err).
+        let resume = summary_rx.try_recv().expect("Drop must deliver one resume");
+        assert_eq!(resume.key, key);
+        assert!(
+            resume.done.result.is_err(),
+            "dropped-summary resume must carry an error result"
+        );
+        assert!(
+            summary_rx.try_recv().is_err(),
+            "exactly one resume — no extra"
+        );
+
+        // Process it on the loop: the parked client is answered with a
+        // GetSummaryResponse error (mock executor's finish_summarize is the trait
+        // default, which just surfaces the carried result — no pool needed).
+        handle_summary_resume(&mut handler, resume).await;
+
+        let (_id, ev) = resp_rx.await.expect("client must be answered");
+        match ev {
+            ContractHandlerEvent::GetSummaryResponse { key: k, summary } => {
+                assert_eq!(k, key);
+                assert!(
+                    summary.is_err(),
+                    "dropped-summary must surface a summary error to the client"
+                );
+            }
+            other => panic!("expected GetSummaryResponse error, got {other}"),
+        }
+    }
+
+    /// (#4534, unit): the success path delivers EXACTLY ONE summary resume — the
+    /// explicit `send` consumes the payload, so the guard's `Drop` is a no-op
+    /// (never a double-send → never a double-return of the executor / double
+    /// client answer). Mirrors `resume_guard_success_sends_exactly_one_resume`.
+    #[tokio::test]
+    async fn summary_guard_success_sends_exactly_one_resume() {
+        let (summary_tx, mut summary_rx) = tokio::sync::mpsc::unbounded_channel::<SummaryResume>();
+        let key = make_contract(b"once_summary_k").key();
+        let (resp_tx, _resp_rx) = tokio::sync::oneshot::channel();
+
+        let guard = SummaryGuard::new(
+            summary_tx,
+            key,
+            Some(StashedResponder::for_test(4, resp_tx)),
+        );
+        // Success send (the carried SummaryDone shape is irrelevant to exactly-once;
+        // the guard forwards whatever it is). Then the guard drops at end of scope.
+        guard.send(crate::contract::executor::runtime::SummaryDone::lost_to_drop());
+
+        let resume = summary_rx
+            .try_recv()
+            .expect("success path must deliver one resume");
+        assert_eq!(resume.key, key);
+        assert!(
+            summary_rx.try_recv().is_err(),
             "exactly one resume — Drop must NOT send again after a success send"
         );
     }

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -714,6 +714,43 @@ pub(crate) trait ContractExecutor: Send + 'static {
         async move { done.into_result() }
     }
 
+    /// Admit a `Background` contract-state summary to run OFF the contract loop
+    /// (#4534). `summarize_contract_state` runs the contract's `summarize_state`
+    /// and can await on the state store / related-contract bridge; running it
+    /// inline parks the single-threaded loop, and a burst of interest-sync
+    /// summaries serializing there is what starved client GET/PUT/UPDATE in the
+    /// "contract queue full" incident. This checks out a pooled executor and
+    /// returns an opaque `SummaryJob`; the caller (the loop) moves it into a
+    /// background task, calls `SummaryJob::run` there, and hands the resulting
+    /// [`runtime::SummaryDone`] back to [`Self::finish_summarize`] on the loop.
+    ///
+    /// Concurrency is bounded ([`runtime::MAX_CONCURRENT_SUMMARIES`]); over the
+    /// cap, or when no executor is immediately free, returns
+    /// [`runtime::SummaryAdmission::Busy`] and the caller summarizes INLINE —
+    /// off-loading is a latency optimization, never a correctness requirement.
+    ///
+    /// The default implementation returns
+    /// [`runtime::SummaryAdmission::Unsupported`]: only the production
+    /// `RuntimePool` (multi-executor) off-loads. Mock / single-executor
+    /// executors summarize inline.
+    /// NON-BLOCKING: runs on the contract loop, so it must never await/park.
+    fn try_begin_summarize(&mut self, _key: ContractKey) -> runtime::SummaryAdmission {
+        runtime::SummaryAdmission::Unsupported
+    }
+
+    /// Return (or, on a panicked/dropped summary task, replace) the executor a
+    /// `SummaryJob` borrowed, and yield the summary RESULT for the client.
+    /// Called on the contract loop once the background summary task delivers its
+    /// [`runtime::SummaryDone`]. Default returns the carried result without
+    /// touching a pool (mock executors never admit).
+    fn finish_summarize(
+        &mut self,
+        _key: ContractKey,
+        done: runtime::SummaryDone,
+    ) -> impl Future<Output = Result<StateSummary<'static>, ExecutorError>> + Send {
+        async move { done.into_result() }
+    }
+
     fn get_subscription_info(&self) -> Vec<crate::message::SubscriptionInfo>;
 
     /// Remove all subscriptions for a disconnected client.

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -11,7 +11,10 @@ use super::{
 };
 pub(crate) use contract_ops::ReclaimOutcome;
 pub use pool::RuntimePool;
-pub(crate) use pool::{ExportAdmission, ExportDone, MAX_CONCURRENT_EXPORTS};
+pub(crate) use pool::{
+    ExportAdmission, ExportDone, MAX_CONCURRENT_EXPORTS, MAX_CONCURRENT_SUMMARIES,
+    SummaryAdmission, SummaryDone,
+};
 
 /// Maximum number of related contracts a single validation can request.
 /// Bounds worst-case first-time cost: N GETs of up to 50MB each.
@@ -1105,32 +1108,39 @@ mod executor_pin_tests {
         );
     }
 
-    /// The anti-deadlock invariant (#4531): off-loop export concurrency is
-    /// `min(MAX_CONCURRENT_EXPORTS, pool_size - 1)`, so at least one executor is
-    /// ALWAYS reserved for normal contract ops — exports can never hold every
-    /// executor and wedge the loop. On a 1-executor pool this is 0 (exports
-    /// disabled → Busy/503). Pure-function guard for the math.
+    /// The JOINT anti-deadlock invariant (#4531 export + #4534 summary): ALL
+    /// off-loop work draws from ONE shared budget
+    /// `min(MAX_CONCURRENT_EXPORTS + MAX_CONCURRENT_SUMMARIES, pool_size - 1)`, so
+    /// at least one executor is ALWAYS reserved for foreground ops no matter how
+    /// the budget splits between exports and summaries. This is the guard against
+    /// the small-pool deadlock window that two INDEPENDENT per-class semaphores
+    /// (each sized `pool_size-1`) would have re-opened: on `pool_size` 2–4 their
+    /// sum could reach `pool_size` and wedge the loop. Pure-function guard.
     #[test]
-    fn effective_export_permits_always_reserves_one_executor() {
-        use super::pool::{MAX_CONCURRENT_EXPORTS, effective_export_permits};
-        // 1-executor pool: exports DISABLED (no spare executor to lend).
-        assert_eq!(effective_export_permits(1), 0);
-        // 2-executor pool: exactly one export, one executor reserved for ops.
-        assert_eq!(effective_export_permits(2), 1);
-        // Below the MAX_CONCURRENT_EXPORTS ceiling, scales with pool_size - 1.
-        assert_eq!(effective_export_permits(3), MAX_CONCURRENT_EXPORTS.min(2));
-        // Large pool: clamped to MAX_CONCURRENT_EXPORTS, never more.
-        assert_eq!(effective_export_permits(64), MAX_CONCURRENT_EXPORTS);
-        // The invariant: for any pool_size >= 1, permits <= pool_size - 1, so a
-        // spare executor always remains for normal ops.
-        for n in 1..=64usize {
+    fn effective_offload_permits_always_reserves_one_executor() {
+        use super::pool::{
+            MAX_CONCURRENT_EXPORTS, MAX_CONCURRENT_SUMMARIES, effective_offload_permits,
+        };
+        let nominal = MAX_CONCURRENT_EXPORTS + MAX_CONCURRENT_SUMMARIES;
+        // 1-executor pool: ALL off-loop work DISABLED (no spare executor).
+        assert_eq!(effective_offload_permits(1), 0);
+        // 2-executor pool: exactly one off-loop slot, one executor reserved.
+        assert_eq!(effective_offload_permits(2), 1);
+        // Below the nominal ceiling, scales with pool_size - 1.
+        assert_eq!(effective_offload_permits(3), nominal.min(2));
+        assert_eq!(effective_offload_permits(4), nominal.min(3));
+        // Large pool: clamped to the nominal sum, never more.
+        assert_eq!(effective_offload_permits(64), nominal);
+        // THE invariant: for any pool_size, the TOTAL off-loop budget is
+        // <= pool_size - 1, so a spare executor always remains for foreground —
+        // exports and summaries TOGETHER can never hold every executor.
+        for n in 0..=64usize {
             assert!(
-                effective_export_permits(n) <= n.saturating_sub(1),
-                "must always reserve >=1 executor for normal ops (pool_size={n})"
+                effective_offload_permits(n) <= n.saturating_sub(1),
+                "shared off-loop budget must always reserve >=1 executor for \
+                 foreground work, jointly across exports+summaries (pool_size={n})"
             );
         }
-        // Degenerate pool_size == 0 must not panic (saturating).
-        assert_eq!(effective_export_permits(0), 0);
     }
 
     /// Pin (#4531): when the offloaded export task PANICS, the executor is lost
@@ -1188,6 +1198,64 @@ mod executor_pin_tests {
         assert!(
             !arm.contains(".export_user_secrets("),
             "the export arm must NOT call export_user_secrets inline on the loop"
+        );
+    }
+
+    /// Pin (#4534): when the off-loop summary task PANICS/is dropped, the
+    /// executor is lost with it, so `RuntimePool::finish_summarize` MUST
+    /// reconcile the missing slot — build a replacement (restoring the permit) —
+    /// and on success return the executor via `return_checked`. Same lost-slot
+    /// reconciliation as `finish_export`.
+    #[test]
+    fn finish_summarize_replaces_panicked_executor() {
+        let src = include_str!("runtime/pool.rs");
+        let body = src
+            .split("async fn finish_summarize(")
+            .nth(1)
+            .expect("RuntimePool::finish_summarize must exist")
+            .split("\n    fn get_subscription_info(")
+            .next()
+            .expect("end of finish_summarize");
+        assert!(
+            body.contains("create_replacement_executor("),
+            "finish_summarize must replace a panic-lost executor (create_replacement_executor)"
+        );
+        assert!(
+            body.contains("return_checked("),
+            "finish_summarize must return a healthy executor to the pool"
+        );
+    }
+
+    /// Pin (#4534): the `GetSummaryQuery` dispatch arm MUST off-load a
+    /// `Background` summary onto a spawned task (so the loop keeps draining)
+    /// rather than awaiting every summary inline. The interest-sync summary
+    /// burst serializing inline is the "contract queue full" incident; a
+    /// refactor that drops the off-load re-introduces it and fails CI here.
+    /// Anchored on the arm gating on `Priority::Background`, admitting via
+    /// `try_begin_summarize`, and spawning the job.
+    #[test]
+    fn get_summary_arm_offloads_background() {
+        let src = include_str!("../../contract.rs");
+        let arm = src
+            .split("ContractHandlerEvent::GetSummaryQuery { key } => {")
+            .nth(1)
+            .expect("GetSummaryQuery dispatch arm must exist")
+            .split("ContractHandlerEvent::GetDeltaQuery")
+            .next()
+            .expect("end of GetSummaryQuery arm");
+        assert!(
+            arm.contains("Priority::Background"),
+            "the summary arm must gate off-loading on Priority::Background \
+             (foreground summaries stay inline for latency)"
+        );
+        assert!(
+            arm.contains("try_begin_summarize("),
+            "the summary arm must admit Background off-load via try_begin_summarize"
+        );
+        assert!(
+            arm.contains("GlobalExecutor::spawn("),
+            "the summary arm must run the Background summary on a spawned task, \
+             not await it inline on the contract loop (#4534)"
         );
     }
 

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -99,45 +99,70 @@ pub struct RuntimePool {
     /// `lookup_key`, `get_subscription_info`, `remove_client`
     /// (read-only / no executor checkout).
     in_flight_contracts: HashMap<ContractKey, usize>,
-    /// Bounds how many hosted-mode secret exports may run OFF-LOOP concurrently
-    /// (#4381 P5). Each admitted export holds one permit (in its `ExportJob`)
-    /// AND one pool executor for its duration. Sized to
-    /// [`effective_export_permits`] (`min(MAX_CONCURRENT_EXPORTS, pool_size-1)`)
-    /// so >=1 executor is ALWAYS reserved for normal contract ops — this is the
-    /// enforced anti-deadlock invariant (see `effective_export_permits`), not a
-    /// prose hope. `Arc` so an admitted `ExportJob` can hold an owned permit
-    /// across the spawned background task without borrowing the pool.
-    export_semaphore: Arc<Semaphore>,
+    /// SHARED off-loop concurrency budget for ALL classes of off-loop work that
+    /// check out a pool executor and run on a spawned task — hosted-mode secret
+    /// exports (#4381 P5) AND `Background` contract-state summaries (#4534).
+    ///
+    /// One semaphore, not one per class, because the anti-deadlock invariant is
+    /// JOINT, not per-class: every off-loop job holds one pool executor for its
+    /// duration, and the only executor-return paths (`finish_export` /
+    /// `finish_summarize`) run ON the contract loop. If the off-loop classes
+    /// could TOGETHER hold every executor, a foreground op would park the loop on
+    /// `pop_executor().await` waiting for an executor that only the (now-parked)
+    /// loop can return — a permanent self-deadlock. Two independent per-class
+    /// semaphores each sized `pool_size-1` do NOT compose: on a small pool
+    /// (`pool_size` 2–4) `exports + summaries` could still sum to `pool_size` and
+    /// re-open the hang. A single budget sized [`effective_offload_permits`]
+    /// (`min(MAX_CONCURRENT_EXPORTS + MAX_CONCURRENT_SUMMARIES, pool_size-1)`)
+    /// guarantees `>=1` executor is ALWAYS reserved for foreground (client/relay)
+    /// work no matter how the off-loop budget is split between exports and
+    /// summaries. `Arc` so an admitted job can hold an owned permit across its
+    /// spawned task without borrowing the pool.
+    offload_semaphore: Arc<Semaphore>,
 }
 
-/// Max hosted-mode secret exports allowed to run off-loop at once (#4381 P5),
-/// BEFORE the pool-size clamp in [`effective_export_permits`].
-///
-/// Small and fixed: exports are an occasional self-host-migration action, not a
-/// hot path, and each one holds a pool executor for its duration. The real cap
-/// is `min(this, pool_size - 1)` so >=1 executor is ALWAYS free for normal ops.
-/// A request that arrives while that many exports are in flight (or that can't
-/// immediately reserve an executor) is rejected with a typed busy error (HTTP
-/// 503), never queued on the contract loop.
+/// Nominal share of the shared off-loop budget for hosted-mode secret exports
+/// (#4381 P5). Exports are an occasional self-host-migration action, not a hot
+/// path. This is a NOMINAL ceiling: the real bound is the SHARED
+/// [`effective_offload_permits`] budget that exports and summaries draw from
+/// together (`min(MAX_CONCURRENT_EXPORTS + MAX_CONCURRENT_SUMMARIES,
+/// pool_size-1)`), so on a small pool exports may get fewer than this when
+/// summaries are also running. Over the shared budget (or when no executor is
+/// immediately free) → typed busy error (HTTP 503), never queued on the loop.
 pub(crate) const MAX_CONCURRENT_EXPORTS: usize = 2;
 
-/// Effective off-loop export concurrency for a pool of `pool_size` executors.
+/// Nominal share of the shared off-loop budget for `Background` summaries
+/// (#4534). Like [`MAX_CONCURRENT_EXPORTS`], a nominal ceiling on top of the
+/// SHARED [`effective_offload_permits`] budget — a summary that can't reserve a
+/// shared off-loop slot (or an executor) is NOT off-loaded; the caller runs it
+/// inline on the loop, exactly as before #4534 (summaries are
+/// correctness-neutral; the only question is on- vs off-loop).
+pub(crate) const MAX_CONCURRENT_SUMMARIES: usize = 2;
+
+/// Effective SHARED off-loop concurrency for a pool of `pool_size` executors —
+/// the single budget that BOTH off-loop classes (exports #4381 P5, summaries
+/// #4534) acquire from.
 ///
-/// `min(MAX_CONCURRENT_EXPORTS, pool_size - 1)` — this is the load-bearing
-/// anti-deadlock invariant, ENFORCED in code (not prose): an admitted export
-/// holds one pool executor off-loop, and the only executor-return path
-/// (`finish_export`) runs ON the contract loop. If exports could hold EVERY
-/// executor, a normal contract op would park the loop waiting for an executor
-/// that only the (now-parked) loop can return — a permanent self-deadlock.
-/// Reserving at least one executor for normal ops makes that impossible.
+/// `min(MAX_CONCURRENT_EXPORTS + MAX_CONCURRENT_SUMMARIES, pool_size - 1)` — the
+/// load-bearing anti-deadlock invariant, ENFORCED in code (not prose): every
+/// off-loop job holds one pool executor, and the only executor-return paths
+/// (`finish_export` / `finish_summarize`) run ON the contract loop. If off-loop
+/// work could hold EVERY executor, a foreground op would park the loop on
+/// `pop_executor().await` waiting for an executor only the (now-parked) loop can
+/// return — a permanent self-deadlock.
 ///
-/// `pool_size == 1` → 0: exports are DISABLED on a single-executor node (they
-/// return the typed Busy → 503). That is correct, not a regression — a tiny
-/// 1-executor node has no spare executor to lend a deferred export anyway, and
-/// the alternative (running it on the sole executor) is exactly the inline
-/// blocking this whole change removes.
-pub(crate) fn effective_export_permits(pool_size: usize) -> usize {
-    MAX_CONCURRENT_EXPORTS.min(pool_size.saturating_sub(1))
+/// Crucially this is a JOINT budget, not per-class. Two independent per-class
+/// semaphores each sized `pool_size-1` do NOT compose: on a small pool
+/// (`pool_size` 2–4) exports + summaries could each take their own share and
+/// together hold all `pool_size` executors, re-opening the hang. Drawing both
+/// classes from ONE `pool_size-1`-capped budget reserves >=1 executor for
+/// foreground work no matter how the budget splits between exports and summaries.
+///
+/// `pool_size == 1` → 0: off-loop work is DISABLED on a single-executor node
+/// (exports return Busy → 503; summaries run inline). Correct — a 1-executor
+/// node has no spare executor to lend.
+pub(crate) fn effective_offload_permits(pool_size: usize) -> usize {
+    (MAX_CONCURRENT_EXPORTS + MAX_CONCURRENT_SUMMARIES).min(pool_size.saturating_sub(1))
 }
 
 /// Result of [`RuntimePool::try_begin_export`]: an admitted off-loop export job,
@@ -241,6 +266,98 @@ impl ExportDone {
     /// the executor to); the real `RuntimePool::finish_export` returns the
     /// executor to the pool instead of dropping it.
     pub(crate) fn into_result(self) -> Result<Vec<u8>, ExecutorError> {
+        self.result
+    }
+}
+
+/// Result of [`RuntimePool::try_begin_summarize`]: an admitted off-loop summary
+/// job, or a rejection because too many summaries are already in flight / no
+/// executor is momentarily free, or because this executor kind cannot off-load
+/// (mock / test / single-executor). On any non-`Admitted` outcome the caller
+/// summarizes INLINE on the loop — off-loading is a latency optimization, never
+/// a correctness requirement.
+pub(crate) enum SummaryAdmission {
+    /// Admitted. The contract-handling loop moves this `SummaryJob` into a
+    /// background task and calls [`SummaryJob::run`] there; the resulting
+    /// [`SummaryDone`] comes back to the loop, which calls
+    /// [`RuntimePool::finish_summarize`] to return/replace the executor. Boxed
+    /// because a `SummaryJob` owns a whole `Executor<Runtime>`.
+    Admitted(Box<SummaryJob>),
+    /// `MAX_CONCURRENT_SUMMARIES` summaries are already running, or no executor
+    /// was immediately free. The caller summarizes inline on the loop.
+    Busy,
+    /// This executor kind cannot off-load (mock / single-executor pool). The
+    /// caller summarizes inline.
+    Unsupported,
+}
+
+/// An admitted `Background` summary, owning everything it needs to run OFF the
+/// contract loop: an exclusively-checked-out pool executor, the summary-
+/// concurrency permit (released when the job is consumed by `run`), and the
+/// contract key. Opaque to the loop, which just moves it into a background task.
+pub(crate) struct SummaryJob {
+    executor: Executor<Runtime>,
+    /// Held for the lifetime of the job so the summary-concurrency slot is
+    /// occupied until the work finishes; dropped at the end of `run`.
+    _permit: tokio::sync::OwnedSemaphorePermit,
+    key: ContractKey,
+}
+
+impl SummaryJob {
+    /// Run the summary off the contract loop and produce a [`SummaryDone`] to
+    /// hand back to the loop.
+    ///
+    /// Unlike the export job, `summarize_contract_state` is itself `async` (it
+    /// may await on the state store / related-contract bridge), so there is no
+    /// synchronous CPU body to push onto `spawn_blocking` — the off-loading is
+    /// achieved by running this whole job on a SEPARATE spawned task instead of
+    /// inline on the serial loop. A panic inside the `.await` aborts THIS task;
+    /// the `SummaryGuard` that owns the parked responder then delivers a
+    /// drop-style `SummaryDone` (executor `None`) so the loop replaces the lost
+    /// executor and answers the client — exactly the export panic semantics.
+    ///
+    /// Intended to be called from a spawned background task, NOT on the contract
+    /// loop — that is the whole point of the deferral (#4534).
+    pub(crate) async fn run(mut self) -> SummaryDone {
+        let result = self.executor.summarize_contract_state(self.key).await;
+        SummaryDone {
+            executor: Some(self.executor),
+            result,
+        }
+        // `_permit` drops here, freeing the summary-concurrency slot for the next
+        // request. The executor is returned to the pool by the loop via
+        // `finish_summarize`.
+    }
+}
+
+/// The completed summary, handed back to the contract loop. Carries the result
+/// for the client and the executor to return to the pool (`None` only on the
+/// drop/panic path, in which case the loop replaces the lost executor).
+pub(crate) struct SummaryDone {
+    executor: Option<Executor<Runtime>>,
+    pub(crate) result: Result<StateSummary<'static>, ExecutorError>,
+}
+
+impl SummaryDone {
+    /// A `SummaryDone` for the case where the off-loop summary task was dropped /
+    /// cancelled / panicked before producing a result. Carries no executor — the
+    /// job owned it and is gone — so the loop's `finish_summarize` treats it like
+    /// the export panic path (replace the lost slot) and answers the client with
+    /// an error. Delivered by `SummaryGuard::drop`.
+    pub(crate) fn lost_to_drop() -> Self {
+        Self {
+            executor: None,
+            result: Err(ExecutorError::other(anyhow::anyhow!(
+                "background summary task was dropped before completion"
+            ))),
+        }
+    }
+
+    /// Consume the `SummaryDone`, dropping any carried executor and returning just
+    /// the result. Used by the trait default `finish_summarize` (no pool to
+    /// return the executor to); the real `RuntimePool::finish_summarize` returns
+    /// the executor to the pool instead of dropping it.
+    pub(crate) fn into_result(self) -> Result<StateSummary<'static>, ExecutorError> {
         self.result
     }
 }
@@ -394,7 +511,7 @@ impl RuntimePool {
             delegate_notification_tx,
             delegate_notification_rx: Some(delegate_notification_rx),
             in_flight_contracts: HashMap::new(),
-            export_semaphore: Arc::new(Semaphore::new(effective_export_permits(pool_size_usize))),
+            offload_semaphore: Arc::new(Semaphore::new(effective_offload_permits(pool_size_usize))),
         })
     }
 
@@ -1023,11 +1140,12 @@ impl ContractExecutor for RuntimePool {
         // FULLY NON-BLOCKING admission — this runs ON the contract loop, so it
         // must never await/park. Two non-blocking gates, in order:
         //
-        // 1. Export-concurrency permit. Sized to `min(MAX_CONCURRENT_EXPORTS,
-        //    pool_size-1)` so admitted exports can never hold every executor. On
+        // 1. A SHARED off-loop permit (exports + summaries draw from the same
+        //    `effective_offload_permits` budget). Sized so the off-loop classes
+        //    can NEVER jointly hold every executor — see `offload_semaphore`. On
         //    a 1-executor pool this is 0, so exports are disabled here. Over the
-        //    cap → Busy (HTTP 503), never queued.
-        let Ok(permit) = self.export_semaphore.clone().try_acquire_owned() else {
+        //    shared budget → Busy (HTTP 503), never queued.
+        let Ok(permit) = self.offload_semaphore.clone().try_acquire_owned() else {
             return ExportAdmission::Busy;
         };
         // 2. A pool executor, taken NON-BLOCKING. If every executor is momentarily
@@ -1090,6 +1208,74 @@ impl ContractExecutor for RuntimePool {
                 }
             }
         }
+        result
+    }
+
+    /// Try to admit a `Background` summary for OFF-loop execution (#4534).
+    ///
+    /// FULLY NON-BLOCKING — this runs ON the contract loop, so it must never
+    /// await/park. Two non-blocking gates, in order, identical in shape to
+    /// `try_begin_export`:
+    ///
+    /// 1. A SHARED off-loop permit (exports + summaries draw from the same
+    ///    `effective_offload_permits` budget) so off-loop work can never jointly
+    ///    hold every executor — see `offload_semaphore`. On a 1-executor pool
+    ///    this is 0, so off-loading is disabled here.
+    /// 2. A pool executor, taken NON-BLOCKING. If every executor is momentarily
+    ///    busy, we do NOT await (that would park the loop) — we return `Busy` and
+    ///    the permit drops here (restoring the slot).
+    ///
+    /// On `Busy`/`Unsupported` the caller summarizes INLINE; nothing is lost.
+    /// `track_contract_checkout` is recorded here (mirroring the inline
+    /// `summarize_contract_state`); the matching `track_contract_return` happens
+    /// in `finish_summarize`.
+    fn try_begin_summarize(&mut self, key: ContractKey) -> SummaryAdmission {
+        let Ok(permit) = self.offload_semaphore.clone().try_acquire_owned() else {
+            return SummaryAdmission::Busy;
+        };
+        let Some(executor) = self.try_pop_executor() else {
+            return SummaryAdmission::Busy;
+        };
+        self.track_contract_checkout(&key);
+        SummaryAdmission::Admitted(Box::new(SummaryJob {
+            executor,
+            _permit: permit,
+            key,
+        }))
+    }
+
+    /// Reconcile a completed off-loop summary back onto the contract loop:
+    /// return (or replace) the executor and surface the result for the client.
+    /// Mirrors `finish_export` exactly, plus the `track_contract_return` that the
+    /// inline `summarize_contract_state` would have done.
+    async fn finish_summarize(
+        &mut self,
+        key: ContractKey,
+        done: SummaryDone,
+    ) -> Result<StateSummary<'static>, ExecutorError> {
+        let SummaryDone { executor, result } = done;
+        match executor {
+            Some(executor) => {
+                self.return_checked(executor, "summarize_contract_state")
+                    .await;
+            }
+            None => {
+                tracing::error!(
+                    "summary offload task panicked/dropped; replacing the lost pool executor"
+                );
+                match self.create_replacement_executor().await {
+                    Ok(replacement) => self.return_executor(replacement),
+                    Err(e) => {
+                        tracing::error!(
+                            error = %e,
+                            "failed to replace summary-panicked executor; pool capacity reduced by one"
+                        );
+                        self.checked_out.fetch_sub(1, Ordering::SeqCst);
+                    }
+                }
+            }
+        }
+        self.track_contract_return(&key);
         result
     }
 

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -384,7 +384,11 @@ impl FairEventQueue {
     /// for client work.
     ///
     /// Returns `None` if all tiers are empty.
-    pub(super) fn pop(&mut self) -> Option<(EventId, ContractHandlerEvent)> {
+    ///
+    /// The popped event's [`Priority`] is returned alongside it so the loop can
+    /// route Background work off-loop (#4534) — e.g. a Background summary is
+    /// off-loaded while client/relay summaries stay inline for latency.
+    pub(super) fn pop(&mut self) -> Option<QueuedItem> {
         let client_nonempty = self.tiers[Priority::ClientLocal as usize].queued > 0;
         let lower_nonempty = self.tiers[Priority::NetworkRelay as usize].queued > 0
             || self.tiers[Priority::Background as usize].queued > 0;
@@ -413,7 +417,7 @@ impl FairEventQueue {
         };
 
         for priority in order {
-            if let Some((id, event, _)) = self.tiers[priority as usize].pop() {
+            if let Some((id, event, item_priority)) = self.tiers[priority as usize].pop() {
                 debug_assert!(self.total_queued > 0);
                 self.total_queued = self.total_queued.saturating_sub(1);
                 // Track the ClientLocal streak only while lower work waits — an
@@ -423,7 +427,7 @@ impl FairEventQueue {
                 } else {
                     self.client_streak = 0;
                 }
-                return Some((id, event));
+                return Some((id, event, item_priority));
             }
         }
         None
@@ -560,7 +564,7 @@ mod tests {
 
         // Pop all — should interleave: A, B, A, B, ...
         let mut results = Vec::new();
-        while let Some((_, event)) = queue.pop() {
+        while let Some((_, event, _)) = queue.pop() {
             let ContractHandlerEvent::GetQuery { instance_id, .. } = event else {
                 panic!("unexpected event type");
             };
@@ -734,7 +738,7 @@ mod tests {
 
         // Pop all and verify order matches insertion order
         let mut popped_ids = Vec::new();
-        while let Some((id, _)) = queue.pop() {
+        while let Some((id, _, _)) = queue.pop() {
             popped_ids.push(id.id);
         }
 
@@ -765,7 +769,7 @@ mod tests {
 
         // Pop all events and count per-contract
         let mut per_contract_counts: HashMap<ContractInstanceId, usize> = HashMap::new();
-        while let Some((_, event)) = queue.pop() {
+        while let Some((_, event, _)) = queue.pop() {
             let ContractHandlerEvent::GetQuery { instance_id, .. } = event else {
                 panic!("unexpected event type");
             };
@@ -815,7 +819,7 @@ mod tests {
         let mut cold_positions = Vec::new();
 
         let mut position = 0;
-        while let Some((_, event)) = queue.pop() {
+        while let Some((_, event, _)) = queue.pop() {
             let ContractHandlerEvent::GetQuery { instance_id, .. } = event else {
                 panic!("unexpected event type");
             };
@@ -924,7 +928,7 @@ mod tests {
         queue
             .try_push_default(make_event_id(0), make_get_event(a))
             .unwrap();
-        let (id0, _) = queue.pop().expect("should pop A");
+        let (id0, _, _) = queue.pop().expect("should pop A");
         assert_eq!(id0.id, 0);
 
         // Push events for B and A
@@ -937,14 +941,14 @@ mod tests {
 
         // Round-robin should give B first (B was added after A was drained,
         // so B is at front of round_robin)
-        let (id1, ev1) = queue.pop().expect("should pop B");
+        let (id1, ev1, _) = queue.pop().expect("should pop B");
         let ContractHandlerEvent::GetQuery { instance_id, .. } = ev1 else {
             panic!("unexpected event type");
         };
         assert_eq!(instance_id, b, "expected B (id={})", id1.id);
 
         // Then A
-        let (id2, ev2) = queue.pop().expect("should pop A");
+        let (id2, ev2, _) = queue.pop().expect("should pop A");
         let ContractHandlerEvent::GetQuery { instance_id, .. } = ev2 else {
             panic!("unexpected event type");
         };
@@ -978,7 +982,7 @@ mod tests {
         // Pop 3 — should be one from each (A, B, C in round-robin)
         let mut first_round = Vec::new();
         for _ in 0..3 {
-            let (_, ev) = queue.pop().unwrap();
+            let (_, ev, _) = queue.pop().unwrap();
             let ContractHandlerEvent::GetQuery { instance_id, .. } = ev else {
                 panic!("unexpected");
             };
@@ -989,7 +993,7 @@ mod tests {
         // C is now drained, so second round is A, B
         let mut second_round = Vec::new();
         for _ in 0..2 {
-            let (_, ev) = queue.pop().unwrap();
+            let (_, ev, _) = queue.pop().unwrap();
             let ContractHandlerEvent::GetQuery { instance_id, .. } = ev else {
                 panic!("unexpected");
             };
@@ -998,7 +1002,7 @@ mod tests {
         assert_eq!(second_round, vec![a, b]);
 
         // Third round: only A remains
-        let (_, ev) = queue.pop().unwrap();
+        let (_, ev, _) = queue.pop().unwrap();
         let ContractHandlerEvent::GetQuery { instance_id, .. } = ev else {
             panic!("unexpected");
         };
@@ -1204,7 +1208,7 @@ mod tests {
             .unwrap();
 
         let order: Vec<ContractInstanceId> = std::iter::from_fn(|| queue.pop())
-            .map(|(_, ev)| get_cid(ev))
+            .map(|(_, ev, _)| get_cid(ev))
             .collect();
         assert_eq!(
             order,
@@ -1321,7 +1325,7 @@ mod tests {
             .expect("ClientLocal on a Background-saturated contract must still be admitted");
 
         // And ClientLocal drains first despite being pushed last.
-        let (_, ev) = queue.pop().unwrap();
+        let (_, ev, _) = queue.pop().unwrap();
         assert_eq!(get_cid(ev), key);
         assert_eq!(queue.tier_queued(Priority::ClientLocal), 0);
         assert_eq!(
@@ -1348,7 +1352,7 @@ mod tests {
                 .unwrap();
         }
         let order: Vec<ContractInstanceId> = std::iter::from_fn(|| queue.pop())
-            .map(|(_, ev)| get_cid(ev))
+            .map(|(_, ev, _)| get_cid(ev))
             .collect();
         assert_eq!(order, vec![a, b, a, b, a, b, a, b]);
     }
@@ -1389,7 +1393,7 @@ mod tests {
         let mut max_gap = 0usize;
         let mut relay_served = 0usize;
         for _ in 0..400 {
-            let (_, ev) = queue.pop().unwrap();
+            let (_, ev, _) = queue.pop().unwrap();
             let cid = get_cid(ev);
             // relay contracts are the 2000.. series
             let is_relay = (2000..3000).any(|s| make_contract_id_u32(s) == cid);


### PR DESCRIPTION
## Problem

`GetSummaryQuery` ran `summarize_contract_state().await` **inline on the single-threaded contract event loop**. The periodic InterestSync interest-exchange emits these as `Priority::Background` in high volume, so a burst of them serialized on the loop behind (and ahead of) client GET/PUT/UPDATE — the "contract queue full, try again later" client outage (#4534).

#4535 priority-tiered the queue so client work *drains* first, but priority controls ordering only: a Background summary already at the loop head still parks the loop for its full execution duration regardless of what's queued behind it. This PR fixes that residual head-of-line stall.

## Solution

Off-load the Background summary execution onto a spawned task, mirroring the just-landed #4531/#4381 P5 hosted-export off-load so the pool has **one** off-loading idiom, not two.

- **pool.rs**: `try_begin_summarize` (non-blocking, via P5's `try_pop_executor`) admits a `SummaryJob` owning the checked-out executor; `finish_summarize` returns/replaces it on the loop. Reuses P5's `return_checked` / `create_replacement_executor` — **no new executor-return channel**.
- **Shared off-loop budget (key correctness point):** exports (#4531 P5) and summaries (#4534) draw from **one** `offload_semaphore` sized `effective_offload_permits = min(MAX_CONCURRENT_EXPORTS + MAX_CONCURRENT_SUMMARIES, pool_size-1)`. Two *independent* per-class semaphores each sized `pool_size-1` do **not** compose: on a small pool (`pool_size` 2–4 → 3–5 core nodes, since `pool_size = available_parallelism()-1`) exports + summaries could jointly hold every executor, and a foreground op then parking on `pop_executor().await` would wait for an executor only the now-parked loop can return — a self-deadlock. The shared budget keeps **≥1 executor reserved for foreground** regardless of how off-loop work splits between the classes. (#4391's related-fetch deferral is *not* a third class — it releases its executor before the off-loop network wait.)
- **contract.rs**: `SummaryResume`/`SummaryGuard` give exactly-once delivery (drop = error resume → client always answered, executor always reclaimed) via a `summary_resume_tx` on `DeferralCtx`, drained every loop turn. The `GetSummaryQuery` arm off-loads **only** `Priority::Background` when a `DeferralCtx` + free executor are present; foreground summaries (NetworkRelay/ClientLocal — resync / a direct client ask) stay inline for latency. Mock / single-executor / delegate-driven paths inherit the trait default (`Unsupported`) and summarize inline, so the simulation runner stays deterministic and fully inline.
- **fair_queue::pop()** now returns the popped event's `Priority`, threaded into `handle_contract_event` so the arm can route on it.

**Correctness-neutral:** a summary computes the same value on or off the loop; the only change is whether it blocks the loop while doing so.

## Testing

- `effective_offload_permits_always_reserves_one_executor` — asserts the **joint** cap (`exports + summaries ≤ pool_size-1` for all n) — the small-pool deadlock guard.
- `dropped_summary_guard_answers_client_with_error` / `summary_guard_success_sends_exactly_one_resume` — behavioral exactly-once for `SummaryGuard` (drop delivers one error resume + answers the client; success send makes Drop a no-op), mirroring the existing `ResumeGuard` tests.
- `finish_summarize_replaces_panicked_executor` — panic-lost executor is replaced.
- `get_summary_arm_offloads_background` — source-scrape pin that the arm gates on Background, admits via `try_begin_summarize`, spawns the job.
- contract (501) + export (33) + node suites green; clippy clean.

Reviewed by a multi-perspective pass (code-first / testing / skeptical / big-picture); the deadlock window above was caught in review and fixed via the shared budget, then re-reviewed clean.

## Fixes

Refs #4534 (third installment of the remediation: priority queue #4535 → migration-admission gate #4537 → this off-load).

https://claude.ai/code/session_01JZGPSEa8g1Z8Nomv528c8g