### PR TITLE
fix: route delegate notification ApplicationMessages to registered apps

### DIFF
--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1343,6 +1343,44 @@ async fn process_open_request(
                     "Received delegate operation from client"
                 );
                 let delegate_key = req.key().clone();
+
+                // Register (or refresh) this app's routing path so the delegate
+                // can push notification-driven ApplicationMessages back to it
+                // (#3275). An app "registers with a delegate" by talking to it
+                // over a connection that carries an async notification channel;
+                // any ApplicationMessages request with such a channel establishes
+                // the path. UnregisterDelegate tears it down. RegisterDelegate
+                // (installing the delegate binary) does NOT register an app —
+                // it's an admin op, not an app conversation.
+                match &req {
+                    freenet_stdlib::client_api::DelegateRequest::ApplicationMessages { .. } => {
+                        if let Some(sender) = &subscription_listener {
+                            if !crate::contract::delegate_app_registry::register_app(
+                                &delegate_key,
+                                client_id,
+                                sender.clone(),
+                            ) {
+                                tracing::warn!(
+                                    %client_id,
+                                    delegate = %delegate_key,
+                                    "App not registered for delegate notifications (registry at capacity)"
+                                );
+                            }
+                        }
+                    }
+                    freenet_stdlib::client_api::DelegateRequest::UnregisterDelegate(key) => {
+                        crate::contract::delegate_app_registry::remove_delegate(key);
+                    }
+                    // RegisterDelegate installs a delegate binary (admin op), not
+                    // an app conversation, so it registers no routing path. The
+                    // wildcard also absorbs future `#[non_exhaustive]` variants;
+                    // it exists ONLY to satisfy non_exhaustive (see
+                    // git-workflow.md) — new app-facing variants must be handled
+                    // explicitly above, not swept here.
+                    #[allow(clippy::wildcard_enum_match_arm)]
+                    freenet_stdlib::client_api::DelegateRequest::RegisterDelegate { .. } | _ => {}
+                }
+
                 // Derive a short discriminant tag for the INFO logs, but only when INFO is
                 // enabled — the Vec<&str> collect + format! would otherwise allocate on every
                 // delegate dispatch even when the log line is suppressed.
@@ -1502,6 +1540,10 @@ async fn process_open_request(
                     request_id = %request_id,
                     "Received disconnect request from client, triggering subscription cleanup"
                 );
+
+                // Drop any delegate-notification routing registrations for this
+                // client (#3275).
+                crate::contract::delegate_app_registry::remove_client(client_id);
 
                 let result = op_manager
                     .ring

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -535,7 +535,7 @@ impl WebSocketProxy {
     fn setup_subscription(
         &self,
         client_id: ClientId,
-        key: ContractInstanceId,
+        key: String,
         req: Box<ClientRequest<'static>>,
         auth_token: Option<AuthToken>,
         origin_contract: Option<ContractInstanceId>,
@@ -593,19 +593,36 @@ impl WebSocketProxy {
                 user_context,
                 ..
             } => {
-                // Extract the subscription key if this request needs a notification channel.
-                let sub_key = match &*req {
-                    ClientRequest::ContractOp(ContractRequest::Subscribe { key, .. }) => Some(*key),
+                // Extract a notification-channel label if this request needs one.
+                // Contract subscriptions attach a channel so state updates flow
+                // back to the client; a delegate `ApplicationMessages` request
+                // attaches one so notification-driven delegate replies can be
+                // routed back to this app (#3275). The label is display-only; the
+                // callback receiver is what actually carries the messages.
+                let sub_key: Option<String> = match &*req {
+                    ClientRequest::ContractOp(ContractRequest::Subscribe { key, .. }) => {
+                        Some(key.to_string())
+                    }
                     ClientRequest::ContractOp(ContractRequest::Get {
                         key,
                         subscribe: true,
                         ..
-                    }) => Some(*key),
+                    }) => Some(key.to_string()),
                     ClientRequest::ContractOp(ContractRequest::Put {
                         contract,
                         subscribe: true,
                         ..
-                    }) => Some(*contract.key().id()),
+                    }) => Some(contract.key().id().to_string()),
+                    // A delegate app-message request registers this app for
+                    // notification-driven delegate replies (#3275): thread a
+                    // notification channel so process_open_request can register
+                    // it and so those replies reach this client's WS.
+                    ClientRequest::DelegateOp(
+                        freenet_stdlib::client_api::DelegateRequest::ApplicationMessages {
+                            key,
+                            ..
+                        },
+                    ) => Some(key.to_string()),
                     ClientRequest::DelegateOp(_)
                     | ClientRequest::ContractOp(_)
                     | ClientRequest::Disconnect { .. }
@@ -1606,7 +1623,9 @@ async fn new_client_connection(
 }
 
 struct NewSubscription {
-    key: ContractInstanceId,
+    /// Display label for the notification source (contract instance id or, for
+    /// delegate app-message routing #3275, a delegate key). Logging only.
+    key: String,
     callback: mpsc::Receiver<HostResult>,
 }
 
@@ -4087,5 +4106,76 @@ mod tests {
             drive_msg(auth, Some(&ctx), Some(&limiter)).await,
             "Authenticate must not be rate-limited even with an empty op bucket"
         );
+    }
+
+    /// Regression for #3275 (production WS-proxy wiring).
+    ///
+    /// A delegate `ApplicationMessages` request from a real client MUST get a
+    /// notification channel threaded onto its `OpenRequest`. That channel is the
+    /// exact `subscription_listener` `process_open_request` hands to
+    /// `delegate_app_registry::register_app` — without it, registration never
+    /// fires in production and notification-driven delegate `ApplicationMessage`s
+    /// have no app to route to (the inert-fix bug that made the 2nd pass dead).
+    ///
+    /// Before the wiring fix, `ClientRequest::DelegateOp(_)` fell into the
+    /// `None` arm of `internal_proxy_recv`'s `sub_key` match, so the built
+    /// `OpenRequest` carried `notification_channel == None` and this test's two
+    /// assertions both fail (no `SubscriptionChannel` callback is delivered, and
+    /// `notification_channel` is `None`).
+    #[tokio::test]
+    async fn delegate_app_messages_request_gets_notification_channel() {
+        use freenet_stdlib::client_api::DelegateRequest;
+        use freenet_stdlib::prelude::{CodeHash, DelegateKey};
+
+        let (mut proxy, _router) = WebSocketProxy::create_router(axum::Router::new());
+
+        // Register a response channel for the client, exactly as a NewConnection
+        // does — this is where a delegate app-message subscription callback is
+        // delivered so the client's WS reader can forward routed replies.
+        let client_id = ClientId::next();
+        let (cb_tx, mut cb_rx) = mpsc::unbounded_channel::<HostCallbackResult>();
+        proxy.response_channels.insert(client_id, cb_tx);
+
+        let delegate_key = DelegateKey::new([3u8; 32], CodeHash::new([3u8; 32]));
+        let req = Box::new(ClientRequest::DelegateOp(
+            DelegateRequest::ApplicationMessages {
+                key: delegate_key.clone(),
+                params: vec![].into(),
+                inbound: vec![],
+            },
+        ));
+
+        let open_req = proxy
+            .internal_proxy_recv(ClientConnection::Request {
+                client_id,
+                req,
+                auth_token: None,
+                origin_contract: None,
+                user_context: None,
+                api_version: ApiVersion::V1,
+            })
+            .await
+            .expect("proxy recv must not error")
+            .expect("delegate request must yield an OpenRequest");
+
+        // The core assertion: the WS proxy threaded a notification channel — the
+        // one process_open_request will register with the delegate.
+        assert!(
+            open_req.notification_channel.is_some(),
+            "a delegate ApplicationMessages request MUST carry a notification \
+             channel so register_app fires in production (#3275)"
+        );
+
+        // And the matching subscription callback was delivered to the client's
+        // response channel, keyed by the delegate for logging.
+        match cb_rx.try_recv() {
+            Ok(HostCallbackResult::SubscriptionChannel { id, key, .. }) => {
+                assert_eq!(id, client_id);
+                assert_eq!(key, delegate_key.to_string());
+            }
+            other => panic!(
+                "expected a SubscriptionChannel callback for the delegate request, got {other:?}"
+            ),
+        }
     }
 }

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use either::Either;
 use freenet_stdlib::prelude::*;
 
+pub(crate) mod delegate_app_registry;
 mod executor;
 mod fair_queue;
 pub(crate) use fair_queue::Priority;
@@ -1181,6 +1182,9 @@ where
                     if let ContractHandlerEvent::ClientDisconnect { client_id } = &event {
                         let client_id = *client_id;
                         contract_handler.executor().remove_client(client_id);
+                        // Drop any delegate-notification routing registrations
+                        // for this client (#3275).
+                        delegate_app_registry::remove_client(client_id);
                         contract_handler.channel().drop_waiting_response(id);
                         continue;
                     }
@@ -1959,23 +1963,18 @@ async fn handle_delegate_notification<CH, P>(
     )
     .await;
 
-    // TODO: Route outbound ApplicationMessages to subscribed apps #3275
-    // handle_delegate_with_contract_requests already processes contract requests
-    // (GET/PUT/UPDATE/SUBSCRIBE) internally. The remaining outbound messages are
-    // ApplicationMessages meant for connected apps, but notification-driven
-    // invocations have no originating client connection to route them to.
-    // When delegate-to-app notification routing is implemented, these should be
-    // forwarded to all apps registered with this delegate.
-    for msg in &outbound {
-        match msg {
-            OutboundDelegateMsg::ApplicationMessage(app_msg) => {
-                tracing::warn!(
-                    delegate = %delegate_key,
-                    payload_len = app_msg.payload.len(),
-                    "Delegate produced ApplicationMessage from contract notification \
-                     but no client routing is available yet — message dropped"
-                );
-            }
+    // Route outbound ApplicationMessages to the apps registered with this
+    // delegate (#3275). handle_delegate_with_contract_requests already
+    // processed the contract requests (GET/PUT/UPDATE/SUBSCRIBE) internally;
+    // the residual ApplicationMessages are the delegate's replies meant for
+    // connected apps. A notification-driven invocation has no originating
+    // client request to answer, so we fan them out via the delegate->apps
+    // registry (delegate_app_registry) — the mirror of DELEGATE_SUBSCRIPTIONS,
+    // populated when an app talks to the delegate over its WS connection.
+    let app_messages: Vec<OutboundDelegateMsg> = outbound
+        .into_iter()
+        .filter(|msg| match msg {
+            OutboundDelegateMsg::ApplicationMessage(_) => true,
             OutboundDelegateMsg::RequestUserInput(_)
             | OutboundDelegateMsg::ContextUpdated(_)
             | OutboundDelegateMsg::GetContractRequest(_)
@@ -1988,7 +1987,37 @@ async fn handle_delegate_notification<CH, P>(
                     msg_type = ?std::mem::discriminant(msg),
                     "Delegate produced unexpected outbound message from contract notification — dropped"
                 );
+                false
             }
+        })
+        .collect();
+
+    // Opportunistic TTL sweep of the delegate->apps registry, mirroring how
+    // prune_expired_contexts sweeps on delegate activity rather than via a
+    // background task. Bounds stale registrations for apps that vanished
+    // without a clean disconnect (AGENTS.md GC-exemption rule).
+    delegate_app_registry::sweep_expired();
+
+    if app_messages.is_empty() {
+        return;
+    }
+
+    // One HostResponse per ApplicationMessage so an app sees each reply as a
+    // distinct DelegateResponse, exactly as it would for a client-initiated
+    // ApplicationMessages request.
+    for app_msg in app_messages {
+        let response: crate::client_events::HostResult =
+            Ok(freenet_stdlib::client_api::HostResponse::DelegateResponse {
+                key: delegate_key.clone(),
+                values: vec![app_msg],
+            });
+        let delivered = delegate_app_registry::route_to_apps(&delegate_key, response);
+        if delivered == 0 {
+            tracing::debug!(
+                delegate = %delegate_key,
+                "Delegate notification produced an ApplicationMessage but no apps \
+                 are registered with this delegate — nothing to route to"
+            );
         }
     }
 }

--- a/crates/core/src/contract/delegate_app_registry.rs
+++ b/crates/core/src/contract/delegate_app_registry.rs
@@ -1,0 +1,422 @@
+//! Registry mapping a delegate key to the client connections ("apps") that
+//! talk to it, so notification-driven delegate invocations can route their
+//! outbound [`ApplicationMessage`]s back to those apps.
+//!
+//! This is the mirror of [`crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS`]:
+//! `DELEGATE_SUBSCRIPTIONS` maps `contract -> delegates` (which delegates want
+//! to hear about a contract's state changes); this registry maps
+//! `delegate -> apps` (which client connections should receive the delegate's
+//! resulting `ApplicationMessage`s).
+//!
+//! # Why it exists (issue #3275)
+//!
+//! When a delegate receives a `ContractNotification` (via the subscription
+//! pipeline from #2830 / PR #3251) it may produce
+//! [`OutboundDelegateMsg::ApplicationMessage`] responses intended for connected
+//! apps. But a notification-driven invocation has no originating client request
+//! to respond to — the delegate ran because a *contract* changed, not because a
+//! client asked. Before this registry those messages were logged and dropped.
+//!
+//! An app establishes a routing path simply by talking to the delegate over its
+//! WebSocket connection: any `DelegateRequest` that carries a notification
+//! channel (`subscription_listener`) registers `(client, sender)` under the
+//! delegate key. From then on, notification-driven `ApplicationMessage`s for
+//! that delegate are pushed to the app's channel.
+//!
+//! # Bounded-collection invariants (`.claude/rules/code-style.md`)
+//!
+//! Both the number of apps per delegate ([`MAX_APPS_PER_DELEGATE`]) and the
+//! number of delegates a single client may register with
+//! ([`MAX_DELEGATES_PER_CLIENT`]) are capped, rejecting at insertion. Without
+//! caps a client could open unbounded channels or a delegate could accrue
+//! unbounded fan-out targets — an amplification vector.
+//!
+//! # TTL / GC-exemption bound (AGENTS.md)
+//!
+//! Each registration records the [`tokio::time::Instant`] it was last
+//! (re)confirmed. [`REGISTRATION_TTL`] bounds how long a registration survives
+//! without the app talking to the delegate again; [`sweep_expired`] prunes
+//! entries past the TTL. This guarantees the map cannot pin channels for a
+//! disconnected-but-not-cleanly-closed client forever, satisfying the AGENTS.md
+//! rule that any cleanup exemption be time-bounded. Clean disconnects
+//! ([`remove_client`]) and delegate unregistration ([`remove_delegate`]) purge
+//! eagerly; the TTL is the backstop.
+
+use std::sync::LazyLock;
+
+use dashmap::DashMap;
+use freenet_stdlib::prelude::DelegateKey;
+use tokio::sync::mpsc;
+
+use crate::client_events::{ClientId, HostResult};
+
+/// Maximum number of distinct client connections that may register with a
+/// single delegate. Caps notification fan-out cost per delegate.
+pub(crate) const MAX_APPS_PER_DELEGATE: usize = 128;
+
+/// Maximum number of distinct delegates a single client may register with.
+/// Prevents a resource-spreading attack where one client registers with many
+/// delegates to hold many channels.
+pub(crate) const MAX_DELEGATES_PER_CLIENT: usize = 256;
+
+/// How long a registration survives without the app re-confirming it (by
+/// talking to the delegate again). The registry is refreshed on every
+/// `DelegateRequest` the app sends, so an actively-used app never expires; this
+/// only reaps apps whose connection died without a clean disconnect event.
+///
+/// 30 minutes is comfortably longer than any reasonable gap between an app's
+/// delegate interactions while keeping stale channels from lingering for the
+/// process lifetime.
+pub(crate) const REGISTRATION_TTL: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+/// One app's registration with a delegate: where to push messages, plus when it
+/// was last confirmed (for TTL eviction).
+struct AppRegistration {
+    client_id: ClientId,
+    sender: mpsc::Sender<HostResult>,
+    /// `tokio::time::Instant` (not `std::time::Instant`) so tests using
+    /// `tokio::time::pause` / `advance` can drive TTL eviction deterministically,
+    /// matching the convention used by `DelegateContextEntry` and `RealTime`.
+    last_seen: tokio::time::Instant,
+}
+
+/// `delegate -> [app registrations]`.
+///
+/// A `Vec` (not a map keyed by `ClientId`) because the expected cardinality is
+/// small (one app, occasionally a few) and we iterate the whole list on every
+/// notification fan-out anyway. Bounded by [`MAX_APPS_PER_DELEGATE`].
+static DELEGATE_APPS: LazyLock<DashMap<DelegateKey, Vec<AppRegistration>>> =
+    LazyLock::new(DashMap::default);
+
+/// `client -> number of delegates it is registered with`, for O(1)
+/// per-client cap enforcement without scanning [`DELEGATE_APPS`].
+static CLIENT_REGISTRATION_COUNTS: LazyLock<DashMap<ClientId, usize>> =
+    LazyLock::new(DashMap::default);
+
+/// Register `client_id`'s notification channel with `delegate_key`, or refresh
+/// its TTL if already registered.
+///
+/// Returns `false` (and does not register) when a per-key or per-client cap
+/// would be exceeded, so the caller can log the rejection. Re-registering an
+/// existing `(delegate, client)` pair always succeeds and refreshes both the
+/// sender (the client may have reconnected with a fresh channel) and the TTL.
+pub(crate) fn register_app(
+    delegate_key: &DelegateKey,
+    client_id: ClientId,
+    sender: mpsc::Sender<HostResult>,
+) -> bool {
+    let now = tokio::time::Instant::now();
+    let mut apps = DELEGATE_APPS.entry(delegate_key.clone()).or_default();
+
+    // Refresh path: already registered → update sender + TTL, no cap change.
+    if let Some(existing) = apps.iter_mut().find(|a| a.client_id == client_id) {
+        existing.sender = sender;
+        existing.last_seen = now;
+        return true;
+    }
+
+    // New registration for this delegate: enforce per-key cap.
+    if apps.len() >= MAX_APPS_PER_DELEGATE {
+        tracing::warn!(
+            delegate = %delegate_key,
+            %client_id,
+            cap = MAX_APPS_PER_DELEGATE,
+            "Rejecting app registration: delegate at max apps"
+        );
+        return false;
+    }
+
+    // Enforce per-client cap.
+    let mut count = CLIENT_REGISTRATION_COUNTS.entry(client_id).or_insert(0);
+    if *count >= MAX_DELEGATES_PER_CLIENT {
+        tracing::warn!(
+            delegate = %delegate_key,
+            %client_id,
+            cap = MAX_DELEGATES_PER_CLIENT,
+            "Rejecting app registration: client at max delegate registrations"
+        );
+        return false;
+    }
+
+    apps.push(AppRegistration {
+        client_id,
+        sender,
+        last_seen: now,
+    });
+    *count += 1;
+    true
+}
+
+/// Route a notification-driven `ApplicationMessage` (already wrapped in a
+/// [`HostResult`]) to every app registered with `delegate_key`.
+///
+/// Uses `try_send` (never `.await`) so it is safe to call from the
+/// single-threaded contract-handling loop — a full or closed client channel is
+/// dropped/logged, never blocks the loop (see `.claude/rules/channel-safety.md`).
+/// Returns the number of apps the message was delivered to. Closed channels are
+/// pruned as a side effect (the client is gone).
+pub(crate) fn route_to_apps(delegate_key: &DelegateKey, message: HostResult) -> usize {
+    let Some(mut apps) = DELEGATE_APPS.get_mut(delegate_key) else {
+        return 0;
+    };
+
+    let mut delivered = 0usize;
+    let mut closed_clients: Vec<ClientId> = Vec::new();
+
+    apps.retain(|app| match app.sender.try_send(message.clone()) {
+        Ok(()) => {
+            delivered += 1;
+            true
+        }
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            tracing::warn!(
+                delegate = %delegate_key,
+                client_id = %app.client_id,
+                "App notification channel full — delegate ApplicationMessage dropped"
+            );
+            true
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            // Client disconnected without a clean event; drop the registration.
+            closed_clients.push(app.client_id);
+            false
+        }
+    });
+
+    let now_empty = apps.is_empty();
+    drop(apps);
+
+    for client_id in closed_clients {
+        decrement_client_count(client_id);
+    }
+    if now_empty {
+        DELEGATE_APPS.remove_if(delegate_key, |_, v| v.is_empty());
+    }
+
+    delivered
+}
+
+/// Remove every registration for `client_id` (clean disconnect).
+pub(crate) fn remove_client(client_id: ClientId) {
+    let mut removed_any = false;
+    DELEGATE_APPS.retain(|_, apps| {
+        let before = apps.len();
+        apps.retain(|a| a.client_id != client_id);
+        removed_any |= apps.len() != before;
+        !apps.is_empty()
+    });
+    if removed_any {
+        CLIENT_REGISTRATION_COUNTS.remove(&client_id);
+    }
+}
+
+/// Remove all app registrations for `delegate_key` (delegate unregistered).
+pub(crate) fn remove_delegate(delegate_key: &DelegateKey) {
+    if let Some((_, apps)) = DELEGATE_APPS.remove(delegate_key) {
+        for app in apps {
+            decrement_client_count(app.client_id);
+        }
+    }
+}
+
+/// Prune registrations older than [`REGISTRATION_TTL`]. The TTL backstop for
+/// clients that vanished without a clean disconnect or channel-close signal.
+pub(crate) fn sweep_expired() {
+    let now = tokio::time::Instant::now();
+    let mut expired: Vec<ClientId> = Vec::new();
+    DELEGATE_APPS.retain(|_, apps| {
+        apps.retain(|a| {
+            let keep = now.saturating_duration_since(a.last_seen) < REGISTRATION_TTL;
+            if !keep {
+                expired.push(a.client_id);
+            }
+            keep
+        });
+        !apps.is_empty()
+    });
+    for client_id in expired {
+        decrement_client_count(client_id);
+    }
+}
+
+fn decrement_client_count(client_id: ClientId) {
+    if let Some(mut count) = CLIENT_REGISTRATION_COUNTS.get_mut(&client_id) {
+        *count = count.saturating_sub(1);
+        if *count == 0 {
+            drop(count);
+            CLIENT_REGISTRATION_COUNTS.remove_if(&client_id, |_, v| *v == 0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use freenet_stdlib::prelude::CodeHash;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // The registry is a process-global (mirroring DELEGATE_SUBSCRIPTIONS), so
+    // these unit tests run against SHARED state under plain `cargo test`'s
+    // in-process parallelism. Each test therefore carves out its OWN key/id
+    // namespace from a global counter instead of relying on clear_for_test()
+    // for isolation (which would race with concurrently-running tests). Keys
+    // and ClientIds from different tests never collide, so parallel execution
+    // is safe without serialization.
+    static NS: AtomicUsize = AtomicUsize::new(1);
+
+    /// A block of 2^16 distinct delegate keys + client ids private to one test.
+    struct Namespace(usize);
+    impl Namespace {
+        fn new() -> Self {
+            Namespace(NS.fetch_add(1, Ordering::Relaxed))
+        }
+        fn key(&self, n: usize) -> DelegateKey {
+            let mut bytes = [0u8; 32];
+            bytes[0..8].copy_from_slice(&(self.0 as u64).to_le_bytes());
+            bytes[8..16].copy_from_slice(&(n as u64).to_le_bytes());
+            DelegateKey::new(bytes, CodeHash::new(bytes))
+        }
+        fn client(&self, n: usize) -> ClientId {
+            // 16 low bits for the per-test index, rest for the namespace.
+            ClientId((self.0 << 24) | (n & 0xFF_FFFF))
+        }
+    }
+
+    fn host_msg() -> HostResult {
+        use freenet_stdlib::client_api::HostResponse;
+        use freenet_stdlib::prelude::{ApplicationMessage, OutboundDelegateMsg};
+        Ok(HostResponse::DelegateResponse {
+            key: DelegateKey::new([0u8; 32], CodeHash::new([0u8; 32])),
+            values: vec![OutboundDelegateMsg::ApplicationMessage(
+                ApplicationMessage::new(vec![1]),
+            )],
+        })
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn register_and_route_delivers_to_app() {
+        let ns = Namespace::new();
+        let dk = ns.key(0);
+        let (tx, mut rx) = mpsc::channel::<HostResult>(4);
+        assert!(register_app(&dk, ns.client(0), tx));
+
+        let delivered = route_to_apps(&dk, host_msg());
+        assert_eq!(delivered, 1);
+        assert!(rx.try_recv().is_ok(), "app must receive the message");
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn route_to_unknown_delegate_delivers_nothing() {
+        let ns = Namespace::new();
+        let delivered = route_to_apps(&ns.key(0), host_msg());
+        assert_eq!(delivered, 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn per_delegate_cap_rejects_excess_apps() {
+        let ns = Namespace::new();
+        let dk = ns.key(0);
+        for i in 0..MAX_APPS_PER_DELEGATE {
+            let (tx, _rx) = mpsc::channel::<HostResult>(1);
+            assert!(register_app(&dk, ns.client(i), tx));
+        }
+        let (tx, _rx) = mpsc::channel::<HostResult>(1);
+        assert!(
+            !register_app(&dk, ns.client(MAX_APPS_PER_DELEGATE), tx),
+            "registration past per-delegate cap must be rejected"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn per_client_cap_rejects_excess_delegates() {
+        let ns = Namespace::new();
+        let client = ns.client(0);
+        for i in 0..MAX_DELEGATES_PER_CLIENT {
+            let (tx, _rx) = mpsc::channel::<HostResult>(1);
+            assert!(register_app(&ns.key(i), client, tx));
+        }
+        let (tx, _rx) = mpsc::channel::<HostResult>(1);
+        assert!(
+            !register_app(&ns.key(MAX_DELEGATES_PER_CLIENT), client, tx),
+            "registration past per-client cap must be rejected"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn remove_client_frees_registrations() {
+        let ns = Namespace::new();
+        let dk = ns.key(0);
+        let client = ns.client(0);
+        let (tx, _rx) = mpsc::channel::<HostResult>(1);
+        assert!(register_app(&dk, client, tx));
+        remove_client(client);
+        assert_eq!(route_to_apps(&dk, host_msg()), 0);
+        // Count freed, so client can register up to the cap again.
+        for i in 0..MAX_DELEGATES_PER_CLIENT {
+            let (tx, _rx) = mpsc::channel::<HostResult>(1);
+            assert!(register_app(&ns.key(i + 1), client, tx));
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn closed_channel_is_pruned_on_route() {
+        let ns = Namespace::new();
+        let dk = ns.key(0);
+        let client = ns.client(0);
+        let (tx, rx) = mpsc::channel::<HostResult>(1);
+        assert!(register_app(&dk, client, tx));
+        drop(rx); // client gone
+        assert_eq!(route_to_apps(&dk, host_msg()), 0);
+        // Registration pruned and client count freed: can fill cap again.
+        for i in 0..MAX_DELEGATES_PER_CLIENT {
+            let (t, _r) = mpsc::channel::<HostResult>(1);
+            assert!(register_app(&ns.key(i + 1), client, t));
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn ttl_sweep_evicts_stale_registration() {
+        let ns = Namespace::new();
+        let dk = ns.key(0);
+        let (tx, _rx) = mpsc::channel::<HostResult>(1);
+        assert!(register_app(&dk, ns.client(0), tx));
+
+        tokio::time::advance(REGISTRATION_TTL + std::time::Duration::from_secs(1)).await;
+        sweep_expired();
+        assert_eq!(
+            route_to_apps(&dk, host_msg()),
+            0,
+            "stale registration must be swept after TTL"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn reregister_refreshes_ttl() {
+        let ns = Namespace::new();
+        let dk = ns.key(0);
+        let client = ns.client(0);
+        let (tx, mut rx) = mpsc::channel::<HostResult>(4);
+        assert!(register_app(&dk, client, tx.clone()));
+
+        // Advance nearly to TTL, then refresh.
+        tokio::time::advance(REGISTRATION_TTL - std::time::Duration::from_secs(10)).await;
+        assert!(register_app(&dk, client, tx));
+        // Advance past the ORIGINAL expiry but within the refreshed window.
+        tokio::time::advance(std::time::Duration::from_secs(20)).await;
+        sweep_expired();
+        assert_eq!(
+            route_to_apps(&dk, host_msg()),
+            1,
+            "refreshed registration must survive"
+        );
+        assert!(rx.try_recv().is_ok());
+    }
+}

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -103,8 +103,10 @@ pub(crate) enum HostCallbackResult {
     },
     SubscriptionChannel {
         id: ClientId,
-        /// The contract being subscribed to (identified by instance_id since full key may not be known yet)
-        key: ContractInstanceId,
+        /// Display label for the notification source (a contract instance id, or
+        /// a delegate key for delegate app-message routing — #3275). Used only
+        /// for logging; the callback receiver is what actually delivers messages.
+        key: String,
         callback: tokio::sync::mpsc::Receiver<HostResult>,
     },
 }

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -3337,6 +3337,193 @@ async fn test_subscribe_then_notify_roundtrip() -> Result<(), Box<dyn std::error
     Ok(())
 }
 
+/// Regression test for #3275: a notification-driven delegate `ApplicationMessage`
+/// is routed to the app registered with that delegate, instead of being dropped.
+///
+/// Drives the real production `Runtime`: an app subscribes a delegate to a
+/// contract, the contract's state changes, the delegate emits an
+/// `ApplicationMessage` from the `ContractNotification` callback, and this test
+/// registers the app's notification channel in `delegate_app_registry` and
+/// routes via `route_to_apps` — the exact helper `handle_delegate_notification`
+/// invokes in production. Before the fix there was no registry and no routing
+/// call; the message was logged-and-dropped, so the app channel stayed empty.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+// Test asserts on specific outbound/response variants; the `other => panic!`
+// arms deliberately catch every non-matching (and future non_exhaustive) case.
+#[allow(clippy::wildcard_enum_match_arm)]
+async fn test_notification_application_message_routed_to_registered_app()
+-> Result<(), Box<dyn std::error::Error>> {
+    use crate::client_events::{ClientId, HostResult};
+    use crate::contract::delegate_app_registry;
+    use crate::wasm_runtime::StateStorage;
+    use capabilities_messages::*;
+    use freenet_stdlib::client_api::HostResponse;
+
+    let temp_dir = get_temp_dir();
+    let contracts_dir = temp_dir.path().join("contracts");
+    let delegates_dir = temp_dir.path().join("delegates");
+    let secrets_dir = temp_dir.path().join("secrets");
+
+    let db = crate::contract::storages::Storage::new(temp_dir.path()).await?;
+    let contract_store = ContractStore::new(contracts_dir, 10_000, db.clone())?;
+    let delegate_store = DelegateStore::new(delegates_dir, 10_000, db.clone())?;
+    let secret_store = SecretsStore::new(secrets_dir, Default::default(), db.clone())?;
+
+    let mut runtime = Runtime::build(contract_store, delegate_store, secret_store, false).unwrap();
+    runtime.set_state_store_db(db.clone());
+
+    // Contract the delegate will subscribe to.
+    let contract_instance_id = ContractInstanceId::new([7u8; 32]);
+    let contract_code = ContractCode::from(vec![7, 7, 7]);
+    let contract_key = ContractKey::from_id_and_code(contract_instance_id, *contract_code.hash());
+    runtime.contract_store.ensure_key_indexed(&contract_key)?;
+    db.store(contract_key, WrappedState::new(vec![1, 2, 3]))
+        .await?;
+
+    // Load the capabilities delegate.
+    let delegate = {
+        let bytes = super::super::tests::get_test_module(TEST_DELEGATE_CAPABILITIES)?;
+        DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(Delegate::from((
+            &bytes.into(),
+            &vec![].into(),
+        ))))
+    };
+    let _stored = runtime.delegate_store.store_delegate(delegate.clone());
+    let key = XChaCha20Poly1305::generate_key(&mut OsRng);
+    let cipher = XChaCha20Poly1305::new(&key);
+    let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+    let _registered = runtime
+        .secret_store
+        .register_delegate(delegate.key().clone(), cipher, nonce);
+    let delegate_key = delegate.key().clone();
+
+    // The delegate subscribes to the contract.
+    let subscribe_cmd = DelegateCommand::SubscribeContract {
+        contract_id: contract_instance_id,
+    };
+    let outbound = runtime.inbound_app_message(
+        &delegate_key,
+        &vec![].into(),
+        None,
+        None,
+        vec![InboundDelegateMsg::ApplicationMessage(
+            ApplicationMessage::new(bincode::serialize(&subscribe_cmd)?),
+        )],
+    )?;
+    let subscribe_req = match &outbound[0] {
+        OutboundDelegateMsg::SubscribeContractRequest(req) => req.clone(),
+        other => panic!("Expected SubscribeContractRequest, got {other:?}"),
+    };
+    crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
+        .entry(subscribe_req.contract_id)
+        .or_default()
+        .insert(delegate_key.clone());
+    // Feed the subscribe response back so the delegate finishes subscribing.
+    let _ = runtime.inbound_app_message(
+        &delegate_key,
+        &vec![].into(),
+        None,
+        None,
+        vec![InboundDelegateMsg::SubscribeContractResponse(
+            SubscribeContractResponse {
+                contract_id: subscribe_req.contract_id,
+                result: Ok(()),
+                context: subscribe_req.context.clone(),
+            },
+        )],
+    )?;
+
+    // The app registers its notification channel with the delegate (this is what
+    // client_events.rs does for an ApplicationMessages request carrying a
+    // notification channel).
+    let app_client = ClientId::FIRST;
+    let (app_tx, mut app_rx) = tokio::sync::mpsc::channel::<HostResult>(8);
+    assert!(
+        delegate_app_registry::register_app(&delegate_key, app_client, app_tx),
+        "app registration must succeed"
+    );
+
+    // Contract state changes → the delegate is notified and emits an
+    // ApplicationMessage (ContractNotificationReceived) meant for the app.
+    let updated_state = vec![9, 8, 7, 6];
+    let outbound = runtime.inbound_app_message(
+        &delegate_key,
+        &vec![].into(),
+        None,
+        None,
+        vec![InboundDelegateMsg::ContractNotification(
+            ContractNotification {
+                contract_id: contract_instance_id,
+                new_state: WrappedState::new(updated_state.clone()),
+                context: DelegateContext::default(),
+            },
+        )],
+    )?;
+    let app_msg = match &outbound[0] {
+        OutboundDelegateMsg::ApplicationMessage(msg) => msg.clone(),
+        other => panic!("Expected ApplicationMessage, got {other:?}"),
+    };
+
+    // Production routing: fan the ApplicationMessage out to registered apps,
+    // exactly as handle_delegate_notification does.
+    let response: HostResult = Ok(HostResponse::DelegateResponse {
+        key: delegate_key.clone(),
+        values: vec![OutboundDelegateMsg::ApplicationMessage(app_msg)],
+    });
+    let delivered = delegate_app_registry::route_to_apps(&delegate_key, response);
+    assert_eq!(delivered, 1, "message must reach the one registered app");
+
+    // The registered app receives the delegate's notification-driven reply.
+    let received = app_rx
+        .try_recv()
+        .expect("registered app must receive the ApplicationMessage");
+    match received {
+        Ok(HostResponse::DelegateResponse { key, values }) => {
+            assert_eq!(key, delegate_key);
+            assert_eq!(values.len(), 1);
+            match &values[0] {
+                OutboundDelegateMsg::ApplicationMessage(msg) => {
+                    let resp: DelegateResponse = bincode::deserialize(&msg.payload)?;
+                    match resp {
+                        DelegateResponse::ContractNotificationReceived {
+                            contract_id,
+                            new_state,
+                        } => {
+                            assert_eq!(contract_id, contract_instance_id);
+                            assert_eq!(new_state, updated_state);
+                        }
+                        other => panic!("Expected ContractNotificationReceived, got {other:?}"),
+                    }
+                }
+                other => panic!("Expected ApplicationMessage, got {other:?}"),
+            }
+        }
+        other => panic!("Expected DelegateResponse, got {other:?}"),
+    }
+
+    // Clean up: disconnecting the app removes its registration.
+    delegate_app_registry::remove_client(app_client);
+    assert_eq!(
+        delegate_app_registry::route_to_apps(
+            &delegate_key,
+            Ok(HostResponse::DelegateResponse {
+                key: delegate_key.clone(),
+                values: vec![],
+            }),
+        ),
+        0,
+        "after disconnect no app should remain registered"
+    );
+
+    crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.retain(|_, subs| {
+        subs.remove(&delegate_key);
+        !subs.is_empty()
+    });
+    std::mem::drop(temp_dir);
+    Ok(())
+}
+
 /// Test: removing a contract cleans up DELEGATE_SUBSCRIPTIONS.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_contract_removal_cleans_subscriptions() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Problem

When a delegate receives a `ContractNotification` (via the subscription pipeline from #2830 / PR #3251) and produces `OutboundDelegateMsg::ApplicationMessage`, the notification-driven invocation has no originating client connection, so the message was **dropped with a warning** at `crates/core/src/contract/mod.rs` (`TODO-MUST-FIX: Route outbound ApplicationMessages to subscribed apps #2830`). Apps registered with the delegate never received notification-driven `ApplicationMessage`s.

## Solution

**A `delegate-key → registered-client-ids` registry** (`crates/core/src/contract/delegate_app_registry.rs`), the mirror of `DELEGATE_SUBSCRIPTIONS`:

- Populated when a client issues a `DelegateRequest::ApplicationMessages` request. `handle_delegate_notification` now routes emitted `ApplicationMessage`s to exactly those registered clients (via `route_to_apps`, `try_send`), instead of dropping them.
- **Bounded + TTL'd** per `.claude/rules/code-style.md` / the GC-exemption rule: per-key cap (128 clients/delegate), per-client cap (256), rejected at insertion, plus a 30-min TTL swept opportunistically on notification and purged on client disconnect / `UnregisterDelegate`.

**Production wiring (the load-bearing part).** The WebSocket proxy (`client_events/websocket.rs::internal_proxy_recv`) previously attached a notification channel only to contract Subscribe/Get/Put-subscribe requests; a `DelegateOp::ApplicationMessages` request fell into the `None` arm, so its `OpenRequest` carried `notification_channel == None` and `process_open_request`'s `register_app` never fired for a real client. `internal_proxy_recv` now threads a notification channel for `DelegateRequest::ApplicationMessages`, reusing the existing `SubscriptionChannel` callback path so notification-driven delegate replies reach the client's WS. (The `SubscriptionChannel`/`NewSubscription` `key` field — only ever a log label — was widened from `ContractInstanceId` to a display `String` so it can carry a delegate key.)

## Testing

- `delegate_app_messages_request_gets_notification_channel` (websocket.rs) drives the **real production call site**: feeds a `ClientRequest::DelegateOp(DelegateRequest::ApplicationMessages{..})` through `internal_proxy_recv` and asserts the returned `OpenRequest.notification_channel.is_some()` (the exact `subscription_listener` `process_open_request` hands to `register_app`) and that the `SubscriptionChannel` callback reaches the client. **Verified it fails against the dead-path code**: removing the new `DelegateOp::ApplicationMessages` arm makes the test fail at the "MUST carry a notification channel" assertion; restoring it passes.
- `test_notification_application_message_routed_to_registered_app` — end-to-end through the real WASM `Runtime`: notification → delegate emits `ApplicationMessage` → `route_to_apps` → registered client channel.
- 8 registry unit tests (caps, TTL sweep, purge). All pass; `cargo fmt --check` clean; `cargo clippy --locked -- -D warnings` (CI's invocation, default features) clean.

## Fixes

Fixes #3275