### PR TITLE
fix(hosted): dark-mode + dismiss account popover on outside click

### DIFF
--- a/crates/core/src/server/path_handlers/assets/hosted_bar.css
+++ b/crates/core/src/server/path_handlers/assets/hosted_bar.css
@@ -98,3 +98,43 @@ iframe {
   color: #2a8a55;
   font-size: 12px;
 }
+
+/* Respect the OS dark-mode preference. Same restrained, near-monochrome
+   character as the light theme: charcoal bar, light-grey text, hairline
+   borders. */
+@media (prefers-color-scheme: dark) {
+  #fnbar {
+    background: #1c1c1e;
+    border-bottom-color: #303032;
+    color: #98989c;
+  }
+  #fnbar .fn {
+    color: #ececee;
+  }
+  #fnbar .nt {
+    color: #88888c;
+  }
+  #fnbar button {
+    color: #e6e6e8;
+    background: #2c2c2f;
+    border-color: #46464a;
+  }
+  #fnbar button:hover {
+    border-color: #6a6a6e;
+  }
+  #fnpop {
+    background: #252528;
+    border-color: #3a3a3e;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.5);
+    color: #c2c2c6;
+  }
+  #fnpop h4 {
+    color: #88888c;
+  }
+  #fnpop p {
+    color: #a0a0a4;
+  }
+  #fnok {
+    color: #5cbd83;
+  }
+}

--- a/crates/core/src/server/path_handlers/assets/hosted_bar.js
+++ b/crates/core/src/server/path_handlers/assets/hosted_bar.js
@@ -15,6 +15,13 @@
   document.addEventListener('click', function (e) {
     if (!acct.contains(e.target)) pop.classList.remove('open');
   });
+  // Clicking into the sandboxed iframe (the app, which fills most of the page)
+  // does NOT fire the document click above — the click lands in the iframe's
+  // own document. It does blur the shell window, so dismiss the popover on
+  // focus loss too, otherwise it stays open until you click the bar again.
+  window.addEventListener('blur', function () {
+    pop.classList.remove('open');
+  });
   document.getElementById('fncopy').addEventListener('click', function () {
     var t =
       typeof __freenet_user_token !== 'undefined' ? __freenet_user_token : null;


### PR DESCRIPTION
## Problem
The hosted shell bar (node-rendered chrome above the sandboxed app iframe) (1) hardcoded light colors so it clashed on a dark-mode OS, and (2) the Account popover only dismissed by clicking Account again — the existing document-click handler never fired because the click landed inside the sandboxed iframe (separate document, no bubble to the shell).

## Solution
1. `@media (prefers-color-scheme: dark)` block — restrained near-monochrome (charcoal bar, light-grey text, hairline borders, dark buttons/popover), matching the light theme's character.
2. Dismiss the popover on `window` blur too — clicking into the iframe blurs the shell window, covering the case the document handler can't see.

## Testing
Rendered light + forced-dark via headless Chrome to confirm the palette (screenshot shared with the maintainer). Shell Playwright E2E exercises the shell render. No Rust logic changed (CSS + a one-line JS handler in include_str! assets).

Refs #4381

[AI-assisted - Claude]