### PR TITLE
fix: stop placement-migration subscription roots from storming on renewal (#4440)

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -143,9 +143,9 @@ pub mod dev_tool {
         ContractSubscription, ProximityViolation, RenewalMetrics, TopologySnapshot,
         TopologyValidationResult, aggregate_renewal_metrics, clear_all_topology_snapshots,
         clear_current_network_name, clear_renewal_metrics, clear_topology_snapshots,
-        get_all_topology_snapshots, get_current_network_name, get_renewal_metrics,
-        get_topology_snapshot, register_topology_snapshot, set_current_network_name,
-        validate_topology, validate_topology_from_snapshots,
+        get_all_renewal_metrics, get_all_topology_snapshots, get_current_network_name,
+        get_renewal_metrics, get_topology_snapshot, register_topology_snapshot,
+        set_current_network_name, validate_topology, validate_topology_from_snapshots,
     };
     pub use wasm_runtime::secret_export::{
         BundleKeyMaterial, ExportError, ImportReport, TargetScope, export_bundle, import_bundle,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -140,11 +140,12 @@ pub mod dev_tool {
 
     // Re-export topology registry for subscription validation in tests
     pub use ring::topology_registry::{
-        ContractSubscription, ProximityViolation, TopologySnapshot, TopologyValidationResult,
-        clear_all_topology_snapshots, clear_current_network_name, clear_topology_snapshots,
-        get_all_topology_snapshots, get_current_network_name, get_topology_snapshot,
-        register_topology_snapshot, set_current_network_name, validate_topology,
-        validate_topology_from_snapshots,
+        ContractSubscription, ProximityViolation, RenewalMetrics, TopologySnapshot,
+        TopologyValidationResult, aggregate_renewal_metrics, clear_all_topology_snapshots,
+        clear_current_network_name, clear_renewal_metrics, clear_topology_snapshots,
+        get_all_topology_snapshots, get_current_network_name, get_renewal_metrics,
+        get_topology_snapshot, register_topology_snapshot, set_current_network_name,
+        validate_topology, validate_topology_from_snapshots,
     };
     pub use wasm_runtime::secret_export::{
         BundleKeyMaterial, ExportError, ImportReport, TargetScope, export_bundle, import_bundle,

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -375,6 +375,13 @@ pub struct ControlledSimulationResult {
     #[cfg(any(test, feature = "testing"))]
     #[allow(dead_code)]
     pub(crate) node_rings: HashMap<NodeLabel, Arc<crate::ring::Ring>>,
+    /// Per-peer subscription-renewal metrics captured at the end of the
+    /// simulation, keyed by socket address. Captured here (before the
+    /// `SimNetwork` is dropped, which clears the registry) so renewal-storm
+    /// tests can read `wire_attempts` / `terminus_satisfied` after the run
+    /// returns. See `crate::ring::topology_registry::RenewalMetrics` (#4440).
+    pub renewal_metrics:
+        HashMap<std::net::SocketAddr, crate::ring::topology_registry::RenewalMetrics>,
 }
 
 #[cfg(any(test, feature = "testing"))]
@@ -391,6 +398,28 @@ impl ControlledSimulationResult {
         self.node_rings
             .get(label)
             .is_some_and(|ring| ring.is_hosting_contract(key))
+    }
+
+    /// Subscription-renewal metrics for the peer at `addr` (captured before the
+    /// `SimNetwork` was dropped). Returns `RenewalMetrics::default()` (all zero)
+    /// if the peer recorded no renewal activity. See #4440.
+    pub fn renewal_metrics_for(
+        &self,
+        addr: &std::net::SocketAddr,
+    ) -> crate::ring::topology_registry::RenewalMetrics {
+        self.renewal_metrics.get(addr).copied().unwrap_or_default()
+    }
+
+    /// Sum of the renewal metrics across every peer in the simulation. See #4440.
+    pub fn aggregate_renewal_metrics(&self) -> crate::ring::topology_registry::RenewalMetrics {
+        self.renewal_metrics.values().fold(
+            crate::ring::topology_registry::RenewalMetrics::default(),
+            |mut acc, m| {
+                acc.wire_attempts += m.wire_attempts;
+                acc.terminus_satisfied += m.terminus_satisfied;
+                acc
+            },
+        )
     }
 }
 
@@ -4236,6 +4265,12 @@ impl SimNetwork {
         // Capture topology snapshots BEFORE self is dropped (which clears them)
         let topology_snapshots = get_all_topology_snapshots(&network_name);
 
+        // Capture renewal metrics BEFORE self is dropped — `SimNetwork::Drop`
+        // calls `clear_renewal_metrics(&self.name)`, so reading the registry
+        // after this function returns would always see an empty map (#4440).
+        let renewal_metrics =
+            crate::ring::topology_registry::get_all_renewal_metrics(&network_name);
+
         // Extract the live Rings captured during the run BEFORE self drops.
         let node_rings: HashMap<NodeLabel, Arc<crate::ring::Ring>> = self
             .shared_rings
@@ -4248,6 +4283,7 @@ impl SimNetwork {
             topology_snapshots,
             node_storages,
             node_rings,
+            renewal_metrics,
         }
     }
 

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -5304,7 +5304,7 @@ impl Drop for SimNetwork {
     fn drop(&mut self) {
         use crate::node::network_bridge::set_fault_injector;
         use crate::ring::topology_registry::{
-            clear_current_network_name, clear_topology_snapshots,
+            clear_current_network_name, clear_renewal_metrics, clear_topology_snapshots,
         };
         use crate::transport::in_memory_socket::{
             clear_network_address_mappings, remove_network_socket_registry,
@@ -5315,6 +5315,7 @@ impl Drop for SimNetwork {
         set_fault_injector(&self.name, None);
         unregister_network_time_source(&self.name);
         clear_topology_snapshots(&self.name);
+        clear_renewal_metrics(&self.name);
         remove_network_socket_registry(&self.name);
         clear_network_address_mappings(&self.name);
 

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -352,30 +352,48 @@ pub(crate) async fn run_renewal_subscribe(
     // `SubscriptionRecoveryGuard::complete(true)` then clears the pending mark
     // and resets the subscription backoff with success semantics.
     //
-    // It DOES refresh the LOCAL `active_subscriptions` lease, even though the
-    // lease has no upstream meaning for a root. This is purely local (extends an
-    // expiry in a local map — no wire traffic) and is what keeps the
-    // root-satisfied path cheap at scale: without it, a root with a client
-    // subscription (or recent local access) whose lease lapsed would be
-    // re-selected by `contracts_needing_renewal()` on EVERY 30s maintenance
-    // cycle (the client-subscription / local-access paths fire whenever there is
-    // no live lease), so it would consume a `MAX_RECOVERY_ATTEMPTS_PER_INTERVAL`
-    // batch slot every cycle and could starve real (non-root) wire renewals that
-    // still need to reach the network. Refreshing the lease moves the root back
-    // onto the normal ~6-minute renewal cadence (lease-expiry path) instead of
-    // every cycle, while still never sending a wire request.
+    // Lease handling — CONDITIONAL on genuine, time-bounded interest:
+    //
+    //   * Root that is `contract_in_use` (has a local client subscription or a
+    //     downstream subscriber — both time-bounded, see `contract_in_use`):
+    //     refresh the LOCAL `active_subscriptions` lease. This is purely local
+    //     (extends an expiry in a local map — no wire traffic) and keeps the
+    //     root-satisfied path cheap at scale. Without it, an in-use root whose
+    //     lease lapsed would be re-selected by `contracts_needing_renewal()` on
+    //     EVERY 30s cycle (the client-subscription / local-access paths fire
+    //     whenever there is no live lease), consuming a
+    //     `MAX_RECOVERY_ATTEMPTS_PER_INTERVAL` batch slot every cycle and
+    //     starving real (non-root) wire renewals. Refreshing moves the in-use
+    //     root onto the normal ~6-minute lease-expiry cadence, and because the
+    //     interest signals are time-bounded the lease cannot self-perpetuate
+    //     past the interest.
+    //
+    //   * Root that is NOT `contract_in_use`: DO NOT refresh. Refreshing an
+    //     `is_subscribed`-only lease unconditionally would be an UNBOUNDED
+    //     retention exemption — `contracts_needing_renewal` section 1 renews any
+    //     live active subscription with no interest re-check, so an
+    //     unconditional refresh would re-select a no-interest root forever and
+    //     keep its lease (and thus the contract) alive indefinitely. That is
+    //     exactly the unbounded-`is_subscribed` retention the `contract_in_use`
+    //     rustdoc and the AGENTS.md time-bounded-exemption rule forbid. Letting
+    //     the lease lapse is correct: a no-interest root then drops out of the
+    //     renewal set entirely (no live active sub for path 1; no client
+    //     sub/recent access for paths 2/3), bounded and quiet.
     //
     // This is NOT `complete_local_subscription`, whose semantics differ (it
     // emits `LocalSubscribeComplete` and registers client interest); the
-    // root-satisfied path is deliberately distinct — a bare local lease refresh
-    // plus a clean `Success`.
+    // root-satisfied path is deliberately distinct — a conditional local lease
+    // refresh plus a clean `Success`.
     if let Some(key) = op_manager
         .ring
         .body_holding_subscription_root_key(&instance_id)
     {
-        // Refresh the local lease so the root is not re-selected for renewal
-        // every cycle (see rationale above). Local-only; no wire traffic.
-        op_manager.ring.subscribe(key);
+        // Only refresh the local lease when the root has genuine, time-bounded
+        // interest; otherwise let it lapse so the no-interest root leaves the
+        // renewal set (see rationale above). Local-only; never any wire traffic.
+        if op_manager.ring.contract_in_use(&key) {
+            op_manager.ring.subscribe(key);
+        }
         op_manager.ring.record_renewal_terminus_satisfied();
         // Simulation-test observability (no-op in production — see
         // `topology_registry::record_renewal_terminus_satisfied`).
@@ -387,13 +405,22 @@ pub(crate) async fn run_renewal_subscribe(
             contract = %key,
             phase = "renewal_terminus_satisfied",
             "subscribe renewal: node is the body-holding subscription root; \
-             satisfying renewal locally (lease refreshed, no upstream request) (#4440)"
+             satisfying renewal locally without an upstream request (#4440)"
         );
         return RenewalOutcome::Success;
     }
 
     // Not a body-holding root: renew normally over the wire. Record the
     // wire-attempt for simulation-test observability (no-op in production).
+    //
+    // This counts a renewal *entering the wire-renewal driver*, not a request
+    // confirmed on the wire — it is the upper bound on wire renewals for this
+    // contract this cycle. For an isolated / not-yet-joined node the driver may
+    // bail before sending (e.g. `PeerNotJoined` / no candidates), so the counter
+    // can over-count actual wire sends in those edge cases. That is fine for the
+    // test's purpose: the storm signature is "a body-holding root entering the
+    // wire path at all", and the counter being non-zero for a non-root host is
+    // exactly the stoppage-guard signal the test asserts.
     if let Some(addr) = op_manager.ring.connection_manager.get_own_addr() {
         crate::ring::topology_registry::record_renewal_wire_attempt(addr);
     }
@@ -2919,12 +2946,21 @@ mod tests {
             before_drive[predicate_at..].contains("record_renewal_terminus_satisfied()"),
             "the root-satisfied path must record the renewal_terminus_satisfied counter"
         );
+        let branch = &before_drive[predicate_at..];
         assert!(
-            before_drive[predicate_at..].contains("op_manager.ring.subscribe(key)"),
-            "the root-satisfied path must refresh the LOCAL lease so the root is not \
-             re-selected for renewal every maintenance cycle (Codex P2): a lapsed lease \
+            branch.contains("op_manager.ring.subscribe(key)"),
+            "the root-satisfied path must be able to refresh the LOCAL lease so an in-use \
+             root is not re-selected for renewal every maintenance cycle: a lapsed lease \
              plus a client subscription / recent local access re-selects the root on every \
              30s cycle and can starve real wire renewals"
+        );
+        assert!(
+            branch.contains("contract_in_use(&key)"),
+            "the local lease refresh MUST be gated on contract_in_use — an unconditional \
+             refresh of an is_subscribed-only lease is an unbounded retention exemption \
+             (contracts_needing_renewal section 1 re-selects any live active sub with no \
+             interest re-check), violating the contract_in_use rustdoc + AGENTS.md \
+             time-bounded-exemption rule"
         );
         // The short-circuit must NOT reuse complete_local_subscription (different
         // semantics — it emits LocalSubscribeComplete and was the wrong vehicle

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -333,6 +333,55 @@ pub(crate) async fn run_renewal_subscribe(
     instance_id: ContractInstanceId,
     renewal_tx: Transaction,
 ) -> RenewalOutcome {
+    // #4440 proposal 1 — root-satisfied short-circuit.
+    //
+    // If this node is the body-holding subscription root for the contract (it
+    // hosts the body AND no connected neighbor is closer to the contract's ring
+    // location), it has no peer closer than itself to subscribe to. Renewing an
+    // upstream subscription would route the wire `Subscribe::Request` greedily
+    // toward the contract, dead-end at this node, and be retried every cycle —
+    // and at scale that loop is the renewal storm (in prod it also shows up as
+    // the renewal task overrunning its cycle deadline).
+    //
+    // A root has no use for an upstream subscription: hosting, eviction
+    // protection, and UPDATE delivery are all decoupled from the
+    // `active_subscriptions` lease (UPDATEs route to whoever is closest — this
+    // node — and fan out to interested peers independently of the lease). So the
+    // root takes a dedicated "root-satisfied" path: send NO wire request,
+    // deliver NO client result, and return `Success`. The renewal-loop's
+    // `SubscriptionRecoveryGuard::complete(true)` then clears the pending mark
+    // and resets the subscription backoff with success semantics; the
+    // `active_subscriptions` lease is intentionally allowed to lapse.
+    //
+    // This is NOT `complete_local_subscription`, whose semantics differ (it
+    // emits `LocalSubscribeComplete` and does not refresh the lease in the way a
+    // root needs); the root-satisfied path is deliberately distinct.
+    if op_manager
+        .ring
+        .is_body_holding_subscription_root_by_instance(&instance_id)
+    {
+        op_manager.ring.record_renewal_terminus_satisfied();
+        // Simulation-test observability (no-op in production — see
+        // `topology_registry::record_renewal_terminus_satisfied`).
+        if let Some(addr) = op_manager.ring.connection_manager.get_own_addr() {
+            crate::ring::topology_registry::record_renewal_terminus_satisfied(addr);
+        }
+        tracing::debug!(
+            tx = %renewal_tx,
+            contract = %instance_id,
+            phase = "renewal_terminus_satisfied",
+            "subscribe renewal: node is the body-holding subscription root; \
+             satisfying renewal locally without an upstream request (#4440)"
+        );
+        return RenewalOutcome::Success;
+    }
+
+    // Not a body-holding root: renew normally over the wire. Record the
+    // wire-attempt for simulation-test observability (no-op in production).
+    if let Some(addr) = op_manager.ring.connection_manager.get_own_addr() {
+        crate::ring::topology_registry::record_renewal_wire_attempt(addr);
+    }
+
     let result = drive_client_subscribe_inner(
         &op_manager,
         instance_id,
@@ -2814,6 +2863,54 @@ mod tests {
             classify_renewal_result(result),
             RenewalOutcome::Failed { .. }
         ));
+    }
+
+    /// #4440 proposal 1 — root-satisfied short-circuit pin.
+    ///
+    /// `run_renewal_subscribe` MUST check whether this node is the body-holding
+    /// subscription root for the contract and, if so, take the root-satisfied
+    /// path — return `RenewalOutcome::Success` WITHOUT calling
+    /// `drive_client_subscribe_inner` (no wire `Subscribe::Request`). A future
+    /// refactor that drops this check or moves it after the wire send would
+    /// silently reintroduce the renewal storm; this source-scrape pin fails the
+    /// build if that happens. (Behavioural coverage is the simulation test
+    /// `test_subscription_root_renewal_does_not_storm`; an equivalent unit test
+    /// would need a fully-built multi-peer Ring, hence the source pin — same
+    /// approach as `migration_counter_sites_present`.)
+    #[test]
+    fn run_renewal_subscribe_short_circuits_body_holding_root() {
+        let src = include_str!("op_ctx_task.rs");
+        let entry = src
+            .find("pub(crate) async fn run_renewal_subscribe(")
+            .expect("run_renewal_subscribe must exist");
+        let drive_at = src[entry..]
+            .find("drive_client_subscribe_inner(")
+            .expect("run_renewal_subscribe must still drive the wire renewal in the non-root case");
+        let before_drive = &src[entry..entry + drive_at];
+
+        let predicate_at = before_drive
+            .find("is_body_holding_subscription_root_by_instance(&instance_id)")
+            .expect(
+                "run_renewal_subscribe must check is_body_holding_subscription_root_by_instance \
+                 BEFORE driving a wire renewal (the storm short-circuit)",
+            );
+        assert!(
+            before_drive[predicate_at..].contains("return RenewalOutcome::Success;"),
+            "the body-holding-root branch must return RenewalOutcome::Success (root-satisfied \
+             path) WITHOUT falling through to the wire renewal driver"
+        );
+        assert!(
+            before_drive[predicate_at..].contains("record_renewal_terminus_satisfied()"),
+            "the root-satisfied path must record the renewal_terminus_satisfied counter"
+        );
+        // The short-circuit must NOT reuse complete_local_subscription (different
+        // semantics — it emits LocalSubscribeComplete and was the wrong vehicle
+        // in an earlier draft). The dedicated path returns Success directly.
+        let branch = &before_drive[predicate_at..];
+        assert!(
+            !branch.contains("complete_local_subscription"),
+            "the root-satisfied path must be dedicated, not reuse complete_local_subscription"
+        );
     }
 
     // ── classify_executor_subscribe_result tests ─────────────────────

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -343,23 +343,39 @@ pub(crate) async fn run_renewal_subscribe(
     // and at scale that loop is the renewal storm (in prod it also shows up as
     // the renewal task overrunning its cycle deadline).
     //
-    // A root has no use for an upstream subscription: hosting, eviction
+    // A root has no use for an UPSTREAM subscription: hosting, eviction
     // protection, and UPDATE delivery are all decoupled from the
     // `active_subscriptions` lease (UPDATEs route to whoever is closest — this
     // node — and fan out to interested peers independently of the lease). So the
     // root takes a dedicated "root-satisfied" path: send NO wire request,
     // deliver NO client result, and return `Success`. The renewal-loop's
     // `SubscriptionRecoveryGuard::complete(true)` then clears the pending mark
-    // and resets the subscription backoff with success semantics; the
-    // `active_subscriptions` lease is intentionally allowed to lapse.
+    // and resets the subscription backoff with success semantics.
+    //
+    // It DOES refresh the LOCAL `active_subscriptions` lease, even though the
+    // lease has no upstream meaning for a root. This is purely local (extends an
+    // expiry in a local map — no wire traffic) and is what keeps the
+    // root-satisfied path cheap at scale: without it, a root with a client
+    // subscription (or recent local access) whose lease lapsed would be
+    // re-selected by `contracts_needing_renewal()` on EVERY 30s maintenance
+    // cycle (the client-subscription / local-access paths fire whenever there is
+    // no live lease), so it would consume a `MAX_RECOVERY_ATTEMPTS_PER_INTERVAL`
+    // batch slot every cycle and could starve real (non-root) wire renewals that
+    // still need to reach the network. Refreshing the lease moves the root back
+    // onto the normal ~6-minute renewal cadence (lease-expiry path) instead of
+    // every cycle, while still never sending a wire request.
     //
     // This is NOT `complete_local_subscription`, whose semantics differ (it
-    // emits `LocalSubscribeComplete` and does not refresh the lease in the way a
-    // root needs); the root-satisfied path is deliberately distinct.
-    if op_manager
+    // emits `LocalSubscribeComplete` and registers client interest); the
+    // root-satisfied path is deliberately distinct — a bare local lease refresh
+    // plus a clean `Success`.
+    if let Some(key) = op_manager
         .ring
-        .is_body_holding_subscription_root_by_instance(&instance_id)
+        .body_holding_subscription_root_key(&instance_id)
     {
+        // Refresh the local lease so the root is not re-selected for renewal
+        // every cycle (see rationale above). Local-only; no wire traffic.
+        op_manager.ring.subscribe(key);
         op_manager.ring.record_renewal_terminus_satisfied();
         // Simulation-test observability (no-op in production — see
         // `topology_registry::record_renewal_terminus_satisfied`).
@@ -368,10 +384,10 @@ pub(crate) async fn run_renewal_subscribe(
         }
         tracing::debug!(
             tx = %renewal_tx,
-            contract = %instance_id,
+            contract = %key,
             phase = "renewal_terminus_satisfied",
             "subscribe renewal: node is the body-holding subscription root; \
-             satisfying renewal locally without an upstream request (#4440)"
+             satisfying renewal locally (lease refreshed, no upstream request) (#4440)"
         );
         return RenewalOutcome::Success;
     }
@@ -2889,9 +2905,9 @@ mod tests {
         let before_drive = &src[entry..entry + drive_at];
 
         let predicate_at = before_drive
-            .find("is_body_holding_subscription_root_by_instance(&instance_id)")
+            .find("body_holding_subscription_root_key(&instance_id)")
             .expect(
-                "run_renewal_subscribe must check is_body_holding_subscription_root_by_instance \
+                "run_renewal_subscribe must check body_holding_subscription_root_key \
                  BEFORE driving a wire renewal (the storm short-circuit)",
             );
         assert!(
@@ -2902,6 +2918,13 @@ mod tests {
         assert!(
             before_drive[predicate_at..].contains("record_renewal_terminus_satisfied()"),
             "the root-satisfied path must record the renewal_terminus_satisfied counter"
+        );
+        assert!(
+            before_drive[predicate_at..].contains("op_manager.ring.subscribe(key)"),
+            "the root-satisfied path must refresh the LOCAL lease so the root is not \
+             re-selected for renewal every maintenance cycle (Codex P2): a lapsed lease \
+             plus a client subscription / recent local access re-selects the root on every \
+             30s cycle and can starve real wire renewals"
         );
         // The short-circuit must NOT reuse complete_local_subscription (different
         // semantics — it emits LocalSubscribeComplete and was the wrong vehicle

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -692,37 +692,35 @@ impl Ring {
     /// Maximum contract-directed CONNECTs per cycle.
     const MAX_CONTRACT_CONNECTS_PER_CYCLE: usize = 2;
 
-    /// Returns true if this peer is the body-holding subscription root for the
-    /// contract identified by `instance_id`: it hosts the contract (has the
-    /// body) AND no connected neighbor is closer to the contract's ring location
-    /// than this peer.
+    /// If this peer is the body-holding subscription root for the contract
+    /// identified by `instance_id`, returns the resolved [`ContractKey`];
+    /// otherwise returns `None`.
     ///
-    /// This is the "body-holding terminus" predicate from the placement-migration
-    /// design. Such a peer has no peer closer than itself to subscribe to, so a
-    /// renewal toward the contract would dead-end and retry forever — the #4440
-    /// renewal storm. The renewal driver (which holds only the instance id) uses
-    /// this to short-circuit (proposal 1).
+    /// "Body-holding subscription root" means: this peer hosts the contract (has
+    /// the body) AND no connected neighbor is closer to the contract's ring
+    /// location than this peer — the "body-holding terminus" from the
+    /// placement-migration design. Such a peer has no peer closer than itself to
+    /// subscribe to, so a renewal toward the contract would dead-end and retry
+    /// forever — the #4440 renewal storm. The renewal driver (which holds only
+    /// the instance id) uses this to short-circuit (proposal 1); it returns the
+    /// key so the caller can refresh the local lease without a second lookup.
     ///
     /// Resolves the hosted [`ContractKey`] by matching `instance_id` against the
     /// hosting set (a node hosts at most one contract per instance id, so the
     /// match is exact), then delegates to [`Self::is_subscription_root`], whose
     /// definition already requires `is_hosting_contract` (= has body) and
-    /// closest-connected, so the two predicates can never disagree. Returns
-    /// `false` when the contract is not hosted (no body → not a body-holding
-    /// terminus).
-    pub(crate) fn is_body_holding_subscription_root_by_instance(
+    /// closest-connected, so the two never disagree. Returns `None` when the
+    /// contract is not hosted (no body → not a body-holding terminus).
+    pub(crate) fn body_holding_subscription_root_key(
         &self,
         instance_id: &ContractInstanceId,
-    ) -> bool {
-        let Some(key) = self
+    ) -> Option<ContractKey> {
+        let key = self
             .hosting_manager
             .hosting_contract_keys()
             .into_iter()
-            .find(|k| k.id() == instance_id)
-        else {
-            return false;
-        };
-        self.is_subscription_root(&key)
+            .find(|k| k.id() == instance_id)?;
+        self.is_subscription_root(&key).then_some(key)
     }
 
     /// Record that a renewal short-circuited because this node is the

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -315,6 +315,39 @@ fn classify_op_manager_ref<T>(slot: &RwLock<Option<Weak<T>>>) -> OpManagerState<
     }
 }
 
+/// Pure core of [`Ring::is_subscription_root`]'s neighbor scan: is there NO
+/// connected neighbor that is both *routable* (a renewal could route to it) and
+/// strictly closer to the contract than this node?
+///
+/// `my_distance` is this node's ring distance to the contract. Each neighbor is
+/// `(its location, is it routable)`:
+/// - A neighbor with no known location can't be compared, so it never makes us
+///   "not the root" on distance grounds (it is skipped).
+/// - A non-routable neighbor (transient or not-yet-ready) is skipped, mirroring
+///   the eligibility `k_closest_potentially_hosting` applies — so the predicate
+///   agrees with where a renewal would actually route (#4440).
+///
+/// Returns `true` when no routable neighbor is strictly closer (this node is the
+/// effective terminus), `false` otherwise. Factored out as a pure function so the
+/// distance/eligibility logic has direct unit coverage without a full `Ring`.
+fn no_closer_routable_neighbor(
+    my_distance: Distance,
+    contract_location: Location,
+    neighbors: impl Iterator<Item = (Option<Location>, bool)>,
+) -> bool {
+    for (peer_loc, routable) in neighbors {
+        if !routable {
+            continue;
+        }
+        if let Some(peer_loc) = peer_loc {
+            if peer_loc.distance(contract_location) < my_distance {
+                return false;
+            }
+        }
+    }
+    true
+}
+
 /// Race an `.await` point in a background loop against the Ring shutdown
 /// token. Returns `true` if shutdown fired (the caller should stop its loop)
 /// and `false` if the wrapped future completed first (carry on).
@@ -715,6 +748,12 @@ impl Ring {
         &self,
         instance_id: &ContractInstanceId,
     ) -> Option<ContractKey> {
+        // `hosting_contract_keys()` clones the hosting set and we linear-scan for
+        // the matching instance id. This runs at most once per renewal task
+        // (`SUBSCRIPTION_RECOVERY_INTERVAL` = 30 s, bounded by
+        // `MAX_RECOVERY_ATTEMPTS_PER_INTERVAL` per cycle), so the clone+scan is
+        // not on any hot path. A reverse instance-id → key index on the hosting
+        // cache would avoid the clone if this ever becomes per-message.
         let key = self
             .hosting_manager
             .hosting_contract_keys()
@@ -744,16 +783,45 @@ impl Ring {
         let my_distance = my_location.distance(contract_location);
 
         let connections = self.connection_manager.get_connections_by_location();
-        for (_loc, conns) in connections.iter() {
-            for conn in conns {
-                if let Some(peer_loc) = conn.location.location() {
-                    if peer_loc.distance(contract_location) < my_distance {
-                        return false;
-                    }
-                }
-            }
-        }
-        true
+        let neighbors = connections.iter().flat_map(|(_loc, conns)| {
+            conns.iter().map(|conn| {
+                // A peer counts as a "closer routable neighbor" (so I'm NOT the
+                // root) only if a renewal could actually route to it. Match the
+                // ACTUAL eligibility `k_closest_potentially_hosting` applies, and
+                // mind its asymmetry between the two filters:
+                //
+                //  * Transient peers (short-TTL CONNECT-coordination slots) are
+                //    excluded UNCONDITIONALLY by `k_closest` (no fallback,
+                //    ring.rs ~:2401). So a transient closer neighbor is NOT a
+                //    real route target — exclude it here too. Without this, a
+                //    node whose only closer neighbor is transient would fail to
+                //    recognise itself as the terminus, wire-renew, dead-end (the
+                //    transient is excluded by `k_closest`), and storm (#4440).
+                //
+                //  * Not-yet-ready peers are excluded by `k_closest` ONLY when
+                //    ready candidates exist; if there are none it FALLS BACK to
+                //    the not-ready peers (ring.rs ~:2445). So a not-ready closer
+                //    neighbor CAN still be a route target. Treat it as routable
+                //    here (conservative): excluding it would wrongly classify the
+                //    node as the root in early-startup / low-degree topologies and
+                //    suppress a renewal that would in fact route to that closer
+                //    peer, delaying upstream subscription propagation. The cost of
+                //    treating a not-ready peer as routable is at most one extra
+                //    wire renewal (re-evaluated next cycle once it is ready),
+                //    which is strictly safer than suppressing a needed renewal.
+                //
+                // Addressless peers are treated as routable (conservative): they
+                // bypass the addr-keyed filters in `k_closest` too, so a renewal
+                // could still route to one.
+                let routable = match conn.location.socket_addr() {
+                    Some(addr) => !self.connection_manager.is_transient(addr),
+                    None => true,
+                };
+                (conn.location.location(), routable)
+            })
+        });
+
+        no_closer_routable_neighbor(my_distance, contract_location, neighbors)
     }
 
     /// Check if a contract-directed CONNECT is currently in backoff.
@@ -6410,6 +6478,105 @@ mod instant_now_pin_test {
              update EXPECTED_BARE_INSTANT_NOW; if this fired on PRODUCTION code, \
              migrate it to `self.time_source.now()` instead of bumping the count."
         );
+    }
+}
+
+/// Direct unit coverage for the pure core of `is_subscription_root` /
+/// `body_holding_subscription_root_key` (#4440). Building a full `Ring`
+/// fixture is heavyweight (async `Ring::new` spawns background tasks), so the
+/// distance + routability decision is factored into the pure
+/// `no_closer_routable_neighbor` helper and tested here. The hosting-gate and
+/// instance-id resolution are covered end-to-end by the simulation test
+/// `test_subscription_root_renewal_does_not_storm`.
+#[cfg(test)]
+mod subscription_root_predicate_tests {
+    use super::no_closer_routable_neighbor;
+    use crate::ring::location::Location;
+
+    // Contract at 0.50; "me" hosting it at distance 0.05 (I'm at 0.55).
+    const CONTRACT: f64 = 0.50;
+    fn contract_loc() -> Location {
+        Location::new(CONTRACT)
+    }
+    fn my_distance() -> super::Distance {
+        Location::new(0.55).distance(contract_loc())
+    }
+
+    #[test]
+    fn no_neighbors_means_terminus() {
+        // Hosting, closest by default (nobody else) → terminus.
+        assert!(no_closer_routable_neighbor(
+            my_distance(),
+            contract_loc(),
+            std::iter::empty(),
+        ));
+    }
+
+    #[test]
+    fn routable_closer_neighbor_means_not_terminus() {
+        // A ready, non-transient peer AT the key (distance 0) is strictly closer
+        // → I am NOT the terminus.
+        let neighbors = [(Some(Location::new(CONTRACT)), true)];
+        assert!(!no_closer_routable_neighbor(
+            my_distance(),
+            contract_loc(),
+            neighbors.into_iter(),
+        ));
+    }
+
+    #[test]
+    fn farther_routable_neighbor_keeps_terminus() {
+        // A routable peer that is FARTHER from the key than me (at 0.20,
+        // distance 0.30 > my 0.05) doesn't unseat me.
+        let neighbors = [(Some(Location::new(0.20)), true)];
+        assert!(no_closer_routable_neighbor(
+            my_distance(),
+            contract_loc(),
+            neighbors.into_iter(),
+        ));
+    }
+
+    #[test]
+    fn closer_but_non_routable_neighbor_keeps_terminus() {
+        // The ONLY closer neighbor is non-routable (a transient peer, which
+        // `k_closest` excludes unconditionally). A renewal could not route to
+        // it, so I am still the effective terminus — the #4440 false-negative
+        // guard. (Not-ready peers are mapped to routable=true by
+        // `is_subscription_root` because `k_closest` falls back to them, so they
+        // do NOT reach this `routable=false` case — see the mapping there.)
+        let neighbors = [(Some(Location::new(CONTRACT)), false)];
+        assert!(no_closer_routable_neighbor(
+            my_distance(),
+            contract_loc(),
+            neighbors.into_iter(),
+        ));
+    }
+
+    #[test]
+    fn closer_routable_among_non_routable_means_not_terminus() {
+        // Mixed: one closer non-routable peer (ignored) AND one closer routable
+        // peer (decisive) → NOT the terminus.
+        let neighbors = [
+            (Some(Location::new(0.51)), false), // closer but non-routable → skip
+            (Some(Location::new(0.49)), true),  // closer AND routable → unseats
+        ];
+        assert!(!no_closer_routable_neighbor(
+            my_distance(),
+            contract_loc(),
+            neighbors.into_iter(),
+        ));
+    }
+
+    #[test]
+    fn locationless_neighbor_does_not_unseat() {
+        // A routable neighbor with no known location can't be compared on
+        // distance, so it never makes us "not the root" on its own.
+        let neighbors = [(None, true)];
+        assert!(no_closer_routable_neighbor(
+            my_distance(),
+            contract_loc(),
+            neighbors.into_iter(),
+        ));
     }
 }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -692,6 +692,46 @@ impl Ring {
     /// Maximum contract-directed CONNECTs per cycle.
     const MAX_CONTRACT_CONNECTS_PER_CYCLE: usize = 2;
 
+    /// Returns true if this peer is the body-holding subscription root for the
+    /// contract identified by `instance_id`: it hosts the contract (has the
+    /// body) AND no connected neighbor is closer to the contract's ring location
+    /// than this peer.
+    ///
+    /// This is the "body-holding terminus" predicate from the placement-migration
+    /// design. Such a peer has no peer closer than itself to subscribe to, so a
+    /// renewal toward the contract would dead-end and retry forever — the #4440
+    /// renewal storm. The renewal driver (which holds only the instance id) uses
+    /// this to short-circuit (proposal 1).
+    ///
+    /// Resolves the hosted [`ContractKey`] by matching `instance_id` against the
+    /// hosting set (a node hosts at most one contract per instance id, so the
+    /// match is exact), then delegates to [`Self::is_subscription_root`], whose
+    /// definition already requires `is_hosting_contract` (= has body) and
+    /// closest-connected, so the two predicates can never disagree. Returns
+    /// `false` when the contract is not hosted (no body → not a body-holding
+    /// terminus).
+    pub(crate) fn is_body_holding_subscription_root_by_instance(
+        &self,
+        instance_id: &ContractInstanceId,
+    ) -> bool {
+        let Some(key) = self
+            .hosting_manager
+            .hosting_contract_keys()
+            .into_iter()
+            .find(|k| k.id() == instance_id)
+        else {
+            return false;
+        };
+        self.is_subscription_root(&key)
+    }
+
+    /// Record that a renewal short-circuited because this node is the
+    /// body-holding subscription root for the contract (#4440 proposal 1).
+    pub(crate) fn record_renewal_terminus_satisfied(&self) {
+        self.placement_migration_metrics
+            .record_renewal_terminus_satisfied();
+    }
+
     /// Returns true if this peer is the closest to the contract among its connected neighbors
     /// (i.e., it's a subscription root for this contract).
     fn is_subscription_root(&self, contract_key: &ContractKey) -> bool {
@@ -1412,6 +1452,7 @@ impl Ring {
             snapshot.subscribe_hint_sent = Some(pm.sent);
             snapshot.subscribe_hint_received = Some(pm.received);
             snapshot.subscribe_hint_acted = Some(pm.acted);
+            snapshot.renewal_terminus_satisfied = Some(pm.renewal_terminus_satisfied);
 
             tracing::info!(
                 failure_events = snapshot.failure_events,
@@ -1435,6 +1476,7 @@ impl Ring {
                 subscribe_hint_sent = pm.sent,
                 subscribe_hint_received = pm.received,
                 subscribe_hint_acted = pm.acted,
+                renewal_terminus_satisfied = pm.renewal_terminus_satisfied,
                 "router_snapshot"
             );
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -791,17 +791,20 @@ impl Ring {
                 // mind its asymmetry between the two filters:
                 //
                 //  * Transient peers (short-TTL CONNECT-coordination slots) are
-                //    excluded UNCONDITIONALLY by `k_closest` (no fallback,
-                //    ring.rs ~:2401). So a transient closer neighbor is NOT a
-                //    real route target — exclude it here too. Without this, a
-                //    node whose only closer neighbor is transient would fail to
-                //    recognise itself as the terminus, wire-renew, dead-end (the
-                //    transient is excluded by `k_closest`), and storm (#4440).
+                //    excluded UNCONDITIONALLY by `k_closest_potentially_hosting`
+                //    (no fallback — see its `is_transient(addr)` /
+                //    `skipped_transient` branch). So a transient closer neighbor
+                //    is NOT a real route target — exclude it here too. Without
+                //    this, a node whose only closer neighbor is transient would
+                //    fail to recognise itself as the terminus, wire-renew,
+                //    dead-end (the transient is excluded by `k_closest`), and
+                //    storm (#4440).
                 //
                 //  * Not-yet-ready peers are excluded by `k_closest` ONLY when
                 //    ready candidates exist; if there are none it FALLS BACK to
-                //    the not-ready peers (ring.rs ~:2445). So a not-ready closer
-                //    neighbor CAN still be a route target. Treat it as routable
+                //    the not-ready peers (its `not_ready_fallback` path). So a
+                //    not-ready closer neighbor CAN still be a route target. Treat
+                //    it as routable
                 //    here (conservative): excluding it would wrongly classify the
                 //    node as the root in early-startup / low-degree topologies and
                 //    suppress a renewal that would in fact route to that closer
@@ -5515,6 +5518,48 @@ mod k_closest_source_tests {
             body.contains("not_ready_fallback"),
             "k_closest_potentially_hosting must keep the not-yet-ready peer \
              fallback so cold-start nodes don't fail every GET with EmptyRing."
+        );
+    }
+
+    /// #4440: `is_subscription_root`'s routability mapping must stay in sync with
+    /// `k_closest_potentially_hosting`'s eligibility asymmetry, because the
+    /// renewal short-circuit only suppresses a wire renewal when no routable
+    /// neighbor is closer. The two filters differ:
+    ///   * transient peers are excluded UNCONDITIONALLY by k_closest → the root
+    ///     check must call `is_transient(addr)` and treat transient as
+    ///     non-routable, else a node whose only closer neighbor is transient
+    ///     fails to recognise itself as the terminus and storms.
+    ///   * not-ready peers are k_closest's *fallback* when no ready candidate
+    ///     exists → the root check must NOT exclude them (treat as routable),
+    ///     else it wrongly classifies a node as root in cold-start / low-degree
+    ///     topologies and suppresses a renewal that would in fact route to the
+    ///     closer (not-ready) peer.
+    /// This pin fails the build if the mapping silently drifts from that intent.
+    #[test]
+    fn is_subscription_root_routability_matches_k_closest_eligibility() {
+        let src = production_source();
+        let body = extract_fn_body(
+            src,
+            "fn is_subscription_root(&self, contract_key: &ContractKey) -> bool {",
+        );
+        assert!(
+            body.contains("is_transient(addr)"),
+            "is_subscription_root must call is_transient(addr) when deciding whether a \
+             closer neighbor is routable — k_closest excludes transient peers \
+             unconditionally, so a transient closer neighbor must NOT keep this node \
+             from being the terminus (#4440)."
+        );
+        // The not-ready filter (`is_peer_ready`) must NOT appear in the routability
+        // mapping: k_closest falls back to not-ready peers, so they remain valid
+        // route targets and the root check must treat them as routable. Anchoring on
+        // the absence of `is_peer_ready` guards against a future edit that
+        // "symmetrises" the two filters and reintroduces the false-positive-root bug.
+        assert!(
+            !body.contains("is_peer_ready"),
+            "is_subscription_root must NOT exclude not-ready peers (do not call \
+             is_peer_ready in the routability mapping): k_closest falls back to \
+             not-ready peers, so a not-ready closer neighbor is still a valid route \
+             target and must keep this node from short-circuiting its renewal (#4440)."
         );
     }
 }

--- a/crates/core/src/ring/placement_migration_metrics.rs
+++ b/crates/core/src/ring/placement_migration_metrics.rs
@@ -7,10 +7,11 @@
 //! low-overhead observability primitives that piggyback on the existing 5-minute
 //! `router_snapshot` gauge cadence — no new per-message events:
 //!
-//! 1. [`PlacementMigrationMetrics`] — three cumulative `AtomicU64` counters
-//!    (`sent` / `received` / `acted`) incremented at the three migration sites,
-//!    read once per snapshot. Lets us trend whether the migration is firing and
-//!    at what rate.
+//! 1. [`PlacementMigrationMetrics`] — cumulative `AtomicU64` counters
+//!    (`sent` / `received` / `acted` / `renewal_terminus_satisfied`) incremented
+//!    at the migration sites and the renewal driver, read once per snapshot.
+//!    Lets us trend whether the migration is firing and at what rate, and how
+//!    often a subscription-root renewal short-circuits (#4440 proposal 1).
 //! 2. [`placement_quality`] — a pure function over this node's ring location and
 //!    the locations of the contracts it hosts. Produces the host-to-hosted-key
 //!    ring-distance distribution (median / p90 / fraction within 0.1 / min /
@@ -37,6 +38,14 @@ pub(crate) struct PlacementMigrationMetrics {
     /// Incremented only when an inbound `SubscribeHint` actually triggers a
     /// directed subscribe (the migration is acted upon, not dropped by a gate).
     acted: AtomicU64,
+    /// Incremented each time a subscription-renewal cycle short-circuits because
+    /// this node is the body-holding subscription root for the contract (#4440
+    /// proposal 1). A body-holding root has no peer closer than itself to
+    /// subscribe to, so renewing an upstream subscription would route greedily
+    /// toward the contract, dead-end, and retry — the renewal storm. The root
+    /// instead satisfies its renewal locally and sends no wire request; this
+    /// counter trends how much renewal traffic that removes.
+    renewal_terminus_satisfied: AtomicU64,
 }
 
 /// A point-in-time read of [`PlacementMigrationMetrics`] for telemetry emission.
@@ -45,6 +54,7 @@ pub(crate) struct PlacementMigrationSnapshot {
     pub sent: u64,
     pub received: u64,
     pub acted: u64,
+    pub renewal_terminus_satisfied: u64,
 }
 
 impl PlacementMigrationMetrics {
@@ -68,12 +78,21 @@ impl PlacementMigrationMetrics {
         self.acted.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Read all three counters for telemetry.
+    /// Record that a renewal cycle short-circuited because this node is the
+    /// body-holding subscription root for the contract (#4440 proposal 1).
+    #[inline]
+    pub(crate) fn record_renewal_terminus_satisfied(&self) {
+        self.renewal_terminus_satisfied
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Read all counters for telemetry.
     pub(crate) fn snapshot(&self) -> PlacementMigrationSnapshot {
         PlacementMigrationSnapshot {
             sent: self.sent.load(Ordering::Relaxed),
             received: self.received.load(Ordering::Relaxed),
             acted: self.acted.load(Ordering::Relaxed),
+            renewal_terminus_satisfied: self.renewal_terminus_satisfied.load(Ordering::Relaxed),
         }
     }
 }
@@ -265,7 +284,15 @@ mod tests {
     fn metrics_counters_increment_independently() {
         let m = PlacementMigrationMetrics::default();
         let s0 = m.snapshot();
-        assert_eq!((s0.sent, s0.received, s0.acted), (0, 0, 0));
+        assert_eq!(
+            (
+                s0.sent,
+                s0.received,
+                s0.acted,
+                s0.renewal_terminus_satisfied
+            ),
+            (0, 0, 0, 0)
+        );
 
         m.record_sent();
         m.record_sent();
@@ -273,11 +300,19 @@ mod tests {
         m.record_acted();
         m.record_received();
         m.record_received();
+        m.record_renewal_terminus_satisfied();
+        m.record_renewal_terminus_satisfied();
+        m.record_renewal_terminus_satisfied();
+        m.record_renewal_terminus_satisfied();
 
         let s1 = m.snapshot();
         assert_eq!(s1.sent, 2, "sent");
         assert_eq!(s1.received, 3, "received");
         assert_eq!(s1.acted, 1, "acted");
+        assert_eq!(
+            s1.renewal_terminus_satisfied, 4,
+            "renewal_terminus_satisfied"
+        );
     }
 
     /// Source-pin the three migration counter sites so a refactor that drops a

--- a/crates/core/src/ring/topology_registry.rs
+++ b/crates/core/src/ring/topology_registry.rs
@@ -239,6 +239,20 @@ pub fn get_renewal_metrics(network_name: &str, peer_addr: &SocketAddr) -> Option
         .map(|r| *r.value())
 }
 
+/// Snapshot all per-peer renewal metrics for a network into an owned map.
+///
+/// Used by `run_controlled_simulation` to capture the metrics BEFORE
+/// `SimNetwork::Drop` clears the registry, mirroring how it captures topology
+/// snapshots — the simulation consumes `self`, so its `Drop` (which calls
+/// [`clear_renewal_metrics`]) runs before control returns to the test.
+pub fn get_all_renewal_metrics(network_name: &str) -> HashMap<SocketAddr, RenewalMetrics> {
+    RENEWAL_METRICS_REGISTRY
+        .iter()
+        .filter(|entry| entry.key().0 == network_name)
+        .map(|entry| (entry.key().1, *entry.value()))
+        .collect()
+}
+
 /// Sum the renewal metrics across all peers in a network.
 pub fn aggregate_renewal_metrics(network_name: &str) -> RenewalMetrics {
     RENEWAL_METRICS_REGISTRY

--- a/crates/core/src/ring/topology_registry.rs
+++ b/crates/core/src/ring/topology_registry.rs
@@ -175,6 +175,87 @@ pub fn clear_all_topology_snapshots() {
     TOPOLOGY_REGISTRY.clear();
 }
 
+// ============================================================================
+// Renewal-metrics registry (#4440 proposal 1 — simulation-test observability)
+// ============================================================================
+//
+// The subscription renewal storm (#4440) is invisible to the captured
+// `NetLogMessage` event stream: `is_renewal` is not recorded on the logged
+// subscribe events, and the `subscription_renewal_outcome` telemetry is
+// fire-and-forget to the remote collector. To assert the storm signature (and
+// its absence after the fix) deterministically in `run_simulation_direct`
+// tests, the renewal driver publishes a tiny per-node counter into this global
+// registry whenever a simulation network name is set (the same `thread_local`
+// gating the topology snapshots use). Production builds running outside a
+// simulation never set a network name, so this registry stays empty and the
+// `record_*` calls are cheap no-ops.
+
+/// Per-node subscription-renewal counters for one simulation network.
+///
+/// Cumulative lifetime totals, keyed by `(network_name, peer_address)`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RenewalMetrics {
+    /// Renewal cycles that sent (or attempted to send) a wire `Subscribe`
+    /// request because the node is NOT the body-holding subscription root.
+    /// Before the #4440 fix, a body-holding root falls into this bucket too —
+    /// every such attempt routes greedily toward the contract, dead-ends, and
+    /// is retried: the storm.
+    pub wire_attempts: u64,
+    /// Renewal cycles short-circuited by the root-satisfied path (#4440
+    /// proposal 1): the node is the body-holding subscription root, so it
+    /// satisfies the renewal locally and sends no wire request.
+    pub terminus_satisfied: u64,
+}
+
+static RENEWAL_METRICS_REGISTRY: LazyLock<DashMap<(String, SocketAddr), RenewalMetrics>> =
+    LazyLock::new(DashMap::new);
+
+/// Record that a renewal cycle sent (or attempted) a wire subscribe request.
+/// No-op outside a simulation context (no current network name).
+pub fn record_renewal_wire_attempt(peer_addr: SocketAddr) {
+    if let Some(network_name) = get_current_network_name() {
+        RENEWAL_METRICS_REGISTRY
+            .entry((network_name, peer_addr))
+            .or_default()
+            .wire_attempts += 1;
+    }
+}
+
+/// Record that a renewal cycle short-circuited via the root-satisfied path.
+/// No-op outside a simulation context (no current network name).
+pub fn record_renewal_terminus_satisfied(peer_addr: SocketAddr) {
+    if let Some(network_name) = get_current_network_name() {
+        RENEWAL_METRICS_REGISTRY
+            .entry((network_name, peer_addr))
+            .or_default()
+            .terminus_satisfied += 1;
+    }
+}
+
+/// Get the renewal metrics for a specific peer in a network.
+pub fn get_renewal_metrics(network_name: &str, peer_addr: &SocketAddr) -> Option<RenewalMetrics> {
+    RENEWAL_METRICS_REGISTRY
+        .get(&(network_name.to_string(), *peer_addr))
+        .map(|r| *r.value())
+}
+
+/// Sum the renewal metrics across all peers in a network.
+pub fn aggregate_renewal_metrics(network_name: &str) -> RenewalMetrics {
+    RENEWAL_METRICS_REGISTRY
+        .iter()
+        .filter(|entry| entry.key().0 == network_name)
+        .fold(RenewalMetrics::default(), |mut acc, entry| {
+            acc.wire_attempts += entry.value().wire_attempts;
+            acc.terminus_satisfied += entry.value().terminus_satisfied;
+            acc
+        })
+}
+
+/// Clear renewal metrics for a network (for test cleanup).
+pub fn clear_renewal_metrics(network_name: &str) {
+    RENEWAL_METRICS_REGISTRY.retain(|key, _| key.0 != network_name);
+}
+
 /// Result of topology validation.
 #[derive(Debug, Default)]
 pub struct TopologyValidationResult {

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -268,6 +268,11 @@ pub(crate) struct RouterSnapshotInfo {
     pub subscribe_hint_sent: Option<u64>,
     pub subscribe_hint_received: Option<u64>,
     pub subscribe_hint_acted: Option<u64>,
+    /// Count of renewal cycles short-circuited because this node is the
+    /// body-holding subscription root for the contract (#4440 proposal 1).
+    /// Monotonic lifetime total; trends how much renewal traffic the
+    /// root-satisfied path removes. `None` until the snapshot task populates it.
+    pub renewal_terminus_satisfied: Option<u64>,
     /// Per-operation-type estimator curves, keyed by op type name (e.g., "GET").
     pub per_op_curves: HashMap<String, PerOpCurves>,
     /// Renegade predictor diagnostics. These (and `renegade_accuracy_pairs`) are
@@ -1094,6 +1099,7 @@ impl Router {
             subscribe_hint_sent: None,
             subscribe_hint_received: None,
             subscribe_hint_acted: None,
+            renewal_terminus_satisfied: None,
             // Renegade predictor diagnostics
             renegade_failure_events: self.renegade_predictor.len(),
             renegade_response_time_events: self.renegade_predictor.stage_sizes().1,

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -1987,6 +1987,11 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "migration_admission_would_change_total".to_string(),
                     serde_json::json!(snapshot.migration_admission_would_change_total),
                 );
+                // Renewal-terminus short-circuit counter (#4440 proposal 1).
+                obj.insert(
+                    "renewal_terminus_satisfied".to_string(),
+                    serde_json::json!(snapshot.renewal_terminus_satisfied),
+                );
             }
             body
         }
@@ -2174,12 +2179,14 @@ mod tests {
         info.subscribe_hint_sent = Some(11);
         info.subscribe_hint_received = Some(13);
         info.subscribe_hint_acted = Some(7);
+        info.renewal_terminus_satisfied = Some(9);
         let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
         for (key, want) in [
             ("hosted_contracts_count", 5u64),
             ("subscribe_hint_sent", 11),
             ("subscribe_hint_received", 13),
             ("subscribe_hint_acted", 7),
+            ("renewal_terminus_satisfied", 9),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -10820,3 +10820,222 @@ fn test_get_dead_ends_at_close_cluster_without_migration() {
          and obtain NO state (the far host is off the greedy path toward the key)"
     );
 }
+
+/// Reproduction + regression test for the placement-migration renewal storm
+/// (#4440, the storm symptom of the #4404 placement work).
+///
+/// ## The storm
+///
+/// When the placement migration drifts a contract onto the peer closest to its
+/// ring location, that peer becomes the *body-holding subscription root*: it
+/// hosts the contract AND no connected neighbor is closer to the key. Such a
+/// peer has no peer closer than itself to subscribe to upstream. Before the fix,
+/// the subscription-renewal driver did not recognise that role: every renewal
+/// cycle it still sent a wire `Subscribe::Request`, which routes greedily toward
+/// the contract, dead-ends at the root itself, fails, and is retried on the next
+/// 30s cycle — forever. Across many such contracts that loop is the renewal
+/// storm that made the 500-node nightly go metastable (`subscribe: attempt
+/// timed out ... is_renewal: true` floods; in prod the renewal task also
+/// overruns its 25s cycle deadline).
+///
+/// ## What this test ignites
+///
+/// A small, deterministic topology where one node is unambiguously the
+/// body-holding subscription root for a contract AND keeps that contract in the
+/// renewal set (it holds a client subscription for it, so
+/// `contracts_needing_renewal()` returns it every cycle). Migration is enabled
+/// so the run reflects the production condition the storm appears under. Over the
+/// simulation the root's renewal driver fires repeatedly.
+///
+/// ## The deterministic signal
+///
+/// `is_renewal` is not recorded on the captured `NetLogMessage` event stream and
+/// the `subscription_renewal_outcome` telemetry is fire-and-forget to a remote
+/// collector, so neither is readable in-sim. Instead the renewal driver publishes
+/// a per-node counter into the simulation-only renewal-metrics registry
+/// (`freenet::dev_tool::{aggregate_renewal_metrics, get_renewal_metrics}`):
+///   - `wire_attempts`: the node sent (or attempted) a wire renewal request —
+///     the storm signature for a body-holding root, because each such attempt
+///     dead-ends and is retried.
+///   - `terminus_satisfied`: the renewal short-circuited via the root-satisfied
+///     path the fix adds.
+///
+/// **Before the fix** the root's renewals are all `wire_attempts` (the storm) and
+/// `terminus_satisfied` is zero — the asserts below FAIL. **After the fix** the
+/// root's renewals are `terminus_satisfied` and it makes essentially no wire
+/// renewal attempts — the asserts PASS. The test is run across several seeds
+/// because the storm is metastable (one green run is not proof).
+#[test_log::test]
+fn test_subscription_root_renewal_does_not_storm() {
+    use freenet::dev_tool::{
+        Location, NodeLabel, ScheduledOperation, SimNetwork, SimOperation,
+        aggregate_renewal_metrics, clear_renewal_metrics, get_renewal_metrics,
+    };
+
+    // The storm is metastable; assert across several seeds, not just one.
+    for seed in [0x4440_0001u64, 0x4440_0002, 0x4440_0003] {
+        let network_name = format!("renewal-storm-{seed:x}");
+        // Leak the name to obtain the &'static str SimNetwork::new requires; one
+        // small allocation per seed in a test is fine.
+        let network_name: &'static str = Box::leak(network_name.into_boxed_str());
+        setup_deterministic_state(seed);
+        // Start from a clean registry so a prior seed's counters can't leak in.
+        clear_renewal_metrics(network_name);
+
+        // Place the root node exactly at the key and everyone else far from it,
+        // so the root is unambiguously the closest connected peer (the
+        // body-holding subscription root) and no migration can move the contract
+        // off it.
+        let contract = SimOperation::create_test_contract(0x44);
+        let contract_id = *contract.key().id();
+        let contract_key = contract.key();
+        let key_loc = Location::from(&contract_key).as_f64();
+
+        let wrap = |x: f64| x.rem_euclid(1.0);
+        // node order 1 = root (AT the key); orders 2..=4 far from the key.
+        let node_locations = vec![
+            key_loc, // root
+            wrap(key_loc + 0.30),
+            wrap(key_loc + 0.45),
+            wrap(key_loc + 0.60),
+        ];
+        let num_nodes = node_locations.len();
+
+        let rt = create_runtime();
+        let mut sim = rt.block_on(async {
+            SimNetwork::new_with_node_locations(
+                network_name,
+                1,         // 1 gateway
+                num_nodes, // 4 regular nodes
+                10,        // ring_max_htl
+                7,         // rnd_if_htl_above
+                8,         // max_connections
+                3,         // min_connections
+                seed,
+                &node_locations,
+            )
+            .await
+        });
+        // Match the production condition the storm appears under: migration ON.
+        sim.enable_placement_migration();
+
+        let root_label = NodeLabel::node(network_name, 1); // AT the key
+
+        // Resolve the root's address now — `run_controlled_simulation` consumes
+        // `sim`, and we need this to key into the renewal-metrics registry after.
+        let root_addr = sim
+            .node_address(&root_label)
+            .unwrap_or_else(|| panic!("root node {root_label:?} has no address (seed {seed:x})"));
+
+        // Sanity: the root must be strictly closer to the key than every other
+        // regular node, so it is genuinely the body-holding subscription root.
+        let locs = sim.get_peer_locations(); // [gateway, node1..node4]
+        let ring_dist = |a: f64, b: f64| {
+            let d = (a - b).abs();
+            d.min(1.0 - d)
+        };
+        let root_dist = ring_dist(locs[1], key_loc);
+        let others_min = (2..=num_nodes)
+            .map(|i| ring_dist(locs[i], key_loc))
+            .fold(f64::INFINITY, f64::min);
+        assert!(
+            root_dist < others_min,
+            "scenario setup wrong (seed {seed:x}): the root must be the closest peer to the key \
+             (root_dist={root_dist}, others_min={others_min})"
+        );
+
+        let operations = vec![
+            // The root genuinely HOSTS the contract (state + host_contract +
+            // active subscription), with no network propagation — so
+            // `is_subscription_root` is true and renewal eligibility starts.
+            ScheduledOperation::new(
+                root_label.clone(),
+                SimOperation::SeedHostedContract {
+                    contract: contract.clone(),
+                    state: vec![1, 2, 3, 4],
+                },
+            ),
+            // A local client on the root subscribes, so the contract stays in
+            // `contracts_needing_renewal()` every cycle (the client-subscription
+            // path), keeping the renewal driver firing on the root for the whole
+            // run regardless of lease timing.
+            ScheduledOperation::new(root_label.clone(), SimOperation::Subscribe { contract_id }),
+        ];
+
+        // Run long enough for the network to form and several 30s renewal cycles
+        // to fire on the root. `run_controlled_simulation` advances virtual time
+        // by the test client's sleeps (3s warmup + 3s per op + the
+        // post-operations wait), not the `simulation_duration` cap. The seeded
+        // active subscription has an 8-minute lease and only enters the renewal
+        // window at 6 minutes, so the post-operations wait must comfortably
+        // exceed that to exercise the renewal driver on the root. 540s gives
+        // several 30s renewal cycles inside the window. (Virtual time is cheap:
+        // this whole run is a few seconds of wall-clock under Turmoil.)
+        let result = sim.run_controlled_simulation(
+            seed,
+            operations,
+            Duration::from_secs(900),
+            Duration::from_secs(540),
+        );
+        assert!(
+            result.turmoil_result.is_ok(),
+            "simulation failed (seed {seed:x}): {:?}",
+            result.turmoil_result.err()
+        );
+
+        // The root must still host the contract (its body-holding-root status,
+        // and thus the storm condition, held for the whole run).
+        assert!(
+            result.is_node_hosting(&root_label, &contract_key),
+            "root should still host the seeded contract after the simulation (seed {seed:x})"
+        );
+
+        let root_metrics = get_renewal_metrics(network_name, &root_addr).unwrap_or_default();
+        let totals = aggregate_renewal_metrics(network_name);
+
+        tracing::info!(
+            seed = format!("{seed:x}"),
+            root_wire_attempts = root_metrics.wire_attempts,
+            root_terminus_satisfied = root_metrics.terminus_satisfied,
+            total_wire_attempts = totals.wire_attempts,
+            total_terminus_satisfied = totals.terminus_satisfied,
+            "renewal storm metrics"
+        );
+
+        // The renewal driver must have actually run on the root — otherwise the
+        // test proves nothing (neither storm nor fix exercised).
+        assert!(
+            root_metrics.wire_attempts + root_metrics.terminus_satisfied > 0,
+            "renewal driver never ran on the body-holding root (seed {seed:x}); \
+             test exercised neither the storm nor the fix \
+             (wire_attempts={}, terminus_satisfied={})",
+            root_metrics.wire_attempts,
+            root_metrics.terminus_satisfied,
+        );
+
+        // CORE OF THE FIX: a body-holding subscription root satisfies its
+        // renewals locally and sends no wire renewal request.
+        //
+        // Before the fix this is the storm: every renewal on the root is a
+        // doomed wire attempt and `terminus_satisfied` is zero — both asserts
+        // below fail. After the fix the root's renewals are terminus-satisfied
+        // and it makes no wire renewal attempts.
+        assert!(
+            root_metrics.terminus_satisfied > 0,
+            "body-holding root never took the root-satisfied renewal path (seed {seed:x}): \
+             terminus_satisfied=0, wire_attempts={}. Before the #4440 fix the root storms \
+             with doomed upstream renewals instead of satisfying them locally.",
+            root_metrics.wire_attempts,
+        );
+        assert_eq!(
+            root_metrics.wire_attempts, 0,
+            "body-holding root must NOT send wire renewal requests — that is the storm \
+             (seed {seed:x}): wire_attempts={}, terminus_satisfied={}. Each wire renewal \
+             from a root routes greedily toward the key, dead-ends at the root, fails, and \
+             retries next cycle.",
+            root_metrics.wire_attempts, root_metrics.terminus_satisfied,
+        );
+
+        clear_renewal_metrics(network_name);
+    }
+}

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -10867,10 +10867,7 @@ fn test_get_dead_ends_at_close_cluster_without_migration() {
 /// because the storm is metastable (one green run is not proof).
 #[test_log::test]
 fn test_subscription_root_renewal_does_not_storm() {
-    use freenet::dev_tool::{
-        Location, NodeLabel, ScheduledOperation, SimNetwork, SimOperation,
-        aggregate_renewal_metrics, clear_renewal_metrics, get_renewal_metrics,
-    };
+    use freenet::dev_tool::{Location, NodeLabel, ScheduledOperation, SimNetwork, SimOperation};
 
     // The storm is metastable; assert across several seeds, not just one.
     for seed in [0x4440_0001u64, 0x4440_0002, 0x4440_0003] {
@@ -10879,8 +10876,6 @@ fn test_subscription_root_renewal_does_not_storm() {
         // small allocation per seed in a test is fine.
         let network_name: &'static str = Box::leak(network_name.into_boxed_str());
         setup_deterministic_state(seed);
-        // Start from a clean registry so a prior seed's counters can't leak in.
-        clear_renewal_metrics(network_name);
 
         // Place the root node exactly at the key and everyone else far from it,
         // so the root is unambiguously the closest connected peer (the
@@ -10928,21 +10923,67 @@ fn test_subscription_root_renewal_does_not_storm() {
             .unwrap_or_else(|| panic!("root node {root_label:?} has no address (seed {seed:x})"));
 
         // Sanity: the root must be strictly closer to the key than every other
-        // regular node, so it is genuinely the body-holding subscription root.
+        // peer (regular nodes AND the gateway), so it is genuinely the
+        // body-holding subscription root. The root is placed AT the key, so its
+        // distance is 0 — assert that directly plus the strict-closest invariant.
         let locs = sim.get_peer_locations(); // [gateway, node1..node4]
         let ring_dist = |a: f64, b: f64| {
             let d = (a - b).abs();
             d.min(1.0 - d)
         };
         let root_dist = ring_dist(locs[1], key_loc);
-        let others_min = (2..=num_nodes)
+        // Include the gateway (index 0) in the "everyone else" set.
+        let others_min = (0..locs.len())
+            .filter(|&i| i != 1)
             .map(|i| ring_dist(locs[i], key_loc))
             .fold(f64::INFINITY, f64::min);
+        // The root is placed AT the key; location quantization (loopback-port
+        // assignment) introduces a tiny offset (~1e-6), so assert ~0 with a small
+        // epsilon rather than exact zero.
+        assert!(
+            root_dist < 1e-3,
+            "scenario setup wrong (seed {seed:x}): the root is placed AT the key, \
+             so its distance must be ~0 (root_dist={root_dist})"
+        );
         assert!(
             root_dist < others_min,
             "scenario setup wrong (seed {seed:x}): the root must be the closest peer to the key \
-             (root_dist={root_dist}, others_min={others_min})"
+             including the gateway (root_dist={root_dist}, others_min={others_min})"
         );
+
+        // A SECOND contract, seeded on a NON-root node (node 2) that is NOT its
+        // closest peer, so node 2 must keep renewing it over the wire. This is
+        // the guard against a silent network-wide renewal STOPPAGE: if
+        // `is_subscription_root` / `body_holding_subscription_root_key` ever
+        // regressed to return `Some` too liberally, every node would
+        // short-circuit and NO node would wire-renew — a regression worse than
+        // the storm. Pick a contract whose ring location is closest to a peer
+        // OTHER than node 2, then seed it on node 2 with a client subscription.
+        let non_root_label = NodeLabel::node(network_name, 2);
+        let non_root_addr = sim.node_address(&non_root_label).unwrap_or_else(|| {
+            panic!("non-root node {non_root_label:?} has no address (seed {seed:x})")
+        });
+        let non_root_loc = locs[2];
+        let (contract2, contract2_id) = {
+            // Search deterministic contract seeds for one whose key is NOT
+            // closest to node 2 (so node 2 is a genuine non-root host).
+            let mut chosen = None;
+            for byte in 0u8..=255 {
+                let c = SimOperation::create_test_contract(byte);
+                let cloc = Location::from(&c.key()).as_f64();
+                let node2_d = ring_dist(non_root_loc, cloc);
+                let someone_closer = (0..locs.len())
+                    .filter(|&i| i != 2)
+                    .any(|i| ring_dist(locs[i], cloc) < node2_d);
+                if someone_closer {
+                    chosen = Some((c.clone(), *c.key().id()));
+                    break;
+                }
+            }
+            chosen.unwrap_or_else(|| {
+                panic!("seed {seed:x}: could not find a contract node 2 is NOT the root for")
+            })
+        };
 
         let operations = vec![
             // The root genuinely HOSTS the contract (state + host_contract +
@@ -10956,10 +10997,26 @@ fn test_subscription_root_renewal_does_not_storm() {
                 },
             ),
             // A local client on the root subscribes, so the contract stays in
-            // `contracts_needing_renewal()` every cycle (the client-subscription
-            // path), keeping the renewal driver firing on the root for the whole
-            // run regardless of lease timing.
+            // `contracts_needing_renewal()` (the client-subscription path),
+            // keeping the renewal driver firing on the root and marking it
+            // `contract_in_use` (so the root-satisfied path refreshes the lease).
             ScheduledOperation::new(root_label.clone(), SimOperation::Subscribe { contract_id }),
+            // Second contract on a NON-root node, with a client subscription so
+            // it stays renewal-eligible. Node 2 is not its closest peer, so it
+            // must wire-renew — the non-root control for the stoppage guard.
+            ScheduledOperation::new(
+                non_root_label.clone(),
+                SimOperation::SeedHostedContract {
+                    contract: contract2.clone(),
+                    state: vec![5, 6, 7, 8],
+                },
+            ),
+            ScheduledOperation::new(
+                non_root_label.clone(),
+                SimOperation::Subscribe {
+                    contract_id: contract2_id,
+                },
+            ),
         ];
 
         // Run long enough for the network to form and several 30s renewal cycles
@@ -10990,13 +11047,19 @@ fn test_subscription_root_renewal_does_not_storm() {
             "root should still host the seeded contract after the simulation (seed {seed:x})"
         );
 
-        let root_metrics = get_renewal_metrics(network_name, &root_addr).unwrap_or_default();
-        let totals = aggregate_renewal_metrics(network_name);
+        // Read the renewal metrics captured inside `run_controlled_simulation`
+        // BEFORE the SimNetwork was dropped (the Drop impl clears the global
+        // registry, so reading it here would always see zeros — #4440).
+        let root_metrics = result.renewal_metrics_for(&root_addr);
+        let non_root_metrics = result.renewal_metrics_for(&non_root_addr);
+        let totals = result.aggregate_renewal_metrics();
 
         tracing::info!(
             seed = format!("{seed:x}"),
             root_wire_attempts = root_metrics.wire_attempts,
             root_terminus_satisfied = root_metrics.terminus_satisfied,
+            non_root_wire_attempts = non_root_metrics.wire_attempts,
+            non_root_terminus_satisfied = non_root_metrics.terminus_satisfied,
             total_wire_attempts = totals.wire_attempts,
             total_terminus_satisfied = totals.terminus_satisfied,
             "renewal storm metrics"
@@ -11036,6 +11099,177 @@ fn test_subscription_root_renewal_does_not_storm() {
             root_metrics.wire_attempts, root_metrics.terminus_satisfied,
         );
 
-        clear_renewal_metrics(network_name);
+        // UPPER BOUND on the root's terminus-satisfied count (regression guard
+        // for the lease-refresh gating, #4440 blocker 2). The in-use root
+        // refreshes its LOCAL lease on each root-satisfied renewal, which moves
+        // it onto the ~6-minute lease-expiry renewal cadence. Over this ~9-minute
+        // run that is at most ~2 cycles. If the lease refresh were accidentally
+        // dropped (or made unconditional in a way that re-selected the root every
+        // 30s cycle), the root would fire the root-satisfied path on EVERY cycle
+        // and this count would balloon into the teens — caught here.
+        assert!(
+            root_metrics.terminus_satisfied <= 4,
+            "root took the root-satisfied path {} times (seed {seed:x}) — far more than the \
+             ~6-minute lease-expiry cadence allows over this run. The local-lease refresh \
+             is supposed to keep an in-use root OFF the every-30s-cycle renewal selection; \
+             a count this high means it is being re-selected every cycle (the batch-starvation \
+             regression).",
+            root_metrics.terminus_satisfied,
+        );
+
+        // STOPPAGE GUARD (#4440): renewals must NOT have globally stopped. A
+        // non-root host (node 2, not the closest peer for contract2) must keep
+        // renewing over the wire. If `is_subscription_root` regressed to return
+        // true too liberally, EVERY node would short-circuit and this would be 0
+        // — a silent network-wide renewal stoppage, worse than the storm.
+        assert!(
+            non_root_metrics.wire_attempts > 0,
+            "non-root host made no wire renewal attempts (seed {seed:x}): wire_attempts=0, \
+             terminus_satisfied={}. A non-root host MUST keep renewing upstream; zero here \
+             means the root short-circuit is firing on non-roots too (silent global renewal \
+             stoppage).",
+            non_root_metrics.terminus_satisfied,
+        );
+        // And the non-root must NOT have taken the root-satisfied path (it is not
+        // a root for contract2).
+        assert_eq!(
+            non_root_metrics.terminus_satisfied, 0,
+            "non-root host wrongly took the root-satisfied path (seed {seed:x}): \
+             terminus_satisfied={}, wire_attempts={}. Only a body-holding root may \
+             short-circuit; a non-root host must wire-renew.",
+            non_root_metrics.terminus_satisfied, non_root_metrics.wire_attempts,
+        );
     }
+}
+
+/// Regression test for #4440 blocker 2: a body-holding subscription root with NO
+/// genuine interest (no local client subscription, no downstream subscriber)
+/// must let its `active_subscriptions` lease **lapse** rather than refresh it on
+/// the root-satisfied renewal path.
+///
+/// Why this matters: `contracts_needing_renewal` section 1 re-selects ANY live
+/// active subscription with no interest re-check. If the root-satisfied path
+/// refreshed the lease unconditionally, a no-interest root would re-select
+/// itself every renewal cycle forever — an unbounded `is_subscribed`-only
+/// retention exemption that the `contract_in_use` rustdoc and the AGENTS.md
+/// time-bounded-exemption rule forbid. The fix gates the lease refresh on
+/// `contract_in_use`, so a no-interest root does NOT refresh and the lease
+/// lapses (`SUBSCRIPTION_LEASE_DURATION` = 8 min) — after which it drops out of
+/// the renewal set entirely.
+///
+/// This test seeds a hosted contract on a body-holding root with NO client
+/// subscription, runs past the lease window, and asserts the root's final
+/// `active_subscription_keys` (captured from the topology snapshot) no longer
+/// contains the contract — i.e. the lease was allowed to lapse, not
+/// self-perpetuated.
+#[test_log::test]
+fn test_no_interest_subscription_root_lease_lapses() {
+    use freenet::dev_tool::{Location, NodeLabel, ScheduledOperation, SimNetwork, SimOperation};
+
+    const SEED: u64 = 0x4440_0009;
+    let network_name = "renewal-root-lease-lapse";
+    setup_deterministic_state(SEED);
+
+    let contract = SimOperation::create_test_contract(0x4A);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    let key_loc = Location::from(&contract_key).as_f64();
+
+    let wrap = |x: f64| x.rem_euclid(1.0);
+    // node order 1 = root (AT the key); orders 2..=4 far from the key.
+    let node_locations = vec![
+        key_loc,
+        wrap(key_loc + 0.30),
+        wrap(key_loc + 0.45),
+        wrap(key_loc + 0.60),
+    ];
+    let num_nodes = node_locations.len();
+
+    let rt = create_runtime();
+    let mut sim = rt.block_on(async {
+        SimNetwork::new_with_node_locations(
+            network_name,
+            1,
+            num_nodes,
+            10,
+            7,
+            8,
+            3,
+            SEED,
+            &node_locations,
+        )
+        .await
+    });
+    sim.enable_placement_migration();
+
+    let root_label = NodeLabel::node(network_name, 1);
+    let root_addr = sim
+        .node_address(&root_label)
+        .expect("root node has an address");
+
+    // Seed the contract as hosted on the root, but DO NOT subscribe a client and
+    // DO NOT create any downstream subscriber — so `contract_in_use` is false.
+    let operations = vec![ScheduledOperation::new(
+        root_label.clone(),
+        SimOperation::SeedHostedContract {
+            contract: contract.clone(),
+            state: vec![1, 2, 3, 4],
+        },
+    )];
+
+    // Run past the 8-minute lease (post-op wait 600s ≈ 10 min) so a refreshed
+    // lease would still be live at the end, while a lapsed lease is gone — the
+    // discriminating signal.
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(900),
+        Duration::from_secs(600),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "simulation failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    // The root still HOSTS the contract (hosting is decoupled from the lease).
+    assert!(
+        result.is_node_hosting(&root_label, &contract_key),
+        "root should still host the contract (hosting does not depend on the lease)"
+    );
+
+    // The root must NOT have made wire renewal attempts (it is the body-holding
+    // root) — its renewals take the root-satisfied path.
+    let root_metrics = result.renewal_metrics_for(&root_addr);
+    assert_eq!(
+        root_metrics.wire_attempts, 0,
+        "body-holding root must not wire-renew (wire_attempts={}, terminus_satisfied={})",
+        root_metrics.wire_attempts, root_metrics.terminus_satisfied,
+    );
+
+    // CORE ASSERTION: the lease lapsed. The root's final active-subscription set
+    // (captured in the topology snapshot before drop) must NOT contain the
+    // contract — a no-interest root does not refresh, so after 8 minutes the
+    // lease is gone and the root has dropped out of the renewal set. If the
+    // refresh were unconditional, the lease would still be live here.
+    let root_snapshot = result
+        .topology_snapshots
+        .iter()
+        .find(|s| s.peer_addr == root_addr)
+        .expect("root topology snapshot present");
+    assert!(
+        !root_snapshot
+            .active_subscription_keys
+            .contains(&contract_id),
+        "no-interest body-holding root self-perpetuated its lease: the contract is still in \
+         active_subscription_keys after the 8-minute lease window. The root-satisfied path \
+         must NOT refresh the lease when the contract is not in use (#4440 blocker 2) — \
+         otherwise it is an unbounded is_subscribed-only retention exemption."
+    );
+
+    tracing::info!(
+        root_terminus_satisfied = root_metrics.terminus_satisfied,
+        active_subs = root_snapshot.active_subscription_keys.len(),
+        "no-interest root lease lapsed as expected"
+    );
 }

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -10852,8 +10852,10 @@ fn test_get_dead_ends_at_close_cluster_without_migration() {
 /// `is_renewal` is not recorded on the captured `NetLogMessage` event stream and
 /// the `subscription_renewal_outcome` telemetry is fire-and-forget to a remote
 /// collector, so neither is readable in-sim. Instead the renewal driver publishes
-/// a per-node counter into the simulation-only renewal-metrics registry
-/// (`freenet::dev_tool::{aggregate_renewal_metrics, get_renewal_metrics}`):
+/// a per-node counter into a simulation-only renewal-metrics registry that
+/// `run_controlled_simulation` snapshots before the `SimNetwork` is dropped; the
+/// test reads it via `ControlledSimulationResult::{renewal_metrics_for,
+/// aggregate_renewal_metrics}`:
 ///   - `wire_attempts`: the node sent (or attempted) a wire renewal request —
 ///     the storm signature for a body-holding root, because each such attempt
 ///     dead-ends and is retried.


### PR DESCRIPTION
## Problem

When the placement migration drifts a contract onto the peer closest to its ring location, that peer becomes the **body-holding subscription root**: it hosts the contract AND no connected neighbor is closer to the key. Such a peer has no peer closer than itself to subscribe to upstream.

The subscription-renewal driver did not recognise that role. Every renewal cycle it still sent a wire `Subscribe::Request`, which routes greedily toward the contract, dead-ends at the root itself, fails, and is retried on the next 30s cycle — forever. Across many such contracts that loop is the renewal storm that made the 500-node nightly go metastable (`subscribe: attempt timed out ... is_renewal: true` floods; in production the renewal task also overruns its 25s cycle deadline). This is the storm symptom of the #4404 placement work, tracked in #4440.

## Solution (placement "proposal 1")

In the renewal driver (`run_renewal_subscribe`), **before** driving a wire renewal, the node checks whether it is the body-holding subscription root for the contract via `Ring::body_holding_subscription_root_key` (hosts the body AND is the closest connected peer — `is_subscription_root`). If it is, it takes a dedicated **root-satisfied path**:

- record the new `renewal_terminus_satisfied` counter,
- **conditionally** refresh the LOCAL `active_subscriptions` lease (see below),
- send **no** wire `Subscribe::Request`, deliver **no** client result,
- return `RenewalOutcome::Success` (the renewal loop's `SubscriptionRecoveryGuard::complete(true)` then clears the pending mark and resets the subscription backoff with success semantics).

### Lease handling is gated on `contract_in_use` (not unconditional)

The local lease refresh is **conditional on genuine, time-bounded interest** (`contract_in_use`: a local client subscription or a downstream subscriber):

- **In-use root** → refresh the local lease (a local-only map update, no wire traffic). This moves the root onto the normal ~6-minute lease-expiry renewal cadence instead of being re-selected by `contracts_needing_renewal()` every 30s cycle (which would consume a renewal-batch slot every cycle with a no-op local success and could starve real non-root wire renewals). Because the interest signals are time-bounded, the lease cannot self-perpetuate past the interest.
- **No-interest root** → **do NOT refresh**; let the lease lapse. `contracts_needing_renewal` section 1 re-selects any live active subscription with no interest re-check, so an unconditional refresh would be an unbounded `is_subscribed`-only retention exemption (forbidden by the `contract_in_use` rustdoc + AGENTS.md time-bounded-exemption rule). A no-interest root's lease lapses and it drops out of the renewal set entirely. Guarded by `test_no_interest_subscription_root_lease_lapses`.

### Routability matches `k_closest_potentially_hosting` eligibility (transient-only exclusion)

The root predicate only counts a closer neighbor as "I'm not the root" if a renewal could actually route to it, mirroring `k_closest`'s asymmetry:

- **Transient peers** are excluded unconditionally by `k_closest` → excluded in the root check too (else a node whose only closer neighbor is transient would skip the short-circuit and storm).
- **Not-ready peers** are `k_closest`'s fallback when no ready candidate exists → treated as **routable** in the root check (else a node would be wrongly classified as root in cold-start / low-degree topologies and suppress a renewal that would in fact route to that closer peer). Pinned by `is_subscription_root_routability_matches_k_closest_eligibility`.

This is a **dedicated** path, deliberately NOT `complete_local_subscription` (different semantics — emits `LocalSubscribeComplete` and registers client interest). The new counter is surfaced on `router_snapshot` and mirrored into the hand-written OTLP body (guarded by the existing pin test).

**Scope is strictly proposal 1.** The other placement proposals (bodyless forwarding, displacement/make-room, retention grant, `is_upstream` cleanup) are intentionally NOT implemented here.

## Testing

- **Reproduction-first simulation test** `test_subscription_root_renewal_does_not_storm` (3 seeds, the storm is metastable): a body-holding root with a client subscription keeps firing renewals. Asserts the root takes the root-satisfied path (`terminus_satisfied > 0`, bounded `<= 4` to catch an accidental every-cycle refresh) and sends **no** wire renewals (`wire_attempts == 0`), plus a **non-root host control** (a second contract on a node that is not its closest peer) that MUST keep wire-renewing (`wire_attempts > 0`, `terminus_satisfied == 0`) — a guard against a silent network-wide renewal stoppage. Confirmed it FAILS before the fix (root storms: `wire_attempts=3, terminus_satisfied=0`) and PASSES after (`wire_attempts=0, terminus_satisfied=1`).
- **`test_no_interest_subscription_root_lease_lapses`**: a no-interest body-holding root's lease lapses (final `active_subscription_keys` no longer contains the contract) — no unbounded self-perpetuation.
- **Source-pin unit tests**: `run_renewal_subscribe_short_circuits_body_holding_root` (check runs before wire send, returns Success, gated lease refresh, no `complete_local_subscription` reuse) and `is_subscription_root_routability_matches_k_closest_eligibility` (mapping stays in sync with k_closest).
- **Direct predicate unit tests** (`no_closer_routable_neighbor`): closer-routable → not root; closer-but-non-routable (transient) → still root; farther → root; no neighbors → root; locationless → doesn't unseat.
- Counter unit test + OTLP pin test updated for `renewal_terminus_satisfied`.
- Existing placement-migration sim tests still pass — no regression.
- The simulation-only renewal-metrics signal is captured inside `run_controlled_simulation` before `SimNetwork::Drop` clears the registry, read via `ControlledSimulationResult::{renewal_metrics_for, aggregate_renewal_metrics}`. (`is_renewal` is not on the captured `NetLogMessage` stream; the registry `record_*` calls are no-ops in production.)
- `cargo fmt` clean; `cargo clippy` clean on all changed files.

## Rebase note

Rebased onto main after #4584 (interest-tier shadow gauges) merged. The conflict in `router_snapshot` gauges + the OTLP hand-mirror block + the OTLP pin test (router.rs / telemetry.rs / ring.rs) was resolved **additively** — both #4584's interest-tier shadow gauges and this PR's `renewal_terminus_satisfied` gauge are kept. Both OTLP pin tests pass.

## Review status

External **Codex** review run against `main`: surfaced and addressed two P2s across review rounds (lease-lapse batch starvation; not-ready-peer routability). Final Codex run: no findings. Full multi-model review came back clean. This touches the subscribe/renewal state machine (a high-risk surface).

Closes #4440 (storm portion); refs #4404

[AI-assisted - Claude]