### PR TITLE
fix: pre-flight size check for fdev website publish and reconcile state-size limits

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -160,6 +160,14 @@ pub mod dev_tool {
         SecretStoreError, SecretsStore, StateStore, UserSecretContext,
     };
 
+    /// Maximum size (in bytes) of a single contract-state blob a node will
+    /// accept, re-exported for client-side pre-flight checks. This is the
+    /// binding publish limit; see
+    /// `wasm_runtime::state_store::MAX_STATE_SIZE` for the full limit
+    /// hierarchy. `fdev website publish` uses this to reject oversized sites
+    /// before sending a PUT (#4653).
+    pub use wasm_runtime::MAX_STATE_SIZE as MAX_CONTRACT_STATE_SIZE;
+
     // Re-export simulation types for test infrastructure
     pub use crate::simulation::{
         FaultConfig, FaultConfigBuilder, Partition, SimulationRng, TimeSource, VirtualTime,

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -60,7 +60,10 @@ pub use secrets_store::{
 #[allow(unused_imports)]
 pub(crate) use simulation_runtime::{InMemoryContractStore, SimulationStores};
 pub use state_store::StateStore;
-pub(crate) use state_store::{MAX_STATE_SIZE, StateStorage, StateStoreError, state_hash};
+// `MAX_STATE_SIZE` is `pub` (not `pub(crate)`) so it can be re-exported from the
+// crate root as `dev_tool::MAX_CONTRACT_STATE_SIZE` for fdev's client-side check.
+pub use state_store::MAX_STATE_SIZE;
+pub(crate) use state_store::{StateStorage, StateStoreError, state_hash};
 
 /// Rename a code-hash-named WASM file from the legacy all-lowercase Base58
 /// name to the canonical mixed-case name (issue #4214).

--- a/crates/core/src/wasm_runtime/state_store.rs
+++ b/crates/core/src/wasm_runtime/state_store.rs
@@ -25,8 +25,10 @@ use moka::sync::Cache as MokaCache;
 /// - The stdlib WebSocket transport cap, `MAX_TOTAL_CHUNKS * CHUNK_SIZE`
 ///   (256 * 256 KiB = 64 MiB, in `freenet_stdlib::client_api::streaming`), is the largest
 ///   streamed API message the node will reassemble. It must stay `>=` this constant so any state
-///   the node would accept can actually be transmitted; otherwise an accepted-size state fails
-///   during stream reassembly with a cryptic `total_chunks N exceeds maximum 256` error (#4653).
+///   the node would accept can actually be transmitted. A state between this constant and the
+///   transport cap (~50-64 MiB) still reassembles and is rejected here by the state-size check
+///   below; only a state larger than the transport cap fails earlier, during stream reassembly,
+///   with a cryptic `total_chunks N exceeds maximum 256` error (#4653).
 /// - The website contract's own `MAX_WEB_SIZE` (100 MiB, in `crates/website-contract/src/lib.rs`)
 ///   is a loose sanity bound that this constant and the transport cap both bind before it is ever
 ///   reached.

--- a/crates/core/src/wasm_runtime/state_store.rs
+++ b/crates/core/src/wasm_runtime/state_store.rs
@@ -15,7 +15,27 @@ use moka::sync::Cache as MokaCache;
 /// 50 MiB is conservative enough to prevent disk exhaustion by malicious contracts while
 /// remaining large enough for legitimate use cases (web apps, documents, datasets). A contract
 /// whose `validate_state` returns `Valid` for arbitrarily large state cannot bypass this limit.
-pub(crate) const MAX_STATE_SIZE: usize = 50 * 1024 * 1024; // 50 MiB
+///
+/// # Limit hierarchy (this is the binding one)
+///
+/// This is the *effective* publishable-state ceiling: the node rejects any PUT/UPDATE whose
+/// state exceeds it (see the `store`/`update` checks below). Two related ceilings exist and must
+/// never drop below it:
+///
+/// - The stdlib WebSocket transport cap, `MAX_TOTAL_CHUNKS * CHUNK_SIZE`
+///   (256 * 256 KiB = 64 MiB, in `freenet_stdlib::client_api::streaming`), is the largest
+///   streamed API message the node will reassemble. It must stay `>=` this constant so any state
+///   the node would accept can actually be transmitted; otherwise an accepted-size state fails
+///   during stream reassembly with a cryptic `total_chunks N exceeds maximum 256` error (#4653).
+/// - The website contract's own `MAX_WEB_SIZE` (100 MiB, in `crates/website-contract/src/lib.rs`)
+///   is a loose sanity bound that this constant and the transport cap both bind before it is ever
+///   reached.
+///
+/// `fdev website publish` enforces this limit client-side, via the public re-export
+/// `freenet::dev_tool::MAX_CONTRACT_STATE_SIZE`, so an oversized site fails fast with an
+/// actionable error instead of the reassembly failure above. Keep that re-export in sync with
+/// this constant.
+pub const MAX_STATE_SIZE: usize = 50 * 1024 * 1024; // 50 MiB
 
 /// Maximum number of per-contract state-hash entries retained for the cheap
 /// summarize/delta change-detector (see [`StateStore::cached_state_hash`]).

--- a/crates/fdev/src/website.rs
+++ b/crates/fdev/src/website.rs
@@ -8,6 +8,7 @@ use anyhow::Context;
 use ciborium::ser::into_writer;
 use clap::Subcommand;
 use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+use freenet::dev_tool::MAX_CONTRACT_STATE_SIZE;
 use freenet::server::WebApp;
 use freenet_stdlib::client_api::{ContractRequest, ContractResponse, HostResponse};
 use freenet_stdlib::prelude::*;
@@ -182,6 +183,29 @@ fn sign_webapp(
     WebContainerMetadata { version, signature }
 }
 
+/// Fail fast if a packed website state exceeds the node's contract-state limit.
+///
+/// A node's state store rejects any state larger than [`MAX_CONTRACT_STATE_SIZE`]
+/// (50 MiB). Without this pre-flight check the oversized PUT is streamed all the
+/// way to the node and rejected during stream reassembly with a cryptic
+/// `stream reassembly error: total_chunks N exceeds maximum 256` message
+/// (issue #4653). Checking here lets us surface the actual size, the limit, and
+/// a concrete remediation hint before anything is sent.
+fn ensure_state_within_limit(state_len: usize, dir: &Path) -> anyhow::Result<()> {
+    if state_len > MAX_CONTRACT_STATE_SIZE {
+        let state_mib = state_len as f64 / (1024.0 * 1024.0);
+        let limit_mib = MAX_CONTRACT_STATE_SIZE / (1024 * 1024);
+        anyhow::bail!(
+            "Website is {state_mib:.1} MiB after compression, exceeding Freenet's \
+             {limit_mib} MiB contract-state limit. Reduce the size of {dir}: check for \
+             large media files, or an accidentally included node_modules/, .git/, or \
+             build/target/ directory.",
+            dir = dir.display(),
+        );
+    }
+    Ok(())
+}
+
 fn load_contract_wasm(custom_path: Option<&Path>) -> anyhow::Result<Vec<u8>> {
     match custom_path {
         Some(path) => {
@@ -321,6 +345,11 @@ pub async fn publish(
     let webapp = WebApp::from_compressed(metadata_bytes, webapp_bytes)?;
     let state: State = webapp.pack()?.into();
 
+    // Pre-flight size check: reject an oversized site here with a clear,
+    // actionable error rather than letting the node reject it during stream
+    // reassembly with a cryptic chunk-count message (#4653).
+    ensure_state_within_limit(state.as_ref().len(), &directory)?;
+
     println!("Publishing website as contract {key} (version {version})");
 
     let request = ContractRequest::Put {
@@ -429,6 +458,42 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("Missing keys.signing_key"),
+        );
+    }
+
+    #[test]
+    fn test_ensure_state_within_limit() {
+        let dir = Path::new("/tmp/my-site");
+
+        // Just over the limit: rejected, and the error names both the actual
+        // size and the limit so the user can act on it.
+        let over = ensure_state_within_limit(MAX_CONTRACT_STATE_SIZE + 1, dir);
+        assert!(over.is_err(), "state over the limit must be rejected");
+        let msg = over.unwrap_err().to_string();
+        assert!(
+            msg.contains("50 MiB"),
+            "error should mention the 50 MiB limit: {msg}"
+        );
+        assert!(
+            msg.contains("50.0 MiB"),
+            "error should mention the actual size in MiB: {msg}"
+        );
+        assert!(
+            msg.contains("/tmp/my-site"),
+            "error should name the directory to trim: {msg}"
+        );
+
+        // Exactly at the limit: accepted (the limit is inclusive, matching the
+        // node's state store, which accepts state of exactly MAX_STATE_SIZE).
+        assert!(
+            ensure_state_within_limit(MAX_CONTRACT_STATE_SIZE, dir).is_ok(),
+            "state at exactly the limit must be accepted"
+        );
+
+        // A small state: accepted.
+        assert!(
+            ensure_state_within_limit(1024, dir).is_ok(),
+            "small state must be accepted"
         );
     }
 

--- a/crates/fdev/src/website.rs
+++ b/crates/fdev/src/website.rs
@@ -186,8 +186,12 @@ fn sign_webapp(
 /// Fail fast if a packed website state exceeds the node's contract-state limit.
 ///
 /// A node's state store rejects any state larger than [`MAX_CONTRACT_STATE_SIZE`]
-/// (50 MiB). Without this pre-flight check the oversized PUT is streamed all the
-/// way to the node and rejected during stream reassembly with a cryptic
+/// (50 MiB). Without this pre-flight check the oversized PUT is sent and rejected
+/// by the node either way, but with an opaque message: a state in the ~50-64 MiB
+/// range reassembles fine and is rejected by the node's own state-size check
+/// (`state size X bytes exceeds maximum allowed 52428800 bytes`), while a very
+/// large site (>64 MiB serialized) exceeds the WebSocket transport cap and is
+/// rejected during stream reassembly with a cryptic
 /// `stream reassembly error: total_chunks N exceeds maximum 256` message
 /// (issue #4653). Checking here lets us surface the actual size, the limit, and
 /// a concrete remediation hint before anything is sent.
@@ -346,8 +350,9 @@ pub async fn publish(
     let state: State = webapp.pack()?.into();
 
     // Pre-flight size check: reject an oversized site here with a clear,
-    // actionable error rather than letting the node reject it during stream
-    // reassembly with a cryptic chunk-count message (#4653).
+    // actionable error rather than letting the node reject it with an opaque
+    // message (its state-size limit for ~50-64 MiB, or a cryptic chunk-count
+    // stream-reassembly error for >64 MiB serialized) (#4653).
     ensure_state_within_limit(state.as_ref().len(), &directory)?;
 
     println!("Publishing website as contract {key} (version {version})");

--- a/crates/website-contract/src/lib.rs
+++ b/crates/website-contract/src/lib.rs
@@ -7,6 +7,20 @@ use freenet_stdlib::prelude::*;
 use serde::{Deserialize, Serialize};
 
 const MAX_METADATA_SIZE: u64 = 1024;
+
+/// Loose upper bound on the packed website payload (100 MiB). This is a sanity
+/// ceiling only and is never actually the binding limit: a publish is bound
+/// first by the node's `MAX_STATE_SIZE` (50 MiB, in
+/// `crates/core/src/wasm_runtime/state_store.rs`) and by the stdlib WebSocket
+/// transport cap (`MAX_TOTAL_CHUNKS * CHUNK_SIZE` = 64 MiB), both well below
+/// this value, so state this large can never reach the contract.
+///
+/// WARNING: do NOT casually change this value. It is compiled into
+/// `crates/fdev/resources/website_contract.wasm`, and changing the WASM changes
+/// every website contract key (the key is derived from the code hash). Editing
+/// it therefore requires rebuilding that committed WASM binary AND a
+/// contract-key migration for every existing website. Adjust the binding
+/// limits (above) instead.
 const MAX_WEB_SIZE: u64 = 100 * 1024 * 1024;
 
 /// Metadata for a website container state, serialized as CBOR.


### PR DESCRIPTION
## Problem

`fdev website publish` compresses a directory (tar+xz), packs it into a website-contract state, and sends the whole thing as a single `ContractRequest::Put` over the WebSocket API. A user's site serialized to ~394 MiB. The WS API caps a streamed message at `MAX_TOTAL_CHUNKS`(256) × `CHUNK_SIZE`(256 KiB) = **64 MiB**, so the node rejected the message during reassembly with a cryptic error surfaced verbatim by fdev:

```
stream reassembly error: total_chunks 1578 exceeds maximum 256
```

Nothing told the user the real problem (their site is too big) or what to do about it. Worse, there were **three inconsistent size ceilings** with no documented relationship:

- Node state store: `MAX_STATE_SIZE = 50 MiB` (the binding/effective limit — the node rejects any state larger than this).
- WS transport chunk cap: 64 MiB (`MAX_TOTAL_CHUNKS * CHUNK_SIZE` in freenet-stdlib).
- Website contract's own check: `MAX_WEB_SIZE = 100 MiB`.

## Solution

Two fixes on the same code surface (the publish size limit):

**1. Pre-flight size check in fdev.** `publish()` now validates the packed state length against the node's effective 50 MiB limit *before* building/sending the PUT, and bails with an actionable error naming the actual size, the limit, the directory, and the usual culprits (large media, an accidentally included `node_modules/`, `.git/`, or `build/target/`). The numeric check is factored into a small free function `ensure_state_within_limit` so it is unit-testable without allocating 50 MiB.

**2. Single source of truth + documented hierarchy.** `MAX_STATE_SIZE` is now exposed publicly as `freenet::dev_tool::MAX_CONTRACT_STATE_SIZE`, and fdev references that constant rather than a literal `50 * 1024 * 1024`. Cross-referencing doc comments now tie the three constants together:
- `MAX_STATE_SIZE` documents that it is the binding limit, that the transport cap (64 MiB) must stay ≥ it, and that fdev enforces it client-side.
- `MAX_WEB_SIZE` gets a **comment-only** note that 100 MiB is a loose bound never actually reached, plus a warning that changing it requires rebuilding `crates/fdev/resources/website_contract.wasm` **and** a contract-key migration (the key is derived from the code hash), so it must not be casually edited.

Deliberately out of scope: this PR does **not** change the value of `MAX_WEB_SIZE`, does **not** recompile/replace `website_contract.wasm`, and does **not** raise `MAX_STATE_SIZE`. Raising the network-wide state limit is a separate feature needing design approval; the goal here is only to fail fast with a clear message and reconcile/document the existing limits.

## Testing

- New unit test `website::tests::test_ensure_state_within_limit`: rejects a length one byte over `MAX_CONTRACT_STATE_SIZE` (asserting the error mentions the size, the limit, and the directory), and accepts a length exactly at the limit (inclusive, matching the state store) and a small length. Lengths are passed as integers, so no large allocation.
- `cargo test -p fdev website` → 4 passed, 0 failed.
- `cargo clippy -p fdev -- -D warnings` and `cargo clippy -p freenet -- -D warnings` → clean.
- `cargo build -p fdev` and `cargo check -p freenet-website-contract` → clean.

Closes #4653

[AI-assisted - Claude]