### PR TITLE
ci: authenticate binstall smoke-test GitHub API calls with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/binstall-smoke-test.yml
+++ b/.github/workflows/binstall-smoke-test.yml
@@ -68,8 +68,18 @@ jobs:
       # mirror or a from-source compile — and the smoke test would pass while
       # the exact failure mode it exists to detect (a broken release upload)
       # went unnoticed. The whole point is to fail when the GitHub asset is bad.
+      # cargo-binstall resolves the release by hitting the GitHub REST API
+      # (GET /repos/.../releases/tags/v{version}). Authenticate those calls
+      # with GITHUB_TOKEN: unauthenticated they share the per-IP 60 req/hr
+      # limit, and GitHub-hosted runner IPs are shared across tenants, so the
+      # lookup intermittently 403s and the step hard-fails (the smoke test
+      # runs with compile fallback disabled, so a 403 can't fall through).
+      # binstall auto-detects GITHUB_TOKEN/GH_TOKEN and switches to the
+      # 5000 req/hr authenticated limit. See run 28280841654 (2026-06-27).
       - name: Install freenet via cargo binstall
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cargo binstall --no-confirm --strategies crate-meta-data \
             --targets "${{ matrix.target }}" \
@@ -77,6 +87,8 @@ jobs:
 
       - name: Install fdev via cargo binstall
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cargo binstall --no-confirm --strategies crate-meta-data \
             --targets "${{ matrix.target }}" \


### PR DESCRIPTION
## Problem

The nightly **binstall smoke test** intermittently fails with a GitHub REST API **403** while `cargo-binstall` resolves the release tag (`GET /repos/freenet/freenet-core/releases/tags/v{version}`).

Latest instance: run [28280841654](https://github.com/freenet/freenet-core/actions/runs/28280841654) (2026-06-27). The Linux leg 403'd on the `freenet` lookup while the **Windows leg of the same run passed**, and `v0.2.83`'s release assets + binstall metadata were both correct — so this is a transient rate-limit, not a broken release.

**Root cause:** the two `cargo binstall` steps make those API calls **unauthenticated**. The unauthenticated GitHub API limit is **60 req/hr per IP**, and GitHub-hosted runner IPs are shared across tenants, so the lookup periodically trips the limit and 403s. Because the smoke test runs with `--strategies crate-meta-data` (compile fallback disabled by design), a 403 can't fall through — it hard-fails the job. 10 prior nightlies were green, so it's an intermittent flake that will keep recurring.

## Solution

`cargo-binstall` auto-detects `GITHUB_TOKEN`/`GH_TOKEN` in the environment and switches its API calls to the **5000 req/hr** authenticated limit. Wire the already-available `secrets.GITHUB_TOKEN` into both binstall steps.

These are read-only release-asset downloads, **not** event-emitting steps, so the #4118 token-coalesce guard does not apply — bare `GITHUB_TOKEN` is correct here (`RELEASE_PAT` coalesce is only for steps that must fire downstream workflow events).

## Testing

Workflow-only change. Verified the added `GITHUB_TOKEN:` env lines do **not** match the `check-token-coalesce.yml` grep patterns (which key on `GH_TOKEN:` and `token: github.token`). Validated by the nightly schedule / `workflow_dispatch` run going green without the intermittent 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-assisted - Claude]