### PR TITLE
fix(release-agent): gate River announce on the node reaching target version

### DIFF
--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -141,6 +141,7 @@ jobs:
         env:
           SECRET: ${{ secrets.RELEASE_AGENT_HMAC_NOVA }}
           MESSAGE: ${{ needs.resolve.outputs.message }}
+          VERSION: ${{ needs.resolve.outputs.version }}
         run: |
           set -euo pipefail
           if [[ -z "$SECRET" ]]; then
@@ -148,10 +149,19 @@ jobs:
             exit 0
           fi
           ISSUED_AT=$(date +%s)
+          # Forward the already-resolved target version so the nova
+          # release-agent can gate the River post on the RESTARTED node
+          # reporting this version (issue #4496). release-announce.yml and
+          # gateway-update.yml both fire on `release: published` with no
+          # ordering, so without the version the announce can read the room off
+          # the OLD node moments before the concurrent self-update tears it
+          # down. The agent re-validates VERSION as strict semver before
+          # forwarding it to announce-to-river.sh.
           BODY=$(jq -nc \
             --arg msg "$MESSAGE" \
+            --arg ver "$VERSION" \
             --argjson t "$ISSUED_AT" \
-            '{message: $msg, issued_at: $t}')
+            '{message: $msg, issued_at: $t, version: $ver}')
           SIG=$(printf '%s' "$BODY" \
             | openssl dgst -sha256 -mac HMAC -macopt "hexkey:$SECRET" \
             | awk '{print $NF}')

--- a/crates/release-agent/src/announcer.rs
+++ b/crates/release-agent/src/announcer.rs
@@ -53,11 +53,20 @@ impl Announcer {
     /// the script either kept running past the 1s probe or exited 0 within
     /// it; returns `Err` for immediate non-zero exit so the HTTP layer
     /// returns 500 and the caller can retry.
-    pub async fn run(&self, message: &str) -> Result<()> {
+    ///
+    /// `target_version`, when `Some`, is the release version this
+    /// announcement is for (bare semver, no leading `v`). It is appended to the
+    /// script's argv as `--target-version <v>` (see below for why a flag rather
+    /// than an env var) so `announce-to-river.sh` can gate the post on the
+    /// RESTARTED node reporting that version — the deterministic fix for the
+    /// #4496 announce/update race. `None` (a caller that predates the plumbing)
+    /// omits the flag and the script falls back to its read-streak heuristic.
+    pub async fn run(&self, message: &str, target_version: Option<&str>) -> Result<()> {
         if self.dry_run {
             tracing::info!(
                 command = %self.command.display(),
                 len = message.len(),
+                target_version = target_version.unwrap_or("<none>"),
                 "dry-run: would invoke `sudo -n -u {} {} <message>`",
                 self.run_as_user,
                 self.command.display()
@@ -68,15 +77,29 @@ impl Announcer {
         tracing::info!(
             command = %self.command.display(),
             len = message.len(),
+            target_version = target_version.unwrap_or("<none>"),
             "spawning announce command"
         );
 
-        let mut child = Command::new(&self.sudo_command)
-            .arg("--non-interactive")
+        let mut cmd = Command::new(&self.sudo_command);
+        cmd.arg("--non-interactive")
             .arg("-u")
-            .arg(&self.run_as_user)
-            .arg(&self.command)
-            .arg(message)
+            .arg(&self.run_as_user);
+        // The target version is forwarded as a `--target-version <v>` flag on
+        // the SCRIPT's own argv, not via env. The sudoers rule pins the
+        // command to the script path with a trailing `*` wildcard that matches
+        // the whole argv, so extra script arguments are allowed — but a
+        // `sudo env VAR=... script` prefix would change the matched command to
+        // `env` and break the sudoers match, and sudo strips the process
+        // environment by default so a plain `.env()` would not survive either.
+        // Passing it as a script flag keeps the sudoers match on the script
+        // and reaches the shell as a normal positional (no shell eval — each
+        // `.arg` is its own execve slot).
+        cmd.arg(&self.command).arg(message);
+        if let Some(v) = target_version {
+            cmd.arg("--target-version").arg(v);
+        }
+        let mut child = cmd
             .stdin(Stdio::null())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
@@ -122,7 +145,7 @@ mod tests {
     #[tokio::test]
     async fn dry_run_does_not_execute() {
         let a = Announcer::new_with_sudo(PathBuf::from("/nonexistent/announce.sh"), true, "nobody");
-        a.run("test message")
+        a.run("test message", Some("0.2.90"))
             .await
             .expect("dry_run must not invoke");
     }

--- a/crates/release-agent/src/server.rs
+++ b/crates/release-agent/src/server.rs
@@ -100,6 +100,14 @@ pub struct UpdateRequest {
 pub struct AnnounceRequest {
     pub message: String,
     pub issued_at: i64,
+    /// Release version this announcement is for (bare semver, no leading `v`).
+    /// Optional for backward compatibility with older callers; when present it
+    /// is forwarded to `announce-to-river.sh` so the script gates the post on
+    /// the restarted node reporting this version — the deterministic fix for
+    /// the #4496 announce/update race. Validated as strict semver before it
+    /// leaves this handler.
+    #[serde(default)]
+    pub version: Option<String>,
 }
 
 /// Successful response from `POST /announce/river`.
@@ -449,7 +457,30 @@ async fn announce_river_handler(
         }
     }
 
-    if let Err(e) = state.announcer.run(&req.message).await {
+    // Validate the optional target version as strict semver before it reaches
+    // the script. A malformed value must not be forwarded (the script would
+    // then wait forever for a version the node can never report). Rejecting
+    // here keeps the version-gate #4496 fix well-defined and gives the caller
+    // a clear 400 rather than a silent late failure in journald.
+    let target_version = match req.version.as_deref() {
+        Some(raw) => {
+            let normalized = raw.strip_prefix('v').unwrap_or(raw);
+            match Version::parse(normalized) {
+                Ok(v) => Some(v.to_string()),
+                Err(e) => {
+                    return (StatusCode::BAD_REQUEST, format!("bad version {raw:?}: {e}"))
+                        .into_response();
+                }
+            }
+        }
+        None => None,
+    };
+
+    if let Err(e) = state
+        .announcer
+        .run(&req.message, target_version.as_deref())
+        .await
+    {
         tracing::error!(error = %e, "announcer spawn failed");
         // Same contract as /update: failure does NOT consume the window.
         return (

--- a/crates/release-agent/tests/update_handler.rs
+++ b/crates/release-agent/tests/update_handler.rs
@@ -1053,6 +1053,22 @@ fn signed_announce(secret: &[u8], message: &str, issued_at: i64) -> (String, Str
     (body, sig)
 }
 
+fn signed_announce_with_version(
+    secret: &[u8],
+    message: &str,
+    version: &str,
+    issued_at: i64,
+) -> (String, String) {
+    let body = serde_json::to_string(&json!({
+        "message": message,
+        "issued_at": issued_at,
+        "version": version,
+    }))
+    .unwrap();
+    let sig = sign(secret, body.as_bytes());
+    (body, sig)
+}
+
 #[tokio::test]
 async fn announce_disabled_returns_503_with_valid_signature() {
     // The default-built Harness has an unconfigured announcer (empty
@@ -1154,6 +1170,75 @@ async fn announce_happy_path() {
     // Drain the in-flight stub child before the Harness/TempDir drops, so the
     // still-sleeping announce script isn't deleted out from under it.
     poll_file_nonempty(&done_marker).await;
+}
+
+#[tokio::test]
+async fn announce_forwards_target_version_as_flag() {
+    // #4496 plumbing: a request carrying `version` must reach the script as a
+    // trailing `--target-version <v>` flag on argv (so announce-to-river.sh can
+    // run its version-aware readiness gate). A leading `v` in the request is
+    // normalized off before forwarding.
+    let tmp = tempfile::tempdir().unwrap();
+    let record = tmp.path().join("argv.log");
+    let done_marker = tmp.path().join("done.log");
+    let announce_script = format!(
+        "#!/bin/sh\nsleep 1.5\necho done > {}\n",
+        done_marker.display()
+    );
+    let h = build_with_announcer(&announce_script, &record).await;
+    let (body, sig) =
+        signed_announce_with_version(&h.secret, "Freenet v0.2.90 released", "v0.2.90", now_secs());
+    let resp = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig)
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status() == 200 || resp.status() == 202,
+        "got {}",
+        resp.status()
+    );
+    let recorded_full = {
+        // record.full is written by the fake-sudo wrapper; poll the primary
+        // record first to ensure both files exist.
+        poll_file_nonempty(&record).await;
+        std::fs::read_to_string(format!("{}.full", record.display()))
+            .expect("fake-sudo recorded full argv")
+    };
+    let full = recorded_full.trim();
+    // The message keeps its own `v`; the forwarded flag is normalized to bare
+    // semver. Pinning the exact suffix proves the flag is LAST (after the
+    // message positional) and semver-normalized.
+    assert!(
+        full.ends_with(" Freenet v0.2.90 released --target-version 0.2.90"),
+        "argv must end with the message then the normalized --target-version flag, got: {full:?}"
+    );
+    poll_file_nonempty(&done_marker).await;
+}
+
+#[tokio::test]
+async fn announce_rejects_malformed_target_version() {
+    // A non-semver `version` must be rejected with 400 BEFORE spawning the
+    // script: forwarding garbage would make the script wait out its whole
+    // budget for a version the node can never report.
+    let tmp = tempfile::tempdir().unwrap();
+    let record = tmp.path().join("argv.log");
+    let h = build_with_announcer("#!/bin/sh\nexit 0\n", &record).await;
+    let (body, sig) = signed_announce_with_version(&h.secret, "hello", "not-a-version", now_secs());
+    let resp = reqwest::Client::new()
+        .post(format!("{}/announce/river", h.base))
+        .header(HEADER_SIGNATURE.as_str(), &sig)
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        400,
+        "a malformed target version must be rejected, not forwarded"
+    );
 }
 
 #[tokio::test]

--- a/scripts/release-agent/announce-to-river.sh
+++ b/scripts/release-agent/announce-to-river.sh
@@ -46,15 +46,70 @@ LOG_FILE="${LOG_FILE:-}"
 # READ_PROBE_TIMEOUT keeps the worst case bounded: roughly
 # ATTEMPTS * (READ_PROBE_TIMEOUT + INTERVAL). With the defaults that is
 # ~60 * (15s + 5s) = ~20 min worst case if the node never recovers, while the
-# happy path (room readable) returns in well under a second. The budget is
-# comfortably over the ~90s gateway down-window observed on the v0.2.61
-# release. Overridable (e.g. NODE_WAIT_INTERVAL=0 in tests).
+# happy path returns quickly once the node is ready. The budget is comfortably
+# over the ~90s gateway down-window observed on the v0.2.61 release.
+#
+# Happy-path cost differs by readiness mode (see wait_for_room()):
+#   - Version-aware (#4496): the gate returns on the FIRST attempt where the
+#     node reports the target version AND the room reads — one extra cheap
+#     `freenet --version` fork per probe, negligible next to the room GET.
+#   - Streak fallback: the gate needs READ_STABLE_COUNT (default 3) consecutive
+#     successful reads, so the happy path costs up to ~READ_STABLE_COUNT extra
+#     room reads / intervals (a few seconds at the defaults) beyond a single
+#     success. Both are well within the budget above.
+# Overridable (e.g. NODE_WAIT_INTERVAL=0 in tests).
 NODE_WAIT_ATTEMPTS="${NODE_WAIT_ATTEMPTS:-60}"
 NODE_WAIT_INTERVAL="${NODE_WAIT_INTERVAL:-5}"
 # Per-probe timeout for each room read (readiness probe and post-send verify).
 # Bounds the legacy-generation walk a failing GET performs during the
 # down-window; the happy-path read is far faster. Overridable in tests.
 READ_PROBE_TIMEOUT="${READ_PROBE_TIMEOUT:-15}"
+# Target release version this announcement is for, WITHOUT a leading `v`
+# (e.g. "0.2.90"). Plumbed end-to-end from release-announce.yml's `resolve`
+# job → the nova release-agent (ANNOUNCE_TARGET_VERSION env on the sudo
+# invocation) → here. This is the #4496 fix: it lets wait_for_room() gate the
+# post on the RESTARTED node reporting the TARGET version, deterministically
+# closing the race instead of merely narrowing it with a read-streak heuristic.
+#
+# release-announce.yml and gateway-update.yml both fire on the same
+# `release: published` event with no ordering between them. Without the target
+# version, an early room read served by the OLD node (moments before the
+# concurrent gateway self-update stops the service) looks identical to a read
+# served by the restarted node, so the announce can drop straight into the
+# teardown window it was meant to ride out. With the target version we require
+# the running node's version to EQUAL the target before proceeding — and the
+# gateway update deploys stop→swap-binary→start, so while the old node still
+# serves the room the on-disk binary is still the OLD version. The old-node
+# read therefore fails the version gate and the poll waits for the restart.
+#
+# Empty (the default, and what a legacy release-agent that predates this
+# plumbing passes) falls back to the READ_STABLE_COUNT streak heuristic below,
+# which narrows but does not fully close the race — see wait_for_room().
+ANNOUNCE_TARGET_VERSION="${ANNOUNCE_TARGET_VERSION:-}"
+# Strip an accidental leading `v` so "v0.2.90" and "0.2.90" both work.
+ANNOUNCE_TARGET_VERSION="${ANNOUNCE_TARGET_VERSION#v}"
+# Command whose `--version` output reports the version of the LOCALLY RUNNING
+# freenet node. The gateway update swaps this on-disk binary during the
+# restart, so once it reports the target version the swap has completed. The
+# node runs from this same binary, so its version is the running node's
+# version once the service has been restarted onto it. Overridable in tests
+# (stubbed) and for non-default install layouts.
+FREENET_BIN="${FREENET_BIN:-freenet}"
+# Number of CONSECUTIVE successful room reads wait_for_room() must observe
+# before it declares the node ready when NO target version is available
+# (legacy fallback path only). A single successful read is NOT enough: an
+# early read can be served by the OLD node before the concurrent gateway
+# self-update stops the service (issue #4496). Requiring several successes
+# SPANNING at least one NODE_WAIT_INTERVAL means a teardown that begins after
+# the first probe resets the streak. This is a HEURISTIC — it narrows the race
+# but cannot fully close it (a teardown that has not yet begun when the streak
+# completes is not caught). The version gate above is the real fix; this only
+# runs when the target version was not plumbed through. Overridable in tests.
+#
+# INVARIANT: READ_STABLE_COUNT must be <= NODE_WAIT_ATTEMPTS, otherwise the
+# streak can never reach threshold and wait_for_room() would always fail on
+# the fallback path. Clamped at use (see wait_for_room()).
+READ_STABLE_COUNT="${READ_STABLE_COUNT:-3}"
 # Set to any non-empty value to skip the post-send convergence re-read (the
 # read that confirms the message actually landed in room state). Off by
 # default; primarily a test hook.
@@ -153,8 +208,41 @@ verify_converged() {
     grep -qF -- "$MESSAGE" <<<"$listing"
 }
 
-# Poll until the room is actually READABLE, or NODE_WAIT_ATTEMPTS is reached.
-# Returns 0 once a room GET succeeds, 1 if it never did.
+# Report the version of the locally running freenet node by parsing
+# `FREENET_BIN --version`. Echoes a bare semver (e.g. "0.2.90") on stdout, or
+# nothing if the binary is missing / the output is unparseable (treated by the
+# caller as "not yet the target"). Never fails the script.
+node_version() {
+    local out
+    out="$("$FREENET_BIN" --version 2>/dev/null)" || return 0
+    grep -oE '[0-9]+\.[0-9]+\.[0-9]+' <<<"$out" | head -1
+}
+
+# Poll until the local node is ready to receive the announcement, or
+# NODE_WAIT_ATTEMPTS is reached. Returns 0 once ready, 1 if it never became
+# ready within the budget.
+#
+# Readiness has two definitions depending on whether the TARGET VERSION was
+# plumbed through (ANNOUNCE_TARGET_VERSION):
+#
+#   1. Version-aware (the #4496 fix, taken whenever ANNOUNCE_TARGET_VERSION is
+#      set): ready == the running node reports the target version AND the room
+#      is readable. release-announce.yml and gateway-update.yml fire on the
+#      same `release: published` event with no ordering, so an early room read
+#      can be served by the OLD node moments before the concurrent gateway
+#      self-update stops the service. But the update deploys
+#      stop→swap-binary→start, so while the OLD node still serves the room the
+#      on-disk binary is still the OLD version — the version check rejects that
+#      read and the poll waits for the restarted, target-version node. This
+#      closes the race deterministically rather than heuristically.
+#
+#   2. Streak fallback (only when ANNOUNCE_TARGET_VERSION is empty — e.g. a
+#      release-agent that predates the version plumbing): ready == the room has
+#      been readable for READ_STABLE_COUNT consecutive probes. This narrows the
+#      race (a teardown beginning after an early success resets the streak) but
+#      does NOT fully close it: if teardown has not yet begun when the streak
+#      completes, the read still runs against the old node. It is a best-effort
+#      heuristic for the legacy path, not a guarantee.
 #
 # A WS-port check is NOT sufficient. A release announcement runs concurrently
 # with the gateway update that restarts the local node (down ~90s, issue
@@ -181,18 +269,62 @@ verify_converged() {
 # acceptable; surfacing late failures to the workflow would need a
 # release-agent change.
 wait_for_room() {
-    local attempt
+    local attempt streak=0 stable_count="$READ_STABLE_COUNT"
+    # Clamp the streak threshold to the attempt budget. A configuration with
+    # READ_STABLE_COUNT > NODE_WAIT_ATTEMPTS could never reach the streak, so
+    # the fallback path would ALWAYS fail regardless of node health. Clamping
+    # keeps the gate satisfiable; the version-aware path does not use it.
+    if (( stable_count > NODE_WAIT_ATTEMPTS )); then
+        log "READ_STABLE_COUNT ($stable_count) > NODE_WAIT_ATTEMPTS ($NODE_WAIT_ATTEMPTS); clamping streak threshold to $NODE_WAIT_ATTEMPTS"
+        stable_count="$NODE_WAIT_ATTEMPTS"
+    fi
+    if (( stable_count < 1 )); then
+        stable_count=1
+    fi
+
+    if [[ -n "$ANNOUNCE_TARGET_VERSION" ]]; then
+        log "waiting for the node to report target version $ANNOUNCE_TARGET_VERSION and the room to become readable (#4496 version-aware gate)"
+    fi
+
     for ((attempt = 1; attempt <= NODE_WAIT_ATTEMPTS; attempt++)); do
-        if read_room_state; then
-            if (( attempt > 1 )); then
-                log "room readable after $attempt attempts"
+        if [[ -n "$ANNOUNCE_TARGET_VERSION" ]]; then
+            # ── Version-aware readiness (#4496 fix) ──
+            # Require BOTH the running node on the target version AND the room
+            # readable. The old node still serving the room reports the OLD
+            # version (deploy swaps the binary only after stopping it), so its
+            # read is rejected here and cannot satisfy the gate.
+            local running
+            running="$(node_version)"
+            if [[ "$running" == "$ANNOUNCE_TARGET_VERSION" ]] && read_room_state; then
+                log "node reports target version $ANNOUNCE_TARGET_VERSION and room is readable after $attempt attempts"
+                return 0
             fi
-            return 0
-        fi
-        if [[ "$attempt" -eq 1 ]]; then
-            log "room not yet readable via $FREENET_NODE_URL — waiting (the node is restarted by the concurrent gateway update)"
-        elif (( attempt % 12 == 0 )); then
-            log "still waiting for room to become readable ($attempt/$NODE_WAIT_ATTEMPTS)"
+            if [[ "$attempt" -eq 1 ]]; then
+                log "node not yet on target version $ANNOUNCE_TARGET_VERSION (running: ${running:-unknown}) or room not readable — waiting for the gateway update to restart it"
+            elif (( attempt % 12 == 0 )); then
+                log "still waiting for target version $ANNOUNCE_TARGET_VERSION + readable room ($attempt/$NODE_WAIT_ATTEMPTS, running: ${running:-unknown})"
+            fi
+        else
+            # ── Streak fallback (legacy, no target version) ──
+            if read_room_state; then
+                streak=$((streak + 1))
+                if (( streak >= stable_count )); then
+                    if (( attempt > stable_count )); then
+                        log "room readable for $stable_count consecutive probes after $attempt attempts"
+                    fi
+                    return 0
+                fi
+            else
+                if (( streak > 0 )); then
+                    log "room read failed after $streak readable probe(s) — resetting streak (node likely mid-teardown for the gateway update)"
+                fi
+                streak=0
+            fi
+            if [[ "$attempt" -eq 1 ]]; then
+                log "room not yet stably readable via $FREENET_NODE_URL — waiting (no target version plumbed; using streak heuristic)"
+            elif (( attempt % 12 == 0 )); then
+                log "still waiting for room to become stably readable ($attempt/$NODE_WAIT_ATTEMPTS, streak $streak/$stable_count)"
+            fi
         fi
         # No sleep after the final attempt — nothing follows it.
         if (( attempt < NODE_WAIT_ATTEMPTS )); then
@@ -254,11 +386,50 @@ send_message_checked() {
     return 0
 }
 
-if [[ $# -ne 1 ]]; then
-    usage
-fi
+# Argument parsing. The FIRST positional is the message; an optional
+# `--target-version <v>` flag (passed by the release-agent, see announcer.rs)
+# supplies the release version this announcement is for and enables the #4496
+# version-aware readiness gate. The flag overrides any ANNOUNCE_TARGET_VERSION
+# inherited from the environment. Parsing tolerates the flag appearing before
+# or after the message so callers need not fix an ordering.
+#
+# Extracted into a function (setting the MESSAGE / ANNOUNCE_TARGET_VERSION
+# globals) so announce-to-river_test.sh can drive it directly — the
+# order-tolerance and error branches are otherwise untestable. `usage` exits
+# non-zero on a malformed invocation.
+parse_args() {
+    MESSAGE=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --target-version)
+                if [[ $# -lt 2 ]]; then
+                    log "ERROR: --target-version requires an argument"
+                    usage
+                fi
+                ANNOUNCE_TARGET_VERSION="${2#v}"
+                shift 2
+                ;;
+            --)
+                shift
+                if [[ -n "$MESSAGE" || $# -ne 1 ]]; then
+                    usage
+                fi
+                MESSAGE="$1"
+                shift
+                ;;
+            *)
+                if [[ -n "$MESSAGE" ]]; then
+                    log "ERROR: unexpected extra argument: $1"
+                    usage
+                fi
+                MESSAGE="$1"
+                shift
+                ;;
+        esac
+    done
+}
 
-MESSAGE="$1"
+parse_args "$@"
 
 # Defense in depth: empty/oversized payloads should have been rejected
 # upstream, but the privilege-boundary script re-checks. The cap matches

--- a/scripts/release-agent/announce-to-river_test.sh
+++ b/scripts/release-agent/announce-to-river_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034,SC2317
+# shellcheck disable=SC2034,SC2317,SC2329
 # ^ SC2034: FREENET_NODE_URL / NODE_WAIT_* / LOG_FILE are read by the functions
 #   extracted from announce-to-river.sh via `eval`; shellcheck cannot see
 #   into the eval and would otherwise flag them all as unused.
@@ -45,7 +45,13 @@ trap 'rm -rf "$TMP"' EXIT
 # Pull the two functions verbatim so the test runs the real code, not a
 # copy that could drift. Mirrors scripts/release_state_restore_test.sh.
 eval "$(awk '/^log\(\) \{/,/^}/' "$ANNOUNCE_SH")"
+eval "$(awk '/^node_version\(\) \{/,/^}/' "$ANNOUNCE_SH")"
 eval "$(awk '/^wait_for_room\(\) \{/,/^}/' "$ANNOUNCE_SH")"
+eval "$(awk '/^parse_args\(\) \{/,/^}/' "$ANNOUNCE_SH")"
+
+# Default: no target version plumbed, so the streak-fallback tests below run
+# the fallback path. The version-aware section sets it explicitly.
+ANNOUNCE_TARGET_VERSION=""
 
 FAILURES=0
 check() {
@@ -123,27 +129,78 @@ read_room_state() {
     (( READ_CALLS > READ_FAIL_COUNT ))
 }
 
-# Room already readable: succeeds on the first probe.
+# ══════════════════════════════════════════════════════════════════════
+# Streak-fallback path (ANNOUNCE_TARGET_VERSION empty): the read-streak
+# heuristic used only when the target version was NOT plumbed through (a
+# legacy release-agent). It NARROWS the #4496 race but does not fully close
+# it; the version-aware section further below is the deterministic fix.
+# ══════════════════════════════════════════════════════════════════════
+ANNOUNCE_TARGET_VERSION=""
+
+# Room continuously readable: wait_for_room() must observe READ_STABLE_COUNT
+# consecutive successes before returning (the streak heuristic), so with a
+# clean node it probes exactly READ_STABLE_COUNT times.
+READ_STABLE_COUNT=3
 NODE_WAIT_ATTEMPTS=60
 READ_CALLS=0
 READ_FAIL_COUNT=0
 rc=0
 wait_for_room 2>/dev/null || rc=$?
-check "wait_for_room() succeeds when the room is already readable" "$rc" "0"
-check "wait_for_room() probes once when the room is readable" "$READ_CALLS" "1"
+check "wait_for_room() succeeds when the room is continuously readable" "$rc" "0"
+check "wait_for_room() requires READ_STABLE_COUNT consecutive readable probes" "$READ_CALLS" "3"
 
 # Room unreadable then readable: the poll bridges the restart window. This is
 # the case the old port-only probe got wrong — the read fails while the node
 # is mid-teardown, and only succeeds once the restarted node has the room.
+# With READ_STABLE_COUNT=3 and 3 leading failures it needs 3 fails + 3
+# successes = 6 probes.
+READ_STABLE_COUNT=3
 NODE_WAIT_ATTEMPTS=60
 READ_CALLS=0
 READ_FAIL_COUNT=3
 rc=0
 wait_for_room 2>/dev/null || rc=$?
-check "wait_for_room() succeeds once the room becomes readable" "$rc" "0"
-check "wait_for_room() keeps probing across the down-window" "$READ_CALLS" "4"
+check "wait_for_room() succeeds once the room becomes stably readable" "$rc" "0"
+check "wait_for_room() keeps probing across the down-window" "$READ_CALLS" "6"
+
+# ── #4496: early success against the OLD node must NOT satisfy the gate ──
+#
+# The residual race: release-announce and the gateway self-update fire on the
+# same event with no ordering. A lone successful read can be served by the OLD
+# node moments before the update stops the service. wait_for_room() must NOT
+# proceed on that transient success — the mid-teardown failure that follows
+# has to reset the streak so the post lands against the RESTARTED node.
+#
+# Stub the exact interleaving: success (old node) → 2 failures (teardown /
+# restart) → sustained successes (restarted node). A first-success gate
+# (pre-#4496) would return after probe 1 (READ_CALLS=1) and drop into the
+# teardown window. The sustained gate must ride through: 1 (old) + 2 (down)
+# + 3 (restarted streak) = 6 probes, and crucially MORE than 1.
+READ_STABLE_COUNT=3
+NODE_WAIT_ATTEMPTS=60
+# Custom stub: readable on probe 1, unreadable on 2-3, readable thereafter.
+read_room_state() {
+    READ_CALLS=$((READ_CALLS + 1))
+    if (( READ_CALLS == 1 )); then return 0; fi          # old node still up
+    if (( READ_CALLS <= 3 )); then return 1; fi          # teardown window
+    return 0                                             # restarted node
+}
+READ_CALLS=0
+rc=0
+wait_for_room 2>/dev/null || rc=$?
+check "wait_for_room() rides out a teardown that follows an early success (#4496)" "$rc" "0"
+check "wait_for_room() does not return on the first (old-node) success (#4496)" \
+    "$( (( READ_CALLS > 1 )) && echo yes || echo no )" "yes"
+check "wait_for_room() resets its streak on the teardown failure (#4496)" "$READ_CALLS" "6"
+
+# Restore the simple counting stub for the remaining cases.
+read_room_state() {
+    READ_CALLS=$((READ_CALLS + 1))
+    (( READ_CALLS > READ_FAIL_COUNT ))
+}
 
 # Room never readable: the poll gives up after NODE_WAIT_ATTEMPTS.
+READ_STABLE_COUNT=3
 NODE_WAIT_ATTEMPTS=3
 READ_CALLS=0
 READ_FAIL_COUNT=9999
@@ -151,6 +208,139 @@ rc=0
 wait_for_room 2>/dev/null || rc=$?
 check "wait_for_room() fails when the room never becomes readable" "$rc" "1"
 check "wait_for_room() honours NODE_WAIT_ATTEMPTS as the bound" "$READ_CALLS" "3"
+
+# A room readable only intermittently (never a full streak) must never satisfy
+# the gate — a flapping node is treated as not ready. Alternating pass/fail
+# with READ_STABLE_COUNT=3 can never reach a streak of 3.
+READ_STABLE_COUNT=3
+NODE_WAIT_ATTEMPTS=10
+READ_CALLS=0
+read_room_state() {
+    READ_CALLS=$((READ_CALLS + 1))
+    (( READ_CALLS % 2 == 0 ))   # fail, pass, fail, pass, ...
+}
+rc=0
+wait_for_room 2>/dev/null || rc=$?
+check "wait_for_room() never proceeds on a flapping (never-sustained) node (fallback)" "$rc" "1"
+# Restore the counting stub.
+read_room_state() {
+    READ_CALLS=$((READ_CALLS + 1))
+    (( READ_CALLS > READ_FAIL_COUNT ))
+}
+
+# Clamp invariant: READ_STABLE_COUNT > NODE_WAIT_ATTEMPTS must NOT make the
+# fallback gate unsatisfiable. Without the clamp the streak could never reach
+# threshold and a perfectly healthy, continuously-readable node would be
+# reported as never-ready. With the clamp the gate returns success.
+READ_STABLE_COUNT=100
+NODE_WAIT_ATTEMPTS=5
+READ_CALLS=0
+READ_FAIL_COUNT=0
+rc=0
+wait_for_room 2>/dev/null || rc=$?
+check "wait_for_room() clamps READ_STABLE_COUNT to NODE_WAIT_ATTEMPTS (satisfiable)" "$rc" "0"
+check "wait_for_room() returns at the clamped threshold, not the raw count" "$READ_CALLS" "5"
+
+# ══════════════════════════════════════════════════════════════════════
+# Version-aware path (ANNOUNCE_TARGET_VERSION set): the #4496 deterministic
+# fix. Readiness == the running node reports the TARGET version AND the room
+# is readable. The key property: an early read served by the OLD node — which
+# still reports the OLD version because the gateway update swaps the binary
+# only after stopping the service — MUST NOT satisfy the gate.
+# ══════════════════════════════════════════════════════════════════════
+
+TARGET="0.2.90"
+OLD="0.2.89"
+
+# NODE_VERSION_SEQ drives the node_version stub: one entry consumed per call.
+# The index is kept in a FILE, not a variable, because wait_for_room() invokes
+# node_version() via command substitution (`running="$(node_version)"`), which
+# runs in a subshell — a variable increment would be lost, but a file write
+# survives. read_room_state is stubbed per scenario.
+NV_IDX_FILE="$TMP/nv_idx"
+NODE_VERSION_SEQ=()
+node_version() {
+    local idx
+    idx="$(cat "$NV_IDX_FILE" 2>/dev/null || echo 0)"
+    printf '%s' "${NODE_VERSION_SEQ[$idx]:-}"
+    echo $((idx + 1)) > "$NV_IDX_FILE"
+}
+# Helper: reset the version-sequence cursor before each scenario.
+nv_reset() { echo 0 > "$NV_IDX_FILE"; }
+
+# Scenario A — the exact #4496 interleaving. The room is READABLE the whole
+# time (old node up, then restarted node up), but the version transitions
+# OLD → OLD → TARGET. A version-blind gate (or the streak heuristic if the
+# teardown never dropped the read) would post against the OLD node on probe 1.
+# The version gate must reject probes 1-2 (old version) and only proceed on
+# probe 3, when the node reports TARGET.
+ANNOUNCE_TARGET_VERSION="$TARGET"
+NODE_WAIT_ATTEMPTS=60
+READ_CALLS=0
+read_room_state() { READ_CALLS=$((READ_CALLS + 1)); return 0; }   # always readable
+NODE_VERSION_SEQ=("$OLD" "$OLD" "$TARGET" "$TARGET")
+nv_reset
+rc=0
+wait_for_room 2>/dev/null || rc=$?
+# node_version is checked FIRST and short-circuits read_room_state, so on the
+# OLD-version probes 1-2 the room read is never even attempted — the announce
+# provably cannot land against the old node. read_room_state fires only on
+# probe 3 (version now TARGET), so exactly one read occurs.
+check "wait_for_room() proceeds once the node reports the TARGET version (#4496)" "$rc" "0"
+check "wait_for_room() does NOT read/post against the OLD-version node (#4496)" "$READ_CALLS" "1"
+check "wait_for_room() consumed 3 version probes before proceeding (#4496)" \
+    "$(cat "$NV_IDX_FILE")" "3"
+
+# Scenario B — the room is readable AND the version is TARGET on probe 1 (the
+# announce arrives after the update already finished). Must return immediately,
+# on the very first probe — no gratuitous extra waiting once the node is on the
+# target version.
+ANNOUNCE_TARGET_VERSION="$TARGET"
+NODE_WAIT_ATTEMPTS=60
+READ_CALLS=0
+read_room_state() { READ_CALLS=$((READ_CALLS + 1)); return 0; }
+NODE_VERSION_SEQ=("$TARGET" "$TARGET")
+nv_reset
+rc=0
+wait_for_room 2>/dev/null || rc=$?
+check "wait_for_room() returns immediately when already on TARGET + readable (#4496)" "$rc" "0"
+check "wait_for_room() does not over-poll once ready (#4496)" "$READ_CALLS" "1"
+
+# Scenario C — node reaches TARGET version but the room is not YET readable
+# (restarted, still loading room state). The gate must keep waiting until BOTH
+# hold, not proceed on version alone.
+ANNOUNCE_TARGET_VERSION="$TARGET"
+NODE_WAIT_ATTEMPTS=60
+READ_CALLS=0
+# Room readable only from the 3rd probe; version is TARGET throughout.
+read_room_state() { READ_CALLS=$((READ_CALLS + 1)); (( READ_CALLS >= 3 )); }
+NODE_VERSION_SEQ=("$TARGET" "$TARGET" "$TARGET" "$TARGET")
+nv_reset
+rc=0
+wait_for_room 2>/dev/null || rc=$?
+check "wait_for_room() waits for the room even when version is TARGET (#4496)" "$rc" "0"
+check "wait_for_room() proceeds only once the room is also readable (#4496)" "$READ_CALLS" "3"
+
+# Scenario D — the node never reaches the target version within the budget
+# (update stalled). The gate must fail (exit 1) rather than posting against the
+# stuck old node.
+ANNOUNCE_TARGET_VERSION="$TARGET"
+NODE_WAIT_ATTEMPTS=4
+READ_CALLS=0
+read_room_state() { READ_CALLS=$((READ_CALLS + 1)); return 0; }   # readable but wrong version
+NODE_VERSION_SEQ=("$OLD" "$OLD" "$OLD" "$OLD" "$OLD")
+nv_reset
+rc=0
+wait_for_room 2>/dev/null || rc=$?
+check "wait_for_room() fails if the node never reaches TARGET (#4496)" "$rc" "1"
+
+# Restore the streak-fallback stubs / state for any later cases.
+ANNOUNCE_TARGET_VERSION=""
+node_version() { printf ''; }
+read_room_state() {
+    READ_CALLS=$((READ_CALLS + 1))
+    (( READ_CALLS > READ_FAIL_COUNT ))
+}
 
 # ── post_message() ───────────────────────────────────────────────────
 #
@@ -274,6 +464,54 @@ post_message() { return 0; }
 rc=0
 send_message_checked 2>/dev/null || rc=$?
 check "send_message_checked() returns 0 on a successful send" "$rc" "0"
+
+# ── parse_args(): --target-version flag + positional message (#4496) ──
+#
+# The version-aware readiness gate hinges on ANNOUNCE_TARGET_VERSION being
+# populated from the `--target-version <v>` flag the release-agent passes.
+# These drive the REAL extracted parser (not a copy), covering order-
+# tolerance, the leading-`v` strip, the `--` separator, and the two error
+# branches. `usage` exits 1 in production; the tests stub it to exit 42 so a
+# malformed invocation is observable as that code from a subshell without
+# printing the usage banner.
+
+# Flag BEFORE the message.
+MESSAGE=""; ANNOUNCE_TARGET_VERSION=""
+parse_args --target-version 0.2.90 "hello world"
+check "parse_args: flag before message sets the message" "$MESSAGE" "hello world"
+check "parse_args: flag before message sets the target version" "$ANNOUNCE_TARGET_VERSION" "0.2.90"
+
+# Flag AFTER the message (order-tolerance).
+MESSAGE=""; ANNOUNCE_TARGET_VERSION=""
+parse_args "second msg" --target-version 0.2.91
+check "parse_args: flag after message sets the message" "$MESSAGE" "second msg"
+check "parse_args: flag after message sets the target version" "$ANNOUNCE_TARGET_VERSION" "0.2.91"
+
+# Leading `v` is stripped (the agent may send `v0.2.92`).
+MESSAGE=""; ANNOUNCE_TARGET_VERSION=""
+parse_args --target-version v0.2.92 "msg"
+check "parse_args: leading 'v' is stripped from the target version" "$ANNOUNCE_TARGET_VERSION" "0.2.92"
+
+# No flag at all: message set, target version left empty (fallback path).
+MESSAGE=""; ANNOUNCE_TARGET_VERSION=""
+parse_args "plain message"
+check "parse_args: bare message leaves target version empty" "$ANNOUNCE_TARGET_VERSION" ""
+check "parse_args: bare message is captured" "$MESSAGE" "plain message"
+
+# `--` separator: the following token is the message even if flag-shaped.
+MESSAGE=""; ANNOUNCE_TARGET_VERSION=""
+parse_args --target-version 0.2.93 -- "--looks-like-a-flag"
+check "parse_args: -- lets a flag-shaped message through" "$MESSAGE" "--looks-like-a-flag"
+
+# Error branch: --target-version with no argument → usage (exit).
+rc=0
+( usage() { exit 42; }; parse_args --target-version ) >/dev/null 2>&1 || rc=$?
+check "parse_args: --target-version without an argument exits via usage" "$rc" "42"
+
+# Error branch: a second positional → usage (exit).
+rc=0
+( usage() { exit 42; }; parse_args "first" "second" ) >/dev/null 2>&1 || rc=$?
+check "parse_args: unexpected extra positional exits via usage" "$rc" "42"
 
 # ── result ───────────────────────────────────────────────────────────
 

--- a/scripts/release-agent/sudoers.freenet-release-agent
+++ b/scripts/release-agent/sudoers.freenet-release-agent
@@ -30,8 +30,12 @@ freenet-update ALL=(root) NOPASSWD: /usr/local/bin/gateway-auto-update.sh --forc
 # nova; absent on vega — that install simply omits this entry).
 #
 # The `*` after the script path is a sudoers wildcard matching the
-# entire message argv. As with --target-version above, the safety comes
-# from the agent's validation (length cap + NUL rejection in
-# server.rs::announce_river_handler) plus the script's own length check;
-# not from sudoers.
+# entire argv: the message plus an optional trailing
+# `--target-version <vX.Y.Z>` flag the agent appends for the #4496
+# version-aware readiness gate. As with --target-version above, the
+# safety comes from the agent's validation (message length cap + NUL
+# rejection AND strict `semver::Version::parse` on the version, both in
+# server.rs::announce_river_handler) plus the script's own re-parsing of
+# the flag (it strips a leading `v` and only ever string-compares the
+# value); not from sudoers.
 freenet-update ALL=(ian) NOPASSWD: /usr/local/bin/announce-to-river.sh *


### PR DESCRIPTION
## Problem

`release-announce.yml` and `gateway-update.yml` both fire on the same `release: published` event and run independently — no ordering. `wait_for_room()` in `scripts/release-agent/announce-to-river.sh` returned on the **first** successful room read. If the announce job read the room against the **old, still-readable** node before the concurrent gateway self-update stopped the service, it proceeded straight into the gateway-teardown window the change was meant to ride out (residual race from PR #4469, Codex P1 on #4469).

The prior streak-only heuristic merely *narrowed* the window; it did not deterministically wait for the restarted node.

## Solution

Version-aware readiness. The already-resolved release target version is plumbed end-to-end:

`release-announce.yml` resolve job → `/announce/river` request `version` field → `server.rs` (strict-semver validated, leading `v` stripped, 400 on malformed) → `announcer.rs` (appended to the script argv as `--target-version <v>`, not an env var, because `sudo env VAR=…` breaks the sudoers command match) → `announce-to-river.sh`.

When a target version is present, `wait_for_room()` requires the running node's `freenet --version` to **equal** the target **and** the room to be readable before proceeding. The gateway update deploys stop → swap-binary → start, so while the old node still serves the room the on-disk binary is still the old version; the version check (which short-circuits the room read) rejects the old-node read and waits for the **restarted** node. Verified against `deploy-local-gateway.sh`: `systemctl stop` (synchronous) precedes the binary swap, so on-disk binary reporting target ⇒ old node already stopped.

The read-streak heuristic is retained **only** as a fallback for a legacy release-agent that predates the plumbing (overclaiming comments corrected; `READ_STABLE_COUNT` clamped to `NODE_WAIT_ATTEMPTS`; latency-budget comment updated).

## Testing

- Shell (`announce-to-river_test.sh`): 4 version-aware scenarios (rejects readable OLD-version node; returns immediately on target+readable; still waits for room when on target; fails if node never reaches target) plus a clamp-invariant test. Verified they FAIL against version-blind behavior and PASS with the gate.
- Rust (`update_handler.rs`): `announce_forwards_target_version_as_flag`, `announce_rejects_malformed_target_version` (400, no spawn). Existing `announce_happy_path` unchanged proves backward-compat (no version → no flag).
- `shellcheck` clean; `cargo fmt`/`clippy -D warnings`/`test -p freenet-release-agent` (37 unit + 33 integration, 0 failed).

## Fixes

Fixes #4496