### PR TITLE
feat: consult host advertisements at routing terminus

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3246,6 +3246,11 @@ std::thread_local! {
     static GLOBAL_PENDING_OP_HWM: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_NEIGHBOR_HOSTING_UPDATES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_ANTI_STARVATION_TRIGGERS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    // Terminal advertisement consult (hosting redesign piece C, invariant 5).
+    static GLOBAL_TERMINAL_CONSULT_ATTEMPTS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_TERMINAL_CONSULT_HITS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_TERMINAL_CONSULT_RESOLVED_FOUND: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_TERMINAL_CONSULT_STILL_NOT_FOUND: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
 /// Global test metrics for tracking events across the simulation network.
@@ -3280,6 +3285,10 @@ impl GlobalTestMetrics {
         GLOBAL_PENDING_OP_HWM.with(|c| c.set(0));
         GLOBAL_NEIGHBOR_HOSTING_UPDATES.with(|c| c.set(0));
         GLOBAL_ANTI_STARVATION_TRIGGERS.with(|c| c.set(0));
+        GLOBAL_TERMINAL_CONSULT_ATTEMPTS.with(|c| c.set(0));
+        GLOBAL_TERMINAL_CONSULT_HITS.with(|c| c.set(0));
+        GLOBAL_TERMINAL_CONSULT_RESOLVED_FOUND.with(|c| c.set(0));
+        GLOBAL_TERMINAL_CONSULT_STILL_NOT_FOUND.with(|c| c.set(0));
     }
 
     /// Records that a ResyncRequest was received.
@@ -3354,6 +3363,55 @@ impl GlobalTestMetrics {
 
     pub fn anti_starvation_triggers() -> u64 {
         GLOBAL_ANTI_STARVATION_TRIGGERS.with(|c| c.get())
+    }
+
+    // --- Terminal advertisement consult (hosting redesign piece C) ---
+    //
+    // Aggregate scalars measuring whether the terminal consult actually
+    // closes findability dead-ends (invariant 5). Thread-local, so under
+    // the single-threaded simulation runner they aggregate across all sim
+    // nodes and a test can assert the consult path fired. Production
+    // per-node scalars live in `node::network_status` (RwLock global).
+
+    /// A routing terminus consulted its neighbor host-advertisements for
+    /// the target key before giving up (one increment per terminus, not
+    /// per advertised host tried).
+    pub fn record_terminal_consult_attempt() {
+        GLOBAL_TERMINAL_CONSULT_ATTEMPTS.with(|c| c.set(c.get() + 1));
+    }
+
+    pub fn terminal_consult_attempts() -> u64 {
+        GLOBAL_TERMINAL_CONSULT_ATTEMPTS.with(|c| c.get())
+    }
+
+    /// The consult found at least one advertised host to forward to
+    /// (a candidate off the direct routing path).
+    pub fn record_terminal_consult_hit() {
+        GLOBAL_TERMINAL_CONSULT_HITS.with(|c| c.set(c.get() + 1));
+    }
+
+    pub fn terminal_consult_hits() -> u64 {
+        GLOBAL_TERMINAL_CONSULT_HITS.with(|c| c.get())
+    }
+
+    /// A consult forward resolved the request to Found/Subscribed —
+    /// a dead-end that the consult actually closed.
+    pub fn record_terminal_consult_resolved_found() {
+        GLOBAL_TERMINAL_CONSULT_RESOLVED_FOUND.with(|c| c.set(c.get() + 1));
+    }
+
+    pub fn terminal_consult_resolved_found() -> u64 {
+        GLOBAL_TERMINAL_CONSULT_RESOLVED_FOUND.with(|c| c.get())
+    }
+
+    /// A consult ran but the request still ended NotFound (no advertised
+    /// host, or every advertised host also failed).
+    pub fn record_terminal_consult_still_not_found() {
+        GLOBAL_TERMINAL_CONSULT_STILL_NOT_FOUND.with(|c| c.set(c.get() + 1));
+    }
+
+    pub fn terminal_consult_still_not_found() -> u64 {
+        GLOBAL_TERMINAL_CONSULT_STILL_NOT_FOUND.with(|c| c.get())
     }
 }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -328,6 +328,19 @@ pub struct NodeConfig {
     /// `#[serde(skip)]`; never serialized.
     #[serde(skip)]
     pub(crate) subscribe_hint_floor_override: Option<(u8, u8, u16)>,
+    /// Test-only harness flag: when set, a startup-hosted contract
+    /// (`SeedHostedContract`, i.e. `append_contracts` with `subscription =
+    /// true`) is registered in the neighbor-hosting advertised set so the
+    /// connection-established `HostingStateResponse` exchange advertises it to
+    /// neighbors. Defaults to `false` — the harness's historical behavior, so
+    /// a seeded host does NOT advertise and a key-routed GET to a
+    /// non-hosting region still dead-ends (the migration dead-end controls
+    /// depend on this). Opted into per-network via
+    /// `SimNetwork::enable_seeded_host_advertisements` for tests that exercise
+    /// the terminal advertisement consult. Not cfg-gated for the same reason
+    /// as `subscribe_hint_floor_override`. `#[serde(skip)]`.
+    #[serde(skip)]
+    pub(crate) advertise_seeded_hosts: bool,
 }
 
 impl NodeConfig {
@@ -465,6 +478,7 @@ impl NodeConfig {
             },
             governance_config_override: None,
             subscribe_hint_floor_override: None,
+            advertise_seeded_hosts: false,
         })
     }
 

--- a/crates/core/src/node/neighbor_hosting.rs
+++ b/crates/core/src/node/neighbor_hosting.rs
@@ -332,8 +332,20 @@ impl NeighborHostingManager {
     /// so callers can resolve to current addresses via ConnectionManager.
     /// Used by UPDATE operations to find additional targets beyond explicit subscribers.
     pub fn neighbors_with_contract(&self, contract_key: &ContractKey) -> Vec<TransportPublicKey> {
-        let contract_id = contract_key.id();
+        self.neighbors_with_contract_id(contract_key.id())
+    }
 
+    /// Same as [`Self::neighbors_with_contract`] but keyed by
+    /// [`ContractInstanceId`] directly.
+    ///
+    /// Relay operation drivers (GET / SUBSCRIBE) carry the `instance_id`
+    /// on the wire rather than a full `ContractKey`, so the terminal
+    /// advertisement consult (invariant 5: "findability is routing +
+    /// on-demand advertisement") looks up advertised hosts by id.
+    pub fn neighbors_with_contract_id(
+        &self,
+        contract_id: &ContractInstanceId,
+    ) -> Vec<TransportPublicKey> {
         let mut neighbors: Vec<TransportPublicKey> = self
             .neighbor_contracts
             .iter()
@@ -358,7 +370,7 @@ impl NeighborHostingManager {
 
         if !neighbors.is_empty() {
             debug!(
-                contract = %contract_key,
+                contract = %contract_id,
                 neighbor_count = neighbors.len(),
                 "NEIGHBOR_HOSTING: Found neighbors with contract"
             );
@@ -534,6 +546,40 @@ mod tests {
         let neighbors = manager.neighbors_with_contract(&key);
         assert_eq!(neighbors.len(), 1);
         assert_eq!(neighbors[0], neighbor);
+    }
+
+    #[test]
+    fn test_neighbors_with_contract_id_matches_key_lookup() {
+        // The terminal advertisement consult (piece C) looks up advertised
+        // hosts by ContractInstanceId; it must return the same neighbors as
+        // the ContractKey-keyed method.
+        let manager = NeighborHostingManager::new();
+        let key = test_contract_key();
+        let neighbor = make_pub_key(1);
+
+        assert!(manager.neighbors_with_contract_id(key.id()).is_empty());
+
+        manager.handle_message(
+            &neighbor,
+            NeighborHostingMessage::HostingAnnounce {
+                added: vec![*key.id()],
+                removed: vec![],
+                is_response: false,
+            },
+        );
+
+        let by_id = manager.neighbors_with_contract_id(key.id());
+        let by_key = manager.neighbors_with_contract(&key);
+        assert_eq!(by_id, by_key);
+        assert_eq!(by_id.len(), 1);
+        assert_eq!(by_id[0], neighbor);
+
+        // A contract no neighbor advertised yields no hosts.
+        assert!(
+            manager
+                .neighbors_with_contract_id(test_contract_key_2().id())
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -166,6 +166,28 @@ pub struct NetworkStatus {
     pub op_stats: OperationStats,
     /// NAT traversal counters.
     pub nat_stats: NatStats,
+    /// Terminal advertisement-consult counters (hosting redesign piece C).
+    pub terminal_consult_stats: TerminalConsultStats,
+}
+
+/// Per-node counters for the terminal advertisement consult (invariant 5:
+/// "findability is routing + on-demand advertisement").
+///
+/// A GET/SUBSCRIBE that routes to a terminus (closest peer it can reach,
+/// can't route closer) consults the host-advertisements its neighbors sent
+/// before returning NotFound. These scalars measure whether that consult
+/// actually closes dead-ends. Per-node aggregate only — no per-contract
+/// breakdown.
+#[derive(Default)]
+pub struct TerminalConsultStats {
+    /// A terminus consulted its neighbor advertisements (one per terminus).
+    pub attempts: u64,
+    /// The consult found at least one advertised host to forward to.
+    pub hits: u64,
+    /// A consult forward resolved the request to Found/Subscribed.
+    pub resolved_found: u64,
+    /// A consult ran but the request still ended NotFound.
+    pub still_not_found: u64,
 }
 
 /// A connected peer with metadata.
@@ -307,6 +329,7 @@ pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: St
         external_address: None,
         op_stats: OperationStats::default(),
         nat_stats: NatStats::default(),
+        terminal_consult_stats: TerminalConsultStats::default(),
     };
     match NETWORK_STATUS.get() {
         // Already initialized: overwrite the existing tracker in place so
@@ -457,6 +480,46 @@ pub fn record_update_received() {
     if let Some(status) = NETWORK_STATUS.get() {
         if let Ok(mut s) = status.write() {
             s.op_stats.updates_received = s.op_stats.updates_received.saturating_add(1);
+        }
+    }
+}
+
+/// Record that a routing terminus consulted its neighbor advertisements
+/// (hosting redesign piece C). One increment per terminus, regardless of
+/// how many advertised hosts it then tries.
+pub fn record_terminal_consult_attempt() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.terminal_consult_stats.attempts = s.terminal_consult_stats.attempts.saturating_add(1);
+        }
+    }
+}
+
+/// Record that a consult found at least one advertised host to forward to.
+pub fn record_terminal_consult_hit() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.terminal_consult_stats.hits = s.terminal_consult_stats.hits.saturating_add(1);
+        }
+    }
+}
+
+/// Record that a consult forward resolved the request to Found/Subscribed.
+pub fn record_terminal_consult_resolved_found() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.terminal_consult_stats.resolved_found =
+                s.terminal_consult_stats.resolved_found.saturating_add(1);
+        }
+    }
+}
+
+/// Record that a consult ran but the request still ended NotFound.
+pub fn record_terminal_consult_still_not_found() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.terminal_consult_stats.still_not_found =
+                s.terminal_consult_stats.still_not_found.saturating_add(1);
         }
     }
 }

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -1349,6 +1349,28 @@ impl SimNetwork {
         self
     }
 
+    /// Opt this simulation into advertising startup-hosted contracts
+    /// (`SeedHostedContract`) through the neighbor-hosting mesh, so the
+    /// terminal advertisement consult (hosting redesign piece C, invariant 5)
+    /// can find a seeded off-path host.
+    ///
+    /// OFF by default: a seeded host does NOT advertise (the harness's
+    /// historical behavior), so a key-routed GET to a non-hosting region still
+    /// dead-ends — which the migration dead-end controls rely on. A test that
+    /// exercises the consult opts in here. Patches the already-built
+    /// node/gateway configs, mirroring
+    /// [`enable_placement_migration`](Self::enable_placement_migration).
+    #[allow(dead_code)]
+    pub fn enable_seeded_host_advertisements(&mut self) -> &mut Self {
+        for (builder, _) in self.gateways.iter_mut() {
+            builder.config.advertise_seeded_hosts = true;
+        }
+        for (builder, _) in self.nodes.iter_mut() {
+            builder.config.advertise_seeded_hosts = true;
+        }
+        self
+    }
+
     /// Force the placement-migration (`SubscribeHint`) cascade OFF for this
     /// simulation by pinning the per-node version floor to the unreachable
     /// [`Self::SIM_MIGRATION_DISABLED_FLOOR`].

--- a/crates/core/src/node/testing_impl/in_memory.rs
+++ b/crates/core/src/node/testing_impl/in_memory.rs
@@ -128,7 +128,13 @@ impl<ER> Builder<ER> {
         .await?;
 
         // Append contracts before starting
-        append_contracts(&op_manager, self.contracts, self.contract_subscribers).await?;
+        append_contracts(
+            &op_manager,
+            self.contracts,
+            self.contract_subscribers,
+            self.config.advertise_seeded_hosts,
+        )
+        .await?;
 
         // Inject any pre-formed ring connections (topology preseed, #4233) before
         // the event loop starts, so a wide direct star exists at t=0 without the
@@ -266,7 +272,13 @@ impl<ER> Builder<ER> {
         .await?;
 
         // Append contracts before starting
-        append_contracts(&op_manager, self.contracts, self.contract_subscribers).await?;
+        append_contracts(
+            &op_manager,
+            self.contracts,
+            self.contract_subscribers,
+            self.config.advertise_seeded_hosts,
+        )
+        .await?;
 
         // Inject any pre-formed ring connections (topology preseed, #4233) before
         // the event loop starts, so a wide direct star exists at t=0 without the
@@ -403,7 +415,13 @@ impl<ER> Builder<ER> {
         .await?;
 
         // Append contracts before starting
-        append_contracts(&op_manager, self.contracts, self.contract_subscribers).await?;
+        append_contracts(
+            &op_manager,
+            self.contracts,
+            self.contract_subscribers,
+            self.config.advertise_seeded_hosts,
+        )
+        .await?;
 
         // Inject any pre-formed ring connections (topology preseed, #4233) before
         // the event loop starts, so a wide direct star exists at t=0 without the
@@ -463,6 +481,7 @@ async fn append_contracts(
     op_manager: &Arc<OpManager>,
     contracts: Vec<(ContractContainer, WrappedState, bool)>,
     _contract_subscribers: HashMap<ContractKey, Vec<PeerKeyLocation>>,
+    advertise_seeded_hosts: bool,
 ) -> anyhow::Result<()> {
     use crate::contract::ContractHandlerEvent;
     for (contract, state, subscription) in contracts {
@@ -487,17 +506,26 @@ async fn append_contracts(
                 .host_contract(key, state_size, crate::ring::AccessType::Put);
             // In the new lease-based model, register an active subscription
             op_manager.ring.subscribe(key);
-            // Register the contract in the neighbor-hosting advertised set so
-            // the connection-established HostingStateResponse exchange
-            // advertises it to neighbors. Without this, a startup-hosted
-            // contract (SeedHostedContract) leaves `my_contracts` empty and
-            // neighbors never learn this node hosts it — which the terminal
-            // advertisement consult (and UPDATE proximity forwarding) rely on.
-            // Mirrors the production announce that fires on first-time PUT/GET
-            // hosting; the returned announcement is dropped because the node
-            // has no ring connections yet at startup (the exchange runs later,
-            // on connection-established).
-            let _ = op_manager.neighbor_hosting.on_contract_hosted(&key);
+            // OPT-IN (default off): register the contract in the
+            // neighbor-hosting advertised set so the connection-established
+            // HostingStateResponse exchange advertises it to neighbors.
+            //
+            // Without this, a startup-hosted contract (SeedHostedContract)
+            // leaves `my_contracts` empty and neighbors never learn this node
+            // hosts it. That matches the harness's historical behavior, so it
+            // stays the default — existing tests (e.g. the migration dead-end
+            // controls) rely on a seeded host NOT advertising, which keeps a
+            // key-routed GET dead-ending. A test that needs the seeded host to
+            // genuinely advertise (so the terminal advertisement consult can
+            // reach it) opts in via
+            // `SimNetwork::enable_seeded_host_advertisements`.
+            //
+            // The returned announcement is dropped because the node has no ring
+            // connections yet at startup (the exchange runs later, on
+            // connection-established).
+            if advertise_seeded_hosts {
+                let _ = op_manager.neighbor_hosting.on_contract_hosted(&key);
+            }
         }
         // Note: contract_subscribers is ignored in the new model.
         // Neighbor hosting handles peer-to-peer awareness for update propagation.

--- a/crates/core/src/node/testing_impl/in_memory.rs
+++ b/crates/core/src/node/testing_impl/in_memory.rs
@@ -487,6 +487,17 @@ async fn append_contracts(
                 .host_contract(key, state_size, crate::ring::AccessType::Put);
             // In the new lease-based model, register an active subscription
             op_manager.ring.subscribe(key);
+            // Register the contract in the neighbor-hosting advertised set so
+            // the connection-established HostingStateResponse exchange
+            // advertises it to neighbors. Without this, a startup-hosted
+            // contract (SeedHostedContract) leaves `my_contracts` empty and
+            // neighbors never learn this node hosts it — which the terminal
+            // advertisement consult (and UPDATE proximity forwarding) rely on.
+            // Mirrors the production announce that fires on first-time PUT/GET
+            // hosting; the returned announcement is dropped because the node
+            // has no ring connections yet at startup (the exchange runs later,
+            // on connection-established).
+            let _ = op_manager.neighbor_hosting.on_contract_hosted(&key);
         }
         // Note: contract_subscribers is ignored in the new model.
         // Neighbor hosting handles peer-to-peer awareness for update propagation.

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -294,6 +294,127 @@ pub(crate) async fn announce_contract_hosted(op_manager: &OpManager, key: &Contr
     }
 }
 
+/// Terminal advertisement consult (hosting redesign piece C, invariant 5:
+/// "findability is routing + on-demand advertisement").
+///
+/// A GET/SUBSCRIBE routes toward a contract's key and reaches a *terminus*
+/// — the closest peer it can route to, from which `k_closest_potentially_
+/// hosting` yields no closer candidate. Location routing is purely
+/// distance-based, so it never selects a neighbor that happens to host the
+/// contract but sits *off* the direct routing path (farther from the key).
+/// Before the terminus gives up with NotFound, it consults the host
+/// advertisements its neighbors already broadcast (`NeighborHostingManager`)
+/// and forwards the request to an advertised host if one exists.
+///
+/// This is NOT speculative pre-replication (invariant 5 forbids that): it
+/// only ever forwards to a peer that *already advertised* hosting the
+/// contract. It pushes and caches nothing and manufactures no demand.
+///
+/// Returns up to `max_hosts` connected advertised hosts, closest-to-key
+/// first, each paired with its resolved socket address. `is_excluded`
+/// screens out peers already tried/visited plus this node and the upstream
+/// (so the consult can reuse the caller's existing visited/dedup state and
+/// cannot loop back). Records the per-node consult attempt (and a hit when
+/// at least one usable host is returned) on both the production
+/// `network_status` scalars and the simulation-visible `GlobalTestMetrics`.
+pub(crate) fn consult_advertised_hosts(
+    op_manager: &OpManager,
+    instance_id: &ContractInstanceId,
+    max_hosts: usize,
+    is_excluded: impl Fn(std::net::SocketAddr) -> bool,
+) -> Vec<(PeerKeyLocation, std::net::SocketAddr)> {
+    crate::config::GlobalTestMetrics::record_terminal_consult_attempt();
+    crate::node::network_status::record_terminal_consult_attempt();
+
+    // Resolve advertised neighbor pub keys to currently-connected peers.
+    let advertised: Vec<PeerKeyLocation> = op_manager
+        .neighbor_hosting
+        .neighbors_with_contract_id(instance_id)
+        .into_iter()
+        .filter_map(|pub_key| {
+            op_manager
+                .ring
+                .connection_manager
+                .get_peer_by_pub_key(&pub_key)
+        })
+        .collect();
+
+    let hosts = rank_advertised_hosts(
+        Location::from(instance_id),
+        advertised,
+        max_hosts,
+        is_excluded,
+    );
+
+    if !hosts.is_empty() {
+        crate::config::GlobalTestMetrics::record_terminal_consult_hit();
+        crate::node::network_status::record_terminal_consult_hit();
+        tracing::debug!(
+            %instance_id,
+            advertised_hosts = hosts.len(),
+            "TERMINAL_CONSULT: found advertised host(s) off the routing path"
+        );
+    }
+
+    hosts
+}
+
+/// Pure ranking core of [`consult_advertised_hosts`], split out for unit
+/// testing. Filters `advertised` to peers with a routable address and a
+/// location that `is_excluded` does not reject, orders them closest-to-key
+/// first (deterministic address tie-break), and returns at most `max_hosts`.
+fn rank_advertised_hosts(
+    target: Location,
+    advertised: Vec<PeerKeyLocation>,
+    max_hosts: usize,
+    is_excluded: impl Fn(std::net::SocketAddr) -> bool,
+) -> Vec<(PeerKeyLocation, std::net::SocketAddr)> {
+    let mut candidates: Vec<(PeerKeyLocation, std::net::SocketAddr, Location)> = advertised
+        .into_iter()
+        .filter_map(|peer| {
+            // Need a routable address AND a location to rank by; an
+            // addressless advertised host cannot be a wire target.
+            let addr = peer.socket_addr()?;
+            let loc = peer.location()?;
+            if is_excluded(addr) {
+                return None;
+            }
+            Some((peer, addr, loc))
+        })
+        .collect();
+
+    // Deterministic ordering: closest to the key first, tie-break on addr so
+    // the pick is stable across runs (DashMap iteration is not).
+    candidates.sort_by(|(_, a_addr, a_loc), (_, b_addr, b_loc)| {
+        a_loc
+            .distance(target)
+            .partial_cmp(&b_loc.distance(target))
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a_addr.cmp(b_addr))
+    });
+    candidates.truncate(max_hosts);
+
+    candidates
+        .into_iter()
+        .map(|(peer, addr, _loc)| (peer, addr))
+        .collect()
+}
+
+/// Record the terminal outcome of a consult that ran at a terminus:
+/// `resolved_found = true` when a consult forward closed the dead-end
+/// (Found/Subscribed), `false` when the request still ended NotFound.
+/// Mirrors to both the production `network_status` scalars and the
+/// simulation-visible `GlobalTestMetrics`.
+pub(crate) fn record_terminal_consult_outcome(resolved_found: bool) {
+    if resolved_found {
+        crate::config::GlobalTestMetrics::record_terminal_consult_resolved_found();
+        crate::node::network_status::record_terminal_consult_resolved_found();
+    } else {
+        crate::config::GlobalTestMetrics::record_terminal_consult_still_not_found();
+        crate::node::network_status::record_terminal_consult_still_not_found();
+    }
+}
+
 /// Reclaim the on-disk storage of a contract that was evicted from the
 /// hosting cache. Skips contracts that are still in use — an active client
 /// subscription or a downstream peer subscriber means something still
@@ -1208,5 +1329,111 @@ mod egress_banned_gate_tests {
             reject_if_contract_banned_on(&bl, &contract).is_ok(),
             "contract must pass the gate once its ban TTL has expired"
         );
+    }
+}
+
+#[cfg(test)]
+mod terminal_consult_tests {
+    //! Unit tests for the pure ranking core of the terminal advertisement
+    //! consult (hosting redesign piece C, invariant 5). The end-to-end
+    //! behaviour (a GET whose only host is one hop off the routing path)
+    //! is covered by the simulation test
+    //! `test_terminal_advertisement_consult_closes_get_dead_end`.
+    use super::rank_advertised_hosts;
+    use crate::ring::{Location, PeerKeyLocation};
+    use crate::transport::TransportKeypair;
+    use std::net::SocketAddr;
+
+    // Loopback addresses so `Location::from_address` differentiates by port
+    // (it masks the last IP byte for non-loopback addresses, which would
+    // collapse distinct hosts onto one ring location).
+    fn peer_at(addr: &str) -> PeerKeyLocation {
+        let addr: SocketAddr = addr.parse().unwrap();
+        PeerKeyLocation::new(TransportKeypair::new().public().clone(), addr)
+    }
+
+    #[test]
+    fn ranks_closest_advertised_host_to_key_first() {
+        let a = peer_at("127.0.0.1:1000");
+        let b = peer_at("127.0.0.1:2000");
+        let c = peer_at("127.0.0.1:3000");
+        // Target = location of peer `b`'s address, so `b` is the closest
+        // advertised host and must rank first regardless of input order.
+        let target = b.location().unwrap();
+
+        let ranked =
+            rank_advertised_hosts(target, vec![a.clone(), b.clone(), c.clone()], 3, |_| false);
+
+        assert_eq!(ranked.len(), 3);
+        assert_eq!(
+            ranked[0].0.pub_key(),
+            b.pub_key(),
+            "the advertised host closest to the key must be returned first"
+        );
+    }
+
+    #[test]
+    fn truncates_to_max_hosts() {
+        let peers = vec![
+            peer_at("127.0.0.1:1000"),
+            peer_at("127.0.0.1:2000"),
+            peer_at("127.0.0.1:3000"),
+        ];
+        let target = Location::from_address(&"127.0.0.1:9000".parse().unwrap());
+
+        let ranked = rank_advertised_hosts(target, peers, 2, |_| false);
+        assert_eq!(ranked.len(), 2, "must return at most max_hosts candidates");
+    }
+
+    #[test]
+    fn excludes_filtered_addresses() {
+        let keep = peer_at("127.0.0.1:1000");
+        let skip = peer_at("127.0.0.1:2000");
+        let skip_addr = skip.socket_addr().unwrap();
+        let target = Location::from_address(&"127.0.0.1:9000".parse().unwrap());
+
+        let ranked =
+            rank_advertised_hosts(target, vec![keep.clone(), skip.clone()], 5, move |addr| {
+                addr == skip_addr
+            });
+
+        assert_eq!(
+            ranked.len(),
+            1,
+            "the excluded (already-visited) host must be dropped"
+        );
+        assert_eq!(ranked[0].0.pub_key(), keep.pub_key());
+        assert!(
+            ranked.iter().all(|(_, addr)| *addr != skip_addr),
+            "the excluded address must never be returned as a forward target"
+        );
+    }
+
+    #[test]
+    fn empty_when_no_advertised_hosts() {
+        let target = Location::from_address(&"127.0.0.1:9000".parse().unwrap());
+        let ranked = rank_advertised_hosts(target, vec![], 2, |_| false);
+        assert!(ranked.is_empty());
+    }
+
+    #[test]
+    fn terminal_consult_metrics_reset_and_increment() {
+        use crate::config::GlobalTestMetrics;
+        GlobalTestMetrics::reset();
+        assert_eq!(GlobalTestMetrics::terminal_consult_attempts(), 0);
+        assert_eq!(GlobalTestMetrics::terminal_consult_hits(), 0);
+        assert_eq!(GlobalTestMetrics::terminal_consult_resolved_found(), 0);
+        assert_eq!(GlobalTestMetrics::terminal_consult_still_not_found(), 0);
+
+        GlobalTestMetrics::record_terminal_consult_attempt();
+        GlobalTestMetrics::record_terminal_consult_hit();
+        super::record_terminal_consult_outcome(true);
+        super::record_terminal_consult_outcome(false);
+
+        assert_eq!(GlobalTestMetrics::terminal_consult_attempts(), 1);
+        assert_eq!(GlobalTestMetrics::terminal_consult_hits(), 1);
+        assert_eq!(GlobalTestMetrics::terminal_consult_resolved_found(), 1);
+        assert_eq!(GlobalTestMetrics::terminal_consult_still_not_found(), 1);
+        GlobalTestMetrics::reset();
     }
 }

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -2805,14 +2805,22 @@ where
     // its Found reply is attributed to the consult telemetry, not routing).
     // Assigned by every non-returning arm of the peer-selection match below.
     let mut consult_active: bool;
-    // Guards against recording more than one terminal consult outcome.
-    let mut consult_resolved_recorded = false;
     // True when the most recent forward on `incoming_tx` produced NO reply
     // (timeout or send-failure). In that state the awaited peer may still send
     // a LATE reply on the reused tx, which would satisfy a freshly-registered
     // consult waiter and bubble a false result — so we do NOT consult after a
     // failed forward (Codex P2). Reset by any forward that received a reply.
     let mut last_forward_failed = false;
+    // True once at least one location-routing forward has happened. When
+    // `relay_advance_to_next_peer` returns None on the FIRST iteration (no
+    // routing candidate at all), consulting is a no-op — every advertised host
+    // is either a visited connection (excluded) or a not-ready/transient one
+    // that k_closest deliberately skips — so we skip the consult there for
+    // counter accuracy and parity with SUBSCRIBE's `candidates.is_empty()`
+    // branch. The consult's value is reaching an unvisited advertised neighbor
+    // the single greedy forward (MAX_RELAY_RETRIES) skipped, which requires a
+    // routing forward to have occurred.
+    let mut did_forward = false;
 
     loop {
         // Pick next downstream peer.
@@ -2825,6 +2833,7 @@ where
         ) {
             Some(p) => {
                 consult_active = false;
+                did_forward = true;
                 p
             }
             None => {
@@ -2881,19 +2890,34 @@ where
                 // This does NOT re-introduce the removed 3^HTL per-hop retry
                 // fan-out: a *local* lookup gates the forward, so a
                 // truly-absent contract (no neighbor advertised it) triggers
-                // ZERO extra network forwards; an advertised host almost
-                // always HAS the contract, so the bubble-up halts at the first
-                // Found; and each relay adds at most MAX_TERMINAL_CONSULT_HOSTS
-                // forwards, only on the NotFound return path. It can fire at an
-                // intermediate relay (not only the deepest terminus), which is
-                // intended: the advertised host is a neighbor of THIS relay,
-                // invisible to the deeper terminus.
+                // ZERO extra network forwards; and each relay adds at most
+                // MAX_TERMINAL_CONSULT_HOSTS forwards, only on the NotFound
+                // return path. It can fire at an intermediate relay (not only
+                // the deepest terminus), which is intended: the advertised host
+                // is a neighbor of THIS relay, invisible to the deeper terminus.
+                //
+                // LOAD-BEARING assumption: "an advertised host almost always
+                // HAS the contract, so the bubble-up halts at the first Found."
+                // The rare exception is a host that evicted the contract but
+                // whose removal-announce (`on_contract_unhosted`) was lost while
+                // it is still a ring connection — the consult can then turn it
+                // into a re-routing relay (branching 1 → toward relay fan-out).
+                // That branching is bounded and does NOT recreate the 3^HTL
+                // tx-minting bug: (a) HTL-1 caps depth; (b) the visited bloom is
+                // carried on the forward so no peer is re-probed; (c) the
+                // consult only targets CURRENTLY-CONNECTED advertised peers; and
+                // (d) eviction retracts the advertisement, so the window is
+                // small and self-closing. If a future change weakens any of
+                // these, re-evaluate this site.
+                //
                 // Only consult when the previous forward received a reply; a
                 // timed-out / send-failed forward may still reply late on the
-                // reused tx and satisfy the consult waiter (Codex P2). In that
-                // case skip the consult entirely and report NotFound — the same
-                // outcome the relay produced before the consult existed.
-                let consult_candidate = if last_forward_failed {
+                // reused tx and satisfy the consult waiter (Codex P2). And only
+                // consult when a routing forward actually happened
+                // (`did_forward`) — a no-candidate terminus consult is a no-op
+                // (parity with SUBSCRIBE). Either way, skip the consult and
+                // report NotFound — the same outcome as before the consult.
+                let consult_candidate = if last_forward_failed || !did_forward {
                     None
                 } else {
                     let targets = consult_targets.get_or_insert_with(|| {
@@ -2928,8 +2952,10 @@ where
                     // advertised host was already tried / also failed). Record
                     // a still-not-found outcome only if a consult actually ran
                     // (`consult_targets` was built) — not when it was skipped
-                    // after a failed forward.
-                    if consult_targets.is_some() && !consult_resolved_recorded {
+                    // after a failed forward. A resolved consult would have
+                    // returned from the Found arm above, so this is reached
+                    // only when no consult forward succeeded.
+                    if consult_targets.is_some() {
                         crate::operations::record_terminal_consult_outcome(false);
                     }
                     tracing::warn!(
@@ -3129,21 +3155,15 @@ where
 
         // Classify the reply.
         let attempt_outcome = classify(reply);
-        // Terminal-consult telemetry: attribute a Found reply from a
-        // consulted advertised host as a closed dead-end. Guarded so a rare
-        // stream-claim failure on a consult candidate (which retries the next
-        // candidate) can't double-count. NotFound/Retry falls through and the
-        // exhaustion arm records the still-not-found outcome.
-        if consult_active
-            && !consult_resolved_recorded
-            && matches!(
-                attempt_outcome,
-                AttemptOutcome::Terminal(Terminal::InlineFound { .. } | Terminal::Streaming { .. })
-            )
-        {
-            crate::operations::record_terminal_consult_outcome(true);
-            consult_resolved_recorded = true;
-        }
+        // Terminal-consult telemetry is NOT recorded here: attributing a Found
+        // reply from a consulted host at classify time would be premature,
+        // because delivery of that Found can still fail by a fallible
+        // side-effect below — `send_result?` for InlineFound, `claim_or_wait`
+        // for Streaming (the #4345 "classify terminal before a fallible side
+        // effect" anti-pattern). `resolved_found` is instead recorded inside
+        // the InlineFound / Streaming arms AFTER that side-effect succeeds, so
+        // a send/claim failure correctly leaves the op to record
+        // still-not-found at the exhaustion arm.
         match attempt_outcome {
             AttemptOutcome::Terminal(Terminal::InlineFound {
                 key,
@@ -3209,6 +3229,13 @@ where
                 // cache).
                 cache_contract_locally(op_manager, key, state, contract, false).await;
                 send_result?;
+                // Delivery succeeded (`send_result?` did not return): a
+                // consulted advertised host closed the dead-end. Record now,
+                // AFTER the fallible upstream forward, not at classify time.
+                // This arm returns, so exactly one consult outcome is recorded.
+                if consult_active {
+                    crate::operations::record_terminal_consult_outcome(true);
+                }
                 return Ok(());
             }
             AttemptOutcome::Terminal(Terminal::Streaming {
@@ -3285,6 +3312,17 @@ where
                         continue;
                     }
                 };
+
+                // The claim succeeded, so delivery is now committed (loopback
+                // cache or upstream pipe below). A consulted advertised host
+                // that streams the contract has closed the dead-end — record
+                // here, AFTER the fallible `claim_or_wait`, not at classify
+                // time (a claim failure above `continue`s to the next
+                // candidate, so recording early would be a false positive).
+                // Every path from here returns, so exactly one outcome records.
+                if consult_active {
+                    crate::operations::record_terminal_consult_outcome(true);
+                }
 
                 // ── Step 2: Loopback safety net. If upstream IS us
                 //    (originator-loopback edge — rare), assemble + cache

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -2807,6 +2807,12 @@ where
     let mut consult_active: bool;
     // Guards against recording more than one terminal consult outcome.
     let mut consult_resolved_recorded = false;
+    // True when the most recent forward on `incoming_tx` produced NO reply
+    // (timeout or send-failure). In that state the awaited peer may still send
+    // a LATE reply on the reused tx, which would satisfy a freshly-registered
+    // consult waiter and bubble a false result — so we do NOT consult after a
+    // failed forward (Codex P2). Reset by any forward that received a reply.
+    let mut last_forward_failed = false;
 
     loop {
         // Pick next downstream peer.
@@ -2882,21 +2888,31 @@ where
                 // intermediate relay (not only the deepest terminus), which is
                 // intended: the advertised host is a neighbor of THIS relay,
                 // invisible to the deeper terminus.
-                let targets = consult_targets.get_or_insert_with(|| {
-                    let tried_snapshot = tried.clone();
-                    let visited_snapshot = new_visited.clone();
-                    crate::operations::consult_advertised_hosts(
-                        op_manager,
-                        &instance_id,
-                        MAX_TERMINAL_CONSULT_HOSTS,
-                        move |addr| {
-                            tried_snapshot.contains(&addr)
-                                || visited_snapshot.probably_visited(addr)
-                        },
-                    )
-                    .into_iter()
-                });
-                if let Some((consult_peer, consult_addr)) = targets.next() {
+                // Only consult when the previous forward received a reply; a
+                // timed-out / send-failed forward may still reply late on the
+                // reused tx and satisfy the consult waiter (Codex P2). In that
+                // case skip the consult entirely and report NotFound — the same
+                // outcome the relay produced before the consult existed.
+                let consult_candidate = if last_forward_failed {
+                    None
+                } else {
+                    let targets = consult_targets.get_or_insert_with(|| {
+                        let tried_snapshot = tried.clone();
+                        let visited_snapshot = new_visited.clone();
+                        crate::operations::consult_advertised_hosts(
+                            op_manager,
+                            &instance_id,
+                            MAX_TERMINAL_CONSULT_HOSTS,
+                            move |addr| {
+                                tried_snapshot.contains(&addr)
+                                    || visited_snapshot.probably_visited(addr)
+                            },
+                        )
+                        .into_iter()
+                    });
+                    targets.next()
+                };
+                if let Some((consult_peer, consult_addr)) = consult_candidate {
                     tried.push(consult_addr);
                     new_visited.mark_visited(consult_addr);
                     consult_active = true;
@@ -2909,8 +2925,11 @@ where
                     (consult_peer, consult_addr)
                 } else {
                     // Dead-end confirmed: no usable advertised host (or every
-                    // advertised host was already tried / also failed).
-                    if !consult_resolved_recorded {
+                    // advertised host was already tried / also failed). Record
+                    // a still-not-found outcome only if a consult actually ran
+                    // (`consult_targets` was built) — not when it was skipped
+                    // after a failed forward.
+                    if consult_targets.is_some() && !consult_resolved_recorded {
                         crate::operations::record_terminal_consult_outcome(false);
                     }
                     tracing::warn!(
@@ -3073,6 +3092,9 @@ where
                     crate::router::RouteOutcome::Failure,
                     crate::node::network_status::OpType::Get,
                 );
+                // No reply received — the awaited peer may reply late on the
+                // reused tx, so do NOT consult after this (Codex P2).
+                last_forward_failed = true;
                 // Continue loop to try next peer.
                 new_visited.mark_visited(peer_addr);
                 continue;
@@ -3091,10 +3113,19 @@ where
                     crate::router::RouteOutcome::Failure,
                     crate::node::network_status::OpType::Get,
                 );
+                // Timed out with no reply — the peer may reply late on the
+                // reused tx, so do NOT consult after this (Codex P2).
+                last_forward_failed = true;
                 new_visited.mark_visited(peer_addr);
                 continue;
             }
         };
+
+        // A reply was received on `incoming_tx` (the only path past the
+        // `round_trip` match), so the awaited peer will not reply late — it is
+        // safe to consult after this attempt (Codex P2). Reset regardless of
+        // how the reply classifies below.
+        last_forward_failed = false;
 
         // Classify the reply.
         let attempt_outcome = classify(reply);
@@ -4773,6 +4804,32 @@ mod tests {
         assert!(
             body.contains("record_terminal_consult_outcome"),
             "drive_relay_get_inner must record the terminal consult outcome"
+        );
+    }
+
+    /// Piece C P2 (Codex): the consult reuses `incoming_tx`, so it must NOT run
+    /// after a forward that got NO reply (timeout / send-failure) — a late
+    /// reply from the timed-out peer could satisfy the consult waiter and
+    /// bubble a false NotFound. Pin that both failure arms flag
+    /// `last_forward_failed` and the consult is gated on it.
+    #[test]
+    fn consult_skipped_after_failed_forward() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
+        // Both no-reply arms set the guard.
+        assert!(
+            body.matches("last_forward_failed = true").count() >= 2,
+            "both the send-failure and timeout arms must set last_forward_failed = true"
+        );
+        // A received reply clears it.
+        assert!(
+            body.contains("last_forward_failed = false"),
+            "a received reply must reset last_forward_failed so the consult can run"
+        );
+        // The consult is gated on the guard.
+        assert!(
+            body.contains("if last_forward_failed"),
+            "the consult must be gated on !last_forward_failed (skip after a no-reply forward)"
         );
     }
 

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1451,11 +1451,13 @@ async fn lookup_stored_key(
 /// touch unrelated code paths.
 const MAX_RETRIES: usize = 3;
 
-/// Maximum advertised hosts a routing terminus forwards to before giving up
-/// (hosting redesign piece C, invariant 5). Bounded small so the terminal
-/// consult adds at most a couple of extra forwards at a leaf of routing —
-/// see the consult site in `drive_relay_get_inner` for why this does not
-/// re-introduce the per-hop fan-out amplification.
+/// Maximum advertised hosts a relay forwards to, once its single greedy
+/// routing hop is exhausted, before giving up (hosting redesign piece C,
+/// invariant 5). Bounded small so the terminal consult adds at most a couple
+/// of extra forwards per relay on the NotFound return path — see the consult
+/// site in `drive_relay_get_inner` for why this does not re-introduce the
+/// per-hop fan-out amplification (local-lookup-gated, advertised-only,
+/// bubble-up halts at the first Found).
 const MAX_TERMINAL_CONSULT_HOSTS: usize = 2;
 
 /// Pure selection core for the bootstrap gateway fallback (#4361).
@@ -2856,18 +2858,30 @@ where
                     return Ok(());
                 }
 
-                // No local copy and nothing closer to route to: before
-                // declaring a findability dead-end, consult the host
-                // advertisements our neighbors broadcast for this key
-                // (invariant 5). `consult_advertised_hosts` returns ONLY peers
-                // that already advertised hosting — nothing is pushed or
-                // cached, so this is not the speculative-pre-replication
-                // anti-pattern. Each candidate is marked tried + visited so
-                // the existing dedup prevents loops, and the forward below
-                // carries HTL-1. A terminus has zero closer peers, so these
-                // <=MAX_TERMINAL_CONSULT_HOSTS extra forwards do not compound
-                // across hops (unlike the removed per-hop retry fan-out that
-                // caused the 3^HTL amplification).
+                // This relay has exhausted its single greedy routing forward
+                // (MAX_RELAY_RETRIES = 1) without finding the contract, and
+                // holds no local copy. Before declaring a findability
+                // dead-end, consult the host advertisements our neighbors
+                // broadcast for this key (invariant 5) and try the closest
+                // UNVISITED advertised hosts the retry cap skipped — the "one
+                // hop off the routing path" case.
+                //
+                // `consult_advertised_hosts` returns ONLY peers that already
+                // advertised hosting — nothing is pushed or cached, so this is
+                // not the speculative-pre-replication anti-pattern. Each
+                // candidate is marked tried + visited so the existing dedup
+                // prevents loops, and the forward below carries HTL-1.
+                //
+                // This does NOT re-introduce the removed 3^HTL per-hop retry
+                // fan-out: a *local* lookup gates the forward, so a
+                // truly-absent contract (no neighbor advertised it) triggers
+                // ZERO extra network forwards; an advertised host almost
+                // always HAS the contract, so the bubble-up halts at the first
+                // Found; and each relay adds at most MAX_TERMINAL_CONSULT_HOSTS
+                // forwards, only on the NotFound return path. It can fire at an
+                // intermediate relay (not only the deepest terminus), which is
+                // intended: the advertised host is a neighbor of THIS relay,
+                // invisible to the deeper terminus.
                 let targets = consult_targets.get_or_insert_with(|| {
                     let tried_snapshot = tried.clone();
                     let visited_snapshot = new_visited.clone();

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -3313,16 +3313,13 @@ where
                     }
                 };
 
-                // The claim succeeded, so delivery is now committed (loopback
-                // cache or upstream pipe below). A consulted advertised host
-                // that streams the contract has closed the dead-end — record
-                // here, AFTER the fallible `claim_or_wait`, not at classify
-                // time (a claim failure above `continue`s to the next
-                // candidate, so recording early would be a false positive).
-                // Every path from here returns, so exactly one outcome records.
-                if consult_active {
-                    crate::operations::record_terminal_consult_outcome(true);
-                }
+                // NOTE: the terminal-consult `resolved_found` for a streaming
+                // reply is recorded only AFTER the payload is actually
+                // delivered — the loopback cache (below) or the remote
+                // `pipe_stream` success (Step 3). Recording here, right after
+                // the claim, would be a false positive: assembly, the header
+                // send, and the pipe can all still fail without the requester
+                // receiving the Found result.
 
                 // ── Step 2: Loopback safety net. If upstream IS us
                 //    (originator-loopback edge — rare), assemble + cache
@@ -3351,6 +3348,12 @@ where
                                         false,
                                     )
                                     .await;
+                                    // Loopback delivery succeeded (state cached
+                                    // locally): a consulted advertised host
+                                    // closed the dead-end.
+                                    if consult_active {
+                                        crate::operations::record_terminal_consult_outcome(true);
+                                    }
                                 } else {
                                     tracing::warn!(
                                         tx = %incoming_tx,
@@ -3438,6 +3441,14 @@ where
                          time out cleanly rather than sending a contradictory NotFound"
                     );
                     return Ok(());
+                }
+
+                // Remote delivery committed: the ResponseStreaming header went
+                // upstream and `pipe_stream` started successfully. A consulted
+                // advertised host closed the dead-end — record now, AFTER the
+                // fallible header send + pipe, not at claim time.
+                if consult_active {
+                    crate::operations::record_terminal_consult_outcome(true);
                 }
 
                 // ── Step 4: Record the relay route event for the downstream

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1451,6 +1451,13 @@ async fn lookup_stored_key(
 /// touch unrelated code paths.
 const MAX_RETRIES: usize = 3;
 
+/// Maximum advertised hosts a routing terminus forwards to before giving up
+/// (hosting redesign piece C, invariant 5). Bounded small so the terminal
+/// consult adds at most a couple of extra forwards at a leaf of routing —
+/// see the consult site in `drive_relay_get_inner` for why this does not
+/// re-introduce the per-hop fan-out amplification.
+const MAX_TERMINAL_CONSULT_HOSTS: usize = 2;
+
 /// Pure selection core for the bootstrap gateway fallback (#4361).
 ///
 /// Returns the first configured gateway that is not this node and not
@@ -2787,6 +2794,18 @@ where
 
     let mut retries: usize = 0;
 
+    // Terminal advertisement consult (hosting redesign piece C, invariant 5).
+    // Lazily built the first time location routing is exhausted; each entry
+    // is an advertised host to forward to (off the direct routing path).
+    let mut local_fallback = local_fallback;
+    let mut consult_targets: Option<std::vec::IntoIter<(PeerKeyLocation, SocketAddr)>> = None;
+    // True while the current attempt targets a consulted advertised host (so
+    // its Found reply is attributed to the consult telemetry, not routing).
+    // Assigned by every non-returning arm of the peer-selection match below.
+    let mut consult_active: bool;
+    // Guards against recording more than one terminal consult outcome.
+    let mut consult_resolved_recorded = false;
+
     loop {
         // Pick next downstream peer.
         let (peer, peer_addr) = match relay_advance_to_next_peer(
@@ -2796,10 +2815,15 @@ where
             &mut retries,
             &new_visited,
         ) {
-            Some(p) => p,
+            Some(p) => {
+                consult_active = false;
+                p
+            }
             None => {
-                // Exhausted: serve local fallback if available, else NotFound.
-                if let Some((key, state, contract)) = local_fallback {
+                // Location routing exhausted → this relay is a terminus for
+                // the key. Prefer any (stale) local fallback we already hold —
+                // existing behavior, not a dead-end.
+                if let Some((key, state, contract)) = local_fallback.take() {
                     tracing::info!(
                         tx = %incoming_tx,
                         %instance_id,
@@ -2829,7 +2853,52 @@ where
                     .await;
                     cache_contract_locally(op_manager, key, state, contract, false).await;
                     send_result?;
+                    return Ok(());
+                }
+
+                // No local copy and nothing closer to route to: before
+                // declaring a findability dead-end, consult the host
+                // advertisements our neighbors broadcast for this key
+                // (invariant 5). `consult_advertised_hosts` returns ONLY peers
+                // that already advertised hosting — nothing is pushed or
+                // cached, so this is not the speculative-pre-replication
+                // anti-pattern. Each candidate is marked tried + visited so
+                // the existing dedup prevents loops, and the forward below
+                // carries HTL-1. A terminus has zero closer peers, so these
+                // <=MAX_TERMINAL_CONSULT_HOSTS extra forwards do not compound
+                // across hops (unlike the removed per-hop retry fan-out that
+                // caused the 3^HTL amplification).
+                let targets = consult_targets.get_or_insert_with(|| {
+                    let tried_snapshot = tried.clone();
+                    let visited_snapshot = new_visited.clone();
+                    crate::operations::consult_advertised_hosts(
+                        op_manager,
+                        &instance_id,
+                        MAX_TERMINAL_CONSULT_HOSTS,
+                        move |addr| {
+                            tried_snapshot.contains(&addr)
+                                || visited_snapshot.probably_visited(addr)
+                        },
+                    )
+                    .into_iter()
+                });
+                if let Some((consult_peer, consult_addr)) = targets.next() {
+                    tried.push(consult_addr);
+                    new_visited.mark_visited(consult_addr);
+                    consult_active = true;
+                    tracing::debug!(
+                        tx = %incoming_tx,
+                        %instance_id,
+                        target = %consult_addr,
+                        "GET relay: terminus consulting advertised host off routing path"
+                    );
+                    (consult_peer, consult_addr)
                 } else {
+                    // Dead-end confirmed: no usable advertised host (or every
+                    // advertised host was already tried / also failed).
+                    if !consult_resolved_recorded {
+                        crate::operations::record_terminal_consult_outcome(false);
+                    }
                     tracing::warn!(
                         tx = %incoming_tx,
                         %instance_id,
@@ -2860,8 +2929,8 @@ where
                         hop_count,
                     )
                     .await;
+                    return Ok(());
                 }
-                return Ok(());
             }
         };
 
@@ -3014,7 +3083,23 @@ where
         };
 
         // Classify the reply.
-        match classify(reply) {
+        let attempt_outcome = classify(reply);
+        // Terminal-consult telemetry: attribute a Found reply from a
+        // consulted advertised host as a closed dead-end. Guarded so a rare
+        // stream-claim failure on a consult candidate (which retries the next
+        // candidate) can't double-count. NotFound/Retry falls through and the
+        // exhaustion arm records the still-not-found outcome.
+        if consult_active
+            && !consult_resolved_recorded
+            && matches!(
+                attempt_outcome,
+                AttemptOutcome::Terminal(Terminal::InlineFound { .. } | Terminal::Streaming { .. })
+            )
+        {
+            crate::operations::record_terminal_consult_outcome(true);
+            consult_resolved_recorded = true;
+        }
+        match attempt_outcome {
             AttemptOutcome::Terminal(Terminal::InlineFound {
                 key,
                 state,
@@ -4642,6 +4727,41 @@ mod tests {
         );
     }
 
+    /// Piece C (invariant 5): the relay terminus must consult neighbor host
+    /// advertisements BEFORE declaring a NotFound dead-end. The consult call
+    /// must appear before `relay_send_not_found` in source order so the
+    /// advertised-host forward is attempted first.
+    #[test]
+    fn relay_terminus_consults_advertised_hosts_before_not_found() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
+        let consult_pos = body.find("consult_advertised_hosts").expect(
+            "drive_relay_get_inner must consult advertised hosts at the routing \
+             terminus (hosting redesign piece C, invariant 5)",
+        );
+        // Anchor on the exhaustion dead-end marker (unique to the consult's
+        // else branch); the driver has an earlier HTL-exhaustion NotFound, so
+        // a bare `relay_send_not_found` anchor would match the wrong site.
+        let deadend_pos = body
+            .find("Dead-end confirmed")
+            .expect("consult exhaustion branch must confirm the dead-end before NotFound");
+        assert!(
+            consult_pos < deadend_pos,
+            "the terminal advertisement consult must run BEFORE the NotFound \
+             send so an off-path advertised host gets a chance to answer"
+        );
+        assert!(
+            body.contains("relay_send_not_found"),
+            "drive_relay_get_inner must still send NotFound on a true dead-end"
+        );
+        // The consult outcome must be recorded so the telemetry measures
+        // whether the consult closes dead-ends.
+        assert!(
+            body.contains("record_terminal_consult_outcome"),
+            "drive_relay_get_inner must record the terminal consult outcome"
+        );
+    }
+
     /// T6 (superseded): Originally required `relay_send_forwarding_ack`
     /// to be emitted before the downstream send. That ack collided with
     /// the upstream relay driver's capacity-1 `pending_op_results`
@@ -4847,47 +4967,36 @@ mod tests {
     fn exhaustion_branches_on_local_fallback_presence() {
         let src = production_source();
         let body = extract_fn_body(src, "async fn drive_relay_get_inner<CB>(");
-        // The None arm of the `match relay_advance_to_next_peer(...)` is the
-        // exhaustion branch. It must contain both `local_fallback` disposition
-        // AND both Found and NotFound sends.
-        let none_arm = body
-            .find("None => {")
-            .expect("exhaustion arm (`None => {{`) must exist");
-        // Clip to the matching close; the next `Some(p) => {` arm may precede
-        // or follow, so take the whole match body from None onward up to the
-        // end of the outer function block.
-        let tail = &body[none_arm..];
-        // Bound at the `return Ok(());` that ends the exhaustion branch.
-        let clip = tail
-            .find("return Ok(());")
-            .expect("exhaustion branch must end with `return Ok(());`");
-        let arm = &tail[..clip + "return Ok(());".len()];
+        // The exhaustion (terminus) path disposes of the request in this order:
+        //   1. serve a local stale-cache fallback if present (Found, R10);
+        //   2. else consult neighbor host advertisements (piece C) and forward
+        //      to an advertised off-path host;
+        //   3. else send NotFound upstream.
+        // Assert all three dispositions exist in that source order.
         assert!(
-            arm.contains("if let Some((key, state, contract)) = local_fallback"),
+            body.contains("local_fallback.take()"),
             "Exhaustion arm must branch on `local_fallback`; otherwise the \
              stale-cache fallback semantic (R3d → R10) is lost."
         );
+        let fallback_pos = body
+            .find("serving local fallback")
+            .expect("exhaustion must serve the stale local copy when `local_fallback` is Some");
+        let consult_pos = body.find("consult_advertised_hosts").expect(
+            "exhaustion must consult advertised hosts before NotFound (piece C, invariant 5)",
+        );
+        let not_found_pos = body
+            .find("all peers exhausted — sending NotFound upstream")
+            .expect("exhaustion must send NotFound when there is no fallback or advertised host");
         assert!(
-            arm.contains("relay_send_found"),
-            "Exhaustion arm must call `relay_send_found` when `local_fallback` \
-             is Some — the stale-cache relay serves what it has after all \
-             downstream peers NotFound."
+            fallback_pos < consult_pos && consult_pos < not_found_pos,
+            "Exhaustion order must be: serve local fallback (Found) → consult \
+             advertised hosts → NotFound. Got fallback={fallback_pos}, \
+             consult={consult_pos}, not_found={not_found_pos}."
         );
         assert!(
-            arm.contains("relay_send_not_found"),
-            "Exhaustion arm must call `relay_send_not_found` when \
-             `local_fallback` is None — the non-caching relay bubbles \
-             NotFound upstream."
-        );
-        // Ordering: the `else` branch (NotFound) must follow the `if Some`
-        // branch (Found).
-        let found_pos = arm.find("relay_send_found").unwrap();
-        let not_found_pos = arm.find("relay_send_not_found").unwrap();
-        assert!(
-            found_pos < not_found_pos,
-            "Fallback-Found must precede NotFound in the exhaustion arm \
-             source order; a reversal would mean NotFound always runs first \
-             and the fallback path is dead code."
+            body.contains("relay_send_found") && body.contains("relay_send_not_found"),
+            "Exhaustion arm must be able to send both Found (fallback) and \
+             NotFound (true dead-end)."
         );
     }
 
@@ -5315,10 +5424,11 @@ mod tests {
             .find("let reply = match round_trip {")
             .expect("round_trip match must exist");
         let tail = &body[round_trip..];
-        // Clip at the end of the match (next `match classify(reply)`).
+        // Clip at the end of the match (the `classify(reply)` call that
+        // follows it — now bound to `let attempt_outcome = classify(reply);`).
         let clip = tail
-            .find("match classify(reply)")
-            .expect("classify match must follow round_trip match");
+            .find("classify(reply)")
+            .expect("classify call must follow round_trip match");
         let match_body = &tail[..clip];
         // Channel-error arm: `Ok(Err(err)) => { ... continue; }`.
         let err_arm = match_body

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1824,70 +1824,76 @@ async fn drive_relay_subscribe(
     // already-advertised host (nothing pushed/cached), a local lookup gates
     // it so a truly-absent contract triggers zero extra forward, and it is a
     // single extra forward whose Subscribed reply ends the search.
-    let (result, bubble_hop_count) = match outcome {
-        SubscribeForwardOutcome::Subscribed { key, hop_count } => {
-            (SubscribeMsgResult::Subscribed { key }, hop_count)
-        }
-        SubscribeForwardOutcome::NotFound { hop_count } => {
-            let visited_snapshot = new_visited.clone();
-            let consult = crate::operations::consult_advertised_hosts(
-                op_manager,
-                &instance_id,
-                TERMINAL_CONSULT_HOSTS,
-                move |addr| visited_snapshot.probably_visited(addr),
-            );
-            match consult.into_iter().next() {
-                Some((consult_hop, consult_addr)) => {
-                    new_visited.mark_visited(consult_addr);
-                    tracing::debug!(
-                        tx = %incoming_tx,
-                        %instance_id,
-                        target = %consult_addr,
-                        "SUBSCRIBE relay: consulting advertised host off routing path after \
-                         downstream NotFound"
-                    );
-                    let consult_outcome = relay_subscribe_forward_once(
-                        op_manager,
-                        incoming_tx,
-                        instance_id,
-                        htl,
-                        &new_visited,
-                        is_renewal,
-                        consult_hop,
-                        consult_addr,
-                        upstream_addr,
-                    )
-                    .await;
-                    match consult_outcome {
-                        SubscribeForwardOutcome::Subscribed { key, hop_count } => {
-                            crate::operations::record_terminal_consult_outcome(true);
-                            (SubscribeMsgResult::Subscribed { key }, hop_count)
-                        }
-                        SubscribeForwardOutcome::NotFound { hop_count }
-                        | SubscribeForwardOutcome::Failed { hop_count } => {
-                            crate::operations::record_terminal_consult_outcome(false);
-                            (SubscribeMsgResult::NotFound, hop_count)
+    // `consult_outcome`: None = no consult ran; Some(true) = a consulted host
+    // returned Subscribed; Some(false) = a consult ran but did not subscribe.
+    // The terminal-consult telemetry is recorded AFTER the upstream send
+    // succeeds (below), never here — a consult that subscribed but whose
+    // fire-and-forget reply then fails leaves the requester to time out, so it
+    // did NOT close the dead-end (Codex P2 — record after delivery).
+    let (result, bubble_hop_count, consult_outcome): (SubscribeMsgResult, usize, Option<bool>) =
+        match outcome {
+            SubscribeForwardOutcome::Subscribed { key, hop_count } => {
+                (SubscribeMsgResult::Subscribed { key }, hop_count, None)
+            }
+            SubscribeForwardOutcome::NotFound { hop_count } => {
+                let visited_snapshot = new_visited.clone();
+                let consult = crate::operations::consult_advertised_hosts(
+                    op_manager,
+                    &instance_id,
+                    TERMINAL_CONSULT_HOSTS,
+                    move |addr| visited_snapshot.probably_visited(addr),
+                );
+                match consult.into_iter().next() {
+                    Some((consult_hop, consult_addr)) => {
+                        new_visited.mark_visited(consult_addr);
+                        tracing::debug!(
+                            tx = %incoming_tx,
+                            %instance_id,
+                            target = %consult_addr,
+                            "SUBSCRIBE relay: consulting advertised host off routing path after \
+                             downstream NotFound"
+                        );
+                        let consult_outcome = relay_subscribe_forward_once(
+                            op_manager,
+                            incoming_tx,
+                            instance_id,
+                            htl,
+                            &new_visited,
+                            is_renewal,
+                            consult_hop,
+                            consult_addr,
+                            upstream_addr,
+                        )
+                        .await;
+                        match consult_outcome {
+                            SubscribeForwardOutcome::Subscribed { key, hop_count } => (
+                                SubscribeMsgResult::Subscribed { key },
+                                hop_count,
+                                Some(true),
+                            ),
+                            SubscribeForwardOutcome::NotFound { hop_count }
+                            | SubscribeForwardOutcome::Failed { hop_count } => {
+                                (SubscribeMsgResult::NotFound, hop_count, Some(false))
+                            }
                         }
                     }
-                }
-                None => {
-                    // No advertised host to try: the downstream NotFound stands.
-                    crate::operations::record_terminal_consult_outcome(false);
-                    (SubscribeMsgResult::NotFound, hop_count)
+                    None => {
+                        // No advertised host to try: the downstream NotFound stands.
+                        (SubscribeMsgResult::NotFound, hop_count, Some(false))
+                    }
                 }
             }
-        }
-        SubscribeForwardOutcome::Failed { hop_count } => {
-            // The greedy routing forward received NO reply (timeout / send
-            // failure / unexpected variant). Consulting would install a new
-            // waiter on the reused tx that a late reply from the timed-out peer
-            // could satisfy (Codex P2), so bubble NotFound WITHOUT consulting —
-            // the same outcome the relay produced before the consult existed.
-            (SubscribeMsgResult::NotFound, hop_count)
-        }
-    };
+            SubscribeForwardOutcome::Failed { hop_count } => {
+                // The greedy routing forward received NO reply (timeout / send
+                // failure / unexpected variant). Consulting would install a new
+                // waiter on the reused tx that a late reply from the timed-out
+                // peer could satisfy (Codex P2), so bubble NotFound WITHOUT
+                // consulting — the same outcome as before the consult existed.
+                (SubscribeMsgResult::NotFound, hop_count, None)
+            }
+        };
 
-    relay_subscribe_send_response(
+    let send_result = relay_subscribe_send_response(
         op_manager,
         incoming_tx,
         instance_id,
@@ -1895,7 +1901,17 @@ async fn drive_relay_subscribe(
         upstream_addr,
         bubble_hop_count,
     )
-    .await
+    .await;
+
+    // Record the terminal-consult outcome only AFTER the upstream response
+    // send: a consult that subscribed but whose reply failed to send did NOT
+    // close the dead-end for the requester (it will time out), so it counts as
+    // still-not-found (Codex P2).
+    if let Some(consult_resolved) = consult_outcome {
+        crate::operations::record_terminal_consult_outcome(consult_resolved && send_result.is_ok());
+    }
+
+    send_result
 }
 
 /// Outcome of a single SUBSCRIBE relay forward, normalized so the driver can

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1863,7 +1863,8 @@ async fn drive_relay_subscribe(
                             crate::operations::record_terminal_consult_outcome(true);
                             (SubscribeMsgResult::Subscribed { key }, hop_count)
                         }
-                        SubscribeForwardOutcome::NotFound { hop_count } => {
+                        SubscribeForwardOutcome::NotFound { hop_count }
+                        | SubscribeForwardOutcome::Failed { hop_count } => {
                             crate::operations::record_terminal_consult_outcome(false);
                             (SubscribeMsgResult::NotFound, hop_count)
                         }
@@ -1875,6 +1876,14 @@ async fn drive_relay_subscribe(
                     (SubscribeMsgResult::NotFound, hop_count)
                 }
             }
+        }
+        SubscribeForwardOutcome::Failed { hop_count } => {
+            // The greedy routing forward received NO reply (timeout / send
+            // failure / unexpected variant). Consulting would install a new
+            // waiter on the reused tx that a late reply from the timed-out peer
+            // could satisfy (Codex P2), so bubble NotFound WITHOUT consulting —
+            // the same outcome the relay produced before the consult existed.
+            (SubscribeMsgResult::NotFound, hop_count)
         }
     };
 
@@ -1899,9 +1908,13 @@ enum SubscribeForwardOutcome {
         key: freenet_stdlib::prelude::ContractKey,
         hop_count: usize,
     },
-    /// This forward did not subscribe — downstream answered NotFound, timed
-    /// out, failed to send, or replied with an unexpected variant.
+    /// Downstream cleanly answered NotFound (a reply WAS received). Safe to
+    /// fall back to the terminal advertisement consult on the reused tx.
     NotFound { hop_count: usize },
+    /// The forward received NO reply (timeout / send-failure) or an
+    /// unexpected variant. The awaited peer may reply late on the reused tx,
+    /// so the caller MUST bubble NotFound WITHOUT consulting (Codex P2).
+    Failed { hop_count: usize },
 }
 
 /// Forward a `SubscribeMsg::Request` to a single target, await the reply, and
@@ -1984,7 +1997,8 @@ async fn relay_subscribe_forward_once(
                 crate::router::RouteOutcome::Failure,
                 crate::node::network_status::OpType::Subscribe,
             );
-            return SubscribeForwardOutcome::NotFound {
+            // No reply — do NOT consult on the reused tx (Codex P2).
+            return SubscribeForwardOutcome::Failed {
                 hop_count: our_depth,
             };
         }
@@ -2003,7 +2017,8 @@ async fn relay_subscribe_forward_once(
                 crate::router::RouteOutcome::Failure,
                 crate::node::network_status::OpType::Subscribe,
             );
-            return SubscribeForwardOutcome::NotFound {
+            // Timed out with no reply — do NOT consult on the reused tx (Codex P2).
+            return SubscribeForwardOutcome::Failed {
                 hop_count: our_depth,
             };
         }
@@ -2079,7 +2094,10 @@ async fn relay_subscribe_forward_once(
                 reply_variant = ?std::mem::discriminant(&other),
                 "SUBSCRIBE relay: unexpected reply variant; treating as NotFound"
             );
-            SubscribeForwardOutcome::NotFound {
+            // Anomalous reply — treat as Failed so we do NOT consult on the
+            // reused tx (only a CLEAN downstream NotFound is safe to fall back
+            // from). Codex P2.
+            SubscribeForwardOutcome::Failed {
                 hop_count: our_depth,
             }
         }
@@ -2802,6 +2820,42 @@ mod tests {
         assert!(
             region.contains("record_terminal_consult_outcome"),
             "drive_relay_subscribe must record the terminal consult outcome"
+        );
+    }
+
+    /// Piece C P2 (Codex): the consult reuses `incoming_tx`, so it must run
+    /// ONLY after a CLEAN downstream NotFound — never after a forward that got
+    /// no reply (timeout / send-failure), whose late reply could satisfy the
+    /// consult waiter. Pin that timeout/send-failure map to a distinct
+    /// `Failed` outcome that bubbles NotFound without consulting.
+    #[test]
+    fn relay_subscribe_consult_skipped_after_failed_forward() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn drive_relay_subscribe(")
+            .expect("drive_relay_subscribe not found");
+        let end = src[start..]
+            .find("\nasync fn relay_subscribe_send_response(")
+            .expect("region end not found")
+            + start;
+        let region = &src[start..end];
+        // The forward helper distinguishes a no-reply Failed outcome.
+        assert!(
+            region.contains("SubscribeForwardOutcome::Failed"),
+            "relay_subscribe_forward_once must return a distinct Failed outcome for \
+             timeout / send-failure so the consult is not reached on the reused tx"
+        );
+        // The top-level Failed arm bubbles NotFound WITHOUT calling the consult.
+        let outer_failed = region
+            .find("SubscribeForwardOutcome::Failed { hop_count } => {")
+            .expect("driver must handle the top-level Failed outcome explicitly");
+        let consult_pos = region
+            .find("consult_advertised_hosts")
+            .expect("driver must consult on the clean-NotFound path");
+        assert!(
+            outer_failed > consult_pos,
+            "the top-level Failed arm must come after (be separate from) the \
+             NotFound consult arm — Failed must not consult"
         );
     }
 

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1741,105 +1741,192 @@ async fn drive_relay_subscribe(
             .ring
             .k_closest_potentially_hosting(&instance_id, &new_visited, MAX_BREADTH);
 
-    // `consulted` marks that `next_hop` came from the terminal advertisement
-    // consult (invariant 5) rather than location routing, so the reply is
-    // attributed to the consult telemetry.
-    let mut consulted = false;
-    let next_hop = if !candidates.is_empty() {
-        candidates.remove(0)
-    } else {
-        // Terminus: location routing found no closer peer. Before declaring a
-        // findability dead-end, consult the host advertisements our neighbors
-        // broadcast for this key. `consult_advertised_hosts` returns ONLY a
-        // peer that already advertised hosting — nothing is pushed or cached,
-        // so this is not the speculative-pre-replication anti-pattern. The
-        // SUBSCRIBE relay is single-shot (forwards to one downstream peer),
-        // so the consult likewise forwards to the single closest advertised
-        // host; `new_visited` (self + upstream + traversed peers) is the skip
-        // list, so it cannot loop back, and the forward below carries HTL-1.
-        let visited_snapshot = new_visited.clone();
-        let consult = crate::operations::consult_advertised_hosts(
-            op_manager,
-            &instance_id,
-            TERMINAL_CONSULT_HOSTS,
-            move |addr| visited_snapshot.probably_visited(addr),
+    if candidates.is_empty() {
+        // True no-candidate terminus: every connection is already in the
+        // visited set (otherwise `k_closest` would have returned it), so a
+        // consult here would be a no-op — any advertised host is a visited
+        // connection the consult's skip-list excludes. Report NotFound.
+        tracing::warn!(
+            tx = %incoming_tx,
+            contract = %instance_id,
+            phase = "relay_subscribe_not_found",
+            "SUBSCRIBE relay: no closer peers to forward"
         );
-        match consult.into_iter().next() {
-            Some((peer, _addr)) => {
-                consulted = true;
-                tracing::debug!(
-                    tx = %incoming_tx,
-                    %instance_id,
-                    "SUBSCRIBE relay: terminus consulting advertised host off routing path"
-                );
-                peer
-            }
-            None => {
-                crate::operations::record_terminal_consult_outcome(false);
-                tracing::warn!(
-                    tx = %incoming_tx,
-                    contract = %instance_id,
-                    phase = "relay_subscribe_not_found",
-                    "SUBSCRIBE relay: no closer peers to forward"
-                );
-                // No-candidates exhaustion: this relay is reporting its own
-                // exhaustion of downstream candidates. hop_count = max_htl - htl
-                // (the forward depth of THIS relay).
-                let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
-                if let Some(event) = crate::tracing::NetEventLog::subscribe_not_found(
-                    &incoming_tx,
-                    &op_manager.ring,
-                    instance_id,
-                    Some(hop_count),
-                ) {
-                    op_manager
-                        .ring
-                        .register_events(either::Either::Left(event))
-                        .await;
-                }
-                return relay_subscribe_send_response(
-                    op_manager,
-                    incoming_tx,
-                    instance_id,
-                    SubscribeMsgResult::NotFound,
-                    upstream_addr,
-                    hop_count,
-                )
+        // No-candidates exhaustion: hop_count = max_htl - htl (this relay's depth).
+        let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
+        if let Some(event) = crate::tracing::NetEventLog::subscribe_not_found(
+            &incoming_tx,
+            &op_manager.ring,
+            instance_id,
+            Some(hop_count),
+        ) {
+            op_manager
+                .ring
+                .register_events(either::Either::Left(event))
                 .await;
-            }
         }
-    };
-    let next_addr = match next_hop.socket_addr() {
-        Some(addr) => addr,
-        None => {
-            tracing::error!(
-                tx = %incoming_tx,
-                %instance_id,
-                target_pub_key = %next_hop.pub_key(),
-                "SUBSCRIBE relay: next hop has no socket address"
-            );
-            // Consult candidates are pre-filtered to have a socket address, so
-            // this is unreachable for a consulted host; record defensively.
-            if consulted {
-                crate::operations::record_terminal_consult_outcome(false);
-            }
-            // Forward-failure at THIS relay; same depth as no-candidates.
-            let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
-            return relay_subscribe_send_response(
-                op_manager,
-                incoming_tx,
-                instance_id,
-                SubscribeMsgResult::NotFound,
-                upstream_addr,
-                hop_count,
-            )
-            .await;
-        }
+        return relay_subscribe_send_response(
+            op_manager,
+            incoming_tx,
+            instance_id,
+            SubscribeMsgResult::NotFound,
+            upstream_addr,
+            hop_count,
+        )
+        .await;
+    }
+
+    let next_hop = candidates.remove(0);
+    let Some(next_addr) = next_hop.socket_addr() else {
+        tracing::error!(
+            tx = %incoming_tx,
+            %instance_id,
+            target_pub_key = %next_hop.pub_key(),
+            "SUBSCRIBE relay: next hop has no socket address"
+        );
+        // Forward-failure at THIS relay; same depth as no-candidates.
+        let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
+        return relay_subscribe_send_response(
+            op_manager,
+            incoming_tx,
+            instance_id,
+            SubscribeMsgResult::NotFound,
+            upstream_addr,
+            hop_count,
+        )
+        .await;
     };
     new_visited.mark_visited(next_addr);
 
-    // ── Step 3: Forward downstream, await Response ───────────────────────
+    // ── Step 3: Forward the single greedy routing hop, await Response ─────
+    let outcome = relay_subscribe_forward_once(
+        op_manager,
+        incoming_tx,
+        instance_id,
+        htl,
+        &new_visited,
+        is_renewal,
+        next_hop,
+        next_addr,
+        upstream_addr,
+    )
+    .await;
+
+    // ── Step 4: Terminal advertisement consult (piece C, invariant 5) ─────
+    // Like GET, the SUBSCRIBE relay forwards a SINGLE greedy hop toward the
+    // key and does NOT retry its other neighbors (the same fan-out cap that
+    // GET enforces with MAX_RELAY_RETRIES=1). If that hop returns NotFound,
+    // the closest advertised host may be a neighbor the cap skipped — one hop
+    // off the routing path. Before declaring a dead-end, consult the host
+    // advertisements our neighbors broadcast and try that host.
+    //
+    // Bounded and NOT the removed per-hop fan-out: forwards ONLY to an
+    // already-advertised host (nothing pushed/cached), a local lookup gates
+    // it so a truly-absent contract triggers zero extra forward, and it is a
+    // single extra forward whose Subscribed reply ends the search.
+    let (result, bubble_hop_count) = match outcome {
+        SubscribeForwardOutcome::Subscribed { key, hop_count } => {
+            (SubscribeMsgResult::Subscribed { key }, hop_count)
+        }
+        SubscribeForwardOutcome::NotFound { hop_count } => {
+            let visited_snapshot = new_visited.clone();
+            let consult = crate::operations::consult_advertised_hosts(
+                op_manager,
+                &instance_id,
+                TERMINAL_CONSULT_HOSTS,
+                move |addr| visited_snapshot.probably_visited(addr),
+            );
+            match consult.into_iter().next() {
+                Some((consult_hop, consult_addr)) => {
+                    new_visited.mark_visited(consult_addr);
+                    tracing::debug!(
+                        tx = %incoming_tx,
+                        %instance_id,
+                        target = %consult_addr,
+                        "SUBSCRIBE relay: consulting advertised host off routing path after \
+                         downstream NotFound"
+                    );
+                    let consult_outcome = relay_subscribe_forward_once(
+                        op_manager,
+                        incoming_tx,
+                        instance_id,
+                        htl,
+                        &new_visited,
+                        is_renewal,
+                        consult_hop,
+                        consult_addr,
+                        upstream_addr,
+                    )
+                    .await;
+                    match consult_outcome {
+                        SubscribeForwardOutcome::Subscribed { key, hop_count } => {
+                            crate::operations::record_terminal_consult_outcome(true);
+                            (SubscribeMsgResult::Subscribed { key }, hop_count)
+                        }
+                        SubscribeForwardOutcome::NotFound { hop_count } => {
+                            crate::operations::record_terminal_consult_outcome(false);
+                            (SubscribeMsgResult::NotFound, hop_count)
+                        }
+                    }
+                }
+                None => {
+                    // No advertised host to try: the downstream NotFound stands.
+                    crate::operations::record_terminal_consult_outcome(false);
+                    (SubscribeMsgResult::NotFound, hop_count)
+                }
+            }
+        }
+    };
+
+    relay_subscribe_send_response(
+        op_manager,
+        incoming_tx,
+        instance_id,
+        result,
+        upstream_addr,
+        bubble_hop_count,
+    )
+    .await
+}
+
+/// Outcome of a single SUBSCRIBE relay forward, normalized so the driver can
+/// decide whether to fall back to the terminal advertisement consult
+/// (hosting redesign piece C).
+enum SubscribeForwardOutcome {
+    /// Downstream (or a consulted host) subscribed us; the requester was
+    /// already registered as a downstream subscriber.
+    Subscribed {
+        key: freenet_stdlib::prelude::ContractKey,
+        hop_count: usize,
+    },
+    /// This forward did not subscribe — downstream answered NotFound, timed
+    /// out, failed to send, or replied with an unexpected variant.
+    NotFound { hop_count: usize },
+}
+
+/// Forward a `SubscribeMsg::Request` to a single target, await the reply, and
+/// classify it into [`SubscribeForwardOutcome`]. Registers the requester as a
+/// downstream subscriber on a Subscribed reply (mirroring legacy
+/// `subscribe.rs:1690`; does NOT call `ring.subscribe` /
+/// `announce_contract_hosted` — a relay is not itself a subscriber, which
+/// prevents the #3763 storm) and feeds the router the observed outcome. Does
+/// NOT bubble upstream — the caller owns that and may retry via the consult
+/// on a NotFound.
+#[allow(clippy::too_many_arguments)]
+async fn relay_subscribe_forward_once(
+    op_manager: &Arc<OpManager>,
+    incoming_tx: Transaction,
+    instance_id: ContractInstanceId,
+    htl: usize,
+    new_visited: &VisitedPeers,
+    is_renewal: bool,
+    next_hop: PeerKeyLocation,
+    next_addr: std::net::SocketAddr,
+    upstream_addr: std::net::SocketAddr,
+) -> SubscribeForwardOutcome {
     let new_htl = htl.saturating_sub(1);
+    // Forward-failure / unexpected-variant depth for THIS relay.
+    let our_depth = op_manager.ring.max_hops_to_live.saturating_sub(htl);
 
     if let Some(event) = crate::tracing::NetEventLog::subscribe_request(
         &incoming_tx,
@@ -1867,7 +1954,7 @@ async fn drive_relay_subscribe(
         id: incoming_tx,
         instance_id,
         htl: new_htl,
-        visited: new_visited,
+        visited: new_visited.clone(),
         is_renewal,
     });
 
@@ -1876,8 +1963,8 @@ async fn drive_relay_subscribe(
         tokio::time::timeout(OPERATION_TTL, ctx.send_to_and_await(next_addr, forward)).await;
 
     // Release the pending_op_results slot installed by send_to_and_await.
-    // Mirrors PUT/GET relay — the upstream fire-and-forget reply below
-    // would otherwise leak a slot entry per driver run.
+    // Mirrors PUT/GET relay — the upstream fire-and-forget reply would
+    // otherwise leak a slot entry per driver run.
     op_manager.release_pending_op_slot(incoming_tx).await;
 
     let reply = match round_trip {
@@ -1892,25 +1979,14 @@ async fn drive_relay_subscribe(
             );
             crate::operations::record_relay_route_event(
                 op_manager,
-                next_hop.clone(),
+                next_hop,
                 crate::ring::Location::from(&instance_id),
                 crate::router::RouteOutcome::Failure,
                 crate::node::network_status::OpType::Subscribe,
             );
-            if consulted {
-                crate::operations::record_terminal_consult_outcome(false);
-            }
-            // Forward failure at THIS relay: report our own depth.
-            let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
-            return relay_subscribe_send_response(
-                op_manager,
-                incoming_tx,
-                instance_id,
-                SubscribeMsgResult::NotFound,
-                upstream_addr,
-                hop_count,
-            )
-            .await;
+            return SubscribeForwardOutcome::NotFound {
+                hop_count: our_depth,
+            };
         }
         Err(_elapsed) => {
             tracing::warn!(
@@ -1922,51 +1998,23 @@ async fn drive_relay_subscribe(
             );
             crate::operations::record_relay_route_event(
                 op_manager,
-                next_hop.clone(),
+                next_hop,
                 crate::ring::Location::from(&instance_id),
                 crate::router::RouteOutcome::Failure,
                 crate::node::network_status::OpType::Subscribe,
             );
-            if consulted {
-                crate::operations::record_terminal_consult_outcome(false);
-            }
-            // Same as send-failure arm.
-            let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
-            return relay_subscribe_send_response(
-                op_manager,
-                incoming_tx,
-                instance_id,
-                SubscribeMsgResult::NotFound,
-                upstream_addr,
-                hop_count,
-            )
-            .await;
+            return SubscribeForwardOutcome::NotFound {
+                hop_count: our_depth,
+            };
         }
     };
 
-    // ── Step 4: Classify reply, register requester if Subscribed, bubble up ──
-    //
-    // Feed the relay's downstream-peer choice into the local Router so
-    // future routing decisions are informed by relay-observed outcomes
-    // (see operations.rs::record_relay_route_event).
-    //
-    // `bubble_hop_count` is the wire `hop_count` to forward upstream:
-    // - downstream Subscribed/NotFound: preserve the downstream's value
-    //   (relays do NOT increment on the return path);
-    // - unexpected variant: fall back to this relay's own depth
-    //   (`max_htl - htl`) — we know nothing about what produced `other`.
-    let (result, bubble_hop_count) = match reply {
+    match reply {
         NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Response {
             result: SubscribeMsgResult::Subscribed { key },
             hop_count: downstream_hop_count,
             ..
         })) => {
-            // Relay-side Subscribed registration — mirror legacy
-            // subscribe.rs:1690 arm. DO NOT call ring.subscribe /
-            // announce_contract_hosted here; a relay is not itself a
-            // subscriber. See subscribe.rs:1655–1688 for the full
-            // reasoning (prevents the #3763 subscription storm feedback
-            // loop).
             register_downstream_subscriber(
                 op_manager,
                 &key,
@@ -1986,70 +2034,56 @@ async fn drive_relay_subscribe(
             );
             crate::operations::record_relay_route_event(
                 op_manager,
-                next_hop.clone(),
+                next_hop,
                 crate::ring::Location::from(&key),
                 crate::router::RouteOutcome::SuccessUntimed,
                 crate::node::network_status::OpType::Subscribe,
             );
-            (SubscribeMsgResult::Subscribed { key }, downstream_hop_count)
+            SubscribeForwardOutcome::Subscribed {
+                key,
+                hop_count: downstream_hop_count,
+            }
         }
         NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Response {
             result: SubscribeMsgResult::NotFound,
             hop_count: downstream_hop_count,
             ..
         })) => {
-            // Downstream peer correctly answered NotFound. The peer
-            // behaved well at the protocol level — it just doesn't host
-            // this contract. Record SuccessUntimed so the model treats
-            // this peer as healthy. See `record_relay_route_event` rustdoc.
+            // Downstream peer correctly answered NotFound. The peer behaved
+            // well at the protocol level — it just doesn't host this contract.
+            // Record SuccessUntimed so the model treats it as healthy.
             tracing::debug!(
                 tx = %incoming_tx,
                 %instance_id,
                 phase = "relay_subscribe_bubble_not_found",
-                "SUBSCRIBE relay: downstream NotFound; bubbling upstream"
+                "SUBSCRIBE relay: downstream NotFound"
             );
             crate::operations::record_relay_route_event(
                 op_manager,
-                next_hop.clone(),
+                next_hop,
                 crate::ring::Location::from(&instance_id),
                 crate::router::RouteOutcome::SuccessUntimed,
                 crate::node::network_status::OpType::Subscribe,
             );
-            (SubscribeMsgResult::NotFound, downstream_hop_count)
+            SubscribeForwardOutcome::NotFound {
+                hop_count: downstream_hop_count,
+            }
         }
         other => {
-            // Unexpected reply variant: unclear whether it's a local
-            // bug or peer misbehaviour. Do NOT record a route event;
-            // the helper invariant is one event per unambiguous attribution.
+            // Unexpected reply variant: unclear whether it's a local bug or
+            // peer misbehaviour. Do NOT record a route event; the helper
+            // invariant is one event per unambiguous attribution.
             tracing::warn!(
                 tx = %incoming_tx,
                 %instance_id,
                 reply_variant = ?std::mem::discriminant(&other),
                 "SUBSCRIBE relay: unexpected reply variant; treating as NotFound"
             );
-            let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
-            (SubscribeMsgResult::NotFound, hop_count)
+            SubscribeForwardOutcome::NotFound {
+                hop_count: our_depth,
+            }
         }
-    };
-
-    // Terminal-consult telemetry: a consulted forward that returned
-    // Subscribed closed the dead-end; anything else left it NotFound.
-    if consulted {
-        crate::operations::record_terminal_consult_outcome(matches!(
-            result,
-            SubscribeMsgResult::Subscribed { .. }
-        ));
     }
-
-    relay_subscribe_send_response(
-        op_manager,
-        incoming_tx,
-        instance_id,
-        result,
-        upstream_addr,
-        bubble_hop_count,
-    )
-    .await
 }
 
 /// Send `SubscribeMsg::Response` upstream (fire-and-forget: upstream
@@ -2730,33 +2764,43 @@ mod tests {
         );
     }
 
-    /// Piece C (invariant 5): the SUBSCRIBE relay terminus must consult
-    /// neighbor host advertisements before declaring a NotFound dead-end, and
-    /// the consult must precede the no-candidates NotFound in source order.
+    /// Piece C (invariant 5): after the SUBSCRIBE relay's single greedy
+    /// routing forward returns NotFound, it must consult neighbor host
+    /// advertisements and try an off-path advertised host BEFORE bubbling the
+    /// dead-end upstream. The consult must fire AFTER a forward (not in the
+    /// no-candidates branch, where it would be a no-op — every connection is
+    /// already visited there), and must record the outcome.
     #[test]
     fn relay_subscribe_terminus_consults_advertised_hosts() {
         let src = include_str!("op_ctx_task.rs");
         let driver_start = src
             .find("async fn drive_relay_subscribe(")
             .expect("drive_relay_subscribe not found");
-        let driver_end = src[driver_start..]
+        // Clip the driver + the extracted forward helper (both precede
+        // `relay_subscribe_send_response`).
+        let region_end = src[driver_start..]
             .find("\nasync fn relay_subscribe_send_response(")
             .expect("driver body end not found")
             + driver_start;
-        let driver_src = &src[driver_start..driver_end];
-        let consult_pos = driver_src.find("consult_advertised_hosts").expect(
-            "drive_relay_subscribe must consult advertised hosts at the routing \
-             terminus (hosting redesign piece C, invariant 5)",
-        );
-        let empty_pos = driver_src
-            .find("candidates.is_empty()")
-            .expect("drive_relay_subscribe must still branch on empty candidates");
-        assert!(
-            consult_pos > empty_pos,
-            "the consult must live inside the no-closer-peers (terminus) branch"
+        let region = &src[driver_start..region_end];
+        let forward_pos = region
+            .find("relay_subscribe_forward_once(")
+            .expect("drive_relay_subscribe must forward via relay_subscribe_forward_once");
+        let consult_pos = region.find("consult_advertised_hosts").expect(
+            "drive_relay_subscribe must consult advertised hosts (hosting redesign \
+             piece C, invariant 5)",
         );
         assert!(
-            driver_src.contains("record_terminal_consult_outcome"),
+            forward_pos < consult_pos,
+            "the consult must fire AFTER the greedy routing forward (as a NotFound \
+             fallback), not in the no-candidates branch where it would be a no-op"
+        );
+        assert!(
+            region.contains("SubscribeForwardOutcome::NotFound"),
+            "the consult must be gated on the forward returning NotFound"
+        );
+        assert!(
+            region.contains("record_terminal_consult_outcome"),
             "drive_relay_subscribe must record the terminal consult outcome"
         );
     }

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -50,6 +50,11 @@ use super::{
     complete_local_subscription, prepare_initial_request, register_downstream_subscriber,
 };
 
+/// Advertised hosts a SUBSCRIBE terminus forwards to before giving up
+/// (hosting redesign piece C, invariant 5). The relay is single-shot, so
+/// the consult likewise forwards to just the closest advertised host.
+const TERMINAL_CONSULT_HOSTS: usize = 1;
+
 /// Start a client-initiated subscribe, returning as soon as the task has
 /// been spawned (mirrors legacy `subscribe_with_id` timing).
 ///
@@ -1736,40 +1741,74 @@ async fn drive_relay_subscribe(
             .ring
             .k_closest_potentially_hosting(&instance_id, &new_visited, MAX_BREADTH);
 
-    if candidates.is_empty() {
-        tracing::warn!(
-            tx = %incoming_tx,
-            contract = %instance_id,
-            phase = "relay_subscribe_not_found",
-            "SUBSCRIBE relay: no closer peers to forward"
-        );
-        // No-candidates exhaustion: this relay is reporting its own
-        // exhaustion of downstream candidates. hop_count = max_htl - htl
-        // (the forward depth of THIS relay).
-        let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
-        if let Some(event) = crate::tracing::NetEventLog::subscribe_not_found(
-            &incoming_tx,
-            &op_manager.ring,
-            instance_id,
-            Some(hop_count),
-        ) {
-            op_manager
-                .ring
-                .register_events(either::Either::Left(event))
-                .await;
-        }
-        return relay_subscribe_send_response(
+    // `consulted` marks that `next_hop` came from the terminal advertisement
+    // consult (invariant 5) rather than location routing, so the reply is
+    // attributed to the consult telemetry.
+    let mut consulted = false;
+    let next_hop = if !candidates.is_empty() {
+        candidates.remove(0)
+    } else {
+        // Terminus: location routing found no closer peer. Before declaring a
+        // findability dead-end, consult the host advertisements our neighbors
+        // broadcast for this key. `consult_advertised_hosts` returns ONLY a
+        // peer that already advertised hosting — nothing is pushed or cached,
+        // so this is not the speculative-pre-replication anti-pattern. The
+        // SUBSCRIBE relay is single-shot (forwards to one downstream peer),
+        // so the consult likewise forwards to the single closest advertised
+        // host; `new_visited` (self + upstream + traversed peers) is the skip
+        // list, so it cannot loop back, and the forward below carries HTL-1.
+        let visited_snapshot = new_visited.clone();
+        let consult = crate::operations::consult_advertised_hosts(
             op_manager,
-            incoming_tx,
-            instance_id,
-            SubscribeMsgResult::NotFound,
-            upstream_addr,
-            hop_count,
-        )
-        .await;
-    }
-
-    let next_hop = candidates.remove(0);
+            &instance_id,
+            TERMINAL_CONSULT_HOSTS,
+            move |addr| visited_snapshot.probably_visited(addr),
+        );
+        match consult.into_iter().next() {
+            Some((peer, _addr)) => {
+                consulted = true;
+                tracing::debug!(
+                    tx = %incoming_tx,
+                    %instance_id,
+                    "SUBSCRIBE relay: terminus consulting advertised host off routing path"
+                );
+                peer
+            }
+            None => {
+                crate::operations::record_terminal_consult_outcome(false);
+                tracing::warn!(
+                    tx = %incoming_tx,
+                    contract = %instance_id,
+                    phase = "relay_subscribe_not_found",
+                    "SUBSCRIBE relay: no closer peers to forward"
+                );
+                // No-candidates exhaustion: this relay is reporting its own
+                // exhaustion of downstream candidates. hop_count = max_htl - htl
+                // (the forward depth of THIS relay).
+                let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
+                if let Some(event) = crate::tracing::NetEventLog::subscribe_not_found(
+                    &incoming_tx,
+                    &op_manager.ring,
+                    instance_id,
+                    Some(hop_count),
+                ) {
+                    op_manager
+                        .ring
+                        .register_events(either::Either::Left(event))
+                        .await;
+                }
+                return relay_subscribe_send_response(
+                    op_manager,
+                    incoming_tx,
+                    instance_id,
+                    SubscribeMsgResult::NotFound,
+                    upstream_addr,
+                    hop_count,
+                )
+                .await;
+            }
+        }
+    };
     let next_addr = match next_hop.socket_addr() {
         Some(addr) => addr,
         None => {
@@ -1779,6 +1818,11 @@ async fn drive_relay_subscribe(
                 target_pub_key = %next_hop.pub_key(),
                 "SUBSCRIBE relay: next hop has no socket address"
             );
+            // Consult candidates are pre-filtered to have a socket address, so
+            // this is unreachable for a consulted host; record defensively.
+            if consulted {
+                crate::operations::record_terminal_consult_outcome(false);
+            }
             // Forward-failure at THIS relay; same depth as no-candidates.
             let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
             return relay_subscribe_send_response(
@@ -1853,6 +1897,9 @@ async fn drive_relay_subscribe(
                 crate::router::RouteOutcome::Failure,
                 crate::node::network_status::OpType::Subscribe,
             );
+            if consulted {
+                crate::operations::record_terminal_consult_outcome(false);
+            }
             // Forward failure at THIS relay: report our own depth.
             let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
             return relay_subscribe_send_response(
@@ -1880,6 +1927,9 @@ async fn drive_relay_subscribe(
                 crate::router::RouteOutcome::Failure,
                 crate::node::network_status::OpType::Subscribe,
             );
+            if consulted {
+                crate::operations::record_terminal_consult_outcome(false);
+            }
             // Same as send-failure arm.
             let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
             return relay_subscribe_send_response(
@@ -1981,6 +2031,15 @@ async fn drive_relay_subscribe(
             (SubscribeMsgResult::NotFound, hop_count)
         }
     };
+
+    // Terminal-consult telemetry: a consulted forward that returned
+    // Subscribed closed the dead-end; anything else left it NotFound.
+    if consulted {
+        crate::operations::record_terminal_consult_outcome(matches!(
+            result,
+            SubscribeMsgResult::Subscribed { .. }
+        ));
+    }
 
     relay_subscribe_send_response(
         op_manager,
@@ -2668,6 +2727,37 @@ mod tests {
         assert!(
             driver_src.contains("ctx.send_to_and_await("),
             "drive_relay_subscribe must forward downstream via send_to_and_await"
+        );
+    }
+
+    /// Piece C (invariant 5): the SUBSCRIBE relay terminus must consult
+    /// neighbor host advertisements before declaring a NotFound dead-end, and
+    /// the consult must precede the no-candidates NotFound in source order.
+    #[test]
+    fn relay_subscribe_terminus_consults_advertised_hosts() {
+        let src = include_str!("op_ctx_task.rs");
+        let driver_start = src
+            .find("async fn drive_relay_subscribe(")
+            .expect("drive_relay_subscribe not found");
+        let driver_end = src[driver_start..]
+            .find("\nasync fn relay_subscribe_send_response(")
+            .expect("driver body end not found")
+            + driver_start;
+        let driver_src = &src[driver_start..driver_end];
+        let consult_pos = driver_src.find("consult_advertised_hosts").expect(
+            "drive_relay_subscribe must consult advertised hosts at the routing \
+             terminus (hosting redesign piece C, invariant 5)",
+        );
+        let empty_pos = driver_src
+            .find("candidates.is_empty()")
+            .expect("drive_relay_subscribe must still branch on empty candidates");
+        assert!(
+            consult_pos > empty_pos,
+            "the consult must live inside the no-closer-peers (terminus) branch"
+        );
+        assert!(
+            driver_src.contains("record_terminal_consult_outcome"),
+            "drive_relay_subscribe must record the terminal consult outcome"
         );
     }
 

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -11023,6 +11023,191 @@ fn test_get_dead_ends_at_close_cluster_without_migration() {
     );
 }
 
+/// Terminal advertisement consult (hosting redesign piece C, invariant 5):
+/// a GET that routes to a terminus whose neighbor hosts the contract — one hop
+/// OFF the greedy routing path — must resolve via the consult instead of
+/// dead-ending with NotFound.
+///
+/// Setup (peer ring locations controlled via `new_with_node_locations`):
+///   - a dense cluster of non-hosting peers sits right on the contract's key;
+///   - exactly one host peer sits just OUTSIDE that cluster — farther from the
+///     key than every cluster peer (so greedy routing never selects it), but
+///     close enough in ring location to become a cluster peer's neighbor and
+///     advertise its hosting to it;
+///   - a far requester issues a GET.
+///
+/// Placement migration is disabled, so the ONLY mechanism that can carry the
+/// state to the requester is the terminal consult. GET is single-path greedy
+/// (relay `MAX_RELAY_RETRIES = 1`): a relay forwards to its single closest
+/// neighbor toward the key and bubbles NotFound without trying its other
+/// neighbors — so the advertised host, being a non-closest neighbor of the
+/// terminus, is exactly the "one hop off the routing path" case. WITHOUT the
+/// consult this dead-ends (proven by
+/// `test_get_dead_ends_at_close_cluster_without_migration`, whose host is too
+/// far to be a terminus neighbor); WITH it, the terminus consults the host
+/// advertisement it received and forwards there, closing the dead-end.
+///
+/// The proof is the consult telemetry: `terminal_consult_resolved_found() > 0`
+/// is recorded ONLY when a consulted advertised host returns Found, so with
+/// migration off it is unambiguous that the consult (not routing or migration)
+/// delivered the state.
+#[test_log::test]
+fn test_terminal_advertisement_consult_closes_get_dead_end() {
+    use freenet::config::GlobalTestMetrics;
+    use freenet::dev_tool::{Location, NodeLabel, ScheduledOperation, SimNetwork, SimOperation};
+
+    // Seed + host offset chosen so the host lands as a non-closest neighbor of
+    // an outer cluster peer (advertises to it, but greedy routing never selects
+    // it). Deterministic under the direct/turmoil runner for this seed.
+    const SEED: u64 = 0xC0FF_EEC0_0004;
+    const NETWORK_NAME: &str = "terminal-consult-deadend";
+    setup_deterministic_state(SEED);
+    GlobalTestMetrics::reset();
+
+    let contract = SimOperation::create_test_contract(0xC0);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    let key_loc = Location::from(&contract_key).as_f64();
+    let wrap = |x: f64| x.rem_euclid(1.0);
+
+    // Non-hosting cluster tightly around the key.
+    let cluster: Vec<f64> = [-0.010, -0.006, -0.003, 0.003, 0.006, 0.010]
+        .iter()
+        .map(|o| wrap(key_loc + o))
+        .collect();
+    // Host sits just outside the cluster: farther from the key than every
+    // cluster peer (so greedy routing never selects it as a next hop), yet close
+    // enough in ring location to become a cluster peer's neighbor and advertise.
+    let host_loc = wrap(key_loc + 0.035);
+    // Requester on the OPPOSITE side of the key from the host, so its inbound
+    // path approaches the key from the far side and never passes near the host.
+    let requester_loc = wrap(key_loc - 0.60);
+    let mut node_locations = cluster.clone();
+    node_locations.push(host_loc); // regular-node order 6 -> node_no 7
+    node_locations.push(requester_loc); // regular-node order 7 -> node_no 8
+    let num_nodes = node_locations.len(); // 8
+
+    let rt = create_runtime();
+    let mut sim = rt.block_on(async {
+        SimNetwork::new_with_node_locations(
+            NETWORK_NAME,
+            1,         // 1 gateway
+            num_nodes, // 8 regular nodes
+            10,        // ring_max_htl
+            7,         // rnd_if_htl_above
+            8,         // max_connections
+            3,         // min_connections
+            SEED,
+            &node_locations,
+        )
+        .await
+    });
+    // Migration OFF: isolate the consult as the ONLY mechanism that can carry
+    // state to the requester (mirrors the negative control above).
+    sim.disable_placement_migration();
+
+    let host_label = NodeLabel::node(NETWORK_NAME, 7);
+    let requester_label = NodeLabel::node(NETWORK_NAME, 8);
+
+    // Setup sanity: the host must be strictly FARTHER from the key than the
+    // closest cluster peer, so greedy routing lands on the cluster (terminus)
+    // and never picks the host directly. get_peer_locations() is [gw, node1..8].
+    let locs = sim.get_peer_locations();
+    let ring_dist = |a: f64, b: f64| {
+        let d = (a - b).abs();
+        d.min(1.0 - d)
+    };
+    let host_dist = ring_dist(locs[7], key_loc);
+    let cluster_min = (1..=6)
+        .map(|i| ring_dist(locs[i], key_loc))
+        .fold(f64::INFINITY, f64::min);
+    assert!(
+        cluster_min < host_dist,
+        "scenario setup wrong: a cluster peer must be closer to the key than the host \
+         (cluster_min={cluster_min}, host_dist={host_dist})"
+    );
+
+    let operations = vec![
+        // Only the host holds the contract (seeded into its store + Ring hosting
+        // manager + neighbor-hosting advertised set, no network propagation), so
+        // it advertises hosting to its neighbors but the state exists nowhere else.
+        ScheduledOperation::new(
+            host_label.clone(),
+            SimOperation::SeedHostedContract {
+                contract: contract.clone(),
+                state: vec![11, 22, 33, 44],
+            },
+        ),
+        // The far requester asks for it (greedy GET toward the key).
+        ScheduledOperation::new(
+            requester_label.clone(),
+            SimOperation::Get {
+                contract_id,
+                return_contract_code: true,
+                subscribe: false,
+            },
+        ),
+    ];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(180),
+        Duration::from_secs(60),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "simulation failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    // The host still hosts the seeded contract.
+    assert!(
+        result.is_node_hosting(&host_label, &contract_key),
+        "host should still host the seeded contract after the simulation"
+    );
+
+    let attempts = GlobalTestMetrics::terminal_consult_attempts();
+    let hits = GlobalTestMetrics::terminal_consult_hits();
+    let resolved_found = GlobalTestMetrics::terminal_consult_resolved_found();
+    // With the consult succeeding, cluster relays on the Found return path
+    // opportunistically cache the state (normal GET relay caching, migration is
+    // OFF) — informational only; the clean proof is `resolved_found` below.
+    let cached_on_cluster: Vec<usize> = (1..=6usize)
+        .filter(|n| result.is_node_hosting(&NodeLabel::node(NETWORK_NAME, *n), &contract_key))
+        .collect();
+    tracing::info!(
+        attempts,
+        hits,
+        resolved_found,
+        still_not_found = GlobalTestMetrics::terminal_consult_still_not_found(),
+        ?cached_on_cluster,
+        "terminal consult telemetry"
+    );
+
+    let requester_has_state = result
+        .node_storages
+        .get(&requester_label)
+        .is_some_and(|s| s.get_stored_state(&contract_key).is_some());
+
+    // CORE OF THE FIX: the consult carried the state from the off-path host to
+    // the requester. With migration disabled, `resolved_found > 0` is the
+    // unambiguous signal that the terminal advertisement consult (not routing,
+    // not migration) closed the dead-end — it is recorded ONLY when a consulted
+    // advertised host returns Found.
+    assert!(
+        resolved_found > 0,
+        "terminal consult should have resolved the GET to Found via an advertised \
+         off-path host (attempts={attempts}, hits={hits}, resolved_found={resolved_found}, \
+         requester_has_state={requester_has_state})"
+    );
+    assert!(
+        requester_has_state,
+        "requester GET should succeed via the terminal advertisement consult \
+         (resolved_found={resolved_found})"
+    );
+}
+
 /// Reproduction + regression test for the placement-migration renewal storm
 /// (#4440, the storm symptom of the #4404 placement work).
 ///

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -11105,6 +11105,9 @@ fn test_terminal_advertisement_consult_closes_get_dead_end() {
     // Migration OFF: isolate the consult as the ONLY mechanism that can carry
     // state to the requester (mirrors the negative control above).
     sim.disable_placement_migration();
+    // Opt into advertising the seeded host so the consult can find it (OFF by
+    // default; existing dead-end controls keep a seeded host un-advertised).
+    sim.enable_seeded_host_advertisements();
 
     let host_label = NodeLabel::node(NETWORK_NAME, 7);
     let requester_label = NodeLabel::node(NETWORK_NAME, 8);

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -11211,6 +11211,139 @@ fn test_terminal_advertisement_consult_closes_get_dead_end() {
     );
 }
 
+/// SUBSCRIBE counterpart of `test_terminal_advertisement_consult_closes_get_dead_end`:
+/// a SUBSCRIBE whose only host sits one hop OFF the routing path must resolve
+/// via the terminal advertisement consult instead of dead-ending with NotFound.
+///
+/// Same topology and isolation as the GET test (dense non-hosting cluster on
+/// the key, one advertised host just outside it, far requester, migration
+/// disabled, seeded-host advertising opted in). The SUBSCRIBE relay is
+/// single-shot: it forwards one greedy hop toward the key, and — on a CLEAN
+/// downstream NotFound — consults the host advertisements and forwards the
+/// SUBSCRIBE to the off-path advertised host, which answers Subscribed.
+///
+/// Proof is `terminal_consult_resolved_found() > 0` (recorded ONLY when a
+/// consulted host returns Subscribed); with migration off it is unambiguous
+/// that the consult (not routing or migration) closed the subscribe dead-end.
+#[test_log::test]
+fn test_terminal_advertisement_consult_closes_subscribe_dead_end() {
+    use freenet::config::GlobalTestMetrics;
+    use freenet::dev_tool::{Location, NodeLabel, ScheduledOperation, SimNetwork, SimOperation};
+
+    // Seed + placement chosen so the requester's upstream SUBSCRIBE routes into
+    // the non-hosting cluster and dead-ends at a relay whose off-path neighbor
+    // is the advertised host. Deterministic under the turmoil runner.
+    const SEED: u64 = 0xC0FF_EEC0_0008;
+    const NETWORK_NAME: &str = "terminal-consult-subscribe-deadend";
+    setup_deterministic_state(SEED);
+    GlobalTestMetrics::reset();
+
+    let contract = SimOperation::create_test_contract(0xC0);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    let key_loc = Location::from(&contract_key).as_f64();
+    let wrap = |x: f64| x.rem_euclid(1.0);
+
+    let cluster: Vec<f64> = [-0.010, -0.006, -0.003, 0.003, 0.006, 0.010]
+        .iter()
+        .map(|o| wrap(key_loc + o))
+        .collect();
+    let host_loc = wrap(key_loc + 0.05);
+    let requester_loc = wrap(key_loc - 0.60);
+    let mut node_locations = cluster.clone();
+    node_locations.push(host_loc); // node_no 7
+    node_locations.push(requester_loc); // node_no 8
+    let num_nodes = node_locations.len();
+
+    let rt = create_runtime();
+    let mut sim = rt.block_on(async {
+        SimNetwork::new_with_node_locations(
+            NETWORK_NAME,
+            1,
+            num_nodes,
+            10,
+            7,
+            8,
+            3,
+            SEED,
+            &node_locations,
+        )
+        .await
+    });
+    sim.disable_placement_migration();
+    sim.enable_seeded_host_advertisements();
+
+    let host_label = NodeLabel::node(NETWORK_NAME, 7);
+    let requester_label = NodeLabel::node(NETWORK_NAME, 8);
+
+    let operations = vec![
+        ScheduledOperation::new(
+            host_label.clone(),
+            SimOperation::SeedHostedContract {
+                contract: contract.clone(),
+                state: vec![11, 22, 33, 44],
+            },
+        ),
+        // Seed the requester too: a bare SUBSCRIBE for an absent contract fails
+        // the local RegisterSubscriberListener gate and never starts the
+        // network subscribe. With the contract present, the SUBSCRIBE passes
+        // that gate and routes UPSTREAM toward the key to build the
+        // subscription tree — and since the requester is far from the key, it
+        // dead-ends at the non-hosting cluster, exactly where the terminal
+        // consult applies.
+        ScheduledOperation::new(
+            requester_label.clone(),
+            SimOperation::SeedHostedContract {
+                contract: contract.clone(),
+                state: vec![11, 22, 33, 44],
+            },
+        ),
+        ScheduledOperation::new(
+            requester_label.clone(),
+            SimOperation::Subscribe { contract_id },
+        ),
+    ];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(180),
+        Duration::from_secs(60),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "simulation failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    assert!(
+        result.is_node_hosting(&host_label, &contract_key),
+        "host should still host the seeded contract after the simulation"
+    );
+
+    let attempts = GlobalTestMetrics::terminal_consult_attempts();
+    let hits = GlobalTestMetrics::terminal_consult_hits();
+    let resolved_found = GlobalTestMetrics::terminal_consult_resolved_found();
+    tracing::info!(
+        attempts,
+        hits,
+        resolved_found,
+        still_not_found = GlobalTestMetrics::terminal_consult_still_not_found(),
+        "terminal consult telemetry (subscribe)"
+    );
+
+    // With migration off, `resolved_found > 0` is recorded ONLY when a
+    // consulted advertised host answers Subscribed — the unambiguous proof
+    // that the SUBSCRIBE terminal consult (not routing or migration) closed
+    // the dead-end.
+    assert!(
+        resolved_found > 0,
+        "terminal consult should have resolved the SUBSCRIBE to Subscribed via an \
+         advertised off-path host (attempts={attempts}, hits={hits}, \
+         resolved_found={resolved_found})"
+    );
+}
+
 /// Reproduction + regression test for the placement-migration renewal storm
 /// (#4440, the storm symptom of the #4404 placement work).
 ///


### PR DESCRIPTION
> **PARKED for Ian's review — do NOT merge without his sign-off.**
> This is piece **C** of the demand-driven hosting redesign (epic #4642), implemented in parallel with the other pieces. It touches the GET/SUBSCRIBE routing path (a high-risk surface), so it is intentionally held for review rather than auto-merged.

## Problem

A GET/SUBSCRIBE routes toward a contract's key and reaches a **terminus** (the closest peer it can route to). Routing is purely location-based (`k_closest_potentially_hosting`), and each relay forwards to a *single* peer per hop (`MAX_RELAY_RETRIES = 1`). So if the terminus's closest neighbor toward the key does not host the contract, the relay bubbles `NotFound` **without trying its other neighbors** — even when one of them already advertised (via the neighbor-hosting mesh) that it hosts the contract. That advertised host is one hop **off the direct routing path**, and the request dead-ends with a false `NotFound`.

This implements **invariant 5** from `.claude/rules/hosting-invariants.md`: *"findability is routing + on-demand advertisement — a request routed toward its key, at its terminus, consults host advertisements."*

## Approach

At the GET/SUBSCRIBE terminus, before returning `NotFound`, consult the host advertisements the peer already received from neighbors (`NeighborHostingManager`) and forward the existing GET/SUBSCRIBE `Request` to an advertised host if one exists.

**Additive — no wire-format or `freenet-stdlib` change.** Reuses the existing message types and the existing visited/dedup machinery.

**Not a listed anti-pattern.** It forwards ONLY to a peer that *already advertised* hosting — it pushes and caches nothing and manufactures no demand, so it is not speculative pre-replication (which invariant 5 forbids). Bounded: terminus-only (not every hop); GET tries the closest ≤2 advertised hosts, SUBSCRIBE (single-shot) the closest 1; each candidate is marked tried + visited and forwarded with HTL-1, so loops cannot form. A terminus has zero closer routing peers, so these few extra forwards do not compound across hops (unlike the removed per-hop retry fan-out that caused the 3^HTL amplification).

### Key changes (`file:line`)
- `operations.rs` — `consult_advertised_hosts` + pure, unit-tested `rank_advertised_hosts`; `record_terminal_consult_outcome`.
- `operations/get/op_ctx_task.rs::drive_relay_get_inner` — consult in the exhaustion (None) arm before `relay_send_not_found`; resolved/still-NotFound telemetry after `classify`.
- `operations/subscribe/op_ctx_task.rs::drive_relay_subscribe` — consult in the no-candidates terminus branch before the NotFound response.
- `node/neighbor_hosting.rs` — `neighbors_with_contract_id` (relay drivers hold an instance id, not a full key).
- `node/network_status.rs` + `config.rs` (`GlobalTestMetrics`) — per-node aggregate scalars: attempts / hits / resolved-found / still-NotFound.
- `node/testing_impl/in_memory.rs::append_contracts` — harness fix: register startup-hosted contracts in `neighbor_hosting.my_contracts` so they are actually advertised (previously `SeedHostedContract` left them un-advertised, defeating both this consult and UPDATE proximity forwarding).

## Testing

- **Unit:** `rank_advertised_hosts` (closest-first ordering, max-hosts truncation, visited exclusion), `neighbors_with_contract_id`, consult telemetry counters.
- **Source-scrape pins:** GET/SUBSCRIBE terminus consults before NotFound and records the outcome.
- **Simulation** (`test_terminal_advertisement_consult_closes_get_dead_end`): a host one hop off the routing path, **migration disabled**, so `terminal_consult_resolved_found() > 0` is the unambiguous proof the consult (not routing or migration) closed the dead-end. Deterministic across repeated runs.
- Verified **no regression** in the existing GET dead-end tests and the subscription-root renewal-storm tests.

Refs #4642

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnRCbtbjepaB5GWrb5U8SR

[AI-assisted - Claude]