### PR TITLE
fix: distinguish fast-crash from update exit to bound #4551 crash loops

### DIFF
--- a/crates/core/src/bin/commands/auto_update.rs
+++ b/crates/core/src/bin/commands/auto_update.rs
@@ -43,6 +43,21 @@ pub const EXIT_CODE_UPDATE_NEEDED: i32 = 42;
 /// operator, loudly, when an update was detected but will not be applied.
 pub const SUPERVISED_ENV_VAR: &str = "FREENET_SUPERVISED";
 
+/// Environment variable set ONLY by the freshly-generated Freenet **systemd** units
+/// (see `service/linux.rs`) on the `freenet network` child. Its presence is positive
+/// evidence that the supervising unit understands the distinct fast-crash exit code
+/// 45 (#4551): the unit keeps 45 OUT of `SuccessExitStatus` (so it counts toward
+/// `StartLimitBurst`), sets `StartLimitAction=none`, and fires `ExecStopPost`
+/// `freenet update` on exit 42 OR 45.
+///
+/// The node entry point gates [`freenet::enable_fast_crash_exit_code`] on this
+/// marker. Unlike [`SUPERVISED_ENV_VAR`], the macOS/Windows run-wrapper does NOT set
+/// it (the wrapper only understands exit 42), and an OLD systemd unit (e.g. a node
+/// auto-updated to a 45-aware binary but whose unit file was never regenerated) won't
+/// have it either — so in those cases the node keeps emitting the burst-exempt
+/// self-healing exit 42 rather than a 45 the supervisor would mishandle.
+pub const SYSTEMD_FAST_CRASH_ENV_VAR: &str = "FREENET_SYSTEMD_FAST_CRASH";
+
 /// Whether the running node appears to be under a supervisor that will catch
 /// exit code 42 and apply the update.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -460,6 +460,54 @@ mod tests {
     use super::wrapper::*;
     use std::path::PathBuf;
 
+    /// Return the section header (e.g. `[Unit]`, `[Service]`) that a given `key=`
+    /// directive line appears under in a generated systemd unit, or `None` if the
+    /// directive is absent. Comment lines (`# ...`) and the directive's value are
+    /// ignored — only a line that *starts* with `{key}=` counts.
+    ///
+    /// Used to assert `StartLimitAction` lives in `[Unit]` (#4551): systemd SILENTLY
+    /// IGNORES the `StartLimit*` directives when placed in `[Service]`, so a substring
+    /// check that only proves the key *exists* would pass even with the limiter knob
+    /// disabled. (The `[Unit]` placement of `StartLimitBurst`/`StartLimitIntervalSec`
+    /// themselves is asserted by the linux.rs unit tests added in #4570.)
+    #[cfg(target_os = "linux")]
+    fn section_of_directive(unit: &str, key: &str) -> Option<String> {
+        let prefix = format!("{key}=");
+        let mut current: Option<String> = None;
+        for line in unit.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with('[') && trimmed.ends_with(']') && !trimmed.contains(' ') {
+                current = Some(trimmed.to_string());
+            } else if trimmed.starts_with(&prefix) {
+                return current;
+            }
+        }
+        None
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn section_of_directive_parses_sections() {
+        let unit = "[Unit]\nDescription=x\nStartLimitBurst=5\n\n[Service]\nType=simple\n# StartLimitBurst=99 in a comment must be ignored\nExecStart=/bin/freenet network\n";
+        assert_eq!(
+            section_of_directive(unit, "Description").as_deref(),
+            Some("[Unit]")
+        );
+        assert_eq!(
+            section_of_directive(unit, "StartLimitBurst").as_deref(),
+            Some("[Unit]")
+        );
+        assert_eq!(
+            section_of_directive(unit, "Type").as_deref(),
+            Some("[Service]")
+        );
+        assert_eq!(
+            section_of_directive(unit, "ExecStart").as_deref(),
+            Some("[Service]")
+        );
+        assert_eq!(section_of_directive(unit, "Nonexistent"), None);
+    }
+
     #[test]
     fn command_line_args_strips_quoted_executable_path() {
         assert_eq!(
@@ -1117,9 +1165,35 @@ mod tests {
         assert!(service_content.contains("Restart=always"));
         assert!(service_content.contains("RestartSec=10"));
 
-        // Verify restart loop prevention (limits consecutive failures)
+        // Verify restart loop prevention (limits consecutive failures).
+        // StartLimitBurst/StartLimitIntervalSec are present and [Unit]-placed; their
+        // section placement is asserted by the linux.rs unit tests added in #4570
+        // (user_unit_places_start_limit_directives_in_unit_section). Here we only
+        // assert this PR's additions: StartLimitAction placement + the exit-45 guard.
         assert!(service_content.contains("StartLimitBurst=5"));
         assert!(service_content.contains("StartLimitIntervalSec=120"));
+        // #4551: StartLimitAction MUST also be in [Unit]; systemd SILENTLY IGNORES
+        // it in [Service] (same trap as StartLimitBurst). StartLimitAction=none stops
+        // (does not reboot) the host on a tripped loop.
+        assert_eq!(
+            section_of_directive(&service_content, "StartLimitAction").as_deref(),
+            Some("[Unit]"),
+            "StartLimitAction must be in [Unit] (#4551)"
+        );
+        assert!(
+            service_content.contains("StartLimitAction=none"),
+            "StartLimitAction=none keeps a tripped crash-loop as a stopped unit rather \
+             than rebooting the host (#4551)"
+        );
+        // The 45 fast-crash code (crate::node::p2p_impl) must NOT be whitelisted by
+        // SuccessExitStatus, or a boot-wedge loop would never count toward the burst.
+        assert!(
+            !service_content.contains("SuccessExitStatus=42 43 45")
+                && !service_content.contains("SuccessExitStatus=42 45 43")
+                && !service_content.contains("SuccessExitStatus=45"),
+            "exit 45 (fast-crash) must stay OUT of SuccessExitStatus so it counts \
+             toward StartLimitBurst (#4551)"
+        );
 
         // Verify auto-update support via ExecStopPost. The `$EXIT_STATUS` systemd
         // sets in the ExecStopPost environment must reach /bin/sh as a literal
@@ -1132,6 +1206,29 @@ mod tests {
                 && service_content.contains("\"$$EXIT_STATUS\""),
             "ExecStopPost must use the doubled $$EXIT_STATUS so systemd passes a \
              literal $EXIT_STATUS to sh (a single-$ revert silently breaks auto-update)"
+        );
+        // #4551: ExecStopPost must fire `freenet update` for BOTH exit 42 (healthy
+        // node hit a fault/update) AND exit 45 (fast boot-crash) — firing on 45
+        // preserves the #4549 self-heal for a boot-crash a newer release fixes, while
+        // 45 staying out of SuccessExitStatus still counts it toward StartLimitBurst.
+        // A `case` (not `&&`/`||`) avoids shell-precedence pitfalls.
+        assert!(
+            service_content.contains("case \"$$EXIT_STATUS\" in 42|45)")
+                && service_content.contains("update --quiet"),
+            "ExecStopPost must run `freenet update` for exit 42 OR 45 via a case \
+             statement (boot-crash self-heal preserved; #4551)"
+        );
+        // #4551: the unit must advertise fast-crash (exit-45) support via the marker
+        // env var the node gates on. Using the const (not a literal) pins template,
+        // entry-point check, and test to one source of truth so they can't drift —
+        // a drift would silently disable exit 45 (node never opts in).
+        assert!(
+            service_content.contains(&format!(
+                "Environment={}=1",
+                super::super::auto_update::SYSTEMD_FAST_CRASH_ENV_VAR
+            )),
+            "user unit must set the {} marker so the node opts in to exit 45 (#4551)",
+            super::super::auto_update::SYSTEMD_FAST_CRASH_ENV_VAR
         );
 
         // Verify exit code 42 is treated as success (doesn't count against StartLimitBurst)
@@ -1190,6 +1287,20 @@ mod tests {
         assert!(service_content.contains("Restart=always"));
         assert!(service_content.contains("StartLimitBurst=5"));
         assert!(service_content.contains("StartLimitIntervalSec=120"));
+        // StartLimitBurst/IntervalSec [Unit] placement is asserted by #4570's linux.rs
+        // tests (system_unit_places_start_limit_directives_in_unit_section). Here we
+        // assert this PR's additions: StartLimitAction placement + the exit-45 guard.
+        assert_eq!(
+            section_of_directive(&service_content, "StartLimitAction").as_deref(),
+            Some("[Unit]"),
+            "StartLimitAction must be in [Unit] (#4551)"
+        );
+        assert!(service_content.contains("StartLimitAction=none"));
+        assert!(
+            !service_content.contains("SuccessExitStatus=42 43 45")
+                && !service_content.contains("SuccessExitStatus=45"),
+            "exit 45 (fast-crash) must stay OUT of SuccessExitStatus (#4551)"
+        );
         assert!(service_content.contains("LimitNOFILE=65536"));
         // ExecStopPost must double the env var (`$$EXIT_STATUS`) so systemd passes a
         // literal `$EXIT_STATUS` to sh; a single-`$` revert silently breaks auto-update.
@@ -1197,6 +1308,22 @@ mod tests {
             service_content.contains("ExecStopPost=")
                 && service_content.contains("\"$$EXIT_STATUS\""),
             "ExecStopPost must use the doubled $$EXIT_STATUS (single-$ revert breaks auto-update)"
+        );
+        // #4551: ExecStopPost fires `freenet update` for exit 42 OR 45 (system unit too).
+        assert!(
+            service_content.contains("case \"$$EXIT_STATUS\" in 42|45)")
+                && service_content.contains("update --quiet"),
+            "ExecStopPost must run `freenet update` for exit 42 OR 45 via a case \
+             statement (boot-crash self-heal preserved; #4551)"
+        );
+        // #4551: system unit must also set the fast-crash (exit-45) support marker.
+        assert!(
+            service_content.contains(&format!(
+                "Environment={}=1",
+                super::super::auto_update::SYSTEMD_FAST_CRASH_ENV_VAR
+            )),
+            "system unit must set the {} marker so the node opts in to exit 45 (#4551)",
+            super::super::auto_update::SYSTEMD_FAST_CRASH_ENV_VAR
         );
 
         // Verify exit code 42 is treated as success (doesn't count against StartLimitBurst)

--- a/crates/core/src/bin/commands/service/linux.rs
+++ b/crates/core/src/bin/commands/service/linux.rs
@@ -264,11 +264,28 @@ Description=Freenet Node
 Documentation=https://freenet.org
 After=network-online.target
 Wants=network-online.target
-# Stop restart loop after 5 failures in 2 minutes (e.g., port conflict with
-# a stale process). Without this, systemd restarts indefinitely.
-# SuccessExitStatus=42 ensures auto-update exits don't count as failures.
+# Crash-loop rate limiting (issue #4551). StartLimitBurst / StartLimitIntervalSec
+# are [Unit]-section directives (#4570 moved them here from [Service], where systemd
+# SILENTLY IGNORES them — which had disabled the limiter entirely, so with
+# Restart=always + RestartSec=10 a crashing node restarted every ~10s forever).
+#
+# Only a RAPID loop trips this: more than 5 starts within 120s. A legitimate
+# single restart (auto-update, an occasional reboot, a one-off crash) is nowhere
+# near 5-in-120s and is never penalised. A boot-wedge / fast crash exits 45 (a
+# counted failure — see SuccessExitStatus in [Service]), so a tight no-fix loop of
+# those trips the limiter and the unit stops; a node that ran healthily first
+# exits the burst-exempt code 42 (see crate::node::p2p_impl). BOTH 42 and 45 still
+# fire the ExecStopPost `freenet update` self-heal in [Service], so a boot-crash
+# that a newer release fixes recovers even though exit 45 is counted.
+#
+# StartLimitAction=none (the default, made explicit) STOPS the unit on trip (it
+# enters "failed") rather than rebooting the host — the desired terminal state
+# for a crash loop: better than looping forever, and loud to the operator.
+# Recover with `systemctl reset-failed freenet && systemctl start freenet` (the
+# lockout also clears on the next reboot / `freenet update`).
 StartLimitBurst=5
 StartLimitIntervalSec=120
+StartLimitAction=none
 
 [Service]
 Type=simple
@@ -278,6 +295,13 @@ Type=simple
 # systemd also sets INVOCATION_ID for every service, which the node detects as a
 # fallback; this makes the intent explicit and robust.
 Environment=FREENET_SUPERVISED=1
+# #4551: advertise to the node that THIS unit understands the fast-crash exit code
+# 45 — it keeps 45 out of SuccessExitStatus (so 45 counts toward StartLimitBurst),
+# sets StartLimitAction=none, and runs `freenet update` on exit 42 OR 45. The node
+# emits 45 only when it sees this marker, so a binary running under an OLD unit
+# (auto-updated but not reinstalled) or the mac/Windows wrapper keeps emitting the
+# self-healing exit 42 instead of a 45 the supervisor would mishandle.
+Environment={fast_crash_marker}=1
 # Stale-orphan self-heal (issue #3967): RestartPreventExitStatus=43 below
 # means an exit 43 ("another instance already running") never restarts the
 # unit. That is correct for a legitimate second instance, but if the port
@@ -305,7 +329,8 @@ Environment=FREENET_SUPERVISED=1
 ExecStartPre=-/bin/sh -c 'self=$$$$; ondisk=$$(timeout 5 {binary} --version 2>/dev/null | grep "^Freenet version:"); for pid in $$(pgrep -f -u "$$(id -u)" "freenet network" 2>/dev/null); do [ "$$pid" = "$$self" ] && continue; [ "$$pid" = "1" ] && continue; exe=$$(readlink -f /proc/$$pid/exe 2>/dev/null); hv=""; [ -x "$$exe" ] && hv=$$(timeout 5 "$$exe" --version 2>/dev/null | grep "^Freenet version:"); ppid=$$(sed "s/.*) //" /proc/$$pid/stat 2>/dev/null | awk "{{print \$$2}}"); mismatch=1; [ -n "$$ondisk" ] && [ -n "$$hv" ] && [ "$$hv" != "$$ondisk" ] && mismatch=0; if [ "$$ppid" = "1" ] && {{ [ "$$mismatch" = "0" ] || [ -z "$$hv" ]; }}; then kill -TERM "$$pid" 2>/dev/null || true; w=0; while kill -0 "$$pid" 2>/dev/null && [ $$w -lt 12 ]; do sleep 1; w=$$((w+1)); done; kill -0 "$$pid" 2>/dev/null && kill -KILL "$$pid" 2>/dev/null || true; fi; done'
 ExecStart={binary} network
 Restart=always
-# Wait 10 seconds before restart to avoid rapid restart loops
+# Wait 10 seconds before restart to avoid rapid restart loops. The actual
+# crash-loop cap (StartLimit*) lives in the [Unit] section above (#4551).
 RestartSec=10
 # Allow 45 seconds for graceful shutdown before SIGKILL.
 # The node handles SIGTERM by (1) waiting up to `shutdown-drain-secs`
@@ -315,15 +340,29 @@ RestartSec=10
 # cleanup. If you raise `shutdown-drain-secs`, raise this in lockstep.
 TimeoutStopSec=45
 
-# Auto-update: if peer exits with code 42 (version mismatch with gateway),
-# run update before systemd restarts the service. The '-' prefix means
-# ExecStopPost failure won't affect service restart. $$EXIT_STATUS is doubled
-# so systemd passes a literal $EXIT_STATUS through to sh (which systemd itself
-# sets in the ExecStopPost environment).
-ExecStopPost=-/bin/sh -c '[ "$$EXIT_STATUS" = "42" ] && {binary} update --quiet || true'
-# Treat exit code 42 as success so it doesn't count against StartLimitBurst.
-# Without this, rapid update cycles (exit 42 → ExecStopPost → restart) can
-# exhaust the burst limit and permanently kill the service.
+# Auto-update / boot-crash self-heal: run `freenet update` before systemd
+# restarts the service when the node exits 42 (a healthy node that hit a version
+# mismatch / fatal fault) OR 45 (a fast crash / boot-wedge, #4551). Firing update
+# on 45 too preserves the #4549 self-heal for a boot-crash that a NEWER release
+# fixes — `freenet update` is a SEPARATE process that can succeed even when
+# `freenet network` crashes at startup. This does NOT exempt 45 from the
+# crash-loop limiter: ExecStopPost runs AFTER the process exits (the '-' prefix
+# means its own result never affects restart) and 45 stays OUT of
+# SuccessExitStatus below, so a no-fix tight loop still trips StartLimitBurst and
+# the unit stops. A `case` (not `&&`/`||`) avoids shell-precedence pitfalls.
+# $$EXIT_STATUS is doubled so systemd passes a literal $EXIT_STATUS through to sh
+# (systemd itself sets it in the ExecStopPost environment).
+ExecStopPost=-/bin/sh -c 'case "$$EXIT_STATUS" in 42|45) {binary} update --quiet ;; esac'
+# Exit 42 (auto-update) and 43 (another instance) are clean exits, so they are
+# not counted as failures — without this, rapid update cycles (exit 42 →
+# ExecStopPost → restart) could exhaust the burst limit and kill the service.
+# Exit 45 (fast-crash / boot-wedge, #4551) is deliberately NOT whitelisted here:
+# it must COUNT toward StartLimitBurst so a tight crash loop trips the [Unit]
+# limiter and the unit stops — even though the ExecStopPost above still runs
+# `freenet update` for it. Counting (StartLimit) and self-heal (ExecStopPost) are
+# independent: the former bounds a no-fix loop, the latter rescues a boot-crash a
+# newer release fixes. (44 is the internal bundle-update-staged code, never
+# emitted by `freenet network`.)
 SuccessExitStatus=42 43
 # Exit code 43 = another instance is already running on the port.
 # Do NOT restart — the existing instance is healthy.
@@ -356,7 +395,8 @@ CPUQuota=200%
 WantedBy=default.target
 "#,
         binary = binary_path.display(),
-        log_dir = log_dir.display()
+        log_dir = log_dir.display(),
+        fast_crash_marker = super::super::auto_update::SYSTEMD_FAST_CRASH_ENV_VAR,
     )
 }
 
@@ -373,11 +413,14 @@ Description=Freenet Node
 Documentation=https://freenet.org
 After=network-online.target
 Wants=network-online.target
-# Stop restart loop after 5 failures in 2 minutes (e.g., port conflict with
-# a stale process). Without this, systemd restarts indefinitely.
-# SuccessExitStatus=42 ensures auto-update exits don't count as failures.
+# Crash-loop rate limiting (issue #4551) — see the matching comment in the user
+# unit. StartLimit* live in [Unit] (#4570); systemd silently ignores them in
+# [Service]. Only a rapid loop (>5 starts / 120s) trips; a fast crash exits the
+# counted code 45 while a healthy-then-died node exits the burst-exempt 42.
+# StartLimitAction=none stops the unit (it does NOT reboot the host) on trip.
 StartLimitBurst=5
 StartLimitIntervalSec=120
+StartLimitAction=none
 
 [Service]
 Type=simple
@@ -388,6 +431,10 @@ Environment=HOME={home}
 # applied by ExecStopPost below, so it logs an informational message instead of
 # a loud "no supervisor" error on update exit.
 Environment=FREENET_SUPERVISED=1
+# #4551 fast-crash-aware marker — see the matching comment in the user unit. The
+# node emits exit 45 only when this is present (this unit handles 45); otherwise it
+# keeps the self-healing exit 42.
+Environment={fast_crash_marker}=1
 # Stale-orphan self-heal (issue #3967): see the matching comment in the user
 # unit (including the systemd $$-escaping, the PPID-after-final-')' parse, and
 # why we do NOT anchor on the holder's exe equalling this unit's on-disk binary
@@ -403,7 +450,8 @@ Environment=FREENET_SUPERVISED=1
 ExecStartPre=-/bin/sh -c 'self=$$$$; ondisk=$$(timeout 5 {binary} --version 2>/dev/null | grep "^Freenet version:"); for pid in $$(pgrep -f -u "$$(id -u)" "freenet network" 2>/dev/null); do [ "$$pid" = "$$self" ] && continue; [ "$$pid" = "1" ] && continue; exe=$$(readlink -f /proc/$$pid/exe 2>/dev/null); hv=""; [ -x "$$exe" ] && hv=$$(timeout 5 "$$exe" --version 2>/dev/null | grep "^Freenet version:"); ppid=$$(sed "s/.*) //" /proc/$$pid/stat 2>/dev/null | awk "{{print \$$2}}"); mismatch=1; [ -n "$$ondisk" ] && [ -n "$$hv" ] && [ "$$hv" != "$$ondisk" ] && mismatch=0; if [ "$$ppid" = "1" ] && {{ [ "$$mismatch" = "0" ] || [ -z "$$hv" ]; }}; then kill -TERM "$$pid" 2>/dev/null || true; w=0; while kill -0 "$$pid" 2>/dev/null && [ $$w -lt 12 ]; do sleep 1; w=$$((w+1)); done; kill -0 "$$pid" 2>/dev/null && kill -KILL "$$pid" 2>/dev/null || true; fi; done'
 ExecStart={binary} network
 Restart=always
-# Wait 10 seconds before restart to avoid rapid restart loops
+# Wait 10 seconds before restart to avoid rapid restart loops. The actual
+# crash-loop cap (StartLimit*) lives in the [Unit] section above (#4551).
 RestartSec=10
 # Allow 45 seconds for graceful shutdown before SIGKILL.
 # The node handles SIGTERM by (1) waiting up to `shutdown-drain-secs`
@@ -413,15 +461,29 @@ RestartSec=10
 # cleanup. If you raise `shutdown-drain-secs`, raise this in lockstep.
 TimeoutStopSec=45
 
-# Auto-update: if peer exits with code 42 (version mismatch with gateway),
-# run update before systemd restarts the service. The '-' prefix means
-# ExecStopPost failure won't affect service restart. $$EXIT_STATUS is doubled
-# so systemd passes a literal $EXIT_STATUS through to sh (which systemd itself
-# sets in the ExecStopPost environment).
-ExecStopPost=-/bin/sh -c '[ "$$EXIT_STATUS" = "42" ] && {binary} update --quiet || true'
-# Treat exit code 42 as success so it doesn't count against StartLimitBurst.
-# Without this, rapid update cycles (exit 42 → ExecStopPost → restart) can
-# exhaust the burst limit and permanently kill the service.
+# Auto-update / boot-crash self-heal: run `freenet update` before systemd
+# restarts the service when the node exits 42 (a healthy node that hit a version
+# mismatch / fatal fault) OR 45 (a fast crash / boot-wedge, #4551). Firing update
+# on 45 too preserves the #4549 self-heal for a boot-crash that a NEWER release
+# fixes — `freenet update` is a SEPARATE process that can succeed even when
+# `freenet network` crashes at startup. This does NOT exempt 45 from the
+# crash-loop limiter: ExecStopPost runs AFTER the process exits (the '-' prefix
+# means its own result never affects restart) and 45 stays OUT of
+# SuccessExitStatus below, so a no-fix tight loop still trips StartLimitBurst and
+# the unit stops. A `case` (not `&&`/`||`) avoids shell-precedence pitfalls.
+# $$EXIT_STATUS is doubled so systemd passes a literal $EXIT_STATUS through to sh
+# (systemd itself sets it in the ExecStopPost environment).
+ExecStopPost=-/bin/sh -c 'case "$$EXIT_STATUS" in 42|45) {binary} update --quiet ;; esac'
+# Exit 42 (auto-update) and 43 (another instance) are clean exits, so they are
+# not counted as failures — without this, rapid update cycles (exit 42 →
+# ExecStopPost → restart) could exhaust the burst limit and kill the service.
+# Exit 45 (fast-crash / boot-wedge, #4551) is deliberately NOT whitelisted here:
+# it must COUNT toward StartLimitBurst so a tight crash loop trips the [Unit]
+# limiter and the unit stops — even though the ExecStopPost above still runs
+# `freenet update` for it. Counting (StartLimit) and self-heal (ExecStopPost) are
+# independent: the former bounds a no-fix loop, the latter rescues a boot-crash a
+# newer release fixes. (44 is the internal bundle-update-staged code, never
+# emitted by `freenet network`.)
 SuccessExitStatus=42 43
 # Exit code 43 = another instance is already running on the port.
 # Do NOT restart — the existing instance is healthy.
@@ -456,7 +518,8 @@ WantedBy=multi-user.target
         binary = binary_path.display(),
         log_dir = log_dir.display(),
         username = username,
-        home = home_dir.display()
+        home = home_dir.display(),
+        fast_crash_marker = super::super::auto_update::SYSTEMD_FAST_CRASH_ENV_VAR,
     )
 }
 
@@ -563,28 +626,57 @@ mod tests {
 
     use super::{generate_system_service_file, generate_user_service_file};
 
+    /// Byte offset of the section header line (a line whose trimmed content is
+    /// exactly `[name]`). Matches by LINE, not a naive substring search, so a
+    /// bracketed section name mentioned inside a comment (e.g. "...ignored in
+    /// `[Service]`" inside the `[Unit]` section, #4551) is never mistaken for the
+    /// real section header.
+    fn section_header_offset(unit: &str, name: &str) -> usize {
+        let header = format!("[{name}]");
+        let mut offset = 0usize;
+        for line in unit.split_inclusive('\n') {
+            if line.trim() == header {
+                return offset;
+            }
+            offset += line.len();
+        }
+        panic!("unit must contain a {header} section header line");
+    }
+
+    /// Body of the `[name]` section: everything between that section's header line
+    /// and the next section header line. Header lines are matched by line (a
+    /// comment containing a bracketed name is ignored), so this is robust to
+    /// `[Service]`/`[Unit]` being referenced inside comments.
     fn section<'a>(unit: &'a str, name: &str) -> &'a str {
         let header = format!("[{name}]");
-        let start = unit
-            .find(&header)
-            .unwrap_or_else(|| panic!("unit must contain {header} section"));
-        let content_start = start + header.len();
-        let content = &unit[content_start..];
-        let end = content
-            .find("\n[")
-            .map(|offset| content_start + offset)
-            .unwrap_or(unit.len());
-
-        &unit[content_start..end]
+        let mut offset = 0usize;
+        let mut body_start: Option<usize> = None;
+        for line in unit.split_inclusive('\n') {
+            let trimmed = line.trim();
+            match body_start {
+                None => {
+                    if trimmed == header {
+                        body_start = Some(offset + line.len());
+                    }
+                }
+                Some(start) => {
+                    if trimmed.starts_with('[') && trimmed.ends_with(']') && !trimmed.contains(' ')
+                    {
+                        return &unit[start..offset];
+                    }
+                }
+            }
+            offset += line.len();
+        }
+        match body_start {
+            Some(start) => &unit[start..],
+            None => panic!("unit must contain {header} section"),
+        }
     }
 
     fn assert_start_limit_directives_are_in_unit_section(unit_name: &str, unit: &str) {
-        let unit_header = unit
-            .find("[Unit]")
-            .unwrap_or_else(|| panic!("{unit_name} unit must contain [Unit]"));
-        let service_header = unit
-            .find("[Service]")
-            .unwrap_or_else(|| panic!("{unit_name} unit must contain [Service]"));
+        let unit_header = section_header_offset(unit, "Unit");
+        let service_header = section_header_offset(unit, "Service");
         let unit_section = section(unit, "Unit");
         let service_section = section(unit, "Service");
 

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -241,6 +241,18 @@ async fn run_network_node_with_signals(
     // in teardown that leaves the node network-dead and spinning.
     freenet::enable_abort_on_fatal_listener_exit();
 
+    // #4551: only emit the distinct fast-crash exit code (45) for a sub-60s fatal
+    // exit when the supervising unit actually understands it. The regenerated Freenet
+    // systemd unit advertises that via SYSTEMD_FAST_CRASH_ENV_VAR (it keeps 45 out of
+    // SuccessExitStatus, sets StartLimitAction=none, and runs `freenet update` on 42
+    // OR 45). A node running this binary under an OLD/custom systemd unit (auto-updated
+    // but not reinstalled), under the macOS/Windows run-wrapper (knows only 42), or
+    // unsupervised must keep exiting 42 so its existing exit-42 self-heal/limiting
+    // still works — so the marker, not a broad systemd heuristic, is the gate.
+    if std::env::var_os(commands::auto_update::SYSTEMD_FAST_CRASH_ENV_VAR).is_some() {
+        freenet::enable_fast_crash_exit_code();
+    }
+
     // Set up SIGTERM handler for Unix systems
     #[cfg(unix)]
     let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -20,8 +20,8 @@ mod message;
 /// Node configuration, implementations and execution (entry points for the binaries).
 mod node;
 pub use node::{
-    EventLoopExitReason, Node, ShutdownHandle, enable_abort_on_fatal_listener_exit, run_local_node,
-    run_network_node,
+    EventLoopExitReason, Node, ShutdownHandle, enable_abort_on_fatal_listener_exit,
+    enable_fast_crash_exit_code, run_local_node, run_network_node,
 };
 
 /// Network operation/transaction state machines.

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -80,7 +80,7 @@ mod p2p_impl;
 mod request_router;
 pub(crate) mod testing_impl;
 
-pub use p2p_impl::enable_abort_on_fatal_listener_exit;
+pub use p2p_impl::{enable_abort_on_fatal_listener_exit, enable_fast_crash_exit_code};
 pub use request_router::{DeduplicatedRequest, RequestRouter};
 
 /// Handle to trigger graceful shutdown of the node.

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -26,25 +26,118 @@ use crate::{
 
 use super::{OpManager, background_task_monitor::BackgroundTaskMonitor};
 
-/// Exit code requested when the network event loop dies on a fatal (non-graceful)
-/// condition (#4549). `42` == `EXIT_CODE_UPDATE_NEEDED` (see
-/// `crates/core/src/bin/commands/auto_update.rs`) and is also hard-coded in the
+/// Exit code requested when a node that had been up for a *healthy* amount of
+/// time (>= [`MIN_HEALTHY_UPTIME_FOR_UPDATE_EXIT`]) dies on a fatal
+/// (non-graceful) listener condition (#4549). `42` == `EXIT_CODE_UPDATE_NEEDED`
+/// (see `crates/core/src/bin/commands/auto_update.rs`) and is matched by the
 /// GENERATED systemd unit template (`crates/core/src/bin/commands/service/linux.rs`,
 /// `[ "$EXIT_STATUS" = "42" ]`). Its `ExecStopPost` hook runs `freenet update`, so a
-/// wedged OLD binary auto-upgrades to a fixed version (the self-heal path that rolls
-/// this fix out), and `Restart=always` (`RestartSec=10`) restarts it.
+/// wedged OLD binary that ran fine for a while auto-upgrades to a fixed version (the
+/// self-heal path that rolls a fix out), and `Restart=always` (`RestartSec=10`)
+/// restarts it.
 ///
-/// The restart loop is bounded by `RestartSec` and is visible (a `CRITICAL` log per
-/// exit + climbing `NRestarts`) — strictly better than the #4549 dark wedge. NOTE:
-/// the unit's `StartLimitBurst`/`StartLimitIntervalSec` are currently emitted in the
-/// `[Service]` section, where systemd ignores them, so they do NOT rate-limit a
-/// repeating wedge today; moving them to `[Unit]` (and then a min-uptime exit-code
-/// guard) is tracked in #4551 and is out of scope for this hotfix.
+/// The unit also lists `42` in `SuccessExitStatus`, so it is treated as a clean exit
+/// and does NOT count toward the `[Unit]`-section `StartLimitBurst`. That is correct
+/// for a long-uptime node (a real fault / update), but it would let a *boot-wedge*
+/// loop restart forever — so a fatal exit that happens too soon after start uses
+/// [`FAST_CRASH_EXIT_CODE`] instead (see [`fatal_listener_exit_code`]).
 ///
 /// Caveat (macOS): the macOS service wrapper treats a non-zero `freenet update`
 /// result (the no-op "already up to date" exit) as a failure and applies restart
 /// backoff. Production gateways are Linux, so this only slows restart on macOS.
 const FATAL_LISTENER_EXIT_CODE: i32 = 42;
+
+/// Exit code for a fatal listener exit that happened too soon after start
+/// (uptime < [`MIN_HEALTHY_UPTIME_FOR_UPDATE_EXIT`]) to be a healthy node hitting
+/// an update / transient fault — i.e. a fast crash or boot-wedge (#4551).
+///
+/// It is deliberately DISTINCT from [`FATAL_LISTENER_EXIT_CODE`] (42) precisely so
+/// the systemd unit's `SuccessExitStatus=42 43` does NOT whitelist it: systemd then
+/// counts each fast-crash restart toward `StartLimitBurst`, so a tight loop trips
+/// the (now correctly `[Unit]`-placed) limiter and the unit is STOPPED instead of
+/// looping every ~10s forever. The boot-crash self-heal is NOT lost: the systemd
+/// unit's `ExecStopPost` runs `freenet update` on exit 42 OR 45, so a boot-crash
+/// that a newer release fixes still upgrades (the `freenet update` child is a
+/// separate process that can succeed even when `freenet network` crashes at
+/// startup). Counting and self-heal are independent.
+///
+/// Emitted ONLY when the binary opted in via [`enable_fast_crash_exit_code`] — which
+/// happens solely under a regenerated Freenet systemd unit that advertises 45 support
+/// (see [`EMIT_FAST_CRASH_EXIT_CODE`]). Under the macOS/Windows in-process run-wrapper
+/// (understands only exit 42; self-heals + bounds via its own backoff/50-cap), an old
+/// or custom systemd unit, or unsupervised, the node keeps emitting 42 so its existing
+/// self-heal is preserved.
+///
+/// NOT `44`: that is `EXIT_CODE_BUNDLE_UPDATE_STAGED`, an internal `freenet update`
+/// code never emitted by `freenet network`.
+const FAST_CRASH_EXIT_CODE: i32 = 45;
+
+/// Minimum uptime for a fatal listener exit to be treated as a "ran healthily,
+/// then died" event eligible for the burst-exempt auto-update self-heal path
+/// (exit [`FATAL_LISTENER_EXIT_CODE`] = 42). A fatal exit BELOW this threshold is
+/// classified as a fast crash / boot-wedge and uses the counted
+/// [`FAST_CRASH_EXIT_CODE`] instead so a tight loop is rate-limited.
+///
+/// 60s is comfortably longer than normal node startup (bind sockets, load
+/// contracts, connect to gateways) yet far below any "ran for a while" duration,
+/// so genuine boot-wedges fall below it while healthy nodes that later die fall
+/// above it. The exact value is not safety-critical: the `StartLimitBurst=5` /
+/// `StartLimitIntervalSec=120` cap only stops a *rapid* loop, and a legitimate
+/// single restart (update, reboot, one-off crash) never approaches 5-in-120s
+/// regardless of which code it used.
+const MIN_HEALTHY_UPTIME_FOR_UPDATE_EXIT: Duration = Duration::from_secs(60);
+
+/// Choose the process exit code for a fatal (non-graceful) network-listener exit,
+/// based on how long the node had been up and whether the supervisor understands the
+/// distinct fast-crash code (#4551).
+///
+/// - `fast_crash_enabled` && uptime < [`MIN_HEALTHY_UPTIME_FOR_UPDATE_EXIT`] →
+///   [`FAST_CRASH_EXIT_CODE`] (45): a counted failure, so a tight boot-wedge loop
+///   trips `StartLimitBurst` and the unit stops. The unit's `ExecStopPost` still
+///   runs `freenet update` on 45, so a fixable boot-crash self-heals.
+/// - otherwise → [`FATAL_LISTENER_EXIT_CODE`] (42): burst-exempt, fires the
+///   `freenet update` self-heal hook.
+///
+/// `fast_crash_enabled` comes from [`EMIT_FAST_CRASH_EXIT_CODE`], which the binary
+/// turns on ONLY under a regenerated Freenet systemd unit (the only supervisor that
+/// handles 45). See that flag's docs for why every other supervisor must keep 42.
+///
+/// Extracted as a pure function so the decision can be unit-tested without the
+/// surrounding `process::exit` (per `.claude/rules/deployment.md`).
+fn fatal_listener_exit_code(uptime: Duration, fast_crash_enabled: bool) -> i32 {
+    if fast_crash_enabled && uptime < MIN_HEALTHY_UPTIME_FOR_UPDATE_EXIT {
+        FAST_CRASH_EXIT_CODE
+    } else {
+        FATAL_LISTENER_EXIT_CODE
+    }
+}
+
+/// When `true`, a sub-[`MIN_HEALTHY_UPTIME_FOR_UPDATE_EXIT`] fatal listener exit
+/// uses the distinct [`FAST_CRASH_EXIT_CODE`] (45) instead of the default
+/// [`FATAL_LISTENER_EXIT_CODE`] (42). Off by default; the binary opts in (via
+/// [`enable_fast_crash_exit_code`]) ONLY when the supervisor is known to understand
+/// exit 45 — i.e. the freshly-generated Freenet systemd unit, detected by the
+/// supervisor marker it sets.
+///
+/// Gating is essential: exit 45 only helps under the regenerated systemd unit, where
+/// `SuccessExitStatus` excludes it (so it counts toward `StartLimitBurst`) and
+/// `ExecStopPost` runs `freenet update` on 42 OR 45 (boot-crash self-heal). Under any
+/// other supervisor, emitting 45 would be a generic failure that LOSES the exit-42
+/// self-heal: the macOS/Windows in-process run-wrapper only knows 42 (it self-heals
+/// and bounds the loop via its own backoff and 50-failure cap); an OLD or custom
+/// systemd unit (e.g. a node auto-updated to this binary but whose unit file was not
+/// regenerated) lacks the 45 handling; an unsupervised run is moot. So the default
+/// (flag off) keeps emitting 42 everywhere.
+static EMIT_FAST_CRASH_EXIT_CODE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Opt in to the distinct [`FAST_CRASH_EXIT_CODE`] for fast boot-crashes (#4551).
+/// Call ONLY from the production node entry point, and ONLY after confirming the
+/// supervising systemd unit advertises support for exit 45 (see the entry point's
+/// marker check). See [`EMIT_FAST_CRASH_EXIT_CODE`].
+pub fn enable_fast_crash_exit_code() {
+    EMIT_FAST_CRASH_EXIT_CODE.store(true, std::sync::atomic::Ordering::Relaxed);
+}
 
 /// When `true`, a fatal (non-graceful) exit of the network event listener aborts
 /// the whole process with [`FATAL_LISTENER_EXIT_CODE`] instead of unwinding through
@@ -463,16 +556,30 @@ impl NodeP2P {
                if !listener_exit_is_graceful(&e)
                    && ABORT_ON_FATAL_LISTENER_EXIT.load(std::sync::atomic::Ordering::Relaxed)
                {
+                   // #4551: pick 42 (burst-exempt, fires the auto-update self-heal
+                   // hook) for a node that ran healthily before dying, vs the counted
+                   // FAST_CRASH_EXIT_CODE for a fast crash / boot-wedge so a tight loop
+                   // trips the unit's StartLimitBurst and is stopped instead of looping.
+                   // The fast-crash code is emitted only when the binary opted in (a
+                   // regenerated systemd unit that handles 45); otherwise 42 is kept so
+                   // an old unit / the mac/Windows run-wrapper still self-heals.
+                   let uptime = start_time.elapsed();
+                   let exit_code = fatal_listener_exit_code(
+                       uptime,
+                       EMIT_FAST_CRASH_EXIT_CODE.load(std::sync::atomic::Ordering::Relaxed),
+                   );
                    eprintln!("CRITICAL: Network event listener exited (fatal): {e}");
                    tracing::error!(
                        error = %e,
-                       exit_code = FATAL_LISTENER_EXIT_CODE,
-                       uptime_secs = start_time.elapsed().as_secs(),
+                       exit_code,
+                       uptime_secs = uptime.as_secs(),
+                       fast_crash = exit_code == FAST_CRASH_EXIT_CODE,
                        "Network event listener exited unexpectedly; forcing immediate process \
-                        exit so the service manager restarts the node promptly and the \
-                        auto-update hook can fire (avoids the wedged-but-alive dark window, #4549)"
+                        exit so the service manager restarts the node promptly and (for a \
+                        long-uptime exit) the auto-update hook can fire (avoids the \
+                        wedged-but-alive dark window, #4549; crash-loop bounding, #4551)"
                    );
-                   std::process::exit(FATAL_LISTENER_EXIT_CODE);
+                   std::process::exit(exit_code);
                }
                eprintln!("CRITICAL: Network event listener exited: {e}");
                tracing::error!("Network event listener exited: {}", e);
@@ -846,10 +953,104 @@ mod tests {
             !ABORT_ON_FATAL_LISTENER_EXIT.load(std::sync::atomic::Ordering::Relaxed),
             "fatal-listener fast-exit must be opt-in (off unless the binary enables it)"
         );
+        // #4551: the distinct fast-crash exit code (45) must ALSO be opt-in — off
+        // unless the binary detects a 45-aware systemd unit. A default-on flip would
+        // emit 45 under the mac/Windows wrapper or an old unit, losing the exit-42
+        // self-heal.
+        assert!(
+            !EMIT_FAST_CRASH_EXIT_CODE.load(std::sync::atomic::Ordering::Relaxed),
+            "fast-crash exit code must be opt-in (off unless the binary enables it)"
+        );
         assert_eq!(
             FATAL_LISTENER_EXIT_CODE, 42,
             "must match EXIT_CODE_UPDATE_NEEDED so the systemd ExecStopPost auto-update \
              hook fires on a wedge"
+        );
+    }
+
+    /// #4551: the fast-crash exit code must be distinct from the update code so the
+    /// systemd unit's `SuccessExitStatus=42 43` does NOT whitelist it — otherwise a
+    /// boot-wedge loop would be treated as a clean exit and never trip
+    /// `StartLimitBurst`. Also pin that it does not collide with the other declared
+    /// exit codes (43 = already-running, 44 = bundle-update-staged).
+    #[test]
+    fn fast_crash_exit_code_is_distinct_and_counted() {
+        assert_eq!(
+            FAST_CRASH_EXIT_CODE, 45,
+            "fast-crash code is 45 (45 must stay OUT of the unit's SuccessExitStatus \
+             so it counts toward StartLimitBurst)"
+        );
+        assert_ne!(
+            FAST_CRASH_EXIT_CODE, FATAL_LISTENER_EXIT_CODE,
+            "a fast crash must NOT reuse the burst-exempt update code 42"
+        );
+        // 43 = EXIT_CODE_ALREADY_RUNNING (RestartPreventExitStatus), 44 =
+        // EXIT_CODE_BUNDLE_UPDATE_STAGED. The fast-crash code must avoid both.
+        assert_ne!(
+            FAST_CRASH_EXIT_CODE, 43,
+            "must not collide with already-running (43)"
+        );
+        assert_ne!(
+            FAST_CRASH_EXIT_CODE, 44,
+            "must not collide with bundle-update-staged (44)"
+        );
+    }
+
+    /// #4551: with fast-crash enabled (a 45-aware systemd unit), a fatal listener exit
+    /// that happens *soon* after start is a fast crash / boot-wedge — it must use the
+    /// counted [`FAST_CRASH_EXIT_CODE`] so a tight loop trips the limiter. An exit after
+    /// a *healthy* uptime keeps the burst-exempt update code 42 so a real fault/update
+    /// self-heals and is never rate-limited.
+    #[test]
+    fn fatal_listener_exit_code_distinguishes_fast_crash_from_healthy_uptime() {
+        // Fast crash / boot-wedge: well under the healthy-uptime threshold.
+        for secs in [0u64, 1, 10, 30, 59] {
+            assert_eq!(
+                fatal_listener_exit_code(Duration::from_secs(secs), true),
+                FAST_CRASH_EXIT_CODE,
+                "with fast-crash enabled, a fatal exit after only {secs}s uptime is a \
+                 fast crash → counted code"
+            );
+        }
+        // Boundary: exactly the threshold counts as healthy (>= is update-exit).
+        assert_eq!(
+            fatal_listener_exit_code(MIN_HEALTHY_UPTIME_FOR_UPDATE_EXIT, true),
+            FATAL_LISTENER_EXIT_CODE,
+            "uptime exactly at the threshold is treated as a healthy-then-died exit"
+        );
+        // Healthy uptime: the node ran for a while before dying.
+        for secs in [60u64, 120, 3600, 86_400] {
+            assert_eq!(
+                fatal_listener_exit_code(Duration::from_secs(secs), true),
+                FATAL_LISTENER_EXIT_CODE,
+                "a fatal exit after {secs}s uptime keeps the burst-exempt update code"
+            );
+        }
+    }
+
+    /// #4551 (Codex P2): the fast-crash exit code 45 is meaningful ONLY under a
+    /// regenerated systemd unit that handles it (fast-crash DISABLED otherwise). Under
+    /// the macOS/Windows run-wrapper, an OLD/custom systemd unit (e.g. a node
+    /// auto-updated to this binary but not reinstalled), or unsupervised, the node must
+    /// keep emitting 42 — those supervisors self-heal on 42 (and the wrapper bounds the
+    /// loop with its own backoff + 50-failure cap), whereas a 45 is a generic crash that
+    /// loses the self-heal. So when fast-crash is disabled, every uptime — including a
+    /// fast boot-crash — must map to [`FATAL_LISTENER_EXIT_CODE`] (42).
+    #[test]
+    fn fatal_listener_exit_code_uses_update_code_when_fast_crash_disabled() {
+        for secs in [0u64, 1, 10, 30, 59, 60, 120, 3600, 86_400] {
+            assert_eq!(
+                fatal_listener_exit_code(Duration::from_secs(secs), false),
+                FATAL_LISTENER_EXIT_CODE,
+                "with fast-crash disabled, a fatal exit after {secs}s must keep exit 42 \
+                 (an old unit / the run-wrapper only understands 42); 45 would lose the \
+                 self-heal"
+            );
+        }
+        // The boundary value is also the update code when fast-crash is disabled.
+        assert_eq!(
+            fatal_listener_exit_code(MIN_HEALTHY_UPTIME_FOR_UPDATE_EXIT, false),
+            FATAL_LISTENER_EXIT_CODE,
         );
     }
 


### PR DESCRIPTION
## Problem

#4570 moved `StartLimitBurst`/`StartLimitIntervalSec` into the `[Unit]` section so systemd now actually honours the crash-loop limiter (they were silently ignored in `[Service]`). With the limiter effective, gaps remained:

1. The unit's `SuccessExitStatus=42 43` whitelists the node's fatal-listener exit code (42, from #4549). A node stuck in a **boot-wedge loop** exits 42 every ~10s and never counts toward `StartLimitBurst` — so the limiter wouldn't bound the one case it most needs to.
2. The limiter's terminal action was implicit (a tripped loop should stop the unit, not reboot the host).

## Solution

Builds on #4570. Adds a crash-vs-update distinction so the now-effective limiter bounds real boot-wedge loops **without** losing the auto-update self-heal, on **every** supervision path.

### systemd path
- **`StartLimitAction=none`** (default, made explicit) in both units: a tripped loop STOPS the unit rather than rebooting the host. Recover with `systemctl reset-failed freenet && systemctl start freenet`.
- **`FAST_CRASH_EXIT_CODE = 45`** (kept OUT of `SuccessExitStatus`) + a min-uptime guard, `fatal_listener_exit_code(uptime, fast_crash_enabled)`:
  - fatal listener exit **< 60s uptime** → exit **45** (counted, so a tight loop trips `StartLimitBurst` and the unit stops);
  - **>= 60s** → exit **42** (burst-exempt).
- **`ExecStopPost` runs `freenet update` on exit 42 OR 45** (via a `case`, avoiding `&&`/`||` precedence pitfalls). Counting (StartLimit) and self-heal (ExecStopPost) are independent, so a boot-crash that a newer release fixes still self-heals (#4549) even though exit 45 is rate-limited — `freenet update` is a separate process that can succeed even when `freenet network` boot-crashes.

### cross-platform / cross-version safety
Exit 45 is meaningful only under a unit that handles it, so it is emitted **only when the binary opts in** (`enable_fast_crash_exit_code()`, mirroring the existing `enable_abort_on_fatal_listener_exit()`), and the entry point opts in **only when the supervising unit advertises 45 support** via a marker env var (`FREENET_SYSTEMD_FAST_CRASH`) that the **regenerated** systemd unit sets. This ties runtime behavior to the on-disk unit's actual capability:

- macOS/Windows in-process **run-wrapper** (knows only 42; self-heals on 42 and bounds the loop with its own backoff + 50-failure cap) → no marker → keeps emitting **42**.
- **Old/custom systemd unit** — including a node auto-updated to this binary but whose unit file was never regenerated → no marker → keeps emitting **42** (its existing exit-42 self-heal works).
- **Unsupervised** → no marker → **42** (moot).

The marker is referenced through the `SYSTEMD_FAST_CRASH_ENV_VAR` const in both the unit template and the entry-point check (single source of truth, no literal drift).

## Testing
- `node::p2p_impl`: fast-crash code distinct + counted; uptime split when enabled; **always 42 when disabled** (run-wrapper / old-unit / unsupervised); both the abort and fast-crash flags are opt-in / off-by-default.
- `service.rs`: `StartLimitAction` in `[Unit]`; exit-45 out of `SuccessExitStatus`; `ExecStopPost` fires update on `42|45`; fast-crash marker present (asserted via the const).
- `StartLimitBurst`/`IntervalSec` `[Unit]`-placement is covered by #4570's `linux.rs` tests (not duplicated). Those `#4570` helpers are also hardened to find section headers **by line**, not substring, so the legitimate `[Service]` reference now in a `[Unit]` comment isn't misparsed.
- `cargo fmt`; `cargo clippy --locked -- -D warnings` and `--features trace-ot` both clean. Both generated units pass `systemd-analyze verify` (exit 0; only the pre-existing ExecStartPre shell-escape notice).

Refs #4551 (the section-placement fix landed in #4570); this completes the crash-loop bounding. Builds on #4570.

> [!NOTE]
> The systemd burst-behavior change (counting exit 45 toward `StartLimitBurst`, `StartLimitAction=none`, marker-gated opt-in) wants a smoke-test on a live systemd host before the next release, per `.claude/rules/deployment.md` (a `cfg(target_os = "linux")` service path CI does not exercise end-to-end).

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)