### PR TITLE
fix: preserve upstream interest across ChangeInterests gossip

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2707,13 +2707,42 @@ async fn handle_interest_sync_message(
                             continue;
                         }
 
-                        // Register their interest
-                        let is_new = op_manager.interest_manager.register_peer_interest(
-                            &contract,
-                            pk.clone(),
-                            None,
-                            false,
-                        );
+                        // Register their interest — but preserve an existing
+                        // entry's `is_upstream` flag (and cached summary). A
+                        // ChangeInterests "added" gossip from a peer that is
+                        // ALREADY our upstream host (is_upstream = true, set when
+                        // we subscribed through it — subscribe.rs / operations.rs)
+                        // must NOT be downgraded to a plain downstream interest.
+                        // A bare re-registration with is_upstream=false overwrites
+                        // the whole PeerInterest, flipping is_upstream true -> false
+                        // and wiping the delta-sync summary to None. The is_upstream
+                        // clobber defeats event-driven collapse:
+                        // `send_unsubscribe_upstream` locates the upstream via
+                        // `is_upstream`, so after the first gossip round the
+                        // Unsubscribe is never sent upstream and the chain only
+                        // lapses on lease expiry (~6 min stale window). An upstream
+                        // peer hosts the contract, so it re-advertises interest on
+                        // every ~5-min interest-sync heartbeat, making this clobber
+                        // deterministic and periodic. Mirror the refresh-guard the
+                        // `Interests` full-replace arm above uses. (Guarded wiring
+                        // pinned by change_interests_arm_guards_register_with_refresh_pin.)
+                        let is_new = if op_manager
+                            .interest_manager
+                            .get_peer_interest(&contract, pk)
+                            .is_some()
+                        {
+                            op_manager
+                                .interest_manager
+                                .refresh_peer_interest(&contract, pk);
+                            false
+                        } else {
+                            op_manager.interest_manager.register_peer_interest(
+                                &contract,
+                                pk.clone(),
+                                None,
+                                false,
+                            )
+                        };
                         if is_new {
                             // #4359 (MUST-FIX 1): a ChangeInterests addition
                             // makes this peer a viable broadcast target. Flush
@@ -3498,6 +3527,67 @@ mod tests {
             gated_calls >= 3,
             "expected the 3 periodic interest-sync arms to call \
              summary_if_hosted_or_in_use, found {gated_calls}"
+        );
+    }
+
+    /// Regression pin for the D2 `is_upstream` clobber in the `ChangeInterests`
+    /// interest-sync arm.
+    ///
+    /// A peer that is already our UPSTREAM host (`is_upstream = true`, set when
+    /// we subscribed through it) re-advertises interest on every ~5-min
+    /// interest-sync heartbeat (it hosts the contract, so it is interested).
+    /// A bare `register_peer_interest(.., is_upstream = false)` overwrites the
+    /// whole `PeerInterest`, flipping `is_upstream` true -> false and wiping the
+    /// cached delta-sync summary. The is_upstream clobber defeats event-driven
+    /// chain collapse: `send_unsubscribe_upstream` finds the upstream via
+    /// `is_upstream`, so after the first gossip round the Unsubscribe is never
+    /// sent upstream and the chain only lapses on lease expiry (~6-min stale
+    /// window). The arm therefore MUST guard re-registration of an existing
+    /// entry with `get_peer_interest().is_some() -> refresh_peer_interest()`,
+    /// exactly like the `Interests` full-replace arm.
+    ///
+    /// The primitive behaviour (refresh preserves, bare register clobbers) is
+    /// pinned in `ring/interest.rs` by
+    /// `upstream_interest_survives_refresh_but_bare_register_clobbers_it`.
+    /// Driving the async handler end-to-end needs a full OpManager + connection
+    /// fixture, so — following the codebase convention for interest-sync
+    /// wiring (see `op_state_manager.rs` #4359 pins) — the HANDLER wiring is
+    /// pinned at the source level here.
+    #[test]
+    fn change_interests_arm_guards_register_with_refresh_pin() {
+        let src = include_str!("node.rs");
+
+        let handler_start = src
+            .find("async fn handle_interest_sync_message(")
+            .expect("handle_interest_sync_message not found");
+        let handler_src = &src[handler_start..];
+
+        // Bound the slice to the ChangeInterests arm: from its match pattern up
+        // to the next arm (ResyncRequest), so the guard assertions below can't
+        // false-pass on a neighbouring arm's guard.
+        let arm_start = handler_src
+            .find("InterestMessage::ChangeInterests { added, removed } =>")
+            .expect("ChangeInterests arm not found");
+        let arm_len = handler_src[arm_start..]
+            .find("InterestMessage::ResyncRequest")
+            .expect("ResyncRequest arm (ChangeInterests terminator) not found");
+        let arm = &handler_src[arm_start..arm_start + arm_len];
+
+        // Presence of BOTH guard calls is the regression signal: the pre-fix
+        // (unguarded) arm re-registered every peer with a bare
+        // `is_upstream = false` and contained NEITHER call. Reverting to that
+        // clobber removes both, tripping this pin. (Presence-based rather than
+        // positional so a future comment mentioning a call token can't
+        // spuriously fail it — the sibling `Interests` arm uses the same guard.)
+        assert!(
+            arm.contains("get_peer_interest("),
+            "ChangeInterests arm MUST guard re-registration with get_peer_interest() \
+             so an existing upstream peer is not clobbered to is_upstream=false (D2)"
+        );
+        assert!(
+            arm.contains("refresh_peer_interest("),
+            "ChangeInterests arm MUST refresh (not re-register) an existing entry to \
+             preserve is_upstream + the cached summary (D2)"
         );
     }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2718,14 +2718,22 @@ async fn handle_interest_sync_message(
                         // and wiping the delta-sync summary to None. The is_upstream
                         // clobber defeats event-driven collapse:
                         // `send_unsubscribe_upstream` locates the upstream via
-                        // `is_upstream`, so after the first gossip round the
-                        // Unsubscribe is never sent upstream and the chain only
-                        // lapses on lease expiry (~6 min stale window). An upstream
-                        // peer hosts the contract, so it re-advertises interest on
-                        // every ~5-min interest-sync heartbeat, making this clobber
-                        // deterministic and periodic. Mirror the refresh-guard the
-                        // `Interests` full-replace arm above uses. (Guarded wiring
-                        // pinned by change_interests_arm_guards_register_with_refresh_pin.)
+                        // `is_upstream`, so after such a gossip the Unsubscribe is
+                        // never sent upstream and the chain only lapses on lease
+                        // expiry (~6 min stale window). This path is EVENT-DRIVEN,
+                        // not periodic: `ChangeInterests` is emitted only on a 0->1
+                        // interest transition (`broadcast_change_interests`); the
+                        // ~5-min interest-sync heartbeat sends `Interests` (the
+                        // guarded full-replace arm above), NOT `ChangeInterests`.
+                        // Hitting a real upstream edge needs the upstream's own
+                        // interest to lapse-and-revive so it re-emits an "added" for
+                        // a contract we already hold it as upstream for — uncommon on
+                        // current main (hosts renew leases unconditionally, so
+                        // upstream interest does not lapse) but load-bearing under
+                        // piece-D interest-gated renewal (#4642). Mirror the
+                        // refresh-guard the `Interests` full-replace arm above uses.
+                        // (Guarded wiring pinned by
+                        // change_interests_arm_guards_register_with_refresh_pin.)
                         let is_new = if op_manager
                             .interest_manager
                             .get_peer_interest(&contract, pk)
@@ -3534,27 +3542,50 @@ mod tests {
     /// interest-sync arm.
     ///
     /// A peer that is already our UPSTREAM host (`is_upstream = true`, set when
-    /// we subscribed through it) re-advertises interest on every ~5-min
-    /// interest-sync heartbeat (it hosts the contract, so it is interested).
-    /// A bare `register_peer_interest(.., is_upstream = false)` overwrites the
-    /// whole `PeerInterest`, flipping `is_upstream` true -> false and wiping the
-    /// cached delta-sync summary. The is_upstream clobber defeats event-driven
-    /// chain collapse: `send_unsubscribe_upstream` finds the upstream via
-    /// `is_upstream`, so after the first gossip round the Unsubscribe is never
-    /// sent upstream and the chain only lapses on lease expiry (~6-min stale
-    /// window). The arm therefore MUST guard re-registration of an existing
-    /// entry with `get_peer_interest().is_some() -> refresh_peer_interest()`,
-    /// exactly like the `Interests` full-replace arm.
+    /// we subscribed through it) can re-advertise interest via a
+    /// `ChangeInterests { added }` gossip. That path is EVENT-DRIVEN, not
+    /// periodic: `ChangeInterests` is emitted only on a 0->1 interest transition
+    /// (`broadcast_change_interests`), whereas the ~5-min interest-sync
+    /// *heartbeat* sends `InterestMessage::Interests` (the already-guarded
+    /// full-replace arm), NOT `ChangeInterests`. A bare
+    /// `register_peer_interest(.., is_upstream = false)` overwrites the whole
+    /// `PeerInterest`, flipping `is_upstream` true -> false and wiping the cached
+    /// delta-sync summary. The is_upstream clobber defeats event-driven chain
+    /// collapse: `send_unsubscribe_upstream` finds the upstream via `is_upstream`,
+    /// so once clobbered the Unsubscribe is never sent upstream and the chain
+    /// only lapses on lease expiry (~6-min stale window). Hitting a real upstream
+    /// edge needs the upstream's own interest to lapse-and-revive (uncommon on
+    /// current main, where leases renew unconditionally; load-bearing under
+    /// piece-D interest-gated renewal, #4642). The arm therefore MUST guard
+    /// re-registration of an existing entry with
+    /// `get_peer_interest().is_some() -> refresh_peer_interest()`, exactly like
+    /// the `Interests` full-replace arm.
     ///
-    /// The primitive behaviour (refresh preserves, bare register clobbers) is
-    /// pinned in `ring/interest.rs` by
+    /// This is the regression signal for the handler WIRING: it FAILS on the
+    /// pre-fix code (whose arm had a single unguarded bare
+    /// `register_peer_interest(.., false)` — NEITHER guard call) and passes only
+    /// on the guarded shape. Driving the async handler end-to-end needs a full
+    /// OpManager + connection fixture (none exists in this test module), so —
+    /// following the codebase convention for interest-sync wiring (see
+    /// `op_state_manager.rs` #4359 pins) — the wiring is pinned by structural
+    /// source-scrape here. The PRIMITIVE behaviour the guard relies on (refresh
+    /// preserves, bare register clobbers) is separately pinned in
+    /// `ring/interest.rs` by
     /// `upstream_interest_survives_refresh_but_bare_register_clobbers_it`.
-    /// Driving the async handler end-to-end needs a full OpManager + connection
-    /// fixture, so — following the codebase convention for interest-sync
-    /// wiring (see `op_state_manager.rs` #4359 pins) — the HANDLER wiring is
-    /// pinned at the source level here.
     #[test]
     fn change_interests_arm_guards_register_with_refresh_pin() {
+        // Strip `//` line comments so the structural assertions below match only
+        // real code, not a comment that mentions a guard token. Without this a
+        // future comment naming `refresh_peer_interest(` could let a reverted,
+        // bare `register_peer_interest(.., false)` arm false-PASS this pin (L1).
+        // Crude but sufficient: the arm has no `//` inside a string literal.
+        fn strip_line_comments(src: &str) -> String {
+            src.lines()
+                .map(|line| line.split_once("//").map(|(code, _)| code).unwrap_or(line))
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+
         let src = include_str!("node.rs");
 
         let handler_start = src
@@ -3563,7 +3594,7 @@ mod tests {
         let handler_src = &src[handler_start..];
 
         // Bound the slice to the ChangeInterests arm: from its match pattern up
-        // to the next arm (ResyncRequest), so the guard assertions below can't
+        // to the next arm (ResyncRequest), so the assertions below can't
         // false-pass on a neighbouring arm's guard.
         let arm_start = handler_src
             .find("InterestMessage::ChangeInterests { added, removed } =>")
@@ -3571,23 +3602,64 @@ mod tests {
         let arm_len = handler_src[arm_start..]
             .find("InterestMessage::ResyncRequest")
             .expect("ResyncRequest arm (ChangeInterests terminator) not found");
-        let arm = &handler_src[arm_start..arm_start + arm_len];
+        let arm = strip_line_comments(&handler_src[arm_start..arm_start + arm_len]);
 
-        // Presence of BOTH guard calls is the regression signal: the pre-fix
-        // (unguarded) arm re-registered every peer with a bare
-        // `is_upstream = false` and contained NEITHER call. Reverting to that
-        // clobber removes both, tripping this pin. (Presence-based rather than
-        // positional so a future comment mentioning a call token can't
-        // spuriously fail it — the sibling `Interests` arm uses the same guard.)
-        assert!(
-            arm.contains("get_peer_interest("),
-            "ChangeInterests arm MUST guard re-registration with get_peer_interest() \
-             so an existing upstream peer is not clobbered to is_upstream=false (D2)"
+        // Structural pin (NOT mere token presence): the arm must GUARD the
+        // re-registration — look up the existing entry, and on a hit REFRESH it
+        // (preserving is_upstream + summary) rather than clobber it with a bare
+        // register. We assert the SHAPE and ORDER
+        //   get_peer_interest( .. ).is_some() -> refresh_peer_interest( .. )
+        //     -> register_peer_interest( .. )
+        // so the register can only be the else-branch fallback for a genuinely
+        // new peer, never the primary path. The pre-fix arm had a single
+        // unguarded `register_peer_interest(.., false)` and NEITHER the
+        // presence check nor the refresh call, so the first two `expect`s below
+        // trip on it.
+        let get_at = arm.find("get_peer_interest(").expect(
+            "ChangeInterests arm MUST look up the existing entry with \
+             get_peer_interest() before (re-)registering, so an existing upstream \
+             peer is not clobbered to is_upstream=false (D2)",
         );
+        let is_some_at = arm[get_at..]
+            .find(".is_some()")
+            .map(|off| get_at + off)
+            .expect(
+                "ChangeInterests arm MUST use get_peer_interest(..).is_some() as the \
+                 presence check that gates the refresh (D2)",
+            );
+        let refresh_at = arm[is_some_at..]
+            .find("refresh_peer_interest(")
+            .map(|off| is_some_at + off)
+            .expect(
+                "ChangeInterests arm MUST refresh (not re-register) an existing entry \
+                 to preserve is_upstream + the cached summary (D2)",
+            );
+        let register_at = arm[refresh_at..]
+            .find("register_peer_interest(")
+            .map(|off| refresh_at + off)
+            .expect(
+                "ChangeInterests arm MUST still register a genuinely new peer in the \
+                 else branch (and flush the #4359 deferred broadcast)",
+            );
+
+        // The sequential slice searches already enforce
+        // get_at < is_some_at < refresh_at < register_at; assert it explicitly so
+        // a reshape that reorders (e.g. an unguarded register before the check)
+        // gets a clear message.
         assert!(
-            arm.contains("refresh_peer_interest("),
-            "ChangeInterests arm MUST refresh (not re-register) an existing entry to \
-             preserve is_upstream + the cached summary (D2)"
+            get_at < is_some_at && is_some_at < refresh_at && refresh_at < register_at,
+            "ChangeInterests guard must be shaped get_peer_interest().is_some() -> \
+             refresh_peer_interest(), with register_peer_interest() only as the \
+             else-branch fallback (D2)"
+        );
+
+        // Exactly ONE register in the arm — the guarded fallback. A second would
+        // mean an unguarded bare register slipped back in alongside the guard.
+        assert_eq!(
+            arm.matches("register_peer_interest(").count(),
+            1,
+            "ChangeInterests arm must contain exactly one (guarded, else-branch) \
+             register_peer_interest call; a second would be an unguarded clobber (D2)"
         );
     }
 

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -4726,6 +4726,72 @@ mod tests {
     fn strip_cfg_test_regions(src: &str) -> String {
         const MARKER: &str = "#[cfg(test)]";
         let bytes = src.as_bytes();
+
+        // Advance past a `//` line comment, `/* */` (nesting) block comment, or
+        // `"..."` string literal starting at `pos`, so braces/brackets inside
+        // them are NOT counted during region-boundary detection. Returns the
+        // index just past the construct, or None if `pos` does not start one.
+        //
+        // Why this matters: the gated-item boundary is found by raw brace
+        // balance, and a stray `}` in a comment or string (e.g. a doc comment
+        // that writes "its closing `}`" or a `.find("\n}\n")` call) used to tip
+        // the balance to zero early, truncating the strip mid-module. Everything
+        // after the truncation then leaked into the "production" text and was
+        // mis-counted by the register/flush pairing assertion. `char` literals
+        // are intentionally NOT handled — `'a` lifetimes make `'` ambiguous, and
+        // no `char` literal containing a brace or quote exists in the scanned
+        // sources (asserted implicitly by this pin staying green). Raw strings
+        // likewise don't appear; add handling here if one is ever introduced.
+        // Byte-only (never slices `src`): the scanning loops advance one byte at
+        // a time and can land in the middle of a multi-byte UTF-8 char (e.g. a
+        // box-drawing glyph inside a doc comment), where `&src[pos..]` would
+        // panic. All the sentinels here (`/`, `*`, `"`, `\`, `\n`) are ASCII and
+        // never occur as a UTF-8 continuation byte, so byte scanning is correct.
+        fn skip_lexical(bytes: &[u8], pos: usize) -> Option<usize> {
+            let at = |o: usize| bytes.get(o).copied();
+            // `//` line comment → to just past the newline (or EOF).
+            if at(pos) == Some(b'/') && at(pos + 1) == Some(b'/') {
+                let mut j = pos + 2;
+                while j < bytes.len() && bytes[j] != b'\n' {
+                    j += 1;
+                }
+                return Some((j + 1).min(bytes.len()));
+            }
+            // `/* */` block comment (Rust block comments nest).
+            if at(pos) == Some(b'/') && at(pos + 1) == Some(b'*') {
+                let mut depth = 0usize;
+                let mut j = pos;
+                while j < bytes.len() {
+                    if bytes[j] == b'/' && at(j + 1) == Some(b'*') {
+                        depth += 1;
+                        j += 2;
+                    } else if bytes[j] == b'*' && at(j + 1) == Some(b'/') {
+                        depth -= 1;
+                        j += 2;
+                        if depth == 0 {
+                            return Some(j);
+                        }
+                    } else {
+                        j += 1;
+                    }
+                }
+                return Some(bytes.len());
+            }
+            // `"..."` string literal (with `\` escapes).
+            if at(pos) == Some(b'"') {
+                let mut j = pos + 1;
+                while j < bytes.len() {
+                    match bytes[j] {
+                        b'\\' => j += 2, // skip the escaped byte
+                        b'"' => return Some(j + 1),
+                        _ => j += 1,
+                    }
+                }
+                return Some(bytes.len());
+            }
+            None
+        }
+
         let mut out = String::with_capacity(src.len());
         let mut i = 0usize;
         while i < src.len() {
@@ -4738,10 +4804,15 @@ mod tests {
                     while j < src.len() && bytes[j].is_ascii_whitespace() {
                         j += 1;
                     }
-                    if src[j..].starts_with("#[") {
-                        // Skip a balanced `#[ ... ]` attribute.
+                    if bytes.get(j) == Some(&b'#') && bytes.get(j + 1) == Some(&b'[') {
+                        // Skip a balanced `#[ ... ]` attribute (lexical-aware, so
+                        // a bracket inside a string attribute value can't skew it).
                         let mut depth = 0i32;
                         while j < src.len() {
+                            if let Some(nj) = skip_lexical(bytes, j) {
+                                j = nj;
+                                continue;
+                            }
                             match bytes[j] {
                                 b'[' => depth += 1,
                                 b']' => {
@@ -4764,6 +4835,10 @@ mod tests {
                 let mut k = j;
                 let mut found_brace = false;
                 while k < src.len() {
+                    if let Some(nk) = skip_lexical(bytes, k) {
+                        k = nk;
+                        continue;
+                    }
                     match bytes[k] {
                         b'{' => {
                             found_brace = true;
@@ -4775,9 +4850,14 @@ mod tests {
                     k += 1;
                 }
                 if found_brace {
-                    // Brace-balance to the matching close.
+                    // Brace-balance to the matching close, skipping lexicals so a
+                    // brace inside a comment/string is never counted.
                     let mut depth = 0i32;
                     while k < src.len() {
+                        if let Some(nk) = skip_lexical(bytes, k) {
+                            k = nk;
+                            continue;
+                        }
                         match bytes[k] {
                             b'{' => depth += 1,
                             b'}' => {
@@ -4798,9 +4878,9 @@ mod tests {
                 i = k;
                 continue;
             }
-            // Copy one byte of production source. `src` is valid UTF-8 and we
-            // only ever split on ASCII boundaries (markers/braces/`;`), so
-            // pushing the char at this index is safe.
+            // Copy one char of production source verbatim (comments and strings
+            // are preserved in the output — downstream assertions match on
+            // production comment text, e.g. the "Source 1 / proximity" check).
             let ch = src[i..].chars().next().unwrap();
             out.push(ch);
             i += ch.len_utf8();

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -2171,6 +2171,90 @@ mod tests {
         assert!(!downstream_entry.1.is_upstream);
     }
 
+    /// Regression for the D2 clobber in the `ChangeInterests` interest-sync
+    /// handler (`node.rs`): a peer that is already our UPSTREAM host
+    /// (`is_upstream = true`, set when we subscribed through it) must not be
+    /// downgraded to a plain downstream interest when it re-advertises interest
+    /// on the periodic interest-sync heartbeat.
+    ///
+    /// `register_peer_interest(.., is_upstream = false)` overwrites the whole
+    /// `PeerInterest`, flipping `is_upstream` true -> false and wiping the
+    /// cached delta-sync summary to `None`. The handlers therefore guard the
+    /// re-registration of an EXISTING entry with
+    /// `get_peer_interest().is_some() -> refresh_peer_interest()`, which
+    /// preserves both. This pins the primitive behaviour that guard relies on:
+    ///   1. `refresh` PRESERVES `is_upstream` + summary, so
+    ///      `send_unsubscribe_upstream`'s lookup
+    ///      (`get_interested_peers().find(|i| i.is_upstream)`) still resolves,
+    ///      keeping event-driven chain collapse working; and
+    ///   2. a bare `register(false)` CLOBBERS both — the failure mode the
+    ///      `ChangeInterests` handler exhibited before the guard was added.
+    #[test]
+    fn upstream_interest_survives_refresh_but_bare_register_clobbers_it() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(1);
+        let upstream = make_peer_key(1);
+        let summary = StateSummary::from(vec![1u8, 2, 3]);
+
+        // We subscribed through `upstream`, so it is registered as our upstream
+        // host with a cached delta-sync summary.
+        manager.register_peer_interest(&contract, upstream.clone(), Some(summary.clone()), true);
+        let before = manager.get_peer_interest(&contract, &upstream).unwrap();
+        assert!(before.is_upstream);
+        assert_eq!(before.summary.as_ref(), Some(&summary));
+
+        // FIXED handler path: an existing entry is refreshed, not
+        // re-registered. Refresh preserves is_upstream AND the cached summary.
+        manager.refresh_peer_interest(&contract, &upstream);
+        let after_refresh = manager.get_peer_interest(&contract, &upstream).unwrap();
+        assert!(
+            after_refresh.is_upstream,
+            "refresh must preserve is_upstream so send_unsubscribe_upstream can \
+             still find the upstream"
+        );
+        assert_eq!(
+            after_refresh.summary.as_ref(),
+            Some(&summary),
+            "refresh must preserve the cached delta-sync summary"
+        );
+
+        // `send_unsubscribe_upstream` locates the upstream exactly this way;
+        // assert it still resolves after the heartbeat refresh.
+        let found = manager
+            .get_interested_peers(&contract)
+            .into_iter()
+            .find(|(_, i)| i.is_upstream)
+            .map(|(p, _)| p);
+        assert_eq!(
+            found,
+            Some(upstream.clone()),
+            "the upstream lookup used by send_unsubscribe_upstream must still \
+             find the peer after a refresh"
+        );
+
+        // BUG path (the pre-fix unguarded `ChangeInterests` handler): a bare
+        // register(false) overwrites the entry, clobbering BOTH fields.
+        manager.register_peer_interest(&contract, upstream.clone(), None, false);
+        let clobbered = manager.get_peer_interest(&contract, &upstream).unwrap();
+        assert!(
+            !clobbered.is_upstream,
+            "documents the clobber: a bare register(false) flips is_upstream \
+             true -> false"
+        );
+        assert!(
+            clobbered.summary.is_none(),
+            "documents the clobber: a bare register(false) wipes the cached summary"
+        );
+        assert!(
+            manager
+                .get_interested_peers(&contract)
+                .into_iter()
+                .all(|(_, i)| !i.is_upstream),
+            "after the clobber, send_unsubscribe_upstream can no longer find any \
+             upstream — the event-driven-collapse defeat this fix prevents"
+        );
+    }
+
     #[test]
     fn test_register_peer_interest_resets_ttl() {
         // Verify that register_peer_interest resets TTL for existing entries.

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -2171,18 +2171,29 @@ mod tests {
         assert!(!downstream_entry.1.is_upstream);
     }
 
-    /// Regression for the D2 clobber in the `ChangeInterests` interest-sync
-    /// handler (`node.rs`): a peer that is already our UPSTREAM host
-    /// (`is_upstream = true`, set when we subscribed through it) must not be
-    /// downgraded to a plain downstream interest when it re-advertises interest
-    /// on the periodic interest-sync heartbeat.
+    /// Primitive-contract pin underpinning the D2 clobber fix in the
+    /// `ChangeInterests` interest-sync handler (`node.rs`): a peer that is
+    /// already our UPSTREAM host (`is_upstream = true`, set when we subscribed
+    /// through it) must not be downgraded to a plain downstream interest when it
+    /// re-advertises interest via a `ChangeInterests { added }` gossip. (That
+    /// gossip is EVENT-DRIVEN — emitted only on a 0->1 interest transition, not
+    /// on the ~5-min heartbeat, which sends the already-guarded `Interests`
+    /// full-replace arm.)
     ///
     /// `register_peer_interest(.., is_upstream = false)` overwrites the whole
     /// `PeerInterest`, flipping `is_upstream` true -> false and wiping the
-    /// cached delta-sync summary to `None`. The handlers therefore guard the
+    /// cached delta-sync summary to `None`. The handler therefore guards the
     /// re-registration of an EXISTING entry with
     /// `get_peer_interest().is_some() -> refresh_peer_interest()`, which
-    /// preserves both. This pins the primitive behaviour that guard relies on:
+    /// preserves both.
+    ///
+    /// SCOPE: this exercises the InterestManager PRIMITIVES directly, so it is a
+    /// characterization of the contract the guard relies on — it PASSES on the
+    /// pre-fix handler too (the bug was the handler calling the wrong
+    /// primitive, not a primitive misbehaving). The handler-WIRING regression
+    /// signal — the test that FAILS on the pre-fix unguarded arm — is
+    /// `change_interests_arm_guards_register_with_refresh_pin` in `node.rs`.
+    /// What this pins:
     ///   1. `refresh` PRESERVES `is_upstream` + summary, so
     ///      `send_unsubscribe_upstream`'s lookup
     ///      (`get_interested_peers().find(|i| i.is_upstream)`) still resolves,


### PR DESCRIPTION
## Problem

The `ChangeInterests` interest-sync handler (`node.rs::handle_interest_sync_message`) re-registered every peer that re-advertises interest with a bare `register_peer_interest(.., is_upstream = false)`. `register_peer_interest` overwrites the **whole** `PeerInterest` entry, so when the peer is already our **upstream** host (`is_upstream = true`, set at subscribe time in `subscribe.rs` / `operations.rs`), this:

- flips `is_upstream` **true -> false**, and
- wipes the cached delta-sync summary to `None`.

**User impact — event-driven chain collapse is defeated.** `OpManager::send_unsubscribe_upstream` finds the upstream via `get_interested_peers().find(|i| i.is_upstream)`. Once the flag is clobbered it can no longer locate the upstream, so the `Unsubscribe` is never sent up the chain on client/downstream departure. The subscription then only lapses on lease expiry (~6-min stale window) instead of collapsing promptly when the last local interest goes.

**The clobber is event-driven, not periodic.** The `ChangeInterests` "added" path fires only when a peer's interest in a contract transitions 0→1 (broadcast via `broadcast_change_interests` as a `BroadcastChangeInterests` event); the ~5-min interest-sync **heartbeat** sends `InterestMessage::Interests` (the full-replace arm, already guarded — `ring.rs`), **not** `ChangeInterests`. Hitting a real upstream edge therefore requires our upstream host's own interest to **lapse and revive**, so it re-emits an "added" for a contract we already hold it as upstream for. That is **uncommon on current `main`** — hosts renew leases unconditionally, so an upstream's interest does not lapse — but it becomes **load-bearing under piece-D interest-gated renewal** (freenet/freenet-core#4642), where interest lapses when demand goes and revives when it returns. Guarding now keeps the flag correct before D makes the edge routine. (The earlier description of this as "deterministic and periodic via the heartbeat" was inaccurate and has been corrected here and in the code/test docs.)

## Solution

The sibling `Interests` full-replace arm already guards re-registration of an existing entry:

```rust
if get_peer_interest(&contract, pk).is_some() {
    refresh_peer_interest(&contract, pk);   // preserves is_upstream + summary
} else {
    register_peer_interest(&contract, pk.clone(), None, false);
}
```

This mirrors that guard in the `ChangeInterests` arm. `refresh_peer_interest` preserves both `is_upstream` and the cached summary; a brand-new peer is still registered (and still flushes the #4359 deferred broadcast). No wire-format change; no new `register_peer_interest`/`flush_pending_broadcast_on_interest` call, so the existing #4359 pairing pin and the #4473 summarize-gate pin stay green.

### Audit of the other `register_peer_interest(.., false)` sites
- `broadcast_queue.rs` occurrences are **test-only** — no clobber risk.
- `subscribe.rs:643` (`register_downstream_subscriber`) and `get/op_ctx_task.rs:2650` register a **genuine downstream party** (a peer subscribing to / GETting from us) as `is_upstream = false`, which is the intended semantic. They only clobber in a **cyclic** topology (a peer that is simultaneously our upstream *and* our downstream for the same contract), which does not form under normal chain routing and self-corrects on the next subscribe. Left unchanged to keep this fix focused on the deterministic collapse-defeat — filed as **follow-up freenet/freenet-core#4672** (the clean class-wide fix is a primitive-level `is_upstream = existing || new` merge). Not required for this PR.

### Scope
This is the pre-existing `is_upstream` formation-flag collapse path on `main` (present since #3143). It is independent of the computed-upstream redesign (piece D, draft #4661) — piece D does not touch this handler, so the fix stands alone and improves current released behaviour.

## Testing
- `change_interests_arm_guards_register_with_refresh_pin` (node.rs) — the handler-**wiring** regression signal. A **structural** source-scrape (comments stripped first) that the `ChangeInterests` arm has the guard SHAPE `get_peer_interest(..).is_some() -> refresh_peer_interest(..)` with `register_peer_interest(..)` only as the else-branch fallback (ordered offsets + exactly-one register), not mere token presence. Verified it **FAILS on the pre-fix bare register** and passes on the guarded shape.
- `upstream_interest_survives_refresh_but_bare_register_clobbers_it` (ring/interest.rs) — a **characterization** of the InterestManager primitives the guard relies on (refresh preserves `is_upstream` + summary and the `send_unsubscribe_upstream` lookup still resolves; a bare `register(false)` clobbers both). It exercises the primitives directly, so it passes on the pre-fix handler too — the docstring now says so and points to the wiring pin above.

Both new tests pass; `cargo fmt`, `cargo clippy --locked -- -D warnings`, and the affected existing pins (`interest_sync_periodic_arms_summarize_only_hosted_or_in_use_pin`, `pending_broadcast_flush_wired_at_all_interest_sites`, `test_is_upstream_flag_registration`) are green.

> Touches the subscription-collapse path — Full multi-model review before merge; **no auto-merge**.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnRCbtbjepaB5GWrb5U8SR
