### PR TITLE
fix: gate periodic summarize/broadcast on state-presence (#4610)

### DIFF
--- a/.claude/rules/ring.md
+++ b/.claude/rules/ring.md
@@ -162,14 +162,26 @@ WHEN exchanging peer lists in sync protocols (e.g., interest sync):
 WHEN summarizing contracts in the InterestSync heartbeat handlers
 (handle_interest_sync_message: Interests / Summaries / ChangeInterests):
   → ONLY call get_contract_summary for contracts we host OR actively serve
-    (is_hosting_contract || contract_in_use) — go through
-    summary_if_hosted_or_in_use, never a bare get_contract_summary.
+    AND for which we actually hold state:
+    (is_hosting_contract || contract_in_use) && contract_state_present — go
+    through summary_if_hosted_or_in_use, never a bare get_contract_summary. The
+    same composed predicate gates the broadcast path
+    (should_broadcast_contract, broadcast_queue.rs).
   → A node carries phantom peer-interest in contracts it neither hosts nor
     serves (placement-migration after-effect, #4404). Summarizing those issues a
     GetSummaryQuery round-trip on the serial contract_handling loop that returns
     "state not found" every heartbeat — the #4473/#4145 summarize storm
     (~40/sec vs <10 real updates/hr) that wedged gateways. The ResyncRequest arm
     is exempt: it is state-gated and not heartbeat-driven.
+  → #4610: the (is_hosting || in_use) gate ALONE is NOT sufficient. The inbound
+    relay-SUBSCRIBE / placement path marks a contract is_hosting/in_use WITHOUT
+    its state ever being fetched/stored, so phantom (interested-but-stateless)
+    contracts still passed and re-drove the storm (~70-80/sec on 0.2.84/0.2.85).
+    contract_state_present (a cheap on-disk STATE-store existence check, NOT the
+    in-memory hosting cache) is the term that excludes them. It MUST read the
+    state store so an evicted-but-on-disk contract (state present, not in the
+    hosting cache, still in_use) keeps summarizing — keying on is_hosting_contract
+    there would wrongly drop it.
 ```
 
 ### Cleanup Exemptions Must Be Time-Bounded

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2773,9 +2773,7 @@ async fn summary_if_hosted_or_in_use(
     op_manager: &Arc<OpManager>,
     key: &freenet_stdlib::prelude::ContractKey,
 ) -> Option<freenet_stdlib::prelude::StateSummary<'static>> {
-    if (op_manager.ring.is_hosting_contract(key) || op_manager.ring.contract_in_use(key))
-        && op_manager.ring.contract_state_present(key)
-    {
+    if op_manager.ring.should_summarize_or_broadcast(key) {
         // Periodic interest-sync summarize: best-effort background work, so it
         // yields the contract loop to client/relay traffic (#4534 / #4473).
         get_contract_summary(op_manager, key, crate::contract::Priority::Background).await
@@ -3173,9 +3171,14 @@ mod tests {
     fn interest_sync_periodic_arms_summarize_only_hosted_or_in_use_pin() {
         let src = include_str!("node.rs");
 
-        // The helper must gate the expensive call on BOTH the hosting check and
-        // the in-use check: gating on hosting alone wrongly drops the proactive
-        // heal for an evicted-but-in-use stateful contract (Codex P1 on #4475).
+        // The helper must gate the expensive call on the SINGLE composed
+        // predicate `Ring::should_summarize_or_broadcast`, which is
+        // `(is_hosting_contract || contract_in_use) && contract_state_present`.
+        // The composition (incl. the load-bearing `&&` vs `||` — an `||` would
+        // let a phantom pass and re-open the #4610 storm) is behaviourally
+        // verified by `summarize_gate_skips_stateless_phantom_keeps_stateful_4610`
+        // in ring/hosting.rs. Here we only pin that the helper DELEGATES to it
+        // rather than re-inlining a partial gate.
         let helper_start = src
             .find("async fn summary_if_hosted_or_in_use(")
             .expect("summary_if_hosted_or_in_use helper not found");
@@ -3187,21 +3190,11 @@ mod tests {
                 .expect("summary_if_hosted_or_in_use body end not found");
         let helper_src = &src[helper_start..helper_end];
         assert!(
-            helper_src.contains("is_hosting_contract"),
-            "summary_if_hosted_or_in_use must gate on is_hosting_contract"
-        );
-        assert!(
-            helper_src.contains("contract_in_use"),
-            "summary_if_hosted_or_in_use must ALSO gate on contract_in_use so an \
-             evicted-but-in-use stateful contract keeps its interest-sync heal"
-        );
-        assert!(
-            helper_src.contains("contract_state_present"),
-            "summary_if_hosted_or_in_use must ALSO gate on contract_state_present \
-             (actual state in the on-disk store) so a phantom \
-             (interested-but-stateless) contract is NOT summarized every heartbeat \
-             — the #4610 storm. Must read the state store, not the in-memory \
-             hosting cache, so an evicted-but-on-disk contract still summarizes."
+            helper_src.contains("should_summarize_or_broadcast"),
+            "summary_if_hosted_or_in_use must gate on the composed \
+             should_summarize_or_broadcast predicate (single source of truth, \
+             #4610), not re-inline a partial (is_hosting || in_use) gate that \
+             would re-admit phantom stateless contracts"
         );
 
         // Slice the periodic arms = handler start .. the ResyncRequest arm.

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2752,23 +2752,30 @@ async fn get_contract_summary(
 /// real GET/PUT/UPDATE on relays; feeding the #4145 notification-channel
 /// saturation on gateways). #4473.
 ///
-/// Gating on `is_hosting_contract || contract_in_use` is correct, not just a
-/// heuristic:
-/// - Phantom contracts (the storm) are neither hosted nor in use, so they are
-///   skipped — empirically ~95% of the storm on technic.
-/// - A contract we hold state for but evicted from the hosting cache is only
-///   reachable while NOT in use (`evict_over_budget` retains `contract_in_use`
-///   entries), and `reclaim_evicted_contract` deletes its state once not in use.
-///   So a skipped contract has no live subscriber depending on its interest-sync
-///   heal, and (outside a brief pending-reclamation window) no state to advertise.
-/// - The moment a contract gains a live subscriber it is `contract_in_use`, so
-///   we resume summarizing and healing it — no loss of proactive repair for any
-///   contract a peer is actually subscribed to.
+/// Gating on `(is_hosting_contract || contract_in_use)` alone proved
+/// insufficient (#4610): the inbound relay-SUBSCRIBE / placement-migration path
+/// marks a contract `is_hosting`/`contract_in_use` (a downstream subscriber
+/// renewal) WITHOUT its state ever being fetched and stored, so ~655 "phantom"
+/// (interested-but-stateless) contracts still passed the gate and drove the
+/// `summarize_contract_state` storm back to ~70-80/sec (#4440 root cause). The
+/// gate therefore ALSO requires `contract_state_present` — actual state in the
+/// on-disk store — which is the only signal that distinguishes a phantom from a
+/// contract we can really summarize:
+/// - Phantom contracts (the storm) have no stored state, so they are skipped.
+/// - An evicted-but-in-use contract keeps its state ON DISK
+///   (`evict_over_budget` retains `contract_in_use` entries, and
+///   `reclaim_evicted_contract` only deletes state once NOT in use), so
+///   `contract_state_present` is true and it KEEPS summarizing — which is why
+///   the gate reads the state store, not the in-memory hosting cache.
+/// - The moment a contract's state is fetched/stored it summarizes again — no
+///   loss of proactive repair for any contract we genuinely hold.
 async fn summary_if_hosted_or_in_use(
     op_manager: &Arc<OpManager>,
     key: &freenet_stdlib::prelude::ContractKey,
 ) -> Option<freenet_stdlib::prelude::StateSummary<'static>> {
-    if op_manager.ring.is_hosting_contract(key) || op_manager.ring.contract_in_use(key) {
+    if (op_manager.ring.is_hosting_contract(key) || op_manager.ring.contract_in_use(key))
+        && op_manager.ring.contract_state_present(key)
+    {
         // Periodic interest-sync summarize: best-effort background work, so it
         // yields the contract loop to client/relay traffic (#4534 / #4473).
         get_contract_summary(op_manager, key, crate::contract::Priority::Background).await
@@ -3187,6 +3194,14 @@ mod tests {
             helper_src.contains("contract_in_use"),
             "summary_if_hosted_or_in_use must ALSO gate on contract_in_use so an \
              evicted-but-in-use stateful contract keeps its interest-sync heal"
+        );
+        assert!(
+            helper_src.contains("contract_state_present"),
+            "summary_if_hosted_or_in_use must ALSO gate on contract_state_present \
+             (actual state in the on-disk store) so a phantom \
+             (interested-but-stateless) contract is NOT summarized every heartbeat \
+             — the #4610 storm. Must read the state store, not the in-memory \
+             hosting cache, so an evicted-but-on-disk contract still summarizes."
         );
 
         // Slice the periodic arms = handler start .. the ResyncRequest arm.

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -130,19 +130,28 @@ impl BroadcastStreamMetrics {
 /// #4475 rollout (#4473). With no local state there is nothing to broadcast to
 /// the peer, so skipping is the correct behavior, not just a throttle.
 ///
-/// Gating on `is_hosting_contract || contract_in_use` is correct, not merely a
-/// heuristic — same reasoning as #4475: a phantom contract is neither hosted
-/// nor in use (skipped); a contract whose state we evicted from the hosting
-/// cache is only reachable while NOT in use, and has no live subscriber whose
-/// broadcast we'd be dropping; the moment a contract gains a live subscriber it
-/// is `contract_in_use`, so we resume broadcasting it.
+/// Gating on `(is_hosting_contract || contract_in_use)` alone proved
+/// insufficient (#4610): the inbound relay-SUBSCRIBE / placement-migration path
+/// marks a contract hosted / in-use (a downstream subscriber renewal) WITHOUT
+/// its state ever being fetched and stored, so "phantom"
+/// (interested-but-stateless) contracts still passed this gate and drove the
+/// residual `summarize_contract_state` storm. The gate therefore ALSO requires
+/// `contract_state_present` — actual state in the on-disk store:
+/// - a phantom contract has no stored state, so it is skipped (nothing to
+///   broadcast);
+/// - an evicted-but-in-use contract keeps its state ON DISK (the hosting cache
+///   evicts but `reclaim_evicted_contract` only deletes state once NOT in use),
+///   so `contract_state_present` is true and we keep broadcasting it — which is
+///   why the gate reads the state store, not the in-memory hosting cache.
 ///
-/// NOTE: it is surprising the broadcast path runs at all for a contract we hold
-/// no state for — that points at a routing/subscription leak upstream of
-/// `broadcast_state_to_peers` (tracked separately on #4473). This gate stops the
-/// storm symptom; it does not fix that upstream question.
+/// NOTE: it is surprising the broadcast/interest path runs at all for a contract
+/// we hold no state for — that points at a routing/subscription leak upstream
+/// (the inbound relay-SUBSCRIBE registering downstream-subscriber + interest
+/// without state, tracked separately on #4440/#4610). This gate stops the storm
+/// symptom; it does not fix that upstream question.
 pub(super) fn should_broadcast_contract(op_manager: &Arc<OpManager>, key: &ContractKey) -> bool {
-    op_manager.ring.is_hosting_contract(key) || op_manager.ring.contract_in_use(key)
+    (op_manager.ring.is_hosting_contract(key) || op_manager.ring.contract_in_use(key))
+        && op_manager.ring.contract_state_present(key)
 }
 
 // The `BroadcastQueue` struct (constants, types, impl) is only used in the
@@ -1234,6 +1243,15 @@ mod tests {
             helper_src.contains("contract_in_use"),
             "should_broadcast_contract must ALSO gate on contract_in_use so an \
              evicted-but-in-use stateful contract keeps being broadcast"
+        );
+        assert!(
+            helper_src.contains("contract_state_present"),
+            "should_broadcast_contract must ALSO gate on contract_state_present \
+             (actual state in the on-disk store) so a phantom \
+             (interested-but-stateless) contract is NOT broadcast/summarized every \
+             heartbeat — the #4610 storm. Must read the state store, not the \
+             in-memory hosting cache, so an evicted-but-on-disk contract still \
+             broadcasts."
         );
 
         // 2. `broadcast_to_single_peer` must call the gate BEFORE the expensive

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -134,15 +134,15 @@ impl BroadcastStreamMetrics {
 /// insufficient (#4610): the inbound relay-SUBSCRIBE / placement-migration path
 /// marks a contract hosted / in-use (a downstream subscriber renewal) WITHOUT
 /// its state ever being fetched and stored, so "phantom"
-/// (interested-but-stateless) contracts still passed this gate and drove the
-/// residual `summarize_contract_state` storm. The gate therefore ALSO requires
-/// `contract_state_present` — actual state in the on-disk store:
-/// - a phantom contract has no stored state, so it is skipped (nothing to
-///   broadcast);
-/// - an evicted-but-in-use contract keeps its state ON DISK (the hosting cache
-///   evicts but `reclaim_evicted_contract` only deletes state once NOT in use),
-///   so `contract_state_present` is true and we keep broadcasting it — which is
-///   why the gate reads the state store, not the in-memory hosting cache.
+/// (interested-but-stateless) contracts still passed and drove the residual
+/// `summarize_contract_state` storm. The fix delegates to the single composed
+/// predicate `Ring::should_summarize_or_broadcast` —
+/// `(is_hosting_contract || contract_in_use) && contract_state_present` — which
+/// is shared with `node.rs::summary_if_hosted_or_in_use` so the two paths cannot
+/// drift. The `contract_state_present` term reads the on-disk STATE store (NOT
+/// the in-memory hosting cache), so a phantom with no stored state is skipped
+/// while an evicted-but-in-use contract whose state is still on disk keeps
+/// broadcasting. See `HostingManager::should_summarize_or_broadcast`.
 ///
 /// NOTE: it is surprising the broadcast/interest path runs at all for a contract
 /// we hold no state for — that points at a routing/subscription leak upstream
@@ -150,8 +150,7 @@ impl BroadcastStreamMetrics {
 /// without state, tracked separately on #4440/#4610). This gate stops the storm
 /// symptom; it does not fix that upstream question.
 pub(super) fn should_broadcast_contract(op_manager: &Arc<OpManager>, key: &ContractKey) -> bool {
-    (op_manager.ring.is_hosting_contract(key) || op_manager.ring.contract_in_use(key))
-        && op_manager.ring.contract_state_present(key)
+    op_manager.ring.should_summarize_or_broadcast(key)
 }
 
 // The `BroadcastQueue` struct (constants, types, impl) is only used in the
@@ -1224,9 +1223,15 @@ mod tests {
     fn broadcast_single_peer_gates_summarize_on_hosted_or_in_use_pin() {
         let src = include_str!("broadcast_queue.rs");
 
-        // 1. The gate helper must check BOTH predicates: gating on hosting alone
-        //    wrongly drops the broadcast for an evicted-but-in-use stateful
-        //    contract (the #4475 Codex-P1 lesson, applied to this path).
+        // 1. The gate helper must delegate to the SINGLE composed predicate
+        //    `Ring::should_summarize_or_broadcast` =
+        //    `(is_hosting_contract || contract_in_use) && contract_state_present`,
+        //    shared with node.rs::summary_if_hosted_or_in_use. The composition
+        //    (incl. the load-bearing `&&` vs `||` that keeps phantom stateless
+        //    contracts out — #4610) is behaviourally verified by
+        //    `summarize_gate_skips_stateless_phantom_keeps_stateful_4610` in
+        //    ring/hosting.rs. Here we only pin the delegation, so a future edit
+        //    cannot re-inline a partial (is_hosting || in_use) gate.
         let helper_start = src
             .find("pub(super) fn should_broadcast_contract(")
             .expect("should_broadcast_contract helper not found");
@@ -1236,22 +1241,11 @@ mod tests {
                 .expect("should_broadcast_contract body end not found");
         let helper_src = &src[helper_start..helper_end];
         assert!(
-            helper_src.contains("is_hosting_contract"),
-            "should_broadcast_contract must gate on is_hosting_contract"
-        );
-        assert!(
-            helper_src.contains("contract_in_use"),
-            "should_broadcast_contract must ALSO gate on contract_in_use so an \
-             evicted-but-in-use stateful contract keeps being broadcast"
-        );
-        assert!(
-            helper_src.contains("contract_state_present"),
-            "should_broadcast_contract must ALSO gate on contract_state_present \
-             (actual state in the on-disk store) so a phantom \
-             (interested-but-stateless) contract is NOT broadcast/summarized every \
-             heartbeat — the #4610 storm. Must read the state store, not the \
-             in-memory hosting cache, so an evicted-but-on-disk contract still \
-             broadcasts."
+            helper_src.contains("should_summarize_or_broadcast"),
+            "should_broadcast_contract must delegate to the composed \
+             should_summarize_or_broadcast predicate (single source of truth, \
+             #4610), not re-inline a partial (is_hosting || in_use) gate that \
+             would re-admit phantom stateless contracts"
         );
 
         // 2. `broadcast_to_single_peer` must call the gate BEFORE the expensive

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2297,14 +2297,14 @@ impl Ring {
         self.hosting_manager.is_hosting_contract(key)
     }
 
-    /// Whether this node has stored state on disk for this contract (see
-    /// [`HostingManager::contract_state_present`]). Used by the #4610
-    /// summarize/broadcast gates to skip phantom (interested-but-stateless)
-    /// contracts while still serving evicted-but-in-use ones whose state
-    /// remains on disk.
+    /// The composed #4610 summarize/broadcast gate (see
+    /// [`HostingManager::should_summarize_or_broadcast`]):
+    /// `(is_hosting_contract || contract_in_use) && contract_state_present`.
+    /// Skips phantom (interested-but-stateless) contracts while still serving
+    /// evicted-but-in-use ones whose state remains on disk.
     #[inline]
-    pub fn contract_state_present(&self, key: &ContractKey) -> bool {
-        self.hosting_manager.contract_state_present(key)
+    pub fn should_summarize_or_broadcast(&self, key: &ContractKey) -> bool {
+        self.hosting_manager.should_summarize_or_broadcast(key)
     }
 
     /// Set the storage reference for hosting metadata persistence.

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2297,6 +2297,16 @@ impl Ring {
         self.hosting_manager.is_hosting_contract(key)
     }
 
+    /// Whether this node has stored state on disk for this contract (see
+    /// [`HostingManager::contract_state_present`]). Used by the #4610
+    /// summarize/broadcast gates to skip phantom (interested-but-stateless)
+    /// contracts while still serving evicted-but-in-use ones whose state
+    /// remains on disk.
+    #[inline]
+    pub fn contract_state_present(&self, key: &ContractKey) -> bool {
+        self.hosting_manager.contract_state_present(key)
+    }
+
     /// Set the storage reference for hosting metadata persistence.
     ///
     /// Must be called after executor creation. This enables automatic

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -1174,11 +1174,15 @@ impl HostingManager {
                 return match storage.get_state_size(key) {
                     Ok(size) => size.is_some(),
                     Err(e) => {
-                        tracing::warn!(
+                        // debug!, not warn!: this runs per-hosted-contract
+                        // per-heartbeat, so a persistent store error would itself
+                        // log-storm (~1000/heartbeat) — the same failure class
+                        // #4610 fixes. Assume present so a real hosted contract is
+                        // never dropped from interest-sync on a transient error.
+                        tracing::debug!(
                             contract = %key,
                             error = %e,
-                            "state-presence check failed; assuming present so a real \
-                             hosted contract is not dropped from interest-sync"
+                            "state-presence check failed; assuming present"
                         );
                         true
                     }
@@ -1192,6 +1196,31 @@ impl HostingManager {
             let _ = key;
         }
         true
+    }
+
+    /// The composed #4610 gate: summarize / broadcast a contract's state ONLY
+    /// when we host or actively serve it AND we actually hold its state:
+    /// `(is_hosting_contract || contract_in_use) && contract_state_present`.
+    ///
+    /// SINGLE SOURCE OF TRUTH for the gate, called by both
+    /// `node::summary_if_hosted_or_in_use` (periodic interest-sync) and
+    /// `broadcast_queue::should_broadcast_contract` (broadcast fan-out). Keeping
+    /// the predicate in one place means the two paths cannot drift, and an
+    /// `&&`→`||` miswire (which would let a phantom pass and re-open the storm)
+    /// is caught by ONE behavioural test
+    /// (`summarize_gate_skips_stateless_phantom_keeps_stateful_4610`) rather than
+    /// needing one per call site.
+    ///
+    /// `contract_state_present` does a deliberate cheap SYNCHRONOUS redb point
+    /// lookup on the state store. That is intentional and net-cheaper than the
+    /// pre-#4610 behavior (it replaces a failing full-fetch round-trip on the
+    /// serial contract-handling loop). Do NOT "optimize" it into an in-memory
+    /// hosting-cache check: that would reintroduce the evicted-but-on-disk
+    /// regression (a contract whose state is still on disk but no longer in the
+    /// cache must keep summarizing/broadcasting).
+    pub fn should_summarize_or_broadcast(&self, key: &ContractKey) -> bool {
+        (self.is_hosting_contract(key) || self.contract_in_use(key))
+            && self.contract_state_present(key)
     }
 
     /// Get all hosted contract keys.
@@ -3262,16 +3291,25 @@ mod tests {
     /// every heartbeat — a full fetch that always failed "Contract state not
     /// found in store" (~70-80/sec at scale; CPU pegged, memory to the 2G cap).
     ///
-    /// The fix adds a `contract_state_present` (actual on-disk state) term to
-    /// both gates. This drives the exact storm signature through real
-    /// subscriber registration + a real redb state store and asserts:
-    ///   - a phantom (in_use, no stored state) → the OLD predicate is TRUE but
-    ///     `contract_state_present` is FALSE → the gate now SKIPS it;
-    ///   - a stateful in-use contract → present → still summarized/broadcast;
+    /// The fix adds a `contract_state_present` (actual on-disk state) term,
+    /// composed with the host-or-serve check in the single
+    /// `should_summarize_or_broadcast` predicate that BOTH gate call sites use.
+    /// This drives the exact storm signature through real subscriber
+    /// registration + a real redb state store and asserts the COMPOSED gate
+    /// decision (not just the leaf signals) for each case:
+    ///   - a phantom (in_use, no stored state) → the OLD `(is_hosting||in_use)`
+    ///     predicate is TRUE but the composed gate is FALSE → SKIPPED;
+    ///   - a stateful in-use contract → composed gate TRUE → summarized/broadcast;
     ///   - an evicted-but-on-disk contract (state present, NOT in the hosting
-    ///     cache, in_use) → present → still summarized — the regression the
-    ///     state-STORE check prevents (keying on `is_hosting_contract`, i.e.
-    ///     cache membership, would wrongly drop it).
+    ///     cache, in_use) → composed gate TRUE → still summarized — the
+    ///     regression the state-STORE check prevents (keying on
+    ///     `is_hosting_contract`, i.e. cache membership, would wrongly drop it).
+    ///
+    /// Asserting the COMPOSED predicate (not the individual leaf signals) is what
+    /// makes this test catch an `&&`→`||` miswire in
+    /// `should_summarize_or_broadcast`: with `||`, the phantom (in_use but
+    /// stateless) would pass and this test fails. Verified by flipping the
+    /// operator. A leaf-only assertion would NOT catch that.
     #[cfg(feature = "redb")]
     #[tokio::test]
     async fn summarize_gate_skips_stateless_phantom_keeps_stateful_4610() {
@@ -3311,34 +3349,79 @@ mod tests {
 
         manager.set_storage(storage);
 
-        // Storm signature: the OLD predicate (is_hosting || in_use) is TRUE for
-        // the phantom — that is exactly why it stormed before the fix.
+        // Preconditions documenting the storm signature: the OLD predicate
+        // (is_hosting || in_use) is TRUE for the phantom — that is exactly why
+        // it stormed before the fix — yet it has no stored state.
         assert!(
             manager.contract_in_use(&phantom),
             "phantom must look in-use (downstream subscriber) — the pre-#4610 \
              gate would have summarized it every heartbeat"
         );
-
-        // The fix: only the state-present contracts pass the new term.
         assert!(
             !manager.contract_state_present(&phantom),
-            "#4610: a phantom (interested-but-stateless) contract MUST be \
-             reported state-absent so the summarize/broadcast gate skips it"
-        );
-        assert!(
-            manager.contract_state_present(&stateful),
-            "a contract with stored state MUST still be summarized/broadcast"
+            "phantom precondition: no stored state"
         );
         assert!(
             !manager.is_hosting_contract(&evicted_on_disk),
-            "precondition: the evicted contract is not in the hosting cache"
+            "evicted precondition: not in the hosting cache"
         );
         assert!(
             manager.contract_state_present(&evicted_on_disk),
-            "#4610 regression guard: an evicted-but-on-disk contract MUST stay \
-             summarized — the gate reads the state STORE, not the hosting cache"
+            "evicted precondition: state still on disk"
+        );
+
+        // The actual gate decision (composed predicate, shared by both call
+        // sites). Asserting THIS — not the leaf signals — is what catches an
+        // `&&`→`||` miswire: with `||`, the phantom would pass.
+        assert!(
+            !manager.should_summarize_or_broadcast(&phantom),
+            "#4610: a phantom (in_use but stateless) contract MUST be gated OUT \
+             of summarize/broadcast. If this fails after an edit, check for an \
+             `&&`→`||` miswire in should_summarize_or_broadcast."
+        );
+        assert!(
+            manager.should_summarize_or_broadcast(&stateful),
+            "a hosted/in-use contract WITH stored state MUST be summarized/broadcast"
+        );
+        assert!(
+            manager.should_summarize_or_broadcast(&evicted_on_disk),
+            "#4610 regression guard: an evicted-but-on-disk contract (state on \
+             disk, in_use, NOT in the hosting cache) MUST stay summarized — the \
+             gate reads the state STORE, not the hosting cache"
         );
     }
+
+    /// #4610 fallback: with NO storage handle set (the pre-startup window, before
+    /// `set_storage`), `contract_state_present` MUST return `true` (assume
+    /// present). A refactor that returned `false` here would drop EVERY contract
+    /// from summarize/broadcast during the startup window. So the composed gate
+    /// reduces to the pre-#4610 `(is_hosting || in_use)` behavior until storage
+    /// is attached.
+    #[test]
+    fn contract_state_present_assumes_present_without_storage_handle() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let key = make_contract_key(80);
+        assert!(
+            manager.contract_state_present(&key),
+            "without a storage handle, contract_state_present must assume present \
+             so startup-window contracts are not all dropped"
+        );
+        // And the composed gate still passes for an in-use contract pre-storage.
+        let peer = make_peer_key(8);
+        manager.add_downstream_subscriber(&key, peer);
+        assert!(
+            manager.should_summarize_or_broadcast(&key),
+            "pre-storage, the gate must fall back to (is_hosting || in_use)"
+        );
+    }
+
+    // NOTE: no sqlite-backend fallback test. The sqlite store has no cheap
+    // *synchronous* existence check, so `contract_state_present` returns `true`
+    // there (the `#[cfg(not(feature = "redb"))]` branch, preserving pre-#4610
+    // behavior). A `#[cfg(all(feature = "sqlite", not(feature = "redb")))]` test
+    // would never run: the sqlite backend does not compile on main (unrelated
+    // pre-existing errors, e.g. missing `get_user_secrets_index`) and there is
+    // no sqlite CI lane, so such a test would be unverifiable dead code.
 
     /// Generation flow through `HostingManager`: bumping the state
     /// generation BEFORE `record_contract_access` makes the captured

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -1130,6 +1130,70 @@ impl HostingManager {
         self.hosting_cache.read().contains(key)
     }
 
+    /// Whether this node has STORED STATE for `key` in the contract state
+    /// store (on disk), as opposed to merely tracking it in an in-memory
+    /// cache or subscriber map.
+    ///
+    /// This is the load-bearing distinction for the #4610 summarize/broadcast
+    /// gate. A contract can be marked hosted (`is_hosting_contract`) or be
+    /// `contract_in_use` (a downstream subscriber renewing an inbound relay
+    /// SUBSCRIBE) WITHOUT its state ever having been fetched and stored — the
+    /// "phantom" (interested-but-stateless) contracts of #4440. Summarizing or
+    /// broadcasting such a contract is pointless: there is nothing to
+    /// summarize, every attempt fails with "Contract state not found in
+    /// store", and at scale the periodic interest-sync/broadcast loops fire
+    /// ~70-80 of these per second — the #4610 CPU/memory storm.
+    ///
+    /// Reads the state store directly so the answer is correct in the cases
+    /// the in-memory caches get wrong:
+    /// - a cache-hosted contract whose state was never stored → absent (skip);
+    /// - an evicted-but-in-use contract whose state is still on disk
+    ///   (`evict_over_budget` retains `contract_in_use` entries, and
+    ///   `reclaim_evicted_contract` only deletes state once NOT in use) →
+    ///   present, so it KEEPS summarizing/broadcasting (no regression). This
+    ///   is exactly why the gate must NOT key on `is_hosting_contract`, which
+    ///   reads only the in-memory hosting cache.
+    ///
+    /// Cheap: a single redb point lookup on the STATE table that does not
+    /// deserialize the value (`get_state_size` reads only the value length).
+    /// It runs per-hosted-contract per-heartbeat, but REPLACES a far more
+    /// expensive failing round-trip (a `GetSummaryQuery` on the serial
+    /// contract-handling loop → full fetch → `MissingContract`) for every
+    /// phantom contract, so it is a net reduction in work.
+    ///
+    /// Conservative on uncertainty: an unset storage handle (pre-startup) or a
+    /// transient store error returns `true` (treat as present) so a real
+    /// hosted contract is never wrongly dropped from interest-sync repair. The
+    /// sqlite backend has no cheap *synchronous* existence check, so it also
+    /// returns `true`, preserving pre-#4610 behavior; the storm is a
+    /// redb-production phenomenon.
+    pub fn contract_state_present(&self, key: &ContractKey) -> bool {
+        #[cfg(feature = "redb")]
+        {
+            if let Some(storage) = self.storage.read().as_ref() {
+                return match storage.get_state_size(key) {
+                    Ok(size) => size.is_some(),
+                    Err(e) => {
+                        tracing::warn!(
+                            contract = %key,
+                            error = %e,
+                            "state-presence check failed; assuming present so a real \
+                             hosted contract is not dropped from interest-sync"
+                        );
+                        true
+                    }
+                };
+            }
+        }
+        #[cfg(not(feature = "redb"))]
+        {
+            // No cheap synchronous existence check on this backend; preserve
+            // pre-#4610 behavior. Touch `key` so it is not flagged unused.
+            let _ = key;
+        }
+        true
+    }
+
     /// Get all hosted contract keys.
     pub fn hosting_contract_keys(&self) -> Vec<ContractKey> {
         self.hosting_cache.read().iter().collect()
@@ -3184,6 +3248,96 @@ mod tests {
              of auto-fetch (#4473): keeping it would re-introduce the phantom churn"
         );
         manager.unsubscribe(&upstream_only);
+    }
+
+    /// Behavioural regression for the #4610 summarize/broadcast storm.
+    ///
+    /// The inbound relay-SUBSCRIBE / placement-migration path marks a contract
+    /// `contract_in_use` (a downstream-subscriber renewal) WITHOUT its state
+    /// ever being fetched/stored — a "phantom" (interested-but-stateless)
+    /// contract (#4440). Before #4610 the summarize gate
+    /// (`is_hosting_contract || contract_in_use`) and the broadcast gate
+    /// `should_broadcast_contract` both passed such a contract, so the periodic
+    /// interest-sync / broadcast loops called `summarize_contract_state` for it
+    /// every heartbeat — a full fetch that always failed "Contract state not
+    /// found in store" (~70-80/sec at scale; CPU pegged, memory to the 2G cap).
+    ///
+    /// The fix adds a `contract_state_present` (actual on-disk state) term to
+    /// both gates. This drives the exact storm signature through real
+    /// subscriber registration + a real redb state store and asserts:
+    ///   - a phantom (in_use, no stored state) → the OLD predicate is TRUE but
+    ///     `contract_state_present` is FALSE → the gate now SKIPS it;
+    ///   - a stateful in-use contract → present → still summarized/broadcast;
+    ///   - an evicted-but-on-disk contract (state present, NOT in the hosting
+    ///     cache, in_use) → present → still summarized — the regression the
+    ///     state-STORE check prevents (keying on `is_hosting_contract`, i.e.
+    ///     cache membership, would wrongly drop it).
+    #[cfg(feature = "redb")]
+    #[tokio::test]
+    async fn summarize_gate_skips_stateless_phantom_keeps_stateful_4610() {
+        use freenet_stdlib::prelude::WrappedState;
+
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+
+        // Real redb state store, like production.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = crate::contract::storages::ReDb::new(temp_dir.path())
+            .await
+            .unwrap();
+
+        let peer = make_peer_key(7);
+
+        // Phantom: a remote peer relay-subscribed (downstream subscriber) but
+        // we NEVER fetched/stored its state.
+        let phantom = make_contract_key(70);
+        manager.add_downstream_subscriber(&phantom, peer.clone());
+
+        // Stateful: state actually stored AND in use.
+        let stateful = make_contract_key(71);
+        storage
+            .store_state_sync(&stateful, WrappedState::new(vec![1, 2, 3, 4]))
+            .unwrap();
+        manager.add_downstream_subscriber(&stateful, peer.clone());
+
+        // Evicted-but-on-disk: state stored, in use, but NOT in the hosting
+        // cache (never `host_contract`-ed). The gate must NOT skip this one —
+        // keying on `is_hosting_contract` (cache membership) would wrongly drop
+        // it, so this is the regression the state-store check prevents.
+        let evicted_on_disk = make_contract_key(72);
+        storage
+            .store_state_sync(&evicted_on_disk, WrappedState::new(vec![9, 9, 9]))
+            .unwrap();
+        manager.add_downstream_subscriber(&evicted_on_disk, peer.clone());
+
+        manager.set_storage(storage);
+
+        // Storm signature: the OLD predicate (is_hosting || in_use) is TRUE for
+        // the phantom — that is exactly why it stormed before the fix.
+        assert!(
+            manager.contract_in_use(&phantom),
+            "phantom must look in-use (downstream subscriber) — the pre-#4610 \
+             gate would have summarized it every heartbeat"
+        );
+
+        // The fix: only the state-present contracts pass the new term.
+        assert!(
+            !manager.contract_state_present(&phantom),
+            "#4610: a phantom (interested-but-stateless) contract MUST be \
+             reported state-absent so the summarize/broadcast gate skips it"
+        );
+        assert!(
+            manager.contract_state_present(&stateful),
+            "a contract with stored state MUST still be summarized/broadcast"
+        );
+        assert!(
+            !manager.is_hosting_contract(&evicted_on_disk),
+            "precondition: the evicted contract is not in the hosting cache"
+        );
+        assert!(
+            manager.contract_state_present(&evicted_on_disk),
+            "#4610 regression guard: an evicted-but-on-disk contract MUST stay \
+             summarized — the gate reads the state STORE, not the hosting cache"
+        );
     }
 
     /// Generation flow through `HostingManager`: bumping the state


### PR DESCRIPTION
## Problem

A regular (non-gateway) node on **0.2.84 / 0.2.85** exhibits an unbounded `summarize_contract_state` storm (~70-80/sec, CPU pegged, memory to the 2G `MemoryMax` cap) completely decoupled from user activity (#4610).

Root cause, confirmed on the affected node: the inbound relay-SUBSCRIBE / placement-migration path marks contracts `is_hosting` / `contract_in_use` via downstream-subscriber renewals **WITHOUT their state ever being fetched and stored**. The periodic interest-sync and broadcast loops iterate the hosted/in-use set every heartbeat and call `summarize_contract_state` on each; for the ~655 stateless "phantom" contracts every call fails `Contract state not found in store`. On the affected node: `hosted_contracts_count ≈ 900-1000`, but **655 distinct contracts** have no stored state, and the phantom set has **100% overlap** with the relay-subscribed set.

The prior #4475/#4473 gate `(is_hosting_contract || contract_in_use)` could not filter these, because the ring genuinely reports them hosted/in-use — the missing signal is whether we actually hold the state.

## Solution

Add a **state-presence** term and route both gate sites through a single composed predicate `Ring::should_summarize_or_broadcast` → `HostingManager::should_summarize_or_broadcast`:

```
(is_hosting_contract || contract_in_use) && contract_state_present
```

Both `summary_if_hosted_or_in_use` (`crates/core/src/node.rs`, the periodic interest-sync summarize path) and `should_broadcast_contract` (`crates/core/src/node/network_bridge/broadcast_queue.rs`, the broadcast fan-out, also consulted by the sim-inline `broadcast_state_to_peers`) delegate to it. One source of truth means the two paths cannot drift.

`contract_state_present` reads the **on-disk STATE store** (via the existing cheap `get_state_size` point-lookup — no value deserialize), **NOT the in-memory hosting cache**. This is the load-bearing distinction:

- a phantom (no stored state) → skipped, the storm stops;
- an **evicted-but-in-use** contract whose state is still on disk (the hosting cache evicts but `reclaim_evicted_contract` only deletes state once NOT in use) → reported present, so it **keeps** summarizing/broadcasting — keying on `is_hosting_contract` (cache membership) would wrongly drop it.

It is **net-cheaper** than today: it replaces a failing full-fetch round-trip on the serial contract-handling loop for every phantom with a single redb point lookup. Conservative on uncertainty — an unset storage handle (pre-startup), a transient store error (logged at `debug!`, not `warn!`, to avoid a per-heartbeat log-storm), or the sqlite backend (no cheap *sync* existence check) all return `true` (treat as present), so a real contract is never wrongly dropped.

**Scope: storm-stop only.** This stops the `summarize_contract_state` storm. It does NOT fix the deeper root cause — that a contract gets marked hosted/in-use without its state (the inbound relay-SUBSCRIBE registering downstream-subscriber + interest without fetching state); reconciling the hosting set against the state store is a larger, riskier follow-up (root-cause tracker to be filed). It also does not address contract retrievability / GET dead-ends, which remain on #4404.

## Testing

- Behavioural regression test `summarize_gate_skips_stateless_phantom_keeps_stateful_4610` (`ring/hosting.rs`) drives the storm signature through real subscriber registration + a real redb state store and asserts the **composed gate decision** (not just leaf signals): phantom→excluded, stateful→included, evicted-but-on-disk→included. This **validates the predicate and its composition** (it is not a full end-to-end node test). **Verified it FAILS on an `&&`→`||` miswire** in `should_summarize_or_broadcast` and passes with `&&` — so a fix-defeating miswire is caught by CI.
- Fallback test `contract_state_present_assumes_present_without_storage_handle`: pre-startup (no storage handle) returns present, so the gate never drops every contract during startup.
- The two source-scrape pins now assert each call site **delegates** to `should_summarize_or_broadcast` (cannot re-inline a partial gate). Existing pins (`broadcast_state_to_peers_gates_summarize_on_hosted_or_in_use`, `auto_fetch_gate_skips_phantom_contracts_and_passes_served_ones`) still pass.
- `cargo fmt` + `cargo clippy --locked -- -D warnings` clean. `codex review --base origin/main`: no correctness issues. (No sqlite-backend test: sqlite does not compile on main for unrelated pre-existing reasons and has no CI lane; the production fallback is documented in-code.)
- Doc updated: `.claude/rules/ring.md` gate invariant reflects the added state-presence term.

This is an immediate storm-stop intended for an **ASAP release**.

Refs #4610

[AI-assisted - Claude]