### PR TITLE
feat: export terminal-consult (piece C) counters to router_snapshot telemetry

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -524,6 +524,22 @@ pub fn record_terminal_consult_still_not_found() {
     }
 }
 
+/// Read the current terminal advertisement-consult counters (hosting redesign
+/// piece C, #4646) for export to the `router_snapshot` telemetry event (#4658).
+///
+/// Returns `(attempts, hits, resolved_found, still_not_found)` — the four
+/// per-node monotonic aggregates recorded by the consult sites — or `None`
+/// before the `NETWORK_STATUS` singleton is initialized. `Ring` polls this on
+/// the snapshot cadence and copies the values onto `RouterSnapshotInfo` so the
+/// production findability baseline (dead-end decomposition) is legible in
+/// central telemetry, not just the internal singleton / sim-only metrics.
+pub fn terminal_consult_counts() -> Option<(u64, u64, u64, u64)> {
+    let status = NETWORK_STATUS.get()?;
+    let s = status.read().ok()?;
+    let c = &s.terminal_consult_stats;
+    Some((c.attempts, c.hits, c.resolved_found, c.still_not_found))
+}
+
 /// Record a NAT traversal attempt.
 pub fn record_nat_attempt(success: bool) {
     if let Some(status) = NETWORK_STATUS.get() {
@@ -1181,6 +1197,45 @@ mod tests {
     fn test_html_escape() {
         assert_eq!(html_escape("<script>"), "&lt;script&gt;");
         assert_eq!(html_escape("a&b"), "a&amp;b");
+    }
+
+    /// End-to-end for #4658: the terminal-consult record sites must feed the
+    /// `terminal_consult_counts()` getter that `Ring` polls for the
+    /// `router_snapshot` telemetry export. `init()` resets the counters, each
+    /// `record_*` bumps its own field, and the getter returns them in
+    /// `(attempts, hits, resolved_found, still_not_found)` order — so a wiring
+    /// mistake (wrong field, dropped increment, transposed getter tuple) fails
+    /// here rather than silently emitting zeros in production.
+    #[test]
+    fn terminal_consult_counts_reflect_recorded_events() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        // Fresh singleton state for a deterministic baseline (init overwrites
+        // the process-global tracker in place, zeroing the consult counters).
+        init(31337, HashSet::new(), "test".to_string());
+
+        assert_eq!(
+            terminal_consult_counts(),
+            Some((0, 0, 0, 0)),
+            "counters start at zero after init"
+        );
+
+        // Distinct counts per field so a transposition can't pass.
+        record_terminal_consult_attempt();
+        record_terminal_consult_attempt();
+        record_terminal_consult_attempt();
+        record_terminal_consult_hit();
+        record_terminal_consult_hit();
+        record_terminal_consult_resolved_found();
+        record_terminal_consult_still_not_found();
+        record_terminal_consult_still_not_found();
+        record_terminal_consult_still_not_found();
+        record_terminal_consult_still_not_found();
+
+        assert_eq!(
+            terminal_consult_counts(),
+            Some((3, 2, 1, 4)),
+            "getter returns (attempts, hits, resolved_found, still_not_found)"
+        );
     }
 
     #[test]

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1486,6 +1486,25 @@ impl Ring {
             snapshot.hosting_local_hits_total = Some(ring.hosting_manager.local_get_serves());
             snapshot.hosting_local_misses_total = Some(ring.hosting_manager.local_get_forwards());
 
+            // Terminal advertisement-consult counters (hosting redesign piece C,
+            // #4646). Exported here per #4658 so the production findability
+            // baseline — the dead-end decomposition (off-path-advertised-host
+            // dead-ends that C closes: attempts→hits→resolved_found, vs the
+            // no-host-near-key residual `still_not_found` that needs piece D) —
+            // is legible in central telemetry ahead of the piece-E / 0.2.92
+            // decision, instead of only in the internal singleton and sim-only
+            // metrics. Read from the per-node network_status singleton where the
+            // consult sites record them; `None` only before the singleton is
+            // initialized (i.e. always populated in production snapshots).
+            if let Some((attempts, hits, resolved_found, still_not_found)) =
+                crate::node::network_status::terminal_consult_counts()
+            {
+                snapshot.terminal_consult_attempts = Some(attempts);
+                snapshot.terminal_consult_hits = Some(hits);
+                snapshot.terminal_consult_resolved_found = Some(resolved_found);
+                snapshot.terminal_consult_still_not_found = Some(still_not_found);
+            }
+
             // Keep the hosting manager's copy of our own ring location current so
             // the proximity-prior demand estimate (#4642 A3) can turn a contract
             // key into a distance. Best-effort: only push a known location.
@@ -1607,6 +1626,10 @@ impl Ring {
                 subscribe_hint_received = pm.received,
                 subscribe_hint_acted = pm.acted,
                 renewal_terminus_satisfied = pm.renewal_terminus_satisfied,
+                terminal_consult_attempts = ?snapshot.terminal_consult_attempts,
+                terminal_consult_hits = ?snapshot.terminal_consult_hits,
+                terminal_consult_resolved_found = ?snapshot.terminal_consult_resolved_found,
+                terminal_consult_still_not_found = ?snapshot.terminal_consult_still_not_found,
                 "router_snapshot"
             );
 

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -218,6 +218,28 @@ pub(crate) struct RouterSnapshotInfo {
     pub hosting_evictions_of_recently_read_total: Option<u64>,
     pub hosting_local_hits_total: Option<u64>,
     pub hosting_local_misses_total: Option<u64>,
+    /// Terminal advertisement-consult counters (hosting redesign piece C,
+    /// #4646; exported to central telemetry per #4658), populated by `Ring`
+    /// from the per-node `network_status` singleton on the snapshot cadence.
+    ///
+    /// A GET/SUBSCRIBE that routes to a terminus (the closest peer it can reach,
+    /// can't route closer) consults the host-advertisements its neighbors sent
+    /// before returning NotFound. These four counters decompose dead-ends —
+    /// `attempts` → `hits` (found an advertised off-path host) → `resolved_found`
+    /// (that forward resolved to Found/Subscribed) are the dead-ends piece C
+    /// closes; `still_not_found` is the residual (no reachable host near the key)
+    /// that needs piece D. That decomposition is the findability baseline the
+    /// piece-E / 0.2.92 decision rests on, which is why it must be observable in
+    /// production rather than only in simulation. All monotonic lifetime totals
+    /// (the collector differences them across the cadence to derive rates),
+    /// segmentable by release via the `service.version` OTLP resource attribute
+    /// stamped on every batch. `None` until the ring's snapshot task has
+    /// populated them (i.e. always populated in production snapshots). Per-node
+    /// aggregate scalars.
+    pub terminal_consult_attempts: Option<u64>,
+    pub terminal_consult_hits: Option<u64>,
+    pub terminal_consult_resolved_found: Option<u64>,
+    pub terminal_consult_still_not_found: Option<u64>,
     /// Interest-weighted (two-tier) module-cache SHADOW gauges (#4441/#4534),
     /// populated by `Ring` from the same per-node `ModuleCacheMetrics` `Arc`.
     /// These are ALWAYS ON, independent of the `FREENET_MODULE_CACHE_INTEREST_TIERED`
@@ -1123,6 +1145,13 @@ impl Router {
             hosting_evictions_of_recently_read_total: None,
             hosting_local_hits_total: None,
             hosting_local_misses_total: None,
+            // Terminal advertisement-consult counters (piece C, #4646),
+            // populated by Ring from the network_status singleton on the
+            // snapshot cadence (#4658).
+            terminal_consult_attempts: None,
+            terminal_consult_hits: None,
+            terminal_consult_resolved_found: None,
+            terminal_consult_still_not_found: None,
             // Interest-weighted (two-tier) module-cache shadow gauges,
             // populated by Ring on the snapshot cadence (#4441/#4534).
             contract_module_cache_cold_evictable_bytes: None,

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2188,6 +2188,30 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "hosting_local_misses_total".to_string(),
                     serde_json::json!(snapshot.hosting_local_misses_total),
                 );
+                // Terminal advertisement-consult counters (hosting redesign
+                // piece C, #4646; exported per #4658). Same hand-mirrored
+                // footgun as the gauges above: a new `RouterSnapshotInfo` field
+                // is invisible to the collector unless added here. These are the
+                // findability-baseline signal that decomposes production
+                // dead-ends (attempts → hits → resolved_found vs still_not_found)
+                // ahead of the piece-E / 0.2.92 decision. Pinned by
+                // `router_snapshot_json_includes_terminal_consult_counters`.
+                obj.insert(
+                    "terminal_consult_attempts".to_string(),
+                    serde_json::json!(snapshot.terminal_consult_attempts),
+                );
+                obj.insert(
+                    "terminal_consult_hits".to_string(),
+                    serde_json::json!(snapshot.terminal_consult_hits),
+                );
+                obj.insert(
+                    "terminal_consult_resolved_found".to_string(),
+                    serde_json::json!(snapshot.terminal_consult_resolved_found),
+                );
+                obj.insert(
+                    "terminal_consult_still_not_found".to_string(),
+                    serde_json::json!(snapshot.terminal_consult_still_not_found),
+                );
             }
             body
         }
@@ -2401,6 +2425,35 @@ mod tests {
             ("hosting_evictions_of_recently_read_total", 277),
             ("hosting_local_hits_total", 281),
             ("hosting_local_misses_total", 283),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
+    }
+
+    /// Pin: the terminal advertisement-consult counters (hosting redesign piece
+    /// C, #4646) must also reach the hand-mirrored OTLP body — same footgun as
+    /// the gauges above. These four counters are the findability baseline #4658
+    /// exports so the piece-E / 0.2.92 decision rests on the production dead-end
+    /// decomposition (off-path-advertised-host dead-ends C closes vs the
+    /// no-host-near-key residual needing piece D), not simulation. A silent drop
+    /// would re-blind central telemetry to C's effectiveness — the exact gap
+    /// this change closes.
+    #[test]
+    fn router_snapshot_json_includes_terminal_consult_counters() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.terminal_consult_attempts = Some(311);
+        info.terminal_consult_hits = Some(313);
+        info.terminal_consult_resolved_found = Some(317);
+        info.terminal_consult_still_not_found = Some(331);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        for (key, want) in [
+            ("terminal_consult_attempts", 311),
+            ("terminal_consult_hits", 313),
+            ("terminal_consult_resolved_found", 317),
+            ("terminal_consult_still_not_found", 331),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }


### PR DESCRIPTION
## Problem

Piece C (terminal advertisement consult, PR #4646, shipped in 0.2.90) records its counters — consult **attempts**, **hits**, **resolved-found**, **still-not-found** — only to the internal `network_status` singleton and the sim-only `GlobalTestMetrics`, plus a debug-level `TERMINAL_CONSULT` log line. They never reach the `router_snapshot` telemetry event or the collector, so operators cannot see C's effectiveness on the production 374-peer network (confirmed unobservable in the 0.2.90 canary).

This is the highest-value item in the 0.2.91 **instrument-and-de-risk** release: it makes the live network report the **real findability numbers**, so the piece-E / 0.2.92 decision is data-driven instead of sim-based. The four counters decompose dead-ends into the two cases the redesign cares about:

- **off-path-advertised-host dead-ends** that C closes: `attempts` → `hits` (found an advertised host off the routing path) → `resolved_found` (that forward resolved to Found/Subscribed)
- the **no-host-near-key residual** `still_not_found`, which needs piece D

## Approach

The four counters already exist and are already incremented correctly at every consult site (GET/SUBSCRIBE relay termini). This PR only adds the **missing export hop**, following the exact pattern the A2/A3 hosting gauges already use to reach central telemetry:

1. `network_status::terminal_consult_counts()` — a read-only getter returning the four per-node counters from the singleton.
2. Four `Option<u64>` fields on `RouterSnapshotInfo`.
3. `Ring::emit_router_snapshot_telemetry` polls the getter on the snapshot cadence and copies the values onto the snapshot (and the local `router_snapshot` `info!` log).
4. Four `obj.insert(...)` mirrors in `event_kind_to_json`'s `RouterSnapshot` arm (the hand-mirrored OTLP body), pinned by a new guard test.

**Purely additive instrumentation — no routing/consult/hosting behavior change.** Safe to ship independent of the piece-E bundle. `RouterSnapshotInfo` is a local-only telemetry struct (AOF event log + OTLP body), never a peer wire message, so there is no protocol/wire-format concern; adding `Option<u64>` fields matches the ~8 prior gauge additions to this exact struct.

**Version segmentation** is already provided by the existing pipeline: every OTLP batch carries the sender's `service.version` resource attribute (pinned by `test_otlp_resource_includes_service_version`), so the collector can group these counters by release (0.2.91 baseline vs later) with no new plumbing.

### Related findability signals — already exported, no change needed

GET/SUBSCRIBE success and NotFound are **already** in the collector stream as discrete per-request events (`get_success`, `get_not_found`, `subscribe_success`, `subscribe_not_found`), so the overall dead-end rate and success rates are already derivable per-release. The only missing piece of the findability baseline was the **consult** decomposition, which this PR adds. (The `network_status` op-stats aggregates are exported to the local homepage only, not the collector — left as-is to keep this change one logical thing.)

## Testing

- `terminal_consult_counts_reflect_recorded_events` (network_status): `init()` → `record_*` → getter round-trip with distinct per-field counts, so a dropped increment or transposed tuple fails here instead of silently emitting zeros in production.
- `router_snapshot_json_includes_terminal_consult_counters` (telemetry): pins the four fields through the hand-mirrored OTLP body, matching the existing `router_snapshot_json_includes_*` guards (the #4009/#4010 manually-mirrored-telemetry footgun).
- `cargo fmt` + `cargo clippy -- -D warnings` (default and `trace-ot`) clean; the existing `router_snapshot_json_includes_*` pins still pass.

Closes #4658

[AI-assisted - Claude]