### PR TITLE
style: fix doc_lazy_continuation clippy lints and document sysconf SAFETY

### DIFF
--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -3861,8 +3861,9 @@ mod tests {
     /// - `Ok(false)` => the request was REJECTED with an error message,
     ///   and asserts the error decodes to an `OperationError` (the rate-limit
     ///   rejection variant),
-    /// and confirms forward/reject is consistent with whether anything landed
-    /// on the request channel.
+    ///   and confirms forward/reject is consistent with whether anything landed
+    ///   on the request channel.
+    ///
     /// Drive a GET op (the common case for most rate-limit tests).
     async fn drive_one_op(
         user_context: Option<&UserSecretContext>,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -5534,6 +5534,7 @@ mod k_closest_source_tests {
     ///     else it wrongly classifies a node as root in cold-start / low-degree
     ///     topologies and suppresses a renewal that would in fact route to the
     ///     closer (not-ready) peer.
+    ///
     /// This pin fails the build if the mapping silently drifts from that intent.
     #[test]
     fn is_subscription_root_routability_matches_k_closest_eligibility() {

--- a/crates/core/src/wasm_runtime/module_cache.rs
+++ b/crates/core/src/wasm_runtime/module_cache.rs
@@ -1109,8 +1109,12 @@ fn read_total_ram_bytes() -> Option<usize> {
     }
     #[cfg(all(unix, not(target_os = "linux")))]
     {
-        // SAFETY: sysconf is a pure read of a system constant; no pointers.
+        // SAFETY: `sysconf` is an FFI call that is always sound to invoke with
+        // a valid name constant. It takes no pointers, has no preconditions for
+        // these names, and returns the value or -1 on error (handled by the
+        // `> 0` checks below).
         let pages = unsafe { libc::sysconf(libc::_SC_PHYS_PAGES) };
+        // SAFETY: same FFI contract as the `_SC_PHYS_PAGES` call above.
         let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
         if pages > 0 && page_size > 0 {
             (pages as usize).checked_mul(page_size as usize)


### PR DESCRIPTION
## Problem

A local clippy run with `--all-targets` (toolchain 1.94, the pinned version)
surfaces several lints in **test code** that CI does not catch. CI runs
`cargo clippy --locked -- -D warnings` **without** `--all-targets`
(`.github/workflows/ci.yml:402`), so it never lints `#[cfg(test)]` modules.
This is preemptive cleanup so that a future toolchain bump or the addition of
`--all-targets` to CI doesn't suddenly turn these into build failures.

This PR fixes only the subset that is genuinely fixable with **comment / doc
formatting alone** — no logic changes.

## Solution

- **`client_events/websocket.rs`** and **`ring.rs`**: fix
  `clippy::doc_lazy_continuation`. List-continuation lines now carry the
  correct indentation, and concluding sentences that followed a list are
  separated into their own paragraph with a blank doc line. Pure formatting;
  no wording changed.
- **`wasm_runtime/module_cache.rs`**: give each `libc::sysconf` unsafe block in
  the non-Linux RAM-detection path its own accurate `// SAFETY:` comment. The
  call is a pointer-free FFI read that returns `-1` on error, already handled by
  the surrounding `> 0` checks. (This path is `#[cfg]`'d out on Linux, so it's
  preemptive for macOS/BSD builds.)

### Deliberately NOT changed (need more than a comment/doc edit)

Two `--all-targets` lints remain and are intentionally left for a separate,
explicitly-authorized change because they are **not** comment/doc-only:

- `module_cache.rs` — 4× `undocumented_unsafe_blocks` on the test-only
  `std::env::set_var`/`remove_var` calls (`interest_tiered_enabled_reads_env_at_construction`).
  Per the std 1.94 docs, `set_var`/`remove_var` are sound only when env access
  is single-threaded; the canonical audit guidance is "the environment access
  only happens in single-threaded code." The function-local `ENV_GUARD` mutex
  does **not** make a parallel cargo-test binary single-threaded, and it is not
  taken by the ~14 other tests that read `INTEREST_TIERED_ENV` via
  `with_interest_for_test` → `with_label_and_interest`. Writing a "serialized via
  mutex" SAFETY comment would therefore be inaccurate. A truthful fix is a logic
  change (e.g. make `with_interest_for_test` actually bypass the env read, as its
  own doc already claims, or read the flag via an injectable source rather than
  mutating the process env).
- `client_events/user_op_rate_limit.rs:671` — `clippy::redundant_locals`
  (`let user = user;` in a test); removing it is a code change, out of scope here.

## Testing

- `cargo clippy --locked -- -D warnings` (the exact CI invocation) — **clean (exit 0)**.
- `cargo clippy --all-targets` — the four fixed lints are gone; only the two
  deliberately-deferred items above remain.
- `cargo fmt --check` — clean.
- External review: `codex review --base origin/main` — no findings (doc/comment
  wording only).

[AI-assisted - Claude]