### PR TITLE
fix: stop placement migration firing in every simulation (#4601)

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -307,16 +307,25 @@ pub struct NodeConfig {
     #[serde(skip)]
     pub(crate) governance_config_override: Option<crate::contract::governance::GovernanceConfig>,
     /// Test-only override for the placement-migration version floor
-    /// (`SUBSCRIBE_HINT_MIN_VERSION`). Simulation peers all report the current
-    /// build version, which is below the production floor until release, so the
-    /// `SubscribeHint` gate would never fire in a sim. A test that exercises the
-    /// migration cascade sets this to `Some((0,0,0))` for its own nodes, leaving
-    /// every other sim (and production) at the real floor — so the cascade is
-    /// opt-in and cannot perturb unrelated simulations.
+    /// (`SUBSCRIBE_HINT_MIN_VERSION`). The floor is consulted as
+    /// `subscribe_hint_floor_override().unwrap_or(SUBSCRIBE_HINT_MIN_VERSION)`
+    /// on both the send gate (`p2p_protoc::peer_supports_subscribe_hint`) and the
+    /// receive gate (`node::handle_pure_network_message_v1`).
     ///
-    /// `None` in production. Not cfg-gated for the same reason as
-    /// `governance_config_override`: `node::testing_impl` sets it and is compiled
-    /// unconditionally. `#[serde(skip)]`; never serialized.
+    /// In production this is `None` → the real `(0,2,80)` floor (untouched).
+    ///
+    /// In simulations the crate version is now AT/ABOVE the real floor, so a
+    /// `None` override would make the `SubscribeHint` gate fire in EVERY sim and
+    /// pile migration load onto unrelated simulations (the #4601 regression that
+    /// reddened the 500-node nightly). `SimNetwork` therefore defaults this to an
+    /// unreachable floor (`SimNetwork::SIM_MIGRATION_DISABLED_FLOOR`) — FAIL-CLOSED,
+    /// so migration is genuinely OPT-IN. A test exercising the cascade calls
+    /// `SimNetwork::enable_placement_migration`, which sets it to `Some((0,0,0))`
+    /// for its own nodes; every other sim stays off and cannot be perturbed.
+    ///
+    /// Not cfg-gated for the same reason as `governance_config_override`:
+    /// `node::testing_impl` sets it and is compiled unconditionally.
+    /// `#[serde(skip)]`; never serialized.
     #[serde(skip)]
     pub(crate) subscribe_hint_floor_override: Option<(u8, u8, u16)>,
 }

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -417,6 +417,8 @@ impl ControlledSimulationResult {
             |mut acc, m| {
                 acc.wire_attempts += m.wire_attempts;
                 acc.terminus_satisfied += m.terminus_satisfied;
+                // Per-node peak → aggregate as the max across peers.
+                acc.max_cycle_batch = acc.max_cycle_batch.max(m.max_cycle_batch);
                 acc
             },
         )
@@ -1010,11 +1012,14 @@ pub struct SimNetwork {
     /// path actually feeds the detector. See #4301.
     governance_config_override: Option<crate::contract::governance::GovernanceConfig>,
     /// Per-node placement-migration version-floor override (see
-    /// [`SimNetwork::enable_placement_migration`]). `None` leaves the production
-    /// floor, so the `SubscribeHint` cascade stays OFF in sim (its peers report a
-    /// version below the floor) — only a test that explicitly enables migration
-    /// gets the cascade. Keeps the migration feature from perturbing unrelated
-    /// simulations.
+    /// [`SimNetwork::enable_placement_migration`]). Defaults to
+    /// `Some(SIM_MIGRATION_DISABLED_FLOOR)` (an unreachable floor) so the
+    /// `SubscribeHint` cascade is FAIL-CLOSED — OFF — in every sim regardless of
+    /// build version, and only a test that explicitly calls
+    /// `enable_placement_migration` gets the cascade. This keeps migration from
+    /// perturbing unrelated simulations now that the crate version is past the
+    /// real production floor (#4601). Production is untouched: `NodeConfig::new`
+    /// sets this to `None`, which resolves to the real `SUBSCRIBE_HINT_MIN_VERSION`.
     subscribe_hint_floor_override: Option<(u8, u8, u16)>,
     /// Per-node capture slots for the live `Arc<Ring>`, populated by
     /// `run_controlled_simulation` so governance sim tests can read each
@@ -1043,6 +1048,19 @@ pub struct SimNetwork {
 impl SimNetwork {
     /// Default seed for deterministic simulation
     pub const DEFAULT_SEED: u64 = 0xDEADBEEF_CAFEBABE;
+
+    /// Placement-migration version floor that pins the `SubscribeHint` cascade
+    /// OFF for a simulation: an unreachable value above any real or simulated
+    /// crate version, so `version_supports_subscribe_hint` always returns false.
+    /// This is the per-node default for every `SimNetwork` (see `new_inner`),
+    /// making migration genuinely OPT-IN in sims; `enable_placement_migration`
+    /// lowers it to [`Self::SIM_MIGRATION_ENABLED_FLOOR`]. See #4601.
+    pub(crate) const SIM_MIGRATION_DISABLED_FLOOR: (u8, u8, u16) = (255, 255, 65535);
+
+    /// Placement-migration version floor that forces the `SubscribeHint` cascade
+    /// ON for a simulation regardless of build version (every peer's version is
+    /// `>= (0,0,0)`). Set by [`Self::enable_placement_migration`].
+    pub(crate) const SIM_MIGRATION_ENABLED_FLOOR: (u8, u8, u16) = (0, 0, 0);
 
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
@@ -1167,7 +1185,16 @@ impl SimNetwork {
             skip_convergence_wait: false,
             churn_config: None,
             governance_config_override: None,
-            subscribe_hint_floor_override: None,
+            // Fail-closed by default: pin the placement-migration (`SubscribeHint`)
+            // cascade OFF for every simulation unless a test explicitly opts in
+            // via `enable_placement_migration`. The cascade gates on the build
+            // version being `>= SUBSCRIBE_HINT_MIN_VERSION` (0.2.80); since this
+            // crate is now past that floor, a `None` override (real floor) would
+            // run migration in EVERY sim and pile directed-subscribe + renewal
+            // load onto unrelated simulations — the #4601 regression that turned
+            // the 500-node nightly red. Defaulting to an unreachable floor keeps
+            // migration genuinely opt-in, as the docs have always claimed.
+            subscribe_hint_floor_override: Some(Self::SIM_MIGRATION_DISABLED_FLOOR),
             shared_rings: HashMap::new(),
             node_port_override,
         };
@@ -1298,58 +1325,53 @@ impl SimNetwork {
     }
 
     /// Enable the placement-migration (`SubscribeHint`) cascade for this
-    /// simulation by lowering the version floor to `(0,0,0)` on every node.
+    /// simulation by lowering the version floor to
+    /// [`Self::SIM_MIGRATION_ENABLED_FLOOR`] (`(0,0,0)`) on every node.
     ///
-    /// The cascade's default depends on the build version: peers report the
-    /// current build version, so the gate fires whenever that version is `>=`
-    /// the production `SUBSCRIBE_HINT_MIN_VERSION` (currently `(0,2,80)`). This
-    /// crate is already past that floor, so #4404 migration is ON by default in
-    /// sim now — call [`disable_placement_migration`](Self::disable_placement_migration)
-    /// to pin it OFF for a test whose premise assumes the contract stays put.
-    /// This method forces it ON regardless of build version (floor `(0,0,0)`),
-    /// for a test that specifically exercises migration; every other sim is left
-    /// untouched. Like `with_governance_config`, this patches the already-built
-    /// node/gateway configs (config_* ran during construction when the override
-    /// was still `None`).
+    /// Migration is OFF by default in every `SimNetwork` (the per-node floor
+    /// defaults to the unreachable [`Self::SIM_MIGRATION_DISABLED_FLOOR`], so the
+    /// `SubscribeHint` gate never fires — see `new_inner` and #4601). This makes
+    /// the cascade genuinely opt-in: only a test that specifically exercises
+    /// migration calls this to force it ON regardless of build version; every
+    /// other sim is left untouched and cannot be perturbed by migration load.
+    /// Like `with_governance_config`, this patches the already-built node/gateway
+    /// configs (config_* ran during construction with the disabled default).
     #[allow(dead_code)]
     pub fn enable_placement_migration(&mut self) -> &mut Self {
-        const TEST_FLOOR: (u8, u8, u16) = (0, 0, 0);
-        self.subscribe_hint_floor_override = Some(TEST_FLOOR);
+        let floor = Some(Self::SIM_MIGRATION_ENABLED_FLOOR);
+        self.subscribe_hint_floor_override = floor;
         for (builder, _) in self.gateways.iter_mut() {
-            builder.config.subscribe_hint_floor_override = Some(TEST_FLOOR);
+            builder.config.subscribe_hint_floor_override = floor;
         }
         for (builder, _) in self.nodes.iter_mut() {
-            builder.config.subscribe_hint_floor_override = Some(TEST_FLOOR);
+            builder.config.subscribe_hint_floor_override = floor;
         }
         self
     }
 
     /// Force the placement-migration (`SubscribeHint`) cascade OFF for this
-    /// simulation, regardless of the build version, by raising the per-node
-    /// version floor to an unreachable value `(255, 255, 65535)`.
+    /// simulation by pinning the per-node version floor to the unreachable
+    /// [`Self::SIM_MIGRATION_DISABLED_FLOOR`].
     ///
     /// The mirror of [`enable_placement_migration`](Self::enable_placement_migration).
-    /// The cascade is already OFF by default in sim *on a build below the
-    /// production `SUBSCRIBE_HINT_MIN_VERSION` floor* — but a test must not rely
-    /// on that build-version gating: when the build version reaches the floor
-    /// (e.g. on the v0.2.73 release branch, where #4404 ships active), the
-    /// default flips to ON and silently perturbs any test whose premise assumes
-    /// the contract stays put. A test that exercises relay/assembly/dead-end
-    /// mechanics (not placement) calls this to pin migration OFF at any build
-    /// version. Like `enable_placement_migration`, this patches the
-    /// already-built node/gateway configs (config_* ran during construction
-    /// when the override was still `None`).
+    /// Since #4601 the cascade is already OFF by default in every sim (the
+    /// per-node floor defaults to this same unreachable value), so this is now
+    /// belt-and-suspenders: it makes a test's "migration must stay off" premise
+    /// explicit at the call site. Calling it is harmless and recommended for
+    /// tests whose correctness depends on migration NOT running. Like
+    /// `enable_placement_migration`, this patches the already-built node/gateway
+    /// configs.
     #[allow(dead_code)]
     pub fn disable_placement_migration(&mut self) -> &mut Self {
         // Unreachable floor: no real or simulated peer version reaches it, so
         // `version_supports_subscribe_hint` always returns false → cascade off.
-        const UNREACHABLE_FLOOR: (u8, u8, u16) = (255, 255, 65535);
-        self.subscribe_hint_floor_override = Some(UNREACHABLE_FLOOR);
+        let floor = Some(Self::SIM_MIGRATION_DISABLED_FLOOR);
+        self.subscribe_hint_floor_override = floor;
         for (builder, _) in self.gateways.iter_mut() {
-            builder.config.subscribe_hint_floor_override = Some(UNREACHABLE_FLOOR);
+            builder.config.subscribe_hint_floor_override = floor;
         }
         for (builder, _) in self.nodes.iter_mut() {
-            builder.config.subscribe_hint_floor_override = Some(UNREACHABLE_FLOOR);
+            builder.config.subscribe_hint_floor_override = floor;
         }
         self
     }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2059,6 +2059,23 @@ impl Ring {
                     "Subscription renewal cycle complete"
                 );
             }
+
+            // Simulation-test observability (no-op in production — gated on a
+            // current network name, like the wire-attempt/terminus counters):
+            // record this cycle's spawn count so a migration-at-scale test can
+            // assert the per-node renewal rate cap holds (`attempted` is bounded
+            // by `MAX_RECOVERY_ATTEMPTS_PER_INTERVAL` above). Only when this
+            // cycle actually spawned renewals — a zero batch never raises the
+            // per-node max, so skip it to avoid creating empty registry entries.
+            // See #4601.
+            if attempted > 0 {
+                if let Some(addr) = ring.connection_manager.get_own_addr() {
+                    crate::ring::topology_registry::record_renewal_cycle_batch(
+                        addr,
+                        attempted as u64,
+                    );
+                }
+            }
         }
     }
 

--- a/crates/core/src/ring/topology_registry.rs
+++ b/crates/core/src/ring/topology_registry.rs
@@ -205,6 +205,16 @@ pub struct RenewalMetrics {
     /// proposal 1): the node is the body-holding subscription root, so it
     /// satisfies the renewal locally and sends no wire request.
     pub terminus_satisfied: u64,
+    /// Largest number of renewal tasks this node spawned in ANY single 30s
+    /// recovery cycle (the per-cycle batch size, `attempted`). This is the
+    /// direct, deterministic measurement of the production renewal rate cap:
+    /// `recover_orphaned_subscriptions` breaks its spawn loop once `attempted`
+    /// reaches `MAX_RECOVERY_ATTEMPTS_PER_INTERVAL` (10), so under the cap this
+    /// value can never exceed 10 no matter how many contracts are eligible. A
+    /// migration-at-scale test asserts `max_cycle_batch <= 10` per node as the
+    /// regression guard for the cap (#4601); if the cap were removed, a node
+    /// with N > 10 simultaneously-eligible contracts would record N here.
+    pub max_cycle_batch: u64,
 }
 
 static RENEWAL_METRICS_REGISTRY: LazyLock<DashMap<(String, SocketAddr), RenewalMetrics>> =
@@ -229,6 +239,21 @@ pub fn record_renewal_terminus_satisfied(peer_addr: SocketAddr) {
             .entry((network_name, peer_addr))
             .or_default()
             .terminus_satisfied += 1;
+    }
+}
+
+/// Record the number of renewal tasks spawned in one 30s recovery cycle (the
+/// per-cycle batch size), keeping the per-node running maximum. No-op outside a
+/// simulation context (no current network name). Used by the migration-at-scale
+/// test to assert the production renewal rate cap holds per node (#4601).
+pub fn record_renewal_cycle_batch(peer_addr: SocketAddr, batch_size: u64) {
+    if let Some(network_name) = get_current_network_name() {
+        let mut entry = RENEWAL_METRICS_REGISTRY
+            .entry((network_name, peer_addr))
+            .or_default();
+        if batch_size > entry.max_cycle_batch {
+            entry.max_cycle_batch = batch_size;
+        }
     }
 }
 
@@ -261,6 +286,10 @@ pub fn aggregate_renewal_metrics(network_name: &str) -> RenewalMetrics {
         .fold(RenewalMetrics::default(), |mut acc, entry| {
             acc.wire_attempts += entry.value().wire_attempts;
             acc.terminus_satisfied += entry.value().terminus_satisfied;
+            // Aggregate as the max across peers (it is a per-node peak, not a
+            // count), so the aggregate stays meaningful as "worst single-cycle
+            // batch any node reached".
+            acc.max_cycle_batch = acc.max_cycle_batch.max(entry.value().max_cycle_batch);
             acc
         })
 }

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -11275,3 +11275,214 @@ fn test_no_interest_subscription_root_lease_lapses() {
         "no-interest root lease lapsed as expected"
     );
 }
+
+/// Opt-in migration-at-scale regression guard (#4601).
+///
+/// ## What this is the home for
+///
+/// The placement-migration (`SubscribeHint`) cascade is OFF by default in every
+/// simulation since #4601 (the per-node version floor defaults to an unreachable
+/// value — see `SimNetwork::SIM_MIGRATION_DISABLED_FLOOR`), so the general
+/// throughput nightlies no longer carry migration load. This test is the
+/// DEDICATED place that turns migration ON (`enable_placement_migration`) and
+/// proves its load is BOUNDED at scale — not merely that the sim completes.
+///
+/// ## The bound it asserts
+///
+/// The production subscription-renewal driver
+/// (`Ring::recover_orphaned_subscriptions`) hard-caps the number of renewal
+/// tasks it spawns per 30s recovery cycle at
+/// `Ring::MAX_RECOVERY_ATTEMPTS_PER_INTERVAL` (10), regardless of how many
+/// contracts are eligible. That per-node rate cap is the reason the renewal path
+/// is load-safe in production (prod telemetry shows real peers well under it).
+/// This test exercises the cap by hosting MANY (`NUM_CONTRACTS` = 20) contracts
+/// on one node, all of which enter the 2-minute renewal window simultaneously
+/// (they share an ~8-minute lease set at startup) so a single cycle has far more
+/// eligible contracts than the cap. It then asserts, via the per-node
+/// `max_cycle_batch` metric (the largest `attempted` count any cycle reached):
+///
+///   * (cap holds, EVERY node) `max_cycle_batch <= MAX_RECOVERY_ATTEMPTS_PER_INTERVAL`.
+///     This is the regression guard: if the spawn cap were removed, the loaded
+///     node would record `max_cycle_batch == NUM_CONTRACTS` (20) and FAIL.
+///   * (cap engaged, loaded node) `max_cycle_batch == MAX_RECOVERY_ATTEMPTS_PER_INTERVAL`.
+///     Proves demand exceeded the cap and the cap actually clipped — without
+///     this the bound above could pass vacuously on a node that never had >10
+///     eligible contracts at once.
+///
+/// ## Why migration must be ON for this to be meaningful
+///
+/// With migration ON the loaded node also nudges its closer-to-the-key neighbors
+/// to host its contracts (directed subscribes), so the run carries the real
+/// migration traffic the #4601 regression piled onto unrelated sims. The test
+/// additionally asserts at least one contract migrated onto another node, so the
+/// cascade is genuinely exercised (not silently inert).
+#[test_log::test]
+fn test_placement_migration_at_scale_renewal_load_stays_bounded() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimNetwork, SimOperation};
+
+    // Mirrors `ring::Ring::MAX_RECOVERY_ATTEMPTS_PER_INTERVAL` (private to the
+    // crate). The renewal driver breaks its spawn loop once `attempted` reaches
+    // this value, so no node may exceed it in a single 30s cycle. Frozen value;
+    // if the production constant changes, update this and the rationale above.
+    const MAX_RECOVERY_ATTEMPTS_PER_INTERVAL: u64 = 10;
+    // Hosted-on-the-loaded-node contract count. Chosen well above the cap so a
+    // single renewal-window cycle has many more eligible contracts than the cap
+    // can spawn — that is what makes the cap regression detectable.
+    const NUM_CONTRACTS: usize = 20;
+
+    // Metastable load behavior: assert across several seeds, not just one.
+    for seed in [0x4601_0001u64, 0x4601_0002, 0x4601_0003] {
+        let network_name = format!("migration-scale-{seed:x}");
+        // Leak to obtain the &'static str SimNetwork::new requires; one small
+        // allocation per seed in a test is fine (same pattern as the storm test).
+        let network_name: &'static str = Box::leak(network_name.into_boxed_str());
+        setup_deterministic_state(seed);
+
+        // 1 gateway + 8 regular nodes spread around the ring. The loaded node
+        // (node 1) sits at 0.5; the others are scattered so that for most of the
+        // hosted contracts SOME peer is strictly closer to the key than the
+        // loaded node — giving the migration cascade real targets to nudge.
+        let loaded_loc = 0.5;
+        let node_locations = vec![
+            loaded_loc, // node 1 = the loaded node
+            0.05, 0.15, 0.30, 0.42, 0.62, 0.78, 0.92,
+        ];
+        let num_nodes = node_locations.len();
+
+        let rt = create_runtime();
+        let mut sim = rt.block_on(async {
+            SimNetwork::new_with_node_locations(
+                network_name,
+                1,         // 1 gateway
+                num_nodes, // 8 regular nodes
+                10,        // ring_max_htl
+                7,         // rnd_if_htl_above
+                16,        // max_connections (room for the small mesh)
+                3,         // min_connections
+                seed,
+                &node_locations,
+            )
+            .await
+        });
+        // OPT IN to placement migration — the whole point of this test.
+        sim.enable_placement_migration();
+
+        let loaded_label = NodeLabel::node(network_name, 1);
+        let loaded_addr = sim
+            .node_address(&loaded_label)
+            .unwrap_or_else(|| panic!("loaded node has no address (seed {seed:x})"));
+
+        // Build NUM_CONTRACTS distinct contracts and host them all on the loaded
+        // node (seeded as genuinely hosted + actively subscribed at startup, so
+        // their leases all start together → they all enter the renewal window in
+        // the same cycle). A client Subscribe per contract keeps them
+        // renewal-eligible past lease expiry (path 2) so the high-demand window
+        // spans several cycles.
+        let contracts: Vec<_> = (0..NUM_CONTRACTS)
+            .map(|i| SimOperation::create_test_contract(i as u8))
+            .collect();
+        let contract_keys: Vec<_> = contracts.iter().map(|c| c.key()).collect();
+
+        let mut operations = Vec::with_capacity(NUM_CONTRACTS * 2);
+        for contract in &contracts {
+            operations.push(ScheduledOperation::new(
+                loaded_label.clone(),
+                SimOperation::SeedHostedContract {
+                    contract: contract.clone(),
+                    state: vec![1, 2, 3, 4],
+                },
+            ));
+        }
+        for contract in &contracts {
+            operations.push(ScheduledOperation::new(
+                loaded_label.clone(),
+                SimOperation::Subscribe {
+                    contract_id: *contract.key().id(),
+                },
+            ));
+        }
+
+        // Run past the 6-minute renewal-window opening (8-min lease − 2-min
+        // window) and several 30s cycles into it. 540s post-op wait gives the
+        // window-burst cycles where all NUM_CONTRACTS are eligible at once.
+        let result = sim.run_controlled_simulation(
+            seed,
+            operations,
+            Duration::from_secs(900),
+            Duration::from_secs(540),
+        );
+        assert!(
+            result.turmoil_result.is_ok(),
+            "simulation failed (seed {seed:x}): {:?}",
+            result.turmoil_result.err()
+        );
+
+        let loaded_metrics = result.renewal_metrics_for(&loaded_addr);
+        let totals = result.aggregate_renewal_metrics();
+        tracing::info!(
+            seed = format!("{seed:x}"),
+            loaded_max_cycle_batch = loaded_metrics.max_cycle_batch,
+            loaded_wire_attempts = loaded_metrics.wire_attempts,
+            loaded_terminus = loaded_metrics.terminus_satisfied,
+            agg_max_cycle_batch = totals.max_cycle_batch,
+            agg_wire_attempts = totals.wire_attempts,
+            "migration-at-scale renewal load"
+        );
+
+        // (A) CAP HOLDS for EVERY node — the regression guard. If the per-cycle
+        // spawn cap were removed, the loaded node (with NUM_CONTRACTS eligible at
+        // once) would record max_cycle_batch == NUM_CONTRACTS > the cap.
+        for (addr, m) in &result.renewal_metrics {
+            assert!(
+                m.max_cycle_batch <= MAX_RECOVERY_ATTEMPTS_PER_INTERVAL,
+                "node {addr} spawned {} renewal tasks in a single 30s cycle (seed {seed:x}) — \
+                 exceeds the production cap MAX_RECOVERY_ATTEMPTS_PER_INTERVAL={}. The renewal \
+                 rate cap in recover_orphaned_subscriptions has regressed (#4601).",
+                m.max_cycle_batch,
+                MAX_RECOVERY_ATTEMPTS_PER_INTERVAL,
+            );
+        }
+
+        // (B) CAP ENGAGED on the loaded node — non-vacuous. With NUM_CONTRACTS
+        // (>cap) eligible simultaneously, the loaded node must have hit the cap in
+        // at least one cycle. If this is < cap the test proved nothing about the
+        // cap (demand never exceeded it), so the guard in (A) would be vacuous.
+        assert_eq!(
+            loaded_metrics.max_cycle_batch, MAX_RECOVERY_ATTEMPTS_PER_INTERVAL,
+            "loaded node never reached the renewal cap (seed {seed:x}): max_cycle_batch={}, \
+             expected exactly MAX_RECOVERY_ATTEMPTS_PER_INTERVAL={}. With {} contracts entering \
+             the renewal window together the cap must clip a cycle to exactly the cap; a lower \
+             value means the high-demand burst did not form and (A) is vacuous.",
+            loaded_metrics.max_cycle_batch, MAX_RECOVERY_ATTEMPTS_PER_INTERVAL, NUM_CONTRACTS,
+        );
+
+        // (C) MIGRATION genuinely ran — at least one hosted contract migrated
+        // onto another node via the directed-subscribe cascade. Without this the
+        // test could pass with migration silently inert (which would defeat its
+        // purpose as migration's scale home).
+        let mut migrated: Vec<(usize, usize)> = Vec::new();
+        for ci in 0..NUM_CONTRACTS {
+            // Non-loaded regular nodes are node_no 2..=num_nodes (node 1 is the
+            // loaded host; the loaded node hosting its own seeded contract is not
+            // a migration).
+            for n in 2..=num_nodes {
+                if result.is_node_hosting(&NodeLabel::node(network_name, n), &contract_keys[ci]) {
+                    migrated.push((ci, n));
+                }
+            }
+        }
+        assert!(
+            !migrated.is_empty(),
+            "placement migration was enabled but NO contract migrated off the loaded node to a \
+             closer neighbor (seed {seed:x}). Either the cascade is inert (gate regression) or \
+             the topology never let a neighbor become a migration target — the test is not \
+             exercising migration. (contract_idx, node_no) hosting pairs: {migrated:?}",
+        );
+
+        tracing::info!(
+            seed = format!("{seed:x}"),
+            migrated_pairs = migrated.len(),
+            "migration-at-scale: cap held, cap engaged, migration ran"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

The **Large scale test (500 nodes)** step of `Simulation Tests (Nightly)` has been red on ~4 of every 5 runs since 0.2.80 shipped (#4601). It is not an assertion failure — it hits the GitHub 60-minute wall-clock cap while drowning in subscribe / renewal / `get-subop` timeouts.

Root cause (confirmed in #4601): the placement-migration (`SubscribeHint`) cascade was supposed to stay dormant in simulations. That safety relied on sim peers reporting a crate version *below* the frozen floor `SUBSCRIBE_HINT_MIN_VERSION = (0,2,80)`. The moment 0.2.80 released, the crate version reached the floor, so the gate now fires in **every** simulation. Migration runs unthrottled in the general throughput nightly, piling directed-subscribe + renewal load onto an already-marginal 500-node topology (#4362) and pushing the run past the cap. The `node.rs` comment still claimed migration was "opt-in and cannot perturb unrelated simulations" — that contract had silently inverted.

This is a **simulation-only artifact**. The renewal path is already hard-bounded in production: `recover_orphaned_subscriptions` spawns at most `MAX_RECOVERY_ATTEMPTS_PER_INTERVAL = 10` renewals per `SUBSCRIPTION_RECOVERY_INTERVAL = 30s` per node, and prod telemetry shows real peers well under that cap with ~zero channel-full drops. So **no production change and no release are needed.**

## Solution (TEST-ONLY)

Option 1 from #4601 — restore sim isolation and give migration a dedicated, honest scale test.

1. **Restore sim isolation (the fix that greens the nightly).** `SimNetwork` now defaults the per-node `subscribe_hint_floor_override` to an unreachable floor (`SIM_MIGRATION_DISABLED_FLOOR = (255,255,65535)`) instead of `None`. This makes the `SubscribeHint` gate FAIL-CLOSED in every simulation regardless of build version — migration is genuinely opt-in, exactly as the docs always claimed. The general 500-node throughput nightly (`fdev test … single-process` → `SimNetwork::new`, which never opts in) now runs migration OFF and exits cleanly. **Production is untouched:** `NodeConfig::new` still sets `None` → the real `(0,2,80)` floor.

2. **Dedicated opt-in migration-at-scale test** (`test_placement_migration_at_scale_renewal_load_stays_bounded`). It explicitly calls `enable_placement_migration()`, hosts 20 contracts on one node (all entering the renewal window together so demand far exceeds the cap), runs past the renewal window, and asserts **bounded load**, not merely that the sim completes:
   - **(A) cap holds, every node:** per-node `max_cycle_batch <= MAX_RECOVERY_ATTEMPTS_PER_INTERVAL (10)`. This is the regression guard — if the per-cycle spawn cap were removed, the loaded node would record `max_cycle_batch == 20` and fail.
   - **(B) cap engaged, loaded node:** `max_cycle_batch == 10`, proving demand exceeded the cap and the cap actually clipped (so (A) isn't vacuous).
   - **(C) migration ran:** at least one contract migrated off the loaded node onto a closer neighbor, so the cascade is genuinely exercised.

   To measure (A)/(B) deterministically, a sim-gated `max_cycle_batch` counter was added to the existing renewal-metrics registry (`record_renewal_cycle_batch`, called once per renewal cycle). It is a **no-op in production** (gated on a simulation network name, exactly like the existing `wire_attempts` / `terminus_satisfied` counters) — no production behaviour change.

3. **Updated the now-stale comments** (`node.rs` `subscribe_hint_floor_override` doc, `SimNetwork::{enable,disable}_placement_migration` docs, the field doc) to reflect that the override now defaults fail-closed.

## Testing

- `cargo fmt` + `cargo clippy --locked -p freenet -- -D warnings` (CI-equivalent): clean.
- New test passes across 3 seeds: `loaded_max_cycle_batch=10`, `agg_max_cycle_batch=10` (cap held for every node), `migrated_pairs=72` (migration ran).
- Existing migration/renewal/fan-out tests still pass with the default flip + new metric: `test_contract_migrates_to_close_cluster_resolving_get_dead_end`, `test_get_dead_ends_at_close_cluster_without_migration`, `test_subscription_root_renewal_does_not_storm`, `test_no_interest_subscription_root_lease_lapses`, `test_fanout_liveness_incident_scale_migration_{off,on}`.
- The full 500-node repro (`fdev test --name nightly-large-500 …`) is ~60 min wall-clock and impractical to run locally here; the fix is structural — the fdev nightly path constructs `SimNetwork` without opting into migration, so the new fail-closed default turns migration OFF for it. CI's nightly run is the end-to-end confirmation.

This is **TEST-ONLY**: the production renewal path is already bounded (≤10/30s/node, frozen `SUBSCRIBE_HINT_MIN_VERSION`), so there is no production behaviour change and no release is required.

Closes #4601

[AI-assisted - Claude]
