### PR TITLE
fix: actionable recovery on hosted per-user-isolation error page

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -3406,6 +3406,86 @@ mod tests {
         );
     }
 
+    /// Regression test for #4645: the hosted fail-closed page must give the
+    /// user an ACTIONABLE recovery path, not a dead end.
+    ///
+    /// The dominant real-world trigger is opening a Freenet app link as a NEW
+    /// TAB/WINDOW from inside the sandboxed app iframe (the browser's "open
+    /// link in new tab", a middle-click, a right-click menu, `window.open`, or
+    /// a `target=_blank` link). Such a context inherits the iframe sandbox, so
+    /// it has an opaque origin (`window.origin === 'null'`), so `localStorage`
+    /// throws and the per-user token can't be read — and the shell fails
+    /// closed. The pre-#4645 page only said "reconnect using https / enable
+    /// storage", which is useless for that case: the tab already IS https with
+    /// storage; the opaque origin is what blocks it. The page must instead
+    /// detect the opaque-origin case and tell the user to re-open the address
+    /// in a normal tab, surfacing the URL for one-click copy.
+    #[test]
+    fn fail_closed_page_gives_actionable_recovery_4645() {
+        // Detects the opaque-origin (sandboxed new-tab) case. The tell-tale is
+        // `window.origin` serializing to the string "null" for an opaque
+        // origin (confirmed empirically against try.freenet.org).
+        assert!(
+            SHELL_BRIDGE_JS.contains("window.origin === 'null'"),
+            "fail-closed page must detect the opaque-origin (sandboxed new-tab) \
+             case so it can give the right recovery guidance (#4645)"
+        );
+        // The "open in a normal tab" recovery only helps on a SECURE connection:
+        // over http even a fresh tab can't mint a token (SHELL_USER_TOKEN_JS
+        // refuses), so the https guidance must win when a page is BOTH sandboxed
+        // and plaintext. Pin that the reopen affordance is gated on
+        // `opaqueOrigin && !plaintext` rather than opaqueOrigin alone (Codex P3).
+        assert!(
+            SHELL_BRIDGE_JS.contains("opaqueOrigin && !plaintext"),
+            "the re-open recovery must be gated on a secure connection, so an \
+             http+sandboxed page is told to use https rather than to re-open a \
+             URL that still can't mint a token"
+        );
+        // For that case it surfaces the current URL so the user can re-open it
+        // in a normal top-level tab (where a real origin lets the token mint).
+        assert!(
+            SHELL_BRIDGE_JS.contains("field.value = location.href"),
+            "fail-closed page must surface the page URL for the user to re-open"
+        );
+        assert!(
+            SHELL_BRIDGE_JS.contains("Copy address"),
+            "fail-closed page must offer a one-click copy of the address"
+        );
+        // The three distinct causes (opaque-origin restricted tab, plain http,
+        // storage disabled) get distinct headings so the guidance actually
+        // matches the situation rather than blaming https/storage for all.
+        assert!(
+            SHELL_BRIDGE_JS.contains("Open this app in a normal tab")
+                && SHELL_BRIDGE_JS.contains("Secure connection required")
+                && SHELL_BRIDGE_JS.contains("Browser storage required"),
+            "fail-closed page must tailor its heading to each of the three causes"
+        );
+        // Anti-footgun: the fail-closed block must NOT try to re-open the app
+        // via `window.open` — a popup opened from this already-sandboxed context
+        // inherits the sandbox and hits the exact same dead end. Recovery is the
+        // user opening a fresh top-level tab themselves. (The bridge does call
+        // window.open legitimately in the open_url handler far below, so scope
+        // the check to the fail-closed rendering block.)
+        let block_start = SHELL_BRIDGE_JS
+            .find("if (hostedNoToken) {")
+            .expect("fail-closed block present");
+        // Anchor the block end on CODE from the normal (non-fail-closed) load
+        // branch rather than a comment, so a future comment reword can't
+        // silently move the boundary. `iframe.getAttribute('data-src')` is the
+        // first statement of the else branch and never appears in the
+        // fail-closed block.
+        let block_end = SHELL_BRIDGE_JS[block_start..]
+            .find("iframe.getAttribute('data-src')")
+            .expect("fail-closed block is followed by the normal iframe-load branch")
+            + block_start;
+        let fail_closed_block = &SHELL_BRIDGE_JS[block_start..block_end];
+        assert!(
+            !fail_closed_block.contains("window.open("),
+            "fail-closed recovery must not call window.open (a popup from this \
+             sandboxed context inherits the sandbox and re-hits the dead end)"
+        );
+    }
+
     /// Non-hosted mode must NEVER reach the fail-closed path: the bridge is
     /// called with one argument, so `hostedMode` is undefined and the whole
     /// hostedNoToken branch is inert — the app loads and connects over http

--- a/crates/core/src/server/path_handlers/assets/shell_bridge.js
+++ b/crates/core/src/server/path_handlers/assets/shell_bridge.js
@@ -34,36 +34,139 @@ function freenetBridge(authToken, userToken, hostedMode) {
   // independent barrier.
   var hostedNoToken = hostedMode === true && !userToken;
   if (hostedNoToken) {
-    var msg = document.createElement('div');
-    msg.setAttribute('role', 'alert');
-    msg.style.cssText =
-      'position:fixed;inset:0;display:flex;align-items:center;justify-content:center;' +
-      'padding:2rem;font:16px/1.5 system-ui,sans-serif;color:#1a1a1a;' +
-      'background:#fff;text-align:center;box-sizing:border-box;';
+    // The token is missing for one of three reasons; tailor the guidance so
+    // the user can actually recover instead of hitting a dead end (#4645).
+    // `window.origin` serializes to the string "null" for an opaque
+    // (sandboxed) origin, which is the tell-tale of the DOMINANT case: this
+    // page was opened as a NEW TAB/WINDOW from inside a Freenet app (the
+    // browser's "open link in new tab", a middle-click, a right-click menu,
+    // window.open, or a target=_blank link). Such a context inherits the app
+    // iframe's sandbox, so it has an opaque origin, so localStorage throws and
+    // the per-user token can't be read. Re-opening the SAME address as a
+    // normal top-level tab gets a real origin and works. The other two cases
+    // (served over plain http, or storage genuinely disabled) can't be fixed
+    // by re-opening, so they get their own guidance.
+    var opaqueOrigin = window.origin === 'null';
+    var plaintext = location.protocol !== 'https:';
+    // Plaintext is the HARD blocker: over http the token is never minted or
+    // transmitted (SHELL_USER_TOKEN_JS refuses), so re-opening in a normal tab
+    // still fails until the connection is https. So when the page is served
+    // insecurely that guidance wins even if the tab is ALSO a sandboxed popup.
+    // Only a SECURE sandboxed tab is recoverable by re-opening, so that is the
+    // one case that gets the "open in a normal tab" copy-URL affordance.
+    var reopenCase = opaqueOrigin && !plaintext;
+    var panel = document.createElement('div');
+    panel.setAttribute('role', 'alert');
+    panel.style.cssText =
+      'position:fixed;inset:0;display:flex;align-items:center;' +
+      'justify-content:center;padding:2rem;box-sizing:border-box;' +
+      'font:16px/1.6 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;' +
+      'color:#1a1a1a;background:#fff;';
     var inner = document.createElement('div');
-    inner.style.maxWidth = '32rem';
+    inner.style.cssText = 'max-width:34rem;width:100%;text-align:left;';
     var h = document.createElement('h1');
     h.style.cssText = 'font-size:1.25rem;margin:0 0 0.75rem;';
-    h.textContent = 'Per-user isolation unavailable';
-    var p = document.createElement('p');
-    // Generic wording: the token may be missing because of a plaintext (http)
-    // connection OR because browser storage is unavailable. Both disable
-    // per-user isolation, so the app must not load in either case.
-    p.textContent =
-      'This hosted Freenet node requires HTTPS and browser storage for ' +
-      'per-user data isolation. Because that is unavailable here, the app ' +
-      'will not load. Reconnect using an https:// address in a browser with ' +
-      'storage enabled.';
+    var lead = document.createElement('p');
+    lead.style.cssText = 'margin:0 0 1rem;';
+    if (plaintext) {
+      h.textContent = 'Secure connection required';
+      lead.textContent =
+        'This hosted Freenet node needs an https:// connection to protect ' +
+        'your per-user access key, so the app won’t load over plain ' +
+        'http. Reconnect using the https:// address.';
+    } else if (opaqueOrigin) {
+      h.textContent = 'Open this app in a normal tab';
+      lead.textContent =
+        'This page opened in a new tab or window from inside a Freenet app ' +
+        '(for example via "open link in new tab", a middle-click, or a ' +
+        'right-click menu). Tabs opened that way run in a restricted mode ' +
+        'that can’t reach the access key this hosted node uses to keep ' +
+        'your data separate, so the app won’t load here.';
+    } else {
+      h.textContent = 'Browser storage required';
+      lead.textContent =
+        'This hosted Freenet node keeps a per-user access key in your ' +
+        'browser to keep your data separate, but storage is unavailable ' +
+        'here (it can be blocked in private-browsing mode or by browser ' +
+        'settings). Enable storage for this site, or use a different ' +
+        'browser, then reload.';
+    }
     inner.appendChild(h);
-    inner.appendChild(p);
-    msg.appendChild(inner);
+    inner.appendChild(lead);
+    // For the secure restricted-tab case, re-opening the same address in a
+    // normal tab is the fix, so surface the URL with a one-click copy. We
+    // deliberately do NOT offer a "retry" button that re-opens the app in a
+    // popup: a popup spawned from this (already sandboxed) context would
+    // inherit the sandbox again and hit the exact same dead end, so the user
+    // must open a fresh top-level tab themselves. (Gated on reopenCase, not
+    // opaqueOrigin, so an http+sandboxed page doesn't offer to re-open a URL
+    // that still can't mint a token — see the plaintext heading above.)
+    if (reopenCase) {
+      var howto = document.createElement('p');
+      howto.style.cssText = 'margin:0 0 0.5rem;';
+      howto.textContent =
+        'To continue, open this address in a normal browser tab ' +
+        '(one you start yourself, e.g. Ctrl/Cmd+T, then paste):';
+      inner.appendChild(howto);
+      var row = document.createElement('div');
+      row.style.cssText = 'display:flex;gap:0.5rem;flex-wrap:wrap;';
+      var field = document.createElement('input');
+      field.type = 'text';
+      field.readOnly = true;
+      field.value = location.href;
+      field.style.cssText =
+        'flex:1 1 16rem;min-width:0;padding:0.5rem 0.6rem;' +
+        'font:13px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace;' +
+        'border:1px solid #ccc;border-radius:6px;color:#1a1a1a;background:#fafafa;';
+      field.addEventListener('focus', function () {
+        field.select();
+      });
+      field.addEventListener('click', function () {
+        field.select();
+      });
+      var copyBtn = document.createElement('button');
+      copyBtn.type = 'button';
+      copyBtn.textContent = 'Copy address';
+      copyBtn.style.cssText =
+        'padding:0.5rem 0.9rem;border:1px solid #2563eb;border-radius:6px;' +
+        'background:#2563eb;color:#fff;font:14px system-ui,sans-serif;' +
+        'cursor:pointer;';
+      var status = document.createElement('span');
+      status.setAttribute('role', 'status');
+      status.style.cssText = 'align-self:center;font-size:13px;color:#4b5563;';
+      copyBtn.addEventListener('click', function () {
+        function fallback() {
+          field.select();
+          status.textContent = 'Press Ctrl/Cmd+C to copy';
+        }
+        // navigator.clipboard is often unavailable or rejects in a sandboxed
+        // (opaque-origin) context, so always keep the select-and-Ctrl+C path.
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(location.href).then(
+            function () {
+              status.textContent = 'Copied';
+            },
+            function () {
+              fallback();
+            },
+          );
+        } else {
+          fallback();
+        }
+      });
+      row.appendChild(field);
+      row.appendChild(copyBtn);
+      inner.appendChild(row);
+      inner.appendChild(status);
+    }
+    panel.appendChild(inner);
     // Remove the (not-yet-loaded, data-src) iframe and show the message. The
     // iframe never had its .src set, so the app never started.
     if (iframe && iframe.parentNode) {
       iframe.parentNode.removeChild(iframe);
     }
-    document.body.appendChild(msg);
-    document.title = 'Freenet — isolation unavailable';
+    document.body.appendChild(panel);
+    document.title = 'Freenet: app not loaded here';
     // Keep listening for iframe messages purely so the WS-open handler can
     // return an 'error' to any app that somehow loaded; but we never set
     // iframe.src, so in practice nothing runs. Fall through to install the


### PR DESCRIPTION
## Problem

On a hosted node (try.freenet.org), opening a Freenet app link as a **new
tab/window from inside the sandboxed app iframe** — the browser's "open link in
new tab", a middle-click, a right-click menu, `window.open`, or a
`target="_blank"` link — creates a top-level document that **inherits the iframe
sandbox**. With no `allow-same-origin` that document has an **opaque origin**, so
`localStorage` throws, so the shell can't read the per-user access token and
fails closed to the "Per-user isolation unavailable" page.

The old page said *"reconnect using an https:// address in a browser with storage
enabled"* — which is useless for this case: the tab already **is** https with
storage; the opaque origin is what blocks it. The user hits a dead end. Reported
in #4645.

Confirmed empirically against live try.freenet.org with Playwright: `window.open`,
`<form target="_blank">`, and `<a target="_blank">` from inside the iframe all
reproduce the error with `window.origin === "null"`; the same navigation from the
top window works.

## Solution

Rewrite the fail-closed page to detect the cause and give the right recovery:

- **Opaque-origin (sandboxed new-tab) case** — the common one — detected via
  `window.origin === 'null'`. Explains that the tab opened in a restricted mode,
  tells the user to open the address in a normal tab, and surfaces the URL with a
  one-click **Copy address**. Deliberately **no "retry" button**: a `window.open()`
  from this sandboxed context would inherit the sandbox and re-hit the same dead
  end, so the user must open a fresh top-level tab themselves.
- **Plain http case** → "use the https:// address".
- **Storage-disabled case** → "enable storage / use a different browser".

Only the rendered message + recovery affordance change. The fail-closed
**condition** (`hostedMode && !userToken`) and the second WS-open refusal barrier
are untouched, so the isolation guarantee is unchanged.

This is the pragmatic fix for the dominant, *uninterceptable* trigger (the
browser's own "open in new tab" fires no JS event, so no interceptor can catch
it). Making such tabs actually load would require moving the per-user token off
`localStorage` into a gateway-scoped cookie — a larger #4381 design change, noted
on the issue, not attempted here.

## Testing

- New Rust regression test `fail_closed_page_gives_actionable_recovery_4645` pins:
  opaque-origin detection, the URL-for-copy affordance, the three tailored
  headings, and the anti-footgun (the fail-closed block must not call
  `window.open`).
- ESLint + Prettier clean on the asset JS (`npm run lint` in `crates/core/src/server`).
- Rendering validated in a real browser against live try.freenet.org.

## Scope

Addresses the **bug** in #4645 (the error page). The issue also suggests an
"add new access key / identity" button in the Account popup — that's a small
follow-up PR, so this PR intentionally does **not** close #4645.

[AI-assisted - Claude]
