### PR TITLE
fix: disable SubscribeHint placement migration [HOLD — LIKELY UNNECESSARY, see body banner]

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1774,19 +1774,22 @@ where
                 .ring
                 .placement_migration_metrics()
                 .record_received();
-            // Placement-migration version gate. The migration is re-enabled at
-            // floor `(0, 2, 80)` (#4499 made it load-safe). The SEND side
+            // Placement-migration version gate. The migration is DISABLED in
+            // production: the floor is parked at `(0, 3, 0)`, above every shipped
+            // 0.2.x release, because it is net-negative (#4610 / #4440 / #4534
+            // costs with no placement benefit — see the `SUBSCRIBE_HINT_MIN_VERSION`
+            // doc comment). The SEND side
             // (`p2p_protoc::peer_supports_subscribe_hint`) gates emission on the
-            // remote peer's version; the RECEIVE path must gate too, so a node on
-            // an older release does not ACT on a hint from an upgraded peer and
-            // keep migration load alive on a peer that predates the load-safe fix.
+            // remote peer's version; the RECEIVE path gates too, so a node does not
+            // ACT on a hint even if some peer were to emit one.
             //
             // The symmetric (sender-version) gate is not cleanly reachable here:
             // the per-connection remote version lives in `P2pConnManager.connections`
             // and is not exposed through the `NetworkBridge` trait, so use this
-            // node's OWN version against the SAME floor the send side uses. A node
-            // on `>= 0.2.80` acts on inbound hints; a pre-floor node ignores them.
-            // Lowering the floor (sim override) re-activates both sides together.
+            // node's OWN version against the SAME floor the send side uses. With the
+            // floor at `(0, 3, 0)` no shipped 0.2.x node acts on inbound hints.
+            // Lowering the floor (sim override, or a deliberate canary-gated
+            // re-enable) re-activates both sides together.
             //
             // Read the floor via `subscribe_hint_floor_override().unwrap_or(...)`,
             // identical to the send side, so a simulation that opts into the
@@ -3479,23 +3482,24 @@ mod tests {
 
     // Tests for the INBOUND `SubscribeHint` receive gate.
     //
-    // The placement migration is RE-ENABLED at floor `(0, 2, 80)` (#4499 made it
-    // load-safe). The receive handler shares this floor with the send side, so a
-    // node acts on an inbound hint only when both it and the producing peer are at
-    // or above the floor; it still ignores hints from pre-floor peers, which
-    // preserves wire-compat during the staggered rollout.
+    // The placement migration is DISABLED: the floor is parked at `(0, 3, 0)`,
+    // above every shipped 0.2.x release, because it is net-negative in production
+    // (#4610 / #4440 / #4534 costs with no placement benefit — see the
+    // `SUBSCRIBE_HINT_MIN_VERSION` doc comment). The receive handler shares this
+    // floor with the send side, so no shipped 0.2.x node acts on an inbound hint.
+    // Lowering the floor (sim override, or a deliberate canary-gated re-enable)
+    // re-activates both sides together.
     mod inbound_subscribe_hint_gate {
         use crate::node::network_bridge::p2p_protoc::{
             SUBSCRIBE_HINT_MIN_VERSION, own_crate_version, version_supports_subscribe_hint,
         };
 
-        // Superseded: the placement migration was RE-ENABLED at `(0, 2, 80)` by
-        // PR #4511 (#4145 fixed in #4499). This test pinned the v0.2.74
-        // deactivation (own version below the parked floor, so all inbound hints
-        // ignored) and now documents that prior behavior; its `own < floor`
-        // assert no longer holds once the crate reaches the floor. Replaced by
-        // `receive_gate_active_at_reenable_floor` below.
-        #[ignore]
+        /// The placement migration is DISABLED: the floor is parked at `(0, 3, 0)`,
+        /// above every shipped 0.2.x release (including this crate's own version),
+        /// so the receive gate IGNORES every inbound hint. Re-disabled because the
+        /// migration is net-negative in production (#4610 / #4440 / #4534 costs
+        /// with no placement benefit). See the `SUBSCRIBE_HINT_MIN_VERSION` doc
+        /// comment.
         #[test]
         fn receive_gate_ignores_hint_while_deactivated() {
             let own = own_crate_version();
@@ -3515,36 +3519,33 @@ mod tests {
             ));
         }
 
-        /// At the re-enable floor the receive gate ACTS on hints from peers at or
-        /// above the floor and IGNORES hints from pre-floor peers (wire-compat).
+        /// With the floor parked at `(0, 3, 0)` the receive gate IGNORES hints
+        /// from every shipped 0.2.x peer (the migration is disabled). The
+        /// `!supported(0,2,255)` + `supported(0,3,0)` pair pins the floor to
+        /// EXACTLY `(0, 3, 0)`: lowering it (a re-enable) trips these asserts —
+        /// the intended tripwire, since re-enabling must be a deliberate,
+        /// canary-gated change (see docs/RELEASING.md and the const doc comment).
         /// Uses explicit versions rather than `own_crate_version` so the assertion
-        /// is stable across the 0.2.79 -> 0.2.80 boundary (the crate is still
-        /// 0.2.79 until the re-enable release bumps it to the floor version).
+        /// is stable across release bumps. See issues #4404 / #4610 / #4440.
         #[test]
-        fn receive_gate_active_at_reenable_floor() {
-            // The `supported(0,2,80)` + `!supported(0,2,79)` pair pins the floor
-            // to exactly `(0, 2, 80)`; an accidental change trips these asserts.
-            // Peers at or above the floor are acted on.
-            assert!(version_supports_subscribe_hint(
+        fn receive_gate_disabled_above_all_0_2_x() {
+            // Highest possible 0.2.x patch is still below the floor: ignored.
+            assert!(!version_supports_subscribe_hint(
+                Some((0, 2, 255)),
+                SUBSCRIBE_HINT_MIN_VERSION
+            ));
+            assert!(!version_supports_subscribe_hint(
                 Some((0, 2, 80)),
                 SUBSCRIBE_HINT_MIN_VERSION
             ));
+            // Exactly at the disabled floor `(0, 3, 0)` qualifies — this pins the
+            // floor value so an accidental lowering trips the assert above.
             assert!(version_supports_subscribe_hint(
                 Some((0, 3, 0)),
                 SUBSCRIBE_HINT_MIN_VERSION
             ));
-            // Pre-floor peers are still ignored: older 0.2.x peers, and the
-            // original 0.2.73 sender from the staggered rollout.
-            assert!(!version_supports_subscribe_hint(
-                Some((0, 2, 79)),
-                SUBSCRIBE_HINT_MIN_VERSION
-            ));
-            assert!(!version_supports_subscribe_hint(
-                Some((0, 2, 73)),
-                SUBSCRIBE_HINT_MIN_VERSION
-            ));
-            // Unknown remote version fails closed (the migration's send/receive
-            // gate must never act on a peer whose version we could not determine).
+            // Unknown remote version fails closed (the gate must never act on a
+            // peer whose version we could not determine).
             assert!(!version_supports_subscribe_hint(
                 None,
                 SUBSCRIBE_HINT_MIN_VERSION

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -751,31 +751,43 @@ pub(in crate::node) struct P2pConnManager {
 /// Minimum negotiated protocol version a peer must report before we send it a
 /// [`SubscribeHint`](crate::message::NetMessageV1::SubscribeHint).
 ///
-/// RE-ENABLED at `(0, 2, 80)` after the #4145 event-loop fix (#4499) made the
-/// migration load-safe. 0.2.80 is the first release that ships SubscribeHint with
-/// that fix, so the floor follows the standard "set to the first-shipping release
-/// version, then FREEZE" rule. The gate (`remote.is_some_and(|v| v >= floor)`,
-/// fail-closed on unknown) sends a hint only to peers on `>= 0.2.80`, so the
-/// migration activates among upgraded peers and ramps with fleet upgrade rather
-/// than switching on everywhere at once.
+/// DISABLED at `(0, 3, 0)` — above every shipped 0.2.x release — so the
+/// SubscribeHint placement migration is OFF for the entire live network. The
+/// gate (`remote.is_some_and(|v| v >= floor)`, fail-closed on unknown) can
+/// never be satisfied by any 0.2.x peer, so no node sends or acts on hints.
 ///
-/// History: the migration first shipped in v0.2.73, where the placement-migration
-/// path (directed subscribes plus the `ConsiderContractMigration` emits) amplified
-/// the #4145/#4231 broadcast-backpressure surface and drove a network-wide
-/// UPDATE-broadcast degradation. v0.2.74 disabled it by raising this floor to
-/// `(0, 3, 0)`, above every shipped 0.2.x peer. It was re-enabled at `(0, 2, 80)`
-/// only after #4145 was fixed (#4499), validated at incident-scale fan-out, and
-/// the broadcast-assembly-failure telemetry (#4498) was deployed.
+/// WHY DISABLED — the #4404 placement migration is net-negative in production.
+/// It imposes real, measurable cost: it drives the #4610 full-state summarize
+/// storm, the #4440 subscription-renewal load, and #4534 module-cache thrash —
+/// while delivering NO measurable placement benefit. Production telemetry over
+/// the re-enabled window showed `hosted_key_distance` FLAT (placement did not
+/// tighten at all) and the inbound-hint act-rate collapsed to ~0.05%
+/// (received-but-not-acted), so the network paid the storm / renewal / thrash
+/// cost for essentially zero migrations. Disabling removes that cost with no
+/// placement regression. Authorized by Ian + overseer (2026-06).
 ///
-/// Wire-compat contract: a peer is only sent SubscribeHint if its negotiated
-/// version is `>=` this floor; older peers cannot deserialize the wire variant and
-/// would drop the connection. None (unknown, e.g. joiner->gateway) is treated as
-/// unsupported.
+/// REVERSIBLE — this is a single const. Lowering the floor (e.g. back to a
+/// shipped 0.2.x version) re-enables BOTH the SEND gate
+/// (`select_migration_target` → `peer_supports_subscribe_hint`) and the RECEIVE
+/// gate (`node.rs` inbound `SubscribeHint` handler, which gates on this node's
+/// own version) together.
 ///
-/// DO NOT bump this floor on later releases. Once shipped in 0.2.80, peers running
-/// 0.2.80+ can deserialize the variant, so the floor must stay at 0.2.80 forever;
-/// raising it would silently stop sending hints to fully-capable peers. (This is
-/// why there is no `floor` vs `CARGO_PKG_VERSION` unit test; see docs/RELEASING.md.)
+/// BAR FOR RE-ENABLING — do NOT lower this floor on the strength of a passing
+/// simulation test alone. A sim can show hints flowing, but the production
+/// failure was precisely that hints flowed, cost a lot, and moved placement
+/// nowhere. Any future re-enable MUST be gated on a CANARY showing
+/// `hosted_key_distance` measurably TIGHTENING under the migration (i.e. real
+/// placement benefit on real peers), with the #4610 / #4440 / #4534 costs
+/// bounded — not just a green test. If you cannot show placement improving on
+/// production peers, leave it off. This is a deliberate re-disable, NOT a stale
+/// "forgot to lower the floor" — do not reflex-revert it.
+///
+/// Wire-compat note: a peer is only sent SubscribeHint if its negotiated
+/// version is `>=` this floor; older peers cannot deserialize the wire variant
+/// and would drop the connection. With the floor parked above every 0.2.x
+/// release this is moot today, but if the floor is ever lowered to re-enable,
+/// pick a value no lower than the first release that can deserialize the variant
+/// (0.2.73). None (unknown, e.g. joiner->gateway) is treated as unsupported.
 ///
 /// This is a single non-cfg constant: deliberately NOT lowered under any test
 /// feature, because `testing` is pulled into the SHIPPED release binary (`fdev`
@@ -784,30 +796,34 @@ pub(in crate::node) struct P2pConnManager {
 /// so a cfg-gated test floor would defeat the wire-compat gate in production.
 /// Simulation tests that want the cascade lower the floor per-node at runtime via
 /// `NodeConfig::subscribe_hint_floor_override` (set by
-/// `SimNetwork::enable_placement_migration`), which never touches production.
+/// `SimNetwork::enable_placement_migration`), which never touches production — so
+/// the migration-on sim tests still run the cascade with this production floor
+/// parked.
 ///
 /// `pub(crate)` so the INBOUND `SubscribeHint` receive handler in
 /// [`crate::node`] can share the same floor: the send-side gate alone is not
-/// enough, because a 0.2.74 node would otherwise still ACT on hints sent by a
-/// pre-floor 0.2.73 peer and keep the (deactivated) migration load alive during
-/// the staggered rollout.
+/// enough, because a node would otherwise still ACT on hints sent by a peer and
+/// keep the (disabled) migration load alive.
 ///
-/// Set to `(0, 2, 80)`: the first release that ships SubscribeHint together with
-/// the #4145 event-loop fix (#4499) that makes the migration load-safe. The
-/// migration is RE-ENABLED at this floor, and the value is now FROZEN per the
-/// general wire-gated-floor rule in `docs/RELEASING.md` (do NOT bump it on later
-/// releases). Only peer pairs both on `>= 0.2.80` exchange hints, so activation
-/// ramps with fleet upgrade rather than switching on everywhere at once.
-pub(crate) const SUBSCRIBE_HINT_MIN_VERSION: (u8, u8, u16) = (0, 2, 80);
+/// History: the migration first shipped in v0.2.73, where the placement-migration
+/// path (directed subscribes plus the `ConsiderContractMigration` emits) amplified
+/// the #4145/#4231 broadcast-backpressure surface and drove a network-wide
+/// UPDATE-broadcast degradation. v0.2.74 disabled it by parking this floor at
+/// `(0, 3, 0)`. It was RE-ENABLED at `(0, 2, 80)` (#4511) after #4145 was fixed
+/// (#4499) and validated at incident-scale fan-out — but production telemetry then
+/// showed it net-negative (the storm / renewal / thrash costs above, with flat
+/// `hosted_key_distance` and a ~0.05% act-rate), so it is RE-DISABLED here by
+/// parking the floor at `(0, 3, 0)` again.
+pub(crate) const SUBSCRIBE_HINT_MIN_VERSION: (u8, u8, u16) = (0, 3, 0);
 
 /// This node's own crate version as a `(major, minor, patch)` tuple, parsed at
 /// compile time from `CARGO_PKG_VERSION`.
 ///
 /// Used by the INBOUND `SubscribeHint` receive gate (see [`crate::node`]) to ask
 /// "is the placement migration active for a node running THIS version?" via
-/// [`version_supports_subscribe_hint`]. With the floor at `(0, 2, 80)`, a node on
-/// `>= 0.2.80` acts on inbound hints and a pre-floor node ignores them; the send
-/// and receive sides share this floor so they activate together.
+/// [`version_supports_subscribe_hint`]. With the floor parked at `(0, 3, 0)` the
+/// migration is DISABLED, so no shipped 0.2.x node acts on inbound hints; the
+/// send and receive sides share this floor so they enable/disable together.
 pub(crate) const fn own_crate_version() -> (u8, u8, u16) {
     parse_crate_version(env!("CARGO_PKG_VERSION"))
 }
@@ -3468,12 +3484,12 @@ mod tests {
             assert!(!version_supports_subscribe_hint(None, (0, 0, 0)));
         }
 
-        // Superseded: the placement migration was RE-ENABLED at `(0, 2, 80)` by
-        // PR #4511 (#4145 fixed in #4499). This test pinned the v0.2.74
-        // deactivation (dormant for every 0.2.x peer) and now documents that
-        // prior behavior; its asserts no longer hold against the lowered floor.
-        // Replaced by `placement_migration_active_at_reenable_floor` below.
-        #[ignore]
+        /// The placement migration is DISABLED for every shipped 0.2.x peer: the
+        /// floor is parked at `(0, 3, 0)`, so no 0.2.x version — and no unknown
+        /// version — is ever sent or acts on a hint. Re-disabled because the
+        /// migration is net-negative in production (#4610 / #4440 / #4534 costs
+        /// with flat `hosted_key_distance` and a ~0.05% act-rate, i.e. no
+        /// placement benefit). See the `SUBSCRIBE_HINT_MIN_VERSION` doc comment.
         #[test]
         fn placement_migration_deactivated_for_all_0_2_x() {
             assert!(!version_supports_subscribe_hint(
@@ -3491,33 +3507,29 @@ mod tests {
         }
 
         /// Pin the PRODUCTION constant (not the local `FLOOR`): the placement
-        /// migration is RE-ENABLED at `(0, 2, 80)` (#4499 made it load-safe), so
-        /// peers at or above that floor participate while pre-floor 0.2.x peers
-        /// and unknown versions stay gated off (wire-compat with the staggered
-        /// rollout). An accidental change to the floor moves the activation set
-        /// and trips the pinned value below. See docs/RELEASING.md and issues
-        /// #4145 / #4499.
+        /// migration is DISABLED by parking the floor at `(0, 3, 0)`, above every
+        /// shipped 0.2.x release, because it is net-negative in production
+        /// (#4610 / #4440 / #4534 costs, flat `hosted_key_distance`, ~0.05%
+        /// act-rate). The `!supported(0,2,255)` + `supported(0,3,0)` pair pins the
+        /// floor to EXACTLY `(0, 3, 0)`: lowering it (a re-enable) trips these
+        /// asserts — the intended tripwire, since re-enabling must be a deliberate,
+        /// canary-gated change (see docs/RELEASING.md and the const doc comment).
+        /// See issues #4404 / #4610 / #4440.
         #[test]
-        fn placement_migration_active_at_reenable_floor() {
-            // The `supported(0,2,80)` + `!supported(0,2,79)` pair below pins the
-            // floor to exactly `(0, 2, 80)`: an accidental change moves the
-            // activation set and trips these asserts.
-            // At or above the floor: active.
-            assert!(version_supports_subscribe_hint(
-                Some((0, 2, 80)),
-                SUBSCRIBE_HINT_MIN_VERSION
-            ));
-            assert!(version_supports_subscribe_hint(
+        fn placement_migration_disabled_above_all_0_2_x() {
+            // Highest possible 0.2.x patch is still below the floor: disabled.
+            assert!(!version_supports_subscribe_hint(
                 Some((0, 2, 255)),
                 SUBSCRIBE_HINT_MIN_VERSION
             ));
-            // Below the floor: still gated off.
             assert!(!version_supports_subscribe_hint(
-                Some((0, 2, 79)),
+                Some((0, 2, 80)),
                 SUBSCRIBE_HINT_MIN_VERSION
             ));
-            assert!(!version_supports_subscribe_hint(
-                Some((0, 2, 73)),
+            // Exactly at the disabled floor `(0, 3, 0)` qualifies — this pins the
+            // floor value so an accidental lowering trips the assert above.
+            assert!(version_supports_subscribe_hint(
+                Some((0, 3, 0)),
                 SUBSCRIBE_HINT_MIN_VERSION
             ));
             // Unknown version fails closed.
@@ -3525,6 +3537,27 @@ mod tests {
                 None,
                 SUBSCRIBE_HINT_MIN_VERSION
             ));
+        }
+
+        /// Regression pin for the deliberate re-disable: the production floor MUST
+        /// stay at the disabled value `(0, 3, 0)` (above every shipped 0.2.x
+        /// release). The #4404 placement migration is net-negative in production
+        /// (#4610 / #4440 / #4534 costs with no placement benefit — flat
+        /// `hosted_key_distance`, ~0.05% act-rate), so it is intentionally OFF.
+        /// This direct equality is the loudest tripwire against a reflex-revert to
+        /// `(0, 2, 80)` (the prior re-enable value): re-enabling must be a
+        /// deliberate, canary-gated change (see docs/RELEASING.md and the const
+        /// doc comment), NOT an accidental edit. See #4404 / #4610 / #4440.
+        #[test]
+        fn subscribe_hint_floor_is_parked_at_disabled_value() {
+            assert_eq!(
+                SUBSCRIBE_HINT_MIN_VERSION,
+                (0, 3, 0),
+                "SubscribeHint placement migration must stay DISABLED — the floor \
+                 must remain parked at (0, 3, 0). Lowering it re-enables a \
+                 net-negative migration and must only be done via a deliberate, \
+                 canary-gated change."
+            );
         }
     }
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -92,28 +92,38 @@ Current wire-gated floors:
 - `SUBSCRIBE_HINT_MIN_VERSION` in `crates/core/src/node/network_bridge/p2p_protoc.rs`
   (SubscribeHint placement migration, #4404).
 
-  Set to **`(0, 2, 80)`** and FROZEN. 0.2.80 is the first release that ships
-  SubscribeHint together with the #4145 event-loop fix (#4499) that makes the
-  migration load-safe, so this floor now follows the general "set to the
-  first-shipping release version, then freeze" rule above. The SEND gate emits a
-  hint only to peers reported at `>= 0.2.80`; the inbound-hint RECEIVE gate (in
-  `node.rs`) acts on a hint only if THIS node is itself `>= 0.2.80` (a proxy: the
-  per-connection sender version is not exposed at the receive handler, so the
-  load-bearing receiver gates on its own version, which guarantees the node that
-  takes on migration load always has the #4145 fix). Because pre-0.2.80 releases
-  have parked floors and emit no hints, in practice hints flow only between
-  `>= 0.2.80` peers, so activation ramps with fleet upgrade rather than switching
-  on everywhere at once. **DO NOT bump this floor on later releases** (raising it
-  above the first-shipping version would silently stop sending to fully-capable
-  peers).
+  **DISABLED — parked at `(0, 3, 0)`**, above every shipped 0.2.x release, so the
+  migration is OFF for the entire live network. The SEND gate emits a hint only to
+  peers reported at `>= (0, 3, 0)` (none today); the inbound-hint RECEIVE gate (in
+  `node.rs`) acts on a hint only if THIS node is itself `>= (0, 3, 0)` (none
+  today). With the floor above all 0.2.x peers, no node sends or acts on hints.
+
+  This is a DELIBERATE re-disable, NOT a "freeze at the first-shipping version"
+  floor — the #4404 placement migration is net-negative in production. It drives
+  the #4610 full-state summarize storm, the #4440 subscription-renewal load, and
+  #4534 module-cache thrash, while delivering NO measurable placement benefit:
+  production telemetry over the re-enabled window showed `hosted_key_distance` FLAT
+  (placement did not tighten) and the inbound-hint act-rate collapsed to ~0.05%
+  (received-but-not-acted). The network paid the storm / renewal / thrash cost for
+  essentially zero migrations, so disabling removes that cost with no placement
+  regression. Authorized by Ian + overseer (2026-06).
+
+  **REVERSIBLE, but gated.** Lowering the floor (e.g. back to a shipped 0.2.x
+  version) re-enables both gates together. Do NOT lower it on the strength of a
+  passing simulation test alone — a sim can show hints flowing, but the production
+  failure was exactly that hints flowed, cost a lot, and moved placement nowhere.
+  Any future re-enable MUST be gated on a CANARY showing `hosted_key_distance`
+  measurably TIGHTENING under the migration (real placement benefit on real
+  peers), with the #4610 / #4440 / #4534 costs bounded — not just a green test. If
+  you cannot show placement improving on production peers, leave it off.
 
   History: the migration first shipped in v0.2.73 and its directed-subscribe /
   hint-broadcast load drove a network-wide UPDATE-broadcast degradation by
   amplifying the latent #4145 event-loop wedge. v0.2.74 disabled it by parking
-  this floor at `(0, 3, 0)`, above all live peers. It was re-enabled at
-  `(0, 2, 80)` only after #4145 was fixed (#4499), the fix was validated at
-  incident-scale fan-out, and the broadcast-assembly-failure telemetry (#4498)
-  was deployed to record a baseline and watch the rollout.
+  this floor at `(0, 3, 0)`. It was re-enabled at `(0, 2, 80)` (#4511) after #4145
+  was fixed (#4499) and validated at incident-scale fan-out — but production
+  telemetry then showed it net-negative (the costs above), so it is RE-DISABLED by
+  parking the floor at `(0, 3, 0)` again (#4404 / #4610 / #4440).
 
 When a NEW wire-gated feature first ships (not this one), set its floor to
 **exactly that release version** and freeze it, as described above.


### PR DESCRIPTION
## ⚠️ HOLD — LIKELY UNNECESSARY. DO NOT IMPLEMENT OR MERGE without checking with @sanity first (2026-06-28)

**This PR's premise has been superseded by a later diagnosis. Disabling is now the *fallback*, not the plan.**

The "no placement benefit / act-rate collapsed" conclusion below was a **misdiagnosis**. The migration is not net-negative — it is **starved by a mis-measured admission gate (#4534)**, and the storm cost it was blamed for was the separate #4610 bug (already fixed in #4611, shipped 0.2.86).

Live 0.2.86 telemetry (787 peers): of 635 small-cache (≤320 MB) nodes, the **340 (53.5%) the admission gate refuses ALL have interested-cache occupancy ~0%** — median *raw* occupancy is 98.1% (benign cold LRU fill, not real pressure), while median *interested* occupancy is 0.0%. **100% of those refused nodes would be admitted** under an interested/effective-occupancy gate. The needed metric (`interested_bytes`) is already populated in production, and the in-code shadow counter (`migration_admission_would_change_total` = 353,832 across 407 peers) confirms the flip fires constantly.

**The correct fix is to change the admission gate (`node.rs:1875`) from raw `total/budget` to interested/effective occupancy — NOT to disable the migration.** That work supersedes this PR.

**This PR stays parked as a fallback for ONE scenario only:** after the gate fix ships, if the act-rate rises but `hosted_key_distance` still stays flat (the migration acts but genuinely doesn't deliver). Until that is measured, disabling would throw away a working-but-starved feature.

Full diagnosis: `~/code/tmp/subscribehint-gate-analysis.html`.

---

<sub>Original draft body retained below for the record (its conclusions are superseded by the banner above).</sub>

---

> **DRAFT** — merges AFTER the #4610 fix (PR #4611). This is a separate, follow-on change. Also needs a release to reach the network. Do not merge until #4611 has merged.

## Problem

The #4404 SubscribeHint placement migration is **net-negative in production**. It imposes real, measurable cost while delivering no placement benefit:

- **Cost:** drives the #4610 full-state summarize storm, the #4440 subscription-renewal load, and #4534 module-cache thrash.
- **No benefit:** production telemetry over the re-enabled window (re-enabled at `(0, 2, 80)` in #4511) showed `hosted_key_distance` **flat** (placement did not tighten at all) and the inbound-hint **act-rate collapsed to ~0.05%** (received-but-not-acted).

So the network paid the storm / renewal / thrash cost for essentially zero migrations. Disabling removes that cost with no placement regression. Authorized by Ian.

## Solution

Park the wire-gate floor `SUBSCRIBE_HINT_MIN_VERSION` at `(0, 3, 0)` (was `(0, 2, 80)`), above every shipped 0.2.x release. This single const disables **both** sides of the migration:

- **SEND** — `select_migration_target` → `peer_supports_subscribe_hint` never selects a target (no peer satisfies the floor).
- **RECEIVE** — the `node.rs` inbound `SubscribeHint` handler gates on this node's own version (`0.2.x < 0.3.0`) and ignores all inbound hints.

**Reversible:** lowering the floor re-enables both sides together. The const doc comment and `docs/RELEASING.md` now record that re-enabling is a deliberate, **canary-gated** decision — a passing simulation test is explicitly *not* sufficient; any future re-enable must show `hosted_key_distance` measurably tightening on real peers with the #4610/#4440/#4534 costs bounded. This is documented so the disable is not reflex-reverted.

No sim co-change: simulation tests drive the cascade via `subscribe_hint_floor_override` (set by `SimNetwork::enable_placement_migration`), not this const, so migration-on sim tests still run and pass. The `ConsiderContractMigration` `NodeEvent` emits are left as-is (they now fire a no-op `select_migration_target`; harmless).

## Testing

- Updated the two "active at re-enable floor" pin tests to disabled semantics — they now pin the floor to **exactly** `(0, 3, 0)` (`!supported(0,2,255)` + `supported(0,3,0)`), so an accidental lowering trips the assert.
- Un-ignored the two previously-`#[ignore]`d "deactivated" tests; they assert the disabled semantics and are accurate again at `(0, 3, 0)`.
- Added a new regression-pin test `subscribe_hint_floor_is_parked_at_disabled_value` that asserts the production const equals the disabled floor `(0, 3, 0)` — the loudest tripwire against a reflex-revert to `(0, 2, 80)`.
- All 11 version-gate / inbound-hint-gate unit tests pass (0 ignored).
- `cargo fmt` + `cargo clippy --locked -- -D warnings` clean.

## Open review finding (for decision before un-drafting)

Codex flagged one **[P2]**: parking at `(0, 3, 0)` means the migration will **auto-re-enable when the network reaches version 0.3.0** during a normal minor bump, which contradicts the new "canary-gated re-enable only" promise. The value `(0, 3, 0)` was chosen to match the documented v0.2.74 disable precedent and is above every *shipped* 0.2.x release (network is on 0.2.85), so it is safe today. Options to resolve before merge: (a) raise the park value to a never-reachable sentinel (the codebase already uses `(255, 255, 65535)` as `SIM_MIGRATION_DISABLED_FLOOR` for exactly this), or (b) ensure the re-enable decision is made before 0.3.0 ships. Flagging for the maintainer to decide.

Refs #4404, #4610, #4440, #4534

[AI-assisted - Claude]

