### PR TITLE
refactor: retire dormant MAD governance from dashboard, surface demand-driven eviction

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -47,6 +47,16 @@ pub type RingStatsProvider = Arc<dyn Fn() -> RingStatsSnapshot + Send + Sync + '
 /// `Ring::contract_ban_list` directly — no mirrored counter to rot.
 pub type BanListProvider = Arc<dyn Fn() -> BanListSnapshot + Send + Sync + 'static>;
 
+/// Provider for the demand-driven hosting snapshot (piece A, #4642). Same
+/// pattern as the other providers: registered at node startup, replaceable
+/// for multi-node test harnesses, read by `get_snapshot` on every dashboard
+/// request. In production the closure captures `Arc<Ring>` and calls
+/// `Ring::dashboard_hosting_snapshot()`, which reads the canonical hosting
+/// cache (Greedy-Dual keep_score + capability-relative RAM budget) — the
+/// mechanism that actually governs retention now, replacing the dormant MAD
+/// governance detector (#4296).
+pub type HostingProvider = Arc<dyn Fn() -> HostingSnapshot + Send + Sync + 'static>;
+
 /// Snapshot of ring-level statistics exposed to the dashboard.
 #[derive(Debug, Clone, Default)]
 pub struct RingStatsSnapshot {
@@ -109,6 +119,16 @@ static BAN_LIST_PROVIDER: parking_lot::RwLock<Option<BanListProvider>> =
 /// harnesses can re-wire to the current node.
 pub fn set_ban_list_provider(provider: BanListProvider) {
     *BAN_LIST_PROVIDER.write() = Some(provider);
+}
+
+static HOSTING_PROVIDER: parking_lot::RwLock<Option<HostingProvider>> =
+    parking_lot::RwLock::new(None);
+
+/// Register the dashboard's demand-driven hosting data source (piece A,
+/// #4642). Replaces any previously-registered provider so multi-node
+/// in-process harnesses can re-wire to the current node.
+pub fn set_hosting_provider(provider: HostingProvider) {
+    *HOSTING_PROVIDER.write() = Some(provider);
 }
 
 /// Replaceable storage for the subscription provider. Wrapped in a
@@ -645,6 +665,11 @@ pub struct NetworkStatusSnapshot {
     /// provider closure — no mirrored counter to rot. Empty when nothing
     /// is banned (the common case).
     pub ban_list: BanListSnapshot,
+    /// Demand-driven hosting state (piece A, #4642): the capability-relative
+    /// RAM budget + per-contract Greedy-Dual keep_score that actually governs
+    /// retention. Drives the "Demand-driven eviction" card. Read from the
+    /// canonical hosting cache via the provider closure — no mirrored counter.
+    pub hosting: HostingSnapshot,
 }
 
 /// Snapshot of the contract ban list for the dashboard (#4302).
@@ -863,6 +888,56 @@ pub struct ContractSnapshot {
     pub instance_id: String,
     pub subscribed_secs: u64,
     pub last_updated_secs: Option<u64>,
+    /// Whether this node is genuinely receiving updates for the contract —
+    /// the real per-contract freshness signal (`is_hosting` is NOT; only an
+    /// active subscription keeps the cache fresh, PR #3699).
+    pub is_receiving_updates: bool,
+    /// Whether real demand pins the contract (local client subscription or a
+    /// registered downstream subscriber).
+    pub in_use: bool,
+}
+
+/// Snapshot of the demand-driven hosting cache (piece A, #4642) for the
+/// local-peer dashboard. This is the mechanism that actually governs
+/// retention today — a capability-relative RAM budget plus a Greedy-Dual
+/// `keep_score` per contract (`ring/hosting/{cache,demand}.rs`) — and it
+/// replaced the dormant MAD `GovernanceManager` (#4296). Default (all zeros,
+/// no contracts) when the node hosts nothing yet or the provider is unset.
+#[derive(Default, Clone)]
+pub struct HostingSnapshot {
+    /// Configured RAM-scaled byte budget for hosted contract state.
+    pub budget_bytes: u64,
+    /// Bytes currently used by hosted contract state. Headroom = budget - used.
+    pub used_bytes: u64,
+    /// Number of contracts currently in the hosting cache.
+    pub contract_count: u64,
+    /// Monotonic count of contracts evicted specifically for being over budget.
+    pub budget_evictions_total: u64,
+    /// Over-budget evictions whose victim had genuine repeat demand (read >= 2
+    /// times). Should stay near zero; a rising value means the demand estimate
+    /// is mis-ordering the working set (the #4338 miscalibration symptom).
+    pub evictions_of_recently_read_total: u64,
+    /// Per-contract Greedy-Dual rows in EVICTION order (the next victim under
+    /// budget pressure is first). May be truncated by the renderer; the full
+    /// count is `contract_count`.
+    pub contracts: Vec<HostedContractEntry>,
+}
+
+/// One hosted contract's demand-driven eviction row for the dashboard.
+#[derive(Clone)]
+pub struct HostedContractEntry {
+    /// Full contract-key string.
+    pub key_full: String,
+    /// Truncated key for display.
+    pub key_short: String,
+    /// Greedy-Dual priority (`eviction_floor + predicted_demand`). Lowest evicts first.
+    pub keep_score: f64,
+    /// Stored per-contract read-demand estimate (reads/second).
+    pub predicted_demand: f64,
+    /// Per-contract memory cost (state bytes).
+    pub size_bytes: u64,
+    /// Read accesses (GET/SUBSCRIBE) observed over this entry's residency.
+    pub read_count: u32,
 }
 
 /// Snapshot of operation stats. Each tuple is `(success_count, failure_count)`.
@@ -1000,6 +1075,8 @@ pub fn get_snapshot() -> Option<NetworkStatusSnapshot> {
                         instance_id,
                         subscribed_secs: c.subscribed_secs,
                         last_updated_secs: c.last_updated_secs,
+                        is_receiving_updates: c.is_receiving_updates,
+                        in_use: c.in_use,
                     }
                 })
                 .collect()
@@ -1070,6 +1147,11 @@ pub fn get_snapshot() -> Option<NetworkStatusSnapshot> {
             .map(|provider| provider())
             .unwrap_or_default(),
         ban_list: BAN_LIST_PROVIDER
+            .read()
+            .as_ref()
+            .map(|provider| provider())
+            .unwrap_or_default(),
+        hosting: HOSTING_PROVIDER
             .read()
             .as_ref()
             .map(|provider| provider())
@@ -1403,11 +1485,15 @@ mod tests {
                 key: key_a,
                 subscribed_secs: 30,
                 last_updated_secs: Some(5),
+                is_receiving_updates: true,
+                in_use: true,
             },
             crate::ring::SubscribedContractSnapshot {
                 key: key_b,
                 subscribed_secs: 30,
                 last_updated_secs: None,
+                is_receiving_updates: true,
+                in_use: true,
             },
         ];
         set_subscription_provider(Arc::new(move || snapshot.clone()));

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -938,6 +938,13 @@ pub struct HostedContractEntry {
     pub size_bytes: u64,
     /// Read accesses (GET/SUBSCRIBE) observed over this entry's residency.
     pub read_count: u32,
+    /// Whether the over-budget sweep would actually consider this contract for
+    /// eviction: past its `min_ttl` age gate AND not pinned by demand
+    /// (`contract_in_use`). The renderer badges "next to evict" on the first
+    /// eligible row, NOT the raw lowest-keep-score row — a within-TTL or
+    /// in-use low-score contract is skipped by the real sweep, so badging it
+    /// would mislead the operator.
+    pub eviction_eligible: bool,
 }
 
 /// Snapshot of operation stats. Each tuple is `(success_count, failure_count)`.

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -501,6 +501,14 @@ impl NodeP2P {
         super::network_status::set_ban_list_provider(std::sync::Arc::new(move || {
             ban_list_ring.dashboard_ban_list_snapshot()
         }));
+        // Same pattern for the demand-driven hosting snapshot (piece A,
+        // #4642) — dashboard reads the canonical hosting cache (RAM budget +
+        // Greedy-Dual keep_score), the mechanism that actually governs
+        // retention now, replacing the dormant MAD governance detector.
+        let hosting_ring = self.op_manager.ring.clone();
+        super::network_status::set_hosting_provider(std::sync::Arc::new(move || {
+            hosting_ring.dashboard_hosting_snapshot()
+        }));
 
         // Wire live ring stats for the dashboard: connection count +
         // hosted contracts + own public key, read on every homepage

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -612,12 +612,14 @@ impl Ring {
 
         // Spawn periodic governance reaper tick.
         // Computes per-contract state from accumulated cost/benefit
-        // samples and logs `ReaperDecision`s. Mode defaults to DryRun
-        // per the staged-rollout plan, so this task only ever logs —
-        // no eviction actions until the operator (or release default)
-        // flips to Enforce. The dashboard reads `governance.score_snapshot`
-        // independently of the tick; the tick is only the engine that
-        // updates state.
+        // samples and logs `ReaperDecision`s. Mode defaults to `Off`
+        // (see `GovernanceConfig` in contract/governance.rs): the MAD
+        // outlier detector is dormant and being replaced by demand-driven
+        // eviction (#4296, #4642), so this task is a no-op on default
+        // nodes and only ever logs (never evicts) even when an operator
+        // explicitly flips it to DryRun/Enforce. The dashboard reads the
+        // governance snapshot independently of the tick; the tick is only
+        // the engine that updates state.
         task_monitor.register(
             "governance_reaper",
             GlobalExecutor::spawn(Self::governance_reaper_loop(ring.clone())),
@@ -3122,6 +3124,54 @@ impl Ring {
             norms,
             last_tick_at,
             state_by_id,
+        }
+    }
+
+    /// Snapshot of the demand-driven hosting state for the local-peer
+    /// dashboard (piece A, #4642). Reads the canonical hosting cache — the
+    /// capability-relative RAM budget + per-contract Greedy-Dual keep_score
+    /// that actually governs retention today, replacing the dormant MAD
+    /// governance detector (#4296). No mirror, no cache: the aggregate gauges
+    /// and per-contract rows come straight from the `HostingManager`, so the
+    /// panel can't drift the way a mirrored counter would.
+    ///
+    /// Per-contract rows are returned in EVICTION order (next victim first).
+    /// The renderer bounds how many it displays; the full count is
+    /// `contract_count`.
+    pub fn dashboard_hosting_snapshot(&self) -> crate::node::network_status::HostingSnapshot {
+        use crate::node::network_status as ns;
+
+        let stats = self.hosting_manager.hosting_cache_stats();
+        let contracts: Vec<ns::HostedContractEntry> = self
+            .hosting_manager
+            .dashboard_hosting_scores()
+            .into_iter()
+            .map(|row| {
+                let key_full = row.key.to_string();
+                let key_short = if key_full.chars().count() > 12 {
+                    let trunc: String = key_full.chars().take(12).collect();
+                    format!("{trunc}...")
+                } else {
+                    key_full.clone()
+                };
+                ns::HostedContractEntry {
+                    key_full,
+                    key_short,
+                    keep_score: row.keep_score,
+                    predicted_demand: row.predicted_demand,
+                    size_bytes: row.size_bytes,
+                    read_count: row.read_count,
+                }
+            })
+            .collect();
+
+        ns::HostingSnapshot {
+            budget_bytes: stats.budget_bytes,
+            used_bytes: stats.current_bytes,
+            contract_count: stats.contract_count,
+            budget_evictions_total: stats.budget_evictions_total,
+            evictions_of_recently_read_total: stats.evictions_of_recently_read_total,
+            contracts,
         }
     }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -3142,11 +3142,16 @@ impl Ring {
         use crate::node::network_status as ns;
 
         let stats = self.hosting_manager.hosting_cache_stats();
+        // Two-phase: `dashboard_hosting_scores()` returns owned rows with the
+        // `hosting_cache` read lock already dropped, so folding in
+        // `is_eviction_eligible` (which reads only the subscription maps via
+        // `contract_in_use`) holds no cache lock — no re-lock deadlock.
         let contracts: Vec<ns::HostedContractEntry> = self
             .hosting_manager
             .dashboard_hosting_scores()
             .into_iter()
             .map(|row| {
+                let eviction_eligible = self.hosting_manager.is_eviction_eligible(&row);
                 let key_full = row.key.to_string();
                 let key_short = if key_full.chars().count() > 12 {
                     let trunc: String = key_full.chars().take(12).collect();
@@ -3161,6 +3166,7 @@ impl Ring {
                     predicted_demand: row.predicted_demand,
                     size_bytes: row.size_bytes,
                     read_count: row.read_count,
+                    eviction_eligible,
                 }
             })
             .collect();

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -34,6 +34,7 @@ mod demand;
 
 use crate::util::backoff::{ExponentialBackoff, TrackedBackoff};
 use crate::util::time_source::{InstantTimeSrc, TimeSource};
+pub(crate) use cache::HostingContractScore;
 /// The pre-A2 flat 1 GiB budget, used as the upgrade-migration sentinel in
 /// `config::ConfigArgs::build` (see the constant's docs).
 pub(crate) use cache::LEGACY_FLAT_HOSTING_BUDGET_BYTES;
@@ -181,6 +182,17 @@ pub struct SubscribedContractSnapshot {
     pub subscribed_secs: u64,
     /// Seconds since the most recent observed state update, if any.
     pub last_updated_secs: Option<u64>,
+    /// Whether this node is genuinely receiving updates for this contract —
+    /// the real freshness signal ([`HostingManager::is_receiving_updates`]).
+    /// `is_hosting` is NOT a freshness signal (a hosting-cache copy can go
+    /// stale after its subscription lapses); only an active network/client
+    /// subscription guarantees the cached state is kept current (PR #3699).
+    pub is_receiving_updates: bool,
+    /// Whether real demand pins this contract: a local client subscription or
+    /// a registered downstream subscriber ([`HostingManager::contract_in_use`]).
+    /// Distinguishes contracts held for actual demand from network-only
+    /// subscriptions with no local/downstream reader.
+    pub in_use: bool,
 }
 
 // =============================================================================
@@ -550,22 +562,40 @@ impl HostingManager {
     /// and lost its recording hook.
     pub fn dashboard_subscription_snapshot(&self) -> Vec<SubscribedContractSnapshot> {
         let now = self.time_source.now();
-        let mut snapshot: Vec<SubscribedContractSnapshot> = self
+        // Phase 1: collect the lease data while iterating `active_subscriptions`.
+        // Do NOT call `is_receiving_updates`/`is_subscribed` in here — they
+        // re-`.get()` `active_subscriptions`, which would deadlock against the
+        // shard guard this `.iter()` holds when the key hashes to the same
+        // shard. Compute the freshness/demand booleans in phase 2, after the
+        // iterator's guards are released.
+        let leases: Vec<(ContractKey, u64, Option<u64>)> = self
             .active_subscriptions
             .iter()
             .filter(|entry| entry.value().expires_at > now)
             .map(|entry| {
                 let lease = *entry.value();
-                SubscribedContractSnapshot {
-                    key: *entry.key(),
-                    subscribed_secs: now
-                        .saturating_duration_since(lease.subscribed_since)
+                (
+                    *entry.key(),
+                    now.saturating_duration_since(lease.subscribed_since)
                         .as_secs(),
-                    last_updated_secs: lease
+                    lease
                         .last_updated
                         .map(|t| now.saturating_duration_since(t).as_secs()),
-                }
+                )
             })
+            .collect();
+        // Phase 2: iterator guards are dropped; the per-key lookups are now safe.
+        let mut snapshot: Vec<SubscribedContractSnapshot> = leases
+            .into_iter()
+            .map(
+                |(key, subscribed_secs, last_updated_secs)| SubscribedContractSnapshot {
+                    key,
+                    subscribed_secs,
+                    last_updated_secs,
+                    is_receiving_updates: self.is_receiving_updates(&key),
+                    in_use: self.contract_in_use(&key),
+                },
+            )
             .collect();
         // Most recently updated first; never-updated entries fall to the
         // end. Ties on `last_updated_secs` (including the (None, None)
@@ -1355,6 +1385,15 @@ impl HostingManager {
     /// read lock, for the per-node `RouterSnapshot` telemetry (A2).
     pub(crate) fn hosting_cache_stats(&self) -> HostingCacheStats {
         self.hosting_cache.read().stats()
+    }
+
+    /// Per-contract Greedy-Dual eviction rows for the local-peer dashboard,
+    /// in eviction order (next victim first). Reads the canonical hosting
+    /// cache under a single lock — this is piece A's live demand-driven
+    /// retention state (#4642), the mechanism that replaced the dormant MAD
+    /// governance detector. See [`HostingContractScore`].
+    pub(crate) fn dashboard_hosting_scores(&self) -> Vec<HostingContractScore> {
+        self.hosting_cache.read().eviction_ordered_scores()
     }
 
     /// Check if we should continue hosting a contract.
@@ -2551,6 +2590,43 @@ mod tests {
 
         manager.add_client_subscription(contract.id(), client_id);
         assert!(manager.is_receiving_updates(&contract));
+    }
+
+    /// The dashboard subscription snapshot must carry the per-contract
+    /// freshness (`is_receiving_updates`) and demand (`in_use`) signals, and
+    /// building it must NOT deadlock (the booleans are computed in a second
+    /// pass after the `active_subscriptions` iterator's guards are released —
+    /// `is_receiving_updates` re-`.get()`s that same DashMap).
+    #[test]
+    fn dashboard_subscription_snapshot_reports_freshness_and_demand() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        // Network subscription only: receiving updates, but no local/downstream demand.
+        let network_only = make_contract_key(1);
+        manager.subscribe(network_only);
+        // Network + client subscription: receiving updates AND in use.
+        let in_use = make_contract_key(2);
+        manager.subscribe(in_use);
+        manager.add_client_subscription(in_use.id(), crate::client_events::ClientId::next());
+
+        let snap = manager.dashboard_subscription_snapshot();
+        let net = snap
+            .iter()
+            .find(|c| c.key == network_only)
+            .expect("network-only subscription present");
+        assert!(
+            net.is_receiving_updates,
+            "an active network subscription is receiving updates"
+        );
+        assert!(
+            !net.in_use,
+            "a network-only subscription has no local/downstream demand"
+        );
+        let used = snap
+            .iter()
+            .find(|c| c.key == in_use)
+            .expect("in-use subscription present");
+        assert!(used.is_receiving_updates);
+        assert!(used.in_use, "a client subscription is real demand → in_use");
     }
 
     #[test]

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -1396,6 +1396,26 @@ impl HostingManager {
         self.hosting_cache.read().eviction_ordered_scores()
     }
 
+    /// Whether the over-budget sweep would currently CONSIDER `score`'s
+    /// contract for eviction — i.e. whether it passes the same per-contract
+    /// filter [`cache::HostingCache::evict_over_budget`] applies:
+    /// `past_min_ttl` (the TTL half, precomputed by the cache) AND NOT
+    /// [`contract_in_use`](Self::contract_in_use) (the `should_retain` half).
+    ///
+    /// The dashboard uses this to badge the true "next to evict" contract: the
+    /// raw lowest-keep-score row can be an entry the sweep would SKIP (still
+    /// within `min_ttl`, or pinned by a local client / downstream subscriber),
+    /// so badging it unconditionally mislabels an eviction-exempt contract.
+    ///
+    /// Deadlock-safe by construction: `score` is already-collected owned data
+    /// (the `hosting_cache` read guard was released when
+    /// [`dashboard_hosting_scores`](Self::dashboard_hosting_scores) returned),
+    /// and `contract_in_use` reads only the subscription maps — never the
+    /// hosting cache — so there is no lock held across this call.
+    pub(crate) fn is_eviction_eligible(&self, score: &HostingContractScore) -> bool {
+        score.past_min_ttl && !self.contract_in_use(&score.key)
+    }
+
     /// Check if we should continue hosting a contract.
     ///
     /// Returns true if:
@@ -2592,11 +2612,18 @@ mod tests {
         assert!(manager.is_receiving_updates(&contract));
     }
 
-    /// The dashboard subscription snapshot must carry the per-contract
-    /// freshness (`is_receiving_updates`) and demand (`in_use`) signals, and
-    /// building it must NOT deadlock (the booleans are computed in a second
-    /// pass after the `active_subscriptions` iterator's guards are released —
-    /// `is_receiving_updates` re-`.get()`s that same DashMap).
+    /// Characterizes the dashboard subscription snapshot: it must carry the
+    /// per-contract freshness (`is_receiving_updates`) and demand (`in_use`)
+    /// signals with the correct values.
+    ///
+    /// NOTE: this asserts the two-phase snapshot's OUTPUT, not deadlock-safety.
+    /// The same-shard DashMap re-lock the two-phase split avoids
+    /// (`is_receiving_updates` re-`.get()`s `active_subscriptions`) is prevented
+    /// BY CONSTRUCTION — phase 2 runs only after the iterator's shard guards
+    /// drop. It does NOT manifest in this single-threaded, no-concurrent-writer
+    /// test: a re-inlined same-shard read would still pass here. The guard
+    /// against re-inlining is the load-bearing comment in
+    /// `dashboard_subscription_snapshot`, not this test.
     #[test]
     fn dashboard_subscription_snapshot_reports_freshness_and_demand() {
         let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
@@ -2627,6 +2654,79 @@ mod tests {
             .expect("in-use subscription present");
         assert!(used.is_receiving_updates);
         assert!(used.in_use, "a client subscription is real demand → in_use");
+    }
+
+    /// `is_eviction_eligible` must combine BOTH halves of the
+    /// `evict_over_budget` skip filter — the cache's `past_min_ttl` age gate
+    /// AND `!contract_in_use` — so the dashboard's "next to evict" badge only
+    /// marks a contract the sweep would actually consider. A within-TTL OR an
+    /// in-use low-score contract must read as NOT eligible (the sweep skips it);
+    /// badging it would mislabel an eviction-exempt contract.
+    #[test]
+    fn dashboard_is_eviction_eligible_matches_sweep_skip_filter() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+
+        // Case 1 — default cache (DEFAULT_MIN_TTL): a freshly-accessed contract
+        // is within its TTL window → past_min_ttl false → NOT eligible even
+        // though nothing pins it.
+        let fresh = make_contract_key(1);
+        manager.record_contract_access(fresh, 100, AccessType::Get);
+        let scores = manager.dashboard_hosting_scores();
+        let fresh_score = scores
+            .iter()
+            .find(|s| s.key == fresh)
+            .expect("fresh contract present");
+        assert!(
+            !fresh_score.past_min_ttl,
+            "a freshly-accessed contract is within min_ttl"
+        );
+        assert!(
+            !manager.is_eviction_eligible(fresh_score),
+            "within-TTL contract is skipped by the sweep → not eligible"
+        );
+
+        // Case 2 — override with a ZERO-TTL cache so every entry is instantly
+        // past the TTL gate; eligibility is then decided solely by
+        // `contract_in_use`.
+        {
+            let mut cache = manager.hosting_cache.write();
+            *cache = cache::HostingCache::new(
+                10_000,
+                std::time::Duration::ZERO,
+                crate::util::time_source::InstantTimeSrc::new(),
+            );
+        }
+        let evictable = make_contract_key(2);
+        let pinned = make_contract_key(3);
+        manager.record_contract_access(evictable, 100, AccessType::Get);
+        manager.record_contract_access(pinned, 100, AccessType::Get);
+        // Pin `pinned` with a local client subscription → contract_in_use true.
+        let client = crate::client_events::ClientId::next();
+        manager.add_client_subscription(pinned.id(), client);
+        assert!(manager.contract_in_use(&pinned));
+        assert!(!manager.contract_in_use(&evictable));
+
+        let scores = manager.dashboard_hosting_scores();
+        let ev = scores
+            .iter()
+            .find(|s| s.key == evictable)
+            .expect("evictable contract present");
+        let pin = scores
+            .iter()
+            .find(|s| s.key == pinned)
+            .expect("pinned contract present");
+        assert!(
+            ev.past_min_ttl && pin.past_min_ttl,
+            "zero TTL → both entries are past the TTL gate"
+        );
+        assert!(
+            manager.is_eviction_eligible(ev),
+            "past-TTL and not in use → eligible (the real next victim)"
+        );
+        assert!(
+            !manager.is_eviction_eligible(pin),
+            "past-TTL but in use → NOT eligible (sweep skips it)"
+        );
     }
 
     #[test]

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -150,6 +150,30 @@ pub(crate) struct HostingCacheStats {
     pub evictions_of_recently_read_total: u64,
 }
 
+/// Per-contract Greedy-Dual priority row for the local-peer dashboard.
+///
+/// This is what actually governs retention today (piece A of the
+/// demand-driven hosting redesign, #4642): the over-budget walk evicts the
+/// lowest `keep_score` first. Surfaced on the dashboard so an operator can
+/// see the live demand-ordered eviction policy — the mechanism that
+/// replaced the dormant MAD governance detector (#4296). Collected under a
+/// single cache read lock by [`HostingCache::eviction_ordered_scores`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct HostingContractScore {
+    pub key: ContractKey,
+    /// Greedy-Dual priority = `eviction_floor + predicted_demand` at the last
+    /// refresh. Lowest evicts first.
+    pub keep_score: f64,
+    /// Stored per-contract read-demand estimate (reads/second).
+    pub predicted_demand: f64,
+    /// Per-contract memory cost (state bytes).
+    pub size_bytes: u64,
+    /// Read accesses (GET/SUBSCRIBE) observed over this entry's residency.
+    pub read_count: u32,
+    /// Monotonic access sequence, the LRU tiebreak when keep_scores are equal.
+    pub last_access_seq: u64,
+}
+
 /// Multiplier for TTL relative to subscription renewal interval.
 /// Gives this many renewal attempts before eviction if renewals keep failing.
 pub const TTL_RENEWAL_MULTIPLIER: u32 = 4;
@@ -804,6 +828,33 @@ impl<T: TimeSource> HostingCache<T> {
             budget_evictions_total: self.budget_evictions_total,
             evictions_of_recently_read_total: self.evictions_of_recently_read_total,
         }
+    }
+
+    /// Per-contract Greedy-Dual rows for the local dashboard, in EVICTION
+    /// order (ascending `(keep_score, last_access_seq, key)` — the same order
+    /// [`Self::keys_eviction_order`] uses). The front of the vec is the next
+    /// victim under budget pressure. Unlike that test-only helper this carries
+    /// the score fields the dashboard renders and is available in production.
+    pub(crate) fn eviction_ordered_scores(&self) -> Vec<HostingContractScore> {
+        let mut rows: Vec<HostingContractScore> = self
+            .contracts
+            .iter()
+            .map(|(k, v)| HostingContractScore {
+                key: *k,
+                keep_score: v.keep_score,
+                predicted_demand: v.predicted_demand,
+                size_bytes: v.size_bytes,
+                read_count: v.read_count,
+                last_access_seq: v.last_access_seq,
+            })
+            .collect();
+        rows.sort_by(|a, b| {
+            a.keep_score
+                .total_cmp(&b.keep_score)
+                .then_with(|| a.last_access_seq.cmp(&b.last_access_seq))
+                .then_with(|| a.key.as_bytes().cmp(b.key.as_bytes()))
+        });
+        rows
     }
 
     /// Get all hosted contract keys in EVICTION order — the order the
@@ -1473,6 +1524,36 @@ mod tests {
             cache.has_recent_local_client_access(&key, lease),
             "Re-marking should refresh the age gate"
         );
+    }
+
+    #[test]
+    fn eviction_ordered_scores_matches_key_order_and_carries_fields() {
+        // The dashboard reads `eviction_ordered_scores` (production) to render
+        // piece A's demand-driven eviction. It must yield the same order as the
+        // test-only `keys_eviction_order` and carry each entry's score fields.
+        let (mut cache, _) = make_cache(10_000, Duration::from_secs(60));
+        let key1 = make_key(1);
+        let key2 = make_key(2);
+        let key3 = make_key(3);
+        cache.record_access(key1, 111, AccessType::Get, 0, |_| false);
+        cache.record_access(key2, 222, AccessType::Get, 0, |_| false);
+        cache.record_access(key3, 333, AccessType::Get, 0, |_| false);
+
+        let scores = cache.eviction_ordered_scores();
+        let score_keys: Vec<_> = scores.iter().map(|s| s.key).collect();
+        assert_eq!(
+            score_keys,
+            cache.keys_eviction_order(),
+            "eviction_ordered_scores must use the same order as keys_eviction_order"
+        );
+        for s in &scores {
+            let entry = cache.get(&s.key).expect("scored key is in the cache");
+            assert_eq!(s.keep_score, entry.keep_score);
+            assert_eq!(s.size_bytes, entry.size_bytes);
+            assert_eq!(s.read_count, entry.read_count);
+            assert_eq!(s.predicted_demand, entry.predicted_demand);
+            assert_eq!(s.last_access_seq, entry.last_access_seq);
+        }
     }
 
     // --- Recently-abandoned priority (demand-credit strip) ---

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -172,6 +172,14 @@ pub(crate) struct HostingContractScore {
     pub read_count: u32,
     /// Monotonic access sequence, the LRU tiebreak when keep_scores are equal.
     pub last_access_seq: u64,
+    /// Whether this entry is past its `min_ttl` age gate — the TTL half of the
+    /// `evict_over_budget` eviction filter (`age >= min_ttl && !should_retain`).
+    /// This is the only half the cache can decide on its own; the
+    /// `!should_retain` (in-use) half is folded in by the `HostingManager`
+    /// layer via [`super::HostingManager::is_eviction_eligible`]. Used by the
+    /// dashboard so the "next to evict" badge only marks a contract the
+    /// over-budget sweep would actually consider — never one it would skip.
+    pub past_min_ttl: bool,
 }
 
 /// Multiplier for TTL relative to subscription renewal interval.
@@ -836,6 +844,10 @@ impl<T: TimeSource> HostingCache<T> {
     /// victim under budget pressure. Unlike that test-only helper this carries
     /// the score fields the dashboard renders and is available in production.
     pub(crate) fn eviction_ordered_scores(&self) -> Vec<HostingContractScore> {
+        // `past_min_ttl` mirrors the `age >= self.min_ttl` term of the
+        // `evict_over_budget` filter so the dashboard reflects real sweep
+        // behavior rather than raw keep-score order (see `past_min_ttl` doc).
+        let now = self.time_source.now();
         let mut rows: Vec<HostingContractScore> = self
             .contracts
             .iter()
@@ -846,6 +858,7 @@ impl<T: TimeSource> HostingCache<T> {
                 size_bytes: v.size_bytes,
                 read_count: v.read_count,
                 last_access_seq: v.last_access_seq,
+                past_min_ttl: now.saturating_duration_since(v.last_accessed) >= self.min_ttl,
             })
             .collect();
         rows.sort_by(|a, b| {
@@ -1553,7 +1566,40 @@ mod tests {
             assert_eq!(s.read_count, entry.read_count);
             assert_eq!(s.predicted_demand, entry.predicted_demand);
             assert_eq!(s.last_access_seq, entry.last_access_seq);
+            // Just accessed with a 60s min_ttl → not yet past the TTL gate.
+            assert!(
+                !s.past_min_ttl,
+                "a freshly-accessed entry is within min_ttl, so it is not \
+                 eviction-eligible yet"
+            );
         }
+    }
+
+    #[test]
+    fn eviction_ordered_scores_flags_past_min_ttl_after_ttl_elapses() {
+        // `past_min_ttl` must mirror the `age >= min_ttl` term of the
+        // `evict_over_budget` filter: false while within the TTL window, true
+        // once the entry has aged past it. This is the cache half of the
+        // dashboard "next to evict" eligibility (the in-use half is folded in
+        // by `HostingManager::is_eviction_eligible`).
+        let min_ttl = Duration::from_secs(60);
+        let (mut cache, time_source) = make_cache(10_000, min_ttl);
+        let key = make_key(1);
+        cache.record_access(key, 111, AccessType::Get, 0, |_| false);
+
+        let before = cache.eviction_ordered_scores();
+        assert!(
+            !before[0].past_min_ttl,
+            "within min_ttl → not past the TTL gate"
+        );
+
+        // Age the entry past min_ttl.
+        time_source.advance_time(min_ttl + Duration::from_secs(1));
+        let after = cache.eviction_ordered_scores();
+        assert!(
+            after[0].past_min_ttl,
+            "past min_ttl → now eligible for the TTL gate"
+        );
     }
 
     // --- Recently-abandoned priority (demand-credit strip) ---

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -19,8 +19,8 @@ pub(super) use std::fmt::Write;
 
 use assets::{CSS, JS};
 use cards::{
-    build_ban_list_card, build_contracts_card, build_governance_card, build_ops_card,
-    build_peers_card, build_status_card, build_transfer_card,
+    build_ban_list_card, build_contracts_card, build_governance_card, build_hosting_card,
+    build_ops_card, build_peers_card, build_status_card, build_transfer_card,
 };
 use favicon::build_favicon_data_uri;
 use peer_detail::peer_detail_html;
@@ -115,6 +115,7 @@ fn homepage_html() -> String {
 
     let status_card = build_status_card(&snap);
     let peers_card = build_peers_card(&snap);
+    let hosting_card = build_hosting_card(&snap);
     let governance_card = build_governance_card(&snap);
     let ban_list_card = build_ban_list_card(&snap);
     let contracts_card = build_contracts_card(&snap);
@@ -172,6 +173,7 @@ fn homepage_html() -> String {
         status_card = status_card,
         peers_card = peers_card,
         transfer_card = transfer_card,
+        hosting_card = hosting_card,
         governance_card = governance_card,
         ban_list_card = ban_list_card,
         contracts_card = contracts_card,
@@ -226,6 +228,7 @@ mod tests {
             transport_snapshot: TransportSnapshot::default(),
             governance: Default::default(),
             ban_list: Default::default(),
+            hosting: Default::default(),
         }
     }
 
@@ -765,6 +768,8 @@ mod tests {
                 instance_id: "ABC123".to_string(),
                 subscribed_secs: 100,
                 last_updated_secs: Some(5),
+                is_receiving_updates: true,
+                in_use: true,
             },
             ContractSnapshot {
                 key_short: "DEF4...".to_string(),
@@ -772,6 +777,8 @@ mod tests {
                 instance_id: "DEF456".to_string(),
                 subscribed_secs: 50,
                 last_updated_secs: None,
+                is_receiving_updates: true,
+                in_use: true,
             },
         ];
         let html = build_ops_card(&Some(snap));
@@ -1315,6 +1322,8 @@ mod tests {
             instance_id: "ABC123XYZ".to_string(),
             subscribed_secs: 100,
             last_updated_secs: Some(5),
+            is_receiving_updates: true,
+            in_use: true,
         }];
         let html = build_contracts_card(&Some(snap));
         assert!(
@@ -1463,6 +1472,8 @@ mod tests {
                 instance_id: "HOST1".to_string(),
                 subscribed_secs: 60,
                 last_updated_secs: Some(5),
+                is_receiving_updates: true,
+                in_use: true,
             },
             ContractSnapshot {
                 key_short: "HOST2...".to_string(),
@@ -1470,6 +1481,8 @@ mod tests {
                 instance_id: "HOST2".to_string(),
                 subscribed_secs: 60,
                 last_updated_secs: Some(5),
+                is_receiving_updates: true,
+                in_use: true,
             },
             // This one is ALSO flagged — should be skipped in the
             // hosted dim-dot loop to avoid a duplicate marker.
@@ -1479,6 +1492,8 @@ mod tests {
                 instance_id: "FLAG1".to_string(),
                 subscribed_secs: 60,
                 last_updated_secs: Some(5),
+                is_receiving_updates: true,
+                in_use: true,
             },
         ];
 
@@ -1581,6 +1596,8 @@ mod tests {
             instance_id: "DEADBEEF".to_string(),
             subscribed_secs: 60,
             last_updated_secs: Some(2),
+            is_receiving_updates: true,
+            in_use: true,
         }];
         let html = build_contracts_card(&Some(snap));
         assert!(
@@ -1619,6 +1636,8 @@ mod tests {
                 instance_id: "FRESH".to_string(),
                 subscribed_secs: 1,
                 last_updated_secs: Some(1),
+                is_receiving_updates: true,
+                in_use: true,
             },
             ContractSnapshot {
                 key_short: "NEVER..".to_string(),
@@ -1626,6 +1645,8 @@ mod tests {
                 instance_id: "NEVER".to_string(),
                 subscribed_secs: 1,
                 last_updated_secs: None,
+                is_receiving_updates: true,
+                in_use: true,
             },
         ];
         let html = build_contracts_card(&Some(snap));
@@ -1637,43 +1658,64 @@ mod tests {
         );
     }
 
-    /// Regression test for the ContractKey/ContractInstanceId
-    /// id-vs-key string mismatch that Codex review of #4298 caught:
-    /// `GovernanceSnapshot.state_by_id` is keyed by
-    /// `ContractInstanceId::to_string()` (the 32-byte content hash),
-    /// while `ContractSnapshot.key_full` is the full `ContractKey`
-    /// encoding (including parameters / code-hash bookkeeping). The
-    /// two strings are NOT equal, so a lookup keyed on `key_full`
-    /// would silently miss every flagged contract.
-    ///
-    /// Pin: with a contract whose `instance_id` differs from
-    /// `key_full` and whose state in `state_by_id` is Banned, the
-    /// rendered row MUST show "banned" (not "ok"). Pre-fix the
-    /// assertion would have failed because the lookup never found
-    /// the entry.
+    /// The Subscribed Contracts table's second column shows the REAL
+    /// per-contract freshness/demand signal, not the retired MAD-governance
+    /// state. `is_receiving_updates` drives the fresh/stale pill (only an
+    /// active subscription keeps the cache current — `is_hosting` is NOT a
+    /// freshness signal, PR #3699); `in_use` drives the in-use/idle pill
+    /// (real demand: a local client or a downstream subscriber).
     #[test]
-    fn contracts_table_gov_column_uses_instance_id_not_key_full() {
-        use crate::node::network_status::{ContractSnapshot, GovernanceStateSnapshot};
+    fn contracts_table_shows_freshness_and_demand_pills() {
+        use crate::node::network_status::ContractSnapshot;
         let mut snap = base_snapshot();
         snap.open_connections = 1;
-        // The critical part: instance_id ≠ key_full. In production
-        // key_full includes the params / code hash so this is the
-        // common case, not an edge.
-        snap.contracts = vec![ContractSnapshot {
-            key_short: "FOO1234...".to_string(),
-            key_full: "FOO1234WITH_PARAMS_AND_CODE_HASH".to_string(),
-            instance_id: "FOO1234".to_string(),
-            subscribed_secs: 60,
-            last_updated_secs: Some(10),
-        }];
-        snap.governance
-            .state_by_id
-            .insert("FOO1234".to_string(), GovernanceStateSnapshot::Banned);
+        snap.contracts = vec![
+            // Fresh + genuinely in use.
+            ContractSnapshot {
+                key_short: "FRESH...".to_string(),
+                key_full: "FRESH_IN_USE".to_string(),
+                instance_id: "FRESH_IN_USE".to_string(),
+                subscribed_secs: 60,
+                last_updated_secs: Some(10),
+                is_receiving_updates: true,
+                in_use: true,
+            },
+            // Not receiving updates and no demand → stale + idle.
+            ContractSnapshot {
+                key_short: "STALE...".to_string(),
+                key_full: "STALE_IDLE".to_string(),
+                instance_id: "STALE_IDLE".to_string(),
+                subscribed_secs: 60,
+                last_updated_secs: None,
+                is_receiving_updates: false,
+                in_use: false,
+            },
+        ];
         let html = build_contracts_card(&Some(snap));
         assert!(
-            html.contains(r#"<span class="gov-pill gov-banned">banned</span>"#),
-            "Gov column lookup must use `instance_id` (not `key_full`) so \
-             state_by_id keys match — got:\n{html}"
+            html.contains(r#"<span class="fresh-pill fresh-ok">fresh</span>"#),
+            "receiving-updates contract must render the fresh pill — got:\n{html}"
+        );
+        assert!(
+            html.contains(r#"<span class="fresh-pill use-active">in use</span>"#),
+            "in-use contract must render the in-use pill — got:\n{html}"
+        );
+        assert!(
+            html.contains(r#"<span class="fresh-pill fresh-stale">stale</span>"#),
+            "non-receiving contract must render the stale pill — got:\n{html}"
+        );
+        assert!(
+            html.contains(r#"<span class="fresh-pill use-idle">idle</span>"#),
+            "no-demand contract must render the idle pill — got:\n{html}"
+        );
+        // The retired governance column must be gone.
+        assert!(
+            !html.contains("gov-pill"),
+            "the retired MAD-governance column must not render — got:\n{html}"
+        );
+        assert!(
+            html.contains(">Freshness<"),
+            "the second column header should now be 'Freshness' — got:\n{html}"
         );
     }
 
@@ -1868,11 +1910,12 @@ mod tests {
     }
 
     #[test]
-    fn governance_card_empty_state_off_mode_is_disabled() {
-        // Regression (#4338 review): with the default mode now Off, the
-        // empty state must NOT claim "scoring activates after N contracts"
-        // — scoring never activates while Off, so that copy is misleading
-        // on every default node. It must say governance is off instead.
+    fn governance_card_hidden_when_off() {
+        // The MAD governance detector is default-Off and is being replaced by
+        // demand-driven eviction (#4296, #4642). On a default (Off) node the
+        // dashboard must NOT render the dormant, superseded governance card at
+        // all — it only ever said "Governance is off" and misled operators.
+        // The demand-driven eviction card surfaces live retention instead.
         let mut snap = base_snapshot();
         snap.governance = GovernanceSnapshot {
             mode: GovernanceModeSnapshot::Off,
@@ -1885,16 +1928,8 @@ mod tests {
         };
         let html = build_governance_card(&Some(snap));
         assert!(
-            html.contains("Governance is off"),
-            "Off empty state must say governance is off — got:\n{html}"
-        );
-        assert!(
-            !html.contains("Scoring activates"),
-            "Off empty state must NOT claim scoring will activate — got:\n{html}"
-        );
-        assert!(
-            html.contains(r#"g-mode g-mode-off">off<"#),
-            "Off empty state must show the off mode pill — got:\n{html}"
+            html.is_empty(),
+            "Off-mode governance card must be hidden entirely — got:\n{html}"
         );
     }
 
@@ -1981,8 +2016,10 @@ mod tests {
 
     #[test]
     fn governance_card_mode_pill_reflects_snapshot_mode() {
+        // Off is hidden entirely (see governance_card_hidden_when_off); only
+        // the explicitly-enabled modes render, and when they do the pill must
+        // reflect the mode.
         for (mode, label) in [
-            (GovernanceModeSnapshot::Off, "off"),
             (GovernanceModeSnapshot::DryRun, "dry-run"),
             (GovernanceModeSnapshot::Enforce, "enforce"),
         ] {
@@ -2002,12 +2039,96 @@ mod tests {
                 "mode pill should reflect {label} — got:\n{html}"
             );
         }
+
+        // And the Off mode renders nothing at all.
+        let mut off = base_snapshot();
+        off.governance = GovernanceSnapshot {
+            mode: GovernanceModeSnapshot::Off,
+            contracts: vec![mk_entry(GovernanceStateSnapshot::Normal, "ok")],
+            norms: NetworkNorms::default(),
+            observed_count: 0,
+            min_samples: 30,
+            last_tick_at: None,
+            state_by_id: std::collections::HashMap::new(),
+        };
+        assert!(
+            build_governance_card(&Some(off)).is_empty(),
+            "Off mode must render no governance card"
+        );
     }
 
     #[test]
     fn governance_card_omits_when_snap_is_none() {
         let html = build_governance_card(&None);
         assert!(html.is_empty());
+    }
+
+    // ─── Demand-driven eviction card (piece A, #4642) ───────────────
+
+    #[test]
+    fn hosting_card_hidden_when_nothing_hosted() {
+        // A fresh/idle node hosts nothing → the card is noise, hide it.
+        let snap = base_snapshot(); // default hosting: contract_count == 0
+        assert!(build_hosting_card(&Some(snap)).is_empty());
+        assert!(build_hosting_card(&None).is_empty());
+    }
+
+    #[test]
+    fn hosting_card_renders_budget_and_eviction_order() {
+        use crate::node::network_status::{HostedContractEntry, HostingSnapshot};
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            budget_bytes: 256 * 1024 * 1024,
+            used_bytes: 64 * 1024 * 1024,
+            contract_count: 2,
+            budget_evictions_total: 3,
+            evictions_of_recently_read_total: 1,
+            // Provider emits rows in eviction order (lowest keep_score first).
+            contracts: vec![
+                HostedContractEntry {
+                    key_full: "VICTIM_FULL".to_string(),
+                    key_short: "VICTIM...".to_string(),
+                    keep_score: 0.10,
+                    predicted_demand: 0.0,
+                    size_bytes: 1024,
+                    read_count: 0,
+                },
+                HostedContractEntry {
+                    key_full: "HOT_FULL".to_string(),
+                    key_short: "HOT...".to_string(),
+                    keep_score: 5.0,
+                    predicted_demand: 4.0,
+                    size_bytes: 2048,
+                    read_count: 42,
+                },
+            ],
+        };
+        let html = build_hosting_card(&Some(snap));
+        assert!(
+            html.contains("Demand-driven eviction"),
+            "card title — got:\n{html}"
+        );
+        assert!(
+            html.contains("64.0 MB / 256.0 MB"),
+            "RAM used/budget tile — got:\n{html}"
+        );
+        // Non-zero recently-read evictions are the miscalibration alarm: colored.
+        assert!(
+            html.contains("var(--danger"),
+            "recently-read eviction count should be highlighted — got:\n{html}"
+        );
+        // The next-to-evict badge attaches to the first (lowest keep_score) row.
+        let victim_idx = html.find("VICTIM_FULL").expect("victim row present");
+        let hot_idx = html.find("HOT_FULL").expect("hot row present");
+        let badge_idx = html.find("next to evict").expect("next-to-evict badge");
+        assert!(
+            victim_idx < hot_idx,
+            "rows must be in eviction order (lowest keep_score first) — got:\n{html}"
+        );
+        assert!(
+            badge_idx > victim_idx && badge_idx < hot_idx,
+            "the next-to-evict badge must be on the victim (first) row — got:\n{html}"
+        );
     }
 
     // ─── Contract ban-list card (#4302) ────────────────────────────
@@ -2081,10 +2202,12 @@ mod tests {
             html.contains("OperatorBannedContract22"),
             "operator-banned contract id must appear — got:\n{html}"
         );
-        // Reasons distinguish AutoMad vs Operator.
+        // Reasons distinguish AutoMad vs Operator. The AutoMad path is
+        // dormant (governance default-Off, being replaced by demand-driven
+        // eviction), so its label is de-emphasized as legacy/dormant.
         assert!(
-            html.contains("auto (governance)"),
-            "AutoMad ban must render an 'auto (governance)' reason — got:\n{html}"
+            html.contains("auto (legacy governance, dormant)"),
+            "AutoMad ban must render the de-emphasized legacy-governance reason — got:\n{html}"
         );
         assert!(
             html.contains(">operator<"),

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2092,6 +2092,7 @@ mod tests {
                     predicted_demand: 0.0,
                     size_bytes: 1024,
                     read_count: 0,
+                    eviction_eligible: true,
                 },
                 HostedContractEntry {
                     key_full: "HOT_FULL".to_string(),
@@ -2100,6 +2101,7 @@ mod tests {
                     predicted_demand: 4.0,
                     size_bytes: 2048,
                     read_count: 42,
+                    eviction_eligible: false,
                 },
             ],
         };
@@ -2128,6 +2130,90 @@ mod tests {
         assert!(
             badge_idx > victim_idx && badge_idx < hot_idx,
             "the next-to-evict badge must be on the victim (first) row — got:\n{html}"
+        );
+    }
+
+    fn mk_hosted_entry(
+        key: &str,
+        keep_score: f64,
+        eviction_eligible: bool,
+    ) -> crate::node::network_status::HostedContractEntry {
+        use crate::node::network_status::HostedContractEntry;
+        HostedContractEntry {
+            key_full: format!("{key}_FULL"),
+            key_short: format!("{key}..."),
+            keep_score,
+            predicted_demand: 0.0,
+            size_bytes: 1024,
+            read_count: 0,
+            eviction_eligible,
+        }
+    }
+
+    #[test]
+    fn hosting_card_badges_first_eligible_row_not_lowest_score() {
+        use crate::node::network_status::HostingSnapshot;
+        // The lowest-keep-score row is eviction-INELIGIBLE (within min_ttl or
+        // in use), so the real over-budget sweep would SKIP it. The badge must
+        // land on the first ELIGIBLE row instead — badging the lowest-score row
+        // would mislabel an eviction-exempt contract (the finding this fixes).
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            budget_bytes: 256 * 1024 * 1024,
+            used_bytes: 300 * 1024 * 1024, // over budget
+            contract_count: 2,
+            budget_evictions_total: 0,
+            evictions_of_recently_read_total: 0,
+            contracts: vec![
+                // Lowest score, but pinned (in use / within TTL) → not eligible.
+                mk_hosted_entry("PINNED", 0.10, false),
+                // Higher score, but actually eligible → this is the real victim.
+                mk_hosted_entry("EVICTABLE", 2.0, true),
+            ],
+        };
+        let html = build_hosting_card(&Some(snap));
+        let pinned_idx = html.find("PINNED_FULL").expect("pinned row present");
+        let evictable_idx = html.find("EVICTABLE_FULL").expect("evictable row present");
+        let badge_idx = html
+            .find("next to evict")
+            .expect("next-to-evict badge present");
+        assert!(
+            badge_idx > evictable_idx,
+            "badge must be on the EVICTABLE (eligible) row, not the pinned \
+             lowest-score row — got:\n{html}"
+        );
+        // The pinned row (rendered first) must NOT carry the badge.
+        assert!(
+            !(badge_idx > pinned_idx && badge_idx < evictable_idx),
+            "the pinned lowest-score row must not be badged — got:\n{html}"
+        );
+    }
+
+    #[test]
+    fn hosting_card_no_badge_when_nothing_eligible() {
+        use crate::node::network_status::HostingSnapshot;
+        // Every hosted contract is within-TTL / in use → the sweep can evict
+        // none of them right now, so NO row is labelled "next to evict".
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            budget_bytes: 256 * 1024 * 1024,
+            used_bytes: 300 * 1024 * 1024,
+            contract_count: 2,
+            budget_evictions_total: 0,
+            evictions_of_recently_read_total: 0,
+            contracts: vec![
+                mk_hosted_entry("A", 0.10, false),
+                mk_hosted_entry("B", 2.0, false),
+            ],
+        };
+        let html = build_hosting_card(&Some(snap));
+        assert!(
+            html.contains("Demand-driven eviction"),
+            "card still renders (hosting > 0) — got:\n{html}"
+        );
+        assert!(
+            !html.contains("next to evict"),
+            "no row may be badged when nothing is eviction-eligible — got:\n{html}"
         );
     }
 

--- a/crates/core/src/server/home_page/assets/home.html
+++ b/crates/core/src/server/home_page/assets/home.html
@@ -35,6 +35,7 @@
         {status_card}
         {peers_card}
         {transfer_card}
+        {hosting_card}
         {governance_card}
         {ban_list_card}
         {contracts_card}

--- a/crates/core/src/server/home_page/assets/style.css
+++ b/crates/core/src/server/home_page/assets/style.css
@@ -1286,6 +1286,54 @@ table.sortable thead th.sort-desc::after {
   color: #d33682;
 }
 
+/* Freshness / demand pills in the Subscribed Contracts table (replaces the
+ * retired MAD-governance column). Same compact shape as `.gov-pill`. */
+.fresh-pill {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  font-size: 0.72rem;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 500;
+  line-height: 1.2;
+}
+.fresh-ok {
+  background: rgba(67, 193, 120, 0.16);
+  color: #43c178;
+}
+.fresh-stale {
+  background: rgba(255, 138, 61, 0.2);
+  color: #ff8a3d;
+}
+.use-active {
+  background: rgba(88, 166, 255, 0.16);
+  color: #58a6ff;
+}
+.use-idle {
+  background: rgba(139, 148, 158, 0.16);
+  color: var(--text-muted, #8b949e);
+}
+
+/* "next to evict" badge on the front row of the Demand-driven eviction
+ * table (the lowest keep-score contract, i.e. the next budget-pressure
+ * victim). */
+.hz-badge {
+  display: inline-block;
+  margin-left: 0.35rem;
+  padding: 0.05rem 0.4rem;
+  font-size: 0.66rem;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 500;
+  vertical-align: middle;
+}
+.hz-next {
+  background: rgba(255, 138, 61, 0.2);
+  color: #ff8a3d;
+}
+
 /* Denominator in the empty-state verdict ("3/30"). Smaller than the
  * numerator so the eye reads the count first and the threshold
  * second. */

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -777,6 +777,18 @@ pub fn build_governance_card(snap: &Option<network_status::NetworkStatusSnapshot
     };
     let g = &snap.governance;
 
+    // Retire the dormant MAD-governance card on default nodes. The MAD-based
+    // `GovernanceManager` is default-Off (see `GovernanceConfig` in
+    // contract/governance.rs) and is being replaced by demand-driven eviction
+    // (#4296, #4642); on a default node it only ever renders "Governance is
+    // off", so hide the card entirely unless an operator has explicitly enabled
+    // governance (DryRun/Enforce). Live retention is surfaced by the
+    // demand-driven eviction card instead. See .claude/rules/hosting-invariants.md
+    // (retention is now demand-driven, not MAD cost/benefit outlier detection).
+    if matches!(g.mode, network_status::GovernanceModeSnapshot::Off) {
+        return String::new();
+    }
+
     let mode_txt = match g.mode {
         network_status::GovernanceModeSnapshot::Off => "off",
         network_status::GovernanceModeSnapshot::DryRun => "dry-run",
@@ -804,17 +816,14 @@ pub fn build_governance_card(snap: &Option<network_status::NetworkStatusSnapshot
     if g.contracts.is_empty() {
         let observed = g.observed_count;
         let needed = g.min_samples;
-        // When governance is Off (the default — see `GovernanceConfig`),
-        // no contract is ever scored, so the ramp-up / "scoring activates"
-        // copy below would be misleading on every default node. Render a
-        // disabled message instead.
-        let is_off = matches!(g.mode, network_status::GovernanceModeSnapshot::Off);
+        // NOTE: this branch is only reachable when governance is explicitly
+        // enabled (DryRun/Enforce) — the default `Off` mode returns an empty
+        // card above, so the ramp-up / "scoring activates" copy below is only
+        // shown to an operator who opted in.
         // Tiny pluralization helper so the user-facing messages
         // don't read "1 contracts" — Codex review nit.
         let plural = |n: usize| if n == 1 { "contract" } else { "contracts" };
-        let progress_msg = if is_off {
-            "Governance is off: contracts are not scored, and nothing is evicted.".to_string()
-        } else if needed == 0 {
+        let progress_msg = if needed == 0 {
             "Governance manager is not yet wired.".to_string()
         } else if observed == 0 {
             format!(
@@ -844,12 +853,7 @@ pub fn build_governance_card(snap: &Option<network_status::NetworkStatusSnapshot
                 n_word = plural(observed),
             )
         };
-        let verdict_main = if is_off {
-            r#"<div class="verdict-num">—</div>
-                   <div class="verdict-headline">Governance off</div>
-                   <div class="verdict-detail">Contracts are not scored or evicted.</div>"#
-                .to_string()
-        } else if observed >= needed {
+        let verdict_main = if observed >= needed {
             format!(
                 r#"<div class="verdict-num">✓</div>
                    <div class="verdict-headline">{observed} contracts within normal range</div>
@@ -1108,6 +1112,107 @@ pub fn build_governance_card(snap: &Option<network_status::NetworkStatusSnapshot
     )
 }
 
+/// Build the demand-driven eviction card (piece A, #4642). Surfaces the
+/// capability-relative RAM budget and the per-contract Greedy-Dual
+/// `keep_score` that ACTUALLY governs retention today — the mechanism that
+/// replaced the dormant MAD `GovernanceManager` (#4296), whose dashboard card
+/// is now hidden on default nodes. Every value comes from
+/// `Ring::dashboard_hosting_snapshot` reading the canonical hosting cache;
+/// nothing is invented at render time. See `.claude/rules/hosting-invariants.md`.
+///
+/// Hidden when the node hosts nothing (a fresh/idle node) — the budget still
+/// exists but there's nothing to retain, so the panel would just be noise.
+pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> String {
+    let Some(snap) = snap else {
+        return String::new();
+    };
+    let h = &snap.hosting;
+    if h.contract_count == 0 {
+        return String::new();
+    }
+
+    let budget = h.budget_bytes.max(1);
+    let used_pct = (h.used_bytes as f64 / budget as f64 * 100.0).min(100.0);
+    let headroom = h.budget_bytes.saturating_sub(h.used_bytes);
+
+    // Recently-read evictions are the miscalibration alarm (#4338): evicting a
+    // repeatedly-requested contract means the demand estimate is mis-ordering
+    // the working set. Color it when non-zero so an operator notices.
+    let recently_read_value = if h.evictions_of_recently_read_total > 0 {
+        format!(
+            r#"<span style="color: var(--danger, #c0392b);">{}</span>"#,
+            h.evictions_of_recently_read_total
+        )
+    } else {
+        "0".to_string()
+    };
+
+    // Per-contract table, bounded. Rows arrive in EVICTION order (next victim
+    // first); show at most MAX_ROWS. The tile carries the full count.
+    const MAX_ROWS: usize = 20;
+    let mut rows = String::new();
+    for (i, c) in h.contracts.iter().take(MAX_ROWS).enumerate() {
+        let next_badge = if i == 0 {
+            r#" <span class="hz-badge hz-next">next to evict</span>"#
+        } else {
+            ""
+        };
+        rows.push_str(&format!(
+            r#"<tr><td title="{full}" data-sort="{full}"><code>{short}</code><button type="button" class="copy-key" data-copy="{full}" title="Copy contract key" aria-label="Copy contract key">⧉</button>{next}</td><td class="right" data-sort="{keep:.6}">{keep:.3}</td><td class="right" data-sort="{demand:.6}">{demand:.3}</td><td class="right" data-sort="{size}">{size_fmt}</td><td class="right" data-sort="{reads}">{reads}</td></tr>"#,
+            full = html_escape(&c.key_full),
+            short = html_escape(&c.key_short),
+            next = next_badge,
+            keep = c.keep_score,
+            demand = c.predicted_demand,
+            size = c.size_bytes,
+            size_fmt = format_bytes(c.size_bytes),
+            reads = c.read_count,
+        ));
+    }
+    let shown = (h.contracts.len()).min(MAX_ROWS);
+    let footer = if (h.contract_count as usize) > shown {
+        format!(
+            r#"<p class="empty" style="margin: 0.4rem 0.9rem 0.6rem; font-size: 0.78rem; color: var(--text-muted, #888);">Showing the {shown} most-evictable of {total} hosted contracts (lowest keep-score first).</p>"#,
+            shown = shown,
+            total = h.contract_count,
+        )
+    } else {
+        String::new()
+    };
+
+    format!(
+        r##"<div class="card">
+            <div class="card-header"><h2>Demand-driven eviction</h2><span class="g-mode g-mode-enforce">piece A</span></div>
+            <p class="empty" style="margin: 0.2rem 0.9rem 0.4rem; font-size: 0.82rem; color: var(--text-muted, #888);">Retention is demand-driven: contracts with the lowest predicted read-demand (keep-score) are evicted first when over the RAM budget.</p>
+            <div class="g-verdict-row">
+                <div class="g-norms">
+                    <div class="g-norm"><div class="g-norm-label">RAM used</div><div class="g-norm-value">{used} / {budget} ({pct:.0}%)</div></div>
+                    <div class="g-norm"><div class="g-norm-label">Headroom</div><div class="g-norm-value">{headroom}</div></div>
+                    <div class="g-norm"><div class="g-norm-label">Hosted</div><div class="g-norm-value">{count}</div></div>
+                    <div class="g-norm"><div class="g-norm-label">Budget evictions</div><div class="g-norm-value">{budget_evictions}</div></div>
+                    <div class="g-norm"><div class="g-norm-label">Evicted w/ demand</div><div class="g-norm-value">{recently_read}</div></div>
+                </div>
+            </div>
+            <div class="table-wrap">
+                <table class="sortable" data-table-id="hosting">
+                    <thead><tr><th data-sort-type="text">Contract</th><th class="right" data-sort-type="num">Keep-score</th><th class="right" data-sort-type="num">Demand</th><th class="right" data-sort-type="num">Size</th><th class="right" data-sort-type="num">Reads</th></tr></thead>
+                    <tbody>{rows}</tbody>
+                </table>
+            </div>
+            {footer}
+        </div>"##,
+        used = format_bytes(h.used_bytes),
+        budget = format_bytes(h.budget_bytes),
+        pct = used_pct,
+        headroom = format_bytes(headroom),
+        count = h.contract_count,
+        budget_evictions = h.budget_evictions_total,
+        recently_read = recently_read_value,
+        rows = rows,
+        footer = footer,
+    )
+}
+
 /// Contract ban-list card (#4302). Surfaces the canonical
 /// `Ring::contract_ban_list` so operators can see whether the Phase 7
 /// hardening mechanism is catching abusers or sitting idle.
@@ -1154,7 +1259,10 @@ pub fn build_ban_list_card(snap: &Option<network_status::NetworkStatusSnapshot>)
         let mut rows = String::new();
         for e in &b.entries {
             let reason_txt = match e.reason {
-                network_status::BanReasonSnapshot::AutoMad => "auto (governance)",
+                // The MAD auto-ban path is dormant (governance default-Off,
+                // being replaced by demand-driven eviction — #4296/#4642), so
+                // in practice only the operator path produces live entries.
+                network_status::BanReasonSnapshot::AutoMad => "auto (legacy governance, dormant)",
                 network_status::BanReasonSnapshot::Operator => "operator",
             };
             let remaining = if e.expires_in_secs == 0 {
@@ -1216,7 +1324,6 @@ pub fn build_contracts_card(snap: &Option<network_status::NetworkStatusSnapshot>
         return String::new();
     }
 
-    let state_by_id = &snap.governance.state_by_id;
     let mut rows = String::new();
     for c in &snap.contracts {
         let last_update = c
@@ -1224,32 +1331,33 @@ pub fn build_contracts_card(snap: &Option<network_status::NetworkStatusSnapshot>
             .map(format_ago)
             .unwrap_or_else(|| "—".to_string());
         let last_update_sort = c.last_updated_secs.unwrap_or(u64::MAX);
-        // Governance state cell. A contract may appear in the
-        // Subscribed Contracts table without being flagged by
-        // governance — in that case the state isn't in `state_by_id`
-        // (the snapshot only carries flagged contracts) and we
-        // render it as "ok". Absence from the table specifically
-        // means "not flagged"; we trust the back-end's `iter_flagged_
-        // scores` filter.
-        let (gov_class, gov_label, gov_sort) = match state_by_id.get(&c.instance_id) {
-            None => ("gov-ok", "ok", 0u8),
-            Some(network_status::GovernanceStateSnapshot::Normal) => ("gov-ok", "ok", 0),
-            Some(network_status::GovernanceStateSnapshot::Borderline) => {
-                ("gov-borderline", "borderline", 1)
-            }
-            Some(network_status::GovernanceStateSnapshot::WouldEvict) => {
-                ("gov-wouldevict", "would evict", 2)
-            }
-            Some(network_status::GovernanceStateSnapshot::Evicted) => ("gov-evicted", "evicted", 3),
-            Some(network_status::GovernanceStateSnapshot::Banned) => ("gov-banned", "banned", 4),
+        // Freshness / demand cell (replaces the retired MAD-governance
+        // column). `is_receiving_updates` is the REAL per-contract freshness
+        // signal — only an active subscription keeps the cached state current
+        // (is_hosting is NOT a freshness signal, PR #3699). `in_use` shows
+        // whether real demand (a local client or a downstream subscriber)
+        // pins the contract, vs. a network-only subscription with no reader.
+        let (fresh_class, fresh_label) = if c.is_receiving_updates {
+            ("fresh-ok", "fresh")
+        } else {
+            ("fresh-stale", "stale")
         };
+        let (use_class, use_label) = if c.in_use {
+            ("use-active", "in use")
+        } else {
+            ("use-idle", "idle")
+        };
+        // Sort healthiest-first: freshness weighs more than in-use demand.
+        let fresh_sort = (c.is_receiving_updates as u8) * 2 + (c.in_use as u8);
         rows.push_str(&format!(
-            r#"<tr><td title="{full}" data-sort="{full}"><code>{short}</code><button type="button" class="copy-key" data-copy="{full}" title="Copy contract key" aria-label="Copy contract key">⧉</button></td><td data-sort="{gov_sort}"><span class="gov-pill {gov_class}">{gov_label}</span></td><td data-sort="{sub_secs}">{subscribed}</td><td data-sort="{last_sort}">{last_update}</td></tr>"#,
+            r#"<tr><td title="{full}" data-sort="{full}"><code>{short}</code><button type="button" class="copy-key" data-copy="{full}" title="Copy contract key" aria-label="Copy contract key">⧉</button></td><td data-sort="{fresh_sort}"><span class="fresh-pill {fresh_class}">{fresh_label}</span> <span class="fresh-pill {use_class}">{use_label}</span></td><td data-sort="{sub_secs}">{subscribed}</td><td data-sort="{last_sort}">{last_update}</td></tr>"#,
             full = html_escape(&c.key_full),
             short = html_escape(&c.key_short),
-            gov_sort = gov_sort,
-            gov_class = gov_class,
-            gov_label = gov_label,
+            fresh_sort = fresh_sort,
+            fresh_class = fresh_class,
+            fresh_label = fresh_label,
+            use_class = use_class,
+            use_label = use_label,
             sub_secs = c.subscribed_secs,
             subscribed = format_ago(c.subscribed_secs),
             last_sort = last_update_sort,
@@ -1262,7 +1370,7 @@ pub fn build_contracts_card(snap: &Option<network_status::NetworkStatusSnapshot>
             <h2>Subscribed Contracts</h2>
             <div class="table-wrap">
                 <table class="sortable" data-table-id="contracts">
-                    <thead><tr><th data-sort-type="text">Contract</th><th data-sort-type="num">Gov</th><th data-sort-type="num">Subscribed</th><th data-sort-type="num">Last Update</th></tr></thead>
+                    <thead><tr><th data-sort-type="text">Contract</th><th data-sort-type="num">Freshness</th><th data-sort-type="num">Subscribed</th><th data-sort-type="num">Last Update</th></tr></thead>
                     <tbody>{rows}</tbody>
                 </table>
             </div>

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1147,13 +1147,23 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
         "0".to_string()
     };
 
-    // Per-contract table, bounded. Rows arrive in EVICTION order (next victim
-    // first); show at most MAX_ROWS. The tile carries the full count.
+    // Per-contract table, bounded. Rows arrive in EVICTION order (lowest
+    // keep-score first); show at most MAX_ROWS. The tile carries the full count.
+    //
+    // The "next to evict" badge marks the first EVICTION-ELIGIBLE row, not
+    // simply the lowest keep-score row: the over-budget sweep SKIPS contracts
+    // that are within `min_ttl` or still in use (`should_retain`), so the
+    // lowest-score row may be one the cache would never actually evict. Badging
+    // it would mislabel an eviction-exempt contract — exactly the "dashboard
+    // misleads the operator" problem this card exists to fix. When nothing is
+    // currently eligible (every hosted contract is within-TTL / in use), no row
+    // is badged.
     const MAX_ROWS: usize = 20;
+    let next_victim_idx = h.contracts.iter().position(|c| c.eviction_eligible);
     let mut rows = String::new();
     for (i, c) in h.contracts.iter().take(MAX_ROWS).enumerate() {
-        let next_badge = if i == 0 {
-            r#" <span class="hz-badge hz-next">next to evict</span>"#
+        let next_badge = if Some(i) == next_victim_idx {
+            r#" <span class="hz-badge hz-next" title="Lowest keep-score among eviction-eligible contracts (past min-TTL and not in use) — the over-budget sweep would evict this one first.">next to evict</span>"#
         } else {
             ""
         };


### PR DESCRIPTION
## Problem

The local peer dashboard (`GET /`) still presented the **old MAD-based `GovernanceManager`** as its retention story, which is misleading on every real node:

- The **"Contract Governance" card** rendered the MAD cost/benefit outlier detector, which is **default-Off** (`contract/governance.rs`) and is being **replaced** by demand-driven eviction (#4296 — it was miscalibrated, flagging a large fraction of a node's contracts, incl. the official River room, as `WouldEvict`). On real nodes it only ever said "Governance is off" — a dormant, superseded mechanism taking prime dashboard space.
- The **"Eviction threshold" tile** (a MAD log-ratio) was actively misleading: zero relation to what actually evicts contracts today.
- **Piece A — the eviction that actually governs retention now** (demand-driven Greedy-Dual `keep_score` + capability-relative RAM budget, shipped 0.2.90; `ring/hosting/{demand,cache}.rs`) was **surfaced nowhere**.
- The Subscribed Contracts table's "Gov" column was always "ok" (fed from the dormant governance `state_by_id`), not a real freshness/demand signal.
- A **stale comment** in `ring.rs` claimed the reaper "defaults to DryRun" when it actually defaults to `Off`.

Ian (project lead) authorized this cleanup.

## Solution

1. **Gate the Contract Governance card** — render it only when governance `mode != Off`, so it vanishes on default nodes but stays for anyone who explicitly enables governance. Removed the now-dead `is_off` empty-state branches.
2. **Fix the stale `ring.rs` comment** (defaults to `Off`, not DryRun).
3. **Replace the always-"ok" Gov column** in Subscribed Contracts with a real **freshness/demand** indicator: `is_receiving_updates` (the true freshness signal — `is_hosting` is not, PR #3699) + `contract_in_use` (real demand). Plumbed two bools through `SubscribedContractSnapshot` / `ContractSnapshot`.
4. **Add a "Demand-driven eviction" card** surfacing piece A: RAM budget used vs headroom, contract count, budget-triggered evictions, the recently-read-eviction miscalibration alarm (#4338), and a per-contract table (keep-score / predicted demand / size / reads) in **eviction order** with a "next to evict" badge on the first **eviction-eligible** row — past `min_ttl` and not in use, i.e. the contract the over-budget sweep would actually evict first; **no badge** when every hosted contract is within-TTL / in use. New `HostingSnapshot` provider reads the canonical hosting cache (no mirror); new `HostingCache::eviction_ordered_scores()` accessor.
5. **De-emphasize** the dormant "auto (governance)" ban reason (only the operator path is live).

**Eviction-eligibility (review follow-up, P2):** the over-budget sweep (`evict_over_budget`) skips contracts that are within `min_ttl` or pinned by demand (`should_retain` / `contract_in_use`), so the raw lowest-keep-score row is not necessarily the one the cache would evict. The badge now marks the first **eligible** row: the cache reports `past_min_ttl` per contract, `HostingManager::is_eviction_eligible` folds in `!contract_in_use`, and the renderer badges the first eligible row (or none). This keeps the "next to evict" label from mislabelling an eviction-exempt contract.

**Deadlock safety (by construction):** the subscription-snapshot booleans are computed in a second pass *after* the `active_subscriptions` iterator's shard guards drop — `is_receiving_updates` re-`.get()`s that same DashMap, which would same-shard deadlock if called inside the iterator. This is prevented **by construction** (the two-phase split), *not* by a test: the regression test `dashboard_subscription_snapshot_reports_freshness_and_demand` characterizes the two-phase **output** (field correctness), but in a single-threaded, no-concurrent-writer test a re-inlined same-shard read would still pass — so it does not itself catch the deadlock. The guard against re-inlining is the load-bearing code comment in `dashboard_subscription_snapshot`. The same two-phase, lock-released-first shape is used for the eviction-eligibility fold (`is_eviction_eligible` reads only the subscription maps; the `hosting_cache` read guard is already released).

### Deferred (noted for follow-up, not in this first slice)
- `eviction_floor` value and live (recomputed) per-contract demand (`distance_and_demand` is private) — the card uses the stored `keep_score`/`predicted_demand` captured at last refresh.
- `abandoned_at` surfacing; exporting the piece-C consult counters (#4658).
- Since every row in the Subscribed Contracts table is by construction an active subscription, `is_receiving_updates` is ~always true there — the varying signal in that table is `in_use`. `is_receiving_updates` still renders as an explicit freshness confirmation and would surface any future divergence.

## Testing

- `governance_card_hidden_when_off` / updated `governance_card_mode_pill_reflects_snapshot_mode` — Off renders nothing.
- `contracts_table_shows_freshness_and_demand_pills` — fresh/stale + in-use/idle pills replace the retired gov column.
- `hosting_card_hidden_when_nothing_hosted` / `hosting_card_renders_budget_and_eviction_order` — budget tiles, recently-read alarm, next-to-evict on the first eviction-eligible row.
- `hosting_card_badges_first_eligible_row_not_lowest_score` / `hosting_card_no_badge_when_nothing_eligible` (P2) — the badge follows eligibility, not raw keep-score order, and disappears when nothing is eligible.
- `dashboard_is_eviction_eligible_matches_sweep_skip_filter` (manager) — `is_eviction_eligible` combines the `past_min_ttl` age gate and the `!contract_in_use` pin, matching the real sweep skip filter.
- `eviction_ordered_scores_flags_past_min_ttl_after_ttl_elapses` (cache) — the `past_min_ttl` flag flips false→true once the entry ages past `min_ttl`.
- `dashboard_subscription_snapshot_reports_freshness_and_demand` (backend) — characterizes the two-phase snapshot output (see the deadlock-safety note; deadlock-safety itself is by construction).
- `eviction_ordered_scores_matches_key_order_and_carries_fields` (cache accessor).
- Updated ban-list reason assertion.
- `cargo fmt` + `clippy` clean on changed code; full `home_page` / `ring::hosting` / `node::network_status` unit suites green.

Draft: needs review + Ian's eyes on the dashboard before merge. No auto-merge.

Refs #4642, #4296
Closes #4676

[AI-assisted - Claude]
