### PR TITLE
feat: size the hosting budget by available node RAM

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -481,8 +481,22 @@ impl ConfigArgs {
                 self.network_api.location.get_or_insert(loc);
             }
             self.log_level.get_or_insert(cfg.log_level);
-            self.max_hosting_storage
-                .get_or_insert(cfg.max_hosting_storage);
+            // #4565 upgrade migration: a pre-A2 release auto-persisted the OLD
+            // flat 1 GiB default as `max-hosting-storage = 1073741824`. Treat
+            // that exact historical sentinel as auto-derived (NOT an explicit
+            // operator choice) so it RE-DERIVES from live RAM on upgrade —
+            // otherwise a small box that upgraded would keep the 1 GiB budget and
+            // stay on the #4565 OOM path. `skip_serializing_if` alone only stops
+            // NEW configs from pinning; it can't unpin the historical value.
+            // CLI/env explicit values are parsed into `self` BEFORE this file
+            // merge, so `--max-hosting-storage 1073741824` / the env var still
+            // wins; only a FILE value equal to the sentinel is re-derived. On a
+            // >=8 GiB box the re-derivation yields 1 GiB anyway; on a smaller box
+            // reducing it is the whole point.
+            if cfg.max_hosting_storage != crate::ring::LEGACY_FLAT_HOSTING_BUDGET_BYTES {
+                self.max_hosting_storage
+                    .get_or_insert(cfg.max_hosting_storage);
+            }
             self.per_user_secret_quota_bytes
                 .get_or_insert(cfg.per_user_secret_quota_bytes);
             self.per_user_inactive_ttl_secs
@@ -1090,9 +1104,19 @@ pub struct Config {
     /// 128 MiB, 1 GiB)`, so a memory-constrained host gets a proportionally
     /// smaller budget instead of the old flat 1 GiB (#4642 A2 / #4565). Set an
     /// explicit value to override the RAM-scaled default.
+    ///
+    /// `skip_serializing_if` drops this field from `config.toml` when it holds
+    /// the auto-derived default, so the budget RE-DERIVES from live RAM on every
+    /// boot instead of being pinned at first boot. Without this, a node that
+    /// first-booted on a large box would bake the large budget into `config.toml`
+    /// and keep it after moving to a smaller box / tighter cgroup — defeating the
+    /// #4565 OOM protection. An explicit operator value differs from the derived
+    /// default, so it is persisted and survives restarts. See
+    /// [`is_default_hosting_budget`].
     #[serde(
         default = "default_max_hosting_storage",
-        rename = "max-hosting-storage"
+        rename = "max-hosting-storage",
+        skip_serializing_if = "is_default_hosting_budget"
     )]
     pub max_hosting_storage: u64,
     /// Per-user secret-storage quota in bytes for hosted mode (#4561, P5 of
@@ -1187,6 +1211,20 @@ fn default_max_blocking_threads() -> usize {
 /// budget (addresses #4565); an explicit value always overrides it.
 fn default_max_hosting_storage() -> u64 {
     crate::ring::default_hosting_budget_bytes()
+}
+
+/// `skip_serializing_if` predicate for [`Config::max_hosting_storage`]: true
+/// when the resolved value equals the auto-derived RAM-scaled default, so it is
+/// omitted from `config.toml` and re-derived from live RAM on the next boot
+/// (#4565 first-boot-pinning fix — see the field docs).
+///
+/// Because the derived default is always clamped to `[128 MiB, 1 GiB]`, an
+/// explicit operator value OUTSIDE that range can never match and is always
+/// persisted. The one ambiguous case — an explicit value that happens to equal
+/// the current derived default — re-derives on a RAM change, which is the safe
+/// direction (toward the smaller, capability-relative budget) anyway.
+fn is_default_hosting_budget(v: &u64) -> bool {
+    *v == default_max_hosting_storage()
 }
 
 /// Default per-user secret-storage quota (4 MiB). Resolves to
@@ -3657,7 +3695,13 @@ mod tests {
     #[tokio::test]
     async fn max_hosting_storage_explicit_value_round_trips() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let custom = 256 * 1024 * 1024_u64;
+        // 2 GiB is deliberately ABOVE the auto-derived clamp ceiling (1 GiB), so
+        // an explicit operator value can never coincide with the RAM-scaled
+        // default and is therefore always persisted / honored across restarts —
+        // regardless of the CI host's real RAM (a 2 GiB runner's derived default
+        // is 256 MiB, which a 256 MiB test value would collide with once
+        // `skip_serializing_if` drops the auto-derived value; #4565 fix).
+        let custom = 2 * 1024 * 1024 * 1024_u64;
         let args = ConfigArgs {
             mode: Some(OperationMode::Local),
             config_paths: ConfigPathsArgs {
@@ -3671,11 +3715,126 @@ mod tests {
         let cfg = args.build().await.unwrap();
         assert_eq!(cfg.max_hosting_storage, custom);
 
-        // Round-trips through TOML serialization.
+        // An explicit override is persisted (NOT skipped) and round-trips.
         let serialized = toml::to_string(&cfg).unwrap();
-        assert!(serialized.contains("max-hosting-storage"));
+        assert!(
+            serialized.contains("max-hosting-storage"),
+            "an explicit operator value must be persisted, got:\n{serialized}"
+        );
         let deserialized: Config = toml::from_str(&serialized).unwrap();
         assert_eq!(deserialized.max_hosting_storage, custom);
+    }
+
+    /// First-boot-pinning fix (#4565): a node that first-boots with the
+    /// auto-derived (RAM-scaled) budget must NOT bake it into `config.toml`, so a
+    /// later boot re-derives from live RAM. Concretely: (1) the auto-derived
+    /// value is omitted from the serialized config, and (2) a `config.toml`
+    /// without the key rebuilds to the live-RAM default rather than a pinned
+    /// value. Combined with the RAM-scaling proof in `cache.rs`
+    /// (`budget_for_ram_scales_and_clamps`), this means a node that first-boots on
+    /// a large box and restarts on a smaller box / tighter cgroup gets the
+    /// SMALLER budget, not the pinned old one.
+    #[tokio::test]
+    async fn auto_derived_hosting_budget_is_not_persisted_and_re_derives() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let args = ConfigArgs {
+            mode: Some(OperationMode::Local),
+            config_paths: ConfigPathsArgs {
+                config_dir: Some(temp_dir.path().to_path_buf()),
+                data_dir: Some(temp_dir.path().to_path_buf()),
+                log_dir: Some(temp_dir.path().to_path_buf()),
+            },
+            // No explicit max_hosting_storage -> resolves to the auto-derived
+            // RAM-scaled default.
+            ..Default::default()
+        };
+        let cfg = args.build().await.unwrap();
+        assert_eq!(
+            cfg.max_hosting_storage,
+            crate::ring::default_hosting_budget_bytes(),
+            "with no operator value, the budget must be the auto-derived default"
+        );
+
+        // (1) The auto-derived value must be OMITTED from config.toml, so nothing
+        // is pinned for the next boot to inherit.
+        let serialized = toml::to_string(&cfg).unwrap();
+        assert!(
+            !serialized.contains("max-hosting-storage"),
+            "the auto-derived budget must not be pinned into config.toml, got:\n{serialized}"
+        );
+
+        // (2) A config.toml WITHOUT the key rebuilds to the live-RAM default
+        // (serde `default = default_max_hosting_storage`), i.e. it re-derives
+        // rather than reverting to a stale pinned value. On a smaller box the
+        // rebuilt value would be smaller; here (same host) it equals the current
+        // derived default.
+        let rebuilt: Config = toml::from_str(&serialized).unwrap();
+        assert_eq!(
+            rebuilt.max_hosting_storage,
+            crate::ring::default_hosting_budget_bytes(),
+            "a config.toml without the key must re-derive the budget from live RAM"
+        );
+    }
+
+    /// #4565 upgrade migration: an existing `config.toml` from a pre-A2 release
+    /// pinned the OLD flat 1 GiB default as `max-hosting-storage = 1073741824`.
+    /// `skip_serializing_if` alone only stops NEW configs from pinning, so on
+    /// upgrade that historical value must be treated as auto-derived and
+    /// re-derived from live RAM — otherwise a small box that upgraded keeps the
+    /// 1 GiB budget and stays on the #4565 OOM path.
+    ///
+    /// `default_hosting_budget_bytes()` reads the test host's real RAM, so on a
+    /// >= 8 GiB host the re-derived value coincidentally equals 1 GiB. The
+    /// control case (b) — an explicit non-legacy value must survive — is what
+    /// makes this test meaningful regardless of host RAM; on a small /
+    /// cgroup-limited host, case (a) additionally fails without the migration.
+    #[tokio::test]
+    async fn legacy_pinned_hosting_budget_re_derives_but_explicit_survives() {
+        // (a) A legacy config.toml pinning the exact 1 GiB sentinel. Generate a
+        // valid config first (the auto value is skip-serialized), then inject the
+        // historical line to mimic the pre-A2 on-disk state, then rebuild as an
+        // "upgrade boot".
+        let legacy_dir = tempfile::tempdir().unwrap();
+        clap_bare_args(legacy_dir.path()).build().await.unwrap();
+        let cfg_path = legacy_dir.path().join("config.toml");
+        let existing = std::fs::read_to_string(&cfg_path).unwrap();
+        assert!(
+            !existing.contains("max-hosting-storage"),
+            "fresh build must not persist the auto-derived value, got:\n{existing}"
+        );
+        // Top-level key prepended before any table header (valid TOML).
+        std::fs::write(
+            &cfg_path,
+            format!("max-hosting-storage = 1073741824\n{existing}"),
+        )
+        .unwrap();
+        let upgraded = clap_bare_args(legacy_dir.path()).build().await.unwrap();
+        assert_eq!(
+            upgraded.max_hosting_storage,
+            crate::ring::default_hosting_budget_bytes(),
+            "a legacy auto-persisted 1 GiB default must re-derive from live RAM \
+             on upgrade, not stay pinned"
+        );
+
+        // (b) Control: an explicit NON-legacy persisted value (2 GiB, above the
+        // auto ceiling) is a real operator choice and MUST survive the upgrade.
+        // This proves the migration is value-specific (targets only the old
+        // default sentinel), not a blanket re-derivation — meaningful on any RAM.
+        let explicit_dir = tempfile::tempdir().unwrap();
+        clap_bare_args(explicit_dir.path()).build().await.unwrap();
+        let cfg_path = explicit_dir.path().join("config.toml");
+        let existing = std::fs::read_to_string(&cfg_path).unwrap();
+        std::fs::write(
+            &cfg_path,
+            format!("max-hosting-storage = 2147483648\n{existing}"),
+        )
+        .unwrap();
+        let upgraded = clap_bare_args(explicit_dir.path()).build().await.unwrap();
+        assert_eq!(
+            upgraded.max_hosting_storage,
+            2 * 1024 * 1024 * 1024_u64,
+            "an explicit non-legacy persisted value must survive upgrade"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -942,7 +942,7 @@ impl ConfigArgs {
                 .unwrap_or_else(default_max_blocking_threads),
             max_hosting_storage: self
                 .max_hosting_storage
-                .unwrap_or(crate::ring::DEFAULT_HOSTING_BUDGET_BYTES),
+                .unwrap_or_else(crate::ring::default_hosting_budget_bytes),
             per_user_secret_quota_bytes: self
                 .per_user_secret_quota_bytes
                 .unwrap_or(crate::wasm_runtime::DEFAULT_PER_USER_SECRET_QUOTA_BYTES as u64),
@@ -1085,6 +1085,11 @@ pub struct Config {
     /// are evicted (least-valuable-first) and their on-disk state reclaimed.
     /// This bounds tracked contract state only — WASM code blobs and ReDb/
     /// SQLite database overhead are additional and not counted against it.
+    ///
+    /// The default is capability-relative (RAM-scaled): `clamp(total_ram / 8,
+    /// 128 MiB, 1 GiB)`, so a memory-constrained host gets a proportionally
+    /// smaller budget instead of the old flat 1 GiB (#4642 A2 / #4565). Set an
+    /// explicit value to override the RAM-scaled default.
     #[serde(
         default = "default_max_hosting_storage",
         rename = "max-hosting-storage"
@@ -1171,14 +1176,17 @@ fn default_max_blocking_threads() -> usize {
         .unwrap_or(8)
 }
 
-/// Default operator-facing budget for hosted contract state (1 GiB).
+/// Default operator-facing budget for hosted contract state (RAM-scaled).
 ///
-/// Resolves to [`crate::ring::DEFAULT_HOSTING_BUDGET_BYTES`], which is
-/// the single source of truth for this value — the in-code fallback used by the
-/// hosting cache and its tests. This indirection keeps the operator-facing
-/// default and the in-code default from ever drifting apart.
+/// Resolves to [`crate::ring::default_hosting_budget_bytes`], the single source
+/// of truth for this value — the RAM-scaled in-code default used by the hosting
+/// cache and its tests. This indirection keeps the operator-facing default and
+/// the in-code default from ever drifting apart. The default is capability-
+/// relative (`clamp(total_ram / 8, 128 MiB, 1 GiB)`, #4642 A2) rather than a
+/// flat constant, so a memory-constrained host gets a proportionally smaller
+/// budget (addresses #4565); an explicit value always overrides it.
 fn default_max_hosting_storage() -> u64 {
-    crate::ring::DEFAULT_HOSTING_BUDGET_BYTES
+    crate::ring::default_hosting_budget_bytes()
 }
 
 /// Default per-user secret-storage quota (4 MiB). Resolves to
@@ -3493,7 +3501,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn max_hosting_storage_defaults_to_one_gib() {
+    async fn max_hosting_storage_defaults_to_ram_scaled_clamped() {
         let temp_dir = tempfile::tempdir().unwrap();
         let args = ConfigArgs {
             mode: Some(OperationMode::Local),
@@ -3505,16 +3513,23 @@ mod tests {
             ..Default::default()
         };
         let cfg = args.build().await.unwrap();
+        // The default is now capability-relative (RAM-scaled, #4642 A2), not a
+        // flat 1 GiB. It must resolve to the hosting cache's single-source-of-
+        // truth default and land within the documented clamp range on any host.
+        // Reference the constants rather than hardcoded byte values so this test
+        // never drifts from the clamp.
+        let min = crate::ring::MIN_DEFAULT_HOSTING_BUDGET_BYTES;
+        let max = crate::ring::MAX_DEFAULT_HOSTING_BUDGET_BYTES;
         assert_eq!(
             cfg.max_hosting_storage,
-            crate::ring::DEFAULT_HOSTING_BUDGET_BYTES,
+            crate::ring::default_hosting_budget_bytes(),
             "default max_hosting_storage should resolve to the hosting cache's \
-             single-source-of-truth default budget"
+             single-source-of-truth RAM-scaled default budget"
         );
-        assert_eq!(
-            crate::ring::DEFAULT_HOSTING_BUDGET_BYTES,
-            1024 * 1024 * 1024,
-            "default hosting budget should be 1 GiB"
+        assert!(
+            (min..=max).contains(&cfg.max_hosting_storage),
+            "default budget {} must be within the [{min}, {max}] clamp",
+            cfg.max_hosting_storage
         );
     }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -88,6 +88,10 @@ pub(crate) use connection_manager::ConnectionManager;
 mod connection;
 mod hosting;
 pub(crate) use broken_invariants::{BrokenInvariant, BrokenInvariantsTracker};
+/// The pre-A2 flat 1 GiB budget, used as the upgrade-migration sentinel in
+/// `config::ConfigArgs::build` so an upgraded node re-derives its hosting budget
+/// instead of keeping the historically-pinned default (#4565).
+pub(crate) use hosting::LEGACY_FLAT_HOSTING_BUDGET_BYTES;
 /// Single source of truth for the default hosted-contract-state budget.
 /// `config::default_max_hosting_storage()` resolves to this so the
 /// operator-facing default and the in-code fallback can never drift. The
@@ -1458,11 +1462,12 @@ impl Ring {
             snapshot.delegate_module_cache_evictions_total = Some(mc.delegate_evictions_total);
 
             // Capability-relative hosting-budget gauges (#4642 A2): the
-            // RAM-scaled budget, its current occupancy (headroom ratio =
-            // current / budget, derived by the collector), the hosted-contract
-            // count, and the monotonic budget-triggered eviction counter. These
-            // let us observe in production whether the RAM-scaled budget keeps a
-            // small box off the #4565 OOM path. Per-node aggregate scalars only.
+            // RAM-scaled budget, its current occupancy (occupancy/utilization
+            // ratio = current / budget, headroom = 1 - that; derived by the
+            // collector), the hosted-contract count, and the monotonic
+            // budget-triggered eviction counter. These let us observe in
+            // production whether the RAM-scaled budget keeps a small box off the
+            // #4565 OOM path. Per-node aggregate scalars only.
             let hosting = ring.hosting_manager.hosting_cache_stats();
             snapshot.hosting_budget_bytes = Some(hosting.budget_bytes);
             snapshot.hosting_current_bytes = Some(hosting.current_bytes);

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -90,9 +90,13 @@ mod hosting;
 pub(crate) use broken_invariants::{BrokenInvariant, BrokenInvariantsTracker};
 /// Single source of truth for the default hosted-contract-state budget.
 /// `config::default_max_hosting_storage()` resolves to this so the
-/// operator-facing default and the in-code fallback can never drift.
-pub(crate) use hosting::DEFAULT_HOSTING_BUDGET_BYTES;
+/// operator-facing default and the in-code fallback can never drift. The
+/// default is RAM-scaled (capability-relative, A2) rather than a flat constant.
+pub(crate) use hosting::default_hosting_budget_bytes;
 pub use hosting::{AccessType, RecordAccessResult};
+/// Clamp bounds re-exported only for the config-default round-trip test.
+#[cfg(test)]
+pub(crate) use hosting::{MAX_DEFAULT_HOSTING_BUDGET_BYTES, MIN_DEFAULT_HOSTING_BUDGET_BYTES};
 pub mod interest;
 mod live_tx;
 mod location;
@@ -1452,6 +1456,18 @@ impl Ring {
             snapshot.delegate_module_cache_total_bytes = Some(mc.delegate_total_bytes);
             snapshot.delegate_module_cache_budget_bytes = Some(mc.delegate_budget_bytes);
             snapshot.delegate_module_cache_evictions_total = Some(mc.delegate_evictions_total);
+
+            // Capability-relative hosting-budget gauges (#4642 A2): the
+            // RAM-scaled budget, its current occupancy (headroom ratio =
+            // current / budget, derived by the collector), the hosted-contract
+            // count, and the monotonic budget-triggered eviction counter. These
+            // let us observe in production whether the RAM-scaled budget keeps a
+            // small box off the #4565 OOM path. Per-node aggregate scalars only.
+            let hosting = ring.hosting_manager.hosting_cache_stats();
+            snapshot.hosting_budget_bytes = Some(hosting.budget_bytes);
+            snapshot.hosting_current_bytes = Some(hosting.current_bytes);
+            snapshot.hosting_contract_count = Some(hosting.contract_count);
+            snapshot.hosting_budget_evictions_total = Some(hosting.budget_evictions_total);
 
             // Interest-weighted (two-tier) module-cache SHADOW gauges
             // (#4441/#4534): always-on, independent of the

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -34,11 +34,18 @@ mod cache;
 use crate::util::backoff::{ExponentialBackoff, TrackedBackoff};
 use crate::util::time_source::{InstantTimeSrc, TimeSource};
 /// Re-exported as the single source of truth for the default hosting storage
-/// budget. `config::default_max_hosting_storage()` resolves to this constant so
-/// the operator-facing default and the in-code fallback can never drift.
-pub(crate) use cache::DEFAULT_HOSTING_BUDGET_BYTES;
+/// budget. `config::default_max_hosting_storage()` resolves to this function so
+/// the operator-facing default and the in-code fallback can never drift. The
+/// default is RAM-scaled (capability-relative, A2) rather than a flat constant.
+pub(crate) use cache::default_hosting_budget_bytes;
 pub use cache::{AccessType, RecordAccessResult};
-use cache::{DEFAULT_MIN_TTL, HostingCache};
+use cache::{DEFAULT_MIN_TTL, HostingCache, HostingCacheStats};
+/// Clamp bounds re-exported only for the config-default round-trip test, which
+/// asserts the resolved default lands within [MIN, MAX] without hardcoding the
+/// byte values. Gated to test builds so the re-export isn't an unused import
+/// under `-D warnings` in release.
+#[cfg(test)]
+pub(crate) use cache::{MAX_DEFAULT_HOSTING_BUDGET_BYTES, MIN_DEFAULT_HOSTING_BUDGET_BYTES};
 use dashmap::{DashMap, DashSet};
 use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
 use parking_lot::RwLock;
@@ -1248,6 +1255,13 @@ impl HostingManager {
         self.hosting_cache.read().budget_bytes()
     }
 
+    /// Snapshot the hosting cache's aggregate resource gauges (budget, current
+    /// bytes, contract count, budget-triggered eviction count) under a single
+    /// read lock, for the per-node `RouterSnapshot` telemetry (A2).
+    pub(crate) fn hosting_cache_stats(&self) -> HostingCacheStats {
+        self.hosting_cache.read().stats()
+    }
+
     /// Check if we should continue hosting a contract.
     ///
     /// Returns true if:
@@ -1941,7 +1955,7 @@ impl HostingManager {
 
 impl Default for HostingManager {
     fn default() -> Self {
-        Self::new(DEFAULT_HOSTING_BUDGET_BYTES)
+        Self::new(default_hosting_budget_bytes())
     }
 }
 
@@ -1953,6 +1967,12 @@ impl Default for HostingManager {
 mod tests {
     use super::*;
     use freenet_stdlib::prelude::CodeHash;
+
+    /// Fixed 1 GiB budget for the behavioral tests below. The production default
+    /// is now RAM-scaled (capability-relative, #4642 A2); these tests
+    /// deliberately pin a large, deterministic budget so eviction is driven only
+    /// by the sizes they set, independent of the test host's real RAM.
+    const DEFAULT_HOSTING_BUDGET_BYTES: u64 = 1024 * 1024 * 1024;
 
     fn make_contract_key(seed: u8) -> ContractKey {
         ContractKey::from_id_and_code(

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -2002,11 +2002,14 @@ mod tests {
             "HostingManager::new should pass the budget through to the cache"
         );
 
-        // The default constructor still uses the in-code default.
+        // The default constructor uses the in-code default, which is now
+        // RAM-scaled (#4642 A2) rather than the fixed test constant — assert
+        // against the production default fn so this doesn't flake on a
+        // low-memory / cgroup-limited CI host (Codex #4644 review).
         let default_manager = HostingManager::default();
         assert_eq!(
             default_manager.hosting_budget_bytes(),
-            DEFAULT_HOSTING_BUDGET_BYTES
+            default_hosting_budget_bytes()
         );
     }
 

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -33,6 +33,9 @@ mod cache;
 
 use crate::util::backoff::{ExponentialBackoff, TrackedBackoff};
 use crate::util::time_source::{InstantTimeSrc, TimeSource};
+/// The pre-A2 flat 1 GiB budget, used as the upgrade-migration sentinel in
+/// `config::ConfigArgs::build` (see the constant's docs).
+pub(crate) use cache::LEGACY_FLAT_HOSTING_BUDGET_BYTES;
 /// Re-exported as the single source of truth for the default hosting storage
 /// budget. `config::default_max_hosting_storage()` resolves to this function so
 /// the operator-facing default and the in-code fallback can never drift. The

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -17,17 +17,98 @@ use std::time::Duration;
 use tokio::time::Instant;
 
 use crate::util::time_source::TimeSource;
+use crate::wasm_runtime::read_total_ram_bytes;
 
-/// Default hosting storage budget (1 GiB).
+/// Lower clamp for the RAM-scaled default hosting budget (128 MiB).
+///
+/// Even a genuinely tiny host should still be able to host a useful amount of
+/// contract state. The budget tracks on-disk **state** bytes (not RSS), so this
+/// floor is a disk allowance, not a memory reservation.
+pub const MIN_DEFAULT_HOSTING_BUDGET_BYTES: u64 = 128 * 1024 * 1024;
+
+/// Upper clamp for the RAM-scaled default hosting budget (1 GiB).
+///
+/// Equal to the historical flat default, on purpose: a host with ample RAM
+/// (>= 8 GiB at the current divisor) resolves to exactly the previous 1 GiB
+/// budget and sees NO behavior change. Only memory-constrained hosts get a
+/// smaller, proportional budget. This makes the capability-relative default a
+/// pure "small boxes get less" change (addresses #4565, gateway RSS -> OOM on
+/// small boxes) rather than a budget increase for anyone.
+pub const MAX_DEFAULT_HOSTING_BUDGET_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Fraction of total system RAM used to size the default hosting budget: 1/8.
+///
+/// Mirrors the module cache's `DEFAULT_MODULE_CACHE_RAM_DIVISOR`. The divisor —
+/// NOT the `MAX` ceiling — is the small-box protection (#4441): the fix that
+/// replaced the flat budget must itself never OOM a small box, so the budget
+/// scales DOWN with RAM below the ceiling instead of being a fixed
+/// count/constant. 1/8 leaves the other 7/8 of RAM for the rest of the node
+/// (state store, module caches, transport buffers, WASM arenas, the OS).
+const DEFAULT_HOSTING_BUDGET_RAM_DIVISOR: u64 = 8;
+
+/// Fallback total-RAM estimate (1 GiB) when the OS query fails. Conservative:
+/// at 1 GiB the divisor yields 128 MiB (the floor), so an unknown-RAM host gets
+/// the smallest sane budget rather than the max.
+const FALLBACK_TOTAL_RAM_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Default hosting-storage budget, scaled to the memory the node may use.
+///
+/// Replaces the historical flat 1 GiB default. Returns
+/// `clamp(total_ram / DEFAULT_HOSTING_BUDGET_RAM_DIVISOR,
+/// MIN_DEFAULT_HOSTING_BUDGET_BYTES, MAX_DEFAULT_HOSTING_BUDGET_BYTES)`
+/// (currently `clamp(total_ram / 8, 128 MiB, 1 GiB)`), where `total_ram` is
+/// `min(host RAM, cgroup limit)` from the SAME single source
+/// [`crate::wasm_runtime::read_total_ram_bytes`] that sizes the module cache and
+/// the A1 resource-utilization telemetry — so the node has one notion of "how
+/// much memory do I have".
 ///
 /// This is the single source of truth for the default budget: the operator-
 /// facing `config::default_max_hosting_storage()` resolves to it (re-exported
-/// via `ring::hosting::DEFAULT_HOSTING_BUDGET_BYTES`).
+/// via `ring::hosting`). The operator override
+/// (`--max-hosting-storage` / `max_hosting_storage` config / env) always wins
+/// when explicitly set; only this DEFAULT is RAM-scaled.
 ///
 /// The budget tracks hosted contract **state** bytes only. WASM code blobs and
 /// ReDb/SQLite database overhead are additional and not counted against it, so
 /// this is not a hard bound on total on-disk usage.
-pub const DEFAULT_HOSTING_BUDGET_BYTES: u64 = 1024 * 1024 * 1024;
+pub fn default_hosting_budget_bytes() -> u64 {
+    let total_ram = read_total_ram_bytes()
+        .map(|v| v as u64)
+        .unwrap_or(FALLBACK_TOTAL_RAM_BYTES);
+    budget_for_ram(total_ram)
+}
+
+/// Pure clamp math behind [`default_hosting_budget_bytes`], split out so the
+/// small-box / large-box boundary behavior is unit-testable without depending
+/// on the test host's real RAM. Returns the hosting-cache byte budget for a
+/// host with `total_ram` bytes of usable memory.
+fn budget_for_ram(total_ram: u64) -> u64 {
+    (total_ram / DEFAULT_HOSTING_BUDGET_RAM_DIVISOR).clamp(
+        MIN_DEFAULT_HOSTING_BUDGET_BYTES,
+        MAX_DEFAULT_HOSTING_BUDGET_BYTES,
+    )
+}
+
+/// Point-in-time hosting-cache resource gauges for per-node telemetry.
+///
+/// Aggregate scalars only (never per-contract), emitted on the existing
+/// `RouterSnapshot` cadence so the capability-relative budget's behavior is
+/// observable in production (design principle: instrumentation is horizontal —
+/// see `docs/design/hosting-eviction.md`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HostingCacheStats {
+    /// Configured byte budget (the RAM-scaled default, or the operator override).
+    pub budget_bytes: u64,
+    /// Current tracked contract-state bytes. Headroom ratio is
+    /// `current_bytes / budget_bytes`, derived by the collector.
+    pub current_bytes: u64,
+    /// Number of contracts currently in the hosting cache.
+    pub contract_count: u64,
+    /// Monotonic count of contracts evicted specifically because the cache was
+    /// over budget. The collector differences it across the cadence to derive a
+    /// budget-triggered eviction rate.
+    pub budget_evictions_total: u64,
+}
 
 /// Multiplier for TTL relative to subscription renewal interval.
 /// Gives this many renewal attempts before eviction if renewals keep failing.
@@ -149,6 +230,11 @@ pub struct HostingCache<T: TimeSource> {
     lru_order: VecDeque<ContractKey>,
     /// Contract metadata indexed by key
     contracts: HashMap<ContractKey, HostedContract>,
+    /// Monotonic count of contracts evicted because the cache was over budget.
+    /// Only `evict_over_budget` increments it, so it counts budget-triggered
+    /// evictions specifically (not TTL sweeps that found nothing over budget).
+    /// Exposed via [`HostingCache::stats`] for per-node telemetry.
+    budget_evictions_total: u64,
     /// Time source for testability
     time_source: T,
 }
@@ -162,6 +248,7 @@ impl<T: TimeSource> HostingCache<T> {
             min_ttl,
             lru_order: VecDeque::new(),
             contracts: HashMap::new(),
+            budget_evictions_total: 0,
             time_source,
         }
     }
@@ -202,6 +289,7 @@ impl<T: TimeSource> HostingCache<T> {
                     let generation = entry.write_generation;
                     self.contracts.remove(key);
                     self.current_bytes = self.current_bytes.saturating_sub(size);
+                    self.budget_evictions_total = self.budget_evictions_total.saturating_add(1);
                     evicted.push((*key, generation));
                     false
                 } else {
@@ -455,6 +543,17 @@ impl<T: TimeSource> HostingCache<T> {
     #[allow(dead_code)] // Public API for introspection
     pub fn budget_bytes(&self) -> u64 {
         self.budget_bytes
+    }
+
+    /// Snapshot the cache's aggregate resource gauges under a single read for
+    /// per-node telemetry. See [`HostingCacheStats`].
+    pub fn stats(&self) -> HostingCacheStats {
+        HostingCacheStats {
+            budget_bytes: self.budget_bytes,
+            current_bytes: self.current_bytes,
+            contract_count: self.contracts.len() as u64,
+            budget_evictions_total: self.budget_evictions_total,
+        }
     }
 
     /// Get all hosted contract keys in LRU order (oldest first).
@@ -1233,5 +1332,113 @@ mod tests {
         assert!(evicted.is_empty(), "no pressure → no eviction");
         assert!(cache.contains(&key1));
         assert!(cache.contains(&key2));
+    }
+
+    // --- Capability-relative default budget + telemetry (A2) ---
+
+    const MIB: u64 = 1024 * 1024;
+    const GIB: u64 = 1024 * 1024 * 1024;
+
+    /// The default budget scales with the memory the node may use, clamped to a
+    /// sane floor/ceiling: `clamp(total_ram / 8, 128 MiB, 1 GiB)`.
+    #[test]
+    fn budget_for_ram_scales_and_clamps() {
+        // Tiny box: total_ram / 8 is below the floor -> clamped up to MIN.
+        assert_eq!(budget_for_ram(512 * MIB), MIN_DEFAULT_HOSTING_BUDGET_BYTES);
+        assert_eq!(budget_for_ram(GIB), MIN_DEFAULT_HOSTING_BUDGET_BYTES);
+
+        // Mid-range boxes scale linearly with RAM. The #4565 target: a 2 GiB VM
+        // gets 256 MiB, far below the old flat 1 GiB, so it stops accumulating
+        // hosted state toward OOM.
+        assert_eq!(budget_for_ram(2 * GIB), 256 * MIB);
+        assert_eq!(budget_for_ram(4 * GIB), 512 * MIB);
+
+        // Ample-RAM box (>= 8 GiB) hits the ceiling, which equals the historical
+        // flat default, so large gateways see NO change.
+        assert_eq!(budget_for_ram(8 * GIB), MAX_DEFAULT_HOSTING_BUDGET_BYTES);
+        assert_eq!(budget_for_ram(128 * GIB), MAX_DEFAULT_HOSTING_BUDGET_BYTES);
+    }
+
+    /// #4441 shape guard: the budget is RAM-SCALED, not a fixed count/constant.
+    /// The old fixed >1024-contract cap was removed because it thrashed/OOM'd;
+    /// the replacement budget must vary with RAM in the scaling band, and a
+    /// memory-constrained box must get strictly LESS than a large one (and less
+    /// than the old flat 1 GiB default).
+    #[test]
+    fn budget_for_ram_is_ram_scaled_not_fixed() {
+        let small = budget_for_ram(2 * GIB);
+        let large = budget_for_ram(6 * GIB);
+        assert!(
+            small < large,
+            "budget must vary with RAM within the band, got small={small} large={large}"
+        );
+        assert!(
+            small < MAX_DEFAULT_HOSTING_BUDGET_BYTES,
+            "a memory-constrained box must get less than the old flat 1 GiB default"
+        );
+        // Genuinely a function of RAM, not a constant: distinct in-band inputs
+        // give distinct budgets.
+        assert_ne!(budget_for_ram(2 * GIB), budget_for_ram(3 * GIB));
+        assert_ne!(budget_for_ram(3 * GIB), budget_for_ram(4 * GIB));
+    }
+
+    /// The real resolved default always lands within the documented clamp,
+    /// whatever RAM the test host has.
+    #[test]
+    fn default_hosting_budget_within_clamp() {
+        let b = default_hosting_budget_bytes();
+        assert!(
+            (MIN_DEFAULT_HOSTING_BUDGET_BYTES..=MAX_DEFAULT_HOSTING_BUDGET_BYTES).contains(&b),
+            "default {b} must be within [{}, {}]",
+            MIN_DEFAULT_HOSTING_BUDGET_BYTES,
+            MAX_DEFAULT_HOSTING_BUDGET_BYTES,
+        );
+    }
+
+    /// The budget-triggered eviction counter increments once per over-budget
+    /// eviction and is surfaced via `stats()`; a TTL-protected or no-pressure
+    /// cache leaves it untouched. This is the telemetry A2 ships to observe its
+    /// own eviction rate.
+    #[test]
+    fn test_budget_eviction_counter_tracks_over_budget_evictions() {
+        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let key1 = make_key(1);
+        let key2 = make_key(2);
+        let key3 = make_key(3);
+
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| false);
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| false);
+        assert_eq!(cache.stats().budget_evictions_total, 0);
+
+        // Over budget but every entry is under TTL: no budget eviction yet.
+        cache.record_access(key3, 100, AccessType::Get, 0, |_| false);
+        assert_eq!(
+            cache.stats().budget_evictions_total,
+            0,
+            "TTL-protected entries must not count as budget evictions"
+        );
+
+        // Past TTL: a sweep now evicts the single over-budget entry.
+        time.advance_time(Duration::from_secs(61));
+        let evicted = cache.sweep_expired(|_| false);
+        assert_eq!(
+            evicted.len(),
+            1,
+            "one 100-byte entry brings 300 back to 200"
+        );
+        let stats = cache.stats();
+        assert_eq!(stats.budget_evictions_total, 1);
+        assert_eq!(stats.current_bytes, 200);
+        assert_eq!(stats.contract_count, 2);
+        assert_eq!(stats.budget_bytes, 200);
+
+        // No pressure now (at budget): the counter is unchanged.
+        let evicted = cache.sweep_expired(|_| false);
+        assert!(evicted.is_empty(), "at budget -> no further eviction");
+        assert_eq!(
+            cache.stats().budget_evictions_total,
+            1,
+            "counter must not advance with no budget pressure"
+        );
     }
 }

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -36,6 +36,19 @@ pub const MIN_DEFAULT_HOSTING_BUDGET_BYTES: u64 = 128 * 1024 * 1024;
 /// small boxes) rather than a budget increase for anyone.
 pub const MAX_DEFAULT_HOSTING_BUDGET_BYTES: u64 = 1024 * 1024 * 1024;
 
+/// The pre-A2 flat hosting budget (1 GiB) that older releases auto-persisted
+/// into `config.toml` as `max-hosting-storage = 1073741824`.
+///
+/// Used ONLY as the one-time upgrade-migration sentinel in
+/// `config::ConfigArgs::build`: a persisted value exactly equal to this is
+/// treated as the old auto-derived default (NOT an explicit operator choice) and
+/// re-derived from live RAM, so a small box that upgrades from a pre-A2 release
+/// stops carrying the pinned 1 GiB (#4565). Deliberately a SEPARATE constant
+/// from [`MAX_DEFAULT_HOSTING_BUDGET_BYTES`] even though they share a value
+/// today: the migration sentinel must stay 1 GiB even if the clamp ceiling
+/// later changes.
+pub const LEGACY_FLAT_HOSTING_BUDGET_BYTES: u64 = 1024 * 1024 * 1024;
+
 /// Fraction of total system RAM used to size the default hosting budget: 1/8.
 ///
 /// Mirrors the module cache's `DEFAULT_MODULE_CACHE_RAM_DIVISOR`. The divisor —
@@ -99,8 +112,9 @@ fn budget_for_ram(total_ram: u64) -> u64 {
 pub(crate) struct HostingCacheStats {
     /// Configured byte budget (the RAM-scaled default, or the operator override).
     pub budget_bytes: u64,
-    /// Current tracked contract-state bytes. Headroom ratio is
-    /// `current_bytes / budget_bytes`, derived by the collector.
+    /// Current tracked contract-state bytes. The occupancy (utilization) ratio
+    /// is `current_bytes / budget_bytes`; headroom is `1 - that`. The collector
+    /// derives whichever it wants from these two raw scalars.
     pub current_bytes: u64,
     /// Number of contracts currently in the hosting cache.
     pub contract_count: u64,

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -193,6 +193,17 @@ pub(crate) struct RouterSnapshotInfo {
     pub delegate_module_cache_total_bytes: Option<u64>,
     pub delegate_module_cache_budget_bytes: Option<u64>,
     pub delegate_module_cache_evictions_total: Option<u64>,
+    /// Capability-relative hosting-budget gauges (#4642 A2), populated by `Ring`
+    /// from the `HostingManager` on the snapshot cadence. `hosting_budget_bytes`
+    /// is the RAM-scaled default (or operator override); `hosting_current_bytes`
+    /// is the tracked contract-state occupancy (headroom ratio =
+    /// current / budget, derived by the collector); `hosting_budget_evictions_total`
+    /// is a monotonic counter the collector differences to get a budget-triggered
+    /// eviction rate. `None` until the ring is built. Per-node aggregate scalars.
+    pub hosting_budget_bytes: Option<u64>,
+    pub hosting_current_bytes: Option<u64>,
+    pub hosting_contract_count: Option<u64>,
+    pub hosting_budget_evictions_total: Option<u64>,
     /// Interest-weighted (two-tier) module-cache SHADOW gauges (#4441/#4534),
     /// populated by `Ring` from the same per-node `ModuleCacheMetrics` `Arc`.
     /// These are ALWAYS ON, independent of the `FREENET_MODULE_CACHE_INTEREST_TIERED`
@@ -1087,6 +1098,12 @@ impl Router {
             delegate_module_cache_total_bytes: None,
             delegate_module_cache_budget_bytes: None,
             delegate_module_cache_evictions_total: None,
+            // Capability-relative hosting-budget gauges populated by Ring on the
+            // snapshot cadence (#4642 A2).
+            hosting_budget_bytes: None,
+            hosting_current_bytes: None,
+            hosting_contract_count: None,
+            hosting_budget_evictions_total: None,
             // Interest-weighted (two-tier) module-cache shadow gauges,
             // populated by Ring on the snapshot cadence (#4441/#4534).
             contract_module_cache_cold_evictable_bytes: None,

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -196,10 +196,11 @@ pub(crate) struct RouterSnapshotInfo {
     /// Capability-relative hosting-budget gauges (#4642 A2), populated by `Ring`
     /// from the `HostingManager` on the snapshot cadence. `hosting_budget_bytes`
     /// is the RAM-scaled default (or operator override); `hosting_current_bytes`
-    /// is the tracked contract-state occupancy (headroom ratio =
-    /// current / budget, derived by the collector); `hosting_budget_evictions_total`
-    /// is a monotonic counter the collector differences to get a budget-triggered
-    /// eviction rate. `None` until the ring is built. Per-node aggregate scalars.
+    /// is the tracked contract-state occupancy (occupancy/utilization ratio =
+    /// current / budget, headroom = 1 - that; derived by the collector);
+    /// `hosting_budget_evictions_total` is a monotonic counter the collector
+    /// differences to get a budget-triggered eviction rate. `None` until the ring
+    /// is built. Per-node aggregate scalars.
     pub hosting_budget_bytes: Option<u64>,
     pub hosting_current_bytes: Option<u64>,
     pub hosting_contract_count: Option<u64>,

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2101,6 +2101,28 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "renewal_terminus_satisfied".to_string(),
                     serde_json::json!(snapshot.renewal_terminus_satisfied),
                 );
+                // Capability-relative hosting-budget gauges (#4642 A2). Inserted
+                // here (not as inline `json!` keys) to keep the macro under its
+                // recursion limit, same as the gauges above — but this body is
+                // still hand-mirrored, so a new `RouterSnapshotInfo` field is
+                // invisible to the collector unless added here. Pinned by
+                // `router_snapshot_json_includes_hosting_budget_gauges`.
+                obj.insert(
+                    "hosting_budget_bytes".to_string(),
+                    serde_json::json!(snapshot.hosting_budget_bytes),
+                );
+                obj.insert(
+                    "hosting_current_bytes".to_string(),
+                    serde_json::json!(snapshot.hosting_current_bytes),
+                );
+                obj.insert(
+                    "hosting_contract_count".to_string(),
+                    serde_json::json!(snapshot.hosting_contract_count),
+                );
+                obj.insert(
+                    "hosting_budget_evictions_total".to_string(),
+                    serde_json::json!(snapshot.hosting_budget_evictions_total),
+                );
             }
             body
         }
@@ -2265,6 +2287,31 @@ mod tests {
             ("delegate_module_cache_total_bytes", 23),
             ("delegate_module_cache_budget_bytes", 29),
             ("delegate_module_cache_evictions_total", 31),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
+    }
+
+    /// Pin: the capability-relative hosting-budget gauges (#4642 A2) must also
+    /// reach the hand-mirrored OTLP body — same footgun as the gauges above. A
+    /// silent drop would re-blind us to whether the RAM-scaled budget keeps a
+    /// small box off the #4565 OOM path (the whole point of instrumenting A2).
+    #[test]
+    fn router_snapshot_json_includes_hosting_budget_gauges() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.hosting_budget_bytes = Some(257);
+        info.hosting_current_bytes = Some(263);
+        info.hosting_contract_count = Some(269);
+        info.hosting_budget_evictions_total = Some(271);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        for (key, want) in [
+            ("hosting_budget_bytes", 257),
+            ("hosting_current_bytes", 263),
+            ("hosting_contract_count", 269),
+            ("hosting_budget_evictions_total", 271),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }

--- a/crates/core/src/wasm_runtime/module_cache.rs
+++ b/crates/core/src/wasm_runtime/module_cache.rs
@@ -1111,9 +1111,10 @@ pub const MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES: usize = 64 * 1024 * 1024;
 ///   canonical case: `total_ram / 8` is ~15 GiB, so the *only* thing capping
 ///   its default cache was this clamp, and 384 MiB was well below its working
 ///   set. 1.5 GiB holds ~1000 modules at the measured size — comfortably above
-///   a healthy gateway's hot set — and matches the 1 GiB default hosted-*state*
-///   budget (`ring::DEFAULT_HOSTING_BUDGET_BYTES`): a node allowed ~1 GiB of
-///   contract state should be able to cache the corresponding compiled code.
+///   a healthy gateway's hot set — and matches the ceiling of the RAM-scaled
+///   hosted-*state* budget (`ring::MAX_DEFAULT_HOSTING_BUDGET_BYTES`, 1 GiB):
+///   a node allowed ~1 GiB of contract state should be able to cache the
+///   corresponding compiled code.
 /// - **Too high → wasted memory on huge hosts.** Past ~1000 resident modules
 ///   the working-set benefit flattens while absolute memory cost keeps rising.
 ///   Without a ceiling, `total_ram / 8` would default a 125 GiB box to a


### PR DESCRIPTION
> **PARKED for Ian's review — do NOT merge without his sign-off.** (Was stacked on #4643/A1, now merged; this branch was rebased onto `main` and the base retargeted to `main`.)

Piece **A2** of the demand-driven hosting redesign (epic #4642; design spec `docs/design/hosting-eviction.md`, invariants `.claude/rules/hosting-invariants.md`).

## Problem
The hosting-storage budget was a flat 1 GiB default applied to every node regardless of the memory it actually has. On a small box (2 GB VM, laptop) that lets the node accumulate ~1 GiB of hosted contract state on top of the module caches, WASM arenas, and transport buffers, driving gateway RSS toward OOM (#4565). The budget was not sized by the node's own scarcest resource — the first thing the redesign needs.

## Approach
Make **only the DEFAULT** budget capability-relative; keep the existing byte-LRU eviction **policy** unchanged (the demand-driven fuel gauge is A3, a separate later PR).

- `cache::default_hosting_budget_bytes()` = `clamp(read_total_ram_bytes() / 8, 128 MiB, 1 GiB)`, reusing the `min(host RAM, cgroup limit)` source A1 exposed. `budget_for_ram()` splits the pure clamp math out for testing.
- **Heeds #4441:** the budget is RAM-scaled, **not** a fixed count/constant (the old fixed `>1024`-contract cap thrashed/OOM'd). The **divisor**, not the ceiling, is the small-box protection; the ceiling equals the historical flat 1 GiB, so a host with `>= 8 GiB` RAM sees **no change** and only memory-constrained hosts get less. Mirrors `module_cache.rs::budget_for_ram`.
- **Operator override preserved:** an explicit `max_hosting_storage` (flag / config / env) still wins; only the DEFAULT changed.

### Re-derive on each boot (first-boot + upgrade persistence, #4565)
`build()` serializes the resolved `Config` into `config.toml`, so the auto-derived budget would be **pinned** — a node that first-booted (or was on a pre-A2 release) on a large box would keep the large budget after moving to a smaller box / tighter cgroup, defeating the whole point. Fixed in two parts:
- `skip_serializing_if = "is_default_hosting_budget"` omits the auto-derived value from `config.toml`, so each boot re-derives from live RAM (fresh configs).
- A one-time upgrade migration in `ConfigArgs::build` re-derives a **file** value equal to the pre-A2 flat 1 GiB sentinel (`LEGACY_FLAT_HOSTING_BUDGET_BYTES`), so existing gateways stop carrying the pinned 1 GiB. CLI/env explicit values are parsed before the file merge, so they still win.

## Instrumentation (mandatory per the spec's horizontal-instrumentation rule)
Per-node aggregate scalars added to the existing `RouterSnapshot` telemetry (same home as the module-cache budget/eviction gauges): `hosting_budget_bytes`, `hosting_current_bytes` (occupancy ratio = `current / budget`, derived by the collector), `hosting_contract_count`, and a monotonic `hosting_budget_evictions_total`. Per-node scalars only, no per-contract firehose. `HostingCache` gained a `budget_evictions_total` counter (incremented only in `evict_over_budget`) and a `stats()` snapshot.

## Testing
- `cache.rs`: `budget_for_ram` scales-and-clamps; **#4441 shape guard** (RAM-scaled not fixed; small box < large box, and < old flat 1 GiB); default within clamp; budget-eviction counter + `stats()`.
- `config.rs`: RAM-scaled default within `[MIN, MAX]`; auto value not persisted + re-derives; **upgrade migration** re-derives the legacy 1 GiB sentinel while an explicit non-legacy value survives; explicit override round-trips; persisted-fields round-trip guard.
- `telemetry.rs`: pin test that all four hosting gauges reach the OTLP body.
- `cargo fmt`, both CI clippy gates, `cargo check -p freenet` green.

## Fixes
Refs #4642. Addresses #4565.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01LnRCbtbjepaB5GWrb5U8SR