### PR TITLE
fix: require sustained health before gateway-update verify success

### DIFF
--- a/.github/workflows/gateway-update.yml
+++ b/.github/workflows/gateway-update.yml
@@ -263,6 +263,15 @@ jobs:
           # Remember if we ever saw the old-agent (no service_active) response,
           # so the deadline error can point at the real cause.
           SAW_FALLBACK=false
+          # #4567: require the gateway to report `success` on this many
+          # CONSECUTIVE polls before declaring the update converged. Confirming
+          # health at a single instant let a gateway that came up active then
+          # died within the window (flap-after-up) still report green. The
+          # release-agent's 2s service_active TTL cache means a crash-loop flaps
+          # the field across the 5s polls, resetting the streak. Cost on the
+          # happy path: (REQUIRED_SUCCESS_POLLS-1)*5s ≈ 10s.
+          REQUIRED_SUCCESS_POLLS=3
+          SUCCESS_STREAK=0
           while (( $(date +%s) < DEADLINE )); do
             RESPONSE=$(curl -sS --max-time 5 "$GATEWAY_URL/version" || true)
             INSTALLED=$(printf '%s' "$RESPONSE" | jq -r '.version // empty' 2>/dev/null || echo "")
@@ -271,8 +280,12 @@ jobs:
 
             case "$DECISION" in
               success)
-                echo "✓ Gateway ${{ matrix.gateway.name }} reports version $INSTALLED and service ${MANAGED_SERVICE:-?} is active"
-                exit 0
+                SUCCESS_STREAK=$(stability_streak "$DECISION" "$SUCCESS_STREAK")
+                if [[ "$(stability_confirmed "$SUCCESS_STREAK" "$REQUIRED_SUCCESS_POLLS")" == "confirm" ]]; then
+                  echo "✓ Gateway ${{ matrix.gateway.name }} reports version $INSTALLED and service ${MANAGED_SERVICE:-?} is active (stable across $SUCCESS_STREAK consecutive polls)"
+                  exit 0
+                fi
+                echo "Gateway ${{ matrix.gateway.name }} reports version $INSTALLED and service ${MANAGED_SERVICE:-?} active ($SUCCESS_STREAK/$REQUIRED_SUCCESS_POLLS consecutive healthy polls); confirming stability…"
                 ;;
               success-fallback)
                 # The agent predates the service_active field, so we cannot
@@ -291,11 +304,17 @@ jobs:
                   echo "✓ Gateway ${{ matrix.gateway.name }} now reports version $INSTALLED (binary-only check)"
                   exit 0
                 fi
+                # Not confirmed as active this poll → break any success streak.
+                SUCCESS_STREAK=0
                 SAW_FALLBACK=true
                 echo "::warning::Gateway ${{ matrix.gateway.name }} agent predates the service-health check (no 'service_active' in /version); cannot confirm the service is actually running. Update the release-agent (>= the #4378 build) to enable the service-health gate, or re-run with allow_binary_only_fallback=true to accept binary-only verification."
                 echo "Binary is $INSTALLED but service health is UNVERIFIABLE on this agent; treating as not-yet-converged…"
                 ;;
               wait)
+                # A non-success poll (service not active, unreachable, or
+                # malformed) breaks the consecutive-success streak (#4567): a
+                # gateway that flaps active→down cannot accumulate the run.
+                SUCCESS_STREAK=0
                 if [[ "$INSTALLED" == "$VERSION" ]]; then
                   echo "Binary is $INSTALLED but service ${MANAGED_SERVICE:-?} is NOT active yet; waiting for restart…"
                 else

--- a/scripts/release-agent/verify-version-decision.sh
+++ b/scripts/release-agent/verify-version-decision.sh
@@ -97,3 +97,57 @@ fallback_decision() {
         echo "hold"
     fi
 }
+
+# Stability gate for the "Verify version after update" poll (#4567). Extracted
+# here (rather than inline in gateway-update.yml) so the consecutive-success
+# semantics are unit-tested and cannot silently regress.
+#
+# WHY: the verify loop used to `exit 0` on the FIRST poll that produced a
+# `success` token. That confirms health at a single instant only, so a gateway
+# that comes up `active` and then dies within the remaining verify window
+# (flap-after-up: the racing-updater shape from the nova v0.2.78 incident, or a
+# crash-loop that happens to be up on the first poll) was still reported green.
+# Requiring N CONSECUTIVE `success` polls exploits the release-agent's 2s
+# service_active TTL cache: a crash-loop flaps service_active across polls, so
+# the streak resets and the update is not confirmed until the deadline fails it
+# closed.
+#
+# Usage (per poll):
+#   streak=$(stability_streak "$DECISION" "$streak")   # updated running count
+#   if [[ "$(stability_confirmed "$streak" "$REQUIRED")" == "confirm" ]]; then
+#       exit 0
+#   fi
+#
+# stability_streak echoes the new consecutive-success count: the previous count
+# + 1 on a `success` token, otherwise 0 (any non-success poll — wait,
+# unreachable, malformed — breaks the streak). Resetting on non-success is what
+# catches flap-after-up: an up→down sequence cannot accumulate the required run.
+# A normal restart gap happens BEFORE the first success (the service is down
+# while the binary is swapped), so it only delays the start of the streak; it
+# does not reset a streak already in progress. A restart AFTER first success
+# simply restarts the count within the same budget — failing closed only at the
+# deadline, which is the conservative, correct behaviour.
+stability_streak() {
+    local token="$1" prev="$2"
+    if [[ "$token" == "success" ]]; then
+        echo $(( prev + 1 ))
+    else
+        echo 0
+    fi
+}
+
+# stability_confirmed echoes `confirm` once the streak has reached the required
+# number of consecutive successes, otherwise `keep-polling`. `required` <= 0 is
+# treated as 1 (a misconfiguration must not disable the gate entirely — at least
+# one success is always needed).
+stability_confirmed() {
+    local streak="$1" required="$2"
+    if (( required < 1 )); then
+        required=1
+    fi
+    if (( streak >= required )); then
+        echo "confirm"
+    else
+        echo "keep-polling"
+    fi
+}

--- a/scripts/release-agent/verify-version-decision_test.sh
+++ b/scripts/release-agent/verify-version-decision_test.sh
@@ -134,6 +134,103 @@ check_fallback "success-fallback + allow=true → accept (explicit opt-in)" \
 check_fallback "wait token + allow=true → hold (only success-fallback can accept)" \
     "wait" "true" "hold"
 
+# ── stability gate: consecutive-success requirement (#4567) ───────────
+#
+# The verify loop must require N CONSECUTIVE `success` polls before declaring
+# convergence, so a gateway that comes up active then dies within the window
+# (flap-after-up) is NOT reported green off a single lucky poll.
+
+# Assertion dispatcher: `check <kind> <description> <args...>`.
+# `kind` selects the function under test (streak | confirmed | replay).
+# Kept as a single `check` front-door so the assertions read uniformly and
+# stay visible to the fix:-PR regression-test lint (ci.yml counts added
+# `check ` lines in *_test.sh self-tests).
+check() {
+    local kind="$1" desc="$2"; shift 2
+    local expected actual
+    case "$kind" in
+        streak)
+            # check streak <description> <token> <prev> <expected-new-streak>
+            expected="$3"
+            actual=$(stability_streak "$1" "$2")
+            ;;
+        confirmed)
+            # check confirmed <description> <streak> <required> <expected>
+            expected="$3"
+            actual=$(stability_confirmed "$1" "$2")
+            ;;
+        replay)
+            # check replay <description> <expected> <required> <token...>
+            expected="$1"; shift
+            actual=$(replay_confirms "$@")
+            ;;
+        *)
+            echo "FAIL - unknown check kind '$kind'" >&2
+            FAILURES=$((FAILURES + 1))
+            return
+            ;;
+    esac
+    if [[ "$actual" == "$expected" ]]; then
+        echo "ok   - $desc"
+    else
+        echo "FAIL - $desc (got '$actual', expected '$expected')" >&2
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# stability_streak: success increments, anything else resets to 0.
+check streak "success increments the streak" "success" "1" "2"
+check streak "success from 0 starts the streak" "success" "0" "1"
+check streak "wait resets the streak (flap-after-up)" "wait" "2" "0"
+check streak "success-fallback resets the streak" "success-fallback" "2" "0"
+
+# stability_confirmed: confirm only once the streak reaches the requirement.
+check confirmed "below requirement → keep polling" "1" "3" "keep-polling"
+check confirmed "one short → keep polling" "2" "3" "keep-polling"
+check confirmed "at requirement → confirm" "3" "3" "confirm"
+check confirmed "above requirement → confirm" "4" "3" "confirm"
+# Misconfiguration guard: required<1 must still demand at least one success
+# (never confirm on a zero streak — that would disable the gate entirely).
+check confirmed "required=0 clamped to 1: zero streak → keep polling" "0" "0" "keep-polling"
+check confirmed "required=0 clamped to 1: one success → confirm" "1" "0" "confirm"
+
+# ── end-to-end poll sequences: the load-bearing #4567 assertions ──────
+#
+# Replays a sequence of /version responses through the SAME streak logic the
+# workflow runs, asserting whether the update would be confirmed within the
+# window. `confirmed` is true iff the streak reaches REQUIRED at any poll.
+replay_confirms() {
+    # replay_confirms <required> <token...> → echoes "yes" or "no"
+    local required="$1"; shift
+    local streak=0 token
+    for token in "$@"; do
+        streak=$(stability_streak "$token" "$streak")
+        if [[ "$(stability_confirmed "$streak" "$required")" == "confirm" ]]; then
+            echo "yes"
+            return 0
+        fi
+    done
+    echo "no"
+}
+
+# THE bug: up on the first poll, then dies → must NOT confirm (was the latch).
+check replay "flap-after-up (success then dead) must NOT confirm" \
+    "no" 3 success wait wait wait wait
+# Sustained health → confirms.
+check replay "sustained up (3 consecutive) confirms" \
+    "yes" 3 success success success
+# A single transient false DURING convergence must not permanently fail: the
+# streak resets but a subsequent sustained run still confirms.
+check replay "transient false mid-convergence then sustained-up confirms" \
+    "yes" 3 wait success wait success success success
+# Crash-loop that keeps flapping never accumulates the run → never confirms
+# (fails closed at the deadline in the workflow).
+check replay "crash-loop flapping never confirms" \
+    "no" 3 success wait success wait success wait
+# Normal restart gap BEFORE first success only delays the streak start.
+check replay "restart gap before first success still confirms" \
+    "yes" 3 wait wait success success success
+
 # ── result ────────────────────────────────────────────────────────────
 
 if (( FAILURES > 0 )); then


### PR DESCRIPTION
## Problem

`gateway-update.yml`'s post-update verify loop `exit 0`s on the **first** poll where `/version` reports `version == target && service_active == true` (`.github/workflows/gateway-update.yml:272-276`). Service health is confirmed at a single instant, so a gateway that comes up `active` and then dies within the remaining ~120s window — the racing-updater / crash-loop shape from the original nova v0.2.78 incident — is still reported as a **successful** update (flap-after-up).

Follow-up to #4492 (fixed by #4494); this residual was outside #4492's documented three-link scope. Defense-in-depth, not a reopening.

## Solution

Require `REQUIRED_SUCCESS_POLLS` (=3) **consecutive** `success` polls before `exit 0`. Any non-success poll resets the streak, so an active→dead sequence can never accumulate the run and fails closed at the deadline. This exploits the release-agent's 2s `service_active` TTL cache: a crash-loop reliably surfaces a non-success poll across the 5s poll interval.

The consecutive-success logic is added as two sourceable functions (`stability_streak`, `stability_confirmed`) in `verify-version-decision.sh`, mirroring the existing `verify_version_decision`/`fallback_decision` pattern so the semantics are unit-tested and shared with the workflow. A normal restart gap (service down during binary swap) precedes the first success and never resets an in-progress streak; a healthy convergence with one transient false still confirms.

## Testing

Extended `verify-version-decision_test.sh` (CI-wired) with unit tests for `stability_streak`/`stability_confirmed` plus end-to-end poll-sequence replays: flap-after-up (success→dead) must NOT confirm; sustained 3-consecutive confirms; transient-false-mid-convergence then sustained-up confirms; crash-loop flapping never confirms; restart-gap-before-first-success still confirms. Reproduced the original bug: `required=1` (old latch) confirms flap-after-up, `required=3` does not. All 29 tests pass; `shellcheck -x` clean; workflow YAML validated.

## Fixes

Fixes #4567