### PR TITLE
fix: implement gateway fallback for empty ring in put, update and subscribe operations

### DIFF
--- a/apps/freenet-ping/Cargo.lock
+++ b/apps/freenet-ping/Cargo.lock
@@ -725,6 +725,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -1104,6 +1110,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1196,6 +1203,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,7 +1272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
  "ctutils",
 ]
@@ -1404,6 +1421,30 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "either"
@@ -1634,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.2.82"
+version = "0.2.90"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1657,6 +1698,7 @@ dependencies = [
  "delegate",
  "directories",
  "dirs",
+ "ed25519-dalek",
  "either",
  "event-listener",
  "flatbuffers 25.12.19",
@@ -3996,6 +4038,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4986,6 +5038,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5062,6 +5123,16 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -7419,6 +7490,7 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -13,6 +13,7 @@ use crate::{
     ring::{Location, PeerKeyLocation, RingError},
 };
 
+pub(crate) mod bootstrap;
 pub(crate) mod connect;
 pub(crate) mod get;
 pub(crate) mod op_ctx;

--- a/crates/core/src/operations/bootstrap.rs
+++ b/crates/core/src/operations/bootstrap.rs
@@ -1,0 +1,192 @@
+//! Bootstrap-window gateway fallback shared across operations (#4361 / #4365).
+//!
+//! A freshly started node has an empty ring (`connections_by_location` has no
+//! entries) for its first minutes, yet already holds a live transient transport
+//! connection to its gateway. Operation peer-selection consults only the ring,
+//! so without a fallback every op in that window either fails or finalizes
+//! locally without ever using the transient gateway connection.
+//!
+//! GET introduced the bounded gateway fallback in #4364; this module lifts the
+//! selection core out of GET so PUT, UPDATE, and SUBSCRIBE reuse exactly the
+//! same rule at their own decision points (#4365).
+
+use std::net::SocketAddr;
+
+use crate::node::OpManager;
+use crate::ring::PeerKeyLocation;
+
+/// Pure selection core for the bootstrap gateway fallback (#4361).
+///
+/// Returns the first configured gateway that is not this node and not
+/// excluded by the caller's skip predicate — but ONLY when the ring is
+/// empty (`ring_connection_count == 0`). A non-empty ring means normal
+/// routing had ring entries to consider (its candidates may still all
+/// be filtered as transient/visited, but that exhaustion is genuine),
+/// so the fallback must stay out of the way.
+///
+/// Selection is deliberately deterministic (config order), unlike the
+/// randomized pick in #3219's CONNECT re-bootstrap: independent selectors
+/// (e.g. a client driver and the per-attempt loopback relay) must converge
+/// on the same gateway given the same exclusion set — stream claims and
+/// route telemetry are attributed via the chosen target, so divergence
+/// would mis-key both. Failover diversity comes from the exclusion
+/// predicate (tried/visited), not from randomization.
+///
+/// Split out from [`bootstrap_gateway_target`] so unit tests can
+/// exercise the selection rules without constructing an `OpManager`.
+pub(crate) fn select_bootstrap_gateway(
+    ring_connection_count: usize,
+    configured_gateways: &[PeerKeyLocation],
+    own_addr: Option<SocketAddr>,
+    is_excluded: impl Fn(SocketAddr) -> bool,
+) -> Option<(PeerKeyLocation, SocketAddr)> {
+    if ring_connection_count > 0 {
+        return None;
+    }
+    configured_gateways.iter().find_map(|gw| {
+        let addr = gw.socket_addr()?;
+        if Some(addr) == own_addr || is_excluded(addr) {
+            return None;
+        }
+        Some((gw.clone(), addr))
+    })
+}
+
+/// Bootstrap gateway fallback (#4361).
+///
+/// A node whose ring is still empty (`connections_by_location` has no
+/// entries) has zero routing candidates, so without a fallback an
+/// operation either fails instantly or finalizes locally — even though
+/// the node has a live transient transport connection to its gateway
+/// (the same connection its CONNECT handshake is negotiating over).
+/// Production analog: a freshly started node misbehaves on every op for
+/// its first minutes until ring promotion completes.
+///
+/// When the ring is empty, fall back to a configured gateway. Wire
+/// delivery works before ring promotion: the event loop's
+/// `OutboundMessageWithTarget` handler resolves targets by socket addr
+/// against the transport map (which includes transient connections)
+/// and re-dials configured gateways if the transport lapsed. Mirrors
+/// the #3219 zero-connection CONNECT re-bootstrap shape, which gates
+/// on the same `connection_count() == 0` condition.
+///
+/// Load-bearing assumption: `connection_count()` counts only **promoted
+/// ring** peers (`connections_by_location`), a map disjoint from the
+/// transient-connection map. That is what makes `== 0` fire precisely
+/// during the bootstrap window (transient gateway connection present,
+/// ring not yet formed) and stay out of the way the moment any ring
+/// connection is promoted. If a future change ever inserted transient
+/// connections into `connections_by_location`, this gate would silently
+/// no-op the fallback across all ops.
+///
+/// Tradeoff for genuinely unreachable gateways (e.g. an offline
+/// machine): a dial failure is not surfaced to the waiting driver, so
+/// each attempt waits its full per-attempt timeout before advancing,
+/// where the pre-fallback behavior failed instantly. The instant
+/// failure was a false answer (a false "contract absent" for GET, a
+/// false "success" for PUT), so slower but honest is preferred; a
+/// distinct fail-fast "not bootstrapped / unreachable" client error is
+/// #4166's scope.
+pub(crate) fn bootstrap_gateway_target(
+    op_manager: &OpManager,
+    is_excluded: impl Fn(SocketAddr) -> bool,
+) -> Option<(PeerKeyLocation, SocketAddr)> {
+    select_bootstrap_gateway(
+        op_manager.ring.connection_manager.connection_count(),
+        &op_manager.configured_gateways,
+        op_manager.ring.connection_manager.get_own_addr(),
+        is_excluded,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gw(port: u16) -> PeerKeyLocation {
+        let key = crate::transport::TransportPublicKey::from_bytes([port as u8; 32]);
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        PeerKeyLocation::new(key, addr)
+    }
+
+    /// Regression for #4361: a node with an empty ring but configured
+    /// gateways must select a gateway instead of exhausting. Before the
+    /// fix, every op on a freshly-bootstrapped node misbehaved without
+    /// sending a single wire message.
+    #[test]
+    fn bootstrap_fallback_selects_gateway_when_ring_empty() {
+        let gateway = gw(4001);
+        let selected = select_bootstrap_gateway(0, std::slice::from_ref(&gateway), None, |_| false);
+        let (peer, addr) = selected.expect("empty ring + configured gateway must select it");
+        assert_eq!(peer.socket_addr(), gateway.socket_addr());
+        assert_eq!(addr, gateway.socket_addr().unwrap());
+    }
+
+    /// The fallback must stay out of the way when the ring has ANY
+    /// connections — a non-empty ring means normal routing had its
+    /// chance and exhaustion is genuine.
+    #[test]
+    fn bootstrap_fallback_inactive_when_ring_non_empty() {
+        let gateway = gw(4001);
+        assert!(
+            select_bootstrap_gateway(1, &[gateway], None, |_| false).is_none(),
+            "fallback must not fire with ring connections present"
+        );
+    }
+
+    /// A gateway node must never select itself (self-loop guard), but
+    /// must still be able to fall back to OTHER configured gateways.
+    #[test]
+    fn bootstrap_fallback_skips_self() {
+        let gw1 = gw(4001);
+        let gw2 = gw(4002);
+        let own_addr = gw1.socket_addr();
+        let selected =
+            select_bootstrap_gateway(0, &[gw1.clone(), gw2.clone()], own_addr, |_| false);
+        let (peer, _) = selected.expect("second gateway should be selected");
+        assert_eq!(
+            peer.socket_addr(),
+            gw2.socket_addr(),
+            "self gateway must be skipped"
+        );
+        assert!(
+            select_bootstrap_gateway(0, std::slice::from_ref(&gw1), gw1.socket_addr(), |_| false)
+                .is_none(),
+            "sole self gateway must yield no fallback"
+        );
+    }
+
+    /// Already-tried/visited gateways are excluded, so retries cannot
+    /// loop on the same gateway and a request that already traversed a
+    /// gateway is never bounced back to it.
+    #[test]
+    fn bootstrap_fallback_excludes_tried_gateways() {
+        let gw1 = gw(4001);
+        let gw2 = gw(4002);
+        let tried = [gw1.socket_addr().unwrap()];
+        let selected = select_bootstrap_gateway(0, &[gw1.clone(), gw2.clone()], None, |addr| {
+            tried.contains(&addr)
+        });
+        let (peer, _) = selected.expect("untried gateway should be selected");
+        assert_eq!(peer.socket_addr(), gw2.socket_addr());
+        let all_tried = [gw1.socket_addr().unwrap(), gw2.socket_addr().unwrap()];
+        assert!(
+            select_bootstrap_gateway(0, &[gw1, gw2], None, |addr| all_tried.contains(&addr))
+                .is_none(),
+            "all gateways tried must yield no fallback"
+        );
+    }
+
+    /// Boundary: a node with an empty ring but NO configured gateways has
+    /// nothing to fall back to, so selection yields `None` and the caller
+    /// keeps its genuinely-isolated path (PUT finalizes locally, UPDATE /
+    /// SUBSCRIBE return an explicit error). The fallback is strictly
+    /// additive — it never fires when there is no usable gateway.
+    #[test]
+    fn bootstrap_fallback_none_when_no_gateways_configured() {
+        assert!(
+            select_bootstrap_gateway(0, &[], None, |_| false).is_none(),
+            "empty ring with no configured gateways must yield no fallback"
+        );
+    }
+}

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1461,44 +1461,6 @@ const MAX_RETRIES: usize = 3;
 /// bubble-up halts at the first Found).
 const MAX_TERMINAL_CONSULT_HOSTS: usize = 2;
 
-/// Pure selection core for the bootstrap gateway fallback (#4361).
-///
-/// Returns the first configured gateway that is not this node and not
-/// excluded by the caller's skip predicate — but ONLY when the ring is
-/// empty (`ring_connection_count == 0`). A non-empty ring means normal
-/// routing had ring entries to consider (its candidates may still all
-/// be filtered as transient/visited, but that exhaustion is genuine),
-/// so the fallback must stay out of the way.
-///
-/// Selection is deliberately deterministic (config order), unlike the
-/// randomized pick in #3219's CONNECT re-bootstrap: the client driver
-/// and the per-attempt loopback relay select independently and must
-/// converge on the same gateway given the same exclusion set — stream
-/// claims and route telemetry are attributed via the client's
-/// `current_target`, so divergence would mis-key both. Failover
-/// diversity comes from the exclusion predicate (tried/visited), not
-/// from randomization.
-///
-/// Split out from [`bootstrap_gateway_target`] so unit tests can
-/// exercise the selection rules without constructing an `OpManager`.
-fn select_bootstrap_gateway(
-    ring_connection_count: usize,
-    configured_gateways: &[PeerKeyLocation],
-    own_addr: Option<SocketAddr>,
-    is_excluded: impl Fn(SocketAddr) -> bool,
-) -> Option<(PeerKeyLocation, SocketAddr)> {
-    if ring_connection_count > 0 {
-        return None;
-    }
-    configured_gateways.iter().find_map(|gw| {
-        let addr = gw.socket_addr()?;
-        if Some(addr) == own_addr || is_excluded(addr) {
-            return None;
-        }
-        Some((gw.clone(), addr))
-    })
-}
-
 /// Carry the client driver's tried set into a fresh attempt's visited
 /// bloom, excluding the attempt's intended destination (#4361 / #4364
 /// review H1). Split out so unit tests can pin the exclusion behavior

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -52,6 +52,7 @@ use crate::operations::op_ctx::{
 };
 use crate::operations::OpError;
 use crate::operations::VisitedPeers;
+use crate::operations::bootstrap::bootstrap_gateway_target;
 use crate::ring::{Location, PeerKeyLocation};
 use crate::router::{RouteEvent, RouteOutcome};
 use crate::transport::peer_connection::StreamId;
@@ -1518,44 +1519,6 @@ fn carry_tried_into_visited(
             visited.mark_visited(*addr);
         }
     }
-}
-
-/// Bootstrap gateway fallback (#4361).
-///
-/// A node whose ring is still empty (`connections_by_location` has no
-/// entries) has zero routing candidates, so without a fallback every
-/// GET fails instantly with NotFound — even though the node has a live
-/// transient transport connection to its gateway (the same connection
-/// its CONNECT handshake is negotiating over). Production analog: a
-/// freshly started node fails all GETs for its first minutes until
-/// ring promotion completes.
-///
-/// When the ring is empty, fall back to a configured gateway. Wire
-/// delivery works before ring promotion: the event loop's
-/// `OutboundMessageWithTarget` handler resolves targets by socket addr
-/// against the transport map (which includes transient connections)
-/// and re-dials configured gateways if the transport lapsed. Mirrors
-/// the #3219 zero-connection CONNECT re-bootstrap shape, which gates
-/// on the same `connection_count() == 0` condition.
-///
-/// Tradeoff for genuinely unreachable gateways (e.g. an offline
-/// machine): a dial failure is not surfaced to the waiting driver, so
-/// each attempt waits its full per-attempt timeout (`OPERATION_TTL`,
-/// 60s) before advancing — up to ~3 minutes across the retry budget,
-/// where the pre-fallback behavior returned NotFound instantly. The
-/// instant NotFound was a false "contract absent" answer, so slower
-/// but honest is preferred; a distinct fail-fast "not bootstrapped /
-/// unreachable" client error is #4166's scope.
-fn bootstrap_gateway_target(
-    op_manager: &OpManager,
-    is_excluded: impl Fn(SocketAddr) -> bool,
-) -> Option<(PeerKeyLocation, SocketAddr)> {
-    select_bootstrap_gateway(
-        op_manager.ring.connection_manager.connection_count(),
-        &op_manager.configured_gateways,
-        op_manager.ring.connection_manager.get_own_addr(),
-        is_excluded,
-    )
 }
 
 fn advance_to_next_peer(
@@ -3655,80 +3618,10 @@ mod tests {
     }
 
     // --- Bootstrap gateway fallback (#4361) ---
-
-    fn gw(port: u16) -> PeerKeyLocation {
-        let key = crate::transport::TransportPublicKey::from_bytes([port as u8; 32]);
-        let addr = SocketAddr::from(([127, 0, 0, 1], port));
-        PeerKeyLocation::new(key, addr)
-    }
-
-    /// Regression for #4361: a node with an empty ring but configured
-    /// gateways must select a gateway instead of exhausting. Before the
-    /// fix, every GET on a freshly-bootstrapped node returned NotFound
-    /// without sending a single wire message.
-    #[test]
-    fn bootstrap_fallback_selects_gateway_when_ring_empty() {
-        let gateway = gw(4001);
-        let selected = select_bootstrap_gateway(0, std::slice::from_ref(&gateway), None, |_| false);
-        let (peer, addr) = selected.expect("empty ring + configured gateway must select it");
-        assert_eq!(peer.socket_addr(), gateway.socket_addr());
-        assert_eq!(addr, gateway.socket_addr().unwrap());
-    }
-
-    /// The fallback must stay out of the way when the ring has ANY
-    /// connections — a non-empty ring means normal routing had its
-    /// chance and exhaustion is genuine.
-    #[test]
-    fn bootstrap_fallback_inactive_when_ring_non_empty() {
-        let gateway = gw(4001);
-        assert!(
-            select_bootstrap_gateway(1, &[gateway], None, |_| false).is_none(),
-            "fallback must not fire with ring connections present"
-        );
-    }
-
-    /// A gateway node must never select itself (self-loop guard), but
-    /// must still be able to fall back to OTHER configured gateways.
-    #[test]
-    fn bootstrap_fallback_skips_self() {
-        let gw1 = gw(4001);
-        let gw2 = gw(4002);
-        let own_addr = gw1.socket_addr();
-        let selected =
-            select_bootstrap_gateway(0, &[gw1.clone(), gw2.clone()], own_addr, |_| false);
-        let (peer, _) = selected.expect("second gateway should be selected");
-        assert_eq!(
-            peer.socket_addr(),
-            gw2.socket_addr(),
-            "self gateway must be skipped"
-        );
-        assert!(
-            select_bootstrap_gateway(0, std::slice::from_ref(&gw1), gw1.socket_addr(), |_| false)
-                .is_none(),
-            "sole self gateway must yield no fallback"
-        );
-    }
-
-    /// Already-tried/visited gateways are excluded, so retries cannot
-    /// loop on the same gateway and a request that already traversed a
-    /// gateway is never bounced back to it.
-    #[test]
-    fn bootstrap_fallback_excludes_tried_gateways() {
-        let gw1 = gw(4001);
-        let gw2 = gw(4002);
-        let tried = [gw1.socket_addr().unwrap()];
-        let selected = select_bootstrap_gateway(0, &[gw1.clone(), gw2.clone()], None, |addr| {
-            tried.contains(&addr)
-        });
-        let (peer, _) = selected.expect("untried gateway should be selected");
-        assert_eq!(peer.socket_addr(), gw2.socket_addr());
-        let all_tried = [gw1.socket_addr().unwrap(), gw2.socket_addr().unwrap()];
-        assert!(
-            select_bootstrap_gateway(0, &[gw1, gw2], None, |addr| all_tried.contains(&addr))
-                .is_none(),
-            "all gateways tried must yield no fallback"
-        );
-    }
+    //
+    // The pure-selection unit tests for `select_bootstrap_gateway` now live
+    // alongside the helper in `operations/bootstrap.rs`. The source pin below
+    // stays here because it asserts on GET's own call sites.
 
     /// Source pin (#4361): the GET peer-selection sites — client
     /// initial pick, sub-op initial pick, client advance, relay advance —

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -34,6 +34,7 @@ use crate::node::NetworkBridge;
 use crate::node::OpManager;
 use crate::node::WaiterReply;
 use crate::operations::OpError;
+use crate::operations::bootstrap::bootstrap_gateway_target;
 use crate::operations::op_ctx::{
     AdvanceOutcome, AttemptOutcome, OpCtx, RetryDriver, RetryLoopOutcome, drive_retry_loop,
 };
@@ -215,7 +216,22 @@ async fn drive_client_put_inner(
     }
 
     // Pre-select initial target for the driver's retry state. The actual
-    // routing decision is made by process_message, not the driver.
+    // routing decision is made by the relay driver (`start_relay_put`),
+    // not here.
+    //
+    // Bootstrap note (#4361 / #4365): on an empty ring this stays
+    // `own_location()` — the bootstrap gateway fallback is applied at the
+    // relay's next-hop selection, NOT here. Unlike GET (whose client
+    // driver re-picks the wire target per attempt and therefore had to
+    // carry `tried` into each attempt's visited bloom for gateway
+    // failover, see `carry_tried_into_visited`), PUT's `current_target` is
+    // only driver-side telemetry / retry bookkeeping: the request value
+    // carries the contract (not a target), the relay decides the next hop,
+    // and the terminal reply returns via the originator-loopback bypass on
+    // `pending_op_results[tx]` — none of which read `current_target`. So a
+    // self-vs-gateway divergence here is cosmetic, not a routing bug.
+    // (Multi-gateway failover across PUT retries is intentionally not
+    // implemented; see the design doc's out-of-scope notes.)
     let initial_target = op_manager
         .ring
         .closest_potentially_hosting(&key, tried.as_slice());
@@ -1305,24 +1321,61 @@ where
             (peer, addr)
         }
         None => {
-            // No next hop — this node is the final destination.
-            tracing::info!(
-                tx = %incoming_tx,
-                contract = %key,
-                phase = "relay_put_complete",
-                "PUT relay: no next hop, finalizing at this node"
-            );
-            // Same arm as above: this node IS the storer.
-            let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
-            return relay_put_finalize_local(
-                op_manager,
-                incoming_tx,
-                key,
-                merged_value,
-                upstream_addr,
-                hop_count,
-            )
-            .await;
+            // Bootstrap fallback (#4361 / #4365): with an empty ring,
+            // forward via a configured gateway instead of finalizing
+            // locally. Without this, a freshly-bootstrapped node's PUT is
+            // stored locally (Step 1 above) and finalized here, so the
+            // client gets a success while the contract never reaches the
+            // network — the PUT analog of GET's empty-ring blind spot.
+            // Bypasses the #4363 terminus guard on purpose: an empty ring
+            // has no overshoot to guard against, we only need to reach the
+            // network. The local replica is already stored, so the
+            // originator keeps it AND the gateway relays the PUT toward the
+            // contract location. Respects `new_skip_list` (self + upstream).
+            //
+            // Intentional asymmetry with `drive_relay_put_streaming` (which
+            // gates the gateway fallback on `htl > 0`): this arm is also
+            // reached when `htl == 0` (next_hop is forced None then), so it
+            // can forward to a gateway at htl 0. Benign — the contract is
+            // already stored locally (no false success), it is a single
+            // bounded next-hop (no fan-out), the gateway forwards at
+            // `htl - 1 == 0` and finalizes on its populated ring (better
+            // placement than this empty-ring node), and the originator
+            // loopback always starts at max_htl so it never hits htl 0 here.
+            // Do not "harmonize" the two paths — there is no correctness gain.
+            match bootstrap_gateway_target(op_manager, |addr| new_skip_list.contains(&addr)) {
+                Some((gateway, gateway_addr)) => {
+                    tracing::info!(
+                        tx = %incoming_tx,
+                        contract = %key,
+                        gateway = %gateway_addr,
+                        phase = "relay_put_bootstrap_gateway",
+                        "PUT relay: ring empty — forwarding to configured gateway"
+                    );
+                    (gateway, gateway_addr)
+                }
+                None => {
+                    // No next hop and no configured gateway — genuinely
+                    // isolated, so this node is the final destination.
+                    tracing::info!(
+                        tx = %incoming_tx,
+                        contract = %key,
+                        phase = "relay_put_complete",
+                        "PUT relay: no next hop, finalizing at this node"
+                    );
+                    // Same arm as above: this node IS the storer.
+                    let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
+                    return relay_put_finalize_local(
+                        op_manager,
+                        incoming_tx,
+                        key,
+                        merged_value,
+                        upstream_addr,
+                        hop_count,
+                    )
+                    .await;
+                }
+            }
         }
     };
 
@@ -2404,6 +2457,32 @@ where
         None
     };
 
+    // Bootstrap fallback (#4361 / #4365), streaming path: with an empty
+    // ring `closest_potentially_hosting` yields nothing, so route via a
+    // configured gateway instead of finalizing locally and reporting a
+    // false success. Computed here, before the terminus guard, and fed
+    // into the guard's `None` arm below so it bypasses the guard — an
+    // empty ring has no overshoot to reason about, and the stream is
+    // assembled and stored locally in step 5/6 regardless, so the
+    // originator keeps its replica while the gateway relays onward.
+    let bootstrap_gateway = if next_hop.is_none() && htl > 0 {
+        match bootstrap_gateway_target(op_manager, |addr| new_skip_list.contains(&addr)) {
+            Some((gateway, gateway_addr)) => {
+                tracing::info!(
+                    tx = %incoming_tx,
+                    contract = %contract_key,
+                    gateway = %gateway_addr,
+                    phase = "relay_put_streaming_bootstrap_gateway",
+                    "PUT streaming relay: ring empty — forwarding to configured gateway"
+                );
+                Some(gateway)
+            }
+            None => None,
+        }
+    } else {
+        None
+    };
+
     // Greedy-routing terminus guard (#4363), streaming path. Mirrors the
     // non-streaming `drive_relay_put` guard: finalize here only when the
     // chain has descended to this node AND the next hop would climb back
@@ -2450,7 +2529,9 @@ where
                 Some(peer)
             }
         }
-        None => None,
+        // Empty ring: no ring candidate to run the terminus guard against,
+        // so take the bootstrap gateway fallback computed above (#4361 / #4365).
+        None => bootstrap_gateway,
     };
 
     let next_hop_addr = next_hop.as_ref().and_then(|p| p.socket_addr());
@@ -3198,6 +3279,50 @@ mod tests {
              caps by name in the selection so future readers see the \
              split — bare integer literals are forbidden here."
         );
+    }
+
+    /// Source-grep pin (#4361 / #4365): both relay PUT drivers must
+    /// consult `bootstrap_gateway_target` when
+    /// `closest_potentially_hosting` yields no next hop, so a
+    /// freshly-bootstrapped node (empty ring) forwards the PUT through a
+    /// configured gateway instead of finalizing locally and reporting a
+    /// false success to the client. Dropping either call site silently
+    /// reintroduces the empty-ring silent-store bug that GET fixed in
+    /// #4364.
+    #[test]
+    fn relay_put_drivers_use_bootstrap_gateway_fallback() {
+        let src = include_str!("op_ctx_task.rs");
+        for entry in [
+            "async fn drive_relay_put<CB>",
+            "async fn drive_relay_put_streaming<CB>",
+        ] {
+            let start = src
+                .find(entry)
+                .unwrap_or_else(|| panic!("{entry} must exist"));
+            // Body spans from the fn signature to the start of the next
+            // top-level `async fn`. The call site lives in the empty-ring
+            // branch of the next-hop selection, which can sit far from the
+            // signature, so scan the whole body rather than a fixed window.
+            let after_sig = start + entry.len();
+            let body_end = src[after_sig..]
+                .find("\nasync fn ")
+                .map(|off| after_sig + off)
+                .unwrap_or(src.len());
+            let body = &src[start..body_end];
+            assert!(
+                body.contains("bootstrap_gateway_target("),
+                "{entry} must fall back to bootstrap_gateway_target on an \
+                 empty ring instead of finalizing locally (#4361 / #4365)"
+            );
+            // The exclusion predicate must be the relay skip list (self +
+            // upstream + already-tried), not a no-op — otherwise the fallback
+            // could re-pick self/upstream and bounce the PUT.
+            assert!(
+                body.contains("bootstrap_gateway_target(op_manager, |addr| new_skip_list.contains"),
+                "{entry} must exclude the relay skip list when selecting the \
+                 bootstrap gateway (#4361 / #4365)"
+            );
+        }
     }
 
     /// `start_client_put` must call `admit_client_op()` before the

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1338,11 +1338,17 @@ where
             // reached when `htl == 0` (next_hop is forced None then), so it
             // can forward to a gateway at htl 0. Benign — the contract is
             // already stored locally (no false success), it is a single
-            // bounded next-hop (no fan-out), the gateway forwards at
-            // `htl - 1 == 0` and finalizes on its populated ring (better
-            // placement than this empty-ring node), and the originator
-            // loopback always starts at max_htl so it never hits htl 0 here.
-            // Do not "harmonize" the two paths — there is no correctness gain.
+            // bounded next-hop (no fan-out), and the forward is terminating:
+            // each hop adds itself (and its upstream) to `new_skip_list`, so
+            // in a pathological all-empty-ring chain `select_bootstrap_gateway`
+            // eventually excludes every configured gateway and returns None
+            // (finalize locally). Termination here is skip_list exhaustion —
+            // NOT htl, and NOT the receiving gateway's ring being populated.
+            // In the normal case the gateway does have a populated ring and
+            // routes the PUT toward the contract location (better placement
+            // than this empty-ring node). The originator loopback always
+            // starts at max_htl so it never hits htl 0 here. Do not
+            // "harmonize" the two paths — there is no correctness gain.
             match bootstrap_gateway_target(op_manager, |addr| new_skip_list.contains(&addr)) {
                 Some((gateway, gateway_addr)) => {
                     tracing::info!(
@@ -3281,6 +3287,51 @@ mod tests {
         );
     }
 
+    /// Truncate this file's source at the `#[cfg(test)]` marker so the
+    /// source-pin tests never match code or comments inside the test
+    /// module itself (mirrors the GET / UPDATE helpers).
+    fn production_source() -> &'static str {
+        const FULL: &str = include_str!("op_ctx_task.rs");
+        let cutoff = FULL
+            .find("#[cfg(test)]")
+            .expect("file must have a #[cfg(test)] section");
+        &FULL[..cutoff]
+    }
+
+    /// Isolate a named fn's body by brace-matching from its opening `{`
+    /// to the matching `}`, so a pin cannot silently run past the
+    /// function into unrelated source. The defect this replaces did
+    /// exactly that: a `"\nasync fn "` EOF scan on `drive_relay_put_streaming`
+    /// found no following top-level `async fn`, ran the "body" to EOF, and
+    /// swallowed the whole test module — so neutering the streaming call
+    /// site still left the pin green.
+    fn extract_fn_body<'a>(source: &'a str, signature_prefix: &str) -> &'a str {
+        let start = source
+            .find(signature_prefix)
+            .unwrap_or_else(|| panic!("could not find {signature_prefix}"));
+        let brace = source[start..]
+            .find('{')
+            .expect("fn signature must have a body");
+        let body_start = start + brace + 1;
+        let bytes = source.as_bytes();
+        let mut depth: i32 = 1;
+        let mut i = body_start;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &source[body_start..i];
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        panic!("unterminated fn body for {signature_prefix}");
+    }
+
     /// Source-grep pin (#4361 / #4365): both relay PUT drivers must
     /// consult `bootstrap_gateway_target` when
     /// `closest_potentially_hosting` yields no next hop, so a
@@ -3289,26 +3340,26 @@ mod tests {
     /// false success to the client. Dropping either call site silently
     /// reintroduces the empty-ring silent-store bug that GET fixed in
     /// #4364.
+    ///
+    /// Uses brace-matched `extract_fn_body` over `production_source()`,
+    /// NOT a `"\nasync fn "` EOF scan: the old scan let the streaming
+    /// driver's "body" run to EOF and swallow this module, so neutering
+    /// the streaming call site left the pin green — the exact regression
+    /// this guards (verified fail-without-fix by neutering each call site
+    /// in turn). A driver-level *behavioral* test (build an `OpManager`
+    /// with `connection_count()==0` + a configured gateway and assert the
+    /// gateway is the chosen next hop) is deferred: there is no `OpManager`
+    /// unit-test builder, and a static sim self-promotes its gateway into
+    /// the ring (`connection_count()` settles at 1, not 0) — the same infra
+    /// gap that deferred GET's equivalent (#4364).
     #[test]
     fn relay_put_drivers_use_bootstrap_gateway_fallback() {
-        let src = include_str!("op_ctx_task.rs");
+        let src = production_source();
         for entry in [
             "async fn drive_relay_put<CB>",
             "async fn drive_relay_put_streaming<CB>",
         ] {
-            let start = src
-                .find(entry)
-                .unwrap_or_else(|| panic!("{entry} must exist"));
-            // Body spans from the fn signature to the start of the next
-            // top-level `async fn`. The call site lives in the empty-ring
-            // branch of the next-hop selection, which can sit far from the
-            // signature, so scan the whole body rather than a fixed window.
-            let after_sig = start + entry.len();
-            let body_end = src[after_sig..]
-                .find("\nasync fn ")
-                .map(|off| after_sig + off)
-                .unwrap_or(src.len());
-            let body = &src[start..body_end];
+            let body = extract_fn_body(src, entry);
             assert!(
                 body.contains("bootstrap_gateway_target("),
                 "{entry} must fall back to bootstrap_gateway_target on an \

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -19,6 +19,7 @@ use either::Either;
 
 pub(crate) use self::messages::{SubscribeMsg, SubscribeMsgResult};
 use super::OpError;
+use super::bootstrap::bootstrap_gateway_target;
 use crate::ring::PeerKeyLocation;
 use crate::tracing::NetEventLog;
 use crate::{
@@ -276,9 +277,28 @@ pub(super) async fn prepare_initial_request(
                     target
                 }
                 None => {
-                    // Truly no connections available - fall back to local completion only if isolated.
-                    // This handles the case of a standalone node or when we're the only node with the contract.
-                    if let Some(key) = super::has_contract(op_manager, instance_id).await? {
+                    // Bootstrap fallback (#4361 / #4365): the ring-connection
+                    // scan above sees only promoted ring peers
+                    // (`get_connections_by_location`), so an empty-ring node
+                    // finds nothing here even though it holds a live transient
+                    // gateway connection. Route the initial request via a
+                    // configured gateway so a freshly-bootstrapped node can
+                    // still join the subscription tree, before falling back to
+                    // local completion / NoHostingPeers.
+                    if let Some((gateway, gateway_addr)) =
+                        bootstrap_gateway_target(op_manager, |addr| visited.probably_visited(addr))
+                    {
+                        tracing::info!(
+                            tx = %id,
+                            contract = %instance_id,
+                            gateway = %gateway_addr,
+                            phase = "bootstrap_gateway",
+                            "subscribe: ring empty — routing initial request via configured gateway"
+                        );
+                        gateway
+                    } else if let Some(key) = super::has_contract(op_manager, instance_id).await? {
+                        // No gateway either - fall back to local completion only if isolated.
+                        // This handles a standalone node or when we're the only node with the contract.
                         tracing::info!(
                             tx = %id,
                             contract = %key,
@@ -286,9 +306,10 @@ pub(super) async fn prepare_initial_request(
                             "Contract available locally and no network connections, completing subscription locally"
                         );
                         return Ok(InitialRequest::LocallyComplete { key });
+                    } else {
+                        tracing::warn!(tx = %id, contract = %instance_id, phase = "error", "No remote peers available for subscription");
+                        return Ok(InitialRequest::NoHostingPeers);
                     }
-                    tracing::warn!(tx = %id, contract = %instance_id, phase = "error", "No remote peers available for subscription");
-                    return Ok(InitialRequest::NoHostingPeers);
                 }
             }
         };

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -6,6 +6,41 @@
 
 use super::*;
 
+/// Source-grep pin (#4361 / #4365): `prepare_initial_request` must
+/// consult `bootstrap_gateway_target` before giving up, so a
+/// freshly-bootstrapped node (empty ring) routes its initial
+/// Subscribe::Request via a configured gateway instead of failing flat
+/// with `NoHostingPeers`. The ring-connection fallback above scans only
+/// promoted ring peers (`get_connections_by_location`), which an
+/// empty-ring node has none of, even though it holds a live transient
+/// gateway connection.
+#[test]
+fn prepare_initial_request_uses_bootstrap_gateway_fallback() {
+    const SOURCE: &str = include_str!("../subscribe.rs");
+    let fn_start = SOURCE
+        .find("pub(super) async fn prepare_initial_request(")
+        .expect("prepare_initial_request must exist in subscribe.rs");
+    let fn_end = SOURCE[fn_start..]
+        .find("\nasync fn complete_local_subscription(")
+        .map(|off| fn_start + off)
+        .expect("complete_local_subscription anchor must follow prepare_initial_request");
+    let body = &SOURCE[fn_start..fn_end];
+    assert!(
+        body.contains("bootstrap_gateway_target("),
+        "prepare_initial_request must fall back to bootstrap_gateway_target \
+         on an empty ring before returning NoHostingPeers (#4361 / #4365)"
+    );
+    // The exclusion predicate must respect the request's visited bloom (which
+    // already marks own_addr) — not a no-op that could re-pick a visited peer.
+    assert!(
+        body.contains(
+            "bootstrap_gateway_target(op_manager, |addr| visited.probably_visited(addr))"
+        ),
+        "prepare_initial_request must exclude visited peers when selecting the \
+         bootstrap gateway (#4361 / #4365)"
+    );
+}
+
 /// Pin: `handle_unsubscribe_inbound` preserves the four behavioral
 /// branches inherited from the legacy
 /// `process_message::Unsubscribe` arm, plus the counter-symmetry

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -23,6 +23,7 @@ use crate::contract::{ContractHandlerEvent, StoreResponse};
 use crate::message::{DeltaOrFullState, InterestMessage, NetMessage, NodeEvent, Transaction};
 use crate::node::OpManager;
 use crate::operations::OpError;
+use crate::operations::bootstrap::bootstrap_gateway_target;
 use crate::ring::{PeerKeyLocation, RingError};
 use crate::tracing::{NetEventLog, OperationFailure, state_hash_full};
 
@@ -218,6 +219,27 @@ async fn drive_client_update(
         op_manager
             .ring
             .closest_potentially_hosting(&key, [sender_addr].as_slice())
+            // Bootstrap fallback (#4361 / #4365): with an empty ring there
+            // is no routing candidate, so route the UPDATE via a configured
+            // gateway instead of handling it locally. In the hosting case
+            // the remote-target branch applies the update locally and
+            // forwards it to the gateway, so it actually propagates instead
+            // of broadcasting to an empty ring. In the not-hosting case the
+            // local apply fails with missing params and the existing
+            // auto-fetch + retry path primes the store from the gateway —
+            // far better than the flat NoHostingPeers a fresh node hits today.
+            .or_else(|| {
+                bootstrap_gateway_target(op_manager, |addr| addr == sender_addr).map(
+                    |(gateway, gateway_addr)| {
+                        tracing::info!(
+                            %key,
+                            gateway = %gateway_addr,
+                            "update: ring empty — target falls back to configured gateway"
+                        );
+                        gateway
+                    },
+                )
+            })
     };
 
     match target {
@@ -2087,6 +2109,40 @@ mod tests {
             src.contains("value: updated_value"),
             "RequestUpdate must use the post-merge updated_value, not the original \
              client update_data (mirrors legacy update.rs:2055)"
+        );
+    }
+
+    /// Source-grep pin (#4361 / #4365): the client UPDATE driver must
+    /// consult `bootstrap_gateway_target` when neither the proximity
+    /// cache nor `closest_potentially_hosting` yields a target, so a
+    /// freshly-bootstrapped node (empty ring) routes the UPDATE through a
+    /// configured gateway. In the hosting case this propagates the update
+    /// instead of applying it locally to no audience; in the not-hosting
+    /// case it lets the existing missing-params auto-fetch + retry path
+    /// prime the local store from the gateway rather than failing flat.
+    #[test]
+    fn drive_client_update_uses_bootstrap_gateway_fallback() {
+        let src = include_str!("op_ctx_task.rs");
+        let entry = "async fn drive_client_update";
+        let start = src.find(entry).expect("drive_client_update must exist");
+        let after_sig = start + entry.len();
+        let body_end = src[after_sig..]
+            .find("\nasync fn ")
+            .map(|off| after_sig + off)
+            .unwrap_or(src.len());
+        let body = &src[start..body_end];
+        assert!(
+            body.contains("bootstrap_gateway_target("),
+            "drive_client_update must fall back to bootstrap_gateway_target \
+             on an empty ring instead of applying locally to no audience or \
+             failing with NoHostingPeers (#4361 / #4365)"
+        );
+        // The exclusion predicate must skip this node's own address, matching
+        // the skip list passed to closest_potentially_hosting — not a no-op.
+        assert!(
+            body.contains("bootstrap_gateway_target(op_manager, |addr| addr == sender_addr)"),
+            "drive_client_update must exclude its own address (sender_addr) \
+             when selecting the bootstrap gateway (#4361 / #4365)"
         );
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -2122,15 +2122,15 @@ mod tests {
     /// prime the local store from the gateway rather than failing flat.
     #[test]
     fn drive_client_update_uses_bootstrap_gateway_fallback() {
-        let src = include_str!("op_ctx_task.rs");
-        let entry = "async fn drive_client_update";
-        let start = src.find(entry).expect("drive_client_update must exist");
-        let after_sig = start + entry.len();
-        let body_end = src[after_sig..]
-            .find("\nasync fn ")
-            .map(|off| after_sig + off)
-            .unwrap_or(src.len());
-        let body = &src[start..body_end];
+        // Brace-matched `extract_fn_body` over `production_source()` (not a
+        // `"\nasync fn "` EOF scan): the scan bounded this pin only by
+        // function ordering — if `drive_client_update` ever became the last
+        // top-level `async fn`, its "body" would run to EOF and swallow the
+        // test module (the defect that neutered the PUT streaming pin, #4635
+        // review). Brace-matching bounds it structurally instead.
+        const SOURCE: &str = include_str!("op_ctx_task.rs");
+        let prod = production_source(SOURCE);
+        let body = extract_fn_body(prod, "async fn drive_client_update(");
         assert!(
             body.contains("bootstrap_gateway_target("),
             "drive_client_update must fall back to bootstrap_gateway_target \


### PR DESCRIPTION
## Problem

A freshly started node has an empty ring (`connections_by_location` is empty) for its first minutes but already holds a live transient connection to its gateway. PUT/UPDATE/SUBSCRIBE peer-selection consulted only the ring, so during that window they ignored the gateway. #4364 fixed this for GET; the #4365 audit asks the other three to meet the same bar — in the bootstrap window an op must either **work** or **fail with an explicit, retryable error**, never silently misbehave.

Behavior on an empty ring before this change:

- **PUT** — the relay stored the contract locally and finalized locally, so the client got a *successful* `LocalCompletion` while the contract never reached the network (no re-replication on this path; see #4363). A false success.
- **UPDATE** — if hosting, applied locally and broadcast to an empty ring (reached no one); if not hosting, returned `NoHostingPeers`. The hosting case has PUT's no-propagation gap.
- **SUBSCRIBE** — already fail-fasts with `NoHostingPeers`, but its fallback scans only ring connections, so a node with a live transient gateway connection still gave up.

Note: the fix is **not** in `drive_client_put_inner` (its `own_location()` is only retry bookkeeping); the real empty-ring decision point is the relay's next-hop selection.

## Solution

When `connection_count() == 0`, each op's real decision point falls back to a configured gateway instead of finalizing locally / failing — the same bounded fallback #4364 added to GET.

- **Shared helper** — `select_bootstrap_gateway` (pure) and `bootstrap_gateway_target` (`OpManager` wrapper) lifted out of GET into `operations/bootstrap.rs`; all four ops now share one source of truth. GET behavior unchanged.
- **PUT** — `drive_relay_put` / `drive_relay_put_streaming` forward via the gateway on an empty ring. The local store already ran, so the originator keeps its replica *and* the gateway relays the PUT toward the contract location. Bypasses the #4363 terminus guard (no overshoot to guard against on an empty ring).
- **UPDATE** — `drive_client_update` uses the gateway as target. Hosting → applies locally and forwards (propagates); not-hosting → the existing missing-params auto-fetch + retry primes the store from the gateway.
- **SUBSCRIBE** — `prepare_initial_request` tries the gateway before `NoHostingPeers`.

Wire delivery needs no new plumbing: `OutboundMessageWithTarget` resolves targets by socket addr against the transport map and re-dials configured gateways, independent of the message variant.

Boundary: a node that hasn't yet learned its own address (phase 1) keeps its current behavior; the fallback targets the dominant phase-2 window (address known, ring still empty). PUT's `current_target` stays `own_location()` there — unlike GET it is only driver-side telemetry, so the divergence is cosmetic (documented in code).

## Testing

- **Selection logic (executed):** unit tests in `operations/bootstrap.rs` assert empty-ring activation, self-skip, tried/visited exclusion, inactive-when-ring-non-empty, and no-configured-gateways → `None`.
- **Call sites (source pins):** one per op, asserting both the call and the correct exclusion predicate (PUT `new_skip_list.contains`, UPDATE `addr == sender_addr`, SUBSCRIBE `visited.probably_visited`), so a no-op predicate trips the build.
- **No regression:** for a lone gateway the fallback is a strict no-op (no non-self gateway → `select_bootstrap_gateway` returns `None`); `isolated_node_regression.rs` covers this on CI.
- **Delivery premise** verified by code inspection (op-agnostic `OutboundMessageWithTarget`). `cargo fmt`, `clippy -D warnings`, and touched-module suites clean.
- **Adversarial audit:** every empty-ring decision point across the four ops was mapped and skeptically reviewed; it confirmed the routing is correct and complete for the originator scope, that the `connection_count() == 0` gate keys only on promoted ring connections (transient gateway connections are a disjoint map), and surfaced the residuals documented below.

**Deferred (follow-up):** an end-to-end behavioral test where a non-gateway node in its empty-ring window PUTs and a second node GETs the contract. A probe confirmed a small static sim can't reproduce the state — a lone node promotes its gateway into the ring (`connection_count()` settles at 1, not 0). The realistic shape is a multi-node simulation diagnostic with empty-ring windows occurring naturally, with a revert-to-verify gate — the way #4364's GET diagnostic worked.

## Out of scope / follow-ups

The fix targets the **originator** bootstrap window. An adversarial audit of every empty-ring decision point across the four ops confirmed the routing is correct and complete in scope — and that adding the fallback to any *other* site would be either harmful (cross-gateway bounce / duplicate store / placement regression) or a separate concern. The residuals (all already fail explicitly in scope — none silently misbehave):

- **No-usable-gateway hosting case** — a node that hosts the contract and has *no* configured gateway can still report success on PUT/UPDATE (nowhere to propagate; GET's isolated-no-gateway case is symmetric). Outside #4365's premise (which assumes a live transient gateway connection); the honest fix is a symmetric fail-fast "not bootstrapped" error across all ops → #4166.
- **Relay-forward / retry parity** — UPDATE's and SUBSCRIBE's relay-forward paths (`drive_relay_request_update`, `drive_relay_subscribe`) and SUBSCRIBE's retry (`advance_to_next_peer_impl`) are not gateway-aware. They already fail explicitly (`NoHostingPeers`/`NotFound`) and are out of scope (a relay holds a connection from its sender). Extending them is **not** free parity: `UpdateMsg::RequestUpdate` carries no HTL/visited bloom, so a gateway fallback there would risk a bounce until loop-prevention is added.
- **PUT htl-gating asymmetry** — `drive_relay_put`'s empty-ring arm can forward to a gateway at `htl == 0` while the streaming path gates on `htl > 0`. Benign (single bounded hop, no false success, better placement than this empty-ring node) and documented in-code; harmonizing has no correctness benefit.
- **End-to-end propagation behavioral test** (multi-node simulation diagnostic) — deferred; per-op wiring ships with source-grep pins + pure-helper unit tests.
- Bootstrap acceptance collapse (#4362), PUT placement/re-replication (#4363).

## Fixes

Closes #4365