### PR TITLE
feat: live secret-import core + local import endpoint (#4592 chunk 1)

### DIFF
--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1319,10 +1319,11 @@ where
     }
 }
 
-/// Send an `ImportSecretsResponse` to a still-waiting client inline (the
-/// rejection paths: no deferral ctx, busy, unsupported). Logs at debug if the
-/// client already disconnected. The import mirror of
-/// [`send_export_response_inline`] (#4592).
+/// Send the `ImportSecretsResponse` to the waiting client. Because the live
+/// import (#4592) runs fully ON the contract loop (no off-loop deferral, unlike
+/// the export), this is the SOLE response path for the import and carries EVERY
+/// outcome — success and failure alike — not just rejections. Logs at debug if
+/// the client already disconnected.
 async fn send_import_response_inline<CH>(
     contract_handler: &mut CH,
     id: handler::EventId,
@@ -1342,11 +1343,15 @@ async fn send_import_response_inline<CH>(
     }
 }
 
-/// Handle a completed off-loop import (#4592): return/replace the executor in the
-/// pool and answer the parked client. Runs ON the loop (the pool return needs
-/// `&mut contract_handler`), but the work is just a pool slot-return + a oneshot
-/// send — microseconds, never the import itself. Mirror of
-/// [`handle_export_resume`].
+/// Resume a PUT/UPDATE upsert whose related-contract fetch was deferred off-loop
+/// (#4391). Runs ON the contract loop. Reclaims the parked client responder,
+/// injects the off-loop-fetched related states so the re-run resolves them
+/// locally (no second network round trip), re-runs the upsert in DEFERRABLE mode
+/// (a further `DeferRelated` is converted to `MissingRelated` — the one-deferral
+/// cap), then answers the parked client exactly once. This is the related-contract
+/// upsert resume path, NOT a secrets-import path: the live import (#4592) runs
+/// fully on-loop and never defers (see the `ImportSecrets` arm and
+/// [`send_import_response_inline`]).
 async fn handle_deferred_resume<CH>(
     contract_handler: &mut CH,
     deferral_ctx: &mut DeferralCtx,

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -24,10 +24,11 @@ pub(crate) use executor::{
 // Re-export CRDT emulation functions for testing
 pub use executor::mock_runtime::{clear_crdt_contracts, is_crdt_contract, register_crdt_contract};
 pub(crate) use handler::{
-    ClientResponsesReceiver, ClientResponsesSender, ContractHandler, ContractHandlerChannel,
-    ContractHandlerEvent, NetworkContractHandler, RedactedToken, SenderHalve, SessionMessage,
-    StashedResponder, StoreResponse, WaitingResolution, WaitingTransaction,
-    client_responses_channel, contract_handler_channel,
+    BundleKeyKind, ClientResponsesReceiver, ClientResponsesSender, ContractHandler,
+    ContractHandlerChannel, ContractHandlerEvent, ImportBundle, ImportTargetScope,
+    NetworkContractHandler, RedactedToken, SenderHalve, SessionMessage, StashedResponder,
+    StoreResponse, WaitingResolution, WaitingTransaction, client_responses_channel,
+    contract_handler_channel,
     in_memory::{
         MemoryContractHandler, MockWasmContractHandler, MockWasmHandlerBuilder,
         SimulationContractHandler, SimulationHandlerBuilder,
@@ -1318,6 +1319,34 @@ where
     }
 }
 
+/// Send an `ImportSecretsResponse` to a still-waiting client inline (the
+/// rejection paths: no deferral ctx, busy, unsupported). Logs at debug if the
+/// client already disconnected. The import mirror of
+/// [`send_export_response_inline`] (#4592).
+async fn send_import_response_inline<CH>(
+    contract_handler: &mut CH,
+    id: handler::EventId,
+    result: Result<crate::wasm_runtime::secret_export::ImportReport, ExecutorError>,
+) where
+    CH: ContractHandler + Send + 'static,
+{
+    if let Err(error) = contract_handler
+        .channel()
+        .send_to_sender(id, ContractHandlerEvent::ImportSecretsResponse(result))
+        .await
+    {
+        tracing::debug!(
+            error = %error,
+            "Failed to send IMPORT response (client may have disconnected)"
+        );
+    }
+}
+
+/// Handle a completed off-loop import (#4592): return/replace the executor in the
+/// pool and answer the parked client. Runs ON the loop (the pool return needs
+/// `&mut contract_handler`), but the work is just a pool slot-return + a oneshot
+/// send — microseconds, never the import itself. Mirror of
+/// [`handle_export_resume`].
 async fn handle_deferred_resume<CH>(
     contract_handler: &mut CH,
     deferral_ctx: &mut DeferralCtx,
@@ -1838,6 +1867,10 @@ async fn send_queue_full_response(
         ContractHandlerEvent::ExportUserSecrets { .. } => {
             ContractHandlerEvent::ExportUserSecretsResponse(Err(make_err()))
         }
+        // Import likewise has a typed response variant the HTTP handler awaits.
+        ContractHandlerEvent::ImportSecrets { .. } => {
+            ContractHandlerEvent::ImportSecretsResponse(Err(make_err()))
+        }
         // Events without error response variants: drop the oneshot sender to
         // unblock the caller. The caller's receiver will get a RecvError, which
         // maps to ContractError::NoEvHandlerResponse. This prevents leaking
@@ -1845,6 +1878,7 @@ async fn send_queue_full_response(
         ContractHandlerEvent::DelegateRequest { .. }
         | ContractHandlerEvent::DelegateResponse(_)
         | ContractHandlerEvent::ExportUserSecretsResponse(_)
+        | ContractHandlerEvent::ImportSecretsResponse(_)
         | ContractHandlerEvent::PutResponse { .. }
         | ContractHandlerEvent::GetResponse { .. }
         | ContractHandlerEvent::UpdateResponse { .. }
@@ -2390,6 +2424,52 @@ where
                 }
             }
         }
+        ContractHandlerEvent::ImportSecrets {
+            target_scope,
+            bundle,
+            key_material,
+            key_kind,
+            overwrite,
+        } => {
+            // Live secret import (P3-live of #4592). Runs ON this serial contract
+            // loop — DELIBERATELY, unlike the hosted EXPORT which is off-loop.
+            //
+            // The import is the FIRST writer to the `SecretsStore` outside the
+            // serial loop's existing on-loop write path (delegate `store_secret`).
+            // The store's write path (fixed sibling `.tmp` + check-then-write
+            // collision handling) assumes node-wide write serialization; running
+            // the import off-loop on a separate pooled executor would let it race
+            // an on-loop delegate write (or another import) on the same secret
+            // file and corrupt it. Running it on the loop keeps every secret WRITE
+            // in one serialization domain, matching that assumption (Codex P1).
+            //
+            // Blocking the loop for the import's duration is acceptable here
+            // because — unlike the export — this endpoint is gated to LOOPBACK +
+            // the node's own dashboard origin (`hosted_import`): only the node's
+            // operator, over loopback, in a one-shot migration, can trigger it.
+            // It is NOT the authenticated-REMOTE token-holder DoS surface that
+            // justified moving export off-loop (#4381 P5). The request body is
+            // also bounded (`MAX_IMPORT_BUNDLE_BYTES`).
+            //
+            // Log only non-secret shape (bytes/scope/overwrite); never the key.
+            tracing::debug!(
+                bytes = bundle.expose().len(),
+                ?target_scope,
+                overwrite,
+                "Processing live secret import request"
+            );
+            let result = contract_handler
+                .executor()
+                .import_secrets(
+                    target_scope,
+                    bundle.expose(),
+                    key_material.expose(),
+                    key_kind,
+                    overwrite,
+                )
+                .await;
+            send_import_response_inline(contract_handler, id, result).await;
+        }
         ContractHandlerEvent::RegisterSubscriberListener {
             key,
             client_id,
@@ -2531,6 +2611,7 @@ where
         }
         ContractHandlerEvent::DelegateResponse(_)
         | ContractHandlerEvent::ExportUserSecretsResponse(_)
+        | ContractHandlerEvent::ImportSecretsResponse(_)
         | ContractHandlerEvent::PutResponse { .. }
         | ContractHandlerEvent::GetResponse { .. }
         | ContractHandlerEvent::UpdateResponse { .. }

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -156,6 +156,56 @@ impl std::fmt::Display for ExportBusy {
 
 impl std::error::Error for ExportBusy {}
 
+/// Typed marker carried by an [`ExecutorError`] when a live secret import failed
+/// on CLIENT-supplied input: a wrong decryption key, bad magic, a truncated or
+/// unsupported bundle, an unknown KDF, a malformed entry, or a post-decrypt CBOR
+/// parse failure. Lets the import HTTP layer downcast and return a 4xx (the
+/// client uploaded the wrong bundle/key) instead of a generic 500. The `message`
+/// is non-secret (it never echoes the key or any plaintext), so it is safe to
+/// surface. See #4592.
+#[derive(Debug, Clone)]
+pub struct ImportBadBundle {
+    pub message: String,
+}
+
+impl std::fmt::Display for ImportBadBundle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ImportBadBundle {}
+
+/// Classify a [`crate::wasm_runtime::secret_export::ExportError`] from an import
+/// as CLIENT-input (the uploaded bundle/key is wrong → 4xx) vs NODE-side (store
+/// / IO / internal → 500).
+///
+/// Exhaustive match (no wildcard) so a future `ExportError` variant fails to
+/// COMPILE here until it is explicitly classified — the catch-all would
+/// otherwise silently misclassify a new variant (and trip
+/// `clippy::wildcard_enum_match_arm`).
+pub(crate) fn is_bad_bundle_input(e: &crate::wasm_runtime::secret_export::ExportError) -> bool {
+    use crate::wasm_runtime::secret_export::ExportError;
+    match e {
+        // Client uploaded the wrong bundle or presented the wrong key.
+        ExportError::AuthFailed
+        | ExportError::BadMagic
+        | ExportError::UnsupportedVersion(_)
+        | ExportError::UnknownKdf(_)
+        | ExportError::Truncated(_)
+        | ExportError::BadEntryField { .. }
+        | ExportError::CborDe(_) => true,
+        // Node-side faults (or not reachable on the import path): a 500.
+        ExportError::TooLarge { .. }
+        | ExportError::Store(_)
+        | ExportError::Runtime(_)
+        | ExportError::CborSer(_)
+        | ExportError::Argon2(_)
+        | ExportError::EncryptFailed
+        | ExportError::Io(_) => false,
+    }
+}
+
 /// Typed marker carried by an [`ExecutorError`] when an upsert was invoked
 /// in *deferrable* mode (see [`ContractExecutor::upsert_contract_state_deferrable`])
 /// and discovered it needs to fetch related contracts from the network to
@@ -400,6 +450,18 @@ impl ExecutorError {
         match &self.inner {
             Either::Left(_) => false,
             Either::Right(err) => err.downcast_ref::<ExportBusy>().is_some(),
+        }
+    }
+
+    /// Returns true if this error is the typed [`ImportBadBundle`] marker (a live
+    /// import rejected because the client-supplied bundle/key was wrong: wrong
+    /// key, bad magic, truncated/unsupported bundle, or a malformed entry). The
+    /// import HTTP handler gates a 4xx on this — a client-input fault, NOT a node
+    /// fault, so it must not read as a 500. See #4592.
+    pub fn is_import_bad_bundle(&self) -> bool {
+        match &self.inner {
+            Either::Left(_) => false,
+            Either::Right(err) => err.downcast_ref::<ImportBadBundle>().is_some(),
         }
     }
 
@@ -712,6 +774,33 @@ pub(crate) trait ContractExecutor: Send + 'static {
         done: runtime::ExportDone,
     ) -> impl Future<Output = Result<Vec<u8>, ExecutorError>> + Send {
         async move { done.into_result() }
+    }
+
+    /// Import delegate secrets from an encrypted `bundle` into the node's secrets
+    /// store at `target_scope`, LIVE (#4592). Runs ON the contract loop
+    /// (serialized with delegate `store_secret`) — DELIBERATELY not off-loop like
+    /// the export, because the import WRITES and the store write path assumes
+    /// node-wide write serialization (see `RuntimePool::import_secrets` and the
+    /// `ImportSecrets` arm in `contract.rs`).
+    ///
+    /// Default returns a not-supported error: only the production `RuntimePool`
+    /// (which owns real `SecretsStore`-backed executors) supports import; mock
+    /// executors keep no on-disk secrets.
+    fn import_secrets(
+        &mut self,
+        _target_scope: crate::contract::handler::ImportTargetScope,
+        _bundle: &[u8],
+        _key: &[u8],
+        _key_kind: crate::contract::handler::BundleKeyKind,
+        _overwrite: bool,
+    ) -> impl Future<
+        Output = Result<crate::wasm_runtime::secret_export::ImportReport, ExecutorError>,
+    > + Send {
+        async move {
+            Err(ExecutorError::other(anyhow::anyhow!(
+                "secret import is not supported by this executor"
+            )))
+        }
     }
 
     fn get_subscription_info(&self) -> Vec<crate::message::SubscriptionInfo>;

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -52,6 +52,48 @@ impl Executor<Runtime> {
             })
     }
 
+    /// Import delegate secrets from an encrypted `bundle` into this node's
+    /// secrets store at `target_scope`, LIVE — the durable counterpart of
+    /// [`Self::export_user_secrets`] and the mutating mirror of it (P3-live of
+    /// #4592). Runs on the executor (which owns the `SecretsStore` via its
+    /// `Runtime`). Unlike the read-only export, this is invoked ON the contract
+    /// loop by the pool caller (`RuntimePool::import_secrets`) — the import WRITES
+    /// and the store write path assumes node-wide write serialization, so it must
+    /// not run off-loop where it could race another writer on the same secret.
+    ///
+    /// The bundle is decrypted under `material`; `import_bundle` authenticates
+    /// the WHOLE bundle BEFORE writing anything, so a wrong key / corrupt bundle
+    /// fails with NOTHING written (all-or-nothing on the key). `overwrite`
+    /// controls collision handling (skip+report vs overwrite-with-snapshot).
+    ///
+    /// A client-input failure (wrong key, bad magic, truncated/unsupported
+    /// bundle, malformed entry) is preserved as the typed [`ImportBadBundle`]
+    /// marker so the HTTP layer can map it to a 4xx instead of a generic 500;
+    /// its `Display` text is non-secret (never echoes the key or plaintext).
+    /// Node-side failures (store/IO) stay an opaque executor error (→ 500). The
+    /// `material` and the plaintext it decrypts live only in borrowed/`Zeroizing`
+    /// buffers; nothing is logged.
+    pub fn import_secrets(
+        &mut self,
+        target_scope: &crate::wasm_runtime::secret_export::TargetScope,
+        bundle: &[u8],
+        material: &crate::wasm_runtime::secret_export::BundleKeyMaterial<'_>,
+        overwrite: bool,
+    ) -> Result<crate::wasm_runtime::secret_export::ImportReport, ExecutorError> {
+        use crate::contract::executor::{ImportBadBundle, is_bad_bundle_input};
+        self.runtime
+            .import_secret_bundle(bundle, material, target_scope, overwrite)
+            .map_err(|e| {
+                if is_bad_bundle_input(&e) {
+                    ExecutorError::other(ImportBadBundle {
+                        message: e.to_string(),
+                    })
+                } else {
+                    ExecutorError::other(anyhow::anyhow!("secret import failed: {e}"))
+                }
+            })
+    }
+
     pub fn delegate_request(
         &mut self,
         req: DelegateRequest<'_>,

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -107,6 +107,12 @@ pub struct RuntimePool {
     /// enforced anti-deadlock invariant (see `effective_export_permits`), not a
     /// prose hope. `Arc` so an admitted `ExportJob` can hold an owned permit
     /// across the spawned background task without borrowing the pool.
+    ///
+    /// NOTE: this is EXPORT-only. The live secret IMPORT (#4592) deliberately
+    /// runs ON the contract loop (serialized with delegate `store_secret`), not
+    /// off-loop, so it takes no permit here — see the `import_secrets` impl and
+    /// the `ImportSecrets` arm in `contract.rs` for why (the store write path
+    /// assumes node-wide write serialization).
     export_semaphore: Arc<Semaphore>,
     /// Inactive-user reclaim sweep task (#4561, P5 of #4381). `Some` ONLY when
     /// hosted mode is on AND `per-user-inactive-ttl > 0`. The pool owns the
@@ -1161,6 +1167,46 @@ impl ContractExecutor for RuntimePool {
                 }
             }
         }
+        result
+    }
+
+    /// Run a live secret import ON the contract loop (#4592). DELIBERATELY
+    /// on-loop, NOT off-loop like the export: the import WRITES to the
+    /// `SecretsStore`, whose write path (fixed sibling `.tmp` + check-then-write)
+    /// assumes node-wide write serialization. Checking out a pooled executor and
+    /// running the import here — awaited by the single-threaded contract loop —
+    /// keeps every secret write in one serialization domain (with delegate
+    /// `store_secret`), so an import can never race another writer on the same
+    /// secret file (Codex P1). The heavy work is acceptable on the loop because
+    /// the endpoint is loopback + dashboard-gated (operator's one-shot migration),
+    /// not the authenticated-remote DoS surface that justified off-loop export.
+    ///
+    /// `pop_executor().await` always succeeds promptly: an in-flight export holds
+    /// at most `pool_size-1` executors, so >=1 is always free for the loop.
+    async fn import_secrets(
+        &mut self,
+        target_scope: crate::contract::handler::ImportTargetScope,
+        bundle: &[u8],
+        key: &[u8],
+        key_kind: crate::contract::handler::BundleKeyKind,
+        overwrite: bool,
+    ) -> Result<crate::wasm_runtime::secret_export::ImportReport, ExecutorError> {
+        use crate::contract::handler::{BundleKeyKind, ImportTargetScope};
+        use crate::wasm_runtime::secret_export::{BundleKeyMaterial, TargetScope};
+        let mut executor = self.pop_executor().await;
+        let scope = match target_scope {
+            ImportTargetScope::Local => TargetScope::Local,
+        };
+        let material = match key_kind {
+            BundleKeyKind::Token => BundleKeyMaterial::Token(key),
+            BundleKeyKind::Passphrase => BundleKeyMaterial::Passphrase(key),
+        };
+        // Synchronous decrypt + per-secret write. No `.await` between checkout and
+        // return, so the executor is held for exactly this op.
+        let result = executor.import_secrets(&scope, bundle, &material, overwrite);
+        // The import runs no WASM, so the executor stays healthy; route it back
+        // through the health-checked return for accounting parity with every op.
+        self.return_checked(executor, "import_secrets").await;
         result
     }
 

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -465,6 +465,8 @@ fn extract_contract_id(event: &ContractHandlerEvent) -> Option<ContractInstanceI
         | ContractHandlerEvent::DelegateResponse(_)
         | ContractHandlerEvent::ExportUserSecrets { .. }
         | ContractHandlerEvent::ExportUserSecretsResponse(_)
+        | ContractHandlerEvent::ImportSecrets { .. }
+        | ContractHandlerEvent::ImportSecretsResponse(_)
         | ContractHandlerEvent::PutResponse { .. }
         | ContractHandlerEvent::GetResponse { .. }
         | ContractHandlerEvent::UpdateResponse { .. }

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -732,6 +732,55 @@ impl std::fmt::Debug for RedactedToken {
     }
 }
 
+/// Which key-derivation the import bundle was sealed with. The bundle header
+/// also records the KDF, and [`crate::wasm_runtime::secret_export::open_bundle`]
+/// rejects a mismatch with a clean auth failure — so a wrong `kind` surfaces as
+/// a 4xx (bad key/bundle), never a panic or a 500.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BundleKeyKind {
+    /// HKDF-SHA256 over the opaque per-user token (the hosted-export default).
+    Token,
+    /// Argon2id over a user passphrase (the offline `freenet secrets export
+    /// --passphrase` form, supported for the file-upload fallback).
+    Passphrase,
+}
+
+/// Where a live import places the incoming secrets. v1 supports only `Local`
+/// (a normal single-user node taking its data home, #4592); the `User` re-host
+/// target is reserved for a future hosted-side flow and is not constructed by
+/// any current endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ImportTargetScope {
+    /// Place imported secrets at the node-local / single-user scope.
+    Local,
+}
+
+/// The raw bundle bytes carried on a [`ContractHandlerEvent::ImportSecrets`]
+/// event. Wraps `Vec<u8>` only so its `Debug` prints the byte LENGTH instead of
+/// dumping the (up-to-256-MiB) ciphertext into a log line — `ContractHandlerEvent`
+/// derives `Debug` and is logged. The bytes are encrypted-at-rest ciphertext
+/// (the plaintext is only ever materialized inside `import_bundle`'s `Zeroizing`
+/// buffers), not a secret; the wrapper exists purely to keep a multi-hundred-
+/// megabyte `?event` log line from ever forming.
+pub(crate) struct ImportBundle(Vec<u8>);
+
+impl ImportBundle {
+    pub(crate) fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the raw bundle bytes (handed to `import_bundle`).
+    pub(crate) fn expose(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for ImportBundle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ImportBundle({} bytes)", self.0.len())
+    }
+}
+
 #[derive(Debug)]
 pub(crate) enum ContractHandlerEvent {
     DelegateRequest {
@@ -766,6 +815,32 @@ pub(crate) enum ContractHandlerEvent {
     /// Response to an `ExportUserSecrets` request: the encrypted bundle bytes,
     /// or an executor error.
     ExportUserSecretsResponse(Result<Vec<u8>, ExecutorError>),
+    /// Import delegate secrets from an encrypted bundle into this node's local
+    /// (single-user) `SecretsStore`, LIVE — without stopping the node (P3-live
+    /// of #4592, the durable counterpart of [`Self::ExportUserSecrets`]). The
+    /// raw `bundle` bytes are decrypted with `key_material` (interpreted per
+    /// `key_kind`); the decrypt is all-or-nothing and runs BEFORE any write, so
+    /// a wrong key / corrupt bundle fails with nothing written.
+    ///
+    /// `key_material` is the high-value bundle decryption key, redacted in
+    /// `Debug` and wiped on drop; `bundle`'s `Debug` prints only its length.
+    /// Neither is ever rendered by the `Display` impl.
+    ImportSecrets {
+        /// Where the imported secrets land. v1 is always `Local`.
+        target_scope: ImportTargetScope,
+        /// The encrypted bundle bytes (`FNSX` format).
+        bundle: ImportBundle,
+        /// Raw bundle-key material, redacted in `Debug` and wiped on drop.
+        key_material: RedactedToken,
+        /// How to interpret `key_material` (token-HKDF vs passphrase-Argon2id).
+        key_kind: BundleKeyKind,
+        /// Collision policy: `false` skips+reports an entry whose secret already
+        /// exists; `true` overwrites it (the prior value is snapshotted first).
+        overwrite: bool,
+    },
+    /// Response to an `ImportSecrets` request: the per-entry import accounting,
+    /// or an executor error.
+    ImportSecretsResponse(Result<crate::wasm_runtime::secret_export::ImportReport, ExecutorError>),
     /// Try to push/put a new value into the contract
     PutQuery {
         key: ContractKey,
@@ -1000,6 +1075,28 @@ impl std::fmt::Display for ContractHandlerEvent {
                     bundle.len()
                 ),
                 Err(e) => write!(f, "export user secrets failed {{ {e} }}"),
+            },
+            // `key_material` deliberately omitted (high-value credential); the
+            // bundle is rendered as a byte count only (never its contents).
+            ContractHandlerEvent::ImportSecrets {
+                target_scope,
+                bundle,
+                key_kind,
+                overwrite,
+                ..
+            } => write!(
+                f,
+                "import secrets {{ scope: {target_scope:?}, {} bytes, kind: {key_kind:?}, overwrite: {overwrite} }}",
+                bundle.expose().len()
+            ),
+            ContractHandlerEvent::ImportSecretsResponse(result) => match result {
+                Ok(report) => write!(
+                    f,
+                    "import secrets response {{ imported: {}, skipped: {} }}",
+                    report.imported,
+                    report.skipped.len()
+                ),
+                Err(e) => write!(f, "import secrets failed {{ {e} }}"),
             },
         }
     }

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -518,6 +518,8 @@ pub(crate) async fn has_contract(
         | crate::contract::ContractHandlerEvent::DelegateResponse(_)
         | crate::contract::ContractHandlerEvent::ExportUserSecrets { .. }
         | crate::contract::ContractHandlerEvent::ExportUserSecretsResponse(_)
+        | crate::contract::ContractHandlerEvent::ImportSecrets { .. }
+        | crate::contract::ContractHandlerEvent::ImportSecretsResponse(_)
         | crate::contract::ContractHandlerEvent::PutQuery { .. }
         | crate::contract::ContractHandlerEvent::PutResponse { .. }
         | crate::contract::ContractHandlerEvent::GetQuery { .. }

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -635,6 +635,8 @@ pub(crate) async fn update_contract(
                             | ContractHandlerEvent::DelegateResponse(_)
                             | ContractHandlerEvent::ExportUserSecrets { .. }
                             | ContractHandlerEvent::ExportUserSecretsResponse(_)
+                            | ContractHandlerEvent::ImportSecrets { .. }
+                            | ContractHandlerEvent::ImportSecretsResponse(_)
                             | ContractHandlerEvent::PutQuery { .. }
                             | ContractHandlerEvent::PutResponse { .. }
                             | ContractHandlerEvent::GetQuery { .. }

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -95,6 +95,7 @@ fn sandbox_origin_from_headers(headers: &axum::http::HeaderMap) -> String {
 }
 
 pub(crate) mod hosted_export;
+pub(crate) mod hosted_import;
 mod permission_prompts;
 mod v1;
 mod v2;
@@ -215,6 +216,12 @@ impl HttpClientApi {
             // `ExportOpManagerHandle` Extension below.
             .merge(hosted_export::routes(ApiVersion::V1))
             .merge(hosted_export::routes(ApiVersion::V2))
+            // Live "import my data" endpoint (P3-live of #4592). Writes secrets,
+            // so it is gated to the node's own dashboard origin over loopback
+            // (see `hosted_import`). Reuses the SAME per-node
+            // `ExportOpManagerHandle` Extension below to reach the executor.
+            .merge(hosted_import::routes(ApiVersion::V1))
+            .merge(hosted_import::routes(ApiVersion::V2))
             .merge(permission_prompts::routes())
             .layer(Extension(origin_contracts.clone()))
             .layer(Extension(pending_prompts))

--- a/crates/core/src/server/client_api/hosted_export.rs
+++ b/crates/core/src/server/client_api/hosted_export.rs
@@ -127,7 +127,11 @@ impl ExportOpManagerHandle {
     }
 
     /// Resolve the live `OpManager`, if the node is up and not torn down.
-    fn current(&self) -> Option<Arc<OpManager>> {
+    ///
+    /// `pub(crate)` so the live-import endpoint (`hosted_import`) can REUSE this
+    /// same per-node handle to reach the executor (it submits an `ImportSecrets`
+    /// event on the same op_manager the export endpoint uses).
+    pub(crate) fn current(&self) -> Option<Arc<OpManager>> {
         self.0.get().and_then(Weak::upgrade)
     }
 }

--- a/crates/core/src/server/client_api/hosted_import.rs
+++ b/crates/core/src/server/client_api/hosted_import.rs
@@ -43,13 +43,24 @@
 //!    `Origin: null`, which is exactly what a sandboxed contract iframe presents
 //!    (the sandbox omits `allow-same-origin`), so the per-contract iframe is
 //!    excluded here.
-//! 3. **No per-contract `AuthToken`.** A per-contract webapp's shell page is
-//!    same-origin with the node (so it would pass the origin check) but carries a
-//!    per-contract `AuthToken` registered in the [`OriginContractMap`]. The
-//!    node's own first-party dashboard carries no such token. So any request
-//!    presenting a registered origin-contract token — via the `Authorization`
-//!    bearer header, the `authToken` query param, or the `Authorization` cookie —
-//!    is rejected, excluding the per-contract `AuthToken` origin.
+//! 3. **No per-contract `AuthToken`** (best-effort defense-in-depth, NOT the
+//!    primary iframe exclusion). A per-contract webapp's shell page is
+//!    same-origin with the node, so it would pass check #2; it carries a
+//!    per-contract `AuthToken` registered in the [`OriginContractMap`], while the
+//!    node's own first-party dashboard carries none. So a request presenting a
+//!    registered origin-contract token — via the `Authorization` bearer header,
+//!    the `authToken` query param, or the `Authorization` cookie — is rejected.
+//!    But this only CLASSIFIES a *well-behaved* client that actually presents its
+//!    token: a hostile script could simply omit the token to evade this check, so
+//!    #3 cannot be relied on to exclude a malicious contract web app on its own.
+//!
+//! The load-bearing exclusion of sandboxed contract iframes is **check #2**: the
+//! sandbox omits `allow-same-origin`, so the iframe presents `Origin: null`,
+//! which `is_origin_trusted` rejects. Check #3 is an extra layer that catches a
+//! cooperative same-origin shell page; it does NOT backstop #2. A future
+//! maintainer MUST NOT weaken check #2 (e.g. start admitting `Origin: null` or a
+//! cross-site origin) on the belief that #3 will still keep contract web apps
+//! out — it will not.
 //!
 //! The bundle's decryption key is the real authorization for the DATA: a caller
 //! who passes the gate still cannot import anything they cannot decrypt. The
@@ -186,6 +197,17 @@ fn import_gate_or_reject(
             "import is not available to contract web apps",
         ));
     }
+
+    // DEFERRED (Sec-Fetch-Site hardening, #4592 follow-up): browsers attach
+    // `Sec-Fetch-Site: same-origin` to a first-party fetch and `cross-site` to a
+    // cross-origin one. Checking it would add a fetch-metadata CSRF layer on top
+    // of the Origin gate (#2). We do NOT enforce it here on purpose: the header
+    // is browser-only, so a legitimate non-browser client (a future
+    // `freenet secrets import --live` CLI, curl in a migration script) omits it
+    // entirely. "Reject when missing" would break those clients; "enforce only
+    // when present" is weaker and needs a deliberate call. Left as a follow-up
+    // decision rather than a silent default. Until then the Origin gate (#2) is
+    // the CSRF boundary.
 
     Ok(())
 }

--- a/crates/core/src/server/client_api/hosted_import.rs
+++ b/crates/core/src/server/client_api/hosted_import.rs
@@ -1,0 +1,666 @@
+//! Live "import my data" HTTP endpoint (P3-live of #4592, CHUNK 1).
+//!
+//! `POST /v{1,2}/import` writes delegate secrets from an encrypted P3
+//! [`crate::wasm_runtime::secret_export`] bundle (`FNSX` format) into THIS
+//! node's local single-user [`crate::wasm_runtime::secrets_store::SecretsStore`]
+//! — LIVE, while the node keeps running. It is the durable counterpart of the
+//! live EXPORT (`hosted_export`) and the backend for both the magic-link pull
+//! and the file-upload fallback of #4592.
+//!
+//! # Why route through the running node (not open ReDb directly)
+//!
+//! The offline `freenet secrets import` CLI opens the secrets ReDb directly,
+//! which is single-writer — so it requires the node to be STOPPED. This endpoint
+//! instead submits a [`crate::contract::ContractHandlerEvent::ImportSecrets`]
+//! event to the running node's contract loop, which routes it to the ONE
+//! legitimate `SecretsStore` (owned by a pooled executor). Unlike the read-only
+//! export (which runs off-loop), the import runs ON the contract loop (see
+//! `RuntimePool::import_secrets`): it WRITES, and the store write path assumes
+//! node-wide write serialization, so on-loop keeps every secret write in one
+//! serialization domain (with delegate `store_secret`). The brief loop-block is
+//! acceptable because this endpoint is loopback + dashboard-gated (a one-shot
+//! operator migration), not the authenticated-remote DoS surface of the export.
+//!
+//! # Security — the import GATE (fail-closed)
+//!
+//! This endpoint WRITES secrets, so it is the highest-value write surface in the
+//! HTTP API. The receiving node is a NORMAL single-user node (hosted mode OFF)
+//! importing into [`crate::wasm_runtime::secrets_store::SecretScope::Local`], so
+//! it does NOT reuse the hosted-export token gate (which needs hosted ON + a
+//! per-user token). Instead it must be reachable ONLY from the node's own
+//! dashboard/shell origin over loopback — NEVER from a per-contract `AuthToken`
+//! origin or a sandboxed contract iframe. The gate ([`import_gate_or_reject`])
+//! enforces, in order:
+//!
+//! 1. **Loopback source IP**, read from the kernel-set `ConnectInfo<SocketAddr>`
+//!    (not spoofable off-host). A MISSING `ConnectInfo` (only in unit tests that
+//!    omit it) fails CLOSED — we cannot prove loopback, so we reject. Mirrors
+//!    the export handler's source-IP read.
+//! 2. **Trusted dashboard/shell origin**, via the SAME
+//!    [`super::permission_prompts::is_origin_trusted`] decision the
+//!    permission-prompt CSRF guard uses: the `Origin` header must be present and
+//!    match a loopback / LAN-CIDR / allowed-host origin. That helper REJECTS
+//!    `Origin: null`, which is exactly what a sandboxed contract iframe presents
+//!    (the sandbox omits `allow-same-origin`), so the per-contract iframe is
+//!    excluded here.
+//! 3. **No per-contract `AuthToken`.** A per-contract webapp's shell page is
+//!    same-origin with the node (so it would pass the origin check) but carries a
+//!    per-contract `AuthToken` registered in the [`OriginContractMap`]. The
+//!    node's own first-party dashboard carries no such token. So any request
+//!    presenting a registered origin-contract token — via the `Authorization`
+//!    bearer header, the `authToken` query param, or the `Authorization` cookie —
+//!    is rejected, excluding the per-contract `AuthToken` origin.
+//!
+//! The bundle's decryption key is the real authorization for the DATA: a caller
+//! who passes the gate still cannot import anything they cannot decrypt. The
+//! decrypt is all-or-nothing and happens BEFORE any write
+//! ([`crate::wasm_runtime::secret_export::import_bundle`] → `open_bundle`), so a
+//! wrong key surfaces as a 4xx with NOTHING written — never a 500, never a
+//! partial write. The key material rides in a HEADER (never the URL/logs), in a
+//! redacted/zeroizing wrapper, and is never logged.
+
+use axum::{
+    Json, Router,
+    extract::{ConnectInfo, DefaultBodyLimit},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::post,
+};
+use std::net::{IpAddr, SocketAddr};
+
+use crate::client_events::AuthToken;
+use crate::client_events::websocket::is_loopback_source;
+use crate::contract::{
+    BundleKeyKind, ContractHandlerEvent, ImportBundle, ImportTargetScope, Priority, RedactedToken,
+};
+use crate::node::OpManager;
+use crate::server::{AllowedHosts, AllowedSourceCidrs};
+use crate::wasm_runtime::secret_export::MAX_EXPORT_TOTAL_PLAINTEXT_BYTES;
+
+use super::hosted_export::ExportOpManagerHandle;
+use super::permission_prompts::is_origin_trusted;
+use super::{ApiVersion, OriginContractMap};
+
+/// Header carrying the bundle decryption key (the token, or passphrase). A
+/// HEADER (not a query param) so this high-value secret never lands in the
+/// request URI / access logs — same discipline as the export's
+/// `X-Freenet-User-Token`.
+const BUNDLE_KEY_HEADER: &str = "x-freenet-bundle-key";
+
+/// Header selecting how to interpret [`BUNDLE_KEY_HEADER`]: `token` (default,
+/// the hosted-export form) or `passphrase` (the offline `--passphrase` form).
+const BUNDLE_KEY_KIND_HEADER: &str = "x-freenet-bundle-key-kind";
+
+/// Header controlling collision handling: `true` overwrites an existing secret,
+/// anything else (default) skips + reports it. Off unless explicitly opted in.
+const OVERWRITE_HEADER: &str = "x-freenet-import-overwrite";
+
+/// `authToken` cookie / bearer name used by the per-contract web shell (see
+/// `client_api.rs` — the cookie is set under the `Authorization` header name,
+/// lowercased on the wire).
+const AUTHORIZATION_NAME: &str = "authorization";
+
+/// Request-body cap for the uploaded bundle, sized to accept ANY bundle the
+/// existing `export_bundle` can produce (so a valid max-size export is never
+/// rejected with a spurious 413), while still bounding what one import buffers.
+///
+/// The export limit ([`MAX_EXPORT_TOTAL_PLAINTEXT_BYTES`]) counts DECRYPTED
+/// plaintext bytes, but the bundle body is CBOR-serialized BEFORE encryption and
+/// `secret_export` encodes each secret's `Vec<u8>` as a CBOR ARRAY OF INTEGERS,
+/// not a byte string (a deliberate choice — see its `BundleEntry` note), so a
+/// plaintext byte costs up to 2 bytes on the wire. A legitimate export can thus
+/// serialize to ~2x its plaintext, plus per-entry delegate-key/code-hash/
+/// secret-hash CBOR arrays (bounded by `MAX_EXPORT_SECRET_COUNT`) and the small
+/// header + AEAD tag. We size the cap to `2x plaintext + 64 MiB` — the doubling
+/// covers the CBOR integer-array overhead and the 64 MiB margin generously
+/// covers the per-entry key/hash overhead (~200 B x up to 10k entries) plus
+/// framing. Over the cap → HTTP 413.
+const MAX_IMPORT_BUNDLE_BYTES: usize = 2 * MAX_EXPORT_TOTAL_PLAINTEXT_BYTES + 64 * 1024 * 1024;
+
+/// Registers the live-import route for `version`. The handler reaches the node
+/// through the per-node [`ExportOpManagerHandle`] carried as a request
+/// `Extension` (the SAME handle the export endpoint uses, injected in
+/// `HttpClientApi::as_router_with_origin_contracts`). A [`DefaultBodyLimit`] of
+/// [`MAX_IMPORT_BUNDLE_BYTES`] bounds the uploaded bundle.
+pub(super) fn routes(version: ApiVersion) -> Router {
+    let path = format!("/{}/import", version.prefix());
+    Router::new()
+        .route(&path, post(import_handler))
+        .layer(DefaultBodyLimit::max(MAX_IMPORT_BUNDLE_BYTES))
+}
+
+/// Apply the live-import gate. Pure + unit-testable: takes the request's headers,
+/// the kernel-set source IP, the host/CIDR allowlists, the (raw) query string,
+/// and the origin-contract map, and decides whether the request may import.
+///
+/// On rejection returns `(StatusCode::FORBIDDEN, reason)` with a fixed,
+/// non-secret reason string (never echoes the key or any token). See the module
+/// docs for the three layered checks. FAIL-CLOSED throughout.
+fn import_gate_or_reject(
+    headers: &HeaderMap,
+    source_ip: Option<IpAddr>,
+    allowed_hosts: Option<&AllowedHosts>,
+    allowed_source_cidrs: Option<&AllowedSourceCidrs>,
+    query: Option<&str>,
+    origin_contracts: &OriginContractMap,
+) -> Result<(), (StatusCode, &'static str)> {
+    // (1) Loopback source. A missing ConnectInfo cannot prove loopback ⇒ reject
+    // (fail closed), mirroring the export handler.
+    let Some(ip) = source_ip else {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "import requires a loopback connection",
+        ));
+    };
+    if !is_loopback_source(ip) {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "import requires a loopback connection",
+        ));
+    }
+
+    // (2) Trusted dashboard/shell origin. The Origin header must be present and
+    // pass the shared `is_origin_trusted` decision, which rejects `Origin: null`
+    // (the sandboxed contract iframe) and cross-site origins, and requires a
+    // loopback / LAN-CIDR / allowed-host origin.
+    let Some(origin) = headers.get("origin").and_then(|v| v.to_str().ok()) else {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "import requires a trusted same-origin request (missing Origin)",
+        ));
+    };
+    if !is_origin_trusted(headers, origin, allowed_hosts, allowed_source_cidrs) {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "import is only available from the node's own dashboard origin",
+        ));
+    }
+
+    // (3) Exclude per-contract AuthToken origins. The node's first-party
+    // dashboard carries no per-contract token; a per-contract web shell does.
+    // Reject if ANY presented credential (bearer header / authToken query /
+    // Authorization cookie) is a registered origin-contract token.
+    if presented_tokens(headers, query).any(|tok| origin_contracts.contains_key(&tok)) {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "import is not available to contract web apps",
+        ));
+    }
+
+    Ok(())
+}
+
+/// Collect every `AuthToken` candidate the request presents, across the three
+/// channels a per-contract web shell could carry one on: the `Authorization`
+/// bearer header, the `authToken` query param, and the `Authorization` cookie
+/// (value `Bearer <token>`). Pure (no map lookup) so it is unit-testable on its
+/// own; the gate checks each against the origin-contract map.
+fn presented_tokens<'a>(
+    headers: &'a HeaderMap,
+    query: Option<&'a str>,
+) -> impl Iterator<Item = AuthToken> + 'a {
+    let mut tokens: Vec<AuthToken> = Vec::new();
+
+    // (a) Authorization: Bearer <token>
+    if let Some(v) = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        && let Some(tok) = strip_bearer(v)
+    {
+        tokens.push(AuthToken::from(tok.to_owned()));
+    }
+
+    // (b) ?authToken=<token>
+    if let Some(q) = query {
+        for (k, val) in url_query_pairs(q) {
+            if k == "authToken" && !val.is_empty() {
+                tokens.push(AuthToken::from(val));
+            }
+        }
+    }
+
+    // (c) Cookie: authorization=Bearer <token> (the per-contract shell cookie).
+    if let Some(cookies) = headers
+        .get(axum::http::header::COOKIE)
+        .and_then(|v| v.to_str().ok())
+    {
+        for part in cookies.split(';') {
+            let part = part.trim();
+            if let Some((name, value)) = part.split_once('=')
+                && name.trim().eq_ignore_ascii_case(AUTHORIZATION_NAME)
+            {
+                // The value may be `Bearer <tok>` (possibly quoted / %20-encoded
+                // for the space). Strip a Bearer prefix in any of those forms;
+                // otherwise treat the whole value as the token.
+                let value = value.trim().trim_matches('"');
+                let tok = strip_bearer(value)
+                    .or_else(|| value.strip_prefix("Bearer%20"))
+                    .unwrap_or(value);
+                if !tok.is_empty() {
+                    tokens.push(AuthToken::from(tok.to_owned()));
+                }
+            }
+        }
+    }
+
+    tokens.into_iter()
+}
+
+/// Strip a `Bearer ` (case-insensitive, single ASCII space) prefix from an
+/// `Authorization` value, returning the bare token. `None` if the value is not a
+/// bearer credential.
+fn strip_bearer(value: &str) -> Option<&str> {
+    let rest = value.strip_prefix("Bearer ").or_else(|| {
+        value
+            .get(..7)
+            .filter(|p| p.eq_ignore_ascii_case("Bearer "))
+            .map(|_| &value[7..])
+    })?;
+    Some(rest.trim())
+}
+
+/// Minimal `application/x-www-form-urlencoded` query splitter for the `authToken`
+/// lookup. Does NOT percent-decode (the gate only needs to MATCH a token, and a
+/// percent-encoded token would simply not match a registered one — fail safe).
+fn url_query_pairs(query: &str) -> impl Iterator<Item = (&str, String)> {
+    query.split('&').filter_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        Some((k, v.to_owned()))
+    })
+}
+
+/// Parse the bundle-key-kind header. Default [`BundleKeyKind::Token`] (the
+/// hosted-export form). An unrecognized value is a client error (400).
+fn parse_key_kind(headers: &HeaderMap) -> Result<BundleKeyKind, (StatusCode, &'static str)> {
+    match headers
+        .get(BUNDLE_KEY_KIND_HEADER)
+        .and_then(|v| v.to_str().ok())
+    {
+        None => Ok(BundleKeyKind::Token),
+        Some(s) if s.eq_ignore_ascii_case("token") => Ok(BundleKeyKind::Token),
+        Some(s) if s.eq_ignore_ascii_case("passphrase") => Ok(BundleKeyKind::Passphrase),
+        Some(_) => Err((
+            StatusCode::BAD_REQUEST,
+            "X-Freenet-Bundle-Key-Kind must be 'token' or 'passphrase'",
+        )),
+    }
+}
+
+/// `POST /v{1,2}/import` — import delegate secrets from an encrypted bundle into
+/// this node's Local scope, live.
+///
+/// Takes the whole `Request` (rather than typed extractors) so it can read the
+/// `ConnectInfo<SocketAddr>` source and the host/CIDR/origin-contract extensions
+/// from `extensions()` directly — the same approach the export handler uses, and
+/// necessary because this crate builds `axum` without the `ConnectInfo`
+/// extractor feature. The body is read AFTER the gate + readiness checks so an
+/// unauthorized or not-ready request never makes the node buffer a large bundle.
+async fn import_handler(req: axum::extract::Request) -> Response {
+    let (parts, body) = req.into_parts();
+    let headers = &parts.headers;
+
+    // Source IP from the kernel-set ConnectInfo extension; missing ⇒ fail closed.
+    let source_ip = parts
+        .extensions
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0.ip());
+
+    let allowed_hosts = parts.extensions.get::<AllowedHosts>();
+    let allowed_source_cidrs = parts.extensions.get::<AllowedSourceCidrs>();
+    // Origin-contract map is always present (layered in
+    // `as_router_with_origin_contracts`); absent only in a standalone test
+    // composition, in which case there are no per-contract tokens to exclude.
+    let empty_origin_contracts: OriginContractMap = std::sync::Arc::new(dashmap::DashMap::new());
+    let origin_contracts = parts
+        .extensions
+        .get::<OriginContractMap>()
+        .unwrap_or(&empty_origin_contracts);
+
+    if let Err((status, reason)) = import_gate_or_reject(
+        headers,
+        source_ip,
+        allowed_hosts,
+        allowed_source_cidrs,
+        parts.uri.query(),
+        origin_contracts,
+    ) {
+        // Never log the key. Log only the non-secret source IP + reason.
+        tracing::warn!(source_ip = ?source_ip, reason, "Rejected live import request");
+        return (status, reason).into_response();
+    }
+
+    // Bundle key material (required, non-empty) from the HEADER only.
+    let key = match headers.get(BUNDLE_KEY_HEADER).and_then(|v| v.to_str().ok()) {
+        Some(k) if !k.is_empty() => k.to_owned(),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                "import requires a bundle key (X-Freenet-Bundle-Key header)",
+            )
+                .into_response();
+        }
+    };
+    let key_kind = match parse_key_kind(headers) {
+        Ok(k) => k,
+        Err((status, reason)) => return (status, reason).into_response(),
+    };
+    let overwrite = headers
+        .get(OVERWRITE_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.eq_ignore_ascii_case("true"));
+
+    // Per-node route to the executor (the SAME handle the export uses). Absent /
+    // not-yet-filled ⇒ 503.
+    let op_manager = parts
+        .extensions
+        .get::<ExportOpManagerHandle>()
+        .and_then(ExportOpManagerHandle::current);
+    let Some(op_manager) = op_manager else {
+        tracing::warn!("Live import requested but no running node is registered");
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "node is not ready to serve imports",
+        )
+            .into_response();
+    };
+
+    // Read the body only now that the request is authorized and the node is
+    // ready. `to_bytes` enforces the same cap as the DefaultBodyLimit layer; an
+    // over-cap body surfaces as 413.
+    let bundle = match axum::body::to_bytes(body, MAX_IMPORT_BUNDLE_BYTES).await {
+        Ok(b) => b.to_vec(),
+        Err(_) => {
+            return (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "import bundle exceeds the maximum allowed size",
+            )
+                .into_response();
+        }
+    };
+    if bundle.is_empty() {
+        return (StatusCode::BAD_REQUEST, "import bundle is empty").into_response();
+    }
+
+    match run_import(&op_manager, bundle, key, key_kind, overwrite).await {
+        Ok(report) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "imported": report.imported,
+                "skipped": report.skipped,
+            })),
+        )
+            .into_response(),
+        Err(status_and_msg) => status_and_msg.into_response(),
+    }
+}
+
+/// Drive the import on the node's executor and return the [`ImportReport`].
+///
+/// The bundle bytes and the key are moved into the (redacted/zeroizing) event
+/// wrappers so the high-value key is wiped after the bundle is decrypted and
+/// never reaches a log; the bundle's `Debug` prints only its length.
+async fn run_import(
+    op_manager: &OpManager,
+    bundle: Vec<u8>,
+    key: String,
+    key_kind: BundleKeyKind,
+    overwrite: bool,
+) -> Result<crate::wasm_runtime::secret_export::ImportReport, (StatusCode, &'static str)> {
+    let event = ContractHandlerEvent::ImportSecrets {
+        // v1 always targets the node-local single-user scope.
+        target_scope: ImportTargetScope::Local,
+        bundle: ImportBundle::new(bundle),
+        key_material: RedactedToken::new(key.into_bytes()),
+        key_kind,
+        overwrite,
+    };
+
+    // Initiated by a local HTTP client → ClientLocal lane (#4534).
+    match op_manager
+        .notify_contract_handler_prioritized(event, Priority::ClientLocal)
+        .await
+    {
+        Ok(ContractHandlerEvent::ImportSecretsResponse(Ok(report))) => Ok(report),
+        Ok(ContractHandlerEvent::ImportSecretsResponse(Err(e))) => {
+            // A wrong key / corrupt bundle is a CLIENT-input fault: surface 4xx
+            // (with NOTHING written — the decrypt fails before any write), so the
+            // caller can tell it apart from a genuine 500. The message is
+            // non-secret (never echoes the key or any plaintext).
+            if e.is_import_bad_bundle() {
+                tracing::warn!(error = %e, "Rejected live import: bad bundle/key");
+                return Err((
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "could not decrypt the bundle: wrong key or corrupt bundle",
+                ));
+            }
+            // The contract loop's fair queue is full (#4534): a transient
+            // back-pressure condition, not a real failure. 503 so the caller can
+            // distinguish "retry later" from a genuine error.
+            if e.is_contract_queue_full() {
+                tracing::warn!(error = %e, "Rejected live import: contract queue full");
+                return Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "node is busy; retry the import shortly",
+                ));
+            }
+            // Executor-side failure (store/IO). Do not leak internals; log the
+            // detail, return a generic 500.
+            tracing::error!(error = %e, "Live import failed on the executor");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "import failed on the node",
+            ))
+        }
+        Ok(other) => {
+            tracing::error!(
+                response = %other,
+                "Unexpected contract-handler response to ImportSecrets"
+            );
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "import failed on the node",
+            ))
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "Contract handler unavailable for live import");
+            Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "node is not ready to serve imports",
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    const LOOPBACK: Option<IpAddr> = Some(IpAddr::V4(Ipv4Addr::LOCALHOST));
+    const LOCAL_ORIGIN: &str = "http://127.0.0.1:50509";
+
+    fn headers_with(origin: Option<&str>) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        if let Some(o) = origin {
+            h.insert("origin", HeaderValue::from_str(o).unwrap());
+        }
+        h
+    }
+
+    fn empty_map() -> OriginContractMap {
+        std::sync::Arc::new(dashmap::DashMap::new())
+    }
+
+    /// Headline: loopback source + a localhost dashboard origin + no
+    /// per-contract token ⇒ the gate admits.
+    #[test]
+    fn gate_admits_loopback_dashboard_origin() {
+        let headers = headers_with(Some(LOCAL_ORIGIN));
+        import_gate_or_reject(&headers, LOOPBACK, None, None, None, &empty_map())
+            .expect("loopback dashboard request must be admitted");
+    }
+
+    /// A missing ConnectInfo cannot prove loopback ⇒ fail closed (403).
+    #[test]
+    fn gate_rejects_missing_source_ip() {
+        let headers = headers_with(Some(LOCAL_ORIGIN));
+        let err =
+            import_gate_or_reject(&headers, None, None, None, None, &empty_map()).unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    /// A non-loopback source IP is never honored (403), even with a good origin.
+    #[test]
+    fn gate_rejects_non_loopback_source() {
+        let headers = headers_with(Some(LOCAL_ORIGIN));
+        let public = Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7)));
+        let err =
+            import_gate_or_reject(&headers, public, None, None, None, &empty_map()).unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    /// `::ffff:127.0.0.1` from a dual-stack socket normalizes to loopback and is
+    /// admitted.
+    #[test]
+    fn gate_admits_ipv4_mapped_loopback() {
+        let headers = headers_with(Some(LOCAL_ORIGIN));
+        let mapped = Some(IpAddr::V6(Ipv4Addr::LOCALHOST.to_ipv6_mapped()));
+        import_gate_or_reject(&headers, mapped, None, None, None, &empty_map())
+            .expect("ipv4-mapped loopback must be admitted");
+    }
+
+    /// A missing Origin header is rejected (CSRF: a state-changing write needs a
+    /// trusted origin).
+    #[test]
+    fn gate_rejects_missing_origin() {
+        let headers = headers_with(None);
+        let err =
+            import_gate_or_reject(&headers, LOOPBACK, None, None, None, &empty_map()).unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    /// `Origin: null` (the sandboxed contract iframe) is rejected — the
+    /// per-contract iframe exclusion.
+    #[test]
+    fn gate_rejects_null_origin_sandbox_iframe() {
+        let headers = headers_with(Some("null"));
+        let err =
+            import_gate_or_reject(&headers, LOOPBACK, None, None, None, &empty_map()).unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    /// A cross-site origin (not a loopback/allowed host) is rejected.
+    #[test]
+    fn gate_rejects_cross_site_origin() {
+        let headers = headers_with(Some("https://evil.example.com"));
+        let err =
+            import_gate_or_reject(&headers, LOOPBACK, None, None, None, &empty_map()).unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    /// A request presenting a registered per-contract AuthToken (bearer header)
+    /// is rejected even from a loopback dashboard origin — the AuthToken-origin
+    /// exclusion.
+    #[test]
+    fn gate_rejects_registered_origin_contract_bearer() {
+        let map: OriginContractMap = std::sync::Arc::new(dashmap::DashMap::new());
+        let tok = AuthToken::from("contract-token-xyz".to_owned());
+        map.insert(tok.clone(), dummy_origin_contract());
+
+        let mut headers = headers_with(Some(LOCAL_ORIGIN));
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_str("Bearer contract-token-xyz").unwrap(),
+        );
+        let err = import_gate_or_reject(&headers, LOOPBACK, None, None, None, &map).unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    /// A request presenting a registered per-contract AuthToken via the
+    /// `Authorization` cookie is likewise rejected.
+    #[test]
+    fn gate_rejects_registered_origin_contract_cookie() {
+        let map: OriginContractMap = std::sync::Arc::new(dashmap::DashMap::new());
+        let tok = AuthToken::from("cookie-token-abc".to_owned());
+        map.insert(tok.clone(), dummy_origin_contract());
+
+        let mut headers = headers_with(Some(LOCAL_ORIGIN));
+        headers.insert(
+            axum::http::header::COOKIE,
+            HeaderValue::from_str("authorization=Bearer cookie-token-abc").unwrap(),
+        );
+        let err = import_gate_or_reject(&headers, LOOPBACK, None, None, None, &map).unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    /// A bearer token NOT registered as an origin contract does not trip the
+    /// exclusion (it is not a per-contract origin).
+    #[test]
+    fn gate_admits_unregistered_bearer() {
+        let mut headers = headers_with(Some(LOCAL_ORIGIN));
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_str("Bearer some-unrelated-token").unwrap(),
+        );
+        import_gate_or_reject(&headers, LOOPBACK, None, None, None, &empty_map())
+            .expect("an unregistered bearer is not a contract origin");
+    }
+
+    #[test]
+    fn presented_tokens_reads_header_query_and_cookie() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_str("Bearer header-tok").unwrap(),
+        );
+        headers.insert(
+            axum::http::header::COOKIE,
+            HeaderValue::from_str("foo=bar; authorization=Bearer cookie-tok").unwrap(),
+        );
+        let toks: Vec<String> = presented_tokens(&headers, Some("a=b&authToken=query-tok"))
+            .map(|t| t.as_str().to_owned())
+            .collect();
+        assert!(toks.contains(&"header-tok".to_owned()));
+        assert!(toks.contains(&"query-tok".to_owned()));
+        assert!(toks.contains(&"cookie-tok".to_owned()));
+    }
+
+    #[test]
+    fn parse_key_kind_defaults_and_variants() {
+        let mut h = HeaderMap::new();
+        assert_eq!(parse_key_kind(&h).unwrap(), BundleKeyKind::Token);
+        h.insert(
+            BUNDLE_KEY_KIND_HEADER,
+            HeaderValue::from_static("passphrase"),
+        );
+        assert_eq!(parse_key_kind(&h).unwrap(), BundleKeyKind::Passphrase);
+        h.insert(BUNDLE_KEY_KIND_HEADER, HeaderValue::from_static("TOKEN"));
+        assert_eq!(parse_key_kind(&h).unwrap(), BundleKeyKind::Token);
+        h.insert(BUNDLE_KEY_KIND_HEADER, HeaderValue::from_static("bogus"));
+        assert_eq!(parse_key_kind(&h).unwrap_err().0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn strip_bearer_handles_case_and_absence() {
+        assert_eq!(strip_bearer("Bearer abc"), Some("abc"));
+        assert_eq!(strip_bearer("bearer abc"), Some("abc"));
+        assert_eq!(strip_bearer("Token abc"), None);
+    }
+
+    #[test]
+    fn gate_rejects_ipv6_non_loopback() {
+        let headers = headers_with(Some(LOCAL_ORIGIN));
+        let public6 = Some(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));
+        let err =
+            import_gate_or_reject(&headers, public6, None, None, None, &empty_map()).unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    fn dummy_origin_contract() -> super::super::OriginContract {
+        use freenet_stdlib::prelude::ContractInstanceId;
+        // Any contract id works; the gate only checks token membership.
+        let id = ContractInstanceId::new([0u8; 32]);
+        super::super::OriginContract::new(id, crate::client_events::ClientId::FIRST)
+    }
+}

--- a/crates/core/src/server/client_api/permission_prompts.rs
+++ b/crates/core/src/server/client_api/permission_prompts.rs
@@ -523,7 +523,12 @@ fn is_caller_trusted(
 ///    victim-hostname:7509`, `Origin: https://evil.com`, which would
 ///    otherwise pass an Origin-less allowed-host check. When the
 ///    `AllowedHosts` extension is missing, branch 3 is inactive.
-fn is_origin_trusted(
+///
+/// `pub(crate)` so the live-import endpoint (`hosted_import`) reuses the EXACT
+/// same origin-trust decision as the permission-prompt CSRF guard — one source
+/// of truth for "is this request from the node's own dashboard/shell origin (and
+/// not a sandboxed `Origin: null` contract iframe)". See `hosted_import`'s gate.
+pub(crate) fn is_origin_trusted(
     headers: &HeaderMap,
     origin: &str,
     allowed_hosts: Option<&AllowedHosts>,

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -305,6 +305,49 @@ impl Runtime {
         super::secret_export::export_bundle(&self.secret_store, scope, material)
     }
 
+    /// Import secrets from an encrypted [`super::secret_export`] bundle into this
+    /// runtime's secrets store at `target_scope` (the live counterpart of the
+    /// offline `freenet secrets import` CLI — but without stopping the node,
+    /// P3-live of #4592).
+    ///
+    /// The MUTATING analogue of [`Self::export_secret_bundle`], and the ONLY
+    /// route to the `pub(super) secret_store` for a write from outside the
+    /// `wasm_runtime` module (the executor lives in a different module tree and
+    /// cannot touch the field directly, so it wraps secret access in `Runtime`
+    /// methods exactly as `register_delegate` / `export_secret_bundle` do).
+    ///
+    /// All-or-nothing on the KEY: [`super::secret_export::import_bundle`] calls
+    /// `open_bundle` (which decrypts the WHOLE bundle and authenticates it)
+    /// BEFORE any write, so a wrong key / corrupt bundle returns an error with
+    /// NOTHING written. Plaintext exists only in the `Zeroizing` buffers inside
+    /// `import_bundle`; the re-encrypted-at-rest blobs are written under this
+    /// node's per-delegate DEK.
+    ///
+    /// PERFORMANCE: this decrypts every entry AND writes each to disk (one ReDb
+    /// index update + one file per secret), synchronously. The live-import caller
+    /// (`RuntimePool::import_secrets`) runs it ON the contract loop (serialized
+    /// with delegate `store_secret`) — DELIBERATELY on-loop, because the import
+    /// WRITES and the store write path assumes node-wide write serialization
+    /// (running it off-loop would let it race another writer on the same secret
+    /// file). The loop-block is acceptable: the endpoint is loopback +
+    /// dashboard-gated (a one-shot operator migration), not the authenticated-
+    /// remote DoS surface that justified moving the read-only EXPORT off-loop.
+    pub(crate) fn import_secret_bundle(
+        &mut self,
+        bundle: &[u8],
+        material: &super::secret_export::BundleKeyMaterial<'_>,
+        target_scope: &super::secret_export::TargetScope,
+        overwrite: bool,
+    ) -> Result<super::secret_export::ImportReport, super::secret_export::ExportError> {
+        super::secret_export::import_bundle(
+            &mut self.secret_store,
+            bundle,
+            material,
+            target_scope,
+            overwrite,
+        )
+    }
+
     pub fn build_with_config(
         contract_store: ContractStore,
         delegate_store: DelegateStore,

--- a/crates/core/src/wasm_runtime/secret_export.rs
+++ b/crates/core/src/wasm_runtime/secret_export.rs
@@ -329,10 +329,20 @@ fn seal_bundle(
             })
             .collect(),
     };
+    seal_payload(&payload, material)
+}
 
+/// Serialize + encrypt an already-built [`BundlePayload`] into a complete bundle
+/// byte string. Split out from [`seal_bundle`] so tests can seal a hand-crafted
+/// payload (e.g. one with a deliberately malformed entry) through the exact same
+/// crypto path a real export uses.
+fn seal_payload(
+    payload: &BundlePayload,
+    material: &BundleKeyMaterial<'_>,
+) -> Result<Vec<u8>, ExportError> {
     // CBOR-serialize into a Zeroizing buffer (it holds plaintext secrets).
     let mut plaintext = Zeroizing::new(Vec::new());
-    ciborium::ser::into_writer(&payload, &mut *plaintext)
+    ciborium::ser::into_writer(payload, &mut *plaintext)
         .map_err(|e| ExportError::CborSer(e.to_string()))?;
 
     // Random salt + nonce per bundle.
@@ -543,7 +553,15 @@ pub fn import_bundle(
 ) -> Result<ImportReport, ExportError> {
     let payload = open_bundle(bundle, material)?;
 
-    let mut report = ImportReport::default();
+    // FIRST PASS — validate EVERY entry's key/hash field lengths BEFORE writing
+    // anything. A `BadEntryField` discovered mid-write would otherwise leave the
+    // already-written entries committed while the call returns an error; callers
+    // (notably the live-import HTTP endpoint, which classifies `BadEntryField` as
+    // a "corrupt bundle ⇒ NOTHING written" 4xx) advertise no-partial-write on
+    // that failure. Combined with `open_bundle`'s all-or-nothing decrypt, this
+    // makes the whole decrypt+parse phase fail before the first store write, so
+    // the no-partial-write guarantee holds for malformed entries too.
+    let mut parsed: Vec<(DelegateKey, [u8; 32])> = Vec::with_capacity(payload.entries.len());
     for entry in &payload.entries {
         // Reconstruct the typed DelegateKey from the two 32-byte halves.
         let delegate_bytes: [u8; 32] =
@@ -577,7 +595,12 @@ pub fn import_bundle(
                     expected: 32,
                 })?;
         let delegate = DelegateKey::new(delegate_bytes, CodeHash::from(&code_hash_bytes));
+        parsed.push((delegate, secret_hash));
+    }
 
+    // SECOND PASS — every entry is now known well-formed; write them.
+    let mut report = ImportReport::default();
+    for (entry, (delegate, secret_hash)) in payload.entries.iter().zip(parsed) {
         let plaintext = Zeroizing::new(entry.plaintext.clone());
         let scope = target_scope.as_scope();
         let wrote = store
@@ -933,6 +956,67 @@ mod test {
         assert_eq!(report.imported, 1);
         assert!(report.skipped.is_empty());
         assert_eq!(read_local(&target, &d, &h), b"orig");
+    }
+
+    /// A bundle that decrypts cleanly (correct key) but whose SECOND entry has a
+    /// malformed (wrong-length) `delegate_key` must be rejected with
+    /// `BadEntryField` and write NOTHING — not even the well-formed FIRST entry.
+    /// Guards the no-partial-write guarantee the live-import endpoint advertises
+    /// for a corrupt bundle (it classifies `BadEntryField` as a 4xx with nothing
+    /// written). Without the pre-write validation pass, entry 0 would be
+    /// committed before entry 1's length check failed.
+    #[tokio::test]
+    async fn import_malformed_entry_writes_nothing_before_rejecting() {
+        let d = delegate(9);
+        let good_secret = SecretsId::new(b"good".to_vec());
+        let pass = BundleKeyMaterial::Passphrase(b"pw");
+
+        let payload = BundlePayload {
+            schema_version: PAYLOAD_SCHEMA_V1,
+            source_scope: "local".to_string(),
+            created_unix_secs: 0,
+            entries: vec![
+                // Well-formed entry — would import fine on its own.
+                BundleEntry {
+                    delegate_key: d.key().bytes().to_vec(),
+                    code_hash: d.key().code_hash().as_ref().to_vec(),
+                    secret_hash: good_secret.hash().to_vec(),
+                    plaintext: b"should-not-be-written".to_vec(),
+                },
+                // Malformed entry — delegate_key is 31 bytes, not 32.
+                BundleEntry {
+                    delegate_key: vec![0u8; 31],
+                    code_hash: vec![0u8; 32],
+                    secret_hash: vec![0u8; 32],
+                    plaintext: b"irrelevant".to_vec(),
+                },
+            ],
+        };
+        let bundle = seal_payload(&payload, &pass).expect("seal");
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = new_store(tmp.path()).await;
+        let err = import_bundle(&mut store, &bundle, &pass, &TargetScope::Local, false)
+            .expect_err("a malformed entry must be rejected");
+        assert!(
+            matches!(
+                err,
+                ExportError::BadEntryField {
+                    field: "delegate_key",
+                    ..
+                }
+            ),
+            "expected BadEntryField(delegate_key), got {err:?}"
+        );
+
+        // CRITICAL: the well-formed first entry must NOT have been written — the
+        // rejection happens in the pre-write validation pass.
+        let entries = store.export_scope_entries(SecretScope::Local).unwrap();
+        assert!(
+            entries.is_empty(),
+            "a rejected (malformed) import must write NOTHING, found {} entries",
+            entries.len()
+        );
     }
 
     #[tokio::test]

--- a/crates/core/tests/hosted_mode_import.rs
+++ b/crates/core/tests/hosted_mode_import.rs
@@ -1,0 +1,616 @@
+//! Live end-to-end integration test for the secrets IMPORT endpoint
+//! (`POST /v{1,2}/import`, P3-live of #4592, CHUNK 1).
+//!
+//! Boots a REAL NORMAL single-user node (hosted mode OFF) — full event loop,
+//! contract executor, WASM runtime — then proves the durable property the old
+//! `freenet secrets import` CLI could NOT do: import delegate secrets into the
+//! running node's local `SecretsStore` **while the node stays up** (the CLI
+//! opens ReDb directly, single-writer, so it needs the node stopped).
+//!
+//! 1. Builds an encrypted P3 bundle IN-PROCESS (a throwaway `SecretsStore` +
+//!    `export_bundle`) holding one `SecretScope::Local` secret under the test
+//!    delegate, sealed with a token — standing in for a `.fnsx` the user brought
+//!    from elsewhere.
+//! 2. `POST /v1/import` over loopback with the dashboard `Origin` + the bundle
+//!    key header, and asserts 200 + an `ImportReport` of `imported=1`.
+//! 3. Reads the secret back THROUGH THE LIVE STACK (register the delegate over
+//!    WS, then a delegate `get_secret`/`has_secret`) WHILE THE NODE IS STILL
+//!    RUNNING, and asserts it decrypts to the original plaintext.
+//!
+//! Negatives: a wrong key → 4xx with NO write (the secret stays absent); a
+//! missing `Origin` (the dashboard-origin gate) → 403. The gate's loopback,
+//! null-origin (sandbox iframe) and per-contract-`AuthToken` exclusions are
+//! covered by the `hosted_import` unit tests (they can't be produced against a
+//! loopback-bound live server). A collision import (`overwrite=false`) is
+//! covered too.
+
+#![allow(clippy::wildcard_enum_match_arm)]
+
+use std::{
+    net::{Ipv4Addr, TcpListener},
+    path::Path,
+    time::{Duration, Instant},
+};
+
+use freenet::{
+    dev_tool::{BundleKeyMaterial, SecretScope, Secrets, SecretsStore, export_bundle},
+    local_node::NodeConfig,
+    server::serve_client_api,
+    test_utils::load_delegate,
+};
+use freenet_stdlib::{
+    client_api::{ClientRequest, DelegateRequest, HostResponse, WebApi},
+    prelude::*,
+};
+use serde::{Deserialize, Serialize};
+use tokio::time::timeout;
+use tokio_tungstenite::{connect_async, tungstenite::client::IntoClientRequest};
+use tracing::info;
+use zeroize::Zeroizing;
+
+const TEST_DELEGATE: &str = "test-delegate-2";
+
+const TEST_DELEGATE_CIPHER: [u8; 32] = [
+    0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+    0x0f, 0x1e, 0x2d, 0x3c, 0x4b, 0x5a, 0x69, 0x78, 0x87, 0x96, 0xa5, 0xb4, 0xc3, 0xd2, 0xe1, 0xf0,
+];
+const TEST_DELEGATE_NONCE: [u8; 24] = [0u8; 24];
+
+// Mirror of the fixture's `InboundAppMessage` / `OutboundAppMessage` (variant
+// ORDER must match for bincode discriminants — see hosted_mode_export.rs).
+#[allow(dead_code)]
+#[derive(Debug, Serialize)]
+enum InboundAppMessage {
+    CreateInboxRequest,
+    PleaseSignMessage(Vec<u8>),
+    WriteContext(Vec<u8>),
+    ReadContext,
+    ClearContext,
+    IncrementCounter,
+    HasSecret(Vec<u8>),
+    GetNonExistentSecret(Vec<u8>),
+    StoreSecret { key: Vec<u8>, value: Vec<u8> },
+    RemoveSecret(Vec<u8>),
+    WriteLargeContext(usize),
+    StoreLargeSecret { key: Vec<u8>, size: usize },
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+enum OutboundAppMessage {
+    CreateInboxResponse(Vec<u8>),
+    MessageSigned(Vec<u8>),
+    ContextData(Vec<u8>),
+    CounterValue(u32),
+    SecretExists(bool),
+    SecretResult(Option<Vec<u8>>),
+    ContextWritten,
+    ContextCleared,
+    SecretStored,
+    SecretRemoved,
+    LargeContextWritten(usize),
+    LargeSecretStored(usize),
+    SecretStoreFailed,
+}
+
+fn reserve_port() -> anyhow::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    Ok(listener.local_addr()?.port())
+}
+
+fn node_config(
+    dir: &Path,
+    ws_port: u16,
+    network_port: u16,
+    keypair_path: &Path,
+) -> freenet::config::ConfigArgs {
+    freenet::config::ConfigArgs {
+        ws_api: freenet::config::WebsocketApiArgs {
+            address: Some(Ipv4Addr::LOCALHOST.into()),
+            ws_api_port: Some(ws_port),
+            // A NORMAL single-user node: hosted mode OFF. Import targets Local.
+            hosted_mode: Some(false),
+            per_user_op_rate_limit: Some(0),
+            ..Default::default()
+        },
+        network_api: freenet::config::NetworkArgs {
+            public_address: Some(Ipv4Addr::LOCALHOST.into()),
+            public_port: Some(network_port),
+            is_gateway: true,
+            skip_load_from_network: true,
+            gateways: Some(vec![]),
+            location: Some(0.5),
+            ignore_protocol_checking: true,
+            address: Some(Ipv4Addr::LOCALHOST.into()),
+            network_port: Some(network_port),
+            ..Default::default()
+        },
+        config_paths: freenet::config::ConfigPathsArgs {
+            config_dir: Some(dir.to_path_buf()),
+            data_dir: Some(dir.to_path_buf()),
+            log_dir: Some(dir.to_path_buf()),
+        },
+        secrets: freenet::config::SecretArgs {
+            transport_keypair: Some(keypair_path.to_path_buf()),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+struct TestNode {
+    ws_port: u16,
+    shutdown: freenet::ShutdownHandle,
+    run: tokio::task::JoinHandle<Result<std::convert::Infallible, anyhow::Error>>,
+    _data_dir: tempfile::TempDir,
+}
+
+impl TestNode {
+    async fn start() -> anyhow::Result<Self> {
+        let data_dir = tempfile::tempdir()?;
+        let data_path = data_dir.path().to_path_buf();
+
+        let key = freenet::dev_tool::TransportKeypair::new();
+        let keypair_path = data_path.join("private.pem");
+        key.save(&keypair_path)?;
+        key.public().save(data_path.join("public.pem"))?;
+
+        let ws_port = reserve_port()?;
+        let net_port = reserve_port()?;
+
+        let cfg = node_config(&data_path, ws_port, net_port, &keypair_path)
+            .build()
+            .await?;
+        let node = NodeConfig::new(cfg.clone())
+            .await?
+            .build(serve_client_api(cfg.ws_api.clone()).await?)
+            .await?;
+        let shutdown = node.shutdown_handle();
+        let run = tokio::spawn(async move { node.run().await });
+
+        wait_ws_ready(ws_port, Duration::from_secs(30)).await?;
+
+        Ok(Self {
+            ws_port,
+            shutdown,
+            run,
+            _data_dir: data_dir,
+        })
+    }
+
+    async fn shutdown(self) {
+        self.shutdown.shutdown().await;
+        if timeout(Duration::from_secs(30), self.run).await.is_err() {
+            info!("node run loop did not exit within 30s of shutdown (cleanup only)");
+        }
+    }
+}
+
+async fn wait_ws_ready(port: u16, within: Duration) -> anyhow::Result<()> {
+    let url = format!("ws://127.0.0.1:{port}/v1/contract/command?encodingProtocol=native");
+    let deadline = Instant::now() + within;
+    loop {
+        match connect_async(&url).await {
+            Ok((stream, _)) => {
+                drop(stream);
+                return Ok(());
+            }
+            Err(e) => {
+                if Instant::now() >= deadline {
+                    anyhow::bail!("WS API on port {port} did not come up within {within:?}: {e}");
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        }
+    }
+}
+
+/// Plain WS connection (no user token — this is a normal single-user node).
+async fn connect_plain(port: u16) -> anyhow::Result<WebApi> {
+    let url = format!("ws://127.0.0.1:{port}/v1/contract/command?encodingProtocol=native");
+    let request = url.as_str().into_client_request()?;
+    let (stream, _) = connect_async(request).await?;
+    Ok(WebApi::start(stream))
+}
+
+async fn register_delegate(
+    client: &mut WebApi,
+    delegate: &DelegateContainer,
+    delegate_key: &DelegateKey,
+) -> anyhow::Result<()> {
+    client
+        .send(ClientRequest::DelegateOp(
+            DelegateRequest::RegisterDelegate {
+                delegate: delegate.clone(),
+                cipher: TEST_DELEGATE_CIPHER,
+                nonce: TEST_DELEGATE_NONCE,
+            },
+        ))
+        .await?;
+    let resp = timeout(Duration::from_secs(15), client.recv()).await??;
+    match resp {
+        HostResponse::DelegateResponse { key, .. } => {
+            anyhow::ensure!(
+                &key == delegate_key,
+                "register acked a different key: {key}"
+            );
+            Ok(())
+        }
+        other => anyhow::bail!("unexpected response to RegisterDelegate: {other:?}"),
+    }
+}
+
+/// Send a single `InboundAppMessage` to the delegate and decode the single
+/// `OutboundAppMessage` reply — the live secret read path.
+async fn delegate_app_msg(
+    client: &mut WebApi,
+    delegate_key: &DelegateKey,
+    msg: &InboundAppMessage,
+) -> anyhow::Result<OutboundAppMessage> {
+    let payload = bincode::serialize(msg)?;
+    client
+        .send(ClientRequest::DelegateOp(
+            DelegateRequest::ApplicationMessages {
+                key: delegate_key.clone(),
+                params: Parameters::from(vec![]),
+                inbound: vec![InboundDelegateMsg::ApplicationMessage(
+                    ApplicationMessage::new(payload),
+                )],
+            },
+        ))
+        .await?;
+    let resp = timeout(Duration::from_secs(15), client.recv()).await??;
+    match resp {
+        HostResponse::DelegateResponse { values, .. } => {
+            let out = match &values[0] {
+                OutboundDelegateMsg::ApplicationMessage(m) => m,
+                other => anyhow::bail!("expected ApplicationMessage, got {other:?}"),
+            };
+            Ok(bincode::deserialize::<OutboundAppMessage>(&out.payload)?)
+        }
+        other => anyhow::bail!("unexpected response to ApplicationMessages: {other:?}"),
+    }
+}
+
+/// Read a secret VALUE back through the live delegate (decrypts via the running
+/// node's `SecretsStore`).
+async fn get_secret_via_delegate(
+    client: &mut WebApi,
+    delegate_key: &DelegateKey,
+    key: &[u8],
+) -> anyhow::Result<Option<Vec<u8>>> {
+    match delegate_app_msg(
+        client,
+        delegate_key,
+        &InboundAppMessage::GetNonExistentSecret(key.to_vec()),
+    )
+    .await?
+    {
+        OutboundAppMessage::SecretResult(v) => Ok(v),
+        other => anyhow::bail!("expected SecretResult, got {other:?}"),
+    }
+}
+
+/// Whether a secret exists, through the live delegate.
+async fn has_secret_via_delegate(
+    client: &mut WebApi,
+    delegate_key: &DelegateKey,
+    key: &[u8],
+) -> anyhow::Result<bool> {
+    match delegate_app_msg(
+        client,
+        delegate_key,
+        &InboundAppMessage::HasSecret(key.to_vec()),
+    )
+    .await?
+    {
+        OutboundAppMessage::SecretExists(b) => Ok(b),
+        other => anyhow::bail!("expected SecretExists, got {other:?}"),
+    }
+}
+
+/// Build an encrypted P3 bundle IN-PROCESS holding one `Local`-scope secret
+/// under `delegate_key`, sealed with token-HKDF over `token`. Stands in for a
+/// `.fnsx` the user brought from another peer. The throwaway store's node KEK is
+/// irrelevant: the bundle carries PLAINTEXT (re-encrypted under `token`), so it
+/// decrypts purely from the token on the receiving node.
+async fn build_token_bundle(
+    delegate_key: &DelegateKey,
+    secret_key: &[u8],
+    value: &[u8],
+    token: &[u8],
+) -> anyhow::Result<Vec<u8>> {
+    let tmp = tempfile::tempdir()?;
+    let secrets_dir = tmp.path().join("secrets");
+    std::fs::create_dir_all(&secrets_dir)?;
+    let db = freenet::storages::Storage::new(tmp.path()).await?;
+    let secrets = Secrets::load_for_secrets_dir(&secrets_dir)?;
+    let mut store = SecretsStore::new(secrets_dir, secrets, db)?;
+    let secret_id = SecretsId::new(secret_key.to_vec());
+    store.store_secret(
+        delegate_key,
+        &secret_id,
+        SecretScope::Local,
+        Zeroizing::new(value.to_vec()),
+    )?;
+    let bundle = export_bundle(&store, SecretScope::Local, &BundleKeyMaterial::Token(token))?;
+    Ok(bundle)
+}
+
+/// `POST /v1/import`. `origin` → `Origin` header; `key`/`kind`/`overwrite` →
+/// the bundle headers. Returns the raw response so callers assert on status.
+async fn http_import(
+    port: u16,
+    bundle: Vec<u8>,
+    key: Option<&str>,
+    kind: Option<&str>,
+    overwrite: bool,
+    origin: Option<&str>,
+) -> anyhow::Result<reqwest::Response> {
+    let url = format!("http://127.0.0.1:{port}/v1/import");
+    let mut req = reqwest::Client::new()
+        .post(&url)
+        .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+        .body(bundle);
+    if let Some(k) = key {
+        req = req.header("X-Freenet-Bundle-Key", k);
+    }
+    if let Some(kd) = kind {
+        req = req.header("X-Freenet-Bundle-Key-Kind", kd);
+    }
+    if overwrite {
+        req = req.header("X-Freenet-Import-Overwrite", "true");
+    }
+    if let Some(o) = origin {
+        req = req.header(reqwest::header::ORIGIN, o);
+    }
+    Ok(req.send().await?)
+}
+
+#[derive(Deserialize)]
+struct ImportResponseBody {
+    imported: usize,
+    skipped: Vec<(String, String)>,
+}
+
+/// Headline: a bundle imported over `POST /v1/import` lands in the running node's
+/// store and is immediately readable through the live delegate stack — WHILE THE
+/// NODE STAYS UP (the property the node-stopped CLI import cannot provide).
+#[serial_test::serial]
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn live_import_round_trip_node_stays_up() -> anyhow::Result<()> {
+    // Pin a multi-executor pool so the import is admitted regardless of the CI
+    // runner's core count (a 1-core runner's default pool of 1 disables off-loop
+    // secret jobs).
+    let _pool = PoolSizeEnv::set(4);
+    let node = TestNode::start().await?;
+    let port = node.ws_port;
+
+    let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
+    let delegate_key = delegate.key().clone();
+
+    const TOKEN: &str = "import-bundle-key-aaaaaaaaaaaaaaaaaaaa";
+    const SECRET_KEY: &[u8] = b"imported-secret-key";
+    const VALUE: &[u8] = b"the-value-the-user-brought-home";
+
+    // Build the bundle out-of-band (as if downloaded from try.freenet.org).
+    let bundle = build_token_bundle(&delegate_key, SECRET_KEY, VALUE, TOKEN.as_bytes()).await?;
+    assert_eq!(
+        &bundle[0..4],
+        b"FNSX",
+        "fixture must produce an FNSX bundle"
+    );
+
+    let origin = format!("http://127.0.0.1:{port}");
+
+    // Sanity: the secret is NOT present before the import.
+    let mut conn = connect_plain(port).await?;
+    register_delegate(&mut conn, &delegate, &delegate_key).await?;
+    assert!(
+        !has_secret_via_delegate(&mut conn, &delegate_key, SECRET_KEY).await?,
+        "secret must be absent before import"
+    );
+
+    // Import over HTTP (loopback + dashboard origin + the bundle key).
+    let resp = http_import(
+        port,
+        bundle,
+        Some(TOKEN),
+        Some("token"),
+        false,
+        Some(&origin),
+    )
+    .await?;
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "live import over loopback must be 200 OK"
+    );
+    let report: ImportResponseBody = resp.json().await?;
+    assert_eq!(report.imported, 1, "exactly the one secret imports");
+    assert!(report.skipped.is_empty());
+
+    // Read it back THROUGH THE LIVE STACK while the node is still running.
+    let read = get_secret_via_delegate(&mut conn, &delegate_key, SECRET_KEY).await?;
+    assert_eq!(
+        read.as_deref(),
+        Some(VALUE),
+        "the imported secret must decrypt to its original plaintext via the live node"
+    );
+    assert!(
+        has_secret_via_delegate(&mut conn, &delegate_key, SECRET_KEY).await?,
+        "has_secret must see the imported secret"
+    );
+
+    drop(conn);
+    node.shutdown().await;
+    Ok(())
+}
+
+/// A wrong key cannot decrypt the bundle: 4xx, and NOTHING is written (the
+/// decrypt fails before any write). The secret stays absent on the live node.
+#[serial_test::serial]
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn live_import_wrong_key_rejected_no_write() -> anyhow::Result<()> {
+    let _pool = PoolSizeEnv::set(4);
+    let node = TestNode::start().await?;
+    let port = node.ws_port;
+
+    let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
+    let delegate_key = delegate.key().clone();
+
+    const TOKEN: &str = "the-real-bundle-key-bbbbbbbbbbbbbbbb";
+    const SECRET_KEY: &[u8] = b"wrong-key-secret";
+    const VALUE: &[u8] = b"should-never-land";
+
+    let bundle = build_token_bundle(&delegate_key, SECRET_KEY, VALUE, TOKEN.as_bytes()).await?;
+    let origin = format!("http://127.0.0.1:{port}");
+
+    // Import with a DIFFERENT key → must fail authentication.
+    let resp = http_import(
+        port,
+        bundle,
+        Some("a-completely-different-key"),
+        Some("token"),
+        false,
+        Some(&origin),
+    )
+    .await?;
+    assert!(
+        resp.status().is_client_error(),
+        "a wrong key must be a 4xx (client fault), got {}",
+        resp.status()
+    );
+
+    // NO write: the secret must be absent on the live node.
+    let mut conn = connect_plain(port).await?;
+    register_delegate(&mut conn, &delegate, &delegate_key).await?;
+    assert!(
+        !has_secret_via_delegate(&mut conn, &delegate_key, SECRET_KEY).await?,
+        "a failed (wrong-key) import must write NOTHING"
+    );
+
+    drop(conn);
+    node.shutdown().await;
+    Ok(())
+}
+
+/// The dashboard-origin gate: a request with no `Origin` header is rejected
+/// (403) by the live server — exercises the gate end-to-end (its loopback /
+/// null-origin / per-contract-token branches are unit-tested in `hosted_import`).
+#[serial_test::serial]
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn live_import_missing_origin_rejected() -> anyhow::Result<()> {
+    let _pool = PoolSizeEnv::set(4);
+    let node = TestNode::start().await?;
+    let port = node.ws_port;
+
+    let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
+    let delegate_key = delegate.key().clone();
+    let bundle = build_token_bundle(&delegate_key, b"k", b"v", b"key-cccccccccccccccccccc").await?;
+
+    // No Origin header → the gate rejects with 403 before any work.
+    let resp = http_import(
+        port,
+        bundle,
+        Some("key-cccccccccccccccccccc"),
+        Some("token"),
+        false,
+        None,
+    )
+    .await?;
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::FORBIDDEN,
+        "an import without a trusted Origin must be 403"
+    );
+
+    node.shutdown().await;
+    Ok(())
+}
+
+/// Collision handling: re-importing the same secret with `overwrite=false` skips
+/// it and reports it (idempotent), leaving the value untouched and still
+/// readable via the live stack.
+#[serial_test::serial]
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn live_import_collision_skips_and_reports() -> anyhow::Result<()> {
+    let _pool = PoolSizeEnv::set(4);
+    let node = TestNode::start().await?;
+    let port = node.ws_port;
+
+    let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
+    let delegate_key = delegate.key().clone();
+
+    const TOKEN: &str = "collision-key-dddddddddddddddddddd";
+    const SECRET_KEY: &[u8] = b"collision-secret";
+    const VALUE: &[u8] = b"first-import-value";
+
+    let origin = format!("http://127.0.0.1:{port}");
+
+    // First import lands the secret.
+    let bundle = build_token_bundle(&delegate_key, SECRET_KEY, VALUE, TOKEN.as_bytes()).await?;
+    let resp = http_import(
+        port,
+        bundle,
+        Some(TOKEN),
+        Some("token"),
+        false,
+        Some(&origin),
+    )
+    .await?;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let first: ImportResponseBody = resp.json().await?;
+    assert_eq!(first.imported, 1);
+
+    // Second import of the SAME secret with overwrite=false → skipped+reported.
+    let bundle = build_token_bundle(&delegate_key, SECRET_KEY, VALUE, TOKEN.as_bytes()).await?;
+    let resp = http_import(
+        port,
+        bundle,
+        Some(TOKEN),
+        Some("token"),
+        false,
+        Some(&origin),
+    )
+    .await?;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let second: ImportResponseBody = resp.json().await?;
+    assert_eq!(
+        second.imported, 0,
+        "a colliding secret must not be re-imported"
+    );
+    assert_eq!(second.skipped.len(), 1, "the collision must be reported");
+
+    // The value is still readable via the live stack.
+    let mut conn = connect_plain(port).await?;
+    register_delegate(&mut conn, &delegate, &delegate_key).await?;
+    assert_eq!(
+        get_secret_via_delegate(&mut conn, &delegate_key, SECRET_KEY)
+            .await?
+            .as_deref(),
+        Some(VALUE)
+    );
+
+    drop(conn);
+    node.shutdown().await;
+    Ok(())
+}
+
+/// RAII guard that sets `FREENET_RUNTIME_POOL_SIZE` for the duration of a
+/// (serialized) test and restores it on drop. Safe only because these tests are
+/// `#[serial]` — no other node start overlaps the env-var window.
+struct PoolSizeEnv;
+impl PoolSizeEnv {
+    fn set(n: usize) -> Self {
+        // SAFETY: serialized tests; no concurrent node start reads this var.
+        unsafe { std::env::set_var("FREENET_RUNTIME_POOL_SIZE", n.to_string()) };
+        Self
+    }
+}
+impl Drop for PoolSizeEnv {
+    fn drop(&mut self) {
+        // SAFETY: serialized tests; no concurrent node start reads this var.
+        unsafe { std::env::remove_var("FREENET_RUNTIME_POOL_SIZE") };
+    }
+}

--- a/crates/core/tests/hosted_mode_import.rs
+++ b/crates/core/tests/hosted_mode_import.rs
@@ -703,6 +703,82 @@ async fn live_import_collision_skips_and_reports() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Collision handling with `overwrite=true`: re-importing the same secret key
+/// with a DIFFERENT value REPLACES the existing value (imported=1, nothing
+/// skipped), and the new value is readable via the live stack. Exercises the
+/// `X-Freenet-Import-Overwrite: true` header → `overwrite: true` event-field
+/// wiring end-to-end (the `import_bundle(overwrite=true)` core is unit-tested,
+/// but the HTTP header-to-event path was not covered live).
+#[serial_test::serial]
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn live_import_overwrite_replaces_existing() -> anyhow::Result<()> {
+    let _pool = PoolSizeEnv::set(4);
+    let node = TestNode::start().await?;
+    let port = node.ws_port;
+
+    let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
+    let delegate_key = delegate.key().clone();
+
+    const TOKEN: &str = "overwrite-key-eeeeeeeeeeeeeeeeeeee";
+    const SECRET_KEY: &[u8] = b"overwrite-secret";
+    const VALUE_OLD: &[u8] = b"the-old-value";
+    const VALUE_NEW: &[u8] = b"the-overwritten-value";
+
+    let origin = format!("http://127.0.0.1:{port}");
+
+    // First import lands the old value.
+    let bundle = build_token_bundle(&delegate_key, SECRET_KEY, VALUE_OLD, TOKEN.as_bytes()).await?;
+    let resp = http_import(
+        port,
+        bundle,
+        Some(TOKEN),
+        Some("token"),
+        false,
+        Some(&origin),
+    )
+    .await?;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let first: ImportResponseBody = resp.json().await?;
+    assert_eq!(first.imported, 1);
+
+    // Re-import the SAME key with a NEW value and overwrite=true → replaces it.
+    let bundle = build_token_bundle(&delegate_key, SECRET_KEY, VALUE_NEW, TOKEN.as_bytes()).await?;
+    let resp = http_import(
+        port,
+        bundle,
+        Some(TOKEN),
+        Some("token"),
+        true,
+        Some(&origin),
+    )
+    .await?;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let second: ImportResponseBody = resp.json().await?;
+    assert_eq!(
+        second.imported, 1,
+        "overwrite=true must re-import (replace) the colliding secret"
+    );
+    assert!(
+        second.skipped.is_empty(),
+        "overwrite=true must not report a skip"
+    );
+
+    // The live stack now returns the NEW value.
+    let mut conn = connect_plain(port).await?;
+    register_delegate(&mut conn, &delegate, &delegate_key).await?;
+    assert_eq!(
+        get_secret_via_delegate(&mut conn, &delegate_key, SECRET_KEY)
+            .await?
+            .as_deref(),
+        Some(VALUE_NEW),
+        "the overwritten secret must decrypt to the NEW plaintext via the live node"
+    );
+
+    drop(conn);
+    node.shutdown().await;
+    Ok(())
+}
+
 /// RAII guard that sets `FREENET_RUNTIME_POOL_SIZE` for the duration of a
 /// (serialized) test and restores it on drop. Safe only because these tests are
 /// `#[serial]` — no other node start overlaps the env-var window.

--- a/crates/core/tests/hosted_mode_import.rs
+++ b/crates/core/tests/hosted_mode_import.rs
@@ -337,6 +337,37 @@ async fn build_token_bundle(
     Ok(bundle)
 }
 
+/// Same as [`build_token_bundle`] but seals under a user-chosen PASSPHRASE
+/// (Argon2id-stretched) instead of a token. This is the file-upload-fallback
+/// path of #4592 (`X-Freenet-Bundle-Key-Kind: passphrase`): the user supplies
+/// the same passphrase they protected the export with.
+async fn build_passphrase_bundle(
+    delegate_key: &DelegateKey,
+    secret_key: &[u8],
+    value: &[u8],
+    passphrase: &[u8],
+) -> anyhow::Result<Vec<u8>> {
+    let tmp = tempfile::tempdir()?;
+    let secrets_dir = tmp.path().join("secrets");
+    std::fs::create_dir_all(&secrets_dir)?;
+    let db = freenet::storages::Storage::new(tmp.path()).await?;
+    let secrets = Secrets::load_for_secrets_dir(&secrets_dir)?;
+    let mut store = SecretsStore::new(secrets_dir, secrets, db)?;
+    let secret_id = SecretsId::new(secret_key.to_vec());
+    store.store_secret(
+        delegate_key,
+        &secret_id,
+        SecretScope::Local,
+        Zeroizing::new(value.to_vec()),
+    )?;
+    let bundle = export_bundle(
+        &store,
+        SecretScope::Local,
+        &BundleKeyMaterial::Passphrase(passphrase),
+    )?;
+    Ok(bundle)
+}
+
 /// `POST /v1/import`. `origin` → `Origin` header; `key`/`kind`/`overwrite` →
 /// the bundle headers. Returns the raw response so callers assert on status.
 async fn http_import(
@@ -447,6 +478,80 @@ async fn live_import_round_trip_node_stays_up() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Same round-trip as above but via the PASSPHRASE KDF (Argon2id) instead of the
+/// token HKDF — the file-upload-fallback path of #4592. Seal a bundle under a
+/// passphrase, import it with `X-Freenet-Bundle-Key-Kind: passphrase`, and read
+/// the secret back through the live stack while the node stays up. Only the token
+/// path was exercised end-to-end before; this covers the passphrase branch of the
+/// live import (`BundleKeyKind::Passphrase` → `BundleKeyMaterial::Passphrase`).
+#[serial_test::serial]
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn live_import_passphrase_round_trip_node_stays_up() -> anyhow::Result<()> {
+    let _pool = PoolSizeEnv::set(4);
+    let node = TestNode::start().await?;
+    let port = node.ws_port;
+
+    let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
+    let delegate_key = delegate.key().clone();
+
+    const PASSPHRASE: &str = "correct horse battery staple";
+    const SECRET_KEY: &[u8] = b"passphrase-imported-secret-key";
+    const VALUE: &[u8] = b"the-value-sealed-under-a-passphrase";
+
+    let bundle =
+        build_passphrase_bundle(&delegate_key, SECRET_KEY, VALUE, PASSPHRASE.as_bytes()).await?;
+    assert_eq!(
+        &bundle[0..4],
+        b"FNSX",
+        "fixture must produce an FNSX bundle"
+    );
+
+    let origin = format!("http://127.0.0.1:{port}");
+
+    // Sanity: the secret is NOT present before the import.
+    let mut conn = connect_plain(port).await?;
+    register_delegate(&mut conn, &delegate, &delegate_key).await?;
+    assert!(
+        !has_secret_via_delegate(&mut conn, &delegate_key, SECRET_KEY).await?,
+        "secret must be absent before import"
+    );
+
+    // Import over HTTP with the PASSPHRASE kind.
+    let resp = http_import(
+        port,
+        bundle,
+        Some(PASSPHRASE),
+        Some("passphrase"),
+        false,
+        Some(&origin),
+    )
+    .await?;
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "live passphrase import over loopback must be 200 OK"
+    );
+    let report: ImportResponseBody = resp.json().await?;
+    assert_eq!(report.imported, 1, "exactly the one secret imports");
+    assert!(report.skipped.is_empty());
+
+    // Read it back THROUGH THE LIVE STACK while the node is still running.
+    let read = get_secret_via_delegate(&mut conn, &delegate_key, SECRET_KEY).await?;
+    assert_eq!(
+        read.as_deref(),
+        Some(VALUE),
+        "the passphrase-imported secret must decrypt to its original plaintext via the live node"
+    );
+    assert!(
+        has_secret_via_delegate(&mut conn, &delegate_key, SECRET_KEY).await?,
+        "has_secret must see the imported secret"
+    );
+
+    drop(conn);
+    node.shutdown().await;
+    Ok(())
+}
+
 /// A wrong key cannot decrypt the bundle: 4xx, and NOTHING is written (the
 /// decrypt fails before any write). The secret stays absent on the live node.
 #[serial_test::serial]
@@ -476,9 +581,10 @@ async fn live_import_wrong_key_rejected_no_write() -> anyhow::Result<()> {
         Some(&origin),
     )
     .await?;
-    assert!(
-        resp.status().is_client_error(),
-        "a wrong key must be a 4xx (client fault), got {}",
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::UNPROCESSABLE_ENTITY,
+        "a wrong key must be 422 UNPROCESSABLE_ENTITY (ImportBadBundle → no write), got {}",
         resp.status()
     );
 


### PR DESCRIPTION
## Problem

The hosted "try Freenet" proxy (#4381) makes the **exit** one click — Account → Export downloads an encrypted `freenet-data.fnsx` bundle over HTTPS — but the **entrance** is a terminal command: to keep their data a user must install a peer, **stop it**, run `freenet secrets import` with their key (#4035), and restart. That node-stopped CLI step is a friction cliff at the exact moment we want to convert a non-technical person. The CLI must stop the node because it opens the secrets ReDb directly (single-writer).

This is **chunk 1/4 of the secrets-migration v1** (#4592): the durable, source-agnostic LIVE-import core + a local import endpoint. It is the keystone and the file-upload fallback's backend.

## Solution

Route the import **through the running node's executor** (which owns the one legitimate `SecretsStore`) instead of opening ReDb directly, so no node stop is needed. Mirrors the existing live EXPORT path, with one deliberate difference (below).

- `Executor::import_secrets` / `Runtime::import_secret_bundle` — mutating mirror of `export_user_secrets` / `export_secret_bundle`, calling the existing `secret_export::import_bundle` (unchanged for v1).
- `ContractHandlerEvent::ImportSecrets{..}` + `ImportSecretsResponse`. Bundle key in a `RedactedToken` (wiped/redacted); bundle bytes in an `ImportBundle` whose `Debug` prints only a length. Neither is ever logged.
- `RuntimePool::import_secrets`: pops an executor, runs the import, returns it.
- New `POST /v{1,2}/import` (`server/client_api/hosted_import.rs`): raw `application/octet-stream` body (no axum multipart feature), key material + kind + overwrite in headers, a `DefaultBodyLimit` sized to accept any bundle `export_bundle` can produce. Reuses the export endpoint's `ExportOpManagerHandle`. Submits via `notify_contract_handler_prioritized` at `Priority::ClientLocal`.

### On-loop, NOT off-loop (deliberate; resolves a Codex P1)

The EXPORT runs off-loop because it is a read-only, authenticated-**remote** DoS surface. The IMPORT is the **first writer** to `SecretsStore` outside the serial loop's existing on-loop write path (delegate `store_secret`). That write path (fixed sibling `.tmp` + check-then-write) assumes **node-wide write serialization**; running the import off-loop on a separate pooled executor would let it race an on-loop delegate write (or another import) on the same secret file and corrupt it. So the import runs **on** the contract loop, keeping every secret write in one serialization domain. The brief loop-block is acceptable: this endpoint is gated to **loopback + the node's own dashboard origin** (one-shot operator migration), not the remote-token DoS surface that justified off-loop export. (An initial off-loop version was flagged by Codex as a P1 concurrency/corruption risk; this resolves it with zero change to the crypto write path.)

### The gate (fail-closed) — the key review item

The receiving node is a NORMAL single-user node (hosted OFF) importing into `SecretScope::Local`, so it does **not** reuse the hosted-export token gate. Since this endpoint **writes** secrets it must be reachable ONLY from the node's own dashboard/shell origin over loopback. `import_gate_or_reject` enforces, in order, fail-closed:

1. **Loopback source IP** from the kernel-set `ConnectInfo` (missing ⇒ reject — mirrors `hosted_export`).
2. **Trusted origin** via the SAME `permission_prompts::is_origin_trusted` the CSRF guard uses — which **rejects `Origin: null`** (i.e. the sandboxed contract iframe, whose sandbox omits `allow-same-origin`) and cross-site origins; requires loopback / allowed-host.
3. **No per-contract `AuthToken`** — a per-contract web shell is same-origin with the node, so the token is what distinguishes it: reject any request presenting an origin-contract-registered token via the `Authorization` bearer header, the `authToken` query param, or the `Authorization` cookie.

The bundle's decryption key is the data authorization. Decrypt is all-or-nothing and runs **before any write** (`import_bundle` → `open_bundle`), so a wrong key is a 4xx (`ImportBadBundle`) with **nothing written**, never a 500 or a partial write. Key material rides in a header (never the URL/logs), redacted/zeroizing, never logged.

## Testing

- **14 gate unit tests** (`hosted_import`): loopback / missing-ConnectInfo (fail-closed), `Origin: null` sandbox iframe, cross-site origin, per-contract token via header **and** cookie, ipv4-mapped loopback, key-kind / bearer parsing.
- **4 live integration tests** (`tests/hosted_mode_import.rs`): import a bundle over `POST /v1/import` and read the secret back **through the live stack while the node stays up** (the property the node-stopped CLI couldn't provide); wrong key → 4xx + **no write**; missing `Origin` → 403; collision (`overwrite=false`) skips + reports.
- **7 existing live export tests** still pass.
- `cargo fmt` + `cargo clippy --lib -- -D warnings` clean; `codex review --base origin/main` (P1 resolved; one P2 — body-size cap — addressed).

**Note: test-only, no release. Crypto-sensitive — the import gate is the key review item.** Holding before merge for a full review.

## Review follow-up (multi-lens + Codex)

Full review (multi-lens + Codex) came back clean (no Must-fix). Addressed the Should-fix/Consider items plus findings from re-review:

- **Gate doc accuracy**: reworded check #3 (no per-contract `AuthToken`) as best-effort defense-in-depth that only classifies a *well-behaved* client; the load-bearing sandbox-iframe exclusion is check #2 (`Origin: null` rejection). Added a maintainer warning not to weaken #2 believing #3 backstops it.
- **Stale docs**: fixed `handle_deferred_resume` (it resumes the #4391 related-contract upsert, not an import) and `send_import_response_inline` (sole response path for the on-loop import, all outcomes).
- **Test coverage**: added a live PASSPHRASE-KDF (Argon2id) round-trip, an `overwrite=true` end-to-end test, and tightened the wrong-key assertion to `== 422`.
- **No-partial-write (Codex P2)**: `import_bundle` now validates every entry's key/hash lengths *before* any write, so a malformed-but-authenticated bundle is rejected with nothing written (matches the endpoint's documented guarantee). Regression test added.

### Deferred: `Sec-Fetch-Site` hardening (deliberate follow-up)

NOT done this round (a Consider, not a blocker). Enforcing `Sec-Fetch-Site` would add a fetch-metadata CSRF layer on top of the Origin gate, but the header is browser-only: a legitimate non-browser client (a future `freenet secrets import --live` CLI, curl in a migration script) omits it entirely. "Reject when missing" would break those clients; "enforce only when present" is weaker — the choice needs a deliberate call, so it's left as a documented follow-up (see the comment near `import_gate_or_reject`). Until then the Origin gate (#2) is the CSRF boundary.

Refs #4592

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dGjU1Q6Vpk2dm4sUf4pdU
