### PR TITLE
DIAG: NAT baseline on pre-PR main (do not merge)

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -186,3 +186,5 @@ pub mod dev_tool {
 pub mod deadlock_detection;
 
 pub mod test_utils;
+
+// diag: trigger NAT baseline on pre-PR main (#4574, do not merge)


### PR DESCRIPTION
Diagnostic only. Triggers NAT Validation on the exact pre-PR main commit (922e40bd9) to determine whether the NAT failures on #4572 are pre-existing flake or introduced by that PR. Close after CI.