### PR TITLE
feat: demand-ordered hosting eviction (A3)

### DIFF
--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -948,6 +948,10 @@ async fn process_open_request(
                                 "Returning locally cached contract state"
                             );
 
+                            // #4642 A3 hit-rate instrumentation: this client GET
+                            // was answered from local hosted state (a hit).
+                            op_manager.ring.record_get_served_locally();
+
                             // Handle subscription for locally found contracts
                             if subscribe {
                                 if let Some(subscription_listener) = subscription_listener {
@@ -977,6 +981,11 @@ async fn process_open_request(
                                 contract,
                             })));
                         }
+
+                        // #4642 A3 hit-rate instrumentation: this client GET could
+                        // not be answered locally and is routed to the network
+                        // (a forward/miss).
+                        op_manager.ring.record_get_forwarded();
 
                         // Driver owns its routing state in task
                         // locals and calls notify_contract_handler

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1474,6 +1474,25 @@ impl Ring {
             snapshot.hosting_contract_count = Some(hosting.contract_count);
             snapshot.hosting_budget_evictions_total = Some(hosting.budget_evictions_total);
 
+            // Demand-ordered eviction gauge (#4642 A3): the
+            // #4338 miscalibration signal (evictions of repeatedly-read
+            // contracts). Per-node aggregate scalar on the same cadence.
+            snapshot.hosting_evictions_of_recently_read_total =
+                Some(hosting.evictions_of_recently_read_total);
+            // Local-client GET hit-rate (#4642 A3): served-locally vs routed to
+            // the network. Driven by the real serve/forward decision in the
+            // client GET handler, so it is read from the manager counters (not
+            // cache membership).
+            snapshot.hosting_local_hits_total = Some(ring.hosting_manager.local_get_serves());
+            snapshot.hosting_local_misses_total = Some(ring.hosting_manager.local_get_forwards());
+
+            // Keep the hosting manager's copy of our own ring location current so
+            // the proximity-prior demand estimate (#4642 A3) can turn a contract
+            // key into a distance. Best-effort: only push a known location.
+            if let Some(own_loc) = ring.connection_manager.own_location().location() {
+                ring.hosting_manager.set_own_location(own_loc);
+            }
+
             // Interest-weighted (two-tier) module-cache SHADOW gauges
             // (#4441/#4534): always-on, independent of the
             // FREENET_MODULE_CACHE_INTEREST_TIERED feature flag. They quantify
@@ -2319,6 +2338,18 @@ impl Ring {
     /// and which contracts were evicted (if any).
     pub fn record_get_access(&self, key: ContractKey, size_bytes: u64) -> RecordAccessResult {
         self.host_contract(key, size_bytes, AccessType::Get)
+    }
+
+    /// Record that a local-client GET was answered from local hosted state
+    /// (a hit) — see [`HostingManager::record_local_get_serve`]. (#4642 A3)
+    pub fn record_get_served_locally(&self) {
+        self.hosting_manager.record_local_get_serve();
+    }
+
+    /// Record that a local-client GET was routed to the network (a forward/miss)
+    /// — see [`HostingManager::record_local_get_forward`]. (#4642 A3)
+    pub fn record_get_forwarded(&self) {
+        self.hosting_manager.record_local_get_forward();
     }
 
     /// Whether this node is hosting this contract (has it in cache).

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -30,6 +30,7 @@
 //! - TTL protects recently accessed contracts from premature eviction
 
 mod cache;
+mod demand;
 
 use crate::util::backoff::{ExponentialBackoff, TrackedBackoff};
 use crate::util::time_source::{InstantTimeSrc, TimeSource};
@@ -50,13 +51,16 @@ use cache::{DEFAULT_MIN_TTL, HostingCache, HostingCacheStats};
 #[cfg(test)]
 pub(crate) use cache::{MAX_DEFAULT_HOSTING_BUDGET_BYTES, MIN_DEFAULT_HOSTING_BUDGET_BYTES};
 use dashmap::{DashMap, DashSet};
+use demand::ProximityPrior;
 use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
 use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::time::Instant;
 use tracing::{debug, info};
 
+use super::Location;
 use super::interest::PeerKey;
 
 // =============================================================================
@@ -211,9 +215,32 @@ pub(crate) struct HostingManager {
     /// Prevents hosting cache eviction while client subscriptions exist.
     client_subscriptions: DashMap<ContractInstanceId, HashSet<crate::client_events::ClientId>>,
 
-    /// Unified hosting cache with byte-budget LRU and TTL protection.
-    /// This is the single source of truth for which contracts we're hosting.
+    /// Unified hosting cache with byte-budget demand-ordered eviction ("fuel
+    /// gauge") and TTL protection. This is the single source of truth for which
+    /// contracts we're hosting.
     hosting_cache: RwLock<HostingCache<InstantTimeSrc>>,
+
+    /// Proximity-prior demand estimator (A3, freenet/freenet-core#4642). Maps a
+    /// contract's ring distance from this peer to a predicted read rate, used as
+    /// the `predicted_demand` term in the demand-ordered `keep_score`. Trained
+    /// from this peer's own observed read rates; see [`demand::ProximityPrior`].
+    demand_estimator: RwLock<ProximityPrior>,
+
+    /// This peer's own ring location, pushed in by `Ring` on the snapshot
+    /// cadence (`set_own_location`). `None` until the node has learned its
+    /// location, in which case demand falls back to neutral (eviction degrades
+    /// to Greedy-Dual floor + recency). The estimator needs it to turn a
+    /// contract key into a distance.
+    own_location: RwLock<Option<Location>>,
+
+    /// Local-client GET hit-rate counters (#4642 A3 instrumentation). Driven by
+    /// the actual serve-vs-forward DECISION in the client GET handler
+    /// (`client_events`), not by cache membership: `local_get_serves` counts
+    /// client GETs answered from local hosted state; `local_get_forwards` counts
+    /// those routed to the network. The collector derives the hit-rate as
+    /// `serves / (serves + forwards)`. Monotonic per-node scalars.
+    local_get_serves: AtomicU64,
+    local_get_forwards: AtomicU64,
 
     /// Downstream peers subscribed to contracts we host, with lease timestamps.
     /// Drives `should_unsubscribe_upstream()` decisions.
@@ -302,6 +329,10 @@ impl HostingManager {
                 DEFAULT_MIN_TTL,
                 InstantTimeSrc::new(),
             )),
+            demand_estimator: RwLock::new(ProximityPrior::new()),
+            own_location: RwLock::new(None),
+            local_get_serves: AtomicU64::new(0),
+            local_get_forwards: AtomicU64::new(0),
             downstream_subscribers: DashMap::new(),
             time_source: InstantTimeSrc::new(),
             pending_subscription_requests: DashSet::new(),
@@ -1026,6 +1057,52 @@ impl HostingManager {
     // Hosting Cache Management
     // =========================================================================
 
+    /// Update this peer's own ring location, used to turn a contract key into a
+    /// distance for the proximity-prior demand estimate. Pushed by `Ring` on the
+    /// snapshot cadence (`own_location()` can be `None` early in a node's life,
+    /// so callers should only push a known location).
+    pub(crate) fn set_own_location(&self, location: Location) {
+        *self.own_location.write() = Some(location);
+    }
+
+    /// Record that a local-client GET was answered from local hosted state (a
+    /// hit). Counted at the actual serve decision in the client GET handler, not
+    /// by cache membership, so the hit-rate metric reflects real serves. (#4642 A3)
+    pub(crate) fn record_local_get_serve(&self) {
+        self.local_get_serves.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record that a local-client GET was routed to the network (a miss/forward).
+    /// Counterpart to [`record_local_get_serve`](Self::record_local_get_serve).
+    pub(crate) fn record_local_get_forward(&self) {
+        self.local_get_forwards.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Monotonic count of local-client GETs served from local hosted state.
+    pub(crate) fn local_get_serves(&self) -> u64 {
+        self.local_get_serves.load(Ordering::Relaxed)
+    }
+
+    /// Monotonic count of local-client GETs routed to the network.
+    pub(crate) fn local_get_forwards(&self) -> u64 {
+        self.local_get_forwards.load(Ordering::Relaxed)
+    }
+
+    /// Ring distance from this peer to `key`, and the proximity-prior demand at
+    /// that distance. Returns `(None, NEUTRAL_DEMAND)` when this peer's own
+    /// location is not yet known — demand degrades to neutral, so eviction falls
+    /// back to Greedy-Dual floor + recency ordering (still demand-aware via the
+    /// read-refresh floor, just without distance weighting).
+    fn distance_and_demand(&self, key: &ContractKey) -> (Option<f64>, f64) {
+        let own = *self.own_location.read();
+        let distance = own.map(|loc| loc.distance(Location::from(key)).as_f64());
+        let demand = match distance {
+            Some(d) => self.demand_estimator.read().predict(d),
+            None => demand::NEUTRAL_DEMAND,
+        };
+        (distance, demand)
+    }
+
     /// Record a contract access in the hosting cache.
     ///
     /// This is the main entry point for adding contracts to the hosting cache.
@@ -1061,13 +1138,28 @@ impl HostingManager {
         // refreshed by the subsequent `record_contract_access` from that
         // write path.
         let current_generation = self.state_generation(&key);
-        let result = self.hosting_cache.write().record_access(
+
+        // Demand-ordered eviction (A3): predict this contract's read-demand from its
+        // ring distance to us via the proximity prior. The read guard is dropped
+        // before the hosting-cache write lock is taken (no nested lock order).
+        let (distance, predicted_demand) = self.distance_and_demand(&key);
+
+        let result = self.hosting_cache.write().record_access_with_demand(
             key,
             size_bytes,
             access_type,
             current_generation,
+            predicted_demand,
             |k: &ContractKey| self.contract_in_use(k),
         );
+
+        // Train the proximity prior from this peer's own observed read rate for
+        // the accessed contract (only reads yield a sample; PUT is a seed). The
+        // estimator is trained on the aggregate distance -> rate relationship;
+        // the per-contract blend is A4. Cache lock already dropped.
+        if let (Some(d), Some(rate)) = (distance, result.observed_read_rate) {
+            self.demand_estimator.write().observe(d, rate);
+        }
 
         // Persist hosting metadata for the accessed contract
         if let Some(storage) = self.storage.read().as_ref() {
@@ -1338,11 +1430,25 @@ impl HostingManager {
         self.hosting_cache.read().has_local_client_access(key)
     }
 
-    /// Touch a contract in the hosting cache (refresh TTL without adding).
+    /// Touch a contract in the hosting cache (refresh demand without adding).
     ///
-    /// Called when a user GET serves a hosted contract from local cache.
+    /// Called when a user GET serves a hosted contract from local cache — the
+    /// dominant read path for hot contracts. Trains the proximity prior from the
+    /// observed local-serve read rate (A3), the same way `record_contract_access`
+    /// does for network GETs, so the prior is not blind to the reads it is meant
+    /// to model. The cache write lock is dropped before the estimator write lock
+    /// (no nested lock order), matching `record_contract_access`.
     pub fn touch_hosting(&self, key: &ContractKey) {
-        self.hosting_cache.write().touch(key);
+        let observed_read_rate = self.hosting_cache.write().touch(key);
+        if let Some(rate) = observed_read_rate {
+            let distance = {
+                let own = *self.own_location.read();
+                own.map(|loc| loc.distance(Location::from(key)).as_f64())
+            };
+            if let Some(d) = distance {
+                self.demand_estimator.write().observe(d, rate);
+            }
+        }
     }
 
     /// Sweep for expired entries in the hosting cache.
@@ -2013,6 +2119,109 @@ mod tests {
         assert_eq!(
             default_manager.hosting_budget_bytes(),
             default_hosting_budget_bytes()
+        );
+    }
+
+    /// The demand path (A3): once the manager knows its own ring location, a
+    /// repeated read of a contract trains the proximity prior with a
+    /// `(distance, rate)` sample, and `distance_and_demand` yields a distance +
+    /// a finite, non-negative demand. Without a known location, demand is
+    /// neutral and no distance is available (eviction degrades to floor + LRU).
+    #[test]
+    fn test_demand_estimator_trains_from_repeated_reads() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let key = make_contract_key(1);
+
+        // No own-location yet: no distance, neutral demand, no training.
+        let (dist, demand) = manager.distance_and_demand(&key);
+        assert!(dist.is_none(), "distance unknown until own location is set");
+        assert_eq!(demand, demand::NEUTRAL_DEMAND);
+        assert_eq!(manager.demand_estimator.read().len(), 0);
+
+        // Learn our location, then read the contract twice. The second read has
+        // non-zero residency (floored at 1s), so it yields a training sample.
+        manager.set_own_location(Location::new(0.5));
+        manager.record_contract_access(key, 1_000, AccessType::Get);
+        manager.record_contract_access(key, 1_000, AccessType::Get);
+
+        assert_eq!(
+            manager.demand_estimator.read().len(),
+            1,
+            "a repeated read must train the proximity prior with one sample"
+        );
+
+        let (dist, demand) = manager.distance_and_demand(&key);
+        assert!(dist.is_some(), "distance is known once own location is set");
+        assert!(
+            demand.is_finite() && demand >= 0.0,
+            "predicted demand must be finite and non-negative, got {demand}"
+        );
+    }
+
+    /// A PUT is a SEED at the manager level too: it must NOT feed the proximity
+    /// prior (only reads are demand). Regression guard against wiring PUT into
+    /// the training path.
+    #[test]
+    fn test_put_does_not_train_demand_estimator() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let key = make_contract_key(1);
+        manager.set_own_location(Location::new(0.5));
+
+        manager.record_contract_access(key, 1_000, AccessType::Put);
+        manager.record_contract_access(key, 1_000, AccessType::Put);
+
+        assert_eq!(
+            manager.demand_estimator.read().len(),
+            0,
+            "PUT is a seed, not read-demand -- it must not train the prior"
+        );
+    }
+
+    /// Local-client GET hit-rate counters (#4642 A3) are driven by explicit
+    /// serve/forward signals from the client GET handler, not by cache
+    /// membership, and accumulate monotonically per node.
+    #[test]
+    fn test_local_get_hit_rate_counters() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        assert_eq!(manager.local_get_serves(), 0);
+        assert_eq!(manager.local_get_forwards(), 0);
+
+        manager.record_local_get_serve();
+        manager.record_local_get_serve();
+        manager.record_local_get_forward();
+
+        assert_eq!(manager.local_get_serves(), 2, "two local serves recorded");
+        assert_eq!(manager.local_get_forwards(), 1, "one forward recorded");
+    }
+
+    /// The local-serve path (`touch_hosting`) also trains the proximity prior, so
+    /// the dominant read path for hot contracts is not invisible to the estimator
+    /// (A3 — addresses the Codex/adversarial review finding that only network
+    /// refetches trained the prior).
+    #[test]
+    fn test_touch_hosting_trains_demand_estimator() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let key = make_contract_key(1);
+        manager.set_own_location(Location::new(0.5));
+
+        // Host the contract (a new-entry insert yields no rate sample), then
+        // serve it locally: the touch has non-zero residency so it trains.
+        manager.record_contract_access(key, 1_000, AccessType::Get);
+        let before = manager.demand_estimator.read().len();
+        manager.touch_hosting(&key);
+        assert!(
+            manager.demand_estimator.read().len() > before,
+            "a local-serve touch must train the proximity prior"
+        );
+
+        // Touching an unhosted contract is a no-op and trains nothing.
+        let absent = make_contract_key(2);
+        let n = manager.demand_estimator.read().len();
+        manager.touch_hosting(&absent);
+        assert_eq!(
+            manager.demand_estimator.read().len(),
+            n,
+            "touching an absent contract must not train the prior"
         );
     }
 

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -1,21 +1,38 @@
 //! Unified hosting cache for contract state caching.
 //!
-//! This module implements a byte-budget aware LRU cache with TTL protection for hosted contracts.
-//! It unifies the previously separate `SeedingCache` (now called hosting cache) and `GetSubscriptionCache` into a single
-//! source of truth for which contracts a peer is hosting.
+//! This module implements a byte-budget aware, **demand-ordered** ("fuel
+//! gauge") cache with TTL protection for hosted contracts. It unifies the
+//! previously separate `SeedingCache` (now called hosting cache) and
+//! `GetSubscriptionCache` into a single source of truth for which contracts a
+//! peer is hosting.
 //!
 //! # Design Principles
 //!
 //! 1. **Single source of truth**: All hosted contracts are tracked in one cache
-//! 2. **Resource-aware eviction**: Byte-budget LRU with TTL protection
+//! 2. **Demand-ordered eviction (Greedy-Dual)**: when over budget,
+//!    the contract with the lowest `keep_score` is evicted, where
+//!    `keep_score = eviction_floor + predicted_demand`. The `eviction_floor` is
+//!    a per-peer running value that ratchets up to the `keep_score` of each
+//!    evicted contract (Greedy-Dual aging, measured in cache-contention, not
+//!    wall-clock). A read (GET/SUBSCRIBE) refreshes a contract's `keep_score`
+//!    to the current frontier, so repeatedly-requested contracts float above
+//!    never-requested ones. See piece A3 of the demand-driven hosting redesign
+//!    (freenet/freenet-core#4642) and `docs/design/hosting-eviction.md`.
 //! 3. **Subscription renewal**: All hosted contracts get subscription renewal
 //! 4. **Access type tracking**: Records how contract was accessed (GET/PUT/SUBSCRIBE)
+//!
+//! `predicted_demand` is supplied by the caller (`HostingManager`, which owns
+//! the proximity-prior estimator and the peer's own ring location — see
+//! [`super::demand`]). The cache itself is location-agnostic: it only orders by
+//! the demand scalar it is handed, so this module stays unit-testable without a
+//! ring.
 
 use freenet_stdlib::prelude::ContractKey;
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::time::Duration;
 use tokio::time::Instant;
 
+use super::demand::NEUTRAL_DEMAND;
 use crate::util::time_source::TimeSource;
 use crate::wasm_runtime::read_total_ram_bytes;
 
@@ -122,6 +139,15 @@ pub(crate) struct HostingCacheStats {
     /// over budget. The collector differences it across the cadence to derive a
     /// budget-triggered eviction rate.
     pub budget_evictions_total: u64,
+    /// Monotonic count of over-budget evictions whose victim had been READ
+    /// (GET/SUBSCRIBE) more than once during its residency (`read_count >= 2`,
+    /// i.e. genuine repeat demand, not a one-off seed). Under a well-calibrated
+    /// demand-ordered policy this stays near zero — evicting a repeatedly-requested
+    /// contract is the #4338 miscalibration symptom (a real-demand contract
+    /// evicted ahead of junk). A rising rate here (differenced against
+    /// [`Self::budget_evictions_total`]) is the alarm that the demand estimate
+    /// is mis-ordering the working set.
+    pub evictions_of_recently_read_total: u64,
 }
 
 /// Multiplier for TTL relative to subscription renewal interval.
@@ -163,6 +189,13 @@ pub struct RecordAccessResult {
     /// deletion-time guard in `RuntimePool::remove_contract` can detect
     /// a re-host that occurred between eviction and disk reclamation.
     pub evicted: Vec<(ContractKey, u64)>,
+    /// Observed read-rate training sample (reads/second) for the accessed
+    /// contract, or `None` when no meaningful rate is available (a seed/PUT, a
+    /// brand-new entry, or a read with zero residency). `HostingManager` pairs
+    /// this with the contract's ring distance and feeds it to the proximity
+    /// prior (`super::demand::ProximityPrior`). Purely a training signal — it
+    /// never affects THIS access's `keep_score`.
+    pub observed_read_rate: Option<f64>,
 }
 
 /// Metadata about a hosted contract.
@@ -170,8 +203,48 @@ pub struct RecordAccessResult {
 pub struct HostedContract {
     /// Size of the contract state in bytes
     pub size_bytes: u64,
-    /// Last time this contract was accessed (via GET/PUT/SUBSCRIBE)
+    /// Last time this contract was accessed (via GET/PUT/SUBSCRIBE). Drives the
+    /// TTL gate (an entry is not eviction-eligible until `min_ttl` since this).
     pub last_accessed: Instant,
+    /// Monotonic access sequence number stamped on every access (insert / read /
+    /// seed / touch). Used as the eviction tiebreak when two entries have equal
+    /// `keep_score`: the lower sequence (least-recently-accessed) evicts first —
+    /// LRU as a tiebreaker. A dedicated counter, not `last_accessed`, so the
+    /// ordering is exact even when several accesses share a mock-clock instant.
+    pub last_access_seq: u64,
+    /// Demand-ordered (Greedy-Dual) priority: `eviction_floor + predicted_demand` captured at the
+    /// last read-demand refresh (or at insert). The over-budget walk evicts the
+    /// entry with the lowest `keep_score` (ties broken by `last_accessed`). A
+    /// read (GET/SUBSCRIBE) recomputes this against the CURRENT `eviction_floor`,
+    /// so recently-requested contracts sit at the frontier while never-requested
+    /// ones fall behind as the floor ratchets up. See the module docs.
+    pub keep_score: f64,
+    /// Per-contract read-demand estimate (reads/second) from the proximity-prior
+    /// estimator, supplied by the caller at insert / read-refresh. Stored so a
+    /// `touch` (which has no estimator access) can recompute `keep_score` from
+    /// the current floor without recomputing the prior. For A3 this is the
+    /// proximity prior only; A4 blends it toward the contract's own observed
+    /// read rate.
+    pub predicted_demand: f64,
+    /// Number of read accesses (GET/SUBSCRIBE, including `touch`) observed over
+    /// this entry's residency. A PUT is a SEED, not a read, so it does not
+    /// increment this. Drives (a) the observed-rate training sample fed back to
+    /// the proximity prior (`read_count / residency`) and (b) the
+    /// `evictions_of_recently_read` miscalibration counter (`>= 2` = genuine
+    /// repeat demand).
+    ///
+    /// Note: a single client GET of a hosted-but-stale contract can bump this
+    /// twice — once via `touch` (the pre-decision TTL refresh in the client GET
+    /// handler) and once via the network refetch's `record_access(Get)`. This is
+    /// a bounded (2x) over-count on the stale-refetch path only; it slightly
+    /// inflates the trained rate and can make `evictions_of_recently_read` fire
+    /// for a contract read just once. Both are soft, directional signals, so the
+    /// inaccuracy is accepted rather than deduplicated (which would require
+    /// threading GET-request identity through both paths).
+    pub read_count: u32,
+    /// When this entry was first inserted. Used with `read_count` to derive an
+    /// observed read-rate training sample for the proximity prior.
+    pub inserted_at: Instant,
     /// Type of the last access
     pub access_type: AccessType,
     /// Whether a local client (HTTP/WebSocket) accessed this contract.
@@ -194,22 +267,27 @@ pub struct HostedContract {
     /// `None` means the entry has never been abandoned, or has been
     /// re-accessed since its last abandonment.
     ///
-    /// The abandonment hook moves the entry to the FRONT of the LRU order
-    /// so that under disk pressure it is evicted before older-but-still-
-    /// active entries. Once past TTL, `evict_over_budget` walks the LRU
-    /// front-first as before — abandoned entries simply sit at the front.
-    /// Refreshing the entry via `record_access` clears this field and
-    /// moves the entry back to the LRU tail.
+    /// The abandonment hook drops the entry's `keep_score` to the current
+    /// `eviction_floor` (stripping its demand credit) so that under budget
+    /// pressure it is evicted before still-active entries, whose `keep_score` is
+    /// `floor + demand >= floor`. With strictly positive demand it sorts strictly
+    /// below them; when demand is zero (a far contract under a trained prior) it
+    /// ties an active entry at the floor, and the least-recently-accessed
+    /// tiebreak (`last_access_seq`) still tends to evict the abandoned entry
+    /// first (it has not been read since it lost its subscribers). Once past TTL,
+    /// `evict_over_budget` picks the lowest `keep_score` first. Refreshing the
+    /// entry via a read (`record_access` / `touch`) clears this field and
+    /// restores its `keep_score` to `floor + predicted_demand`.
     ///
     /// Idle contracts with no subscribers but recent demand are NOT
-    /// affected: they keep their natural LRU position. Only entries that
-    /// were actively in use and then lost all in-use signals get bumped
-    /// to the priority bucket, since their `last_accessed` would otherwise
-    /// keep them at the LRU tail despite no longer mattering.
+    /// affected: they keep their earned `keep_score`. Only entries that
+    /// were actively in use and then lost all in-use signals get their
+    /// demand credit stripped, since their recency would otherwise keep
+    /// them ahead despite no longer mattering.
     ///
     /// The timestamp itself is written but not read by eviction logic
-    /// (eviction priority comes purely from LRU position, which
-    /// `record_abandonment` adjusts as a side effect). It is retained
+    /// (eviction priority comes from `keep_score`, which `record_abandonment`
+    /// adjusts as a side effect). It is retained
     /// for the governance dashboard (PR #4270) so an operator can see
     /// how long ago a flagged contract was last actively used. A future
     /// refactor that removes the field can do so only after the
@@ -227,7 +305,9 @@ pub struct HostedContract {
 ///   in tracked contract **state** bytes only; WASM code blobs and database
 ///   overhead are not counted against it.
 /// - TTL protection: Contracts can't be evicted until min_ttl has passed
-/// - LRU ordering: Oldest contracts evicted first when over budget
+/// - Demand-ordered eviction (Greedy-Dual): when over budget the
+///   contract with the lowest `keep_score` is evicted first (ties broken by
+///   least-recently-read), NOT purely the oldest. See the module docs.
 ///
 /// # Subscription Renewal
 ///
@@ -240,15 +320,31 @@ pub struct HostingCache<T: TimeSource> {
     current_bytes: u64,
     /// Minimum time since last access before eviction is allowed
     min_ttl: Duration,
-    /// LRU order - front is oldest, back is newest
-    lru_order: VecDeque<ContractKey>,
-    /// Contract metadata indexed by key
+    /// Contract metadata indexed by key. Eviction order is derived from each
+    /// entry's `keep_score` (then `last_accessed`), not from a separate LRU
+    /// list, so there is no second structure to keep in sync.
     contracts: HashMap<ContractKey, HostedContract>,
+    /// Monotonic access counter. Incremented on every access (insert / read /
+    /// seed / touch) and stamped onto the entry's `last_access_seq`, giving an
+    /// exact least-recently-accessed tiebreak for eviction that is independent
+    /// of mock-clock granularity.
+    access_seq: u64,
+    /// Greedy-Dual aging value. Monotonically non-decreasing:
+    /// each over-budget eviction ratchets it up to the evicted contract's
+    /// `keep_score`. A read refreshes the read contract's `keep_score` to
+    /// `eviction_floor + predicted_demand`, so the floor is the moving frontier
+    /// that separates still-wanted contracts from stale ones. Measured in
+    /// cache-contention units, not wall-clock.
+    eviction_floor: f64,
     /// Monotonic count of contracts evicted because the cache was over budget.
     /// Only `evict_over_budget` increments it, so it counts budget-triggered
     /// evictions specifically (not TTL sweeps that found nothing over budget).
     /// Exposed via [`HostingCache::stats`] for per-node telemetry.
     budget_evictions_total: u64,
+    /// Monotonic count of over-budget evictions whose victim had `read_count >= 2`
+    /// (genuine repeat demand). The #4338 miscalibration signal — see
+    /// [`HostingCacheStats::evictions_of_recently_read_total`].
+    evictions_of_recently_read_total: u64,
     /// Time source for testability
     time_source: T,
 }
@@ -260,23 +356,45 @@ impl<T: TimeSource> HostingCache<T> {
             budget_bytes,
             current_bytes: 0,
             min_ttl,
-            lru_order: VecDeque::new(),
             contracts: HashMap::new(),
+            access_seq: 0,
+            eviction_floor: 0.0,
             budget_evictions_total: 0,
+            evictions_of_recently_read_total: 0,
             time_source,
         }
     }
 
-    /// Evict past-TTL, non-retained contracts while the cache is over budget.
+    /// Next monotonic access sequence number, stamped onto an entry on every
+    /// access to give an exact least-recently-accessed eviction tiebreak.
+    fn next_seq(&mut self) -> u64 {
+        self.access_seq = self.access_seq.saturating_add(1);
+        self.access_seq
+    }
+
+    /// Evict past-TTL, non-retained contracts while the cache is over budget,
+    /// lowest `keep_score` first (Greedy-Dual, demand-ordered).
     ///
-    /// Walks `lru_order` front-first (oldest first). An entry is evicted when
-    /// it is past `min_ttl` since its last access AND `should_retain(key)` is
-    /// `false`. Eviction stops as soon as `current_bytes <= budget_bytes`.
-    /// Entries that are retained (in use) or still within `min_ttl` are kept
-    /// even if that leaves the cache over budget.
+    /// An entry is eligible for eviction when it is past `min_ttl` since its
+    /// last access AND `should_retain(key)` is `false`. Among eligible entries
+    /// the victim order is ascending `(keep_score, last_accessed)`: the least
+    /// demand-worthy contract goes first, and a least-recently-read tiebreak
+    /// resolves equal scores (so with uniform demand this degrades to LRU).
+    /// Each eviction ratchets `eviction_floor` up to the victim's `keep_score`
+    /// (Greedy-Dual aging). Eviction stops as soon as
+    /// `current_bytes <= budget_bytes`. Retained (in use) and still-within-TTL
+    /// entries are kept even if that leaves the cache over budget.
     ///
-    /// Uses a `retain()`-style walk so the LRU ordering of surviving entries
-    /// is preserved. Returns the evicted keys.
+    /// Returns the evicted `(key, write_generation)` pairs; the generation is
+    /// captured atomically under the cache's write lock so the `EvictContract`
+    /// deletion-time guard can detect a re-host that races with this eviction
+    /// (see `RuntimePool::remove_contract`).
+    ///
+    /// do NOT revert to byte-only LRU — see hosting-invariants (byte-only
+    /// eviction anti-pattern). Byte-only / recency-only eviction is demand-blind
+    /// and re-opens the #4338 miscalibration class (a repeatedly-requested
+    /// contract evicted ahead of never-requested junk). Eviction MUST order by
+    /// `keep_score` (demand-driven), with bytes only a tiebreak/ceiling.
     fn evict_over_budget<F>(&mut self, should_retain: &F) -> Vec<(ContractKey, u64)>
     where
         F: Fn(&ContractKey) -> bool,
@@ -286,35 +404,56 @@ impl<T: TimeSource> HostingCache<T> {
         }
 
         let now = self.time_source.now();
-        let mut evicted = Vec::new();
 
-        self.lru_order.retain(|key| {
-            if self.current_bytes <= self.budget_bytes {
-                return true; // back under budget, stop evicting
-            }
-            if let Some(entry) = self.contracts.get(key) {
+        // Collect eviction-eligible entries (past TTL, not retained) with their
+        // ordering keys, then evict lowest-priority first until back under
+        // budget. O(n log n) per over-budget event; n is the hosted-contract
+        // count (hundreds to ~1k), and this only runs when actually over budget.
+        let mut candidates: Vec<(ContractKey, f64, u64)> = self
+            .contracts
+            .iter()
+            .filter(|(key, entry)| {
                 let age = now.saturating_duration_since(entry.last_accessed);
-                if age >= self.min_ttl && !should_retain(key) {
-                    let size = entry.size_bytes;
-                    // Capture the generation atomically under the cache's
-                    // write lock so the `EvictContract` deletion-time
-                    // guard can detect a re-host that races with this
-                    // eviction. See `RuntimePool::remove_contract`.
-                    let generation = entry.write_generation;
-                    self.contracts.remove(key);
-                    self.current_bytes = self.current_bytes.saturating_sub(size);
-                    self.budget_evictions_total = self.budget_evictions_total.saturating_add(1);
-                    evicted.push((*key, generation));
-                    false
-                } else {
-                    // Retained (in use) or still within TTL — keep it even
-                    // if that leaves the cache over budget.
-                    true
-                }
-            } else {
-                false // orphaned LRU entry
-            }
+                age >= self.min_ttl && !should_retain(key)
+            })
+            .map(|(key, entry)| (*key, entry.keep_score, entry.last_access_seq))
+            .collect();
+
+        // Ascending by keep_score, then by access sequence (least recently
+        // accessed first), then by contract-key bytes as a final deterministic
+        // tiebreak. `total_cmp` gives a total order over f64 with no NaN
+        // surprises (keep_score is always finite here, but be defensive). The
+        // access sequence is already unique per live entry, so the key tiebreak
+        // only matters for the transient pre-`finalize_loading` seq-0 case; it
+        // orders on `as_bytes()` (the instance-id byte string) explicitly rather
+        // than relying on `ContractKey`'s deref-to-`[u8; N]` coercion.
+        candidates.sort_by(|a, b| {
+            a.1.total_cmp(&b.1)
+                .then_with(|| a.2.cmp(&b.2))
+                .then_with(|| a.0.as_bytes().cmp(b.0.as_bytes()))
         });
+
+        let mut evicted = Vec::new();
+        for (key, keep_score, _) in candidates {
+            if self.current_bytes <= self.budget_bytes {
+                break; // back under budget, stop evicting
+            }
+            if let Some(entry) = self.contracts.remove(&key) {
+                self.current_bytes = self.current_bytes.saturating_sub(entry.size_bytes);
+                self.budget_evictions_total = self.budget_evictions_total.saturating_add(1);
+                if entry.read_count >= 2 {
+                    self.evictions_of_recently_read_total =
+                        self.evictions_of_recently_read_total.saturating_add(1);
+                }
+                // Greedy-Dual aging: ratchet the floor up to the victim's score
+                // (never down — an entry whose stale score is below the current
+                // floor leaves the floor untouched).
+                if keep_score > self.eviction_floor {
+                    self.eviction_floor = keep_score;
+                }
+                evicted.push((key, entry.write_generation));
+            }
+        }
 
         evicted
     }
@@ -347,6 +486,11 @@ impl<T: TimeSource> HostingCache<T> {
     /// entry is later evicted, its `write_generation` snapshot travels
     /// with the `EvictContract` event and is compared against the
     /// then-current generation at deletion time.
+    // Neutral-demand convenience wrapper. Production always goes through
+    // `record_access_with_demand` (the `HostingManager` supplies the
+    // proximity-prior estimate), so in a non-test build this wrapper is unused;
+    // it is retained for callers/tests that have no demand estimate.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn record_access<F>(
         &mut self,
         key: ContractKey,
@@ -358,10 +502,54 @@ impl<T: TimeSource> HostingCache<T> {
     where
         F: Fn(&ContractKey) -> bool,
     {
+        // Neutral demand: with a uniform demand term for every contract,
+        // `keep_score` ordering degrades to the least-recently-read tiebreak
+        // (LRU). This wrapper is used by callers that have no demand estimate
+        // (and by the cache's own unit tests); `HostingManager` uses
+        // `record_access_with_demand` to supply the proximity-prior estimate.
+        self.record_access_with_demand(
+            key,
+            size_bytes,
+            access_type,
+            write_generation,
+            NEUTRAL_DEMAND,
+            should_retain,
+        )
+    }
+
+    /// Like [`record_access`](Self::record_access) but with an explicit
+    /// `predicted_demand` for the demand-ordered `keep_score`.
+    ///
+    /// Semantics by access kind:
+    /// - **New entry (any kind):** `keep_score = eviction_floor + predicted_demand`.
+    ///   A GET/SUBSCRIBE also counts as one read (`read_count = 1`); a PUT is a
+    ///   SEED (`read_count = 0`).
+    /// - **Existing entry, GET/SUBSCRIBE (read-demand):** refresh `keep_score`
+    ///   to the CURRENT `eviction_floor + predicted_demand` (float to the
+    ///   frontier), bump `read_count`, refresh recency, clear any abandonment.
+    ///   Returns an `observed_read_rate` training sample.
+    /// - **Existing entry, PUT (seed only):** refresh recency/size/generation
+    ///   and the stored `predicted_demand`, but do NOT refresh `keep_score` — a
+    ///   write is not read-demand, so it earns no frontier credit and cannot
+    ///   keep a contract alive against reads.
+    pub fn record_access_with_demand<F>(
+        &mut self,
+        key: ContractKey,
+        size_bytes: u64,
+        access_type: AccessType,
+        write_generation: u64,
+        predicted_demand: f64,
+        should_retain: F,
+    ) -> RecordAccessResult
+    where
+        F: Fn(&ContractKey) -> bool,
+    {
         let now = self.time_source.now();
+        let seq = self.next_seq();
+        let is_read = matches!(access_type, AccessType::Get | AccessType::Subscribe);
 
         if let Some(existing) = self.contracts.get_mut(&key) {
-            // Already cached - update size if changed and refresh position
+            // Already cached - update size if changed
             if existing.size_bytes != size_bytes {
                 // Adjust byte accounting: add new size, subtract old size
                 self.current_bytes = self
@@ -371,24 +559,33 @@ impl<T: TimeSource> HostingCache<T> {
                 existing.size_bytes = size_bytes;
             }
             existing.last_accessed = now;
+            existing.last_access_seq = seq;
             existing.access_type = access_type;
             // Refresh the generation snapshot: a re-access is a fresh
             // "I'm hosting this state" assertion, so its captured generation
             // should track the current state-write generation.
             existing.write_generation = write_generation;
-            // A re-access clears the abandoned bucket: the contract is
-            // back in active use, so the priority-eviction marker no
-            // longer applies and the entry returns to the LRU tail
-            // below.
-            existing.abandoned_at = None;
+            // Keep the stored demand estimate current so a later `touch`
+            // (which has no estimator access) refreshes against the latest prior.
+            existing.predicted_demand = predicted_demand;
 
-            // Move to back of LRU (most recently used)
-            self.lru_order.retain(|k| k != &key);
-            self.lru_order.push_back(key);
+            let observed_read_rate = if is_read {
+                // Read-demand: float this contract's keep_score to the frontier
+                // and count the read. A re-access clears the abandoned marker.
+                existing.read_count = existing.read_count.saturating_add(1);
+                existing.abandoned_at = None;
+                existing.keep_score = self.eviction_floor + predicted_demand;
+                Self::rate_sample(existing.read_count, now, existing.inserted_at)
+            } else {
+                // Seed (PUT) on an existing entry: no frontier credit, no read
+                // count. keep_score is intentionally left untouched.
+                None
+            };
 
             RecordAccessResult {
                 is_new: false,
                 evicted: Vec::new(),
+                observed_read_rate,
             }
         } else {
             // Not cached - insert the new entry first, then evict over-budget
@@ -397,6 +594,11 @@ impl<T: TimeSource> HostingCache<T> {
             let contract = HostedContract {
                 size_bytes,
                 last_accessed: now,
+                last_access_seq: seq,
+                keep_score: self.eviction_floor + predicted_demand,
+                predicted_demand,
+                read_count: if is_read { 1 } else { 0 },
+                inserted_at: now,
                 access_type,
                 local_client_access: false,
                 local_client_last_access: None,
@@ -404,7 +606,6 @@ impl<T: TimeSource> HostingCache<T> {
                 abandoned_at: None,
             };
             self.contracts.insert(key, contract);
-            self.lru_order.push_back(key);
             self.current_bytes = self.current_bytes.saturating_add(size_bytes);
 
             let evicted = self.evict_over_budget(&should_retain);
@@ -412,8 +613,24 @@ impl<T: TimeSource> HostingCache<T> {
             RecordAccessResult {
                 is_new: true,
                 evicted,
+                // Brand-new entry has zero residency -> no rate sample yet.
+                observed_read_rate: None,
             }
         }
+    }
+
+    /// Derive an observed read-rate (reads/second) sample from a contract's
+    /// read count and residency. `None` when residency is non-positive (no
+    /// elapsed time to divide by). Residency is floored at one second so a burst
+    /// of quick reads can't produce an unbounded spike that would dominate the
+    /// proximity-prior fit.
+    fn rate_sample(read_count: u32, now: Instant, inserted_at: Instant) -> Option<f64> {
+        let residency = now.saturating_duration_since(inserted_at);
+        if residency.is_zero() {
+            return None;
+        }
+        let residency_secs = residency.as_secs_f64().max(1.0);
+        Some(read_count as f64 / residency_secs)
     }
 
     /// Mark a contract as accessed by a local client (HTTP/WebSocket).
@@ -448,35 +665,53 @@ impl<T: TimeSource> HostingCache<T> {
             .unwrap_or(false)
     }
 
-    /// Touch/refresh a contract's timestamp without adding it if missing.
+    /// Touch/refresh a contract's demand without adding it if missing.
     ///
-    /// Called when a user GET serves a hosted contract from local cache.
-    /// This refreshes the TTL and LRU position so actively requested
-    /// contracts stay in the cache.
-    pub fn touch(&mut self, key: &ContractKey) {
+    /// Called when a user GET serves a hosted contract from local cache — the
+    /// dominant read path for hot contracts. This is read-demand: it refreshes
+    /// the TTL clock and floats the contract's `keep_score` back to the frontier
+    /// (`eviction_floor + predicted_demand`, using the demand estimate stored at
+    /// the last `record_access`), counts the read, and clears any abandonment —
+    /// so actively requested contracts stay in the cache.
+    ///
+    /// Returns the observed read-rate training sample (`read_count / residency`)
+    /// the same way `record_access_with_demand` does, so the caller
+    /// (`HostingManager::touch_hosting`) can feed the proximity prior from the
+    /// local-serve path too — otherwise the prior would train only on network
+    /// refetches and stay blind to the reads A3 is meant to model. `None` when
+    /// the contract is absent or residency is zero.
+    pub fn touch(&mut self, key: &ContractKey) -> Option<f64> {
+        let floor = self.eviction_floor;
+        let seq = self.next_seq();
+        let now = self.time_source.now();
         if let Some(existing) = self.contracts.get_mut(key) {
-            existing.last_accessed = self.time_source.now();
-            // A fresh touch is evidence of demand — clear any abandoned
-            // marker so the entry leaves the priority-eviction bucket.
+            existing.last_accessed = now;
+            existing.last_access_seq = seq;
+            existing.read_count = existing.read_count.saturating_add(1);
+            // A fresh touch is evidence of demand — clear any abandoned marker
+            // and refresh keep_score to the current frontier.
             existing.abandoned_at = None;
-            // Move to back of LRU
-            self.lru_order.retain(|k| k != key);
-            self.lru_order.push_back(*key);
+            existing.keep_score = floor + existing.predicted_demand;
+            Self::rate_sample(existing.read_count, now, existing.inserted_at)
+        } else {
+            None
         }
     }
 
-    /// Mark `key` as recently abandoned and move it to the front of the
-    /// LRU order so it is the first candidate for eviction under disk
-    /// pressure.
+    /// Mark `key` as recently abandoned and strip its demand credit so it is the
+    /// first candidate for eviction under budget pressure.
     ///
     /// Called by `HostingManager` when a contract transitions from "in
     /// use" (has subscribers / clients / downstream peers) to "no longer
     /// in use" — the moment its `contract_in_use` predicate flips from
-    /// `true` to `false`. The TTL gate in `evict_over_budget` still
-    /// applies: an abandoned entry within `min_ttl` of its last access is
-    /// not yet eligible. Once past TTL, abandoned entries are evicted
-    /// before older-but-still-active entries because they now sit at the
-    /// LRU front.
+    /// `true` to `false`. The entry's `keep_score` is dropped to the current
+    /// `eviction_floor` (zero demand credit), so among the credited band it
+    /// sorts first: a still-active entry keeps `floor + demand >= floor`, strictly
+    /// above when demand is positive, tying at the floor only when demand is zero
+    /// (there the least-recently-accessed tiebreak still favors evicting the
+    /// abandoned entry). The TTL gate in `evict_over_budget` still applies: an
+    /// abandoned entry within
+    /// `min_ttl` of its last access is not yet eligible.
     ///
     /// No-op when `key` is absent (already evicted). Idempotent: calling
     /// it on an already-abandoned entry leaves the existing marker (and
@@ -485,17 +720,17 @@ impl<T: TimeSource> HostingCache<T> {
     ///
     /// Network forgetfulness is explicitly preserved: this method does
     /// **not** evict the contract or shorten its TTL. It only changes the
-    /// eviction *order* used when the cache is genuinely over budget. A
-    /// contract that's abandoned but no longer than other entries' TTL
-    /// stays cached just like before.
+    /// eviction *priority* used when the cache is genuinely over budget. A
+    /// contract that's abandoned but under budget pressure stays cached.
     pub fn record_abandonment(&mut self, key: &ContractKey) {
+        let floor = self.eviction_floor;
         if let Some(existing) = self.contracts.get_mut(key) {
             if existing.abandoned_at.is_none() {
                 existing.abandoned_at = Some(self.time_source.now());
-                // Move to FRONT of LRU so the next over-budget walk
-                // evaluates this entry first.
-                self.lru_order.retain(|k| k != key);
-                self.lru_order.push_front(*key);
+                // Strip demand credit: drop keep_score to the frontier so the
+                // next over-budget walk evaluates this entry before any
+                // still-credited (floor + demand) entry.
+                existing.keep_score = floor;
             }
         }
     }
@@ -567,13 +802,34 @@ impl<T: TimeSource> HostingCache<T> {
             current_bytes: self.current_bytes,
             contract_count: self.contracts.len() as u64,
             budget_evictions_total: self.budget_evictions_total,
+            evictions_of_recently_read_total: self.evictions_of_recently_read_total,
         }
     }
 
-    /// Get all hosted contract keys in LRU order (oldest first).
+    /// Get all hosted contract keys in EVICTION order — the order the
+    /// over-budget walk would evict them: ascending `(keep_score,
+    /// last_accessed, key)`, i.e. the least demand-worthy (then
+    /// least-recently-read) contract first. With uniform demand this is LRU.
     #[cfg(test)]
-    pub fn keys_lru_order(&self) -> Vec<ContractKey> {
-        self.lru_order.iter().cloned().collect()
+    pub fn keys_eviction_order(&self) -> Vec<ContractKey> {
+        let mut entries: Vec<_> = self
+            .contracts
+            .iter()
+            .map(|(k, v)| (*k, v.keep_score, v.last_access_seq))
+            .collect();
+        entries.sort_by(|a, b| {
+            a.1.total_cmp(&b.1)
+                .then_with(|| a.2.cmp(&b.2))
+                .then_with(|| a.0.as_bytes().cmp(b.0.as_bytes()))
+        });
+        entries.into_iter().map(|(k, _, _)| k).collect()
+    }
+
+    /// The current Greedy-Dual aging value (the eviction floor). Test-only
+    /// introspection for the eviction-floor ratchet.
+    #[cfg(test)]
+    pub fn eviction_floor(&self) -> f64 {
+        self.eviction_floor
     }
 
     /// Iterate over all hosted contract keys.
@@ -583,13 +839,12 @@ impl<T: TimeSource> HostingCache<T> {
 
     /// Sweep for contracts past TTL when the cache is over budget.
     ///
-    /// Only evicts when `current_bytes > budget_bytes`. Among over-budget
-    /// entries, contracts past `min_ttl` since their last access are evicted
-    /// (oldest first via LRU order) unless the `should_retain` predicate
-    /// returns `true` (e.g., contracts with active client subscriptions or
-    /// downstream subscribers).
+    /// Only evicts when `current_bytes > budget_bytes`. Among over-budget,
+    /// past-TTL, non-retained entries, the lowest `keep_score` is evicted first
+    /// (demand-ordered; ties broken by least-recently-read) unless
+    /// the `should_retain` predicate returns `true` (e.g., contracts with active
+    /// client subscriptions or downstream subscribers).
     ///
-    /// Uses `retain()` to preserve LRU ordering for non-evicted entries.
     /// Returns `(ContractKey, write_generation)` pairs for evicted contracts;
     /// the generation snapshot is carried through `EvictContract` so the
     /// deletion-time guard can detect a re-host race.
@@ -599,7 +854,7 @@ impl<T: TimeSource> HostingCache<T> {
     {
         // Over-budget eviction logic is shared with `record_access` via
         // `evict_over_budget`: it returns early when under budget, then
-        // evicts past-TTL, non-retained entries oldest-first.
+        // evicts past-TTL, non-retained entries lowest-keep_score-first.
         self.evict_over_budget(&should_retain)
     }
 
@@ -638,6 +893,20 @@ impl<T: TimeSource> HostingCache<T> {
         let contract = HostedContract {
             size_bytes,
             last_accessed,
+            // Assigned a proper order by `finalize_loading` once all entries are
+            // loaded (sorted by persisted recency). Temporary 0 until then.
+            last_access_seq: 0,
+            // Loaded entries start with the neutral demand estimate at the
+            // current floor; the first live access re-scores them against the
+            // proximity prior. `last_accessed` (from the persisted age) is the
+            // tiebreak, so among equal (neutral) scores the oldest evicts first —
+            // the same recency ordering the old LRU load path produced.
+            keep_score: self.eviction_floor + NEUTRAL_DEMAND,
+            predicted_demand: NEUTRAL_DEMAND,
+            // Reads observed this run start at zero; the persisted access_type
+            // reflects the last pre-restart access, not this run's read count.
+            read_count: 0,
+            inserted_at: now,
             access_type,
             local_client_access,
             local_client_last_access,
@@ -654,14 +923,17 @@ impl<T: TimeSource> HostingCache<T> {
 
         self.contracts.insert(key, contract);
         self.current_bytes = self.current_bytes.saturating_add(size_bytes);
-        // Note: LRU order will be sorted after all entries are loaded
     }
 
-    /// Sort the LRU order by last_accessed time after bulk loading.
+    /// Finalize bulk loading: assign each loaded entry an access sequence in
+    /// persisted-recency order (oldest last-access -> lowest sequence), so the
+    /// eviction tiebreak evicts the least-recently-accessed loaded contract
+    /// first — the same recency ordering the old LRU load path produced. The
+    /// running access counter is advanced past the assigned range so subsequent
+    /// live accesses keep sorting after loaded entries.
     ///
     /// Call this after `load_persisted_entry` calls are complete.
     pub fn finalize_loading(&mut self) {
-        // Build LRU order from contracts sorted by last_accessed (oldest first)
         let mut entries: Vec<_> = self
             .contracts
             .iter()
@@ -669,9 +941,11 @@ impl<T: TimeSource> HostingCache<T> {
             .collect();
         entries.sort_by_key(|(_, last_accessed)| *last_accessed);
 
-        self.lru_order.clear();
         for (key, _) in entries {
-            self.lru_order.push_back(key);
+            let seq = self.next_seq();
+            if let Some(entry) = self.contracts.get_mut(&key) {
+                entry.last_access_seq = seq;
+            }
         }
     }
 }
@@ -815,11 +1089,12 @@ mod tests {
         cache.record_access(key1, 100, AccessType::Get, 0, |_| false);
         cache.record_access(key2, 100, AccessType::Get, 0, |_| false);
 
-        // Access key1 again - should move it to back of LRU
+        // Access key1 again - a read refreshes its keep_score/recency, so it
+        // becomes the LAST eviction candidate; key2 is now first.
         cache.record_access(key1, 100, AccessType::Subscribe, 0, |_| false);
 
-        // LRU order should now be [key2, key1]
-        let order = cache.keys_lru_order();
+        // Eviction order (least-worthy first) should now be [key2, key1]
+        let order = cache.keys_eviction_order();
         assert_eq!(order, vec![key2, key1]);
 
         // Advance past TTL and add key3 - should evict key2 (now oldest)
@@ -1200,31 +1475,37 @@ mod tests {
         );
     }
 
-    // --- Recently-abandoned priority bucket (Phase 1) ---
+    // --- Recently-abandoned priority (demand-credit strip) ---
 
     #[test]
-    fn test_record_abandonment_moves_entry_to_lru_front() {
+    fn test_record_abandonment_moves_entry_to_eviction_front() {
         let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
         let key1 = make_key(1);
         let key2 = make_key(2);
         let key3 = make_key(3);
 
+        // Equal (neutral) demand -> equal keep_score; eviction order is by
+        // access sequence: key1, key2, key3.
         cache.record_access(key1, 100, AccessType::Get, 0, |_| false);
         cache.record_access(key2, 100, AccessType::Get, 0, |_| false);
         cache.record_access(key3, 100, AccessType::Get, 0, |_| false);
+        assert_eq!(cache.keys_eviction_order(), vec![key1, key2, key3]);
 
-        // Insertion order without abandonment: key1, key2, key3.
-        assert_eq!(cache.keys_lru_order(), vec![key1, key2, key3]);
-
-        // Abandon key3 — the most recently used — and it should jump to
-        // the FRONT so disk-pressure eviction sees it first.
+        // Abandon key3 — the most recently used — and its keep_score drops to
+        // the floor (below the still-credited key1/key2), so it jumps to the
+        // FRONT of the eviction order so budget pressure sees it first.
         cache.record_abandonment(&key3);
-        assert_eq!(cache.keys_lru_order(), vec![key3, key1, key2]);
+        assert_eq!(cache.keys_eviction_order(), vec![key3, key1, key2]);
 
         let info = cache.get(&key3).unwrap();
         assert!(
             info.abandoned_at.is_some(),
             "Abandonment must record a timestamp"
+        );
+        assert_eq!(
+            info.keep_score,
+            cache.eviction_floor(),
+            "abandonment must strip demand credit to the floor"
         );
     }
 
@@ -1454,5 +1735,266 @@ mod tests {
             1,
             "counter must not advance with no budget pressure"
         );
+    }
+
+    // --- Demand-ordered (Greedy-Dual) eviction (A3) ---
+
+    /// `keep_score` is `eviction_floor + predicted_demand` on insert, and a read
+    /// refreshes it to the CURRENT floor + demand. Since the floor only rises,
+    /// a repeatedly-read contract's keep_score climbs while an untouched one's
+    /// stays put.
+    #[test]
+    fn fuel_gauge_keep_score_set_on_insert_and_refreshed_on_read() {
+        let (mut cache, _) = make_cache(10_000, Duration::from_secs(60));
+        let key = make_key(1);
+
+        // Insert at floor 0 with demand 3.0 -> keep_score 3.0.
+        cache.record_access_with_demand(key, 100, AccessType::Get, 0, 3.0, |_| false);
+        assert_eq!(cache.get(&key).unwrap().keep_score, 3.0);
+        assert_eq!(cache.get(&key).unwrap().predicted_demand, 3.0);
+        assert_eq!(cache.get(&key).unwrap().read_count, 1);
+
+        // A read with a new demand estimate refreshes keep_score = floor + demand.
+        cache.record_access_with_demand(key, 100, AccessType::Get, 0, 5.0, |_| false);
+        assert_eq!(cache.get(&key).unwrap().keep_score, 5.0);
+        assert_eq!(cache.get(&key).unwrap().read_count, 2);
+    }
+
+    /// Pure demand-ordering: a higher-demand contract survives even when a
+    /// lower-demand one was inserted MORE recently — demand beats recency.
+    #[test]
+    fn fuel_gauge_evicts_lowest_demand_not_lru() {
+        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let high = make_key(1);
+        let low = make_key(2);
+        let trigger = make_key(3);
+
+        // `high` inserted first (older) with strong demand; `low` inserted after
+        // with weak demand. A recency-only (LRU) policy would evict `high`.
+        cache.record_access_with_demand(high, 100, AccessType::Get, 0, 10.0, |_| false);
+        cache.record_access_with_demand(low, 100, AccessType::Get, 0, 1.0, |_| false);
+        assert_eq!(cache.current_bytes(), 200);
+
+        time.advance_time(Duration::from_secs(61));
+
+        // Over-budget insert must evict the LOWEST keep_score (`low`), not the
+        // oldest (`high`).
+        let result =
+            cache.record_access_with_demand(trigger, 100, AccessType::Get, 0, 1.0, |_| false);
+        assert_eq!(
+            result.evicted,
+            vec![(low, 0)],
+            "lowest-demand contract must evict, not the least-recently-used one"
+        );
+        assert!(cache.contains(&high), "high-demand contract must survive");
+        assert!(!cache.contains(&low));
+    }
+
+    /// The #4338 check at the cache level, written to actually DISCRIMINATE
+    /// demand-ordering from recency: a repeatedly-read HIGH-demand contract (a
+    /// River room) survives eviction against a NEWER low-demand junk contract
+    /// even though the room is past TTL and is the *least-recently-accessed* of
+    /// the two. Byte-LRU-with-TTL evicts the oldest past-TTL entry, so it would
+    /// evict the room here — this test fails under that policy and passes only
+    /// because eviction is ordered by `keep_score` (demand), not recency.
+    ///
+    /// Note the discrimination comes from NON-UNIFORM demand, not the floor
+    /// alone: with uniform demand `keep_score = eviction_floor_at_last_refresh +
+    /// constant` is monotone in refresh time (the floor only rises), i.e.
+    /// identical to LRU ordering. The Greedy-Dual floor supplies aging, but the
+    /// demand term is what lets an older contract outrank a newer one.
+    #[test]
+    fn fuel_gauge_keeps_repeatedly_read_contract_over_junk() {
+        // Budget for two 100-byte contracts.
+        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let room = make_key(1); // the "River room": repeatedly read, high demand
+        let junk = make_key(2); // never re-read, low demand, inserted LATER
+        let trigger = make_key(3);
+
+        // Seed the room with strong demand, then read it repeatedly (simulating
+        // recurring GETs). These reads are the room's LAST accesses.
+        cache.record_access_with_demand(room, 100, AccessType::Get, 0, 10.0, |_| false);
+        for _ in 0..3 {
+            time.advance_time(Duration::from_secs(5));
+            cache.touch(&room);
+        }
+
+        // Junk arrives AFTER the room's last read, so junk is the more-recently-
+        // accessed entry — and carries weak demand.
+        time.advance_time(Duration::from_secs(5));
+        cache.record_access_with_demand(junk, 100, AccessType::Get, 0, 1.0, |_| false);
+
+        // Advance so BOTH are past TTL and eviction-eligible; the room, last read
+        // 5s before junk, is the least-recently-accessed of the two.
+        time.advance_time(Duration::from_secs(61));
+
+        // Make the discrimination explicit and checked, not just asserted in
+        // prose: the room is LRU-older yet carries more demand credit.
+        let room_entry = cache.get(&room).expect("room hosted");
+        let junk_entry = cache.get(&junk).expect("junk hosted");
+        assert!(
+            room_entry.last_access_seq < junk_entry.last_access_seq,
+            "room must be the least-recently-accessed of the two, so recency \
+             alone (byte-LRU) would evict it first"
+        );
+        assert!(
+            room_entry.keep_score > junk_entry.keep_score,
+            "room must carry more demand credit than junk ({} vs {})",
+            room_entry.keep_score,
+            junk_entry.keep_score,
+        );
+
+        // Over-budget insert: the fuel gauge evicts the lowest keep_score (junk).
+        // Byte-LRU-with-TTL would instead evict the room (the oldest past-TTL
+        // entry) — so this assertion is what fails under a recency-only policy.
+        let result =
+            cache.record_access_with_demand(trigger, 100, AccessType::Get, 0, 1.0, |_| false);
+        assert_eq!(
+            result.evicted,
+            vec![(junk, 0)],
+            "low-demand junk must evict, NOT the older-but-high-demand room"
+        );
+        assert!(
+            cache.contains(&room),
+            "the repeatedly-read high-demand room survives even though it is the \
+             least-recently-accessed past-TTL entry (byte-LRU would have evicted it)"
+        );
+        assert!(!cache.contains(&junk));
+        // The room (read_count >= 2) was never a victim, so no repeat-demand
+        // eviction is recorded (junk, read once, does not count).
+        assert_eq!(
+            cache.stats().evictions_of_recently_read_total,
+            0,
+            "a repeatedly-read contract must never be evicted (no miscalibration)"
+        );
+    }
+
+    /// The `eviction_floor` ratchets up to each evicted contract's `keep_score`
+    /// and never decreases (Greedy-Dual aging).
+    #[test]
+    fn eviction_floor_ratchets_up_on_eviction() {
+        let (mut cache, time) = make_cache(100, Duration::from_secs(60));
+        assert_eq!(cache.eviction_floor(), 0.0);
+
+        // Insert a demand-7 contract, let it age, then evict it via an
+        // over-budget insert; the floor must climb to 7.
+        let a = make_key(1);
+        cache.record_access_with_demand(a, 100, AccessType::Get, 0, 7.0, |_| false);
+        time.advance_time(Duration::from_secs(61));
+        let b = make_key(2);
+        let r = cache.record_access_with_demand(b, 100, AccessType::Get, 0, 2.0, |_| false);
+        assert_eq!(r.evicted, vec![(a, 0)]);
+        assert_eq!(
+            cache.eviction_floor(),
+            7.0,
+            "floor ratchets to evicted score"
+        );
+
+        // b's keep_score was floor(0)+2 = 2 at insert; a later eviction of a
+        // lower-scored victim must not drop the floor below 7.
+        time.advance_time(Duration::from_secs(61));
+        let c = make_key(3);
+        let r = cache.record_access_with_demand(c, 100, AccessType::Get, 0, 1.0, |_| false);
+        assert_eq!(r.evicted, vec![(b, 0)], "b (keep_score 2) evicts");
+        assert_eq!(
+            cache.eviction_floor(),
+            7.0,
+            "floor must not drop below its high-water mark"
+        );
+    }
+
+    /// A PUT is a SEED, not read-demand: on an existing entry it must NOT bump
+    /// `read_count` or refresh `keep_score` to the frontier, so a repeatedly-PUT
+    /// contract cannot outrank a repeatedly-GET one.
+    #[test]
+    fn put_seeds_but_earns_no_read_demand_credit() {
+        let (mut cache, _) = make_cache(10_000, Duration::from_secs(60));
+        let key = make_key(1);
+
+        // Seed via PUT: keep_score = floor(0) + demand, read_count 0.
+        cache.record_access_with_demand(key, 100, AccessType::Put, 0, 2.0, |_| false);
+        assert_eq!(cache.get(&key).unwrap().read_count, 0, "PUT is not a read");
+        let seed_score = cache.get(&key).unwrap().keep_score;
+        assert_eq!(seed_score, 2.0);
+
+        // Manually raise the floor by evicting something else would be indirect;
+        // instead assert that a re-PUT does NOT refresh keep_score or read_count.
+        cache.record_access_with_demand(key, 100, AccessType::Put, 0, 9.0, |_| false);
+        assert_eq!(
+            cache.get(&key).unwrap().read_count,
+            0,
+            "re-PUT must not count as a read"
+        );
+        assert_eq!(
+            cache.get(&key).unwrap().keep_score,
+            seed_score,
+            "re-PUT (seed) must not refresh keep_score to the frontier"
+        );
+
+        // A GET, by contrast, IS read-demand and refreshes both.
+        cache.record_access_with_demand(key, 100, AccessType::Get, 0, 9.0, |_| false);
+        assert_eq!(cache.get(&key).unwrap().read_count, 1);
+        assert_eq!(cache.get(&key).unwrap().keep_score, 9.0);
+    }
+
+    /// The recently-read eviction counter fires only for victims with genuine
+    /// repeat demand (`read_count >= 2`), not one-off seeds.
+    #[test]
+    fn evictions_of_recently_read_counts_only_repeat_demand() {
+        let (mut cache, time) = make_cache(100, Duration::from_secs(60));
+
+        // A contract read twice (repeat demand), then forced out by junk.
+        let read_twice = make_key(1);
+        cache.record_access(read_twice, 100, AccessType::Get, 0, |_| false);
+        cache.touch(&read_twice); // second read -> read_count 2
+        time.advance_time(Duration::from_secs(61));
+        // Evict it by inserting a higher-demand junk (so read_twice is the victim).
+        let junk = make_key(2);
+        let r = cache.record_access_with_demand(junk, 100, AccessType::Get, 0, 5.0, |_| false);
+        assert_eq!(r.evicted, vec![(read_twice, 0)]);
+        assert_eq!(
+            cache.stats().evictions_of_recently_read_total,
+            1,
+            "evicting a twice-read contract is a miscalibration signal"
+        );
+
+        // Now evict the junk seed (read_count 1) -> must NOT increment.
+        time.advance_time(Duration::from_secs(61));
+        let seed = make_key(3);
+        // junk currently has demand 5 (>seed's), so make the new one higher.
+        let r = cache.record_access_with_demand(seed, 100, AccessType::Get, 0, 9.0, |_| false);
+        assert_eq!(r.evicted, vec![(junk, 0)], "junk (read once) evicts");
+        assert_eq!(
+            cache.stats().evictions_of_recently_read_total,
+            1,
+            "a one-off seed eviction must not count as recently-read"
+        );
+    }
+
+    /// A subscribed (retained) contract is exempt from eviction even when its
+    /// `keep_score` is the lowest and it is past TTL — the pin dominates demand
+    /// ordering.
+    #[test]
+    fn subscribe_pin_exempts_lowest_score_from_eviction() {
+        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let pinned = make_key(1); // lowest demand, but subscribed
+        let other = make_key(2);
+        let trigger = make_key(3);
+
+        cache.record_access_with_demand(pinned, 100, AccessType::Get, 0, 0.1, |_| false);
+        cache.record_access_with_demand(other, 100, AccessType::Get, 0, 5.0, |_| false);
+        time.advance_time(Duration::from_secs(61));
+
+        // Over budget: `pinned` has the lowest keep_score and would evict first,
+        // but should_retain protects it, so `other` is evicted instead.
+        let result = cache
+            .record_access_with_demand(trigger, 100, AccessType::Get, 0, 5.0, |k| *k == pinned);
+        assert_eq!(
+            result.evicted,
+            vec![(other, 0)],
+            "an active subscription pins the contract even at the lowest keep_score"
+        );
+        assert!(cache.contains(&pinned));
+        assert!(!cache.contains(&other));
     }
 }

--- a/crates/core/src/ring/hosting/demand.rs
+++ b/crates/core/src/ring/hosting/demand.rs
@@ -1,0 +1,256 @@
+//! Proximity-prior demand estimator for demand-driven hosting eviction (A3).
+//!
+//! Piece A3 of the demand-driven hosting redesign (freenet/freenet-core#4642).
+//! The demand-ordered (Greedy-Dual) eviction policy in [`super::cache`] orders contracts by
+//! `keep_score = eviction_floor + predicted_demand(X)`. This module supplies
+//! `predicted_demand(X)`: a per-contract estimate of X's read-request rate at
+//! this peer.
+//!
+//! For A3 the estimate is the **proximity prior only** — `g(distance-to-key)`,
+//! a monotone non-increasing function of the ring distance between this peer
+//! and the contract's key. Contracts near this peer's location are, on average,
+//! requested more often (routing gravity), so demand falls off with distance.
+//! The blend toward each contract's OWN observed read rate is deferred to A4
+//! (see `docs/design/hosting-eviction.md`); this estimator only tracks the
+//! aggregate distance -> rate relationship.
+//!
+//! The prior is fit with the same isotonic-regression (PAVA) machinery the
+//! router uses for its distance -> outcome curves ([`crate::router`] /
+//! `pav_regression`), deliberately reused rather than re-implemented. Points are
+//! `(distance, observed_read_rate)` samples this peer collects from its own
+//! reads; the fit is **descending** (rate non-increasing in distance). A rolling
+//! window bounds the retained points, so the curve tracks the peer's recent
+//! demand geometry rather than its whole history.
+//!
+//! Only RATIOS matter to eviction ordering (`keep_score` is compared, never
+//! interpreted as an absolute rate), so no absolute calibration is required.
+
+use pav_regression::{IsotonicRegression, Point};
+use std::collections::VecDeque;
+
+/// Minimum retained sample count before the fitted prior is trusted. Below this
+/// the estimator returns [`NEUTRAL_DEMAND`] for every distance, which makes
+/// `keep_score` degenerate to `eviction_floor + NEUTRAL_DEMAND` for all
+/// contracts — i.e. pure Greedy-Dual aging with a recency tiebreak, the sane
+/// cold-start behavior before any demand geometry is known.
+const MIN_POINTS_FOR_PRIOR: usize = 5;
+
+/// Maximum raw `(distance, rate)` points retained. Once reached, each new
+/// observation evicts the oldest (FIFO rolling window), mirroring the router's
+/// `MAX_REGRESSION_POINTS`. Keeps the fit tracking recent demand and bounds
+/// memory + refit cost.
+const MAX_PRIOR_POINTS: usize = 500;
+
+/// Demand returned when the prior has insufficient data (or cannot interpolate).
+/// Positive and uniform: with equal demand for every contract, eviction reduces
+/// to Greedy-Dual floor-ordering with a last-read tiebreak. Must be `> 0` so
+/// that an abandoned contract (whose `keep_score` is dropped to the current
+/// `eviction_floor`, i.e. zero demand credit) sorts below a still-credited one.
+pub(crate) const NEUTRAL_DEMAND: f64 = 1.0;
+
+/// Per-peer proximity-prior demand estimator.
+///
+/// Wraps a descending isotonic regression over `(distance, read_rate)` samples.
+/// `predict(distance)` gives the expected read rate at that ring distance, used
+/// as `predicted_demand` in the demand-ordered `keep_score`.
+pub(crate) struct ProximityPrior {
+    /// Descending isotonic fit: expected read rate as a non-increasing function
+    /// of ring distance to the contract key.
+    regression: IsotonicRegression<f64>,
+    /// Raw input points in insertion order. When the length exceeds
+    /// [`MAX_PRIOR_POINTS`], the oldest is evicted via `remove_points` so the
+    /// fit tracks a bounded recent window.
+    raw_points: VecDeque<Point<f64>>,
+}
+
+impl ProximityPrior {
+    /// Create an empty estimator. Until [`MIN_POINTS_FOR_PRIOR`] observations
+    /// accrue, [`predict`](Self::predict) returns [`NEUTRAL_DEMAND`].
+    pub(crate) fn new() -> Self {
+        // `new_descending` on an empty slice yields an empty regression; the
+        // router relies on the same empty-construction path.
+        let empty: [Point<f64>; 0] = [];
+        let regression = IsotonicRegression::new_descending(&empty)
+            .expect("empty descending isotonic regression is always constructible");
+        Self {
+            regression,
+            raw_points: VecDeque::new(),
+        }
+    }
+
+    /// Record one observed `(distance, read_rate)` sample. `distance` is the
+    /// ring distance in `[0, 0.5]`; `read_rate` is a non-negative reads/second
+    /// estimate for a contract at that distance. Non-finite or negative inputs
+    /// are ignored (they would corrupt the fit).
+    pub(crate) fn observe(&mut self, distance: f64, read_rate: f64) {
+        if !distance.is_finite() || !read_rate.is_finite() || distance < 0.0 || read_rate < 0.0 {
+            return;
+        }
+        let point = Point::new(distance, read_rate);
+        self.regression.add_points(&[point]);
+        self.raw_points.push_back(point);
+        if self.raw_points.len() > MAX_PRIOR_POINTS {
+            if let Some(oldest) = self.raw_points.pop_front() {
+                // `remove_points` correctly drops the sample even after PAVA has
+                // pooled it into a merged block: pav_regression's `remove_points`
+                // subtracts the removed point's weighted influence from the
+                // nearest aggregate AND decrements the centroid exactly (see its
+                // rustdoc), so the oldest observation's contribution is removed,
+                // not retained. This is the same incremental rolling-window
+                // mechanism the router's `IsotonicEstimator` relies on in
+                // production; a full rebuild from `raw_points` here would be
+                // O(n log n) per observation for no correctness gain.
+                self.regression.remove_points(&[oldest]);
+            }
+        }
+    }
+
+    /// Predict the read-demand for a contract at ring `distance` from this peer.
+    ///
+    /// Returns [`NEUTRAL_DEMAND`] until [`MIN_POINTS_FOR_PRIOR`] samples have
+    /// accrued, or if the regression cannot interpolate. Otherwise returns the
+    /// fitted rate, floored at `0.0` (the descending fit can extrapolate
+    /// slightly negative near the data-range edges).
+    pub(crate) fn predict(&self, distance: f64) -> f64 {
+        if self.raw_points.len() < MIN_POINTS_FOR_PRIOR || !distance.is_finite() {
+            return NEUTRAL_DEMAND;
+        }
+        match self.regression.interpolate(distance) {
+            Some(rate) if rate.is_finite() => rate.max(0.0),
+            _ => NEUTRAL_DEMAND,
+        }
+    }
+
+    /// Number of retained raw observations (test/introspection).
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.raw_points.len()
+    }
+}
+
+impl Default for ProximityPrior {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// With no data the estimator is neutral for every distance, so eviction
+    /// degenerates to floor-ordering + recency (the cold-start contract).
+    #[test]
+    fn empty_prior_is_neutral_everywhere() {
+        let prior = ProximityPrior::new();
+        assert_eq!(prior.len(), 0);
+        assert_eq!(prior.predict(0.0), NEUTRAL_DEMAND);
+        assert_eq!(prior.predict(0.25), NEUTRAL_DEMAND);
+        assert_eq!(prior.predict(0.5), NEUTRAL_DEMAND);
+    }
+
+    /// Below the minimum sample count the fit is not trusted yet.
+    #[test]
+    fn prior_stays_neutral_below_min_points() {
+        let mut prior = ProximityPrior::new();
+        for i in 0..(MIN_POINTS_FOR_PRIOR - 1) {
+            prior.observe(0.1 * i as f64, 10.0 - i as f64);
+        }
+        assert!(prior.len() < MIN_POINTS_FOR_PRIOR);
+        assert_eq!(prior.predict(0.0), NEUTRAL_DEMAND);
+    }
+
+    /// The fitted prior is monotone NON-INCREASING in distance: closer contracts
+    /// predict at least as much demand as farther ones. This is the defining
+    /// property of the proximity prior and the reason a descending isotonic fit
+    /// is used.
+    #[test]
+    fn fitted_prior_is_monotone_non_increasing() {
+        let mut prior = ProximityPrior::new();
+        // Near contracts see high rates, far contracts low rates, with noise.
+        let samples = [
+            (0.02, 20.0),
+            (0.05, 18.0),
+            (0.05, 22.0), // noise around the near band
+            (0.10, 12.0),
+            (0.15, 9.0),
+            (0.20, 7.0),
+            (0.30, 3.0),
+            (0.40, 2.0),
+            (0.45, 1.0),
+            (0.48, 0.5),
+        ];
+        for (d, r) in samples {
+            prior.observe(d, r);
+        }
+        assert!(prior.len() >= MIN_POINTS_FOR_PRIOR);
+
+        // Sample the curve WITHIN the observed data range [0.05, 0.45] (where
+        // interpolation between the non-increasing fitted points is guaranteed
+        // monotone) and assert non-increasing. Extrapolation beyond the data
+        // edges is exercised separately by `prediction_is_non_negative_out_of_range`.
+        let mut prev = f64::INFINITY;
+        let mut x = 0.05;
+        while x <= 0.45 + 1e-9 {
+            let y = prior.predict(x);
+            assert!(
+                y <= prev + 1e-9,
+                "prior must be non-increasing in distance: g({x}) = {y} > previous {prev}"
+            );
+            prev = y;
+            x += 0.02;
+        }
+
+        // A near contract must predict strictly more demand than a far one.
+        assert!(
+            prior.predict(0.05) > prior.predict(0.45),
+            "near-key demand must exceed far-key demand: near={}, far={}",
+            prior.predict(0.05),
+            prior.predict(0.45),
+        );
+    }
+
+    /// The rolling window bounds retained points; the estimator keeps producing
+    /// finite, non-negative predictions after eviction.
+    #[test]
+    fn rolling_window_is_bounded() {
+        let mut prior = ProximityPrior::new();
+        for i in 0..(MAX_PRIOR_POINTS + 100) {
+            let d = (i % 50) as f64 / 100.0; // distances 0.0..0.49
+            prior.observe(d, (50 - (i % 50)) as f64);
+        }
+        assert!(
+            prior.len() <= MAX_PRIOR_POINTS,
+            "raw points must be bounded, got {}",
+            prior.len()
+        );
+        let y = prior.predict(0.1);
+        assert!(y.is_finite() && y >= 0.0, "prediction must stay valid: {y}");
+    }
+
+    /// Garbage inputs (NaN, negatives) are dropped rather than corrupting the
+    /// fit.
+    #[test]
+    fn invalid_observations_are_ignored() {
+        let mut prior = ProximityPrior::new();
+        prior.observe(f64::NAN, 5.0);
+        prior.observe(0.1, f64::INFINITY);
+        prior.observe(-0.1, 5.0);
+        prior.observe(0.1, -5.0);
+        assert_eq!(prior.len(), 0, "no invalid point should be retained");
+        assert_eq!(prior.predict(0.1), NEUTRAL_DEMAND);
+    }
+
+    /// Predicted demand is always non-negative, even at distances beyond the
+    /// observed data range where the isotonic fit may extrapolate.
+    #[test]
+    fn prediction_is_non_negative_out_of_range() {
+        let mut prior = ProximityPrior::new();
+        for i in 0..10 {
+            // All samples clustered near the origin; predict far away.
+            prior.observe(0.01 * i as f64, 5.0 - 0.4 * i as f64);
+        }
+        assert!(prior.predict(0.5) >= 0.0);
+        assert!(prior.predict(0.49) >= 0.0);
+    }
+}

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -205,6 +205,19 @@ pub(crate) struct RouterSnapshotInfo {
     pub hosting_current_bytes: Option<u64>,
     pub hosting_contract_count: Option<u64>,
     pub hosting_budget_evictions_total: Option<u64>,
+    /// Demand-ordered eviction gauges (#4642 A3), populated by
+    /// `Ring` from the `HostingManager` on the snapshot cadence.
+    /// `hosting_evictions_of_recently_read_total` is the #4338 miscalibration
+    /// signal (evictions whose victim had genuine repeat demand);
+    /// `hosting_local_hits_total` / `hosting_local_misses_total` are the local
+    /// hit-rate, counted at the actual serve-vs-forward decision in the client
+    /// GET handler (`client_events`) — a hit is a client GET answered from local
+    /// hosted state, a miss is one routed to the network — NOT a cache-membership
+    /// proxy. All monotonic counters the collector differences into rates.
+    /// `None` until the ring is built. Per-node aggregate scalars.
+    pub hosting_evictions_of_recently_read_total: Option<u64>,
+    pub hosting_local_hits_total: Option<u64>,
+    pub hosting_local_misses_total: Option<u64>,
     /// Interest-weighted (two-tier) module-cache SHADOW gauges (#4441/#4534),
     /// populated by `Ring` from the same per-node `ModuleCacheMetrics` `Arc`.
     /// These are ALWAYS ON, independent of the `FREENET_MODULE_CACHE_INTEREST_TIERED`
@@ -1105,6 +1118,11 @@ impl Router {
             hosting_current_bytes: None,
             hosting_contract_count: None,
             hosting_budget_evictions_total: None,
+            // Demand-ordered eviction gauges, populated by Ring
+            // on the snapshot cadence (#4642 A3).
+            hosting_evictions_of_recently_read_total: None,
+            hosting_local_hits_total: None,
+            hosting_local_misses_total: None,
             // Interest-weighted (two-tier) module-cache shadow gauges,
             // populated by Ring on the snapshot cadence (#4441/#4534).
             contract_module_cache_cold_evictable_bytes: None,

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2171,6 +2171,23 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "hosting_budget_evictions_total".to_string(),
                     serde_json::json!(snapshot.hosting_budget_evictions_total),
                 );
+                // Demand-ordered eviction gauges (#4642 A3). Same
+                // hand-mirrored footgun as the A2 gauges above: a new
+                // `RouterSnapshotInfo` field is invisible to the collector unless
+                // added here. Pinned by
+                // `router_snapshot_json_includes_hosting_fuel_gauge_gauges`.
+                obj.insert(
+                    "hosting_evictions_of_recently_read_total".to_string(),
+                    serde_json::json!(snapshot.hosting_evictions_of_recently_read_total),
+                );
+                obj.insert(
+                    "hosting_local_hits_total".to_string(),
+                    serde_json::json!(snapshot.hosting_local_hits_total),
+                );
+                obj.insert(
+                    "hosting_local_misses_total".to_string(),
+                    serde_json::json!(snapshot.hosting_local_misses_total),
+                );
             }
             body
         }
@@ -2360,6 +2377,30 @@ mod tests {
             ("hosting_current_bytes", 263),
             ("hosting_contract_count", 269),
             ("hosting_budget_evictions_total", 271),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
+    }
+
+    /// Pin: the demand-ordered eviction gauges (#4642 A3) must
+    /// also reach the hand-mirrored OTLP body — same footgun as the A2 gauges. A
+    /// silent drop would re-blind us to the #4338 miscalibration signal
+    /// (evicting repeatedly-read contracts) and the local hit-rate, the whole
+    /// point of instrumenting A3.
+    #[test]
+    fn router_snapshot_json_includes_hosting_fuel_gauge_gauges() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.hosting_evictions_of_recently_read_total = Some(277);
+        info.hosting_local_hits_total = Some(281);
+        info.hosting_local_misses_total = Some(283);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        for (key, want) in [
+            ("hosting_evictions_of_recently_read_total", 277),
+            ("hosting_local_hits_total", 281),
+            ("hosting_local_misses_total", 283),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }

--- a/docs/design/hosting-eviction.md
+++ b/docs/design/hosting-eviction.md
@@ -8,7 +8,7 @@ A peer hosts the contracts it is most likely to be asked for, within a budget si
 - **Instrumentation is horizontal.** Every piece of this redesign ships with the telemetry needed to observe its OWN behavior in production. This is a PR acceptance criterion: a feature PR that adds a mechanism but no instrumentation for it gets bounced in review. Rationale: the behavior here is emergent and resource-dependent, so it cannot be fully tested pre-production — production telemetry IS the validation instrument, and it must grow WITH each piece rather than being deferred to a later "observability" PR. (This is why A1, telemetry, is the foundational sub-PR.)
 - **Telemetry shape: per-node aggregate scalars/rates only.** Emit resource/behavior metrics as per-node aggregate scalars and rates carried on the existing periodic snapshot. NEVER per-contract or per-request event streams — nova ingests the whole fleet, so a per-contract/per-request stream multiplied across every peer is an ingestion DoS on the collector.
 
-## Eviction (Greedy-Dual / "fuel gauge")
+## Eviction (Greedy-Dual, demand-ordered)
 - Each hosted contract X has `keep_score(X) = eviction_floor + predicted_demand(X)`, set on insert and refreshed on every read (GET/SUBSCRIBE).
 - `eviction_floor`: one per-peer running value; when over budget, evict the min keep_score and set `eviction_floor = keep_score(evicted)`. Greedy-Dual aging, measured in cache-contention, not wall-clock.
 - `predicted_demand(X)`: per-contract estimate of X's read-request rate at this peer. Seeded at a proximity prior; blended toward X's own observed read rate as evidence accrues (prior washes out with data). Only RATIOS matter (scale-invariant), so no absolute calibration needed.
@@ -24,7 +24,7 @@ A peer hosts the contracts it is most likely to be asked for, within a budget si
 - GET hosts-on-first and lets the gauge evict one-offs (demand-driven, so NOT the relay-caching anti-pattern; guard-comment the site). SUBSCRIBE builds a chain of demand-pinned hosts. An over-committed peer REFUSES new subscriptions.
 
 ## Sub-PRs (sequenced; share ring/hosting)
-A1 resource telemetry (this PR); A2 memory-capability budget (`read_total_ram_bytes` -> hosting budget); A3 fuel-gauge eviction policy; A4 blend.
+A1 resource telemetry (this PR); A2 memory-capability budget (`read_total_ram_bytes` -> hosting budget); A3 demand-ordered eviction policy; A4 blend.
 
 ## Validation
 Sim health metrics (subscribe/GET success, tree formation, time-to-first-op) + a check that a real-demand contract (e.g. a River room) is NOT evicted ahead of junk (the #4338 miscalibration test).


### PR DESCRIPTION
> **PARKED for Ian's review — do NOT merge.** This is the core of the
> resource-usage rearchitecture and the highest-risk piece of the demand-driven
> hosting redesign. No auto-merge.
>
> **Now based on `main`.** A2 (#4644, capability-relative budget) and #4649
> (resource-telemetry cadence) have merged, so this was **rebased from A2's
> branch onto `main`** and the PR base retargeted to `main`. The rebase was
> **clean, no conflicts**: A2's squash-merge (`398adaff`) is byte-identical to
> the A2 tip this branched from for every hosting file, so the A3 eviction
> changes replayed onto the merged budget code untouched; the only diverging file
> on main was `telemetry.rs` (#4649's cadence throttle), whose changes don't
> overlap the A3 gauges — both coexist (verified: hosting + telemetry lib tests
> green, 158 passed).

## Problem

Hosting-cache eviction was byte-budget **LRU**: over budget, it dropped the
least-recently-*accessed* contract. Recency is demand-blind — a repeatedly-
requested contract (a live River room) could be evicted ahead of never-requested
junk just because the junk was touched more recently. This is the #4338
miscalibration class and the "byte-only eviction" anti-pattern called out in
`.claude/rules/hosting-invariants.md`.

## Approach

Piece **A3** of the demand-driven hosting redesign (#4642). Eviction becomes a
Greedy-Dual, **demand-ordered**:

- Each hosted contract has `keep_score = eviction_floor + predicted_demand`, set
  on insert and **refreshed to the current frontier on every read**
  (GET/SUBSCRIBE).
- `eviction_floor` is a per-peer running value that ratchets up to the
  `keep_score` of each evicted contract (Greedy-Dual aging, in cache-contention
  units, **not** wall-clock). Over budget, the **lowest** `keep_score` is
  evicted; ties break by least-recently-accessed, so **uniform demand degrades
  to LRU** (every prior LRU test still passes unchanged).
- `predicted_demand` is the **proximity prior only** (the observed-rate blend is
  A4): `g(distance-to-key)`, a monotone non-increasing isotonic regression fit
  from this peer's own `(distance, read-rate)` samples. **Reuses the existing
  `pav_regression`/PAVA machinery** the router uses — new estimator in
  `ring/hosting/demand.rs`, no re-implementation.
- Interest signals: GET/SUBSCRIBE = read-demand (refresh `keep_score`, train the
  prior); **PUT = SEED only** (sets the estimate, earns no frontier credit,
  doesn't train); an active **SUBSCRIBE pins** the contract via the existing
  `contract_in_use` retain predicate (exempt from eviction). The pin is
  deliberately NOT widened to `is_subscribed` — that would re-introduce an
  unbounded GC exemption (ring.md / AGENTS.md).
- A2's **capability-relative byte budget stays the pressure threshold**; bytes
  are now only a tiebreak/ceiling.

The estimator + own-location live in `HostingManager` (Ring pushes
`own_location` on the snapshot cadence). `HostingCache` stays location-agnostic —
it orders only by the demand scalar it is handed — so it remains unit-testable
without a ring.

**Guard comment** added at the eviction site: *do NOT revert to byte-only LRU —
see hosting-invariants*.

### Instrumentation (horizontal — a PR acceptance criterion)

Per-node aggregate scalars on the existing snapshot / OTLP body:
- **local hit-rate** (`hosting_local_hits_total` / `hosting_local_misses_total`)
  — served-locally vs had-to-fetch (cache-membership proxy);
- **eviction rate** (`hosting_budget_evictions_total`, from A2);
- **evictions-of-recently-read** (`hosting_evictions_of_recently_read_total`) —
  the #4338 miscalibration alarm (evicting a contract with genuine repeat demand).

## Testing

- **demand.rs**: isotonic prior fit is monotone non-increasing, neutral below
  min samples, bounded rolling window, non-negative out-of-range, invalid inputs
  ignored.
- **cache.rs**: `keep_score` set-on-insert / refresh-on-read, eviction-floor
  ratchet, **demand beats recency** (the LRU-distinguishing regression — fails
  under byte-LRU), the **#4338 River-room scenario** (repeatedly-read survives a
  junk stream, zero recently-read evictions), PUT-seeds-not-demand, subscribe-pin
  exemption, recently-read + hit/miss counters. All prior LRU tests retained.
- **hosting.rs**: manager demand path trains the prior from repeated reads; PUT
  does not train.
- **telemetry.rs**: pin test that the A3 gauges reach the OTLP body.

`cargo fmt` clean; `cargo clippy --locked -p freenet` clean (the 3 remaining
warnings are pre-existing on the A2 base, in test-only targets CI's clippy does
not lint); hosting + telemetry lib tests green (122 passed).

### On the simulation test

The task called for a full-network `run_simulation_direct` #4338 test. This is
**impractical within A3's scope** and I judged forcing it would produce a flaky
test (against `flaky-tests` policy): the hosting cache's TTL gate is wall-clock
with `min_ttl = 8 min`, the direct sim runner drives *random* events (can't
target one contract for repeated GETs vs junk), and there is no per-node hosting-
budget knob in the harness. A faithful sim eviction test would need a sim
`TimeSource` plumbed into `HostingManager` (today it hardcodes `InstantTimeSrc`)
— a cross-cutting change that would *also* give A2's budget eviction its
currently-absent sim coverage. I therefore validated the demand-ordering
guarantee **deterministically at the cache + manager level** and flag the
sim-time plumbing as a sensible separable follow-up for Ian to weigh.

Refs #4642

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnRCbtbjepaB5GWrb5U8SR
