### PR TITLE
feat: node resource-utilization telemetry for demand-driven hosting

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -78,6 +78,7 @@ pub(crate) mod network_status;
 mod op_state_manager;
 mod p2p_impl;
 mod request_router;
+pub(crate) mod resource_metrics;
 pub(crate) mod testing_impl;
 
 pub use p2p_impl::{enable_abort_on_fatal_listener_exit, enable_fast_crash_exit_code};

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -53,28 +53,6 @@ mod connection_lifecycle;
 mod dispatch;
 mod migration;
 
-/// Returns the process RSS (Resident Set Size) in bytes by reading /proc/self/statm.
-/// Returns None on non-Linux platforms or if the read fails.
-fn get_rss_bytes() -> Option<u64> {
-    #[cfg(target_os = "linux")]
-    {
-        let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
-        let rss_pages: u64 = statm.split_whitespace().nth(1)?.parse().ok()?;
-        // SAFETY: `sysconf(_SC_PAGESIZE)` is a POSIX-defined, signal-safe
-        // call that reads a system constant and has no preconditions.
-        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
-        if page_size > 0 {
-            Some(rss_pages * page_size as u64)
-        } else {
-            None
-        }
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        None
-    }
-}
-
 /// Represents the different ways the event loop can exit.
 ///
 /// This enum is used instead of string-based error matching to provide
@@ -2445,7 +2423,8 @@ impl P2pConnManager {
                                     let pending_ops = op_manager.pending_op_counts();
                                     let contract_waiters_count =
                                         op_manager.contract_waiters_count();
-                                    let memory_rss_bytes = get_rss_bytes();
+                                    let memory_rss_bytes =
+                                        crate::node::resource_metrics::rss_bytes();
                                     tracing::info!(
                                         pending_connect = pending_ops[0],
                                         pending_put = pending_ops[1],

--- a/crates/core/src/node/resource_metrics.rs
+++ b/crates/core/src/node/resource_metrics.rs
@@ -1,0 +1,238 @@
+//! Node self-resource-utilization sampling for the internal telemetry path.
+//!
+//! Foundational piece (A1) of the demand-driven hosting redesign
+//! (freenet/freenet-core#4642 — see `docs/design/hosting-eviction.md`). The
+//! capability-relative hosting budget and its eviction policy (pieces A2/A3)
+//! must be validated against a node's REAL scarcest-resource headroom, but the
+//! node currently surfaces no resource-utilization metrics at all. This module
+//! samples the node's own memory / CPU / bandwidth usage from cheap local
+//! sources and exposes it so it can be emitted on the INTERNAL telemetry stream
+//! the dashboard consumes.
+//!
+//! Scope guard (#4642 A1): this is deliberately NOT on the client-facing wire
+//! protocol. It must never be added to `SystemMetrics`, `HostResponse`, or any
+//! other `freenet-stdlib` bincode type — doing so would be a wire-format break
+//! requiring separate coordination. All sampling here reads process-local
+//! sources (`/proc`, in-process transport counters); nothing crosses the peer
+//! wire.
+
+use crate::transport::TRANSPORT_METRICS;
+
+/// A point-in-time sample of the node's own resource utilization.
+///
+/// Every field is best-effort: the memory / CPU fields are `Option` because
+/// their `/proc` sources are Linux-only and can fail to parse; the bandwidth
+/// counters are always available from the in-process transport metrics.
+///
+/// Serialized to JSON for the telemetry stream (`resource_utilization` event).
+/// It is NOT a wire-protocol type and must not be embedded in one.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
+pub(crate) struct ResourceUtilization {
+    /// Resident set size (bytes): the node process's current physical-memory
+    /// footprint. `None` off Linux or if `/proc/self/statm` is unreadable.
+    pub memory_rss_bytes: Option<u64>,
+    /// Memory ceiling the node may use (bytes): `min(host RAM, cgroup limit)`.
+    /// This is the SAME source that sizes the module cache and (piece A2) the
+    /// hosting budget — [`crate::wasm_runtime::read_total_ram_bytes`] — so the
+    /// dashboard can compute real headroom (`rss / limit`). `None` if it can't
+    /// be determined (e.g. non-unix).
+    pub memory_limit_bytes: Option<u64>,
+    /// Cumulative process CPU time (user + system) in seconds since start.
+    /// `None` off Linux or if `/proc/self/stat` is unreadable. Deltas between
+    /// samples give CPU utilization; the raw counter is monotonic.
+    pub cpu_time_seconds: Option<f64>,
+    /// Cumulative bytes sent at the UDP socket layer since start (never reset).
+    pub cumulative_bytes_sent: u64,
+    /// Cumulative bytes received at the UDP socket layer since start (never
+    /// reset).
+    pub cumulative_bytes_received: u64,
+}
+
+impl ResourceUtilization {
+    /// Serialize to a JSON value for the `resource_utilization` telemetry
+    /// event. Infallible: a serialization failure (should never happen for
+    /// this plain struct) degrades to `Value::Null` rather than panicking.
+    pub(crate) fn to_telemetry_value(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
+    }
+}
+
+/// Sample the node's current resource utilization from cheap local sources.
+///
+/// Reads `/proc/self/statm` (RSS), `/proc/self/stat` (CPU time),
+/// [`crate::wasm_runtime::read_total_ram_bytes`] (memory ceiling) and the
+/// in-process [`TRANSPORT_METRICS`] cumulative byte counters. Never blocks on
+/// the network and never panics.
+pub(crate) fn sample() -> ResourceUtilization {
+    ResourceUtilization {
+        memory_rss_bytes: rss_bytes(),
+        memory_limit_bytes: crate::wasm_runtime::read_total_ram_bytes().map(|v| v as u64),
+        cpu_time_seconds: cpu_time_seconds(),
+        cumulative_bytes_sent: TRANSPORT_METRICS.cumulative_bytes_sent(),
+        cumulative_bytes_received: TRANSPORT_METRICS.cumulative_bytes_received(),
+    }
+}
+
+/// Returns the process RSS (Resident Set Size) in bytes by reading
+/// `/proc/self/statm`. Returns `None` on non-Linux platforms or if the read
+/// fails.
+pub(crate) fn rss_bytes() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+        let rss_pages: u64 = statm.split_whitespace().nth(1)?.parse().ok()?;
+        // SAFETY: `sysconf(_SC_PAGESIZE)` is a POSIX-defined, signal-safe call
+        // that reads a system constant and has no preconditions.
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if page_size > 0 {
+            Some(rss_pages * page_size as u64)
+        } else {
+            None
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+/// Returns cumulative process CPU time (user + system) in seconds by reading
+/// `/proc/self/stat`. Returns `None` on non-Linux platforms or if the read /
+/// parse fails.
+pub(crate) fn cpu_time_seconds() -> Option<f64> {
+    #[cfg(target_os = "linux")]
+    {
+        let stat = std::fs::read_to_string("/proc/self/stat").ok()?;
+        let ticks = parse_proc_stat_cpu_ticks(&stat)?;
+        // SAFETY: `sysconf(_SC_CLK_TCK)` is a POSIX-defined, signal-safe call
+        // reading a system constant; no preconditions, no pointers.
+        let clk_tck = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+        if clk_tck > 0 {
+            Some(ticks as f64 / clk_tck as f64)
+        } else {
+            None
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+/// Pure parse of `utime + stime` (CPU ticks) from `/proc/self/stat` contents.
+///
+/// The `comm` field (field 2) is wrapped in parentheses and may itself contain
+/// spaces and `)` characters, so the reliable anchor is the LAST `)` in the
+/// line: after it, whitespace-separated fields resume at field 3 (`state`).
+/// `utime` is field 14 and `stime` field 15 (1-indexed), i.e. the 12th and
+/// 13th tokens after the last `)`.
+#[cfg(target_os = "linux")]
+fn parse_proc_stat_cpu_ticks(stat: &str) -> Option<u64> {
+    let after_comm = stat.rsplit_once(')').map(|(_, rest)| rest.trim_start())?;
+    let mut fields = after_comm.split_whitespace();
+    // Field 3 (state) is index 0 here, so utime (field 14) is index 11.
+    let utime: u64 = fields.nth(11)?.parse().ok()?;
+    let stime: u64 = fields.next()?.parse().ok()?;
+    Some(utime + stime)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The sampler populates the memory and CPU axes on Linux (CI + prod) and
+    /// always populates the bandwidth counters. This is the piece-A1 guarantee:
+    /// a node's resource headroom is observable rather than absent.
+    #[test]
+    fn sample_populates_resource_axes() {
+        let sample = sample();
+
+        // Bandwidth counters are always available (in-process, all platforms).
+        // They are cumulative u64s; asserting the type is populated is enough
+        // (a fresh test node may legitimately have sent zero bytes).
+        let _ = sample.cumulative_bytes_sent;
+        let _ = sample.cumulative_bytes_received;
+
+        #[cfg(target_os = "linux")]
+        {
+            assert!(
+                sample.memory_rss_bytes.is_some_and(|rss| rss > 0),
+                "RSS must be sampled and non-zero on Linux, got {:?}",
+                sample.memory_rss_bytes
+            );
+            assert!(
+                sample.memory_limit_bytes.is_some_and(|limit| limit > 0),
+                "memory limit (min RAM/cgroup) must be sampled on Linux, got {:?}",
+                sample.memory_limit_bytes
+            );
+            assert!(
+                sample.cpu_time_seconds.is_some_and(|cpu| cpu >= 0.0),
+                "CPU time must be sampled on Linux, got {:?}",
+                sample.cpu_time_seconds
+            );
+        }
+    }
+
+    /// The telemetry JSON carries every axis as a populated key, so the
+    /// dashboard sees non-absent fields it can chart. Guards against the field
+    /// silently dropping out of the serialized event.
+    #[test]
+    fn telemetry_value_contains_all_axes() {
+        let value = sample().to_telemetry_value();
+        let obj = value
+            .as_object()
+            .expect("sample serializes to a JSON object");
+
+        for key in [
+            "memory_rss_bytes",
+            "memory_limit_bytes",
+            "cpu_time_seconds",
+            "cumulative_bytes_sent",
+            "cumulative_bytes_received",
+        ] {
+            assert!(obj.contains_key(key), "telemetry value missing key `{key}`");
+        }
+
+        // On Linux the memory/CPU axes must serialize to concrete numbers, not
+        // JSON null — i.e. the sample actually resolved them.
+        #[cfg(target_os = "linux")]
+        {
+            assert!(
+                obj["memory_rss_bytes"].is_number(),
+                "memory_rss_bytes should be a number on Linux, got {}",
+                obj["memory_rss_bytes"]
+            );
+            assert!(
+                obj["memory_limit_bytes"].is_number(),
+                "memory_limit_bytes should be a number on Linux, got {}",
+                obj["memory_limit_bytes"]
+            );
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_proc_stat_cpu_ticks_handles_parens_in_comm() {
+        // comm = "(freenet)"; utime = field 14 = 100, stime = field 15 = 55.
+        let line = "1234 (freenet) S 1 1234 1234 0 -1 4194304 100 0 0 0 \
+                    100 55 0 0 20 0 8 0 999 12345 678 rest ignored";
+        assert_eq!(parse_proc_stat_cpu_ticks(line), Some(155));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_proc_stat_cpu_ticks_handles_spaces_and_parens_in_comm() {
+        // Pathological comm containing a space AND a close-paren; the parser
+        // must anchor on the LAST ')', not the first.
+        let line = "42 (weird )name) R 1 42 42 0 -1 0 7 3 0 0 \
+                    12 8 0 0 20 0 1 0 100 200 300 tail";
+        assert_eq!(parse_proc_stat_cpu_ticks(line), Some(20));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_proc_stat_cpu_ticks_rejects_garbage() {
+        assert_eq!(parse_proc_stat_cpu_ticks("not a stat line"), None);
+        assert_eq!(parse_proc_stat_cpu_ticks(""), None);
+    }
+}

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -539,6 +539,27 @@ impl TelemetryWorker {
         }
     }
 
+    /// Sample this node's OWN resource utilization (memory RSS + ceiling, CPU
+    /// time, cumulative bandwidth) into a `resource_utilization` telemetry
+    /// event, attributed to this node's peer id.
+    ///
+    /// Foundational piece (A1) of the demand-driven hosting redesign
+    /// (freenet/freenet-core#4642): the capability-relative hosting budget and
+    /// eviction policy (pieces A2/A3) must be validated against a node's real
+    /// scarcest-resource headroom, which was previously not observable at all.
+    /// Sampled from cheap process-local sources — see
+    /// [`crate::node::resource_metrics`]; nothing crosses the peer wire.
+    fn resource_utilization_telemetry(&self) -> TelemetryEvent {
+        TelemetryEvent {
+            timestamp: current_timestamp_ms(),
+            peer_id: self.local_peer_id.clone(),
+            transaction_id: String::new(), // Node-wide, not tied to a transaction.
+            event_type: "resource_utilization".to_string(),
+            event_data: crate::node::resource_metrics::sample().to_telemetry_value(),
+            priority: EventPriority::Operational,
+        }
+    }
+
     /// Wrap a transport-layer transfer event into a `TelemetryEvent`,
     /// stamped with this node's own peer id. The transport layer has
     /// no peer-identity context of its own, so before #4345 these
@@ -603,6 +624,13 @@ impl TelemetryWorker {
                     }
                 },
                 _ = batch_interval.tick() => {
+                    // Emit this node's own resource-utilization sample (#4642
+                    // A1) on the batch cadence, so a peer's memory/CPU/bandwidth
+                    // headroom is observable on the telemetry stream the
+                    // dashboard consumes. Cheap process-local sources; buffered
+                    // like any other event, then flushed below.
+                    let resource_event = self.resource_utilization_telemetry();
+                    self.handle_event(resource_event).await;
                     self.flush().await;
                 },
                 _ = transport_snapshot_interval.tick() => {
@@ -2570,6 +2598,50 @@ mod tests {
             "transport snapshots must be attributed to the emitting \
              node's own peer id (#4345)"
         );
+    }
+
+    #[test]
+    fn test_resource_utilization_carries_local_peer_id() {
+        // #4642 A1: node self-resource-utilization events must be attributed
+        // to the emitting node's own peer id, tagged with the stable
+        // `resource_utilization` event_type at Operational priority, and carry
+        // the sampled axes as a per-node aggregate-scalar object (never a
+        // per-contract / per-request map). Same attribution contract as the
+        // transport_snapshot / transfer siblings above.
+        let (_cmd_tx, cmd_rx) = mpsc::channel(1);
+        let (_transfer_tx, transfer_rx) = mpsc::channel(1);
+        let worker = TelemetryWorker::new(
+            "http://localhost:4318".to_string(),
+            cmd_rx,
+            0,
+            transfer_rx,
+            "resource-peer-id".to_string(),
+        );
+        let event = worker.resource_utilization_telemetry();
+        assert_eq!(event.event_type, "resource_utilization");
+        assert_eq!(
+            event.peer_id, "resource-peer-id",
+            "resource-utilization events must be attributed to the emitting \
+             node's own peer id"
+        );
+        assert_eq!(
+            event.priority,
+            EventPriority::Operational,
+            "resource-utilization is operational telemetry, not shadow"
+        );
+        let obj = event
+            .event_data
+            .as_object()
+            .expect("resource_utilization event_data must be a JSON object");
+        for key in [
+            "memory_rss_bytes",
+            "memory_limit_bytes",
+            "cpu_time_seconds",
+            "cumulative_bytes_sent",
+            "cumulative_bytes_received",
+        ] {
+            assert!(obj.contains_key(key), "event_data missing key `{key}`");
+        }
     }
 
     #[tokio::test]

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -28,7 +28,7 @@ pub use module_cache::default_module_cache_budget_bytes;
 pub(crate) use module_cache::{
     DELEGATE_MODULE_CACHE_BUDGET_DIVISOR, InterestPredicate, ModuleCache, ModuleCacheMetrics,
     contract_cache_interested_occupancy_pct, contract_cache_occupancy_pct, interest_tiered_enabled,
-    migration_admission_recovered_now,
+    migration_admission_recovered_now, read_total_ram_bytes,
 };
 // Clamp bounds are referenced only by the config-default round-trip test, which
 // asserts the resolved default lands within [MIN, MAX] without hardcoding the

--- a/crates/core/src/wasm_runtime/module_cache.rs
+++ b/crates/core/src/wasm_runtime/module_cache.rs
@@ -1221,7 +1221,14 @@ fn budget_for_ram(total_ram: usize) -> usize {
 ///
 /// Never panics; any failure (missing file, parse error, non-positive sysconf)
 /// yields `None` for that source and falls back.
-fn read_total_ram_bytes() -> Option<usize> {
+///
+/// `pub(crate)` because the demand-driven hosting redesign reuses this exact
+/// "memory the node may use" ceiling in two places beyond the module-cache
+/// budget: the resource-utilization telemetry sample (piece A1,
+/// `node::resource_metrics`) and — later — the capability-relative hosting
+/// budget (piece A2). Keeping a single source avoids two drifting notions of
+/// "how much memory does this node have". See `docs/design/hosting-eviction.md`.
+pub(crate) fn read_total_ram_bytes() -> Option<usize> {
     #[cfg(target_os = "linux")]
     {
         let phys = read_proc_meminfo_total_bytes();

--- a/docs/design/hosting-eviction.md
+++ b/docs/design/hosting-eviction.md
@@ -1,0 +1,32 @@
+# Demand-driven hosting: eviction & retention (piece A)
+Design resolved 2026-06-30. Tracker: freenet/freenet-core#4642. Invariants: `.claude/rules/hosting-invariants.md`.
+
+## Goal
+A peer hosts the contracts it is most likely to be asked for, within a budget sized by its own scarcest resource.
+
+## Design principles
+- **Instrumentation is horizontal.** Every piece of this redesign ships with the telemetry needed to observe its OWN behavior in production. This is a PR acceptance criterion: a feature PR that adds a mechanism but no instrumentation for it gets bounced in review. Rationale: the behavior here is emergent and resource-dependent, so it cannot be fully tested pre-production — production telemetry IS the validation instrument, and it must grow WITH each piece rather than being deferred to a later "observability" PR. (This is why A1, telemetry, is the foundational sub-PR.)
+- **Telemetry shape: per-node aggregate scalars/rates only.** Emit resource/behavior metrics as per-node aggregate scalars and rates carried on the existing periodic snapshot. NEVER per-contract or per-request event streams — nova ingests the whole fleet, so a per-contract/per-request stream multiplied across every peer is an ingestion DoS on the collector.
+
+## Eviction (Greedy-Dual / "fuel gauge")
+- Each hosted contract X has `keep_score(X) = eviction_floor + predicted_demand(X)`, set on insert and refreshed on every read (GET/SUBSCRIBE).
+- `eviction_floor`: one per-peer running value; when over budget, evict the min keep_score and set `eviction_floor = keep_score(evicted)`. Greedy-Dual aging, measured in cache-contention, not wall-clock.
+- `predicted_demand(X)`: per-contract estimate of X's read-request rate at this peer. Seeded at a proximity prior; blended toward X's own observed read rate as evidence accrues (prior washes out with data). Only RATIOS matter (scale-invariant), so no absolute calibration needed.
+- Proximity prior `g(distance)`: isotonic regression (monotone non-increasing) fit from this peer's observed (distance-to-key, request-rate) data, binned by distance, refit periodically. Reuse the existing isotonic/PAVA machinery.
+- Interest signals: GET and SUBSCRIBE = read-demand (same weight); PUT only SEEDS (sets predicted_demand to the proximity prior, not demand); an active SUBSCRIBE PINS the contract (exempt from eviction; grace clock starts only at subscription termination).
+
+## Budget (capability-relative)
+- The budget is how many contracts the peer can host before its SCARCEST resource saturates. Empirically the binding cost is per-contract MEMORY (~1 MB) and update FANOUT, not storage bytes (~650 KB/contract, negligible). Binding resource differs by hardware (laptop=memory, small VM=CPU, residential=uplink).
+- Memory axis: reuse `module_cache.rs::read_total_ram_bytes()` (min(RAM, cgroup)) to size the hosting budget instead of the flat 1 GiB `DEFAULT_HOSTING_BUDGET_BYTES`. Addresses #4565.
+- Within budget per-contract cost is ~uniform, so eviction is near-pure demand-ordering; storage bytes are a minor tiebreaker + hard ceiling. Fanout cost is an ADMISSION concern, not eviction (fanout only accrues while pinned).
+
+## Admission (piece B, summary)
+- GET hosts-on-first and lets the gauge evict one-offs (demand-driven, so NOT the relay-caching anti-pattern; guard-comment the site). SUBSCRIBE builds a chain of demand-pinned hosts. An over-committed peer REFUSES new subscriptions.
+
+## Sub-PRs (sequenced; share ring/hosting)
+A1 resource telemetry (this PR); A2 memory-capability budget (`read_total_ram_bytes` -> hosting budget); A3 fuel-gauge eviction policy; A4 blend.
+
+## Validation
+Sim health metrics (subscribe/GET success, tree formation, time-to-first-op) + a check that a real-demand contract (e.g. a River room) is NOT evicted ahead of junk (the #4338 miscalibration test).
+
+[AI-assisted - Claude]


### PR DESCRIPTION
**First PR of the demand-driven hosting redesign (piece A1). PARKED for Ian's review, do NOT merge without his sign-off.**

## Problem
The demand-driven hosting redesign (#4642) sizes each peer's hosting budget by its own scarcest resource and evicts by demand. Validating that capability-relative budget and its eviction policy requires observing a node's real resource headroom in production, but the node surfaces zero resource-utilization metrics today: RSS is sampled only for an ad-hoc log line, the memory ceiling (min host RAM / cgroup) is computed only to size the module cache, and CPU/bandwidth are not aggregated anywhere the dashboard can see. The behavior is emergent and resource-dependent, so production telemetry is the validation instrument and must land first (instrumentation-is-horizontal principle, see the design doc).

## Solution
Foundational sub-PR A1: purely-additive resource telemetry, no behavior change.

- New `node::resource_metrics` samples the node's OWN utilization as **per-node aggregate scalars**: memory RSS + ceiling, cumulative CPU time, and cumulative bytes sent/received. RSS and the memory ceiling reuse existing sources (the RSS reader moved out of `p2p_protoc`, deduplicated; the ceiling reuses `wasm_runtime::read_total_ram_bytes`, now `pub(crate)` — the same value that will size the hosting budget in A2).
- Emitted as a periodic `resource_utilization` event on the **internal** telemetry stream (the batch cadence in `TelemetryReporter`'s worker), attributed to this node's peer id. Aggregate scalars only, never per-contract/per-request (nova ingests the whole fleet).
- Deliberately **NOT** on the client-facing wire protocol: nothing touches `SystemMetrics`, `HostResponse`, or any `freenet-stdlib` bincode type (that would be a wire-format break, out of scope for A1).
- Adds `docs/design/hosting-eviction.md`, the build guide for piece A.

## Testing
- `resource_metrics` unit tests: the sample populates every axis (RSS, ceiling, CPU non-absent on Linux; bandwidth always), the telemetry JSON carries every axis as a populated key, and the `/proc/self/stat` CPU parser handles parens/spaces in the comm field and rejects garbage.
- `cargo fmt`, `cargo clippy --locked -- -D warnings` and the `trace-ot` clippy gate both clean; `cargo check -p freenet` green.

## Fixes
Refs #4642

## Deferred
CPU and bandwidth are included (cheap local sources). No axis deferred. Piece A2 will consume `read_total_ram_bytes` to size the hosting budget.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01LnRCbtbjepaB5GWrb5U8SR