### PR TITLE
fix: restore telemetry on release binaries (testing-feature leak since 0.2.81)

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -34,8 +34,19 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y musl-tools musl-dev
 
       - name: Compile for x86_64-unknown-linux-musl
-        # Only build freenet and fdev - cdylib crates (contracts) don't support musl
-        run: cargo build --release --target x86_64-unknown-linux-musl -p freenet -p fdev
+        # Build `freenet` and `fdev` in SEPARATE cargo invocations. fdev depends
+        # on `freenet` with `features = ["testing"]`; a combined
+        # `-p freenet -p fdev` build lets Cargo resolver-v2 feature unification
+        # turn `testing` ON for the shipped freenet binary. That silently disabled
+        # telemetry on every release node from 0.2.81 onward (the guard in
+        # crates/core/src/tracing/telemetry.rs used to key suppression on
+        # `cfg!(feature = "testing")`) and pulled in parking_lot/deadlock_detection
+        # overhead. Building freenet first and alone keeps `testing` off the
+        # shipped asset. cdylib crates (contracts) don't support musl, so we still
+        # only build these two crates.
+        run: |
+          cargo build --release --target x86_64-unknown-linux-musl -p freenet
+          cargo build --release --target x86_64-unknown-linux-musl -p fdev
 
       - name: Upload freenet binary
         uses: actions/upload-artifact@v7
@@ -71,8 +82,13 @@ jobs:
           sudo apt-get install -y musl-tools musl-dev
 
       - name: Compile for aarch64-unknown-linux-musl
-        # Only build freenet and fdev - cdylib crates (contracts) don't support musl
-        run: cargo build --release --target aarch64-unknown-linux-musl -p freenet -p fdev
+        # Separate freenet/fdev invocations to stop fdev's `freenet/testing`
+        # leaking onto the shipped freenet binary (see x86_64 step for the full
+        # rationale — the 0.2.81 telemetry blackout). cdylib crates (contracts)
+        # don't support musl, so we still only build these two crates.
+        run: |
+          cargo build --release --target aarch64-unknown-linux-musl -p freenet
+          cargo build --release --target aarch64-unknown-linux-musl -p fdev
 
       - name: Upload freenet binary
         uses: actions/upload-artifact@v7
@@ -109,7 +125,13 @@ jobs:
           # Without this, the binary links to /opt/homebrew/opt/xz/lib/liblzma.5.dylib
           # which doesn't exist on fresh macOS installations
           LZMA_API_STATIC: "1"
-        run: cargo build --release
+        # Build freenet and fdev in SEPARATE cargo invocations (was a bare
+        # `cargo build --release`, which builds the whole workspace incl. fdev and
+        # so unifies fdev's `freenet/testing` onto the shipped freenet binary —
+        # the 0.2.81 telemetry blackout; see x86_64-linux step for full rationale).
+        run: |
+          cargo build --release -p freenet
+          cargo build --release -p fdev
 
       - name: Ad-hoc sign binaries
         run: |
@@ -153,7 +175,12 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: "11.0"
           # Force static linking of liblzma to avoid dependency on Homebrew's xz
           LZMA_API_STATIC: "1"
-        run: cargo build --release --target x86_64-apple-darwin -p freenet -p fdev
+        # Separate freenet/fdev invocations so fdev's `freenet/testing` cannot
+        # leak onto the shipped freenet binary (the 0.2.81 telemetry blackout;
+        # see x86_64-linux step for full rationale).
+        run: |
+          cargo build --release --target x86_64-apple-darwin -p freenet
+          cargo build --release --target x86_64-apple-darwin -p fdev
 
       - name: Ad-hoc sign binaries
         run: |
@@ -192,7 +219,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Compile for x86_64-pc-windows-msvc
-        run: cargo build --release
+        # Build freenet and fdev in SEPARATE cargo invocations (was a bare
+        # `cargo build --release`, which builds the whole workspace incl. fdev and
+        # so unifies fdev's `freenet/testing` onto the shipped freenet binary —
+        # the 0.2.81 telemetry blackout; see x86_64-linux step for full rationale).
+        run: |
+          cargo build --release -p freenet
+          cargo build --release -p fdev
 
       - name: Smoke test
         run: |

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -336,12 +336,22 @@ impl TelemetryReporter {
         // Cargo feature-unification with `fdev` leaked `testing` onto the shipped
         // `freenet` binary.
         //
-        // #4366 intent preserved: the integration tests under `crates/core/tests/*.rs`
-        // (operations_before_join / hosted_mode_* / in_process_restart / …) build
-        // `NodeConfig` directly without `--id`, so `is_test_environment` stays false;
-        // they still trip the `running_under_cargo_test()` signal (every cargo test
-        // binary runs from a `deps/` dir), so they continue to be suppressed and do
-        // not re-pollute the production OTLP collector.
+        // #4366 intent preserved: the IN-PROCESS integration tests under
+        // `crates/core/tests/*.rs` (operations_before_join / hosted_mode_* /
+        // in_process_restart / …) build `NodeConfig` directly without `--id`, so
+        // `is_test_environment` stays false; they still trip the
+        // `running_under_cargo_test()` signal (every cargo test binary runs from a
+        // `deps/` dir), so they continue to be suppressed and do not re-pollute the
+        // production OTLP collector.
+        //
+        // CAVEAT: that `deps/` signal only covers nodes running INSIDE the test
+        // binary. A test that spawns the real `freenet` binary as a SUBPROCESS
+        // (e.g. `crates/core/tests/persistence_roundtrip.rs`) runs it from
+        // `target/<profile>/freenet`, whose parent is not `deps/`, and without
+        // `--id` — so neither test signal fires and the subprocess would default
+        // telemetry ON. Such tests MUST pin it off explicitly with
+        // `.env("FREENET_TELEMETRY_ENABLED", "false")` (the same env this flag
+        // reads). Do not assume subprocess-spawned nodes are auto-suppressed.
         match telemetry_suppression_reason(config, cfg!(test), running_under_cargo_test()) {
             Some(TelemetrySuppression::Disabled) => {
                 tracing::info!("Telemetry reporting is disabled");

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -262,6 +262,60 @@ fn running_under_cargo_test() -> bool {
         .unwrap_or(false)
 }
 
+/// Why a [`TelemetryReporter`] was not initialized.
+///
+/// Extracted from [`TelemetryReporter::new`] so the prod-vs-test decision is a
+/// pure function that can be unit-tested for BOTH directions without being
+/// defeated by the ambient `cfg(test)` / cargo-`deps/` environment of the test
+/// process itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TelemetrySuppression {
+    /// Operator turned telemetry off (`telemetry-enabled = false`).
+    Disabled,
+    /// `--id` test environment (integration/CLI harness sets `is_test_environment`).
+    TestEnvironmentFlag,
+    /// A `cfg(test)` build or a binary running under a cargo test/bench harness.
+    TestHarness,
+}
+
+/// Decide whether telemetry should be suppressed, given the config plus the two
+/// test signals that a genuine production release binary never trips.
+///
+/// Pure and side-effect free: callers pass `cfg!(test)` and the result of
+/// [`running_under_cargo_test`] so this can be unit-tested for a prod release
+/// binary (`is_test_build = false`, `running_under_cargo_test = false`, no
+/// `--id` → MUST return `None`) AND for every test/sim path (MUST return
+/// `Some`).
+///
+/// CRITICAL (#4366 intent + the 0.2.81 telemetry-blackout regression):
+/// suppression is keyed ONLY on signals a real release binary never matches —
+/// it is deliberately NOT keyed on `cfg!(feature = "testing")`. That compile
+/// flag leaked onto the shipped `freenet` binary via Cargo resolver-v2 feature
+/// unification with `fdev` (which depends on `freenet` with
+/// `features = ["testing"]`), so every auto-updating release node since 0.2.81
+/// silently self-disabled telemetry. The real test/sim runs that #4366 must
+/// keep suppressed all run either under `cfg(test)` (unit tests) or from a
+/// cargo `deps/` harness (integration tests + nightly nextest sims), so the two
+/// remaining signals still catch them. The DST simulation framework
+/// (`node/testing_impl.rs`, used by `fdev` sims) never constructs a
+/// `TelemetryReporter` at all, so it cannot emit regardless.
+fn telemetry_suppression_reason(
+    config: &TelemetryConfig,
+    is_test_build: bool,
+    running_under_cargo_test: bool,
+) -> Option<TelemetrySuppression> {
+    if !config.enabled {
+        return Some(TelemetrySuppression::Disabled);
+    }
+    if config.is_test_environment {
+        return Some(TelemetrySuppression::TestEnvironmentFlag);
+    }
+    if is_test_build || running_under_cargo_test {
+        return Some(TelemetrySuppression::TestHarness);
+    }
+    None
+}
+
 impl TelemetryReporter {
     /// Create a new telemetry reporter.
     ///
@@ -270,47 +324,38 @@ impl TelemetryReporter {
     /// that have no `NetLogMessage` context.
     ///
     /// Returns None if telemetry is disabled, in a `--id` test environment,
-    /// or in a test build/harness (`cfg(test)` / `feature = "testing"` /
-    /// running under cargo test — see `running_under_cargo_test`).
+    /// or in a test build/harness (`cfg(test)` / running under a cargo
+    /// `deps/` harness — see `running_under_cargo_test` and
+    /// `telemetry_suppression_reason`).
     pub fn new(config: &TelemetryConfig, local_peer_id: String) -> Option<Self> {
-        if !config.enabled {
-            tracing::info!("Telemetry reporting is disabled");
-            return None;
-        }
-
-        // Disable telemetry in test environments (detected via --id flag) to avoid
-        // flooding the production collector with CI/integration test data.
-        if config.is_test_environment {
-            tracing::info!("Telemetry disabled in test environment (--id flag detected)");
-            return None;
-        }
-
-        // Belt-and-suspenders guard for test binaries that build `NodeConfig`
-        // directly without going through the `--id` CLI path, so
-        // `is_test_environment` stays false (the integration tests under
-        // `crates/core/tests/*.rs`, e.g. operations_before_join /
-        // hosted_mode_* / in_process_restart / error_notification). Without
-        // this, those tests shipped events — including simulation-loopback
-        // `get_not_found` and one-shot synthetic "gateway" peers — to the
-        // production OTLP collector at `DEFAULT_TELEMETRY_ENDPOINT`,
-        // contaminating network metrics (issue #4366).
+        // The suppression decision lives in the pure `telemetry_suppression_reason`
+        // so it can be unit-tested for both a production release binary (must NOT
+        // suppress) and every test/sim path (must suppress). See that function for
+        // why suppression is deliberately NOT keyed on `cfg!(feature = "testing")`
+        // — doing so silently disabled telemetry on every 0.2.81+ release node when
+        // Cargo feature-unification with `fdev` leaked `testing` onto the shipped
+        // `freenet` binary.
         //
-        // Three overlapping signals, none of which the real node binary
-        // matches, so production telemetry is unaffected:
-        //   - `cfg!(test)`: the library's own unit tests.
-        //   - `cfg!(feature = "testing")`: integration/simulation tests as
-        //     CI compiles them (`--features ...,testing`, see ci.yml /
-        //     simulation-nightly.yml).
-        //   - `running_under_cargo_test()`: a runtime check that also covers
-        //     the *documented* local dev path `cargo test -p freenet` WITHOUT
-        //     `--features testing` (AGENTS.md), where the library links as a
-        //     normal dependency so `cfg!(test)` is false and the integration
-        //     tests build `ConfigArgs::default()` (no `--id`). The real
-        //     `freenet` binary never runs from a cargo `deps/` test harness,
-        //     so it never trips this.
-        if cfg!(test) || cfg!(feature = "testing") || running_under_cargo_test() {
-            tracing::info!("Telemetry disabled in test build/harness");
-            return None;
+        // #4366 intent preserved: the integration tests under `crates/core/tests/*.rs`
+        // (operations_before_join / hosted_mode_* / in_process_restart / …) build
+        // `NodeConfig` directly without `--id`, so `is_test_environment` stays false;
+        // they still trip the `running_under_cargo_test()` signal (every cargo test
+        // binary runs from a `deps/` dir), so they continue to be suppressed and do
+        // not re-pollute the production OTLP collector.
+        match telemetry_suppression_reason(config, cfg!(test), running_under_cargo_test()) {
+            Some(TelemetrySuppression::Disabled) => {
+                tracing::info!("Telemetry reporting is disabled");
+                return None;
+            }
+            Some(TelemetrySuppression::TestEnvironmentFlag) => {
+                tracing::info!("Telemetry disabled in test environment (--id flag detected)");
+                return None;
+            }
+            Some(TelemetrySuppression::TestHarness) => {
+                tracing::info!("Telemetry disabled in test build/harness");
+                return None;
+            }
+            None => {}
         }
 
         let endpoint = config.endpoint.clone();
@@ -2003,34 +2048,97 @@ mod tests {
     // `TelemetryConfig` and `TelemetryReporter` come in via `super::*`.
     use super::*;
 
-    /// Regression for #4366: a test build must NOT initialize a
-    /// `TelemetryReporter` (and thus must not ship events to the production
-    /// OTLP collector) even when the config looks like a real production
-    /// node — `enabled: true`, the production `DEFAULT_TELEMETRY_ENDPOINT`,
-    /// and `is_test_environment: false`. That is exactly the config the
-    /// integration tests under `crates/core/tests/*.rs` build (via
-    /// `ConfigArgs { ..Default::default() }`, which leaves `--id` unset).
-    /// Before the fix they leaked synthetic peers / simulation-loopback
-    /// `get_not_found` events to `nova.locut.us:4318`.
-    ///
-    /// This test runs under `cfg(test)` (and via the cargo `deps/` harness),
-    /// so it pins the shared early-return that all three signals trigger —
-    /// `cfg!(test)`, `cfg!(feature = "testing")` (CI integration/sim runs),
-    /// and `running_under_cargo_test()` (the no-feature `cargo test -p freenet`
-    /// dev path). The production binary trips none of them and is unaffected.
-    #[test]
-    fn telemetry_reporter_suppressed_in_test_build() {
-        let prod_like = TelemetryConfig {
+    /// A config that looks exactly like a real production node: telemetry on,
+    /// the production `DEFAULT_TELEMETRY_ENDPOINT`, and `is_test_environment:
+    /// false` (no `--id`). The only thing separating a prod node from a test
+    /// run is the two ambient signals passed to `telemetry_suppression_reason`.
+    fn prod_like_config() -> TelemetryConfig {
+        TelemetryConfig {
             enabled: true,
             endpoint: crate::config::DEFAULT_TELEMETRY_ENDPOINT.to_string(),
             transport_snapshot_interval_secs: 30,
             is_test_environment: false,
             reference_ping_enabled: false,
             iface_tx_enabled: false,
-        };
+        }
+    }
+
+    /// Regression for #4366: a test build must NOT initialize a
+    /// `TelemetryReporter` (and thus must not ship events to the production
+    /// OTLP collector) even when the config looks like a real production
+    /// node. That is exactly the config the integration tests under
+    /// `crates/core/tests/*.rs` build (via `ConfigArgs { ..Default::default() }`,
+    /// which leaves `--id` unset). Before the fix they leaked synthetic peers /
+    /// simulation-loopback `get_not_found` events to `nova.locut.us:4318`.
+    ///
+    /// This test runs under `cfg(test)` AND from the cargo `deps/` harness, so
+    /// it pins the real entry point's early-return via the two surviving
+    /// signals — `cfg!(test)` and `running_under_cargo_test()`. The production
+    /// binary trips neither and is unaffected.
+    #[test]
+    fn telemetry_reporter_suppressed_in_test_build() {
         assert!(
-            TelemetryReporter::new(&prod_like, "peer-under-test".to_string()).is_none(),
+            TelemetryReporter::new(&prod_like_config(), "peer-under-test".to_string()).is_none(),
             "test builds must not ship telemetry to the production collector (#4366)"
+        );
+    }
+
+    /// The fix for the 0.2.81 telemetry blackout: a genuine production release
+    /// binary — `cfg(test)` false, NOT run from a cargo `deps/` harness, no
+    /// `--id` — must NOT self-suppress telemetry. Regressing this is exactly
+    /// what happened when Cargo feature-unification with `fdev` leaked
+    /// `feature = "testing"` onto the shipped `freenet` binary and the guard
+    /// keyed suppression on it: telemetry went silently OFF on every
+    /// auto-updating release node from 0.2.81 onward.
+    #[test]
+    fn prod_release_binary_emits_telemetry() {
+        assert_eq!(
+            telemetry_suppression_reason(
+                &prod_like_config(),
+                /* is_test_build */ false,
+                /* running_under_cargo_test */ false,
+            ),
+            None,
+            "a production release binary must NOT self-suppress telemetry"
+        );
+    }
+
+    /// The #4366 intent preserved: every real test/sim path that reaches
+    /// `TelemetryReporter::new` must still be suppressed so it can't re-pollute
+    /// the production collector. The DST simulation framework never builds a
+    /// `TelemetryReporter` at all; the paths that DO are unit tests (`cfg(test)`)
+    /// and integration / nightly-nextest sims (run from a cargo `deps/` harness),
+    /// both covered here, plus the `--id` CLI harness.
+    #[test]
+    fn test_and_sim_runs_still_suppress_telemetry() {
+        // Unit-test build: `cfg!(test)` is true.
+        assert_eq!(
+            telemetry_suppression_reason(&prod_like_config(), true, false),
+            Some(TelemetrySuppression::TestHarness),
+            "cfg(test) unit-test builds must suppress (#4366)"
+        );
+        // Integration test / nightly nextest sim: not a cfg(test) build, but the
+        // binary runs from a cargo `deps/` dir (no `--id`).
+        assert_eq!(
+            telemetry_suppression_reason(&prod_like_config(), false, true),
+            Some(TelemetrySuppression::TestHarness),
+            "cargo deps/ test harness runs must suppress (#4366)"
+        );
+        // `--id` test environment (integration/CLI harness).
+        let mut id_env = prod_like_config();
+        id_env.is_test_environment = true;
+        assert_eq!(
+            telemetry_suppression_reason(&id_env, false, false),
+            Some(TelemetrySuppression::TestEnvironmentFlag),
+            "--id test environments must suppress"
+        );
+        // Operator turned telemetry off.
+        let mut disabled = prod_like_config();
+        disabled.enabled = false;
+        assert_eq!(
+            telemetry_suppression_reason(&disabled, false, false),
+            Some(TelemetrySuppression::Disabled),
+            "telemetry-enabled = false must suppress"
         );
     }
 

--- a/crates/core/tests/cross_compile_feature_split.rs
+++ b/crates/core/tests/cross_compile_feature_split.rs
@@ -1,0 +1,89 @@
+//! Recurrence guard for the freenet/fdev build split in
+//! `.github/workflows/cross-compile.yml`.
+//!
+//! Context (PR #4605 / the 0.2.81 telemetry blackout): `fdev` depends on
+//! `freenet` with `features = ["testing"]`. If the cross-compile workflow
+//! compiles `freenet` and `fdev` in the SAME `cargo build` invocation — either
+//! explicitly (`-p freenet -p fdev`) or implicitly (a bare `cargo build` that
+//! compiles the whole workspace, the original macOS/Windows form) — Cargo
+//! resolver-v2 feature unification turns the `testing` feature ON for the
+//! SHIPPED `freenet` binary. That silently disabled telemetry on every release
+//! node from 0.2.81 onward (back when the suppression guard keyed on
+//! `cfg!(feature = "testing")`) and pulled in deadlock-detection overhead. The
+//! fix is to build `freenet` first and ALONE, then `fdev` separately.
+//!
+//! This is a cheap, read-only guard (no boot step, no `compile_error!`): it
+//! fails CI if any `cargo build` line in the cross-compile workflow would
+//! compile `freenet` together with `fdev`.
+
+use std::path::PathBuf;
+
+fn cross_compile_yml() -> String {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace layout: crates/core/../../ should resolve")
+        .to_path_buf();
+    let path = workspace_root.join(".github/workflows/cross-compile.yml");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {path:?}: {e}"))
+}
+
+#[test]
+fn freenet_and_fdev_build_in_separate_cargo_invocations() {
+    let yml = cross_compile_yml();
+
+    // Real build commands only: skip comment lines (YAML `#` and shell `#`
+    // inside `run:` blocks both start with `#` after trimming) so the prose
+    // that documents this very regression doesn't trip the guard.
+    let build_lines: Vec<&str> = yml
+        .lines()
+        .map(str::trim)
+        .filter(|l| l.contains("cargo build") && !l.starts_with('#'))
+        .collect();
+
+    assert!(
+        !build_lines.is_empty(),
+        "no `cargo build` command lines found in cross-compile.yml — did the workflow \
+         move or change shape? This guard (the 0.2.81 telemetry blackout) must be \
+         updated so it keeps protecting the freenet/fdev build split."
+    );
+
+    let mut freenet_invocations = 0usize;
+    let mut fdev_invocations = 0usize;
+    for line in &build_lines {
+        let has_freenet = line.contains("-p freenet");
+        let has_fdev = line.contains("-p fdev");
+
+        assert!(
+            !(has_freenet && has_fdev),
+            "cross-compile.yml builds freenet and fdev in ONE cargo invocation:\n  {line}\n\
+             A combined `-p freenet -p fdev` build unifies fdev's `freenet/testing` feature \
+             onto the SHIPPED freenet binary (the 0.2.81 telemetry blackout). Build freenet \
+             first and alone, then fdev separately."
+        );
+        assert!(
+            has_freenet || has_fdev,
+            "cross-compile.yml has a `cargo build` that selects neither `-p freenet` nor \
+             `-p fdev`:\n  {line}\n\
+             A bare / whole-workspace build compiles freenet TOGETHER with fdev, unifying \
+             fdev's `freenet/testing` onto the shipped freenet binary (the 0.2.81 telemetry \
+             blackout). Always build the shipped binaries with an explicit `-p freenet` \
+             (alone) then `-p fdev`."
+        );
+
+        if has_freenet {
+            freenet_invocations += 1;
+        } else {
+            fdev_invocations += 1;
+        }
+    }
+
+    assert!(
+        freenet_invocations > 0,
+        "cross-compile.yml never builds `freenet` via a dedicated `-p freenet` invocation"
+    );
+    assert!(
+        fdev_invocations > 0,
+        "cross-compile.yml never builds `fdev` via a dedicated `-p fdev` invocation"
+    );
+}

--- a/crates/core/tests/persistence_roundtrip.rs
+++ b/crates/core/tests/persistence_roundtrip.rs
@@ -126,6 +126,17 @@ impl NodeProcess {
     ) -> anyhow::Result<Self> {
         let child = Command::new(freenet_bin())
             .arg("network")
+            // This spawns the REAL release-style `freenet` binary as a separate
+            // process. Unlike in-process `#[freenet_test]` nodes (which run from
+            // the cargo `deps/` harness and are auto-suppressed by
+            // `running_under_cargo_test()`), this subprocess runs from
+            // `target/<profile>/freenet` with no `--id`, so neither test signal
+            // fires and telemetry would default ON — POSTing release-tagged
+            // events to the production OTLP collector (#4366 contamination
+            // class). Pin it OFF via the same env the binary reads for the
+            // `telemetry-enabled` flag (config.rs: env = "FREENET_TELEMETRY_ENABLED"),
+            // which is also how freenet-test-network disables it for spawned nodes.
+            .env("FREENET_TELEMETRY_ENABLED", "false")
             .args(["--ws-api-address", "127.0.0.1"])
             .args(["--ws-api-port", &ws_port.to_string()])
             .args(["--network-address", "127.0.0.1"])


### PR DESCRIPTION
Closes #4606

## Problem
Telemetry has been silently OFF on every auto-updating freenet release node since **v0.2.81** (~June 21). The central OTLP collector shows 0.2.71–0.2.80 + 0.2.83 (source/`cargo install` builds) but **no 0.2.81/0.2.82/0.2.84** — the whole recent release fleet is invisible to monitoring.

Root cause: the CI release build (`.github/workflows/cross-compile.yml`) ran `cargo build --release -p freenet -p fdev` in **one invocation**. `fdev` depends on `freenet` with `features = ["testing"]`, and Cargo resolver-v2 feature unification turns `testing` **on** for the shipped `freenet` binary. The #4366/#4538 telemetry-suppression guard then keyed on `cfg!(feature = "testing")`, so the production binary self-disabled telemetry (log: "Telemetry disabled in test build/harness"). The same leak also pulled `parking_lot/deadlock_detection` into prod.

## Solution
**Part A — harden the guard (restores telemetry).** Extract a pure `telemetry_suppression_reason(config, is_test_build, running_under_cargo_test)` that suppresses only on signals a real release binary never trips: `!config.enabled`, `--id` `is_test_environment`, `cfg!(test)`, and `running_under_cargo_test()`. The `cfg!(feature="testing")` check is removed. **#4366's intent is preserved**: the integration tests under `crates/core/tests/*.rs` (which build `NodeConfig` without `--id`) still run from a cargo `deps/` harness, so `running_under_cargo_test()` keeps suppressing them — they won't re-pollute the collector. The fdev DST sims never construct a `TelemetryReporter` at all.

**Part B — stop the feature leak (root cause + removes deadlock-detection overhead).** Build the `freenet` release asset in its own `cargo build -p freenet` invocation, separate from `fdev`, across all targets, so feature unification can't leak `testing` onto the shipped binary.

## Testing
- New unit tests pin BOTH directions via the pure function: a prod-like config (no test signals) must NOT suppress (`prod_release_binary_emits_telemetry`), and a test build/harness MUST suppress (`telemetry_reporter_suppressed_in_test_build`, the #4366 regression).
- **Reviewers please verify:** (1) Part A still suppresses real sims/tests (no collector re-pollution); (2) Part B's separate-invocation build actually yields a `testing`-free **uploaded** `freenet` binary despite the shared target dir (the later `fdev` build rebuilds the freenet lib with `testing` — confirm the bin artifact stays no-testing); (3) the build split doesn't break the signing/upload pipeline.

Deploying requires a new release (it fixes the shipped binary); telemetry returns network-wide as nodes adopt it.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_014dGjU1Q6Vpk2dm4sUf4pdU

