### PR TITLE
feat: add ed25519 release-artifact signing and verification to auto-update

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -452,6 +452,50 @@ jobs:
           echo "=== SHA256 Checksums ==="
           cat SHA256SUMS.txt
 
+      - name: Sign SHA256SUMS.txt (ed25519)
+        # Produce a detached raw ed25519 signature over the exact bytes of
+        # SHA256SUMS.txt. The auto-update client (crates/core/.../update.rs)
+        # verifies this against a baked-in public key before trusting any hash
+        # in the manifest, which is what makes the checksum gate meaningful.
+        env:
+          # PEM-encoded ed25519 private key. Repo secret; present on tag-push
+          # and workflow_dispatch (this workflow never runs on fork PRs).
+          FREENET_RELEASE_SIGNING_KEY: ${{ secrets.FREENET_RELEASE_SIGNING_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FREENET_RELEASE_SIGNING_KEY:-}" ]; then
+            # Degrade gracefully: clients tolerate an absent signature during
+            # the two-release transition (REQUIRE_RELEASE_SIGNATURE=false), so
+            # a missing secret must not fail the whole release.
+            echo "::warning::FREENET_RELEASE_SIGNING_KEY not set; release will be UNSIGNED."
+            exit 0
+          fi
+
+          # Write the key to a 0600 temp PEM and remove it on every exit path.
+          # Never echo the key (no set -x, no echo "$KEY"): it is only ever
+          # redirected into the file and passed to openssl by path.
+          KEY_FILE="$(mktemp)"
+          chmod 600 "$KEY_FILE"
+          trap 'rm -f "$KEY_FILE"' EXIT
+          printf '%s\n' "$FREENET_RELEASE_SIGNING_KEY" > "$KEY_FILE"
+
+          # Raw ed25519 sign (-rawin: message is signed as-is; ed25519 hashes
+          # internally). Produces a 64-byte detached signature. Needs openssl
+          # >= 3.0, which ubuntu-latest provides.
+          openssl pkeyutl -sign -inkey "$KEY_FILE" -rawin \
+            -in SHA256SUMS.txt -out SHA256SUMS.txt.sig
+
+          # Shred the key immediately (belt-and-braces alongside the trap).
+          shred -u "$KEY_FILE" 2>/dev/null || rm -f "$KEY_FILE"
+          trap - EXIT
+
+          SIG_SIZE=$(wc -c < SHA256SUMS.txt.sig)
+          echo "Wrote SHA256SUMS.txt.sig (${SIG_SIZE} bytes)"
+          if [ "$SIG_SIZE" -ne 64 ]; then
+            echo "::error::Expected a 64-byte raw ed25519 signature, got ${SIG_SIZE} bytes"
+            exit 1
+          fi
+
       - name: Upload binaries to release
         env:
           # Coalesce on RELEASE_PAT so the `gh release edit --draft=false`
@@ -472,6 +516,9 @@ jobs:
             [ -f "$f" ] && ASSETS="$ASSETS $f"
           done
           ASSETS="$ASSETS SHA256SUMS.txt"
+          # Attach the detached signature when the signing step produced one
+          # (absent only if FREENET_RELEASE_SIGNING_KEY was unset).
+          [ -f SHA256SUMS.txt.sig ] && ASSETS="$ASSETS SHA256SUMS.txt.sig"
 
           # Upload all available archives and checksums to the release
           gh release upload "$TAG_NAME" $ASSETS \

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -458,15 +458,26 @@ jobs:
         # verifies this against a baked-in public key before trusting any hash
         # in the manifest, which is what makes the checksum gate meaningful.
         env:
-          # PEM-encoded ed25519 private key. Repo secret; present on tag-push
-          # and workflow_dispatch (this workflow never runs on fork PRs).
+          # PEM-encoded ed25519 private key. Repo secret, available to this
+          # (non-fork) workflow. NOTE: the enclosing `attach-to-release` job
+          # only runs on tag pushes (see its `if:`), so this step runs as part
+          # of a real release, not on a plain workflow_dispatch. The separate
+          # `verify-signing-key` job covers the workflow_dispatch dry-run.
           FREENET_RELEASE_SIGNING_KEY: ${{ secrets.FREENET_RELEASE_SIGNING_KEY }}
         run: |
           set -euo pipefail
+          # An empty manifest means the checksum step matched no assets — a
+          # broken release. Signing it would produce a valid signature over
+          # nothing, so refuse here rather than ship a meaningless signature.
+          if [ ! -s SHA256SUMS.txt ]; then
+            echo "::error::SHA256SUMS.txt is missing or empty; refusing to sign."
+            exit 1
+          fi
           if [ -z "${FREENET_RELEASE_SIGNING_KEY:-}" ]; then
             # Degrade gracefully: clients tolerate an absent signature during
             # the two-release transition (REQUIRE_RELEASE_SIGNATURE=false), so
-            # a missing secret must not fail the whole release.
+            # a missing secret must not fail the whole release. The upload step
+            # deletes any stale .sig so the release stays consistently unsigned.
             echo "::warning::FREENET_RELEASE_SIGNING_KEY not set; release will be UNSIGNED."
             exit 0
           fi
@@ -518,7 +529,17 @@ jobs:
           ASSETS="$ASSETS SHA256SUMS.txt"
           # Attach the detached signature when the signing step produced one
           # (absent only if FREENET_RELEASE_SIGNING_KEY was unset).
-          [ -f SHA256SUMS.txt.sig ] && ASSETS="$ASSETS SHA256SUMS.txt.sig"
+          if [ -f SHA256SUMS.txt.sig ]; then
+            ASSETS="$ASSETS SHA256SUMS.txt.sig"
+          else
+            # No signature this run. `--clobber` only replaces the assets we
+            # list, so a stale SHA256SUMS.txt.sig from a prior signed run for
+            # this tag would survive and be verified against the (possibly
+            # changed) manifest — making the release uninstallable instead of
+            # gracefully unsigned. Proactively delete any leftover signature.
+            gh release delete-asset "$TAG_NAME" SHA256SUMS.txt.sig \
+              --repo ${{ github.repository }} --yes 2>/dev/null || true
+          fi
 
           # Upload all available archives and checksums to the release
           gh release upload "$TAG_NAME" $ASSETS \
@@ -532,3 +553,59 @@ jobs:
             --repo ${{ github.repository }} \
             --draft=false
           echo "✅ Release $TAG_NAME published with all binaries attached"
+
+  verify-signing-key:
+    name: Verify release signing key (dry-run)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Manual dry-run only: confirm the CI signing secret works AND matches the
+    # public key baked into the binary BEFORE relying on it for a real release.
+    # Runs nothing on normal pushes/tags (the real signing happens in
+    # attach-to-release); produces no release assets / side effects.
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Sign/verify round-trip and confirm the key matches the baked-in pubkey
+        env:
+          FREENET_RELEASE_SIGNING_KEY: ${{ secrets.FREENET_RELEASE_SIGNING_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FREENET_RELEASE_SIGNING_KEY:-}" ]; then
+            echo "::error::FREENET_RELEASE_SIGNING_KEY not set; cannot dry-run signing."
+            exit 1
+          fi
+
+          # The public key the auto-update binary verifies against
+          # (crates/core/src/bin/commands/update.rs FREENET_RELEASE_PUBKEY).
+          EXPECTED_PUBKEY_HEX="eb2986604e34a3f985279a7e70852f3764d3347fe82074d92b1e4bc6336f8664"
+
+          KEY_FILE="$(mktemp)"
+          chmod 600 "$KEY_FILE"
+          trap 'rm -f "$KEY_FILE"' EXIT
+          printf '%s\n' "$FREENET_RELEASE_SIGNING_KEY" > "$KEY_FILE"
+
+          # Derive the raw 32-byte public key from the private key: the ed25519
+          # DER SubjectPublicKeyInfo is a fixed 12-byte prefix + the 32-byte key.
+          ACTUAL_PUBKEY_HEX="$(openssl pkey -in "$KEY_FILE" -pubout -outform DER \
+            | tail -c 32 | od -An -v -tx1 | tr -d ' \n')"
+          echo "Derived public key:  $ACTUAL_PUBKEY_HEX"
+          echo "Baked-in public key: $EXPECTED_PUBKEY_HEX"
+          if [ "$ACTUAL_PUBKEY_HEX" != "$EXPECTED_PUBKEY_HEX" ]; then
+            echo "::error::Signing key does NOT match the public key baked into the binary; \
+              every client would reject releases signed with this key."
+            exit 1
+          fi
+
+          # Full round-trip with the exact command the release uses.
+          printf 'dry-run release manifest\n' > sample.txt
+          openssl pkeyutl -sign -inkey "$KEY_FILE" -rawin -in sample.txt -out sample.sig
+          SIG_SIZE=$(wc -c < sample.sig)
+          if [ "$SIG_SIZE" -ne 64 ]; then
+            echo "::error::Expected a 64-byte raw ed25519 signature, got ${SIG_SIZE} bytes"
+            exit 1
+          fi
+          openssl pkey -in "$KEY_FILE" -pubout -out pub.pem
+          openssl pkeyutl -verify -pubin -inkey pub.pem -rawin -in sample.txt -sigfile sample.sig
+
+          shred -u "$KEY_FILE" 2>/dev/null || rm -f "$KEY_FILE"
+          trap - EXIT
+          echo "✅ Signing key matches the baked-in public key; sign/verify round-trip OK."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,6 +272,19 @@ End-to-end procedure for any maintainer is in
 `gh workflow run release.yml --field version=X.Y.Z`. The `RELEASE_PAT`
 section above is the prerequisite for the cascade to fire automatically.
 
+## Release artifact signing (`FREENET_RELEASE_SIGNING_KEY`)
+
+`cross-compile.yml` signs the release `SHA256SUMS.txt` with an ed25519 key
+(`FREENET_RELEASE_SIGNING_KEY` repo secret) and uploads `SHA256SUMS.txt.sig`.
+The auto-updater (`crates/core/src/bin/commands/update.rs`) verifies that
+signature against the public key baked into the binary (`FREENET_RELEASE_PUBKEY`)
+before trusting the checksum manifest. Rotating the key means updating BOTH the
+secret AND the baked-in `FREENET_RELEASE_PUBKEY` (a mismatch would make every
+client refuse the release). To verify the secret matches the baked-in key
+without cutting a release, run `cross-compile.yml` via `workflow_dispatch` and
+check the `verify-signing-key` job. The full prerequisites table (including the
+two-release `REQUIRE_RELEASE_SIGNATURE` transition) is in `docs/RELEASING.md`.
+
 ## Delegate secrets-at-rest
 
 Operator-facing documentation (encryption model, migration matrix,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2034,6 +2034,7 @@ dependencies = [
  "delegate",
  "directories",
  "dirs",
+ "ed25519-dalek",
  "either",
  "event-listener",
  "flatbuffers 25.12.19",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -102,6 +102,10 @@ reqwest = { workspace = true }
 # secrets don't have to be passed on argv (where they leak via `ps`/history).
 rpassword = "7"
 x25519-dalek = { workspace = true }
+# Verifies the ed25519 signature over the release SHA256SUMS.txt manifest in
+# the auto-update path (commands/update.rs). Default features (native std) are
+# sufficient — only verification (and test-only signing) is needed here.
+ed25519-dalek = "2"
 sha2 = { workspace = true }
 
 # Tracing deps

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -895,7 +895,17 @@ async fn download_checksums(url: &str) -> Result<Checksums> {
 /// caller needs the exact bytes (to verify a signature over them, or to feed
 /// to `Signature::from_bytes`) rather than streaming to a file like
 /// [`download_file`].
+///
+/// The read is capped so a compromised or buggy asset server cannot OOM the
+/// updater by streaming an unbounded body in place of a tiny manifest /
+/// signature. Exceeding the cap is treated as a (retryable) download failure,
+/// never a lockout.
 async fn download_bytes(url: &str) -> Result<Vec<u8>> {
+    // Generous vs. any real manifest (a few hundred bytes) or signature (64
+    // bytes), small enough to bound memory.
+    const MAX_ASSET_BYTES: usize = 4 * 1024 * 1024;
+    use futures::StreamExt;
+
     let client = reqwest::Client::builder()
         .user_agent("freenet-updater")
         .build()?;
@@ -910,11 +920,24 @@ async fn download_bytes(url: &str) -> Result<Vec<u8>> {
         anyhow::bail!("Download failed: {}", response.status());
     }
 
-    Ok(response
-        .bytes()
-        .await
-        .context("Failed to read release asset body")?
-        .to_vec())
+    // Reject early if the advertised length already blows the cap.
+    if let Some(len) = response.content_length() {
+        if len > MAX_ASSET_BYTES as u64 {
+            anyhow::bail!("release asset is {len} bytes, exceeding the {MAX_ASSET_BYTES}-byte cap");
+        }
+    }
+
+    // Stream and enforce the cap even when Content-Length is absent or lies.
+    let mut buf = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.context("Failed to read release asset body")?;
+        if buf.len() + chunk.len() > MAX_ASSET_BYTES {
+            anyhow::bail!("release asset exceeds the {MAX_ASSET_BYTES}-byte cap");
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf)
 }
 
 /// Authenticate the raw bytes of `SHA256SUMS.txt` against the baked-in

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -731,10 +731,17 @@ impl UpdateCommand {
         // with no /Applications/Freenet.app (skeptical review H1).
         let _update_lock = acquire_update_lock()?;
 
-        let checksums = match release.assets.iter().find(|a| a.name == "SHA256SUMS.txt") {
-            Some(a) => download_checksums(&a.browser_download_url).await.ok(),
-            None => None,
-        };
+        // Authenticate the manifest signature before trusting any DMG
+        // checksum, exactly like the Linux/Windows binary path. Apple
+        // notarization only proves Apple accepted *some* bundle — it does NOT
+        // bind the DMG to this release's manifest, so without this an attacker
+        // who can serve the release assets could pair a forged SHA256SUMS.txt
+        // with an older/wrong but still-notarized DMG (a downgrade) and pass
+        // the checksum gate. A present-but-invalid signature returns Err here;
+        // the macOS caller treats that as "skip this update and retry next
+        // cycle" (never a lockout, and never a fall-through to binary-replace
+        // that would corrupt the signed bundle).
+        let checksums = self.download_and_verify_checksums(release).await?;
 
         let scratch = tempfile::tempdir().context("Failed to create temp directory")?;
         let dmg_path = scratch.path().join(&dmg_asset_name);
@@ -877,17 +884,6 @@ async fn get_latest_release() -> Result<Release> {
         .json::<Release>()
         .await
         .context("Failed to parse release info")
-}
-
-// macOS DMG path only: the Linux/Windows binary path now goes through
-// `download_and_verify_checksums`, which fetches the raw manifest bytes via
-// `download_bytes` so the same buffer can be both signature-verified and
-// parsed. The macOS DMG is independently Apple-signed + notarized, so its
-// checksum check stays as-is for now.
-#[cfg(target_os = "macos")]
-async fn download_checksums(url: &str) -> Result<Checksums> {
-    let bytes = download_bytes(url).await?;
-    Ok(Checksums::parse(&String::from_utf8_lossy(&bytes)))
 }
 
 /// Download a small release asset fully into memory. Used for the

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -15,6 +15,42 @@ use super::service::{generate_system_service_file, generate_user_service_file};
 
 const GITHUB_API_URL: &str = "https://api.github.com/repos/freenet/freenet-core/releases/latest";
 
+/// Ed25519 public key (raw 32-byte, little-endian compressed point) used to
+/// authenticate the release `SHA256SUMS.txt` manifest before any binary is
+/// installed. The matching private key lives only in the
+/// `FREENET_RELEASE_SIGNING_KEY` CI secret; the release workflow signs the
+/// raw manifest bytes with it and uploads `SHA256SUMS.txt.sig` alongside the
+/// manifest (see `.github/workflows/cross-compile.yml`).
+///
+/// Authenticating the manifest is what makes the existing fail-closed
+/// checksum gate trustworthy: the checksums verify the binary against the
+/// manifest, and this signature verifies the manifest against a key the
+/// attacker does not hold.
+///
+/// The hex form (pinned by `release_pubkey_matches_published_hex`) is:
+/// `eb2986604e34a3f985279a7e70852f3764d3347fe82074d92b1e4bc6336f8664`.
+const FREENET_RELEASE_PUBKEY: [u8; 32] = [
+    0xeb, 0x29, 0x86, 0x60, 0x4e, 0x34, 0xa3, 0xf9, 0x85, 0x27, 0x9a, 0x7e, 0x70, 0x85, 0x2f, 0x37,
+    0x64, 0xd3, 0x34, 0x7f, 0xe8, 0x20, 0x74, 0xd9, 0x2b, 0x1e, 0x4b, 0xc6, 0x33, 0x6f, 0x86, 0x64,
+];
+
+/// Whether a release MUST carry a valid `SHA256SUMS.txt.sig` for the install
+/// to proceed.
+///
+/// Two-release transition (do NOT flip this in the same release that first
+/// ships signing):
+///   * **false (now):** when the signature asset is PRESENT it is always
+///     verified and an invalid/mismatched signature refuses the install
+///     (fail-closed); when it is ABSENT the install is still allowed (with a
+///     warning) so a node can keep updating to/from older, unsigned release
+///     lineages that predate signing.
+///   * **true (a later release):** an absent signature ALSO refuses the
+///     install. Only flip this once every release a live node could be
+///     updating from publishes a signature — i.e. after the signed floor is
+///     established — otherwise nodes on the unsigned lineage brick their own
+///     auto-update.
+const REQUIRE_RELEASE_SIGNATURE: bool = false;
+
 /// Exit code returned when the binary is already up to date (no update performed).
 /// Used by the service wrapper to avoid unnecessary restarts.
 pub const EXIT_CODE_ALREADY_UP_TO_DATE: i32 = 2;
@@ -301,32 +337,25 @@ impl UpdateCommand {
 
         let fdev_asset = release.assets.iter().find(|a| a.name == fdev_asset_name);
 
-        // Try to download the SHA256SUMS.txt manifest. Checksum
-        // verification is MANDATORY (fail-closed) for the freenet binary
-        // install below — see the `required_checksum` gate. We still model
-        // acquisition as `Option` here so a manifest that is absent OR
-        // failed to download flows into the same single fail-closed gate
-        // (and so the best-effort fdev path can reuse it without aborting
-        // the whole run). Any specific download error is surfaced as a
-        // warning; the actual refusal-to-install happens at the gate.
-        let checksums = if let Some(checksums_asset) =
-            release.assets.iter().find(|a| a.name == "SHA256SUMS.txt")
-        {
-            if !self.quiet {
-                println!("Downloading checksums...");
-            }
-            match download_checksums(&checksums_asset.browser_download_url).await {
-                Ok(c) => Some(c),
-                Err(e) => {
-                    if !self.quiet {
-                        eprintln!("Warning: Failed to download checksums: {}.", e);
-                    }
-                    None
-                }
-            }
-        } else {
-            None
-        };
+        // Download the SHA256SUMS.txt manifest AND authenticate it with the
+        // baked-in release public key before trusting any hash inside it.
+        //
+        // Order matters: the signature authenticates the *manifest*, then the
+        // fail-closed `required_checksum` gate below verifies the *binary*
+        // against that now-trusted manifest. Without the signature step the
+        // checksum gate only proves the binary matches whatever manifest was
+        // served — which an attacker who can serve a manifest could forge.
+        //
+        // `download_and_verify_checksums` returns `None` when the manifest is
+        // absent or its download failed (the fail-closed `required_checksum`
+        // gate then refuses the install); it returns `Err` only for a
+        // signature that is present-but-invalid (or absent when signatures
+        // are required). That refusal, like the checksum gate, propagates out
+        // of `download_and_install` BEFORE the `replace_binary` install step
+        // (the only site that calls `record_update_failure`), so it is a
+        // retryable `OtherFailure` (-> `NoChange`), never a
+        // `MAX_UPDATE_FAILURES` lockout.
+        let checksums = self.download_and_verify_checksums(release).await?;
 
         let temp_dir = tempfile::tempdir().context("Failed to create temp directory")?;
 
@@ -500,6 +529,71 @@ impl UpdateCommand {
         }
 
         Ok(())
+    }
+
+    /// Download `SHA256SUMS.txt` and, when the release published it,
+    /// `SHA256SUMS.txt.sig`, returning the parsed checksums only after the
+    /// manifest has been authenticated against [`FREENET_RELEASE_PUBKEY`].
+    ///
+    /// Returns:
+    ///   * `Ok(Some(checksums))` — manifest downloaded and (per the
+    ///     transition policy) authenticated; callers feed this into the
+    ///     fail-closed `required_checksum` gate.
+    ///   * `Ok(None)` — the manifest asset is absent, or its download failed.
+    ///     The caller's `required_checksum` gate turns this into a fail-closed
+    ///     refusal for the freenet binary (and a skip for best-effort fdev).
+    ///   * `Err` — a signature was present but INVALID (tampering / wrong
+    ///     key), the signature asset existed but could not be downloaded, or
+    ///     a signature was required ([`REQUIRE_RELEASE_SIGNATURE`]) but
+    ///     absent. All are fail-closed refusals; because this runs before
+    ///     `replace_binary`, they are retryable `OtherFailure`s, not lockouts.
+    ///
+    /// The signature is verified over the EXACT bytes the checksums are parsed
+    /// from (same in-memory buffer), so there is no time-of-check/time-of-use
+    /// gap between "what was authenticated" and "what is trusted".
+    async fn download_and_verify_checksums(&self, release: &Release) -> Result<Option<Checksums>> {
+        let Some(checksums_asset) = release.assets.iter().find(|a| a.name == "SHA256SUMS.txt")
+        else {
+            // No manifest at all. Leave the fail-closed `required_checksum`
+            // gate to refuse the binary install; nothing to authenticate.
+            return Ok(None);
+        };
+
+        if !self.quiet {
+            println!("Downloading checksums...");
+        }
+        let manifest_bytes = match download_bytes(&checksums_asset.browser_download_url).await {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                if !self.quiet {
+                    eprintln!("Warning: Failed to download checksums: {}.", e);
+                }
+                return Ok(None);
+            }
+        };
+
+        // Fetch the detached signature when the release published one. If the
+        // asset exists but cannot be fetched, refuse rather than silently
+        // downgrading to an unverified install — a signed manifest whose
+        // signature we merely failed to retrieve must not be trusted.
+        let signature = match release
+            .assets
+            .iter()
+            .find(|a| a.name == "SHA256SUMS.txt.sig")
+        {
+            Some(sig_asset) => Some(
+                download_bytes(&sig_asset.browser_download_url)
+                    .await
+                    .context("Failed to download release signature SHA256SUMS.txt.sig")?,
+            ),
+            None => None,
+        };
+
+        verify_release_manifest_signature(&manifest_bytes, signature.as_deref(), self.quiet)?;
+
+        Ok(Some(Checksums::parse(&String::from_utf8_lossy(
+            &manifest_bytes,
+        ))))
     }
 
     /// Try to update fdev, printing warnings on failure. Never returns an error —
@@ -785,7 +879,23 @@ async fn get_latest_release() -> Result<Release> {
         .context("Failed to parse release info")
 }
 
+// macOS DMG path only: the Linux/Windows binary path now goes through
+// `download_and_verify_checksums`, which fetches the raw manifest bytes via
+// `download_bytes` so the same buffer can be both signature-verified and
+// parsed. The macOS DMG is independently Apple-signed + notarized, so its
+// checksum check stays as-is for now.
+#[cfg(target_os = "macos")]
 async fn download_checksums(url: &str) -> Result<Checksums> {
+    let bytes = download_bytes(url).await?;
+    Ok(Checksums::parse(&String::from_utf8_lossy(&bytes)))
+}
+
+/// Download a small release asset fully into memory. Used for the
+/// `SHA256SUMS.txt` manifest and its `.sig` detached signature, where the
+/// caller needs the exact bytes (to verify a signature over them, or to feed
+/// to `Signature::from_bytes`) rather than streaming to a file like
+/// [`download_file`].
+async fn download_bytes(url: &str) -> Result<Vec<u8>> {
     let client = reqwest::Client::builder()
         .user_agent("freenet-updater")
         .build()?;
@@ -794,14 +904,102 @@ async fn download_checksums(url: &str) -> Result<Checksums> {
         .get(url)
         .send()
         .await
-        .context("Failed to download checksums")?;
+        .context("Failed to download release asset")?;
 
     if !response.status().is_success() {
-        anyhow::bail!("Failed to download checksums: {}", response.status());
+        anyhow::bail!("Download failed: {}", response.status());
     }
 
-    let content = response.text().await.context("Failed to read checksums")?;
-    Ok(Checksums::parse(&content))
+    Ok(response
+        .bytes()
+        .await
+        .context("Failed to read release asset body")?
+        .to_vec())
+}
+
+/// Authenticate the raw bytes of `SHA256SUMS.txt` against the baked-in
+/// [`FREENET_RELEASE_PUBKEY`], applying the [`REQUIRE_RELEASE_SIGNATURE`]
+/// transition policy. Thin wrapper over [`verify_manifest_signature_with`] so
+/// the policy core (pubkey + require flag injectable) is unit-testable without
+/// the real signing key and on every target OS.
+fn verify_release_manifest_signature(
+    manifest_bytes: &[u8],
+    signature: Option<&[u8]>,
+    quiet: bool,
+) -> Result<()> {
+    verify_manifest_signature_with(
+        manifest_bytes,
+        signature,
+        &FREENET_RELEASE_PUBKEY,
+        REQUIRE_RELEASE_SIGNATURE,
+        quiet,
+    )
+}
+
+/// Policy core for release-manifest signature verification. Pure (no I/O) and
+/// fully parameterised so tests can exercise every branch — valid signature,
+/// tampered manifest, wrong key, absent signature under both policies —
+/// without ever touching the real private key.
+///
+/// Fail-closed contract:
+///   * signature PRESENT  -> `verify_strict`; any failure (tamper, wrong key,
+///     malformed length) returns `Err` (refuse the install).
+///   * signature ABSENT   -> `Err` iff `require_signature`, else `Ok` with a
+///     warning (the transition allowance for unsigned older lineages).
+fn verify_manifest_signature_with(
+    manifest_bytes: &[u8],
+    signature: Option<&[u8]>,
+    pubkey: &[u8; 32],
+    require_signature: bool,
+    quiet: bool,
+) -> Result<()> {
+    use ed25519_dalek::{Signature, VerifyingKey};
+
+    let Some(sig_bytes) = signature else {
+        if require_signature {
+            anyhow::bail!(
+                "Release is missing SHA256SUMS.txt.sig but a release signature is required; \
+                 refusing to install. The release must publish a signed checksum manifest."
+            );
+        }
+        if !quiet {
+            eprintln!(
+                "Warning: release did not publish SHA256SUMS.txt.sig; \
+                 installing without release-signature verification."
+            );
+        }
+        return Ok(());
+    };
+
+    // ed25519 signatures are exactly 64 bytes. A wrong length means the asset
+    // is truncated or not a raw signature — refuse rather than guess.
+    let sig_array: [u8; 64] = sig_bytes.try_into().map_err(|_| {
+        anyhow::anyhow!(
+            "Release signature has wrong length ({} bytes, expected 64); refusing to install.",
+            sig_bytes.len()
+        )
+    })?;
+    let parsed_signature = Signature::from_bytes(&sig_array);
+
+    let verifying_key = VerifyingKey::from_bytes(pubkey)
+        .context("Baked-in release public key is invalid; refusing to install")?;
+
+    // `verify_strict` rejects non-canonical / small-order points (the same
+    // hardening the website contract uses). A failure here means the manifest
+    // was tampered with or signed by a key we don't trust: fail closed.
+    verifying_key
+        .verify_strict(manifest_bytes, &parsed_signature)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Release signature verification failed: {e}. The checksum manifest may be \
+                 corrupted or tampered with; refusing to install."
+            )
+        })?;
+
+    if !quiet {
+        println!("Verified release signature.");
+    }
+    Ok(())
 }
 
 /// Resolve the expected SHA-256 for a REQUIRED install artifact,
@@ -3199,6 +3397,271 @@ done
             "no record_update_failure may run between the checksum gate and \
              replace_binary — a checksum refusal must stay a retryable \
              OtherFailure, not a MAX_UPDATE_FAILURES lockout"
+        );
+    }
+
+    // ---- Ed25519 release-manifest signing + verification (auto-update). ----
+    //
+    // The release workflow signs the raw bytes of SHA256SUMS.txt with the
+    // private half of FREENET_RELEASE_PUBKEY (openssl, raw ed25519) and
+    // uploads SHA256SUMS.txt.sig. The binary verifies that signature over the
+    // exact manifest bytes before trusting any checksum inside it. These tests
+    // pin: (a) the baked-in key matches the published hex, (b) the
+    // CI-openssl-sign <-> binary-dalek-verify interop is real, and (c) the
+    // fail-closed + transition policy of `verify_manifest_signature_with`.
+    //
+    // None of these tests use the real private key — they sign with throwaway
+    // keys (openssl-generated or dalek `from_bytes` with a fixed test seed).
+
+    /// A deterministic dalek signing key built from a fixed test seed. Never
+    /// the real release key. Returns (signing_key, raw 32-byte verifying key).
+    fn test_signing_key(seed: u8) -> (ed25519_dalek::SigningKey, [u8; 32]) {
+        let sk = ed25519_dalek::SigningKey::from_bytes(&[seed; 32]);
+        let vk = sk.verifying_key().to_bytes();
+        (sk, vk)
+    }
+
+    fn dalek_sign(sk: &ed25519_dalek::SigningKey, msg: &[u8]) -> [u8; 64] {
+        use ed25519_dalek::Signer;
+        sk.sign(msg).to_bytes()
+    }
+
+    const SAMPLE_MANIFEST: &[u8] =
+        b"abc123  freenet-x86_64-unknown-linux-musl.tar.gz\ndef456  fdev-x86_64-unknown-linux-musl.tar.gz\n";
+
+    #[test]
+    fn release_pubkey_matches_published_hex() {
+        // Pins the baked-in key to the documented hex. A copy-paste slip in
+        // the byte array would otherwise silently make every signature fail
+        // (or, worse, trust the wrong key).
+        let expected =
+            hex::decode("eb2986604e34a3f985279a7e70852f3764d3347fe82074d92b1e4bc6336f8664")
+                .unwrap();
+        assert_eq!(FREENET_RELEASE_PUBKEY.as_slice(), expected.as_slice());
+        // Must be a valid ed25519 point, or verification could never succeed.
+        ed25519_dalek::VerifyingKey::from_bytes(&FREENET_RELEASE_PUBKEY)
+            .expect("baked-in release public key must be a valid ed25519 point");
+    }
+
+    #[test]
+    fn transition_flag_is_false_until_signed_floor_established() {
+        // Tripwire for the two-release rollout. Flipping this to `true` makes
+        // an ABSENT signature refuse the install, which bricks auto-update for
+        // any node still updating from an unsigned older release. Only flip it
+        // (and then update this test) once every release a live node could be
+        // updating from publishes SHA256SUMS.txt.sig. See REQUIRE_RELEASE_SIGNATURE.
+        assert!(
+            !REQUIRE_RELEASE_SIGNATURE,
+            "do not require signatures until the signed floor is established; \
+             see the two-release transition note on REQUIRE_RELEASE_SIGNATURE"
+        );
+    }
+
+    #[test]
+    fn valid_signature_accepted() {
+        let (sk, vk) = test_signing_key(7);
+        let sig = dalek_sign(&sk, SAMPLE_MANIFEST);
+        verify_manifest_signature_with(SAMPLE_MANIFEST, Some(&sig), &vk, false, true)
+            .expect("a valid signature over the manifest must be accepted");
+        // Also accepted when signatures are required.
+        verify_manifest_signature_with(SAMPLE_MANIFEST, Some(&sig), &vk, true, true)
+            .expect("a valid signature must be accepted even when required");
+    }
+
+    #[test]
+    fn tampered_manifest_rejected() {
+        let (sk, vk) = test_signing_key(7);
+        let sig = dalek_sign(&sk, SAMPLE_MANIFEST);
+        let mut tampered = SAMPLE_MANIFEST.to_vec();
+        tampered[0] ^= 0x01; // flip one bit of the first checksum
+        let err = verify_manifest_signature_with(&tampered, Some(&sig), &vk, false, true)
+            .expect_err("a signature over different bytes must be refused (fail-closed)");
+        assert!(
+            err.to_string().contains("refusing to install"),
+            "tamper rejection must refuse the install, got: {err}"
+        );
+    }
+
+    #[test]
+    fn wrong_key_signature_rejected() {
+        // Signed by key A, verified against key B's public key.
+        let (sk_a, _vk_a) = test_signing_key(1);
+        let (_sk_b, vk_b) = test_signing_key(2);
+        let sig = dalek_sign(&sk_a, SAMPLE_MANIFEST);
+        let err = verify_manifest_signature_with(SAMPLE_MANIFEST, Some(&sig), &vk_b, false, true)
+            .expect_err("a signature from an untrusted key must be refused (fail-closed)");
+        assert!(err.to_string().contains("refusing to install"));
+    }
+
+    #[test]
+    fn malformed_signature_length_rejected() {
+        let (_sk, vk) = test_signing_key(3);
+        let short = [0u8; 63];
+        let err = verify_manifest_signature_with(SAMPLE_MANIFEST, Some(&short), &vk, false, true)
+            .expect_err("a wrong-length signature must be refused");
+        assert!(err.to_string().contains("wrong length"));
+    }
+
+    #[test]
+    fn absent_signature_allowed_when_not_required() {
+        // Transition behaviour: no .sig published -> allowed (with a warning).
+        verify_manifest_signature_with(SAMPLE_MANIFEST, None, &FREENET_RELEASE_PUBKEY, false, true)
+            .expect("absent signature must be allowed while not required");
+    }
+
+    #[test]
+    fn absent_signature_refused_when_required() {
+        // Post-transition behaviour: no .sig published -> refuse.
+        let err = verify_manifest_signature_with(
+            SAMPLE_MANIFEST,
+            None,
+            &FREENET_RELEASE_PUBKEY,
+            true,
+            true,
+        )
+        .expect_err("absent signature must be refused once signatures are required");
+        assert!(err.to_string().contains("refusing to install"));
+    }
+
+    /// Committed openssl-produced fixture: a raw ed25519 signature generated by
+    /// `openssl pkeyutl -sign -rawin` (the exact command CI uses) over a fixed
+    /// message, with the raw public key extracted from the openssl DER SPKI.
+    /// Verifying it through the binary's dalek path proves openssl <-> dalek
+    /// interop CONCRETELY and HERMETICALLY — no openssl needed at test time, so
+    /// CI always exercises the cross-implementation guarantee.
+    ///
+    /// Regenerate with:
+    ///   openssl genpkey -algorithm ed25519 -out k.pem
+    ///   printf 'freenet-release-interop-fixture-v1\n' > m.txt
+    ///   openssl pkeyutl -sign -inkey k.pem -rawin -in m.txt -out m.sig
+    ///   openssl pkey -in k.pem -pubout -outform DER | tail -c 32 | xxd -p -c64  # pubkey
+    ///   xxd -p -c64 m.sig                                                       # signature
+    #[test]
+    fn openssl_fixture_verifies_via_dalek() {
+        const FIXTURE_MSG: &[u8] = b"freenet-release-interop-fixture-v1\n";
+        let pubkey: [u8; 32] =
+            hex::decode("998007f01e8bd34d736017398822ce214bf78b81a2015e2e5e8de94d9c0cd2ae")
+                .unwrap()
+                .try_into()
+                .unwrap();
+        let sig =
+            hex::decode("062a3ae0db73cc41fcd73f2cbb29eb0cf0cdd9420bb49db7d204ddec8803e81a5aa653b68c13105fd12ee996e8a9ba5eb553ec310133c6913756dbef437b1f0a")
+                .unwrap();
+
+        verify_manifest_signature_with(FIXTURE_MSG, Some(&sig), &pubkey, true, true)
+            .expect("openssl-produced raw ed25519 signature must verify via the dalek path");
+
+        // And the fixture must fail closed if the message is altered, proving
+        // the verification is actually binding the openssl signature to the
+        // message bytes (not trivially passing).
+        let mut tampered = FIXTURE_MSG.to_vec();
+        tampered.push(b'!');
+        assert!(
+            verify_manifest_signature_with(&tampered, Some(&sig), &pubkey, true, true).is_err(),
+            "altering the fixture message must refuse (fail-closed)"
+        );
+    }
+
+    /// Live interop: generate a throwaway ed25519 key with openssl, sign a
+    /// sample SHA256SUMS the SAME way CI will (`pkeyutl -sign -rawin`), then
+    /// verify the resulting 64-byte signature through the binary's exact dalek
+    /// path. This is the proof the user most needs: CI-openssl-sign <->
+    /// binary-dalek-verify actually interoperate on this machine.
+    ///
+    /// Skips (does not fail) only when openssl is absent or too old for raw
+    /// ed25519 signing — the hermetic `openssl_fixture_verifies_via_dalek`
+    /// test still guarantees the interop in that case.
+    #[test]
+    fn interop_openssl_sign_dalek_verify() {
+        use std::process::Command;
+
+        // Environmental availability check: a missing/old openssl is a skip,
+        // not a failure (the committed fixture covers interop unconditionally).
+        let openssl_ok = Command::new("openssl")
+            .arg("version")
+            .output()
+            .ok()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !openssl_ok {
+            eprintln!("skipping interop_openssl_sign_dalek_verify: openssl not available");
+            return;
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key_pem = dir.path().join("key.pem");
+        let msg = dir.path().join("SHA256SUMS.txt");
+        let sig = dir.path().join("SHA256SUMS.txt.sig");
+        let pub_der = dir.path().join("pub.der");
+
+        std::fs::write(&msg, SAMPLE_MANIFEST).unwrap();
+
+        let genkey = Command::new("openssl")
+            .args(["genpkey", "-algorithm", "ed25519", "-out"])
+            .arg(&key_pem)
+            .output()
+            .expect("spawn openssl genpkey");
+        if !genkey.status.success() {
+            eprintln!(
+                "skipping interop_openssl_sign_dalek_verify: openssl genpkey ed25519 unsupported"
+            );
+            return;
+        }
+
+        // The exact signing invocation the CI workflow uses.
+        let sign = Command::new("openssl")
+            .arg("pkeyutl")
+            .arg("-sign")
+            .arg("-inkey")
+            .arg(&key_pem)
+            .arg("-rawin")
+            .arg("-in")
+            .arg(&msg)
+            .arg("-out")
+            .arg(&sig)
+            .output()
+            .expect("spawn openssl pkeyutl sign");
+        if !sign.status.success() {
+            eprintln!(
+                "skipping interop_openssl_sign_dalek_verify: openssl raw ed25519 sign unsupported \
+                 (needs openssl >= 3.0)"
+            );
+            return;
+        }
+
+        // Extract the raw 32-byte public key: the ed25519 DER SubjectPublicKeyInfo
+        // is a fixed 12-byte prefix followed by the 32-byte key.
+        let pubout = Command::new("openssl")
+            .args(["pkey", "-pubout", "-outform", "DER", "-in"])
+            .arg(&key_pem)
+            .arg("-out")
+            .arg(&pub_der)
+            .output()
+            .expect("spawn openssl pkey pubout");
+        assert!(pubout.status.success(), "openssl pkey -pubout must succeed");
+
+        let der = std::fs::read(&pub_der).unwrap();
+        assert!(der.len() >= 32, "DER SPKI must contain a 32-byte key");
+        let pubkey: [u8; 32] = der[der.len() - 32..].try_into().unwrap();
+
+        let sig_bytes = std::fs::read(&sig).unwrap();
+        assert_eq!(
+            sig_bytes.len(),
+            64,
+            "openssl raw ed25519 signature must be exactly 64 bytes"
+        );
+
+        // The real interop assertion: openssl-signed, dalek-verified.
+        verify_manifest_signature_with(SAMPLE_MANIFEST, Some(&sig_bytes), &pubkey, true, true)
+            .expect("openssl-signed manifest must verify through the binary's dalek path");
+
+        // Fail-closed under tampering, end to end.
+        let mut tampered = SAMPLE_MANIFEST.to_vec();
+        tampered[0] ^= 0x01;
+        assert!(
+            verify_manifest_signature_with(&tampered, Some(&sig_bytes), &pubkey, true, true)
+                .is_err(),
+            "a tampered manifest must be refused even with a valid openssl signature"
         );
     }
 }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -63,6 +63,12 @@ a `::warning::` annotation telling you what to fix.
 | `MATRIX_ACCESS_TOKEN` | release-announce.yml | Matrix job warns + skips. |
 | `RELEASE_AGENT_HMAC_NOVA` | gateway-update.yml, release-announce.yml | nova update + River announce fail (HTTP 401). |
 | `RELEASE_AGENT_HMAC_VEGA` | gateway-update.yml | vega update fails (HTTP 401). |
+| `FREENET_RELEASE_SIGNING_KEY` | cross-compile.yml (`Sign SHA256SUMS.txt`) | Releases are UNSIGNED (no `SHA256SUMS.txt.sig` attached). Clients accept unsigned releases during the transition window (`REQUIRE_RELEASE_SIGNATURE = false`), but once that flag is flipped to `true` in a future release, unsigned releases are REFUSED by the auto-updater. PEM-encoded ed25519 private key whose public half is baked into the updater (`update.rs` `FREENET_RELEASE_PUBKEY`). |
+
+To validate `FREENET_RELEASE_SIGNING_KEY` without cutting a release, run the
+`Build and Cross-Compile` workflow via `workflow_dispatch`: its
+`verify-signing-key` job derives the public key from the secret, asserts it
+matches the key baked into the binary, and does a sign/verify round-trip.
 
 `RELEASE_PAT` is a personal access token with `repo` (Contents, Pull
 requests, Metadata) and `workflow` scopes. See AGENTS.md → "Release Workflow


### PR DESCRIPTION
## Problem

Auto-update integrity is checksum-only. #4586 made the `SHA256SUMS.txt`
checksum gate fail-closed, but the manifest itself is unauthenticated: the
checksums only prove a downloaded binary matches whatever `SHA256SUMS.txt`
was served, not that the manifest is genuine. Anyone able to serve the
release assets to a node could pair a forged manifest with a forged binary
and pass the checksum gate. This adds the missing authenticity layer.

## Solution

A signature layer on top of #4586's checksum gate.

**CI signing** (`.github/workflows/cross-compile.yml`): after generating
`SHA256SUMS.txt`, sign its raw bytes with the release private key
(`FREENET_RELEASE_SIGNING_KEY` secret) using openssl raw ed25519
(`pkeyutl -sign -rawin`), producing a 64-byte detached signature uploaded
as `SHA256SUMS.txt.sig`. The key is written to a `0600` temp PEM, never
echoed, and shredded (with a cleanup trap on every exit path). A missing
secret degrades gracefully (warns; unsigned release) so the release is not
blocked during rollout.

**Binary verification** (`crates/core/src/bin/commands/update.rs`): the
release public key is baked in (`FREENET_RELEASE_PUBKEY`). The updater
downloads `SHA256SUMS.txt` and, when present, `SHA256SUMS.txt.sig`; it
verifies the signature over the **exact** manifest bytes with
`ed25519-dalek` `verify_strict`, then parses the checksums from those same
bytes (no time-of-check/time-of-use gap), and only then does the existing
fail-closed checksum gate verify the binary against the now-authenticated
manifest before install.

**Transition policy** (`REQUIRE_RELEASE_SIGNATURE = false`): when a
signature is present it is always verified and any invalid / mismatched /
wrong-length signature refuses the install (fail-closed); when absent the
install is still allowed (with a warning) so nodes can keep updating
to/from older unsigned release lineages. The flag flips to `true` in a
later release once the signed floor is established (a two-release rollout,
documented in code). All refusals propagate **before** `replace_binary`,
so they classify as a retryable `OtherFailure` -> `NoChange`, never a
`MAX_UPDATE_FAILURES` lockout (same property as #4586's checksum refusal).

The macOS DMG-bundle path keeps its checksum-only check for now; that
artifact is independently Apple-signed + notarized. The non-bundle binary
path on macOS goes through the new verification.

## Testing

- **Interop (the key guarantee):** a live test shells out to openssl to
  sign a sample manifest exactly as CI does (`pkeyutl -sign -rawin`), then
  verifies via the binary's `ed25519-dalek` path — proving
  openssl-sign <-> dalek-verify interop (raw 64-byte sig, message = exact
  bytes). A committed, hermetic openssl-produced fixture (test pubkey + a
  real openssl signature over a fixed message) is verified the same way so
  CI proves the interop even when openssl is absent at test time.
- **Unit tests:** valid signature accepted; tampered manifest rejected;
  wrong-key rejected; malformed-length rejected; absent signature allowed
  under `REQUIRE_RELEASE_SIGNATURE=false` and refused when `true`; baked-in
  pubkey matches the published hex; transition-flag tripwire.
- `cargo fmt` + `cargo clippy -- -D warnings` clean; full `freenet` binary
  test suite green (252 passed). No real private key is used in any test.

## Workflow dry-run (before relying on it)

A dedicated `verify-signing-key` job runs on `workflow_dispatch` only and is
the intended dry-run. It has no side effects (uploads nothing): it derives the
public key from the `FREENET_RELEASE_SIGNING_KEY` secret, asserts it matches
the public key baked into the binary, and does a full openssl sign/verify
round-trip with the exact command the release uses. This catches the worst
failure mode (a secret/baked-in-key mismatch would make every client reject
every release) before a real release relies on it.

Run it:

```
gh workflow run cross-compile.yml --ref feat/sign-release-artifacts
```

then check the "Verify release signing key (dry-run)" job output.

Note: the actual signing step lives in the tag-gated `attach-to-release` job,
so a plain `workflow_dispatch` does not exercise the upload path itself — only
the real signing mechanics + key correspondence (which is what matters before
trusting it). End-to-end upload + client-verify is validated on a real release
tag (and can be confirmed locally: reconstruct the DER SPKI from the 32-byte
pubkey and `openssl pkeyutl -verify -pubin -rawin -in SHA256SUMS.txt -sigfile
SHA256SUMS.txt.sig`).

Refs #4073

[AI-assisted - Claude]
