### PR TITLE
feat: host-side scheduled wakeup primitive for delegates (#3972)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ muda = "0.19"
 zip = { version = "8", default-features = false, features = ["deflate", "time"] }
 
 # Freenet
-freenet-stdlib = "0.8.2"
+freenet-stdlib = "0.8.3"
 
 # Crypto (secrets-at-rest KEK + DEK derivation, see crates/core/src/config/kek.rs).
 # `sha2` is already declared above (workspace-wide); only `hkdf` and `keyring`

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1378,6 +1378,7 @@ async fn process_open_request(
                                         "ContractNotification"
                                     }
                                     InboundDelegateMsg::DelegateMessage(_) => "DelegateMessage",
+                                    InboundDelegateMsg::WakeupFired { .. } => "WakeupFired",
                                     _ => "Unknown",
                                 })
                                 .collect();

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -14,6 +14,7 @@ pub(crate) mod governance;
 mod handler;
 pub mod storages;
 pub(crate) mod user_input;
+pub(crate) mod wakeup;
 
 pub(crate) use executor::{
     ContractExecutor, ExecutorTransactionStream, ExportBusy, MAX_CREATED_DELEGATES_PER_NODE,
@@ -53,6 +54,11 @@ const MAX_CONTRACT_REQUEST_ITERATIONS: usize = 100;
 /// Matches the same bounded-drain pattern as MAX_DRAIN_BATCH for contract events,
 /// preventing delegate notification channel growth under sustained contract load.
 const MAX_DELEGATE_DRAIN_BATCH: usize = 16;
+
+/// Max delegate wakeups (#3972) fired per event-loop iteration. Each fire is a
+/// full delegate execution, so bound it like the delegate-notification drain so
+/// a burst of simultaneously-due wakeups can't starve contract events.
+const MAX_WAKEUP_DRAIN_BATCH: usize = 16;
 
 /// Timeout for the off-loop related-contract fetch that backs a deferred
 /// PUT/UPDATE (#4391).
@@ -566,11 +572,14 @@ where
             }
             Err(err) => {
                 // Downgrade "not found" to warn — expected during legacy
-                // migration probes when old delegate WASM isn't on this node
+                // migration probes when old delegate WASM isn't on this node, and
+                // when a scheduled wakeup (#3972) fires for a delegate that has
+                // since been uninstalled (the wakeup is then simply dropped).
                 if err.is_missing_delegate() {
                     tracing::warn!(
                         delegate_key = %delegate_key,
-                        "Delegate not found in store (expected for migration probes)"
+                        "Delegate not found in store (expected for migration probes \
+                         or a fired wakeup on an uninstalled delegate)"
                     );
                 } else {
                     tracing::error!(
@@ -593,6 +602,10 @@ where
         let mut subscribe_requests: Vec<SubscribeContractRequest> = Vec::new();
         let mut delegate_messages: Vec<DelegateMessage> = Vec::new();
         let mut user_input_requests: Vec<UserInputRequest<'static>> = Vec::new();
+        // Wakeups the delegate asked us to schedule this iteration (#3972).
+        // Fire-and-forget: persisted below, NOT re-fed to the delegate, so a
+        // schedule alone does not keep the request loop spinning.
+        let mut schedule_wakeups: Vec<(std::time::SystemTime, Vec<u8>)> = Vec::new();
 
         for msg in values {
             match msg {
@@ -614,11 +627,46 @@ where
                 OutboundDelegateMsg::RequestUserInput(req) => {
                     user_input_requests.push(req);
                 }
+                OutboundDelegateMsg::ScheduleWakeup { at, tag } => {
+                    schedule_wakeups.push((at, tag));
+                }
                 other @ OutboundDelegateMsg::ApplicationMessage(_)
                 | other @ OutboundDelegateMsg::ContextUpdated(_) => {
                     // Accumulate non-request messages
                     accumulated_messages.push(other);
                 }
+            }
+        }
+
+        // Persist any scheduled wakeups. We capture the delegate's CURRENT
+        // params so the wakeup replays it in the exact same param context it
+        // scheduled from (the host has no other way to recover params — the
+        // DelegateKey is a one-way hash of code+params). Re-scheduling the same
+        // (delegate, tag) replaces the prior pending entry (cancel-by-tag).
+        //
+        // NOTE: when a delegate is invoked from the contract-notification path
+        // (`handle_delegate_notification`), `current_params` is empty (that path
+        // passes no params, pre-existing #3275), so a wakeup scheduled from a
+        // notification would replay with empty params. The primary use case
+        // (client-driven scheduling, e.g. River key rotation) carries real
+        // params, and a wakeup re-scheduled from a fired wakeup carries the
+        // originally-captured params forward, so this only affects the
+        // notification-triggered-scheduling edge.
+        if !schedule_wakeups.is_empty() {
+            if let Some(scheduler) = contract_handler.wakeup_scheduler() {
+                let params_bytes = current_params.as_ref().to_vec();
+                for (at, tag) in schedule_wakeups {
+                    // schedule() enforces per-delegate / global / tag-size caps
+                    // and logs on rejection; the delegate is not notified (the
+                    // primitive is fire-and-forget).
+                    scheduler.schedule(delegate_key.clone(), tag, at, params_bytes.clone());
+                }
+            } else {
+                tracing::warn!(
+                    delegate_key = %delegate_key,
+                    "delegate requested ScheduleWakeup but this handler has no \
+                     wakeup scheduler configured; dropping the request"
+                );
             }
         }
 
@@ -1211,6 +1259,33 @@ where
             }
         }
 
+        // Fire any delegate wakeups (#3972) that are now due, bounded per
+        // iteration. Checked every pass (even when the fair queue has work) so a
+        // due wakeup isn't delayed under sustained contract load. Firing happens
+        // INLINE on this task — the same task that owns the executor and runs
+        // delegates — so there is no cross-task channel and no lossy dispatch.
+        // Scheduling also happens on this task (in
+        // `handle_delegate_with_contract_requests`), so a newly-scheduled
+        // earlier wakeup is picked up on the next pass with no notification.
+        //
+        // Wall-clock exception (cf. code-style.md "use TimeSource"): wakeups
+        // target ABSOLUTE `SystemTime`s that must survive restart ("fire next
+        // Tuesday"), which the monotonic/simulated `TimeSource` cannot model, so
+        // real `SystemTime::now()` is the correct clock here — analogous to the
+        // documented `boot_time::Instant` exception. It is also never reached
+        // under DST: simulation handlers return `wakeup_scheduler() == None`
+        // (below), so neither this `now()` nor `sleep_until_wakeup`'s sleep runs
+        // in a paused-time simulation.
+        let due_wakeups = contract_handler
+            .wakeup_scheduler()
+            .map(|scheduler| {
+                scheduler.take_due(std::time::SystemTime::now(), MAX_WAKEUP_DRAIN_BATCH)
+            })
+            .unwrap_or_default();
+        for due in due_wakeups {
+            handle_wakeup_fired(&mut contract_handler, due, &prompter).await;
+        }
+
         // Process one event from the fair queue in normal round-robin order.
         // There is NO per-contract holding: an event for a contract whose
         // PUT/UPDATE is mid-deferral runs immediately and may observe the
@@ -1231,7 +1306,15 @@ where
         }
 
         // Fair queue is empty. Block-wait for a new event, a resumed deferral,
-        // or a delegate notification.
+        // a delegate notification, or the next scheduled wakeup coming due.
+        //
+        // `next_wakeup_due` is read into a local BEFORE the `select!` so the
+        // sleep branch doesn't take a second `&mut contract_handler` (all
+        // branch expressions in a `select!` are evaluated up front). When it's
+        // due the loop simply wakes and re-runs the top-of-loop wakeup drain.
+        let next_wakeup_due = contract_handler
+            .wakeup_scheduler()
+            .and_then(|scheduler| scheduler.next_due());
         tokio::select! {
             result = contract_handler.channel().recv_from_sender() => {
                 let (id, event, priority) = result?;
@@ -1253,6 +1336,92 @@ where
             notification = recv_delegate_notification(&mut delegate_rx) => {
                 handle_delegate_notification(&mut contract_handler, notification, &prompter).await;
             }
+            _ = sleep_until_wakeup(next_wakeup_due) => {
+                // The earliest wakeup is now due; the top-of-loop drain on the
+                // next iteration removes and fires it.
+            }
+        }
+    }
+}
+
+/// Sleep until `next_due`, or forever if there is no pending wakeup (so this
+/// `select!` branch is effectively disabled until one is scheduled). Because
+/// past-due wakeups are already drained at the top of the loop, `next_due` is
+/// always in the future here.
+///
+/// Uses real `SystemTime`/`tokio::time::sleep` rather than `TimeSource` for the
+/// same reason the top-of-loop drain does (see the wall-clock exception comment
+/// there): wakeups fire at absolute wall-clock times and this branch is never
+/// reached under DST (simulation handlers have no wakeup scheduler). A backward
+/// wall-clock jump can at worst oversleep a fire, self-correcting on the next
+/// event since every loop iteration re-drains and recomputes `next_due`.
+async fn sleep_until_wakeup(next_due: Option<std::time::SystemTime>) {
+    match next_due {
+        Some(at) => {
+            let dur = at
+                .duration_since(std::time::SystemTime::now())
+                .unwrap_or(std::time::Duration::ZERO);
+            tokio::time::sleep(dur).await;
+        }
+        None => std::future::pending::<()>().await,
+    }
+}
+
+/// Deliver a fired scheduled wakeup (#3972) to its delegate as an
+/// [`InboundDelegateMsg::WakeupFired`], replaying the params captured at
+/// schedule time so the delegate wakes in its own param context.
+///
+/// If the delegate is no longer registered, `execute_delegate_request` reports a
+/// missing-delegate error which is logged and dropped — the wakeup was already
+/// removed from the schedule by `take_due`, so it is neither re-fired nor
+/// re-installed (matching the issue's "drop on uninstalled delegate" rule).
+async fn handle_wakeup_fired<CH, P>(contract_handler: &mut CH, due: wakeup::DueWakeup, prompter: &P)
+where
+    CH: ContractHandler + Send + 'static,
+    P: UserInputPrompter,
+{
+    let wakeup::DueWakeup {
+        delegate_key,
+        tag,
+        params,
+    } = due;
+
+    tracing::debug!(
+        delegate = %delegate_key,
+        tag_len = tag.len(),
+        "Delivering scheduled wakeup to delegate"
+    );
+
+    let req = DelegateRequest::ApplicationMessages {
+        key: delegate_key.clone(),
+        params: Parameters::from(params),
+        inbound: vec![InboundDelegateMsg::WakeupFired { tag }],
+    };
+
+    let outbound = handle_delegate_with_contract_requests(
+        contract_handler,
+        req,
+        None,
+        // A scheduled wakeup fires outside any client/user connection, so there
+        // is no user token and no per-user secret namespace — secrets stay
+        // `SecretScope::Local`, exactly like a contract notification.
+        None,
+        &delegate_key,
+        prompter,
+    )
+    .await;
+
+    // Like contract notifications, a wakeup-driven invocation has no originating
+    // client connection, so any ApplicationMessages the delegate emits have
+    // nowhere to route yet (#3275). Log and drop.
+    for msg in &outbound {
+        if let OutboundDelegateMsg::ApplicationMessage(app_msg) = msg {
+            tracing::warn!(
+                delegate = %delegate_key,
+                payload_len = app_msg.payload.len(),
+                "Delegate produced ApplicationMessage from a scheduled wakeup but no \
+                 client routing is available yet — message dropped"
+            );
         }
     }
 }
@@ -1982,7 +2151,8 @@ async fn handle_delegate_notification<CH, P>(
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
             | OutboundDelegateMsg::SubscribeContractRequest(_)
-            | OutboundDelegateMsg::SendDelegateMessage(_) => {
+            | OutboundDelegateMsg::SendDelegateMessage(_)
+            | OutboundDelegateMsg::ScheduleWakeup { .. } => {
                 tracing::warn!(
                     delegate = %delegate_key,
                     msg_type = ?std::mem::discriminant(msg),

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -80,11 +80,20 @@ pub(crate) trait ContractHandler {
     fn channel(&mut self) -> &mut ContractHandlerChannel<ContractHandlerHalve>;
 
     fn executor(&mut self) -> &mut Self::ContractExecutor;
+
+    /// The delegate wakeup scheduler (#3972), if this handler backs one. The
+    /// `contract_handling` loop uses it to persist `ScheduleWakeup` requests
+    /// and to drive `WakeupFired` delivery. Handlers without durable delegate
+    /// execution (mocks, simulation) return `None`, disabling wakeups.
+    fn wakeup_scheduler(&mut self) -> Option<&mut super::wakeup::WakeupScheduler> {
+        None
+    }
 }
 
 pub(crate) struct NetworkContractHandler {
     executor: RuntimePool,
     channel: ContractHandlerChannel<ContractHandlerHalve>,
+    wakeups: super::wakeup::WakeupScheduler,
 }
 
 impl ContractHandler for NetworkContractHandler {
@@ -123,6 +132,10 @@ impl ContractHandler for NetworkContractHandler {
         // Set up hosting storage reference for eviction cleanup
         // This must be done before loading the cache so evictions work correctly
         let storage = executor.state_store().inner().clone();
+
+        // Rehydrate any delegate wakeups (#3972) persisted before restart from
+        // the same backing store the executor uses.
+        let wakeups = super::wakeup::WakeupScheduler::load(storage.clone());
         op_manager.ring.set_hosting_storage(storage.clone());
         // Hydrate broken-invariants flags from the same backing store so a
         // node that previously detected a non-idempotent contract doesn't
@@ -165,7 +178,11 @@ impl ContractHandler for NetworkContractHandler {
             .neighbor_hosting
             .initialize_from_hosting_cache(hosted_ids);
 
-        Ok(Self { executor, channel })
+        Ok(Self {
+            executor,
+            channel,
+            wakeups,
+        })
     }
 
     fn channel(&mut self) -> &mut ContractHandlerChannel<ContractHandlerHalve> {
@@ -174,6 +191,10 @@ impl ContractHandler for NetworkContractHandler {
 
     fn executor(&mut self) -> &mut Self::ContractExecutor {
         &mut self.executor
+    }
+
+    fn wakeup_scheduler(&mut self) -> Option<&mut super::wakeup::WakeupScheduler> {
+        Some(&mut self.wakeups)
     }
 }
 

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -50,6 +50,19 @@ pub(crate) const BROKEN_INVARIANTS_TABLE: TableDefinition<&[u8], &[u8]> =
 pub(crate) const SECRETS_INDEX_TABLE: TableDefinition<&[u8], &[u8]> =
     TableDefinition::new("secrets_index");
 
+/// Scheduled delegate wakeups (#3972), persisted so they survive node restart.
+/// Keyed by `(DelegateKey, tag)` so re-scheduling with the same tag overwrites
+/// the prior row (cancel-by-tag). The encode/decode of both key and value lives
+/// in `contract::wakeup`; this table stores the raw bytes.
+///
+/// Key: DelegateKey (64 bytes) || tag (variable)
+/// Value: fire-at seconds-since-epoch (u64 LE) || nanos (u32 LE) || params (variable)
+pub(crate) const WAKEUPS_TABLE: TableDefinition<&[u8], &[u8]> =
+    TableDefinition::new("scheduled_wakeups");
+
+/// A raw `(key_bytes, value_bytes)` wakeup row as stored in [`WAKEUPS_TABLE`].
+pub(crate) type RawWakeupRow = (Vec<u8>, Vec<u8>);
+
 /// Index table for the per-user secret dimension (P1 of #4381). SEPARATE
 /// from [`SECRETS_INDEX_TABLE`] so the existing single-user index keeps its
 /// exact schema and a pre-#4381 database opens unchanged (this table is
@@ -417,6 +430,17 @@ impl ReDb {
                     table = "BROKEN_INVARIANTS_TABLE",
                     phase = "table_init_failed",
                     "Failed to open BROKEN_INVARIANTS_TABLE"
+                );
+                e
+            })?;
+
+            // Absent in pre-#3972 databases → created empty on first open.
+            txn.open_table(WAKEUPS_TABLE).map_err(|e| {
+                tracing::error!(
+                    error = %e,
+                    table = "WAKEUPS_TABLE",
+                    phase = "table_init_failed",
+                    "Failed to open WAKEUPS_TABLE"
                 );
                 e
             })?;
@@ -817,6 +841,46 @@ impl ReDb {
                 let delegate_key =
                     DelegateKey::new(delegate_key_bytes, CodeHash::from(&code_hash_bytes));
                 result.push((delegate_key, CodeHash::from(&value_bytes)));
+            }
+            Ok(result)
+        })
+    }
+
+    // ==================== Scheduled Wakeups (#3972) ====================
+    // Raw-bytes CRUD for the wakeup scheduler; key/value framing lives in
+    // `contract::wakeup`. Keyed by `(DelegateKey, tag)` so `insert` overwrites
+    // on re-schedule (cancel-by-tag).
+
+    /// Insert or replace a scheduled wakeup row.
+    pub fn store_wakeup(&self, key: &[u8], value: &[u8]) -> Result<(), redb::Error> {
+        let txn = self.begin_write()?;
+        {
+            let mut tbl = txn.open_table(WAKEUPS_TABLE)?;
+            tbl.insert(key, value)?;
+        }
+        Self::commit_guarded(txn)
+    }
+
+    /// Remove a scheduled wakeup row (on fire or explicit cancel). Removing an
+    /// absent key is a no-op.
+    pub fn remove_wakeup(&self, key: &[u8]) -> Result<(), redb::Error> {
+        let txn = self.begin_write()?;
+        {
+            let mut tbl = txn.open_table(WAKEUPS_TABLE)?;
+            tbl.remove(key)?;
+        }
+        Self::commit_guarded(txn)
+    }
+
+    /// Load every persisted wakeup as `(key_bytes, value_bytes)` for rebuilding
+    /// the in-memory indexes at startup.
+    pub fn load_all_wakeups(&self) -> Result<Vec<RawWakeupRow>, redb::Error> {
+        self.read_guarded(|txn| {
+            let tbl = txn.open_table(WAKEUPS_TABLE)?;
+            let mut result = Vec::new();
+            for entry in tbl.iter()? {
+                let (key, value) = entry?;
+                result.push((key.value().to_vec(), value.value().to_vec()));
             }
             Ok(result)
         })

--- a/crates/core/src/contract/wakeup.rs
+++ b/crates/core/src/contract/wakeup.rs
@@ -1,0 +1,617 @@
+//! Scheduled-wakeup primitive for delegates (issue #3972).
+//!
+//! A delegate asks the host to wake it at an absolute time via
+//! [`OutboundDelegateMsg::ScheduleWakeup`](freenet_stdlib::prelude::OutboundDelegateMsg::ScheduleWakeup);
+//! the host delivers
+//! [`InboundDelegateMsg::WakeupFired`](freenet_stdlib::prelude::InboundDelegateMsg::WakeupFired)
+//! at (or after) that time. This lets an always-on delegate run periodic
+//! background work (key rotation, TTL pruning, scheduled publication) without a
+//! connected UI, instead of pushing that work into a client sync loop.
+//!
+//! This type owns the schedule:
+//! - a **forward index** ordered by fire time so "what fires next" is O(1),
+//! - a **reverse index** keyed by `(delegate, tag)` for cancel-by-tag, and
+//! - **ReDb persistence** so pending wakeups survive a node restart.
+//!
+//! It is deliberately NOT a standalone background task. The `contract_handling`
+//! event loop (the single task that also runs delegates) owns a
+//! [`WakeupScheduler`], schedules into it when a delegate emits `ScheduleWakeup`,
+//! and drains due wakeups from it each iteration. Because scheduling and firing
+//! happen on the same task, there is no cross-task channel or lock, and a
+//! newly-scheduled earlier wakeup is observed on the loop's next pass with no
+//! explicit notification.
+//!
+//! ## Params capture
+//!
+//! A fired wakeup must invoke the delegate with the same `params` it was
+//! registered with (the [`DelegateKey`] is a one-way hash of code+params, so the
+//! host cannot recover them from the key). We therefore store the delegate's
+//! params alongside each wakeup at schedule time and replay them on fire.
+
+use std::collections::{BTreeMap, HashMap};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use freenet_stdlib::prelude::{CodeHash, DelegateKey};
+
+use super::storages::Storage;
+
+/// 32-byte `key` field + 32-byte `code_hash` field of a [`DelegateKey`].
+const DELEGATE_KEY_LEN: usize = 64;
+/// 8-byte seconds-since-epoch + 4-byte nanos prefix on a persisted value.
+const TIME_PREFIX_LEN: usize = 12;
+/// Max length of a wakeup `tag`. A tag only identifies a wakeup, so a small
+/// bound is ample; it also bounds the `(delegate, tag)` ReDb key size.
+const MAX_TAG_LEN: usize = 256;
+/// Max pending wakeups a single delegate may hold. A delegate is untrusted
+/// WASM: without this, one delegate could schedule unlimited distinct tags and
+/// exhaust memory + ReDb. Re-scheduling an existing tag (cancel-by-tag) does not
+/// count against this. Mirrors the per-actor caps `code-style.md` mandates for
+/// externally-influenced collections (e.g. `MAX_SUBSCRIPTIONS_PER_CLIENT`).
+const MAX_WAKEUPS_PER_DELEGATE: usize = 64;
+/// Global ceiling on pending wakeups across all delegates — the absolute
+/// memory/disk bound, in case many delegates each stay under the per-delegate
+/// cap.
+const MAX_TOTAL_WAKEUPS: usize = 100_000;
+
+/// Identifies a pending wakeup: a delegate plus its opaque tag.
+type WakeupId = (DelegateKey, Vec<u8>);
+
+/// A wakeup that is due and has been removed from the schedule, ready to fire.
+#[derive(Debug, Clone)]
+pub(crate) struct DueWakeup {
+    pub delegate_key: DelegateKey,
+    pub tag: Vec<u8>,
+    /// The delegate's params, captured when the wakeup was scheduled, so it
+    /// replays in the same param context.
+    pub params: Vec<u8>,
+}
+
+/// In-memory bookkeeping for one pending wakeup.
+struct Entry {
+    fire_at: SystemTime,
+    /// Tie-breaker so two wakeups at the same instant get distinct forward-index
+    /// keys (a `BTreeMap` key must be unique).
+    seq: u64,
+    params: Vec<u8>,
+}
+
+/// The per-node schedule of pending delegate wakeups.
+pub(crate) struct WakeupScheduler {
+    /// Persistent backing store. Every mutation writes through so the schedule
+    /// survives restart. `None` disables persistence (used by handlers that
+    /// have no durable store, e.g. simulation).
+    storage: Option<Storage>,
+    /// Forward index ordered by fire time: `(fire_at, seq) -> id`. The first
+    /// entry is always the next wakeup to fire.
+    by_time: BTreeMap<(SystemTime, u64), WakeupId>,
+    /// Reverse index `id -> entry` for O(1) cancel-by-tag: re-scheduling the
+    /// same `(delegate, tag)` finds and removes the prior forward slot.
+    entries: HashMap<WakeupId, Entry>,
+    /// Pending-wakeup count per delegate, kept in sync with `entries` so the
+    /// per-delegate cap is O(1) to check without scanning. A delegate drops out
+    /// of the map when its last wakeup fires.
+    per_delegate: HashMap<DelegateKey, usize>,
+    next_seq: u64,
+}
+
+impl WakeupScheduler {
+    /// An empty scheduler with no persistence (for handlers without a durable
+    /// store).
+    #[cfg(test)]
+    pub(crate) fn in_memory() -> Self {
+        Self {
+            storage: None,
+            by_time: BTreeMap::new(),
+            entries: HashMap::new(),
+            per_delegate: HashMap::new(),
+            next_seq: 0,
+        }
+    }
+
+    /// Build a scheduler backed by `storage`, rehydrating any wakeups persisted
+    /// before a restart. Malformed rows are skipped (logged), never fatal.
+    pub(crate) fn load(storage: Storage) -> Self {
+        let mut scheduler = Self {
+            storage: Some(storage.clone()),
+            by_time: BTreeMap::new(),
+            entries: HashMap::new(),
+            per_delegate: HashMap::new(),
+            next_seq: 0,
+        };
+
+        let rows = match storage.load_all_wakeups() {
+            Ok(rows) => rows,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to load persisted delegate wakeups; starting empty");
+                return scheduler;
+            }
+        };
+
+        let mut loaded = 0usize;
+        for (key_bytes, value_bytes) in rows {
+            let (Some((delegate_key, tag)), Some((fire_at, params))) =
+                (decode_key(&key_bytes), decode_value(&value_bytes))
+            else {
+                tracing::warn!("skipping malformed persisted wakeup row");
+                continue;
+            };
+            // Insert directly into the in-memory indexes WITHOUT re-persisting
+            // (the row is already on disk). Persisted rows are trusted past the
+            // caps: they were accepted under the caps when first scheduled, and
+            // dropping already-durable wakeups on load would be a surprising
+            // data loss on restart.
+            let seq = scheduler.next_seq;
+            scheduler.next_seq += 1;
+            let id = (delegate_key, tag);
+            scheduler.by_time.insert((fire_at, seq), id.clone());
+            *scheduler.per_delegate.entry(id.0.clone()).or_insert(0) += 1;
+            scheduler.entries.insert(
+                id,
+                Entry {
+                    fire_at,
+                    seq,
+                    params,
+                },
+            );
+            loaded += 1;
+        }
+        if loaded > 0 {
+            tracing::info!(count = loaded, "restored persisted delegate wakeups");
+        }
+        scheduler
+    }
+
+    /// Schedule (or reschedule) a wakeup for `delegate_key` at `fire_at`.
+    ///
+    /// Re-scheduling with the same `(delegate_key, tag)` replaces the prior
+    /// pending wakeup (cancel-by-tag), both in memory and in the persistent row
+    /// (the ReDb key is `(delegate, tag)`, so the write overwrites).
+    ///
+    /// Returns `false` and drops the request (delegates are untrusted WASM) if
+    /// the tag exceeds [`MAX_TAG_LEN`] or accepting a NEW `(delegate, tag)` would
+    /// exceed [`MAX_WAKEUPS_PER_DELEGATE`] or [`MAX_TOTAL_WAKEUPS`]. A reschedule
+    /// of an already-pending tag is always accepted (it doesn't grow the set).
+    pub(crate) fn schedule(
+        &mut self,
+        delegate_key: DelegateKey,
+        tag: Vec<u8>,
+        fire_at: SystemTime,
+        params: Vec<u8>,
+    ) -> bool {
+        if tag.len() > MAX_TAG_LEN {
+            tracing::warn!(
+                delegate = %delegate_key,
+                tag_len = tag.len(),
+                max = MAX_TAG_LEN,
+                "dropping ScheduleWakeup with oversized tag"
+            );
+            return false;
+        }
+
+        let id: WakeupId = (delegate_key, tag);
+        let is_reschedule = self.entries.contains_key(&id);
+
+        // Caps apply only to NEW (delegate, tag) pairs; a reschedule replaces an
+        // existing entry and cannot grow the set.
+        if !is_reschedule {
+            if self.entries.len() >= MAX_TOTAL_WAKEUPS {
+                tracing::warn!(
+                    delegate = %id.0,
+                    total = self.entries.len(),
+                    "dropping ScheduleWakeup: global pending-wakeup cap reached"
+                );
+                return false;
+            }
+            let per = self.per_delegate.get(&id.0).copied().unwrap_or(0);
+            if per >= MAX_WAKEUPS_PER_DELEGATE {
+                tracing::warn!(
+                    delegate = %id.0,
+                    pending = per,
+                    max = MAX_WAKEUPS_PER_DELEGATE,
+                    "dropping ScheduleWakeup: per-delegate pending-wakeup cap reached"
+                );
+                return false;
+            }
+        }
+
+        // Cancel-by-tag: drop the prior forward-index slot for this id, if any.
+        // (The per-delegate count is unchanged on a reschedule.)
+        if let Some(prev) = self.entries.get(&id) {
+            self.by_time.remove(&(prev.fire_at, prev.seq));
+        } else {
+            *self.per_delegate.entry(id.0.clone()).or_insert(0) += 1;
+        }
+
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        self.by_time.insert((fire_at, seq), id.clone());
+        self.entries.insert(
+            id.clone(),
+            Entry {
+                fire_at,
+                seq,
+                params: params.clone(),
+            },
+        );
+
+        if let Some(storage) = &self.storage {
+            let key = encode_key(&id.0, &id.1);
+            let value = encode_value(fire_at, &params);
+            if let Err(e) = storage.store_wakeup(&key, &value) {
+                tracing::warn!(
+                    delegate = %id.0,
+                    error = %e,
+                    "failed to persist scheduled wakeup; it will fire this session \
+                     but may not survive a restart"
+                );
+            }
+        }
+        true
+    }
+
+    /// The fire time of the earliest pending wakeup, if any. Used to compute how
+    /// long the event loop should sleep before the next fire.
+    pub(crate) fn next_due(&self) -> Option<SystemTime> {
+        self.by_time.keys().next().map(|(fire_at, _)| *fire_at)
+    }
+
+    /// Remove and return every wakeup due at or before `now`, up to `max` (to
+    /// bound work per event-loop iteration). Each returned wakeup is deleted
+    /// from both indexes and the persistent store, so it fires exactly once and
+    /// is not re-delivered after a restart.
+    pub(crate) fn take_due(&mut self, now: SystemTime, max: usize) -> Vec<DueWakeup> {
+        let mut due = Vec::new();
+        while due.len() < max {
+            // Peek the earliest slot; stop if it isn't due yet.
+            let Some((&slot, _)) = self.by_time.iter().next() else {
+                break;
+            };
+            if slot.0 > now {
+                break;
+            }
+            let id = self
+                .by_time
+                .remove(&slot)
+                .expect("slot came from iter().next()");
+            let params = self
+                .entries
+                .remove(&id)
+                .map(|e| e.params)
+                .unwrap_or_default();
+            // Keep the per-delegate count in sync; drop the delegate's map entry
+            // when its last pending wakeup fires so the map doesn't leak keys.
+            if let Some(count) = self.per_delegate.get_mut(&id.0) {
+                *count -= 1;
+                if *count == 0 {
+                    self.per_delegate.remove(&id.0);
+                }
+            }
+
+            if let Some(storage) = &self.storage {
+                let key = encode_key(&id.0, &id.1);
+                if let Err(e) = storage.remove_wakeup(&key) {
+                    tracing::warn!(
+                        delegate = %id.0,
+                        error = %e,
+                        "failed to delete fired wakeup from store; it may re-fire after a restart"
+                    );
+                }
+            }
+
+            due.push(DueWakeup {
+                delegate_key: id.0,
+                tag: id.1,
+                params,
+            });
+        }
+        due
+    }
+
+    /// Number of pending wakeups.
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        debug_assert_eq!(self.by_time.len(), self.entries.len());
+        debug_assert_eq!(
+            self.entries.len(),
+            self.per_delegate.values().sum::<usize>(),
+            "per_delegate counts must sum to the number of pending wakeups"
+        );
+        self.entries.len()
+    }
+
+    /// The scheduled fire time for a specific `(delegate, tag)`, if pending.
+    #[cfg(test)]
+    pub(crate) fn scheduled_at(
+        &self,
+        delegate_key: &DelegateKey,
+        tag: &[u8],
+    ) -> Option<SystemTime> {
+        self.entries
+            .get(&(delegate_key.clone(), tag.to_vec()))
+            .map(|e| e.fire_at)
+    }
+}
+
+/// `DelegateKey` (64 bytes) || tag.
+fn encode_key(delegate_key: &DelegateKey, tag: &[u8]) -> Vec<u8> {
+    let mut key = Vec::with_capacity(DELEGATE_KEY_LEN + tag.len());
+    key.extend_from_slice(delegate_key.as_ref());
+    key.extend_from_slice(delegate_key.code_hash().as_ref());
+    key.extend_from_slice(tag);
+    key
+}
+
+fn decode_key(bytes: &[u8]) -> Option<(DelegateKey, Vec<u8>)> {
+    if bytes.len() < DELEGATE_KEY_LEN {
+        return None;
+    }
+    let key32: [u8; 32] = bytes[..32].try_into().ok()?;
+    let code32: [u8; 32] = bytes[32..DELEGATE_KEY_LEN].try_into().ok()?;
+    let tag = bytes[DELEGATE_KEY_LEN..].to_vec();
+    Some((DelegateKey::new(key32, CodeHash::from(&code32)), tag))
+}
+
+/// seconds-since-epoch (u64 LE) || nanos (u32 LE) || params.
+fn encode_value(fire_at: SystemTime, params: &[u8]) -> Vec<u8> {
+    let since_epoch = fire_at.duration_since(UNIX_EPOCH).unwrap_or(Duration::ZERO);
+    let mut value = Vec::with_capacity(TIME_PREFIX_LEN + params.len());
+    value.extend_from_slice(&since_epoch.as_secs().to_le_bytes());
+    value.extend_from_slice(&since_epoch.subsec_nanos().to_le_bytes());
+    value.extend_from_slice(params);
+    value
+}
+
+fn decode_value(bytes: &[u8]) -> Option<(SystemTime, Vec<u8>)> {
+    if bytes.len() < TIME_PREFIX_LEN {
+        return None;
+    }
+    let secs = u64::from_le_bytes(bytes[..8].try_into().ok()?);
+    let nanos = u32::from_le_bytes(bytes[8..TIME_PREFIX_LEN].try_into().ok()?);
+    // A corrupt/torn row must be SKIPPED, never crash startup (see `load`'s
+    // contract). `Duration::new` panics if `nanos >= 1e9` carries and overflows
+    // `secs`, and `SystemTime + Duration` panics on overflow — so validate nanos
+    // and use `checked_add` instead of the panicking `+`.
+    if nanos >= 1_000_000_000 {
+        return None;
+    }
+    let fire_at = UNIX_EPOCH.checked_add(Duration::new(secs, nanos))?;
+    let params = bytes[TIME_PREFIX_LEN..].to_vec();
+    Some((fire_at, params))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn dkey(seed: u8) -> DelegateKey {
+        DelegateKey::new([seed; 32], CodeHash::new([seed.wrapping_add(1); 32]))
+    }
+
+    fn at(secs: u64) -> SystemTime {
+        UNIX_EPOCH + Duration::from_secs(secs)
+    }
+
+    #[test]
+    fn key_value_roundtrip() {
+        let k = dkey(7);
+        let encoded = encode_key(&k, b"weekly");
+        let (dk, tag) = decode_key(&encoded).unwrap();
+        assert_eq!(dk, k);
+        assert_eq!(tag, b"weekly");
+
+        let v = encode_value(at(1_700_000_000), b"params-bytes");
+        let (fire_at, params) = decode_value(&v).unwrap();
+        assert_eq!(fire_at, at(1_700_000_000));
+        assert_eq!(params, b"params-bytes");
+    }
+
+    #[test]
+    fn decode_rejects_truncated_rows() {
+        assert!(decode_key(&[0u8; 10]).is_none());
+        assert!(decode_value(&[0u8; 4]).is_none());
+    }
+
+    #[test]
+    fn decode_value_rejects_overflow_instead_of_panicking() {
+        // A corrupt row must be SKIPPED (None), never panic and crash startup.
+        // nanos >= 1e9 (would panic Duration::new on carry-overflow):
+        let mut row = Vec::new();
+        row.extend_from_slice(&0u64.to_le_bytes()); // secs
+        row.extend_from_slice(&u32::MAX.to_le_bytes()); // nanos ~4.29e9
+        assert!(decode_value(&row).is_none());
+        // secs = u64::MAX (would panic UNIX_EPOCH + duration):
+        let mut row = Vec::new();
+        row.extend_from_slice(&u64::MAX.to_le_bytes());
+        row.extend_from_slice(&0u32.to_le_bytes());
+        assert!(decode_value(&row).is_none());
+    }
+
+    #[test]
+    fn oversized_tag_is_rejected() {
+        let mut s = WakeupScheduler::in_memory();
+        let k = dkey(6);
+        let ok = s.schedule(k.clone(), vec![0u8; MAX_TAG_LEN], at(100), vec![]);
+        assert!(ok, "a tag exactly at the limit is accepted");
+        let rejected = s.schedule(k, vec![0u8; MAX_TAG_LEN + 1], at(100), vec![]);
+        assert!(!rejected, "a tag over the limit is dropped");
+        assert_eq!(s.len(), 1);
+    }
+
+    #[test]
+    fn per_delegate_cap_rejects_excess_but_allows_reschedule() {
+        let mut s = WakeupScheduler::in_memory();
+        let k = dkey(8);
+        for i in 0..MAX_WAKEUPS_PER_DELEGATE {
+            assert!(s.schedule(k.clone(), i.to_le_bytes().to_vec(), at(100), vec![]));
+        }
+        assert_eq!(s.len(), MAX_WAKEUPS_PER_DELEGATE);
+        // A NEW tag beyond the cap is rejected...
+        assert!(!s.schedule(k.clone(), b"one-too-many".to_vec(), at(100), vec![]));
+        assert_eq!(s.len(), MAX_WAKEUPS_PER_DELEGATE);
+        // ...but re-scheduling an EXISTING tag is still allowed (no growth).
+        assert!(s.schedule(k.clone(), 0usize.to_le_bytes().to_vec(), at(200), vec![]));
+        assert_eq!(s.len(), MAX_WAKEUPS_PER_DELEGATE);
+        assert_eq!(s.scheduled_at(&k, &0usize.to_le_bytes()), Some(at(200)));
+
+        // A different delegate has its own budget.
+        let k2 = dkey(9);
+        assert!(s.schedule(k2, b"fresh".to_vec(), at(100), vec![]));
+        assert_eq!(s.len(), MAX_WAKEUPS_PER_DELEGATE + 1);
+    }
+
+    #[test]
+    fn per_delegate_count_freed_when_wakeups_fire() {
+        // Firing all of a delegate's wakeups must free its budget so it can
+        // schedule again (the periodic-rearm pattern).
+        let mut s = WakeupScheduler::in_memory();
+        let k = dkey(10);
+        for i in 0..MAX_WAKEUPS_PER_DELEGATE {
+            assert!(s.schedule(k.clone(), i.to_le_bytes().to_vec(), at(100), vec![]));
+        }
+        assert!(!s.schedule(k.clone(), b"blocked".to_vec(), at(100), vec![]));
+        // Fire them all.
+        let fired = s.take_due(at(1_000), MAX_WAKEUPS_PER_DELEGATE);
+        assert_eq!(fired.len(), MAX_WAKEUPS_PER_DELEGATE);
+        assert_eq!(s.len(), 0);
+        // Budget freed → can schedule again.
+        assert!(s.schedule(k, b"after".to_vec(), at(100), vec![]));
+        assert_eq!(s.len(), 1);
+    }
+
+    #[test]
+    fn cancel_by_tag_replaces_prior_entry() {
+        let mut s = WakeupScheduler::in_memory();
+        let k = dkey(1);
+        s.schedule(k.clone(), b"rotate".to_vec(), at(100), vec![]);
+        s.schedule(k.clone(), b"rotate".to_vec(), at(200), vec![]);
+        // Same (delegate, tag) → single entry, replaced with the later time.
+        assert_eq!(s.len(), 1);
+        assert_eq!(s.scheduled_at(&k, b"rotate"), Some(at(200)));
+        assert_eq!(s.next_due(), Some(at(200)));
+    }
+
+    #[test]
+    fn distinct_tags_fire_independently() {
+        let mut s = WakeupScheduler::in_memory();
+        let k = dkey(2);
+        s.schedule(k.clone(), b"a".to_vec(), at(100), vec![1]);
+        s.schedule(k.clone(), b"b".to_vec(), at(200), vec![2]);
+        assert_eq!(s.len(), 2);
+        assert_eq!(s.next_due(), Some(at(100)));
+
+        // Only "a" is due at t=150.
+        let due = s.take_due(at(150), 16);
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].tag, b"a");
+        assert_eq!(due[0].params, vec![1]);
+        assert_eq!(s.len(), 1);
+
+        // "b" fires later.
+        let due = s.take_due(at(250), 16);
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].tag, b"b");
+        assert_eq!(s.len(), 0);
+    }
+
+    #[test]
+    fn take_due_respects_fire_time_and_max() {
+        let mut s = WakeupScheduler::in_memory();
+        let k = dkey(3);
+        for i in 0..5u64 {
+            s.schedule(k.clone(), vec![i as u8], at(100 + i), vec![]);
+        }
+        // Nothing due before the earliest.
+        assert!(s.take_due(at(50), 16).is_empty());
+        // max bounds the batch even when more are due.
+        let batch = s.take_due(at(1_000), 3);
+        assert_eq!(batch.len(), 3);
+        assert_eq!(s.len(), 2);
+        // Remaining drain on a second call.
+        let batch = s.take_due(at(1_000), 16);
+        assert_eq!(batch.len(), 2);
+        assert_eq!(s.len(), 0);
+    }
+
+    #[test]
+    fn take_due_returns_earliest_first() {
+        let mut s = WakeupScheduler::in_memory();
+        let k = dkey(4);
+        s.schedule(k.clone(), b"late".to_vec(), at(300), vec![]);
+        s.schedule(k.clone(), b"early".to_vec(), at(100), vec![]);
+        s.schedule(k.clone(), b"mid".to_vec(), at(200), vec![]);
+        let due = s.take_due(at(1_000), 16);
+        let order: Vec<&[u8]> = due.iter().map(|d| d.tag.as_slice()).collect();
+        assert_eq!(order, vec![b"early".as_slice(), b"mid", b"late"]);
+    }
+
+    // Persistence tests require a real ReDb-backed `Storage`.
+    #[cfg(feature = "redb")]
+    #[tokio::test]
+    async fn persists_across_reload() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new(dir.path()).await.unwrap();
+        let k = dkey(9);
+        {
+            let mut s = WakeupScheduler::load(storage.clone());
+            s.schedule(
+                k.clone(),
+                b"rotate".to_vec(),
+                at(1_700_000_000),
+                b"my-params".to_vec(),
+            );
+            assert_eq!(s.len(), 1);
+        }
+        // A fresh scheduler over the same storage rehydrates the entry
+        // (simulates a node restart).
+        let s2 = WakeupScheduler::load(storage.clone());
+        assert_eq!(s2.len(), 1);
+        assert_eq!(s2.scheduled_at(&k, b"rotate"), Some(at(1_700_000_000)));
+
+        // Firing it removes it from the store too, so it does not re-fire after
+        // a subsequent restart.
+        let mut s3 = WakeupScheduler::load(storage.clone());
+        let due = s3.take_due(at(1_800_000_000), 16);
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].params, b"my-params");
+
+        let s4 = WakeupScheduler::load(storage);
+        assert_eq!(s4.len(), 0);
+    }
+
+    #[cfg(feature = "redb")]
+    #[tokio::test]
+    async fn cancel_by_tag_persists_replacement() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new(dir.path()).await.unwrap();
+        let k = dkey(5);
+        {
+            let mut s = WakeupScheduler::load(storage.clone());
+            s.schedule(k.clone(), b"rotate".to_vec(), at(100), vec![]);
+            s.schedule(k.clone(), b"rotate".to_vec(), at(200), vec![]);
+        }
+        // On reload the persisted row is the replacement, not both.
+        let reloaded = WakeupScheduler::load(storage);
+        assert_eq!(reloaded.len(), 1);
+        assert_eq!(reloaded.scheduled_at(&k, b"rotate"), Some(at(200)));
+    }
+
+    // Many independent schedules must all be retained and persisted — the
+    // "concurrent schedule from many delegates does not lose entries" case.
+    // The scheduler is only ever touched from the single `contract_handling`
+    // task, so this exercises volume rather than thread-level concurrency.
+    #[cfg(feature = "redb")]
+    #[tokio::test]
+    async fn many_schedules_all_persist() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new(dir.path()).await.unwrap();
+        let mut s = WakeupScheduler::load(storage.clone());
+        for i in 0..200u32 {
+            let k = dkey((i % 199) as u8);
+            s.schedule(k, i.to_le_bytes().to_vec(), at(1000 + i as u64), vec![]);
+        }
+        assert_eq!(s.len(), 200);
+        let reloaded = WakeupScheduler::load(storage);
+        assert_eq!(reloaded.len(), 200);
+    }
+}

--- a/crates/core/src/wasm_runtime/delegate/execution.rs
+++ b/crates/core/src/wasm_runtime/delegate/execution.rs
@@ -172,6 +172,7 @@ impl Runtime {
             InboundDelegateMsg::SubscribeContractResponse(_) => "SubscribeContractResponse",
             InboundDelegateMsg::ContractNotification(_) => "ContractNotification",
             InboundDelegateMsg::DelegateMessage(_) => "DelegateMessage",
+            InboundDelegateMsg::WakeupFired { .. } => "WakeupFired",
             // `InboundDelegateMsg` is `#[non_exhaustive]` (stdlib 0.6.0+).
             // Future variants land here for tracing only — they still flow
             // through the wasm boundary as raw bincode below; classifying
@@ -258,6 +259,9 @@ impl Runtime {
                             msg.payload.len()
                         )
                     }
+                    OutboundDelegateMsg::ScheduleWakeup { tag, .. } => {
+                        format!("ScheduleWakeup(tag_len={})", tag.len())
+                    }
                 })
                 .collect::<Vec<String>>()
                 .join(", ");
@@ -296,6 +300,7 @@ impl Runtime {
                         OutboundDelegateMsg::UpdateContractRequest(r) => format!("UpdateContractReq({})", r.contract_id),
                         OutboundDelegateMsg::SubscribeContractRequest(r) => format!("SubscribeContractReq({})", r.contract_id),
                         OutboundDelegateMsg::SendDelegateMessage(m) => format!("SendDelegateMsg(target={})", m.target),
+                        OutboundDelegateMsg::ScheduleWakeup { tag, .. } => format!("ScheduleWakeup(tag_len={})", tag.len()),
                     }
                 }).collect::<Vec<_>>()
             } else {
@@ -452,7 +457,8 @@ impl Runtime {
                             | OutboundDelegateMsg::PutContractRequest(_)
                             | OutboundDelegateMsg::UpdateContractRequest(_)
                             | OutboundDelegateMsg::SubscribeContractRequest(_)
-                            | OutboundDelegateMsg::SendDelegateMessage(_)) => results.push(msg),
+                            | OutboundDelegateMsg::SendDelegateMessage(_)
+                            | OutboundDelegateMsg::ScheduleWakeup { .. }) => results.push(msg),
                         }
                     }
                     break;
@@ -463,6 +469,27 @@ impl Runtime {
                     tracing::debug!("SendDelegateMessage processed");
                     context.clear();
                     context.extend_from_slice(ctx.as_ref());
+                }
+                OutboundDelegateMsg::ScheduleWakeup { at, tag } => {
+                    // Fire-and-forget scheduling request (#3972). The runtime
+                    // layer can't persist it (it has no scheduler handle), so
+                    // surface it to `handle_delegate_with_contract_requests`,
+                    // which owns the `WakeupScheduler`.
+                    //
+                    // Unlike the request arms, we do NOT drain-and-break here:
+                    // draining the rest of `outbound_msgs` verbatim would copy any
+                    // trailing `SendDelegateMessage` through WITHOUT the sender
+                    // attestation its own arm applies, re-opening the drain-bypass
+                    // spoofing hole #3282 closed. Falling through instead routes
+                    // each following message to its own arm (attestation
+                    // preserved), and a trailing `ContextUpdated` still folds into
+                    // `context`. ScheduleWakeup is fire-and-forget, so there is no
+                    // reason to terminate processing early.
+                    tracing::debug!(
+                        tag_len = tag.len(),
+                        "Passing ScheduleWakeup up to be scheduled"
+                    );
+                    results.push(OutboundDelegateMsg::ScheduleWakeup { at, tag });
                 }
             }
         }

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -191,7 +191,8 @@ async fn test_get_contract_request_response() -> Result<(), Box<dyn std::error::
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected GetContractRequest, got {:?}", other)
         }
     };
@@ -217,7 +218,8 @@ async fn test_get_contract_request_response() -> Result<(), Box<dyn std::error::
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
     };
@@ -274,7 +276,8 @@ async fn test_get_contract_not_found() -> Result<(), Box<dyn std::error::Error>>
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected GetContractRequest, got {:?}", other)
         }
     };
@@ -296,7 +299,8 @@ async fn test_get_contract_not_found() -> Result<(), Box<dyn std::error::Error>>
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
     };
@@ -355,7 +359,8 @@ async fn test_multiple_contract_requests() -> Result<(), Box<dyn std::error::Err
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected GetContractRequest, got {:?}", other)
         }
     };
@@ -379,7 +384,8 @@ async fn test_multiple_contract_requests() -> Result<(), Box<dyn std::error::Err
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected GetContractRequest for contract2, got {:?}", other)
         }
     };
@@ -403,7 +409,8 @@ async fn test_multiple_contract_requests() -> Result<(), Box<dyn std::error::Err
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected GetContractRequest for contract3, got {:?}", other)
         }
     };
@@ -427,7 +434,8 @@ async fn test_multiple_contract_requests() -> Result<(), Box<dyn std::error::Err
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
     };
@@ -496,7 +504,8 @@ async fn test_message_accumulation() -> Result<(), Box<dyn std::error::Error>> {
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
             | OutboundDelegateMsg::SubscribeContractRequest(_)
-            | OutboundDelegateMsg::SendDelegateMessage(_) => None,
+            | OutboundDelegateMsg::SendDelegateMessage(_)
+            | OutboundDelegateMsg::ScheduleWakeup { .. } => None,
         })
         .expect("Expected a GetContractRequest");
     assert_eq!(contract_request.contract_id, contract_id);
@@ -511,7 +520,8 @@ async fn test_message_accumulation() -> Result<(), Box<dyn std::error::Error>> {
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
             | OutboundDelegateMsg::SubscribeContractRequest(_)
-            | OutboundDelegateMsg::SendDelegateMessage(_) => None,
+            | OutboundDelegateMsg::SendDelegateMessage(_)
+            | OutboundDelegateMsg::ScheduleWakeup { .. } => None,
         })
         .expect("Expected an ApplicationMessage (Echo)");
     assert!(echo_msg.processed);
@@ -555,7 +565,8 @@ async fn test_message_accumulation() -> Result<(), Box<dyn std::error::Error>> {
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
     };
@@ -662,7 +673,8 @@ async fn test_context_persistence_within_call() -> Result<(), Box<dyn std::error
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -676,7 +688,8 @@ async fn test_context_persistence_within_call() -> Result<(), Box<dyn std::error
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -746,7 +759,8 @@ async fn test_context_persists_between_calls() -> Result<(), Box<dyn std::error:
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -773,7 +787,8 @@ async fn test_context_persists_between_calls() -> Result<(), Box<dyn std::error:
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1161,7 +1176,8 @@ async fn test_has_secret_host_function() -> Result<(), Box<dyn std::error::Error
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1198,7 +1214,8 @@ async fn test_has_secret_host_function() -> Result<(), Box<dyn std::error::Error
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1238,7 +1255,8 @@ async fn test_get_nonexistent_secret() -> Result<(), Box<dyn std::error::Error>>
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1283,7 +1301,8 @@ async fn test_store_and_retrieve_secret() -> Result<(), Box<dyn std::error::Erro
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1307,7 +1326,8 @@ async fn test_store_and_retrieve_secret() -> Result<(), Box<dyn std::error::Erro
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1373,7 +1393,8 @@ async fn test_set_secret_failure_returns_secret_store_failed()
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1418,7 +1439,8 @@ async fn test_read_empty_context() -> Result<(), Box<dyn std::error::Error>> {
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1486,7 +1508,8 @@ async fn test_context_clear() -> Result<(), Box<dyn std::error::Error>> {
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1510,7 +1533,8 @@ async fn test_context_clear() -> Result<(), Box<dyn std::error::Error>> {
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1570,7 +1594,8 @@ async fn test_context_shared_across_batch() -> Result<(), Box<dyn std::error::Er
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
             | OutboundDelegateMsg::SubscribeContractRequest(_)
-            | OutboundDelegateMsg::SendDelegateMessage(_) => {
+            | OutboundDelegateMsg::SendDelegateMessage(_)
+            | OutboundDelegateMsg::ScheduleWakeup { .. } => {
                 panic!("Expected ApplicationMessage")
             }
         };
@@ -1643,7 +1668,8 @@ async fn test_remove_secret_host_function() -> Result<(), Box<dyn std::error::Er
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1666,7 +1692,8 @@ async fn test_remove_secret_host_function() -> Result<(), Box<dyn std::error::Er
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1689,7 +1716,8 @@ async fn test_remove_secret_host_function() -> Result<(), Box<dyn std::error::Er
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1735,7 +1763,8 @@ async fn test_large_context_data() -> Result<(), Box<dyn std::error::Error>> {
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1776,7 +1805,8 @@ async fn test_large_context_data() -> Result<(), Box<dyn std::error::Error>> {
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1846,7 +1876,8 @@ async fn test_large_context_within_batch() -> Result<(), Box<dyn std::error::Err
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1918,7 +1949,8 @@ async fn test_large_secret_data() -> Result<(), Box<dyn std::error::Error>> {
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -1959,7 +1991,8 @@ async fn test_large_secret_data() -> Result<(), Box<dyn std::error::Error>> {
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage")
         }
     };
@@ -2066,7 +2099,8 @@ async fn test_concurrent_delegate_execution() -> Result<(), Box<dyn std::error::
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
             | OutboundDelegateMsg::SubscribeContractRequest(_)
-            | OutboundDelegateMsg::SendDelegateMessage(_) => {
+            | OutboundDelegateMsg::SendDelegateMessage(_)
+            | OutboundDelegateMsg::ScheduleWakeup { .. } => {
                 panic!("Expected ApplicationMessage")
             }
         };
@@ -2146,7 +2180,8 @@ async fn test_concurrent_delegate_execution() -> Result<(), Box<dyn std::error::
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
             | OutboundDelegateMsg::SubscribeContractRequest(_)
-            | OutboundDelegateMsg::SendDelegateMessage(_) => {
+            | OutboundDelegateMsg::SendDelegateMessage(_)
+            | OutboundDelegateMsg::ScheduleWakeup { .. } => {
                 panic!("Expected ApplicationMessage")
             }
         };
@@ -2389,7 +2424,8 @@ async fn test_v2_delegate_reads_contract_state() -> Result<(), Box<dyn std::erro
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
     };
@@ -2476,7 +2512,8 @@ async fn test_v2_delegate_contract_not_found() -> Result<(), Box<dyn std::error:
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
     };
@@ -2587,7 +2624,8 @@ fn send_v2_message(
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
     };
@@ -2796,7 +2834,8 @@ async fn test_put_contract_request_response() -> Result<(), Box<dyn std::error::
         | other @ OutboundDelegateMsg::GetContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected PutContractRequest, got {:?}", other)
         }
     };
@@ -2825,7 +2864,8 @@ async fn test_put_contract_request_response() -> Result<(), Box<dyn std::error::
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
     };
@@ -2885,7 +2925,8 @@ async fn test_update_contract_request_response() -> Result<(), Box<dyn std::erro
         | other @ OutboundDelegateMsg::GetContractRequest(_)
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected UpdateContractRequest, got {:?}", other)
         }
     };
@@ -2914,7 +2955,8 @@ async fn test_update_contract_request_response() -> Result<(), Box<dyn std::erro
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
     };
@@ -2976,7 +3018,8 @@ async fn test_subscribe_contract_request_response() -> Result<(), Box<dyn std::e
         | other @ OutboundDelegateMsg::GetContractRequest(_)
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected SubscribeContractRequest, got {:?}", other)
         }
     };
@@ -3005,7 +3048,8 @@ async fn test_subscribe_contract_request_response() -> Result<(), Box<dyn std::e
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
     };
@@ -3069,7 +3113,8 @@ async fn test_contract_notification_delivered() -> Result<(), Box<dyn std::error
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
     };
@@ -3179,7 +3224,8 @@ async fn test_subscribe_then_notify_roundtrip() -> Result<(), Box<dyn std::error
         | other @ OutboundDelegateMsg::GetContractRequest(_)
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected SubscribeContractRequest, got {:?}", other)
         }
     };
@@ -3245,7 +3291,8 @@ async fn test_subscribe_then_notify_roundtrip() -> Result<(), Box<dyn std::error
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
     }
@@ -3294,7 +3341,8 @@ async fn test_subscribe_then_notify_roundtrip() -> Result<(), Box<dyn std::error
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-        | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+        | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
     };
@@ -3515,7 +3563,8 @@ async fn test_delegate_emits_send_delegate_message() -> Result<(), Box<dyn std::
             | OutboundDelegateMsg::GetContractRequest(_)
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
-            | OutboundDelegateMsg::SubscribeContractRequest(_) => None,
+            | OutboundDelegateMsg::SubscribeContractRequest(_)
+            | OutboundDelegateMsg::ScheduleWakeup { .. } => None,
         })
         .expect("Expected SendDelegateMessage in outbound");
 
@@ -3571,7 +3620,8 @@ async fn test_delegate_receives_delegate_message() -> Result<(), Box<dyn std::er
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!("Expected ApplicationMessage, got {:?}", &outbound[0])
         }
     };
@@ -3704,7 +3754,8 @@ async fn test_delegate_to_delegate_roundtrip() -> Result<(), Box<dyn std::error:
             | OutboundDelegateMsg::GetContractRequest(_)
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
-            | OutboundDelegateMsg::SubscribeContractRequest(_) => None,
+            | OutboundDelegateMsg::SubscribeContractRequest(_)
+            | OutboundDelegateMsg::ScheduleWakeup { .. } => None,
         })
         .expect("Expected SendDelegateMessage from delegate A");
 
@@ -3730,7 +3781,8 @@ async fn test_delegate_to_delegate_roundtrip() -> Result<(), Box<dyn std::error:
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
-        | OutboundDelegateMsg::SendDelegateMessage(_) => {
+        | OutboundDelegateMsg::SendDelegateMessage(_)
+        | OutboundDelegateMsg::ScheduleWakeup { .. } => {
             panic!(
                 "Expected ApplicationMessage from B, got {:?}",
                 &outbound_b[0]
@@ -3818,7 +3870,8 @@ async fn test_multiple_send_delegate_messages_all_attested()
             | OutboundDelegateMsg::GetContractRequest(_)
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
-            | OutboundDelegateMsg::SubscribeContractRequest(_) => None,
+            | OutboundDelegateMsg::SubscribeContractRequest(_)
+            | OutboundDelegateMsg::ScheduleWakeup { .. } => None,
         })
         .collect();
 
@@ -4208,6 +4261,134 @@ mod hosted_user_secrets {
             "user X's secret must be unchanged by the inter-delegate hop"
         );
 
+        std::mem::drop(temp_dir);
+        Ok(())
+    }
+}
+
+// ==================== Scheduled wakeups (#3972) ====================
+
+/// End-to-end tests for the scheduled-wakeup primitive (#3972), driven through
+/// the runtime with the `test-delegate-wakeup` WASM delegate.
+mod wakeup_tests {
+    use super::*;
+
+    const TEST_DELEGATE_WAKEUP: &str = "test_delegate_wakeup";
+
+    /// Message types shared with the `test-delegate-wakeup` WASM delegate.
+    mod wakeup_messages {
+        use super::*;
+
+        #[derive(Debug, Serialize, Deserialize)]
+        pub enum InboundAppMessage {
+            Schedule {
+                at_secs: u64,
+                at_nanos: u32,
+                tag: Vec<u8>,
+            },
+        }
+
+        #[derive(Debug, Serialize, Deserialize)]
+        pub enum OutboundAppMessage {
+            Scheduled { tag: Vec<u8> },
+            Woke { tag: Vec<u8> },
+        }
+    }
+
+    /// End-to-end across the WASM boundary: a delegate emits
+    /// `ScheduleWakeup` (host sees it), and a host-delivered `WakeupFired`
+    /// reaches the delegate's `process()` which reacts to it. This exercises the
+    /// two new wire variants (#3972) both directions through bincode + the
+    /// runtime's `process_outbound` / inbound forwarding.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_schedule_wakeup_and_fire() -> Result<(), Box<dyn std::error::Error>> {
+        use wakeup_messages::*;
+
+        let (delegate, mut runtime, temp_dir) = setup_runtime(TEST_DELEGATE_WAKEUP).await?;
+        let tag = b"weekly-rotation".to_vec();
+
+        // 1. Delegate schedules a wakeup in response to an app message.
+        let command = InboundAppMessage::Schedule {
+            at_secs: 1_700_000_000,
+            at_nanos: 500,
+            tag: tag.clone(),
+        };
+        let payload = bincode::serialize(&command)?;
+        let outbound = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![InboundDelegateMsg::ApplicationMessage(
+                ApplicationMessage::new(payload),
+            )],
+        )?;
+
+        // Delegate emits ScheduleWakeup followed by an ack ApplicationMessage.
+        assert_eq!(
+            outbound.len(),
+            2,
+            "expected ScheduleWakeup + ack, got {outbound:?}"
+        );
+        let OutboundDelegateMsg::ScheduleWakeup { at, tag: got_tag } = &outbound[0] else {
+            panic!("expected ScheduleWakeup, got {:?}", &outbound[0]);
+        };
+        assert_eq!(
+            *at,
+            std::time::UNIX_EPOCH + std::time::Duration::new(1_700_000_000, 500),
+            "the absolute fire time must survive the round trip"
+        );
+        assert_eq!(got_tag, &tag);
+
+        let OutboundDelegateMsg::ApplicationMessage(ack_msg) = &outbound[1] else {
+            panic!("expected ack ApplicationMessage, got {:?}", &outbound[1]);
+        };
+        let ack: OutboundAppMessage = bincode::deserialize(&ack_msg.payload)?;
+        assert!(matches!(ack, OutboundAppMessage::Scheduled { tag: t } if t == tag));
+
+        // 2. Host delivers the wakeup; the delegate receives it and reacts.
+        let fired = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![InboundDelegateMsg::WakeupFired { tag: tag.clone() }],
+        )?;
+        assert_eq!(fired.len(), 1, "expected the delegate's wakeup reaction");
+        let OutboundDelegateMsg::ApplicationMessage(woke_msg) = &fired[0] else {
+            panic!("expected Woke ApplicationMessage, got {:?}", &fired[0]);
+        };
+        let woke: OutboundAppMessage = bincode::deserialize(&woke_msg.payload)?;
+        assert!(
+            matches!(woke, OutboundAppMessage::Woke { tag: t } if t == tag),
+            "delegate should echo the fired tag"
+        );
+
+        std::mem::drop(temp_dir);
+        Ok(())
+    }
+
+    /// A wakeup firing for a delegate that is no longer registered must surface
+    /// a missing-delegate error rather than silently succeeding or reinstalling
+    /// it. The `contract_handling` loop turns this error into a log-and-drop
+    /// (the schedule entry was already removed by `take_due`), giving the
+    /// issue's "drop on uninstalled delegate" behaviour.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_wakeup_fired_for_unregistered_delegate_errors()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (_delegate, mut runtime, temp_dir) = setup_runtime(TEST_DELEGATE_WAKEUP).await?;
+        let unregistered = DelegateKey::new([0xEE; 32], CodeHash::new([0xEF; 32]));
+        let result = runtime.inbound_app_message(
+            &unregistered,
+            &vec![].into(),
+            None,
+            None,
+            vec![InboundDelegateMsg::WakeupFired { tag: b"x".to_vec() }],
+        );
+        assert!(
+            result.is_err(),
+            "firing a wakeup at an unregistered delegate must error, not silently succeed"
+        );
         std::mem::drop(temp_dir);
         Ok(())
     }

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -2319,7 +2319,8 @@ async fn test_delegate_request(ctx: &mut TestContext) -> TestResult {
                 | other @ OutboundDelegateMsg::PutContractRequest(_)
                 | other @ OutboundDelegateMsg::UpdateContractRequest(_)
                 | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-                | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+                | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+                | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
                     bail!("Expected ApplicationMessage, got {:?}", other)
                 }
             };
@@ -2479,7 +2480,8 @@ async fn test_attested_contract_passed_to_delegate(ctx: &mut TestContext) -> Tes
                 | other @ OutboundDelegateMsg::PutContractRequest(_)
                 | other @ OutboundDelegateMsg::UpdateContractRequest(_)
                 | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
-                | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+                | other @ OutboundDelegateMsg::SendDelegateMessage(_)
+                | other @ OutboundDelegateMsg::ScheduleWakeup { .. } => {
                     bail!("Expected ApplicationMessage, got {:?}", other)
                 }
             };

--- a/tests/test-delegate-wakeup/.gitignore
+++ b/tests/test-delegate-wakeup/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/tests/test-delegate-wakeup/Cargo.toml
+++ b/tests/test-delegate-wakeup/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "test-delegate-wakeup"
+version = "0.1.0"
+edition = "2024"
+description = "Test delegate exercising the scheduled-wakeup primitive (#3972)"
+
+[workspace]
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+freenet-stdlib = { version = "0.8.3", features = ["contract"] }
+serde = { version = "1", features = ["derive"] }
+bincode = "1"
+
+[features]
+default = ["freenet-main-delegate"]
+freenet-main-delegate = []
+trace = ["freenet-stdlib/trace"]

--- a/tests/test-delegate-wakeup/src/lib.rs
+++ b/tests/test-delegate-wakeup/src/lib.rs
@@ -1,0 +1,78 @@
+//! Test delegate for the scheduled-wakeup primitive (freenet-core #3972).
+//!
+//! - On an [`InboundAppMessage::Schedule`] application message it emits an
+//!   [`OutboundDelegateMsg::ScheduleWakeup`] for the requested absolute time and
+//!   tag, plus an ack.
+//! - On an [`InboundDelegateMsg::WakeupFired`] it emits an application message
+//!   echoing the tag, so a test can observe that the host delivered the wakeup.
+
+use std::time::{Duration, UNIX_EPOCH};
+
+use freenet_stdlib::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum InboundAppMessage {
+    /// Ask the delegate to schedule a wakeup at `UNIX_EPOCH + (at_secs, at_nanos)`.
+    Schedule {
+        at_secs: u64,
+        at_nanos: u32,
+        tag: Vec<u8>,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum OutboundAppMessage {
+    /// Ack that a `ScheduleWakeup` was emitted for `tag`.
+    Scheduled { tag: Vec<u8> },
+    /// The delegate observed a `WakeupFired` for `tag`.
+    Woke { tag: Vec<u8> },
+}
+
+struct Delegate;
+
+#[delegate]
+impl DelegateInterface for Delegate {
+    fn process(
+        _ctx: &mut DelegateCtx,
+        _params: Parameters<'static>,
+        _origin: Option<MessageOrigin>,
+        message: InboundDelegateMsg,
+    ) -> Result<Vec<OutboundDelegateMsg>, DelegateError> {
+        match message {
+            InboundDelegateMsg::ApplicationMessage(incoming) => {
+                let command: InboundAppMessage = bincode::deserialize(incoming.payload.as_slice())
+                    .map_err(|err| DelegateError::Other(format!("{err}")))?;
+                match command {
+                    InboundAppMessage::Schedule {
+                        at_secs,
+                        at_nanos,
+                        tag,
+                    } => {
+                        let at = UNIX_EPOCH + Duration::new(at_secs, at_nanos);
+                        let ack = bincode::serialize(&OutboundAppMessage::Scheduled {
+                            tag: tag.clone(),
+                        })
+                        .map_err(|err| DelegateError::Other(format!("{err}")))?;
+                        Ok(vec![
+                            OutboundDelegateMsg::ScheduleWakeup { at, tag },
+                            OutboundDelegateMsg::ApplicationMessage(
+                                ApplicationMessage::new(ack).processed(true),
+                            ),
+                        ])
+                    }
+                }
+            }
+            InboundDelegateMsg::WakeupFired { tag } => {
+                let payload = bincode::serialize(&OutboundAppMessage::Woke { tag })
+                    .map_err(|err| DelegateError::Other(format!("{err}")))?;
+                Ok(vec![OutboundDelegateMsg::ApplicationMessage(
+                    ApplicationMessage::new(payload).processed(true),
+                )])
+            }
+            _ => Err(DelegateError::Other(
+                "Unexpected inbound message".to_string(),
+            )),
+        }
+    }
+}


### PR DESCRIPTION
> ⚠️ **Blocked on freenet-stdlib 0.8.3** (adds `ScheduleWakeup` / `WakeupFired`).
> This PR depends on that release being published to crates.io first
> (stdlib-first policy). CI will be red until then. Draft until 0.8.3 is out and
> `Cargo.lock` is refreshed (`cargo update -p freenet-stdlib --precise 0.8.3`).

## Problem

Delegates cannot schedule future execution, so always-on background work (River
private-room key rotation #228, TTL pruning, scheduled publish) has to live in a
UI sync loop and stops when the UI is closed. This implements the host side of
the scheduled-wakeup primitive whose wire variants land in freenet-stdlib 0.8.3.

## Approach

**`WakeupScheduler` (`crates/core/src/contract/wakeup.rs`)** — a per-node
schedule with:
- a time-ordered forward index (`BTreeMap<(SystemTime, seq)>`) so "what fires
  next" is O(1),
- a `(delegate, tag)` reverse index for **cancel-by-tag** (re-scheduling the
  same tag replaces the prior pending wakeup), and
- **ReDb persistence** (new `WAKEUPS_TABLE`) so pending wakeups survive restart;
  the table is created on first open of an upgraded DB.

**Params capture.** A fired wakeup must invoke the delegate with the same params
it was registered with, but the `DelegateKey` is a one-way hash of code+params so
the host can't recover them from the key. Each wakeup therefore stores the
delegate's params at schedule time and replays them on fire — correcting the
empty-params shortcut the contract-notification path takes.

**Inline firing (no separate task).** `OutboundDelegateMsg::ScheduleWakeup` is
intercepted in `handle_delegate_with_contract_requests` and persisted
(fire-and-forget, not re-driven). Wakeups fire **inline** as a new arm in the
`contract_handling` `select!` loop — the same single task that owns the executor
and runs delegates. That means no cross-task channel, no lossy dispatch, and no
`Notify`: because scheduling and firing are on the same task, a newly-scheduled
earlier wakeup is observed on the loop's next pass. Firing delivers
`InboundDelegateMsg::WakeupFired`; a delegate that is no longer registered yields
a missing-delegate error that is logged and dropped (the entry was already
removed by `take_due`), never reinstalled — the issue's "drop on uninstalled
delegate" rule.

This deviates from the issue's suggested standalone-tokio-task sketch on purpose:
firing on the delegate-owning task avoids the whole class of cross-task
channel/back-pressure bugs the project's channel-safety rules exist to prevent.

## Testing

- `WakeupScheduler` unit tests: cancel-by-tag replace, earliest-first fire
  ordering, bounded batch, ReDb persistence across reload (simulated restart),
  cancel-by-tag persisted, and volume/no-loss for many independent schedules.
- New `test-delegate-wakeup` WASM delegate + runtime tests: a delegate emits
  `ScheduleWakeup` (host sees it), a host-delivered `WakeupFired` reaches the
  delegate's `process()` and it reacts — exercising both new variants across the
  WASM bincode boundary — plus the drop-on-uninstalled path.

Closes #3972

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Review

Full-tier multi-model review run pre-PR (wire format + delegate runtime +
concurrency + persistence): Codex (external) + 4 diverse Claude reviewers
(concurrency, persistence/wire-format, adversarial bug-hunt, big-picture). The
data-race and lost-wakeup questions were traced and confirmed safe (single-task
`&mut`, no cross-task mutation). Findings addressed in this PR:

- **Sender-attestation bypass** (Codex/bug-hunt): the `ScheduleWakeup` arm in
  `process_outbound` no longer drain-and-breaks; it falls through so each
  trailing `SendDelegateMessage` reaches its own attesting arm (also preserves
  `ContextUpdated` folding).
- **`decode_value` panic on a corrupt row** (persistence/bug-hunt): now validates
  nanos and uses `checked_add`, returning `None` so a torn row is skipped, not a
  startup crash. New overflow test.
- **Unbounded pending wakeups** (Codex/persistence/big-picture): per-delegate,
  global, and tag-length caps enforced at `schedule()`; new cap tests.
- LOW: wall-clock/`TimeSource` deviation now carries a load-bearing justification
  comment; at-most-once delivery documented on the stdlib variant; the shared
  "migration probes" warn generalised for the uninstalled-wakeup case.

Known follow-ups (filed separately): a loop-level integration test for the
firing glue (a deterministic one is blocked by the intentional wall-clock design;
tracked as an issue), and the pre-existing drain-bypass in the sibling terminal
arms (`ApplicationMessage`/`RequestUserInput`/… — not introduced here).
