### PR TITLE
refactor(hosted): zeroize the per-user token in memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8989,6 +8989,7 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ renegade-ml = "0.3.3"
 pin-project = "1"
 thiserror = "2"
 ulid = { version = "1.1", features = ["serde"] }
-zeroize = { version = "1.8", features = ["derive"] }
+zeroize = { version = "1.8", features = ["derive", "serde"] }
 
 # Async/networking
 axum = { version = "0.8", default-features = false }

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -118,6 +118,7 @@ use futures::{FutureExt, SinkExt, StreamExt, future::BoxFuture, stream::SplitSin
 use headers::Header;
 use serde::Deserialize;
 use tokio::sync::{Mutex, mpsc};
+use zeroize::Zeroizing;
 
 use crate::{
     client_events::AuthToken,
@@ -688,7 +689,14 @@ struct ConnectionInfo {
     /// the WS upgrade URL (the P2-frontend follow-up mints/stores/presents it).
     /// It is honored ONLY when the node runs in hosted mode; otherwise it is
     /// ignored entirely and every connection stays single-user.
-    user_token: Option<String>,
+    ///
+    /// Held in a [`Zeroizing`] buffer so the raw token bytes are wiped on drop
+    /// rather than lingering in freed heap memory: the token is the master seed
+    /// from which the per-user DEK derives (the derived DEK and plaintext
+    /// secrets are already `Zeroizing`). `serde` deserializes the inner `String`
+    /// and moves it into the wrapper, so the token never exists as a separate
+    /// un-zeroized owned copy.
+    user_token: Option<Zeroizing<String>>,
 }
 
 /// Decide a connection's per-user secret namespace from the hosted-mode flag
@@ -970,11 +978,15 @@ async fn connection_info(
     // default-to-false in a real hosted deployment that lost the injection would
     // disable per-user isolation (all users -> Local shared namespace ->
     // cross-user clobber) — for a security flag, fail-loud beats fail-silent.
-    let user_token = req
+    // Wrap the header value directly in `Zeroizing` (the `.to_str()` borrow into
+    // the header buffer is a separate concern) so the only owned copy of the raw
+    // token is wiped on drop. `user_token_q` is already `Zeroizing` from the
+    // query deserialization, so neither branch leaves a plain un-zeroized copy.
+    let user_token: Option<Zeroizing<String>> = req
         .headers()
         .get("x-freenet-user-token")
         .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_owned())
+        .map(|s| Zeroizing::new(s.to_owned()))
         .or(user_token_q);
 
     // REFUSE-PLAINTEXT-TOKEN invariant (#4381): a `userToken` is a durable,
@@ -1011,6 +1023,13 @@ async fn connection_info(
         .and_then(|v| v.to_str().ok())
         .is_some_and(|v| v.eq_ignore_ascii_case("https"));
 
+    // Borrow the token as a `&str` for the gate and derivation. This does NOT
+    // copy the token: it borrows out of the `Zeroizing<String>` buffer, which
+    // still owns the bytes and wipes them on drop. `derive_user_context` keeps
+    // its `Option<&str>` signature, so `from_token` receives byte-identical
+    // input — the only change here is the owning container's zero-on-drop.
+    let token_str: Option<&str> = user_token.as_deref().map(String::as_str);
+
     // `has_token` is a NON-EMPTY check, matching `derive_user_context`'s
     // empty-is-absent semantics. The browser shell sends `?userToken=` (empty)
     // for a brand-new user who has no token yet; that connection must fall
@@ -1019,11 +1038,11 @@ async fn connection_info(
     // token is treated as no token, so it is never gated.
     let user_context = match decide_user_token(
         hosted_mode.0,
-        user_token.as_deref().is_some_and(|t| !t.is_empty()),
+        token_str.is_some_and(|t| !t.is_empty()),
         source_ip,
         xfp_https,
     ) {
-        UserTokenDecision::Honor => derive_user_context(hosted_mode.0, user_token.as_deref()),
+        UserTokenDecision::Honor => derive_user_context(hosted_mode.0, token_str),
         UserTokenDecision::Local => None,
         UserTokenDecision::RejectInsecure => {
             // Fail LOUD, not silent. Dropping the token and falling back to Local


### PR DESCRIPTION
## Problem

The per-user hosted token (the `userToken` presented on the WS upgrade, P2 of #4381) is the **master seed** from which the per-user DEK derives, yet it was the **least** protected secret in memory: it was held as a plain `String` in the `connection_info` websocket middleware, so its raw bytes lingered in freed heap after the connection closed. The derived DEK (`Zeroizing<[u8; 32]>`) and the plaintext secrets (`Zeroizing<Vec<u8>>`) were already zeroized on drop — this closes the gap on the seed itself.

## Solution

Wrap the token in `zeroize::Zeroizing` end-to-end so the raw bytes are wiped on drop. Purely an in-memory container change — no crypto, DEK derivation, wire format, or behavior change.

- `ConnectionInfo.user_token: Option<String>` -> `Option<Zeroizing<String>>`. Enables the zeroize `serde` feature so `serde_urlencoded` deserializes the inner `String` and **moves** it into the wrapper, leaving no separate un-zeroized owned copy.
- The header-sourced token (`x-freenet-user-token`) is wrapped directly in `Zeroizing::new(...)` at extraction, so the only owned copy of the raw token is the zeroizing one. The `.to_str()` borrow into the axum header buffer is a separate concern (out of scope here).
- `derive_user_context` keeps its `Option<&str>` signature; the token is **borrowed** (not copied) as a `&str` view, so `from_token` receives byte-identical input.

No lingering plain `String`/`Vec<u8>` copy of the token survives un-zeroized on either the query path or the header path.

## Testing

- `cargo fmt --check` clean; `cargo clippy -p freenet --lib -- -D warnings` clean.
- No-default-features test-compile combos that bit earlier PRs both compile:
  - `cargo test --no-run -p freenet --features trace,websocket,redb,wasmtime-backend,testing --no-default-features`
  - `cargo test --no-run -p freenet-ping-app --features testing`
- `cargo test -p freenet --test hosted_mode_isolation` — 3/3 pass (token still authenticates and derives the correct per-user namespace end-to-end).
- `cargo test -p freenet --lib client_events::websocket` — 67/67 pass (the `derive_user_context` / `decide_user_token` gate tests).
- `cargo test -p freenet --lib hosted_export` — 13/13 pass.

A "zeroed on drop" property is hard to unit-test directly; verification is (a) it compiles, (b) the token still authenticates/derives correctly (existing tests green), (c) the field type is now `Zeroizing`.

Refs #4381 (hosted-proxy umbrella).

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)