### PR TITLE
feat(hosted): per-user operation rate limit (#4561 P5)

### DIFF
--- a/apps/freenet-ping/app/tests/common/mod.rs
+++ b/apps/freenet-ping/app/tests/common/mod.rs
@@ -151,11 +151,10 @@ pub async fn base_node_test_config_with_rng<R: Rng>(
             // WebSocket binds to same IP as network for test isolation (prevents port conflicts)
             address: Some(network_bind_ip.into()),
             ws_api_port: Some(ws_api_port),
-            token_ttl_seconds: None,
-            token_cleanup_interval_seconds: None,
-            allowed_host: None,
-            allowed_source_cidrs: None,
-            hosted_mode: None,
+            // All other ws_api args default (None). `..Default::default()` so a
+            // new ws_api field (e.g. the per-user rate-limit fields, #4561) can't
+            // break this test helper's compile.
+            ..Default::default()
         },
         network_api: NetworkArgs {
             // Use varied IP for network socket to get unique ring locations

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -39,6 +39,12 @@ pub(crate) mod result_router;
 pub(crate) mod session_actor;
 #[cfg(test)]
 mod test_correlation;
+/// Per-user operation/export rate limiting for hosted mode (#4561, P5 of #4381).
+/// Not gated on the `websocket` feature: it has no axum dependency (just
+/// `DashMap` + `tokio::time` + `UserId`) and its `DEFAULT_*` constants are the
+/// single source of truth for the operator-config defaults in `config.rs`,
+/// which compiles with or without the feature.
+pub(crate) mod user_op_rate_limit;
 #[cfg(feature = "websocket")]
 pub(crate) mod websocket;
 

--- a/crates/core/src/client_events/user_op_rate_limit.rs
+++ b/crates/core/src/client_events/user_op_rate_limit.rs
@@ -53,7 +53,14 @@ pub const DEFAULT_PER_USER_OP_RATE_LIMIT: u64 = 10;
 /// Default per-user burst capacity (max tokens that can accumulate). A user
 /// who has been idle can issue up to this many ops back-to-back before being
 /// throttled to the sustained [`DEFAULT_PER_USER_OP_RATE_LIMIT`].
-pub const DEFAULT_PER_USER_OP_BURST: u64 = 50;
+///
+/// Set generously (100): a heavy-room hosted user's app-load — room list +
+/// per-room state + member lists + delegate secret reads across many rooms —
+/// can plausibly burst past 50 ops in the first second after page load. A
+/// false-positive throttle there breaks the UX worse than allowing a slightly
+/// larger ONE-TIME burst; the sustained [`DEFAULT_PER_USER_OP_RATE_LIMIT`]
+/// (10/sec) is the real flood cap, the burst is just the initial allowance.
+pub const DEFAULT_PER_USER_OP_BURST: u64 = 100;
 
 /// Minimum seconds between hosted-export downloads per user (export is far more
 /// expensive than a single op, so it gets a separate, tighter limit). `0`

--- a/crates/core/src/client_events/user_op_rate_limit.rs
+++ b/crates/core/src/client_events/user_op_rate_limit.rs
@@ -171,9 +171,16 @@ impl TokenBucket {
             state.tokens =
                 (state.tokens + elapsed.as_secs_f64() * self.refill_per_sec).min(self.capacity);
         }
-        // "Essentially full": within one token of capacity. A bucket this full
-        // is not throttling anyone, so re-creation is a no-op for limiting.
-        let safe = state.tokens >= self.capacity - 1.0;
+        // "Essentially full" AND holding at least one whole token. Within one
+        // token of capacity means re-creation is a no-op; the `>= 1.0` clause is
+        // what makes that true even at capacity == 1, where `capacity - 1.0 == 0`
+        // would otherwise classify a DEPLETED (tokens == 0), actively-throttling
+        // bucket as evictable — dropping it would re-create a FULL bucket and let
+        // a burst==1 flooder bypass the limit. `--per-user-op-burst` is operator-
+        // configurable (floored at 1), so burst==1 is a reachable config. For
+        // cap >= 2 the `>= 1.0` clause is already implied by `>= capacity - 1.0`,
+        // so this is a no-op there.
+        let safe = state.tokens >= self.capacity - 1.0 && state.tokens >= 1.0;
         (safe, state.last_access)
     }
 }
@@ -282,6 +289,11 @@ impl Inner {
         // — i.e. too few idle buckets to drop. Not reaching the low-water-mark is
         // expected and fine (it just means the next sweep comes sooner).
         if self.op_buckets.len() > self.max_tracked_users && removed < target_removals {
+            // One-shot per process: this degraded mode (over cap, mostly active
+            // throttling) is a posture signal worth surfacing once, but re-warning
+            // on every subsequent over-cap sweep would itself be log spam under a
+            // sustained flood. Intentionally not re-armed for a later distinct
+            // episode — the metric to watch is the map size, not this line.
             static WARNED: std::sync::atomic::AtomicBool =
                 std::sync::atomic::AtomicBool::new(false);
             if WARNED
@@ -820,6 +832,45 @@ mod tests {
         assert!(
             !limiter.try_acquire_op_at(&flooder, t_check),
             "eviction must NOT have reset the active flooder's depleted bucket"
+        );
+    }
+
+    /// burst == 1 boundary (round-4 finding): at capacity == 1, a DEPLETED
+    /// bucket has tokens == 0.0, and `tokens >= capacity - 1.0` is `0.0 >= 0.0`
+    /// == true — so without the extra `tokens >= 1.0` clause in `evictability`,
+    /// an actively-throttling burst==1 flooder would be classified evictable,
+    /// dropped, and lazily recreated FULL → limit bypass. This test pins the fix:
+    /// a depleted cap=1/burst=1 flooder stays throttled across other-user sweeps.
+    ///
+    /// All events share ONE frozen instant so the flooder sits at EXACTLY
+    /// tokens == 0.0 (no refill) — the precise boundary the bug hit. Before the
+    /// fix this FAILS (flooder evicted+recreated full → final acquire returns
+    /// true); after the fix it PASSES.
+    #[tokio::test(start_paused = true)]
+    async fn eviction_never_resets_active_flooder_burst_one() {
+        // cap = 2, burst = 1, rate 1/s (must be > 0 to enable op limiting).
+        let limiter = UserOpRateLimiter::with_cap(1, 1, 0, 2);
+        let flooder = uid(200);
+        let t0 = Instant::now();
+        // Spend the single burst token, then confirm throttled (tokens now 0.0).
+        assert!(limiter.try_acquire_op_at(&flooder, t0));
+        assert!(
+            !limiter.try_acquire_op_at(&flooder, t0),
+            "burst==1 flooder is now depleted/throttled (tokens == 0.0)"
+        );
+
+        // Parade of other users at the SAME instant t0 → zero refill, so the
+        // flooder stays at exactly tokens == 0.0 throughout the eviction sweeps.
+        for i in 0..40u8 {
+            let other = uid(i); // never 200
+            assert!(limiter.try_acquire_op_at(&other, t0));
+        }
+
+        // Still at t0 → no refill possible. If the depleted bucket had been
+        // evicted+recreated it would now be FULL and admit. It must stay throttled.
+        assert!(
+            !limiter.try_acquire_op_at(&flooder, t0),
+            "burst==1: eviction must NOT have reset the depleted flooder's bucket"
         );
     }
 

--- a/crates/core/src/client_events/user_op_rate_limit.rs
+++ b/crates/core/src/client_events/user_op_rate_limit.rs
@@ -1,0 +1,475 @@
+//! Per-user operation rate limiting for HOSTED mode (#4561, P5 of #4381).
+//!
+//! Bounds how fast a single hosted user (one `userToken` ⇒ one [`UserId`]) can
+//! issue contract operations (GET / PUT / UPDATE / SUBSCRIBE) so one visitor
+//! cannot flood the node's executor and network. Over-rate requests are
+//! REJECTED at the WebSocket boundary BEFORE the request is forwarded to the
+//! node event loop, so a rejection costs no executor or network work; the
+//! client is expected to retry shortly.
+//!
+//! # Why this is hosted-only
+//!
+//! The limiter is consulted ONLY when a connection carries a
+//! [`UserSecretContext`](crate::wasm_runtime::UserSecretContext) — i.e. hosted
+//! mode is on AND the connection presented a user token. Local / non-hosted /
+//! tokenless connections derive no context, so they are NEVER rate-limited:
+//! the single-user node behaves byte-for-byte as before (#4381's "never break
+//! single-user default" invariant).
+//!
+//! # Server-level shared state, not a process global
+//!
+//! The limiter is owned as per-node server state (an `Arc` cloned into each
+//! connection's request path), NOT a process-global `LazyLock`. The WS server
+//! is per-node, so this naturally isolates nodes (a multi-node simulation in
+//! one process never collides) while sharing one user's bucket across all of
+//! that user's concurrent connections — the combined rate is what's bounded.
+//!
+//! # Concurrency
+//!
+//! `process_client_request` runs CONCURRENTLY across many WS connection tasks,
+//! so the bucket must admit at most `capacity` tokens with NO check-then-act
+//! race that lets two concurrent requests both pass when only one token is
+//! left. Each bucket guards its `(tokens, last_refill)` pair behind a short
+//! [`std::sync::Mutex`]; [`TokenBucket::try_acquire`] refills and decrements
+//! inside the SAME lock, so the decision is atomic. The map itself is a
+//! [`DashMap`], so distinct users never contend, and the per-bucket critical
+//! section is a few arithmetic ops (no `.await`, no allocation).
+//!
+//! Token-bucket math (capacity = `burst`, refill = `rate` tokens/sec):
+//! refill `elapsed * rate` tokens (capped at `capacity`) on each acquire, then
+//! admit iff at least one whole token is available.
+
+use std::sync::{Arc, Mutex};
+
+use dashmap::DashMap;
+use tokio::time::Instant;
+
+use crate::wasm_runtime::UserId;
+
+/// Default sustained per-user operation rate (requests/second) in hosted mode.
+/// `0` disables operation rate limiting entirely.
+pub const DEFAULT_PER_USER_OP_RATE_LIMIT: u64 = 10;
+
+/// Default per-user burst capacity (max tokens that can accumulate). A user
+/// who has been idle can issue up to this many ops back-to-back before being
+/// throttled to the sustained [`DEFAULT_PER_USER_OP_RATE_LIMIT`].
+pub const DEFAULT_PER_USER_OP_BURST: u64 = 50;
+
+/// Minimum seconds between hosted-export downloads per user (export is far more
+/// expensive than a single op, so it gets a separate, tighter limit). `0`
+/// disables export rate limiting.
+pub const DEFAULT_PER_USER_EXPORT_MIN_INTERVAL_SECS: u64 = 10;
+
+/// A single user's token bucket. The `(tokens, last_refill)` pair is guarded by
+/// a `Mutex` so refill+decrement is one atomic decision (no check-then-act race
+/// across concurrent connection tasks sharing this user's bucket).
+struct TokenBucket {
+    /// `capacity` (= burst) and `refill_per_sec` (= sustained rate) are fixed at
+    /// construction; only `state` mutates.
+    capacity: f64,
+    refill_per_sec: f64,
+    state: Mutex<BucketState>,
+}
+
+struct BucketState {
+    /// Fractional tokens currently available (≤ `capacity`).
+    tokens: f64,
+    /// When `tokens` was last refilled.
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    /// A fresh bucket starts FULL (`capacity` tokens) so a brand-new user can
+    /// immediately issue a burst — the limiter only ever slows a user down, it
+    /// never makes the first request wait.
+    fn new(capacity: u64, refill_per_sec: u64, now: Instant) -> Self {
+        let capacity = capacity as f64;
+        Self {
+            capacity,
+            refill_per_sec: refill_per_sec as f64,
+            state: Mutex::new(BucketState {
+                tokens: capacity,
+                last_refill: now,
+            }),
+        }
+    }
+
+    /// Try to spend one token. Returns `true` if admitted, `false` if the user
+    /// is over-rate. Refill and decrement happen inside one lock so the
+    /// decision is atomic across concurrent callers.
+    fn try_acquire(&self, now: Instant) -> bool {
+        let mut state = self.state.lock().unwrap_or_else(|p| p.into_inner());
+        // Refill based on elapsed time since the last refill. `saturating_*`
+        // isn't available on Instant arithmetic, but `now` is monotonic and
+        // `>= last_refill` for any single bucket (Instants only move forward),
+        // so `duration_since` is well-defined; guard anyway in case a paused
+        // test clock hands back an equal instant (elapsed = 0, no refill).
+        let elapsed = now.saturating_duration_since(state.last_refill);
+        state.last_refill = now;
+        if self.refill_per_sec > 0.0 {
+            state.tokens =
+                (state.tokens + elapsed.as_secs_f64() * self.refill_per_sec).min(self.capacity);
+        }
+        if state.tokens >= 1.0 {
+            state.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Per-user operation + export rate limiter, owned as per-node server state.
+///
+/// Cheap to clone (`Arc` inside): cloned once into each WS connection's request
+/// path and once onto the HTTP export router. All clones share the same
+/// underlying maps, so a user's multiple connections share one bucket.
+#[derive(Clone)]
+pub(crate) struct UserOpRateLimiter {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    /// Sustained op rate (tokens/sec) and burst capacity. `op_rate == 0`
+    /// disables op rate limiting (every op is admitted).
+    op_rate: u64,
+    op_burst: u64,
+    /// Per-user op token buckets, created lazily on first op from a user.
+    op_buckets: DashMap<UserId, TokenBucket>,
+    /// Minimum interval between exports per user; `0` disables export limiting.
+    export_min_interval_secs: u64,
+    /// Last successful-export instant per user. Created on first export.
+    last_export: DashMap<UserId, Instant>,
+}
+
+impl UserOpRateLimiter {
+    /// Build a limiter from operator config. `op_rate == 0` disables op
+    /// limiting; `export_min_interval_secs == 0` disables export limiting.
+    pub(crate) fn new(op_rate: u64, op_burst: u64, export_min_interval_secs: u64) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                op_rate,
+                // A 0 burst with a non-zero rate would reject everything (the
+                // bucket could never hold a whole token). Clamp burst up to at
+                // least 1 so an operator who sets only the rate still gets a
+                // working limiter rather than a deny-all.
+                op_burst: op_burst.max(1),
+                op_buckets: DashMap::new(),
+                export_min_interval_secs,
+                last_export: DashMap::new(),
+            }),
+        }
+    }
+
+    /// `true` if op rate limiting is active (non-zero configured rate).
+    pub(crate) fn op_limiting_enabled(&self) -> bool {
+        self.inner.op_rate > 0
+    }
+
+    /// Try to admit one operation for `user`. Returns `true` to allow, `false`
+    /// to reject (over-rate). Always allows when op limiting is disabled.
+    ///
+    /// Concurrency-safe: the per-bucket `Mutex` makes refill+decrement atomic,
+    /// so N concurrent calls with only M < N tokens available admit exactly M.
+    pub(crate) fn try_acquire_op(&self, user: &UserId) -> bool {
+        self.try_acquire_op_at(user, Instant::now())
+    }
+
+    /// `try_acquire_op` with an injected clock for deterministic tests.
+    pub(crate) fn try_acquire_op_at(&self, user: &UserId, now: Instant) -> bool {
+        if self.inner.op_rate == 0 {
+            return true;
+        }
+        // `entry` so the lazy insert is atomic w.r.t. the map: two concurrent
+        // first-requests from the same user share one bucket rather than racing
+        // to create two. The created bucket starts full, then this same call
+        // immediately spends its first token below.
+        let bucket = self
+            .inner
+            .op_buckets
+            .entry(*user)
+            .or_insert_with(|| TokenBucket::new(self.inner.op_burst, self.inner.op_rate, now));
+        bucket.try_acquire(now)
+    }
+
+    /// Try to admit one export for `user`. Returns `true` to allow (and records
+    /// the export time), `false` to reject (too soon since the last one).
+    /// Always allows when export limiting is disabled.
+    pub(crate) fn try_acquire_export(&self, user: &UserId) -> bool {
+        self.try_acquire_export_at(user, Instant::now())
+    }
+
+    /// `try_acquire_export` with an injected clock for deterministic tests.
+    pub(crate) fn try_acquire_export_at(&self, user: &UserId, now: Instant) -> bool {
+        let min_interval = self.inner.export_min_interval_secs;
+        if min_interval == 0 {
+            return true;
+        }
+        // Atomic test-and-set on the map entry so two concurrent exports from
+        // one user can't both pass: whoever holds the entry guard decides, and
+        // only an admitted export advances `last_export`.
+        let mut entry = self.inner.last_export.entry(*user).or_insert(
+            // Seed far enough in the past that the FIRST export is always
+            // admitted (now - min_interval), then overwritten below.
+            now - std::time::Duration::from_secs(min_interval),
+        );
+        let elapsed = now.saturating_duration_since(*entry);
+        if elapsed.as_secs() >= min_interval {
+            *entry = now;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Number of distinct users currently tracked (op buckets). Test-only
+    /// visibility into map growth.
+    #[cfg(test)]
+    pub(crate) fn tracked_op_users(&self) -> usize {
+        self.inner.op_buckets.len()
+    }
+}
+
+/// A snapshot of the configured limits, used only for constructing the limiter
+/// from `WebsocketApiConfig`. Keeps the three values bundled so the call sites
+/// can't transpose them.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct UserOpRateLimitConfig {
+    pub op_rate: u64,
+    pub op_burst: u64,
+    pub export_min_interval_secs: u64,
+}
+
+impl UserOpRateLimitConfig {
+    pub(crate) fn build(self) -> UserOpRateLimiter {
+        UserOpRateLimiter::new(self.op_rate, self.op_burst, self.export_min_interval_secs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uid(byte: u8) -> UserId {
+        UserId::new([byte; 32])
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn under_rate_always_passes() {
+        // rate 10/s, burst 50. At ~1 req/sec we never exhaust the bucket.
+        let limiter = UserOpRateLimiter::new(10, 50, 0);
+        let user = uid(1);
+        let mut now = Instant::now();
+        for _ in 0..200 {
+            assert!(
+                limiter.try_acquire_op_at(&user, now),
+                "under-rate must pass"
+            );
+            now += std::time::Duration::from_millis(1000);
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn burst_then_reject() {
+        // burst = 5: 5 back-to-back ops pass, the 6th (same instant) is rejected.
+        let limiter = UserOpRateLimiter::new(10, 5, 0);
+        let user = uid(2);
+        let now = Instant::now();
+        for i in 0..5 {
+            assert!(
+                limiter.try_acquire_op_at(&user, now),
+                "burst op {i} should pass"
+            );
+        }
+        assert!(
+            !limiter.try_acquire_op_at(&user, now),
+            "op beyond burst capacity must be rejected"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn tokens_refill_over_time() {
+        // burst = 5, rate = 10/s. Exhaust the burst, then advance 1s → 10 tokens
+        // would refill but cap at burst (5), so 5 more pass and the 6th rejects.
+        let limiter = UserOpRateLimiter::new(10, 5, 0);
+        let user = uid(3);
+        let t0 = Instant::now();
+        for _ in 0..5 {
+            assert!(limiter.try_acquire_op_at(&user, t0));
+        }
+        assert!(!limiter.try_acquire_op_at(&user, t0), "burst exhausted");
+
+        // Advance 0.5s → 0.5 * 10 = 5 tokens refilled (== burst cap).
+        let t1 = t0 + std::time::Duration::from_millis(500);
+        for i in 0..5 {
+            assert!(
+                limiter.try_acquire_op_at(&user, t1),
+                "refilled op {i} should pass"
+            );
+        }
+        assert!(
+            !limiter.try_acquire_op_at(&user, t1),
+            "refill is capped at burst, so the 6th rejects"
+        );
+
+        // Partial refill: advance 0.1s → 1 token.
+        let t2 = t1 + std::time::Duration::from_millis(100);
+        assert!(limiter.try_acquire_op_at(&user, t2), "1 token refilled");
+        assert!(!limiter.try_acquire_op_at(&user, t2), "only 1 refilled");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn disabled_never_limits() {
+        // rate 0 disables op limiting: a flood always passes and no buckets
+        // are even created.
+        let limiter = UserOpRateLimiter::new(0, 50, 0);
+        assert!(!limiter.op_limiting_enabled());
+        let user = uid(4);
+        let now = Instant::now();
+        for _ in 0..10_000 {
+            assert!(limiter.try_acquire_op_at(&user, now));
+        }
+        assert_eq!(
+            limiter.tracked_op_users(),
+            0,
+            "disabled limiter must not allocate buckets"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn distinct_users_have_independent_buckets() {
+        let limiter = UserOpRateLimiter::new(10, 3, 0);
+        let a = uid(10);
+        let b = uid(11);
+        let now = Instant::now();
+        // Exhaust A's burst.
+        for _ in 0..3 {
+            assert!(limiter.try_acquire_op_at(&a, now));
+        }
+        assert!(!limiter.try_acquire_op_at(&a, now), "A exhausted");
+        // B is untouched — its bucket is full.
+        for _ in 0..3 {
+            assert!(limiter.try_acquire_op_at(&b, now), "B independent of A");
+        }
+        assert!(!limiter.try_acquire_op_at(&b, now), "B now exhausted too");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn same_user_shares_one_bucket() {
+        // Two "connections" are just two call sites against the same UserId.
+        // Combined they share one bucket: 3 total pass, then reject.
+        let limiter = UserOpRateLimiter::new(10, 3, 0);
+        let user = uid(20);
+        let now = Instant::now();
+        assert!(limiter.try_acquire_op_at(&user, now)); // conn 1
+        assert!(limiter.try_acquire_op_at(&user, now)); // conn 2
+        assert!(limiter.try_acquire_op_at(&user, now)); // conn 1
+        assert!(
+            !limiter.try_acquire_op_at(&user, now),
+            "shared bucket: 4th rejected regardless of which connection"
+        );
+        assert_eq!(limiter.tracked_op_users(), 1, "one bucket for one user");
+    }
+
+    /// Concurrency: spawn N threads that hammer the SAME user's bucket at the
+    /// same frozen instant; exactly `burst` may be admitted, never more. This
+    /// is the over-admit race the per-bucket Mutex must prevent. Uses real
+    /// threads (not the paused tokio clock) so the contention is genuine.
+    #[test]
+    fn concurrent_acquire_admits_at_most_burst() {
+        use std::sync::Barrier;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        const THREADS: usize = 64;
+        const BURST: u64 = 10;
+
+        let limiter = UserOpRateLimiter::new(1_000_000, BURST, 0);
+        let user = uid(99);
+        // Freeze a single instant so NO refill happens during the race: the
+        // only tokens available are the initial `BURST`.
+        let now = Instant::now();
+        let admitted = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(THREADS));
+
+        std::thread::scope(|scope| {
+            for _ in 0..THREADS {
+                let limiter = limiter.clone();
+                let admitted = admitted.clone();
+                let barrier = barrier.clone();
+                let user = user;
+                scope.spawn(move || {
+                    // Line everyone up so the acquires actually overlap.
+                    barrier.wait();
+                    // Each thread tries several times to maximize contention;
+                    // the total admitted across ALL threads must still be BURST.
+                    for _ in 0..4 {
+                        if limiter.try_acquire_op_at(&user, now) {
+                            admitted.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                });
+            }
+        });
+
+        assert_eq!(
+            admitted.load(Ordering::SeqCst),
+            BURST as usize,
+            "with no refill, exactly `burst` tokens may be admitted across all \
+             concurrent threads — more means a check-then-act over-admit race"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn export_min_interval_enforced() {
+        // 10s min interval. First export passes; a second within 10s is rejected;
+        // after 10s it passes again.
+        let limiter = UserOpRateLimiter::new(10, 50, 10);
+        let user = uid(30);
+        let t0 = Instant::now();
+        assert!(
+            limiter.try_acquire_export_at(&user, t0),
+            "first export passes"
+        );
+        assert!(
+            !limiter.try_acquire_export_at(&user, t0),
+            "immediate second export rejected"
+        );
+        let t_mid = t0 + std::time::Duration::from_secs(9);
+        assert!(
+            !limiter.try_acquire_export_at(&user, t_mid),
+            "9s later still under the 10s interval"
+        );
+        let t_ok = t0 + std::time::Duration::from_secs(10);
+        assert!(
+            limiter.try_acquire_export_at(&user, t_ok),
+            "10s later export is allowed"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn export_disabled_never_limits() {
+        let limiter = UserOpRateLimiter::new(10, 50, 0);
+        let user = uid(31);
+        let now = Instant::now();
+        for _ in 0..100 {
+            assert!(
+                limiter.try_acquire_export_at(&user, now),
+                "export limiting disabled (0): every export passes"
+            );
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn export_buckets_are_per_user() {
+        let limiter = UserOpRateLimiter::new(10, 50, 10);
+        let a = uid(40);
+        let b = uid(41);
+        let now = Instant::now();
+        assert!(limiter.try_acquire_export_at(&a, now));
+        assert!(!limiter.try_acquire_export_at(&a, now), "A throttled");
+        assert!(
+            limiter.try_acquire_export_at(&b, now),
+            "B's export interval is independent of A's"
+        );
+    }
+}

--- a/crates/core/src/client_events/user_op_rate_limit.rs
+++ b/crates/core/src/client_events/user_op_rate_limit.rs
@@ -60,9 +60,22 @@ pub const DEFAULT_PER_USER_OP_BURST: u64 = 50;
 /// disables export rate limiting.
 pub const DEFAULT_PER_USER_EXPORT_MIN_INTERVAL_SECS: u64 = 10;
 
-/// A single user's token bucket. The `(tokens, last_refill)` pair is guarded by
-/// a `Mutex` so refill+decrement is one atomic decision (no check-then-act race
-/// across concurrent connection tasks sharing this user's bucket).
+/// Hard cap on the number of distinct users tracked in EACH per-user map
+/// (`op_buckets`, `last_export`). The `userToken` is client-chosen and
+/// unvalidated (`UserSecretContext::from_token` just hashes arbitrary bytes —
+/// there is no registry), so an actor past the hosted gate can present an
+/// unbounded number of distinct tokens. Without a cap the maps would grow
+/// permanently — the limiter would be its own memory-DoS, violating the
+/// repo's "cleanup must be time-bounded / no unbounded per-key collection"
+/// rules. The cap is generous (a real public proxy serves far fewer concurrent
+/// users than this) so legitimate traffic never triggers eviction; see
+/// [`Inner::evict_op_buckets_if_needed`] for the safety property (eviction
+/// never resets an actively-throttling bucket).
+const MAX_TRACKED_USERS: usize = 100_000;
+
+/// A single user's token bucket. The bucket `state` is guarded by a `Mutex` so
+/// refill+decrement is one atomic decision (no check-then-act race across
+/// concurrent connection tasks sharing this user's bucket).
 struct TokenBucket {
     /// `capacity` (= burst) and `refill_per_sec` (= sustained rate) are fixed at
     /// construction; only `state` mutates.
@@ -76,6 +89,8 @@ struct BucketState {
     tokens: f64,
     /// When `tokens` was last refilled.
     last_refill: Instant,
+    /// When this bucket was last touched by an acquire. Drives LRU eviction.
+    last_access: Instant,
 }
 
 impl TokenBucket {
@@ -90,6 +105,7 @@ impl TokenBucket {
             state: Mutex::new(BucketState {
                 tokens: capacity,
                 last_refill: now,
+                last_access: now,
             }),
         }
     }
@@ -106,6 +122,7 @@ impl TokenBucket {
         // test clock hands back an equal instant (elapsed = 0, no refill).
         let elapsed = now.saturating_duration_since(state.last_refill);
         state.last_refill = now;
+        state.last_access = now;
         if self.refill_per_sec > 0.0 {
             state.tokens =
                 (state.tokens + elapsed.as_secs_f64() * self.refill_per_sec).min(self.capacity);
@@ -116,6 +133,28 @@ impl TokenBucket {
         } else {
             false
         }
+    }
+
+    /// A bucket is SAFE TO EVICT only when it is essentially full at `now` —
+    /// i.e. the user is NOT currently being throttled. Re-creating a full
+    /// bucket yields an identical full bucket, so dropping it changes nothing.
+    /// A depleted (actively-throttling) bucket must NEVER be evicted: dropping
+    /// it would re-create a FULL bucket and hand the flooder a fresh burst.
+    ///
+    /// Returns `(safe_to_evict, last_access)` computed under one lock, applying
+    /// the same time-based refill as `try_acquire` so "full" reflects `now`.
+    fn evictability(&self, now: Instant) -> (bool, Instant) {
+        let mut state = self.state.lock().unwrap_or_else(|p| p.into_inner());
+        let elapsed = now.saturating_duration_since(state.last_refill);
+        state.last_refill = now;
+        if self.refill_per_sec > 0.0 {
+            state.tokens =
+                (state.tokens + elapsed.as_secs_f64() * self.refill_per_sec).min(self.capacity);
+        }
+        // "Essentially full": within one token of capacity. A bucket this full
+        // is not throttling anyone, so re-creation is a no-op for limiting.
+        let safe = state.tokens >= self.capacity - 1.0;
+        (safe, state.last_access)
     }
 }
 
@@ -140,12 +179,141 @@ struct Inner {
     export_min_interval_secs: u64,
     /// Last successful-export instant per user. Created on first export.
     last_export: DashMap<UserId, Instant>,
+    /// Hard cap on entries in EACH per-user map. Defaults to
+    /// [`MAX_TRACKED_USERS`]; lowered in tests via [`UserOpRateLimiter::with_cap`]
+    /// so eviction can be exercised without inserting 100k entries.
+    max_tracked_users: usize,
+}
+
+impl Inner {
+    /// Bound `op_buckets` to [`MAX_TRACKED_USERS`]. Called only when a new user
+    /// was just inserted (the map grew), so it is amortized O(map size) work
+    /// once per new user rather than per op.
+    ///
+    /// SAFETY OF EVICTION (the load-bearing invariant): we only ever drop
+    /// buckets that are essentially FULL at `now` — i.e. users who are NOT
+    /// currently being throttled (see [`TokenBucket::evictability`]). Dropping a
+    /// full bucket and lazily re-creating it later yields an identical full
+    /// bucket, so eviction can never reset a depleted, actively-throttling
+    /// flooder's bucket and hand them a fresh burst. Among the safe-to-evict
+    /// (full) buckets we drop the LEAST-RECENTLY-USED first.
+    ///
+    /// If the map is over cap but NOTHING is safe to evict — i.e. EVERY tracked
+    /// user is currently being throttled, a genuine mass flood — we evict
+    /// nothing and let the map sit slightly over cap rather than weaken active
+    /// limiting. That state is self-correcting: as soon as any of those buckets
+    /// refills (the flood for that user pauses) it becomes evictable. A one-shot
+    /// warning makes the (rare) degraded mode visible to operators.
+    fn evict_op_buckets_if_needed(&self, now: Instant) {
+        if self.op_buckets.len() <= self.max_tracked_users {
+            return;
+        }
+        // Collect (key, last_access) for buckets that are SAFE to evict (full).
+        // We never even consider a throttling bucket as a candidate.
+        let mut candidates: Vec<(UserId, Instant)> = self
+            .op_buckets
+            .iter()
+            .filter_map(|entry| {
+                let (safe, last_access) = entry.value().evictability(now);
+                safe.then(|| (*entry.key(), last_access))
+            })
+            .collect();
+        // LRU first.
+        candidates.sort_by_key(|(_, last_access)| *last_access);
+
+        let target_removals = self.op_buckets.len() - self.max_tracked_users;
+        let mut removed = 0;
+        for (key, _) in candidates.into_iter().take(target_removals) {
+            // `remove_if` re-checks evictability under the shard write lock so a
+            // bucket that started throttling between the scan and the remove is
+            // NOT dropped (would otherwise reset it). This closes the
+            // scan-then-remove race.
+            if self
+                .op_buckets
+                .remove_if(&key, |_, bucket| bucket.evictability(now).0)
+                .is_some()
+            {
+                removed += 1;
+            }
+        }
+        if removed < target_removals {
+            // Couldn't get back under cap purely from full buckets: the rest are
+            // actively throttling and must not be reset. Surface it once.
+            static WARNED: std::sync::atomic::AtomicBool =
+                std::sync::atomic::AtomicBool::new(false);
+            if WARNED
+                .compare_exchange(
+                    false,
+                    true,
+                    std::sync::atomic::Ordering::SeqCst,
+                    std::sync::atomic::Ordering::Relaxed,
+                )
+                .is_ok()
+            {
+                tracing::warn!(
+                    tracked = self.op_buckets.len(),
+                    cap = self.max_tracked_users,
+                    "per-user op-rate map over cap with no idle entries to evict \
+                     (every tracked user is actively throttling). Holding over cap \
+                     rather than resetting an active limiter; self-corrects as \
+                     buckets refill. Possible distributed token flood."
+                );
+            }
+        }
+    }
+
+    /// Bound `last_export` to [`MAX_TRACKED_USERS`]. An entry is safe to drop
+    /// once it is older than `min_interval` (the next export would be admitted
+    /// anyway, so re-creating it changes nothing — the same way a full op bucket
+    /// is safe). We evict the OLDEST such stale entries first. If nothing is
+    /// stale (every tracked user exported within the last `min_interval`) we
+    /// hold over cap rather than dropping an entry that is still actively
+    /// throttling that user's next export.
+    fn evict_last_export_if_needed(&self, now: Instant, min_interval: u64) {
+        if self.last_export.len() <= self.max_tracked_users {
+            return;
+        }
+        let min = std::time::Duration::from_secs(min_interval);
+        let mut candidates: Vec<(UserId, Instant)> = self
+            .last_export
+            .iter()
+            .filter_map(|entry| {
+                let last = *entry.value();
+                (now.saturating_duration_since(last) >= min).then(|| (*entry.key(), last))
+            })
+            .collect();
+        candidates.sort_by_key(|(_, last)| *last);
+        let target_removals = self.last_export.len() - self.max_tracked_users;
+        for (key, _) in candidates.into_iter().take(target_removals) {
+            // remove_if re-checks staleness under the write lock to avoid
+            // dropping an entry a concurrent export just refreshed.
+            self.last_export
+                .remove_if(&key, |_, last| now.saturating_duration_since(*last) >= min);
+        }
+    }
 }
 
 impl UserOpRateLimiter {
     /// Build a limiter from operator config. `op_rate == 0` disables op
     /// limiting; `export_min_interval_secs == 0` disables export limiting.
     pub(crate) fn new(op_rate: u64, op_burst: u64, export_min_interval_secs: u64) -> Self {
+        Self::with_cap(
+            op_rate,
+            op_burst,
+            export_min_interval_secs,
+            MAX_TRACKED_USERS,
+        )
+    }
+
+    /// Like [`Self::new`] but with an explicit per-map entry cap. Production
+    /// always uses [`MAX_TRACKED_USERS`] via `new`; tests use a small cap so the
+    /// eviction path is exercised without inserting 100k entries.
+    fn with_cap(
+        op_rate: u64,
+        op_burst: u64,
+        export_min_interval_secs: u64,
+        max_tracked_users: usize,
+    ) -> Self {
         Self {
             inner: Arc::new(Inner {
                 op_rate,
@@ -157,6 +325,7 @@ impl UserOpRateLimiter {
                 op_buckets: DashMap::new(),
                 export_min_interval_secs,
                 last_export: DashMap::new(),
+                max_tracked_users: max_tracked_users.max(1),
             }),
         }
     }
@@ -184,12 +353,25 @@ impl UserOpRateLimiter {
         // first-requests from the same user share one bucket rather than racing
         // to create two. The created bucket starts full, then this same call
         // immediately spends its first token below.
-        let bucket = self
-            .inner
-            .op_buckets
-            .entry(*user)
-            .or_insert_with(|| TokenBucket::new(self.inner.op_burst, self.inner.op_rate, now));
-        bucket.try_acquire(now)
+        //
+        // `is_new` tells us whether THIS call created the bucket, so we only run
+        // the (relatively expensive) eviction scan when the map actually grew —
+        // not on every op of an existing user.
+        let mut is_new = false;
+        let admitted = {
+            let bucket = self.inner.op_buckets.entry(*user).or_insert_with(|| {
+                is_new = true;
+                TokenBucket::new(self.inner.op_burst, self.inner.op_rate, now)
+            });
+            // Hold the entry guard ONLY for the acquire; it is dropped at the end
+            // of this block, BEFORE eviction touches the map. Evicting while a
+            // shard guard is held could deadlock DashMap.
+            bucket.try_acquire(now)
+        };
+        if is_new {
+            self.inner.evict_op_buckets_if_needed(now);
+        }
+        admitted
     }
 
     /// Try to admit one export for `user`. Returns `true` to allow (and records
@@ -208,18 +390,27 @@ impl UserOpRateLimiter {
         // Atomic test-and-set on the map entry so two concurrent exports from
         // one user can't both pass: whoever holds the entry guard decides, and
         // only an admitted export advances `last_export`.
-        let mut entry = self.inner.last_export.entry(*user).or_insert(
-            // Seed far enough in the past that the FIRST export is always
-            // admitted (now - min_interval), then overwritten below.
-            now - std::time::Duration::from_secs(min_interval),
-        );
-        let elapsed = now.saturating_duration_since(*entry);
-        if elapsed.as_secs() >= min_interval {
-            *entry = now;
-            true
-        } else {
-            false
+        let mut is_new = false;
+        let admitted = {
+            let mut entry = self.inner.last_export.entry(*user).or_insert_with(|| {
+                is_new = true;
+                // Seed far enough in the past that the FIRST export is always
+                // admitted (now - min_interval), then overwritten below.
+                now - std::time::Duration::from_secs(min_interval)
+            });
+            let elapsed = now.saturating_duration_since(*entry);
+            if elapsed.as_secs() >= min_interval {
+                *entry = now;
+                true
+            } else {
+                false
+            }
+            // entry guard dropped here, before eviction touches the map.
+        };
+        if is_new {
+            self.inner.evict_last_export_if_needed(now, min_interval);
         }
+        admitted
     }
 
     /// Number of distinct users currently tracked (op buckets). Test-only
@@ -227,6 +418,12 @@ impl UserOpRateLimiter {
     #[cfg(test)]
     pub(crate) fn tracked_op_users(&self) -> usize {
         self.inner.op_buckets.len()
+    }
+
+    /// Number of distinct users currently tracked in the export-interval map.
+    #[cfg(test)]
+    pub(crate) fn tracked_export_users(&self) -> usize {
+        self.inner.last_export.len()
     }
 }
 
@@ -471,5 +668,122 @@ mod tests {
             limiter.try_acquire_export_at(&b, now),
             "B's export interval is independent of A's"
         );
+    }
+
+    /// `op_burst = 0` with a non-zero rate must NOT become a deny-all: it is
+    /// clamped up to 1 so the first op of a fresh user still passes.
+    #[tokio::test(start_paused = true)]
+    async fn op_burst_zero_is_clamped_to_one() {
+        let limiter = UserOpRateLimiter::new(10, 0, 0);
+        let user = uid(50);
+        let now = Instant::now();
+        assert!(
+            limiter.try_acquire_op_at(&user, now),
+            "burst 0 must be clamped to 1 — first op passes, not deny-all"
+        );
+        assert!(
+            !limiter.try_acquire_op_at(&user, now),
+            "with clamped burst=1 the second same-instant op is rejected"
+        );
+    }
+
+    /// Export interval uses whole-second granularity (`as_secs()`): 9.5s after
+    /// an export is still under a 10s interval and must be rejected.
+    #[tokio::test(start_paused = true)]
+    async fn export_sub_second_boundary_still_rejects() {
+        let limiter = UserOpRateLimiter::new(10, 50, 10);
+        let user = uid(51);
+        let t0 = Instant::now();
+        assert!(limiter.try_acquire_export_at(&user, t0), "first export");
+        let t_95 = t0 + std::time::Duration::from_millis(9_500);
+        assert!(
+            !limiter.try_acquire_export_at(&user, t_95),
+            "9.5s < 10s interval → still rejected"
+        );
+        let t_10 = t0 + std::time::Duration::from_millis(10_000);
+        assert!(
+            limiter.try_acquire_export_at(&user, t_10),
+            "exactly 10s → allowed"
+        );
+    }
+
+    /// Map bound: admitting ops from many more distinct users than the cap keeps
+    /// the op-bucket map at or below the cap. The evicted users are the IDLE
+    /// (full) ones — so this also asserts that re-touching an old user works.
+    #[tokio::test(start_paused = true)]
+    async fn op_bucket_map_is_bounded() {
+        // cap = 4, big burst so each user's single op leaves the bucket "full"
+        // (essentially full → safe to evict). Advance time between users so
+        // last_access strictly orders them for LRU.
+        let limiter = UserOpRateLimiter::with_cap(1000, 1000, 0, 4);
+        let mut now = Instant::now();
+        for i in 0..50u8 {
+            let user = uid(i);
+            assert!(limiter.try_acquire_op_at(&user, now));
+            now += std::time::Duration::from_millis(10);
+            assert!(
+                limiter.tracked_op_users() <= 4,
+                "op-bucket map must never exceed the cap (was {} after user {i})",
+                limiter.tracked_op_users()
+            );
+        }
+    }
+
+    /// Eviction MUST NOT reset an actively-throttling (depleted) bucket. With a
+    /// tiny cap, a flooding user whose bucket is empty stays throttled even as
+    /// many other distinct users arrive and force eviction scans — the evictor
+    /// only drops the OTHER users' full/idle buckets, never the flooder's.
+    #[tokio::test(start_paused = true)]
+    async fn eviction_never_resets_active_flooder() {
+        // cap = 2, burst = 3, rate tiny so refill is negligible over the test.
+        let limiter = UserOpRateLimiter::with_cap(1, 3, 0, 2);
+        let flooder = uid(200);
+        let t0 = Instant::now();
+        // Exhaust the flooder's bucket (burst 3), then confirm it's throttled.
+        assert!(limiter.try_acquire_op_at(&flooder, t0));
+        assert!(limiter.try_acquire_op_at(&flooder, t0));
+        assert!(limiter.try_acquire_op_at(&flooder, t0));
+        assert!(
+            !limiter.try_acquire_op_at(&flooder, t0),
+            "flooder is now depleted/throttled"
+        );
+
+        // Now a parade of OTHER users arrives, each forcing an eviction scan.
+        // Their full buckets get evicted; the flooder's depleted bucket must not.
+        let mut now = t0;
+        for i in 0..40u8 {
+            now += std::time::Duration::from_millis(1);
+            let other = uid(i); // i never equals 200
+            assert!(limiter.try_acquire_op_at(&other, now));
+        }
+
+        // The flooder, if its bucket had been evicted+recreated, would be FULL
+        // again and admit. It must still be throttled (bucket preserved). Use a
+        // time barely advanced so refill (rate=1/s) hasn't yielded a token.
+        let t_check = now + std::time::Duration::from_millis(1);
+        assert!(
+            !limiter.try_acquire_op_at(&flooder, t_check),
+            "eviction must NOT have reset the active flooder's depleted bucket"
+        );
+    }
+
+    /// Export map is bounded the same way: stale (older than the interval)
+    /// entries are evicted, keeping the map at or below the cap.
+    #[tokio::test(start_paused = true)]
+    async fn export_map_is_bounded() {
+        // cap = 3, interval = 1s. Advance > interval between users so prior
+        // entries are stale (safe to evict).
+        let limiter = UserOpRateLimiter::with_cap(10, 50, 1, 3);
+        let mut now = Instant::now();
+        for i in 0..30u8 {
+            let user = uid(i);
+            assert!(limiter.try_acquire_export_at(&user, now));
+            now += std::time::Duration::from_millis(1100); // > 1s interval
+            assert!(
+                limiter.tracked_export_users() <= 3,
+                "export map must never exceed the cap (was {} after user {i})",
+                limiter.tracked_export_users()
+            );
+        }
     }
 }

--- a/crates/core/src/client_events/user_op_rate_limit.rs
+++ b/crates/core/src/client_events/user_op_rate_limit.rs
@@ -73,6 +73,26 @@ pub const DEFAULT_PER_USER_EXPORT_MIN_INTERVAL_SECS: u64 = 10;
 /// never resets an actively-throttling bucket).
 const MAX_TRACKED_USERS: usize = 100_000;
 
+/// Low-water-mark divisor for eviction hysteresis. When a map exceeds its cap we
+/// evict down to `cap - cap/EVICTION_HYSTERESIS_DIVISOR` (≈90% of cap) rather
+/// than just back to `cap`. This is what bounds the eviction COST under a
+/// new-token-churn attack: without it, a map sitting exactly at cap would run a
+/// full O(n) scan on EVERY new distinct token (each insert lands at cap+1 →
+/// scan → back to cap → repeat), turning a cheap request into an ~O(cap) sweep
+/// — the rate-limiter would amplify CPU instead of bounding it. With the
+/// low-water-mark, one sweep frees ≈cap/10 slots, so the next sweep can't
+/// re-trigger until ≈cap/10 more inserts arrive; every insert in between hits
+/// the cheap `len <= cap` early-return. Net: amortized O(1) eviction work per
+/// insert regardless of how fast fresh tokens churn.
+const EVICTION_HYSTERESIS_DIVISOR: usize = 10;
+
+/// Given a cap, the post-eviction target size (low-water-mark): `cap - cap/10`,
+/// floored at 1. A single sweep evicts down to this, leaving headroom so the
+/// next ≈cap/10 inserts skip the scan entirely.
+fn eviction_low_water_mark(cap: usize) -> usize {
+    cap.saturating_sub(cap / EVICTION_HYSTERESIS_DIVISOR).max(1)
+}
+
 /// A single user's token bucket. The bucket `state` is guarded by a `Mutex` so
 /// refill+decrement is one atomic decision (no check-then-act race across
 /// concurrent connection tasks sharing this user's bucket).
@@ -183,12 +203,26 @@ struct Inner {
     /// [`MAX_TRACKED_USERS`]; lowered in tests via [`UserOpRateLimiter::with_cap`]
     /// so eviction can be exercised without inserting 100k entries.
     max_tracked_users: usize,
+    /// Count of FULL eviction sweeps actually performed (past the cheap
+    /// high-water early-return) across both maps. Used by the amortization test
+    /// to assert hysteresis bounds the number of O(n) sweeps under token churn.
+    /// Incremented on the rare sweep path only, so it's negligible in
+    /// production.
+    sweeps: std::sync::atomic::AtomicU64,
 }
 
 impl Inner {
-    /// Bound `op_buckets` to [`MAX_TRACKED_USERS`]. Called only when a new user
-    /// was just inserted (the map grew), so it is amortized O(map size) work
-    /// once per new user rather than per op.
+    /// Bound `op_buckets` to [`MAX_TRACKED_USERS`]. Called only when a NEW user
+    /// was just inserted (the map grew).
+    ///
+    /// COST / AMORTIZATION: the trigger is the high-water-mark (`len > cap`), but
+    /// when it fires we evict down to the LOW-water-mark
+    /// ([`eviction_low_water_mark`], ≈90% of cap), not just back to cap. So a
+    /// single O(n) sweep frees ≈cap/10 slots and the next ≈cap/10 inserts all hit
+    /// the cheap `len <= cap` early-return below. Without this hysteresis a map
+    /// pinned at cap would run a full O(n) scan on EVERY new distinct token —
+    /// the rate-limiter would become a CPU-amplification DoS under unvalidated
+    /// `userToken` churn. Amortized cost is therefore O(1) per insert.
     ///
     /// SAFETY OF EVICTION (the load-bearing invariant): we only ever drop
     /// buckets that are essentially FULL at `now` — i.e. users who are NOT
@@ -198,16 +232,25 @@ impl Inner {
     /// flooder's bucket and hand them a fresh burst. Among the safe-to-evict
     /// (full) buckets we drop the LEAST-RECENTLY-USED first.
     ///
-    /// If the map is over cap but NOTHING is safe to evict — i.e. EVERY tracked
-    /// user is currently being throttled, a genuine mass flood — we evict
-    /// nothing and let the map sit slightly over cap rather than weaken active
-    /// limiting. That state is self-correcting: as soon as any of those buckets
-    /// refills (the flood for that user pauses) it becomes evictable. A one-shot
-    /// warning makes the (rare) degraded mode visible to operators.
+    /// If the map is over cap but too few buckets are safe to evict — i.e. most
+    /// tracked users are currently being throttled, a genuine mass flood — we
+    /// evict only what is safe and let the map sit over cap rather than weaken
+    /// active limiting. That state is self-correcting: as soon as those buckets
+    /// refill (the flood for that user pauses) they become evictable. A one-shot
+    /// warning makes the (rare) degraded mode visible to operators. (That
+    /// degraded state is also expensive for an attacker to MAINTAIN: a
+    /// brand-new token's bucket starts full, so to keep a bucket un-evictable
+    /// the attacker must spend its whole burst — all but the first of which are
+    /// themselves rate-limited-rejected.)
     fn evict_op_buckets_if_needed(&self, now: Instant) {
-        if self.op_buckets.len() <= self.max_tracked_users {
+        let len = self.op_buckets.len();
+        if len <= self.max_tracked_users {
             return;
         }
+        self.sweeps
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        // Hysteresis: aim for the low-water-mark, not just back to cap.
+        let target_removals = len - eviction_low_water_mark(self.max_tracked_users);
         // Collect (key, last_access) for buckets that are SAFE to evict (full).
         // We never even consider a throttling bucket as a candidate.
         let mut candidates: Vec<(UserId, Instant)> = self
@@ -221,7 +264,6 @@ impl Inner {
         // LRU first.
         candidates.sort_by_key(|(_, last_access)| *last_access);
 
-        let target_removals = self.op_buckets.len() - self.max_tracked_users;
         let mut removed = 0;
         for (key, _) in candidates.into_iter().take(target_removals) {
             // `remove_if` re-checks evictability under the shard write lock so a
@@ -236,9 +278,10 @@ impl Inner {
                 removed += 1;
             }
         }
-        if removed < target_removals {
-            // Couldn't get back under cap purely from full buckets: the rest are
-            // actively throttling and must not be reset. Surface it once.
+        // Warn only if we couldn't even get back under the HIGH-water-mark (cap)
+        // — i.e. too few idle buckets to drop. Not reaching the low-water-mark is
+        // expected and fine (it just means the next sweep comes sooner).
+        if self.op_buckets.len() > self.max_tracked_users && removed < target_removals {
             static WARNED: std::sync::atomic::AtomicBool =
                 std::sync::atomic::AtomicBool::new(false);
             if WARNED
@@ -253,26 +296,31 @@ impl Inner {
                 tracing::warn!(
                     tracked = self.op_buckets.len(),
                     cap = self.max_tracked_users,
-                    "per-user op-rate map over cap with no idle entries to evict \
-                     (every tracked user is actively throttling). Holding over cap \
-                     rather than resetting an active limiter; self-corrects as \
-                     buckets refill. Possible distributed token flood."
+                    "per-user op-rate map over cap with too few idle entries to \
+                     evict (most tracked users are actively throttling). Holding \
+                     over cap rather than resetting an active limiter; self-corrects \
+                     as buckets refill. Possible distributed token flood."
                 );
             }
         }
     }
 
-    /// Bound `last_export` to [`MAX_TRACKED_USERS`]. An entry is safe to drop
-    /// once it is older than `min_interval` (the next export would be admitted
-    /// anyway, so re-creating it changes nothing — the same way a full op bucket
-    /// is safe). We evict the OLDEST such stale entries first. If nothing is
-    /// stale (every tracked user exported within the last `min_interval`) we
-    /// hold over cap rather than dropping an entry that is still actively
-    /// throttling that user's next export.
+    /// Bound `last_export` to [`MAX_TRACKED_USERS`]. Same high-water-trigger /
+    /// low-water-target hysteresis as [`Self::evict_op_buckets_if_needed`] so the
+    /// sweep is amortized O(1) per insert under token churn. An entry is safe to
+    /// drop once it is older than `min_interval` (the next export would be
+    /// admitted anyway, so re-creating it changes nothing — the same way a full
+    /// op bucket is safe). We evict the OLDEST such stale entries first. If too
+    /// few are stale we hold over cap rather than dropping an entry that is still
+    /// actively throttling that user's next export.
     fn evict_last_export_if_needed(&self, now: Instant, min_interval: u64) {
-        if self.last_export.len() <= self.max_tracked_users {
+        let len = self.last_export.len();
+        if len <= self.max_tracked_users {
             return;
         }
+        self.sweeps
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let target_removals = len - eviction_low_water_mark(self.max_tracked_users);
         let min = std::time::Duration::from_secs(min_interval);
         let mut candidates: Vec<(UserId, Instant)> = self
             .last_export
@@ -283,7 +331,6 @@ impl Inner {
             })
             .collect();
         candidates.sort_by_key(|(_, last)| *last);
-        let target_removals = self.last_export.len() - self.max_tracked_users;
         for (key, _) in candidates.into_iter().take(target_removals) {
             // remove_if re-checks staleness under the write lock to avoid
             // dropping an entry a concurrent export just refreshed.
@@ -326,6 +373,7 @@ impl UserOpRateLimiter {
                 export_min_interval_secs,
                 last_export: DashMap::new(),
                 max_tracked_users: max_tracked_users.max(1),
+                sweeps: std::sync::atomic::AtomicU64::new(0),
             }),
         }
     }
@@ -424,6 +472,14 @@ impl UserOpRateLimiter {
     #[cfg(test)]
     pub(crate) fn tracked_export_users(&self) -> usize {
         self.inner.last_export.len()
+    }
+
+    /// Number of full eviction sweeps performed (past the cheap high-water
+    /// early-return). The amortization test asserts hysteresis keeps this far
+    /// below the number of inserts.
+    #[cfg(test)]
+    pub(crate) fn sweeps_performed(&self) -> u64 {
+        self.inner.sweeps.load(std::sync::atomic::Ordering::Relaxed)
     }
 }
 
@@ -785,5 +841,47 @@ mod tests {
                 limiter.tracked_export_users()
             );
         }
+    }
+
+    /// A 32-byte UserId from a u32, so amortization tests can mint >256 users.
+    fn uid32(n: u32) -> UserId {
+        let mut b = [0u8; 32];
+        b[..4].copy_from_slice(&n.to_le_bytes());
+        UserId::new(b)
+    }
+
+    /// AMORTIZATION (review round 3): a sustained churn of fresh tokens at the
+    /// cap must NOT trigger a full O(n) eviction sweep on every insert. With the
+    /// low-water-mark hysteresis, one sweep frees ≈cap/10 slots, so sweeps occur
+    /// at most ~once per cap/10 inserts. Here cap=100 (LWM=90, headroom 10) and
+    /// we churn 2000 fresh users: without hysteresis that would be ~1900 sweeps
+    /// (one per insert past cap); with it, ~(2000-100)/10 ≈ 190. We assert a
+    /// generous bound well below the per-insert figure, AND that the map stays
+    /// bounded throughout.
+    #[tokio::test(start_paused = true)]
+    async fn eviction_is_amortized_under_token_churn() {
+        let cap = 100;
+        let limiter = UserOpRateLimiter::with_cap(1000, 1000, 0, cap);
+        let mut now = Instant::now();
+        let inserts = 2000u32;
+        for i in 0..inserts {
+            let user = uid32(i);
+            assert!(limiter.try_acquire_op_at(&user, now));
+            now += std::time::Duration::from_millis(1);
+            assert!(
+                limiter.tracked_op_users() <= cap + 1,
+                "map must stay bounded (≤ cap+1) during churn; was {} at insert {i}",
+                limiter.tracked_op_users()
+            );
+        }
+        let sweeps = limiter.sweeps_performed();
+        // Per-insert sweeping would be ~inserts - cap ≈ 1900. Hysteresis caps it
+        // near (inserts - cap) / (cap/10) ≈ 190. Assert comfortably below the
+        // per-insert figure to prove amortization without pinning exact math.
+        assert!(
+            sweeps <= 400,
+            "hysteresis must bound sweeps far below per-insert ({sweeps} sweeps \
+             over {inserts} inserts; per-insert would be ~1900)"
+        );
     }
 }

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -129,6 +129,7 @@ use crate::{
 };
 
 use super::{ClientError, ClientEventsProxy, ClientId, HostResult, OpenRequest};
+use crate::client_events::user_op_rate_limit::UserOpRateLimiter;
 use crate::server::client_api::OriginContractMap;
 use crate::wasm_runtime::UserSecretContext;
 
@@ -1068,6 +1069,7 @@ async fn connection_info(
     next.run(req).await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn websocket_commands(
     ws: WebSocketUpgrade,
     Extension(auth_token): Extension<Option<AuthToken>>,
@@ -1079,7 +1081,16 @@ async fn websocket_commands(
     // (hosted mode). `None` outside hosted mode or when no user token was
     // presented. Owned and moved into the connection task below.
     Extension(user_context): Extension<Option<UserSecretContext>>,
+    // Per-node per-user operation rate limiter (#4561, P5 of #4381). Installed
+    // as an `Extension` by `serve_client_api_in_impl` (the only path that has
+    // the operator config). OPTIONAL: the standalone `create_router` test path
+    // and `run_local_node` install no limiter, so absence ⇒ no op rate limiting.
+    // This is safe because op rate limiting only ever fires for a connection
+    // that carries a `UserSecretContext`, which only the hosted serve path
+    // (which DOES install the limiter) ever derives.
+    op_rate_limiter: Option<Extension<UserOpRateLimiter>>,
 ) -> Response {
+    let op_rate_limiter = op_rate_limiter.map(|Extension(l)| l);
     let on_upgrade = move |ws: WebSocket| async move {
         // Get the data we need from the DashMap
         // Track whether a token was provided but is invalid (stale/expired)
@@ -1137,6 +1148,7 @@ async fn websocket_commands(
             rs.clone(),
             auth_and_instance,
             user_context,
+            op_rate_limiter,
             token_is_invalid,
             encoding_protoc,
             api_version,
@@ -1186,6 +1198,7 @@ async fn notify_disconnect(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn websocket_interface(
     request_sender: WebSocketRequest,
     mut auth_token: Option<(AuthToken, ContractInstanceId)>,
@@ -1194,6 +1207,11 @@ async fn websocket_interface(
     // `ClientConnection::Request` so every request from this connection (and
     // only this connection) binds to the same user namespace.
     user_context: Option<UserSecretContext>,
+    // Per-node per-user op rate limiter (hosted mode, #4561). `None` on the
+    // standalone/local paths that install no limiter. Shared across all of a
+    // user's connections; consulted in `process_client_request` only when this
+    // connection carries a `user_context`.
+    op_rate_limiter: Option<UserOpRateLimiter>,
     token_is_invalid: bool,
     encoding_protoc: EncodingProtocol,
     api_version: ApiVersion,
@@ -1317,6 +1335,7 @@ async fn websocket_interface(
                     &mut auth_token.as_mut().map(|t| t.0.clone()),
                     auth_token.as_mut().map(|t| t.1),
                     user_context.as_ref(),
+                    op_rate_limiter.as_ref(),
                     api_version,
                     &mut delegate_rate_limiter,
                     &mut conn_state,
@@ -1582,6 +1601,7 @@ async fn process_client_request(
     auth_token: &mut Option<AuthToken>,
     origin_contract: Option<ContractInstanceId>,
     user_context: Option<&UserSecretContext>,
+    op_rate_limiter: Option<&UserOpRateLimiter>,
     api_version: ApiVersion,
     rate_limiter: &mut DelegateRateLimiter,
     conn_state: &mut ConnectionState,
@@ -1696,6 +1716,41 @@ async fn process_client_request(
             let error: ClientError = ErrorKind::RequestError(RequestError::DelegateError(
                 DelegateError::Missing(delegate_req.key().clone()),
             ))
+            .into();
+            let serialized = match conn_state.encoding_protoc {
+                EncodingProtocol::Flatbuffers => error
+                    .into_fbs_bytes()
+                    .map_err(|e| Some(anyhow::anyhow!("serialize error: {:?}", e)))?,
+                EncodingProtocol::Native => {
+                    bincode::serialize(&Err::<HostResponse, ClientError>(error))
+                        .map_err(|e| Some(anyhow::anyhow!("serialize error: {:?}", e)))?
+                }
+            };
+            return Ok(Some(Message::Binary(serialized.into())));
+        }
+    }
+
+    // Per-user operation rate limit (#4561, P5 of #4381). Bounds how fast a
+    // single HOSTED user can issue contract operations (GET/PUT/UPDATE/
+    // SUBSCRIBE) so one visitor cannot flood the node's executor/network. The
+    // check is GATED on `user_context.is_some()` — i.e. hosted mode honored a
+    // user token for this connection — so Local / non-hosted / tokenless
+    // connections are NEVER rate-limited (the "never break single-user default"
+    // invariant). Reject BEFORE forwarding to the node, so an over-rate request
+    // costs no executor/network work; the client retries shortly.
+    if let (Some(user_context), Some(limiter)) = (user_context, op_rate_limiter) {
+        if limiter.op_limiting_enabled()
+            && matches!(req, ClientRequest::ContractOp(_))
+            && !limiter.try_acquire_op(user_context.user_id())
+        {
+            tracing::debug!(
+                %client_id,
+                user_id = ?user_context.user_id(),
+                "Rejecting contract operation: per-user operation rate limit exceeded"
+            );
+            let error: ClientError = ErrorKind::OperationError {
+                cause: std::borrow::Cow::Borrowed("operation rate limit exceeded; retry shortly"),
+            }
             .into();
             let serialized = match conn_state.encoding_protoc {
                 EncodingProtocol::Flatbuffers => error
@@ -3645,5 +3700,167 @@ mod tests {
 
         let result: Result<HostResponse, ClientError> = Err(ErrorKind::NodeUnavailable.into());
         assert!(extract_stream_content(&result).is_none());
+    }
+
+    // ---- Per-user operation rate limit at the WS boundary (#4561) ----------
+
+    /// A native-encoded `Get` operation message, the cheapest contract op to
+    /// drive `process_client_request` with.
+    fn encoded_get_op() -> Message {
+        let req = ClientRequest::ContractOp(ContractRequest::Get {
+            key: ContractInstanceId::new([7u8; 32]),
+            return_contract_code: false,
+            subscribe: false,
+            blocking_subscribe: false,
+        });
+        Message::Binary(bincode::serialize(&req).unwrap().into())
+    }
+
+    /// Drive ONE request through `process_client_request` with the given
+    /// optional `user_context` + limiter. Returns:
+    /// - `Ok(true)`  => the request was FORWARDED to the node (no rejection),
+    /// - `Ok(false)` => the request was REJECTED with an error message,
+    ///   and asserts the error decodes to an `OperationError` (the rate-limit
+    ///   rejection variant),
+    /// and confirms forward/reject is consistent with whether anything landed
+    /// on the request channel.
+    async fn drive_one_op(
+        user_context: Option<&UserSecretContext>,
+        op_rate_limiter: Option<&UserOpRateLimiter>,
+    ) -> bool {
+        // Large channel so forwarding never blocks within the test.
+        let (tx, mut rx) = mpsc::channel::<ClientConnection>(64);
+        let mut delegate_rate_limiter = DelegateRateLimiter::new();
+        let mut conn_state = test_conn_state(EncodingProtocol::Native);
+        let mut auth_token: Option<AuthToken> = None;
+
+        let out = process_client_request(
+            ClientId::next(),
+            Ok(encoded_get_op()),
+            &tx,
+            &mut auth_token,
+            None,
+            user_context,
+            op_rate_limiter,
+            ApiVersion::V1,
+            &mut delegate_rate_limiter,
+            &mut conn_state,
+        )
+        .await
+        .expect("process_client_request should not error on a valid Get");
+
+        match out {
+            // No message returned => forwarded to the node. Confirm something
+            // actually landed on the request channel.
+            None => {
+                let forwarded = rx.try_recv().is_ok();
+                assert!(forwarded, "forwarded op must reach the request channel");
+                true
+            }
+            // A message returned => a rejection. Confirm it's the rate-limit
+            // OperationError and that NOTHING was forwarded.
+            Some(Message::Binary(bytes)) => {
+                let decoded: Result<HostResponse, ClientError> =
+                    bincode::deserialize(&bytes).expect("rejection must be a native error frame");
+                match decoded {
+                    Err(e) => assert!(
+                        matches!(e.kind(), ErrorKind::OperationError { .. }),
+                        "rate-limit rejection must be an OperationError, got {:?}",
+                        e.kind()
+                    ),
+                    Ok(_) => panic!("rejection frame must be an Err, not Ok"),
+                }
+                assert!(
+                    rx.try_recv().is_err(),
+                    "rejected op must NOT be forwarded to the node"
+                );
+                false
+            }
+            Some(other) => panic!("unexpected non-binary response: {other:?}"),
+        }
+    }
+
+    fn test_user_context(token: &[u8]) -> UserSecretContext {
+        UserSecretContext::from_token(token)
+    }
+
+    /// Local connections (no `user_context`) are NEVER rate-limited: a flood of
+    /// ops far exceeding any burst all forward, even with an aggressive limiter
+    /// present. This is the "never break single-user default" invariant.
+    #[tokio::test]
+    async fn ws_local_flood_is_never_rate_limited() {
+        // Tiny burst, so a hosted user would be throttled almost immediately.
+        let limiter = UserOpRateLimiter::new(1, 1, 0);
+        for i in 0..50 {
+            assert!(
+                drive_one_op(None, Some(&limiter)).await,
+                "Local op {i} must always forward (no user context => no limit)"
+            );
+        }
+        assert_eq!(
+            limiter.tracked_op_users(),
+            0,
+            "Local traffic must never even touch the per-user limiter"
+        );
+    }
+
+    /// A hosted connection (with `user_context`) is throttled: with burst=3,
+    /// the first 3 ops forward and the 4th is rejected as an OperationError.
+    #[tokio::test]
+    async fn ws_hosted_burst_then_reject() {
+        let limiter = UserOpRateLimiter::new(10, 3, 0);
+        let ctx = test_user_context(b"alice");
+        for i in 0..3 {
+            assert!(
+                drive_one_op(Some(&ctx), Some(&limiter)).await,
+                "hosted op {i} within burst should forward"
+            );
+        }
+        assert!(
+            !drive_one_op(Some(&ctx), Some(&limiter)).await,
+            "hosted op beyond burst must be rejected"
+        );
+    }
+
+    /// Hosted, but op limiting DISABLED (rate 0): a hosted flood still forwards.
+    #[tokio::test]
+    async fn ws_hosted_disabled_limit_forwards_all() {
+        let limiter = UserOpRateLimiter::new(0, 3, 0);
+        let ctx = test_user_context(b"bob");
+        for i in 0..20 {
+            assert!(
+                drive_one_op(Some(&ctx), Some(&limiter)).await,
+                "with op limiting disabled, hosted op {i} should forward"
+            );
+        }
+    }
+
+    /// No limiter Extension at all (standalone/local serve path): hosted-looking
+    /// context still forwards, because absence of the limiter means "disabled".
+    #[tokio::test]
+    async fn ws_no_limiter_extension_forwards_all() {
+        let ctx = test_user_context(b"carol");
+        for i in 0..20 {
+            assert!(
+                drive_one_op(Some(&ctx), None).await,
+                "no limiter Extension => op {i} forwards (limiting off)"
+            );
+        }
+    }
+
+    /// Two distinct hosted users get independent buckets at the WS boundary:
+    /// exhausting user A's burst does not throttle user B.
+    #[tokio::test]
+    async fn ws_two_users_independent_buckets() {
+        let limiter = UserOpRateLimiter::new(10, 2, 0);
+        let a = test_user_context(b"user-a");
+        let b = test_user_context(b"user-b");
+        assert!(drive_one_op(Some(&a), Some(&limiter)).await);
+        assert!(drive_one_op(Some(&a), Some(&limiter)).await);
+        assert!(!drive_one_op(Some(&a), Some(&limiter)).await, "A exhausted");
+        // B is independent.
+        assert!(drive_one_op(Some(&b), Some(&limiter)).await);
+        assert!(drive_one_op(Some(&b), Some(&limiter)).await);
+        assert!(!drive_one_op(Some(&b), Some(&limiter)).await, "B exhausted");
     }
 }

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -1593,6 +1593,34 @@ fn extract_stream_content(
     }
 }
 
+/// Which `ClientRequest`s count against the per-user operation rate limit
+/// (#4561). The rule is "does this make the node do real executor/network
+/// work that a hosted visitor could flood with?":
+///
+/// - `ContractOp` — GET/PUT/UPDATE/SUBSCRIBE on the contract loop.
+/// - `DelegateOp` — runs a delegate's WASM on the SAME serial contract loop
+///   (fresh wasmtime instance + secret-store fsync/redb txn); per-user secret
+///   ops are the whole point of hosted mode, so this is the primary flood
+///   vector. The existing `DelegateRateLimiter` only backs off a delegate KEY
+///   that is repeatedly FAILING; a successful-but-abusive delegate flood is
+///   otherwise unbounded.
+/// - `NodeQueries` — `NodeDiagnostics` clones the full connection map and the
+///   hosting-key set inline on the network event loop. We rate-limit it rather
+///   than block it: a hosted client may legitimately query diagnostics, and a
+///   public proxy that wants to forbid recon entirely should drop it at the
+///   proxy allowlist (P4), not here.
+///
+/// Everything else — `Authenticate`, `Disconnect`, `Close`, `StreamChunk`
+/// (control / reassembly, already bounded per-connection by the stdlib) — does
+/// not count, so a client can always authenticate and disconnect even while
+/// throttled.
+fn is_rate_limited_op(req: &ClientRequest<'_>) -> bool {
+    matches!(
+        req,
+        ClientRequest::ContractOp(_) | ClientRequest::DelegateOp(_) | ClientRequest::NodeQueries(_)
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn process_client_request(
     client_id: ClientId,
@@ -1656,6 +1684,14 @@ async fn process_client_request(
     // freenet-stdlib 0.2.2+ automatically chunks large ClientRequest messages
     // (>512 KiB), and the server always reassembles them. Both directions
     // (client→server and server→client) chunk transparently above the threshold.
+    //
+    // TODO(#4561): StreamChunk reassembly runs BEFORE the per-user op rate limit
+    // below, and StreamChunk is intentionally NOT counted as an op (it's
+    // transport framing, not a request). Reassembly is bounded per connection by
+    // the stdlib (MAX_CONCURRENT_STREAMS = 8, STREAM_TTL eviction) but there is
+    // no per-chunk BYTE cap, so a hosted user could stream many large chunks to
+    // pressure memory without ever completing a rate-limited request. Bounding
+    // chunk bytes per user is follow-up hardening, tracked under #4561 P5.
     let req = if let ClientRequest::StreamChunk {
         stream_id,
         index,
@@ -1731,22 +1767,28 @@ async fn process_client_request(
     }
 
     // Per-user operation rate limit (#4561, P5 of #4381). Bounds how fast a
-    // single HOSTED user can issue contract operations (GET/PUT/UPDATE/
-    // SUBSCRIBE) so one visitor cannot flood the node's executor/network. The
-    // check is GATED on `user_context.is_some()` — i.e. hosted mode honored a
-    // user token for this connection — so Local / non-hosted / tokenless
-    // connections are NEVER rate-limited (the "never break single-user default"
-    // invariant). Reject BEFORE forwarding to the node, so an over-rate request
-    // costs no executor/network work; the client retries shortly.
+    // single HOSTED user can issue WORK-CAUSING operations so one visitor cannot
+    // flood the node's executor/network. See `is_rate_limited_op` for exactly
+    // which requests count — crucially this includes DelegateOp (per-user secret
+    // ops run WASM on the SAME serial contract loop and are MORE expensive than
+    // a GET/PUT; the existing `DelegateRateLimiter` only backs off FAILING keys,
+    // so successful delegate floods were entirely unthrottled) and NodeQueries
+    // (NodeDiagnostics clones the connection map + hosting-key set inline on the
+    // network loop). The check is GATED on `user_context.is_some()` — i.e.
+    // hosted mode honored a user token for this connection — so Local /
+    // non-hosted / tokenless connections are NEVER rate-limited (the "never
+    // break single-user default" invariant). Reject BEFORE forwarding to the
+    // node, so an over-rate request costs no executor/network work; the client
+    // retries shortly.
     if let (Some(user_context), Some(limiter)) = (user_context, op_rate_limiter) {
         if limiter.op_limiting_enabled()
-            && matches!(req, ClientRequest::ContractOp(_))
+            && is_rate_limited_op(&req)
             && !limiter.try_acquire_op(user_context.user_id())
         {
             tracing::debug!(
                 %client_id,
                 user_id = ?user_context.user_id(),
-                "Rejecting contract operation: per-user operation rate limit exceeded"
+                "Rejecting operation: per-user operation rate limit exceeded"
             );
             let error: ClientError = ErrorKind::OperationError {
                 cause: std::borrow::Cow::Borrowed("operation rate limit exceeded; retry shortly"),
@@ -3704,16 +3746,38 @@ mod tests {
 
     // ---- Per-user operation rate limit at the WS boundary (#4561) ----------
 
+    fn encode_req(req: ClientRequest<'_>) -> Message {
+        Message::Binary(bincode::serialize(&req).unwrap().into())
+    }
+
     /// A native-encoded `Get` operation message, the cheapest contract op to
     /// drive `process_client_request` with.
     fn encoded_get_op() -> Message {
-        let req = ClientRequest::ContractOp(ContractRequest::Get {
+        encode_req(ClientRequest::ContractOp(ContractRequest::Get {
             key: ContractInstanceId::new([7u8; 32]),
             return_contract_code: false,
             subscribe: false,
             blocking_subscribe: false,
-        });
-        Message::Binary(bincode::serialize(&req).unwrap().into())
+        }))
+    }
+
+    /// A native-encoded delegate op (`UnregisterDelegate`, the cheapest variant
+    /// to construct). Delegate ops are the primary flood vector the per-user
+    /// limit must cover (#4561 review).
+    fn encoded_delegate_op() -> Message {
+        use freenet_stdlib::prelude::{CodeHash, DelegateKey};
+        let key = DelegateKey::new([9u8; 32], CodeHash::new([0u8; 32]));
+        encode_req(ClientRequest::DelegateOp(
+            freenet_stdlib::client_api::DelegateRequest::UnregisterDelegate(key),
+        ))
+    }
+
+    /// A native-encoded node query (`ConnectedPeers`). NodeQueries reach the
+    /// network loop and must also be counted (#4561 review).
+    fn encoded_node_query() -> Message {
+        encode_req(ClientRequest::NodeQueries(
+            freenet_stdlib::client_api::NodeQuery::ConnectedPeers,
+        ))
     }
 
     /// Drive ONE request through `process_client_request` with the given
@@ -3724,7 +3788,18 @@ mod tests {
     ///   rejection variant),
     /// and confirms forward/reject is consistent with whether anything landed
     /// on the request channel.
+    /// Drive a GET op (the common case for most rate-limit tests).
     async fn drive_one_op(
+        user_context: Option<&UserSecretContext>,
+        op_rate_limiter: Option<&UserOpRateLimiter>,
+    ) -> bool {
+        drive_msg(encoded_get_op(), user_context, op_rate_limiter).await
+    }
+
+    /// Drive an arbitrary already-encoded request through
+    /// `process_client_request`. See `drive_one_op` for the return contract.
+    async fn drive_msg(
+        msg: Message,
         user_context: Option<&UserSecretContext>,
         op_rate_limiter: Option<&UserOpRateLimiter>,
     ) -> bool {
@@ -3736,7 +3811,7 @@ mod tests {
 
         let out = process_client_request(
             ClientId::next(),
-            Ok(encoded_get_op()),
+            Ok(msg),
             &tx,
             &mut auth_token,
             None,
@@ -3747,7 +3822,7 @@ mod tests {
             &mut conn_state,
         )
         .await
-        .expect("process_client_request should not error on a valid Get");
+        .expect("process_client_request should not error on a valid request");
 
         match out {
             // No message returned => forwarded to the node. Confirm something
@@ -3862,5 +3937,78 @@ mod tests {
         assert!(drive_one_op(Some(&b), Some(&limiter)).await);
         assert!(drive_one_op(Some(&b), Some(&limiter)).await);
         assert!(!drive_one_op(Some(&b), Some(&limiter)).await, "B exhausted");
+    }
+
+    /// A DelegateOp counts against the SAME per-user bucket as contract ops:
+    /// once the burst is spent (here entirely on delegate ops) the next
+    /// delegate op is rejected, NOT forwarded. Delegate ops are the primary
+    /// flood vector this fix added (#4561 review item #1).
+    #[tokio::test]
+    async fn ws_hosted_delegate_op_is_rate_limited() {
+        let limiter = UserOpRateLimiter::new(10, 2, 0);
+        let ctx = test_user_context(b"delegate-user");
+        assert!(
+            drive_msg(encoded_delegate_op(), Some(&ctx), Some(&limiter)).await,
+            "delegate op 1 within burst forwards"
+        );
+        assert!(
+            drive_msg(encoded_delegate_op(), Some(&ctx), Some(&limiter)).await,
+            "delegate op 2 within burst forwards"
+        );
+        assert!(
+            !drive_msg(encoded_delegate_op(), Some(&ctx), Some(&limiter)).await,
+            "delegate op beyond burst is rejected (not forwarded)"
+        );
+    }
+
+    /// Contract ops and delegate ops share ONE bucket: a contract op spends a
+    /// token that a delegate op then can't, proving they're not counted
+    /// separately.
+    #[tokio::test]
+    async fn ws_contract_and_delegate_share_one_bucket() {
+        let limiter = UserOpRateLimiter::new(10, 1, 0); // burst 1
+        let ctx = test_user_context(b"shared-bucket-user");
+        assert!(
+            drive_msg(encoded_get_op(), Some(&ctx), Some(&limiter)).await,
+            "the single burst token goes to the contract op"
+        );
+        assert!(
+            !drive_msg(encoded_delegate_op(), Some(&ctx), Some(&limiter)).await,
+            "delegate op rejected — it shares the now-empty bucket with the GET"
+        );
+    }
+
+    /// A NodeQuery counts against the per-user bucket too (we rate-limit rather
+    /// than block it for hosted users).
+    #[tokio::test]
+    async fn ws_hosted_node_query_is_rate_limited() {
+        let limiter = UserOpRateLimiter::new(10, 1, 0);
+        let ctx = test_user_context(b"nodequery-user");
+        assert!(
+            drive_msg(encoded_node_query(), Some(&ctx), Some(&limiter)).await,
+            "node query within burst forwards"
+        );
+        assert!(
+            !drive_msg(encoded_node_query(), Some(&ctx), Some(&limiter)).await,
+            "node query beyond burst is rejected"
+        );
+    }
+
+    /// Control messages (here Authenticate) are NOT counted: a hosted user with
+    /// an exhausted op bucket can still authenticate.
+    #[tokio::test]
+    async fn ws_control_message_not_rate_limited() {
+        let limiter = UserOpRateLimiter::new(10, 1, 0);
+        let ctx = test_user_context(b"control-user");
+        // Spend the one burst token on a contract op.
+        assert!(drive_msg(encoded_get_op(), Some(&ctx), Some(&limiter)).await);
+        // An Authenticate must still go through (it doesn't count as an op).
+        let auth = encode_req(ClientRequest::Authenticate {
+            token: "some-token".to_string(),
+        });
+        assert!(
+            drive_msg(auth, Some(&ctx), Some(&limiter)).await,
+            "Authenticate must not be rate-limited even with an empty op bucket"
+        );
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1785,7 +1785,7 @@ pub struct WebsocketApiArgs {
     /// Per-user operation burst capacity for HOSTED mode (#4561). The maximum
     /// number of operations a user who has been idle can issue back-to-back
     /// before being throttled to the sustained `--per-user-op-rate-limit`.
-    /// Default: 50. Paired with the rate limit above; only meaningful when
+    /// Default: 100. Paired with the rate limit above; only meaningful when
     /// op rate limiting is enabled.
     #[arg(long = "per-user-op-burst", env = "PER_USER_OP_BURST")]
     pub per_user_op_burst: Option<u64>,
@@ -2010,7 +2010,7 @@ pub struct WebsocketApiConfig {
 
     /// Per-user operation burst capacity for hosted mode (#4561). Max ops a
     /// previously-idle user may issue back-to-back before being throttled to
-    /// the sustained rate. Default 50.
+    /// the sustained rate. Default 100.
     #[serde(default = "default_per_user_op_burst", rename = "per-user-op-burst")]
     pub per_user_op_burst: u64,
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -194,6 +194,9 @@ impl Default for ConfigArgs {
                 allowed_host: None,
                 allowed_source_cidrs: None,
                 hosted_mode: None,
+                per_user_op_rate_limit: None,
+                per_user_op_burst: None,
+                per_user_export_min_interval_secs: None,
             },
             secrets: Default::default(),
             log_level: Some(tracing::log::LevelFilter::Info),
@@ -365,6 +368,15 @@ impl ConfigArgs {
             self.ws_api
                 .hosted_mode
                 .get_or_insert(cfg.ws_api.hosted_mode);
+            self.ws_api
+                .per_user_op_rate_limit
+                .get_or_insert(cfg.ws_api.per_user_op_rate_limit);
+            self.ws_api
+                .per_user_op_burst
+                .get_or_insert(cfg.ws_api.per_user_op_burst);
+            self.ws_api
+                .per_user_export_min_interval_secs
+                .get_or_insert(cfg.ws_api.per_user_export_min_interval_secs);
             self.network_api
                 .address
                 .get_or_insert(cfg.network_api.address);
@@ -875,6 +887,18 @@ impl ConfigArgs {
                     .transpose()?
                     .unwrap_or_default(),
                 hosted_mode: self.ws_api.hosted_mode.unwrap_or(false),
+                per_user_op_rate_limit: self
+                    .ws_api
+                    .per_user_op_rate_limit
+                    .unwrap_or_else(default_per_user_op_rate_limit),
+                per_user_op_burst: self
+                    .ws_api
+                    .per_user_op_burst
+                    .unwrap_or_else(default_per_user_op_burst),
+                per_user_export_min_interval_secs: self
+                    .ws_api
+                    .per_user_export_min_interval_secs
+                    .unwrap_or_else(default_per_user_export_min_interval_secs),
             },
             secrets,
             log_level: self.log_level.unwrap_or(tracing::log::LevelFilter::Info),
@@ -1747,6 +1771,35 @@ pub struct WebsocketApiArgs {
     )]
     #[serde(rename = "hosted-mode", skip_serializing_if = "Option::is_none")]
     pub hosted_mode: Option<bool>,
+
+    /// Sustained per-user operation rate limit (requests/second) for HOSTED
+    /// mode (#4561, P5 of #4381). Bounds how fast a single hosted user (one
+    /// `userToken`) can issue contract operations (GET/PUT/UPDATE/SUBSCRIBE) so
+    /// one visitor cannot flood the node's executor and network. Over-rate
+    /// requests are REJECTED at the WebSocket boundary (the client retries).
+    /// Default: 10 req/sec. `0` disables operation rate limiting. Has NO effect
+    /// outside hosted mode — local single-user requests are never rate-limited.
+    #[arg(long = "per-user-op-rate-limit", env = "PER_USER_OP_RATE_LIMIT")]
+    pub per_user_op_rate_limit: Option<u64>,
+
+    /// Per-user operation burst capacity for HOSTED mode (#4561). The maximum
+    /// number of operations a user who has been idle can issue back-to-back
+    /// before being throttled to the sustained `--per-user-op-rate-limit`.
+    /// Default: 50. Paired with the rate limit above; only meaningful when
+    /// op rate limiting is enabled.
+    #[arg(long = "per-user-op-burst", env = "PER_USER_OP_BURST")]
+    pub per_user_op_burst: Option<u64>,
+
+    /// Minimum seconds between hosted-export downloads PER USER (#4561). The
+    /// export endpoint enumerates and re-encrypts every secret in the user's
+    /// scope, so it is far more expensive than a single op and gets a separate,
+    /// tighter limit. A request inside this window returns HTTP 429. Default:
+    /// 10s. `0` disables export rate limiting. Hosted-mode only.
+    #[arg(
+        long = "per-user-export-min-interval-secs",
+        env = "PER_USER_EXPORT_MIN_INTERVAL_SECS"
+    )]
+    pub per_user_export_min_interval_secs: Option<u64>,
 }
 
 /// Default telemetry endpoint (nova.locut.us OTLP collector).
@@ -1944,6 +1997,31 @@ pub struct WebsocketApiConfig {
     /// derived, so with the flag off the entire feature is inert.
     #[serde(default, rename = "hosted-mode")]
     pub hosted_mode: bool,
+
+    /// Sustained per-user operation rate limit (requests/second) for hosted
+    /// mode (#4561, P5 of #4381). Bounds how fast a single hosted user can
+    /// issue contract operations so one visitor cannot flood the node. `0`
+    /// disables op rate limiting. No effect outside hosted mode. Default 10.
+    #[serde(
+        default = "default_per_user_op_rate_limit",
+        rename = "per-user-op-rate-limit"
+    )]
+    pub per_user_op_rate_limit: u64,
+
+    /// Per-user operation burst capacity for hosted mode (#4561). Max ops a
+    /// previously-idle user may issue back-to-back before being throttled to
+    /// the sustained rate. Default 50.
+    #[serde(default = "default_per_user_op_burst", rename = "per-user-op-burst")]
+    pub per_user_op_burst: u64,
+
+    /// Minimum seconds between hosted-export downloads per user (#4561). Export
+    /// is expensive, so it gets a separate tighter limit; a request inside this
+    /// window returns HTTP 429. `0` disables export rate limiting. Default 10.
+    #[serde(
+        default = "default_per_user_export_min_interval_secs",
+        rename = "per-user-export-min-interval-secs"
+    )]
+    pub per_user_export_min_interval_secs: u64,
 }
 
 #[inline]
@@ -1956,6 +2034,26 @@ const fn default_token_cleanup_interval_seconds() -> u64 {
     300 // 5 minutes
 }
 
+/// Default sustained per-user op rate (req/sec) in hosted mode. Resolves to the
+/// single source of truth in `client_events::user_op_rate_limit` so the
+/// operator-facing default and the limiter's in-code default never drift.
+#[inline]
+const fn default_per_user_op_rate_limit() -> u64 {
+    crate::client_events::user_op_rate_limit::DEFAULT_PER_USER_OP_RATE_LIMIT
+}
+
+/// Default per-user op burst capacity in hosted mode.
+#[inline]
+const fn default_per_user_op_burst() -> u64 {
+    crate::client_events::user_op_rate_limit::DEFAULT_PER_USER_OP_BURST
+}
+
+/// Default minimum seconds between hosted exports per user.
+#[inline]
+const fn default_per_user_export_min_interval_secs() -> u64 {
+    crate::client_events::user_op_rate_limit::DEFAULT_PER_USER_EXPORT_MIN_INTERVAL_SECS
+}
+
 impl From<SocketAddr> for WebsocketApiConfig {
     fn from(addr: SocketAddr) -> Self {
         Self {
@@ -1966,6 +2064,9 @@ impl From<SocketAddr> for WebsocketApiConfig {
             allowed_hosts: Vec::new(),
             allowed_source_cidrs: Vec::new(),
             hosted_mode: false,
+            per_user_op_rate_limit: default_per_user_op_rate_limit(),
+            per_user_op_burst: default_per_user_op_burst(),
+            per_user_export_min_interval_secs: default_per_user_export_min_interval_secs(),
         }
     }
 }
@@ -1981,6 +2082,9 @@ impl Default for WebsocketApiConfig {
             allowed_hosts: Vec::new(),
             allowed_source_cidrs: Vec::new(),
             hosted_mode: false,
+            per_user_op_rate_limit: default_per_user_op_rate_limit(),
+            per_user_op_burst: default_per_user_op_burst(),
+            per_user_export_min_interval_secs: default_per_user_export_min_interval_secs(),
         }
     }
 }
@@ -3937,6 +4041,9 @@ mod tests {
                 allowed_hosts: vec!["my-host".to_string()],
                 allowed_source_cidrs: vec!["10.0.0.0/8".parse().unwrap()],
                 hosted_mode: true,
+                per_user_op_rate_limit: 33,
+                per_user_op_burst: 77,
+                per_user_export_min_interval_secs: 17,
             },
             secrets: base.secrets.clone(),
             log_level: tracing::log::LevelFilter::Debug,
@@ -4106,6 +4213,9 @@ mod tests {
             allowed_hosts,
             allowed_source_cidrs,
             hosted_mode,
+            per_user_op_rate_limit,
+            per_user_op_burst,
+            per_user_export_min_interval_secs,
         } = ws_api;
         assert_eq!(ws_address, seed.ws_api.address, "ws_api.address");
         assert_eq!(ws_port, seed.ws_api.port, "ws_api.port");
@@ -4123,6 +4233,18 @@ mod tests {
             "allowed_source_cidrs"
         );
         assert_eq!(hosted_mode, seed.ws_api.hosted_mode, "ws_api.hosted_mode");
+        assert_eq!(
+            per_user_op_rate_limit, seed.ws_api.per_user_op_rate_limit,
+            "ws_api.per_user_op_rate_limit"
+        );
+        assert_eq!(
+            per_user_op_burst, seed.ws_api.per_user_op_burst,
+            "ws_api.per_user_op_burst"
+        );
+        assert_eq!(
+            per_user_export_min_interval_secs, seed.ws_api.per_user_export_min_interval_secs,
+            "ws_api.per_user_export_min_interval_secs"
+        );
 
         let TelemetryConfig {
             enabled,

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -679,6 +679,31 @@ async fn serve_client_api_in_impl(
         );
     }
 
+    // Per-user operation + export rate limiter (#4561, P5 of #4381). Built once
+    // here (the only place the operator config is in scope) and injected as an
+    // `Extension` on BOTH the WS path (`process_client_request` consults it for
+    // contract ops) and the HTTP export handler (per-user export throttle). The
+    // SAME `Arc` is shared across every connection, so one user's many
+    // connections share their bucket; nodes don't collide because each node
+    // owns its own router Extension. Op rate limiting only ever fires for a
+    // connection that derives a `UserSecretContext` (hosted mode), so the
+    // single-user / non-hosted path is never throttled even though the
+    // Extension is present.
+    let op_rate_limiter = crate::client_events::user_op_rate_limit::UserOpRateLimitConfig {
+        op_rate: config.per_user_op_rate_limit,
+        op_burst: config.per_user_op_burst,
+        export_min_interval_secs: config.per_user_export_min_interval_secs,
+    }
+    .build();
+    if hosted_mode.0 && op_rate_limiter.op_limiting_enabled() {
+        tracing::info!(
+            op_rate = config.per_user_op_rate_limit,
+            op_burst = config.per_user_op_burst,
+            export_min_interval_secs = config.per_user_export_min_interval_secs,
+            "Hosted per-user operation rate limiting enabled"
+        );
+    }
+
     let needs_lan_filter = !config.address.is_loopback();
     let router = if needs_lan_filter {
         // Layer ordering matters: axum executes layers bottom-to-top per
@@ -695,6 +720,7 @@ async fn serve_client_api_in_impl(
         // `Extension<AllowedSourceCidrs>` for the Host-header CIDR check.
         ws_router
             .layer(Extension(hosted_mode))
+            .layer(Extension(op_rate_limiter))
             .layer(Extension(allowed_hosts))
             .layer(axum::middleware::from_fn(private_network_filter))
             .layer(Extension(allowed_source_cidrs))
@@ -705,6 +731,7 @@ async fn serve_client_api_in_impl(
         // 500 every WS upgrade.
         ws_router
             .layer(Extension(hosted_mode))
+            .layer(Extension(op_rate_limiter))
             .layer(Extension(allowed_hosts))
             .layer(Extension(allowed_source_cidrs))
             .layer(TraceLayer::new_for_http())

--- a/crates/core/src/server/client_api/hosted_export.rs
+++ b/crates/core/src/server/client_api/hosted_export.rs
@@ -204,6 +204,24 @@ pub(crate) fn export_user_context_or_reject(
     }
 }
 
+/// Decide whether this export is over the per-user export rate limit.
+///
+/// Factored out of the handler so the throttle decision is unit-testable
+/// without standing up a node. Returns `true` to REJECT (over-rate). A `None`
+/// limiter (standalone composition / export limiting disabled) never rejects.
+/// On an admitted export this RECORDS the export time (advances the per-user
+/// interval clock), so the call has a side effect and must run exactly once per
+/// request.
+fn export_rate_limited(
+    limiter: Option<&crate::client_events::user_op_rate_limit::UserOpRateLimiter>,
+    user_context: &UserSecretContext,
+) -> bool {
+    match limiter {
+        Some(limiter) => !limiter.try_acquire_export(user_context.user_id()),
+        None => false,
+    }
+}
+
 /// `GET /v{1,2}/hosted/export` — export this hosted user's per-user delegate
 /// secrets as an encrypted bundle download.
 ///
@@ -257,6 +275,31 @@ async fn export_handler(req: axum::extract::Request) -> Response {
                 return (status, reason).into_response();
             }
         };
+
+    // Per-user export rate limit (#4561, P5 of #4381). Export enumerates AND
+    // re-encrypts every secret in the user's scope, so it is far more expensive
+    // than a single op and gets a SEPARATE, tighter limit (min-interval, not a
+    // token bucket). Checked right AFTER the token gate — so only an
+    // authenticated token-holder is throttled, keyed by the gate-derived
+    // (unforgeable) `user_id` — and BEFORE op_manager resolution so a flooding
+    // client gets the 429 back-off signal regardless of node readiness, and a
+    // rejected request never reaches the executor. The limiter Extension is
+    // layered by `serve_client_api_in_impl`; absence (standalone composition)
+    // ⇒ no export limiting. Over-rate ⇒ HTTP 429.
+    let limiter = req
+        .extensions()
+        .get::<crate::client_events::user_op_rate_limit::UserOpRateLimiter>();
+    if export_rate_limited(limiter, &user_context) {
+        tracing::warn!(
+            user_id = ?user_context.user_id(),
+            "Rejected hosted export: per-user export rate limit exceeded"
+        );
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            "export rate limit exceeded; retry shortly",
+        )
+            .into_response();
+    }
 
     // Per-node route to the executor, carried as an Extension and filled by the
     // node at startup. Absent (standalone `as_router` composition with no node)
@@ -466,5 +509,67 @@ mod tests {
         let public6 = Some(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));
         let err = export_user_context_or_reject(&headers, public6, true).unwrap_err();
         assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    // ---- Per-user EXPORT rate limit (#4561) -------------------------------
+
+    use crate::client_events::user_op_rate_limit::UserOpRateLimiter;
+
+    /// No limiter (standalone composition / export limiting off) never rejects,
+    /// no matter how many exports the same user requests.
+    #[test]
+    fn export_rate_limit_absent_limiter_never_rejects() {
+        let ctx = UserSecretContext::from_token(b"tok-export");
+        for _ in 0..10 {
+            assert!(
+                !export_rate_limited(None, &ctx),
+                "absent limiter must never reject"
+            );
+        }
+    }
+
+    /// With a tight export interval the FIRST export passes (not limited) and an
+    /// immediate SECOND export from the same user is rejected (over-rate). This
+    /// is the 429 path the handler maps.
+    #[test]
+    fn export_rate_limit_second_immediate_export_rejected() {
+        // 60s min interval, op rate/burst irrelevant to export limiting.
+        let limiter = UserOpRateLimiter::new(10, 50, 60);
+        let ctx = UserSecretContext::from_token(b"tok-export");
+        assert!(
+            !export_rate_limited(Some(&limiter), &ctx),
+            "first export must pass"
+        );
+        assert!(
+            export_rate_limited(Some(&limiter), &ctx),
+            "immediate second export must be rejected (429 path)"
+        );
+    }
+
+    /// Export interval is per-user: throttling user A does not throttle user B.
+    #[test]
+    fn export_rate_limit_is_per_user() {
+        let limiter = UserOpRateLimiter::new(10, 50, 60);
+        let a = UserSecretContext::from_token(b"user-a");
+        let b = UserSecretContext::from_token(b"user-b");
+        assert!(!export_rate_limited(Some(&limiter), &a), "A first passes");
+        assert!(export_rate_limited(Some(&limiter), &a), "A throttled");
+        assert!(
+            !export_rate_limited(Some(&limiter), &b),
+            "B independent of A"
+        );
+    }
+
+    /// Export interval of 0 disables export limiting: a flood always passes.
+    #[test]
+    fn export_rate_limit_disabled_passes_all() {
+        let limiter = UserOpRateLimiter::new(10, 50, 0);
+        let ctx = UserSecretContext::from_token(b"tok-export");
+        for _ in 0..10 {
+            assert!(
+                !export_rate_limited(Some(&limiter), &ctx),
+                "export limiting disabled (0): every export passes"
+            );
+        }
     }
 }

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -50,7 +50,7 @@ pub use runtime::{ContractExecError, Runtime};
 pub(crate) use runtime::{RuntimeConfig, SharedModuleCache};
 pub use secrets_store::{
     DEFAULT_PER_USER_SECRET_QUOTA_BYTES, ExportSecretEntry, SecretScope, SecretStoreError,
-    SecretsStore, UserSecretContext,
+    SecretsStore, UserId, UserSecretContext,
 };
 // NOTE: InMemoryContractStore and SimulationStores are available but currently unused
 // They provide infrastructure for more sophisticated simulation scenarios

--- a/crates/core/tests/error_notification.rs
+++ b/crates/core/tests/error_notification.rs
@@ -576,11 +576,9 @@ async fn test_connection_drop_error_notification() -> anyhow::Result<()> {
         ws_api: freenet::config::WebsocketApiArgs {
             address: Some(Ipv4Addr::LOCALHOST.into()),
             ws_api_port: Some(gateway_ws_port),
-            token_ttl_seconds: None,
-            token_cleanup_interval_seconds: None,
-            allowed_host: None,
-            allowed_source_cidrs: None,
-            hosted_mode: None,
+            // Remaining ws_api args default. `..Default::default()` so future
+            // ws_api fields (e.g. per-user rate limits, #4561) can't break this.
+            ..Default::default()
         },
         network_api: freenet::config::NetworkArgs {
             public_address: Some(Ipv4Addr::LOCALHOST.into()),
@@ -636,11 +634,9 @@ async fn test_connection_drop_error_notification() -> anyhow::Result<()> {
         ws_api: freenet::config::WebsocketApiArgs {
             address: Some(Ipv4Addr::LOCALHOST.into()),
             ws_api_port: Some(peer_ws_port),
-            token_ttl_seconds: None,
-            token_cleanup_interval_seconds: None,
-            allowed_host: None,
-            allowed_source_cidrs: None,
-            hosted_mode: None,
+            // Remaining ws_api args default. `..Default::default()` so future
+            // ws_api fields (e.g. per-user rate limits, #4561) can't break this.
+            ..Default::default()
         },
         network_api: freenet::config::NetworkArgs {
             public_address: Some(Ipv4Addr::LOCALHOST.into()),

--- a/crates/core/tests/hosted_mode_export.rs
+++ b/crates/core/tests/hosted_mode_export.rs
@@ -105,6 +105,13 @@ fn node_config(
             address: Some(Ipv4Addr::LOCALHOST.into()),
             ws_api_port: Some(ws_port),
             hosted_mode: Some(hosted_mode),
+            // Disable the per-user op rate limit (#4561) for these tests: they
+            // exercise hosted EXPORT behaviour (#4531) and fire bulk store_secret
+            // loops (e.g. 64 ops) as a single user to set up / stress the export,
+            // which is unrelated to rate limiting and would otherwise trip the
+            // limiter. The dedicated rate-limit coverage lives in
+            // `user_op_rate_limit` unit tests.
+            per_user_op_rate_limit: Some(0),
             ..Default::default()
         },
         network_api: freenet::config::NetworkArgs {

--- a/crates/core/tests/operations_before_join.rs
+++ b/crates/core/tests/operations_before_join.rs
@@ -92,11 +92,9 @@ async fn test_operations_blocked_before_join() -> anyhow::Result<()> {
         ws_api: freenet::config::WebsocketApiArgs {
             address: Some(Ipv4Addr::LOCALHOST.into()),
             ws_api_port: Some(gateway_ws_port),
-            token_ttl_seconds: None,
-            token_cleanup_interval_seconds: None,
-            allowed_host: None,
-            allowed_source_cidrs: None,
-            hosted_mode: None,
+            // Remaining ws_api args default. `..Default::default()` so future
+            // ws_api fields (e.g. per-user rate limits, #4561) can't break this.
+            ..Default::default()
         },
         network_api: freenet::config::NetworkArgs {
             public_address: Some(Ipv4Addr::LOCALHOST.into()),
@@ -151,11 +149,9 @@ async fn test_operations_blocked_before_join() -> anyhow::Result<()> {
         ws_api: freenet::config::WebsocketApiArgs {
             address: Some(Ipv4Addr::LOCALHOST.into()),
             ws_api_port: Some(peer_ws_port),
-            token_ttl_seconds: None,
-            token_cleanup_interval_seconds: None,
-            allowed_host: None,
-            allowed_source_cidrs: None,
-            hosted_mode: None,
+            // Remaining ws_api args default. `..Default::default()` so future
+            // ws_api fields (e.g. per-user rate limits, #4561) can't break this.
+            ..Default::default()
         },
         network_api: freenet::config::NetworkArgs {
             public_address: Some(Ipv4Addr::LOCALHOST.into()),

--- a/crates/core/tests/token_expiration.rs
+++ b/crates/core/tests/token_expiration.rs
@@ -34,9 +34,9 @@ async fn create_test_config(
             ws_api_port: Some(ws_socket.local_addr()?.port()),
             token_ttl_seconds: Some(token_ttl_seconds),
             token_cleanup_interval_seconds: Some(cleanup_interval_seconds),
-            allowed_host: None,
-            allowed_source_cidrs: None,
-            hosted_mode: None,
+            // Remaining ws_api args default. `..Default::default()` so future
+            // ws_api fields (e.g. per-user rate limits, #4561) can't break this.
+            ..Default::default()
         },
         network_api: NetworkArgs {
             address: Some(Ipv4Addr::LOCALHOST.into()),
@@ -129,12 +129,10 @@ async fn test_default_token_configuration() -> TestResult {
                 address: Some(Ipv4Addr::LOCALHOST.into()),
                 ws_api_port: Some(ws_socket.local_addr()?.port()),
                 // Don't specify token_ttl_seconds or token_cleanup_interval_seconds
-                // to test default values
-                token_ttl_seconds: None,
-                token_cleanup_interval_seconds: None,
-                allowed_host: None,
-                allowed_source_cidrs: None,
-                hosted_mode: None,
+                // (left as their defaults) to test default values. All other
+                // ws_api args default too. `..Default::default()` so future ws_api
+                // fields (e.g. per-user rate limits, #4561) can't break this.
+                ..Default::default()
             },
             network_api: NetworkArgs {
                 address: Some(Ipv4Addr::LOCALHOST.into()),
@@ -214,9 +212,10 @@ async fn test_token_cleanup_removes_expired_tokens() -> TestResult {
             port: ws_port,
             token_ttl_seconds: TOKEN_TTL_SECS,
             token_cleanup_interval_seconds: CLEANUP_INTERVAL_SECS,
-            allowed_hosts: Vec::new(),
-            allowed_source_cidrs: Vec::new(),
-            hosted_mode: false,
+            // Remaining fields (allowlists, hosted_mode, per-user rate limits)
+            // default. `..Default::default()` so future WebsocketApiConfig fields
+            // (e.g. the per-user rate limits, #4561) can't break this test.
+            ..Default::default()
         };
 
         // Start the client API server (which spawns the cleanup task)

--- a/crates/freenet-macros/src/codegen.rs
+++ b/crates/freenet-macros/src/codegen.rs
@@ -276,11 +276,12 @@ fn generate_node_setup(args: &FreenetTestArgs) -> TokenStream {
                             // Bind to varied IP for test isolation (prevents port conflicts in parallel tests)
                             address: Some(node_ip.into()),
                             ws_api_port: Some(ws_port),
-                            token_ttl_seconds: None,
-                            token_cleanup_interval_seconds: None,
-                            allowed_host: None,
-                            allowed_source_cidrs: None,
-                            hosted_mode: None,
+                            // All other ws_api args default (None) for tests. Use
+                            // `..Default::default()` rather than listing each field
+                            // so a new ws_api arg can't break this macro's compile
+                            // (the per-user rate-limit fields, #4561, did exactly
+                            // that before this change).
+                            ..Default::default()
                         },
                         network_api: freenet::config::NetworkArgs {
                             // Use varied IP for public_address (affects location calculation)
@@ -417,11 +418,12 @@ fn generate_node_setup(args: &FreenetTestArgs) -> TokenStream {
                             // Bind to varied IP for test isolation (prevents port conflicts in parallel tests)
                             address: Some(node_ip.into()),
                             ws_api_port: Some(ws_port),
-                            token_ttl_seconds: None,
-                            token_cleanup_interval_seconds: None,
-                            allowed_host: None,
-                            allowed_source_cidrs: None,
-                            hosted_mode: None,
+                            // All other ws_api args default (None) for tests. Use
+                            // `..Default::default()` rather than listing each field
+                            // so a new ws_api arg can't break this macro's compile
+                            // (the per-user rate-limit fields, #4561, did exactly
+                            // that before this change).
+                            ..Default::default()
                         },
                         network_api: freenet::config::NetworkArgs {
                             // Use varied IP for public_address (affects location calculation)


### PR DESCRIPTION
## Problem

Hosted mode (#4381) lets untrusted web visitors drive a shared node via a per-user `userToken`. The per-user storage quota (#4573) bounds disk, but nothing bounds how **fast** a single hosted user can issue contract operations (GET/PUT/UPDATE/SUBSCRIBE) or hosted-export downloads — one visitor could flood the node's executor and network. Local (non-hosted, single-user) requests must **never** be rate-limited (the "never break single-user default" invariant).

## Solution

A per-user token-bucket operation limiter plus a per-user export min-interval, owned as **per-node server state** (`Arc<DashMap<UserId, _>>`, not a process-global), so multi-node simulations never collide and one user's many connections share a bucket.

- **WS hook** — `process_client_request` (`websocket.rs`) rejects an over-rate contract op **before** forwarding to the node (no executor/network cost), using an existing `ErrorKind::OperationError` frame (no new stdlib wire-format variant), serialized exactly like the existing `DelegateRateLimiter` rejection (both Flatbuffers + Native). Gated on `user_context.is_some()`, so Local / non-hosted / tokenless connections are **never** limited.
- **Export hook** — `hosted_export::export_handler` returns **HTTP 429** when a user exceeds the tighter export interval (export enumerates + re-encrypts every secret in scope, so it's far more expensive than one op). Checked right after the token gate and before op-manager resolution, so a flooding client gets the back-off signal regardless of node readiness.
- **Concurrency** — the WS path is concurrent across connection tasks; each bucket guards `(tokens, last_refill)` behind a short `Mutex` so refill + decrement is one atomic decision — **no check-then-act over-admit race**. The `DashMap` `entry` API makes the lazy bucket insert atomic too. Proven by a 64-thread test asserting that with no refill exactly `burst` tokens are admitted across all threads.
- **Rejection variant** — reuses `ErrorKind::OperationError { cause: "operation rate limit exceeded; retry shortly" }`. No stdlib change.
- **Config** — `--per-user-op-rate-limit` (default 10/s, `0` disables), `--per-user-op-burst` (50), `--per-user-export-min-interval-secs` (10), wired through `WebsocketApiArgs` / `WebsocketApiConfig` exactly like the just-merged quota, including the `ConfigArgs::build()` merge **and** the `all_persisted_config_fields_round_trip_through_build` guard test, so the fields don't silently revert on restart.
- **Time** — `tokio::time::Instant` (matching the existing `PerCallsiteRateLimiter` / `TrackedBackoff` production limiters in this area), injectable in tests via `start_paused` / advance for deterministic refill + interval checks.
- **Limiter primitive** — hand-rolled small atomic token bucket. The existing `PerCallsiteRateLimiter` is a fixed-window counter keyed by tracing callsite (can't express burst≠rate, wrong key type) and `TrackedBackoff` is exponential-backoff-on-failure, so neither fit a (capacity=burst, refill=rate) token bucket keyed by `UserId`.

## Testing

- **10 limiter unit tests**: under-rate passes; burst-then-reject; refill over time (partial + capped at burst); disabled never limits (and allocates no buckets); per-user independence; same-user shared bucket; **64-thread concurrency over-admit guard**; export interval enforced / disabled / per-user.
- **5 WS-boundary integration tests** driving `process_client_request`: Local flood never limited (and never touches the limiter map); hosted burst-then-reject (asserts the `OperationError` frame **and** that a rejected op is NOT forwarded); hosted-disabled forwards all; no-limiter-Extension forwards all; two users independent.
- **4 export helper tests**: absent limiter never rejects; second immediate export rejected (429 path); per-user; disabled passes all.
- `cargo fmt` + `cargo clippy -p freenet --lib -- -D warnings` clean; `cargo test --workspace --no-run` compiles; full **websocket (63)**, **client_events (124)**, **config (70)**, **server (317)**, **hosted_export (13)** suites pass.

Refs #4561, #4381

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD5thGSuULveJZuw9w9tD7