### PR TITLE
feat: default Freenet install to a supervised, auto-updating service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,19 @@ jobs:
       - name: Self-test announce-to-river
         run: bash scripts/release-agent/announce-to-river_test.sh
 
+      # install.sh now sets up a supervised service by default (issue #4073) so
+      # new nodes auto-update. The system-vs-user + lingering decision is the
+      # load-bearing new logic; these smoke tests pin it without needing real
+      # root/sudo. shellcheck guards the installer/uninstaller scripts too.
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Lint install/uninstall scripts (shellcheck)
+        run: shellcheck scripts/install.sh scripts/uninstall.sh scripts/test-install-sh.sh scripts/test-uninstall-sh.sh
+      - name: Self-test install.sh service-mode decision
+        run: sh scripts/test-install-sh.sh
+      - name: Self-test uninstall.sh
+        run: sh scripts/test-uninstall-sh.sh
+
       - name: Check for old-style mod.rs files
         run: |
           # New modules must use foo.rs + foo/ style, not foo/mod.rs

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -43,6 +43,17 @@ pub enum ServiceCommand {
         /// servers, or environments without a user session bus.
         #[arg(long)]
         system: bool,
+        /// Do NOT enable systemd lingering for a user service.
+        ///
+        /// By default a user service enables lingering
+        /// (`loginctl enable-linger <user>`) so it keeps running without an
+        /// active login session — required for the auto-update self-heal to
+        /// work on a headless server (without it, a `--user` service is
+        /// stopped at logout and never catches the node's exit-42 "update
+        /// needed" signal). Pass this to keep the service login-scoped
+        /// instead. Has no effect on a `--system` service.
+        #[arg(long)]
+        no_linger: bool,
     },
     /// Uninstall the Freenet system service
     Uninstall {
@@ -116,7 +127,7 @@ impl ServiceCommand {
         config_dirs: Arc<ConfigPaths>,
     ) -> Result<()> {
         match self {
-            ServiceCommand::Install { system } => install_service(*system),
+            ServiceCommand::Install { system, no_linger } => install_service(*system, *no_linger),
             ServiceCommand::Uninstall {
                 system,
                 purge,
@@ -233,15 +244,17 @@ pub(super) fn dashboard_port_is_listening() -> bool {
 // so `use super::*` in the tests block pulls them all into scope.
 
 #[cfg(target_os = "linux")]
-fn install_service(system: bool) -> Result<()> {
-    linux::install_service(system)
+fn install_service(system: bool, no_linger: bool) -> Result<()> {
+    linux::install_service(system, no_linger)
 }
 #[cfg(target_os = "macos")]
-fn install_service(system: bool) -> Result<()> {
+fn install_service(system: bool, _no_linger: bool) -> Result<()> {
+    // Lingering is a systemd concept; macOS launchd has no equivalent.
     macos::install_service(system)
 }
 #[cfg(target_os = "windows")]
-fn install_service(system: bool) -> Result<()> {
+fn install_service(system: bool, _no_linger: bool) -> Result<()> {
+    // Lingering is a systemd concept; Windows has no equivalent.
     windows::install_service(system)
 }
 
@@ -370,7 +383,7 @@ pub use windows::stop_and_remove_service;
 
 // Fallback for unsupported platforms
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-fn install_service(_system: bool) -> Result<()> {
+fn install_service(_system: bool, _no_linger: bool) -> Result<()> {
     anyhow::bail!("Service installation is not supported on this platform")
 }
 

--- a/crates/core/src/bin/commands/service/linux.rs
+++ b/crates/core/src/bin/commands/service/linux.rs
@@ -114,16 +114,119 @@ fn systemctl_with_hint(system_mode: bool, args: &[&str], action: &str) -> Result
 }
 
 #[cfg(target_os = "linux")]
-pub(super) fn install_service(system: bool) -> Result<()> {
+pub(super) fn install_service(system: bool, no_linger: bool) -> Result<()> {
     if system {
+        // A system service runs at boot independent of any login session, so
+        // lingering does not apply to it; `no_linger` is ignored here.
         install_system_service()
     } else {
-        install_user_service()
+        install_user_service(no_linger)
+    }
+}
+
+/// The lingering action implied by the install flags. Pure decision split out
+/// from the side-effecting install so the policy can be unit-tested:
+/// a system service never lingers (it starts at boot); a user service enables
+/// lingering by default and skips it only on `--no-linger`.
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LingerAction {
+    /// System service: lingering is irrelevant (runs at boot regardless).
+    SystemService,
+    /// User service: enable lingering so it survives logout (the default).
+    EnableForUser,
+    /// User service with `--no-linger`: keep the service login-scoped.
+    SkipForUser,
+}
+
+#[cfg(target_os = "linux")]
+fn linger_action(system: bool, no_linger: bool) -> LingerAction {
+    if system {
+        LingerAction::SystemService
+    } else if no_linger {
+        LingerAction::SkipForUser
+    } else {
+        LingerAction::EnableForUser
+    }
+}
+
+/// Resolve the current login name, for enabling systemd lingering on a user
+/// service. Prefers `$USER`/`$LOGNAME`, falling back to `id -un`.
+#[cfg(target_os = "linux")]
+fn current_username() -> Option<String> {
+    for var in ["USER", "LOGNAME"] {
+        if let Ok(value) = std::env::var(var) {
+            let value = value.trim();
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    std::process::Command::new("id")
+        .arg("-un")
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+        .filter(|name| !name.is_empty())
+}
+
+/// Whether systemd lingering is already enabled for `username`.
+#[cfg(target_os = "linux")]
+fn linger_enabled(username: &str) -> bool {
+    std::process::Command::new("loginctl")
+        .args(["show-user", username, "--property=Linger", "--value"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim() == "yes")
+        .unwrap_or(false)
+}
+
+/// Enable systemd "lingering" for `username` so their `--user` services keep
+/// running without an active login session.
+///
+/// This is ESSENTIAL for a headless server: without lingering, a `--user`
+/// service is bound to the user's login session and is stopped at logout, so
+/// it never restarts on boot and never catches the node's exit-42 "update
+/// needed" signal — the node silently stops auto-updating. Enabling lingering
+/// is the user-service counterpart to a `--system` service starting at boot.
+///
+/// Best-effort: a failure only weakens auto-update across logout, so we warn
+/// (with a remediation hint) rather than aborting the install. Idempotent: a
+/// no-op when lingering is already enabled.
+#[cfg(target_os = "linux")]
+fn enable_linger(username: &str) {
+    if linger_enabled(username) {
+        println!("systemd lingering already enabled for user '{username}'.");
+        return;
+    }
+    match std::process::Command::new("loginctl")
+        .args(["enable-linger", username])
+        .status()
+    {
+        Ok(status) if status.success() => {
+            println!(
+                "Enabled systemd lingering for user '{username}' \
+                 (the service runs without an active login session, so it \
+                 auto-updates on a headless server)."
+            );
+        }
+        _ => {
+            eprintln!(
+                "Warning: could not enable systemd lingering for user '{username}'.\n\
+                 The user service will run ONLY while you are logged in, so it will\n\
+                 NOT auto-update on a headless server. Enable it manually with:\n  \
+                 sudo loginctl enable-linger {username}\n\
+                 Or reinstall as a system service:\n  \
+                 sudo freenet service install --system"
+            );
+        }
     }
 }
 
 #[cfg(target_os = "linux")]
-fn install_user_service() -> Result<()> {
+fn install_user_service(no_linger: bool) -> Result<()> {
     use std::fs;
 
     let exe_path = std::env::current_exe().context("Failed to get current executable path")?;
@@ -161,12 +264,57 @@ fn install_user_service() -> Result<()> {
     // Enable the service
     systemctl_with_hint(false, &["enable", "freenet"], "enable service")?;
 
+    // Enable lingering by default so the service runs without an active login
+    // session (the headless-server auto-update requirement). Opt out with
+    // `--no-linger` to keep the service login-scoped.
+    //
+    // install_user_service is only reached for a user install, so the
+    // SystemService arm is unreachable here, but matching exhaustively keeps
+    // the policy in one place.
+    let action = linger_action(false, no_linger);
+    let username = current_username();
+    let lingering = match action {
+        LingerAction::EnableForUser => match &username {
+            Some(user) => {
+                enable_linger(user);
+                linger_enabled(user)
+            }
+            None => {
+                eprintln!(
+                    "Warning: could not determine the current username to enable \
+                     systemd lingering. The user service will run only while you are \
+                     logged in (no auto-update across logout). Enable it manually with:\n  \
+                     sudo loginctl enable-linger <your-user>"
+                );
+                false
+            }
+        },
+        LingerAction::SkipForUser | LingerAction::SystemService => false,
+    };
+
+    let user_label = username.as_deref().unwrap_or("<your-user>");
+
     println!("Freenet user service installed successfully.");
     println!();
     println!("To start the service now:");
     println!("  freenet service start");
     println!();
-    println!("The service will start automatically on login.");
+    if lingering {
+        println!("The service will start automatically on login and on boot");
+        println!("(systemd lingering is enabled, so it keeps running when you log out).");
+    } else if matches!(action, LingerAction::SkipForUser) {
+        // The operator explicitly opted out, so don't nag with a remediation;
+        // just state the consequence plainly.
+        println!("The service will start automatically on login.");
+        println!("Lingering is disabled (--no-linger): the service stops at logout, so it");
+        println!("will not auto-update on a headless server. Re-enable it any time with:");
+        println!("  sudo loginctl enable-linger {user_label}");
+    } else {
+        println!("The service will start automatically on login.");
+        println!("NOTE: lingering could NOT be enabled, so the service stops at logout and");
+        println!("      will not auto-update on a headless server. Enable it with:");
+        println!("        sudo loginctl enable-linger {user_label}");
+    }
     println!("Logs will be written to: {}", log_dir.display());
 
     Ok(())
@@ -698,7 +846,26 @@ pub(super) fn service_logs(error_only: bool) -> Result<()> {
 mod tests {
     use std::path::Path;
 
-    use super::{generate_system_service_file, generate_user_service_file};
+    use super::{
+        LingerAction, generate_system_service_file, generate_user_service_file, linger_action,
+    };
+
+    /// Policy pin (issue #4073): a system service never lingers (it starts at
+    /// boot regardless), a user service enables lingering by default so it
+    /// survives logout on a headless server, and `--no-linger` keeps a user
+    /// service login-scoped. Lingering is the user-service counterpart to a
+    /// system service's boot start; without it a `--user` node stops at logout
+    /// and silently never auto-updates.
+    #[test]
+    fn linger_action_matches_policy() {
+        // System service: `no_linger` is irrelevant.
+        assert_eq!(linger_action(true, false), LingerAction::SystemService);
+        assert_eq!(linger_action(true, true), LingerAction::SystemService);
+        // User service defaults to enabling lingering.
+        assert_eq!(linger_action(false, false), LingerAction::EnableForUser);
+        // User service with --no-linger stays login-scoped.
+        assert_eq!(linger_action(false, true), LingerAction::SkipForUser);
+    }
 
     /// Byte offset of the section header line (a line whose trimmed content is
     /// exactly `[name]`). Matches by LINE, not a naive substring search, so a

--- a/crates/core/src/bin/commands/service/purge.rs
+++ b/crates/core/src/bin/commands/service/purge.rs
@@ -129,8 +129,11 @@ pub(super) fn service_doctor(system: bool) -> Result<()> {
     println!("freenet service doctor: recovering service install...");
 
     // 1. Re-template wrapper/unit to the current binary.
+    //    no_linger=false: preserve the default linger behaviour when
+    //    re-templating a user service so a recovered headless install keeps
+    //    auto-updating across logout (linger enabling is idempotent).
     println!("  - Re-templating service wrapper/unit to the current binary...");
-    super::install_service(system)?;
+    super::install_service(system, false)?;
 
     // 2. Stop the managed service (best-effort: a wedged install may show the
     //    agent as not-running, in which case stop is a no-op we don't want to

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,12 +2,25 @@
 # Freenet installer script
 # Usage: curl -fsSL https://freenet.org/install.sh | sh
 #
-# This script installs Freenet to ~/.local/bin/ and optionally sets up
-# the system service.
+# This script installs Freenet to ~/.local/bin/ and sets up a supervised
+# service so the node auto-updates.
+#
+# A *supervised* install registers a service manager (systemd on Linux,
+# launchd on macOS) that catches the node's "update needed" exit (code 42)
+# and runs `freenet update`. An UNSUPERVISED node detects a new release,
+# exits to update, and never restarts on the new version - so it silently
+# stops updating. This installer therefore sets up supervision by DEFAULT.
+#
+# On Linux it prefers a system service when it can elevate (root or sudo) -
+# most reliable on the servers/VPS that dominate the node population - and
+# otherwise installs a user service WITH lingering enabled (so it still runs
+# when nobody is logged in). It only leaves a node unsupervised when you
+# explicitly opt out.
 #
 # Options (via environment variables):
 #   FREENET_INSTALL_DIR  - Installation directory (default: ~/.local/bin)
-#   FREENET_NO_SERVICE   - Set to 1 to skip service installation prompt
+#   FREENET_NO_SERVICE   - Set to 1 to install WITHOUT a service. The node
+#                          will NOT auto-update until you set one up.
 #   FREENET_VERSION      - Specific version to install (default: latest)
 #
 # NOTE: This file is mirrored at hugo-site/static/install.sh in
@@ -256,6 +269,180 @@ print_path_instructions() {
     echo ""
 }
 
+# ── Service supervision helpers ───────────────────────────────────────────
+#
+# A supervised install lets the node auto-update (the service manager catches
+# exit code 42 and runs `freenet update`). These helpers decide WHAT kind of
+# supervised service to set up. The pure decision functions
+# (`decide_linux_service_mode`, `resolve_service_action`) delegate every
+# environment probe to small overridable helpers so the test suite
+# (scripts/test-install-sh.sh) can exercise the logic without real root/sudo.
+
+# True if running as uid 0.
+is_root() {
+    [ "$(id -u 2>/dev/null)" = "0" ]
+}
+
+# True if sudo can run WITHOUT an interactive password prompt.
+sudo_noninteractive_ok() {
+    has_cmd sudo && sudo -n true 2>/dev/null
+}
+
+# True if a system-wide systemd unit already exists.
+has_system_unit() {
+    [ -f /etc/systemd/system/freenet.service ]
+}
+
+# True if a user systemd unit already exists for the invoking user.
+has_user_unit() {
+    [ -f "${HOME:-}/.config/systemd/user/freenet.service" ]
+}
+
+# Decide whether a fresh supervised Linux install should be a system service
+# or a user service. Pure function of two booleans so it is unit-testable.
+#   $1 = am_root     ("1"/"0")
+#   $2 = can_elevate ("1"/"0" - root, or sudo available)
+# Echoes "system" or "user". A system service is preferred whenever we can
+# elevate (it runs at boot, survives logout, and is the most reliable choice
+# on headless servers); otherwise we fall back to a user service (which the
+# binary sets up with lingering enabled).
+decide_linux_service_mode() {
+    if [ "$1" = "1" ] || [ "$2" = "1" ]; then
+        echo "system"
+    else
+        echo "user"
+    fi
+}
+
+# Resolve the effective Linux service action, honoring any existing install so
+# a re-run refreshes it instead of creating a duplicate of the other type.
+#   $1 = interactive ("1"/"0")
+# Echoes "system" or "user".
+resolve_service_action() {
+    interactive=$1
+
+    # Existing install wins: refresh the same kind we already have.
+    if has_system_unit; then
+        echo "system"
+        return
+    fi
+    if has_user_unit; then
+        echo "user"
+        return
+    fi
+
+    am_root=0
+    if is_root; then
+        am_root=1
+    fi
+
+    can_elevate=0
+    if [ "$am_root" = "1" ]; then
+        can_elevate=1
+    elif sudo_noninteractive_ok; then
+        can_elevate=1
+    elif [ "$interactive" = "1" ] && has_cmd sudo; then
+        # An interactive run can prompt for the sudo password.
+        can_elevate=1
+    fi
+
+    decide_linux_service_mode "$am_root" "$can_elevate"
+}
+
+# Loud warning printed whenever a node is left unsupervised.
+warn_unsupervised() {
+    bin=$1
+    echo ""
+    warn "Freenet is installed but NOT running under a service manager."
+    warn "An unsupervised node detects new releases, exits to update, and does"
+    warn "NOT restart on the new version - so it silently STOPS auto-updating."
+    echo ""
+    echo "To set up auto-updating supervision later, run ONE of:"
+    echo "  sudo $bin service install --system   # system service (best on servers)"
+    echo "  $bin service install                 # user service (enables lingering)"
+    echo ""
+}
+
+# Install a supervised service for the freenet binary "$1", choosing system vs
+# user (Linux) and falling back to an unsupervised install with a loud warning
+# only as a last resort. "$2" = interactive ("1"/"0").
+setup_service() {
+    bin=$1
+    interactive=$2
+
+    if [ "$os" = "macos" ]; then
+        # launchd user agent; no system/lingering distinction on macOS.
+        info "Setting up the Freenet service (launchd user agent)..."
+        if "$bin" service install; then
+            success "Service installed. Start it with: freenet service start"
+            echo "  Once running, open http://127.0.0.1:7509/ to view your dashboard."
+        else
+            warn "Service installation failed."
+            warn_unsupervised "$bin"
+        fi
+        return
+    fi
+
+    # Linux.
+    action=$(resolve_service_action "$interactive")
+    case "$action" in
+        system)
+            if is_root; then
+                # `curl ... | sudo sh` sets SUDO_USER, which the binary uses as
+                # the non-root service user; a pure-root login has no such user
+                # and the binary refuses to run the node as root.
+                if [ -z "${SUDO_USER:-}" ]; then
+                    warn "Running as root with no SUDO_USER set: the service must"
+                    warn "run as a non-root user. Re-run the installer as that user"
+                    warn "(e.g. 'sudo -u <user> sh install.sh') for a supervised setup."
+                    warn_unsupervised "$bin"
+                    return
+                fi
+                info "Setting up a system service (running as \$SUDO_USER=$SUDO_USER)..."
+                if "$bin" service install --system; then
+                    print_service_success "system"
+                else
+                    warn "System service installation failed."
+                    warn_unsupervised "$bin"
+                fi
+                return
+            fi
+            info "Setting up a system service (requires sudo)..."
+            if sudo "$bin" service install --system; then
+                print_service_success "system"
+            else
+                warn "System service install via sudo failed; falling back to a user service."
+                if "$bin" service install; then
+                    print_service_success "user"
+                else
+                    warn "User service installation failed."
+                    warn_unsupervised "$bin"
+                fi
+            fi
+            ;;
+        user)
+            info "Setting up a user service (with lingering, so it runs when logged out)..."
+            if "$bin" service install; then
+                print_service_success "user"
+            else
+                warn "User service installation failed."
+                warn_unsupervised "$bin"
+            fi
+            ;;
+    esac
+}
+
+# Print the post-install success blurb. "$1" = "system" or "user".
+print_service_success() {
+    echo ""
+    if [ "$1" = "system" ]; then
+        success "System service installed! Start it with: sudo freenet service start --system"
+    else
+        success "Service installed! Start it with: freenet service start"
+    fi
+    echo "  Once running, open http://127.0.0.1:7509/ to view your Freenet dashboard."
+}
+
 # Main installation logic
 main() {
     info "Freenet Installer"
@@ -417,67 +604,89 @@ main() {
         print_path_instructions "$install_dir"
     fi
 
-    # Ask about service installation (unless FREENET_NO_SERVICE is set).
+    # Set up a supervised service so the node auto-updates, UNLESS the user
+    # opted out with FREENET_NO_SERVICE=1. Supervision is the default because
+    # an unsupervised node silently stops updating (it exits to update and
+    # never restarts on the new version).
     #
     # When the script is piped via `curl ... | sh`, sh reads its own script
-    # source from stdin. A plain `read` at this point would consume bytes
-    # of script source instead of capturing the user's answer, so we
-    # redirect from /dev/tty in that case.
+    # source from stdin. A plain `read` would consume bytes of script source
+    # instead of the user's answer, so we redirect from /dev/tty in that case.
     #
-    # We detect "sh is reading the script from stdin" via $0: when sh runs
-    # a script file, $0 is the script path; when sh reads its source from
-    # stdin, $0 is the shell name itself (e.g. "sh", "bash"). In the
-    # script-file case we read from stdin as before, so existing
-    # automation patterns like `printf 'y\n' | sh install.sh` still work.
-    # The shell-name allowlist covers shells likely to appear as
-    # `curl ... | <shell>`; users piping to a more exotic shell can fall
-    # back to FREENET_NO_SERVICE=1 to bypass the prompt.
+    # We detect "sh is reading the script from stdin" via $0: when sh runs a
+    # script file, $0 is the script path; when sh reads its source from stdin,
+    # $0 is the shell name itself (e.g. "sh", "bash"). In the script-file case
+    # we read from stdin as before, so automation like
+    # `printf 'n\n' | sh install.sh` still works. The shell-name allowlist
+    # covers shells likely to appear as `curl ... | <shell>`.
     #
     # `{ true </dev/tty; } 2>/dev/null` is used instead of `[ -r /dev/tty ]`:
-    # the access check can succeed even when the process has no
-    # controlling terminal and the subsequent open(2) fails with ENXIO.
-    # Probe by actually opening /dev/tty.
+    # the access check can succeed even when the process has no controlling
+    # terminal and the subsequent open(2) fails with ENXIO. Probe by actually
+    # opening /dev/tty.
     #
-    # `read -r response || response=""` keeps EOF (e.g. Ctrl-D, closed
-    # stdin) from aborting the script under `set -eu`.
-    if [ "${FREENET_NO_SERVICE:-0}" != "1" ]; then
+    # `read -r response || response=""` keeps EOF (e.g. Ctrl-D, closed stdin)
+    # from aborting the script under `set -eu`.
+    if [ "${FREENET_NO_SERVICE:-0}" = "1" ]; then
+        info "FREENET_NO_SERVICE is set: installing without a service."
+        warn_unsupervised "$install_dir/freenet"
+    else
         echo ""
-        response=""
+        # answer_src: where to read the y/n answer from ("tty", "stdin", or ""
+        # for none). has_tty: whether a real terminal exists, used to decide
+        # whether an interactive sudo password prompt is possible.
+        answer_src=""
+        has_tty=0
         case "${0##*/}" in
             sh|bash|dash|ash|zsh|ksh|mksh|pdksh|yash|busybox|-sh|-bash|-dash|-ash|-zsh|-ksh|-mksh|-yash)
-                # Script source is on stdin (`curl | sh` form).
+                # `curl | sh` form: the script source is on stdin, so the only
+                # place an answer can come from is the controlling terminal.
                 if { true </dev/tty; } 2>/dev/null; then
-                    printf "Would you like to install Freenet as a system service? [y/N] "
-                    read -r response </dev/tty || response=""
+                    answer_src="tty"
+                    has_tty=1
                 fi
                 ;;
             *)
-                # Script ran as a file; stdin carries the user's answer.
-                printf "Would you like to install Freenet as a system service? [y/N] "
+                # Script ran as a file: stdin carries the answer (a terminal OR
+                # a pipe), preserving automation like
+                # `printf 'n\n' | sh install.sh`. An empty/EOF read keeps the
+                # supervised default.
+                answer_src="stdin"
+                if [ -t 0 ]; then
+                    has_tty=1
+                fi
+                ;;
+        esac
+
+        decline=0
+        if [ -n "$answer_src" ]; then
+            # Default is YES (supervision) - note the [Y/n].
+            printf "Set up Freenet to run as an auto-updating background service? [Y/n] "
+            response=""
+            if [ "$answer_src" = "tty" ]; then
+                read -r response </dev/tty || response=""
+            else
                 read -r response || response=""
-                ;;
-        esac
-        case "$response" in
-            [yY]|[yY][eE][sS])
-                info "Installing service..."
-                "$install_dir/freenet" service install
-                echo ""
-                success "Service installed! Start it with: freenet service start"
-                echo "  Once running, open http://127.0.0.1:7509/ to view your Freenet dashboard."
-                ;;
-            *)
-                info "Skipping service installation"
-                echo ""
-                echo "You can install the service later with:"
-                echo "  freenet service install"
-                echo ""
-                echo "To skip this prompt entirely in scripted installs, set FREENET_NO_SERVICE=1."
-                ;;
-        esac
+            fi
+            case "$response" in
+                [nN]|[nN][oO]) decline=1 ;;
+                *) decline=0 ;;
+            esac
+        else
+            info "No interactive terminal detected; setting up supervision by default."
+            info "(set FREENET_NO_SERVICE=1 to install without a service)"
+        fi
+
+        if [ "$decline" = "1" ]; then
+            info "Skipping service installation at your request."
+            warn_unsupervised "$install_dir/freenet"
+        else
+            setup_service "$install_dir/freenet" "$has_tty"
+        fi
     fi
 
     echo ""
-    echo "To run Freenet manually:"
+    echo "To run Freenet manually instead:"
     echo "  freenet network"
     echo ""
     echo "Once running, open http://127.0.0.1:7509/ to view your Freenet dashboard."
@@ -494,5 +703,9 @@ main() {
     echo "For more information, visit: https://freenet.org"
 }
 
-# Run main function
-main "$@"
+# Run main function, unless this file is being sourced by the test suite
+# (scripts/test-install-sh.sh sets FREENET_INSTALL_SH_LIB=1) purely to load
+# the helper functions for unit testing without performing an install.
+if [ "${FREENET_INSTALL_SH_LIB:-0}" != "1" ]; then
+    main "$@"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -453,6 +453,30 @@ setup_service() {
                     warn_unsupervised "$bin"
                     return
                 fi
+                # Executing the binary is not enough: the auto-update path
+                # (ExecStopPost -> `freenet update`, run as $SUDO_USER) REPLACES
+                # the binary in place. replace_binary writes a temp file in the
+                # binary's directory and renames it over the binary, so it needs
+                # WRITE permission on that DIRECTORY (rename/unlink are governed
+                # by directory perms, not the file's own mode/owner). A
+                # root-owned install dir the service user can read+execute but
+                # not write (e.g. FREENET_INSTALL_DIR=/usr/local/bin under
+                # `curl | sudo sh`) passes the exec check above yet would fail
+                # EVERY auto-update -- the exact silent "stops updating" failure
+                # this installer exists to prevent. Refuse to set up a service
+                # that cannot update itself.
+                bindir=$(dirname "$bin")
+                if ! sudo -u "$SUDO_USER" sh -c 'test -w "$1"' sh "$bindir" 2>/dev/null; then
+                    warn "The install directory '$bindir' is not writable by the"
+                    warn "service user '$SUDO_USER', so the node could not replace its"
+                    warn "own binary when auto-updating (it would silently stop"
+                    warn "updating). Install to a user-writable location instead -"
+                    warn "e.g. re-run as '$SUDO_USER' WITHOUT sudo (which defaults"
+                    warn "to a writable directory under their home):"
+                    warn "  curl -fsSL https://freenet.org/install.sh | sh"
+                    warn_unsupervised "$bin"
+                    return
+                fi
                 info "Setting up a system service (running as \$SUDO_USER=$SUDO_USER)..."
                 if "$bin" service install --system; then
                     print_service_success "system" "$bin"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -398,6 +398,21 @@ setup_service() {
                     warn_unsupervised "$bin"
                     return
                 fi
+                # The system unit runs as $SUDO_USER and points ExecStart at
+                # $bin. With `curl | sudo sh`, HOME is usually /root, so $bin
+                # lands under /root/.local/bin which $SUDO_USER cannot traverse:
+                # the unit would install but fail to start. Verify the service
+                # user can actually execute the binary before creating a unit
+                # that points at it. (As root, `sudo -u` needs no password.)
+                if ! sudo -u "$SUDO_USER" sh -c 'test -x "$1"' sh "$bin" 2>/dev/null; then
+                    warn "The installed binary at '$bin' is not accessible to user"
+                    warn "'$SUDO_USER' (it looks like it was installed under root's"
+                    warn "home). A system service pointing there would fail to start."
+                    warn "Re-run the installer as '$SUDO_USER' WITHOUT sudo:"
+                    warn "  curl -fsSL https://freenet.org/install.sh | sh"
+                    warn_unsupervised "$bin"
+                    return
+                fi
                 info "Setting up a system service (running as \$SUDO_USER=$SUDO_USER)..."
                 if "$bin" service install --system; then
                     print_service_success "system"
@@ -410,6 +425,17 @@ setup_service() {
             info "Setting up a system service (requires sudo)..."
             if sudo "$bin" service install --system; then
                 print_service_success "system"
+            elif has_system_unit; then
+                # We picked "system" to REFRESH an existing system unit, but the
+                # sudo refresh failed (e.g. no passwordless sudo in a scripted
+                # rerun). Do NOT fall back to a user service - that would leave
+                # BOTH a system and a user service installed (the duplicate the
+                # existing-install routing exists to prevent). The freshly
+                # downloaded binary is already in place at $bin and takes effect
+                # on the next restart of the existing service.
+                warn "Could not refresh the existing system service (needs sudo)."
+                warn "The updated binary is in place and takes effect on the next restart."
+                warn "To refresh the unit now, run: sudo $bin service install --system"
             else
                 warn "System service install via sudo failed; falling back to a user service."
                 if "$bin" service install; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -298,6 +298,28 @@ has_user_unit() {
     [ -f "${HOME:-}/.config/systemd/user/freenet.service" ]
 }
 
+# Echo the `User=` value of the existing system unit (empty if none/unset).
+existing_system_unit_user() {
+    [ -f /etc/systemd/system/freenet.service ] || return 0
+    sed -n 's/^User=//p' /etc/systemd/system/freenet.service 2>/dev/null | head -n1
+}
+
+# Decide whether it is safe to refresh an existing system unit. The binary
+# derives the service `User=` (and home/log/ExecStart paths) from the user the
+# refresh runs as, so refreshing as a DIFFERENT user would silently re-point
+# the service and orphan the original node's data/identity. Only refresh when
+# the unit's current user matches (or can't be determined). Pure + testable.
+#   $1 = existing `User=` value (may be empty)
+#   $2 = user the refresh would run as
+# Echoes "refresh" or "skip".
+should_refresh_system_unit() {
+    if [ -z "$1" ] || [ "$1" = "$2" ]; then
+        echo "refresh"
+    else
+        echo "skip"
+    fi
+}
+
 # Decide whether a fresh supervised Linux install should be a system service
 # or a user service. Pure function of two booleans so it is unit-testable.
 #   $1 = am_root     ("1"/"0")
@@ -387,6 +409,24 @@ setup_service() {
     action=$(resolve_service_action "$interactive")
     case "$action" in
         system)
+            # Refresh guard: an existing system unit is re-templated using the
+            # user the refresh runs as. Refreshing it as a DIFFERENT user would
+            # silently re-point the service (User=/home/log/ExecStart) and
+            # orphan the original node. Skip the refresh in that case - the new
+            # binary is already on disk and is picked up on the next restart.
+            if has_system_unit; then
+                refresh_user="${SUDO_USER:-$(id -un 2>/dev/null)}"
+                existing_user=$(existing_system_unit_user)
+                if [ "$(should_refresh_system_unit "$existing_user" "$refresh_user")" = "skip" ]; then
+                    warn "An existing system service runs as user '$existing_user'."
+                    warn "Not refreshing it as '$refresh_user' - that would re-point the"
+                    warn "service and orphan the original node's data/identity."
+                    warn "The updated binary is in place; restart the service to use it,"
+                    warn "or re-run the installer as '$existing_user' to refresh the unit."
+                    return
+                fi
+            fi
+
             if is_root; then
                 # `curl ... | sudo sh` sets SUDO_USER, which the binary uses as
                 # the non-root service user; a pure-root login has no such user

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -304,6 +304,16 @@ existing_system_unit_user() {
     sed -n 's/^User=//p' /etc/systemd/system/freenet.service 2>/dev/null | head -n1
 }
 
+# Echo the binary path the existing system unit launches (the first field of
+# its `ExecStart=`, which the template renders as `<binary> network`). Empty if
+# there is no unit / no ExecStart. Used to tell whether a freshly downloaded
+# binary actually lands where the running service looks for it.
+existing_system_unit_binary() {
+    [ -f /etc/systemd/system/freenet.service ] || return 0
+    sed -n 's/^ExecStart=//p' /etc/systemd/system/freenet.service 2>/dev/null \
+        | head -n1 | awk '{print $1}'
+}
+
 # Decide whether it is safe to refresh an existing system unit. The binary
 # derives the service `User=` (and home/log/ExecStart paths) from the user the
 # refresh runs as, so refreshing as a DIFFERENT user would silently re-point
@@ -421,8 +431,26 @@ setup_service() {
                     warn "An existing system service runs as user '$existing_user'."
                     warn "Not refreshing it as '$refresh_user' - that would re-point the"
                     warn "service and orphan the original node's data/identity."
-                    warn "The updated binary is in place; restart the service to use it,"
-                    warn "or re-run the installer as '$existing_user' to refresh the unit."
+                    # Whether "just restart it" is accurate depends on WHERE this
+                    # run put the new binary. With the default per-user install
+                    # dir, '$refresh_user's binary is under their home while the
+                    # existing unit's ExecStart still points at '$existing_user's
+                    # binary, so a restart would keep running the OLD version.
+                    # Only claim the update is in place when the paths match (e.g.
+                    # a shared FREENET_INSTALL_DIR); otherwise direct the operator
+                    # to re-run as the service user so the binary lands where the
+                    # unit looks for it.
+                    existing_bin=$(existing_system_unit_binary)
+                    if [ -n "$existing_bin" ] && [ "$existing_bin" != "$bin" ]; then
+                        warn "This run installed the new binary at '$bin', but the"
+                        warn "existing service runs '$existing_bin' (which was NOT"
+                        warn "updated), so restarting it would keep the OLD version."
+                        warn "To update it, re-run the installer as '$existing_user'."
+                    else
+                        warn "The updated binary is in place; restart the service to use"
+                        warn "it, or re-run the installer as '$existing_user' to refresh"
+                        warn "the unit."
+                    fi
                     return
                 fi
             fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -455,7 +455,7 @@ setup_service() {
                 fi
                 info "Setting up a system service (running as \$SUDO_USER=$SUDO_USER)..."
                 if "$bin" service install --system; then
-                    print_service_success "system"
+                    print_service_success "system" "$bin"
                 else
                     warn "System service installation failed."
                     warn_unsupervised "$bin"
@@ -464,7 +464,7 @@ setup_service() {
             fi
             info "Setting up a system service (requires sudo)..."
             if sudo "$bin" service install --system; then
-                print_service_success "system"
+                print_service_success "system" "$bin"
             elif has_system_unit; then
                 # We picked "system" to REFRESH an existing system unit, but the
                 # sudo refresh failed (e.g. no passwordless sudo in a scripted
@@ -479,7 +479,7 @@ setup_service() {
             else
                 warn "System service install via sudo failed; falling back to a user service."
                 if "$bin" service install; then
-                    print_service_success "user"
+                    print_service_success "user" "$bin"
                 else
                     warn "User service installation failed."
                     warn_unsupervised "$bin"
@@ -489,7 +489,7 @@ setup_service() {
         user)
             info "Setting up a user service (with lingering, so it runs when logged out)..."
             if "$bin" service install; then
-                print_service_success "user"
+                print_service_success "user" "$bin"
             else
                 warn "User service installation failed."
                 warn_unsupervised "$bin"
@@ -498,11 +498,18 @@ setup_service() {
     esac
 }
 
-# Print the post-install success blurb. "$1" = "system" or "user".
+# Print the post-install success blurb.
+#   $1 = "system" or "user"
+#   $2 = absolute path to the installed freenet binary
+# The system start command uses the ABSOLUTE binary path: it runs under sudo,
+# whose secure_path typically excludes ~/.local/bin, so a bare `sudo freenet`
+# would fail with "command not found".
 print_service_success() {
+    bin=$2
     echo ""
     if [ "$1" = "system" ]; then
-        success "System service installed! Start it with: sudo freenet service start --system"
+        success "System service installed! Start it with: sudo $bin service start --system"
+        echo "  (equivalently: sudo systemctl start freenet)"
     else
         success "Service installed! Start it with: freenet service start"
     fi

--- a/scripts/test-install-sh.sh
+++ b/scripts/test-install-sh.sh
@@ -144,6 +144,22 @@ check_eq "resolve: fresh + interactive + sudo present -> system" "system" \
         has_user_unit() { return 1; }
     ' 1)"
 
+# ── should_refresh_system_unit: same-user refresh guard ────────────────────
+
+# Pure helper: only refresh an existing system unit when the unit's current
+# user matches the user the refresh would run as (else the refresh silently
+# re-points the service to a different account).
+refresh_decision() {
+    FREENET_INSTALL_SH_LIB=1 INSTALL="$INSTALL" sh -c '
+        . "$INSTALL"
+        should_refresh_system_unit "$1" "$2"
+    ' _ "$1" "$2"
+}
+
+check_eq "refresh: same user -> refresh"      "refresh" "$(refresh_decision alice alice)"
+check_eq "refresh: different user -> skip"    "skip"    "$(refresh_decision alice bob)"
+check_eq "refresh: empty existing -> refresh" "refresh" "$(refresh_decision '' bob)"
+
 # ── sourcing the lib must not perform an install ───────────────────────────
 #
 # With FREENET_INSTALL_SH_LIB=1, sourcing install.sh must define functions but

--- a/scripts/test-install-sh.sh
+++ b/scripts/test-install-sh.sh
@@ -1,0 +1,162 @@
+#!/bin/sh
+# Smoke tests for the service-supervision decision logic in scripts/install.sh.
+#
+# install.sh now sets up a SUPERVISED service by default (issue #4073) so new
+# nodes auto-update with no user action. On Linux it prefers a system service
+# when it can elevate (root or sudo) and otherwise installs a user service
+# (with lingering). This test exercises that decision in isolation.
+#
+# It sources install.sh with FREENET_INSTALL_SH_LIB=1 (which suppresses the
+# `main` call) and then redefines the small environment-probe helpers
+# (is_root, sudo_noninteractive_ok, has_cmd, has_system_unit, has_user_unit)
+# to simulate each scenario without needing real root/sudo. This is why those
+# probes are factored out as overridable functions in install.sh.
+#
+# Usage: scripts/test-install-sh.sh
+# Exit codes: 0 = all green, 1 = at least one failure.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL="${SCRIPT_DIR}/install.sh"
+
+if [ ! -f "$INSTALL" ]; then
+    echo "missing: $INSTALL" >&2
+    exit 2
+fi
+
+fails=0
+pass() { printf 'PASS  %s\n' "$1"; }
+fail() {
+    printf 'FAIL  %s - %s\n' "$1" "$2" >&2
+    fails=$((fails + 1))
+}
+
+check_eq() {
+    # $1: test name, $2: expected, $3: actual
+    if [ "$2" = "$3" ]; then
+        pass "$1"
+    else
+        fail "$1" "expected '$2', got '$3'"
+    fi
+}
+
+# Call the pure decide function: decide_linux_service_mode AM_ROOT CAN_ELEVATE
+decide() {
+    FREENET_INSTALL_SH_LIB=1 INSTALL="$INSTALL" sh -c '
+        . "$INSTALL"
+        decide_linux_service_mode "$1" "$2"
+    ' _ "$1" "$2"
+}
+
+# Call resolve_service_action with a snippet of helper overrides applied first.
+#   $1: override snippet (shell code), $2: interactive flag ("1"/"0")
+resolve_with() {
+    overrides=$1
+    inter=$2
+    FREENET_INSTALL_SH_LIB=1 INSTALL="$INSTALL" sh -c '
+        . "$INSTALL"
+        '"$overrides"'
+        resolve_service_action "$1"
+    ' _ "$inter"
+}
+
+# ── decide_linux_service_mode: pure system-vs-user policy ──────────────────
+
+check_eq "decide: root + elevate -> system"      "system" "$(decide 1 1)"
+check_eq "decide: root, no-elevate -> system"    "system" "$(decide 1 0)"
+check_eq "decide: non-root + elevate -> system"  "system" "$(decide 0 1)"
+check_eq "decide: non-root, no-elevate -> user"  "user"   "$(decide 0 0)"
+
+# ── resolve_service_action: existing-install routing wins ──────────────────
+
+# Even a non-root, no-sudo run must refresh an existing SYSTEM unit (not
+# create a duplicate user service).
+check_eq "resolve: existing system unit -> system" "system" \
+    "$(resolve_with '
+        is_root() { return 1; }
+        sudo_noninteractive_ok() { return 1; }
+        has_cmd() { return 1; }
+        has_system_unit() { return 0; }
+        has_user_unit() { return 1; }
+    ' 0)"
+
+check_eq "resolve: existing user unit -> user" "user" \
+    "$(resolve_with '
+        is_root() { return 1; }
+        sudo_noninteractive_ok() { return 1; }
+        has_cmd() { return 1; }
+        has_system_unit() { return 1; }
+        has_user_unit() { return 0; }
+    ' 0)"
+
+# ── resolve_service_action: fresh install, elevation detection ─────────────
+
+check_eq "resolve: fresh + root -> system" "system" \
+    "$(resolve_with '
+        is_root() { return 0; }
+        sudo_noninteractive_ok() { return 1; }
+        has_cmd() { return 1; }
+        has_system_unit() { return 1; }
+        has_user_unit() { return 1; }
+    ' 0)"
+
+check_eq "resolve: fresh + passwordless sudo -> system" "system" \
+    "$(resolve_with '
+        is_root() { return 1; }
+        sudo_noninteractive_ok() { return 0; }
+        has_cmd() { return 1; }
+        has_system_unit() { return 1; }
+        has_user_unit() { return 1; }
+    ' 0)"
+
+# Non-interactive, no root, no passwordless sudo -> user (safe supervised
+# fallback rather than leaving the node unsupervised).
+check_eq "resolve: fresh + non-root + no sudo + non-interactive -> user" "user" \
+    "$(resolve_with '
+        is_root() { return 1; }
+        sudo_noninteractive_ok() { return 1; }
+        has_cmd() { return 1; }
+        has_system_unit() { return 1; }
+        has_user_unit() { return 1; }
+    ' 0)"
+
+# Interactive but sudo not installed -> user.
+check_eq "resolve: fresh + interactive + no sudo cmd -> user" "user" \
+    "$(resolve_with '
+        is_root() { return 1; }
+        sudo_noninteractive_ok() { return 1; }
+        has_cmd() { return 1; }
+        has_system_unit() { return 1; }
+        has_user_unit() { return 1; }
+    ' 1)"
+
+# Interactive, sudo present but needs a password -> system (we can prompt).
+# SC2016: the `$1` below is intentionally literal — it is the argument of the
+# overriding has_cmd inside the sourced subshell, not a variable to expand here.
+# shellcheck disable=SC2016
+check_eq "resolve: fresh + interactive + sudo present -> system" "system" \
+    "$(resolve_with '
+        is_root() { return 1; }
+        sudo_noninteractive_ok() { return 1; }
+        has_cmd() { case "$1" in sudo) return 0 ;; *) return 1 ;; esac; }
+        has_system_unit() { return 1; }
+        has_user_unit() { return 1; }
+    ' 1)"
+
+# ── sourcing the lib must not perform an install ───────────────────────────
+#
+# With FREENET_INSTALL_SH_LIB=1, sourcing install.sh must define functions but
+# never run main() (which would try to download). We assert that sourcing is
+# quick and silent rather than attempting any network work.
+src_out=$(FREENET_INSTALL_SH_LIB=1 INSTALL="$INSTALL" sh -c '. "$INSTALL"; echo SOURCED_OK' 2>&1)
+check_eq "sourcing lib does not run main" "SOURCED_OK" "$src_out"
+
+echo
+if [ "$fails" -eq 0 ]; then
+    echo "All install.sh smoke tests passed."
+    exit 0
+else
+    echo "${fails} test(s) failed."
+    exit 1
+fi


### PR DESCRIPTION
## Problem

A typical Linux Freenet install ends up **unsupervised**, so it never auto-updates. `scripts/install.sh` defaulted the "install as a service?" prompt to **No**, and a node with no service manager catching its exit-42 "update needed" signal exits to update and never restarts on the new version - it silently stops updating. Since unsupervised is the dominant default on Linux, much of the network freezes on old releases.

## Solution

Make a **supervised install the default** (part of the auto-update work, #4073):

- **`install.sh` sets up supervision by default**, unless the user explicitly opts out with `FREENET_NO_SERVICE=1`. The interactive prompt now defaults to Yes (`[Y/n]`); a non-interactive `curl | sh` run sets up supervision automatically (the worse default is silently-never-updates).
- **Linux: prefer a SYSTEM service when it can elevate** (already root, or sudo available) - most reliable on the servers/VPS that dominate the node population (runs at boot, survives logout). When it can't elevate, it falls back to a **USER service**. A node is only left unsupervised as a last resort, with a loud warning explaining it won't auto-update.
- **The binary's user-service install now enables systemd lingering** (`loginctl enable-linger <user>`) by default, so a `--user` service runs without an active login session. This is the essential headless-server fix: without lingering, a user service stops at logout and never catches exit-42, so it never auto-updates. A new `--no-linger` flag opts out. System services are unaffected (they start at boot regardless).
- **Idempotent / safe to re-run:** the decision honors an existing install and refreshes the same service type instead of creating a duplicate of the other kind.

The generated systemd units are **unchanged** - this reuses the existing unit generation, so the `StartLimit`/exit-45 work from #4570/#4588 is preserved.

> [!IMPORTANT]
> **This changes default install behavior** (unsupervised -> supervised). New installs (and re-runs over an existing install) will now set up a systemd service by default.

> [!WARNING]
> **freenet.org/install.sh mirror must be updated in lockstep.** `scripts/install.sh` is mirrored at `hugo-site/static/install.sh` in `freenet/web` (served from https://freenet.org/install.sh). The website copy is what actual `curl | sh` users get, so this change does **not** reach users until the mirror is synced. I can't deploy the website - **@sanity to update the mirror after merge.**

## Testing

- **New `scripts/test-install-sh.sh`** smoke-tests the system-vs-user decision (root / passwordless-sudo / existing-unit / interactive permutations) by sourcing `install.sh` and overriding the environment probes - no real root/sudo needed.
- **New `linux.rs` unit test** pins the lingering policy: a system service never lingers; a user service lingers unless `--no-linger`.
- **Wired into CI** (`ci.yml`): the new install smoke test, the existing-but-previously-unwired uninstall smoke test, and `shellcheck` on `install.sh` / `uninstall.sh` / both test scripts.
- `cargo fmt`, `cargo clippy -p freenet --bins -- -D warnings`, and the service module tests (95) are green; `shellcheck` clean.

Refs #4073

[AI-assisted - Claude]