### PR TITLE
fix: gate SubscribeHint admission on interested (not raw) module-cache occupancy (#4534)

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -22,7 +22,7 @@ Driver entry points:
 | GET | `get/op_ctx_task.rs::start_client_get`, `start_relay_get`, `start_sub_op_get`, `start_targeted_sub_op_get` |
 | PUT | `put/op_ctx_task.rs::start_client_put`, `start_relay_put`, `start_relay_put_streaming` |
 | UPDATE | `update/op_ctx_task.rs::start_client_update`, `start_relay_request_update`, `start_relay_broadcast_to`, `start_relay_request_update_streaming`, `start_relay_broadcast_to_streaming` |
-| SUBSCRIBE | `subscribe/op_ctx_task.rs::start_client_subscribe`, `start_directed_subscribe` (SubscribeHint placement nudge, #4404 — the inbound-hint receive arm in `node.rs` now refuses it above the module-cache occupancy ceiling, `migration_admission_allowed`, #4534), `run_executor_subscribe`, `run_renewal_subscribe`, `start_relay_subscribe`; `subscribe.rs::handle_unsubscribe_inbound` for `Unsubscribe` |
+| SUBSCRIBE | `subscribe/op_ctx_task.rs::start_client_subscribe`, `start_directed_subscribe` (SubscribeHint placement nudge, #4404 — the inbound-hint receive arm in `node.rs` now refuses it above the module-cache INTERESTED-occupancy ceiling via `migration_admission_decision`, #4534), `run_executor_subscribe`, `run_renewal_subscribe`, `start_relay_subscribe`; `subscribe.rs::handle_unsubscribe_inbound` for `Unsubscribe` |
 
 The shared retry-loop driver lives in `op_ctx.rs` (`RetryDriver` trait
 + `drive_retry_loop`). UPDATE is fire-and-forget (no retry loop, no

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -359,6 +359,19 @@ impl RuntimePool {
                 }
             }
         }));
+        // Companion GAUGES-ONLY refresher used by the migration-admission gate:
+        // recomputes the interest split for a fresh hot-occupancy read per inbound
+        // SubscribeHint WITHOUT bumping the throttle-sampled would-reclassify
+        // counter or resetting the throttle (Codex review). Same Weak-handle
+        // cycle-break rationale as the snapshot refresher above.
+        let gauges_refresher_cache = Arc::downgrade(&shared_contract_modules);
+        module_cache_metrics.set_interest_gauges_refresher(Arc::new(move || {
+            if let Some(cache) = gauges_refresher_cache.upgrade() {
+                if let Ok(cache) = cache.lock() {
+                    cache.force_refresh_interest_gauges_only();
+                }
+            }
+        }));
         // Shared delegate-context cache so a prompt round-trip routed to a
         // different pool executor still finds its `ctx.write()` blob.
         let shared_delegate_contexts = crate::wasm_runtime::new_delegate_context_cache();

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1810,6 +1810,10 @@ where
                     "Ignoring inbound SubscribeHint: own version is below the \
                      SubscribeHint re-enable floor (pre-floor peer, wire-compat)"
                 );
+                op_manager
+                    .ring
+                    .placement_migration_metrics()
+                    .record_refused_version_floor();
                 return Ok(());
             }
             // Directed-subscribe placement (#4404): a holder is nudging us to
@@ -1823,6 +1827,10 @@ where
                     ?source_addr,
                     "Received SubscribeHint for an already-hosted contract — ignoring"
                 );
+                op_manager
+                    .ring
+                    .placement_migration_metrics()
+                    .record_refused_already_hosting();
                 return Ok(());
             }
             // `hint.holder` is network-sourced. A legitimate sender always sets
@@ -1844,46 +1852,121 @@ where
                     ?source_addr,
                     "Received SubscribeHint whose holder is not the sender — ignoring"
                 );
+                op_manager
+                    .ring
+                    .placement_migration_metrics()
+                    .record_refused_holder_mismatch();
                 return Ok(());
             }
             // Backpressure-aware migration admission (#4534): refuse to take on
-            // a NEW migrated contract when the contract module cache is already
-            // at/above its occupancy ceiling. Accepting more would push the
-            // hosted working set past cache capacity, forcing recompile-on-
-            // access thrash that fills the fair queue ("contract queue full")
-            // and OOMs memory-bound gateways. This gates ONLY the directed-
-            // subscribe placement nudge; the node's own local client
-            // subscribes/GETs are never gated here. The hint is dropped silently
-            // and the holder re-proposes it on its next migration trigger once
-            // headroom returns.
-            // Read the per-node module-cache occupancy off the same `Ring` the
+            // a NEW migrated contract when the contract module cache lacks the
+            // headroom to host it without recompile thrash (which fills the fair
+            // queue / OOMs memory-bound gateways). The signal the gate keys on
+            // depends on the ACTIVE eviction policy, because the gate is only
+            // sound if it predicts what eviction will actually do:
+            //
+            //  * Interest-tiered eviction ACTIVE
+            //    (FREENET_MODULE_CACHE_INTEREST_TIERED): eviction reclaims COLD
+            //    (no-interest) entries first, so admitting while the cache is full
+            //    of cold modules merely evicts cold ones — no thrash. Here we gate
+            //    on INTERESTED (hot) occupancy. This is the fix: the cache is an
+            //    LRU that fills to ~100% with cold modules even on an idle node,
+            //    so the old raw gate refused migration ~permanently on the small-
+            //    cache majority for no real reason (live 0.2.86: 340/635 small
+            //    nodes refused, all at interested-occ ~0% vs raw ~98%).
+            //
+            //  * Plain byte-LRU (DEFAULT): eviction reclaims the absolute LRU
+            //    entry regardless of interest, so admitting into a full cache can
+            //    evict a HOT module and recompile it — exactly the #4534 thrash.
+            //    Cold-evictable headroom is NOT guaranteed to be reclaimed, so the
+            //    interested-occupancy assumption does not hold (Codex review).
+            //    Here we keep gating on RAW occupancy: identical to #4534's
+            //    shipped behavior, so thrash protection is preserved unchanged.
+            //
+            // Preserving #4534 thrash protection is the load-bearing invariant, so
+            // the gate matches the active policy rather than always trusting the
+            // interested signal. To deliver the over-refusal fix to the default
+            // majority, enable interest-tiered eviction (the gate then activates
+            // the interested signal and is sound); the recovered/recoverable
+            // counter below quantifies the benefit that flip would unlock.
+            //
+            // This gates ONLY the directed-subscribe placement nudge; the node's
+            // own local client subscribes/GETs are never gated here. The hint is
+            // dropped silently and the holder re-proposes it on its next migration
+            // trigger once headroom returns.
+            // Read the per-node module-cache metrics off the same `Ring` the
             // caches publish into (a process-global until #4488).
             let module_cache_metrics = op_manager.ring.module_cache_metrics();
-            let contract_cache_occupancy =
-                crate::wasm_runtime::contract_cache_occupancy_pct(&module_cache_metrics);
-            // SHADOW (always-on, behavior-neutral): record when this refuse/admit
-            // decision WOULD flip under a "admit if cold-evictable cache can make
-            // room" gate. This does NOT change the gate below — it only feeds the
-            // `migration_admission_would_change_total` counter so the later #4534
-            // admission change can rest on production data (#4441/#4534).
-            if crate::wasm_runtime::migration_admission_would_change_now(
-                &module_cache_metrics,
-                MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT,
-            ) {
-                module_cache_metrics.record_migration_admission_would_change();
+            let interest_tiered = crate::wasm_runtime::interest_tiered_enabled();
+            // Force a fresh interested/cold recompute BEFORE reading the gauge —
+            // but ONLY when the gate actually reads the interested gauge (tiered
+            // eviction active). The interested-bytes split is otherwise throttled
+            // to ≤ once per INTEREST_SHADOW_REFRESH_INTERVAL (10 s) on cache
+            // touches, and on an idle node only refreshes at the 5-min
+            // router-snapshot cadence; a burst of SubscribeHints would otherwise
+            // be gated against a stale-low hot-occupancy reading and over-admit,
+            // re-opening the #4534 thrash window (Codex review). The refresh is an
+            // O(entries) scan under the cache mutex, so under plain LRU — where the
+            // gate decision uses RAW occupancy (already fresh, O(1) per
+            // insert/remove) and never reads the interested gauge — we skip it to
+            // avoid paying that per-hint cost for nothing (Codex review). The
+            // refresh makes the gauge reflect the cache's CURRENT resident hot set
+            // at decision time (no-op before the runtime pool is built). It cannot
+            // see migrations still in-flight (admitted but not yet
+            // hosted/compiled), so a tight burst can still overshoot by ~one
+            // migration-completion latency before completed migrations push the hot
+            // set to the ceiling — a bounded, self-correcting residual, not the
+            // unbounded 10-s-stale window. Uses the GAUGES-ONLY refresher: it must
+            // NOT bump the throttle-sampled would-reclassify counter (a burst would
+            // inflate it by hint volume) nor reset that throttle (Codex review).
+            if interest_tiered {
+                module_cache_metrics.refresh_interest_gauges_now();
             }
-            if !migration_admission_allowed(contract_cache_occupancy) {
+            // Recovered/recoverable measurement (#4534): bump BEFORE and
+            // independent of the gate decision below. Counts inbound hints the raw
+            // gate refuses but the interested gate would admit — actually RECOVERED
+            // when interest-tiered eviction is active, or RECOVERABLE (the benefit
+            // a tiered-eviction flip would unlock) when it is not. Kept
+            // UNCONDITIONAL so plain-LRU nodes still record the recoverable benefit
+            // — exactly the data that justifies flipping the eviction policy. This
+            // read is cheap (O(1) atomics, no cache mutex / no scan), so unlike the
+            // refresh above it costs nothing per hint; under plain LRU it reads the
+            // throttled (≤10s-stale) interested gauge, which is fine for a coarse
+            // benefit metric.
+            if crate::wasm_runtime::migration_admission_recovered_now(
+                &module_cache_metrics,
+                MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_INTERESTED_OCCUPANCY_PCT,
+            ) {
+                module_cache_metrics.record_migration_admission_recovered();
+            }
+            let admission = migration_admission_decision(&module_cache_metrics, interest_tiered);
+            if !admission.admit {
                 tracing::debug!(
                     key = %hint.key,
                     holder = %hint.holder,
                     ?source_addr,
-                    occupancy_pct = ?contract_cache_occupancy,
-                    ceiling_pct = MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT,
+                    gate_signal = if admission.interest_tiered {
+                        "interested"
+                    } else {
+                        "raw"
+                    },
+                    occupancy_pct = ?admission.occupancy_pct,
+                    interested_occupancy_pct = ?crate::wasm_runtime::contract_cache_interested_occupancy_pct(
+                        &module_cache_metrics
+                    ),
+                    raw_occupancy_pct = ?crate::wasm_runtime::contract_cache_occupancy_pct(
+                        &module_cache_metrics
+                    ),
+                    ceiling_pct = MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_INTERESTED_OCCUPANCY_PCT,
                     "Refusing inbound SubscribeHint: contract module cache at/above \
                      the migration-admission occupancy ceiling — deferring placement \
-                     migration to bound the hosted working set and avoid cache thrash \
-                     (#4534)"
+                     migration to bound the hosted working set and avoid recompile \
+                     thrash (#4534)"
                 );
+                op_manager
+                    .ring
+                    .placement_migration_metrics()
+                    .record_refused_cache_admission();
                 return Ok(());
             }
             tracing::debug!(
@@ -1964,45 +2047,95 @@ fn stale_sync_emit_budget(stale_contracts_len: usize) -> usize {
 /// Maximum contract-module-cache occupancy (percent of budget) at which this
 /// node still accepts an inbound placement-migration `SubscribeHint` (#4534).
 ///
-/// Above this ceiling, inbound hints are refused so the hosted working set
-/// cannot grow past cache capacity and thrash (module recompile-on-access),
-/// which had filled the contract fair queue and produced client-facing
-/// "contract queue full" outages and gateway OOMs on 0.2.80. The ~10% headroom
-/// below 100% is reserved for the node's own locally-requested contracts, whose
-/// directed subscribes are NOT gated here. Refusal is silent and best-effort:
-/// the holder re-proposes the migration on its next trigger, so placement
-/// migration resumes automatically once occupancy falls back below the ceiling.
+/// The ceiling is applied to whichever occupancy signal
+/// [`migration_admission_decision`] selects for the active eviction policy
+/// (INTERESTED occupancy under interest-tiered eviction, RAW occupancy under
+/// plain byte-LRU). The ~10% headroom below 100% is reserved for the node's own
+/// locally-requested contracts, whose directed subscribes are NOT gated here.
+/// Refusal is silent and best-effort: the holder re-proposes the migration on
+/// its next trigger, so placement migration resumes automatically once occupancy
+/// falls back below the ceiling.
 ///
-/// Recovery is real but NOT guaranteed: occupancy only drops when cold modules
-/// age out of the LRU faster than new ones compile (the recent distinct-module
-/// byte-sum falls below the ceiling). On a node whose hosted working set
-/// genuinely exceeds the cache budget — the exact #4534 scenario — occupancy
-/// stays pinned near 100% and migration is refused INDEFINITELY by design. That
-/// is the correct conservative behavior (it stops the thrash), but it means this
-/// gate is a stopgap, not a complete fix: on such a node the operator must raise
-/// `FREENET_MODULE_CACHE_BUDGET_BYTES` to actually re-enable placement. #4534
-/// stays open for the cache-sizing / offload-compilation / interest-weighted-
-/// retention directions; this constant implements only the "couple migration
-/// acceptance to cache headroom" one.
-const MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT: u64 = 90;
+/// Under interest-tiered eviction the signal is the HOT (interested) working set,
+/// which is self-limiting: as admitted migrations complete and compile in, the
+/// hot set grows until it reaches the ceiling and the node sheds further load —
+/// the #4534 thrash boundary, applied to the set that actually causes thrash. The
+/// gate forces a fresh hot-occupancy read at decision time
+/// (`refresh_interest_gauges_now`), so the only slack is migrations admitted but
+/// not yet hosted/compiled: a tight burst can overshoot by ~one migration-
+/// completion latency before completed migrations pull the gauge to the ceiling.
+/// That residual is bounded and self-correcting (and the producer side of the
+/// migration storm is bounded separately, #4440/#4145); accounting for in-flight,
+/// not-yet-compiled migrations would need a reserved-bytes counter with its own
+/// leak/TTL risk and is deliberately left as a follow-up.
+const MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_INTERESTED_OCCUPANCY_PCT: u64 = 90;
 
-/// Whether to accept an inbound placement-migration hint given the current
-/// contract-module-cache occupancy. `None` (budget gauge not yet published — no
-/// runtime pool built) admits, since there is no pressure signal to act on.
+/// Whether to accept an inbound placement-migration hint given the selected
+/// contract-module-cache occupancy signal. `None` (budget gauge not yet published
+/// — no runtime pool built) admits, since there is no pressure signal to act on.
 ///
 /// Split out as a pure function so the threshold logic is unit-testable without
 /// constructing an `OpManager` or touching the global cache gauges (#4534).
-fn migration_admission_allowed(contract_cache_occupancy_pct: Option<u64>) -> bool {
-    match contract_cache_occupancy_pct {
-        Some(pct) => pct < MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT,
+fn migration_admission_allowed(occupancy_pct: Option<u64>) -> bool {
+    match occupancy_pct {
+        Some(pct) => pct < MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_INTERESTED_OCCUPANCY_PCT,
         None => true,
+    }
+}
+
+/// Outcome of the placement-migration admission gate for the current contract-
+/// cache state. Carries the occupancy value the decision was based on and which
+/// signal was used, both for the refuse-path log.
+struct MigrationAdmission {
+    /// Whether to admit the migration hint.
+    admit: bool,
+    /// Occupancy percent the decision was based on (the selected signal), or
+    /// `None` when the budget gauge is unpublished.
+    occupancy_pct: Option<u64>,
+    /// `true` when interest-tiered eviction is active and the gate used INTERESTED
+    /// occupancy; `false` when it fell back to RAW occupancy under plain LRU.
+    interest_tiered: bool,
+}
+
+/// The placement-migration admission decision for the current contract-cache
+/// state, keyed on the signal that matches the ACTIVE eviction policy.
+///
+/// Soundness depends on predicting what eviction will actually do (see the gate
+/// comment in `handle_pure_network_message_v1`):
+/// - interest-tiered eviction active → cold entries are reclaimed first, so the
+///   INTERESTED (hot) occupancy is the right thrash signal (the #4534 fix);
+/// - plain byte-LRU (default) → eviction is interest-blind, so cold-evictable
+///   headroom is not guaranteed to be reclaimed; gating on RAW occupancy keeps
+///   #4534's shipped thrash protection unchanged.
+///
+/// `interest_tiered` is the live eviction policy (the gate passes
+/// [`crate::wasm_runtime::interest_tiered_enabled`]); injected as a parameter so
+/// the unit tests can pin BOTH policies deterministically without touching the
+/// process environment (`gate_*` tests).
+fn migration_admission_decision(
+    metrics: &crate::wasm_runtime::ModuleCacheMetrics,
+    interest_tiered: bool,
+) -> MigrationAdmission {
+    let occupancy_pct = if interest_tiered {
+        crate::wasm_runtime::contract_cache_interested_occupancy_pct(metrics)
+    } else {
+        crate::wasm_runtime::contract_cache_occupancy_pct(metrics)
+    };
+    MigrationAdmission {
+        admit: migration_admission_allowed(occupancy_pct),
+        occupancy_pct,
+        interest_tiered,
     }
 }
 
 #[cfg(test)]
 mod migration_admission_tests {
     use super::{
-        MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT, migration_admission_allowed,
+        MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_INTERESTED_OCCUPANCY_PCT,
+        migration_admission_allowed, migration_admission_decision,
+    };
+    use crate::wasm_runtime::{
+        ModuleCacheMetrics, contract_cache_interested_occupancy_pct, contract_cache_occupancy_pct,
     };
 
     /// No runtime pool / budget gauge yet → no pressure signal → admit.
@@ -2017,7 +2150,7 @@ mod migration_admission_tests {
     fn admits_below_occupancy_ceiling() {
         assert!(migration_admission_allowed(Some(0)));
         assert!(migration_admission_allowed(Some(
-            MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT - 1
+            MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_INTERESTED_OCCUPANCY_PCT - 1
         )));
     }
 
@@ -2026,12 +2159,110 @@ mod migration_admission_tests {
     #[test]
     fn refuses_at_or_above_occupancy_ceiling() {
         assert!(!migration_admission_allowed(Some(
-            MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT
+            MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_INTERESTED_OCCUPANCY_PCT
         )));
         assert!(!migration_admission_allowed(Some(
-            MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_OCCUPANCY_PCT + 5
+            MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_INTERESTED_OCCUPANCY_PCT + 5
         )));
         assert!(!migration_admission_allowed(Some(150)));
+    }
+
+    /// THE FIX (#4534), and its eviction-policy dependency: a cache that is
+    /// LRU-full of COLD modules (raw occupancy 98%) but whose HOT/interested
+    /// working set is ~empty (0%).
+    ///
+    /// - Under interest-tiered eviction (`interest_tiered = true`) the gate keys
+    ///   on interested occupancy and ADMITS — the over-budget bytes are
+    ///   cold-evictable, so admitting only evicts a cold module (no thrash). This
+    ///   is the recovered admission.
+    /// - Under plain byte-LRU (`interest_tiered = false`, the DEFAULT) eviction is
+    ///   interest-blind, so cold-evictable headroom is NOT guaranteed to be
+    ///   reclaimed; the gate keys on raw occupancy and REFUSES, exactly as the
+    ///   shipped #4534 gate did — preserving thrash protection on default nodes
+    ///   (Codex review).
+    ///
+    /// Drives the exact composition the live gate uses, so a regression that
+    /// keyed the tiered branch on raw occupancy (the bug this fixes) would flip
+    /// the admit assertion and fail.
+    #[test]
+    fn gate_admits_cold_filled_only_under_tiered_eviction() {
+        // raw 980/1000 = 98%, interested 0/1000 = 0%.
+        let cold_filled = ModuleCacheMetrics::with_contract_gauges_for_test(980, 1000, 0);
+
+        // Tiered eviction active → interested signal → ADMIT (the fix).
+        let tiered = migration_admission_decision(&cold_filled, true);
+        assert!(tiered.interest_tiered);
+        assert_eq!(tiered.occupancy_pct, Some(0), "hot set is empty");
+        assert!(
+            tiered.admit,
+            "under tiered eviction a cold-filled cache must ADMIT — admitting \
+             evicts only a cold module (no thrash)"
+        );
+
+        // Plain LRU (default) → raw signal → REFUSE (preserve #4534 on default
+        // nodes; cold-evictable headroom is not guaranteed to be reclaimed).
+        let plain = migration_admission_decision(&cold_filled, false);
+        assert!(!plain.interest_tiered);
+        assert_eq!(
+            plain.occupancy_pct,
+            Some(98),
+            "raw occupancy under plain LRU"
+        );
+        assert!(
+            !plain.admit,
+            "under plain byte-LRU the gate must keep refusing at raw 98% — \
+             admitting could evict a hot module and re-open the #4534 thrash"
+        );
+
+        // Witness the divergence directly via the occupancy helpers.
+        assert_eq!(
+            contract_cache_interested_occupancy_pct(&cold_filled),
+            Some(0)
+        );
+        assert_eq!(contract_cache_occupancy_pct(&cold_filled), Some(98));
+    }
+
+    /// Thrash protection preserved under tiered eviction (#4534): raw occupancy
+    /// 98% AND the HOT/interested set is also near budget (95%) → REFUSE.
+    /// Admitting here would force recompile thrash even with cold-first eviction.
+    #[test]
+    fn gate_refuses_when_hot_set_near_budget_under_tiered() {
+        // raw 980/1000 = 98%, interested 950/1000 = 95%.
+        let hot = ModuleCacheMetrics::with_contract_gauges_for_test(980, 1000, 950);
+        let d = migration_admission_decision(&hot, true);
+        assert_eq!(d.occupancy_pct, Some(95));
+        assert!(
+            !d.admit,
+            "a genuinely hot working set near budget must REFUSE (thrash risk)"
+        );
+    }
+
+    /// Boundary (tiered eviction): interested occupancy exactly at the ceiling
+    /// refuses; one below admits. `None` (unpublished budget) admits under both
+    /// policies.
+    #[test]
+    fn gate_boundary_and_unpublished_budget() {
+        // interested exactly at the ceiling → refuse.
+        let at_ceiling = ModuleCacheMetrics::with_contract_gauges_for_test(1000, 1000, 900);
+        assert_eq!(
+            contract_cache_interested_occupancy_pct(&at_ceiling),
+            Some(MIGRATION_ADMISSION_MAX_CONTRACT_CACHE_INTERESTED_OCCUPANCY_PCT)
+        );
+        assert!(!migration_admission_decision(&at_ceiling, true).admit);
+
+        // interested one below the ceiling → admit (even with raw at 100%).
+        let below = ModuleCacheMetrics::with_contract_gauges_for_test(1000, 1000, 890);
+        assert_eq!(contract_cache_interested_occupancy_pct(&below), Some(89));
+        assert!(migration_admission_decision(&below, true).admit);
+
+        // Unpublished budget gauge → no pressure signal → admit under either
+        // eviction policy.
+        let fresh = ModuleCacheMetrics::new();
+        for tiered in [true, false] {
+            let d = migration_admission_decision(&fresh, tiered);
+            assert_eq!(d.occupancy_pct, None);
+            assert!(d.admit);
+        }
     }
 }
 

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -198,8 +198,13 @@ pub(crate) fn start_directed_subscribe(
         // into `result_router_tx` that no client consumes (skewing stats and
         // occupying router capacity during a migration cascade). Best-effort:
         // a failed directed subscribe is retried on the next migration trigger.
+        // #4534 diagnostics: record the directed-subscribe outcome so post-release
+        // telemetry can tell whether acted-on migrations actually host the
+        // contract. Timeout / infrastructure error fold into `failed`.
+        let placement_metrics = op_manager.ring.placement_migration_metrics();
         match outcome {
             DriverOutcome::Publish(Ok(_)) | DriverOutcome::SkipAlreadyDelivered => {
+                placement_metrics.record_acted_succeeded();
                 tracing::debug!(
                     tx = %directed_tx,
                     contract = %instance_id,
@@ -207,6 +212,7 @@ pub(crate) fn start_directed_subscribe(
                 );
             }
             DriverOutcome::Publish(Err(e)) => {
+                placement_metrics.record_acted_failed();
                 tracing::debug!(
                     tx = %directed_tx,
                     contract = %instance_id,
@@ -215,6 +221,7 @@ pub(crate) fn start_directed_subscribe(
                 );
             }
             DriverOutcome::InfrastructureError(err) => {
+                placement_metrics.record_acted_failed();
                 tracing::debug!(
                     tx = %directed_tx,
                     contract = %instance_id,

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -466,11 +466,16 @@ fn test_subscribe_msg_response_hop_count_roundtrip() {
 }
 
 /// Pin: the inbound `SubscribeHint` arm in `node.rs` MUST consult the
-/// backpressure-aware migration-admission gate (`migration_admission_allowed`)
-/// BEFORE calling `start_directed_subscribe`. Without this gate the node accepts
-/// unbounded placement migration, overruns the module cache, and reproduces the
-/// #4534 "contract queue full" outage / gateway OOM. Anchored from this side so
-/// removing or reordering the gate trips the build.
+/// backpressure-aware migration-admission gate (`migration_admission_decision`,
+/// which keys on INTERESTED module-cache occupancy) BEFORE calling
+/// `start_directed_subscribe`, AND must force a fresh interest-shadow recompute
+/// (`refresh_interest_gauges_now`) BEFORE that gate so the gate reads the
+/// cache's current hot occupancy rather than a throttled (≤10s-stale) gauge that
+/// a burst of hints could over-admit against. Without the gate the node accepts
+/// unbounded placement migration and reproduces the #4534 "contract queue full"
+/// outage / gateway OOM; without the pre-gate refresh a burst silently bypasses
+/// the gate. Anchored from this side so removing or reordering either step trips
+/// the build.
 #[test]
 fn subscribe_hint_arm_gates_migration_on_cache_backpressure() {
     const SOURCE: &str = include_str!("../../node.rs");
@@ -485,13 +490,24 @@ fn subscribe_hint_arm_gates_migration_on_cache_backpressure() {
         + branch_start;
     let window = &SOURCE[branch_start..window_end];
 
-    let gate = window.find("migration_admission_allowed(").expect(
-        "SubscribeHint arm must call `migration_admission_allowed` to gate \
+    let refresh = window.find("refresh_interest_gauges_now(").expect(
+        "SubscribeHint arm must force a fresh gauges-only interest recompute \
+         (`refresh_interest_gauges_now`) so the gate reads current hot occupancy, \
+         not a stale-low throttled gauge a burst could over-admit against (#4534)",
+    );
+    let gate = window.find("migration_admission_decision(").expect(
+        "SubscribeHint arm must call `migration_admission_decision` to gate \
          placement migration on module-cache backpressure (#4534)",
     );
     let subscribe = window
         .find("start_directed_subscribe(")
         .expect("SubscribeHint arm must call `start_directed_subscribe` to act on the hint");
+    assert!(
+        refresh < gate,
+        "the interest-shadow refresh must run BEFORE migration_admission_decision, \
+         else the gate reads a stale hot-occupancy gauge and a burst of hints can \
+         over-admit past the ceiling (#4534)"
+    );
     assert!(
         gate < subscribe,
         "the migration-admission gate must run BEFORE start_directed_subscribe, \

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1456,16 +1456,16 @@ impl Ring {
             // Interest-weighted (two-tier) module-cache SHADOW gauges
             // (#4441/#4534): always-on, independent of the
             // FREENET_MODULE_CACHE_INTEREST_TIERED feature flag. They quantify
-            // what the two-tier policy WOULD reclaim/reclassify and how many
-            // migration-admission decisions WOULD change, so flipping the flag
-            // (and the later #4534 admission change) can rest on production data.
+            // what the two-tier policy WOULD reclaim/reclassify; the
+            // migration-admission counter now records actual admissions the
+            // interested-occupancy gate (#4534) RECOVERS versus the old raw gate.
             snapshot.contract_module_cache_cold_evictable_bytes =
                 Some(mc.contract_cold_evictable_bytes);
             snapshot.contract_module_cache_interested_bytes = Some(mc.contract_interested_bytes);
             snapshot.contract_module_cache_evictions_would_reclassify_total =
                 Some(mc.contract_evictions_would_reclassify_total);
-            snapshot.migration_admission_would_change_total =
-                Some(mc.migration_admission_would_change_total);
+            snapshot.migration_admission_recovered_total =
+                Some(mc.migration_admission_recovered_total);
 
             // UPDATE-broadcast stream-assembly failure gauge (#4440): the exact
             // signal that flagged the v0.2.73 incident. The broadcast queue
@@ -1534,6 +1534,15 @@ impl Ring {
             snapshot.subscribe_hint_received = Some(pm.received);
             snapshot.subscribe_hint_acted = Some(pm.acted);
             snapshot.renewal_terminus_satisfied = Some(pm.renewal_terminus_satisfied);
+            // Per-gate refusal + directed-subscribe outcome breakdown (#4534
+            // diagnostics).
+            snapshot.subscribe_hint_refused_version = Some(pm.received_refused_version_floor);
+            snapshot.subscribe_hint_refused_already_hosting =
+                Some(pm.received_refused_already_hosting);
+            snapshot.subscribe_hint_refused_holder = Some(pm.received_refused_holder_mismatch);
+            snapshot.subscribe_hint_refused_cache = Some(pm.received_refused_cache_admission);
+            snapshot.subscribe_hint_acted_succeeded = Some(pm.acted_succeeded);
+            snapshot.subscribe_hint_acted_failed = Some(pm.acted_failed);
 
             tracing::info!(
                 failure_events = snapshot.failure_events,

--- a/crates/core/src/ring/placement_migration_metrics.rs
+++ b/crates/core/src/ring/placement_migration_metrics.rs
@@ -8,10 +8,13 @@
 //! `router_snapshot` gauge cadence — no new per-message events:
 //!
 //! 1. [`PlacementMigrationMetrics`] — cumulative `AtomicU64` counters
-//!    (`sent` / `received` / `acted` / `renewal_terminus_satisfied`) incremented
-//!    at the migration sites and the renewal driver, read once per snapshot.
-//!    Lets us trend whether the migration is firing and at what rate, and how
-//!    often a subscription-root renewal short-circuits (#4440 proposal 1).
+//!    (`sent` / `received` / `acted` / `renewal_terminus_satisfied`, plus the
+//!    #4534 diagnostic breakdowns: per-gate refusal reasons and directed-
+//!    subscribe success/failure) incremented at the migration sites, the renewal
+//!    driver, and the SubscribeHint admission gates, read once per snapshot. Lets
+//!    us trend whether the migration is firing and at what rate, why inbound
+//!    hints are refused, whether acted migrations succeed, and how often a
+//!    subscription-root renewal short-circuits (#4440 proposal 1).
 //! 2. [`placement_quality`] — a pure function over this node's ring location and
 //!    the locations of the contracts it hosts. Produces the host-to-hosted-key
 //!    ring-distance distribution (median / p90 / fraction within 0.1 / min /
@@ -19,14 +22,15 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-/// Three cumulative lifetime counters tracking placement-migration activity.
+/// Cumulative lifetime counters tracking placement-migration activity.
 ///
 /// Constructed once per node in `Ring::new` and shared via `Arc`: the migration
-/// SEND site (`p2p_protoc::migration::consider_contract_migration`) and the two
-/// RECEIVE sites (`node::process_message`) reach it through `op_manager.ring`,
-/// while `emit_router_snapshot_telemetry` reads it. Counters are monotonic
-/// lifetime totals — the collector differences them across the snapshot cadence
-/// to derive a rate. Cheap `Relaxed` atomics; never blocks.
+/// SEND site (`p2p_protoc::migration::consider_contract_migration`), the
+/// RECEIVE/admission-gate sites (`node::process_message`), and the directed-
+/// subscribe driver (`operations::subscribe::op_ctx_task`) reach it through
+/// `op_manager.ring`, while `emit_router_snapshot_telemetry` reads it. Counters
+/// are monotonic lifetime totals — the collector differences them across the
+/// snapshot cadence to derive a rate. Cheap `Relaxed` atomics; never blocks.
 #[derive(Debug, Default)]
 pub(crate) struct PlacementMigrationMetrics {
     /// Incremented each time this node dispatches a `SubscribeHint` nudge to a
@@ -46,6 +50,23 @@ pub(crate) struct PlacementMigrationMetrics {
     /// instead satisfies its renewal locally and sends no wire request; this
     /// counter trends how much renewal traffic that removes.
     renewal_terminus_satisfied: AtomicU64,
+    /// Per-gate refusal counters (#4534 diagnostics): which admission gate dropped
+    /// an inbound `SubscribeHint`. Each is incremented at the matching
+    /// `return Ok(())` in the SubscribeHint receive arm, so together they
+    /// partition `received - acted` by reason and let us see, post-release, why
+    /// hints are being refused (e.g. cache-admission vs already-hosting). Surfaced
+    /// only in the existing 5-min `router_snapshot` — no per-event volume.
+    received_refused_version_floor: AtomicU64,
+    received_refused_already_hosting: AtomicU64,
+    received_refused_holder_mismatch: AtomicU64,
+    received_refused_cache_admission: AtomicU64,
+    /// Directed-subscribe outcome counters (#4534 diagnostics): of the hints this
+    /// node ACTED on, how many directed subscribes completed vs failed
+    /// (timeout / infrastructure error folded into failed). Incremented in the
+    /// outcome match of `start_directed_subscribe`; lets us tell whether acted
+    /// migrations actually succeed in hosting the contract.
+    acted_succeeded: AtomicU64,
+    acted_failed: AtomicU64,
 }
 
 /// A point-in-time read of [`PlacementMigrationMetrics`] for telemetry emission.
@@ -55,6 +76,12 @@ pub(crate) struct PlacementMigrationSnapshot {
     pub received: u64,
     pub acted: u64,
     pub renewal_terminus_satisfied: u64,
+    pub received_refused_version_floor: u64,
+    pub received_refused_already_hosting: u64,
+    pub received_refused_holder_mismatch: u64,
+    pub received_refused_cache_admission: u64,
+    pub acted_succeeded: u64,
+    pub acted_failed: u64,
 }
 
 impl PlacementMigrationMetrics {
@@ -86,6 +113,52 @@ impl PlacementMigrationMetrics {
             .fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Record that an inbound `SubscribeHint` was refused because this node's
+    /// version is below the SubscribeHint re-enable floor (#4534 diagnostics).
+    #[inline]
+    pub(crate) fn record_refused_version_floor(&self) {
+        self.received_refused_version_floor
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record that an inbound `SubscribeHint` was refused because this node
+    /// already hosts the contract (#4534 diagnostics).
+    #[inline]
+    pub(crate) fn record_refused_already_hosting(&self) {
+        self.received_refused_already_hosting
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record that an inbound `SubscribeHint` was refused because the hint's
+    /// holder is not the sender (#4534 diagnostics).
+    #[inline]
+    pub(crate) fn record_refused_holder_mismatch(&self) {
+        self.received_refused_holder_mismatch
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record that an inbound `SubscribeHint` was refused by the module-cache
+    /// admission gate (occupancy at/above the ceiling) (#4534 diagnostics).
+    #[inline]
+    pub(crate) fn record_refused_cache_admission(&self) {
+        self.received_refused_cache_admission
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record that an acted-on directed subscribe completed (now hosting) (#4534
+    /// diagnostics).
+    #[inline]
+    pub(crate) fn record_acted_succeeded(&self) {
+        self.acted_succeeded.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record that an acted-on directed subscribe failed (error / infra / timeout)
+    /// (#4534 diagnostics).
+    #[inline]
+    pub(crate) fn record_acted_failed(&self) {
+        self.acted_failed.fetch_add(1, Ordering::Relaxed);
+    }
+
     /// Read all counters for telemetry.
     pub(crate) fn snapshot(&self) -> PlacementMigrationSnapshot {
         PlacementMigrationSnapshot {
@@ -93,6 +166,20 @@ impl PlacementMigrationMetrics {
             received: self.received.load(Ordering::Relaxed),
             acted: self.acted.load(Ordering::Relaxed),
             renewal_terminus_satisfied: self.renewal_terminus_satisfied.load(Ordering::Relaxed),
+            received_refused_version_floor: self
+                .received_refused_version_floor
+                .load(Ordering::Relaxed),
+            received_refused_already_hosting: self
+                .received_refused_already_hosting
+                .load(Ordering::Relaxed),
+            received_refused_holder_mismatch: self
+                .received_refused_holder_mismatch
+                .load(Ordering::Relaxed),
+            received_refused_cache_admission: self
+                .received_refused_cache_admission
+                .load(Ordering::Relaxed),
+            acted_succeeded: self.acted_succeeded.load(Ordering::Relaxed),
+            acted_failed: self.acted_failed.load(Ordering::Relaxed),
         }
     }
 }
@@ -315,12 +402,46 @@ mod tests {
         );
     }
 
-    /// Source-pin the three migration counter sites so a refactor that drops a
+    /// The #4534 diagnostic counters (per-gate refusals + directed-subscribe
+    /// outcomes) each accumulate independently and surface in the snapshot.
+    #[test]
+    fn diagnostic_counters_increment_independently() {
+        let m = PlacementMigrationMetrics::default();
+        m.record_refused_version_floor();
+        m.record_refused_already_hosting();
+        m.record_refused_already_hosting();
+        m.record_refused_holder_mismatch();
+        m.record_refused_holder_mismatch();
+        m.record_refused_holder_mismatch();
+        m.record_refused_cache_admission();
+        m.record_acted_succeeded();
+        m.record_acted_failed();
+        m.record_acted_failed();
+
+        let s = m.snapshot();
+        assert_eq!(s.received_refused_version_floor, 1, "refused_version_floor");
+        assert_eq!(
+            s.received_refused_already_hosting, 2,
+            "refused_already_hosting"
+        );
+        assert_eq!(
+            s.received_refused_holder_mismatch, 3,
+            "refused_holder_mismatch"
+        );
+        assert_eq!(
+            s.received_refused_cache_admission, 1,
+            "refused_cache_admission"
+        );
+        assert_eq!(s.acted_succeeded, 1, "acted_succeeded");
+        assert_eq!(s.acted_failed, 2, "acted_failed");
+    }
+
+    /// Source-pin the migration counter sites so a refactor that drops a
     /// `record_*` call (or moves an `acted` increment onto a gated branch) fails
-    /// the build. The three sites live in different files and on different
-    /// control-flow branches, so an integration test would need a full multi-node
-    /// migration to exercise them; pinning the call sites in source is the cheap,
-    /// deterministic guard (same approach as
+    /// the build. The sites live in different files and on different control-flow
+    /// branches, so an integration test would need a full multi-node migration to
+    /// exercise them; pinning the call sites in source is the cheap, deterministic
+    /// guard (same approach as
     /// `refresh_router_records_health_on_startup_and_in_loop` in `ring.rs`).
     #[test]
     fn migration_counter_sites_present() {
@@ -375,6 +496,37 @@ mod tests {
             acted_at > act_log_at,
             "`record_acted()` must sit on the act branch (after the directed-subscribe \
              log), so gated/dropped hints are not counted as acted"
+        );
+
+        // REFUSAL breakdown (#4534 diagnostics): each per-gate refusal counter is
+        // incremented exactly once, at its matching `return Ok(())` in the arm.
+        for method in [
+            ".record_refused_version_floor()",
+            ".record_refused_already_hosting()",
+            ".record_refused_holder_mismatch()",
+            ".record_refused_cache_admission()",
+        ] {
+            assert_eq!(
+                arm.matches(method).count(),
+                1,
+                "the SubscribeHint arm must call `{method}` exactly once (at its refusal gate)"
+            );
+        }
+
+        // DIRECTED-SUBSCRIBE OUTCOME breakdown (#4534 diagnostics): the outcome
+        // match in `start_directed_subscribe` records success once and failure on
+        // BOTH the Publish(Err) and InfrastructureError arms.
+        let directed_src = include_str!("../operations/subscribe/op_ctx_task.rs");
+        assert_eq!(
+            directed_src.matches(".record_acted_succeeded()").count(),
+            1,
+            "start_directed_subscribe must record `acted_succeeded` exactly once"
+        );
+        assert_eq!(
+            directed_src.matches(".record_acted_failed()").count(),
+            2,
+            "start_directed_subscribe must record `acted_failed` on BOTH the error \
+             and infrastructure-error outcome arms"
         );
     }
 }

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -205,9 +205,10 @@ pub(crate) struct RouterSnapshotInfo {
     ///   would protect first (the in-use floor).
     /// - `evictions_would_reclassify_total`: monotonic count of eviction steps
     ///   whose victim the two-tier policy would pick differently from plain LRU.
-    /// - `migration_admission_would_change_total`: monotonic count of placement-
-    ///   migration admission decisions where the current ≥90%-occupancy refuse
-    ///   (#4534) would flip to admit if cold-evictable cache were considered.
+    /// - `migration_admission_recovered_total`: monotonic count of inbound
+    ///   placement-migration hints (#4534) that the old raw-occupancy gate would
+    ///   have refused but the current interested-occupancy gate admits — the
+    ///   migrations recovered on caches that are LRU-full of cold modules.
     ///
     /// `None` until the WASM runtime has touched the cache. The contract cache
     /// is the only one with an interest predicate; there are no delegate
@@ -215,7 +216,7 @@ pub(crate) struct RouterSnapshotInfo {
     pub contract_module_cache_cold_evictable_bytes: Option<u64>,
     pub contract_module_cache_interested_bytes: Option<u64>,
     pub contract_module_cache_evictions_would_reclassify_total: Option<u64>,
-    pub migration_admission_would_change_total: Option<u64>,
+    pub migration_admission_recovered_total: Option<u64>,
     /// UPDATE-broadcast stream-assembly gauges (#4440), populated by `Ring` from
     /// the process-global `BROADCAST_STREAM_METRICS` the broadcast queue
     /// publishes into. A streaming broadcast that fails to reach `Delivered`
@@ -268,6 +269,17 @@ pub(crate) struct RouterSnapshotInfo {
     pub subscribe_hint_sent: Option<u64>,
     pub subscribe_hint_received: Option<u64>,
     pub subscribe_hint_acted: Option<u64>,
+    /// Per-gate refusal breakdown of inbound `SubscribeHint`s (#4534
+    /// diagnostics): which admission gate dropped the hint. Together they
+    /// partition `subscribe_hint_received - subscribe_hint_acted` by reason.
+    pub subscribe_hint_refused_version: Option<u64>,
+    pub subscribe_hint_refused_already_hosting: Option<u64>,
+    pub subscribe_hint_refused_holder: Option<u64>,
+    pub subscribe_hint_refused_cache: Option<u64>,
+    /// Outcome breakdown of acted-on directed subscribes (#4534 diagnostics):
+    /// how many completed (now hosting) vs failed (error / infra / timeout).
+    pub subscribe_hint_acted_succeeded: Option<u64>,
+    pub subscribe_hint_acted_failed: Option<u64>,
     /// Count of renewal cycles short-circuited because this node is the
     /// body-holding subscription root for the contract (#4440 proposal 1).
     /// Monotonic lifetime total; trends how much renewal traffic the
@@ -1080,7 +1092,7 @@ impl Router {
             contract_module_cache_cold_evictable_bytes: None,
             contract_module_cache_interested_bytes: None,
             contract_module_cache_evictions_would_reclassify_total: None,
-            migration_admission_would_change_total: None,
+            migration_admission_recovered_total: None,
             // Broadcast stream-assembly + background-task health gauges,
             // populated by Ring on the snapshot cadence (#4440).
             broadcast_stream_attempts_total: None,
@@ -1099,6 +1111,12 @@ impl Router {
             subscribe_hint_sent: None,
             subscribe_hint_received: None,
             subscribe_hint_acted: None,
+            subscribe_hint_refused_version: None,
+            subscribe_hint_refused_already_hosting: None,
+            subscribe_hint_refused_holder: None,
+            subscribe_hint_refused_cache: None,
+            subscribe_hint_acted_succeeded: None,
+            subscribe_hint_acted_failed: None,
             renewal_terminus_satisfied: None,
             // Renegade predictor diagnostics
             renegade_failure_events: self.renegade_predictor.len(),

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2017,6 +2017,32 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "subscribe_hint_acted".to_string(),
                     serde_json::json!(snapshot.subscribe_hint_acted),
                 );
+                // Per-gate refusal + directed-subscribe outcome breakdown (#4534
+                // diagnostics).
+                obj.insert(
+                    "subscribe_hint_refused_version".to_string(),
+                    serde_json::json!(snapshot.subscribe_hint_refused_version),
+                );
+                obj.insert(
+                    "subscribe_hint_refused_already_hosting".to_string(),
+                    serde_json::json!(snapshot.subscribe_hint_refused_already_hosting),
+                );
+                obj.insert(
+                    "subscribe_hint_refused_holder".to_string(),
+                    serde_json::json!(snapshot.subscribe_hint_refused_holder),
+                );
+                obj.insert(
+                    "subscribe_hint_refused_cache".to_string(),
+                    serde_json::json!(snapshot.subscribe_hint_refused_cache),
+                );
+                obj.insert(
+                    "subscribe_hint_acted_succeeded".to_string(),
+                    serde_json::json!(snapshot.subscribe_hint_acted_succeeded),
+                );
+                obj.insert(
+                    "subscribe_hint_acted_failed".to_string(),
+                    serde_json::json!(snapshot.subscribe_hint_acted_failed),
+                );
                 // Interest-weighted (two-tier) module-cache SHADOW gauges
                 // (#4441/#4534). Inserted here (not as inline `json!` keys) to
                 // keep the macro under its recursion limit, same as the
@@ -2039,8 +2065,8 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     ),
                 );
                 obj.insert(
-                    "migration_admission_would_change_total".to_string(),
-                    serde_json::json!(snapshot.migration_admission_would_change_total),
+                    "migration_admission_recovered_total".to_string(),
+                    serde_json::json!(snapshot.migration_admission_recovered_total),
                 );
                 // Renewal-terminus short-circuit counter (#4440 proposal 1).
                 obj.insert(
@@ -2232,7 +2258,7 @@ mod tests {
         info.contract_module_cache_cold_evictable_bytes = Some(101);
         info.contract_module_cache_interested_bytes = Some(103);
         info.contract_module_cache_evictions_would_reclassify_total = Some(107);
-        info.migration_admission_would_change_total = Some(109);
+        info.migration_admission_recovered_total = Some(109);
         let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
         for (key, want) in [
             ("contract_module_cache_cold_evictable_bytes", 101),
@@ -2241,7 +2267,7 @@ mod tests {
                 "contract_module_cache_evictions_would_reclassify_total",
                 107,
             ),
-            ("migration_admission_would_change_total", 109),
+            ("migration_admission_recovered_total", 109),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }
@@ -2298,6 +2324,12 @@ mod tests {
         info.subscribe_hint_received = Some(13);
         info.subscribe_hint_acted = Some(7);
         info.renewal_terminus_satisfied = Some(9);
+        info.subscribe_hint_refused_version = Some(21);
+        info.subscribe_hint_refused_already_hosting = Some(22);
+        info.subscribe_hint_refused_holder = Some(23);
+        info.subscribe_hint_refused_cache = Some(24);
+        info.subscribe_hint_acted_succeeded = Some(25);
+        info.subscribe_hint_acted_failed = Some(26);
         let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
         for (key, want) in [
             ("hosted_contracts_count", 5u64),
@@ -2305,6 +2337,12 @@ mod tests {
             ("subscribe_hint_received", 13),
             ("subscribe_hint_acted", 7),
             ("renewal_terminus_satisfied", 9),
+            ("subscribe_hint_refused_version", 21),
+            ("subscribe_hint_refused_already_hosting", 22),
+            ("subscribe_hint_refused_holder", 23),
+            ("subscribe_hint_refused_cache", 24),
+            ("subscribe_hint_acted_succeeded", 25),
+            ("subscribe_hint_acted_failed", 26),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -27,7 +27,8 @@ pub use mock_state_storage::MockStateStorage;
 pub use module_cache::default_module_cache_budget_bytes;
 pub(crate) use module_cache::{
     DELEGATE_MODULE_CACHE_BUDGET_DIVISOR, InterestPredicate, ModuleCache, ModuleCacheMetrics,
-    contract_cache_occupancy_pct, migration_admission_would_change_now,
+    contract_cache_interested_occupancy_pct, contract_cache_occupancy_pct, interest_tiered_enabled,
+    migration_admission_recovered_now,
 };
 // Clamp bounds are referenced only by the config-default round-trip test, which
 // asserts the resolved default lands within [MIN, MAX] without hardcoding the

--- a/crates/core/src/wasm_runtime/module_cache.rs
+++ b/crates/core/src/wasm_runtime/module_cache.rs
@@ -109,7 +109,7 @@ const EVICTION_WARN_THRESHOLD: u64 = 16;
 /// The `interest` predicate can flip for an already-cached contract WITHOUT any
 /// cache mutation — e.g. a client disconnects or a downstream lease expires —
 /// so recomputing the split only on insert/remove would leave the gauges (and
-/// the `migration_admission_would_change` floor) stale on a read-mostly cache
+/// the interested-occupancy admission floor) stale on a read-mostly cache
 /// (Codex review). Refreshing on `get` fixes that, but a full O(entries) scan on
 /// every hot lookup is too expensive; the gauges are consumed only at the 5-min
 /// snapshot cadence and at admission-gate time, so bounding the recompute to at
@@ -468,12 +468,30 @@ impl<K: Hash + Eq + Clone, V> ModuleCache<K, V> {
     /// two-tier policy would more often help), which is what the flip decision
     /// needs — not a forensic eviction ledger.
     fn record_interest_shadow(&self) {
-        let Some(metrics) = &self.metrics else {
-            return;
-        };
-        if self.interest.is_none() {
-            return;
+        // Divergence-now: plain LRU would evict the (interested) absolute-LRU
+        // entry while a cold entry exists; two-tier would spare it and evict the
+        // cold one instead. Bumped only on the throttled / per-snapshot cadence
+        // (this method's callers), NOT on the gate's per-hint gauge refresh
+        // (which uses `force_refresh_interest_gauges_only`) — so a burst of
+        // SubscribeHints cannot inflate the counter by hint volume (Codex review).
+        if let Some(true) = self.recompute_interest_split() {
+            if let Some(metrics) = &self.metrics {
+                metrics.add_would_reclassify(self.label, 1);
+            }
         }
+    }
+
+    /// Recompute the cold-evictable / interested byte split and STORE it into the
+    /// gauges, returning `Some(diverged)` — whether the next plain-LRU eviction
+    /// would pick an INTERESTED entry while a COLD one exists (the would-reclassify
+    /// signal). Does the O(entries) scan and the gauge store but has NO counter
+    /// side effects and does NOT touch the throttle window, so callers choose
+    /// whether to bump the monotonic divergence counter. `None` when this cache
+    /// has no metrics sink or no interest predicate (nothing to publish).
+    fn recompute_interest_split(&self) -> Option<bool> {
+        let metrics = self.metrics.as_ref()?;
+        // No interest predicate (delegate / test caches) → nothing to classify.
+        self.interest.as_ref()?;
         let mut cold_evictable_bytes: u64 = 0;
         let mut interested_bytes: u64 = 0;
         let mut any_cold = false;
@@ -492,12 +510,7 @@ impl<K: Hash + Eq + Clone, V> ModuleCache<K, V> {
             lru_is_interested = interested;
         }
         metrics.record_interest_shadow(self.label, cold_evictable_bytes, interested_bytes);
-        // Divergence-now: plain LRU would evict the (interested) absolute-LRU
-        // entry while a cold entry exists; two-tier would spare it and evict the
-        // cold one instead.
-        if lru_is_interested && any_cold {
-            metrics.add_would_reclassify(self.label, 1);
-        }
+        Some(lru_is_interested && any_cold)
     }
 
     /// Track eviction volume and emit a RATE-LIMITED operator warning when the
@@ -592,6 +605,18 @@ impl<K: Hash + Eq + Clone, V> ModuleCache<K, V> {
         self.record_interest_shadow();
     }
 
+    /// Recompute + store the interest gauges ONLY: no would-reclassify counter
+    /// bump and no throttle-window reset. Used by the migration-admission gate,
+    /// which needs a fresh hot-occupancy read per inbound `SubscribeHint` but must
+    /// NOT (a) inflate the throttle-sampled divergence counter by hint volume, nor
+    /// (b) reset the throttle that governs that counter's sampling — either would
+    /// corrupt the divergence signal under a migration burst (Codex review).
+    /// Takes `&self` (the scan and gauge store need no mutation); reached via
+    /// [`ModuleCacheMetrics::refresh_interest_gauges_now`].
+    pub(crate) fn force_refresh_interest_gauges_only(&self) {
+        self.recompute_interest_split();
+    }
+
     /// Mark the interest-shadow throttle as DUE, so the next get/insert/remove
     /// will recompute the gauges regardless of how recently one fired. Test-only,
     /// used to exercise the throttled refresh path deterministically.
@@ -655,22 +680,25 @@ struct CacheGauges {
 pub(crate) struct ModuleCacheMetrics {
     contract: CacheGauges,
     delegate: CacheGauges,
-    /// SHADOW (always-on, flag-independent): lifetime count of placement-
-    /// migration admission decisions where the current ≥90%-occupancy refuse
-    /// gate (#4534) and a hypothetical "admit if there are enough cold-evictable
-    /// bytes to make room" gate WOULD DISAGREE — i.e. the current gate refuses
-    /// but the cold tier could be reclaimed to fit the migration. Published by
-    /// the admission gate at `node.rs` (which has no per-cache handle), so it
-    /// lives at the node level rather than under a cache label. Monotonic; the
-    /// collector differences it across the cadence. The gate's BEHAVIOR is
-    /// unchanged in this PR — this only measures the would-be delta (#4534 is a
-    /// later, data-gated change).
+    /// RECOVERED / RECOVERABLE admissions counter (#4534): lifetime count of
+    /// inbound placement-migration `SubscribeHint`s that the raw-occupancy gate
+    /// refuses but the interested-occupancy gate would admit — a cache LRU-full of
+    /// cold (evictable) modules while its hot/interested working set is well under
+    /// the ceiling. Published by the admission gate at `node.rs` (which has no
+    /// per-cache handle), so it lives at the node level rather than under a cache
+    /// label. Monotonic; the collector differences it across the cadence.
     ///
-    /// UPPER BOUND: the modeled cold-aware gate ignores the bytes the INCOMING
-    /// contract would add once it compiles, so it admits in a superset of the
-    /// cases a real gate would — this counter over-counts the eventual flip rate.
-    /// See [`migration_admission_would_change`] for the full rationale.
-    migration_admission_would_change_total: AtomicU64,
+    /// The live gate keys on the active eviction policy, so the meaning is:
+    /// - interest-tiered eviction ACTIVE → the gate actually admits these, so this
+    ///   is an EXACT tally of RECOVERED admissions (neither the gate nor this
+    ///   model reserves cache room for the incoming contract's own bytes, so the
+    ///   modeled admit condition is byte-for-byte the gate's);
+    /// - plain byte-LRU (DEFAULT) → the gate still refuses on raw occupancy, so
+    ///   this is the count that WOULD be recovered if interest-tiered eviction
+    ///   were enabled — i.e. the data that quantifies the benefit of that flip.
+    ///
+    /// See [`migration_admission_recovered`] for the full rationale.
+    migration_admission_recovered_total: AtomicU64,
     /// Hook that forces a fresh recompute of the contract cache's interest split
     /// (cold-evictable / interested bytes) ON DEMAND. Set once by
     /// `RuntimePool::new` to a closure that locks the contract `ModuleCache` and
@@ -685,6 +713,14 @@ pub(crate) struct ModuleCacheMetrics {
     /// occupancy gauge and the live admission gate stay on the lock-free atomics;
     /// only this O(entries) split is refreshed here, once per snapshot.
     interest_shadow_refresher: std::sync::OnceLock<Arc<dyn Fn() + Send + Sync>>,
+    /// Like [`Self::interest_shadow_refresher`] but GAUGES-ONLY: it recomputes and
+    /// stores the interest split WITHOUT bumping the would-reclassify counter or
+    /// resetting the throttle window. Set once by `RuntimePool::new` to a closure
+    /// that calls `force_refresh_interest_gauges_only`. Invoked by the migration-
+    /// admission gate before reading the hot-occupancy gauge, so a burst of
+    /// `SubscribeHint`s gets a fresh read per hint without inflating the
+    /// throttle-sampled divergence counter (Codex review).
+    interest_gauges_refresher: std::sync::OnceLock<Arc<dyn Fn() + Send + Sync>>,
 }
 
 /// A point-in-time read of [`ModuleCacheMetrics`] for telemetry emission.
@@ -705,10 +741,10 @@ pub(crate) struct ModuleCacheMetricsSnapshot {
     pub contract_cold_evictable_bytes: u64,
     pub contract_interested_bytes: u64,
     pub contract_evictions_would_reclassify_total: u64,
-    /// SHADOW (always-on): node-level would-change count for the migration
-    /// admission gate (#4534). See
-    /// [`ModuleCacheMetrics::migration_admission_would_change_total`].
-    pub migration_admission_would_change_total: u64,
+    /// Node-level recovered-admissions count for the migration admission gate
+    /// (#4534). See
+    /// [`ModuleCacheMetrics::migration_admission_recovered_total`].
+    pub migration_admission_recovered_total: u64,
 }
 
 impl ModuleCacheMetrics {
@@ -718,8 +754,9 @@ impl ModuleCacheMetrics {
         Self {
             contract: CacheGauges::default(),
             delegate: CacheGauges::default(),
-            migration_admission_would_change_total: AtomicU64::new(0),
+            migration_admission_recovered_total: AtomicU64::new(0),
             interest_shadow_refresher: std::sync::OnceLock::new(),
+            interest_gauges_refresher: std::sync::OnceLock::new(),
         }
     }
 
@@ -745,6 +782,27 @@ impl ModuleCacheMetrics {
     /// test/tool binaries with no WASM runtime.
     pub(crate) fn refresh_interest_shadow_now(&self) {
         if let Some(refresher) = self.interest_shadow_refresher.get() {
+            refresher();
+        }
+    }
+
+    /// Install the on-demand GAUGES-ONLY interest refresher (see the field docs).
+    /// Called once by `RuntimePool::new`; a second call is ignored.
+    pub(crate) fn set_interest_gauges_refresher(&self, refresher: Arc<dyn Fn() + Send + Sync>) {
+        if self.interest_gauges_refresher.set(refresher).is_err() {
+            tracing::debug!(
+                "module-cache interest-gauges refresher already set; ignoring re-registration"
+            );
+        }
+    }
+
+    /// Force a GAUGES-ONLY recompute of the contract cache's interest split, if a
+    /// refresher has been installed: updates the cold/interested gauges WITHOUT
+    /// bumping the would-reclassify counter or resetting the throttle. Invoked by
+    /// the migration-admission gate before reading the hot-occupancy gauge. No-op
+    /// before the runtime pool is built (early startup / test binaries).
+    pub(crate) fn refresh_interest_gauges_now(&self) {
+        if let Some(refresher) = self.interest_gauges_refresher.get() {
             refresher();
         }
     }
@@ -806,11 +864,12 @@ impl ModuleCacheMetrics {
         }
     }
 
-    /// Record one placement-migration admission decision where the current gate
-    /// and the cold-evictable-aware gate WOULD disagree (#4534 shadow). Called
-    /// from the admission gate; does NOT change the gate's behavior. Monotonic.
-    pub(crate) fn record_migration_admission_would_change(&self) {
-        self.migration_admission_would_change_total
+    /// Record one inbound placement-migration `SubscribeHint` that the old
+    /// raw-occupancy gate would have refused but the current interested-
+    /// occupancy gate admits (#4534 recovered admission). Called from the
+    /// admission gate before/independent of the admit decision. Monotonic.
+    pub(crate) fn record_migration_admission_recovered(&self) {
+        self.migration_admission_recovered_total
             .fetch_add(1, Ordering::Relaxed);
     }
 
@@ -844,10 +903,33 @@ impl ModuleCacheMetrics {
                 .contract
                 .evictions_would_reclassify_total
                 .load(Ordering::Relaxed),
-            migration_admission_would_change_total: self
-                .migration_admission_would_change_total
+            migration_admission_recovered_total: self
+                .migration_admission_recovered_total
                 .load(Ordering::Relaxed),
         }
+    }
+}
+
+#[cfg(test)]
+impl ModuleCacheMetrics {
+    /// Test-only: build a sink with the contract cache's total, budget, and
+    /// interested gauges pre-set, so admission-gate tests in OTHER modules (e.g.
+    /// `node.rs`) can exercise the occupancy helpers without constructing a real
+    /// `ModuleCache`/`RuntimePool`. Cold-evictable bytes are derived as
+    /// `total - interested` to keep the split self-consistent.
+    pub(crate) fn with_contract_gauges_for_test(
+        total_bytes: u64,
+        budget_bytes: u64,
+        interested_bytes: u64,
+    ) -> Self {
+        let m = Self::new();
+        m.record_occupancy("contract", 0, total_bytes as usize, budget_bytes as usize);
+        m.record_interest_shadow(
+            "contract",
+            total_bytes.saturating_sub(interested_bytes),
+            interested_bytes,
+        );
+        m
     }
 }
 
@@ -884,6 +966,47 @@ pub(crate) fn contract_cache_occupancy_pct(metrics: &ModuleCacheMetrics) -> Opti
     )
 }
 
+/// Contract-module-cache INTERESTED (hot working-set) occupancy as a percentage
+/// of the configured byte budget — the signal the placement-migration admission
+/// gate (#4534) actually gates on (see the gate at `node.rs`).
+///
+/// Mirrors [`contract_cache_occupancy_pct`] but over `contract_interested_bytes`
+/// (resident modules the node still has a client/downstream interest in) instead
+/// of `contract_total_bytes` (every resident module, including cold evictable
+/// ones). Same `None`-on-zero-budget semantics: `None` when the budget gauge has
+/// not been published yet (no WASM runtime pool built), which callers treat as
+/// "no pressure signal".
+///
+/// Why the gate uses THIS rather than raw occupancy: the module cache is an LRU
+/// that, in steady state, fills to ~100% with cold modules a node executed once
+/// and never reclaims until something needs the room. Raw occupancy is therefore
+/// ~98% on the small-cache majority even when the hot set is near-zero, which
+/// made the raw-occupancy gate refuse migration ~permanently for no real reason.
+/// The thrash #4534 guards against (recompile-on-access) only happens when the
+/// HOT/interested working set exceeds the budget — admitting a migration while
+/// there is cold-evictable headroom merely evicts a cold module, no recompile
+/// thrash. Gating on interested occupancy refuses exactly when there is real
+/// thrash risk and admits otherwise.
+///
+/// Freshness: the underlying `contract_interested_bytes` gauge is recomputed on
+/// the throttled cache get/insert/remove paths (≤ once per
+/// [`INTEREST_SHADOW_REFRESH_INTERVAL`] = 10 s) and on demand before each 5-min
+/// `router_snapshot`, so a bare read can be up to ~10 s stale (longer on an idle
+/// node). The migration-admission gate therefore calls
+/// [`ModuleCacheMetrics::refresh_interest_gauges_now`] IMMEDIATELY before reading
+/// this, so at gate time the value reflects the cache's CURRENT resident hot set
+/// — important so a burst of `SubscribeHint`s cannot be admitted against a
+/// stale-low reading. The only residual lag is migrations that are admitted but
+/// not yet hosted/compiled (they have not consumed cache yet), which the gate
+/// accounts for as they complete.
+pub(crate) fn contract_cache_interested_occupancy_pct(metrics: &ModuleCacheMetrics) -> Option<u64> {
+    let snapshot = metrics.snapshot();
+    occupancy_pct(
+        snapshot.contract_interested_bytes,
+        snapshot.contract_budget_bytes,
+    )
+}
+
 /// Pure occupancy-percent computation, split out so the threshold arithmetic is
 /// unit-testable without touching the process-global gauges. `None` when
 /// `budget_bytes == 0` (gauge uninitialized): with no known budget there is no
@@ -897,34 +1020,31 @@ fn occupancy_pct(total_bytes: u64, budget_bytes: u64) -> Option<u64> {
     Some(total_bytes.saturating_mul(100) / budget_bytes)
 }
 
-/// SHADOW (always-on, behavior-neutral): would the current ≥`ceiling_pct`-
-/// occupancy migration-admission refuse (#4534) flip to ADMIT under a
-/// hypothetical "admit if there's enough cold-evictable cache to make room"
-/// gate? Returns `true` only when the two gates DISAGREE for this snapshot:
-/// the current gate refuses (occupancy at/above the ceiling) **and** the
-/// cold-aware gate would admit because dropping all cold-evictable bytes would
-/// pull occupancy below the ceiling (i.e. the protected interested floor alone
-/// fits under it).
+/// RECOVERED / RECOVERABLE ADMISSION (#4534): would a raw-occupancy gate REFUSE
+/// this snapshot while an interested-occupancy gate ADMITS it? Returns `true`
+/// only when the two disagree in that direction: raw occupancy is at/above
+/// `ceiling_pct` (raw gate refuses) **and** the interested (hot) occupancy is
+/// below `ceiling_pct` (interested gate admits because the over-budget bytes are
+/// all cold-evictable, so — under cold-first eviction — admitting only evicts a
+/// cold module, no recompile thrash).
 ///
-/// Pure (snapshot in, bool out) so it is unit-testable and so the live gate at
-/// `node.rs` can call it without changing its own behavior — it only feeds the
-/// `migration_admission_would_change_total` shadow counter. `None` budget means
-/// no pressure signal, so the gates cannot disagree (current gate already
-/// admits): returns `false`.
+/// Pure (snapshot fields in, bool out) so it is unit-testable and so the live
+/// gate at `node.rs` can call it to bump the
+/// `migration_admission_recovered_total` counter. `None` budget means no
+/// pressure signal, so neither gate refuses and there is nothing to recover:
+/// returns `false`.
 ///
-/// # This is an UPPER BOUND on the real gate's flip rate
+/// # Exactness depends on the active eviction policy
 ///
-/// The hypothetical cold-aware gate modeled here checks only whether the
-/// *interested floor* fits under the ceiling — it does NOT account for the bytes
-/// the INCOMING migrated contract would itself add to the cache once it compiles.
-/// A real "admit if cold-evictable can make room" gate would have to leave room
-/// for the newcomer too, so it would admit in a STRICT SUBSET of the cases this
-/// function flags. Therefore the resulting `migration_admission_would_change_total`
-/// counter OVER-counts: it is an upper bound on how often the eventual #4534
-/// admission change would actually flip a decision. That is the safe direction
-/// for a shadow metric used to size a future change (it never hides flip
-/// pressure), and it is called out in the field rustdoc and the PR body.
-fn migration_admission_would_change(
+/// The interested-occupancy admit condition modeled here (`interested < ceiling`)
+/// is byte-for-byte the interested-gate's admit condition — neither reserves
+/// cache room for the incoming contract's own bytes. When interest-tiered
+/// eviction is ACTIVE the live gate uses exactly that condition, so this is an
+/// EXACT tally of RECOVERED admissions. When the cache evicts with plain LRU
+/// (the default) the live gate still refuses on raw occupancy, so this is the
+/// RECOVERABLE count — what a tiered-eviction flip would unlock — rather than
+/// admissions that happened. Either way it never over-counts the recoverable set.
+fn migration_admission_recovered(
     total_bytes: u64,
     interested_bytes: u64,
     budget_bytes: u64,
@@ -933,28 +1053,29 @@ fn migration_admission_would_change(
     let Some(occupancy) = occupancy_pct(total_bytes, budget_bytes) else {
         return false;
     };
-    let current_refuses = occupancy >= ceiling_pct;
-    // The cold-aware gate keeps only the interested floor; everything else is
-    // cold-evictable. It would admit when that floor's occupancy is below the
-    // ceiling — i.e. there is enough cold cache to reclaim to make room.
-    let cold_aware_admits = match occupancy_pct(interested_bytes, budget_bytes) {
-        Some(floor_pct) => floor_pct < ceiling_pct,
+    let old_raw_gate_refused = occupancy >= ceiling_pct;
+    // The current gate admits when the interested (hot) occupancy is below the
+    // ceiling — i.e. the over-budget bytes are all cold-evictable, so there is
+    // enough cold cache to reclaim to make room without recompile thrash.
+    let new_interested_gate_admits = match occupancy_pct(interested_bytes, budget_bytes) {
+        Some(interested_pct) => interested_pct < ceiling_pct,
         None => false,
     };
-    current_refuses && cold_aware_admits
+    old_raw_gate_refused && new_interested_gate_admits
 }
 
-/// Snapshot-driven wrapper over [`migration_admission_would_change`] for the
-/// live admission gate. Reads the contract cache's total / interested bytes and
-/// budget from `metrics` and reports whether the current ≥`ceiling_pct` refuse
-/// would flip to admit under the cold-evictable-aware policy. Behavior-neutral —
-/// callers use this ONLY to bump the shadow counter, never to gate.
-pub(crate) fn migration_admission_would_change_now(
+/// Snapshot-driven wrapper over [`migration_admission_recovered`] for the live
+/// admission gate. Reads the contract cache's total / interested bytes and budget
+/// from `metrics` and reports whether the old raw-occupancy gate would have
+/// refused a hint the current interested-occupancy gate admits — i.e. a recovered
+/// admission. The gate calls this to bump `migration_admission_recovered_total`
+/// before and independent of its own admit decision.
+pub(crate) fn migration_admission_recovered_now(
     metrics: &ModuleCacheMetrics,
     ceiling_pct: u64,
 ) -> bool {
     let s = metrics.snapshot();
-    migration_admission_would_change(
+    migration_admission_recovered(
         s.contract_total_bytes,
         s.contract_interested_bytes,
         s.contract_budget_bytes,
@@ -1891,12 +2012,16 @@ mod tests {
     /// Env READ-PATH: `with_label_and_interest` consults `interest_tiered_enabled()`
     /// (the live env var) to decide whether the two-tier policy is active. With the
     /// var set truthy the constructed contract cache is tiered; unset it is not.
-    /// Serialized via a process-wide guard and the prior value is restored, since
-    /// the environment is process-global.
+    /// The prior value is restored at the end. Cross-test isolation comes from
+    /// `cargo nextest` (CI runs each test in its own process); the local guard
+    /// below only serializes this test against its own re-entry.
     #[test]
     fn interest_tiered_enabled_reads_env_at_construction() {
         use std::sync::Mutex as StdMutex;
-        // Serialize against any other test that might touch this same env var.
+        // Serialize this test against its own re-entry. NOTE: this is function-
+        // local, so it does NOT serialize against other env-mutating tests in the
+        // same binary — the real cross-test isolation is nextest's per-process
+        // model (see the SAFETY note on the first `set_var` below).
         static ENV_GUARD: StdMutex<()> = StdMutex::new(());
         let _g = ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner());
 
@@ -1904,7 +2029,14 @@ mod tests {
         let interested = Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
         let pred = || interest_over(interested.clone());
 
-        // SAFETY: single-threaded within this serialized test; restored below.
+        // SAFETY: `set_var`/`remove_var` are unsound only under CONCURRENT env
+        // access. CI runs these lib tests under `cargo nextest`, which executes
+        // each test in its own process, so nothing else mutates `environ` while
+        // this test runs; the prior value is restored at the end. (The
+        // function-local `ENV_GUARD` only serializes this test against its own
+        // re-entry, NOT against other env-mutating tests in the binary, so under
+        // a plain multi-threaded `cargo test` this is best-effort — nextest's
+        // per-process isolation is the real guarantee.)
         unsafe { std::env::set_var(INTEREST_TIERED_ENV, "true") };
         let on =
             ModuleCache::<u64, ()>::with_label_and_interest(10, "contract", None, Some(pred()));
@@ -1913,6 +2045,8 @@ mod tests {
             "flag set truthy → tiered policy active"
         );
 
+        // SAFETY: as on the first `set_var` above — nextest runs this test in its
+        // own process (no concurrent env mutation); value restored at the end.
         unsafe { std::env::remove_var(INTEREST_TIERED_ENV) };
         let off =
             ModuleCache::<u64, ()>::with_label_and_interest(10, "contract", None, Some(pred()));
@@ -1922,6 +2056,8 @@ mod tests {
         );
 
         // A predicate-less cache is never tiered regardless of the env.
+        // SAFETY: as on the first `set_var` above — nextest per-process isolation;
+        // value restored at the end.
         unsafe { std::env::set_var(INTEREST_TIERED_ENV, "true") };
         let none: ModuleCache<u64, ()> =
             ModuleCache::with_label_and_interest(10, "contract", None, None);
@@ -1932,7 +2068,11 @@ mod tests {
 
         // Restore the prior environment.
         match prev {
+            // SAFETY: as on the first `set_var` above — nextest per-process
+            // isolation; this restores the original value.
             Some(v) => unsafe { std::env::set_var(INTEREST_TIERED_ENV, v) },
+            // SAFETY: as on the first `set_var` above — nextest per-process
+            // isolation; this restores the original (unset) value.
             None => unsafe { std::env::remove_var(INTEREST_TIERED_ENV) },
         }
     }
@@ -2354,37 +2494,57 @@ mod tests {
         assert_eq!(s.contract_interested_bytes, 0);
     }
 
-    /// `migration_admission_would_change`: the gates disagree ONLY when the
-    /// current gate refuses (occupancy ≥ ceiling) AND dropping all cold-evictable
-    /// bytes would pull the interested floor below the ceiling.
+    /// `contract_cache_interested_occupancy_pct`: interested bytes over budget,
+    /// `None` on an unpublished (zero) budget, and independent of raw occupancy.
     #[test]
-    fn migration_admission_would_change_logic() {
-        const CEIL: u64 = 90;
-        // Over the ceiling but the interested floor alone is well under it →
-        // cold-aware gate would admit → the gates DISAGREE.
-        assert!(migration_admission_would_change(
-            /* total */ 950, /* interested */ 100, /* budget */ 1000, CEIL
-        ));
-        // Over the ceiling AND the interested floor alone is still over it →
-        // even the cold-aware gate refuses → the gates AGREE.
-        assert!(!migration_admission_would_change(950, 950, 1000, CEIL));
-        // Under the ceiling → current gate already admits → no disagreement.
-        assert!(!migration_admission_would_change(500, 100, 1000, CEIL));
-        // Budget uninitialized → no pressure signal → no disagreement.
-        assert!(!migration_admission_would_change(950, 100, 0, CEIL));
-        // Exactly at the ceiling counts as a refuse; floor under it → disagree.
-        assert!(migration_admission_would_change(900, 100, 1000, CEIL));
+    fn contract_cache_interested_occupancy_pct_reads_interested_over_budget() {
+        // raw occupancy 98% (980/1000) but only 30% of budget is hot (300/1000).
+        let m = ModuleCacheMetrics::with_contract_gauges_for_test(980, 1000, 300);
+        assert_eq!(contract_cache_interested_occupancy_pct(&m), Some(30));
+        // The raw gauge is independent and much higher — this is the whole point.
+        assert_eq!(contract_cache_occupancy_pct(&m), Some(98));
+
+        // No interest at all → 0% even though the cache is nearly full of cold.
+        let cold = ModuleCacheMetrics::with_contract_gauges_for_test(980, 1000, 0);
+        assert_eq!(contract_cache_interested_occupancy_pct(&cold), Some(0));
+
+        // Unpublished budget gauge → None (no pressure signal), same as the raw
+        // helper.
+        let fresh = ModuleCacheMetrics::new();
+        assert_eq!(contract_cache_interested_occupancy_pct(&fresh), None);
     }
 
-    /// The node-level migration-admission would-change counter is monotonic and
+    /// `migration_admission_recovered`: flags exactly the snapshots the old
+    /// raw-occupancy gate refused but the new interested-occupancy gate admits.
+    #[test]
+    fn migration_admission_recovered_logic() {
+        const CEIL: u64 = 90;
+        // Raw over the ceiling but the interested set alone is well under it →
+        // old gate refused, new gate admits → RECOVERED.
+        assert!(migration_admission_recovered(
+            /* total */ 950, /* interested */ 100, /* budget */ 1000, CEIL
+        ));
+        // Raw over the ceiling AND the interested set is still over it → both
+        // gates refuse → not recovered (thrash protection preserved).
+        assert!(!migration_admission_recovered(950, 950, 1000, CEIL));
+        // Raw under the ceiling → old gate already admitted → nothing to recover.
+        assert!(!migration_admission_recovered(500, 100, 1000, CEIL));
+        // Budget uninitialized → no pressure signal → nothing to recover.
+        assert!(!migration_admission_recovered(950, 100, 0, CEIL));
+        // Raw exactly at the ceiling counts as the old refuse; interested under
+        // it → recovered.
+        assert!(migration_admission_recovered(900, 100, 1000, CEIL));
+    }
+
+    /// The node-level migration-admission recovered counter is monotonic and
     /// surfaces in the snapshot.
     #[test]
-    fn migration_admission_would_change_counter_accumulates() {
+    fn migration_admission_recovered_counter_accumulates() {
         let m = ModuleCacheMetrics::new();
-        assert_eq!(m.snapshot().migration_admission_would_change_total, 0);
-        m.record_migration_admission_would_change();
-        m.record_migration_admission_would_change();
-        assert_eq!(m.snapshot().migration_admission_would_change_total, 2);
+        assert_eq!(m.snapshot().migration_admission_recovered_total, 0);
+        m.record_migration_admission_recovered();
+        m.record_migration_admission_recovered();
+        assert_eq!(m.snapshot().migration_admission_recovered_total, 2);
     }
 
     /// The on-demand interest-shadow refresher (the headline Arc-cycle fix):


### PR DESCRIPTION
## Problem

The inbound-`SubscribeHint` placement-migration admission gate (`node.rs`, #4534) refused migration whenever **raw** module-cache occupancy (`total_bytes / budget_bytes`) was `>= 90%`.

But the contract module cache is an LRU that, in steady state, fills to ~100% with **cold, freely-evictable** modules a node executed once — while genuine hot demand (`interested_bytes`, the resident modules with a client/downstream interest) is ~0% on most small nodes. So the raw gate refused migration **~permanently** on the small-cache majority for no real reason.

Live 0.2.86 telemetry: **340 of 635** small-cache nodes were refusing migration, **every one** with interested-occupancy ~0% while median raw occupancy was **98.1%**. Those are exactly the migrations that should have been admitted (the cache has abundant cold headroom). The thrash #4534 guards against — module recompile-on-access that filled the contract fair queue ("contract queue full") and OOM'd memory-bound gateways on 0.2.80 — only happens when the **hot/interested** working set exceeds budget, not when the LRU is merely full of cold junk.

## Fix

Gate on **interested (hot) occupancy** instead of raw occupancy. Admitting a migration while the over-budget bytes are cold-evictable merely evicts a cold module (no recompile thrash). Refuse only when interested-occupancy `>= 90%` (real thrash risk) — so the #4534 thrash protection is preserved on the set that actually causes thrash. Self-limiting: as admitted migrations complete and compile in, the hot set grows until it reaches the ceiling and the node sheds further load.

### Eviction-policy soundness — the gate is policy-aware (please review)

A Codex review pass flagged that "cold is evicted first" only holds under **interest-tiered eviction** (`FREENET_MODULE_CACHE_INTEREST_TIERED`), which is **OFF by default**. Default nodes evict with plain byte-LRU, which is interest-blind: admitting into a full cache can evict a **hot** module and recompile it — re-opening the #4534 thrash, especially on the busy gateways #4534 was built to protect.

Since *preserving #4534 thrash protection is the load-bearing invariant*, the gate is **policy-aware**:

- **interest-tiered eviction active** → key on **interested** occupancy (sound: cold reclaimed first; this is the fix).
- **plain byte-LRU (default)** → key on **raw** occupancy (identical to #4534's shipped behavior — thrash protection unchanged).

**Decision for the reviewer:** as written, the over-refusal fix is *inert on default (plain-LRU) nodes* — i.e. it does **not** yet change behavior on the 340/635 refusing nodes, because they run plain LRU. To actually deliver the fix to that majority, **enable interest-tiered eviction** (then the gate activates the interested signal and is sound everywhere). I did **not** flip that default here: it changes the cache's eviction policy for all nodes (high blast radius, adds an O(entries) victim scan per eviction step) and the flag was deliberately left OFF pending data. The renamed `migration_admission_recovered_total` counter (below) quantifies the benefit that flip would unlock. Options for the lead: (a) merge this as the safe enabling step + flip the eviction flag separately, or (b) ask me to fold the eviction enablement into this PR. I recommend (a).

### Burst freshness

The interested-bytes split is throttled (recomputed `<= once / 10s` on cache touch, or per-5-min router snapshot on idle nodes). A second Codex finding: a burst of hints could be gated against a stale-low reading and over-admit. The gate now forces a fresh recompute (`refresh_interest_shadow_now`) immediately before the decision. Residual: migrations admitted but not yet hosted/compiled aren't counted, so a tight burst can overshoot by ~one migration-completion latency before completed migrations push the gauge to the ceiling — bounded and self-correcting (and the producer side of the migration storm is bounded separately, #4440/#4145). Accounting for in-flight, not-yet-compiled migrations would need a reserved-bytes counter with its own leak/TTL risk; deliberately left as a follow-up.

### Shadow counter renamed

The existing shadow counter computed exactly "raw-refuses && interested-admits". Renamed `migration_admission_would_change*` → `migration_admission_recovered*` (Rust symbols **and** the telemetry JSON key `migration_admission_would_change_total` → `migration_admission_recovered_total`) and re-documented: it now measures **recovered** admissions (under tiered eviction) or **recoverable** ones (the benefit a tiered-eviction flip would unlock, under plain LRU). Heads-up: this renames a telemetry key that exists in 0.2.86 — dashboards keyed on the old name need re-pointing (the underlying value is continuous).

## `interested_bytes` freshness finding

`contract_interested_bytes` is recomputed on the throttled cache get/insert/remove paths (`<= once / INTEREST_SHADOW_REFRESH_INTERVAL = 10s`) and on demand before each router snapshot. A bare read can be up to ~10s stale (longer on a fully idle node). The gate's forced `refresh_interest_shadow_now()` makes it fresh at decision time. (Note: only the O(1) raw-occupancy gauge was previously fresh per insert/remove; the O(entries) interested split is throttled — the field-doc claim that insert/remove "always recompute" the split is inaccurate, the throttle applies to all paths.)

## Testing

New/updated unit tests (all green):

- `contract_cache_interested_occupancy_pct_reads_interested_over_budget` — interested/budget, `None` on zero budget, independent of raw.
- `migration_admission_recovered_logic` / `_counter_accumulates` — the recovered/recoverable computation + monotonic counter + snapshot surfacing.
- `gate_admits_cold_filled_only_under_tiered_eviction` — raw 98% + interested 0% **ADMITS under tiered eviction** (the fix) and **REFUSES under plain LRU** (preserves #4534). **Confirmed fails-without-the-fix:** temporarily pointing the gate's tiered branch at raw occupancy makes this assertion fail (`left: Some(98)` vs `Some(0)`), then reverted.
- `gate_refuses_when_hot_set_near_budget_under_tiered` — raw 98% + interested 95% → REFUSE (thrash protection preserved).
- `gate_boundary_and_unpublished_budget` — interested == ceiling → refuse; one below → admit; `None` → admit under both policies.
- Updated the `subscribe_hint_arm_gates_migration_on_cache_backpressure` source-scrape pin to anchor on `migration_admission_decision`.
- Existing telemetry OTLP test updated for the renamed key.

Local: `cargo fmt` clean, `cargo clippy --locked -- -D warnings` clean (CI gate), all affected tests pass. Codex (`codex review --base origin/main`) reports no correctness issues after both fixes.

Also adds 4 missing `// SAFETY:` comments to pre-existing `unsafe` env calls in `module_cache.rs` **test** code (`undocumented_unsafe_blocks = "deny"`, only trips under `--all-targets`). Note: `cargo clippy --all-targets --all-features` is **red on `main` independently of this PR** (pre-existing errors in `update.rs`, `user_op_rate_limit.rs`, a `SweepOutcome` import, plus the separate #4545 `--all-features` visibility errors) — those are out of scope and left for a separate cleanup; this PR only clears the `module_cache.rs` test-code lints in the file it touches.

## Risk

Touches admission / placement logic — a **high-risk surface** (warrants Full multi-model review). Context: #4534 (closed, Nacho), #4404 (open).

[AI-assisted - Claude]


---

## Update since initial review (HEAD 2f7bdf77)

**Gate freshness path changed (Codex P2):** the gate no longer calls the counter-bumping `refresh_interest_shadow_now` per hint. It now uses a **gauges-only** refresh (`refresh_interest_gauges_now` → `force_refresh_interest_gauges_only`) that recomputes the cold/interested gauges WITHOUT bumping `evictions_would_reclassify_total` or resetting the snapshot throttle (the per-hint full refresh was inflating that shadow counter by hint volume). The refresh is also **skipped on plain-LRU nodes** (`if interest_tiered`) since the gate decides on raw occupancy there.

**New diagnostic telemetry** (cumulative counters in the existing ~5-min `router_snapshot` — no per-event volume):
- Per-gate refusal breakdown: `subscribe_hint_refused_version` / `_already_hosting` / `_holder` / `_cache` — splits the `received − acted` gap into benign (already-hosting) vs blocking (cache-admission).
- Directed-subscribe outcomes: `subscribe_hint_acted_succeeded` / `_acted_failed` — the "fired but didn't deliver" gauge.
- Caveat: `acted_succeeded + acted_failed` can be `< acted` — a hint counted `acted` whose directed-subscribe early-returns (contract banned / no admission slot) before driving increments neither outcome counter. Read the gap as not-driven, not lost-subscribes.

**Review:** re-reviewed (delta vs `7ae75de2`) — Codex + skeptical + code-first lenses, core gate logic unchanged. Deferred follow-ups: in-flight admission accounting, migration stick-rate provenance + aggregate `queue_full` counter (#4627), location-vs-origin retention (#4626).

[AI-assisted - Claude]
