### PR TITLE
feat: periodically re-poll GitHub for new releases so long-running nodes auto-update

### DIFF
--- a/crates/core/src/bin/commands/auto_update.rs
+++ b/crates/core/src/bin/commands/auto_update.rs
@@ -860,6 +860,56 @@ pub(crate) fn compare_versions_for_startup(current: &str, latest: &str) -> Optio
     }
 }
 
+// =============================================================================
+// Periodic re-poll scheduling (#4073)
+// =============================================================================
+
+/// Base interval between periodic direct-GitHub update re-polls.
+///
+/// After the one-shot startup check (#3864), update detection otherwise
+/// depends entirely on a peer signal (urgent / highest-seen / version
+/// mismatch). If an entire network sits on the same old version, no node
+/// re-checks GitHub and a freshly published release is never picked up until
+/// a node happens to restart. This recurring poll closes that gap: a
+/// long-running node re-asks GitHub directly on this cadence, without needing
+/// a restart.
+///
+/// 6h is deliberately conservative against GitHub's unauthenticated REST rate
+/// limit (60 requests/hour/IP): even at the jittered minimum (~4.5h) it is
+/// well under one request/hour, leaving headroom for the bursty
+/// peer-signal-driven checks that share the same IP budget. It is still
+/// frequent enough that a release propagates across the network within hours
+/// rather than never.
+pub const UPDATE_REPOLL_INTERVAL: Duration = Duration::from_secs(6 * 3600);
+
+/// Fraction of jitter applied to each re-poll interval (±25%).
+///
+/// Without jitter, nodes that booted together (e.g. after a coordinated
+/// restart or outage) would re-poll — and therefore exit-42/restart — in
+/// lockstep, producing a thundering herd against both GitHub and the network.
+/// ±25% decorrelates them, preserving the load-spreading intent of the
+/// existing 0-60s startup jitter and 0-4h decentralized-discovery stagger.
+pub const UPDATE_REPOLL_JITTER_FRACTION: f64 = 0.25;
+
+/// Apply symmetric `±jitter_fraction` jitter to `base`, given a uniform random
+/// sample `rand_unit` in `[0, 1]`.
+///
+/// Pure and deterministic: the randomness is injected by the caller (in
+/// production, `GlobalRng`) so the scheduling math is unit-testable without
+/// waiting hours or depending on a clock. `rand_unit` and `jitter_fraction`
+/// are clamped to `[0, 1]` defensively.
+///
+/// Maps `rand_unit` linearly onto the factor range
+/// `[1 - jitter_fraction, 1 + jitter_fraction]`:
+/// `rand_unit = 0.0` → `base * (1 - frac)`, `0.5` → `base`,
+/// `1.0` → `base * (1 + frac)`.
+pub fn jittered_repoll_interval(base: Duration, jitter_fraction: f64, rand_unit: f64) -> Duration {
+    let jitter_fraction = jitter_fraction.clamp(0.0, 1.0);
+    let rand_unit = rand_unit.clamp(0.0, 1.0);
+    let factor = 1.0 - jitter_fraction + 2.0 * jitter_fraction * rand_unit;
+    base.mul_f64(factor)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1655,5 +1705,91 @@ mod tests {
             backoff = std::cmp::min(backoff * 2, MAX_BACKOFF);
         }
         assert_eq!(backoff, MAX_BACKOFF);
+    }
+
+    #[test]
+    fn test_jittered_repoll_interval_bounds() {
+        // For ANY rand_unit in [0,1], the jittered interval must stay within
+        // ±UPDATE_REPOLL_JITTER_FRACTION of the base. The rate-limit and
+        // thundering-herd reasoning both depend on this property holding.
+        let base = UPDATE_REPOLL_INTERVAL;
+        let frac = UPDATE_REPOLL_JITTER_FRACTION;
+        let min = base.mul_f64(1.0 - frac);
+        let max = base.mul_f64(1.0 + frac);
+        for i in 0..=100 {
+            let rand_unit = i as f64 / 100.0;
+            let got = jittered_repoll_interval(base, frac, rand_unit);
+            assert!(
+                got >= min && got <= max,
+                "rand_unit={rand_unit}: {got:?} not in [{min:?}, {max:?}]"
+            );
+        }
+    }
+
+    #[test]
+    fn test_jittered_repoll_interval_endpoints_and_midpoint() {
+        // Exact mapping at the three reference points (1000s base, ±25%).
+        let base = Duration::from_secs(1000);
+        assert_eq!(
+            jittered_repoll_interval(base, 0.25, 0.0),
+            Duration::from_secs(750)
+        );
+        assert_eq!(
+            jittered_repoll_interval(base, 0.25, 0.5),
+            Duration::from_secs(1000)
+        );
+        assert_eq!(
+            jittered_repoll_interval(base, 0.25, 1.0),
+            Duration::from_secs(1250)
+        );
+    }
+
+    #[test]
+    fn test_jittered_repoll_interval_deterministic() {
+        // Same inputs -> same output. The function must have no hidden global
+        // state, so a test can pin it without a clock or RNG.
+        let a = jittered_repoll_interval(UPDATE_REPOLL_INTERVAL, 0.25, 0.37);
+        let b = jittered_repoll_interval(UPDATE_REPOLL_INTERVAL, 0.25, 0.37);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_jittered_repoll_interval_clamps_out_of_range_inputs() {
+        let base = Duration::from_secs(1000);
+        // rand_unit is clamped to [0,1].
+        assert_eq!(
+            jittered_repoll_interval(base, 0.25, -5.0),
+            jittered_repoll_interval(base, 0.25, 0.0)
+        );
+        assert_eq!(
+            jittered_repoll_interval(base, 0.25, 5.0),
+            jittered_repoll_interval(base, 0.25, 1.0)
+        );
+        // jitter_fraction is clamped to [0,1]: a frac of 9.0 behaves as 1.0, so
+        // the factor range is [0, 2].
+        assert_eq!(
+            jittered_repoll_interval(base, 9.0, 0.0),
+            Duration::from_secs(0)
+        );
+        assert_eq!(
+            jittered_repoll_interval(base, 9.0, 1.0),
+            Duration::from_secs(2000)
+        );
+    }
+
+    #[test]
+    fn test_repoll_interval_is_under_github_rate_limit() {
+        // GitHub's unauthenticated REST limit is 60 requests/hour/IP. Even at
+        // the jittered minimum, the periodic re-poll alone must stay far under
+        // that (the bursty peer-signal checks share the same IP budget). We
+        // assert the minimum interval is >= 1 hour, i.e. <= 1 periodic request
+        // per hour — a >=60x safety margin.
+        let min =
+            jittered_repoll_interval(UPDATE_REPOLL_INTERVAL, UPDATE_REPOLL_JITTER_FRACTION, 0.0);
+        assert!(
+            min >= Duration::from_secs(3600),
+            "minimum re-poll interval {min:?} must be >= 1h to stay well under \
+             GitHub's 60 req/hr unauthenticated limit"
+        );
     }
 }

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -228,9 +228,11 @@ async fn run_network_node_with_signals(
     shutdown_handle: freenet::ShutdownHandle,
 ) -> anyhow::Result<()> {
     use commands::auto_update::{
-        UpdateCheckResult, UpdateNeededError, check_if_update_available, clear_version_mismatch,
-        get_open_connection_count, has_reached_max_backoff, has_version_mismatch, reset_backoff,
-        startup_update_check, version_mismatch_generation,
+        UPDATE_REPOLL_INTERVAL, UPDATE_REPOLL_JITTER_FRACTION, UpdateCheckResult,
+        UpdateNeededError, check_if_update_available, clear_version_mismatch,
+        get_open_connection_count, has_reached_max_backoff, has_version_mismatch,
+        jittered_repoll_interval, reset_backoff, should_attempt_update, startup_update_check,
+        version_mismatch_generation,
     };
     use freenet::transport::{clear_urgent_update, get_highest_seen_version, is_urgent_update};
     use tokio::signal;
@@ -332,11 +334,16 @@ async fn run_network_node_with_signals(
 
     // Monitor for version mismatches and check for updates (#3204).
     //
-    // Three update triggers (checked each 60s tick):
+    // Four update triggers (checked each 60s tick):
     //   1. Urgent update: remote's min_compatible > our version → verify with GitHub, exit immediately
     //   2. Decentralized discovery: highest_seen_version > our version → start stagger timer,
     //      verify with GitHub when timer expires
     //   3. Legacy mismatch: existing backoff-based mechanism (fallback)
+    //   4. Periodic re-poll (#4073): re-run the direct startup GitHub check on a
+    //      recurring, jittered ~6h schedule so a long-running node still notices a
+    //      new release without a restart — even when every peer is on the same old
+    //      version (so triggers 1-3 never fire). Detection-only: feeds the SAME
+    //      exit-42 path.
     //
     // GitHub verification before exit-42 is always required — decentralized discovery
     // tells us *when* to check, GitHub confirms *what* to install.
@@ -444,11 +451,26 @@ async fn run_network_node_with_signals(
         // few hours indefinitely when peers report a version that isn't on GitHub yet.
         const STAGGER_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(24 * 3600);
 
+        // Compute the delay until the next periodic GitHub re-poll, jittering the
+        // base interval by ±UPDATE_REPOLL_JITTER_FRACTION using GlobalRng so nodes
+        // that booted together do not poll (and restart) in lockstep.
+        let repoll_delay = || {
+            let rand_unit = freenet::config::GlobalRng::random_range(0.0_f64..1.0);
+            jittered_repoll_interval(
+                UPDATE_REPOLL_INTERVAL,
+                UPDATE_REPOLL_JITTER_FRACTION,
+                rand_unit,
+            )
+        };
+
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
         let mut last_mismatch_generation = version_mismatch_generation();
         let mut isolated_mismatch_since: Option<Instant> = None;
         let mut stagger_deadline: Option<Instant> = None;
         let mut stagger_cooldown_until: Option<Instant> = None;
+        // First periodic re-poll is one (jittered) interval out; the boot-time
+        // startup_update_check above already covered "right now".
+        let mut next_repoll = Instant::now() + repoll_delay();
         let our_version = parse_our_version();
 
         loop {
@@ -659,6 +681,87 @@ async fn run_network_node_with_signals(
                 }
             } else {
                 isolated_mismatch_since = None;
+            }
+
+            // --- Priority 4: Periodic direct GitHub re-poll (#4073) ---
+            //
+            // Independent of any peer signal: re-run the SAME one-shot startup
+            // GitHub check on a recurring, jittered schedule so a node that has
+            // been up for a long time still notices a new release without a
+            // restart. Before this, once the boot-time startup check ran, all
+            // further detection depended on a peer signal (priorities 1-3); if an
+            // entire network sat on the same old version, no node re-checked GitHub
+            // and a freshly published release was never picked up.
+            //
+            // Detection-only: a discovered update feeds the SAME `update_tx` →
+            // graceful-shutdown → exit-42 → `freenet update` path as every trigger
+            // above — identical to the startup check — so all existing
+            // apply/verify/signing safety (checksum fail-closed #4586, signature
+            // verify #4587, crash-loop bounding #4551/#4588) applies unchanged.
+            //
+            // Fail-open + self-throttling: `startup_update_check` returns None on
+            // any GitHub/parse/network error, so a failed poll (rate-limit,
+            // outage) simply retries at the next interval (~6h) — it never hammers
+            // the API or crashes the node. At 6h ± 25% the minimum interval is
+            // ~4.5h, far under GitHub's unauthenticated 60 req/hr/IP limit. The
+            // 60s tick advances `next_repoll`, so only one re-poll runs per
+            // interval and (being sequential in this single task) it never
+            // overlaps an in-flight check.
+            if Instant::now() >= next_repoll {
+                next_repoll = Instant::now() + repoll_delay();
+                // Respect the persistent auto-update failure lockout (#3934).
+                // When installs keep failing (e.g. a non-writable binary path)
+                // the failure counter reaches MAX_UPDATE_FAILURES and the
+                // peer-signal triggers (priorities 1-3) stop exiting for
+                // auto-update via `check_if_update_available`. The periodic
+                // re-poll MUST honor the same lockout — otherwise a locked-out
+                // long-running node would exit-42 every interval and make the
+                // supervisor rerun the same failing update, reintroducing the
+                // exact loop the lockout exists to stop. (The boot-time startup
+                // check bypasses the lockout, but only once per restart; a
+                // *recurring* bypass is the regression.) A successful manual
+                // `freenet update` clears the counter and re-enables this path.
+                if should_attempt_update() {
+                    tracing::debug!(
+                        current = build_info::VERSION,
+                        "Periodic re-poll: checking GitHub directly for a newer release"
+                    );
+                    if let Some(new_version) = startup_update_check(build_info::VERSION).await {
+                        // #4073 (rebase onto #4591/#4593): mirror the boot-time
+                        // startup check — never exit-42 to a version that is
+                        // locally BLOCKED (crash-loop known-bad pin OR repeatedly
+                        // failed install: checksum / signature / download /
+                        // extract). The installer would refuse it anyway, so an
+                        // exit-42 here is a pointless restart cycle; gating it is
+                        // what keeps the failed-install loop stopped. (Rate-limit
+                        // is already honored upstream: this path reaches GitHub
+                        // through `get_latest_version`, which consumes a node
+                        // token and returns None here when the bucket is empty.)
+                        if commands::rollback::is_version_pinned_bad(&new_version)
+                            || commands::rollback::is_version_install_gated(&new_version)
+                        {
+                            tracing::warn!(
+                                new_version = %new_version,
+                                "Periodic re-poll: newer version is locally blocked (crash-loop \
+                                 known-bad pin or repeated install failures); not triggering \
+                                 auto-update (#4073)"
+                            );
+                        } else {
+                            tracing::info!(
+                                new_version = %new_version,
+                                "Periodic re-poll: newer version on GitHub, triggering auto-update"
+                            );
+                            #[allow(clippy::let_underscore_must_use)]
+                            let _ = update_tx.send(new_version);
+                            return;
+                        }
+                    }
+                } else {
+                    tracing::debug!(
+                        "Periodic re-poll: skipped — auto-update locked out after repeated \
+                         failed installs (#3934); run `freenet update` to recover"
+                    );
+                }
             }
         }
     });
@@ -1507,6 +1610,36 @@ mod tests {
             marker_count >= 2,
             "both systemd unit templates must set Environment=FREENET_SUPERVISED=1 \
              (#4580); found {marker_count}"
+        );
+    }
+
+    /// Source-scrape pin (#4073 / Codex P2): the periodic re-poll MUST gate on
+    /// `should_attempt_update()` so it honors the persistent auto-update failure
+    /// lockout (#3934). Without the gate, a locked-out long-running node (e.g. a
+    /// non-writable binary path that makes every install fail) would exit-42 once
+    /// per re-poll interval and make the supervisor rerun the same failing
+    /// update, reintroducing the loop the lockout exists to stop. The boot-time
+    /// startup check bypasses the lockout, but only once per restart; the
+    /// recurring re-poll must not.
+    #[test]
+    fn periodic_repoll_respects_update_lockout() {
+        let src = strip_line_comments(include_str!("freenet.rs"));
+        // `should_attempt_update()` (with parens) appears only at the re-poll
+        // gate; the bare name without parens is the `use` import. The re-poll's
+        // GitHub call is the LAST `startup_update_check(...)` in the file (the
+        // first is the boot-time startup check).
+        let gate = src.find("should_attempt_update()").expect(
+            "periodic re-poll must gate on should_attempt_update() to honor the \
+             #3934 auto-update failure lockout",
+        );
+        let repoll_check = src
+            .rfind("startup_update_check(build_info::VERSION).await")
+            .expect("periodic re-poll startup_update_check call not found");
+        assert!(
+            gate < repoll_check,
+            "the should_attempt_update() lockout gate must precede the periodic \
+             re-poll's startup_update_check call, so a locked-out node does not \
+             exit-42 in a loop (#4073 / #3934)"
         );
     }
 }


### PR DESCRIPTION
## Problem

Auto-update *detection* is effectively once-at-boot. After the one-shot startup
GitHub check (#3864), the update-check loop's three triggers are all driven by
peer signals:

1. **Urgent update** — a peer reports `min_compatible > our version`.
2. **Decentralized discovery** — a peer handshake reports a `highest_seen_version` newer than ours.
3. **Legacy mismatch** — the older backoff-based mechanism.

None of these re-poll GitHub on their own. If an entire network sits on the same
old version, no node ever sees a newer peer version, so no node re-checks GitHub
directly. A freshly published release is then never picked up until a node
happens to restart (which re-runs the startup check). A node that has been up for
weeks never re-checks, and the network can stay frozen on an old version.

## Solution

Add a fourth, peer-signal-independent trigger to the existing update-check loop:
a **periodic direct GitHub re-poll** that re-runs the same `startup_update_check`
on a recurring, jittered schedule, so a long-running node notices a new release
without needing a restart.

- **Detection only.** A discovered update feeds the *same* `update_tx` →
  graceful-shutdown → exit-42 → `freenet update` path as every existing trigger
  (and identically to the boot-time startup check). The apply/verify/signing
  path in `commands/update.rs` is untouched, so all merged safety still applies
  unchanged: fail-closed checksum gate (#4586), ed25519 signature verification
  (#4587), and crash-loop bounding (#4551 / #4588).
- **Interval: 6h, jittered ±25%.** 6h is far under GitHub's unauthenticated REST
  rate limit (60 req/hr/IP) — even at the jittered minimum (~4.5h) it is well
  under one request/hour, leaving headroom for the bursty peer-signal checks
  that share the IP budget; yet it is frequent enough that a release propagates
  within hours rather than never. The ±25% jitter decorrelates nodes that booted
  together so they do not re-poll (and therefore exit-42/restart) in lockstep —
  preserving the load-spreading intent of the existing 0-60s startup jitter and
  0-4h decentralized-discovery stagger. Jitter is drawn from `GlobalRng` (runtime
  jitter; does not affect deterministic simulation seeding).
- **Fail-open + self-throttling.** `startup_update_check` returns `None` on any
  GitHub / parse / network error, so a failed poll (rate-limit, outage) simply
  retries at the next interval — it never hammers the API or crashes the node.
- **Respects existing gates.** It lives inside the existing `update_check_task`,
  so it inherits the dirty/dev-build suppression (the task early-returns for
  `GIT_DIRTY` builds before the loop). The re-poll runs sequentially in that one
  task and advances its deadline before checking, so it never double-fires or
  overlaps an in-flight check, and it is cancellation-safe (the only `.await` is
  in the loop body, not inside a `select!` branch future).
- **Honors the persistent failure lockout (#3934).** The re-poll is gated on
  `should_attempt_update()`. If installs keep failing (e.g. a non-writable
  binary path), the failure counter reaches `MAX_UPDATE_FAILURES` and the
  re-poll skips — so a locked-out node does not exit-42 once per interval and
  drive the supervisor to rerun the same failing update. (The boot-time startup
  check bypasses the lockout, but only once per restart; a *recurring* bypass
  would reintroduce the loop the lockout prevents.) A successful manual
  `freenet update` clears the counter and re-enables the re-poll.

## Testing

- `cargo fmt`, `cargo clippy -p freenet --bin freenet -- -D warnings`: clean.
- `cargo test -p freenet --bin freenet`: 261 passed, 0 failed.
- New unit tests for the (pure, injectable) interval/jitter logic
  (`jittered_repoll_interval`), so it is testable without waiting hours:
  - bounds: result always within ±25% of base for any `rand_unit` in `[0,1]`;
  - exact endpoint/midpoint mapping (0.0 → -25%, 0.5 → base, 1.0 → +25%);
  - determinism (no hidden global state);
  - input clamping (out-of-range `rand_unit` / `jitter_fraction`);
  - rate-limit sanity: the jittered-minimum interval is ≥ 1h (≥60× margin under
    GitHub's 60 req/hr limit).
- A source-scrape pin test (`periodic_repoll_respects_update_lockout`) asserting
  the re-poll gates on `should_attempt_update()`, so a future edit cannot
  silently drop the #3934 lockout gate.
- External review: `codex review --base origin/main` raised one finding (P2) —
  the re-poll bypassing the #3934 failure lockout. Addressed by the
  `should_attempt_update()` gate above and pinned by the new test.

Refs #4073.

[AI-assisted - Claude]
