### PR TITLE
fix: surface auto-update silent failures for unsupervised peers (#4580)

### DIFF
--- a/crates/core/src/bin/commands/auto_update.rs
+++ b/crates/core/src/bin/commands/auto_update.rs
@@ -17,6 +17,7 @@ use anyhow::Result;
 use semver::Version;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime};
 
 pub use freenet::transport::{
@@ -27,6 +28,73 @@ pub use freenet::transport::{
 /// Exit code that signals "update needed and verified against GitHub".
 /// The service wrapper catches this and runs `freenet update` before restarting.
 pub const EXIT_CODE_UPDATE_NEEDED: i32 = 42;
+
+/// Environment variable set by every Freenet supervisor (systemd unit, macOS
+/// launchd wrapper script, and the Windows/Linux in-process `service
+/// run-wrapper` loop) on the `freenet network` child it spawns. Its presence is
+/// positive evidence that *something* will catch exit code 42 and run
+/// `freenet update` before restarting the node.
+///
+/// Auto-update is structurally supervised-install-only: the running node never
+/// replaces its own binary — it exits 42 and relies on its supervisor to apply
+/// the update and restart it. A bare `freenet network` run has no supervisor, so
+/// it detects the update, exits 42, dies, and is never restarted (issue #4580).
+/// We use this marker (and `INVOCATION_ID` as a systemd fallback) to tell the
+/// operator, loudly, when an update was detected but will not be applied.
+pub const SUPERVISED_ENV_VAR: &str = "FREENET_SUPERVISED";
+
+/// Whether the running node appears to be under a supervisor that will catch
+/// exit code 42 and apply the update.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SupervisorStatus {
+    /// The authoritative [`SUPERVISED_ENV_VAR`] marker is set — a Freenet
+    /// supervisor spawned us and *will* catch exit 42 and run `freenet update`.
+    /// Nothing to warn about; exit 42 is expected to be applied.
+    Supervised,
+    /// We are under systemd (`INVOCATION_ID` is set) but our authoritative
+    /// marker is absent. systemd alone does not prove the unit has the
+    /// exit-42 → `freenet update` `ExecStopPost` hook: a custom unit,
+    /// `systemd-run`, or a hand-written service running `freenet network`
+    /// without that hook is also `INVOCATION_ID`-bearing. We therefore can't
+    /// confirm the update will be applied — warn, but more softly, since this
+    /// also covers older Freenet units installed before the marker existed.
+    SupervisedUnverified,
+    /// No evidence of any supervisor. Exit 42 will most likely kill the node
+    /// without the update ever being applied — the operator must run
+    /// `freenet update` manually (or install Freenet as a service).
+    Unsupervised,
+}
+
+/// Detect whether a supervisor is present, using an injectable env lookup so the
+/// logic is unit-testable without mutating the process environment.
+///
+/// Honest by construction: we only claim the fully-quiet [`Supervised`] state on
+/// *our own* marker. systemd's generic `INVOCATION_ID` is reported as
+/// [`SupervisedUnverified`] (still warned about, softly) because it does not
+/// prove the unit carries the exit-42 → `freenet update` hook. Absence of both
+/// is [`Unsupervised`], which drives the loud error.
+///
+/// [`Supervised`]: SupervisorStatus::Supervised
+/// [`SupervisedUnverified`]: SupervisorStatus::SupervisedUnverified
+/// [`Unsupervised`]: SupervisorStatus::Unsupervised
+pub fn detect_supervisor_status<F>(env_get: F) -> SupervisorStatus
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let present = |key: &str| env_get(key).is_some_and(|v| !v.trim().is_empty());
+    if present(SUPERVISED_ENV_VAR) {
+        SupervisorStatus::Supervised
+    } else if present("INVOCATION_ID") {
+        SupervisorStatus::SupervisedUnverified
+    } else {
+        SupervisorStatus::Unsupervised
+    }
+}
+
+/// Read the live supervisor status from the process environment.
+pub fn supervisor_status() -> SupervisorStatus {
+    detect_supervisor_status(|key| std::env::var(key).ok())
+}
 
 /// Initial backoff interval for update checks (1 minute).
 const INITIAL_BACKOFF: Duration = Duration::from_secs(60);
@@ -82,14 +150,39 @@ pub enum UpdateCheckResult {
 ///
 /// Security: This function verifies against GitHub, so a malicious peer
 /// claiming a fake version won't trigger an exit.
+/// Set the first time this process logs the auto-update lockout at warn! level,
+/// so the permanent locked-out state is surfaced loudly once rather than on
+/// every 60s update-loop tick (it can be hit from multiple triggers per tick).
+static LOCKOUT_WARNED: AtomicBool = AtomicBool::new(false);
+
 pub async fn check_if_update_available(current_version: &str) -> UpdateCheckResult {
     // Don't check if we've failed too many times
     if !should_attempt_update() {
-        tracing::debug!(
-            failures = get_update_failure_count(),
-            max = MAX_UPDATE_FAILURES,
-            "Skipping update check - too many previous failures"
-        );
+        // Loud, operator-visible (issue #4580): a persistent lockout means this
+        // peer has stopped trying to auto-update entirely and will silently stay
+        // behind. A common cause is a non-writable binary path (e.g. a
+        // hand-installed binary the service account can't replace), which is a
+        // *permanent* lockout until an operator intervenes. Warn LOUDLY the first
+        // time we observe it this process, then drop to debug! so the permanent
+        // state does not spam the log every minute.
+        let failures = get_update_failure_count();
+        if !LOCKOUT_WARNED.swap(true, Ordering::Relaxed) {
+            tracing::warn!(
+                failures,
+                max = MAX_UPDATE_FAILURES,
+                "Auto-update is LOCKED OUT after {MAX_UPDATE_FAILURES} consecutive failed update \
+                 attempts and will NOT retry. This peer will stay on the current version until an \
+                 operator intervenes. Run `freenet update` manually to update and reset the \
+                 lockout; if updates keep failing, the binary path is likely not writable by this \
+                 account.",
+            );
+        } else {
+            tracing::debug!(
+                failures,
+                max = MAX_UPDATE_FAILURES,
+                "Skipping update check - auto-update locked out (already warned this process)"
+            );
+        }
         return UpdateCheckResult::Skipped;
     }
 
@@ -736,6 +829,116 @@ mod tests {
             "should_attempt_update must fall back to `false` when state_dir \
              is unavailable — falling back to `true` allows the exit-42 loop \
              to run unbounded on Windows service accounts without USERPROFILE."
+        );
+    }
+
+    #[test]
+    fn test_detect_supervisor_status_marker_present() {
+        // Issue #4580: the explicit FREENET_SUPERVISED marker (set by all three
+        // supervisors on the network child) is positive evidence of a supervisor.
+        let env = |key: &str| {
+            if key == SUPERVISED_ENV_VAR {
+                Some("1".to_string())
+            } else {
+                None
+            }
+        };
+        assert_eq!(detect_supervisor_status(env), SupervisorStatus::Supervised);
+    }
+
+    #[test]
+    fn test_detect_supervisor_status_invocation_id_is_unverified() {
+        // systemd sets INVOCATION_ID for EVERY service instance, including custom
+        // units / systemd-run that lack our exit-42 → `freenet update` hook. So a
+        // bare INVOCATION_ID is only *unverified* supervision: we still warn (more
+        // softly), rather than going fully quiet as if the update were guaranteed
+        // to apply. This is the false-positive guard from the Codex review.
+        let env = |key: &str| {
+            if key == "INVOCATION_ID" {
+                Some("a1b2c3d4".to_string())
+            } else {
+                None
+            }
+        };
+        assert_eq!(
+            detect_supervisor_status(env),
+            SupervisorStatus::SupervisedUnverified
+        );
+    }
+
+    #[test]
+    fn test_detect_supervisor_status_marker_beats_invocation_id() {
+        // When BOTH our authoritative marker and systemd's INVOCATION_ID are set
+        // (the normal Freenet systemd-unit case), the marker wins and we report
+        // the fully-quiet Supervised state.
+        let env = |key: &str| match key {
+            SUPERVISED_ENV_VAR => Some("1".to_string()),
+            "INVOCATION_ID" => Some("a1b2c3d4".to_string()),
+            _ => None,
+        };
+        assert_eq!(detect_supervisor_status(env), SupervisorStatus::Supervised);
+    }
+
+    #[test]
+    fn test_detect_supervisor_status_unsupervised_when_absent() {
+        // The whole point of #4580: a bare `freenet network` run has neither
+        // signal and must be reported as Unsupervised so the loud warning fires
+        // instead of silently exiting 42 with nothing to apply the update.
+        let env = |_key: &str| None;
+        assert_eq!(
+            detect_supervisor_status(env),
+            SupervisorStatus::Unsupervised
+        );
+    }
+
+    #[test]
+    fn test_detect_supervisor_status_empty_and_whitespace_are_not_evidence() {
+        // An empty or whitespace-only value (e.g. `FREENET_SUPERVISED=`) must NOT
+        // count as a supervisor — it would suppress the warning while leaving the
+        // update unapplied, which is exactly the silent failure we are fixing.
+        for value in ["", "   ", "\t", "\n"] {
+            let env = move |key: &str| {
+                if key == SUPERVISED_ENV_VAR || key == "INVOCATION_ID" {
+                    Some(value.to_string())
+                } else {
+                    None
+                }
+            };
+            assert_eq!(
+                detect_supervisor_status(env),
+                SupervisorStatus::Unsupervised,
+                "value {value:?} must not count as supervisor evidence"
+            );
+        }
+    }
+
+    #[test]
+    fn test_locked_out_update_check_is_loud() {
+        // Source-scrape pin for #4580: when the failure lockout disables
+        // auto-update, the skip MUST be operator-visible (warn!), not a silent
+        // debug! line. A regression to debug! would re-hide the permanent
+        // lockout (e.g. non-writable binary path) the issue calls out.
+        let src = include_str!("auto_update.rs");
+        let (_, after_fn_start) = src
+            .split_once("pub async fn check_if_update_available(")
+            .expect("check_if_update_available definition not found");
+        let (_, after_guard) = after_fn_start
+            .split_once("if !should_attempt_update() {")
+            .expect("lockout guard not found");
+        let (guard_body, _) = after_guard
+            .split_once("return UpdateCheckResult::Skipped;")
+            .expect("could not locate end of lockout guard");
+        // Strip line comments so the explanatory comment (which itself mentions
+        // "warn!"/"debug!") cannot satisfy the assertion — match only on code.
+        let code_only: String = guard_body
+            .lines()
+            .map(|line| line.split_once("//").map(|(c, _)| c).unwrap_or(line))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            code_only.contains("tracing::warn!"),
+            "the auto-update lockout skip must log at warn! level so a permanent \
+             lockout is diagnosable (#4580), not silently dropped at debug!"
         );
     }
 

--- a/crates/core/src/bin/commands/service/linux.rs
+++ b/crates/core/src/bin/commands/service/linux.rs
@@ -267,6 +267,12 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+# Mark the node as supervised (issue #4580): tells `freenet network` that exit
+# code 42 (update needed) will be applied by ExecStopPost below, so it logs an
+# informational message instead of a loud "no supervisor" error on update exit.
+# systemd also sets INVOCATION_ID for every service, which the node detects as a
+# fallback; this makes the intent explicit and robust.
+Environment=FREENET_SUPERVISED=1
 # Stale-orphan self-heal (issue #3967): RestartPreventExitStatus=43 below
 # means an exit 43 ("another instance already running") never restarts the
 # unit. That is correct for a legitimate second instance, but if the port
@@ -372,6 +378,11 @@ Wants=network-online.target
 Type=simple
 User={username}
 Environment=HOME={home}
+# Mark the node as supervised (issue #4580): see the matching comment in the
+# user unit. Tells `freenet network` that exit code 42 (update needed) will be
+# applied by ExecStopPost below, so it logs an informational message instead of
+# a loud "no supervisor" error on update exit.
+Environment=FREENET_SUPERVISED=1
 # Stale-orphan self-heal (issue #3967): see the matching comment in the user
 # unit (including the systemd $$-escaping, the PPID-after-final-')' parse, and
 # why we do NOT anchor on the holder's exe equalling this unit's on-disk binary

--- a/crates/core/src/bin/commands/service/macos.rs
+++ b/crates/core/src/bin/commands/service/macos.rs
@@ -133,6 +133,12 @@ pub fn generate_wrapper_script(binary_path: &Path) -> String {
 # Includes exponential backoff to prevent rapid restart loops on repeated failures.
 # On startup, kills any stale 'freenet network' processes to avoid port conflicts.
 
+# Mark the node child as supervised (issue #4580). This tells `freenet network`
+# that exit code 42 (update needed) will actually be caught and applied by this
+# wrapper, so it logs an informational message rather than a loud "no supervisor,
+# update will not be applied" error on exit.
+export {supervised_env}=1
+
 BACKOFF=10       # Initial backoff in seconds
 MAX_BACKOFF=300  # Maximum backoff (5 minutes)
 CONSECUTIVE_FAILURES=0
@@ -347,7 +353,8 @@ while true; do
     fi
 done
 "#,
-        binary = binary_path.display()
+        binary = binary_path.display(),
+        supervised_env = super::super::auto_update::SUPERVISED_ENV_VAR,
     )
 }
 

--- a/crates/core/src/bin/commands/service/wrapper.rs
+++ b/crates/core/src/bin/commands/service/wrapper.rs
@@ -801,6 +801,11 @@ fn run_wrapper_loop(
 
         let mut cmd = std::process::Command::new(&exe_path);
         cmd.arg("network");
+        // Mark the child as supervised so it knows exit code 42 will actually be
+        // caught and applied (issue #4580). Without this, the node can only fall
+        // back to systemd's INVOCATION_ID, which the in-process wrapper path does
+        // not set.
+        cmd.env(super::super::auto_update::SUPERVISED_ENV_VAR, "1");
 
         // On Windows, prevent a console window from appearing for the child process.
         // The wrapper has already detached from the console via FreeConsole(),

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -33,6 +33,18 @@ struct Cli {
 #[derive(Subcommand, Debug)]
 enum Command {
     /// Run the node in network mode (default if no subcommand specified)
+    ///
+    /// NOTE ON AUTO-UPDATE: a node detects new releases and exits with code 42
+    /// to request an update, but it does NOT update itself. Applying the update
+    /// requires a supervisor that catches exit code 42 and runs `freenet update`
+    /// before restarting — this is set up by `freenet service install` (systemd
+    /// on Linux, a launchd wrapper on macOS, the tray wrapper on Windows).
+    ///
+    /// A bare `freenet network` run has no such supervisor: it will detect an
+    /// update, exit, and NOT be restarted, so it stays on its current version.
+    /// To keep a hand-run node current, either run `freenet update` yourself when
+    /// prompted in the logs, or install Freenet as a service. Dirty/dev builds
+    /// disable auto-update entirely (it would clobber local changes).
     Network {
         #[command(flatten)]
         config: ConfigArgs,
@@ -306,10 +318,18 @@ async fn run_network_node_with_signals(
         use std::time::Instant;
 
         if auto_update_disabled {
-            tracing::info!(
+            // Loud, operator-visible (issue #4580): a dirty/dev build never even
+            // checks for updates, so this node will stay on its current version
+            // indefinitely with no further signal. That is the intended
+            // behaviour for a local build (auto-update would clobber local
+            // changes, #3245), but it must be surfaced rather than silent.
+            tracing::warn!(
                 git_dirty = build_info::GIT_DIRTY,
-                "Auto-update disabled: this is a dirty (locally modified) build. \
-                 Run `freenet update` manually if needed."
+                "Auto-update is DISABLED for this dirty (locally modified) build: this node will \
+                 NOT detect or apply updates and will stay on version {} until you act. This is \
+                 expected for a local build. Run `freenet update` manually to switch to the \
+                 latest release, or install a clean release build to re-enable auto-update.",
+                build_info::VERSION,
             );
             std::future::pending::<()>().await;
             return;
@@ -860,14 +880,78 @@ fn main() {
     // any worker threads. See `set_secure_umask` and issue #4196.
     set_secure_umask();
 
-    use commands::auto_update::{EXIT_CODE_UPDATE_NEEDED, UpdateNeededError};
+    use commands::auto_update::{
+        EXIT_CODE_UPDATE_NEEDED, SupervisorStatus, UpdateNeededError, supervisor_status,
+    };
 
     match freenet_main() {
         Ok(()) => std::process::exit(0),
         Err(e) => {
             // Check if this is an "update needed" error from auto-update detection
-            if e.downcast_ref::<UpdateNeededError>().is_some() {
-                eprintln!("Update needed, exiting for service wrapper to handle update...");
+            if let Some(update) = e.downcast_ref::<UpdateNeededError>() {
+                // Auto-update is supervised-install-only: the node never replaces
+                // its own binary. It exits 42 and relies on a supervisor (systemd
+                // ExecStopPost, the macOS launchd wrapper, or the Windows/Linux
+                // in-process run-wrapper loop) to run `freenet update` and restart
+                // it. A bare `freenet network` run has no supervisor, so without a
+                // loud warning the update is detected and then silently never
+                // applied (issue #4580). Scale the message by whether we have any
+                // evidence of a supervisor.
+                match supervisor_status() {
+                    SupervisorStatus::Supervised => {
+                        tracing::info!(
+                            new_version = %update.new_version,
+                            "Update {} detected; exiting with code {EXIT_CODE_UPDATE_NEEDED} for \
+                             the service supervisor to apply it and restart.",
+                            update.new_version,
+                        );
+                        eprintln!("Update needed, exiting for service wrapper to handle update...");
+                    }
+                    SupervisorStatus::SupervisedUnverified => {
+                        // Under systemd but without our authoritative marker: the
+                        // unit may or may not have the exit-42 → `freenet update`
+                        // ExecStopPost hook (e.g. a custom or pre-marker unit).
+                        // Warn, but more softly than the bare-CLI case, and tell
+                        // the operator how to confirm.
+                        tracing::warn!(
+                            new_version = %update.new_version,
+                            "Update {} detected; exiting with code {EXIT_CODE_UPDATE_NEEDED}. This \
+                             process is under systemd but its unit was not marked with \
+                             FREENET_SUPERVISED, so we cannot confirm it has the exit-42 → \
+                             `freenet update` hook. If updates do not apply automatically, \
+                             reinstall the service with `freenet service install` (or add an \
+                             ExecStopPost that runs `freenet update` on exit 42).",
+                            update.new_version,
+                        );
+                        eprintln!(
+                            "Update {} detected, exiting with code {EXIT_CODE_UPDATE_NEEDED} for a \
+                             service supervisor to apply it. If updates do not apply, reinstall \
+                             with `freenet service install`.",
+                            update.new_version,
+                        );
+                    }
+                    SupervisorStatus::Unsupervised => {
+                        tracing::error!(
+                            new_version = %update.new_version,
+                            "Update {} was detected, but this process does NOT appear to be \
+                             running under a Freenet service supervisor. Auto-update only works \
+                             when Freenet is installed as a service (`freenet service install`): \
+                             the node exits with code {EXIT_CODE_UPDATE_NEEDED} expecting the \
+                             supervisor to run `freenet update` and restart it. A bare \
+                             `freenet network` run will now EXIT WITHOUT UPDATING and will not be \
+                             restarted. Run `freenet update` and relaunch, or install Freenet as \
+                             a service so future updates apply automatically.",
+                            update.new_version,
+                        );
+                        eprintln!(
+                            "WARNING: update {} detected but no service supervisor was found. \
+                             Exiting with code {EXIT_CODE_UPDATE_NEEDED} WITHOUT applying the \
+                             update. Run `freenet update` and relaunch, or install Freenet as a \
+                             service (`freenet service install`) so updates apply automatically.",
+                            update.new_version,
+                        );
+                    }
+                }
                 std::process::exit(EXIT_CODE_UPDATE_NEEDED);
             }
             // Another instance is already running — exit cleanly so systemd
@@ -1144,6 +1228,102 @@ mod tests {
             worker_dir_mode, 0o700,
             "directory created from tokio worker after set_secure_umask() should be 0o700, \
              got {worker_dir_mode:o}"
+        );
+    }
+
+    /// Strip Rust `//` line comments from source text so a source-scrape pin
+    /// matches only on actual code, not on a comment that happens to mention the
+    /// searched token (addresses the "passes with commented-out code" brittleness
+    /// the Codex review flagged). Crude but sufficient: we only feed it our own
+    /// source and never have `//` inside a string literal on the matched lines.
+    fn strip_line_comments(src: &str) -> String {
+        src.lines()
+            .map(|line| line.split_once("//").map(|(code, _)| code).unwrap_or(line))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Source-scrape pin for issue #4580: the exit-42 handler in `main()` MUST
+    /// branch on supervisor status and escalate to a loud `error!` on the
+    /// unsupervised path. A bare `freenet network` run that detects an update,
+    /// exits 42, and dies without applying it is exactly the silent failure this
+    /// PR makes diagnosable; a regression that drops the branch (back to a bare
+    /// "exiting for service wrapper to handle update") would re-hide it.
+    #[test]
+    fn exit_42_path_warns_loudly_when_unsupervised() {
+        let src = strip_line_comments(include_str!("freenet.rs"));
+        let (_, after_branch) = src
+            .split_once("if let Some(update) = e.downcast_ref::<UpdateNeededError>() {")
+            .expect("exit-42 branch not found in main()");
+        let (branch_body, _) = after_branch
+            .split_once("std::process::exit(EXIT_CODE_UPDATE_NEEDED);")
+            .expect("could not locate end of exit-42 branch");
+        assert!(
+            branch_body.contains("SupervisorStatus::Unsupervised"),
+            "exit-42 handler must distinguish the unsupervised case (#4580)"
+        );
+        assert!(
+            branch_body.contains("tracing::error!"),
+            "exit-42 handler must log at error! level on the unsupervised path \
+             so the silent 'detected update, exited, never applied' failure is \
+             diagnosable (#4580)"
+        );
+    }
+
+    /// Source-scrape pin for #4580: the dirty-build branch that disables
+    /// auto-update entirely must be operator-visible (`warn!`), not a quiet
+    /// `info!`. A dirty build never checks for updates, so the only signal an
+    /// operator gets is this line.
+    #[test]
+    fn dirty_build_disables_update_loudly() {
+        let src = strip_line_comments(include_str!("freenet.rs"));
+        let (_, after_guard) = src
+            .split_once("if auto_update_disabled {")
+            .expect("dirty-build guard not found");
+        let (guard_body, _) = after_guard
+            .split_once("std::future::pending::<()>().await;")
+            .expect("could not locate end of dirty-build guard");
+        assert!(
+            guard_body.contains("tracing::warn!"),
+            "the dirty-build auto-update-disabled branch must log at warn! so it \
+             is operator-visible (#4580)"
+        );
+    }
+
+    /// Source-scrape pin for #4580: each Freenet supervisor must set the
+    /// `FREENET_SUPERVISED` marker on the `freenet network` child it spawns, so
+    /// the node can tell it is supervised and log calmly instead of erroring on
+    /// the exit-42 path. These run on every platform (we scrape source text, not
+    /// the cfg-gated generators) so a regression on any one platform's path is
+    /// caught by CI regardless of the runner OS.
+    #[test]
+    fn supervisors_set_supervised_marker() {
+        // The in-process wrapper loop (Windows + Linux service run-wrapper).
+        let wrapper_src = include_str!("commands/service/wrapper.rs");
+        assert!(
+            wrapper_src.contains("SUPERVISED_ENV_VAR"),
+            "the in-process wrapper must set the FREENET_SUPERVISED marker on the \
+             network child it spawns (#4580)"
+        );
+
+        // The macOS launchd wrapper script.
+        let macos_src = include_str!("commands/service/macos.rs");
+        assert!(
+            macos_src.contains("supervised_env = super::super::auto_update::SUPERVISED_ENV_VAR")
+                && macos_src.contains("export {supervised_env}=1"),
+            "the macOS wrapper script must export the FREENET_SUPERVISED marker \
+             so the launchd-supervised node detects its supervisor (#4580)"
+        );
+
+        // Both systemd unit templates (user + system).
+        let linux_src = include_str!("commands/service/linux.rs");
+        let marker_count = linux_src
+            .matches("Environment=FREENET_SUPERVISED=1")
+            .count();
+        assert!(
+            marker_count >= 2,
+            "both systemd unit templates must set Environment=FREENET_SUPERVISED=1 \
+             (#4580); found {marker_count}"
         );
     }
 }


### PR DESCRIPTION
## Problem

Auto-update is structurally **supervised-install-only**. The running node never replaces its own binary: it detects a newer release, exits with code **42**, and relies on a supervisor to run `freenet update` and restart it:

- systemd `ExecStopPost` (Linux service)
- the launchd wrapper script (macOS)
- the in-process `service run-wrapper` loop (Windows / Linux tray)

A bare `freenet network` run, a **dirty/dev build**, or a peer that hit the **3-failure update lockout** detects the update and then **silently** fails to apply it. There is no operator-visible signal, so this produces a long, self-perpetuating tail of peers that never update (issue #4580).

## Solution

Make the silent failures **diagnosable** without changing update *behaviour* (the self-supervising run mode proposed in the issue is a separate, opt-in feature, left as a follow-up).

- **Supervisor-aware warning at the exit-42 site**, with three states so we never over-claim. Each supervisor now marks the `freenet network` child with a `FREENET_SUPERVISED` env var (systemd unit `Environment=`, macOS wrapper `export`, in-process wrapper `cmd.env`):
  - marker present → `Supervised`: `info!`, exit quietly (the normal service case).
  - systemd only (`INVOCATION_ID`, no marker) → `SupervisedUnverified`: `warn!` softly — a custom/`systemd-run`/pre-marker unit may not actually have the exit-42 hook, so we can't confirm, but we also cover older Freenet units.
  - neither → `Unsupervised`: `error!` + stderr that the update was detected but will **NOT** be applied, and tells the operator to run `freenet update` or install the service.

  Detection is honest by construction: it only goes fully quiet on **our own** marker; systemd's generic `INVOCATION_ID` is not treated as proof of the exit-42 hook.
- **Dirty-build** "auto-update disabled" path bumped `info!` → `warn!` with operator guidance.
- **3-failure lockout** skip bumped `debug!` → `warn!`, logged loudly **once per process** then dropped to `debug!` so the permanent state doesn't spam the 60s update loop.
- `freenet network --help` now documents the supervised-install requirement and the dirty-build behaviour.

No change to when/whether a node exits 42 or applies an update.

## Testing

- Pure `detect_supervisor_status` unit tests: marker → Supervised; `INVOCATION_ID` alone → SupervisedUnverified; marker beats `INVOCATION_ID`; neither → Unsupervised; empty/whitespace values are not evidence.
- Comment-stripped source-scrape pins: the exit-42 path escalates on the unsupervised case (`error!`), the dirty-build and lockout paths log loudly (`warn!`), and all three supervisors set the `FREENET_SUPERVISED` marker (caught on every CI platform since they scrape source text, not cfg-gated generators).
- `cargo fmt` + `cargo clippy --bin freenet -- -D warnings` clean; full `cargo test --bin freenet` green (236 tests).

## Review

External review by Codex (`codex exec`, read-only). First pass raised 1 MEDIUM (`INVOCATION_ID` false-positive) + 2 LOW (lockout log spam, brittle source-scrape tests); all three addressed (three-state detection, once-per-process warn, comment-stripping). Re-run on the fixed diff: "No new findings", all prior findings confirmed resolved.

Closes #4580

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dGjU1Q6Vpk2dm4sUf4pdU