### PR TITLE
ci: fix rule-lint blind spot for top-level src files (#4632)

### DIFF
--- a/.github/scripts/check_banned_patterns.py
+++ b/.github/scripts/check_banned_patterns.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Rule-lint #1/#2/#3: ban NEW use of std::time::Instant::now(),
 rand::thread_rng()/rand::random(), and tokio::net::UdpSocket in
-production code under crates/core/src/**/*.rs.
+production code under crates/core/src/ (top-level files and all subdirs).
 
 These patterns break deterministic simulation testing (DST):
   #1. std::time::Instant::now()  — use TimeSource instead
@@ -309,10 +309,21 @@ def find_violations_in_file(
     build_test_scope_map). A line IS flagged if:
       - It is in added_linenos (added by the PR), AND
       - It matches a banned pattern after comment-stripping, AND
-      - It is NOT test-scoped.
+      - It is NOT test-scoped, AND
+      - Neither the line itself nor the line directly above it carries a
+        ``// rule-lint: ok`` annotation (for intentional documented exceptions).
+
+    The ``// rule-lint: ok`` annotation is for the rare case of a legitimate
+    production use that must bypass the ban — e.g., the one
+    ``tokio::net::UdpSocket`` import in transport.rs that the ``Socket`` trait
+    itself wraps. The annotation MUST include a reason:
+    ``// rule-lint: ok — <reason>``. New uses require maintainer sign-off;
+    this is not a general escape hatch.
     """
     is_test = build_test_scope_map(file_lines)
     violations = []
+
+    rule_lint_ok_re = re.compile(r"//\s*rule-lint:\s*ok")
 
     for lineno in sorted(added_linenos):
         idx = lineno - 1  # 0-based
@@ -323,6 +334,14 @@ def find_violations_in_file(
 
         # Test-scoped lines are legitimately allowed to use real clocks/RNG/sockets.
         if is_test[idx]:
+            continue
+
+        # A ``// rule-lint: ok`` annotation on the flagged line itself or on
+        # the line directly above it suppresses the violation for documented
+        # intentional exceptions (e.g., the one legitimate
+        # tokio::net::UdpSocket import that the Socket trait wraps).
+        prev_line = file_lines[idx - 1] if idx > 0 else ""
+        if rule_lint_ok_re.search(raw) or rule_lint_ok_re.search(prev_line):
             continue
 
         for rule_num, rule_desc, pattern in BANNED_PATTERNS:
@@ -523,6 +542,59 @@ async fn integration_test() {
         {3},
         False,
     ),
+    # -----------------------------------------------------------------------
+    # Fixtures for issue #4632: pathspec now covers top-level src files too
+    # -----------------------------------------------------------------------
+    # A prod banned pattern in a top-level-style file (simulating transport.rs,
+    # node.rs, etc.) MUST flag — this is the class of bug #4632 was missing.
+    (
+        "top-level-file prod Instant::now — MUST flag (issue #4632 regression guard)",
+        """\
+fn prod_fn() {
+    let t = std::time::Instant::now();
+    println!("{:?}", t);
+}
+""",
+        {2},
+        True,  # pathspec fix means this now reaches the linter and MUST flag
+    ),
+    # A banned pattern annotated with ``// rule-lint: ok`` on the SAME line
+    # must NOT flag — covers the intentional transport.rs UdpSocket import.
+    (
+        "banned pattern with // rule-lint: ok on same line — must NOT flag",
+        """\
+use tokio::net::UdpSocket; // rule-lint: ok — intentional low-level construction site
+""",
+        {1},
+        False,
+    ),
+    # A banned pattern with ``// rule-lint: ok`` on the line ABOVE must NOT flag.
+    (
+        "banned pattern with // rule-lint: ok on previous line — must NOT flag",
+        """\
+// rule-lint: ok — intentional documented exception
+use tokio::net::UdpSocket;
+""",
+        {2},
+        False,
+    ),
+    # cfg(test) exemption still works after pathspec broadening (regression guard
+    # for the #4622 exemption not being broken by this PR's changes).
+    (
+        "cfg(test) exemption still works — regression guard for #4622",
+        """\
+fn prod_fn() {}
+
+#[cfg(test)]
+mod tests {
+    fn test_fn() {
+        let _t = std::time::Instant::now();
+    }
+}
+""",
+        {6},
+        False,  # inside cfg(test) — must NOT flag
+    ),
 ]
 
 
@@ -572,6 +644,11 @@ def main(argv: list[str]) -> int:
             "diff",
             rng,
             "--",
+            # Both globs are needed: git's ** does NOT match files directly under
+            # crates/core/src/ (node.rs, transport.rs, etc.) — only files in
+            # subdirectories. Adding the bare *.rs glob covers the top-level files.
+            # See issue #4632.
+            "crates/core/src/*.rs",
             "crates/core/src/**/*.rs",
         ],
         capture_output=True,

--- a/.github/scripts/check_blocking_sends.py
+++ b/.github/scripts/check_blocking_sends.py
@@ -530,6 +530,11 @@ def main(argv) -> int:
             "diff",
             rng,
             "--",
+            # Both globs are needed: git's ** does NOT match files directly under
+            # crates/core/src/ (node.rs, transport.rs, etc.) — only files in
+            # subdirectories. Adding the bare *.rs glob covers the top-level files.
+            # See issue #4632.
+            "crates/core/src/*.rs",
             "crates/core/src/**/*.rs",
         ],
         capture_output=True,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,10 @@ jobs:
             | grep '^+' | grep -v '^+++' || true)
           ALL_ADDED_STRIPPED=$(echo "$ALL_ADDED" | sed 's|//.*||' || true)
 
-          REMOVED=$(git diff "$BASE"..."$HEAD" -- 'crates/core/src/**/*.rs' 'crates/core/tests/**/*.rs' \
+          # Both *.rs and **/*.rs are needed: git's ** does NOT match files
+          # directly under crates/core/src/ — only nested files. The bare *.rs
+          # glob covers top-level files (node.rs, transport.rs, etc.). See #4632.
+          REMOVED=$(git diff "$BASE"..."$HEAD" -- 'crates/core/src/*.rs' 'crates/core/src/**/*.rs' 'crates/core/tests/**/*.rs' \
             | grep '^-' | grep -v '^---' || true)
           REMOVED_STRIPPED=$(echo "$REMOVED" | sed 's|//.*||' || true)
           # The test-exempt label allows mechanical refactors (e.g., retiring a

--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -11,7 +11,10 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::{borrow::Cow, io, net::SocketAddr};
 
 use futures::Future;
-use tokio::net::UdpSocket;
+// This is the one legitimate tokio::net::UdpSocket import in crates/core/src/:
+// transport.rs is the module that implements the Socket trait abstraction over
+// UdpSocket. New code outside this file must use the Socket trait instead.
+use tokio::net::UdpSocket; // rule-lint: ok — Socket trait implementation site
 
 // =============================================================================
 // Auto-update version mismatch detection


### PR DESCRIPTION
## Problem

The CI rule-lint pathspec `crates/core/src/**/*.rs` does **not** match files
directly under `crates/core/src/` in git 2.54.0 (no `core.glob`). The `**`
glob only matches files in subdirectories. This means the ~20 top-level
production modules — `node.rs`, `ring.rs`, `config.rs`, `transport.rs`,
`contract.rs`, `router.rs`, `operations.rs`, `client_events.rs`,
`topology.rs`, etc. — are a **blind spot** for:

- rules #1/#2/#3 in `check_banned_patterns.py` (bans `std::time::Instant::now()`,
  `rand::thread_rng()/rand::random()`, `tokio::net::UdpSocket` in prod code)
- rule #6 in `check_blocking_sends.py` (bans blocking `.send(...).await`)
- rule #4 in `ci.yml` (test-removed check's `REMOVED=` pathspec)

A new production `Instant::now()` added to `node.rs` would silently bypass CI.
Audited: no real violations are hiding today (node.rs Instant::now hits are all
inside `#[cfg(test)] mod tests`; transport.rs has one intentional UdpSocket).

## Solution

**Pathspec fix**: pass both `crates/core/src/*.rs` AND `crates/core/src/**/*.rs`
to all three affected locations. The bare `*.rs` glob matches the top-level
files; `**/*.rs` continues to match nested files. Verified: `git diff
dbc74087d~1...dbc74087d --name-only -- 'crates/core/src/*.rs' 'crates/core/src/**/*.rs' | grep node.rs`
returns `crates/core/src/node.rs` (old single-glob returned 0).

**`// rule-lint: ok` annotation**: broadening the pathspec newly surfaces the
`use tokio::net::UdpSocket;` import at `transport.rs:17`. This is the one
legitimate production use — transport.rs is where the `Socket` trait
abstraction is IMPLEMENTED over `UdpSocket`; the rule exists to push new code
through the trait, not to ban its definition site. Rather than excluding the
whole file (which would reopen the blind spot for everything else in it), the
linter now honours a `// rule-lint: ok — <reason>` annotation on the flagged
line (or the line directly above), mirroring rule #6's `// channel-safety: ok`
mechanism. The transport.rs import is annotated accordingly.

Changed files:
- `.github/scripts/check_banned_patterns.py` — dual pathspec + `// rule-lint: ok` support + 4 new self-test fixtures
- `.github/scripts/check_blocking_sends.py` — dual pathspec
- `.github/workflows/ci.yml` — dual pathspec in rule #4 `REMOVED=` line
- `crates/core/src/transport.rs` — `// rule-lint: ok` annotation on the import

## Testing

Self-tests all pass (`--self-test`):
- **17 fixtures** in `check_banned_patterns.py` including 4 new ones:
  - top-level-file prod `Instant::now` **MUST flag** (regression guard for #4632)
  - `// rule-lint: ok` on same line suppresses (transport.rs pattern)
  - `// rule-lint: ok` on previous line suppresses
  - `cfg(test)` exemption still works after broadening (#4622 regression guard)
- **12+7+file-context** fixtures in `check_blocking_sends.py` all pass

Linter is **green on current main** (`check_banned_patterns.py origin/main HEAD`
returns no offenders — transport.rs passes via annotation, node.rs test code
remains exempt).

## Fixes

Fixes #4632

https://claude.ai/code/session_01CVyrLHuiXpFCC21by4Pzrj