### PR TITLE
fix(put): stream-inactivity timeout for streaming PUT retry loop (#4001)

### DIFF
--- a/crates/core/src/node/network_bridge.rs
+++ b/crates/core/src/node/network_bridge.rs
@@ -61,6 +61,23 @@ pub(crate) trait NetworkBridge: Send + Sync {
         metadata: Option<bytes::Bytes>,
     ) -> impl Future<Output = ConnResult<()>> + Send;
 
+    /// Like [`Self::send_stream`] but attaches an optional stream-progress
+    /// liveness handle (#4001) so the transport records a tick per dispatched
+    /// fragment. Used ONLY by the originator-loopback PUT relay so the
+    /// retry-loop task can apply a true stream-inactivity timeout. The default
+    /// delegates to [`Self::send_stream`] (handle dropped), keeping mock and
+    /// non-streaming bridges unchanged.
+    fn send_stream_with_progress(
+        &self,
+        target_addr: SocketAddr,
+        stream_id: crate::transport::peer_connection::StreamId,
+        data: bytes::Bytes,
+        metadata: Option<bytes::Bytes>,
+        _progress: Option<crate::operations::stream_progress::StreamProgressHandle>,
+    ) -> impl Future<Output = ConnResult<()>> + Send {
+        self.send_stream(target_addr, stream_id, data, metadata)
+    }
+
     /// Pipe an inbound stream to a peer, forwarding fragments as they arrive.
     ///
     /// Unlike `send_stream` which takes complete data and fragments it, this forwards

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -721,6 +721,11 @@ pub(super) async fn broadcast_to_single_peer(
             // when the actual stream transfer finishes.
             let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
 
+            // channel-safety: ok — broadcast_to_single_peer runs on the detached
+            // broadcast-queue task, not the event loop; the StreamSend this
+            // enqueues is drained by the loop, so it cannot self-stall it. The
+            // #4001 `None` progress arg that brought this statement into the diff
+            // does not change the send path.
             if let Err(err) = bridge
                 .send_stream_with_completion(
                     peer_addr,
@@ -728,6 +733,7 @@ pub(super) async fn broadcast_to_single_peer(
                     bytes::Bytes::from(payload_bytes),
                     metadata,
                     Some(completion_tx),
+                    None,
                 )
                 .await
             {

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -170,6 +170,10 @@ pub(crate) enum P2pBridgeEvent {
         /// carrying a [`BroadcastDeliveryOutcome`] so the queue distinguishes a
         /// real delivery from a drop (#4235).
         completion_tx: Option<tokio::sync::oneshot::Sender<BroadcastDeliveryOutcome>>,
+        /// Optional per-fragment progress handle for the streaming-PUT retry
+        /// loop (#4001). Threaded through to `send_stream` so the originator's
+        /// retry loop sees liveness ticks. `None` for every non-originator path.
+        progress: Option<crate::operations::stream_progress::StreamProgressHandle>,
     },
     /// Pipe an inbound stream to a target, forwarding fragments incrementally.
     PipeStream {
@@ -283,7 +287,13 @@ impl P2pBridge {
         data: bytes::Bytes,
         metadata: Option<bytes::Bytes>,
         completion_tx: Option<tokio::sync::oneshot::Sender<BroadcastDeliveryOutcome>>,
+        progress: Option<crate::operations::stream_progress::StreamProgressHandle>,
     ) -> super::ConnResult<()> {
+        // channel-safety: ok — sole caller is the broadcast-queue task
+        // (broadcast_to_single_peer), a detached spawned task, not the event
+        // loop; the StreamSend it enqueues is drained by the loop, so it cannot
+        // self-stall it. Grandfathered enqueue; the #4001 `progress` field that
+        // brought this statement into the diff does not change the send path.
         self.ev_listener_tx
             .send(P2pBridgeEvent::StreamSend {
                 target_addr,
@@ -291,6 +301,7 @@ impl P2pBridge {
                 data,
                 metadata,
                 completion_tx,
+                progress,
             })
             .await
             .map_err(|_| ConnectionError::SendNotCompleted(target_addr))?;
@@ -444,6 +455,10 @@ impl NetworkBridge for P2pBridge {
         data: bytes::Bytes,
         metadata: Option<bytes::Bytes>,
     ) -> super::ConnResult<()> {
+        // channel-safety: ok — grandfathered streaming enqueue; callers are
+        // off-loop spawned op/relay tasks, not the event loop (which drains
+        // StreamSend). The #4001 `progress: None` field that brought this
+        // statement into the diff does not change the send path.
         self.ev_listener_tx
             .send(P2pBridgeEvent::StreamSend {
                 target_addr,
@@ -451,6 +466,37 @@ impl NetworkBridge for P2pBridge {
                 data,
                 metadata,
                 completion_tx: None,
+                progress: None,
+            })
+            .await
+            .map_err(|_| ConnectionError::SendNotCompleted(target_addr))?;
+        Ok(())
+    }
+
+    async fn send_stream_with_progress(
+        &self,
+        target_addr: SocketAddr,
+        stream_id: StreamId,
+        data: bytes::Bytes,
+        metadata: Option<bytes::Bytes>,
+        progress: Option<crate::operations::stream_progress::StreamProgressHandle>,
+    ) -> super::ConnResult<()> {
+        // Enqueues the streaming send carrying the #4001 progress handle so
+        // `outbound_stream::send_stream` records a tick per fragment.
+        // channel-safety: ok — sole caller is the originator-loopback PUT relay
+        // (drive_relay_put), which runs on a spawned op task, not the event
+        // loop; the StreamSend it enqueues is drained by the loop, so it cannot
+        // self-stall it. Identical send path to the grandfathered `send_stream`
+        // above; completion_tx stays None (no broadcast-queue concurrency on
+        // the originator PUT path).
+        self.ev_listener_tx
+            .send(P2pBridgeEvent::StreamSend {
+                target_addr,
+                stream_id,
+                data,
+                metadata,
+                completion_tx: None,
+                progress,
             })
             .await
             .map_err(|_| ConnectionError::SendNotCompleted(target_addr))?;
@@ -1686,6 +1732,7 @@ impl P2pConnManager {
                             data,
                             metadata,
                             completion_tx,
+                            progress,
                         } => {
                             // The event loop must never block indefinitely on a single
                             // congested peer. Reserve a slot with the same 500 ms
@@ -1714,6 +1761,7 @@ impl P2pConnManager {
                                             data,
                                             metadata,
                                             completion_tx,
+                                            progress,
                                         }));
                                     }
                                     Ok(Err(_closed)) => {
@@ -2770,6 +2818,9 @@ pub(super) enum ConnEvent {
         /// Optional completion signal for broadcast queue concurrency control,
         /// carrying a [`BroadcastDeliveryOutcome`] (#4235).
         completion_tx: Option<tokio::sync::oneshot::Sender<BroadcastDeliveryOutcome>>,
+        /// Optional per-fragment progress handle for the streaming-PUT retry
+        /// loop (#4001). `None` for every non-originator path.
+        progress: Option<crate::operations::stream_progress::StreamProgressHandle>,
     },
     /// Pipe an inbound stream to a peer, forwarding fragments as they arrive.
     /// Used for low-latency forwarding at intermediate nodes.
@@ -2869,6 +2920,7 @@ async fn handle_peer_channel_message(
                     data,
                     metadata,
                     completion_tx,
+                    progress,
                     ..
                 } => {
                     tracing::debug!(
@@ -2879,7 +2931,7 @@ async fn handle_peer_channel_message(
                         "[CONN_LIFECYCLE] Sending operations stream data to peer"
                     );
                     if let Err(error) = conn
-                        .send_stream_data(stream_id, data, metadata, completion_tx)
+                        .send_stream_data(stream_id, data, metadata, completion_tx, progress)
                         .await
                     {
                         tracing::error!(
@@ -2905,7 +2957,7 @@ async fn handle_peer_channel_message(
                         "[CONN_LIFECYCLE] Piping stream to peer"
                     );
                     if let Err(error) = conn
-                        .pipe_stream_data(outbound_stream_id, inbound_handle, metadata)
+                        .pipe_stream_data(outbound_stream_id, inbound_handle, metadata, None)
                         .await
                     {
                         tracing::error!(

--- a/crates/core/src/node/network_bridge/p2p_protoc/dispatch.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/dispatch.rs
@@ -347,6 +347,7 @@ impl P2pConnManager {
                 data,
                 metadata,
                 completion_tx,
+                progress,
             }) => EventResult::Event(
                 ConnEvent::StreamSend {
                     target_addr,
@@ -354,6 +355,7 @@ impl P2pConnManager {
                     data,
                     metadata,
                     completion_tx,
+                    progress,
                 }
                 .into(),
             ),

--- a/crates/core/src/node/network_bridge/priority_select/tests.rs
+++ b/crates/core/src/node/network_bridge/priority_select/tests.rs
@@ -2825,6 +2825,7 @@ impl crate::transport::PeerConnectionApi for MockPeerConnection {
         _completion_tx: Option<
             tokio::sync::oneshot::Sender<crate::transport::BroadcastDeliveryOutcome>,
         >,
+        _progress: Option<crate::operations::stream_progress::StreamProgressHandle>,
     ) -> std::pin::Pin<
         Box<
             dyn std::future::Future<Output = Result<(), crate::transport::TransportError>>
@@ -2845,6 +2846,7 @@ impl crate::transport::PeerConnectionApi for MockPeerConnection {
         _outbound_stream_id: crate::transport::peer_connection::StreamId,
         _inbound_handle: crate::transport::peer_connection::streaming::StreamHandle,
         _metadata: Option<bytes::Bytes>,
+        _progress: Option<crate::operations::stream_progress::StreamProgressHandle>,
     ) -> std::pin::Pin<
         Box<
             dyn std::future::Future<Output = Result<(), crate::transport::TransportError>>

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -31,6 +31,7 @@ use crate::{
     message::{InterestMessage, MessageStats, NetMessage, NetMessageV1, NodeEvent, Transaction},
     operations::{
         OpCtx, OpError, connect::ConnectForwardEstimator, orphan_streams::OrphanStreamRegistry,
+        stream_progress::StreamProgressRegistry,
     },
     ring::{
         ConnectionManager, LiveTransactionTracker, PeerConnectionBackoff, PeerKey, PeerKeyLocation,
@@ -132,6 +133,16 @@ pub(crate) struct OpManager {
     /// Coordinates transport layer (which receives fragments) with operations layer
     /// (which receives RequestStreaming/ResponseStreaming messages).
     orphan_stream_registry: Arc<OrphanStreamRegistry>,
+    /// Per-`Transaction` registry of streaming-PUT progress handles (#4001).
+    ///
+    /// A client streaming PUT runs the retry-loop task and the originator-
+    /// loopback relay-streaming task separately, sharing only the
+    /// `Transaction` id. The retry loop inserts a `StreamProgressHandle` here
+    /// before sending and removes it on exit; the loopback relay looks it up
+    /// and records per-fragment progress so the retry loop can use a true
+    /// stream-inactivity timeout instead of a fixed per-attempt deadline. See
+    /// `operations::stream_progress`.
+    stream_progress_registry: Arc<StreamProgressRegistry>,
     /// Size threshold in bytes above which streaming is used.
     pub streaming_threshold: usize,
     /// Backoff tracker for failed gateway connection attempts.
@@ -232,6 +243,7 @@ impl Clone for OpManager {
             pending_broadcasts: self.pending_broadcasts.clone(),
             request_router: self.request_router.clone(),
             orphan_stream_registry: self.orphan_stream_registry.clone(),
+            stream_progress_registry: self.stream_progress_registry.clone(),
             streaming_threshold: self.streaming_threshold,
             gateway_backoff: self.gateway_backoff.clone(),
             gateway_backoff_cleared: self.gateway_backoff_cleared.clone(),
@@ -418,6 +430,7 @@ impl OpManager {
             ),
             request_router,
             orphan_stream_registry,
+            stream_progress_registry: Arc::new(StreamProgressRegistry::new()),
             streaming_threshold,
             gateway_backoff: Arc::new(Mutex::new(PeerConnectionBackoff::new())),
             gateway_backoff_cleared: Arc::new(tokio::sync::Notify::new()),
@@ -1064,6 +1077,15 @@ impl OpManager {
     #[allow(dead_code)] // Phase 3 infrastructure - will be used when streaming handlers are implemented
     pub fn orphan_stream_registry(&self) -> &Arc<OrphanStreamRegistry> {
         &self.orphan_stream_registry
+    }
+
+    /// Returns a reference to the streaming-PUT progress registry (#4001).
+    ///
+    /// The retry loop inserts/removes a `StreamProgressHandle` keyed by the
+    /// attempt `Transaction`; the originator-loopback relay-streaming driver
+    /// looks it up to record per-fragment progress.
+    pub(crate) fn stream_progress_registry(&self) -> &Arc<StreamProgressRegistry> {
+        &self.stream_progress_registry
     }
 
     /// Determines if streaming should be used for a payload of the given size.

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -18,6 +18,7 @@ pub(crate) mod get;
 pub(crate) mod op_ctx;
 pub(crate) mod orphan_streams;
 pub(crate) mod put;
+pub(crate) mod stream_progress;
 pub(crate) mod subscribe;
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/crates/core/src/operations/op_ctx.rs
+++ b/crates/core/src/operations/op_ctx.rs
@@ -466,6 +466,20 @@ pub(crate) trait RetryDriver {
     fn attempt_timeout(&self) -> std::time::Duration {
         OPERATION_TTL
     }
+
+    /// Optional per-attempt stream-progress liveness for streaming PUTs (#4001).
+    ///
+    /// Defaults to `None`: GET / SUBSCRIBE and non-streaming drivers use the
+    /// fixed [`Self::attempt_timeout`] path unchanged. When `Some`, the retry
+    /// loop replaces the fixed per-attempt deadline with a stream-inactivity
+    /// timeout driven by the returned [`StreamProgress`] (Notify + atomic
+    /// tiebreak) bounded by the hard
+    /// [`crate::operations::STREAMING_ATTEMPT_TIMEOUT_CAP`] ceiling. PUT
+    /// overrides this only for streaming-eligible payloads. The seam is
+    /// additive: a later GET/SUBSCRIBE PR can plug into the same default.
+    fn stream_progress(&self) -> Option<crate::operations::stream_progress::StreamProgress> {
+        None
+    }
 }
 
 /// Maximum cheap, fast retries of a `NotificationError` (local callback
@@ -489,6 +503,75 @@ pub(crate) trait RetryDriver {
 /// negligible wall-clock vs a single `STREAMING_ATTEMPT_TIMEOUT_CAP`
 /// (600 s) and stays well under any WS-client per-attempt patience.
 const MAX_INFRA_RETRIES: usize = 3;
+
+/// Await a single streaming attempt under a stream-inactivity timeout (#4001).
+///
+/// Returns `Ok(reply)` when the terminal reply arrives, `Err(())` when the
+/// attempt is abandoned (no fragment for [`STREAM_OP_INACTIVITY_TIMEOUT`], or
+/// the hard [`STREAMING_ATTEMPT_TIMEOUT_CAP`] ceiling is reached). Both map to
+/// the shared `outcome="timeout"` advance arm in [`drive_retry_loop`].
+///
+/// The three concurrent arms:
+/// 1. **Terminal reply** — `ctx.send_and_await(request)`; identical to the
+///    non-streaming path's awaited future, just not wrapped in a fixed timeout.
+/// 2. **Inactivity loop** — wakes on each `Notify` ping and, on each inactivity
+///    sleep expiry, re-reads `last_progress` via the atomic; only declares a
+///    stall when the atomic CONFIRMS no fragment landed in the race window
+///    (the tiebreak that closes the `Notify` lost-wakeup gap).
+/// 3. **Hard ceiling** — a sibling [`STREAMING_ATTEMPT_TIMEOUT_CAP`] sleep,
+///    OUTSIDE the inactivity loop, so a stream that keeps dribbling fragments
+///    forever still can't hold the driver hostage indefinitely.
+///
+/// All sleeps go through the driver's `TimeSource` (via [`StreamProgress`]) so
+/// the path is VirtualTime-correct under DST — `tokio::time::sleep`/`timeout`
+/// would not advance under VirtualTime.
+async fn await_streaming_attempt(
+    ctx: &mut OpCtx,
+    request: NetMessage,
+    progress: &crate::operations::stream_progress::StreamProgress,
+) -> Result<Result<NetMessage, OpError>, ()> {
+    use crate::operations::STREAMING_ATTEMPT_TIMEOUT_CAP;
+    use crate::operations::stream_progress::STREAM_OP_INACTIVITY_TIMEOUT;
+
+    let handle = progress.handle();
+    let round_trip = ctx.send_and_await(request);
+    tokio::pin!(round_trip);
+
+    // Arm 3: hard ceiling sibling — a single sleep started once, raced against
+    // the terminal reply and the inactivity loop.
+    let ceiling = progress.sleep(STREAMING_ATTEMPT_TIMEOUT_CAP);
+    tokio::pin!(ceiling);
+
+    loop {
+        // Arm 2 (inner): one inactivity window. Re-created each iteration so a
+        // `Notify` ping resets the clock by restarting the sleep.
+        let inactivity = progress.sleep(STREAM_OP_INACTIVITY_TIMEOUT);
+
+        tokio::select! {
+            // Arm 1: terminal reply (unchanged semantics).
+            reply = &mut round_trip => return Ok(reply),
+            // Arm 3: hard ceiling.
+            _ = &mut ceiling => return Err(()),
+            // Arm 2: a fragment landed — reset the inactivity window.
+            _ = handle.notified() => continue,
+            // Arm 2: inactivity window elapsed with no Notify ping. Before
+            // declaring a stall, re-read the atomic: a fragment that landed in
+            // the Notify race window (notify_one permit consumed elsewhere, or
+            // store-then-no-wake ordering) makes `since_last` < the window, so
+            // reset and continue. Only a confirmed stall returns Err(()).
+            _ = inactivity => {
+                // `since_last()` reads the handle's own clock — the SAME clock
+                // record() writes to — so this elapsed value is the true gap
+                // since the last fragment (#4001 single-epoch invariant).
+                let elapsed = handle.since_last();
+                if elapsed < STREAM_OP_INACTIVITY_TIMEOUT {
+                    continue;
+                }
+                return Err(());
+            }
+        }
+    }
+}
 
 /// Drive a retry loop against the network.
 ///
@@ -526,7 +609,36 @@ pub(crate) async fn drive_retry_loop<D: RetryDriver>(
 
         let attempt_timeout = driver.attempt_timeout();
         let mut ctx = op_manager.op_ctx(attempt_tx);
-        let round_trip = tokio::time::timeout(attempt_timeout, ctx.send_and_await(request)).await;
+
+        // `round_trip: Result<Result<NetMessage, OpError>, ()>` — `Err(())`
+        // models "attempt timed out" (fixed deadline OR streaming stall/ceiling)
+        // so the downstream match arms below are shared by both paths.
+        let round_trip = match driver.stream_progress() {
+            // Non-streaming path (GET / SUBSCRIBE / non-streaming PUT):
+            // UNCHANGED fixed-deadline `tokio::time::timeout`.
+            None => tokio::time::timeout(attempt_timeout, ctx.send_and_await(request))
+                .await
+                .map_err(|_| ()),
+            // Streaming PUT path (#4001): replace the fixed deadline with a
+            // stream-inactivity timeout driven by real per-fragment progress,
+            // bounded by the STREAMING_ATTEMPT_TIMEOUT_CAP hard ceiling.
+            //
+            // The retry-loop task and the originator-loopback relay-streaming
+            // task share only `attempt_tx`, so we publish the progress handle
+            // into the `OpManager`-owned registry BEFORE sending; the loopback
+            // relay looks it up by `attempt_tx` and records per fragment.
+            // `StreamProgressGuard` removes the entry on Drop — so it is cleaned
+            // up on EVERY exit (success, stall, ceiling, error) AND if this
+            // future is cancelled or panics mid-`await`. It cannot leak.
+            Some(progress) => {
+                let _progress_guard = crate::operations::stream_progress::StreamProgressGuard::new(
+                    op_manager.stream_progress_registry().clone(),
+                    attempt_tx,
+                    progress.handle(),
+                );
+                await_streaming_attempt(&mut ctx, request, &progress).await
+            }
+        };
 
         // Release the per-attempt pending_op_results slot regardless
         // of outcome. Without this, slots are only reclaimed by the
@@ -1880,5 +1992,262 @@ mod tests {
                 other => panic!("expected PeerDisconnected, got: {other:?}"),
             }
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // #4001 stream-inactivity timeout regression tests.
+    //
+    // These drive `await_streaming_attempt` — the core of `drive_retry_loop`'s
+    // streaming branch — directly, which avoids standing up an `OpManager`.
+    // They run under tokio's `start_paused` virtual clock with `RealTime` as
+    // the `TimeSource`; `RealTime::sleep`/`now` delegate to tokio's (paused,
+    // auto-advancing) clock, so virtual time advances deterministically when
+    // all tasks are idle. This is the same pattern as
+    // `renewal_per_attempt_timeout_fires_before_outer_cancel`.
+    //
+    // `await_streaming_attempt` returns `Ok(reply)` on the terminal reply and
+    // `Err(())` on a stream-inactivity stall or the hard ceiling. The pre-fix
+    // behaviour (the non-streaming `None` arm: a fixed `OPERATION_TTL`/scaled
+    // deadline) would fire `Err(())` at the fixed deadline regardless of
+    // fragment progress — which is exactly the #4001 self-retry-while-in-flight
+    // bug these tests guard against.
+    // -------------------------------------------------------------------------
+
+    use crate::operations::stream_progress::{
+        STREAM_OP_INACTIVITY_TIMEOUT, StreamProgress, StreamProgressHandle,
+    };
+    // `TimeSource` is needed for `RealTime::now()` in the elapsed-time asserts.
+    use crate::simulation::{RealTime, TimeSource};
+
+    /// Build an `(OpCtx, StreamProgress)` pair plus the executor receiver, all
+    /// sharing a fresh `RealTime` (tokio paused clock). The returned handle is
+    /// the SAME one bundled in the `StreamProgress` (so its record()/since_last()
+    /// read the loop's clock — the #4001 single-epoch invariant). The receiver
+    /// lets a test spawn a fake peer that replies on its own schedule.
+    fn streaming_attempt_fixture() -> (
+        OpCtx,
+        Transaction,
+        StreamProgressHandle,
+        StreamProgress,
+        mpsc::Receiver<crate::node::OpExecutionPayload>,
+    ) {
+        let (receiver, sender) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            op_execution_receiver,
+            ..
+        } = receiver;
+        let tx = Transaction::new::<ConnectMsg>();
+        let ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+        let progress = StreamProgress::new(RealTime::new());
+        let handle = progress.handle();
+        (ctx, tx, handle, progress, op_execution_receiver)
+    }
+
+    /// A fragment lands every ~10 s of virtual time for 120 s (well past the
+    /// 60 s `OPERATION_TTL` cliff that the OLD fixed-deadline path would fire
+    /// at), then the peer replies at ~125 s. The streaming-inactivity path MUST
+    /// return the terminal reply (`Ok`) — it MUST NOT time out — because the
+    /// 30 s inactivity window is continuously reset by progress.
+    ///
+    /// This FAILS against the pre-#4001 fixed-deadline behaviour: a 60 s
+    /// (or even payload-scaled) deadline fires `Err(())` at 60 s while the
+    /// stream is still flowing, producing the version-conflict self-retry.
+    #[tokio::test(start_paused = true)]
+    async fn streaming_put_does_not_retry_while_chunks_flow() {
+        let (mut ctx, tx, handle, progress, mut rx) = streaming_attempt_fixture();
+
+        // Fake peer: record progress every 10 s for 120 s, reply at 125 s.
+        let producer = tokio::spawn(async move {
+            let (reply_sender, _outbound, _target) =
+                rx.recv().await.expect("outbound msg should be delivered");
+            for _ in 0..12 {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                handle.record();
+            }
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            reply_sender
+                .try_send(WaiterReply::Reply(dummy_reply_with_tx(tx)))
+                .expect("capacity-1 reply channel accepts the reply");
+        });
+
+        let outbound = dummy_reply_with_tx(tx);
+        let result = await_streaming_attempt(&mut ctx, outbound, &progress).await;
+        assert!(
+            result.is_ok(),
+            "stream that keeps flowing for 125 s must deliver the terminal \
+             reply, not time out — a fixed 60 s deadline would have fired the \
+             #4001 self-retry here"
+        );
+        assert_eq!(result.unwrap().unwrap().id(), &tx);
+        producer.await.expect("producer task panicked");
+    }
+
+    /// Progress flows for 40 s then stops. The 30 s inactivity timeout MUST
+    /// fire ~70 s in (40 s of progress + 30 s of silence), returning `Err(())`
+    /// exactly once. Asserts the stall is detected on a genuinely dead stream.
+    #[tokio::test(start_paused = true)]
+    async fn streaming_put_retries_on_true_stall() {
+        let (mut ctx, tx, handle, progress, mut rx) = streaming_attempt_fixture();
+
+        // Fake peer: progress every 10 s for 40 s, then go silent forever
+        // (never replies). The inactivity timeout must fire.
+        let producer = tokio::spawn(async move {
+            let (_reply_sender, _outbound, _target) =
+                rx.recv().await.expect("outbound msg should be delivered");
+            for _ in 0..4 {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                handle.record();
+            }
+            // Hold the reply sender open but never reply; sleep beyond the
+            // ceiling so the task doesn't drop the channel and synthesise a
+            // close before the inactivity timeout fires.
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+        });
+
+        let start = RealTime::new();
+        let t0 = start.now();
+        let outbound = dummy_reply_with_tx(tx);
+        let result = await_streaming_attempt(&mut ctx, outbound, &progress).await;
+        let elapsed = start.now().saturating_sub(t0);
+        assert!(result.is_err(), "a stalled stream must time out (Err)");
+        // Stall detected after 40 s progress + 30 s silence ≈ 70 s, and well
+        // before the 600 s ceiling.
+        assert!(
+            elapsed >= Duration::from_secs(60) && elapsed < Duration::from_secs(120),
+            "inactivity stall should fire ~70 s in (40 s progress + 30 s idle), \
+             got {elapsed:?}"
+        );
+        producer.abort();
+    }
+
+    /// A stream that records a fragment forever (never replies, never stalls
+    /// for 30 s) MUST still be bounded: the hard 600 s
+    /// `STREAMING_ATTEMPT_TIMEOUT_CAP` ceiling fires and returns `Err(())`.
+    #[tokio::test(start_paused = true)]
+    async fn streaming_put_hard_ceiling_fires() {
+        let (mut ctx, tx, handle, progress, mut rx) = streaming_attempt_fixture();
+
+        // Fake peer: keep recording progress every 10 s indefinitely so the
+        // inactivity window NEVER expires — only the ceiling can stop it.
+        let producer = tokio::spawn(async move {
+            let (_reply_sender, _outbound, _target) =
+                rx.recv().await.expect("outbound msg should be delivered");
+            loop {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                handle.record();
+            }
+        });
+
+        let start = RealTime::new();
+        let t0 = start.now();
+        let outbound = dummy_reply_with_tx(tx);
+        let result = await_streaming_attempt(&mut ctx, outbound, &progress).await;
+        let elapsed = start.now().saturating_sub(t0);
+        assert!(result.is_err(), "the hard ceiling must abandon the attempt");
+        assert!(
+            elapsed >= crate::operations::STREAMING_ATTEMPT_TIMEOUT_CAP,
+            "ceiling must fire at/after STREAMING_ATTEMPT_TIMEOUT_CAP (600 s), \
+             got {elapsed:?}"
+        );
+        producer.abort();
+    }
+
+    /// The atomic tiebreak: a fragment whose `record()` store lands inside the
+    /// inactivity window — but whose `Notify` ping is lost (the realistic race
+    /// `Notify` alone cannot cover) — MUST be observed via the `since_last`
+    /// atomic re-check and suppress a false stall.
+    ///
+    /// To exercise the *atomic* path deterministically (not the task scheduler),
+    /// each fragment lands at `window - RACE_SLACK` of virtual time: every
+    /// window expiry therefore finds `since_last < window` and resets via the
+    /// atomic, keeping the attempt alive until the reply. A poll-/Notify-only
+    /// implementation that ignored the atomic would falsely stall.
+    #[tokio::test(start_paused = true)]
+    async fn streaming_put_progress_during_inactivity_race() {
+        // Land each fragment just inside the window so the atomic re-check —
+        // not a fresh timer — is what keeps the stream alive.
+        const RACE_SLACK: Duration = Duration::from_millis(500);
+        let (mut ctx, tx, handle, progress, mut rx) = streaming_attempt_fixture();
+
+        let producer = tokio::spawn(async move {
+            let (reply_sender, _outbound, _target) =
+                rx.recv().await.expect("outbound msg should be delivered");
+            // Several fragments landing just before each inactivity boundary.
+            for _ in 0..5 {
+                tokio::time::sleep(STREAM_OP_INACTIVITY_TIMEOUT - RACE_SLACK).await;
+                handle.record();
+            }
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            reply_sender
+                .try_send(WaiterReply::Reply(dummy_reply_with_tx(tx)))
+                .expect("capacity-1 reply channel accepts the reply");
+        });
+
+        let outbound = dummy_reply_with_tx(tx);
+        let result = await_streaming_attempt(&mut ctx, outbound, &progress).await;
+        assert!(
+            result.is_ok(),
+            "a fragment landing inside the inactivity window must reset it via \
+             the atomic tiebreak, not trigger a false stall"
+        );
+        assert_eq!(result.unwrap().unwrap().id(), &tx);
+        producer.await.expect("producer task panicked");
+    }
+
+    /// Control: a driver whose `stream_progress()` returns `None` (every
+    /// non-streaming op: GET / SUBSCRIBE / small PUT) is byte-identical to the
+    /// pre-#4001 fixed-deadline path — `drive_retry_loop` takes the
+    /// `None => tokio::time::timeout(...)` arm. Pin that the default trait hook
+    /// is `None` so the streaming branch is never entered for those drivers.
+    #[test]
+    fn non_streaming_put_uses_fixed_timeout() {
+        struct NonStreamingDriver;
+        impl RetryDriver for NonStreamingDriver {
+            type Terminal = ();
+            fn new_attempt_tx(&mut self) -> Transaction {
+                unreachable!()
+            }
+            fn build_request(&mut self, _attempt_tx: Transaction) -> NetMessage {
+                unreachable!()
+            }
+            fn classify(&mut self, _reply: NetMessage) -> AttemptOutcome<()> {
+                unreachable!()
+            }
+            fn advance(&mut self) -> AdvanceOutcome {
+                unreachable!()
+            }
+        }
+        assert!(
+            NonStreamingDriver.stream_progress().is_none(),
+            "non-streaming drivers MUST return None so drive_retry_loop keeps \
+             the unchanged fixed-deadline timeout path"
+        );
+
+        // Source pin: the `None` arm of the stream_progress branch is the
+        // unchanged `tokio::time::timeout` path.
+        const SRC: &str = include_str!("op_ctx.rs");
+        let loop_pos = SRC
+            .find("pub(crate) async fn drive_retry_loop")
+            .expect("drive_retry_loop must exist");
+        let body = &SRC[loop_pos..];
+        let branch_pos = body
+            .find("match driver.stream_progress() {")
+            .expect("drive_retry_loop must branch on driver.stream_progress()");
+        let after = &body[branch_pos..];
+        let none_arm = after.find("None =>").expect("None arm must exist");
+        let some_arm = after
+            .find("Some(progress) =>")
+            .expect("Some arm must exist");
+        assert!(
+            none_arm < some_arm,
+            "None arm must precede Some arm in the stream_progress branch"
+        );
+        let none_body = &after[none_arm..some_arm];
+        assert!(
+            none_body
+                .contains("tokio::time::timeout(attempt_timeout, ctx.send_and_await(request))"),
+            "the None arm MUST remain the unchanged fixed-deadline \
+             tokio::time::timeout path; non-streaming ops must not regress"
+        );
     }
 }

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -253,6 +253,12 @@ async fn drive_client_put_inner(
         /// rustdoc and freenet-git#53 for the failure mode this
         /// addresses.
         max_advancements: usize,
+        /// Stream-progress liveness bundle for streaming-eligible payloads
+        /// (#4001). `Some` only when `should_use_streaming` is true; the retry
+        /// loop then uses a stream-inactivity timeout instead of the fixed
+        /// `attempt_timeout`. `None` for non-streaming PUTs (fixed deadline,
+        /// behaviour unchanged).
+        stream_progress: Option<crate::operations::stream_progress::StreamProgress>,
     }
 
     impl RetryDriver for PutRetryDriver<'_> {
@@ -320,6 +326,10 @@ async fn drive_client_put_inner(
         fn attempt_timeout(&self) -> std::time::Duration {
             self.attempt_timeout
         }
+
+        fn stream_progress(&self) -> Option<crate::operations::stream_progress::StreamProgress> {
+            self.stream_progress.clone()
+        }
     }
 
     let attempt_timeout =
@@ -333,10 +343,11 @@ async fn drive_client_put_inner(
         .size()
         .saturating_add(contract.data().len())
         .saturating_add(contract.params().size());
-    let max_advancements = if crate::operations::should_use_streaming(
+    let is_streaming = crate::operations::should_use_streaming(
         op_manager.streaming_threshold,
         payload_size_estimate,
-    ) {
+    );
+    let max_advancements = if is_streaming {
         // Streaming PUTs: 0 advancements = 1 attempt × up-to-600s
         // `STREAMING_ATTEMPT_TIMEOUT_CAP`. Per
         // `MAX_PEER_ADVANCEMENTS_STREAMING` rustdoc, allowing even
@@ -351,6 +362,23 @@ async fn drive_client_put_inner(
         MAX_PEER_ADVANCEMENTS_NON_STREAMING
     };
 
+    // Stream-progress liveness (#4001): only for streaming-eligible payloads.
+    // The retry loop then replaces the fixed `attempt_timeout` with a true
+    // stream-inactivity timeout driven by per-fragment progress recorded by the
+    // originator-loopback relay-streaming task. Production uses `RealTime`;
+    // DST/VirtualTime is injected via the unit tests on `drive_retry_loop`.
+    let stream_progress = if is_streaming {
+        use crate::operations::stream_progress::StreamProgress;
+        use crate::simulation::RealTime;
+        // The StreamProgress owns this single RealTime: the handle's record()/
+        // since_last() and the retry loop's sleeps all read it, so writer and
+        // reader share one epoch (#4001 single-epoch invariant). DST/VirtualTime
+        // is injected via the unit tests on drive_retry_loop.
+        Some(StreamProgress::new(RealTime::new()))
+    } else {
+        None
+    };
+
     let mut driver = PutRetryDriver {
         op_manager,
         key,
@@ -363,6 +391,7 @@ async fn drive_client_put_inner(
         current_target,
         attempt_timeout,
         max_advancements,
+        stream_progress,
     };
 
     let loop_result = drive_retry_loop(op_manager, client_tx, "put", &mut driver).await;
@@ -1386,12 +1415,20 @@ where
                 );
                 return Err(err);
             }
+            // Originator loopback: the retry-loop task (Task A) registered a
+            // stream-progress handle keyed by `incoming_tx` before sending. We
+            // (Task B) look it up and thread it into the transport so each
+            // fragment dispatch records a tick, driving the retry loop's
+            // stream-inactivity timeout (#4001). `None` here (non-streaming
+            // relay, no registered handle) degrades to the plain send.
+            let progress = op_manager.stream_progress_registry().get(&incoming_tx);
             if let Err(err) = conn_manager
-                .send_stream(
+                .send_stream_with_progress(
                     next_addr,
                     stream_id,
                     bytes::Bytes::from(payload_bytes),
                     None,
+                    progress,
                 )
                 .await
             {
@@ -3129,20 +3166,30 @@ mod tests {
         let entry = src
             .find("fn drive_client_put_inner")
             .expect("drive_client_put_inner must exist");
-        // Anchor on the `max_advancements` binding; the if/else
-        // block including its inline rationale comment can be
-        // hundreds of bytes, hence the generous window.
+        // Anchor on the `is_streaming` binding: #4001 hoisted the
+        // streaming decision into `let is_streaming = should_use_streaming(…)`
+        // (shared by both the advancement-cap selection and the
+        // stream-progress handle), so the window starts there and spans the
+        // cap selection that follows. The if/else block including its inline
+        // rationale comment can be hundreds of bytes, hence the generous
+        // window.
         let cap_decision = src[entry..]
-            .find("let max_advancements =")
-            .expect("drive_client_put_inner must compute `let max_advancements = …`");
-        let window = &src[entry + cap_decision..entry + cap_decision + 1500];
+            .find("let is_streaming =")
+            .expect("drive_client_put_inner must compute `let is_streaming = …`");
+        let window = &src[entry + cap_decision..entry + cap_decision + 1800];
         assert!(
             window.contains("should_use_streaming("),
-            "drive_client_put_inner's max_advancements selection must \
+            "drive_client_put_inner's streaming decision must \
              gate on should_use_streaming(threshold, \
              payload_size_estimate). A flat \
              MAX_PEER_ADVANCEMENTS_NON_STREAMING for all PUTs re-opens \
              freenet-git#53."
+        );
+        assert!(
+            window.contains("let max_advancements = if is_streaming"),
+            "the advancement-cap selection must gate on the hoisted \
+             `is_streaming` flag derived from should_use_streaming, so the \
+             streaming cap and the stream-progress handle stay in lockstep."
         );
         assert!(
             window.contains("MAX_PEER_ADVANCEMENTS_STREAMING")

--- a/crates/core/src/operations/stream_progress.rs
+++ b/crates/core/src/operations/stream_progress.rs
@@ -1,0 +1,429 @@
+//! Stream-progress liveness handle for the streaming-PUT retry loop (#4001).
+//!
+//! # Why this exists
+//!
+//! A client-initiated large (streaming) PUT runs as **two** concurrent tasks
+//! on the originator node that share only a [`Transaction`] id:
+//!
+//! 1. **Task A** — `start_client_put` → `drive_retry_loop`
+//!    ([`crate::operations::op_ctx`]). It emits a `PutMsg::Request` via
+//!    `send_and_await` and parks on the reply, owning the per-attempt timeout
+//!    decision.
+//! 2. **Task B** — the originator-loopback relay driver `drive_relay_put`
+//!    ([`crate::operations::put::op_ctx_task`]). The `PutMsg::Request` loops
+//!    back through the local event loop (`source_addr=None` →
+//!    `upstream_addr=own_addr`) and is dispatched to this *separate* spawned
+//!    task, which actually fragments and streams the payload to the next peer
+//!    via `conn_manager.send_stream(...)` →
+//!    [`crate::transport::peer_connection::outbound_stream::send_stream`].
+//!
+//! Because the per-fragment send (`sent_so_far += packet_size`) happens in
+//! Task B's downstream transport task while the timeout decision lives in Task
+//! A, there is no shared per-tx object to thread a handle through directly.
+//! The [`StreamProgressHandle`] bridges them via a `Transaction`-keyed registry
+//! ([`StreamProgressRegistry`]): Task A inserts a handle before sending and
+//! removes it on every loop exit; Task B looks it up by `Transaction` and
+//! records a tick per fragment. This is a *scoped* lookup, not a free-floating
+//! global — the registry is owned by `OpManager` and keyed by `Transaction`,
+//! mirroring the existing `pending_op_results` / `OrphanStreamRegistry`
+//! patterns.
+//!
+//! # Liveness primitive
+//!
+//! The handle holds:
+//! - an `AtomicU64` (`last_progress`, milliseconds) updated relaxed on each
+//!   fragment from the handle's OWN clock, and
+//! - a [`tokio::sync::Notify`] pinged on each fragment.
+//!
+//! The handle owns its clock (a `now_millis` closure over the originator's
+//! `TimeSource`). Crucially, `record()` reads THAT clock — it takes no
+//! caller-supplied timestamp — so the value the writer (transport send task)
+//! stores and the value the reader (retry loop) compares against come from one
+//! epoch. Threading the transport's connection clock into `record()` instead
+//! would silently defeat the timeout, because `TimeSource::now()` is
+//! epoch-relative per-instance (see the single-epoch invariant on
+//! [`StreamProgressHandle`]).
+//!
+//! The retry loop waits on `notify.notified()` racing a `TimeSource::sleep`.
+//! Notify alone is racy (a fragment that lands in the wakeup window can be
+//! missed — lost-wakeup), and polling `last_progress` alone is wasteful, so
+//! the loop uses **both**: it is woken promptly by `Notify`, and on each
+//! inactivity-sleep expiry it re-reads `last_progress` and only declares a
+//! stall if the atomic confirms no fragment landed in the race window. This
+//! handle deliberately has **no dependency on transport or op types** — it is
+//! a neutral handle the transport layer can hold opaquely.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use dashmap::DashMap;
+use tokio::sync::Notify;
+
+use crate::message::Transaction;
+use crate::simulation::TimeSource;
+
+type BoxFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+/// A neutral per-stream liveness handle: records a monotonic "last fragment
+/// dispatched at" timestamp (millis) plus a `Notify` to wake an observer.
+///
+/// # The handle owns its clock (single-epoch invariant)
+///
+/// Both [`Self::record`] (writer, transport send task) and [`Self::since_last`]
+/// (reader, the retry loop) read time from the **same** clock — the
+/// `now_millis` closure captured at construction over the originator's
+/// `TimeSource`. This is load-bearing: `TimeSource::now()` is epoch-relative
+/// per-instance (`RealTime::elapsed()` from a per-instance epoch), so if the
+/// writer recorded against the connection's `RealTime` (epoch = connection
+/// establishment) while the reader measured against the op's `RealTime` (epoch
+/// = op start, strictly later), the stored "last progress" would exceed the
+/// reader's clock, `since_last` would `saturating_sub` to 0 forever, and the
+/// 30 s inactivity stall would NEVER fire — silently degrading to the 600 s
+/// ceiling. Owning the clock here makes `record()` take **no caller timestamp**,
+/// guaranteeing one epoch for both sides and preserving VirtualTime/DST
+/// correctness (one injected clock).
+///
+/// Cheap to clone (two `Arc`s + a cloned `Arc<dyn Fn>`). The recording side
+/// calls [`Self::record`] once per fragment (one clock read + one relaxed store
+/// plus one `notify_one`); the observing side (the retry loop) reads
+/// [`Self::since_last`] and awaits [`Self::notified`].
+#[derive(Clone)]
+pub(crate) struct StreamProgressHandle {
+    last_progress_millis: Arc<AtomicU64>,
+    notify: Arc<Notify>,
+    /// The single shared clock both writer and reader read from. See the
+    /// single-epoch invariant in the type docs.
+    now_millis: Arc<dyn Fn() -> u64 + Send + Sync>,
+}
+
+impl std::fmt::Debug for StreamProgressHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StreamProgressHandle")
+            .field(
+                "last_progress_millis",
+                &self.last_progress_millis.load(Ordering::Relaxed),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+impl StreamProgressHandle {
+    /// Construct a handle bound to `time_source`. Its initial progress is the
+    /// current time, so the inactivity clock starts at construction (op-send
+    /// time), not the epoch.
+    pub(crate) fn new<T: TimeSource>(time_source: T) -> Self {
+        let now_ts = time_source;
+        let now_millis: Arc<dyn Fn() -> u64 + Send + Sync> =
+            Arc::new(move || now_ts.now().as_millis() as u64);
+        let initial = now_millis();
+        Self {
+            last_progress_millis: Arc::new(AtomicU64::new(initial)),
+            notify: Arc::new(Notify::new()),
+            now_millis,
+        }
+    }
+
+    /// Record a fragment dispatch. Reads the handle's OWN clock (never a caller-
+    /// supplied timestamp — see the single-epoch invariant), then a single
+    /// relaxed store plus `notify_one()`. Non-blocking and lock-free (no
+    /// `.send().await`, safe per `channel-safety.md`).
+    pub(crate) fn record(&self) {
+        let now = (self.now_millis)();
+        self.last_progress_millis.store(now, Ordering::Relaxed);
+        self.notify.notify_one();
+    }
+
+    /// Duration since the last recorded progress, against the handle's own
+    /// clock. Saturates at zero if a fragment landed at or after now (race
+    /// window), which is exactly the tiebreak the retry loop relies on to
+    /// suppress a false stall.
+    pub(crate) fn since_last(&self) -> Duration {
+        let now = (self.now_millis)();
+        let last = self.last_progress_millis.load(Ordering::Relaxed);
+        Duration::from_millis(now.saturating_sub(last))
+    }
+
+    /// Await the next `record()` ping.
+    ///
+    /// `Notify::notified()` is a future; a single pending permit stored by a
+    /// `notify_one()` that arrives before this is awaited is consumed on the
+    /// next await, which (together with the `since_last` atomic re-check) closes
+    /// the lost-wakeup race.
+    pub(crate) async fn notified(&self) {
+        self.notify.notified().await;
+    }
+}
+
+/// Streaming-attempt liveness bundle returned by
+/// [`crate::operations::op_ctx::RetryDriver::stream_progress`].
+///
+/// Bundles the per-fragment [`StreamProgressHandle`] (which owns the shared
+/// clock — see its single-epoch invariant) with a type-erased `sleep` over the
+/// driver's [`TimeSource`] (so the retry loop's sleeps obey VirtualTime under
+/// DST without `drive_retry_loop` taking a `TimeSource` type parameter).
+/// [`TimeSource`] is `Clone` and therefore not `dyn`-safe, so `sleep` is
+/// captured as a cloneable closure. The handle and this `sleep` are built from
+/// the SAME `TimeSource`, so liveness reads and the retry loop's sleeps share
+/// one time basis.
+#[derive(Clone)]
+pub(crate) struct StreamProgress {
+    handle: StreamProgressHandle,
+    sleep: Arc<dyn Fn(Duration) -> BoxFuture + Send + Sync>,
+}
+
+impl StreamProgress {
+    /// Build a bundle from a concrete [`TimeSource`]. The handle and the `sleep`
+    /// closure share this one clock, guaranteeing the single-epoch invariant.
+    pub(crate) fn new<T: TimeSource>(time_source: T) -> Self {
+        let handle = StreamProgressHandle::new(time_source.clone());
+        let sleep_ts = time_source;
+        Self {
+            handle,
+            sleep: Arc::new(move |d| sleep_ts.sleep(d)),
+        }
+    }
+
+    /// The progress handle (cloned).
+    pub(crate) fn handle(&self) -> StreamProgressHandle {
+        self.handle.clone()
+    }
+
+    /// Sleep `duration` via the driver's `TimeSource` (VirtualTime-aware).
+    pub(crate) fn sleep(&self, duration: Duration) -> BoxFuture {
+        (self.sleep)(duration)
+    }
+}
+
+/// `Transaction`-keyed registry of in-flight [`StreamProgressHandle`]s.
+///
+/// Owned by `OpManager`. Task A (`drive_retry_loop`) registers a handle keyed
+/// by the attempt `Transaction` via a [`StreamProgressGuard`] (RAII) before
+/// emitting the streaming request, so the entry is removed on EVERY exit path
+/// AND on cancellation/panic; Task B (`drive_relay_put` originator loopback)
+/// looks it up by the same `Transaction` and threads it into the transport send
+/// so per-fragment progress is recorded. A non-streaming PUT, a non-originator
+/// relay, or any op without a registered handle is a no-op on the lookup side.
+pub(crate) struct StreamProgressRegistry {
+    handles: DashMap<Transaction, StreamProgressHandle>,
+}
+
+impl StreamProgressRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            handles: DashMap::new(),
+        }
+    }
+
+    /// Insert (or replace) the handle for `tx`. Called by the observing side
+    /// before the streaming request is emitted.
+    pub(crate) fn insert(&self, tx: Transaction, handle: StreamProgressHandle) {
+        self.handles.insert(tx, handle);
+    }
+
+    /// Remove the handle for `tx`. Idempotent. Production callers go through
+    /// [`StreamProgressGuard`]'s `Drop` so the entry cannot leak even under
+    /// cancellation/panic (the GC concern the registry must satisfy, since it
+    /// has no TTL/sweep).
+    pub(crate) fn remove(&self, tx: &Transaction) {
+        self.handles.remove(tx);
+    }
+
+    /// Look up the handle for `tx`, if one is registered. Called by the
+    /// recording side; `None` means "no progress tracking for this op" and the
+    /// caller records nothing.
+    pub(crate) fn get(&self, tx: &Transaction) -> Option<StreamProgressHandle> {
+        self.handles.get(tx).map(|h| h.clone())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.handles.len()
+    }
+}
+
+impl Default for StreamProgressRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// RAII guard that registers a [`StreamProgressHandle`] for a `Transaction` on
+/// construction and removes it on `Drop`.
+///
+/// Using a Drop guard (rather than an explicit `insert` … `remove` pair) makes
+/// the "cannot leak" claim TRUE even if the holder is cancelled mid-`await` or
+/// panics: the registry has no TTL/sweep, so a skipped `remove` would leak the
+/// entry permanently. Mirrors `RelayPutInflightGuard`
+/// (`put/op_ctx_task.rs`). The guard holds an `Arc<StreamProgressRegistry>` so
+/// it can clean up without borrowing the `OpManager`.
+pub(crate) struct StreamProgressGuard {
+    registry: Arc<StreamProgressRegistry>,
+    tx: Transaction,
+}
+
+impl StreamProgressGuard {
+    /// Register `handle` for `tx`; the entry is removed when the guard drops.
+    pub(crate) fn new(
+        registry: Arc<StreamProgressRegistry>,
+        tx: Transaction,
+        handle: StreamProgressHandle,
+    ) -> Self {
+        registry.insert(tx, handle);
+        Self { registry, tx }
+    }
+}
+
+impl Drop for StreamProgressGuard {
+    fn drop(&mut self) {
+        self.registry.remove(&self.tx);
+    }
+}
+
+/// Op-level stream-inactivity timeout for the streaming-PUT retry loop (#4001).
+///
+/// Distinct from the transport-layer `STREAM_INACTIVITY_TIMEOUT` (5 s in
+/// `transport::peer_connection::streaming`), which bounds the gap between
+/// individual transport fragments on one hop. The op-level timeout is larger on
+/// purpose: it must absorb whole transport retransmit cycles (a hop can stall
+/// for several seconds and recover) without the op layer prematurely declaring
+/// the stream dead and firing a version-conflicting retry. 30 s gives ~6× the
+/// transport inactivity window of slack.
+pub(crate) const STREAM_OP_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::operations::put::PutMsg;
+    use crate::simulation::VirtualTime;
+
+    #[test]
+    fn record_advances_last_progress_and_since_last_tracks_it() {
+        let clock = VirtualTime::new();
+        let handle = StreamProgressHandle::new(clock.clone());
+        // Constructed at t=0 → since_last is 0; advancing 5 s without a record
+        // grows since_last.
+        assert_eq!(handle.since_last(), Duration::ZERO);
+        clock.advance(Duration::from_secs(5));
+        assert_eq!(handle.since_last(), Duration::from_secs(5));
+
+        // record() resets the clock to "now".
+        handle.record();
+        assert_eq!(handle.since_last(), Duration::ZERO);
+        clock.advance(Duration::from_millis(2_500));
+        assert_eq!(handle.since_last(), Duration::from_millis(2_500));
+    }
+
+    /// The single-epoch invariant: writer and reader must read the SAME clock.
+    ///
+    /// Regression for the cross-epoch `RealTime` bug — the writer recorded
+    /// against the connection's epoch (earlier than the op's), so the stored
+    /// value exceeded the reader's clock and `since_last` saturated to 0
+    /// forever, defeating the 30 s stall. Because `record()` now reads the
+    /// handle's OWN clock (no caller timestamp), a clone used by the "writer"
+    /// shares the reader's basis: after a record, then 30 s of silence,
+    /// `since_last` reflects the REAL elapsed time and the stall fires.
+    ///
+    /// This test fails on the pre-fix code (where `record(now_millis)` took an
+    /// external, later-epoch timestamp): the stored value would be > the
+    /// reader's now and `since_last()` would be 0 here, not 30 s.
+    #[test]
+    fn writer_and_reader_share_one_clock_so_stall_is_detectable() {
+        // Reader clock, already advanced (simulating an op that started after
+        // the connection was established — the skew that caused the bug).
+        let clock = VirtualTime::new();
+        clock.advance(Duration::from_secs(120));
+        let reader = StreamProgressHandle::new(clock.clone());
+
+        // The "writer" is a clone handed to the transport. It records using the
+        // handle's own clock — NOT a separate, earlier-epoch connection clock.
+        let writer = reader.clone();
+        writer.record();
+        assert_eq!(reader.since_last(), Duration::ZERO, "fresh record → 0");
+
+        // Stream goes silent for 30 s. since_last MUST reflect the real elapsed
+        // time (not saturate to 0), so the inactivity stall can fire.
+        clock.advance(STREAM_OP_INACTIVITY_TIMEOUT);
+        assert_eq!(
+            reader.since_last(),
+            STREAM_OP_INACTIVITY_TIMEOUT,
+            "after the writer's record + 30 s of silence, since_last must show \
+             the true elapsed time so the stall fires; a cross-epoch clock would \
+             saturate this to 0 and defeat the whole fix"
+        );
+    }
+
+    #[test]
+    fn since_last_saturates_when_progress_is_in_the_future() {
+        // With a single shared clock, since_last is never negative; sanity-check
+        // that a fresh record yields zero elapsed (the race-window tiebreak),
+        // never an underflow panic.
+        let clock = VirtualTime::new();
+        let handle = StreamProgressHandle::new(clock);
+        handle.record();
+        assert_eq!(handle.since_last(), Duration::ZERO);
+    }
+
+    #[tokio::test]
+    async fn notified_wakes_after_record() {
+        let handle = StreamProgressHandle::new(VirtualTime::new());
+        let observer = handle.clone();
+        // notify_one() before notified() leaves a permit; the await returns
+        // immediately, proving the lost-wakeup-avoidance permit semantics.
+        handle.record();
+        tokio::time::timeout(Duration::from_secs(1), observer.notified())
+            .await
+            .expect("a record() before notified() must leave a permit");
+    }
+
+    #[test]
+    fn registry_insert_get_remove_roundtrip_and_is_leak_free() {
+        let registry = StreamProgressRegistry::new();
+        let tx = Transaction::new::<PutMsg>();
+        assert_eq!(registry.len(), 0);
+        assert!(registry.get(&tx).is_none());
+
+        registry.insert(tx, StreamProgressHandle::new(VirtualTime::new()));
+        assert_eq!(registry.len(), 1);
+        assert!(registry.get(&tx).is_some());
+
+        registry.remove(&tx);
+        assert_eq!(registry.len(), 0, "remove must leave the registry empty");
+        // Idempotent: a second remove on an absent key is a no-op.
+        registry.remove(&tx);
+        assert_eq!(registry.len(), 0);
+    }
+
+    /// The `StreamProgressGuard` registers on construction and removes on Drop,
+    /// so the registry entry cannot leak — including when the holder is dropped
+    /// early (cancellation) rather than reaching an explicit cleanup line. This
+    /// is the property that makes the retry loop's "cannot leak under
+    /// cancel/panic" claim true.
+    #[test]
+    fn guard_registers_on_new_and_removes_on_drop_including_early_drop() {
+        let registry = Arc::new(StreamProgressRegistry::new());
+        let tx = Transaction::new::<PutMsg>();
+        let handle = StreamProgressHandle::new(VirtualTime::new());
+
+        // Normal scope: registered while alive, removed when the guard drops.
+        {
+            let _guard = StreamProgressGuard::new(registry.clone(), tx, handle.clone());
+            assert_eq!(registry.len(), 1, "guard must register on construction");
+            assert!(registry.get(&tx).is_some());
+        }
+        assert_eq!(registry.len(), 0, "guard must remove on Drop");
+
+        // Early drop (simulates the future being cancelled mid-await before any
+        // explicit remove line runs): the entry is still cleaned up.
+        let guard = StreamProgressGuard::new(registry.clone(), tx, handle);
+        assert_eq!(registry.len(), 1);
+        drop(guard); // cancellation drops the guard without running a remove stmt
+        assert_eq!(
+            registry.len(),
+            0,
+            "an early/cancellation drop of the guard must still remove the entry"
+        );
+    }
+}

--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -682,6 +682,7 @@ pub(crate) trait PeerConnectionApi: Send {
         data: bytes::Bytes,
         metadata: Option<bytes::Bytes>,
         completion_tx: Option<tokio::sync::oneshot::Sender<BroadcastDeliveryOutcome>>,
+        progress: Option<crate::operations::stream_progress::StreamProgressHandle>,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + '_>>;
 
     /// Pipes an inbound stream to the remote peer, forwarding fragments as they arrive.
@@ -697,6 +698,7 @@ pub(crate) trait PeerConnectionApi: Send {
         outbound_stream_id: crate::transport::peer_connection::StreamId,
         inbound_handle: crate::transport::peer_connection::streaming::StreamHandle,
         metadata: Option<bytes::Bytes>,
+        progress: Option<crate::operations::stream_progress::StreamProgressHandle>,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + '_>>;
 }
 

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -1948,7 +1948,7 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
 
     async fn outbound_stream(&mut self, data: SerializedMessage) {
         let stream_id = StreamId::next();
-        self.outbound_stream_with_id(stream_id, data.into(), None, None)
+        self.outbound_stream_with_id(stream_id, data.into(), None, None, None)
             .await;
     }
 
@@ -1966,6 +1966,7 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
         data: bytes::Bytes,
         metadata: Option<bytes::Bytes>,
         completion_tx: Option<tokio::sync::oneshot::Sender<super::BroadcastDeliveryOutcome>>,
+        progress: Option<crate::operations::stream_progress::StreamProgressHandle>,
     ) {
         let task = GlobalExecutor::spawn(
             outbound_stream::send_stream(
@@ -1981,6 +1982,7 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                 self.time_source.clone(),
                 metadata,
                 completion_tx,
+                progress,
             )
             .instrument(span!(tracing::Level::DEBUG, "outbound_stream")),
         );
@@ -1997,6 +1999,7 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
         outbound_stream_id: StreamId,
         inbound_handle: streaming::StreamHandle,
         metadata: Option<bytes::Bytes>,
+        progress: Option<crate::operations::stream_progress::StreamProgressHandle>,
     ) {
         let task = GlobalExecutor::spawn(
             outbound_stream::pipe_stream(
@@ -2011,6 +2014,7 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                 self.remote_conn.congestion_controller.clone(),
                 self.time_source.clone(),
                 metadata,
+                progress,
             )
             .instrument(span!(tracing::Level::DEBUG, "pipe_stream")),
         );
@@ -2391,11 +2395,12 @@ impl<S: super::Socket> super::PeerConnectionApi for PeerConnection<S> {
         data: bytes::Bytes,
         metadata: Option<bytes::Bytes>,
         completion_tx: Option<tokio::sync::oneshot::Sender<super::BroadcastDeliveryOutcome>>,
+        progress: Option<crate::operations::stream_progress::StreamProgressHandle>,
     ) -> std::pin::Pin<
         Box<dyn futures::Future<Output = Result<(), super::TransportError>> + Send + '_>,
     > {
         Box::pin(async move {
-            self.outbound_stream_with_id(stream_id, data, metadata, completion_tx)
+            self.outbound_stream_with_id(stream_id, data, metadata, completion_tx, progress)
                 .await;
             Ok(())
         })
@@ -2406,11 +2411,12 @@ impl<S: super::Socket> super::PeerConnectionApi for PeerConnection<S> {
         outbound_stream_id: StreamId,
         inbound_handle: streaming::StreamHandle,
         metadata: Option<bytes::Bytes>,
+        progress: Option<crate::operations::stream_progress::StreamProgressHandle>,
     ) -> std::pin::Pin<
         Box<dyn futures::Future<Output = Result<(), super::TransportError>> + Send + '_>,
     > {
         Box::pin(async move {
-            self.pipe_stream_to_remote(outbound_stream_id, inbound_handle, metadata)
+            self.pipe_stream_to_remote(outbound_stream_id, inbound_handle, metadata, progress)
                 .await;
             Ok(())
         })
@@ -2962,6 +2968,7 @@ mod tests {
             token_bucket,
             congestion_controller,
             time_source,
+            None,
             None,
             None,
         ))

--- a/crates/core/src/transport/peer_connection/outbound_stream.rs
+++ b/crates/core/src/transport/peer_connection/outbound_stream.rs
@@ -113,6 +113,7 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
     time_source: T,
     metadata: Option<Bytes>,
     completion_tx: Option<oneshot::Sender<crate::transport::BroadcastDeliveryOutcome>>,
+    progress: Option<crate::operations::stream_progress::StreamProgressHandle>,
 ) -> Result<TransferStats, TransportError> {
     let start_time = time_source.now();
     let bytes_to_send = stream_to_send.len() as u64;
@@ -387,6 +388,13 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
 
         next_fragment_number += 1;
         sent_so_far += 1;
+        if let Some(p) = &progress {
+            // record() reads the handle's OWN clock (the originator's
+            // TimeSource), NOT this connection's time_source — the two have
+            // different epochs and mixing them defeats the inactivity timeout
+            // (#4001 single-epoch invariant; see stream_progress.rs).
+            p.record();
+        }
     }
 
     // Gather congestion control stats for telemetry
@@ -482,6 +490,7 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
     congestion_controller: Arc<CongestionController<T>>,
     time_source: T,
     metadata: Option<Bytes>,
+    progress: Option<crate::operations::stream_progress::StreamProgressHandle>,
 ) -> Result<TransferStats, TransportError> {
     let start_time = time_source.now();
     let total_bytes = inbound_handle.total_bytes();
@@ -763,6 +772,13 @@ pub(super) async fn pipe_stream<S: super::super::Socket, T: TimeSource>(
 
         sent_so_far += packet_size as u64;
         fragment_number += 1;
+        if let Some(p) = &progress {
+            // record() reads the handle's OWN clock (the originator's
+            // TimeSource), NOT this connection's time_source — the two have
+            // different epochs and mixing them defeats the inactivity timeout
+            // (#4001 single-epoch invariant; see stream_progress.rs).
+            p.record();
+        }
     }
 
     let generic_stats = congestion_controller.stats();
@@ -922,6 +938,7 @@ mod tests {
             time_source,
             None,
             None,
+            None,
         ));
 
         let mut inbound_bytes = Vec::with_capacity(message.len());
@@ -1031,6 +1048,7 @@ mod tests {
             time_source,
             None,
             None,
+            None,
         ));
 
         // Wait for send task to complete
@@ -1130,6 +1148,7 @@ mod tests {
             token_bucket,
             congestion_controller,
             time_source,
+            None,
             None,
             None,
         ));
@@ -1239,6 +1258,7 @@ mod tests {
             time_source,
             None,
             None,
+            None,
         ));
 
         // With start_paused=true, tokio auto-advances time through sleep calls.
@@ -1324,6 +1344,7 @@ mod tests {
             token_bucket,
             congestion_controller,
             time_source,
+            None,
             None,
             None,
         ));
@@ -1419,6 +1440,7 @@ mod tests {
             time_source,
             None,
             None,
+            None,
         ));
 
         let err = send_task
@@ -1488,6 +1510,7 @@ mod tests {
             token_bucket,
             cc_for_send,
             time_source,
+            None,
             None,
             None,
         ));
@@ -1561,6 +1584,7 @@ mod tests {
             time_source,
             None,
             Some(completion_tx),
+            None,
         ));
 
         // Drain the socket so the stream can run to completion.
@@ -1635,6 +1659,7 @@ mod tests {
             time_source,
             None,
             Some(completion_tx),
+            None,
         ));
 
         let result = background_task.await?;
@@ -1718,6 +1743,7 @@ mod tests {
             token_bucket,
             congestion_controller,
             time_source,
+            None,
             None,
         ));
 
@@ -1881,6 +1907,7 @@ mod tests {
             congestion_controller,
             time_source,
             None,
+            None,
         ));
 
         let result = pipe_task.await.expect("join error");
@@ -1950,6 +1977,7 @@ mod tests {
             token_bucket,
             congestion_controller,
             time_source,
+            None,
             None,
         ));
 
@@ -2032,6 +2060,7 @@ mod tests {
             token_bucket,
             congestion_controller,
             time_source,
+            None,
             None,
         ));
 


### PR DESCRIPTION
## Problem

`drive_retry_loop` gates each PUT attempt on a fixed per-attempt timeout. For streaming PUTs whose network time exceeds that timeout (e.g. the freenet.org ~2.4 MB upload), the retry loop fires a retry **while the original streaming op is still in flight**. The retry reuses the same contract version and fast-fails with a version conflict ("New state version N must be higher than current N"), so the client gets "put failed after N attempts" even though the original PUT actually completes seconds later.

The already-merged heuristic (`streaming_aware_attempt_timeout`, option b) only *relocates* the cliff by scaling the deadline with payload size. This PR implements the true fix (option c): a stream-inactivity timeout driven by real per-fragment liveness. The heuristic is kept as the fallback and 600 s hard ceiling.

## Solution

A new `StreamProgressHandle` (neutral `AtomicU64` + `Notify`, no transport/op dependencies) records a tick per dispatched fragment. The retry loop, when a streaming driver is in play, replaces the fixed `tokio::time::timeout` with a three-arm `select!`:

1. **Terminal reply** — the awaited `send_and_await` round-trip (unchanged semantics).
2. **Inactivity loop** — woken promptly by `Notify`; on each `STREAM_OP_INACTIVITY_TIMEOUT` (30 s) sleep expiry it re-reads the `AtomicU64` and only declares a stall if **no fragment landed in the race window**. Using both `Notify` and the atomic is deliberate: `Notify` alone is racy (lost-wakeup if a fragment lands in the wakeup window), polling alone is wasteful — the atomic re-check is the tiebreak that closes the gap.
3. **Hard ceiling** — a sibling `STREAMING_ATTEMPT_TIMEOUT_CAP` (600 s) sleep so a stream that dribbles fragments forever still can't hold the driver hostage.

All sleeps go through the driver's `TimeSource` (carried in the `StreamProgress` bundle as cloneable closures, since `TimeSource: Clone` is not `dyn`-safe) so the path is VirtualTime-correct under DST.

### Why a per-`Transaction` registry (not gratuitous coupling)

A client streaming PUT runs as **two concurrent tasks on the originator node that share only the `Transaction` id**:

- **Task A** — `start_client_put` → `drive_retry_loop`, which emits a `PutMsg::Request` via `send_and_await` and owns the per-attempt timeout decision.
- **Task B** — the `PutMsg::Request` loops back through the local event loop (`source_addr=None` → `upstream_addr=own_addr`) and is dispatched to a *separate* spawned `drive_relay_put` task, which actually fragments and streams the payload via `conn_manager.send_stream(...)` → `outbound_stream::send_stream`.

The per-fragment send (`sent_so_far += …`) lives in Task B's downstream transport, while the timeout decision lives in Task A. There is **no shared per-tx object** to thread a handle through directly, so a `StreamProgressRegistry` (`DashMap<Transaction, StreamProgressHandle>`) on `OpManager` bridges them — a *scoped* lookup keyed by `Transaction`, mirroring the existing `pending_op_results` / `OrphanStreamRegistry` patterns, **not** a free-floating module-global. Task A inserts the handle before sending and removes it **unconditionally on every loop-exit path** (success, stall, ceiling, error) so it can't leak; Task B looks it up by `Transaction` and threads it into the transport, which records a tick per fragment. A non-streaming PUT / non-originator relay / op with no registered handle is a no-op on the lookup side.

The `RetryDriver::stream_progress()` hook defaults to `None`, so GET / SUBSCRIBE / non-streaming PUT compile unchanged and take the byte-identical fixed-deadline path.

## Testing

`cargo fmt && cargo clippy -p freenet --lib -- -D warnings && cargo test -p freenet --lib operations` — all clean (443 operations tests pass). Transport (138) and p2p_protoc (49) suites pass; the existing `streaming_aware_attempt_timeout` heuristic tests (10) still pass.

New regression tests against `await_streaming_attempt` (the streaming branch core) under tokio's `start_paused` virtual clock:

- `streaming_put_does_not_retry_while_chunks_flow` — fragments every 10 s for 120 s (past the 60 s cliff), reply at 125 s; asserts the terminal reply is delivered (no timeout). **Verified to FAIL** when the streaming branch is reverted to the fixed 60 s deadline.
- `streaming_put_retries_on_true_stall` — progress to 40 s then silence; asserts the 30 s inactivity timeout fires ~70 s in.
- `streaming_put_hard_ceiling_fires` — records forever; asserts bail at the 600 s ceiling.
- `streaming_put_progress_during_inactivity_race` — fragments land just inside each window; asserts the atomic tiebreak prevents a false stall.
- `non_streaming_put_uses_fixed_timeout` — pins that the default `stream_progress()` is `None` and the `None` arm remains the unchanged `tokio::time::timeout` path.

Plus unit tests on `StreamProgressHandle` / `StreamProgressRegistry` (record/since_last/saturation, notified permit, leak-free insert/get/remove roundtrip).

The two source-scrape pin tests on `drive_retry_loop` (`drive_retry_loop_terminal_arm_does_not_call_advance`, `drive_retry_loop_has_fast_infra_retry_path`) still pass — the change kept their scraped substrings intact. The `drive_client_put_inner_dispatches_streaming_cap_on_should_use_streaming` pin was updated to follow the hoisted `is_streaming` flag (the streaming-cap selection and the new stream-progress handle now derive from one decision).

## Scope

**PUT only.** The additive `RetryDriver::stream_progress()` default-`None` hook is the seam a later GET/SUBSCRIBE PR plugs into — streaming GET is a deferred follow-up. The merged `streaming_aware_attempt_timeout` heuristic is retained as the fallback/ceiling.

## Fixes #4001

https://claude.ai/code/session_01CVyrLHuiXpFCC21by4Pzrj