### PR TITLE
feat: remove relay-caching + GET-auto-subscribe (piece E, #4642) [BLOCKED: PUT half needs D fetch hardening]

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -4852,9 +4852,12 @@ mod tests {
         // make a peer a first-viable-target via `register_peer_interest` and
         // are correctly flush-paired. A NEW production call site in any other
         // file must FAIL this pin — see the set-equality assertion below.
+        // NOTE: "operations.rs" was dropped from this set in piece E of the
+        // demand-driven hosting redesign — its only register_peer_interest call
+        // lived in `complete_piggyback_subscription` (the GET-auto-subscribe
+        // piggyback finalizer), which was removed with GET-auto-subscribe.
         let known_wired: std::collections::BTreeSet<&str> = [
             "node.rs",
-            "operations.rs",
             "operations/subscribe.rs",
             "operations/get/op_ctx_task.rs",
         ]

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -700,7 +700,6 @@ impl OpManager {
     /// * **Source 2 — interest manager** (`register_peer_interest` is_new):
     ///   - `subscribe::register_downstream_subscriber` (downstream subscriber)
     ///   - `subscribe::finalize_originator_subscribe` (originator upstream)
-    ///   - `operations::complete_piggyback_subscription` (GET-piggyback sub)
     ///   - `get::op_ctx_task` remote GET `subscribe=false` (requester interest)
     ///   - `node.rs` Interests / Summaries interest-sync handlers
     /// * **Source 1 — proximity cache** (`neighbors_with_contract`):

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -466,78 +466,18 @@ pub(crate) fn reclaim_evicted_contract(
     );
 }
 
-/// Complete subscription at the originator node via GET piggyback.
-///
-/// The subscription tree was built by relay nodes during GET response propagation.
-/// This function performs the local registration at the originator:
-/// 1. Mark subscribed (lease in active_subscriptions)
-/// 2. Register the upstream peer as an interest source
-/// 3. Register local interest so ChangeInterests from peers are processed
-/// 4. Announce contract hosted so neighbors send UPDATEs
-pub(crate) async fn complete_piggyback_subscription(
-    op_manager: &OpManager,
-    key: &ContractKey,
-    tx: &crate::message::Transaction,
-    sender_from_addr: &Option<crate::ring::PeerKeyLocation>,
-) {
-    op_manager.ring.subscribe(*key);
-    op_manager.ring.complete_subscription_request(key, true);
-
-    // Register local interest so ChangeInterests from peers get properly processed.
-    let became_interested = op_manager.interest_manager.add_local_client(key);
-    if became_interested {
-        broadcast_change_interests(op_manager, vec![*key], vec![]).await;
-    }
-
-    // Announce that we host this contract so neighbors include us in broadcast targets.
-    announce_contract_hosted(op_manager, key).await;
-
-    if let Some(upstream_pkl) = sender_from_addr.as_ref() {
-        let peer_key = crate::ring::interest::PeerKey::from(upstream_pkl.pub_key.clone());
-        let is_new = op_manager
-            .interest_manager
-            .register_peer_interest(key, peer_key, None, true);
-        if is_new {
-            // #4359 (MUST-FIX 1): the piggyback upstream is now a viable
-            // broadcast target — flush any deferred fresh-contract broadcast so
-            // a cold-id PUT that gave up with no targets reaches the network.
-            op_manager.flush_pending_broadcast_on_interest(key).await;
-        }
-        tracing::debug!(tx = %tx, contract = %key, "Subscription completed via GET piggyback");
-    } else {
-        // sender_from_addr can be None for transient connections not yet in the ring.
-        // Subscription is still marked locally; the 2-minute renewal cycle will
-        // establish a full subscription tree via a standard SUBSCRIBE operation.
-        tracing::warn!(
-            tx = %tx,
-            contract = %key,
-            "GET piggyback: upstream peer not in ring, subscription tree incomplete -- renewal will heal"
-        );
-    }
-}
-
-/// Auto-subscribe at the originator: use piggybacked subscription if available,
-/// otherwise fall back to a separate SUBSCRIBE operation.
-///
-/// Called from GET response handling when `AUTO_SUBSCRIBE_ON_GET` is enabled and
-/// the originator is not yet subscribed. Consolidates the piggyback-or-fallback
-/// logic that appears in both streaming and non-streaming response paths.
-pub(crate) async fn auto_subscribe_on_get_response(
-    op_manager: &OpManager,
-    key: &ContractKey,
-    tx: &crate::message::Transaction,
-    sender_from_addr: &Option<crate::ring::PeerKeyLocation>,
-    subscribe_requested: bool,
-    blocking_sub: bool,
-    path_label: &str,
-) {
-    if subscribe_requested {
-        complete_piggyback_subscription(op_manager, key, tx, sender_from_addr).await;
-    } else {
-        let child_tx = start_subscription_request(op_manager, *tx, *key, blocking_sub);
-        tracing::debug!(tx = %tx, %child_tx, blocking = %blocking_sub, "started subscription ({path_label}, fallback)");
-    }
-}
+// `complete_piggyback_subscription` and `auto_subscribe_on_get_response` were
+// REMOVED in piece E of the demand-driven hosting redesign
+// (docs/design/demand-driven-hosting.md §9, hosting-invariants anti-patterns
+// table). Their only caller was the GET-auto-subscribe block in
+// `get/op_ctx_task.rs`, which auto-installed a durable subscription on every
+// successful GET (subscribe=false) — the "GET-auto-subscribe" anti-pattern that
+// manufactures demand no client requested. A GET now hosts on the return path
+// only under piece A's demand gauge (evictable, non-durable); a client that
+// wants ongoing freshness sets `subscribe=true`, which routes through the
+// explicit subscribe path (`maybe_subscribe_child` -> `run_client_subscribe`).
+// do NOT re-add an auto-subscribe-on-GET helper — see hosting-invariants
+// (invariants 1 & 2).
 
 /// Broadcast ChangeInterests message to all connected peers.
 ///

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -446,35 +446,18 @@ async fn drive_client_get_inner(
             )
             .await;
 
-            // Auto-subscribe on successful GET at the originator —
-            // mirrors the legacy branches at get.rs:2313/2408/3136/3185.
-            // AUTO_SUBSCRIBE_ON_GET (ring.rs:60) is a const; we still
-            // guard on `is_subscribed` to avoid duplicate registration
-            // if the request-router already wired up a subscribe.
-            //
-            // When the client explicitly set `subscribe=true`, the
-            // dedicated `maybe_subscribe_child` path below runs — skip
-            // auto-subscribe here so we never double-subscribe.
-            if host_result.is_ok()
-                && !subscribe
-                && crate::ring::AUTO_SUBSCRIBE_ON_GET
-                && !op_manager.ring.is_subscribed(&reply_key)
-            {
-                let path_label = match &terminal {
-                    Terminal::Streaming { .. } => "streaming",
-                    Terminal::InlineFound { .. } | Terminal::LocalCompletion => "non-streaming",
-                };
-                crate::operations::auto_subscribe_on_get_response(
-                    op_manager,
-                    &reply_key,
-                    &client_tx,
-                    &Some(driver.current_target.clone()),
-                    /* subscribe_requested */ false,
-                    /* blocking_sub */ blocking_subscribe,
-                    path_label,
-                )
-                .await;
-            }
+            // GET-auto-subscribe REMOVED (piece E, demand-driven hosting).
+            // A successful GET with subscribe=false previously installed a
+            // durable subscription here (AUTO_SUBSCRIBE_ON_GET). That is the
+            // "GET-auto-subscribe" anti-pattern: it manufactures ongoing demand
+            // no client requested and pins an advertised, self-renewing copy
+            // regardless of real interest. Under the demand-driven model the GET
+            // still hosts on the return path via `cache_contract_locally` above
+            // (bounded + evicted by piece A's demand gauge — the whole
+            // distinction from relay-caching), and a client that wants ongoing
+            // freshness sets `subscribe=true`, handled by `maybe_subscribe_child`
+            // below. do NOT re-add auto-subscribe here — see hosting-invariants
+            // (invariants 1 & 2, anti-patterns table).
 
             // Emit routing event + telemetry — `report_result` (which
             // normally does both) doesn't run because the bypass
@@ -4245,23 +4228,29 @@ mod tests {
         );
     }
 
-    /// Bug #2 reproduction (source-level): the legacy branch calls
-    /// `auto_subscribe_on_get_response` for any client-initiated GET
-    /// when `AUTO_SUBSCRIBE_ON_GET` is true (see `get.rs:2313, 2408`).
-    /// The driver currently never calls it; `maybe_subscribe_child`
-    /// only handles the explicit `subscribe=true` flag. This test
-    /// pairs with `test_driver_inline_get_triggers_auto_subscribe`
-    /// (integration) to lock down both the absence and the symptom.
+    /// Piece E (demand-driven hosting): GET-auto-subscribe was REMOVED.
+    /// A successful GET with `subscribe=false` must NOT install a durable
+    /// subscription — that is the "GET-auto-subscribe" anti-pattern
+    /// (hosting-invariants, invariants 1 & 2). The driver must therefore
+    /// never call `auto_subscribe_on_get_response`; the only subscribe path
+    /// left is the explicit-`subscribe=true` `maybe_subscribe_child`. This
+    /// pairs with `test_driver_inline_get_does_not_auto_subscribe`
+    /// (integration), which asserts the requesting node does NOT subscribe.
     #[test]
-    fn driver_calls_auto_subscribe_on_get_response() {
+    fn driver_does_not_auto_subscribe_on_get_response() {
         let src = production_source();
         assert!(
-            src.contains("auto_subscribe_on_get_response"),
-            "The driver must invoke `auto_subscribe_on_get_response` on \
-             successful GET terminal paths (AUTO_SUBSCRIBE_ON_GET = true in \
-             ring.rs:60). The legacy branch does this at get.rs:2313/2408/3136/3185; \
-             the driver must mirror it so client GETs with subscribe=false \
-             still register the fallback subscription."
+            !src.contains("auto_subscribe_on_get_response"),
+            "GET must NOT auto-subscribe (piece E removed AUTO_SUBSCRIBE_ON_GET). \
+             A GET with subscribe=false hosts on the return path only under the \
+             demand gauge (cache_contract_locally); ongoing freshness requires an \
+             explicit subscribe=true. do NOT re-add auto_subscribe_on_get_response \
+             — see hosting-invariants."
+        );
+        // The explicit subscribe path must still be wired in.
+        assert!(
+            src.contains("maybe_subscribe_child"),
+            "the explicit subscribe=true path (maybe_subscribe_child) must remain"
         );
     }
 

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -336,7 +336,7 @@ async fn drive_client_get_inner(
     // returns (and the side-effect block below has run). Do not add
     // explicit `completed()` calls in the arms here — doing so would
     // race the originator-side side effects (`cache_contract_locally`,
-    // `auto_subscribe_on_get_response`, `maybe_subscribe_child`)
+    // `maybe_subscribe_child`)
     // because once the tx is in `ops.completed`, any
     // `op_manager.push(...)` for that tx is silently dropped (see
     // `op_state_manager.rs::push` short-circuit on

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -2600,9 +2600,19 @@ where
     // re-add store-at-every-hop or replicate-on-terminus — see hosting-invariants.
     let own_addr = op_manager.ring.connection_manager.get_own_addr();
     let originator_loopback = Some(upstream_addr) == own_addr;
-    let finalize_here = next_hop.is_none();
+    // We are the effective terminus for this contract whenever we are NOT going
+    // to forward it downstream. That is `downstream_reply_rx.is_none()`, which
+    // covers BOTH "no next hop" (finalize) AND "next hop chosen but the piped
+    // forward was not set up" (payload below the streaming threshold, next-hop
+    // address unresolved, or send_to_and_register_waiter failed). In every
+    // not-forwarding case this node MUST host, or the Step 7 `else` branch below
+    // reports a successful PutMsg::Response for a contract that was neither
+    // stored here nor forwarded — silently losing the streamed PUT. A hop that
+    // IS piping forward is pure routing and does not host (unless it is the
+    // originator or already hosts the contract).
+    let not_forwarding = downstream_reply_rx.is_none();
     let should_host =
-        originator_loopback || finalize_here || op_manager.ring.is_hosting_contract(&key);
+        originator_loopback || not_forwarding || op_manager.ring.is_hosting_contract(&key);
 
     let merged_value = if should_host {
         // Originator-loopback client PUT → ClientLocal reserved lane (#4534).
@@ -2619,8 +2629,8 @@ where
         )
         .await?
     } else {
-        // Routing-only hop: the fragments were already piped onward; forward
-        // the client's value unchanged as the (unstored) response payload.
+        // Routing-only hop that IS piping the fragments onward: forward the
+        // client's value unchanged as the (unstored) response payload.
         value
     };
 

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1178,24 +1178,7 @@ where
         "PUT relay: processing Request"
     );
 
-    // ── Step 1: Store contract locally (all nodes cache) ────────────────────
-    // Originator-loopback (a local client's own PUT, mapped to
-    // upstream_addr=own_addr in dispatch) is ClientLocal so it lands in the
-    // reserved fair-queue lane; a genuine relay store stays NetworkRelay (#4534).
-    let store_priority = put_store_priority(op_manager, upstream_addr);
-    let merged_value = relay_put_store_locally(
-        op_manager,
-        incoming_tx,
-        key,
-        value.clone(),
-        &contract,
-        related_contracts.clone(),
-        htl,
-        store_priority,
-    )
-    .await?;
-
-    // ── Step 2: Build skip list + select next hop ──────────────────────────
+    // ── Step 1: Build skip list + select next hop ──────────────────────────
     let mut new_skip_list = skip_list;
     new_skip_list.insert(upstream_addr);
     if let Some(own_addr) = op_manager.ring.connection_manager.get_own_addr() {
@@ -1210,18 +1193,21 @@ where
         None
     };
 
-    let (next_peer, next_addr) = match next_hop {
+    // ── Step 2: Decide terminus (finalize/host here) vs forward next hop ────
+    // `None` = this node is the final destination (host the near-key seed);
+    // `Some((peer, addr))` = forward one hop closer to the key (pure routing).
+    let forward_target: Option<(PeerKeyLocation, SocketAddr)> = match next_hop {
         Some(peer) => {
             // Greedy-routing terminus guard (#4363): finalize here only
             // when the chain has provably descended to this node (the
             // closest-seen point) AND the best next hop would climb back
             // out of the contract neighbourhood. Forwarding past an
-            // overshoot would place the authoritative replica where
-            // greedy GETs never descend; terminating *before* the chain
-            // has reached the neighbourhood (e.g. at the originator
-            // loopback) would strand the contract far from the target —
-            // see `put_routing_should_terminate` for why the away-move
-            // alone is not a sufficient stop condition.
+            // overshoot would place the seed where greedy GETs never
+            // descend; terminating *before* the chain has reached the
+            // neighbourhood (e.g. at the originator loopback) would strand
+            // the contract far from the target — see
+            // `put_routing_should_terminate` for why the away-move alone is
+            // not a sufficient stop condition.
             let target = crate::ring::Location::from(&key);
             // own_location() is the address-derived ring position (not the
             // configured get_stored_location()); this matches the
@@ -1251,58 +1237,33 @@ where
                     phase = "relay_put_terminus",
                     "PUT relay: chain descended here and next hop moves away; finalizing here (#4363)"
                 );
-                // Finalize the operation at this closest-seen node (#4363
-                // placement) but STILL replicate the contract one hop onward so
-                // the UPDATE broadcast tree stays connected (#4509 convergence).
-                // See `relay_put_replicate_forward` for why both are required.
-                if let Some(next_addr) = peer.socket_addr() {
-                    relay_put_replicate_forward(
-                        op_manager,
-                        next_addr,
-                        key,
-                        contract.clone(),
-                        related_contracts.clone(),
-                        merged_value.clone(),
-                        htl,
-                        new_skip_list.clone(),
-                    )
-                    .await;
+                // Piece E (demand-driven hosting): the terminus finalizes and
+                // HOSTS the seed here (Step 3), and does NOT replicate the
+                // contract one hop onward. The former #4509
+                // `relay_put_replicate_forward` planted an unsolicited copy on
+                // a peer with no demand to keep the OLD PUT-path UPDATE
+                // broadcast tree connected — that is the relay-caching
+                // anti-pattern. Under the demand-driven model the update mesh
+                // is the connected sub-graph of demand-pinned SUBSCRIBED
+                // co-hosts (docs/design/demand-driven-hosting.md §2), built by
+                // SUBSCRIBE, not by the PUT route. do NOT re-add
+                // replicate-on-terminus — see hosting-invariants.
+                None
+            } else {
+                match peer.socket_addr() {
+                    Some(addr) => Some((peer, addr)),
+                    None => {
+                        tracing::error!(
+                            tx = %incoming_tx,
+                            contract = %key,
+                            target_pub_key = %peer.pub_key(),
+                            "PUT relay: next hop has no socket address"
+                        );
+                        // No usable next hop — act as final destination.
+                        None
+                    }
                 }
-                let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
-                return relay_put_finalize_local(
-                    op_manager,
-                    incoming_tx,
-                    key,
-                    merged_value,
-                    upstream_addr,
-                    hop_count,
-                )
-                .await;
             }
-            let addr = match peer.socket_addr() {
-                Some(a) => a,
-                None => {
-                    tracing::error!(
-                        tx = %incoming_tx,
-                        contract = %key,
-                        target_pub_key = %peer.pub_key(),
-                        "PUT relay: next hop has no socket address"
-                    );
-                    // No next hop — act as final destination.
-                    // This node IS the storer; hop_count = max_htl - htl_we_received.
-                    let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
-                    return relay_put_finalize_local(
-                        op_manager,
-                        incoming_tx,
-                        key,
-                        merged_value,
-                        upstream_addr,
-                        hop_count,
-                    )
-                    .await;
-                }
-            };
-            (peer, addr)
         }
         None => {
             // No next hop — this node is the final destination.
@@ -1312,7 +1273,54 @@ where
                 phase = "relay_put_complete",
                 "PUT relay: no next hop, finalizing at this node"
             );
-            // Same arm as above: this node IS the storer.
+            None
+        }
+    };
+
+    // ── Step 3: Host locally ONLY where demand-driven (piece E) ─────────────
+    // RELAY-CACHING REMOVED. A pure routing hop no longer stores a copy of
+    // every PUT it forwards ("all nodes cache"). This node stores + hosts +
+    // announces ONLY when it has a demand-driven reason to hold the contract:
+    //   * originator loopback — a local client's own PUT (local demand), OR
+    //   * terminus / final destination — the near-key findability seed, OR
+    //   * it already hosts the contract — a real host merges writes it sees.
+    // A peer that merely forwards a PUT one hop closer to the key is ROUTING,
+    // not hosting (docs/design/demand-driven-hosting.md §1); creating a durable
+    // advertised copy there is the "anti-gravity" that scattered hosting across
+    // the ring. do NOT re-add store-at-every-hop — see hosting-invariants
+    // (relay-caching anti-pattern).
+    let own_addr = op_manager.ring.connection_manager.get_own_addr();
+    let originator_loopback = Some(upstream_addr) == own_addr;
+    let finalize_here = forward_target.is_none();
+    let should_host =
+        originator_loopback || finalize_here || op_manager.ring.is_hosting_contract(&key);
+
+    let merged_value = if should_host {
+        // Originator-loopback (a local client's own PUT, mapped to
+        // upstream_addr=own_addr in dispatch) is ClientLocal so it lands in the
+        // reserved fair-queue lane; a genuine relay store stays NetworkRelay (#4534).
+        let store_priority = put_store_priority(op_manager, upstream_addr);
+        relay_put_store_locally(
+            op_manager,
+            incoming_tx,
+            key,
+            value.clone(),
+            &contract,
+            related_contracts.clone(),
+            htl,
+            store_priority,
+        )
+        .await?
+    } else {
+        // Routing-only hop: forward the client's value unchanged. The merge
+        // happens where the state lives (originator + near-key host); in the
+        // commutative-monoid model an intermediate merge is redundant.
+        value.clone()
+    };
+
+    // ── Step 4: Finalize here, or fall through to forward one hop closer ────
+    let (next_peer, next_addr) = match forward_target {
+        None => {
             let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
             return relay_put_finalize_local(
                 op_manager,
@@ -1324,9 +1332,10 @@ where
             )
             .await;
         }
+        Some(target) => target,
     };
 
-    // ── Step 3: Forward downstream, await Response, bubble up ──────────────
+    // ── Step 5: Forward downstream, await Response, bubble up ──────────────
 
     let new_htl = htl.saturating_sub(1);
 
@@ -1360,8 +1369,7 @@ where
     // the originator's still-installed callback. The relay does not
     // bubble up (skipping `relay_put_send_response`) because the
     // originator IS the upstream and is already waiting.
-    let own_addr = op_manager.ring.connection_manager.get_own_addr();
-    let originator_loopback = Some(upstream_addr) == own_addr;
+    // (`originator_loopback` was computed above in Step 3.)
 
     // Streaming upgrade on forward: serialize the payload, and if it
     // exceeds `streaming_threshold`, send a `RequestStreaming` metadata
@@ -1650,10 +1658,12 @@ where
         })) => {
             // Streaming response arrived from downstream. Slice A does
             // not relay-forward streaming payloads, so log and
-            // synthesize a non-streaming Response upstream. This
-            // preserves correctness — the contract IS stored at this
-            // node (step 1) — at the cost of the upstream not getting
-            // the streamed payload. Slice B handles stream pass-through.
+            // synthesize a non-streaming Response upstream. This is a
+            // success bubble because the DOWNSTREAM stored the contract
+            // (it returned ResponseStreaming) — not because this routing
+            // hop cached it (piece E removed store-at-every-hop). The cost
+            // is the upstream not getting the streamed payload; slice B
+            // handles stream pass-through.
             tracing::warn!(
                 tx = %incoming_tx,
                 contract = %reply_key,
@@ -1856,103 +1866,20 @@ async fn relay_put_store_locally(
     Ok(merged_value)
 }
 
-/// Fire-and-forget a replication-only `PutMsg::Request` to `next_addr`
-/// when the #4363 terminus guard finalizes the operation locally.
-///
-/// # Why the guard must still replicate (issue #4509 convergence fix)
-///
-/// The terminus guard makes the *closest-seen* node the authoritative
-/// finalizer (it sends the upstream `PutMsg::Response`, so the originator's
-/// reply and `hop_count` reflect placement at the contract neighbourhood —
-/// the #4363 goal). But finalizing must NOT also stop the contract from
-/// replicating onward: this codebase forms the UPDATE broadcast tree along
-/// the PUT forward path (each relay `host_contract` + `announce_contract_hosted`
-/// in `relay_put_store_locally`). If the guard simply returns after the
-/// upstream Response, the next hop — and everything past it — never receives
-/// the contract, so a later UPDATE that the router fans out to one of those
-/// peers fails with `missing contract` and the network splits into divergent
-/// state groups (observed in `test_six_peer_contract_lifecycle`: contract on
-/// 4/6 peers, a 2/2 v20-vs-v30 split, node-2's updates reaching no one).
-///
-/// To keep placement (#4363) AND replication breadth (convergence), the guard
-/// finalizes locally *and* forwards a replication copy onward with a FRESH
-/// transaction so it does not collide with the upstream finalization waiter
-/// (the originator is already satisfied by this node's Response). The forward
-/// is fire-and-forget: no reply is awaited, and the downstream relay drives
-/// its own replication (including re-applying the same guard one hop deeper).
-/// The skip list — which already contains `upstream_addr` and `own_addr` —
-/// rides along unchanged, and HTL is decremented, so the replication copy is
-/// bounded and cannot loop back upstream. This is the "ensure terminated PUTs
-/// still replicate to the contract neighbourhood" resolution.
-#[allow(clippy::too_many_arguments)]
-async fn relay_put_replicate_forward(
-    op_manager: &OpManager,
-    next_addr: SocketAddr,
-    key: ContractKey,
-    contract: ContractContainer,
-    related_contracts: RelatedContracts<'static>,
-    merged_value: WrappedState,
-    htl: usize,
-    skip_list: HashSet<SocketAddr>,
-) {
-    // The replication copy is sent as a single `PutMsg::Request`. For a
-    // payload that would need streaming we skip the replication forward rather
-    // than re-implement the piped-stream upgrade here: the local store already
-    // placed the authoritative replica at this closest-seen node (#4363), and
-    // the convergence regression this restores (#4509) is on the small-state
-    // non-streaming path. A large-contract terminus is rare; skipping leaves
-    // placement correct and only forgoes the extra broadcast-path replica.
-    let payload = PutStreamingPayload {
-        contract: contract.clone(),
-        related_contracts: related_contracts.clone(),
-        value: merged_value.clone(),
-    };
-    let payload_size = bincode::serialized_size(&payload).unwrap_or(u64::MAX) as usize;
-    if crate::operations::should_use_streaming(op_manager.streaming_threshold, payload_size) {
-        tracing::debug!(
-            contract = %key,
-            target = %next_addr,
-            payload_size,
-            phase = "relay_put_terminus_replicate",
-            "PUT relay: terminus replication skipped for streaming-size payload (placement still correct)"
-        );
-        return;
-    }
-
-    // Fresh tx: the upstream Response under `incoming_tx` already satisfies
-    // the originator's waiter; reusing it would (a) make the downstream relay
-    // bubble a second Response back to a node with no waiter and (b) trip the
-    // per-node dedup gate on `incoming_tx`. A new transaction keeps the
-    // replication copy a clean, independent fire-and-forget op.
-    let replication_tx = Transaction::new::<PutMsg>();
-    let forward = NetMessage::from(PutMsg::Request {
-        id: replication_tx,
-        contract,
-        related_contracts,
-        value: merged_value,
-        htl: htl.saturating_sub(1),
-        skip_list,
-    });
-    let mut ctx = op_manager.op_ctx(replication_tx);
-    if let Err(err) = ctx.send_fire_and_forget(next_addr, forward).await {
-        tracing::debug!(
-            replication_tx = %replication_tx,
-            contract = %key,
-            target = %next_addr,
-            error = %err,
-            phase = "relay_put_terminus_replicate",
-            "PUT relay: terminus replication forward failed (best-effort)"
-        );
-    } else {
-        tracing::debug!(
-            replication_tx = %replication_tx,
-            contract = %key,
-            target = %next_addr,
-            phase = "relay_put_terminus_replicate",
-            "PUT relay: finalized locally but forwarded replication copy onward (#4509)"
-        );
-    }
-}
+// `relay_put_replicate_forward` (the #4509 terminus replication forward) was
+// REMOVED in piece E of the demand-driven hosting redesign. It planted an
+// unsolicited copy of the contract on the next-hop peer whenever the #4363
+// terminus guard fired, in order to keep the OLD PUT-path UPDATE broadcast tree
+// connected — the broadcast tree that `relay_put_store_locally`'s
+// store-at-every-hop built. That whole tree was the relay-caching anti-pattern
+// (docs/design/demand-driven-hosting.md §9, hosting-invariants). Under the
+// demand-driven model the update mesh is the connected sub-graph of
+// demand-pinned SUBSCRIBED co-hosts (§2), built by SUBSCRIBE routing toward the
+// key, not by scattering copies along the PUT route. The #4509 convergence
+// regression it fixed (test_six_peer_contract_lifecycle) is now maintained by
+// subscriptions: that test subscribes every peer, so the mesh forms without
+// PUT-route replication. do NOT re-add a terminus/every-hop replication forward
+// — see hosting-invariants (relay-caching anti-pattern).
 
 /// Finalize at this node when there's no next hop. Emits `put_success`
 /// telemetry and sends `PutMsg::Response` upstream.
@@ -2045,6 +1972,39 @@ async fn relay_put_send_error(
     let mut ctx = op_manager.op_ctx(incoming_tx);
     let own_addr = op_manager.ring.connection_manager.get_own_addr();
     relay_put_send_error_with_ctx(&mut ctx, own_addr, incoming_tx, cause, upstream_addr).await
+}
+
+/// Terminal reply for the streaming relay when the downstream forward failed
+/// (timeout / channel closed / unexpected variant).
+///
+/// Piece E (demand-driven hosting): a pure routing hop no longer stores a copy
+/// of every PUT it forwards, so it can only claim success on downstream failure
+/// when it actually holds the contract (`stored_locally` — originator loopback
+/// or an already-hosting peer). Otherwise the PUT reached no reachable host via
+/// this route, and claiming success would silently lose it — so we report
+/// failure upstream (mirroring the non-streaming relay), letting the
+/// originator's retry loop try another route.
+async fn relay_put_streaming_downstream_failure(
+    op_manager: &OpManager,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    upstream_addr: SocketAddr,
+    htl: usize,
+    stored_locally: bool,
+    reason: &str,
+) -> Result<(), OpError> {
+    if stored_locally {
+        // This node holds a copy — the contract exists in the network here, so
+        // report our own forward depth as a successful placement.
+        let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
+        relay_put_send_response(op_manager, incoming_tx, key, upstream_addr, hop_count).await
+    } else {
+        let cause = bound_cause(format!(
+            "PUT streaming relay: {reason}; this routing hop holds no copy \
+             (piece E: no relay-caching) — retry via another route"
+        ));
+        relay_put_send_error(op_manager, incoming_tx, cause, upstream_addr).await
+    }
 }
 
 /// Shutdown fallback for `run_relay_put`'s originator-loopback error
@@ -2407,18 +2367,12 @@ where
     // Greedy-routing terminus guard (#4363), streaming path. Mirrors the
     // non-streaming `drive_relay_put` guard: finalize here only when the
     // chain has descended to this node AND the next hop would climb back
-    // out (the overshoot). The stream is assembled and stored here in
-    // step 5/6 regardless, so terminating never drops the contract — it
-    // just stops piping the replica to a farther peer the contract
-    // neighbourhood will never descend to. The away-move alone is not a
-    // sufficient stop condition; see `put_routing_should_terminate`.
-    // When the terminus guard fires it drops `next_hop` (stops piping), but
-    // the contract must still replicate one hop onward to keep the UPDATE
-    // broadcast tree connected (#4509 convergence — see
-    // `relay_put_replicate_forward`). The streaming payload isn't assembled
-    // until step 5, so we remember the next-hop address here and forward a
-    // replication copy after the local store in step 6.
-    let mut terminus_replicate_to: Option<SocketAddr> = None;
+    // out (the overshoot). When the guard fires it drops `next_hop`, stopping
+    // the piped forward to a farther peer the contract neighbourhood will
+    // never descend to. The away-move alone is not a sufficient stop
+    // condition; see `put_routing_should_terminate`. Whether this node then
+    // HOSTS the assembled contract (step 6) is a separate demand-driven
+    // decision (piece E) — a pure routing hop pipes onward without storing.
     let next_hop = match next_hop {
         Some(peer) => {
             let target = crate::ring::Location::from(&contract_key);
@@ -2444,7 +2398,6 @@ where
                     phase = "relay_put_streaming_terminus",
                     "PUT streaming relay: chain descended here and next hop moves away; finalizing here (#4363)"
                 );
-                terminus_replicate_to = peer.socket_addr();
                 None
             } else {
                 Some(peer)
@@ -2631,42 +2584,45 @@ where
         return Err(OpError::invalid_transition(incoming_tx));
     }
 
-    // ── Step 6: Store contract locally (shared helper with slice A) ──────
-    // Clone the contract/related-contracts for a possible terminus replication
-    // forward (#4509) before the store consumes `related_contracts`.
-    let replicate_payload =
-        terminus_replicate_to.map(|addr| (addr, contract.clone(), related_contracts.clone()));
-    // Originator-loopback client PUT → ClientLocal reserved lane (#4534).
-    let store_priority = put_store_priority(op_manager, upstream_addr);
-    let merged_value = relay_put_store_locally(
-        op_manager,
-        incoming_tx,
-        key,
-        value,
-        &contract,
-        related_contracts,
-        htl,
-        store_priority,
-    )
-    .await?;
+    // ── Step 6: Host locally ONLY where demand-driven (piece E) ──────────
+    // RELAY-CACHING REMOVED (streaming path). The stream was already piped
+    // one hop closer to the key above (Step 3, routing) without waiting on
+    // this local store, so a pure routing hop pipes onward and does NOT store
+    // a copy. This node stores + hosts + announces the assembled contract ONLY
+    // when it has a demand-driven reason to hold it: originator loopback (local
+    // client PUT), the terminus / final destination (near-key seed), or it
+    // already hosts the contract (a real host merges writes it sees). The
+    // former #4509 terminus `relay_put_replicate_forward` — which planted an
+    // unsolicited copy on a demand-less peer to keep the OLD PUT-path UPDATE
+    // broadcast tree connected — is removed: under the demand-driven model the
+    // update mesh is the connected sub-graph of SUBSCRIBED co-hosts
+    // (docs/design/demand-driven-hosting.md §2), not the PUT route. do NOT
+    // re-add store-at-every-hop or replicate-on-terminus — see hosting-invariants.
+    let own_addr = op_manager.ring.connection_manager.get_own_addr();
+    let originator_loopback = Some(upstream_addr) == own_addr;
+    let finalize_here = next_hop.is_none();
+    let should_host =
+        originator_loopback || finalize_here || op_manager.ring.is_hosting_contract(&key);
 
-    // Terminus guard fired (#4363) on the streaming path: finalize here but
-    // still replicate the assembled contract one hop onward so the UPDATE
-    // broadcast tree stays connected (#4509). Mirrors the non-streaming guard
-    // branch; see `relay_put_replicate_forward`.
-    if let Some((next_addr, contract, related_contracts)) = replicate_payload {
-        relay_put_replicate_forward(
+    let merged_value = if should_host {
+        // Originator-loopback client PUT → ClientLocal reserved lane (#4534).
+        let store_priority = put_store_priority(op_manager, upstream_addr);
+        relay_put_store_locally(
             op_manager,
-            next_addr,
+            incoming_tx,
             key,
-            contract,
+            value,
+            &contract,
             related_contracts,
-            merged_value.clone(),
             htl,
-            new_skip_list.clone(),
+            store_priority,
         )
-        .await;
-    }
+        .await?
+    } else {
+        // Routing-only hop: the fragments were already piped onward; forward
+        // the client's value unchanged as the (unstored) response payload.
+        value
+    };
 
     // ── Step 7: Await downstream reply (if piping), then bubble upstream ──
     //
@@ -2704,16 +2660,20 @@ where
                     );
                 }
                 op_manager.release_pending_op_slot(incoming_tx).await;
-                // Best-effort upstream reply after downstream failure: this
-                // node IS the storer (contract was put locally in step 6),
-                // so hop_count = max_htl - htl_we_received.
-                let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
-                return relay_put_send_response(
+                // Downstream failed. Under piece E this routing hop only holds
+                // a copy if `should_host` (originator/already-hosting); a pure
+                // routing hop did NOT store, so it must NOT claim success (that
+                // would silently lose the PUT). Mirror the non-streaming path:
+                // report failure upstream so the originator retries another
+                // route. A storing hop reports its own forward depth as before.
+                return relay_put_streaming_downstream_failure(
                     op_manager,
                     incoming_tx,
                     key,
                     upstream_addr,
-                    hop_count,
+                    htl,
+                    should_host,
+                    "downstream reply channel closed before reply",
                 )
                 .await;
             }
@@ -2733,15 +2693,16 @@ where
                     );
                 }
                 op_manager.release_pending_op_slot(incoming_tx).await;
-                // Same as the channel-closed arm: this node stored locally
-                // in step 6 so we report our own forward depth.
-                let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
-                return relay_put_send_response(
+                // See the channel-closed arm: a pure routing hop holds no copy
+                // (piece E), so report failure rather than fake success.
+                return relay_put_streaming_downstream_failure(
                     op_manager,
                     incoming_tx,
                     key,
                     upstream_addr,
-                    hop_count,
+                    htl,
+                    should_host,
+                    "downstream reply timed out",
                 )
                 .await;
             }
@@ -2794,10 +2755,18 @@ where
                     reply_variant = ?std::mem::discriminant(&other),
                     "PUT streaming relay: unexpected reply variant"
                 );
-                // Same as the error arms: this node stored locally.
-                let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
-                relay_put_send_response(op_manager, incoming_tx, key, upstream_addr, hop_count)
-                    .await
+                // Same as the error arms: only claim success if this node
+                // actually stored a copy (piece E); otherwise report failure.
+                relay_put_streaming_downstream_failure(
+                    op_manager,
+                    incoming_tx,
+                    key,
+                    upstream_addr,
+                    htl,
+                    should_host,
+                    "unexpected downstream reply variant",
+                )
+                .await
             }
         }
     } else {
@@ -4286,11 +4255,15 @@ mod tests {
         );
     }
 
-    /// Pin: driver MUST call `put_contract` + `host_contract` before
-    /// forwarding (so the local cache + hosting advertisement happens
-    /// regardless of whether the forward succeeds).
+    /// Piece E (demand-driven hosting): the relay driver stores + hosts +
+    /// announces the contract ONLY when it has a demand-driven reason to hold
+    /// it (originator loopback / terminus-final-destination / already-hosting),
+    /// NEVER unconditionally at every routing hop. This pin locks the
+    /// `should_host` gate into the call path so re-introducing store-at-every-hop
+    /// ("all nodes cache", the relay-caching anti-pattern) fails the build.
+    /// See hosting-invariants + docs/design/demand-driven-hosting.md §1.
     #[test]
-    fn drive_relay_put_stores_locally_before_forwarding() {
+    fn drive_relay_put_hosts_only_when_demand_driven() {
         let src = include_str!("op_ctx_task.rs");
         let driver_start = src
             .find("async fn drive_relay_put<CB>(")
@@ -4300,18 +4273,36 @@ mod tests {
             .expect("driver body end not found")
             + driver_start;
         let driver_src = &src[driver_start..driver_end];
+
+        let gate_pos = driver_src.find("let should_host =").expect(
+            "drive_relay_put MUST compute a `should_host` demand gate (piece E: \
+             no store-at-every-hop relay-caching)",
+        );
         let store_pos = driver_src
             .find("relay_put_store_locally(")
             .expect("relay_put_store_locally call missing in driver");
-        let forward_pos = driver_src
-            .find("ctx.send_to_and_await(")
-            .expect("send_to_and_await call missing in driver");
         assert!(
-            store_pos < forward_pos,
-            "local store MUST run before the downstream forward"
+            gate_pos < store_pos,
+            "the `should_host` gate MUST be decided before the store — the store \
+             is only for demand-driven hosting, not every routing hop"
+        );
+        // The gate must include exactly the three demand-driven reasons.
+        let gate_region = &driver_src[gate_pos..store_pos];
+        assert!(
+            gate_region.contains("originator_loopback"),
+            "should_host MUST include originator loopback (local client demand)"
+        );
+        assert!(
+            gate_region.contains("finalize_here"),
+            "should_host MUST include terminus/final-destination (near-key seed)"
+        );
+        assert!(
+            gate_region.contains("is_hosting_contract"),
+            "should_host MUST include already-hosting (a real host merges writes it sees)"
         );
 
-        // Helper must encapsulate put_contract + host_contract + announce.
+        // Helper still performs put_contract + host_contract + announce for the
+        // hosting cases (originator / terminus / already-hosting).
         let helper_start = src
             .find("async fn relay_put_store_locally(")
             .expect("helper not found");
@@ -4341,8 +4332,7 @@ mod tests {
     /// the helper in isolation — without this pin, deleting the call site
     /// (re-introducing the #4363 wander) would leave every unit test
     /// green. This locks the guard into the call path the same way
-    /// `drive_relay_put_stores_locally_before_forwarding` locks the
-    /// store-before-forward ordering.
+    /// `drive_relay_put_hosts_only_when_demand_driven` locks the demand gate.
     #[test]
     fn drive_relay_put_applies_terminus_guard_before_forwarding() {
         let src = include_str!("op_ctx_task.rs");
@@ -4367,11 +4357,13 @@ mod tests {
              PUT and the replica overshoots the contract neighbourhood"
         );
 
-        // The guard must finalize locally on its terminus branch (so the
-        // closest-seen node is the authoritative finalizer, #4363) AND still
-        // replicate the contract one hop onward (so the UPDATE broadcast tree
-        // stays connected, #4509) — not just log, and not fall through to the
-        // forward. Both calls live in the terminus branch before the forward.
+        // The terminus branch finalizes locally (relay_put_finalize_local), so
+        // the closest-seen node is the authoritative finalizer (#4363) and
+        // hosts the near-key seed. Piece E: it does NOT replicate the contract
+        // one hop onward — the #4509 relay_put_replicate_forward was REMOVED
+        // (relay-caching anti-pattern; the update mesh is now built by SUBSCRIBE,
+        // not the PUT route). finalize_local is reached via the `finalize_here`
+        // return in Step 4, which sits between the guard and the forward.
         let guard_region = &body[guard_pos..forward_pos];
         assert!(
             guard_region.contains("relay_put_finalize_local("),
@@ -4379,11 +4371,10 @@ mod tests {
              relay_put_finalize_local, not fall through to the forward"
         );
         assert!(
-            guard_region.contains("relay_put_replicate_forward("),
-            "the terminus branch MUST still replicate the contract onward via \
-             relay_put_replicate_forward (#4509) — finalizing without \
-             replicating orphans the UPDATE broadcast path and splits the \
-             network into divergent state groups"
+            !body.contains("relay_put_replicate_forward("),
+            "piece E removed the #4509 terminus replication forward — do NOT \
+             re-add relay_put_replicate_forward (relay-caching anti-pattern; \
+             see hosting-invariants)"
         );
     }
 
@@ -4425,19 +4416,25 @@ mod tests {
              locally"
         );
 
-        // The streaming guard records the dropped next hop in
-        // `terminus_replicate_to` and, after the local store, replicates the
-        // contract one hop onward via `relay_put_replicate_forward` (#4509) so
-        // the streaming path does not orphan the UPDATE broadcast tree either.
+        // Piece E: the streaming path demand-gates its local store via
+        // `should_host` (no store-at-every-hop) and does NOT replicate the
+        // contract onward — `terminus_replicate_to` and the #4509
+        // relay_put_replicate_forward were REMOVED (relay-caching anti-pattern;
+        // the update mesh is built by SUBSCRIBE, not the PUT route).
         assert!(
-            body.contains("terminus_replicate_to"),
-            "streaming guard MUST record the dropped next hop in \
-             terminus_replicate_to for the #4509 replication forward"
+            body.contains("let should_host ="),
+            "streaming driver MUST demand-gate its local store via should_host \
+             (piece E: no store-at-every-hop)"
         );
         assert!(
-            body.contains("relay_put_replicate_forward("),
-            "streaming terminus path MUST still replicate the contract onward \
-             via relay_put_replicate_forward (#4509)"
+            !body.contains("terminus_replicate_to"),
+            "piece E removed the streaming #4509 replicate-forward — do NOT \
+             re-add terminus_replicate_to (relay-caching anti-pattern)"
+        );
+        assert!(
+            !body.contains("relay_put_replicate_forward("),
+            "piece E removed the streaming #4509 replicate-forward — do NOT \
+             re-add relay_put_replicate_forward (see hosting-invariants)"
         );
     }
 
@@ -4789,9 +4786,11 @@ mod tests {
         // hop_count computation + multi-line call site added in #4248.
         let arm = &b[pos..pos + 1200.min(b.len() - pos)];
         assert!(
-            arm.contains("relay_put_send_response"),
-            "timeout arm must still call relay_put_send_response so the \
-             upstream waiter is not left to its own OPERATION_TTL"
+            arm.contains("relay_put_streaming_downstream_failure"),
+            "timeout arm must reply upstream via relay_put_streaming_downstream_failure \
+             (success if this node stored a copy, else a failure so the originator \
+             retries) so the upstream waiter is not left to its own OPERATION_TTL. \
+             Piece E: a pure routing hop no longer holds a copy to claim success with."
         );
     }
 

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -505,10 +505,10 @@ pub(super) async fn finalize_originator_subscribe(
 ///    later via the sub-op GET's own cache path, `get/op_ctx_task.rs` announces
 ///    there on first-time cache.
 ///
-/// See also `crate::operations::complete_piggyback_subscription` — the
-/// GET-piggyback finalization path, which performs the same conceptual steps in
-/// a different order (no fetch step: the body arrived inside the GET response).
-/// Keep the two in sync when adding host side effects.
+/// (The former `complete_piggyback_subscription` GET-piggyback finalization path
+/// was removed with GET-auto-subscribe in piece E of the demand-driven hosting
+/// redesign; explicit `subscribe=true` GETs now route through the ordinary
+/// subscribe driver, which reaches this helper.)
 pub(super) async fn finalize_host_subscribe(
     op_manager: &OpManager,
     key: ContractKey,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -111,10 +111,15 @@ mod placement_migration_metrics;
 pub mod topology_registry;
 pub(crate) mod update_rate_limit;
 
-/// Whether to auto-subscribe to contracts on GET.
-/// When true, GET operations will automatically subscribe to the contract
-/// to receive updates. This is controlled by hosting cache eviction.
-pub const AUTO_SUBSCRIBE_ON_GET: bool = true;
+// GET auto-subscribe (`AUTO_SUBSCRIBE_ON_GET`) was REMOVED in piece E of the
+// demand-driven hosting redesign (docs/design/demand-driven-hosting.md §9,
+// .claude/rules/hosting-invariants.md anti-patterns table). Auto-installing a
+// durable subscription on every GET manufactures demand that no client asked
+// for — the "GET-auto-subscribe" half of the relay-caching anti-pattern. A GET
+// may still host on the return path under the demand gauge (evictable,
+// non-durable; see `cache_contract_locally`), and a client that wants ongoing
+// freshness sets `subscribe=true` explicitly. do NOT re-add auto-subscribe on
+// GET — see hosting-invariants (invariants 1 & 2).
 
 /// Per-beneficiary weight for a local-client subscription when
 /// computing the LIVE benefit snapshot each governance reaper tick.

--- a/crates/core/tests/nat_subscription.rs
+++ b/crates/core/tests/nat_subscription.rs
@@ -79,8 +79,9 @@
 //! The deterministic fix is to use the supported non-host path: `nat-peer`
 //! issues `GET` with `subscribe=true`. The GET routes *toward* the contract
 //! (so it reliably resolves on `gateway`/`host-peer`), fetches and caches the
-//! body on `nat-peer`, and the GET driver's `auto_subscribe_on_get_response`
-//! then registers the subscription through the SAME relay path a bare SUBSCRIBE
+//! body on `nat-peer`, and the explicit `subscribe=true` flag then registers
+//! the subscription (`maybe_subscribe_child` -> `run_client_subscribe`) through
+//! the SAME relay path a bare SUBSCRIBE
 //! would use — the wire `SubscribeMsg::Request` still carries no address, so
 //! each hop still fills `upstream_addr` from the observed transport
 //! `source_addr` and registers the previous hop as a downstream subscriber.

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -3617,9 +3617,11 @@ fn run_fanout_liveness_scenario_inner(
         // or GET the contract before subscribing (so it can validate/apply
         // incoming updates). `GET+subscribe=true` is the documented exempt path:
         // the GET inherently fetches the WASM+state from the host over the
-        // preseeded connection, and the same op then auto-subscribes
-        // (`auto_subscribe_on_get_response`), registering downstream interest at
-        // the host and joining the broadcast set. The topology preseed only
+        // preseeded connection, and the explicit `subscribe=true` flag then
+        // subscribes (`maybe_subscribe_child` -> `run_client_subscribe`),
+        // registering downstream interest at the host and joining the broadcast
+        // set. (Piece E removed the implicit AUTO_SUBSCRIBE_ON_GET fallback; this
+        // path is unaffected because it always set subscribe=true.) The topology preseed only
         // injects ring connections, not contract state, so without the GET each
         // subscriber's bare subscribe is rejected at t=0 and only the subset
         // that happened to receive the contract first (via an early broadcast /

--- a/crates/core/tests/streaming_e2e.rs
+++ b/crates/core/tests/streaming_e2e.rs
@@ -814,14 +814,18 @@ fn test_streaming_get_1mb_with_packet_loss() {
     );
 }
 
-/// Regression test for #3704: streaming GET path must trigger auto-subscribe
-/// and hosting announcement so that subsequent GETs are served from local cache.
+/// Regression test for #3704: streaming GET path must HOST the fetched
+/// contract on the return path (call `announce_contract_hosted()`, not just
+/// `record_get_access()`) so subsequent GETs can be served from local cache.
 ///
-/// Before the fix, the streaming GET completion path only called `record_get_access()`
-/// but skipped `announce_contract_hosted()` and `start_subscription_request()`, so
-/// `is_receiving_updates()` returned false and every subsequent GET hit the network.
+/// NOTE: piece E of the demand-driven hosting redesign REMOVED GET-auto-subscribe.
+/// The GETting node hosts under piece A's demand gauge (evictable, non-durable),
+/// but it does NOT auto-install a durable subscription. This test therefore
+/// asserts only the hosting side effect (`is_hosting`), not subscription — a GET
+/// with subscribe=false must not subscribe (see hosting-invariants, invariants
+/// 1 & 2, and `test_driver_inline_get_triggers_auto_subscribe`).
 #[test]
-fn test_streaming_get_triggers_auto_subscribe() {
+fn test_streaming_get_hosts_on_return_path() {
     const SEED: u64 = 0xDE1A_0009_CAFE_F00D;
     const NETWORK_NAME: &str = "streaming-get-auto-subscribe";
     const THRESHOLD: usize = 1024;
@@ -850,7 +854,8 @@ fn test_streaming_get_triggers_auto_subscribe() {
             },
         ),
         // Node 2 GETs the contract (will be streamed since >1KB threshold).
-        // subscribe=false here — we're relying on AUTO_SUBSCRIBE_ON_GET to kick in.
+        // subscribe=false: the node hosts the fetched state on the return path
+        // (under the demand gauge) but must NOT auto-subscribe (piece E).
         ScheduledOperation::new(
             NodeLabel::node(NETWORK_NAME, 2),
             SimOperation::Get {
@@ -1136,25 +1141,28 @@ fn test_driver_streaming_get_cold_cache() {
     );
 }
 
-/// Cold-cache non-streaming GET must auto-subscribe at originator.
+/// Cold-cache non-streaming GET must NOT auto-subscribe at the originator
+/// (piece E, demand-driven hosting).
 ///
-/// Scope: bug #2 from the #3884 skeptical review — the driver never calls
-/// `auto_subscribe_on_get_response`, so a client GET with `subscribe=false`
-/// against a cold cache silently skips the AUTO_SUBSCRIBE_ON_GET fallback
-/// that the legacy `process_message` branch would have invoked.
+/// Scope: piece E removed GET-auto-subscribe. A client GET with
+/// `subscribe=false` against a cold cache HOSTS the fetched state on the
+/// return path (under piece A's demand gauge — the node stores the state) but
+/// must NOT install a durable subscription. Auto-subscribing on GET is the
+/// anti-pattern (hosting-invariants, invariants 1 & 2). A client that wants
+/// ongoing freshness sets `subscribe=true` explicitly.
 ///
 /// ## Driver isolation strategy
 ///
 /// Same HTL=1 approach as `test_driver_streaming_get_cold_cache`.
 /// Phase 1 discovers a cold node; phase 2 GETs from it with a small
 /// (inline, not streamed) payload; asserts that the driver fired
-/// (via `GET_DRIVER_CALL_COUNT`) AND that the cold node ended up
-/// with an active subscription (AUTO_SUBSCRIBE_ON_GET fallback).
+/// (via `GET_DRIVER_CALL_COUNT`), that the cold node STORED the state
+/// (host-on-GET), and that NO node ended up with an active subscription.
 ///
 /// Same infrastructure gap as above — currently `#[ignore]`'d.
 #[ignore = "Infrastructure gap — HTL=1 topology isn't routable; see docstring and #3883"]
 #[test]
-fn test_driver_inline_get_triggers_auto_subscribe() {
+fn test_driver_inline_get_does_not_auto_subscribe() {
     use freenet::dev_tool::GET_DRIVER_CALL_COUNT;
     use std::sync::atomic::Ordering;
 
@@ -1275,21 +1283,26 @@ fn test_driver_inline_get_triggers_auto_subscribe() {
         "Cold-cache node should have stored the contract state after the GET"
     );
 
-    // Bug #2 regression: after the driver-routed GET with
-    // subscribe=false, the cold node should have auto-subscribed.
-    // AUTO_SUBSCRIBE_ON_GET = true in ring.rs:60.
-    let auto_subscribed = phase2
+    // Piece E (demand-driven hosting): GET-auto-subscribe was REMOVED. A
+    // driver-routed GET with subscribe=false must NOT install a durable
+    // subscription anywhere — the node still HOSTS the fetched state on the
+    // return path (asserted above: it stored the state, under piece A's demand
+    // gauge), but no client requested ongoing freshness, so no subscription is
+    // created. This inverts the former "Bug #2" assertion: auto-subscribe on
+    // GET is the anti-pattern (hosting-invariants, invariants 1 & 2). Neither
+    // the PUTting gateway nor the cold getter set subscribe=true, so NO node
+    // should carry an active subscription for this contract.
+    let any_subscribed = phase2
         .topology_snapshots
         .iter()
         .any(|s| s.active_subscription_keys.contains(&contract_id));
 
     assert!(
-        auto_subscribed,
-        "Bug #2 regression: cold-cache GET through the driver did not \
-         auto-subscribe the requesting node {cold_node_label:?}. The \
-         driver's Done arm must invoke `auto_subscribe_on_get_response` \
-         for successful GETs when the client did not explicitly set \
-         `subscribe=true`. Active subscriptions: {:#?}",
+        !any_subscribed,
+        "GET-auto-subscribe regression: a GET with subscribe=false installed a \
+         durable subscription. Piece E removed AUTO_SUBSCRIBE_ON_GET — a GET \
+         hosts under the demand gauge but must NOT auto-subscribe. Active \
+         subscriptions: {:#?}",
         phase2
             .topology_snapshots
             .iter()


### PR DESCRIPTION
## Status: DRAFT — DO NOT MERGE. Parked for Ian's review.

Piece E of the demand-driven hosting bundle (#4642), stacked on piece B (#4663) which is stacked on piece D. **The GET half is clean and green; the PUT half is BLOCKED by a design-model gap in piece D** (details below). Bundle target 0.2.91.

## What piece E removes (per hosting-invariants anti-patterns table + demand-driven-hosting §9)

1. **GET-auto-subscribe** (`AUTO_SUBSCRIBE_ON_GET`): a successful GET with `subscribe=false` no longer auto-installs a durable subscription. Manufactures demand no client asked for.
2. **PUT relay-caching** (store-at-every-hop + the #4509 terminus `relay_put_replicate_forward`): a pure routing hop no longer stores/hosts/announces an unsolicited copy.

## What is KEPT (demand-driven replacements, NOT the anti-pattern)
- **Host-on-GET** under piece A's demand gauge (`cache_contract_locally`) — evictable, non-durable.
- **Explicit `subscribe=true`** on GET/PUT (routes through `maybe_subscribe_child` / `start_subscription_after_put`).
- **PUT seeds near the key**: terminus/originator/already-hosting still store+host+announce (`should_host` gate).
- **Downstream-failure correctness** (streaming PUT): a routing-only hop that pipes forward and then loses the downstream now reports failure upstream (new `relay_put_streaming_downstream_failure`) instead of falsely claiming success, so the originator retries rather than silently losing the PUT.

## Two commits (deliberately split)
- `feat: remove GET-auto-subscribe` — **CLEAN. All sim proofs pass.**
- `feat: remove PUT relay-caching` — **BLOCKED. Breaks D's + B's sim proofs (see below).**

## Sim evidence (this is the STOP finding)

Ran the D/B/convergence proofs on three points (nextest, `simulation_tests,testing,nightly_tests`):

| Point | Result |
|---|---|
| Base (`feat/admission-refusal`, D+B) | 9/9 PASS |
| This branch @ **GET-only** commit | 5/5 PASS |
| This branch @ **PUT** commit | 3 pass, **8 FAIL** |

The failures are convergence/propagation: `test_six_peer_contract_lifecycle`, `test_six_peer_lifecycle_mock_wasm`, `test_subscription_relay_propagation`, and D's own proofs (`test_subscription_count_tracks_demand_not_cache`, `..._chain_collapses_on_client_leave`, `..._chain_collapse_reaches_root_no_cycle`) + B's (`..._popular_contract_fanout_bounded_by_admission`, `..._refused_subscription_reroutes_no_deadend`). Symptom: `missing contract ... failed to apply update locally before forwarding`, and `only N peer(s) have state`.

## Root cause: a piece-D gap that PUT relay-caching was masking

D's chain-host state fetch lives in `subscribe.rs::finalize_host_subscribe`: it calls `fetch_contract_if_missing` with a **2s best-effort timeout**; on timeout it defers `announce_contract_hosted` and comments that "the contract may arrive later via UPDATE propagation." But an UPDATE delivered to a **subscribed-but-body-less** node fails with `missing contract`, so that fallback does not actually heal it.

With PUT relay-caching in place (base), the body was already local at those nodes, so the fetch found it instantly and the proofs passed — the proofs were **contaminated by relay-caching**. Remove relay-caching and the chain-host fetch frequently fails to land the body in these topologies, leaving subscribed-but-body-less nodes → convergence breaks.

So piece E's PUT half is correctly gated on D, but **D as implemented in the base does not yet make chain hosts fetch state reliably** — its "real chain hosts fetch state" (design §3) is a 2s best-effort fetch leaning on relay-caching. Per hosting-invariants ("STOP+report on any design-model gap — do NOT improvise"), I stopped rather than hardening D's fetch (out of scope for a removal, and high-risk hosting surface).

## Recommendation for Ian
- **Land the GET-auto-subscribe removal now** (drop the PUT commit; it's clean + green), OR
- **Hold both** until piece D's chain-host fetch is hardened (blocking/retried fetch, and/or fetch-then-apply on UPDATE-to-body-less-node), then re-run these proofs. Either way the PUT half must not merge until D's proofs pass WITHOUT relay-caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnRCbtbjepaB5GWrb5U8SR

[AI-assisted - Claude]