### PR TITLE
perf: avoid full state load+hash on unchanged summarize_contract_state

### DIFF
--- a/crates/core/src/contract/executor/mock_runtime.rs
+++ b/crates/core/src/contract/executor/mock_runtime.rs
@@ -213,6 +213,25 @@ impl Executor<MockRuntime, MockStateStorage> {
         // Use fully in-memory storage with no caching for deterministic simulation:
         // - InMemoryContractStore: no disk I/O, no background threads
         // - StateStore::new_uncached: bypasses moka cache (non-deterministic TinyLFU)
+        //
+        // DETERMINISM NOTE (#4621): `new_uncached` still keeps the
+        // summarize/delta change-detector (`StateStore::state_hash_cache`, a
+        // moka cache) ON — it is the ONE moka cache `new_uncached` does not
+        // disable. That is determinism-SAFE here, on two independent grounds:
+        //   1. The detector only governs WHICH path (fast vs slow) a
+        //      summarize/delta takes; BOTH paths produce byte-identical
+        //      summaries/deltas, so it cannot perturb simulation output or the
+        //      event trace regardless of path selection.
+        //   2. Path selection itself is also stable at simulation scale: the
+        //      detector's only non-determinism source is TinyLFU EVICTION, but
+        //      its capacity (STATE_HASH_CACHE_CAPACITY = 100k) is never reached
+        //      by a sim's distinct-contract count, so no eviction happens and a
+        //      populated entry stays populated.
+        // No sim/conformance/turmoil test asserts on state-LOAD or WASM-CALL
+        // counts (only on output bytes), so even (1) alone suffices; (2) makes
+        // the optimization's load/WASM-skip behavior deterministic too. If a
+        // future test ever asserts on those counts at >100k distinct contracts,
+        // make the detector non-evicting in uncached mode instead.
         let contract_store = InMemoryContractStore::new();
         let state_store = StateStore::new_uncached(shared_storage);
         tracing::debug!("created fully in-memory uncached executor for deterministic simulation");

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -380,6 +380,29 @@ impl Executor<MockWasmRuntime, MockStateStorage> {
         .await
     }
 
+    /// Like [`new_mock_wasm`](Self::new_mock_wasm) but with an UNCACHED
+    /// `StateStore`, so every state load hits the backing storage (and is
+    /// therefore observable via `MockStateStorage::get_count`). Used by the
+    /// summarize/delta change-detector tests to prove the fast path skips the
+    /// state load+hash entirely on an unchanged contract — with the moka state
+    /// cache on, a load would be served from memory and the `get_count` probe
+    /// could not distinguish fast path from slow path.
+    #[cfg(test)]
+    pub async fn new_mock_wasm_uncached(
+        _identifier: &str,
+        shared_storage: MockStateStorage,
+    ) -> anyhow::Result<Self> {
+        let state_store = crate::wasm_runtime::StateStore::new_uncached(shared_storage);
+
+        let runtime = MockWasmRuntime {
+            contract_store: InMemoryContractStore::default(),
+            validate_overrides: HashMap::new(),
+            update_overrides: HashMap::new(),
+        };
+
+        Executor::new(state_store, || Ok(()), OperationMode::Local, runtime, None).await
+    }
+
     /// Mutable access to the inner `MockWasmRuntime` so tests can install
     /// per-contract `validate_overrides` / `update_overrides` after the
     /// executor is wrapped in a handler. The `runtime` field is private to

--- a/crates/core/src/contract/executor/pool_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests.rs
@@ -7,5 +7,6 @@ mod related_contract_tests;
 mod runtime_pool_tests;
 mod subscriber_limit_tests;
 mod subscriber_stress_tests;
+mod summarize_delta_cache_tests;
 #[cfg(feature = "wasmtime-backend")]
 mod wasm_conformance_tests;

--- a/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
@@ -289,6 +289,28 @@ async fn delta_unchanged_skips_state_load() {
         gets_after_first,
         "repeated unchanged delta must not reload the state (fast path)"
     );
+
+    // After an UPDATE the detector is invalidated → the next delta against the
+    // SAME peer summary must reload the changed state (symmetry with
+    // `summarize_unchanged_skips_state_load`).
+    let new_state = WrappedState::new(vec![9, 8, 7, 6, 5, 4]);
+    exec.upsert_contract_state(
+        key,
+        Either::Left(new_state.clone()),
+        RelatedContracts::default(),
+        None,
+    )
+    .await
+    .expect("UPDATE");
+    let gets_before_post_update = storage.get_count();
+    let _ = exec
+        .get_contract_state_delta(key, peer_summary.clone())
+        .await
+        .expect("delta after update");
+    assert!(
+        storage.get_count() > gets_before_post_update,
+        "delta after an update must reload the changed state"
+    );
 }
 
 // =========================================================================

--- a/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
@@ -1,0 +1,354 @@
+//! Tests for the cheap state-change-detector that backs the read-only
+//! `summarize_contract_state` / `get_contract_state_delta` caches.
+//!
+//! The optimization replaces the per-call full-state load + `DefaultHasher`
+//! pass (used only to build the summary/delta cache key) with a cheap
+//! per-contract change-detector kept in `StateStore`. The detector is
+//! invalidated by every state write and repopulated from a freshly-loaded
+//! state, so an unchanged contract summarizes/deltas without reloading or
+//! rehashing the state, or re-running WASM — while a changed contract is always
+//! recomputed.
+//!
+//! The stake is divergence: a stale summary OR delta served against changed
+//! state would hand a peer the wrong bytes. The correctness tests below assert
+//! freshness after an update and would FAIL if the detector missed a write.
+
+use either::Either;
+use freenet_stdlib::prelude::*;
+
+use crate::contract::executor::mock_wasm_runtime::MockWasmRuntime;
+use crate::contract::executor::{ContractExecutor, Executor};
+use crate::wasm_runtime::MockStateStorage;
+
+use super::super::mock_runtime::test::create_test_contract as test_contract;
+
+async fn cached_executor(storage: MockStateStorage) -> Executor<MockWasmRuntime, MockStateStorage> {
+    Executor::new_mock_wasm("summarize_delta_cache", storage, None, None)
+        .await
+        .expect("create cached MockWasmRuntime executor")
+}
+
+// =========================================================================
+// CORRECTNESS (the guard against divergence)
+// =========================================================================
+
+/// PUT a contract, summarize, UPDATE it, summarize again → the second summarize
+/// MUST reflect the updated state, never the stale cached summary. This fails if
+/// the detector misses the write (e.g. if a write path stopped invalidating it).
+#[tokio::test(flavor = "current_thread")]
+async fn summarize_is_fresh_after_update_not_stale_cache() {
+    let storage = MockStateStorage::new();
+    let mut exec = cached_executor(storage).await;
+
+    let contract = test_contract(b"summarize_fresh_after_update");
+    let key = contract.key();
+    let state_a = WrappedState::new(vec![1, 2, 3]);
+    let state_b = WrappedState::new(vec![9, 8, 7, 6]);
+
+    // Initial PUT of state A.
+    exec.upsert_contract_state(
+        key,
+        Either::Left(state_a.clone()),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT A");
+
+    let summary_a = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("summarize A");
+    assert_eq!(
+        summary_a.as_ref(),
+        blake3::hash(state_a.as_ref()).as_bytes(),
+        "summary of A must be blake3(A)"
+    );
+
+    // Repeat on unchanged state: still A (exercises the fast path).
+    let summary_a2 = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("summarize A again");
+    assert_eq!(summary_a2.as_ref(), summary_a.as_ref());
+
+    // UPDATE to state B.
+    exec.upsert_contract_state(
+        key,
+        Either::Left(state_b.clone()),
+        RelatedContracts::default(),
+        None,
+    )
+    .await
+    .expect("UPDATE B");
+
+    // Summarize again: MUST be fresh (B), not the stale cached A.
+    let summary_b = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("summarize B");
+    assert_eq!(
+        summary_b.as_ref(),
+        blake3::hash(state_b.as_ref()).as_bytes(),
+        "summary must reflect updated state B, not stale cached A"
+    );
+    assert_ne!(
+        summary_b.as_ref(),
+        summary_a.as_ref(),
+        "summary must change after the state changed"
+    );
+}
+
+/// The delta sibling of the test above: a delta computed against a fixed peer
+/// summary MUST be recomputed after the state changes, never served stale.
+/// `MockWasmRuntime::get_state_delta` returns the full state as the delta, so a
+/// fresh delta equals the new state bytes and a stale one would equal the old.
+#[tokio::test(flavor = "current_thread")]
+async fn delta_is_fresh_after_update_not_stale_cache() {
+    let storage = MockStateStorage::new();
+    let mut exec = cached_executor(storage).await;
+
+    let contract = test_contract(b"delta_fresh_after_update");
+    let key = contract.key();
+    let state_a = WrappedState::new(vec![1, 2, 3]);
+    let state_b = WrappedState::new(vec![9, 8, 7, 6]);
+    // A fixed peer summary: the same value is used before and after the update so
+    // ONLY the state component of the delta cache key changes.
+    let peer_summary = StateSummary::from(vec![42u8; 4]);
+
+    exec.upsert_contract_state(
+        key,
+        Either::Left(state_a.clone()),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT A");
+
+    let delta_a = exec
+        .get_contract_state_delta(key, peer_summary.clone())
+        .await
+        .expect("delta A");
+    assert_eq!(
+        delta_a.as_ref(),
+        state_a.as_ref(),
+        "mock delta is the full state A"
+    );
+
+    // Repeat on unchanged state + same peer summary: cached, identical delta.
+    let delta_a2 = exec
+        .get_contract_state_delta(key, peer_summary.clone())
+        .await
+        .expect("delta A again");
+    assert_eq!(delta_a2.as_ref(), delta_a.as_ref());
+
+    // UPDATE to state B.
+    exec.upsert_contract_state(
+        key,
+        Either::Left(state_b.clone()),
+        RelatedContracts::default(),
+        None,
+    )
+    .await
+    .expect("UPDATE B");
+
+    // Delta against the SAME peer summary: MUST be fresh (B), not stale (A).
+    let delta_b = exec
+        .get_contract_state_delta(key, peer_summary.clone())
+        .await
+        .expect("delta B");
+    assert_eq!(
+        delta_b.as_ref(),
+        state_b.as_ref(),
+        "delta must reflect updated state B, not stale cached A"
+    );
+    assert_ne!(
+        delta_b.as_ref(),
+        delta_a.as_ref(),
+        "delta must change after the state changed"
+    );
+}
+
+// =========================================================================
+// OPTIMIZATION (the fast path skips the state load + rehash + WASM)
+// =========================================================================
+
+/// On an UNCHANGED contract, repeated summarize must NOT reload the state from
+/// storage (and therefore must not re-hash it or re-run WASM). Uses an uncached
+/// `StateStore` so every load is observable via `MockStateStorage::get_count`.
+#[tokio::test(flavor = "current_thread")]
+async fn summarize_unchanged_skips_state_load() {
+    let storage = MockStateStorage::new();
+    let mut exec = Executor::new_mock_wasm_uncached("summarize_opt", storage.clone())
+        .await
+        .expect("create uncached executor");
+
+    let contract = test_contract(b"summarize_opt");
+    let key = contract.key();
+    let state = WrappedState::new(vec![1, 2, 3, 4, 5]);
+
+    exec.upsert_contract_state(
+        key,
+        Either::Left(state.clone()),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+
+    // First summarize: cold detector → slow path, loads the state.
+    let _ = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("summarize 1");
+    let gets_after_first = storage.get_count();
+    assert!(
+        gets_after_first >= 1,
+        "the cold first summarize must load the state at least once"
+    );
+
+    // Second + third summarize on unchanged state: fast path, NO extra loads.
+    let _ = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("summarize 2");
+    let _ = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("summarize 3");
+    assert_eq!(
+        storage.get_count(),
+        gets_after_first,
+        "repeated unchanged summarize must not reload the state (fast path)"
+    );
+
+    // After an UPDATE the detector is invalidated → the next summarize reloads.
+    let new_state = WrappedState::new(vec![6, 7, 8, 9, 10, 11]);
+    exec.upsert_contract_state(
+        key,
+        Either::Left(new_state.clone()),
+        RelatedContracts::default(),
+        None,
+    )
+    .await
+    .expect("UPDATE");
+    let gets_before_post_update = storage.get_count();
+    let _ = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("summarize after update");
+    assert!(
+        storage.get_count() > gets_before_post_update,
+        "summarize after an update must reload the changed state"
+    );
+}
+
+/// Delta sibling: repeated delta on an UNCHANGED contract against the same peer
+/// summary must NOT reload the state.
+#[tokio::test(flavor = "current_thread")]
+async fn delta_unchanged_skips_state_load() {
+    let storage = MockStateStorage::new();
+    let mut exec = Executor::new_mock_wasm_uncached("delta_opt", storage.clone())
+        .await
+        .expect("create uncached executor");
+
+    let contract = test_contract(b"delta_opt");
+    let key = contract.key();
+    let state = WrappedState::new(vec![5, 4, 3, 2, 1]);
+    let peer_summary = StateSummary::from(vec![7u8; 3]);
+
+    exec.upsert_contract_state(
+        key,
+        Either::Left(state.clone()),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+
+    let _ = exec
+        .get_contract_state_delta(key, peer_summary.clone())
+        .await
+        .expect("delta 1");
+    let gets_after_first = storage.get_count();
+    assert!(
+        gets_after_first >= 1,
+        "cold first delta must load the state"
+    );
+
+    let _ = exec
+        .get_contract_state_delta(key, peer_summary.clone())
+        .await
+        .expect("delta 2");
+    let _ = exec
+        .get_contract_state_delta(key, peer_summary.clone())
+        .await
+        .expect("delta 3");
+    assert_eq!(
+        storage.get_count(),
+        gets_after_first,
+        "repeated unchanged delta must not reload the state (fast path)"
+    );
+}
+
+// =========================================================================
+// EDGE CASES
+// =========================================================================
+
+/// State-absent: summarizing a contract with no stored state must error (the
+/// #4610 state-presence behavior), never fast-path a phantom summary.
+#[tokio::test(flavor = "current_thread")]
+async fn summarize_absent_contract_errors() {
+    let storage = MockStateStorage::new();
+    let mut exec = cached_executor(storage).await;
+    let contract = test_contract(b"summarize_absent");
+    let key = contract.key();
+
+    let result = exec.summarize_contract_state(key).await;
+    assert!(
+        result.is_err(),
+        "summarize of an absent contract must error, not return a phantom summary"
+    );
+}
+
+/// Cold caches (simulating a restart or a detector/LRU eviction): a second
+/// executor that shares the backing storage but has cold detector + summary
+/// caches must recompute the correct summary from the on-disk state, not error
+/// or return a phantom.
+#[tokio::test(flavor = "current_thread")]
+async fn summarize_with_cold_caches_recomputes_correctly() {
+    let storage = MockStateStorage::new();
+    let contract = test_contract(b"summarize_restart");
+    let key = contract.key();
+    let state = WrappedState::new(vec![3, 1, 4, 1, 5]);
+
+    // Executor 1 PUTs and summarizes (warming its caches and the backing store).
+    let mut e1 = cached_executor(storage.clone()).await;
+    e1.upsert_contract_state(
+        key,
+        Either::Left(state.clone()),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+    let s1 = e1
+        .summarize_contract_state(key)
+        .await
+        .expect("summarize e1");
+    assert_eq!(s1.as_ref(), blake3::hash(state.as_ref()).as_bytes());
+
+    // Executor 2 shares the backing storage but its detector + summary caches are
+    // cold (the StateStore detector is per-StateStore-instance). It must still
+    // recompute the correct summary from disk.
+    let mut e2 = cached_executor(storage.clone()).await;
+    let s2 = e2
+        .summarize_contract_state(key)
+        .await
+        .expect("summarize e2");
+    assert_eq!(
+        s2.as_ref(),
+        blake3::hash(state.as_ref()).as_bytes(),
+        "cold-cache executor must recompute the correct summary from disk"
+    );
+}

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -346,18 +346,26 @@ impl Executor<Runtime> {
         let mut rt = Runtime::build(contract_store, delegate_store, secret_store, false).unwrap();
         // Enable V2 delegate contract access by providing the state store DB
         rt.set_state_store_db(state_store.storage());
-        // V2 delegate state writes bypass the executor's
-        // `state_store.{store,update}` chokepoints, so install a callback
-        // that mirrors the bump+refresh+report side effects via
-        // `Ring::commit_state_write`. Without this, V2 delegate PUT/UPDATE
-        // would leave the EvictContract re-host race open AND undercount
-        // StateBytesWritten in the governance meter.
-        if let Some(op_manager_ref) = &op_manager {
-            let op_manager_clone = op_manager_ref.clone();
-            rt.set_state_write_callback(Arc::new(move |key: &ContractKey, state_size: usize| {
-                op_manager_clone.ring.commit_state_write(key, state_size);
-            }));
-        }
+        // V2 delegate state writes (put/update_contract_state_sync) write
+        // directly through the raw `Storage`, bypassing the executor's
+        // `state_store.{store,update}` chokepoints. The callback restores the
+        // side effects those chokepoints perform on every write:
+        //   1. Invalidate the summarize/delta change-detector — ALWAYS. Without
+        //      it, a V2 write would leave a stale detector hash and the
+        //      summarize/delta fast path could serve a STALE summary/delta →
+        //      state divergence (Codex review).
+        //   2. Bump+refresh+report via `Ring::commit_state_write` — only when an
+        //      op_manager is present (it owns the ring/governance state).
+        //      Without this, V2 PUT/UPDATE would leave the EvictContract re-host
+        //      race open AND undercount StateBytesWritten in the meter.
+        let detector = state_store.change_detector();
+        let op_manager_for_cb = op_manager.clone();
+        rt.set_state_write_callback(Arc::new(move |key: &ContractKey, state_size: usize| {
+            detector.invalidate(key);
+            if let Some(op_manager) = &op_manager_for_cb {
+                op_manager.ring.commit_state_write(key, state_size);
+            }
+        }));
         Executor::new(
             state_store,
             move || {
@@ -428,16 +436,21 @@ impl Executor<Runtime> {
         )
         .unwrap();
         rt.set_state_store_db(db);
-        // V2 delegate state writes bypass the executor chokepoints — install
-        // the commit_state_write callback so the bump+refresh+report side
-        // effects are still applied. See `from_config` and
+        // V2 delegate state writes bypass the executor chokepoints — install the
+        // callback that (1) ALWAYS invalidates the summarize/delta change-detector
+        // (a stale detector hash after a V2 write would serve a stale
+        // summary/delta → divergence; Codex review) and (2) mirrors the
+        // bump+refresh+report side effects via `Ring::commit_state_write` when an
+        // op_manager is present. See `from_config` and
         // `Runtime::set_state_write_callback`.
-        if let Some(op_manager_ref) = &op_manager {
-            let op_manager_clone = op_manager_ref.clone();
-            rt.set_state_write_callback(Arc::new(move |key: &ContractKey, state_size: usize| {
-                op_manager_clone.ring.commit_state_write(key, state_size);
-            }));
-        }
+        let detector = shared_state_store.change_detector();
+        let op_manager_for_cb = op_manager.clone();
+        rt.set_state_write_callback(Arc::new(move |key: &ContractKey, state_size: usize| {
+            detector.invalidate(key);
+            if let Some(op_manager) = &op_manager_for_cb {
+                op_manager.ring.commit_state_write(key, state_size);
+            }
+        }));
         Executor::new(
             shared_state_store,
             || Ok(()),
@@ -1736,6 +1749,25 @@ mod state_write_attribution_pin_tests {
              into store_state_sync would not compile, but a refactor \
              that moves state into an intermediate first could regress \
              this silently."
+        );
+    }
+
+    #[test]
+    fn v2_delegate_callback_installers_invalidate_change_detector() {
+        // V2 delegate state writes (put/update_contract_state_sync) bypass
+        // `StateStore::{store,update}`, so both `state_write_callback` installers
+        // (in `from_config` and `from_config_with_shared_modules`) MUST also
+        // invalidate the summarize/delta change-detector. Dropping this would let
+        // a V2 write leave a stale detector hash and the summarize/delta fast
+        // path serve a STALE summary/delta → state divergence (Codex review).
+        let count = count_call_sites(RUNTIME_SRC, "detector.invalidate(");
+        assert_eq!(
+            count, 2,
+            "expected exactly 2 `detector.invalidate(` calls in runtime.rs (one \
+             per V2 state_write_callback installer); found {count}. If a callback \
+             installer stopped invalidating the change-detector, a V2 delegate \
+             state write would leave a stale detector hash and the \
+             summarize/delta fast path could serve a stale result."
         );
     }
 }

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -350,18 +350,19 @@ impl Executor<Runtime> {
         // directly through the raw `Storage`, bypassing the executor's
         // `state_store.{store,update}` chokepoints. The callback restores the
         // side effects those chokepoints perform on every write:
-        //   1. Invalidate the summarize/delta change-detector — ALWAYS. Without
-        //      it, a V2 write would leave a stale detector hash and the
-        //      summarize/delta fast path could serve a STALE summary/delta →
-        //      state divergence (Codex review).
+        //   1. Drop StateStore's cached view of the contract — ALWAYS. The
+        //      bypass write doesn't touch the moka state-bytes cache OR the
+        //      change-detector, so without this a later read would serve the OLD
+        //      bytes from moka and the summarize/delta fast path could serve a
+        //      STALE summary/delta → state divergence (Codex review).
         //   2. Bump+refresh+report via `Ring::commit_state_write` — only when an
         //      op_manager is present (it owns the ring/governance state).
         //      Without this, V2 PUT/UPDATE would leave the EvictContract re-host
         //      race open AND undercount StateBytesWritten in the meter.
-        let detector = state_store.change_detector();
+        let cache_invalidator = state_store.cache_invalidator();
         let op_manager_for_cb = op_manager.clone();
         rt.set_state_write_callback(Arc::new(move |key: &ContractKey, state_size: usize| {
-            detector.invalidate(key);
+            cache_invalidator.invalidate(key);
             if let Some(op_manager) = &op_manager_for_cb {
                 op_manager.ring.commit_state_write(key, state_size);
             }
@@ -437,16 +438,17 @@ impl Executor<Runtime> {
         .unwrap();
         rt.set_state_store_db(db);
         // V2 delegate state writes bypass the executor chokepoints — install the
-        // callback that (1) ALWAYS invalidates the summarize/delta change-detector
-        // (a stale detector hash after a V2 write would serve a stale
+        // callback that (1) ALWAYS drops StateStore's cached view of the contract
+        // (both the moka state-bytes cache and the change-detector; a stale
+        // cached state or detector hash after a V2 write would serve a stale
         // summary/delta → divergence; Codex review) and (2) mirrors the
         // bump+refresh+report side effects via `Ring::commit_state_write` when an
         // op_manager is present. See `from_config` and
         // `Runtime::set_state_write_callback`.
-        let detector = shared_state_store.change_detector();
+        let cache_invalidator = shared_state_store.cache_invalidator();
         let op_manager_for_cb = op_manager.clone();
         rt.set_state_write_callback(Arc::new(move |key: &ContractKey, state_size: usize| {
-            detector.invalidate(key);
+            cache_invalidator.invalidate(key);
             if let Some(op_manager) = &op_manager_for_cb {
                 op_manager.ring.commit_state_write(key, state_size);
             }
@@ -1753,21 +1755,22 @@ mod state_write_attribution_pin_tests {
     }
 
     #[test]
-    fn v2_delegate_callback_installers_invalidate_change_detector() {
+    fn v2_delegate_callback_installers_invalidate_state_caches() {
         // V2 delegate state writes (put/update_contract_state_sync) bypass
         // `StateStore::{store,update}`, so both `state_write_callback` installers
-        // (in `from_config` and `from_config_with_shared_modules`) MUST also
-        // invalidate the summarize/delta change-detector. Dropping this would let
-        // a V2 write leave a stale detector hash and the summarize/delta fast
-        // path serve a STALE summary/delta → state divergence (Codex review).
-        let count = count_call_sites(RUNTIME_SRC, "detector.invalidate(");
+        // (in `from_config` and `from_config_with_shared_modules`) MUST drop
+        // StateStore's cached view of the contract (moka state cache + change
+        // detector). Dropping this would let a V2 write leave a stale cached
+        // state/detector hash and the summarize/delta fast path serve a STALE
+        // summary/delta → state divergence (Codex review).
+        let count = count_call_sites(RUNTIME_SRC, "cache_invalidator.invalidate(");
         assert_eq!(
             count, 2,
-            "expected exactly 2 `detector.invalidate(` calls in runtime.rs (one \
-             per V2 state_write_callback installer); found {count}. If a callback \
-             installer stopped invalidating the change-detector, a V2 delegate \
-             state write would leave a stale detector hash and the \
-             summarize/delta fast path could serve a stale result."
+            "expected exactly 2 `cache_invalidator.invalidate(` calls in \
+             runtime.rs (one per V2 state_write_callback installer); found \
+             {count}. If a callback installer stopped invalidating StateStore's \
+             caches, a V2 delegate state write would leave stale cached state \
+             and the summarize/delta fast path could serve a stale result."
         );
     }
 }

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -1069,6 +1069,14 @@ where
         // freshly-loaded state (see `StateStore::state_hash_cache`), so a hit
         // proves the state is byte-identical to the one that produced the cached
         // summary — the summary is therefore fresh, never stale.
+        //
+        // SERIALIZATION INVARIANT: the no-stale-populate guarantee depends on
+        // ALL summarize/delta reads (this one) AND ALL contract-state writes
+        // running on the single `&mut RuntimePool` contract-handling loop, so no
+        // write can land between the slow path's state load and its detector
+        // populate. Any off-loop work that holds an executor (e.g. the hosted
+        // secret export) MUST stay read-only w.r.t. contract state, or it could
+        // populate the detector against a state a concurrent write has changed.
         if let Some(detector_hash) = self.state_store.cached_state_hash(&key) {
             if let Some((cached_hash, cached_summary)) = self.summary_cache.get(&key) {
                 if *cached_hash == detector_hash {
@@ -1149,6 +1157,12 @@ where
         // `get_state_delta`. The detector guarantees the state is unchanged, so a
         // cached delta computed against the same peer-summary is fresh — a stale
         // delta would diverge the peer just like a stale summary.
+        //
+        // SERIALIZATION INVARIANT: as in `bridged_summarize_contract_state`, the
+        // no-stale-populate guarantee depends on all summarize/delta reads and
+        // all contract-state writes running on the single `&mut RuntimePool`
+        // loop; off-loop work holding an executor must stay read-only w.r.t.
+        // contract state.
         if let Some(detector_hash) = self.state_store.cached_state_hash(&key) {
             let cache_key = (key, detector_hash, summary_hash);
             if let Some(cached_delta) = self.delta_cache.get(&cache_key) {

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -1060,6 +1060,25 @@ where
         &mut self,
         key: ContractKey,
     ) -> Result<StateSummary<'static>, ExecutorError> {
+        // Fast path (the hot path on a busy node — tens/sec over MB-scale
+        // states): if the state store holds a cheap change-detector hash for
+        // this contract's CURRENT state AND we already have a summary cached
+        // against that exact hash, return it WITHOUT loading the full state,
+        // hashing it, or running the WASM `summarize_state`. The detector hash is
+        // invalidated by every state write and (re)populated only from a
+        // freshly-loaded state (see `StateStore::state_hash_cache`), so a hit
+        // proves the state is byte-identical to the one that produced the cached
+        // summary — the summary is therefore fresh, never stale.
+        if let Some(detector_hash) = self.state_store.cached_state_hash(&key) {
+            if let Some((cached_hash, cached_summary)) = self.summary_cache.get(&key) {
+                if *cached_hash == detector_hash {
+                    return Ok(cached_summary.clone());
+                }
+            }
+        }
+
+        // Slow path: state changed, never summarized, or detector cold (after
+        // restart / eviction). Load the state and recompute as before.
         let (state, _) = self.bridged_fetch_contract(key, false).await?;
 
         let state = state.ok_or_else(|| {
@@ -1069,14 +1088,17 @@ where
             })
         })?;
 
-        // Check summary cache: if state hash matches, return cached summary
-        let state_hash = {
-            use std::hash::{Hash, Hasher};
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            state.as_ref().hash(&mut hasher);
-            hasher.finish()
-        };
+        let state_hash = crate::wasm_runtime::state_hash(&state);
 
+        // Repopulate the change-detector so the NEXT summarize of an unchanged
+        // state takes the fast path. Safe under the serialized contract loop: no
+        // write can interleave between the load above and here, so this hash
+        // matches the state currently on disk.
+        self.state_store.cache_state_hash(key, state_hash);
+
+        // The summary may already be cached under this exact hash even when the
+        // detector was cold (the summary cache is per-executor; the detector is
+        // shared). Reuse it to skip the WASM call.
         if let Some((cached_hash, cached_summary)) = self.summary_cache.get(&key) {
             if *cached_hash == state_hash {
                 return Ok(cached_summary.clone());
@@ -1109,6 +1131,33 @@ where
         key: ContractKey,
         their_summary: StateSummary<'static>,
     ) -> Result<StateDelta<'static>, ExecutorError> {
+        // Hash the peer's summary up front — it's a small digest, so this is
+        // cheap (unlike the full state). Only the STATE component of the cache
+        // key gets the cheap change-detector treatment below.
+        let summary_hash = {
+            use std::hash::{Hash, Hasher};
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            their_summary.as_ref().hash(&mut h);
+            h.finish()
+        };
+
+        // Fast path: this runs per-subscriber during broadcast fan-out, so it is
+        // potentially even hotter than summarize. If the state store holds a
+        // change-detector hash for this contract's CURRENT state AND we already
+        // cached the delta for that exact (state, their_summary) pair, return it
+        // WITHOUT loading or hashing the full state, or running the WASM
+        // `get_state_delta`. The detector guarantees the state is unchanged, so a
+        // cached delta computed against the same peer-summary is fresh — a stale
+        // delta would diverge the peer just like a stale summary.
+        if let Some(detector_hash) = self.state_store.cached_state_hash(&key) {
+            let cache_key = (key, detector_hash, summary_hash);
+            if let Some(cached_delta) = self.delta_cache.get(&cache_key) {
+                return Ok(cached_delta.clone());
+            }
+        }
+
+        // Slow path: state changed, this peer-summary not seen for the current
+        // state, or detector cold. Load the state and recompute as before.
         let (state, _) = self.bridged_fetch_contract(key, false).await?;
 
         let state = state.ok_or_else(|| {
@@ -1118,15 +1167,12 @@ where
             })
         })?;
 
-        // Check delta cache: if (state_hash, their_summary_hash) matches, return cached delta
-        let (state_hash, summary_hash) = {
-            use std::hash::{Hash, Hasher};
-            let mut h1 = std::collections::hash_map::DefaultHasher::new();
-            state.as_ref().hash(&mut h1);
-            let mut h2 = std::collections::hash_map::DefaultHasher::new();
-            their_summary.as_ref().hash(&mut h2);
-            (h1.finish(), h2.finish())
-        };
+        let state_hash = crate::wasm_runtime::state_hash(&state);
+
+        // Repopulate the change-detector so the next delta/summarize of an
+        // unchanged state takes the fast path. Safe under the serialized contract
+        // loop (see `bridged_summarize_contract_state`).
+        self.state_store.cache_state_hash(key, state_hash);
 
         let cache_key = (key, state_hash, summary_hash);
         if let Some(cached_delta) = self.delta_cache.get(&cache_key) {

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -406,6 +406,16 @@ impl ReDb {
     ///
     /// Used by V2 delegate host functions that need synchronous writes during
     /// WASM `process()` execution. Hosting metadata integration is a follow-up.
+    ///
+    /// CHANGE-DETECTOR INVARIANT (future writers, read before using this): any
+    /// contract-state write that BYPASSES `StateStore` (as this raw sync write
+    /// does) MUST invalidate `StateStore`'s change-detector via
+    /// `StateCacheInvalidator` (and the moka state-bytes cache), or the
+    /// summarize/delta fast path can serve a STALE summary/delta against the
+    /// new state → peer state divergence (#4621). The V2 delegate callers
+    /// (`put_contract_state_sync` / `update_contract_state_sync`) do this via
+    /// the runtime's `state_write_callback`. A new caller of this method (e.g.
+    /// the #4592 live-import work) must wire the same invalidation.
     pub fn store_state_sync(
         &self,
         key: &ContractKey,
@@ -426,6 +436,11 @@ impl ReDb {
     /// Used by V2 delegate UPDATE host function.
     ///
     /// **Does not update hosting metadata** (same caveat as `store_state_sync`).
+    ///
+    /// CHANGE-DETECTOR INVARIANT: like `store_state_sync`, this bypasses
+    /// `StateStore`, so any caller MUST invalidate the `StateStore`
+    /// change-detector via `StateCacheInvalidator` or summarize/delta can serve
+    /// a stale result → peer state divergence (#4621). See `store_state_sync`.
     pub fn update_state_sync(
         &self,
         key: &ContractKey,

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -59,7 +59,7 @@ pub use secrets_store::{
 #[allow(unused_imports)]
 pub(crate) use simulation_runtime::{InMemoryContractStore, SimulationStores};
 pub use state_store::StateStore;
-pub(crate) use state_store::{MAX_STATE_SIZE, StateStorage, StateStoreError};
+pub(crate) use state_store::{MAX_STATE_SIZE, StateStorage, StateStoreError, state_hash};
 
 /// Rename a code-hash-named WASM file from the legacy all-lowercase Base58
 /// name to the canonical mixed-case name (issue #4214).

--- a/crates/core/src/wasm_runtime/delegate_api.rs
+++ b/crates/core/src/wasm_runtime/delegate_api.rs
@@ -218,7 +218,7 @@ mod tests {
 
     use crate::contract::storages::Storage;
     use crate::util::tests::get_temp_dir;
-    use crate::wasm_runtime::StateStorage;
+    use crate::wasm_runtime::{StateStorage, StateStore};
     use freenet_stdlib::prelude::*;
 
     fn make_contract_key(seed: u8) -> (ContractKey, ContractInstanceId, CodeHash) {
@@ -793,6 +793,136 @@ mod tests {
         assert_eq!(
             calls[0].1, 3,
             "callback must receive the on-disk state byte count (vec![40, 50, 60] = 3 bytes)"
+        );
+    }
+
+    /// END-TO-END: a REAL V2 delegate PUT, driven through the PRODUCTION
+    /// `StateStore::cache_invalidator()` wired as the `state_write_callback`,
+    /// must CLEAR the summarize/delta change-detector for the written contract
+    /// (so the next summarize/delta recomputes fresh) AND drop the moka
+    /// state-bytes cache (so a read-after-write observes the new bytes).
+    ///
+    /// This closes the wrong-key / wrong-store-instance seam that the
+    /// source-pin (`v2_delegate_state_write_paths_invoke_callback_with_state_size`)
+    /// and the observer-only unit tests cannot catch: it drives the actual
+    /// production invalidator from a real `put_contract_state_sync` and asserts
+    /// the effect on the actual detector the fast path reads. If the callback
+    /// were ever wired to a different `StateStore` instance, or invalidated a
+    /// mis-derived key, the detector assertion below would fail.
+    #[tokio::test]
+    async fn test_v2_put_through_production_invalidator_clears_detector() {
+        let mut env_holder = TestEnv::new().await;
+        let contract_id = env_holder.store_contract(123, &[1, 2, 3]).await;
+
+        // Build a StateStore over the SAME backing storage the V2 write path
+        // writes through. In production the V2 delegate write bypasses StateStore
+        // entirely (it writes straight to the raw `Storage`); the ONLY thing that
+        // keeps StateStore's caches coherent is the `state_write_callback` this
+        // test installs. Cached mode mirrors `Executor::from_config`.
+        let state_store = StateStore::new(env_holder.db.clone(), 10_000_000).unwrap();
+
+        // Resolve the contract key EXACTLY as the V2 write path does
+        // (`resolve_contract_key` → `code_hash_from_id` → `from_id_and_code`),
+        // so the detector is keyed under the SAME ContractKey the callback will
+        // invalidate. This is what closes the wrong-key seam.
+        let code_hash = env_holder
+            .contract_store
+            .code_hash_from_id(&contract_id)
+            .expect("contract code must be indexed");
+        let key = ContractKey::from_id_and_code(contract_id, code_hash);
+
+        // Warm BOTH StateStore caches against the OLD state, exactly as a prior
+        // read + summarize slow-path would: the moka state-bytes cache via get()
+        // and the change-detector hash via cache_state_hash().
+        let old_state = state_store.get(&key).await.expect("initial state present");
+        assert_eq!(old_state.as_ref(), &[1, 2, 3]);
+        state_store.cache_state_hash(key, crate::wasm_runtime::state_hash(&old_state));
+        assert!(
+            state_store.cached_state_hash(&key).is_some(),
+            "detector must be populated before the write"
+        );
+
+        // Wire the PRODUCTION invalidator as the callback — the exact shape used
+        // in `Executor::from_config` / `from_config_with_shared_modules`.
+        let invalidator = state_store.cache_invalidator();
+        let cb: super::super::runtime::StateWriteCallback =
+            std::sync::Arc::new(move |k: &ContractKey, _size: usize| {
+                invalidator.invalidate(k);
+            });
+
+        {
+            // SAFETY: `env_holder` is alive for the duration of this test. The
+            // env is scoped so it (and its borrow) drop before the async get()
+            // below — DelegateCallEnv is not Send, so it must not be held across
+            // an await on the default multi-thread test runtime.
+            let env = unsafe { env_holder.make_env_with_callback(cb) };
+            env.put_contract_state_sync(&contract_id, vec![4, 5, 6])
+                .expect("V2 PUT should succeed");
+        }
+
+        // Detector cleared → the next summarize/delta recomputes against the
+        // fresh state instead of serving a stale cached summary/delta.
+        assert_eq!(
+            state_store.cached_state_hash(&key),
+            None,
+            "a real V2 PUT through the production invalidator must clear the \
+             change-detector so the next summarize/delta is fresh"
+        );
+        // moka state-bytes cache dropped → a read-after-write observes the
+        // freshly-written bytes rather than the stale cached copy (the
+        // pre-existing read-after-write staleness this callback also fixes).
+        assert_eq!(
+            state_store.get(&key).await.expect("state present").as_ref(),
+            &[4, 5, 6],
+            "after the V2 PUT, get() must reload the freshly-written bytes"
+        );
+    }
+
+    /// UPDATE sibling of `test_v2_put_through_production_invalidator_clears_detector`:
+    /// a REAL V2 delegate UPDATE through the production invalidator must clear
+    /// the detector and unmask the new state bytes, same as PUT.
+    #[tokio::test]
+    async fn test_v2_update_through_production_invalidator_clears_detector() {
+        let mut env_holder = TestEnv::new().await;
+        let contract_id = env_holder.store_contract(124, &[10, 20, 30]).await;
+
+        let state_store = StateStore::new(env_holder.db.clone(), 10_000_000).unwrap();
+
+        let code_hash = env_holder
+            .contract_store
+            .code_hash_from_id(&contract_id)
+            .expect("contract code must be indexed");
+        let key = ContractKey::from_id_and_code(contract_id, code_hash);
+
+        let old_state = state_store.get(&key).await.expect("initial state present");
+        assert_eq!(old_state.as_ref(), &[10, 20, 30]);
+        state_store.cache_state_hash(key, crate::wasm_runtime::state_hash(&old_state));
+        assert!(state_store.cached_state_hash(&key).is_some());
+
+        let invalidator = state_store.cache_invalidator();
+        let cb: super::super::runtime::StateWriteCallback =
+            std::sync::Arc::new(move |k: &ContractKey, _size: usize| {
+                invalidator.invalidate(k);
+            });
+
+        {
+            // SAFETY: see the PUT sibling test above (scoped to drop before the
+            // async get()).
+            let env = unsafe { env_holder.make_env_with_callback(cb) };
+            env.update_contract_state_sync(&contract_id, vec![40, 50, 60])
+                .expect("V2 UPDATE should succeed");
+        }
+
+        assert_eq!(
+            state_store.cached_state_hash(&key),
+            None,
+            "a real V2 UPDATE through the production invalidator must clear the \
+             change-detector so the next summarize/delta is fresh"
+        );
+        assert_eq!(
+            state_store.get(&key).await.expect("state present").as_ref(),
+            &[40, 50, 60],
+            "after the V2 UPDATE, get() must reload the freshly-written bytes"
         );
     }
 

--- a/crates/core/src/wasm_runtime/state_store.rs
+++ b/crates/core/src/wasm_runtime/state_store.rs
@@ -360,13 +360,24 @@ where
             .store(key, state.clone())
             .await
             .map_err(Into::into)?;
+
+        // The state is now committed to disk. Drop any stale cached view of it
+        // IMMEDIATELY — before store_params, which can fail and early-return via
+        // `?` (the partial-failure window noted above). If we deferred the
+        // invalidation to after store_params, an overwrite whose params write
+        // failed would leave the moka state cache and the change-detector
+        // holding the OLD state, and the summarize/delta fast path could serve a
+        // stale result (Codex review P2). The success path re-warms the state
+        // cache below.
+        self.state_hash_cache.invalidate(&key);
+        if let Some(cache) = &self.state_mem_cache {
+            cache.invalidate(&key);
+        }
+
         self.store
             .store_params(key, params.clone())
             .await
             .map_err(Into::into)?;
-
-        // The state changed: drop any stale change-detector hash (see `update`).
-        self.state_hash_cache.invalidate(&key);
 
         if let Some(cache) = &self.state_mem_cache {
             cache.insert(key, state);
@@ -1262,6 +1273,48 @@ mod tests {
             store.get(&key).await.unwrap(),
             state_b,
             "after invalidation, get must reload the fresh bypass-written bytes"
+        );
+    }
+
+    /// Codex P2: if `store()` overwrites an existing contract and `store_params`
+    /// fails AFTER the state write commits, the caches must NOT keep serving the
+    /// old state (the summarize/delta fast path would diverge). Both the
+    /// detector hash and the moka state cache must be invalidated as soon as the
+    /// state write commits, regardless of the params write outcome.
+    #[tokio::test]
+    async fn store_invalidates_caches_even_when_params_write_fails() {
+        let mock_storage = MockStateStorage::new();
+        let mut store = StateStore::new(mock_storage.clone(), 10_000).unwrap();
+        let key = make_test_key();
+        let params = Parameters::from(vec![1, 2, 3]);
+        let state_a = make_test_state(&[1, 2, 3]);
+        let state_b = make_test_state(&[4, 5, 6, 7]);
+
+        // Initial successful store of A (warms moka) + populate the detector.
+        store
+            .store(key, state_a.clone(), params.clone())
+            .await
+            .unwrap();
+        store.cache_state_hash(key, state_hash(&state_a));
+        assert_eq!(store.cached_state_hash(&key), Some(state_hash(&state_a)));
+
+        // Overwrite with B, but make the params write fail AFTER the state write
+        // has already committed B to the backing store.
+        mock_storage.fail_next_store_params(1);
+        let res = store.store(key, state_b.clone(), params).await;
+        assert!(res.is_err(), "store must surface the params write failure");
+
+        // B is on disk now, so the caches must not still serve A: the detector is
+        // cleared and get() reloads the fresh bytes.
+        assert_eq!(
+            store.cached_state_hash(&key),
+            None,
+            "detector must be cleared once the state write commits"
+        );
+        assert_eq!(
+            store.get(&key).await.unwrap(),
+            state_b,
+            "get must reload the committed state after a params-write failure"
         );
     }
 

--- a/crates/core/src/wasm_runtime/state_store.rs
+++ b/crates/core/src/wasm_runtime/state_store.rs
@@ -43,27 +43,38 @@ pub(crate) fn state_hash(state: &WrappedState) -> u64 {
     hasher.finish()
 }
 
-/// A cheap, cloneable handle to a [`StateStore`]'s state-change detector, for
-/// the contract-state write paths that BYPASS `StateStore` and must still
-/// invalidate it — specifically the V2 delegate writes
-/// (`put_contract_state_sync` / `update_contract_state_sync`), which write
-/// through the raw `Storage` and never call `StateStore::{store,update}`.
+/// A cheap, cloneable handle that drops a [`StateStore`]'s cached view of a
+/// contract, for the write paths that BYPASS `StateStore` and write straight to
+/// the raw `Storage` — specifically the V2 delegate writes
+/// (`put_contract_state_sync` / `update_contract_state_sync`), which never call
+/// `StateStore::{store,update}`.
 ///
-/// Obtained via [`StateStore::change_detector`] and wired into the runtime's
-/// `state_write_callback`. Cloning shares the underlying cache (moka is
-/// internally `Arc`), so an invalidation through the handle is observed by every
-/// executor reading the detector.
+/// It invalidates BOTH read-caches the store keeps for a key:
+///   * the moka state-bytes cache (`state_mem_cache`) — otherwise a later
+///     `StateStore::get` would serve the OLD bytes the bypass write replaced,
+///     and the summarize/delta slow path would re-certify the stale hash;
+///   * the change-detector hash (`state_hash_cache`) — otherwise the fast path
+///     would serve a stale summary/delta.
+///
+/// Obtained via [`StateStore::cache_invalidator`] and wired into the runtime's
+/// `state_write_callback`. Cloning shares the underlying caches (moka is
+/// internally `Arc`), so an invalidation is observed by every executor.
 #[derive(Clone)]
-pub(crate) struct StateChangeDetector {
-    cache: MokaCache<ContractKey, u64>,
+pub(crate) struct StateCacheInvalidator {
+    state_cache: Option<MokaCache<ContractKey, WrappedState>>,
+    hash_cache: MokaCache<ContractKey, u64>,
 }
 
-impl StateChangeDetector {
-    /// Invalidate the detector entry for `key` after a state write made outside
-    /// `StateStore`. Mirrors the invalidation `StateStore::{store,update,delete}`
-    /// do for in-store writes; see [`StateStore::state_hash_cache`].
+impl StateCacheInvalidator {
+    /// Drop the store's cached state bytes AND change-detector hash for `key`
+    /// after a state write made outside `StateStore`, so the next read reloads
+    /// the fresh bytes from storage. Mirrors what
+    /// `StateStore::{store,update,delete}` do for in-store writes.
     pub(crate) fn invalidate(&self, key: &ContractKey) {
-        self.cache.invalidate(key);
+        if let Some(state_cache) = &self.state_cache {
+            state_cache.invalidate(key);
+        }
+        self.hash_cache.invalidate(key);
     }
 }
 
@@ -150,12 +161,13 @@ pub struct StateStore<S: StateStorage> {
     ///     entry, so a changed state can never be served against a stale hash.
     ///   * V2 delegate state writes (`put_contract_state_sync` /
     ///     `update_contract_state_sync`) write directly through the raw
-    ///     `Storage`, BYPASSING `StateStore`, so they invalidate the entry via a
-    ///     [`StateChangeDetector`] handle wired into the runtime's
-    ///     `state_write_callback` (see `Runtime::set_state_write_callback` and
-    ///     the callback installers in `executor/runtime.rs`). Without this a V2
-    ///     write would leave a stale detector hash → stale summary/delta →
-    ///     divergence (caught by Codex review).
+    ///     `Storage`, BYPASSING `StateStore`, so they invalidate this entry (and
+    ///     the moka state-bytes cache) via a [`StateCacheInvalidator`] handle
+    ///     wired into the runtime's `state_write_callback` (see
+    ///     `Runtime::set_state_write_callback` and the callback installers in
+    ///     `executor/runtime.rs`). Without this a V2 write would leave a stale
+    ///     detector hash → stale summary/delta → divergence (caught by Codex
+    ///     review).
     ///   * the summarize/delta slow path re-POPULATES it after loading the
     ///     current state (via [`cache_state_hash`](Self::cache_state_hash)).
     ///
@@ -231,12 +243,14 @@ where
             .build()
     }
 
-    /// A cloneable handle to this store's state-change detector, for the V2
-    /// delegate write path which bypasses `StateStore` (see
-    /// [`StateChangeDetector`]). Wired into the runtime's `state_write_callback`.
-    pub(crate) fn change_detector(&self) -> StateChangeDetector {
-        StateChangeDetector {
-            cache: self.state_hash_cache.clone(),
+    /// A cloneable handle that drops this store's cached view of a contract, for
+    /// the V2 delegate write path which bypasses `StateStore` (see
+    /// [`StateCacheInvalidator`]). Wired into the runtime's
+    /// `state_write_callback`.
+    pub(crate) fn cache_invalidator(&self) -> StateCacheInvalidator {
+        StateCacheInvalidator {
+            state_cache: self.state_mem_cache.clone(),
+            hash_cache: self.state_hash_cache.clone(),
         }
     }
 
@@ -1183,12 +1197,10 @@ mod tests {
         );
     }
 
-    /// The V2-bypass handle ([`StateChangeDetector`]) invalidates the same
-    /// detector the summarize/delta fast path reads. This is the mechanism the
-    /// runtime's `state_write_callback` uses so V2 delegate writes — which
-    /// bypass `StateStore` — cannot leave a stale detector hash.
+    /// The V2-bypass handle ([`StateCacheInvalidator`]) clears the same
+    /// change-detector the summarize/delta fast path reads.
     #[tokio::test]
-    async fn change_detector_handle_invalidates_cached_hash() {
+    async fn cache_invalidator_clears_detector_hash() {
         let mock_storage = MockStateStorage::new();
         let store = StateStore::new_uncached(mock_storage);
         let key = make_test_key();
@@ -1198,12 +1210,58 @@ mod tests {
 
         // A write through the bypass handle must clear the entry, exactly like an
         // in-store write (store/update/delete) does.
-        let detector = store.change_detector();
-        detector.invalidate(&key);
+        let invalidator = store.cache_invalidator();
+        invalidator.invalidate(&key);
         assert_eq!(
             store.cached_state_hash(&key),
             None,
-            "change_detector().invalidate must clear the detector the fast path reads"
+            "cache_invalidator().invalidate must clear the detector the fast path reads"
+        );
+    }
+
+    /// CORRECTNESS of the V2-bypass fix: a write that lands in the backing store
+    /// WITHOUT going through `StateStore` (as V2 delegate writes do) would
+    /// otherwise be masked by the moka state cache — `get` would keep returning
+    /// the stale cached bytes. The [`StateCacheInvalidator`] must drop BOTH the
+    /// state-bytes cache and the detector so the next read reloads fresh bytes.
+    #[tokio::test]
+    async fn cache_invalidator_drops_stale_state_bytes_from_moka() {
+        // Cached store: the moka state-bytes cache is what masks bypass writes.
+        let mock_storage = MockStateStorage::new();
+        let mut store = StateStore::new(mock_storage.clone(), 10_000).unwrap();
+        let key = make_test_key();
+        let params = Parameters::from(vec![1, 2, 3]);
+        let state_a = make_test_state(&[1, 2, 3]);
+        let state_b = make_test_state(&[4, 5, 6, 7]);
+
+        // Normal PUT populates the moka cache with A.
+        store.store(key, state_a.clone(), params).await.unwrap();
+        assert_eq!(store.get(&key).await.unwrap(), state_a);
+        // Pretend the summarize slow path recorded A's hash.
+        store.cache_state_hash(key, state_hash(&state_a));
+
+        // Simulate a V2 delegate write: B lands in the BACKING store directly,
+        // bypassing StateStore (so moka still holds A).
+        mock_storage.seed_state(key, state_b.clone());
+
+        // Without invalidation, the moka cache masks the bypass write.
+        assert_eq!(
+            store.get(&key).await.unwrap(),
+            state_a,
+            "moka cache masks the bypass write until invalidated (the bug)"
+        );
+
+        // The callback-wired invalidator must drop BOTH caches.
+        store.cache_invalidator().invalidate(&key);
+        assert_eq!(
+            store.cached_state_hash(&key),
+            None,
+            "detector hash must be cleared"
+        );
+        assert_eq!(
+            store.get(&key).await.unwrap(),
+            state_b,
+            "after invalidation, get must reload the fresh bypass-written bytes"
         );
     }
 

--- a/crates/core/src/wasm_runtime/state_store.rs
+++ b/crates/core/src/wasm_runtime/state_store.rs
@@ -112,6 +112,17 @@ pub trait StateStorage {
     type Error;
     /// Store state for a contract. Takes `&self` because implementations
     /// (like ReDb) handle internal locking for concurrent access.
+    ///
+    /// CHANGE-DETECTOR INVARIANT (future writers): a contract-state write made
+    /// DIRECTLY through this trait, bypassing the [`StateStore`] wrapper that
+    /// owns the summarize/delta change-detector, MUST invalidate that detector
+    /// via [`StateCacheInvalidator`] (and the moka state-bytes cache) — e.g.
+    /// via the runtime's `state_write_callback`. Otherwise the summarize/delta
+    /// fast path can serve a STALE summary/delta against the new state → peer
+    /// state divergence (#4621). Writes that go through `StateStore::{store,
+    /// update, delete}` already do this; raw-`Storage` writers (V2 delegate
+    /// `store_state_sync`/`update_state_sync`, and any new bypass writer such as
+    /// the #4592 live-import work) must not skip it.
     fn store(
         &self,
         key: ContractKey,
@@ -134,6 +145,11 @@ pub trait StateStorage {
     ) -> impl Future<Output = Result<Option<Parameters<'static>>, Self::Error>> + Send + 'a;
     /// Remove all persisted data for a contract (state and parameters).
     /// Idempotent: removing a contract that is not stored is not an error.
+    ///
+    /// CHANGE-DETECTOR INVARIANT: a removal made DIRECTLY through this trait
+    /// (bypassing [`StateStore::delete`]) must also invalidate the
+    /// summarize/delta change-detector via [`StateCacheInvalidator`], or the
+    /// fast path could keep certifying a hash for state that is now gone (#4621).
     fn remove(&self, key: &ContractKey) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 

--- a/crates/core/src/wasm_runtime/state_store.rs
+++ b/crates/core/src/wasm_runtime/state_store.rs
@@ -1,4 +1,7 @@
 use core::future::Future;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
 use freenet_stdlib::prelude::*;
 use moka::sync::Cache as MokaCache;
 
@@ -13,6 +16,32 @@ use moka::sync::Cache as MokaCache;
 /// remaining large enough for legitimate use cases (web apps, documents, datasets). A contract
 /// whose `validate_state` returns `Valid` for arbitrarily large state cannot bypass this limit.
 pub(crate) const MAX_STATE_SIZE: usize = 50 * 1024 * 1024; // 50 MiB
+
+/// Maximum number of per-contract state-hash entries retained for the cheap
+/// summarize/delta change-detector (see [`StateStore::cached_state_hash`]).
+///
+/// Bounded so the detector can never grow without limit on a node that hosts
+/// many contracts (contract count is influenced by external actors via PUT, so
+/// per the channel/collection-bounding rules it must be capped). Each entry is
+/// only ~40 bytes (key + `u64`), so this ceiling is well under 5 MiB. A miss
+/// simply falls back to loading and hashing the state, so the cap only trades a
+/// little extra work for a hard memory ceiling — never correctness.
+const STATE_HASH_CACHE_CAPACITY: u64 = 100_000;
+
+/// Hash a contract state's bytes into the `u64` change-detector key shared by
+/// the summarize and delta caches.
+///
+/// Centralised so the hash recorded at write time (well — at the slow-path
+/// populate; see [`StateStore::cache_state_hash`]) and the hash recomputed when
+/// summarizing/delta-ing a loaded state are ALWAYS computed identically. If
+/// these ever diverged, a fast-path cache key would never match its slow-path
+/// counterpart and the optimization would silently disable itself (a perf bug,
+/// not a correctness one — but worth ruling out).
+pub(crate) fn state_hash(state: &WrappedState) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    state.as_ref().hash(&mut hasher);
+    hasher.finish()
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum StateStoreError {
@@ -81,6 +110,37 @@ pub trait StateStorage {
 #[derive(Clone)]
 pub struct StateStore<S: StateStorage> {
     state_mem_cache: Option<MokaCache<ContractKey, WrappedState>>,
+    /// Cheap per-contract state-change detector for the read-only summarize and
+    /// delta WASM caches (the `bridged_summarize_contract_state` /
+    /// `bridged_get_contract_state_delta` hot path).
+    ///
+    /// Maps a contract to the `u64` hash of its CURRENTLY-stored state, or holds
+    /// no entry when unknown. The invariant that makes this safe to read on the
+    /// summarize/delta fast path WITHOUT reloading and rehashing the full state:
+    ///
+    ///   the entry is either ABSENT or equal to `state_hash(state on disk)`.
+    ///
+    /// It is maintained by exactly two kinds of operation, both of which funnel
+    /// through this `StateStore`, the single chokepoint for every contract-state
+    /// write:
+    ///   * any write — [`store`](Self::store), [`update`](Self::update),
+    ///     [`delete`](Self::delete) — INVALIDATES the entry, so a changed state
+    ///     can never be served against a stale hash.
+    ///   * the summarize/delta slow path re-POPULATES it after loading the
+    ///     current state (via [`cache_state_hash`](Self::cache_state_hash)).
+    ///
+    /// Because all contract-state writes and all summarize/delta reads are
+    /// serialized through the single `&mut RuntimePool` contract-handling loop,
+    /// no write can interleave between the slow path's load and its populate, so
+    /// the populated hash always matches the state that produced the cached
+    /// summary/delta. Shared across pool executors (moka is internally `Arc`),
+    /// so a populate on one checked-out executor is visible to the next.
+    ///
+    /// Kept separate from `state_mem_cache` (and intentionally always on, even
+    /// in `new_uncached` deterministic mode) because it only governs WHETHER the
+    /// fast path is taken — both paths produce byte-identical summaries/deltas,
+    /// so it cannot perturb simulation output or event-trace determinism.
+    state_hash_cache: MokaCache<ContractKey, u64>,
     store: S,
 }
 
@@ -113,6 +173,7 @@ where
             .build();
         Ok(Self {
             state_mem_cache: Some(cache),
+            state_hash_cache: Self::build_state_hash_cache(),
             store,
         })
     }
@@ -126,8 +187,39 @@ where
     pub fn new_uncached(store: S) -> Self {
         Self {
             state_mem_cache: None,
+            state_hash_cache: Self::build_state_hash_cache(),
             store,
         }
+    }
+
+    /// Build the bounded state-change-detector cache (see the
+    /// [`state_hash_cache`](Self::state_hash_cache) field docs). Entry-count
+    /// bounded via the default weigher.
+    fn build_state_hash_cache() -> MokaCache<ContractKey, u64> {
+        MokaCache::builder()
+            .max_capacity(STATE_HASH_CACHE_CAPACITY)
+            .build()
+    }
+
+    /// Cheap read of the change-detector: the hash of `key`'s currently-stored
+    /// state, or `None` if not currently known (never written/populated, or
+    /// evicted, or invalidated by a write since the last populate).
+    ///
+    /// A `Some(h)` return guarantees the on-disk state hashes to `h` (see the
+    /// field invariant), so a caller holding a cached summary/delta keyed on `h`
+    /// may return it WITHOUT reloading or rehashing the state.
+    pub fn cached_state_hash(&self, key: &ContractKey) -> Option<u64> {
+        self.state_hash_cache.get(key)
+    }
+
+    /// Record the hash of `key`'s currently-stored state so the next
+    /// summarize/delta of an UNCHANGED state takes the fast path.
+    ///
+    /// MUST only be called with a hash freshly computed from the state that is
+    /// currently on disk (i.e. the slow path's just-loaded state), so the field
+    /// invariant — entry equals `state_hash(state on disk)` — is preserved.
+    pub fn cache_state_hash(&self, key: ContractKey, hash: u64) {
+        self.state_hash_cache.insert(key, hash);
     }
 
     pub async fn update(
@@ -170,6 +262,11 @@ where
             .store(*key, state.clone())
             .await
             .map_err(Into::into)?;
+
+        // The state changed: drop any stale change-detector hash so the
+        // summarize/delta fast path can never serve a cached summary/delta for
+        // the previous state. The slow path repopulates it on the next read.
+        self.state_hash_cache.invalidate(key);
 
         if let Some(cache) = &self.state_mem_cache {
             cache.insert(*key, state);
@@ -215,6 +312,9 @@ where
             .await
             .map_err(Into::into)?;
 
+        // The state changed: drop any stale change-detector hash (see `update`).
+        self.state_hash_cache.invalidate(&key);
+
         if let Some(cache) = &self.state_mem_cache {
             cache.insert(key, state);
         }
@@ -239,6 +339,10 @@ where
         if let Some(cache) = &self.state_mem_cache {
             cache.invalidate(key);
         }
+        // The state is gone: drop the change-detector hash so a later
+        // summarize/delta can't fast-path against it (it must fall through to
+        // the slow path, which now reports the contract as absent).
+        self.state_hash_cache.invalidate(key);
         self.store.remove(key).await.map_err(Into::into)?;
         Ok(())
     }
@@ -958,5 +1062,98 @@ mod tests {
             .delete(&key)
             .await
             .expect("delete of a never-stored contract should be Ok");
+    }
+
+    // ============ State-change detector (summarize/delta fast path) ============
+
+    /// `state_hash` distinguishes different state bytes and is stable for equal
+    /// bytes. This is the property the whole change-detector rests on.
+    #[test]
+    fn state_hash_distinguishes_different_states_and_is_stable() {
+        let a = make_test_state(&[1, 2, 3]);
+        let a_again = make_test_state(&[1, 2, 3]);
+        let b = make_test_state(&[1, 2, 4]);
+
+        assert_eq!(
+            state_hash(&a),
+            state_hash(&a_again),
+            "equal state bytes must hash equally"
+        );
+        assert_ne!(
+            state_hash(&a),
+            state_hash(&b),
+            "different state bytes must (with overwhelming probability) hash differently"
+        );
+    }
+
+    /// CORRECTNESS of the detector primitive: a fresh store has no detector
+    /// entry; a populate makes it readable; and EVERY write path
+    /// (store/update/delete) invalidates it so a changed state can never be
+    /// served against a stale hash. This is the invariant the no-divergence
+    /// guarantee depends on.
+    #[tokio::test]
+    async fn state_hash_cache_invalidated_by_every_write_path() {
+        let mock_storage = MockStateStorage::new();
+        let mut store = StateStore::new_uncached(mock_storage);
+        let key = make_test_key();
+        let params = Parameters::from(vec![1, 2, 3]);
+        let state_a = make_test_state(&[1, 2, 3]);
+        let state_b = make_test_state(&[4, 5, 6]);
+
+        // Never populated → absent.
+        assert_eq!(store.cached_state_hash(&key), None);
+
+        // Initial store (PUT) writes state → detector must be absent (a write
+        // invalidates; the summarize slow path repopulates on next read).
+        store
+            .store(key, state_a.clone(), params.clone())
+            .await
+            .unwrap();
+        assert_eq!(
+            store.cached_state_hash(&key),
+            None,
+            "store() must leave the detector absent so the next summarize recomputes"
+        );
+
+        // Simulate the summarize slow path populating it.
+        let h_a = state_hash(&state_a);
+        store.cache_state_hash(key, h_a);
+        assert_eq!(store.cached_state_hash(&key), Some(h_a));
+
+        // UPDATE writes new state → detector invalidated (the critical guard:
+        // without this, a stale hash would serve a stale summary/delta).
+        store.update(&key, state_b.clone()).await.unwrap();
+        assert_eq!(
+            store.cached_state_hash(&key),
+            None,
+            "update() must invalidate the detector"
+        );
+
+        // Repopulate with the new state's hash; it differs from the old one.
+        let h_b = state_hash(&state_b);
+        assert_ne!(h_a, h_b);
+        store.cache_state_hash(key, h_b);
+        assert_eq!(store.cached_state_hash(&key), Some(h_b));
+
+        // delete() removes the state → detector invalidated.
+        store.delete(&key).await.unwrap();
+        assert_eq!(
+            store.cached_state_hash(&key),
+            None,
+            "delete() must invalidate the detector"
+        );
+    }
+
+    /// The detector is present in cached mode too (it is independent of the moka
+    /// state cache, so it works after restart / on disk-only states).
+    #[tokio::test]
+    async fn state_hash_cache_present_in_cached_mode() {
+        let mock_storage = MockStateStorage::new();
+        let store = StateStore::new(mock_storage, 10_000).unwrap();
+        let key = make_test_key();
+
+        assert_eq!(store.cached_state_hash(&key), None);
+        store.cache_state_hash(key, 42);
+        assert_eq!(store.cached_state_hash(&key), Some(42));
     }
 }

--- a/crates/core/src/wasm_runtime/state_store.rs
+++ b/crates/core/src/wasm_runtime/state_store.rs
@@ -43,6 +43,30 @@ pub(crate) fn state_hash(state: &WrappedState) -> u64 {
     hasher.finish()
 }
 
+/// A cheap, cloneable handle to a [`StateStore`]'s state-change detector, for
+/// the contract-state write paths that BYPASS `StateStore` and must still
+/// invalidate it — specifically the V2 delegate writes
+/// (`put_contract_state_sync` / `update_contract_state_sync`), which write
+/// through the raw `Storage` and never call `StateStore::{store,update}`.
+///
+/// Obtained via [`StateStore::change_detector`] and wired into the runtime's
+/// `state_write_callback`. Cloning shares the underlying cache (moka is
+/// internally `Arc`), so an invalidation through the handle is observed by every
+/// executor reading the detector.
+#[derive(Clone)]
+pub(crate) struct StateChangeDetector {
+    cache: MokaCache<ContractKey, u64>,
+}
+
+impl StateChangeDetector {
+    /// Invalidate the detector entry for `key` after a state write made outside
+    /// `StateStore`. Mirrors the invalidation `StateStore::{store,update,delete}`
+    /// do for in-store writes; see [`StateStore::state_hash_cache`].
+    pub(crate) fn invalidate(&self, key: &ContractKey) {
+        self.cache.invalidate(key);
+    }
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum StateStoreError {
     #[error(transparent)]
@@ -120,12 +144,18 @@ pub struct StateStore<S: StateStorage> {
     ///
     ///   the entry is either ABSENT or equal to `state_hash(state on disk)`.
     ///
-    /// It is maintained by exactly two kinds of operation, both of which funnel
-    /// through this `StateStore`, the single chokepoint for every contract-state
-    /// write:
-    ///   * any write — [`store`](Self::store), [`update`](Self::update),
-    ///     [`delete`](Self::delete) — INVALIDATES the entry, so a changed state
-    ///     can never be served against a stale hash.
+    /// It is maintained by three kinds of operation:
+    ///   * any write through this `StateStore` — [`store`](Self::store),
+    ///     [`update`](Self::update), [`delete`](Self::delete) — INVALIDATES the
+    ///     entry, so a changed state can never be served against a stale hash.
+    ///   * V2 delegate state writes (`put_contract_state_sync` /
+    ///     `update_contract_state_sync`) write directly through the raw
+    ///     `Storage`, BYPASSING `StateStore`, so they invalidate the entry via a
+    ///     [`StateChangeDetector`] handle wired into the runtime's
+    ///     `state_write_callback` (see `Runtime::set_state_write_callback` and
+    ///     the callback installers in `executor/runtime.rs`). Without this a V2
+    ///     write would leave a stale detector hash → stale summary/delta →
+    ///     divergence (caught by Codex review).
     ///   * the summarize/delta slow path re-POPULATES it after loading the
     ///     current state (via [`cache_state_hash`](Self::cache_state_hash)).
     ///
@@ -199,6 +229,15 @@ where
         MokaCache::builder()
             .max_capacity(STATE_HASH_CACHE_CAPACITY)
             .build()
+    }
+
+    /// A cloneable handle to this store's state-change detector, for the V2
+    /// delegate write path which bypasses `StateStore` (see
+    /// [`StateChangeDetector`]). Wired into the runtime's `state_write_callback`.
+    pub(crate) fn change_detector(&self) -> StateChangeDetector {
+        StateChangeDetector {
+            cache: self.state_hash_cache.clone(),
+        }
     }
 
     /// Cheap read of the change-detector: the hash of `key`'s currently-stored
@@ -1141,6 +1180,30 @@ mod tests {
             store.cached_state_hash(&key),
             None,
             "delete() must invalidate the detector"
+        );
+    }
+
+    /// The V2-bypass handle ([`StateChangeDetector`]) invalidates the same
+    /// detector the summarize/delta fast path reads. This is the mechanism the
+    /// runtime's `state_write_callback` uses so V2 delegate writes — which
+    /// bypass `StateStore` — cannot leave a stale detector hash.
+    #[tokio::test]
+    async fn change_detector_handle_invalidates_cached_hash() {
+        let mock_storage = MockStateStorage::new();
+        let store = StateStore::new_uncached(mock_storage);
+        let key = make_test_key();
+
+        store.cache_state_hash(key, 7);
+        assert_eq!(store.cached_state_hash(&key), Some(7));
+
+        // A write through the bypass handle must clear the entry, exactly like an
+        // in-store write (store/update/delete) does.
+        let detector = store.change_detector();
+        detector.invalidate(&key);
+        assert_eq!(
+            store.cached_state_hash(&key),
+            None,
+            "change_detector().invalidate must clear the detector the fast path reads"
         );
     }
 


### PR DESCRIPTION
## Problem

`bridged_summarize_contract_state` and its sibling `bridged_get_contract_state_delta` (crates/core/src/contract/executor/runtime/executor_impl.rs) memoize their WASM results in `summary_cache` / `delta_cache`, correctly skipping the WASM call on unchanged state. But they compute the cache key by **loading the full contract state and running `DefaultHasher` over EVERY byte on EVERY call** (plus a disk load on a moka miss). On a busy node — tens of summarize/delta per second over MB-scale River states, the delta path fanned out per-subscriber during broadcast — that per-call full-state hash is the residual cost.

`WrappedState` is `Arc<Vec<u8>>` (cheap clone), so the dominant cost is the O(state-size) hash, plus the disk load on a cache miss.

## Approach

Add a cheap per-contract **state-change detector** in `StateStore` and key the summarize/delta fast path on it instead of re-hashing the full state.

- `StateStore::state_hash_cache: MokaCache<ContractKey, u64>` maps a contract → the hash of its CURRENTLY-stored state, bounded (100k entries) and independent of the moka state cache.
- The fast path reads the detector hash (a cheap map lookup — **no state load, no full-state hash**) and returns the cached summary/delta when the per-executor cache holds an entry for that exact hash. For delta, only the **state component** of the `(key, state_hash, their_summary_hash)` key uses the detector; `their_summary` is a small digest and is still hashed directly.
- The detector is invalidated by every write and repopulated by the summarize/delta slow path from the freshly-loaded state, so it self-warms after restart/eviction.

### Which detector, and why it's correct (the every-write-invalidates proof)

**Invariant:** the detector entry for a key is ABSENT or equals `state_hash(current on-disk state)`. A `Some(h)` therefore proves the state is byte-identical to the one that produced the cached summary/delta → the cached result is fresh, never stale.

This is the **inherently-correct** option over keying on `Ring::state_generation`: a missed generation bump today is a bounded, self-healing disk leak; coupling the read-only caches to it would silently upgrade that same class of miss into **state divergence**. The detector lives at the layer the state bytes actually pass through, and works even on `op_manager == None` paths where no generation is bumped.

**Every contract-state write invalidates the detector. Audited write paths:**

1. **In-store writes** — `StateStore::{store, update, delete}`. These are where the moka state cache is already maintained; the detector is invalidated alongside it. `store()` invalidates the moment the state write commits (before `store_params`, so the #3487 partial-failure window can't leave it stale).
2. **V2 delegate writes** — `put_contract_state_sync` / `update_contract_state_sync` write **directly through the raw `Storage`, bypassing `StateStore`**. They invalidate via a `StateCacheInvalidator` handle wired into the runtime's `state_write_callback` (the existing designated mirror point for V2 write side effects, alongside `Ring::commit_state_write`). The handle drops **both** the moka state-bytes cache AND the detector hash, so a later `get()` reloads the fresh bypass-written bytes rather than masking them.

The ring/hosting layer writes hosting metadata and reclaims (delete) but never writes contract state (the only `store_state_sync` calls there are `#[cfg(test)]`).

**Serialization:** all contract-state writes AND all summarize/delta reads are serialized through the single `&mut RuntimePool` contract-handling loop, so no write can interleave between the slow path's load and its detector populate. The off-loop export holds an executor but is read-only.

The detector being independent of the moka state cache (on even in `new_uncached` deterministic mode) only governs WHETHER the fast path is taken — both paths produce byte-identical summaries/deltas — so it cannot perturb simulation output or event-trace determinism. The #4610 state-presence gate is preserved: a stateless contract has no detector entry → slow path → its `state.ok_or_else(...)` still errors (not summarized).

## Testing

- **state_store unit tests:** detector absent until populated; EVERY write path (store/update/delete) invalidates it; `store()` invalidates even when `store_params` fails after the state write commits; the `StateCacheInvalidator` handle drops both caches (including unmasking a backing-store write that the moka cache would otherwise hide); `state_hash` distinguishes/​is-stable.
- **Correctness (divergence guard):** PUT → summarize → UPDATE → summarize returns the FRESH summary, not the stale cached one; the delta sibling does the same against a fixed peer summary. **Both fail with the exact "must reflect updated state B, not stale cached A" symptom when the write-path invalidation is removed — verified.**
- **Optimization:** repeated summarize/delta on an UNCHANGED contract performs NO additional state load (asserted via `MockStateStorage::get_count` on an uncached store, which implies no full-state rehash and no WASM); a load reappears after an UPDATE.
- **Edges:** cold first summarize; state-absent → error; cold-cache executor (restart/eviction) recomputes correctly.
- **Pin tests:** the V2 callback installers must invalidate the caches (source-pin, mirrors the existing `v2_delegate_state_write_paths_invoke_callback_with_state_size` pin); the `commit_state_write` chokepoint count is unchanged (6).

`cargo fmt`, `cargo clippy --locked -- -D warnings` (and `--features trace-ot`) clean; relevant suites green (221 tests across pool/state_store/delegate/conformance).

This is a **hot-path, correctness-sensitive** change with **no intended behavior change**. An external Codex review pass was run iteratively; it raised three findings (two P1 V2-bypass correctness gaps, one P2 partial-failure window), all fixed and re-reviewed clean.

[AI-assisted - Claude]

## Review follow-up (4 Claude reviews + Codex, no Must/Should correctness findings)

Hardening/clarity follow-ups from the review round (no change to the verified every-write-invalidates fix logic):

- **End-to-end V2 test through the production invalidator.** Added `test_v2_put_through_production_invalidator_clears_detector` / `..._update_..._clears_detector` (delegate_api.rs): they build a `StateStore` over the same backing storage a real V2 write touches, wire the **production** `StateStore::cache_invalidator()` as the `state_write_callback` (exactly as `from_config`), populate the detector via `cache_state_hash`, run a real `put`/`update_contract_state_sync`, and assert the detector hash for the written key is **cleared** (plus a read-after-write `get()` returns the fresh bytes). Closes the wrong-key / wrong-store-instance seam the source-pin can't catch.
- **Future-writer guard comments** on the raw bypass write methods (`redb.rs` `store_state_sync`/`update_state_sync`) and the `StateStorage::store`/`remove` trait methods: any contract-state write that bypasses `StateStore` MUST invalidate the change-detector via `StateCacheInvalidator` or summarize/delta can serve a stale result → divergence (#4621). Protects future bypass writers (e.g. #4592 live-import).
- **Determinism note** at the `new_uncached` mock call site (`mock_runtime.rs`). Verified: **no** sim/conformance/turmoil test asserts on state-LOAD or WASM-CALL counts (only on output bytes), and the detector's moka cache never evicts at sim scale (100k capacity ≫ distinct contracts), so keeping it on in uncached mode is determinism-safe. No logic change.
- **Delta optimization symmetry**: added the post-UPDATE "reload reappears" assertion to `delta_unchanged_skips_state_load` to match the summarize sibling.
- **Serialization-invariant comments** at the summarize/delta detector reads (`executor_impl.rs`): the no-stale-populate-race guarantee relies on all summarize/delta reads + all state writes running on the single `&mut RuntimePool` loop; off-loop work holding an executor must stay read-only w.r.t. contract state.

### Disclosures

- **Bonus correctness fix (not just perf):** the callback install moved from `op_manager`-gated to **unconditional**, and the wired `StateCacheInvalidator` now drops the moka `state_mem_cache` too. Pre-PR the callback only called `commit_state_write` (and wasn't installed at all when `op_manager == None`, i.e. local mode), so a V2 delegate write could leave **stale moka state bytes** that a later `StateStore::get` read-after-write would serve. That pre-existing staleness is now fixed for every mode.
- **Hash collision profile unchanged:** the detector uses the same `DefaultHasher`-over-state-bytes that already keyed the summary/delta cache before this PR, so the (astronomically small) collision risk is identical to pre-PR — not introduced or widened here.

[AI-assisted - Claude]
