### PR TITLE
feat: crash-loop auto-rollback for the auto-updater (#4073)

### DIFF
--- a/crates/core/src/bin/commands/auto_update.rs
+++ b/crates/core/src/bin/commands/auto_update.rs
@@ -266,10 +266,13 @@ pub async fn check_if_update_available(current_version: &str) -> UpdateCheckResu
                     );
                     // Distinct result (NOT Skipped) so the caller clears the
                     // driving signal and does not fall through to the legacy
-                    // max-backoff exit-42 fallback. Reset the GitHub-check
-                    // backoff so a later fix (a version newer than the pin) is
-                    // still noticed promptly once peers re-signal.
-                    reset_backoff();
+                    // max-backoff exit-42 fallback. GROW the GitHub-check backoff
+                    // (do NOT reset it): a node that has already rolled back to a
+                    // good version is in no hurry to find the fix, so it should
+                    // poll at most hourly rather than at the 60s floor while
+                    // peers keep advertising the pinned-bad version. An hourly
+                    // check still catches a later strictly-newer release.
+                    increase_backoff();
                     return UpdateCheckResult::PinnedKnownBad;
                 }
                 tracing::info!(

--- a/crates/core/src/bin/commands/auto_update.rs
+++ b/crates/core/src/bin/commands/auto_update.rs
@@ -242,6 +242,21 @@ pub async fn check_if_update_available(current_version: &str) -> UpdateCheckResu
             };
 
             if latest_ver > current {
+                // #4073 crash-loop auto-rollback: never trigger an exit-42
+                // update to a version pinned known-bad on this node by a prior
+                // rollback. The installer would refuse it anyway; skipping here
+                // also avoids a pointless restart cycle. The mismatch flag is
+                // kept (Skipped) so a later, strictly-newer fixed release is
+                // still picked up.
+                if super::rollback::is_version_pinned_bad(&latest) {
+                    tracing::warn!(
+                        version = %latest,
+                        "Newer version is pinned known-bad after a crash-loop rollback; not \
+                         triggering auto-update to it (#4073)"
+                    );
+                    increase_backoff();
+                    return UpdateCheckResult::Skipped;
+                }
                 tracing::info!(
                     current = %current_version,
                     latest = %latest,
@@ -305,7 +320,12 @@ async fn get_latest_version() -> Result<String> {
 }
 
 /// Get the state directory for update tracking files.
-fn state_dir() -> Option<PathBuf> {
+///
+/// `pub(crate)` so the crash-loop auto-rollback module (`commands::rollback`)
+/// persists its probation / known-bad markers in the SAME directory as the
+/// auto-update failure counter and backoff state, ensuring both the node and
+/// the supervisor-invoked `freenet update` agree on a single state location.
+pub(crate) fn state_dir() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".local/state/freenet"))
 }
 

--- a/crates/core/src/bin/commands/auto_update.rs
+++ b/crates/core/src/bin/commands/auto_update.rs
@@ -151,6 +151,16 @@ pub enum UpdateCheckResult {
     /// Checked GitHub, newer version confirmed.
     /// The caller should clear the version mismatch flag.
     UpdateAvailable(String),
+    /// The newer version on GitHub is pinned known-bad on this node by a prior
+    /// crash-loop rollback (#4073). Distinct from [`Skipped`] so the caller does
+    /// NOT fall through to the legacy "max-backoff + 0 connections -> exit 42"
+    /// fallback: there is nothing safe to update to, so the node must stay put.
+    /// The caller should CLEAR the driving signal (version-mismatch / urgent) so
+    /// it stops trying to exit for this update; the signal re-arms on the next
+    /// peer handshake, which will pick up a later, strictly-newer fix.
+    ///
+    /// [`Skipped`]: UpdateCheckResult::Skipped
+    PinnedKnownBad,
 }
 
 /// Check if an update is available, respecting rate limits and failure counts.
@@ -254,8 +264,13 @@ pub async fn check_if_update_available(current_version: &str) -> UpdateCheckResu
                         "Newer version is pinned known-bad after a crash-loop rollback; not \
                          triggering auto-update to it (#4073)"
                     );
-                    increase_backoff();
-                    return UpdateCheckResult::Skipped;
+                    // Distinct result (NOT Skipped) so the caller clears the
+                    // driving signal and does not fall through to the legacy
+                    // max-backoff exit-42 fallback. Reset the GitHub-check
+                    // backoff so a later fix (a version newer than the pin) is
+                    // still noticed promptly once peers re-signal.
+                    reset_backoff();
+                    return UpdateCheckResult::PinnedKnownBad;
                 }
                 tracing::info!(
                     current = %current_version,

--- a/crates/core/src/bin/commands/mod.rs
+++ b/crates/core/src/bin/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod auto_update;
 pub mod report;
+pub mod rollback;
 pub mod secrets_cmd;
 pub mod service;
 pub mod setup_wizard;

--- a/crates/core/src/bin/commands/rollback.rs
+++ b/crates/core/src/bin/commands/rollback.rs
@@ -1,0 +1,738 @@
+//! Crash-loop auto-rollback for the Freenet auto-updater (#4073).
+//!
+//! Brick-safety: when a node auto-updates to a release that then crash-loops on
+//! startup, this module reverts the node to the immediately-previous,
+//! known-good binary and records the bad version locally so it is NOT
+//! auto-re-applied. Without it, a bad release that wedges at boot leaves the
+//! node down until an operator intervenes (systemd `StartLimitBurst` /
+//! `StartLimitAction=none` stops the unit, the run-wrapper gives up after its
+//! consecutive-failure cap).
+//!
+//! ## How it hooks the EXISTING crash detection (no parallel detector)
+//!
+//! Every Freenet supervisor that applies an auto-update already runs
+//! `freenet update` immediately after the node process stops:
+//!   * **systemd** (Linux): `ExecStopPost` runs `freenet update` on exit 42
+//!     (healthy-then-died / update-needed) OR 45 (fast crash / boot-wedge,
+//!     #4551).
+//!   * **macOS launchd wrapper script**: runs `freenet update` on exit 42.
+//!   * **in-process run-wrapper** (`service/wrapper.rs`, Windows + macOS tray):
+//!     runs `freenet update` on exit 42.
+//!
+//! Each of those supervisors now sets [`POST_STOP_EXIT_CODE_ENV_VAR`] on that
+//! post-stop `freenet update` invocation, carrying the exit code the node just
+//! died with. `freenet update` reads it ([`post_stop_exit_code_from_env`]) and,
+//! when the node is in post-update **probation** (see below), counts the stop as
+//! a crash of the probationary version and rolls back once the crash count
+//! crosses [`ROLLBACK_CRASH_THRESHOLD`]. This reuses the existing exit-code /
+//! restart machinery rather than inventing a second watchdog.
+//!
+//! ## Lifecycle
+//!
+//! 1. **Install** (`commands::update`): before overwriting the running binary,
+//!    snapshot it as the known-good rollback target ([`capture_known_good`]),
+//!    then mark the freshly-installed version as on-probation
+//!    ([`begin_probation`]).
+//! 2. **Commit**: once the new version has run healthily for
+//!    [`COMMIT_HEALTHY_UPTIME_SECS`] the node clears the probation marker
+//!    ([`commit_probation`]). After that, ordinary later crashes never trigger a
+//!    rollback. The window mirrors `MIN_HEALTHY_UPTIME_FOR_UPDATE_EXIT` (the
+//!    same boundary that classifies a fatal exit as a fast crash).
+//! 3. **Detect + revert**: a crash during probation increments the marker's
+//!    crash counter ([`handle_post_stop`]); on the
+//!    [`ROLLBACK_CRASH_THRESHOLD`]th crash the previous binary is restored, the
+//!    bad version is pinned ([`pin_known_bad_at`]), and the marker is cleared.
+//! 4. **Pin**: a pinned version is refused by both the installer
+//!    (`commands::update`) and the node's update checks
+//!    (`commands::auto_update`) so we never loop update → crash → revert →
+//!    re-update. A later, strictly-newer release (a fix) is NOT pinned and is
+//!    applied normally.
+//!
+//! ## Bounded by construction (no new flap/loop)
+//!
+//! * Rollback only ever restores the **known-good** target captured before the
+//!   probationary install. We never forward-chase a newer version while in
+//!   probation, so the rollback target is always a version that previously ran
+//!   (one generation back). [`ROLLBACK_CRASH_THRESHOLD`] is `< 5`
+//!   (`StartLimitBurst`) so a Linux rollback fires before systemd gives up.
+//! * If the reverted version ALSO cannot stay up there is no longer a probation
+//!   marker, so it is NOT rolled back again — the supervisor's existing bound
+//!   (systemd `StartLimit` / the wrapper's consecutive-failure cap) takes over
+//!   and the node is left for the operator.
+//! * If the known-good binary is missing we refuse to "roll back" rather than
+//!   risk deleting the only working binary.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Environment variable a supervisor sets on the post-stop `freenet update`
+/// invocation, carrying the exit code (`$EXIT_STATUS`) the node just stopped
+/// with. Its presence tells `freenet update` it is being run as part of the
+/// restart cycle (as opposed to a manual / tray-initiated update), which is the
+/// only context in which a stop should be counted as a crash for rollback
+/// purposes.
+///
+/// Forward/backward compatible by design (an env var, not a CLI flag): an OLD
+/// `freenet` binary — e.g. the one we just rolled back TO — silently ignores it
+/// instead of erroring on an unknown argument, and a NEW binary under an OLD
+/// supervisor simply never sees it (and behaves exactly as before).
+pub const POST_STOP_EXIT_CODE_ENV_VAR: &str = "FREENET_POST_STOP_EXIT_CODE";
+
+/// Consecutive crashes of a probationary version before we roll back.
+///
+/// MUST stay strictly below the systemd unit's `StartLimitBurst` (5, see
+/// `service/linux.rs`) so the rollback fires while systemd is still willing to
+/// restart the unit — if we waited until the 5th crash, systemd's
+/// `StartLimitAction=none` would already have stopped the unit and the
+/// supervisor would never run the `ExecStopPost` that performs the rollback.
+/// Three confirmed crashes is enough signal: a single crash is noise, two could
+/// be unlucky, by the third the new version is demonstrably not staying up.
+pub(crate) const ROLLBACK_CRASH_THRESHOLD: u32 = 3;
+
+/// Brick-safety invariant, enforced at compile time: a Linux rollback fires
+/// from the `ExecStopPost` of the Nth probation crash, so it must happen BEFORE
+/// systemd's `StartLimitBurst` (5, see `service/linux.rs`) stops the unit and
+/// removes the chance to run `ExecStopPost` at all.
+const _: () = assert!(
+    ROLLBACK_CRASH_THRESHOLD < 5,
+    "ROLLBACK_CRASH_THRESHOLD must be < systemd StartLimitBurst (5) in service/linux.rs"
+);
+
+/// How long a freshly-installed version must run before it is considered
+/// committed (probation cleared). Mirrors
+/// `node::p2p_impl::MIN_HEALTHY_UPTIME_FOR_UPDATE_EXIT` (60s): a fatal exit
+/// before this boundary is the fast-crash / boot-wedge we guard against, so a
+/// node that survives past it has cleared the same bar.
+pub(crate) const COMMIT_HEALTHY_UPTIME_SECS: u64 = 60;
+
+/// Probation marker: JSON describing the on-probation version and its
+/// known-good rollback target.
+const PROBATION_FILE: &str = "update_probation.json";
+
+/// Pinned known-bad version (plain text, a single version string). The
+/// installer and the node's update checks both refuse to (re-)apply this exact
+/// version.
+const KNOWN_BAD_FILE: &str = "known_bad_version";
+
+/// Snapshot of the previous, known-good binary kept as the rollback target.
+const KNOWN_GOOD_BINARY_FILE: &str = "known_good_binary";
+
+/// Persisted post-update probation record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ProbationState {
+    /// The version that was just installed and is on probation.
+    pub new_version: String,
+    /// The previous, known-good version we would roll back to.
+    pub previous_version: String,
+    /// Path to the retained known-good binary blob ([`known_good_binary_path`]).
+    pub rollback_binary: PathBuf,
+    /// Path to the live binary to restore over on rollback.
+    pub target_binary: PathBuf,
+    /// Unix seconds when the probationary version was installed (diagnostics).
+    pub installed_at_unix: u64,
+    /// Number of crashes observed during this probation so far.
+    pub crash_count: u32,
+}
+
+/// Outcome of [`handle_post_stop`], telling the caller (`commands::update`) what
+/// to do next.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PostStopOutcome {
+    /// Not a probation crash (no probation, or a stale marker): the caller
+    /// should run the normal update flow.
+    Proceed,
+    /// A probation crash was recorded but the rollback threshold is not yet
+    /// reached. The caller must NOT perform a normal update this cycle; the
+    /// supervisor will restart the same (probationary) binary.
+    CrashRecorded { crash_count: u32 },
+    /// The previous binary was restored. The caller should exit "success" so
+    /// the supervisor restarts the now-rolled-back binary.
+    RolledBack {
+        restored_version: String,
+        bad_version: String,
+    },
+    /// A rollback was warranted but could not be performed (no retained
+    /// known-good binary, or the restore failed). The caller must NOT perform a
+    /// normal update; the node is left for the supervisor's own bound /
+    /// operator intervention.
+    RollbackUnavailable { reason: String },
+}
+
+// ── State directory plumbing ───────────────────────────────────────────────
+
+fn state_dir() -> Option<PathBuf> {
+    super::auto_update::state_dir()
+}
+
+/// Path to the retained known-good binary blob, if the state dir resolves.
+pub(crate) fn known_good_binary_path() -> Option<PathBuf> {
+    state_dir().map(|d| d.join(KNOWN_GOOD_BINARY_FILE))
+}
+
+// ── Known-good capture ─────────────────────────────────────────────────────
+
+/// Copy `current_binary` to the known-good snapshot, atomically (copy to a
+/// temp sibling, then rename). Called BEFORE the install overwrites the live
+/// binary, and ONLY when transitioning from a committed/healthy version (not
+/// while already on probation), so the snapshot is always a version that
+/// previously ran.
+pub(crate) fn capture_known_good(current_binary: &Path) -> Result<()> {
+    let dir = state_dir().context("could not resolve state directory")?;
+    capture_known_good_at(&dir, current_binary)
+}
+
+pub(crate) fn capture_known_good_at(dir: &Path, current_binary: &Path) -> Result<()> {
+    std::fs::create_dir_all(dir).context("failed to create state directory")?;
+    let dest = dir.join(KNOWN_GOOD_BINARY_FILE);
+    let tmp = dir.join(format!("{KNOWN_GOOD_BINARY_FILE}.tmp"));
+    std::fs::copy(current_binary, &tmp).context("failed to snapshot known-good binary")?;
+    set_executable(&tmp);
+    if let Err(e) = std::fs::rename(&tmp, &dest) {
+        let _rm = std::fs::remove_file(&tmp);
+        return Err(e).context("failed to install known-good binary snapshot");
+    }
+    Ok(())
+}
+
+// ── Probation marker ───────────────────────────────────────────────────────
+
+/// Begin (or refresh) probation for `new_version`, just installed over the live
+/// binary at `target_binary`. `version_being_replaced` is the version of the
+/// binary that was overwritten.
+///
+/// Carries the known-good rollback target forward: if a probation marker
+/// already exists (a chained update WHILE on probation — e.g. a manual
+/// `freenet update`), we keep the existing `previous_version` /
+/// `rollback_binary` rather than treating the unproven probationary binary as
+/// known-good. Clears any known-bad pin, since a successful forward install
+/// means we have moved on.
+pub(crate) fn begin_probation(
+    new_version: &str,
+    version_being_replaced: &str,
+    target_binary: &Path,
+) {
+    if let Some(dir) = state_dir() {
+        begin_probation_at(
+            dir.as_path(),
+            new_version,
+            version_being_replaced,
+            target_binary,
+        );
+    }
+}
+
+pub(crate) fn begin_probation_at(
+    dir: &Path,
+    new_version: &str,
+    version_being_replaced: &str,
+    target_binary: &Path,
+) {
+    let _mkdir = std::fs::create_dir_all(dir);
+    let rollback_binary = dir.join(KNOWN_GOOD_BINARY_FILE);
+    // Preserve the known-good baseline across a chained in-probation install.
+    let previous_version = match read_probation_at(dir) {
+        Some(existing) => existing.previous_version,
+        None => version_being_replaced.to_string(),
+    };
+    let state = ProbationState {
+        new_version: new_version.to_string(),
+        previous_version,
+        rollback_binary,
+        target_binary: target_binary.to_path_buf(),
+        installed_at_unix: now_unix(),
+        crash_count: 0,
+    };
+    let _write = write_probation_at(dir, &state);
+    // Moving forward to a new version supersedes any prior known-bad pin.
+    clear_known_bad_at(dir);
+}
+
+/// Read the current probation marker, if any. A missing or unparseable marker
+/// is reported as "no probation" (we cannot safely act on a corrupt marker).
+pub(crate) fn read_probation() -> Option<ProbationState> {
+    read_probation_at(state_dir()?.as_path())
+}
+
+pub(crate) fn read_probation_at(dir: &Path) -> Option<ProbationState> {
+    let raw = std::fs::read_to_string(dir.join(PROBATION_FILE)).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn write_probation_at(dir: &Path, state: &ProbationState) -> Result<()> {
+    let raw = serde_json::to_string(state).context("failed to serialize probation marker")?;
+    std::fs::write(dir.join(PROBATION_FILE), raw).context("failed to write probation marker")
+}
+
+fn remove_probation_at(dir: &Path) {
+    let _rm = std::fs::remove_file(dir.join(PROBATION_FILE));
+}
+
+/// Clear probation if the running version matches the marker (it has proven
+/// healthy). A marker for a DIFFERENT version is stale (e.g. left over after a
+/// rollback or external install) and is also removed. Returns `Some(version)`
+/// when an in-probation version was committed (for logging).
+pub fn commit_probation(current_version: &str) {
+    if let Some(dir) = state_dir() {
+        match commit_probation_at(dir.as_path(), current_version) {
+            CommitOutcome::Committed => tracing::info!(
+                version = current_version,
+                "Auto-update probation passed: new version ran healthily for \
+                 {COMMIT_HEALTHY_UPTIME_SECS}s; committing (rollback disarmed)."
+            ),
+            CommitOutcome::ClearedStale { marker_version } => tracing::debug!(
+                running = current_version,
+                marker = %marker_version,
+                "Cleared stale auto-update probation marker for a different version."
+            ),
+            CommitOutcome::Nothing => {}
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum CommitOutcome {
+    /// The running version matched the probation marker and was committed.
+    Committed,
+    /// A marker for a different version was found and removed as stale.
+    ClearedStale { marker_version: String },
+    /// No probation marker present.
+    Nothing,
+}
+
+pub(crate) fn commit_probation_at(dir: &Path, current_version: &str) -> CommitOutcome {
+    match read_probation_at(dir) {
+        Some(state) if state.new_version == current_version => {
+            remove_probation_at(dir);
+            CommitOutcome::Committed
+        }
+        Some(state) => {
+            // Running a different version healthily than the marker describes:
+            // the marker can no longer protect anything, so drop it.
+            remove_probation_at(dir);
+            CommitOutcome::ClearedStale {
+                marker_version: state.new_version,
+            }
+        }
+        None => CommitOutcome::Nothing,
+    }
+}
+
+// ── Known-bad pin ──────────────────────────────────────────────────────────
+
+pub(crate) fn pin_known_bad_at(dir: &Path, version: &str) -> Result<()> {
+    let _mkdir = std::fs::create_dir_all(dir);
+    std::fs::write(dir.join(KNOWN_BAD_FILE), format!("{version}\n"))
+        .context("failed to write known-bad pin")
+}
+
+pub(crate) fn read_known_bad_at(dir: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(dir.join(KNOWN_BAD_FILE)).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn clear_known_bad_at(dir: &Path) {
+    let _rm = std::fs::remove_file(dir.join(KNOWN_BAD_FILE));
+}
+
+/// Whether `version` is the locally pinned known-bad version that must not be
+/// auto-(re)applied. Used by both the installer and the node's update checks.
+pub fn is_version_pinned_bad(version: &str) -> bool {
+    state_dir()
+        .map(|d| is_version_pinned_bad_at(d.as_path(), version))
+        .unwrap_or(false)
+}
+
+pub(crate) fn is_version_pinned_bad_at(dir: &Path, version: &str) -> bool {
+    read_known_bad_at(dir).as_deref() == Some(version)
+}
+
+// ── Post-stop crash handling / rollback ────────────────────────────────────
+
+/// Parse the [`POST_STOP_EXIT_CODE_ENV_VAR`] env var into the node's exit code,
+/// if set by a supervisor.
+pub fn post_stop_exit_code_from_env() -> Option<i32> {
+    std::env::var(POST_STOP_EXIT_CODE_ENV_VAR)
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+/// Handle a post-stop `freenet update` invocation for crash-loop rollback.
+///
+/// `current_version` is the version of the binary now running (the one the node
+/// just stopped on). The decision is intentionally independent of whatever
+/// release is "latest" on GitHub: while in probation we never forward-chase a
+/// newer version (that would make the rollback target an unproven binary), so a
+/// stop with no commit yet is treated as a crash of the probationary version.
+pub(crate) fn handle_post_stop(current_version: &str) -> PostStopOutcome {
+    match state_dir() {
+        Some(dir) => handle_post_stop_at(dir.as_path(), current_version),
+        None => PostStopOutcome::Proceed,
+    }
+}
+
+pub(crate) fn handle_post_stop_at(dir: &Path, current_version: &str) -> PostStopOutcome {
+    let Some(mut state) = read_probation_at(dir) else {
+        // Not on probation: a normal supervised restart (e.g. a long-running
+        // version that hit a transient fault, or a genuine update-needed exit).
+        // Let the caller run the ordinary update flow.
+        return PostStopOutcome::Proceed;
+    };
+
+    if state.new_version != current_version {
+        // The marker describes a different version than the one that just
+        // stopped — stale (e.g. an external install changed the binary). Drop
+        // it and fall through to the normal flow rather than acting on it.
+        remove_probation_at(dir);
+        return PostStopOutcome::Proceed;
+    }
+
+    // In probation and the probationary version stopped without committing →
+    // count it as a crash of that version.
+    state.crash_count = state.crash_count.saturating_add(1);
+    let _write = write_probation_at(dir, &state);
+
+    if !should_rollback(state.crash_count) {
+        return PostStopOutcome::CrashRecorded {
+            crash_count: state.crash_count,
+        };
+    }
+
+    // Threshold reached: roll back to the known-good binary.
+    if !state.rollback_binary.exists() {
+        // Never delete the only working binary: with no retained known-good we
+        // cannot restore. Stop counting (the supervisor's own bound takes over)
+        // and surface the situation for the operator.
+        remove_probation_at(dir);
+        return PostStopOutcome::RollbackUnavailable {
+            reason: format!(
+                "no retained known-good binary at {}",
+                state.rollback_binary.display()
+            ),
+        };
+    }
+
+    // Pin BEFORE restoring so that even if the restore is interrupted we never
+    // re-apply the bad version (loop-safety). Pin write failure is best-effort:
+    // it lives in the same directory as the marker we just wrote.
+    if let Err(e) = pin_known_bad_at(dir, &state.new_version) {
+        tracing::warn!(error = %e, version = %state.new_version,
+            "Failed to pin known-bad version during rollback (continuing)");
+    }
+
+    match restore_binary(&state.rollback_binary, &state.target_binary) {
+        Ok(()) => {
+            remove_probation_at(dir);
+            PostStopOutcome::RolledBack {
+                restored_version: state.previous_version.clone(),
+                bad_version: state.new_version.clone(),
+            }
+        }
+        Err(e) => {
+            // Leave the marker in place so a subsequent crash retries the
+            // restore (bounded by the supervisor's own crash limiter). The pin
+            // is already set, so we will not re-apply the bad version meanwhile.
+            PostStopOutcome::RollbackUnavailable {
+                reason: format!("restore failed: {e:#}"),
+            }
+        }
+    }
+}
+
+/// Pure rollback decision: roll back once probation crashes reach the threshold.
+pub(crate) fn should_rollback(crash_count: u32) -> bool {
+    crash_count >= ROLLBACK_CRASH_THRESHOLD
+}
+
+/// Restore `src` (the retained known-good binary) over `target` (the live
+/// binary), without ever deleting `src`. Copies `src` to a same-directory temp,
+/// moves the current (bad) binary aside, then renames the temp into place;
+/// on failure the displaced binary is moved back so we never end up with no
+/// binary at `target`. Moving the current binary aside first is required on
+/// Windows, where a running `.exe` cannot be replaced by renaming over it but
+/// CAN be renamed away — and is harmless on Unix.
+fn restore_binary(src: &Path, target: &Path) -> Result<()> {
+    let parent = target
+        .parent()
+        .context("target binary has no parent directory")?;
+    let stem = target.file_name().unwrap_or_default().to_string_lossy();
+    let temp = parent.join(format!(".{stem}.rollback.tmp"));
+    let displaced = parent.join(format!(".{stem}.badver"));
+
+    std::fs::copy(src, &temp).context("failed to copy known-good binary into place")?;
+    set_executable(&temp);
+
+    if displaced.exists() {
+        let _rm = std::fs::remove_file(&displaced);
+    }
+    if target.exists() {
+        std::fs::rename(target, &displaced).context("failed to move current binary aside")?;
+    }
+    if let Err(e) = std::fs::rename(&temp, target) {
+        // Put the bad binary back so the node still has *a* binary to run.
+        let _restore = std::fs::rename(&displaced, target);
+        let _rm = std::fs::remove_file(&temp);
+        return Err(e).context("failed to install rolled-back binary");
+    }
+    // Best-effort removal of the displaced bad binary (not running anymore).
+    let _rm = std::fs::remove_file(&displaced);
+    Ok(())
+}
+
+fn set_executable(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = std::fs::metadata(path) {
+            let mut perms = meta.permissions();
+            perms.set_mode(0o755);
+            let _chmod = std::fs::set_permissions(path, perms);
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_dummy_binary(path: &Path, contents: &[u8]) {
+        std::fs::write(path, contents).unwrap();
+        set_executable(path);
+    }
+
+    /// Build a probation marker in `dir` for `new_version` over a fake live
+    /// binary, having captured a fake known-good binary first. Returns the live
+    /// binary path.
+    fn setup_probation(dir: &Path, new_version: &str, prev_version: &str) -> PathBuf {
+        let bin_dir = dir.join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let live = bin_dir.join("freenet");
+        // The "previous" (known-good) binary content we will roll back to.
+        write_dummy_binary(&live, b"GOOD-BINARY");
+        capture_known_good_at(dir, &live).unwrap();
+        // Now the live binary is "replaced" by the new (bad) version.
+        write_dummy_binary(&live, b"BAD-BINARY");
+        begin_probation_at(dir, new_version, prev_version, &live);
+        live
+    }
+
+    #[test]
+    fn probation_roundtrip_and_commit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let live = setup_probation(dir, "0.2.84", "0.2.83");
+
+        let state = read_probation_at(dir).expect("probation present");
+        assert_eq!(state.new_version, "0.2.84");
+        assert_eq!(state.previous_version, "0.2.83");
+        assert_eq!(state.crash_count, 0);
+        assert_eq!(state.target_binary, live);
+
+        // Committing the matching version clears the marker.
+        assert_eq!(commit_probation_at(dir, "0.2.84"), CommitOutcome::Committed);
+        assert!(read_probation_at(dir).is_none());
+        // Idempotent.
+        assert_eq!(commit_probation_at(dir, "0.2.84"), CommitOutcome::Nothing);
+    }
+
+    #[test]
+    fn commit_clears_stale_marker_for_other_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        setup_probation(dir, "0.2.84", "0.2.83");
+        // A different version is running healthily → stale marker removed.
+        let CommitOutcome::ClearedStale { marker_version } = commit_probation_at(dir, "0.2.85")
+        else {
+            panic!("expected ClearedStale");
+        };
+        assert_eq!(marker_version, "0.2.84");
+        assert!(read_probation_at(dir).is_none());
+    }
+
+    #[test]
+    fn crash_during_probation_records_then_rolls_back_and_pins() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let live = setup_probation(dir, "0.2.84", "0.2.83");
+
+        // First crashes below threshold are recorded, no rollback.
+        for expected in 1..ROLLBACK_CRASH_THRESHOLD {
+            let PostStopOutcome::CrashRecorded { crash_count } = handle_post_stop_at(dir, "0.2.84")
+            else {
+                panic!("expected CrashRecorded({expected})");
+            };
+            assert_eq!(crash_count, expected);
+            // Still the bad binary, still pinned to nothing.
+            assert_eq!(std::fs::read(&live).unwrap(), b"BAD-BINARY");
+            assert!(read_known_bad_at(dir).is_none());
+            assert!(read_probation_at(dir).is_some());
+        }
+
+        // Threshold crash → rollback.
+        let PostStopOutcome::RolledBack {
+            restored_version,
+            bad_version,
+        } = handle_post_stop_at(dir, "0.2.84")
+        else {
+            panic!("expected RolledBack");
+        };
+        assert_eq!(restored_version, "0.2.83");
+        assert_eq!(bad_version, "0.2.84");
+
+        // Live binary is the known-good content again.
+        assert_eq!(std::fs::read(&live).unwrap(), b"GOOD-BINARY");
+        // Bad version pinned; probation cleared.
+        assert!(is_version_pinned_bad_at(dir, "0.2.84"));
+        assert!(read_probation_at(dir).is_none());
+        // The retained known-good blob is NOT consumed by the restore.
+        assert!(known_good_path(dir).exists());
+    }
+
+    fn known_good_path(dir: &Path) -> PathBuf {
+        dir.join(KNOWN_GOOD_BINARY_FILE)
+    }
+
+    #[test]
+    fn pinned_version_is_not_reapplied_but_newer_is_allowed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        pin_known_bad_at(dir, "0.2.84").unwrap();
+
+        assert!(is_version_pinned_bad_at(dir, "0.2.84"));
+        // A different (newer fix) version is not pinned.
+        assert!(!is_version_pinned_bad_at(dir, "0.2.85"));
+        // The previous good version is not pinned.
+        assert!(!is_version_pinned_bad_at(dir, "0.2.83"));
+
+        // A successful forward install supersedes the pin.
+        let live = dir.join("freenet");
+        write_dummy_binary(&live, b"NEWER");
+        begin_probation_at(dir, "0.2.85", "0.2.83", &live);
+        assert!(!is_version_pinned_bad_at(dir, "0.2.84"));
+    }
+
+    #[test]
+    fn rollback_is_bounded_to_one_generation() {
+        // After a rollback there is no probation marker, so a further crash of
+        // the rolled-back version does NOT trigger a second rollback.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        setup_probation(dir, "0.2.84", "0.2.83");
+        for _ in 0..ROLLBACK_CRASH_THRESHOLD {
+            handle_post_stop_at(dir, "0.2.84");
+        }
+        assert!(read_probation_at(dir).is_none());
+        // Now running the rolled-back version; another stop is a no-op Proceed.
+        assert_eq!(handle_post_stop_at(dir, "0.2.83"), PostStopOutcome::Proceed);
+    }
+
+    #[test]
+    fn no_probation_means_proceed() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(
+            handle_post_stop_at(tmp.path(), "0.2.84"),
+            PostStopOutcome::Proceed
+        );
+    }
+
+    #[test]
+    fn stale_marker_for_other_version_proceeds_and_is_cleared() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        setup_probation(dir, "0.2.84", "0.2.83");
+        // A DIFFERENT version stopped than the marker describes.
+        assert_eq!(handle_post_stop_at(dir, "0.2.99"), PostStopOutcome::Proceed);
+        assert!(read_probation_at(dir).is_none());
+    }
+
+    #[test]
+    fn rollback_unavailable_when_known_good_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let live = setup_probation(dir, "0.2.84", "0.2.83");
+        // Remove the retained known-good blob to simulate a missing target.
+        std::fs::remove_file(known_good_path(dir)).unwrap();
+
+        for _ in 0..ROLLBACK_CRASH_THRESHOLD - 1 {
+            handle_post_stop_at(dir, "0.2.84");
+        }
+        assert!(matches!(
+            handle_post_stop_at(dir, "0.2.84"),
+            PostStopOutcome::RollbackUnavailable { .. }
+        ));
+        // Bad binary still in place (we never deleted the only binary).
+        assert_eq!(std::fs::read(&live).unwrap(), b"BAD-BINARY");
+        // Marker removed so we stop futile rollback attempts.
+        assert!(read_probation_at(dir).is_none());
+    }
+
+    #[test]
+    fn begin_probation_preserves_known_good_across_chained_install() {
+        // A chained install WHILE on probation must not adopt the unproven
+        // probationary version as the rollback target.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let live = setup_probation(dir, "0.2.84", "0.2.83");
+
+        // Chained forward install to 0.2.85 while still on probation for 0.2.84.
+        write_dummy_binary(&live, b"NEWEST");
+        begin_probation_at(dir, "0.2.85", "0.2.84", &live);
+
+        let state = read_probation_at(dir).unwrap();
+        assert_eq!(state.new_version, "0.2.85");
+        // Previous version is still the original known-good, not 0.2.84.
+        assert_eq!(state.previous_version, "0.2.83");
+    }
+
+    #[test]
+    fn restore_binary_preserves_source_and_replaces_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let src = dir.join("good");
+        let target = dir.join("live");
+        write_dummy_binary(&src, b"SRC-GOOD");
+        write_dummy_binary(&target, b"TARGET-BAD");
+
+        restore_binary(&src, &target).unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"SRC-GOOD");
+        // Source binary is preserved (never deleted).
+        assert_eq!(std::fs::read(&src).unwrap(), b"SRC-GOOD");
+    }
+
+    #[test]
+    fn should_rollback_threshold() {
+        assert!(!should_rollback(0));
+        assert!(!should_rollback(ROLLBACK_CRASH_THRESHOLD - 1));
+        assert!(should_rollback(ROLLBACK_CRASH_THRESHOLD));
+        assert!(should_rollback(ROLLBACK_CRASH_THRESHOLD + 1));
+    }
+
+    #[test]
+    fn corrupt_probation_marker_reads_as_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join(PROBATION_FILE), "{not valid json").unwrap();
+        assert!(read_probation_at(dir).is_none());
+        // And a post-stop with a corrupt marker proceeds normally.
+        assert_eq!(handle_post_stop_at(dir, "0.2.84"), PostStopOutcome::Proceed);
+    }
+}

--- a/crates/core/src/bin/commands/rollback.rs
+++ b/crates/core/src/bin/commands/rollback.rs
@@ -22,6 +22,17 @@
 //!     (`SEGV`/`KILL`/`ABRT`), both of which classify as a crash,
 //!   * the fast-crash watchdog exit 45 (sub-60s fatal listener exit, #4551).
 //!
+//! DEPLOY WATCH (accepted tradeoff): an OOM-kill (SIGKILL/137) of the
+//! probationary version during the probation window counts toward rollback.
+//! This is intentional — a real memory-regression OOM is exactly the kind of
+//! bad release we want to roll back. But the production peer cap is 2 GB
+//! (`MemoryMax=2G`), so a legitimately memory-heavy-but-fine release could be
+//! OOM-killed on a capped peer and rolled back. After deploying a release that
+//! changes the memory profile, watch the 2 GB-capped peers for rollback churn
+//! and bump the cap (or fix the regression) rather than letting good releases
+//! bounce. The probation window is short (until first 60s-healthy boot), so a
+//! release that survives its first minute on a capped peer is not affected.
+//!
 //! It deliberately does NOT count as a crash:
 //!   * exit 0 (graceful shutdown), 43 (another instance already running),
 //!   * exit 42. On a systemd unit (which sets [`SYSTEMD_FAST_CRASH_ENV_VAR`])
@@ -171,7 +182,8 @@ pub(crate) struct ProbationState {
     pub new_version: String,
     /// The previous, known-good version we would roll back to.
     pub previous_version: String,
-    /// Path to the retained known-good binary blob ([`known_good_binary_path`]).
+    /// Path to the retained known-good binary blob (the `known_good_binary`
+    /// file in the state dir).
     pub rollback_binary: PathBuf,
     /// Path to the live binary to restore over on rollback.
     pub target_binary: PathBuf,
@@ -232,11 +244,6 @@ pub(crate) enum PostStopOutcome {
 
 fn state_dir() -> Option<PathBuf> {
     super::auto_update::state_dir()
-}
-
-/// Path to the retained known-good binary blob, if the state dir resolves.
-pub(crate) fn known_good_binary_path() -> Option<PathBuf> {
-    state_dir().map(|d| d.join(KNOWN_GOOD_BINARY_FILE))
 }
 
 // ── Durable write helpers (S7: atomic marker/pin; S3: fsync) ───────────────
@@ -305,15 +312,9 @@ fn sha256_file(path: &Path) -> Result<(u64, String)> {
 // ── Known-good capture ─────────────────────────────────────────────────────
 
 /// Copy `current_binary` to the known-good snapshot, durably (copy to a temp
-/// sibling, fsync, rename, fsync dir), and return its size + SHA-256. Called
-/// BEFORE the install overwrites the live binary, and ONLY when transitioning
-/// from a committed/healthy version (not while already on probation), so the
-/// snapshot is always a version that previously ran.
-pub(crate) fn capture_known_good(current_binary: &Path) -> Result<KnownGoodMeta> {
-    let dir = state_dir().context("could not resolve state directory")?;
-    capture_known_good_at(&dir, current_binary)
-}
-
+/// sibling, fsync, rename, fsync dir), and return its size + SHA-256. Called by
+/// [`prepare_known_good_for_install_at`] BEFORE the install overwrites the live
+/// binary, so the snapshot is always a version that previously ran.
 pub(crate) fn capture_known_good_at(dir: &Path, current_binary: &Path) -> Result<KnownGoodMeta> {
     use std::io::Write;
     std::fs::create_dir_all(dir).context("failed to create state directory")?;
@@ -342,27 +343,68 @@ pub(crate) fn capture_known_good_at(dir: &Path, current_binary: &Path) -> Result
 
 // ── Probation marker ───────────────────────────────────────────────────────
 
-/// Begin (or refresh) probation for `new_version`, just installed over the live
-/// binary at `target_binary`. `version_being_replaced` is the version of the
-/// binary that was overwritten; `meta` describes the retained known-good blob.
+/// Decide the rollback target for an install and snapshot it if needed,
+/// returning `(known_good_meta, previous_version)` — the integrity metadata of
+/// the rollback blob AND the version label that MUST accompany it.
 ///
-/// Carries the known-good rollback target forward ONLY for a genuine chained
-/// in-probation install — one where the existing marker's `new_version` equals
-/// the version we are now replacing (e.g. a manual `freenet update` run while
-/// still on probation for the running version). In that case the unproven
-/// running binary must NOT become the known-good, so we keep the existing
-/// `previous_version`. A marker for any OTHER version is stale (e.g. left over
-/// by an external/manual install or a rollback that failed to clear it) and is
-/// ignored: `previous_version` becomes `version_being_replaced`, matching the
-/// freshly-captured known-good blob. Clears any known-bad pin, since a
-/// successful forward install means we have moved on.
+/// The blob and the label are computed together here, in one place, so they can
+/// never diverge (the bug this fixes: capturing fresh in one site while
+/// carrying a stale label forward in another, which would later restore the
+/// wrong binary and report the wrong version).
+///
+/// - **Genuine chained in-probation install** — the existing marker is for the
+///   version we are replacing AND the known-good blob is still present: keep the
+///   existing blob (its recorded integrity meta) and carry its
+///   `previous_version` forward. The live binary is the unproven new version, so
+///   it must NOT become the known-good.
+/// - **Otherwise** — no marker, a stale marker for a different version, OR the
+///   blob was externally deleted: snapshot the about-to-be-replaced
+///   `current_binary` fresh and label it `current_version`, so the blob and the
+///   recorded `previous_version` always agree.
+///
+/// `Err` only if a needed fresh capture fails (full/unwritable state dir); the
+/// caller treats that as "no rollback protection this cycle".
+pub(crate) fn prepare_known_good_for_install(
+    current_version: &str,
+    current_binary: &Path,
+) -> Result<(KnownGoodMeta, String)> {
+    let dir = state_dir().context("could not resolve state directory")?;
+    prepare_known_good_for_install_at(&dir, current_version, current_binary)
+}
+
+pub(crate) fn prepare_known_good_for_install_at(
+    dir: &Path,
+    current_version: &str,
+    current_binary: &Path,
+) -> Result<(KnownGoodMeta, String)> {
+    if let Some(existing) = read_probation_at(dir) {
+        if existing.new_version == current_version && dir.join(KNOWN_GOOD_BINARY_FILE).exists() {
+            return Ok((
+                KnownGoodMeta {
+                    size: existing.rollback_size,
+                    sha256: existing.rollback_sha256,
+                },
+                existing.previous_version,
+            ));
+        }
+    }
+    let meta = capture_known_good_at(dir, current_binary)?;
+    Ok((meta, current_version.to_string()))
+}
+
+/// Begin (or refresh) probation for `new_version`, just installed over the live
+/// binary at `target_binary`. `previous_version` and `meta` are the label and
+/// integrity metadata of the rollback target, computed together by
+/// [`prepare_known_good_for_install`] so they cannot diverge. Clears any
+/// known-bad pin, since a successful forward install means we have moved on.
+///
 /// Returns `Err` if the probation marker could not be persisted (full /
 /// unwritable state dir). In that case the update still succeeded but the new
 /// version has NO crash-loop rollback protection, so the caller MUST surface
 /// the error rather than discard it.
 pub(crate) fn begin_probation(
     new_version: &str,
-    version_being_replaced: &str,
+    previous_version: &str,
     target_binary: &Path,
     meta: &KnownGoodMeta,
 ) -> Result<()> {
@@ -370,7 +412,7 @@ pub(crate) fn begin_probation(
         Some(dir) => begin_probation_at(
             dir.as_path(),
             new_version,
-            version_being_replaced,
+            previous_version,
             target_binary,
             meta,
         ),
@@ -383,25 +425,17 @@ pub(crate) fn begin_probation(
 pub(crate) fn begin_probation_at(
     dir: &Path,
     new_version: &str,
-    version_being_replaced: &str,
+    previous_version: &str,
     target_binary: &Path,
     meta: &KnownGoodMeta,
 ) -> Result<()> {
     let _mkdir = std::fs::create_dir_all(dir);
-    let rollback_binary = dir.join(KNOWN_GOOD_BINARY_FILE);
-    // Preserve the known-good baseline ONLY across a genuine chained
-    // in-probation install (existing marker is for the version we're replacing).
-    // A stale marker for any other version is ignored — see the rustdoc.
-    let previous_version = match read_probation_at(dir) {
-        Some(existing) if existing.new_version == version_being_replaced => {
-            existing.previous_version
-        }
-        _ => version_being_replaced.to_string(),
-    };
     let state = ProbationState {
         new_version: new_version.to_string(),
-        previous_version,
-        rollback_binary,
+        // Stored verbatim — the caller (prepare_known_good_for_install) is the
+        // single source of truth for the blob/label pairing.
+        previous_version: previous_version.to_string(),
+        rollback_binary: dir.join(KNOWN_GOOD_BINARY_FILE),
         target_binary: target_binary.to_path_buf(),
         rollback_size: meta.size,
         rollback_sha256: meta.sha256.clone(),
@@ -1100,49 +1134,72 @@ mod tests {
     }
 
     #[test]
-    fn begin_probation_preserves_known_good_across_chained_install() {
+    fn prepare_known_good_preserves_blob_and_label_for_genuine_chained_install() {
+        // Genuine chained install (existing marker is for the running version,
+        // blob present): keep the existing blob and carry its label forward.
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
-        let live = setup_probation(dir, "0.2.84", "0.2.83");
+        setup_probation(dir, "0.2.84", "0.2.83"); // blob = the 0.2.83 (GOOD) binary
+        let blob_before = std::fs::read(known_good_path(dir)).unwrap();
+        let existing = read_probation_at(dir).unwrap();
+        // The running binary is the 0.2.84 (BAD) content from setup_probation.
+        let live = dir.join("bin").join("freenet");
 
-        // Chained forward install to 0.2.85 while still on probation for 0.2.84
-        // (the version we're replacing == the existing marker's new_version).
-        write_dummy_binary(&live, b"NEWEST");
-        let meta = KnownGoodMeta {
-            size: 6,
-            sha256: "y".repeat(64),
-        };
-        begin_probation_at(dir, "0.2.85", "0.2.84", &live, &meta).unwrap();
+        let (meta, previous) = prepare_known_good_for_install_at(dir, "0.2.84", &live).unwrap();
 
-        let state = read_probation_at(dir).unwrap();
-        assert_eq!(state.new_version, "0.2.85");
-        // Previous version is still the original known-good, not 0.2.84.
-        assert_eq!(state.previous_version, "0.2.83");
+        // Carried forward: previous == 0.2.83, blob unchanged, meta matches marker.
+        assert_eq!(previous, "0.2.83");
+        assert_eq!(std::fs::read(known_good_path(dir)).unwrap(), blob_before);
+        assert_eq!(meta.size, existing.rollback_size);
+        assert_eq!(meta.sha256, existing.rollback_sha256);
     }
 
     #[test]
-    fn begin_probation_ignores_stale_marker_for_other_version() {
-        // A leftover marker for a DIFFERENT version than the one being replaced
-        // (e.g. an external install) must NOT carry its previous_version forward
-        // — that would later roll back to an unrelated older binary.
+    fn prepare_known_good_recaptures_when_blob_externally_deleted() {
+        // #2 regression: if the known-good blob is externally deleted while a
+        // marker persists, a chained install must re-capture the CURRENT binary
+        // and label it the CURRENT version — never carry a stale label forward
+        // onto a freshly-captured blob (which would restore the wrong binary and
+        // report the wrong version on a later rollback).
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
-        // Stale marker: new=0.2.84, prev=0.2.83.
-        setup_probation(dir, "0.2.84", "0.2.83");
+        let live = setup_probation(dir, "0.2.84", "0.2.83");
+        // External deletion of the blob while the marker (new=0.2.84) remains.
+        std::fs::remove_file(known_good_path(dir)).unwrap();
 
-        // Install 0.2.90 over a running 0.2.88 (NOT the stale marker's 0.2.84).
+        let (meta, previous) = prepare_known_good_for_install_at(dir, "0.2.84", &live).unwrap();
+
+        // Re-captured fresh: label is the current version, blob == current binary,
+        // and the recorded meta matches the (re-captured) blob — they agree.
+        assert_eq!(previous, "0.2.84");
+        assert!(known_good_path(dir).exists());
+        assert_eq!(
+            std::fs::read(known_good_path(dir)).unwrap(),
+            std::fs::read(&live).unwrap()
+        );
+        let (size, hash) = sha256_file(&known_good_path(dir)).unwrap();
+        assert_eq!(meta.size, size);
+        assert_eq!(meta.sha256, hash);
+    }
+
+    #[test]
+    fn prepare_known_good_recaptures_for_stale_marker_other_version() {
+        // A leftover marker for a DIFFERENT version than the one being replaced
+        // must be ignored: capture fresh + label the current version.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        setup_probation(dir, "0.2.84", "0.2.83"); // stale marker (new=0.2.84)
         let live = dir.join("freenet2");
-        write_dummy_binary(&live, b"V88");
-        let meta = KnownGoodMeta {
-            size: 3,
-            sha256: "z".repeat(64),
-        };
-        begin_probation_at(dir, "0.2.90", "0.2.88", &live, &meta).unwrap();
+        write_dummy_binary(&live, b"V88-CONTENT");
 
-        let state = read_probation_at(dir).unwrap();
-        assert_eq!(state.new_version, "0.2.90");
-        // previous_version is the actual replaced version, not the stale 0.2.83.
-        assert_eq!(state.previous_version, "0.2.88");
+        // Replacing version 0.2.88 (NOT the stale marker's 0.2.84).
+        let (meta, previous) = prepare_known_good_for_install_at(dir, "0.2.88", &live).unwrap();
+
+        assert_eq!(previous, "0.2.88");
+        assert_eq!(std::fs::read(known_good_path(dir)).unwrap(), b"V88-CONTENT");
+        let (size, hash) = sha256_file(&known_good_path(dir)).unwrap();
+        assert_eq!(meta.size, size);
+        assert_eq!(meta.sha256, hash);
     }
 
     #[cfg(unix)]

--- a/crates/core/src/bin/commands/rollback.rs
+++ b/crates/core/src/bin/commands/rollback.rs
@@ -8,59 +8,80 @@
 //! `StartLimitAction=none` stops the unit, the run-wrapper gives up after its
 //! consecutive-failure cap).
 //!
-//! ## How it hooks the EXISTING crash detection (no parallel detector)
+//! ## What counts as a crash (coverage)
 //!
-//! Every Freenet supervisor that applies an auto-update already runs
-//! `freenet update` immediately after the node process stops:
-//!   * **systemd** (Linux): `ExecStopPost` runs `freenet update` on exit 42
-//!     (healthy-then-died / update-needed) OR 45 (fast crash / boot-wedge,
-//!     #4551).
-//!   * **macOS launchd wrapper script**: runs `freenet update` on exit 42.
-//!   * **in-process run-wrapper** (`service/wrapper.rs`, Windows + macOS tray):
-//!     runs `freenet update` on exit 42.
+//! A "crash" for rollback purposes is ANY non-graceful stop of the
+//! probationary version — not just the network-listener watchdog exits
+//! (42/45). It covers:
+//!   * panics (exit 101 with the default unwinding runtime, SIGABRT/134 under
+//!     `panic=abort`),
+//!   * early-startup failures (exit 1 from config / `node.build()` / a
+//!     non-listener task dying before the watchdog arms),
+//!   * signal deaths — SIGSEGV (139), SIGKILL / OOM-kill (137), SIGABRT (134),
+//!     which systemd surfaces as numeric codes or signal *names*
+//!     (`SEGV`/`KILL`/`ABRT`), both of which classify as a crash,
+//!   * the fast-crash watchdog exit 45 (sub-60s fatal listener exit, #4551).
 //!
-//! Each of those supervisors now sets [`POST_STOP_EXIT_CODE_ENV_VAR`] on that
-//! post-stop `freenet update` invocation, carrying the exit code the node just
-//! died with. `freenet update` reads it ([`post_stop_exit_code_from_env`]) and,
-//! when the node is in post-update **probation** (see below), counts the stop as
-//! a crash of the probationary version and rolls back once the crash count
-//! crosses [`ROLLBACK_CRASH_THRESHOLD`]. This reuses the existing exit-code /
-//! restart machinery rather than inventing a second watchdog.
+//! It deliberately does NOT count as a crash:
+//!   * exit 0 (graceful shutdown), 43 (another instance already running),
+//!   * exit 42. On a systemd unit (which sets [`SYSTEMD_FAST_CRASH_ENV_VAR`])
+//!     a real sub-60s crash uses 45, so a 42 is the node *voluntarily*
+//!     stepping forward to a newer release — counting it would cause a
+//!     spurious backward rollback during a release+hotfix cascade. On the
+//!     macOS/in-process wrappers (no fast-crash marker) the node emits 42 for
+//!     *both* a fatal-listener boot-wedge and a voluntary update, so 42 is
+//!     irreducibly ambiguous there; we treat it as NOT-a-crash to avoid the
+//!     spurious rollback, accepting that a fatal-listener boot-wedge under
+//!     those wrappers is bounded by the wrapper's own consecutive-failure cap
+//!     rather than auto-rolled-back (unchanged from pre-#4073). Panics /
+//!     signals / early errors under those wrappers DO roll back, since they
+//!     use unambiguous crash codes.
+//!
+//! Every supervisor that runs `freenet update` after the node stops forwards
+//! the node's exit status via [`POST_STOP_EXIT_CODE_ENV_VAR`]; `freenet update`
+//! classifies it ([`classify_stop`]) and, when in probation, counts a crash —
+//! **before** any GitHub call, so the count is recorded even if the network is
+//! down.
 //!
 //! ## Lifecycle
 //!
 //! 1. **Install** (`commands::update`): before overwriting the running binary,
-//!    snapshot it as the known-good rollback target ([`capture_known_good`]),
-//!    then mark the freshly-installed version as on-probation
-//!    ([`begin_probation`]).
+//!    snapshot it as the known-good rollback target ([`capture_known_good`],
+//!    fsync'd, with size+SHA-256 recorded), then mark the freshly-installed
+//!    version as on-probation ([`begin_probation`]).
 //! 2. **Commit**: once the new version has run healthily for
 //!    [`COMMIT_HEALTHY_UPTIME_SECS`] the node clears the probation marker
-//!    ([`commit_probation`]). After that, ordinary later crashes never trigger a
-//!    rollback. The window mirrors `MIN_HEALTHY_UPTIME_FOR_UPDATE_EXIT` (the
-//!    same boundary that classifies a fatal exit as a fast crash).
+//!    ([`commit_probation`]). After that, ordinary later crashes never trigger
+//!    a rollback.
 //! 3. **Detect + revert**: a crash during probation increments the marker's
 //!    crash counter ([`handle_post_stop`]); on the
-//!    [`ROLLBACK_CRASH_THRESHOLD`]th crash the previous binary is restored, the
-//!    bad version is pinned ([`pin_known_bad_at`]), and the marker is cleared.
+//!    [`ROLLBACK_CRASH_THRESHOLD`]th crash the previous binary is restored
+//!    (after verifying its integrity), the bad version is pinned
+//!    ([`pin_known_bad_at`]), and the marker is cleared.
 //! 4. **Pin**: a pinned version is refused by both the installer
 //!    (`commands::update`) and the node's update checks
-//!    (`commands::auto_update`) so we never loop update → crash → revert →
+//!    (`commands::auto_update`) so we never loop update -> crash -> revert ->
 //!    re-update. A later, strictly-newer release (a fix) is NOT pinned and is
 //!    applied normally.
 //!
 //! ## Bounded by construction (no new flap/loop)
 //!
 //! * Rollback only ever restores the **known-good** target captured before the
-//!   probationary install. We never forward-chase a newer version while in
-//!   probation, so the rollback target is always a version that previously ran
-//!   (one generation back). [`ROLLBACK_CRASH_THRESHOLD`] is `< 5`
-//!   (`StartLimitBurst`) so a Linux rollback fires before systemd gives up.
-//! * If the reverted version ALSO cannot stay up there is no longer a probation
-//!   marker, so it is NOT rolled back again — the supervisor's existing bound
-//!   (systemd `StartLimit` / the wrapper's consecutive-failure cap) takes over
-//!   and the node is left for the operator.
-//! * If the known-good binary is missing we refuse to "roll back" rather than
-//!   risk deleting the only working binary.
+//!   probationary install, so the rollback target is always a version that
+//!   previously ran (one generation back). [`ROLLBACK_CRASH_THRESHOLD`] is
+//!   `< 5` (`StartLimitBurst`) so a Linux rollback fires before systemd gives
+//!   up, and `< 50` (`WRAPPER_MAX_CONSECUTIVE_FAILURES`) for the wrapper.
+//! * After a rollback there is no probation marker, so a still-crashing
+//!   reverted version is NOT rolled back again — the supervisor's existing
+//!   bound takes over and the node is left for the operator.
+//! * The known-good blob is integrity-checked (size + SHA-256) before any
+//!   restore; a corrupt/truncated blob yields [`PostStopOutcome::RollbackUnavailable`]
+//!   and the running binary is left untouched (never deletes the only working
+//!   binary). The known-bad pin is persisted BEFORE the restore; if it can't
+//!   be persisted the restore is abandoned (no restore-then-loop oscillation).
+//! * Marker is age-bounded: a probation older than [`PROBATION_MAX_AGE_SECS`]
+//!   is treated as stale (committed) so a never-cleared marker cannot roll back
+//!   a long-healthy version much later (GC discipline, AGENTS.md).
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -68,11 +89,14 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Environment variable a supervisor sets on the post-stop `freenet update`
-/// invocation, carrying the exit code (`$EXIT_STATUS`) the node just stopped
-/// with. Its presence tells `freenet update` it is being run as part of the
-/// restart cycle (as opposed to a manual / tray-initiated update), which is the
-/// only context in which a stop should be counted as a crash for rollback
-/// purposes.
+/// invocation, carrying the status (`$EXIT_STATUS`) the node just stopped with.
+/// Its value may be a numeric exit code OR a signal name (systemd passes e.g.
+/// `SEGV`/`ABRT`/`KILL` for signal deaths), so it is forwarded and classified
+/// as an opaque string ([`classify_stop`]).
+///
+/// Its presence tells `freenet update` it is being run as part of the restart
+/// cycle (as opposed to a manual / tray-initiated update), which is the only
+/// context in which a stop should be counted as a crash.
 ///
 /// Forward/backward compatible by design (an env var, not a CLI flag): an OLD
 /// `freenet` binary — e.g. the one we just rolled back TO — silently ignores it
@@ -82,13 +106,12 @@ pub const POST_STOP_EXIT_CODE_ENV_VAR: &str = "FREENET_POST_STOP_EXIT_CODE";
 
 /// Consecutive crashes of a probationary version before we roll back.
 ///
-/// MUST stay strictly below the systemd unit's `StartLimitBurst` (5, see
-/// `service/linux.rs`) so the rollback fires while systemd is still willing to
-/// restart the unit — if we waited until the 5th crash, systemd's
-/// `StartLimitAction=none` would already have stopped the unit and the
-/// supervisor would never run the `ExecStopPost` that performs the rollback.
-/// Three confirmed crashes is enough signal: a single crash is noise, two could
-/// be unlucky, by the third the new version is demonstrably not staying up.
+/// MUST stay strictly below the systemd unit's `StartLimitBurst` (5) AND the
+/// run-wrapper's `WRAPPER_MAX_CONSECUTIVE_FAILURES` (50) so the rollback fires
+/// while the supervisor is still willing to restart — see the compile-time
+/// asserts below. Three confirmed crashes is enough signal: one is noise, two
+/// could be unlucky, by the third the new version is demonstrably not staying
+/// up.
 pub(crate) const ROLLBACK_CRASH_THRESHOLD: u32 = 3;
 
 /// Brick-safety invariant, enforced at compile time: a Linux rollback fires
@@ -100,12 +123,34 @@ const _: () = assert!(
     "ROLLBACK_CRASH_THRESHOLD must be < systemd StartLimitBurst (5) in service/linux.rs"
 );
 
+/// Same invariant for the in-process run-wrapper, whose
+/// `WRAPPER_MAX_CONSECUTIVE_FAILURES` (50, see `service.rs`) bounds its retry
+/// loop: the rollback must fire well before the wrapper gives up.
+const _: () = assert!(
+    ROLLBACK_CRASH_THRESHOLD < 50,
+    "ROLLBACK_CRASH_THRESHOLD must be < WRAPPER_MAX_CONSECUTIVE_FAILURES (50) in service.rs"
+);
+
 /// How long a freshly-installed version must run before it is considered
 /// committed (probation cleared). Mirrors
 /// `node::p2p_impl::MIN_HEALTHY_UPTIME_FOR_UPDATE_EXIT` (60s): a fatal exit
-/// before this boundary is the fast-crash / boot-wedge we guard against, so a
-/// node that survives past it has cleared the same bar.
+/// before this boundary is the fast-crash / boot-wedge we guard against.
+///
+/// The commit timer starts at process main (`run_network_node_with_signals`),
+/// which is marginally EARLIER than the listener-start origin the fast-crash
+/// classifier (`fatal_listener_exit_code`) uses. That skew is fail-safe: the
+/// marker is cleared a beat early, which can only make us roll back LESS, never
+/// roll back a node that has clearly passed the fast-crash window.
 pub(crate) const COMMIT_HEALTHY_UPTIME_SECS: u64 = 60;
+
+/// Absolute age after which a probation marker is treated as stale and cleared
+/// (GC discipline: cleanup exemptions must be time-bounded — AGENTS.md). If the
+/// commit timer ever fails to clear the marker, this stops a long-healthy
+/// version from being rolled back by a much-later transient crash. One hour is
+/// far longer than any real crash-loop (which trips the
+/// [`ROLLBACK_CRASH_THRESHOLD`] within minutes) yet short enough that a marker
+/// surviving it is unambiguously stale.
+pub(crate) const PROBATION_MAX_AGE_SECS: u64 = 3600;
 
 /// Probation marker: JSON describing the on-probation version and its
 /// known-good rollback target.
@@ -130,18 +175,40 @@ pub(crate) struct ProbationState {
     pub rollback_binary: PathBuf,
     /// Path to the live binary to restore over on rollback.
     pub target_binary: PathBuf,
-    /// Unix seconds when the probationary version was installed (diagnostics).
+    /// Size in bytes of the known-good blob at capture (integrity check).
+    pub rollback_size: u64,
+    /// Lowercase hex SHA-256 of the known-good blob at capture (integrity).
+    pub rollback_sha256: String,
+    /// Unix seconds when the probationary version was installed.
     pub installed_at_unix: u64,
     /// Number of crashes observed during this probation so far.
     pub crash_count: u32,
+}
+
+/// Size + SHA-256 of the captured known-good binary, returned by
+/// [`capture_known_good`] and stored in the probation marker for the
+/// pre-restore integrity check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct KnownGoodMeta {
+    pub size: u64,
+    pub sha256: String,
+}
+
+/// Classification of a post-stop status for rollback purposes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StopClass {
+    /// A crash: count toward rollback (when in probation).
+    Crash,
+    /// A clean / voluntary-update stop: do NOT count.
+    NotCrash,
 }
 
 /// Outcome of [`handle_post_stop`], telling the caller (`commands::update`) what
 /// to do next.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PostStopOutcome {
-    /// Not a probation crash (no probation, or a stale marker): the caller
-    /// should run the normal update flow.
+    /// Not a probation crash (clean/voluntary stop, no probation, or a stale
+    /// marker): the caller should run the normal update flow.
     Proceed,
     /// A probation crash was recorded but the rollback threshold is not yet
     /// reached. The caller must NOT perform a normal update this cycle; the
@@ -153,9 +220,10 @@ pub(crate) enum PostStopOutcome {
         restored_version: String,
         bad_version: String,
     },
-    /// A rollback was warranted but could not be performed (no retained
-    /// known-good binary, or the restore failed). The caller must NOT perform a
-    /// normal update; the node is left for the supervisor's own bound /
+    /// A rollback was warranted but could not be performed safely (no retained
+    /// known-good binary, a failed integrity check, an unpersistable pin, or a
+    /// failed restore). The caller must NOT perform a normal update; the
+    /// running binary is left untouched for the supervisor's own bound /
     /// operator intervention.
     RollbackUnavailable { reason: String },
 }
@@ -171,47 +239,123 @@ pub(crate) fn known_good_binary_path() -> Option<PathBuf> {
     state_dir().map(|d| d.join(KNOWN_GOOD_BINARY_FILE))
 }
 
+// ── Durable write helpers (S7: atomic marker/pin; S3: fsync) ───────────────
+
+/// Best-effort directory fsync so a preceding rename is durable. A no-op where
+/// the platform won't open a directory for sync (e.g. Windows).
+fn fsync_dir(dir: &Path) {
+    if let Ok(f) = std::fs::File::open(dir) {
+        let _sync = f.sync_all();
+    }
+}
+
+/// Write `bytes` to `path` atomically and durably: write a sibling temp,
+/// fsync it, rename into place, then fsync the directory. Used for the
+/// probation marker and the known-bad pin so a torn write can never leave a
+/// half-written marker/pin that mis-drives the rollback decision.
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<()> {
+    use std::io::Write;
+    let dir = path.parent().context("path has no parent directory")?;
+    std::fs::create_dir_all(dir).ok();
+    let file_name = path
+        .file_name()
+        .context("path has no file name")?
+        .to_string_lossy();
+    let tmp = dir.join(format!(".{file_name}.tmp"));
+    {
+        let mut f = std::fs::File::create(&tmp).context("create temp for atomic write")?;
+        f.write_all(bytes).context("write temp for atomic write")?;
+        f.sync_all().context("fsync temp for atomic write")?;
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _rm = std::fs::remove_file(&tmp);
+        return Err(e).context("rename temp into place");
+    }
+    fsync_dir(dir);
+    Ok(())
+}
+
+/// SHA-256 + byte length of a file, streamed in chunks.
+fn sha256_file(path: &Path) -> Result<(u64, String)> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+    let mut file = std::fs::File::open(path).context("open file for hashing")?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    let mut size: u64 = 0;
+    loop {
+        let n = file.read(&mut buf).context("read file for hashing")?;
+        if n == 0 {
+            break;
+        }
+        size += n as u64;
+        hasher.update(&buf[..n]);
+    }
+    let hex = hasher
+        .finalize()
+        .iter()
+        .fold(String::with_capacity(64), |mut s, b| {
+            use std::fmt::Write;
+            write!(s, "{b:02x}").expect("writing to String is infallible");
+            s
+        });
+    Ok((size, hex))
+}
+
 // ── Known-good capture ─────────────────────────────────────────────────────
 
-/// Copy `current_binary` to the known-good snapshot, atomically (copy to a
-/// temp sibling, then rename). Called BEFORE the install overwrites the live
-/// binary, and ONLY when transitioning from a committed/healthy version (not
-/// while already on probation), so the snapshot is always a version that
-/// previously ran.
-pub(crate) fn capture_known_good(current_binary: &Path) -> Result<()> {
+/// Copy `current_binary` to the known-good snapshot, durably (copy to a temp
+/// sibling, fsync, rename, fsync dir), and return its size + SHA-256. Called
+/// BEFORE the install overwrites the live binary, and ONLY when transitioning
+/// from a committed/healthy version (not while already on probation), so the
+/// snapshot is always a version that previously ran.
+pub(crate) fn capture_known_good(current_binary: &Path) -> Result<KnownGoodMeta> {
     let dir = state_dir().context("could not resolve state directory")?;
     capture_known_good_at(&dir, current_binary)
 }
 
-pub(crate) fn capture_known_good_at(dir: &Path, current_binary: &Path) -> Result<()> {
+pub(crate) fn capture_known_good_at(dir: &Path, current_binary: &Path) -> Result<KnownGoodMeta> {
+    use std::io::Write;
     std::fs::create_dir_all(dir).context("failed to create state directory")?;
     let dest = dir.join(KNOWN_GOOD_BINARY_FILE);
     let tmp = dir.join(format!("{KNOWN_GOOD_BINARY_FILE}.tmp"));
-    std::fs::copy(current_binary, &tmp).context("failed to snapshot known-good binary")?;
+
+    // Copy + fsync the blob so a power loss can't leave a truncated snapshot
+    // that would later be restored over a working binary (S3).
+    {
+        let mut src = std::fs::File::open(current_binary).context("open current binary")?;
+        let mut dst = std::fs::File::create(&tmp).context("create known-good temp")?;
+        std::io::copy(&mut src, &mut dst).context("copy known-good binary")?;
+        dst.flush().ok();
+        dst.sync_all().context("fsync known-good temp")?;
+    }
     set_executable(&tmp);
     if let Err(e) = std::fs::rename(&tmp, &dest) {
         let _rm = std::fs::remove_file(&tmp);
-        return Err(e).context("failed to install known-good binary snapshot");
+        return Err(e).context("install known-good binary snapshot");
     }
-    Ok(())
+    fsync_dir(dir);
+
+    let (size, sha256) = sha256_file(&dest).context("hash known-good snapshot")?;
+    Ok(KnownGoodMeta { size, sha256 })
 }
 
 // ── Probation marker ───────────────────────────────────────────────────────
 
 /// Begin (or refresh) probation for `new_version`, just installed over the live
 /// binary at `target_binary`. `version_being_replaced` is the version of the
-/// binary that was overwritten.
+/// binary that was overwritten; `meta` describes the retained known-good blob.
 ///
 /// Carries the known-good rollback target forward: if a probation marker
 /// already exists (a chained update WHILE on probation — e.g. a manual
-/// `freenet update`), we keep the existing `previous_version` /
-/// `rollback_binary` rather than treating the unproven probationary binary as
-/// known-good. Clears any known-bad pin, since a successful forward install
-/// means we have moved on.
+/// `freenet update`), we keep the existing `previous_version` rather than
+/// treating the unproven probationary binary as known-good. Clears any
+/// known-bad pin, since a successful forward install means we have moved on.
 pub(crate) fn begin_probation(
     new_version: &str,
     version_being_replaced: &str,
     target_binary: &Path,
+    meta: &KnownGoodMeta,
 ) {
     if let Some(dir) = state_dir() {
         begin_probation_at(
@@ -219,6 +363,7 @@ pub(crate) fn begin_probation(
             new_version,
             version_being_replaced,
             target_binary,
+            meta,
         );
     }
 }
@@ -228,6 +373,7 @@ pub(crate) fn begin_probation_at(
     new_version: &str,
     version_being_replaced: &str,
     target_binary: &Path,
+    meta: &KnownGoodMeta,
 ) {
     let _mkdir = std::fs::create_dir_all(dir);
     let rollback_binary = dir.join(KNOWN_GOOD_BINARY_FILE);
@@ -241,6 +387,8 @@ pub(crate) fn begin_probation_at(
         previous_version,
         rollback_binary,
         target_binary: target_binary.to_path_buf(),
+        rollback_size: meta.size,
+        rollback_sha256: meta.sha256.clone(),
         installed_at_unix: now_unix(),
         crash_count: 0,
     };
@@ -261,8 +409,8 @@ pub(crate) fn read_probation_at(dir: &Path) -> Option<ProbationState> {
 }
 
 fn write_probation_at(dir: &Path, state: &ProbationState) -> Result<()> {
-    let raw = serde_json::to_string(state).context("failed to serialize probation marker")?;
-    std::fs::write(dir.join(PROBATION_FILE), raw).context("failed to write probation marker")
+    let raw = serde_json::to_vec(state).context("serialize probation marker")?;
+    atomic_write(&dir.join(PROBATION_FILE), &raw)
 }
 
 fn remove_probation_at(dir: &Path) {
@@ -271,8 +419,7 @@ fn remove_probation_at(dir: &Path) {
 
 /// Clear probation if the running version matches the marker (it has proven
 /// healthy). A marker for a DIFFERENT version is stale (e.g. left over after a
-/// rollback or external install) and is also removed. Returns `Some(version)`
-/// when an in-probation version was committed (for logging).
+/// rollback or external install) and is also removed.
 pub fn commit_probation(current_version: &str) {
     if let Some(dir) = state_dir() {
         match commit_probation_at(dir.as_path(), current_version) {
@@ -322,9 +469,7 @@ pub(crate) fn commit_probation_at(dir: &Path, current_version: &str) -> CommitOu
 // ── Known-bad pin ──────────────────────────────────────────────────────────
 
 pub(crate) fn pin_known_bad_at(dir: &Path, version: &str) -> Result<()> {
-    let _mkdir = std::fs::create_dir_all(dir);
-    std::fs::write(dir.join(KNOWN_BAD_FILE), format!("{version}\n"))
-        .context("failed to write known-bad pin")
+    atomic_write(&dir.join(KNOWN_BAD_FILE), format!("{version}\n").as_bytes())
 }
 
 pub(crate) fn read_known_bad_at(dir: &Path) -> Option<String> {
@@ -353,37 +498,70 @@ pub(crate) fn is_version_pinned_bad_at(dir: &Path, version: &str) -> bool {
     read_known_bad_at(dir).as_deref() == Some(version)
 }
 
-// ── Post-stop crash handling / rollback ────────────────────────────────────
+// ── Post-stop crash classification / handling / rollback ───────────────────
 
-/// Parse the [`POST_STOP_EXIT_CODE_ENV_VAR`] env var into the node's exit code,
-/// if set by a supervisor.
-pub fn post_stop_exit_code_from_env() -> Option<i32> {
-    std::env::var(POST_STOP_EXIT_CODE_ENV_VAR)
-        .ok()?
-        .trim()
-        .parse()
-        .ok()
+/// Read the raw post-stop status string the supervisor forwarded, if any. May
+/// be a numeric exit code or a signal name; classified by [`classify_stop`].
+pub fn post_stop_status_from_env() -> Option<String> {
+    let raw = std::env::var(POST_STOP_EXIT_CODE_ENV_VAR).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Classify a forwarded post-stop status as a crash or not. See the module-level
+/// "What counts as a crash" section for the full rationale, including why exit
+/// 42 is never counted.
+pub(crate) fn classify_stop(status: &str) -> StopClass {
+    match status.trim() {
+        // Clean / non-crash node exits:
+        //   0  graceful shutdown
+        //   2  EXIT_CODE_ALREADY_UP_TO_DATE (an updater code, not a node crash)
+        //   43 EXIT_CODE_ALREADY_RUNNING (another instance holds the port)
+        //   44 EXIT_CODE_BUNDLE_UPDATE_STAGED (internal updater code)
+        "0" | "2" | "43" | "44" => StopClass::NotCrash,
+        // 42 = FATAL_LISTENER_EXIT_CODE / update-needed. Treated as NOT a crash
+        // everywhere: under the systemd fast-crash marker a real sub-60s crash
+        // would be 45, so 42 is a voluntary forward-update; under the wrappers
+        // 42 is ambiguous and we choose not-a-crash to avoid a spurious
+        // backward rollback (see module docs).
+        "42" => StopClass::NotCrash,
+        // 45 (fast crash), 1, 101, 134/137/139, signal names (SEGV/ABRT/KILL),
+        // or any other/unrecognized status -> a crash.
+        _ => StopClass::Crash,
+    }
 }
 
 /// Handle a post-stop `freenet update` invocation for crash-loop rollback.
 ///
-/// `current_version` is the version of the binary now running (the one the node
-/// just stopped on). The decision is intentionally independent of whatever
-/// release is "latest" on GitHub: while in probation we never forward-chase a
-/// newer version (that would make the rollback target an unproven binary), so a
-/// stop with no commit yet is treated as a crash of the probationary version.
-pub(crate) fn handle_post_stop(current_version: &str) -> PostStopOutcome {
+/// `status` is the forwarded `$EXIT_STATUS`; `current_version` is the version of
+/// the binary that just stopped. No network call is made, so the crash count is
+/// recorded even when GitHub is unreachable.
+pub(crate) fn handle_post_stop(status: &str, current_version: &str) -> PostStopOutcome {
     match state_dir() {
-        Some(dir) => handle_post_stop_at(dir.as_path(), current_version),
+        Some(dir) => handle_post_stop_at(dir.as_path(), status, current_version),
         None => PostStopOutcome::Proceed,
     }
 }
 
-pub(crate) fn handle_post_stop_at(dir: &Path, current_version: &str) -> PostStopOutcome {
+pub(crate) fn handle_post_stop_at(
+    dir: &Path,
+    status: &str,
+    current_version: &str,
+) -> PostStopOutcome {
+    // A clean or voluntary-update stop is never a crash: run the normal flow
+    // (which, for a real update-needed 42, performs the forward update).
+    if classify_stop(status) == StopClass::NotCrash {
+        return PostStopOutcome::Proceed;
+    }
+
     let Some(mut state) = read_probation_at(dir) else {
-        // Not on probation: a normal supervised restart (e.g. a long-running
-        // version that hit a transient fault, or a genuine update-needed exit).
-        // Let the caller run the ordinary update flow.
+        // Crash of a version that is NOT on probation (e.g. a long-running,
+        // committed version hit a transient fault): let the caller run the
+        // ordinary update flow (#4549 self-heal), don't roll back.
         return PostStopOutcome::Proceed;
     };
 
@@ -395,8 +573,17 @@ pub(crate) fn handle_post_stop_at(dir: &Path, current_version: &str) -> PostStop
         return PostStopOutcome::Proceed;
     }
 
-    // In probation and the probationary version stopped without committing →
-    // count it as a crash of that version.
+    // GC discipline (S5): a marker older than the max age means the version has
+    // been around far longer than any boot-wedge would survive. Treat as
+    // committed/stale so a much-later transient crash can't trigger a rollback.
+    if now_unix().saturating_sub(state.installed_at_unix) > PROBATION_MAX_AGE_SECS {
+        remove_probation_at(dir);
+        return PostStopOutcome::Proceed;
+    }
+
+    // In probation and the probationary version crashed without committing →
+    // count it. Persist FIRST (local, no network) so the count survives even if
+    // everything below is skipped.
     state.crash_count = state.crash_count.saturating_add(1);
     let _write = write_probation_at(dir, &state);
 
@@ -420,12 +607,41 @@ pub(crate) fn handle_post_stop_at(dir: &Path, current_version: &str) -> PostStop
         };
     }
 
-    // Pin BEFORE restoring so that even if the restore is interrupted we never
-    // re-apply the bad version (loop-safety). Pin write failure is best-effort:
-    // it lives in the same directory as the marker we just wrote.
+    // S3: verify the retained blob's integrity BEFORE touching the live binary.
+    // A truncated/corrupt snapshot must never be restored over a (bad but
+    // running) binary — that would brick with no recovery.
+    match sha256_file(&state.rollback_binary) {
+        Ok((size, hash)) if size == state.rollback_size && hash == state.rollback_sha256 => {}
+        Ok((size, _hash)) => {
+            // Definitively corrupt: this rollback target is unusable. Drop the
+            // marker so we stop re-attempting it; the next crash falls through
+            // to the normal update flow (which may self-heal forward).
+            remove_probation_at(dir);
+            return PostStopOutcome::RollbackUnavailable {
+                reason: format!(
+                    "known-good integrity check failed (size {size} vs expected {}, or SHA-256 \
+                     mismatch); leaving the running binary in place",
+                    state.rollback_size
+                ),
+            };
+        }
+        Err(e) => {
+            // Transient read error: leave the marker so a later crash retries
+            // (bounded by the supervisor's own crash limiter).
+            return PostStopOutcome::RollbackUnavailable {
+                reason: format!("cannot read known-good binary to verify: {e:#}"),
+            };
+        }
+    }
+
+    // S6: persist the known-bad pin BEFORE restoring. If it can't be persisted
+    // (read-only / full state dir), DON'T restore — restoring without a durable
+    // pin would let the good version re-fetch and re-install the bad version,
+    // oscillating. Leave the marker so a later crash retries.
     if let Err(e) = pin_known_bad_at(dir, &state.new_version) {
-        tracing::warn!(error = %e, version = %state.new_version,
-            "Failed to pin known-bad version during rollback (continuing)");
+        return PostStopOutcome::RollbackUnavailable {
+            reason: format!("cannot persist known-bad pin (not restoring to avoid a loop): {e:#}"),
+        };
     }
 
     match restore_binary(&state.rollback_binary, &state.target_binary) {
@@ -437,9 +653,9 @@ pub(crate) fn handle_post_stop_at(dir: &Path, current_version: &str) -> PostStop
             }
         }
         Err(e) => {
-            // Leave the marker in place so a subsequent crash retries the
-            // restore (bounded by the supervisor's own crash limiter). The pin
-            // is already set, so we will not re-apply the bad version meanwhile.
+            // Leave the marker so a subsequent crash retries the restore
+            // (bounded by the supervisor's own crash limiter). The pin is
+            // already persisted, so we won't re-apply the bad version meanwhile.
             PostStopOutcome::RollbackUnavailable {
                 reason: format!("restore failed: {e:#}"),
             }
@@ -452,39 +668,70 @@ pub(crate) fn should_rollback(crash_count: u32) -> bool {
     crash_count >= ROLLBACK_CRASH_THRESHOLD
 }
 
-/// Restore `src` (the retained known-good binary) over `target` (the live
-/// binary), without ever deleting `src`. Copies `src` to a same-directory temp,
-/// moves the current (bad) binary aside, then renames the temp into place;
-/// on failure the displaced binary is moved back so we never end up with no
-/// binary at `target`. Moving the current binary aside first is required on
-/// Windows, where a running `.exe` cannot be replaced by renaming over it but
-/// CAN be renamed away — and is harmless on Unix.
+/// Restore `src` (the integrity-verified known-good binary) over `target` (the
+/// live binary), without ever deleting `src`.
+///
+/// On Unix `rename(2)` atomically replaces the target, and a running executable
+/// keeps its open inode, so we copy → fsync → rename directly with no window
+/// where `target` is absent (S4). On Windows a running `.exe` cannot be
+/// replaced by renaming over it but CAN be renamed away, so we move the current
+/// binary aside first and restore it on failure so we never end up with no
+/// binary at `target`.
 fn restore_binary(src: &Path, target: &Path) -> Result<()> {
     let parent = target
         .parent()
         .context("target binary has no parent directory")?;
     let stem = target.file_name().unwrap_or_default().to_string_lossy();
     let temp = parent.join(format!(".{stem}.rollback.tmp"));
-    let displaced = parent.join(format!(".{stem}.badver"));
 
-    std::fs::copy(src, &temp).context("failed to copy known-good binary into place")?;
+    // Copy the known-good binary to a same-directory temp and fsync it.
+    {
+        use std::io::Write;
+        let mut s = std::fs::File::open(src).context("open known-good binary")?;
+        let mut t = std::fs::File::create(&temp).context("create rollback temp")?;
+        std::io::copy(&mut s, &mut t).context("copy known-good binary into place")?;
+        t.flush().ok();
+        t.sync_all().context("fsync rollback temp")?;
+    }
     set_executable(&temp);
 
-    if displaced.exists() {
+    #[cfg(not(windows))]
+    {
+        // Atomic replace; the running process keeps its open inode.
+        if let Err(e) = std::fs::rename(&temp, target) {
+            let _rm = std::fs::remove_file(&temp);
+            return Err(e).context("atomically install rolled-back binary");
+        }
+        fsync_dir(parent);
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    {
+        let displaced = parent.join(format!(".{stem}.badver"));
+        if displaced.exists() {
+            let _rm = std::fs::remove_file(&displaced);
+        }
+        if target.exists() {
+            std::fs::rename(target, &displaced).context("move current binary aside")?;
+        }
+        if let Err(e) = std::fs::rename(&temp, target) {
+            // Put the bad binary back so the node still has *a* binary to run.
+            if std::fs::rename(&displaced, target).is_err() {
+                tracing::error!(
+                    target = %target.display(),
+                    displaced = %displaced.display(),
+                    "CRITICAL: rollback failed AND could not restore the displaced binary; \
+                     the previous binary remains at the displaced path for manual recovery"
+                );
+            }
+            let _rm = std::fs::remove_file(&temp);
+            return Err(e).context("install rolled-back binary");
+        }
+        // Best-effort removal of the displaced bad binary (not running anymore).
         let _rm = std::fs::remove_file(&displaced);
+        Ok(())
     }
-    if target.exists() {
-        std::fs::rename(target, &displaced).context("failed to move current binary aside")?;
-    }
-    if let Err(e) = std::fs::rename(&temp, target) {
-        // Put the bad binary back so the node still has *a* binary to run.
-        let _restore = std::fs::rename(&displaced, target);
-        let _rm = std::fs::remove_file(&temp);
-        return Err(e).context("failed to install rolled-back binary");
-    }
-    // Best-effort removal of the displaced bad binary (not running anymore).
-    let _rm = std::fs::remove_file(&displaced);
-    Ok(())
 }
 
 fn set_executable(path: &Path) {
@@ -519,6 +766,10 @@ mod tests {
         set_executable(path);
     }
 
+    fn known_good_path(dir: &Path) -> PathBuf {
+        dir.join(KNOWN_GOOD_BINARY_FILE)
+    }
+
     /// Build a probation marker in `dir` for `new_version` over a fake live
     /// binary, having captured a fake known-good binary first. Returns the live
     /// binary path.
@@ -528,11 +779,25 @@ mod tests {
         let live = bin_dir.join("freenet");
         // The "previous" (known-good) binary content we will roll back to.
         write_dummy_binary(&live, b"GOOD-BINARY");
-        capture_known_good_at(dir, &live).unwrap();
+        let meta = capture_known_good_at(dir, &live).unwrap();
         // Now the live binary is "replaced" by the new (bad) version.
         write_dummy_binary(&live, b"BAD-BINARY");
-        begin_probation_at(dir, new_version, prev_version, &live);
+        begin_probation_at(dir, new_version, prev_version, &live, &meta);
         live
+    }
+
+    #[test]
+    fn classify_stop_crash_vs_not() {
+        // Clean / voluntary-update / already-running: never a crash.
+        for s in ["0", "2", "42", "43", "44", " 42 ", "0\n"] {
+            assert_eq!(classify_stop(s), StopClass::NotCrash, "status {s:?}");
+        }
+        // Fast crash, panics, signals (numeric and name), early errors, unknown.
+        for s in [
+            "45", "1", "101", "134", "137", "139", "SEGV", "ABRT", "KILL", "garbage",
+        ] {
+            assert_eq!(classify_stop(s), StopClass::Crash, "status {s:?}");
+        }
     }
 
     #[test]
@@ -546,6 +811,9 @@ mod tests {
         assert_eq!(state.previous_version, "0.2.83");
         assert_eq!(state.crash_count, 0);
         assert_eq!(state.target_binary, live);
+        // Integrity metadata recorded for the known-good blob.
+        assert_eq!(state.rollback_size, "GOOD-BINARY".len() as u64);
+        assert_eq!(state.rollback_sha256.len(), 64);
 
         // Committing the matching version clears the marker.
         assert_eq!(commit_probation_at(dir, "0.2.84"), CommitOutcome::Committed);
@@ -574,24 +842,25 @@ mod tests {
         let dir = tmp.path();
         let live = setup_probation(dir, "0.2.84", "0.2.83");
 
-        // First crashes below threshold are recorded, no rollback.
+        // First crashes below threshold are recorded, no rollback. Use a panic
+        // exit code (101) to confirm the broadened crash detection (M1).
         for expected in 1..ROLLBACK_CRASH_THRESHOLD {
-            let PostStopOutcome::CrashRecorded { crash_count } = handle_post_stop_at(dir, "0.2.84")
+            let PostStopOutcome::CrashRecorded { crash_count } =
+                handle_post_stop_at(dir, "101", "0.2.84")
             else {
                 panic!("expected CrashRecorded({expected})");
             };
             assert_eq!(crash_count, expected);
-            // Still the bad binary, still pinned to nothing.
             assert_eq!(std::fs::read(&live).unwrap(), b"BAD-BINARY");
             assert!(read_known_bad_at(dir).is_none());
             assert!(read_probation_at(dir).is_some());
         }
 
-        // Threshold crash → rollback.
+        // Threshold crash (a SIGSEGV, surfaced as a signal name) → rollback.
         let PostStopOutcome::RolledBack {
             restored_version,
             bad_version,
-        } = handle_post_stop_at(dir, "0.2.84")
+        } = handle_post_stop_at(dir, "SEGV", "0.2.84")
         else {
             panic!("expected RolledBack");
         };
@@ -600,15 +869,47 @@ mod tests {
 
         // Live binary is the known-good content again.
         assert_eq!(std::fs::read(&live).unwrap(), b"GOOD-BINARY");
-        // Bad version pinned; probation cleared.
+        // Bad version pinned; probation cleared; known-good blob preserved.
         assert!(is_version_pinned_bad_at(dir, "0.2.84"));
         assert!(read_probation_at(dir).is_none());
-        // The retained known-good blob is NOT consumed by the restore.
         assert!(known_good_path(dir).exists());
     }
 
-    fn known_good_path(dir: &Path) -> PathBuf {
-        dir.join(KNOWN_GOOD_BINARY_FILE)
+    #[test]
+    fn voluntary_update_exit_42_during_probation_is_not_a_crash() {
+        // M2 regression: a healthy node stepping forward to a newer release with
+        // exit 42 inside its probation window must NOT be counted as a crash
+        // (which would cause a spurious backward rollback during a release
+        // cascade). It must Proceed and leave crash_count untouched.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        setup_probation(dir, "0.2.84", "0.2.83");
+
+        for _ in 0..ROLLBACK_CRASH_THRESHOLD + 2 {
+            assert_eq!(
+                handle_post_stop_at(dir, "42", "0.2.84"),
+                PostStopOutcome::Proceed
+            );
+            let state = read_probation_at(dir).expect("marker preserved");
+            assert_eq!(
+                state.crash_count, 0,
+                "exit 42 must not increment crash_count"
+            );
+        }
+    }
+
+    #[test]
+    fn clean_exit_codes_during_probation_are_not_crashes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        setup_probation(dir, "0.2.84", "0.2.83");
+        for s in ["0", "43"] {
+            assert_eq!(
+                handle_post_stop_at(dir, s, "0.2.84"),
+                PostStopOutcome::Proceed
+            );
+            assert_eq!(read_probation_at(dir).unwrap().crash_count, 0);
+        }
     }
 
     #[test]
@@ -618,15 +919,17 @@ mod tests {
         pin_known_bad_at(dir, "0.2.84").unwrap();
 
         assert!(is_version_pinned_bad_at(dir, "0.2.84"));
-        // A different (newer fix) version is not pinned.
         assert!(!is_version_pinned_bad_at(dir, "0.2.85"));
-        // The previous good version is not pinned.
         assert!(!is_version_pinned_bad_at(dir, "0.2.83"));
 
         // A successful forward install supersedes the pin.
         let live = dir.join("freenet");
         write_dummy_binary(&live, b"NEWER");
-        begin_probation_at(dir, "0.2.85", "0.2.83", &live);
+        let meta = KnownGoodMeta {
+            size: 5,
+            sha256: "x".repeat(64),
+        };
+        begin_probation_at(dir, "0.2.85", "0.2.83", &live, &meta);
         assert!(!is_version_pinned_bad_at(dir, "0.2.84"));
     }
 
@@ -638,18 +941,21 @@ mod tests {
         let dir = tmp.path();
         setup_probation(dir, "0.2.84", "0.2.83");
         for _ in 0..ROLLBACK_CRASH_THRESHOLD {
-            handle_post_stop_at(dir, "0.2.84");
+            handle_post_stop_at(dir, "101", "0.2.84");
         }
         assert!(read_probation_at(dir).is_none());
-        // Now running the rolled-back version; another stop is a no-op Proceed.
-        assert_eq!(handle_post_stop_at(dir, "0.2.83"), PostStopOutcome::Proceed);
+        // Now running the rolled-back version; another crash is a no-op Proceed.
+        assert_eq!(
+            handle_post_stop_at(dir, "101", "0.2.83"),
+            PostStopOutcome::Proceed
+        );
     }
 
     #[test]
     fn no_probation_means_proceed() {
         let tmp = tempfile::tempdir().unwrap();
         assert_eq!(
-            handle_post_stop_at(tmp.path(), "0.2.84"),
+            handle_post_stop_at(tmp.path(), "101", "0.2.84"),
             PostStopOutcome::Proceed
         );
     }
@@ -659,9 +965,87 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
         setup_probation(dir, "0.2.84", "0.2.83");
-        // A DIFFERENT version stopped than the marker describes.
-        assert_eq!(handle_post_stop_at(dir, "0.2.99"), PostStopOutcome::Proceed);
+        // A DIFFERENT version crashed than the marker describes.
+        assert_eq!(
+            handle_post_stop_at(dir, "101", "0.2.99"),
+            PostStopOutcome::Proceed
+        );
         assert!(read_probation_at(dir).is_none());
+    }
+
+    #[test]
+    fn aged_out_marker_is_treated_as_committed() {
+        // S5: a probation marker older than PROBATION_MAX_AGE_SECS is stale; a
+        // crash then must NOT roll back a long-healthy version.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let live = setup_probation(dir, "0.2.84", "0.2.83");
+
+        // Backdate installed_at beyond the TTL.
+        let mut state = read_probation_at(dir).unwrap();
+        state.installed_at_unix = now_unix().saturating_sub(PROBATION_MAX_AGE_SECS + 60);
+        write_probation_at(dir, &state).unwrap();
+
+        assert_eq!(
+            handle_post_stop_at(dir, "101", "0.2.84"),
+            PostStopOutcome::Proceed
+        );
+        assert!(read_probation_at(dir).is_none(), "stale marker cleared");
+        assert_eq!(std::fs::read(&live).unwrap(), b"BAD-BINARY", "no rollback");
+    }
+
+    #[test]
+    fn corrupt_known_good_blob_does_not_brick() {
+        // S3: if the retained known-good blob is truncated/corrupt, the
+        // integrity check must fail, leave the running binary untouched, and
+        // NOT pin (we never restored).
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let live = setup_probation(dir, "0.2.84", "0.2.83");
+
+        // Corrupt the snapshot (truncate to different content/size).
+        std::fs::write(known_good_path(dir), b"TRUNC").unwrap();
+
+        for _ in 0..ROLLBACK_CRASH_THRESHOLD - 1 {
+            handle_post_stop_at(dir, "101", "0.2.84");
+        }
+        let PostStopOutcome::RollbackUnavailable { reason } =
+            handle_post_stop_at(dir, "101", "0.2.84")
+        else {
+            panic!("expected RollbackUnavailable");
+        };
+        assert!(reason.contains("integrity"), "reason: {reason}");
+        // Running binary untouched (still the bad version), not pinned.
+        assert_eq!(std::fs::read(&live).unwrap(), b"BAD-BINARY");
+        assert!(!is_version_pinned_bad_at(dir, "0.2.84"));
+        // Marker dropped so we stop re-attempting the unusable target.
+        assert!(read_probation_at(dir).is_none());
+    }
+
+    #[test]
+    fn pin_write_failure_aborts_rollback_without_restoring() {
+        // S6: if the known-bad pin can't be persisted, do NOT restore — that
+        // would let the good version re-install the bad one and oscillate.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let live = setup_probation(dir, "0.2.84", "0.2.83");
+
+        // Make the pin path un-writable by occupying it with a directory, so
+        // the final rename in atomic_write fails.
+        std::fs::create_dir(dir.join(KNOWN_BAD_FILE)).unwrap();
+
+        for _ in 0..ROLLBACK_CRASH_THRESHOLD - 1 {
+            handle_post_stop_at(dir, "101", "0.2.84");
+        }
+        let PostStopOutcome::RollbackUnavailable { reason } =
+            handle_post_stop_at(dir, "101", "0.2.84")
+        else {
+            panic!("expected RollbackUnavailable");
+        };
+        assert!(reason.contains("pin"), "reason: {reason}");
+        // Did NOT restore (still the bad binary), marker left for retry.
+        assert_eq!(std::fs::read(&live).unwrap(), b"BAD-BINARY");
+        assert!(read_probation_at(dir).is_some());
     }
 
     #[test]
@@ -669,33 +1053,32 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
         let live = setup_probation(dir, "0.2.84", "0.2.83");
-        // Remove the retained known-good blob to simulate a missing target.
         std::fs::remove_file(known_good_path(dir)).unwrap();
 
         for _ in 0..ROLLBACK_CRASH_THRESHOLD - 1 {
-            handle_post_stop_at(dir, "0.2.84");
+            handle_post_stop_at(dir, "101", "0.2.84");
         }
         assert!(matches!(
-            handle_post_stop_at(dir, "0.2.84"),
+            handle_post_stop_at(dir, "101", "0.2.84"),
             PostStopOutcome::RollbackUnavailable { .. }
         ));
-        // Bad binary still in place (we never deleted the only binary).
         assert_eq!(std::fs::read(&live).unwrap(), b"BAD-BINARY");
-        // Marker removed so we stop futile rollback attempts.
         assert!(read_probation_at(dir).is_none());
     }
 
     #[test]
     fn begin_probation_preserves_known_good_across_chained_install() {
-        // A chained install WHILE on probation must not adopt the unproven
-        // probationary version as the rollback target.
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
         let live = setup_probation(dir, "0.2.84", "0.2.83");
 
         // Chained forward install to 0.2.85 while still on probation for 0.2.84.
         write_dummy_binary(&live, b"NEWEST");
-        begin_probation_at(dir, "0.2.85", "0.2.84", &live);
+        let meta = KnownGoodMeta {
+            size: 6,
+            sha256: "y".repeat(64),
+        };
+        begin_probation_at(dir, "0.2.85", "0.2.84", &live, &meta);
 
         let state = read_probation_at(dir).unwrap();
         assert_eq!(state.new_version, "0.2.85");
@@ -732,7 +1115,28 @@ mod tests {
         let dir = tmp.path();
         std::fs::write(dir.join(PROBATION_FILE), "{not valid json").unwrap();
         assert!(read_probation_at(dir).is_none());
-        // And a post-stop with a corrupt marker proceeds normally.
-        assert_eq!(handle_post_stop_at(dir, "0.2.84"), PostStopOutcome::Proceed);
+        assert_eq!(
+            handle_post_stop_at(dir, "101", "0.2.84"),
+            PostStopOutcome::Proceed
+        );
+    }
+
+    #[test]
+    fn capture_known_good_records_real_hash() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let bin = dir.join("freenet");
+        write_dummy_binary(&bin, b"hello world");
+        let meta = capture_known_good_at(dir, &bin).unwrap();
+        assert_eq!(meta.size, 11);
+        // SHA-256 of "hello world".
+        assert_eq!(
+            meta.sha256,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+        // The blob matches and verifies against the recorded meta.
+        let (size, hash) = sha256_file(&known_good_path(dir)).unwrap();
+        assert_eq!(size, meta.size);
+        assert_eq!(hash, meta.sha256);
     }
 }

--- a/crates/core/src/bin/commands/rollback.rs
+++ b/crates/core/src/bin/commands/rollback.rs
@@ -356,20 +356,27 @@ pub(crate) fn capture_known_good_at(dir: &Path, current_binary: &Path) -> Result
 /// ignored: `previous_version` becomes `version_being_replaced`, matching the
 /// freshly-captured known-good blob. Clears any known-bad pin, since a
 /// successful forward install means we have moved on.
+/// Returns `Err` if the probation marker could not be persisted (full /
+/// unwritable state dir). In that case the update still succeeded but the new
+/// version has NO crash-loop rollback protection, so the caller MUST surface
+/// the error rather than discard it.
 pub(crate) fn begin_probation(
     new_version: &str,
     version_being_replaced: &str,
     target_binary: &Path,
     meta: &KnownGoodMeta,
-) {
-    if let Some(dir) = state_dir() {
-        begin_probation_at(
+) -> Result<()> {
+    match state_dir() {
+        Some(dir) => begin_probation_at(
             dir.as_path(),
             new_version,
             version_being_replaced,
             target_binary,
             meta,
-        );
+        ),
+        // No state dir means the earlier known-good capture would also have
+        // failed (so this is unreachable in practice); nothing to arm.
+        None => Ok(()),
     }
 }
 
@@ -379,7 +386,7 @@ pub(crate) fn begin_probation_at(
     version_being_replaced: &str,
     target_binary: &Path,
     meta: &KnownGoodMeta,
-) {
+) -> Result<()> {
     let _mkdir = std::fs::create_dir_all(dir);
     let rollback_binary = dir.join(KNOWN_GOOD_BINARY_FILE);
     // Preserve the known-good baseline ONLY across a genuine chained
@@ -401,9 +408,11 @@ pub(crate) fn begin_probation_at(
         installed_at_unix: now_unix(),
         crash_count: 0,
     };
-    let _write = write_probation_at(dir, &state);
-    // Moving forward to a new version supersedes any prior known-bad pin.
+    // Moving forward to a new (non-pinned) version supersedes any prior
+    // known-bad pin; best-effort, independent of the marker write.
     clear_known_bad_at(dir);
+    write_probation_at(dir, &state)
+        .context("failed to write crash-loop probation marker; the installed version has no rollback protection")
 }
 
 /// Read the current probation marker, if any. A missing or unparseable marker
@@ -806,7 +815,7 @@ mod tests {
         let meta = capture_known_good_at(dir, &live).unwrap();
         // Now the live binary is "replaced" by the new (bad) version.
         write_dummy_binary(&live, b"BAD-BINARY");
-        begin_probation_at(dir, new_version, prev_version, &live, &meta);
+        begin_probation_at(dir, new_version, prev_version, &live, &meta).unwrap();
         live
     }
 
@@ -953,7 +962,7 @@ mod tests {
             size: 5,
             sha256: "x".repeat(64),
         };
-        begin_probation_at(dir, "0.2.85", "0.2.83", &live, &meta);
+        begin_probation_at(dir, "0.2.85", "0.2.83", &live, &meta).unwrap();
         assert!(!is_version_pinned_bad_at(dir, "0.2.84"));
     }
 
@@ -1103,7 +1112,7 @@ mod tests {
             size: 6,
             sha256: "y".repeat(64),
         };
-        begin_probation_at(dir, "0.2.85", "0.2.84", &live, &meta);
+        begin_probation_at(dir, "0.2.85", "0.2.84", &live, &meta).unwrap();
 
         let state = read_probation_at(dir).unwrap();
         assert_eq!(state.new_version, "0.2.85");
@@ -1128,7 +1137,7 @@ mod tests {
             size: 3,
             sha256: "z".repeat(64),
         };
-        begin_probation_at(dir, "0.2.90", "0.2.88", &live, &meta);
+        begin_probation_at(dir, "0.2.90", "0.2.88", &live, &meta).unwrap();
 
         let state = read_probation_at(dir).unwrap();
         assert_eq!(state.new_version, "0.2.90");

--- a/crates/core/src/bin/commands/rollback.rs
+++ b/crates/core/src/bin/commands/rollback.rs
@@ -346,11 +346,16 @@ pub(crate) fn capture_known_good_at(dir: &Path, current_binary: &Path) -> Result
 /// binary at `target_binary`. `version_being_replaced` is the version of the
 /// binary that was overwritten; `meta` describes the retained known-good blob.
 ///
-/// Carries the known-good rollback target forward: if a probation marker
-/// already exists (a chained update WHILE on probation — e.g. a manual
-/// `freenet update`), we keep the existing `previous_version` rather than
-/// treating the unproven probationary binary as known-good. Clears any
-/// known-bad pin, since a successful forward install means we have moved on.
+/// Carries the known-good rollback target forward ONLY for a genuine chained
+/// in-probation install — one where the existing marker's `new_version` equals
+/// the version we are now replacing (e.g. a manual `freenet update` run while
+/// still on probation for the running version). In that case the unproven
+/// running binary must NOT become the known-good, so we keep the existing
+/// `previous_version`. A marker for any OTHER version is stale (e.g. left over
+/// by an external/manual install or a rollback that failed to clear it) and is
+/// ignored: `previous_version` becomes `version_being_replaced`, matching the
+/// freshly-captured known-good blob. Clears any known-bad pin, since a
+/// successful forward install means we have moved on.
 pub(crate) fn begin_probation(
     new_version: &str,
     version_being_replaced: &str,
@@ -377,10 +382,14 @@ pub(crate) fn begin_probation_at(
 ) {
     let _mkdir = std::fs::create_dir_all(dir);
     let rollback_binary = dir.join(KNOWN_GOOD_BINARY_FILE);
-    // Preserve the known-good baseline across a chained in-probation install.
+    // Preserve the known-good baseline ONLY across a genuine chained
+    // in-probation install (existing marker is for the version we're replacing).
+    // A stale marker for any other version is ignored — see the rustdoc.
     let previous_version = match read_probation_at(dir) {
-        Some(existing) => existing.previous_version,
-        None => version_being_replaced.to_string(),
+        Some(existing) if existing.new_version == version_being_replaced => {
+            existing.previous_version
+        }
+        _ => version_being_replaced.to_string(),
     };
     let state = ProbationState {
         new_version: new_version.to_string(),
@@ -585,13 +594,28 @@ pub(crate) fn handle_post_stop_at(
     // count it. Persist FIRST (local, no network) so the count survives even if
     // everything below is skipped.
     state.crash_count = state.crash_count.saturating_add(1);
-    let _write = write_probation_at(dir, &state);
+    let persisted = write_probation_at(dir, &state).is_ok();
 
     if !should_rollback(state.crash_count) {
+        // Below threshold we rely on the persisted count to accumulate across
+        // restarts. If the write failed (full / unwritable state dir) the count
+        // is lost and we would re-read the old value forever, never reaching the
+        // threshold before the supervisor gives up. Surface that as
+        // RollbackUnavailable instead of silently under-counting.
+        if !persisted {
+            return PostStopOutcome::RollbackUnavailable {
+                reason: "cannot persist probation crash count (state dir full/unwritable); \
+                         crashes cannot accumulate toward rollback"
+                    .to_string(),
+            };
+        }
         return PostStopOutcome::CrashRecorded {
             crash_count: state.crash_count,
         };
     }
+    // At/above threshold we proceed to roll back using the in-memory count even
+    // if the persist failed — the marker is removed on a successful rollback
+    // anyway, and a genuinely broken state dir will surface at the pin step (S6).
 
     // Threshold reached: roll back to the known-good binary.
     if !state.rollback_binary.exists() {
@@ -1072,7 +1096,8 @@ mod tests {
         let dir = tmp.path();
         let live = setup_probation(dir, "0.2.84", "0.2.83");
 
-        // Chained forward install to 0.2.85 while still on probation for 0.2.84.
+        // Chained forward install to 0.2.85 while still on probation for 0.2.84
+        // (the version we're replacing == the existing marker's new_version).
         write_dummy_binary(&live, b"NEWEST");
         let meta = KnownGoodMeta {
             size: 6,
@@ -1084,6 +1109,58 @@ mod tests {
         assert_eq!(state.new_version, "0.2.85");
         // Previous version is still the original known-good, not 0.2.84.
         assert_eq!(state.previous_version, "0.2.83");
+    }
+
+    #[test]
+    fn begin_probation_ignores_stale_marker_for_other_version() {
+        // A leftover marker for a DIFFERENT version than the one being replaced
+        // (e.g. an external install) must NOT carry its previous_version forward
+        // — that would later roll back to an unrelated older binary.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        // Stale marker: new=0.2.84, prev=0.2.83.
+        setup_probation(dir, "0.2.84", "0.2.83");
+
+        // Install 0.2.90 over a running 0.2.88 (NOT the stale marker's 0.2.84).
+        let live = dir.join("freenet2");
+        write_dummy_binary(&live, b"V88");
+        let meta = KnownGoodMeta {
+            size: 3,
+            sha256: "z".repeat(64),
+        };
+        begin_probation_at(dir, "0.2.90", "0.2.88", &live, &meta);
+
+        let state = read_probation_at(dir).unwrap();
+        assert_eq!(state.new_version, "0.2.90");
+        // previous_version is the actual replaced version, not the stale 0.2.83.
+        assert_eq!(state.previous_version, "0.2.88");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn crash_count_write_failure_is_rollback_unavailable() {
+        // If the probation crash count can't be persisted (full/unwritable state
+        // dir), we must surface RollbackUnavailable rather than silently
+        // under-counting forever (a lost increment would never reach threshold).
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        setup_probation(dir, "0.2.84", "0.2.83");
+
+        // Make the state dir read-only so the marker write (temp + rename) fails,
+        // while the existing marker + blob remain readable.
+        let orig = std::fs::metadata(dir).unwrap().permissions();
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let outcome = handle_post_stop_at(dir, "101", "0.2.84");
+
+        // Restore perms before any assertion so tempdir cleanup always works.
+        std::fs::set_permissions(dir, orig).unwrap();
+
+        let PostStopOutcome::RollbackUnavailable { reason } = outcome else {
+            panic!("expected RollbackUnavailable, got {outcome:?}");
+        };
+        assert!(reason.contains("persist"), "reason: {reason}");
     }
 
     #[test]

--- a/crates/core/src/bin/commands/rollback.rs
+++ b/crates/core/src/bin/commands/rollback.rs
@@ -378,7 +378,21 @@ pub(crate) fn prepare_known_good_for_install_at(
     current_binary: &Path,
 ) -> Result<(KnownGoodMeta, String)> {
     if let Some(existing) = read_probation_at(dir) {
-        if existing.new_version == current_version && dir.join(KNOWN_GOOD_BINARY_FILE).exists() {
+        // Only preserve the existing rollback target for a GENUINE chained
+        // in-probation install: the marker is for the version we're replacing,
+        // the blob is present, AND the marker hasn't aged out. The age check
+        // mirrors handle_post_stop's TTL — a marker that survived past
+        // PROBATION_MAX_AGE_SECS means the current version has actually been
+        // running fine for a long time (commit just failed to clear the marker),
+        // so the CURRENT binary is the real known-good. Without this, the next
+        // update would carry forward the stale older blob/label and a later
+        // rollback would skip over the actual immediately-previous good version.
+        let fresh_enough =
+            now_unix().saturating_sub(existing.installed_at_unix) <= PROBATION_MAX_AGE_SECS;
+        if existing.new_version == current_version
+            && fresh_enough
+            && dir.join(KNOWN_GOOD_BINARY_FILE).exists()
+        {
             return Ok((
                 KnownGoodMeta {
                     size: existing.rollback_size,
@@ -1173,6 +1187,34 @@ mod tests {
         // and the recorded meta matches the (re-captured) blob — they agree.
         assert_eq!(previous, "0.2.84");
         assert!(known_good_path(dir).exists());
+        assert_eq!(
+            std::fs::read(known_good_path(dir)).unwrap(),
+            std::fs::read(&live).unwrap()
+        );
+        let (size, hash) = sha256_file(&known_good_path(dir)).unwrap();
+        assert_eq!(meta.size, size);
+        assert_eq!(meta.sha256, hash);
+    }
+
+    #[test]
+    fn prepare_known_good_recaptures_when_marker_aged_out() {
+        // A marker for the CURRENT version that survived past the TTL means the
+        // current version has actually run fine for a long time (commit failed
+        // to clear it). The next install must NOT carry the stale older blob
+        // forward — it must re-capture the current binary as the known-good.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let live = setup_probation(dir, "0.2.84", "0.2.83");
+        // Backdate the marker beyond the TTL.
+        let mut state = read_probation_at(dir).unwrap();
+        state.installed_at_unix = now_unix().saturating_sub(PROBATION_MAX_AGE_SECS + 60);
+        write_probation_at(dir, &state).unwrap();
+
+        let (meta, previous) = prepare_known_good_for_install_at(dir, "0.2.84", &live).unwrap();
+
+        // Re-captured: label is the current version (not the stale 0.2.83), and
+        // the blob is the current binary, so blob and label agree.
+        assert_eq!(previous, "0.2.84");
         assert_eq!(
             std::fs::read(known_good_path(dir)).unwrap(),
             std::fs::read(&live).unwrap()

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -1207,16 +1207,24 @@ mod tests {
             "ExecStopPost must use the doubled $$EXIT_STATUS so systemd passes a \
              literal $EXIT_STATUS to sh (a single-$ revert silently breaks auto-update)"
         );
-        // #4551: ExecStopPost must fire `freenet update` for BOTH exit 42 (healthy
-        // node hit a fault/update) AND exit 45 (fast boot-crash) — firing on 45
-        // preserves the #4549 self-heal for a boot-crash a newer release fixes, while
-        // 45 staying out of SuccessExitStatus still counts it toward StartLimitBurst.
-        // A `case` (not `&&`/`||`) avoids shell-precedence pitfalls.
+        // #4073 / #4551: ExecStopPost must fire `freenet update` for ANY
+        // non-graceful exit — every status except 0 (graceful) and 43 (another
+        // instance) — so it covers the voluntary update-needed 42, the fast-crash
+        // 45, AND the panic/signal/early-error codes the watchdog never produces.
+        // Firing broadly preserves the #4549 self-heal AND enables crash-loop
+        // rollback (#4073); 45 and the crash codes staying out of
+        // SuccessExitStatus still count toward StartLimitBurst. A `case` (not
+        // `&&`/`||`) avoids shell-precedence pitfalls.
         assert!(
-            service_content.contains("case \"$$EXIT_STATUS\" in 42|45)")
+            service_content.contains("case \"$$EXIT_STATUS\" in 0|43) ;; *)")
                 && service_content.contains("update --quiet"),
-            "ExecStopPost must run `freenet update` for exit 42 OR 45 via a case \
-             statement (boot-crash self-heal preserved; #4551)"
+            "ExecStopPost must run `freenet update` for any non-graceful exit via a \
+             case that skips only 0 and 43 (#4073 broadened crash coverage; #4551)"
+        );
+        assert!(
+            !service_content.contains("42|45)"),
+            "ExecStopPost must not use the narrow 42|45 guard — it misses \
+             panic/signal/early-error crashes (#4073 M1)"
         );
         // #4551: the unit must advertise fast-crash (exit-45) support via the marker
         // env var the node gates on. Using the const (not a literal) pins template,
@@ -1309,12 +1317,18 @@ mod tests {
                 && service_content.contains("\"$$EXIT_STATUS\""),
             "ExecStopPost must use the doubled $$EXIT_STATUS (single-$ revert breaks auto-update)"
         );
-        // #4551: ExecStopPost fires `freenet update` for exit 42 OR 45 (system unit too).
+        // #4073 / #4551: ExecStopPost fires `freenet update` for ANY non-graceful
+        // exit (every status except 0 and 43) — system unit too.
         assert!(
-            service_content.contains("case \"$$EXIT_STATUS\" in 42|45)")
+            service_content.contains("case \"$$EXIT_STATUS\" in 0|43) ;; *)")
                 && service_content.contains("update --quiet"),
-            "ExecStopPost must run `freenet update` for exit 42 OR 45 via a case \
-             statement (boot-crash self-heal preserved; #4551)"
+            "ExecStopPost must run `freenet update` for any non-graceful exit via a \
+             case that skips only 0 and 43 (#4073 broadened crash coverage; #4551)"
+        );
+        assert!(
+            !service_content.contains("42|45)"),
+            "ExecStopPost must not use the narrow 42|45 guard — it misses \
+             panic/signal/early-error crashes (#4073 M1)"
         );
         // #4551: system unit must also set the fast-crash (exit-45) support marker.
         assert!(

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -3268,6 +3268,53 @@ echo "RC=$?"
         }
     }
 
+    /// #4073 crash-loop auto-rollback (cross-platform source-scrape pins).
+    ///
+    /// The supervisor → updater handoff that drives rollback is platform-gated
+    /// (systemd unit / macOS shell wrapper / in-process wrapper), so these
+    /// pins assert the wiring exists in the source on every CI platform rather
+    /// than only where the cfg'd code compiles.
+    #[test]
+    fn macos_wrapper_passes_node_exit_code_to_post_stop_update() {
+        let src = include_str!("service/macos.rs");
+        // The wrapper script must run `freenet update` with the node's exit code
+        // exported (only on the exit-42 update/crash branch), and bind the env
+        // name from the rollback module's constant.
+        assert!(
+            src.contains("{post_stop_env}=$EXIT_CODE \"{binary}\" update --quiet"),
+            "macOS wrapper must pass the node exit code to its post-stop \
+             `freenet update` for crash-loop auto-rollback (#4073)"
+        );
+        assert!(
+            src.contains("post_stop_env = super::super::rollback::POST_STOP_EXIT_CODE_ENV_VAR"),
+            "macOS wrapper must source the post-stop env var name from the \
+             rollback module so the two cannot drift (#4073)"
+        );
+    }
+
+    #[test]
+    fn in_process_wrapper_only_passes_exit_code_on_post_crash_update() {
+        let src = include_str!("service/wrapper.rs");
+        // The post-crash auto-update path passes the node's exit code.
+        assert!(
+            src.contains("spawn_update_command(&exe_path, Some(exit_code))"),
+            "the wrapper's post-stop auto-update must pass Some(exit_code) so \
+             `freenet update` can drive crash-loop auto-rollback (#4073)"
+        );
+        // Manual / tray "Check for Updates" paths must NOT pass an exit code —
+        // they are not crashes and must never be counted toward a rollback.
+        assert!(
+            src.contains("spawn_update_command(&exe_path, None)"),
+            "manual tray update paths must pass None so they are not counted as \
+             probation crashes (#4073)"
+        );
+        assert!(
+            src.contains("POST_STOP_EXIT_CODE_ENV_VAR"),
+            "spawn_update_command must set the post-stop env var from the \
+             rollback module constant (#4073)"
+        );
+    }
+
     /// Source-level regression pin for the `FreeConsole()` rule, mirroring
     /// `spawn_update_command_must_null_all_three_standard_handles`.
     ///

--- a/crates/core/src/bin/commands/service/linux.rs
+++ b/crates/core/src/bin/commands/service/linux.rs
@@ -352,7 +352,11 @@ TimeoutStopSec=45
 # the unit stops. A `case` (not `&&`/`||`) avoids shell-precedence pitfalls.
 # $$EXIT_STATUS is doubled so systemd passes a literal $EXIT_STATUS through to sh
 # (systemd itself sets it in the ExecStopPost environment).
-ExecStopPost=-/bin/sh -c 'case "$$EXIT_STATUS" in 42|45) {binary} update --quiet ;; esac'
+# {post_stop_env} carries the node's exit status into `freenet update` so the
+# crash-loop auto-rollback (#4073) can tell a post-stop restart from a manual
+# update and count crashes of a probationary version. An OLD binary (e.g. one we
+# rolled back TO) simply ignores the unknown env var.
+ExecStopPost=-/bin/sh -c 'case "$$EXIT_STATUS" in 42|45) {post_stop_env}="$$EXIT_STATUS" {binary} update --quiet ;; esac'
 # Exit 42 (auto-update) and 43 (another instance) are clean exits, so they are
 # not counted as failures — without this, rapid update cycles (exit 42 →
 # ExecStopPost → restart) could exhaust the burst limit and kill the service.
@@ -397,6 +401,7 @@ WantedBy=default.target
         binary = binary_path.display(),
         log_dir = log_dir.display(),
         fast_crash_marker = super::super::auto_update::SYSTEMD_FAST_CRASH_ENV_VAR,
+        post_stop_env = super::super::rollback::POST_STOP_EXIT_CODE_ENV_VAR,
     )
 }
 
@@ -473,7 +478,11 @@ TimeoutStopSec=45
 # the unit stops. A `case` (not `&&`/`||`) avoids shell-precedence pitfalls.
 # $$EXIT_STATUS is doubled so systemd passes a literal $EXIT_STATUS through to sh
 # (systemd itself sets it in the ExecStopPost environment).
-ExecStopPost=-/bin/sh -c 'case "$$EXIT_STATUS" in 42|45) {binary} update --quiet ;; esac'
+# {post_stop_env} carries the node's exit status into `freenet update` so the
+# crash-loop auto-rollback (#4073) can tell a post-stop restart from a manual
+# update and count crashes of a probationary version. An OLD binary (e.g. one we
+# rolled back TO) simply ignores the unknown env var.
+ExecStopPost=-/bin/sh -c 'case "$$EXIT_STATUS" in 42|45) {post_stop_env}="$$EXIT_STATUS" {binary} update --quiet ;; esac'
 # Exit 42 (auto-update) and 43 (another instance) are clean exits, so they are
 # not counted as failures — without this, rapid update cycles (exit 42 →
 # ExecStopPost → restart) could exhaust the burst limit and kill the service.
@@ -520,6 +529,7 @@ WantedBy=multi-user.target
         username = username,
         home = home_dir.display(),
         fast_crash_marker = super::super::auto_update::SYSTEMD_FAST_CRASH_ENV_VAR,
+        post_stop_env = super::super::rollback::POST_STOP_EXIT_CODE_ENV_VAR,
     )
 }
 
@@ -742,5 +752,36 @@ mod tests {
 
         assert!(user_unit.contains("SuccessExitStatus=42"));
         assert!(system_unit.contains("SuccessExitStatus=42"));
+    }
+
+    #[test]
+    fn systemd_units_pass_node_exit_code_to_post_stop_update() {
+        // #4073 crash-loop auto-rollback: ExecStopPost must forward the node's
+        // exit status to `freenet update` (via the env var) so the updater can
+        // distinguish a post-stop restart from a manual update and count
+        // probation crashes. The env assignment must sit on the ExecStopPost
+        // line, which only fires on exit 42|45.
+        let env = super::super::super::rollback::POST_STOP_EXIT_CODE_ENV_VAR;
+        // systemd escapes `$$` to a literal `$`, so the generated unit carries
+        // `$$EXIT_STATUS`.
+        let expected = format!("42|45) {env}=\"$$EXIT_STATUS\"");
+        let user_unit = generate_user_service_file(
+            Path::new("/usr/local/bin/freenet"),
+            Path::new("/home/test/.local/state/freenet"),
+        );
+        let system_unit = generate_system_service_file(
+            Path::new("/usr/local/bin/freenet"),
+            Path::new("/home/test/.local/state/freenet"),
+            "testuser",
+            Path::new("/home/test"),
+        );
+        assert!(
+            user_unit.contains(&expected),
+            "user unit must pass {env} to the ExecStopPost update (#4073)"
+        );
+        assert!(
+            system_unit.contains(&expected),
+            "system unit must pass {env} to the ExecStopPost update (#4073)"
+        );
     }
 }

--- a/crates/core/src/bin/commands/service/linux.rs
+++ b/crates/core/src/bin/commands/service/linux.rs
@@ -340,23 +340,28 @@ RestartSec=10
 # cleanup. If you raise `shutdown-drain-secs`, raise this in lockstep.
 TimeoutStopSec=45
 
-# Auto-update / boot-crash self-heal: run `freenet update` before systemd
-# restarts the service when the node exits 42 (a healthy node that hit a version
-# mismatch / fatal fault) OR 45 (a fast crash / boot-wedge, #4551). Firing update
-# on 45 too preserves the #4549 self-heal for a boot-crash that a NEWER release
-# fixes — `freenet update` is a SEPARATE process that can succeed even when
-# `freenet network` crashes at startup. This does NOT exempt 45 from the
-# crash-loop limiter: ExecStopPost runs AFTER the process exits (the '-' prefix
-# means its own result never affects restart) and 45 stays OUT of
-# SuccessExitStatus below, so a no-fix tight loop still trips StartLimitBurst and
-# the unit stops. A `case` (not `&&`/`||`) avoids shell-precedence pitfalls.
-# $$EXIT_STATUS is doubled so systemd passes a literal $EXIT_STATUS through to sh
-# (systemd itself sets it in the ExecStopPost environment).
-# {post_stop_env} carries the node's exit status into `freenet update` so the
-# crash-loop auto-rollback (#4073) can tell a post-stop restart from a manual
-# update and count crashes of a probationary version. An OLD binary (e.g. one we
-# rolled back TO) simply ignores the unknown env var.
-ExecStopPost=-/bin/sh -c 'case "$$EXIT_STATUS" in 42|45) {post_stop_env}="$$EXIT_STATUS" {binary} update --quiet ;; esac'
+# Auto-update / crash-loop rollback / boot-crash self-heal: run `freenet update`
+# before systemd restarts the service on ANY non-graceful exit — every
+# $EXIT_STATUS except 0 (graceful) and 43 (another instance already running).
+# That covers the voluntary update-needed exit 42, the fast-crash code 45
+# (#4551), AND the crash codes the listener watchdog never produces: panics
+# (101), SIGABRT/SIGKILL/SIGSEGV (134/137/139, which systemd may pass as signal
+# NAMES like ABRT/KILL/SEGV), and early-startup errors (1). `freenet update`
+# then either steps forward (42 / a newer release) or, for a crash of a
+# freshly-installed version still on probation, counts it and — once it keeps
+# crashing — rolls back to the previous binary (#4073). `freenet update` is a
+# SEPARATE process that can succeed even when `freenet network` crashes at
+# startup, preserving the #4549 self-heal.
+# This does NOT exempt crash codes from the limiter: ExecStopPost runs AFTER the
+# process exits (the '-' prefix means its own result never affects restart) and
+# 45 / 1 / 101 / signals stay OUT of SuccessExitStatus below, so a no-fix tight
+# loop still trips StartLimitBurst and the unit stops. A `case` (not `&&`/`||`)
+# avoids shell-precedence pitfalls. $$EXIT_STATUS is doubled so systemd passes a
+# literal $EXIT_STATUS through to sh. {post_stop_env} forwards that status to
+# `freenet update` so #4073 can tell a post-stop restart from a manual update
+# and classify the crash; an OLD binary (e.g. one we rolled back TO) ignores the
+# unknown env var.
+ExecStopPost=-/bin/sh -c 'case "$$EXIT_STATUS" in 0|43) ;; *) {post_stop_env}="$$EXIT_STATUS" {binary} update --quiet ;; esac'
 # Exit 42 (auto-update) and 43 (another instance) are clean exits, so they are
 # not counted as failures — without this, rapid update cycles (exit 42 →
 # ExecStopPost → restart) could exhaust the burst limit and kill the service.
@@ -466,23 +471,28 @@ RestartSec=10
 # cleanup. If you raise `shutdown-drain-secs`, raise this in lockstep.
 TimeoutStopSec=45
 
-# Auto-update / boot-crash self-heal: run `freenet update` before systemd
-# restarts the service when the node exits 42 (a healthy node that hit a version
-# mismatch / fatal fault) OR 45 (a fast crash / boot-wedge, #4551). Firing update
-# on 45 too preserves the #4549 self-heal for a boot-crash that a NEWER release
-# fixes — `freenet update` is a SEPARATE process that can succeed even when
-# `freenet network` crashes at startup. This does NOT exempt 45 from the
-# crash-loop limiter: ExecStopPost runs AFTER the process exits (the '-' prefix
-# means its own result never affects restart) and 45 stays OUT of
-# SuccessExitStatus below, so a no-fix tight loop still trips StartLimitBurst and
-# the unit stops. A `case` (not `&&`/`||`) avoids shell-precedence pitfalls.
-# $$EXIT_STATUS is doubled so systemd passes a literal $EXIT_STATUS through to sh
-# (systemd itself sets it in the ExecStopPost environment).
-# {post_stop_env} carries the node's exit status into `freenet update` so the
-# crash-loop auto-rollback (#4073) can tell a post-stop restart from a manual
-# update and count crashes of a probationary version. An OLD binary (e.g. one we
-# rolled back TO) simply ignores the unknown env var.
-ExecStopPost=-/bin/sh -c 'case "$$EXIT_STATUS" in 42|45) {post_stop_env}="$$EXIT_STATUS" {binary} update --quiet ;; esac'
+# Auto-update / crash-loop rollback / boot-crash self-heal: run `freenet update`
+# before systemd restarts the service on ANY non-graceful exit — every
+# $EXIT_STATUS except 0 (graceful) and 43 (another instance already running).
+# That covers the voluntary update-needed exit 42, the fast-crash code 45
+# (#4551), AND the crash codes the listener watchdog never produces: panics
+# (101), SIGABRT/SIGKILL/SIGSEGV (134/137/139, which systemd may pass as signal
+# NAMES like ABRT/KILL/SEGV), and early-startup errors (1). `freenet update`
+# then either steps forward (42 / a newer release) or, for a crash of a
+# freshly-installed version still on probation, counts it and — once it keeps
+# crashing — rolls back to the previous binary (#4073). `freenet update` is a
+# SEPARATE process that can succeed even when `freenet network` crashes at
+# startup, preserving the #4549 self-heal.
+# This does NOT exempt crash codes from the limiter: ExecStopPost runs AFTER the
+# process exits (the '-' prefix means its own result never affects restart) and
+# 45 / 1 / 101 / signals stay OUT of SuccessExitStatus below, so a no-fix tight
+# loop still trips StartLimitBurst and the unit stops. A `case` (not `&&`/`||`)
+# avoids shell-precedence pitfalls. $$EXIT_STATUS is doubled so systemd passes a
+# literal $EXIT_STATUS through to sh. {post_stop_env} forwards that status to
+# `freenet update` so #4073 can tell a post-stop restart from a manual update
+# and classify the crash; an OLD binary (e.g. one we rolled back TO) ignores the
+# unknown env var.
+ExecStopPost=-/bin/sh -c 'case "$$EXIT_STATUS" in 0|43) ;; *) {post_stop_env}="$$EXIT_STATUS" {binary} update --quiet ;; esac'
 # Exit 42 (auto-update) and 43 (another instance) are clean exits, so they are
 # not counted as failures — without this, rapid update cycles (exit 42 →
 # ExecStopPost → restart) could exhaust the burst limit and kill the service.
@@ -756,15 +766,15 @@ mod tests {
 
     #[test]
     fn systemd_units_pass_node_exit_code_to_post_stop_update() {
-        // #4073 crash-loop auto-rollback: ExecStopPost must forward the node's
-        // exit status to `freenet update` (via the env var) so the updater can
-        // distinguish a post-stop restart from a manual update and count
-        // probation crashes. The env assignment must sit on the ExecStopPost
-        // line, which only fires on exit 42|45.
+        // #4073 crash-loop auto-rollback: ExecStopPost must (a) fire on ANY
+        // non-graceful exit (every status except 0 and 43) so panics / signals /
+        // early errors are covered, and (b) forward the node's stop status to
+        // `freenet update` via the env var so the updater can classify the
+        // crash. systemd escapes `$$` to a literal `$`.
         let env = super::super::super::rollback::POST_STOP_EXIT_CODE_ENV_VAR;
-        // systemd escapes `$$` to a literal `$`, so the generated unit carries
-        // `$$EXIT_STATUS`.
-        let expected = format!("42|45) {env}=\"$$EXIT_STATUS\"");
+        // Broadened guard: skip only 0 and 43; run update (with the status
+        // forwarded) for everything else.
+        let expected = format!(r#"case "$$EXIT_STATUS" in 0|43) ;; *) {env}="$$EXIT_STATUS""#);
         let user_unit = generate_user_service_file(
             Path::new("/usr/local/bin/freenet"),
             Path::new("/home/test/.local/state/freenet"),
@@ -775,13 +785,18 @@ mod tests {
             "testuser",
             Path::new("/home/test"),
         );
-        assert!(
-            user_unit.contains(&expected),
-            "user unit must pass {env} to the ExecStopPost update (#4073)"
-        );
-        assert!(
-            system_unit.contains(&expected),
-            "system unit must pass {env} to the ExecStopPost update (#4073)"
-        );
+        for (name, unit) in [("user", &user_unit), ("system", &system_unit)] {
+            assert!(
+                unit.contains(&expected),
+                "{name} unit must fire the post-stop update on any non-graceful exit and \
+                 forward {env} (#4073)"
+            );
+            // Regression guard: the OLD narrow `42|45)` form must be gone.
+            assert!(
+                !unit.contains("42|45)"),
+                "{name} unit still uses the narrow 42|45 ExecStopPost guard, missing \
+                 panic/signal/early-error crashes (#4073 M1)"
+            );
+        }
     }
 }

--- a/crates/core/src/bin/commands/service/macos.rs
+++ b/crates/core/src/bin/commands/service/macos.rs
@@ -298,7 +298,10 @@ while true; do
 
     if [ $EXIT_CODE -eq 42 ]; then
         log_event "Update needed, running freenet update..."
-        if "{binary}" update --quiet; then
+        # Pass the node's exit code so crash-loop auto-rollback (#4073) can tell
+        # a post-stop restart from a manual update and count crashes of a
+        # probationary version.
+        if {post_stop_env}=$EXIT_CODE "{binary}" update --quiet; then
             log_event "Update successful, restarting..."
             CONSECUTIVE_FAILURES=0
             PORT_CONFLICT_KILLS=0
@@ -355,6 +358,7 @@ done
 "#,
         binary = binary_path.display(),
         supervised_env = super::super::auto_update::SUPERVISED_ENV_VAR,
+        post_stop_env = super::super::rollback::POST_STOP_EXIT_CODE_ENV_VAR,
     )
 }
 

--- a/crates/core/src/bin/commands/service/macos.rs
+++ b/crates/core/src/bin/commands/service/macos.rs
@@ -346,6 +346,22 @@ while true; do
             else
                 log_event "Port conflict persists after $MAX_PORT_CONFLICT_KILLS kill attempts. Manual intervention may be required ('pkill freenet'). Backing off..."
             fi
+        else
+            # #4073 crash-loop rollback / self-heal: a genuine non-graceful crash
+            # (panic, SIGSEGV/SIGABRT, early-startup error — NOT a port conflict).
+            # Run the post-stop updater with the exit code forwarded: if a
+            # freshly-installed version on probation keeps crashing it rolls back
+            # to the previous binary, and a genuine newer release self-heals
+            # forward. Exit 0 => binary changed (rolled back or updated) =>
+            # restart immediately; any other status => fall through to backoff.
+            if {post_stop_env}=$EXIT_CODE "{binary}" update --quiet; then
+                log_event "Post-crash update/rollback applied (exit $EXIT_CODE); restarting..."
+                CONSECUTIVE_FAILURES=0
+                PORT_CONFLICT_KILLS=0
+                BACKOFF=10
+                sleep 2
+                continue
+            fi
         fi
         CONSECUTIVE_FAILURES=$((CONSECUTIVE_FAILURES + 1))
         PORT_CONFLICT_KILLS=0

--- a/crates/core/src/bin/commands/service/wrapper.rs
+++ b/crates/core/src/bin/commands/service/wrapper.rs
@@ -586,12 +586,30 @@ pub(super) fn run_wrapper(version: &str) -> Result<()> {
 /// #3934 (which was also the root cause of "Check for Updates" being
 /// broken in #3933). Null stdio is harmless on macOS/Linux because
 /// `--quiet` already suppresses all output.
-pub(super) fn spawn_update_command(exe_path: &Path) -> std::io::Result<std::process::ExitStatus> {
+///
+/// `post_stop_exit_code` is `Some(code)` ONLY when this update runs as part of
+/// the node's restart cycle (the node exited `code` and the wrapper is applying
+/// the update before relaunching). In that case the node's exit code is passed
+/// through [`POST_STOP_EXIT_CODE_ENV_VAR`] so `freenet update` can drive
+/// crash-loop auto-rollback (#4073). It MUST be `None` for tray / manual
+/// "Check for Updates" invocations, which are not crashes and must never be
+/// counted toward a rollback.
+pub(super) fn spawn_update_command(
+    exe_path: &Path,
+    post_stop_exit_code: Option<i32>,
+) -> std::io::Result<std::process::ExitStatus> {
     let mut cmd = std::process::Command::new(exe_path);
     cmd.args(["update", "--quiet"])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
+
+    if let Some(code) = post_stop_exit_code {
+        cmd.env(
+            super::super::rollback::POST_STOP_EXIT_CODE_ENV_VAR,
+            code.to_string(),
+        );
+    }
 
     #[cfg(target_os = "windows")]
     {
@@ -887,7 +905,8 @@ fn run_wrapper_loop(
                             // wrapper so the tray shows the correct new version.
                             // Exit 2 means already up to date — no restart needed.
                             status_tx.send(WrapperStatus::Updating).ok();
-                            let result = spawn_update_command(&exe_path);
+                            // Manual tray check: not a crash, so no post-stop code.
+                            let result = spawn_update_command(&exe_path, None);
                             match result {
                                 Ok(s) if s.success() => {
                                     log_wrapper_event(
@@ -977,7 +996,8 @@ fn run_wrapper_loop(
                             super::super::tray::TrayAction::CheckUpdate => {
                                 // Allow checking for updates even while stopped
                                 status_tx.send(WrapperStatus::Updating).ok();
-                                let result = spawn_update_command(&exe_path);
+                                // Manual tray check: not a crash, so no post-stop code.
+                                let result = spawn_update_command(&exe_path, None);
                                 match result {
                                     Ok(s) if s.success() => {
                                         log_wrapper_event(
@@ -1049,7 +1069,9 @@ fn run_wrapper_loop(
                 status_tx.send(WrapperStatus::Updating).ok();
             }
 
-            let result = spawn_update_command(&exe_path);
+            // Post-stop auto-update: pass the node's exit code so `freenet
+            // update` can drive crash-loop auto-rollback (#4073).
+            let result = spawn_update_command(&exe_path, Some(exit_code));
             let outcome = super::super::update::classify_update_subprocess(&result);
 
             // Drive the persistent auto-update failure counter used by
@@ -1230,7 +1252,9 @@ fn run_wrapper_loop(
                             #[cfg(any(target_os = "windows", target_os = "macos"))]
                             if let Some((_, status_tx)) = tray {
                                 status_tx.send(WrapperStatus::Updating).ok();
-                                let result = spawn_update_command(&exe_path);
+                                // Manual "Check for Updates" during backoff: not
+                                // a crash, so no post-stop code (#4073).
+                                let result = spawn_update_command(&exe_path, None);
                                 let outcome =
                                     super::super::update::classify_update_subprocess(&result);
 

--- a/crates/core/src/bin/commands/service/wrapper.rs
+++ b/crates/core/src/bin/commands/service/wrapper.rs
@@ -1065,6 +1065,13 @@ fn run_wrapper_loop(
         // exit code lets `freenet update` classify and count the crash locally
         // (no GitHub call); if it rolled the binary back, re-exec the wrapper so
         // the restored binary runs.
+        //
+        // NOTE: intentional, benign difference from the macOS launchd wrapper
+        // script — that script does NOT pre-gate on a probation marker (it can't
+        // cheaply read one from shell), so a committed-version crash there spawns
+        // `freenet update` (which finds no marker -> Proceed). Both are safe; the
+        // in-process gate just avoids an unnecessary subprocess in the common
+        // committed-crash case where we have the marker check in hand.
         if exit_code != 0
             && exit_code != WRAPPER_EXIT_ALREADY_RUNNING
             && exit_code != WRAPPER_EXIT_UPDATE_NEEDED

--- a/crates/core/src/bin/commands/service/wrapper.rs
+++ b/crates/core/src/bin/commands/service/wrapper.rs
@@ -1055,6 +1055,48 @@ fn run_wrapper_loop(
             .map(|s| s.contains("already in use"))
             .unwrap_or(false);
 
+        // #4073 crash-loop auto-rollback (in-process). The exit-42 path below
+        // handles the voluntary-update code. Here we catch the OTHER non-graceful
+        // crash exits the watchdog never produces — panics (101), signal deaths
+        // (surfaced as exit code 1 here), and early-startup errors (1) — so a
+        // freshly-installed version that crash-loops on one of those still rolls
+        // back. Gated on an existing probation marker so an ordinary crash of a
+        // committed version never spawns an updater subprocess. Forwarding the
+        // exit code lets `freenet update` classify and count the crash locally
+        // (no GitHub call); if it rolled the binary back, re-exec the wrapper so
+        // the restored binary runs.
+        if exit_code != 0
+            && exit_code != WRAPPER_EXIT_ALREADY_RUNNING
+            && exit_code != WRAPPER_EXIT_UPDATE_NEEDED
+            && !is_port_conflict
+            && super::super::rollback::read_probation().is_some()
+        {
+            log_wrapper_event(
+                log_dir,
+                &format!(
+                    "Crash (exit {exit_code}) during update probation; checking crash-loop rollback..."
+                ),
+            );
+            let result = spawn_update_command(&exe_path, Some(exit_code));
+            if matches!(
+                super::super::update::classify_update_subprocess(&result),
+                super::super::update::UpdateSubprocessOutcome::BinaryReplaced
+            ) {
+                log_wrapper_event(
+                    log_dir,
+                    "Crash-loop auto-rollback restored the previous binary; restarting wrapper",
+                );
+                if spawn_new_wrapper(&exe_path, log_dir) {
+                    return Ok(());
+                }
+                // Re-exec failed: relaunch the child with the (now restored)
+                // on-disk binary rather than leaving no node running.
+                continue;
+            }
+            // Crash recorded / rollback unavailable: fall through to the normal
+            // crash backoff via the state machine below.
+        }
+
         // For exit code 42, run the update first and pass result to state machine.
         // On Windows, this works because replace_binary() renames the running exe
         // (freenet.exe → freenet.exe.old) rather than deleting it. Windows allows

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -495,40 +495,29 @@ impl UpdateCommand {
 
         let current_exe = std::env::current_exe().context("Failed to get current executable")?;
 
-        // #4073 crash-loop auto-rollback: snapshot the about-to-be-replaced
-        // binary as the known-good rollback target BEFORE overwriting it. Only
-        // do so when transitioning from a committed/healthy version — if we are
-        // already on probation the live binary is the UNPROVEN new version, so
-        // we must preserve the existing known-good snapshot (and its recorded
-        // size+hash) rather than capture the unproven one. A capture failure
-        // (e.g. disk full) does not block the update; it just means no rollback
+        // #4073 crash-loop auto-rollback: decide the rollback target BEFORE
+        // overwriting the live binary. `prepare_known_good_for_install` computes
+        // the snapshot blob AND its matching version label together, so they can
+        // never diverge: a genuine chained in-probation install keeps the
+        // existing known-good; anything else (no marker, a stale marker, or an
+        // externally-deleted blob) snapshots the about-to-be-replaced binary
+        // fresh and labels it the version we're replacing. A capture failure
+        // (e.g. disk full) does not block the update — it just means no rollback
         // safety net for this cycle.
-        let chained_in_probation = rollback::read_probation()
-            .filter(|existing| existing.new_version == current_version)
-            .filter(|_| rollback::known_good_binary_path().is_some_and(|p| p.exists()));
-        let known_good_meta = if let Some(existing) = chained_in_probation {
-            // Genuine chained install while still on probation for the version we
-            // are running: keep the existing known-good blob's integrity metadata
-            // (the live binary is the UNPROVEN new version). A marker for any
-            // OTHER version is stale and ignored here — we capture fresh below so
-            // we never roll back to an unrelated older binary.
-            Some(rollback::KnownGoodMeta {
-                size: existing.rollback_size,
-                sha256: existing.rollback_sha256,
-            })
-        } else {
-            match rollback::capture_known_good(&current_exe) {
-                Ok(meta) => Some(meta),
-                Err(e) => {
-                    if !self.quiet {
-                        eprintln!(
-                            "Warning: failed to snapshot known-good binary for crash-loop \
+        let known_good = match rollback::prepare_known_good_for_install(
+            current_version,
+            &current_exe,
+        ) {
+            Ok(prepared) => Some(prepared),
+            Err(e) => {
+                if !self.quiet {
+                    eprintln!(
+                        "Warning: failed to snapshot known-good binary for crash-loop \
                              rollback: {e}. Proceeding without rollback protection for this update."
-                        );
-                    }
-                    tracing::warn!(error = %e, "Failed to capture known-good rollback binary (#4073)");
-                    None
+                    );
                 }
+                tracing::warn!(error = %e, "Failed to capture known-good rollback binary (#4073)");
+                None
             }
         };
 
@@ -557,10 +546,10 @@ impl UpdateCommand {
         // probation marker (full/unwritable state dir) does NOT fail the update
         // — the binary is already installed — but it MUST be surfaced, since the
         // new version then has no rollback protection.
-        if let Some(meta) = known_good_meta {
+        if let Some((meta, previous_version)) = known_good {
             if let Err(e) = rollback::begin_probation(
                 release.tag_name.trim_start_matches('v'),
-                current_version,
+                &previous_version,
                 &current_exe,
                 &meta,
             ) {
@@ -1027,6 +1016,12 @@ impl Checksums {
 async fn get_latest_release() -> Result<Release> {
     let client = reqwest::Client::builder()
         .user_agent("freenet-updater")
+        // Bound the request (parity with auto_update::get_latest_version). The
+        // broadened post-stop ExecStopPost reaches this on every committed
+        // crash's Proceed path, so a hung GitHub connection during a crash must
+        // not stall the post-stop updater (only loosely bounded by
+        // TimeoutStopSec on systemd, and worse under the mac/in-process wrapper).
+        .timeout(std::time::Duration::from_secs(10))
         .build()?;
 
     let response = client

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -197,32 +197,32 @@ impl UpdateCommand {
 
     async fn run_async(&self, current_version: &str) -> Result<()> {
         // #4073 crash-loop auto-rollback. When a supervisor runs `freenet
-        // update` immediately after the node stopped, it sets
-        // POST_STOP_EXIT_CODE_ENV_VAR with the node's exit code. If we are in
-        // post-update probation, treat the stop as a crash of the probationary
-        // version: count it, and roll back to the known-good binary once the
-        // crash threshold is reached — instead of performing a normal update.
-        // This needs no network call, so the crash/rollback path never depends
-        // on GitHub being reachable.
-        if let Some(exit_code) = rollback::post_stop_exit_code_from_env() {
-            match rollback::handle_post_stop(current_version) {
+        // update` immediately after the node stopped, it forwards the node's
+        // stop status (exit code or signal name) via POST_STOP_EXIT_CODE_ENV_VAR.
+        // If that status is a crash and we are in post-update probation, count
+        // it and roll back to the known-good binary once the crash threshold is
+        // reached — instead of performing a normal update. This needs no network
+        // call, so the crash/rollback path never depends on GitHub being
+        // reachable.
+        if let Some(status) = rollback::post_stop_status_from_env() {
+            match rollback::handle_post_stop(&status, current_version) {
                 rollback::PostStopOutcome::Proceed => {
-                    // Not a probation crash (no probation, or a stale marker):
-                    // fall through to the normal update flow below.
+                    // Not a probation crash (clean/voluntary stop, no probation,
+                    // or a stale marker): fall through to the normal update flow.
                 }
                 rollback::PostStopOutcome::CrashRecorded { crash_count } => {
                     // Critical brick-safety signal: emit on stderr even under
                     // --quiet (the supervisor routes it to the journal/log).
                     eprintln!(
                         "Freenet {current_version}: crash {crash_count}/{} during post-update \
-                         probation (node exit {exit_code}); not updating, will auto-roll-back if \
-                         it keeps crashing.",
+                         probation (node stop status {status}); not updating, will auto-roll-back \
+                         if it keeps crashing.",
                         rollback::ROLLBACK_CRASH_THRESHOLD,
                     );
                     tracing::warn!(
                         version = current_version,
                         crash_count,
-                        node_exit_code = exit_code,
+                        node_stop_status = %status,
                         threshold = rollback::ROLLBACK_CRASH_THRESHOLD,
                         "Post-update probation crash recorded (#4073)"
                     );
@@ -499,14 +499,24 @@ impl UpdateCommand {
         // binary as the known-good rollback target BEFORE overwriting it. Only
         // do so when transitioning from a committed/healthy version — if we are
         // already on probation the live binary is the UNPROVEN new version, so
-        // we must preserve the existing known-good snapshot rather than capture
-        // the unproven one. A capture failure (e.g. disk full) does not block
-        // the update; it just means no rollback safety net for this cycle.
-        let known_good_ready = if rollback::read_probation().is_some() {
-            rollback::known_good_binary_path().is_some_and(|p| p.exists())
+        // we must preserve the existing known-good snapshot (and its recorded
+        // size+hash) rather than capture the unproven one. A capture failure
+        // (e.g. disk full) does not block the update; it just means no rollback
+        // safety net for this cycle.
+        let known_good_meta = if let Some(existing) = rollback::read_probation() {
+            // Chained install while still on probation: keep the existing
+            // known-good blob's integrity metadata.
+            if rollback::known_good_binary_path().is_some_and(|p| p.exists()) {
+                Some(rollback::KnownGoodMeta {
+                    size: existing.rollback_size,
+                    sha256: existing.rollback_sha256,
+                })
+            } else {
+                None
+            }
         } else {
             match rollback::capture_known_good(&current_exe) {
-                Ok(()) => true,
+                Ok(meta) => Some(meta),
                 Err(e) => {
                     if !self.quiet {
                         eprintln!(
@@ -515,7 +525,7 @@ impl UpdateCommand {
                         );
                     }
                     tracing::warn!(error = %e, "Failed to capture known-good rollback binary (#4073)");
-                    false
+                    None
                 }
             }
         };
@@ -542,11 +552,12 @@ impl UpdateCommand {
         // Arm crash-loop rollback for the freshly-installed version. Skipped
         // when we have no known-good binary to fall back to, so we never
         // advertise a rollback target we cannot honour.
-        if known_good_ready {
+        if let Some(meta) = known_good_meta {
             rollback::begin_probation(
                 release.tag_name.trim_start_matches('v'),
                 current_version,
                 &current_exe,
+                &meta,
             );
         }
 

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -8,6 +8,8 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use super::rollback;
+
 #[cfg(target_os = "macos")]
 use super::service::generate_wrapper_script;
 #[cfg(target_os = "linux")]
@@ -194,6 +196,70 @@ impl UpdateCommand {
     }
 
     async fn run_async(&self, current_version: &str) -> Result<()> {
+        // #4073 crash-loop auto-rollback. When a supervisor runs `freenet
+        // update` immediately after the node stopped, it sets
+        // POST_STOP_EXIT_CODE_ENV_VAR with the node's exit code. If we are in
+        // post-update probation, treat the stop as a crash of the probationary
+        // version: count it, and roll back to the known-good binary once the
+        // crash threshold is reached — instead of performing a normal update.
+        // This needs no network call, so the crash/rollback path never depends
+        // on GitHub being reachable.
+        if let Some(exit_code) = rollback::post_stop_exit_code_from_env() {
+            match rollback::handle_post_stop(current_version) {
+                rollback::PostStopOutcome::Proceed => {
+                    // Not a probation crash (no probation, or a stale marker):
+                    // fall through to the normal update flow below.
+                }
+                rollback::PostStopOutcome::CrashRecorded { crash_count } => {
+                    // Critical brick-safety signal: emit on stderr even under
+                    // --quiet (the supervisor routes it to the journal/log).
+                    eprintln!(
+                        "Freenet {current_version}: crash {crash_count}/{} during post-update \
+                         probation (node exit {exit_code}); not updating, will auto-roll-back if \
+                         it keeps crashing.",
+                        rollback::ROLLBACK_CRASH_THRESHOLD,
+                    );
+                    tracing::warn!(
+                        version = current_version,
+                        crash_count,
+                        node_exit_code = exit_code,
+                        threshold = rollback::ROLLBACK_CRASH_THRESHOLD,
+                        "Post-update probation crash recorded (#4073)"
+                    );
+                    // Exit "already up to date" so the supervisor backs off and
+                    // restarts the same binary rather than treating this as a
+                    // successful update.
+                    std::process::exit(EXIT_CODE_ALREADY_UP_TO_DATE);
+                }
+                rollback::PostStopOutcome::RolledBack {
+                    restored_version,
+                    bad_version,
+                } => {
+                    eprintln!(
+                        "Freenet auto-rollback (#4073): version {bad_version} crash-looped after \
+                         an update; restored known-good {restored_version} and pinned {bad_version} \
+                         as known-bad on this node so it will not be re-applied automatically."
+                    );
+                    tracing::error!(
+                        bad_version = %bad_version,
+                        restored_version = %restored_version,
+                        "Auto-rolled back a crash-looping update (#4073)"
+                    );
+                    // Exit success so the supervisor restarts the restored binary.
+                    std::process::exit(0);
+                }
+                rollback::PostStopOutcome::RollbackUnavailable { reason } => {
+                    eprintln!(
+                        "Freenet auto-rollback (#4073) could not run ({reason}); leaving the node \
+                         to the supervisor's own crash limiter / operator. Run `freenet update \
+                         --force` once a fixed release is available."
+                    );
+                    tracing::error!(reason = %reason, "Auto-rollback unavailable (#4073)");
+                    std::process::exit(EXIT_CODE_ALREADY_UP_TO_DATE);
+                }
+            }
+        }
+
         if !self.quiet {
             println!("Current version: {}", current_version);
             println!("Checking for updates...");
@@ -241,13 +307,36 @@ impl UpdateCommand {
             return Ok(());
         }
 
+        // #4073 crash-loop auto-rollback: refuse to (re-)install a version that
+        // a prior crash-loop rollback pinned as known-bad on THIS node, unless
+        // the operator explicitly forces it. This is what stops the
+        // update → crash → revert → re-update loop. A strictly-newer release (a
+        // fix) is not pinned and installs normally.
+        if !self.force && rollback::is_version_pinned_bad(latest_version) {
+            if !self.quiet {
+                println!(
+                    "Version {latest_version} is pinned as known-bad on this node after a previous \
+                     crash-loop; refusing to re-install it. Run `freenet update --force` to override."
+                );
+            }
+            tracing::warn!(
+                version = latest_version,
+                "Refusing to install a version pinned known-bad after crash-loop rollback (#4073)"
+            );
+            // Behave like 'already up to date' so a supervisor does not
+            // restart-loop trying to apply the bad version: there is nothing
+            // safe to install.
+            super::auto_update::clear_update_failures();
+            std::process::exit(EXIT_CODE_ALREADY_UP_TO_DATE);
+        }
+
         if !self.quiet {
             println!("Downloading update...");
         }
-        self.download_and_install(&latest).await
+        self.download_and_install(&latest, current_version).await
     }
 
-    async fn download_and_install(&self, release: &Release) -> Result<()> {
+    async fn download_and_install(&self, release: &Release, current_version: &str) -> Result<()> {
         // macOS DMG-swap path: when running from inside a .app bundle,
         // in-place binary replacement would invalidate the bundle's code
         // signature and Gatekeeper would refuse to launch the result on
@@ -275,6 +364,19 @@ impl UpdateCommand {
                     if !self.quiet {
                         println!("Bundle update staged. Freenet will relaunch shortly.");
                     }
+                    // SCOPE NOTE (#4073): crash-loop auto-rollback is binary-level
+                    // (snapshot the previous binary, restore it on a crash loop).
+                    // It deliberately does NOT cover the macOS .app DMG-swap path:
+                    // reverting a bundle means retaining and re-swapping a whole
+                    // signed+notarized .app via the detached updater, a separate
+                    // mechanism out of scope here. We therefore exit BEFORE arming
+                    // probation — no probation marker is created for a bundle
+                    // update, so the post-stop handler (reached if a macOS
+                    // supervisor forwards the exit code) simply finds no marker and
+                    // proceeds normally, exactly as before this change. A
+                    // crash-looping DMG release is still bounded by the wrapper's
+                    // own consecutive-failure cap, unchanged. Bundle rollback is
+                    // tracked as future work.
                     std::process::exit(EXIT_CODE_BUNDLE_UPDATE_STAGED);
                 }
                 Ok(false) => {
@@ -392,6 +494,32 @@ impl UpdateCommand {
             extract_binary(&freenet_archive_path, &freenet_extract_dir, "freenet")?;
 
         let current_exe = std::env::current_exe().context("Failed to get current executable")?;
+
+        // #4073 crash-loop auto-rollback: snapshot the about-to-be-replaced
+        // binary as the known-good rollback target BEFORE overwriting it. Only
+        // do so when transitioning from a committed/healthy version — if we are
+        // already on probation the live binary is the UNPROVEN new version, so
+        // we must preserve the existing known-good snapshot rather than capture
+        // the unproven one. A capture failure (e.g. disk full) does not block
+        // the update; it just means no rollback safety net for this cycle.
+        let known_good_ready = if rollback::read_probation().is_some() {
+            rollback::known_good_binary_path().is_some_and(|p| p.exists())
+        } else {
+            match rollback::capture_known_good(&current_exe) {
+                Ok(()) => true,
+                Err(e) => {
+                    if !self.quiet {
+                        eprintln!(
+                            "Warning: failed to snapshot known-good binary for crash-loop \
+                             rollback: {e}. Proceeding without rollback protection for this update."
+                        );
+                    }
+                    tracing::warn!(error = %e, "Failed to capture known-good rollback binary (#4073)");
+                    false
+                }
+            }
+        };
+
         // The failure-counter record/clear is scoped to the install step
         // specifically, NOT to any earlier download / checksum / extract
         // failure. Those are transient (transient GitHub outage, flaky
@@ -409,6 +537,17 @@ impl UpdateCommand {
                 super::auto_update::record_update_failure();
                 return Err(e);
             }
+        }
+
+        // Arm crash-loop rollback for the freshly-installed version. Skipped
+        // when we have no known-good binary to fall back to, so we never
+        // advertise a rollback target we cannot honour.
+        if known_good_ready {
+            rollback::begin_probation(
+                release.tag_name.trim_start_matches('v'),
+                current_version,
+                &current_exe,
+            );
         }
 
         if !self.quiet {

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -553,14 +553,25 @@ impl UpdateCommand {
 
         // Arm crash-loop rollback for the freshly-installed version. Skipped
         // when we have no known-good binary to fall back to, so we never
-        // advertise a rollback target we cannot honour.
+        // advertise a rollback target we cannot honour. A failure to persist the
+        // probation marker (full/unwritable state dir) does NOT fail the update
+        // — the binary is already installed — but it MUST be surfaced, since the
+        // new version then has no rollback protection.
         if let Some(meta) = known_good_meta {
-            rollback::begin_probation(
+            if let Err(e) = rollback::begin_probation(
                 release.tag_name.trim_start_matches('v'),
                 current_version,
                 &current_exe,
                 &meta,
-            );
+            ) {
+                if !self.quiet {
+                    eprintln!(
+                        "Warning: installed the update but failed to arm crash-loop rollback \
+                         protection: {e}. If this version crash-loops it will NOT auto-roll-back."
+                    );
+                }
+                tracing::warn!(error = %e, "Failed to arm crash-loop rollback probation (#4073)");
+            }
         }
 
         if !self.quiet {

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -503,17 +503,19 @@ impl UpdateCommand {
         // size+hash) rather than capture the unproven one. A capture failure
         // (e.g. disk full) does not block the update; it just means no rollback
         // safety net for this cycle.
-        let known_good_meta = if let Some(existing) = rollback::read_probation() {
-            // Chained install while still on probation: keep the existing
-            // known-good blob's integrity metadata.
-            if rollback::known_good_binary_path().is_some_and(|p| p.exists()) {
-                Some(rollback::KnownGoodMeta {
-                    size: existing.rollback_size,
-                    sha256: existing.rollback_sha256,
-                })
-            } else {
-                None
-            }
+        let chained_in_probation = rollback::read_probation()
+            .filter(|existing| existing.new_version == current_version)
+            .filter(|_| rollback::known_good_binary_path().is_some_and(|p| p.exists()));
+        let known_good_meta = if let Some(existing) = chained_in_probation {
+            // Genuine chained install while still on probation for the version we
+            // are running: keep the existing known-good blob's integrity metadata
+            // (the live binary is the UNPROVEN new version). A marker for any
+            // OTHER version is stale and ignored here — we capture fresh below so
+            // we never roll back to an unrelated older binary.
+            Some(rollback::KnownGoodMeta {
+                size: existing.rollback_size,
+                sha256: existing.rollback_sha256,
+            })
         } else {
             match rollback::capture_known_good(&current_exe) {
                 Ok(meta) => Some(meta),

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -468,6 +468,19 @@ async fn run_network_node_with_signals(
                     UpdateCheckResult::Skipped => {
                         // GitHub not reachable or no update yet; will retry next tick
                     }
+                    UpdateCheckResult::PinnedKnownBad => {
+                        // #4073: the only newer release is pinned known-bad on
+                        // this node after a crash-loop rollback. Stop trying to
+                        // exit for it (the updater would only refuse it). Clear
+                        // the driving signals; they re-arm on the next peer
+                        // handshake, which will pick up a later, strictly-newer fix.
+                        clear_urgent_update();
+                        clear_version_mismatch();
+                        tracing::warn!(
+                            "Urgent update target is pinned known-bad after a crash-loop \
+                             rollback; staying put (#4073)"
+                        );
+                    }
                 }
             }
 
@@ -514,6 +527,19 @@ async fn run_network_node_with_signals(
                                     stagger_deadline = None;
                                     stagger_cooldown_until =
                                         Some(Instant::now() + STAGGER_COOLDOWN);
+                                }
+                                UpdateCheckResult::PinnedKnownBad => {
+                                    // #4073: discovered version is pinned known-bad
+                                    // after a crash-loop rollback. Drop the stagger
+                                    // and cool down (don't re-arm every tick); a
+                                    // later strictly-newer fix will re-trigger.
+                                    stagger_deadline = None;
+                                    stagger_cooldown_until =
+                                        Some(Instant::now() + STAGGER_COOLDOWN);
+                                    tracing::warn!(
+                                        "Staggered update target is pinned known-bad after a \
+                                         crash-loop rollback; cooling down (#4073)"
+                                    );
                                 }
                             }
                         }
@@ -589,6 +615,21 @@ async fn run_network_node_with_signals(
                         clear_version_mismatch();
                     }
                     UpdateCheckResult::Skipped => {}
+                    UpdateCheckResult::PinnedKnownBad => {
+                        // #4073: the gateway-advertised newer release is pinned
+                        // known-bad after a crash-loop rollback. Clear the
+                        // mismatch so the legacy "max-backoff + 0 connections ->
+                        // exit 42" / hard-timeout fallbacks never fire for a
+                        // version the updater will only refuse — that would be a
+                        // slow exit-42 restart loop. The flag re-arms on the next
+                        // mismatch handshake, catching a later strictly-newer fix.
+                        clear_version_mismatch();
+                        isolated_mismatch_since = None;
+                        tracing::warn!(
+                            "Version-mismatch update target is pinned known-bad after a \
+                             crash-loop rollback; staying put (#4073)"
+                        );
+                    }
                 }
             } else {
                 isolated_mismatch_since = None;
@@ -1330,6 +1371,47 @@ mod tests {
             guard_body.contains("tracing::warn!"),
             "the dirty-build auto-update-disabled branch must log at warn! so it \
              is operator-visible (#4580)"
+        );
+    }
+
+    /// #4073: a version pinned known-bad after a crash-loop rollback must never
+    /// cause the node to exit for auto-update — the updater would only refuse it,
+    /// producing a slow exit-42 restart loop (the Codex finding on the reworked
+    /// PR). Every `UpdateCheckResult::PinnedKnownBad` arm in the update loop must
+    /// therefore handle the case WITHOUT calling `update_tx.send` (the only thing
+    /// that drives the exit-42 update path).
+    #[test]
+    fn pinned_known_bad_never_triggers_exit_42() {
+        let src = strip_line_comments(include_str!("freenet.rs"));
+        // Build the needle from fragments so this test's OWN source text does not
+        // self-match the contiguous arm marker (include_str! pulls in this file).
+        let needle = concat!("UpdateCheckResult::", "PinnedKnownBad =>");
+        let arms: Vec<&str> = src.split(needle).skip(1).collect();
+        assert_eq!(
+            arms.len(),
+            3,
+            "expected a PinnedKnownBad arm in each of the 3 update-trigger \
+             priorities (urgent / stagger / legacy mismatch) (#4073)"
+        );
+        for (i, arm) in arms.iter().enumerate() {
+            // Bound each arm to before the next match's first arm (capped at 400
+            // chars) so a later UpdateAvailable send can't leak into the window.
+            let end = arm
+                .find("UpdateCheckResult::")
+                .unwrap_or(arm.len())
+                .min(400);
+            let body = &arm[..end];
+            assert!(
+                !body.contains("update_tx.send"),
+                "PinnedKnownBad arm #{i} must NOT send an update — exiting 42 to a \
+                 pinned version would loop (#4073)"
+            );
+        }
+        // The legacy-mismatch arm must also clear the mismatch flag so the
+        // max-backoff / hard-timeout exit-42 fallbacks never fire.
+        assert!(
+            src.contains("Version-mismatch update target is pinned known-bad"),
+            "the legacy-mismatch PinnedKnownBad arm must clear the mismatch flag (#4073)"
         );
     }
 

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -253,6 +253,25 @@ async fn run_network_node_with_signals(
         freenet::enable_fast_crash_exit_code();
     }
 
+    // #4073 crash-loop auto-rollback: once this (possibly freshly auto-updated)
+    // node has run healthily for the commit window, clear any post-update
+    // probation marker so ordinary later crashes never trigger a rollback. The
+    // window mirrors MIN_HEALTHY_UPTIME_FOR_UPDATE_EXIT — a node that survives
+    // it has cleared the same fast-crash boundary. Fire-and-forget: if the node
+    // crashes before the window elapses, the task dies with the process and the
+    // probation marker stays armed (so the supervisor's post-stop `freenet
+    // update` can count the crash and eventually roll back).
+    let commit_probation_task = {
+        let version = build_info::VERSION.to_string();
+        GlobalExecutor::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_secs(
+                commands::rollback::COMMIT_HEALTHY_UPTIME_SECS,
+            ))
+            .await;
+            commands::rollback::commit_probation(&version);
+        })
+    };
+
     // Set up SIGTERM handler for Unix systems
     #[cfg(unix)]
     let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())
@@ -378,13 +397,24 @@ async fn run_network_node_with_signals(
             "Startup update check against GitHub"
         );
         if let Some(new_version) = startup_update_check(build_info::VERSION).await {
-            tracing::info!(
-                new_version = %new_version,
-                "Startup check: newer version on GitHub, triggering auto-update"
-            );
-            #[allow(clippy::let_underscore_must_use)]
-            let _ = update_tx.send(new_version);
-            return;
+            // #4073: don't auto-update to a version pinned known-bad on this
+            // node by a prior crash-loop rollback (the installer would refuse it
+            // anyway; this avoids a needless restart).
+            if commands::rollback::is_version_pinned_bad(&new_version) {
+                tracing::warn!(
+                    new_version = %new_version,
+                    "Startup check: newer version is pinned known-bad after a crash-loop rollback; \
+                     not triggering auto-update (#4073)"
+                );
+            } else {
+                tracing::info!(
+                    new_version = %new_version,
+                    "Startup check: newer version on GitHub, triggering auto-update"
+                );
+                #[allow(clippy::let_underscore_must_use)]
+                let _ = update_tx.send(new_version);
+                return;
+            }
         }
         tracing::debug!("Startup update check: no newer version found");
 
@@ -589,6 +619,7 @@ async fn run_network_node_with_signals(
     // Clean up tasks
     signal_task.abort();
     update_check_task.abort();
+    commit_probation_task.abort();
     #[cfg(all(unix, feature = "jemalloc-prof"))]
     heap_dump_task.abort();
 


### PR DESCRIPTION
## Problem

Auto-update has no recovery path when a node updates to a release that then
crash-loops on startup. The supervisors' existing crash bounds only *stop* the
node — systemd `StartLimitBurst` + `StartLimitAction=none`, and the run-wrapper's
consecutive-failure cap — so a bad release leaves the node down until an operator
intervenes. This is the brick-safety gap in auto-update: a wedged release defeats
the unsupervised-restart self-heal it is supposed to provide.

## Solution

A per-node crash-loop auto-rollback that **reuses the existing crash detection**
rather than adding a second watchdog. New `commands::rollback` module owns the
state machine (pure, directory-injectable, fully unit-tested).

Lifecycle:

1. **Install** — before overwriting the running binary, `freenet update`
   snapshots it as the *known-good* rollback target and marks the new version
   *on-probation*.
2. **Detect** — every supervisor that runs `freenet update` immediately after the
   node stops (systemd `ExecStopPost`, the macOS launchd wrapper script, and the
   in-process run-wrapper) now forwards the node's exit code via
   `FREENET_POST_STOP_EXIT_CODE`. `freenet update` reads it and, while in
   probation, counts the stop as a crash of the probationary version (no network
   call needed on the crash path).
3. **Revert + pin** — on the 3rd probation crash (`< StartLimitBurst=5`, so it
   fires *before* systemd stops the unit) the known-good binary is restored and
   the bad version is pinned locally as known-bad so it is not auto-re-applied.
4. **Commit** — the node clears probation after running healthily for 60s (mirrors
   the existing fast-crash window), so ordinary later crashes never roll back.

The installer **and** the node's update checks refuse a pinned known-bad version
(a strictly-newer fix is still applied normally), which breaks the
update → crash → revert → re-update loop.

### Brick-safety (no new flap/loop)

- Rollback only ever restores the known-good target captured *before* the
  probationary install — always a version that previously ran (one generation).
- After a rollback there is no probation marker, so a still-crashing reverted
  version is **not** rolled back again; it falls to the supervisor's own limiter
  / the operator.
- If no known-good binary exists we refuse to "roll back" rather than risk
  deleting the only working binary.
- The handoff is an env var (not a CLI flag), so it is forward/backward
  compatible: an older binary we rolled back *to*, or an older unit, ignores it.
  `#4588`'s exit-45 / probation behaviour is preserved.

### Per-OS

- **Linux/systemd** (production): `ExecStopPost` forwards `$EXIT_STATUS`; rollback
  runs from `freenet update`. Primary path.
- **macOS launchd wrapper script** and **Windows/macOS in-process run-wrapper**:
  forward the exit code on the post-crash update only (manual/tray "Check for
  Updates" pass nothing, so they are never miscounted as crashes).
- **Unsupervised** / dev (dirty) builds: no behaviour change.
- **macOS `.app` DMG-swap updates** are intentionally out of scope (reverting a
  signed bundle is a separate mechanism); the bundle path degrades to the
  pre-change behaviour and is documented inline. Tracked as follow-up.

## Testing

- 12 unit tests for the state machine: probation roundtrip + commit, stale-marker
  cleanup, crash-records-then-rolls-back-and-pins, pinned-not-reapplied (newer
  allowed), one-generation bound, rollback-unavailable when known-good is missing,
  known-good preserved across a chained in-probation install, restore preserves
  source, corrupt-marker-reads-as-none. A compile-time static assert pins
  `ROLLBACK_CRASH_THRESHOLD < StartLimitBurst`.
- Per-OS source/template pins: systemd user+system units, the macOS shell wrapper,
  and the in-process wrapper all forward the exit code on the post-stop update only.
- `cargo fmt`, `cargo clippy --bin freenet -- -D warnings`, and
  `cargo test -p freenet --bin freenet` (272 tests) all green.
- Codex review run; its one finding (macOS bundle scope) addressed by documenting
  the boundary inline.

Not yet done (flagged for review): live systemd verification on a real node
(force a crash-looping install and confirm the revert + pin fire) before release.

Refs #4073

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dGjU1Q6Vpk2dm4sUf4pdU