### PR TITLE
feat: bake reserved ed25519 revocation public key for future key-revocation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,6 +285,24 @@ without cutting a release, run `cross-compile.yml` via `workflow_dispatch` and
 check the `verify-signing-key` job. The full prerequisites table (including the
 two-release `REQUIRE_RELEASE_SIGNATURE` transition) is in `docs/RELEASING.md`.
 
+### Reserved offline revocation key (`FREENET_REVOCATION_PUBKEY`)
+
+A second ed25519 public key, `FREENET_REVOCATION_PUBKEY`, is baked into the
+binary alongside `FREENET_RELEASE_PUBKEY` but serves a different purpose: it is
+the OFFLINE backup / key-revocation key. Its private half is kept strictly
+offline (never in CI or GitHub secrets, unlike `FREENET_RELEASE_SIGNING_KEY`),
+so it can authorize a key-revocation message even if the online release-signing
+key is compromised. It is RESERVED — the mechanism to fetch and verify a
+revocation message signed by it is deferred to the future signed-policy-over-
+Freenet delivery layer (auto-update epic #4073). It must nevertheless be shipped
+now: a revocation can only be honored by peers whose binary already carries the
+key, so it cannot be retrofitted into already-released builds. The value is
+pinned by the `revocation_pubkey_matches_published_hex` test in `update.rs`.
+It is declared as a `#[used] static` (NOT a `const`) on purpose: a `const`
+with no runtime reader is inlined to nothing and would be absent from the
+shipped binary, defeating the bake-in. Do not "simplify" it to a `const`
+until a runtime path actually reads it.
+
 ## Delegate secrets-at-rest
 
 Operator-facing documentation (encryption model, migration matrix,

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -36,6 +36,46 @@ const FREENET_RELEASE_PUBKEY: [u8; 32] = [
     0x64, 0xd3, 0x34, 0x7f, 0xe8, 0x20, 0x74, 0xd9, 0x2b, 0x1e, 0x4b, 0xc6, 0x33, 0x6f, 0x86, 0x64,
 ];
 
+/// Ed25519 public key (raw 32-byte, little-endian compressed point) reserved
+/// as the OFFLINE backup / key-revocation key.
+///
+/// Unlike [`FREENET_RELEASE_PUBKEY`], whose private half lives in the
+/// `FREENET_RELEASE_SIGNING_KEY` CI secret, the private half of THIS key is
+/// kept strictly offline — never in CI, GitHub Actions secrets, or any
+/// online system. Its sole purpose is to authorize a key-revocation message
+/// in the event the online release-signing key is ever compromised, so a
+/// recovery is possible without trusting the (potentially stolen) release key.
+///
+/// RESERVED — there is intentionally NO verification mechanism wired up yet.
+/// The code that fetches and verifies a revocation message signed by this key
+/// is future work, deferred to ride the signed-policy-over-Freenet delivery
+/// layer (see the auto-update epic #4073). The key MUST nevertheless be baked
+/// into the binary NOW: a revocation can only ever be honored by a peer whose
+/// build already carries the key to verify it against. A key added in a later
+/// release cannot protect binaries that shipped before it, which is exactly
+/// the population a compromise-recovery needs to reach. Hence it is shipped
+/// ahead of the mechanism, deliberately.
+///
+/// The hex form (pinned by `revocation_pubkey_matches_published_hex`) is:
+/// `c93f086b6be206867b65a05592a22146ea72147270d1b356bc368455d13d3722`.
+//
+// This is a `#[used] static`, NOT a `const`, on purpose. A `const` has no
+// storage of its own — it is inlined at each use site — so a `const` that no
+// runtime path references (only the pin test does) contributes ZERO bytes to
+// the release binary. That would defeat the entire point of this key: it has
+// to physically ship in the artifact NOW so a future revocation can be
+// honored by binaries already in the field. `#[used]` forces the bytes into
+// the object file AND retains them against linker dead-code elimination
+// (`--gc-sections`) even though nothing reads the key yet. `#[used]` also
+// marks the item as used, so no dead_code warning is emitted. Verified: with
+// a plain `const` the 32 key bytes are absent from `target/.../freenet`; as a
+// `#[used] static` they are present.
+#[used]
+static FREENET_REVOCATION_PUBKEY: [u8; 32] = [
+    0xc9, 0x3f, 0x08, 0x6b, 0x6b, 0xe2, 0x06, 0x86, 0x7b, 0x65, 0xa0, 0x55, 0x92, 0xa2, 0x21, 0x46,
+    0xea, 0x72, 0x14, 0x72, 0x70, 0xd1, 0xb3, 0x56, 0xbc, 0x36, 0x84, 0x55, 0xd1, 0x3d, 0x37, 0x22,
+];
+
 /// Whether a release MUST carry a valid `SHA256SUMS.txt.sig` for the install
 /// to proceed.
 ///
@@ -3874,6 +3914,24 @@ done
         // Must be a valid ed25519 point, or verification could never succeed.
         ed25519_dalek::VerifyingKey::from_bytes(&FREENET_RELEASE_PUBKEY)
             .expect("baked-in release public key must be a valid ed25519 point");
+    }
+
+    #[test]
+    fn revocation_pubkey_matches_published_hex() {
+        // Pins the reserved offline backup/revocation key to its documented
+        // hex. This both locks the value (a copy-paste slip would otherwise be
+        // silent, since no runtime path references the key yet) and "uses" the
+        // const so it carries the reserved key without a dead_code warning.
+        // The verification mechanism is deferred; see the doc comment on
+        // FREENET_REVOCATION_PUBKEY and the auto-update epic #4073.
+        let expected =
+            hex::decode("c93f086b6be206867b65a05592a22146ea72147270d1b356bc368455d13d3722")
+                .unwrap();
+        assert_eq!(FREENET_REVOCATION_PUBKEY.as_slice(), expected.as_slice());
+        // Must be a valid ed25519 point, or a future revocation message could
+        // never be verified against it.
+        ed25519_dalek::VerifyingKey::from_bytes(&FREENET_REVOCATION_PUBKEY)
+            .expect("baked-in revocation public key must be a valid ed25519 point");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Freenet's auto-updater authenticates the release `SHA256SUMS.txt` manifest
against a single ed25519 key baked into the binary (`FREENET_RELEASE_PUBKEY`),
whose private half lives online in the `FREENET_RELEASE_SIGNING_KEY` CI secret.
If that online key were ever compromised, there is currently no key a peer
already in the field would trust to honor a revocation/recovery message.

A revocation key only protects peers whose binary **already contains it** — it
cannot be retrofitted into builds that have already shipped. So the key has to
be baked in now, well ahead of any mechanism that uses it.

## Solution

Add a second, reserved ed25519 **public** key, `FREENET_REVOCATION_PUBKEY`,
baked into the binary alongside `FREENET_RELEASE_PUBKEY`:

- Its private half is kept strictly **offline** (never in CI or GitHub
  secrets, unlike the release-signing key), so it can authorize a
  key-revocation message even if the online signing key is stolen.
- It is **RESERVED**: there is intentionally no fetch/verify mechanism wired
  up yet. That code is deferred to ride the future signed-policy-over-Freenet
  delivery layer (auto-update epic #4073). This PR adds only the baked-in key
  plus a pin test that locks its value.

Declared as a `#[used] static`, **not** a `const`, on purpose: a `const`
referenced only from a test is inlined to nothing and never appears in the
shipped binary — which would defeat the entire bake-in. `#[used]` forces the
bytes into the artifact and retains them against linker dead-code elimination
even though nothing reads the key at runtime yet. (`#[used]` also suppresses
the dead_code warning, so no `#[allow]` is needed.)

## Testing

- `cargo fmt`, `cargo clippy --bin freenet -- -D warnings` — clean.
- `cargo test -p freenet --bin freenet` — 308 passed, including the new
  `revocation_pubkey_matches_published_hex` pin test (asserts the 32 bytes
  match the documented hex and form a valid ed25519 point).
- Verified the bake-in empirically: the 32 key bytes are **absent** from
  `target/release/freenet` when the key is a plain `const`, and **present**
  in the optimized release artifact as a `#[used] static`.

Refs #4073

[AI-assisted - Claude]