### PR TITLE
feat: event-driven re-subscribe on upstream connection drop

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -187,6 +187,12 @@ pub struct OperationStats {
     /// Count of broadcast updates received via subscription streaming.
     /// These are push-based and don't have success/failure semantics.
     pub updates_received: u32,
+    /// Count of event-driven re-subscribes this node fired because an UPSTREAM
+    /// peer dropped (#4642 piece F). Each is a fresh SUBSCRIBE routed toward the
+    /// key immediately on upstream-loss detection (after the shared
+    /// ban/backoff/dedup gates), rather than waiting for the periodic renewal
+    /// cycle — a per-node measure of how often self-healing re-rooting fired.
+    pub event_driven_resubscribes: u64,
 }
 
 /// Maximum number of recent NAT attempts to track for rolling trend.
@@ -457,6 +463,19 @@ pub fn record_update_received() {
     if let Some(status) = NETWORK_STATUS.get() {
         if let Ok(mut s) = status.write() {
             s.op_stats.updates_received = s.op_stats.updates_received.saturating_add(1);
+        }
+    }
+}
+
+/// Record an event-driven re-subscribe fired on upstream-peer loss (#4642
+/// piece F). Per-node aggregate scalar; incremented once per fresh SUBSCRIBE
+/// spawned by `OpManager::on_ring_connection_lost` for a contract whose upstream
+/// just dropped.
+pub fn record_event_driven_resubscribe() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.op_stats.event_driven_resubscribes =
+                s.op_stats.event_driven_resubscribes.saturating_add(1);
         }
     }
 }
@@ -795,6 +814,8 @@ pub struct OpStatsSnapshot {
     pub subscribes: (u32, u32),
     /// Broadcast updates received via subscription streaming.
     pub updates_received: u32,
+    /// Event-driven re-subscribes fired on upstream-peer loss (#4642 piece F).
+    pub event_driven_resubscribes: u64,
 }
 
 impl OpStatsSnapshot {
@@ -972,6 +993,7 @@ pub fn get_snapshot() -> Option<NetworkStatusSnapshot> {
             updates: s.op_stats.updates,
             subscribes: s.op_stats.subscribes,
             updates_received: s.op_stats.updates_received,
+            event_driven_resubscribes: s.op_stats.event_driven_resubscribes,
         },
         nat_stats: NatStatsSnapshot {
             attempts: s.nat_stats.attempts,
@@ -1244,6 +1266,34 @@ mod tests {
         assert_eq!(snap.op_stats.puts, (1, 0));
         assert_eq!(snap.op_stats.subscribes, (1, 1));
         assert_eq!(snap.op_stats.updates, (2, 1));
+    }
+
+    #[test]
+    fn test_event_driven_resubscribe_recording() {
+        // #4642 piece F: the per-node event-driven re-subscribe scalar must
+        // accumulate through `record_event_driven_resubscribe()` and surface in
+        // the snapshot.
+        let _lock = TEST_MUTEX.lock().unwrap();
+        init(31346, HashSet::new(), "0.1.148".to_string());
+
+        if let Some(status) = NETWORK_STATUS.get() {
+            let mut s = status.write().unwrap();
+            s.op_stats = OperationStats::default();
+        }
+
+        assert_eq!(
+            get_snapshot().unwrap().op_stats.event_driven_resubscribes,
+            0
+        );
+
+        record_event_driven_resubscribe();
+        record_event_driven_resubscribe();
+        record_event_driven_resubscribe();
+
+        assert_eq!(
+            get_snapshot().unwrap().op_stats.event_driven_resubscribes,
+            3
+        );
     }
 
     #[test]

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1226,9 +1226,10 @@ impl OpManager {
                 // Production per-node scalar (aggregate counter on this node).
                 crate::node::network_status::record_event_driven_resubscribe();
                 // Simulation-test observability (no-op in production — gated on a
-                // current network name, like the renewal-cycle counters). Lets a
-                // sim assert this node fired an event-driven re-subscribe promptly
-                // after the upstream drop, well before the lease-renewal window.
+                // current network name, like the renewal-cycle counters). Records
+                // per-node so a simulation harness can observe event-driven
+                // re-subscribes; no behavioral sim consumes it yet (see #4642
+                // piece F PR — a reliable one is blocked on harness support).
                 if let Some(addr) = own_addr {
                     crate::ring::topology_registry::record_event_driven_resubscribe(addr);
                 }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1155,10 +1155,64 @@ impl OpManager {
     /// `expire_stale_downstream_subscribers` sweep, which also decrements the
     /// interest manager's `downstream_subscriber_count` and triggers upstream
     /// unsubscribe when appropriate.
-    pub(crate) fn on_ring_connection_lost(&self, pub_key: &TransportPublicKey) {
+    ///
+    /// # Event-driven re-subscribe (#4642 piece F)
+    ///
+    /// The deferred interest cleanup above is unchanged (it is the safety net for
+    /// a transient blip: if the peer reconnects within the grace period,
+    /// `on_ring_connection_established` cancels the removal). In addition, for
+    /// every contract where the dropped peer was our UPSTREAM in the subscription
+    /// tree, immediately route a fresh SUBSCRIBE toward the key. This bounds the
+    /// update gap by drop-detection latency instead of the periodic
+    /// renewal/lease cadence (~2-min renewal / 8-min lease — the ~minutes-long
+    /// stale window). It is safe under the hosting invariants (invariant 4,
+    /// self-healing re-rooting): it fires ONLY for real, active subscriptions,
+    /// is single-target (routes toward the key), and is rate-limited by the
+    /// periodic renewal path's shared dedup (`mark_subscription_pending`) and
+    /// backoff, so it can neither storm nor double-fire against the 30s recovery
+    /// loop. The periodic loop remains as the backstop for anything this misses.
+    pub(crate) fn on_ring_connection_lost(self: &Arc<Self>, pub_key: &TransportPublicKey) {
         self.neighbor_hosting.on_peer_disconnected(pub_key);
-        self.interest_manager
-            .schedule_deferred_removal(&PeerKey::from(pub_key.clone()));
+        let peer_key = PeerKey::from(pub_key.clone());
+        self.interest_manager.schedule_deferred_removal(&peer_key);
+
+        let open_conns = self.ring.open_connections();
+        let affected = self.interest_manager.upstream_contracts_for_peer(&peer_key);
+        tracing::debug!(
+            dropped_peer = %peer_key.0,
+            open_connections = open_conns,
+            upstream_contracts = affected.len(),
+            "piece-F: evaluating event-driven re-subscribe on upstream loss"
+        );
+
+        // No peers to route a fresh SUBSCRIBE through: skip (mirrors the periodic
+        // renewal loop's zero-connection gate, #3676, which prevents a doomed
+        // subscribe storm on an isolated node).
+        if open_conns == 0 {
+            return;
+        }
+
+        if affected.is_empty() {
+            return;
+        }
+
+        let own_addr = self.ring.connection_manager.get_own_addr();
+        for contract in affected {
+            if self
+                .ring
+                .try_spawn_event_driven_resubscribe(self.clone(), contract)
+            {
+                // Production per-node scalar (aggregate counter on this node).
+                crate::node::network_status::record_event_driven_resubscribe();
+                // Simulation-test observability (no-op in production — gated on a
+                // current network name, like the renewal-cycle counters). Lets a
+                // sim assert this node fired an event-driven re-subscribe promptly
+                // after the upstream drop, well before the lease-renewal window.
+                if let Some(addr) = own_addr {
+                    crate::ring::topology_registry::record_event_driven_resubscribe(addr);
+                }
+            }
+        }
     }
 }
 
@@ -3302,5 +3356,99 @@ mod tests {
         assert_eq!(counter.load(Ordering::Relaxed), 1);
         drop(g);
         assert_eq!(counter.load(Ordering::Relaxed), 0);
+    }
+}
+
+#[cfg(test)]
+mod event_driven_resubscribe_wiring_tests {
+    //! Source-scrape pin for #4642 piece F: `OpManager::on_ring_connection_lost`
+    //! must wire the event-driven re-subscribe end to end.
+    //!
+    //! A behavioral test would need a live `OpManager` + `Ring` with an installed
+    //! upstream subscription and a real peer connection — scaffolding this suite
+    //! does not have (the same reason `ring.rs` pins the renewal ban-gate by
+    //! source-scrape rather than behavior). So this pins the drop handler's
+    //! wiring: the existing deferred-cleanup backstop stays, and the new path
+    //! selects upstream contracts, honours the zero-connection gate, delegates to
+    //! the bounded `try_spawn_event_driven_resubscribe`, and records BOTH the
+    //! production per-node scalar and the sim-observable per-node counter. The
+    //! selection, gating order, and shared-helper routing are covered
+    //! behaviorally/structurally by the tests in `ring/interest.rs`,
+    //! `node/network_status.rs`, and `ring.rs`.
+
+    fn production_source() -> &'static str {
+        const FULL: &str = include_str!("op_state_manager.rs");
+        let cutoff = FULL
+            .find("\n#[cfg(test)]\nmod ")
+            .expect("op_state_manager.rs must have a top-level #[cfg(test)] mod section");
+        &FULL[..cutoff]
+    }
+
+    fn extract_fn_body<'a>(source: &'a str, signature_prefix: &str) -> &'a str {
+        let start = source
+            .find(signature_prefix)
+            .unwrap_or_else(|| panic!("could not find {signature_prefix}"));
+        let brace = source[start..].find('{').expect("fn sig must have body");
+        let body_start = start + brace + 1;
+        let bytes = source.as_bytes();
+        let mut depth: i32 = 1;
+        let mut i = body_start;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &source[body_start..i];
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        panic!("unbalanced braces while extracting {signature_prefix}");
+    }
+
+    #[test]
+    fn on_ring_connection_lost_wires_event_driven_resubscribe() {
+        let src = production_source();
+        let body = extract_fn_body(src, "fn on_ring_connection_lost(self: &Arc<Self>");
+
+        // Backstop preserved: deferred interest cleanup still scheduled.
+        assert!(
+            body.contains("schedule_deferred_removal"),
+            "on_ring_connection_lost must keep the deferred interest-removal \
+             backstop (transient-blip safety net)"
+        );
+
+        // New event-driven path: select upstream contracts, gate on connections,
+        // delegate to the bounded spawn helper.
+        let select = body
+            .find("upstream_contracts_for_peer")
+            .expect("must select the contracts whose upstream just dropped");
+        assert!(
+            body.contains("open_connections"),
+            "must honour the zero-connection gate (mirrors renewal loop #3676)"
+        );
+        let spawn = body.find("try_spawn_event_driven_resubscribe").expect(
+            "must delegate to the bounded try_spawn_event_driven_resubscribe \
+             (shared ban/backoff/dedup gates) — do NOT hand-inline the spawn",
+        );
+        assert!(
+            select < spawn,
+            "must select upstream contracts (offset {select}) before spawning \
+             re-subscribes (offset {spawn})"
+        );
+
+        // Both the production per-node scalar and the sim-observable per-node
+        // counter are recorded when a re-subscribe fires.
+        assert!(
+            body.contains("network_status::record_event_driven_resubscribe"),
+            "must record the production per-node scalar"
+        );
+        assert!(
+            body.contains("topology_registry::record_event_driven_resubscribe"),
+            "must record the sim-observable per-node counter"
+        );
     }
 }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -26,7 +26,7 @@ use tracing::Instrument;
 
 use crate::{
     client_events::HostResult,
-    config::GlobalExecutor,
+    config::{GlobalExecutor, GlobalRng},
     contract::{ContractError, ContractHandlerChannel, ContractHandlerEvent, SenderHalve},
     message::{InterestMessage, MessageStats, NetMessage, NetMessageV1, NodeEvent, Transaction},
     operations::{
@@ -1176,32 +1176,53 @@ impl OpManager {
         let peer_key = PeerKey::from(pub_key.clone());
         self.interest_manager.schedule_deferred_removal(&peer_key);
 
-        let open_conns = self.ring.open_connections();
-        let affected = self.interest_manager.upstream_contracts_for_peer(&peer_key);
-        tracing::debug!(
-            dropped_peer = %peer_key.0,
-            open_connections = open_conns,
-            upstream_contracts = affected.len(),
-            "piece-F: evaluating event-driven re-subscribe on upstream loss"
-        );
-
-        // No peers to route a fresh SUBSCRIBE through: skip (mirrors the periodic
-        // renewal loop's zero-connection gate, #3676, which prevents a doomed
-        // subscribe storm on an isolated node).
-        if open_conns == 0 {
+        // No peers to route a fresh SUBSCRIBE through: skip BEFORE the interest
+        // scan (mirrors the periodic renewal loop's zero-connection gate, #3676,
+        // which prevents a doomed subscribe storm on an isolated node).
+        if self.ring.open_connections() == 0 {
             return;
         }
 
+        let mut affected = self.interest_manager.upstream_contracts_for_peer(&peer_key);
         if affected.is_empty() {
             return;
         }
 
+        // Bound the per-drop burst the SAME way the periodic renewal loop does
+        // (#4601 cap + channel backpressure, #3676): a high-degree upstream can
+        // be the upstream for many of our contracts, and firing a fresh SUBSCRIBE
+        // for every one at once (only 0-1s jitter) would flood the notification
+        // channel and starve the periodic loop this path shares dedup/backoff
+        // state with. Shuffle so we don't always starve the same tail, cap the
+        // spawns to `MAX_RECOVERY_ATTEMPTS_PER_INTERVAL`, and stop early if the
+        // channel is congested. Any contract skipped here is still recovered by
+        // the periodic renewal loop (the backstop), so capping the burst never
+        // drops a subscription — it only smooths the spike.
+        GlobalRng::shuffle(&mut affected);
+        tracing::debug!(
+            dropped_peer = %peer_key.0,
+            upstream_contracts = affected.len(),
+            "piece-F: evaluating event-driven re-subscribe on upstream loss"
+        );
+
+        let sender = self.to_event_listener.notifications_sender();
+        let channel_max = sender.max_capacity();
         let own_addr = self.ring.connection_manager.get_own_addr();
+        let mut fired = 0usize;
         for contract in affected {
+            if fired >= crate::ring::Ring::MAX_RECOVERY_ATTEMPTS_PER_INTERVAL {
+                break;
+            }
+            // Stop spawning if the notification channel is >75% full, mirroring
+            // the periodic loop's `RENEWAL_STOP_CAPACITY_FRACTION` gate.
+            if sender.capacity() < channel_max / crate::ring::Ring::RENEWAL_STOP_CAPACITY_FRACTION {
+                break;
+            }
             if self
                 .ring
                 .try_spawn_event_driven_resubscribe(self.clone(), contract)
             {
+                fired += 1;
                 // Production per-node scalar (aggregate counter on this node).
                 crate::node::network_status::record_event_driven_resubscribe();
                 // Simulation-test observability (no-op in production — gated on a
@@ -3421,23 +3442,45 @@ mod event_driven_resubscribe_wiring_tests {
              backstop (transient-blip safety net)"
         );
 
-        // New event-driven path: select upstream contracts, gate on connections,
+        // New event-driven path: gate on connections, select upstream contracts,
         // delegate to the bounded spawn helper.
+        //
+        // Pin the ACTUAL zero-connection gate `open_connections() == 0`, not just
+        // the substring `open_connections` (which also appears elsewhere): the
+        // #3676 storm gate is the one storm-safety invariant unique to this
+        // caller, and it must run BEFORE the spawn.
+        let gate = body.find("open_connections() == 0").expect(
+            "must honour the zero-connection storm gate `open_connections() == 0` \
+             (mirrors renewal loop #3676)",
+        );
         let select = body
             .find("upstream_contracts_for_peer")
             .expect("must select the contracts whose upstream just dropped");
-        assert!(
-            body.contains("open_connections"),
-            "must honour the zero-connection gate (mirrors renewal loop #3676)"
-        );
         let spawn = body.find("try_spawn_event_driven_resubscribe").expect(
             "must delegate to the bounded try_spawn_event_driven_resubscribe \
              (shared ban/backoff/dedup gates) — do NOT hand-inline the spawn",
         );
         assert!(
-            select < spawn,
-            "must select upstream contracts (offset {select}) before spawning \
-             re-subscribes (offset {spawn})"
+            gate < spawn && select < spawn,
+            "the zero-connection gate (offset {gate}) and upstream selection \
+             (offset {select}) must both run before spawning re-subscribes \
+             (offset {spawn})"
+        );
+
+        // Fan-out cap: a high-degree upstream drop must NOT spawn an unbounded
+        // burst of re-subscribes. The per-drop burst is capped by the same
+        // `MAX_RECOVERY_ATTEMPTS_PER_INTERVAL` the periodic renewal loop uses,
+        // plus the channel-backpressure short-circuit.
+        assert!(
+            body.contains("MAX_RECOVERY_ATTEMPTS_PER_INTERVAL"),
+            "must cap the per-drop re-subscribe burst by \
+             MAX_RECOVERY_ATTEMPTS_PER_INTERVAL (uncapped fan-out is a subscribe \
+             storm on high-degree upstream loss)"
+        );
+        assert!(
+            body.contains("RENEWAL_STOP_CAPACITY_FRACTION"),
+            "must stop early when the notification channel is congested \
+             (channel-backpressure short-circuit, mirrors the renewal loop)"
         );
 
         // Both the production per-node scalar and the sim-observable per-node

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1741,6 +1741,185 @@ impl Ring {
     /// Interval for periodic GET subscription cache sweep.
     pub(crate) const GET_SUBSCRIPTION_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
 
+    /// Spawn the guarded per-contract subscription-renewal task.
+    ///
+    /// Shared by the periodic renewal loop (`recover_orphaned_subscriptions`)
+    /// and the event-driven upstream-loss re-subscribe path
+    /// (`try_spawn_event_driven_resubscribe`, #4642 piece F) so BOTH paths use
+    /// identical bounded machinery. The caller MUST have already reserved the
+    /// per-contract slot via `mark_subscription_pending` (returned `true`); this
+    /// task creates the `SubscriptionRecoveryGuard` that releases that slot (and
+    /// records success/backoff) even on panic or early shutdown, waits
+    /// `jitter_ms` (shutdown-aware), then drives `run_renewal_subscribe` under
+    /// the outer cancel deadline and emits the outcome telemetry.
+    ///
+    /// Do NOT hand-inline a copy of this body at a new call site (see the
+    /// "Manually-inlined originator side effects" rule in
+    /// `.claude/rules/bug-prevention-patterns.md`); both renewal entry points
+    /// are pinned to route through here by
+    /// `renewal_paths_route_through_shared_spawn_helper`.
+    fn spawn_guarded_renewal_task(
+        op_manager: Arc<OpManager>,
+        contract: ContractKey,
+        shutdown: CancellationToken,
+        jitter_ms: u64,
+    ) {
+        GlobalExecutor::spawn(async move {
+            // Guard ensures complete_subscription_request is called even on panic.
+            // Created BEFORE the jitter sleep so an early shutdown return below
+            // still clears the `mark_subscription_pending` flag set above — the
+            // guard's Drop marks the request failed (#4278).
+            let guard = SubscriptionRecoveryGuard::new(op_manager.clone(), contract);
+
+            // The jitter can be up to 15s; bail (dropping the guard, which
+            // completes the pending request as failed) before doing any
+            // renewal work if the node is shutting down (#4278).
+            if sleep_or_shutdown(
+                &shutdown,
+                tokio::time::sleep(Duration::from_millis(jitter_ms)),
+            )
+            .await
+            {
+                return;
+            }
+
+            let instance_id = *contract.id();
+            // Renewal driver: same machinery as
+            // client-initiated SUBSCRIBE, with delivery
+            // returned to this task instead of via
+            // `result_router_tx`. `is_renewal=true` so
+            // the responder skips sending state.
+            //
+            // Outer renewal cancel deadline: a pure backstop for a
+            // *genuinely wedged* driver. In normal operation the
+            // renewal driver self-terminates within
+            // `RENEWAL_TASK_BUDGET` (slow peer) and then runs its
+            // cleanup, so this deadline never fires.
+            //
+            // Issue #4350: the driver clamps each attempt's wait to
+            // the budget remaining until its own task deadline
+            // (`RENEWAL_TASK_BUDGET`, 20 s), so no attempt — first
+            // or retry — is still awaiting when this outer cancel
+            // fires; and the deadline is sized
+            // (`renewal_outer_cancel`, 55 s) to clear the driver's
+            // worst case (full-budget attempt + a fully
+            // backpressured `release_pending_op_slot` cleanup, up to
+            // `NOTIFICATION_SEND_TIMEOUT`). A task outliving the 30 s
+            // recovery interval is safe: `mark_subscription_pending`
+            // (released by `SubscriptionRecoveryGuard` on completion
+            // or cancel) blocks a second concurrent renewal for the
+            // same contract.
+            let renewal_tx =
+                crate::message::Transaction::new::<crate::operations::subscribe::SubscribeMsg>();
+            let renewal_deadline = Self::renewal_outer_cancel();
+            let outcome_enum = match tokio::time::timeout(
+                renewal_deadline,
+                crate::operations::subscribe::run_renewal_subscribe(
+                    op_manager.clone(),
+                    instance_id,
+                    renewal_tx,
+                ),
+            )
+            .await
+            {
+                Ok(outcome) => outcome,
+                Err(_) => crate::operations::subscribe::RenewalOutcome::Failed {
+                    reason: format!(
+                        "renewal task exceeded {}s cycle deadline",
+                        renewal_deadline.as_secs()
+                    ),
+                },
+            };
+
+            let (outcome, error_msg) = match outcome_enum {
+                crate::operations::subscribe::RenewalOutcome::Success => {
+                    tracing::info!(
+                        %contract,
+                        "Subscription renewal succeeded"
+                    );
+                    guard.complete(true);
+                    ("success", None)
+                }
+                crate::operations::subscribe::RenewalOutcome::ChannelCongestion => {
+                    // Channel congestion is a local resource issue, not a
+                    // protocol failure. Don't penalize with backoff — just
+                    // clear the pending mark so the contract is eligible on
+                    // the next cycle.
+                    tracing::warn!(
+                        %contract,
+                        "Subscription renewal skipped (channel full), will retry next cycle"
+                    );
+                    guard.complete(true);
+                    ("dropped_channel_full", None)
+                }
+                crate::operations::subscribe::RenewalOutcome::Failed { reason } => {
+                    tracing::debug!(
+                        %contract,
+                        error = %reason,
+                        "Subscription renewal failed (will retry with backoff)"
+                    );
+                    guard.complete(false);
+                    ("failed", Some(reason))
+                }
+            };
+
+            crate::tracing::telemetry::send_standalone_event(
+                "subscription_renewal_outcome",
+                serde_json::json!({
+                    "contract": contract.to_string(),
+                    "outcome": outcome,
+                    "error": error_msg,
+                }),
+            );
+        });
+    }
+
+    /// Event-driven re-subscribe for a single contract whose upstream peer just
+    /// dropped (#4642 piece F — demand-gated re-rooting, invariant 4).
+    ///
+    /// Applies the SAME bounding as the periodic renewal loop
+    /// (`recover_orphaned_subscriptions`) so the two paths can never storm or
+    /// double-fire against each other:
+    /// - ban gate (#4373): never re-register interest in a banned contract;
+    /// - `can_request_subscription` (exponential backoff on repeated failures);
+    /// - `mark_subscription_pending` (per-contract dedup — shared state with the
+    ///   periodic loop, so an in-flight renewal blocks this event-driven one and
+    ///   vice-versa).
+    ///
+    /// On passing all three gates it spawns the shared guarded renewal task with
+    /// a small jitter (0–1s, versus the loop's 0–15s spread) so the update gap is
+    /// bounded by drop-detection latency rather than the ~lease-renewal cadence
+    /// (2-min renewal / 8-min lease), while still de-synchronising a burst when a
+    /// high-degree upstream drops many of our subscriptions at once. The fresh
+    /// SUBSCRIBE routes greedily toward the key, so it re-roots keyward (gravity)
+    /// onto a live upstream rather than the dropped one.
+    ///
+    /// Returns `true` iff a re-subscribe was actually spawned (for the per-node
+    /// telemetry counter). The caller is responsible for the zero-connection gate
+    /// (mirrors the loop's #3676 gate) and for selecting only contracts where the
+    /// dropped peer was our upstream.
+    pub(crate) fn try_spawn_event_driven_resubscribe(
+        &self,
+        op_manager: Arc<OpManager>,
+        contract: ContractKey,
+    ) -> bool {
+        if self.contract_ban_list.is_banned(contract.id()) {
+            return false;
+        }
+        if !self.can_request_subscription(&contract) {
+            return false;
+        }
+        if !self.mark_subscription_pending(contract) {
+            return false;
+        }
+        // Small jitter (0–1s) to spread a burst when a high-degree upstream drops
+        // many of our subscriptions at once, while keeping the update gap far
+        // below the periodic renewal cadence.
+        let jitter_ms = GlobalRng::random_range(0u64..=1_000);
+        Self::spawn_guarded_renewal_task(op_manager, contract, self.shutdown_token(), jitter_ms);
+        true
+    }
+
     /// Periodically attempt to recover "orphaned hosters" - contracts we're hosting
     /// but don't have an upstream subscription for.
     ///
@@ -1977,120 +2156,12 @@ impl Ring {
                     // Spread tasks across the interval to avoid thundering-herd bursts.
                     let jitter_ms = GlobalRng::random_range(0u64..=15_000);
 
-                    let op_manager_clone = op_manager.clone();
-                    let contract_key = contract;
-                    let task_shutdown = shutdown.clone();
-
-                    GlobalExecutor::spawn(async move {
-                        // Guard ensures complete_subscription_request is called even on panic.
-                        // Created BEFORE the jitter sleep so an early shutdown return below
-                        // still clears the `mark_subscription_pending` flag set above — the
-                        // guard's Drop marks the request failed (#4278).
-                        let guard =
-                            SubscriptionRecoveryGuard::new(op_manager_clone.clone(), contract_key);
-
-                        // The jitter can be up to 15s; bail (dropping the guard, which
-                        // completes the pending request as failed) before doing any
-                        // renewal work if the node is shutting down (#4278).
-                        if sleep_or_shutdown(
-                            &task_shutdown,
-                            tokio::time::sleep(Duration::from_millis(jitter_ms)),
-                        )
-                        .await
-                        {
-                            return;
-                        }
-
-                        let instance_id = *contract_key.id();
-                        // Renewal driver: same machinery as
-                        // client-initiated SUBSCRIBE, with delivery
-                        // returned to this task instead of via
-                        // `result_router_tx`. `is_renewal=true` so
-                        // the responder skips sending state.
-                        //
-                        // Outer renewal cancel deadline: a pure backstop for a
-                        // *genuinely wedged* driver. In normal operation the
-                        // renewal driver self-terminates within
-                        // `RENEWAL_TASK_BUDGET` (slow peer) and then runs its
-                        // cleanup, so this deadline never fires.
-                        //
-                        // Issue #4350: the driver clamps each attempt's wait to
-                        // the budget remaining until its own task deadline
-                        // (`RENEWAL_TASK_BUDGET`, 20 s), so no attempt — first
-                        // or retry — is still awaiting when this outer cancel
-                        // fires; and the deadline is sized
-                        // (`renewal_outer_cancel`, 55 s) to clear the driver's
-                        // worst case (full-budget attempt + a fully
-                        // backpressured `release_pending_op_slot` cleanup, up to
-                        // `NOTIFICATION_SEND_TIMEOUT`). A task outliving the 30 s
-                        // recovery interval is safe: `mark_subscription_pending`
-                        // (released by `SubscriptionRecoveryGuard` on completion
-                        // or cancel) blocks a second concurrent renewal for the
-                        // same contract.
-                        let renewal_tx = crate::message::Transaction::new::<
-                            crate::operations::subscribe::SubscribeMsg,
-                        >();
-                        let renewal_deadline = Self::renewal_outer_cancel();
-                        let outcome_enum = match tokio::time::timeout(
-                            renewal_deadline,
-                            crate::operations::subscribe::run_renewal_subscribe(
-                                op_manager_clone.clone(),
-                                instance_id,
-                                renewal_tx,
-                            ),
-                        )
-                        .await
-                        {
-                            Ok(outcome) => outcome,
-                            Err(_) => crate::operations::subscribe::RenewalOutcome::Failed {
-                                reason: format!(
-                                    "renewal task exceeded {}s cycle deadline",
-                                    renewal_deadline.as_secs()
-                                ),
-                            },
-                        };
-
-                        let (outcome, error_msg) = match outcome_enum {
-                            crate::operations::subscribe::RenewalOutcome::Success => {
-                                tracing::info!(
-                                    %contract_key,
-                                    "Subscription renewal succeeded"
-                                );
-                                guard.complete(true);
-                                ("success", None)
-                            }
-                            crate::operations::subscribe::RenewalOutcome::ChannelCongestion => {
-                                // Channel congestion is a local resource issue, not a
-                                // protocol failure. Don't penalize with backoff — just
-                                // clear the pending mark so the contract is eligible on
-                                // the next cycle.
-                                tracing::warn!(
-                                    %contract_key,
-                                    "Subscription renewal skipped (channel full), will retry next cycle"
-                                );
-                                guard.complete(true);
-                                ("dropped_channel_full", None)
-                            }
-                            crate::operations::subscribe::RenewalOutcome::Failed { reason } => {
-                                tracing::debug!(
-                                    %contract_key,
-                                    error = %reason,
-                                    "Subscription renewal failed (will retry with backoff)"
-                                );
-                                guard.complete(false);
-                                ("failed", Some(reason))
-                            }
-                        };
-
-                        crate::tracing::telemetry::send_standalone_event(
-                            "subscription_renewal_outcome",
-                            serde_json::json!({
-                                "contract": contract_key.to_string(),
-                                "outcome": outcome,
-                                "error": error_msg,
-                            }),
-                        );
-                    });
+                    Self::spawn_guarded_renewal_task(
+                        op_manager.clone(),
+                        contract,
+                        shutdown.clone(),
+                        jitter_ms,
+                    );
                 }
             }
 
@@ -5719,9 +5790,9 @@ mod renewal_ban_gate_source_tests {
         );
 
         // The gate must precede the renewal spawn. Both `mark_subscription_pending`
-        // (which flips per-contract pending state) and `run_renewal_subscribe`
-        // (the outbound-egress driver) must only be reached for non-banned
-        // contracts.
+        // (which flips per-contract pending state) and the guarded-renewal spawn
+        // (which drives the outbound-egress `run_renewal_subscribe`) must only be
+        // reached for non-banned contracts.
         let mark_pending_pos = body
             .find("mark_subscription_pending(contract)")
             .expect("renewal loop must still call mark_subscription_pending");
@@ -5730,13 +5801,135 @@ mod renewal_ban_gate_source_tests {
             "ban gate (offset {gate_pos}) must run BEFORE \
              mark_subscription_pending (offset {mark_pending_pos})"
         );
+        // The outbound-egress `run_renewal_subscribe` now lives in the shared
+        // `spawn_guarded_renewal_task` helper (#4642 piece F); the loop reaches it
+        // only via that spawn call, which must still be gated behind the ban check.
         let spawn_pos = body
-            .find("run_renewal_subscribe(")
-            .expect("renewal loop must still spawn run_renewal_subscribe");
+            .find("spawn_guarded_renewal_task(")
+            .expect("renewal loop must still spawn via spawn_guarded_renewal_task");
         assert!(
             gate_pos < spawn_pos,
             "ban gate (offset {gate_pos}) must run BEFORE the \
-             run_renewal_subscribe outbound-egress spawn (offset {spawn_pos})"
+             spawn_guarded_renewal_task outbound-egress spawn (offset {spawn_pos})"
+        );
+        // And the egress driver itself must live in that helper, so the ban gate
+        // in the loop genuinely fronts the outbound SUBSCRIBE.
+        let helper_body = extract_fn_body(src, "fn spawn_guarded_renewal_task(");
+        assert!(
+            helper_body.contains("run_renewal_subscribe("),
+            "spawn_guarded_renewal_task must drive the outbound-egress \
+             run_renewal_subscribe"
+        );
+    }
+}
+
+#[cfg(test)]
+mod event_driven_resubscribe_source_tests {
+    //! Source-scrape pin for #4642 piece F (event-driven re-subscribe on
+    //! upstream loss). Two invariants the extraction must preserve:
+    //!
+    //! 1. BOTH renewal entry points — the periodic loop and the event-driven
+    //!    path — route through the shared `spawn_guarded_renewal_task` helper
+    //!    rather than hand-inlining `run_renewal_subscribe` (the
+    //!    "Manually-inlined originator side effects" anti-pattern). If a future
+    //!    refactor re-inlines the driver at either call site, this fails CI.
+    //! 2. The event-driven path applies the SAME bounding as the loop — ban gate,
+    //!    then `can_request_subscription` (backoff), then `mark_subscription_pending`
+    //!    (dedup) — BEFORE spawning, so it can neither storm nor double-fire
+    //!    against the 30s recovery loop.
+
+    fn production_source() -> &'static str {
+        const FULL: &str = include_str!("ring.rs");
+        let cutoff = FULL
+            .find("\n#[cfg(test)]\nmod ")
+            .expect("ring.rs must have a top-level #[cfg(test)] mod section");
+        &FULL[..cutoff]
+    }
+
+    fn extract_fn_body<'a>(source: &'a str, signature_prefix: &str) -> &'a str {
+        let start = source
+            .find(signature_prefix)
+            .unwrap_or_else(|| panic!("could not find {signature_prefix}"));
+        let brace = source[start..].find('{').expect("fn sig must have body");
+        let body_start = start + brace + 1;
+        let bytes = source.as_bytes();
+        let mut depth: i32 = 1;
+        let mut i = body_start;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &source[body_start..i];
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        panic!("unbalanced braces while extracting {signature_prefix}");
+    }
+
+    #[test]
+    fn renewal_paths_route_through_shared_spawn_helper() {
+        let src = production_source();
+
+        // The periodic loop must delegate to the helper, not inline the driver.
+        let loop_body = extract_fn_body(
+            src,
+            "async fn recover_orphaned_subscriptions(ring: Arc<Self>",
+        );
+        assert!(
+            loop_body.contains("spawn_guarded_renewal_task("),
+            "the periodic renewal loop must spawn via spawn_guarded_renewal_task"
+        );
+        assert!(
+            !loop_body.contains("run_renewal_subscribe("),
+            "the periodic renewal loop must NOT hand-inline run_renewal_subscribe \
+             — it belongs in the shared spawn_guarded_renewal_task helper"
+        );
+
+        // The event-driven path must delegate to the helper, not inline the driver.
+        let event_body = extract_fn_body(src, "fn try_spawn_event_driven_resubscribe(");
+        assert!(
+            event_body.contains("spawn_guarded_renewal_task("),
+            "the event-driven re-subscribe path must spawn via \
+             spawn_guarded_renewal_task"
+        );
+        assert!(
+            !event_body.contains("run_renewal_subscribe("),
+            "the event-driven re-subscribe path must NOT hand-inline \
+             run_renewal_subscribe — use the shared helper"
+        );
+    }
+
+    #[test]
+    fn event_driven_resubscribe_applies_dedup_and_backoff_before_spawn() {
+        let src = production_source();
+        let body = extract_fn_body(src, "fn try_spawn_event_driven_resubscribe(");
+
+        let ban_pos = body
+            .find("contract_ban_list.is_banned")
+            .expect("event-driven re-subscribe must gate on the ban list (#4373)");
+        let can_request_pos = body
+            .find("can_request_subscription(&contract)")
+            .expect("event-driven re-subscribe must consult can_request_subscription (backoff)");
+        let mark_pending_pos = body
+            .find("mark_subscription_pending(contract)")
+            .expect("event-driven re-subscribe must dedup via mark_subscription_pending");
+        let spawn_pos = body
+            .find("spawn_guarded_renewal_task(")
+            .expect("event-driven re-subscribe must spawn the guarded renewal task");
+
+        assert!(
+            ban_pos < can_request_pos
+                && can_request_pos < mark_pending_pos
+                && mark_pending_pos < spawn_pos,
+            "event-driven re-subscribe must apply ban -> backoff -> dedup gates \
+             (offsets {ban_pos}, {can_request_pos}, {mark_pending_pos}) BEFORE \
+             spawning (offset {spawn_pos}) so it cannot storm or double-fire \
+             against the periodic renewal loop"
         );
     }
 }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1650,7 +1650,10 @@ impl Ring {
     /// subscriptions before renewals can't keep up. The mid-cycle channel
     /// capacity check (RENEWAL_STOP_CAPACITY_FRACTION) provides backpressure
     /// if the network can't absorb this many.
-    const MAX_RECOVERY_ATTEMPTS_PER_INTERVAL: usize = 10;
+    // pub(crate) so the event-driven re-subscribe path
+    // (`OpManager::on_ring_connection_lost`, #4642 piece F) can apply the SAME
+    // per-burst cap the periodic renewal loop uses.
+    pub(crate) const MAX_RECOVERY_ATTEMPTS_PER_INTERVAL: usize = 10;
 
     /// Skip renewal cycle when channel remaining capacity falls below this
     /// fraction of max (i.e. channel is more than 50% full).
@@ -1658,7 +1661,9 @@ impl Ring {
 
     /// Stop spawning mid-cycle when remaining capacity falls below this
     /// fraction of max (i.e. channel is more than 75% full).
-    const RENEWAL_STOP_CAPACITY_FRACTION: usize = 4; // channel_max / 4
+    // pub(crate) so the event-driven re-subscribe path can apply the same
+    // channel-backpressure short-circuit (#4642 piece F).
+    pub(crate) const RENEWAL_STOP_CAPACITY_FRACTION: usize = 4; // channel_max / 4
 
     /// Interval for periodic subscription state telemetry snapshots.
     pub(crate) const SUBSCRIPTION_STATE_INTERVAL: Duration = Duration::from_secs(60);

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -1408,13 +1408,16 @@ impl HostingManager {
     }
 
     /// Mark a subscription request as in-flight.
-    /// Returns false if already pending.
+    ///
+    /// Returns `true` iff this call reserved the slot (the contract was not
+    /// already pending). `DashSet::insert` returns `true` only when the key was
+    /// newly inserted, so the reservation is ATOMIC: if two tasks race for the
+    /// same contract, exactly one gets `true`. This matters since #4642 piece F
+    /// added a second concurrent caller (`on_ring_connection_lost` on the
+    /// event-loop task) alongside the periodic renewal loop — a non-atomic
+    /// check-then-insert here would let both pass and double-fire a re-subscribe.
     pub fn mark_subscription_pending(&self, contract: ContractKey) -> bool {
-        if self.pending_subscription_requests.contains(&contract) {
-            return false;
-        }
-        self.pending_subscription_requests.insert(contract);
-        true
+        self.pending_subscription_requests.insert(contract)
     }
 
     /// Mark a subscription request as completed.
@@ -2279,6 +2282,53 @@ mod tests {
 
         // Now in backoff - can't request immediately
         assert!(!manager.can_request_subscription(&contract));
+    }
+
+    /// #4642 piece F: `mark_subscription_pending` must be an ATOMIC reservation.
+    ///
+    /// Before piece F the only caller was the single sequential periodic renewal
+    /// loop, so a non-atomic check-then-insert never raced. Piece F added a
+    /// second concurrent caller (`on_ring_connection_lost` on the event-loop
+    /// task); if the reservation were non-atomic, two tasks racing for the same
+    /// contract could both observe "not pending", both insert, and both spawn a
+    /// re-subscribe — the double-fire the design forbids. This hammers the same
+    /// key from many threads and asserts EXACTLY ONE reservation wins.
+    #[test]
+    fn mark_subscription_pending_reserves_atomically_under_contention() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let manager = Arc::new(HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES));
+        let contract = make_contract_key(7);
+        let winners = Arc::new(AtomicUsize::new(0));
+
+        const THREADS: usize = 32;
+        let barrier = Arc::new(std::sync::Barrier::new(THREADS));
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let manager = manager.clone();
+                let winners = winners.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    // Line every thread up so they contend on the same instant.
+                    barrier.wait();
+                    if manager.mark_subscription_pending(contract) {
+                        winners.fetch_add(1, Ordering::Relaxed);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(
+            winners.load(Ordering::Relaxed),
+            1,
+            "exactly one thread must win the pending reservation; more than one \
+             means the reservation is non-atomic and the event-driven and \
+             periodic paths can double-fire a re-subscribe"
+        );
     }
 
     #[test]

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -526,6 +526,37 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             .unwrap_or_default()
     }
 
+    /// Contracts for which `peer` is our UPSTREAM in the subscription tree.
+    ///
+    /// Piece F of the demand-driven hosting redesign (#4642): when an upstream
+    /// connection drops, these are exactly the subscriptions whose update flow
+    /// just broke and must be re-routed toward the key. A peer that was only a
+    /// downstream subscriber (`is_upstream == false` — updates flow FROM us TO
+    /// it) is excluded, because its drop does not interrupt our own updates.
+    ///
+    /// Snapshots the `peer_contracts` reverse-index entry and releases its shard
+    /// guard BEFORE touching `interested_peers`, so this never holds the
+    /// `peer_contracts` guard while acquiring an `interested_peers` shard — the
+    /// reverse of the `register_peer_interest` lock order (see the "Cross-DashMap
+    /// Lock Discipline" rule in `.claude/rules/ring.md`; same defensive shape as
+    /// `remove_all_peer_interests`).
+    pub fn upstream_contracts_for_peer(&self, peer: &PeerKey) -> Vec<ContractKey> {
+        let contracts: Vec<ContractKey> = self
+            .peer_contracts
+            .get(peer)
+            .map(|entry| entry.value().iter().cloned().collect())
+            .unwrap_or_default();
+        contracts
+            .into_iter()
+            .filter(|contract| {
+                self.interested_peers
+                    .get(contract)
+                    .and_then(|entry| entry.get(peer).map(|interest| interest.is_upstream))
+                    .unwrap_or(false)
+            })
+            .collect()
+    }
+
     /// Get the peer's cached summary for a contract.
     pub fn get_peer_summary(
         &self,
@@ -2017,6 +2048,66 @@ mod tests {
         let contracts = manager.get_contracts_for_peer(&peer);
         assert_eq!(contracts.len(), 1);
         assert!(contracts.contains(&contract2));
+    }
+
+    #[test]
+    fn test_upstream_contracts_for_peer() {
+        // Piece F (#4642): `upstream_contracts_for_peer` must return only the
+        // contracts for which the given peer is our UPSTREAM (is_upstream=true),
+        // excluding downstream-only entries and entries for other peers.
+        let (manager, _time) = make_manager();
+        let up1 = make_contract_key(1);
+        let up2 = make_contract_key(2);
+        let down_only = make_contract_key(3);
+        let other_peers_upstream = make_contract_key(4);
+
+        let upstream_peer = make_peer_key(1);
+        let other_peer = make_peer_key(2);
+
+        // `upstream_peer` is our upstream for up1 and up2 (is_upstream=true)...
+        manager.register_peer_interest(&up1, upstream_peer.clone(), None, true);
+        manager.register_peer_interest(&up2, upstream_peer.clone(), None, true);
+        // ...but only a downstream subscriber for `down_only` (is_upstream=false).
+        manager.register_peer_interest(&down_only, upstream_peer.clone(), None, false);
+        // A different peer is the upstream for a fourth contract.
+        manager.register_peer_interest(&other_peers_upstream, other_peer.clone(), None, true);
+
+        let sort_by_id =
+            |v: &mut Vec<ContractKey>| v.sort_by(|a, b| a.id().as_bytes().cmp(b.id().as_bytes()));
+        let mut affected = manager.upstream_contracts_for_peer(&upstream_peer);
+        sort_by_id(&mut affected);
+        let mut expected = vec![up1, up2];
+        sort_by_id(&mut expected);
+        assert_eq!(
+            affected, expected,
+            "only the upstream_peer's is_upstream contracts should be affected"
+        );
+
+        // Downstream-only interest must NOT surface as an affected upstream.
+        assert!(!affected.contains(&down_only));
+
+        // The other peer's upstream contract is isolated to that peer.
+        assert_eq!(
+            manager.upstream_contracts_for_peer(&other_peer),
+            vec![other_peers_upstream]
+        );
+
+        // An unknown peer yields nothing.
+        assert!(
+            manager
+                .upstream_contracts_for_peer(&make_peer_key(9))
+                .is_empty()
+        );
+
+        // After the upstream peer's interest is removed (as on disconnect
+        // cleanup), it is no longer reported as an upstream.
+        manager.remove_peer_interest(&up1, &upstream_peer);
+        manager.remove_peer_interest(&up2, &upstream_peer);
+        assert!(
+            manager
+                .upstream_contracts_for_peer(&upstream_peer)
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/core/src/ring/topology_registry.rs
+++ b/crates/core/src/ring/topology_registry.rs
@@ -215,6 +215,14 @@ pub struct RenewalMetrics {
     /// regression guard for the cap (#4601); if the cap were removed, a node
     /// with N > 10 simultaneously-eligible contracts would record N here.
     pub max_cycle_batch: u64,
+    /// Event-driven re-subscribes this node fired because an UPSTREAM peer
+    /// dropped (#4642 piece F). Each increment is one `run_renewal_subscribe`
+    /// spawned immediately on upstream-loss detection (after passing the shared
+    /// ban / backoff / dedup gates), rather than waiting for the periodic
+    /// renewal cycle. A `run_simulation_direct` test asserts this rises promptly
+    /// after crashing a node's upstream — the deterministic proof that recovery
+    /// is event-driven, not lease-timer-driven.
+    pub event_driven_resubscribes: u64,
 }
 
 static RENEWAL_METRICS_REGISTRY: LazyLock<DashMap<(String, SocketAddr), RenewalMetrics>> =
@@ -257,6 +265,18 @@ pub fn record_renewal_cycle_batch(peer_addr: SocketAddr, batch_size: u64) {
     }
 }
 
+/// Record that this node fired an event-driven re-subscribe because an upstream
+/// peer dropped (#4642 piece F). No-op outside a simulation context (no current
+/// network name).
+pub fn record_event_driven_resubscribe(peer_addr: SocketAddr) {
+    if let Some(network_name) = get_current_network_name() {
+        RENEWAL_METRICS_REGISTRY
+            .entry((network_name, peer_addr))
+            .or_default()
+            .event_driven_resubscribes += 1;
+    }
+}
+
 /// Get the renewal metrics for a specific peer in a network.
 pub fn get_renewal_metrics(network_name: &str, peer_addr: &SocketAddr) -> Option<RenewalMetrics> {
     RENEWAL_METRICS_REGISTRY
@@ -290,6 +310,7 @@ pub fn aggregate_renewal_metrics(network_name: &str) -> RenewalMetrics {
             // count), so the aggregate stays meaningful as "worst single-cycle
             // batch any node reached".
             acc.max_cycle_batch = acc.max_cycle_batch.max(entry.value().max_cycle_batch);
+            acc.event_driven_resubscribes += entry.value().event_driven_resubscribes;
             acc
         })
 }

--- a/crates/core/src/ring/topology_registry.rs
+++ b/crates/core/src/ring/topology_registry.rs
@@ -218,10 +218,13 @@ pub struct RenewalMetrics {
     /// Event-driven re-subscribes this node fired because an UPSTREAM peer
     /// dropped (#4642 piece F). Each increment is one `run_renewal_subscribe`
     /// spawned immediately on upstream-loss detection (after passing the shared
-    /// ban / backoff / dedup gates), rather than waiting for the periodic
-    /// renewal cycle. A `run_simulation_direct` test asserts this rises promptly
-    /// after crashing a node's upstream — the deterministic proof that recovery
-    /// is event-driven, not lease-timer-driven.
+    /// ban / backoff / dedup gates and the per-drop burst cap), rather than
+    /// waiting for the periodic renewal cycle. Exposed per-node (gated on a
+    /// simulation network name, no-op in production) so a simulation harness can
+    /// observe event-driven recovery. NOTE: a reliable behavioral sim that
+    /// crashes a *known* upstream and asserts this rises is currently blocked on
+    /// harness support — see the #4642 piece F PR discussion — so the wiring is
+    /// pinned by source-scrape tests instead.
     pub event_driven_resubscribes: u64,
 }
 

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1338,12 +1338,21 @@ pub fn build_ops_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> S
             // which inflates the number and confuses users.
             let active = snap.contracts.len() as u32;
             let total_ops = ops.subscribes.0.saturating_add(ops.subscribes.1);
+            // Event-driven re-subscribes fired on upstream loss (#4642 piece F):
+            // self-healing re-rooting count, shown only once it has happened.
+            let rerooted = ops.event_driven_resubscribes;
+            let rerooted_line = if rerooted > 0 {
+                format!(r#"<div class="op-received">{rerooted} re-rooted</div>"#)
+            } else {
+                String::new()
+            };
             if total_ops > 0 {
                 format!(
                     r#"<div class="op-cell">
                         <div class="op-name">SUBSCRIBE</div>
                         <div class="op-count">{active} active</div>
                         <div class="op-received">{total_ops} ops</div>
+                        {rerooted_line}
                     </div>"#,
                 )
             } else {
@@ -1351,6 +1360,7 @@ pub fn build_ops_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> S
                     r#"<div class="op-cell">
                         <div class="op-name">SUBSCRIBE</div>
                         <div class="op-count">{active} active</div>
+                        {rerooted_line}
                     </div>"#,
                 )
             }


### PR DESCRIPTION
> [!WARNING]
> **PARKED for Ian's review — do NOT merge.** This is piece F of the demand-driven hosting redesign bundle (epic #4642) and targets **0.2.91** (after 0.2.90 validates). It touches the subscription / connection-drop recovery path, so it is intentionally held for maintainer sign-off rather than auto-merged.

## Problem

Subscriptions are lease-based and, since the 2026-01 refactor, deliberately not tied to a peer in the `HostingManager`. When the upstream peer a subscription is routed through drops, the local lease stays valid and updates stop flowing until the periodic renewal cycle re-routes it (~2-min renewal / 8-min lease — a minutes-long stale window). Recovery is entirely lease-timer-driven; nothing reacts to the drop *event* itself.

This is **piece F** of the redesign ("demand-gated re-rooting"): a peer whose upstream vanishes should re-subscribe immediately (a fresh SUBSCRIBE routes toward the key, re-rooting the chain keyward — self-healing, invariant 4), bounded by the existing recovery caps rather than waiting for the timer.

## Approach

`OpManager::on_ring_connection_lost` (the single chokepoint for ring-connection loss) now, **in addition to the unchanged deferred interest cleanup**, immediately re-subscribes for every contract where the dropped peer was our **upstream**:

- **Upstream selection** — the contract→upstream mapping already exists in `InterestManager` (`PeerInterest.is_upstream`). New `upstream_contracts_for_peer` filters the reverse index to those entries, snapshotting `peer_contracts` before touching `interested_peers` to avoid the `register_peer_interest` lock-order inversion (see `ring.md` cross-DashMap discipline).
- **Reuses existing renewal machinery** — the renewal loop's guarded-spawn block is extracted into a shared `Ring::spawn_guarded_renewal_task` so the periodic loop and the event path are byte-identical (single source of truth; pinned). `try_spawn_event_driven_resubscribe` applies the **same** bounding as the loop: ban gate (#4373), `can_request_subscription` (exponential backoff), `mark_subscription_pending` (per-contract dedup — **shared, atomic** state, so the event path and the 30s loop cannot double-fire).
- **Bounded fan-out** — a high-degree upstream can be the upstream for many contracts, so the per-drop burst is shuffled and capped to `MAX_RECOVERY_ATTEMPTS_PER_INTERVAL` with the same channel-backpressure short-circuit the renewal loop uses; the periodic loop recovers any capped remainder (never dropped). Small 0–1s jitter keeps the update gap minimal.
- **Storm-safe** — zero-connection gate mirrors the loop's #3676 guard. No wire / stdlib change. **The periodic timer path's behavior is preserved** (its inline spawn was extracted into the shared `spawn_guarded_renewal_task` that both paths now call — pinned by `renewal_paths_route_through_shared_spawn_helper`), and it remains the backstop.

**Instrumentation** (per-node scalars only): `event_driven_resubscribes` in `network_status` (surfaced on the dashboard SUBSCRIBE card as "N re-rooted") + a sim-observable per-node counter in `topology_registry::RenewalMetrics`.

### Invariant check (hosting-invariants.md)

Recovery for **real** subscriptions (active demand), **single-target** (routes toward the key), **rate-limited** (shared dedup + backoff + burst cap), timer path preserved as backstop — exactly the self-healing re-rooting invariant 4 permits, and re-introduces **no** anti-pattern (no holding-driven push, no relay-caching, no unsubscribed durable cache).

## Testing

Deterministic coverage:
- `test_upstream_contracts_for_peer` — `is_upstream` filtering (excludes downstream-only and other peers).
- `test_event_driven_resubscribe_recording` — counter accumulation + snapshot.
- `mark_subscription_pending_reserves_atomically_under_contention` — 32-thread contention test pinning the atomic reservation (no double-fire).
- Source-scrape pins: `renewal_paths_route_through_shared_spawn_helper` (both paths use the shared helper, neither hand-inlines the driver), `event_driven_resubscribe_applies_dedup_and_backoff_before_spawn` (ban→backoff→dedup ordering), the updated #4373 ban-gate pin, and `on_ring_connection_lost_wires_event_driven_resubscribe` (drop-handler wiring: zero-conn gate + fan-out cap + counters).
- 173 interest/hosting/subscription/renewal unit tests pass; `cargo fmt` + `cargo clippy` clean (no new warnings).

Multi-model review (Codex + 2 adversarial Claude passes) ran and found two MAJOR issues (double-fire race + uncapped fan-out), both fixed in `6c026372`; the re-review is clean. Full write-up in the review comment below.

### Note on the behavioral sim test (for maintainer)

A full-network `run_simulation` crash test was built and investigated but is **not reliably deterministic** for this specific behavior, for three concrete harness reasons:
1. **`is_upstream` is sparse in random-event sims** — `finalize_originator_subscribe` only records a peer-upstream when `get_peer_by_addr(upstream_addr)` resolves and `upstream_addr != own_addr`; many sim subscribes resolve at the root (upstream = self), so no peer-upstream is recorded to crash.
2. **Silent-crash detection floor** — a `crash_node`'d (packet-dropping) peer is only pruned by the ring's periodic health check (`HEALTH_CHECK_INTERVAL` = 300s); the transport-close arm only logs. So the event can't fire before ~300s in that scenario.
3. **No single runner supports both** scripting a known subscription tree (`run_controlled_simulation`) **and** crashing a peer mid-run (`run_simulation`).

Diagnostics confirmed the mechanism is wired correctly (`on_ring_connection_lost` fires with `open_connections > 0`; it just never saw a crashed peer that was a recorded upstream). Rather than land a flaky sim test (flaky = broken), the end-to-end wiring is pinned deterministically via source-scrape (the codebase's established pattern for Ring/OpManager logic lacking behavioral scaffolding — same reason `ring.rs` pins the renewal ban-gate). **Happy to add a real behavioral test if the harness gains scripted-subscribe-plus-mid-run-crash, or a way to force a peer-upstream.** Flagging for your call.

Refs #4642

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnRCbtbjepaB5GWrb5U8SR
