### PR TITLE
feat(hosted): add "New ID" control to hosted Account popover

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -1083,15 +1083,15 @@ const SHELL_USER_TOKEN_JS: &str = include_str!("path_handlers/assets/shell_user_
 const HOSTED_BAR_STYLES: &str = include_str!("path_handlers/assets/hosted_bar.css");
 
 /// Markup for the hosted-mode bar: the always-visible "not private" disclosure
-/// plus an Account popover with the access-key backup/restore and the
-/// export-to-your-own-peer action. The access key is the per-user token, read
-/// from the shell-only `__freenet_user_token` global — it never enters the
-/// sandboxed iframe. The Export action is a placeholder until the node-side
-/// export endpoint lands.
+/// plus an Account popover with the access-key backup/restore, a "New ID"
+/// control to start over with a fresh identity, and the export-to-your-own-peer
+/// action. The access key is the per-user token, read from the shell-only
+/// `__freenet_user_token` global — it never enters the sandboxed iframe.
 const HOSTED_BAR_HTML: &str = include_str!("path_handlers/assets/hosted_bar.html");
 
 /// Behavior for the hosted-mode bar (toggle popover, copy/restore the access
-/// key, export placeholder). Runs in the trusted shell context.
+/// key, mint a fresh identity via "New ID", export data). Runs in the trusted
+/// shell context.
 const HOSTED_BAR_JS: &str = include_str!("path_handlers/assets/hosted_bar.js");
 
 /// JavaScript for the shell page's postMessage bridge.
@@ -3484,6 +3484,58 @@ mod tests {
             "fail-closed recovery must not call window.open (a popup from this \
              sandboxed context inherits the sandbox and re-hits the dead end)"
         );
+    }
+
+    /// Regression test for #4645 (second half): the hosted Account popover must
+    /// offer a "New ID" control so a user can start over with a fresh identity
+    /// from the UI, instead of hand-deleting the token from browser devtools —
+    /// the exact friction the try.freenet.org feedback reported. Minting is
+    /// delegated to SHELL_USER_TOKEN_JS: clearing the stored key is enough
+    /// because the next load mints a new random token when the key is absent.
+    #[test]
+    fn hosted_bar_offers_new_id_control_4645() {
+        // The button exists in the Account popover.
+        assert!(
+            HOSTED_BAR_HTML.contains("id=\"fnnewid\""),
+            "hosted bar must expose a New ID control (#4645)"
+        );
+        // The handler is wired to that button.
+        let handler = HOSTED_BAR_JS
+            .find("getElementById('fnnewid')")
+            .expect("New ID button must have a click handler");
+        // It clears the SAME storage key SHELL_USER_TOKEN_JS mints under, so the
+        // reload re-mints a fresh token. Pin the exact key on BOTH sides: a
+        // rename on either would silently turn "New ID" into a no-op (clears a
+        // key nobody reads) or a broken reset (clears the wrong key).
+        assert!(
+            HOSTED_BAR_JS.contains("removeItem('__freenet_user_token__')"),
+            "New ID must clear the stored per-user token"
+        );
+        assert!(
+            SHELL_USER_TOKEN_JS.contains("__freenet_user_token__"),
+            "New ID clears the key SHELL_USER_TOKEN_JS mints under; keep in sync"
+        );
+        // Destructive action: confirm BEFORE clearing, so a cancelled prompt
+        // leaves the current identity intact.
+        let confirm = HOSTED_BAR_JS[handler..]
+            .find("window.confirm(")
+            .map(|o| o + handler)
+            .expect("New ID must confirm before discarding the current identity");
+        let clear = HOSTED_BAR_JS[handler..]
+            .find("removeItem('__freenet_user_token__')")
+            .map(|o| o + handler)
+            .expect("New ID must clear the token");
+        assert!(
+            confirm < clear,
+            "the confirm prompt must run before the token is cleared, so \
+             cancelling keeps the current identity"
+        );
+        // The reload (which re-mints) comes after clearing.
+        let reload = HOSTED_BAR_JS[clear..]
+            .find("location.reload()")
+            .map(|o| o + clear)
+            .expect("New ID must reload so a fresh token mints");
+        assert!(clear < reload, "must clear the token before reloading");
     }
 
     /// Non-hosted mode must NEVER reach the fail-closed path: the bridge is

--- a/crates/core/src/server/path_handlers/assets/hosted_bar.css
+++ b/crates/core/src/server/path_handlers/assets/hosted_bar.css
@@ -91,6 +91,7 @@ iframe {
 }
 #fnpop .row {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   align-items: center;
 }

--- a/crates/core/src/server/path_handlers/assets/hosted_bar.html
+++ b/crates/core/src/server/path_handlers/assets/hosted_bar.html
@@ -15,6 +15,7 @@
         <div class="row">
           <button class="act" id="fncopy">Copy key</button
           ><button class="act" id="fnrestore">Restore from key</button
+          ><button class="act" id="fnnewid">New ID</button
           ><span id="fnok"></span>
         </div>
       </div>

--- a/crates/core/src/server/path_handlers/assets/hosted_bar.js
+++ b/crates/core/src/server/path_handlers/assets/hosted_bar.js
@@ -60,6 +60,27 @@
       setOk('Storage unavailable');
     }
   });
+  document.getElementById('fnnewid').addEventListener('click', function () {
+    // Start over with a fresh identity. Deleting the stored token is enough:
+    // on reload SHELL_USER_TOKEN_JS mints a new random token because the key is
+    // absent. Destructive (the old data on this server is unreachable without
+    // the old key), so confirm first and point the user at "Copy key".
+    if (
+      !window.confirm(
+        'Start over with a new identity? Your current data on this server ' +
+          'stays under your old access key — copy that key first if you want ' +
+          'to get back to it. This browser will switch to a fresh, empty ID.',
+      )
+    ) {
+      return;
+    }
+    try {
+      localStorage.removeItem('__freenet_user_token__');
+      location.reload();
+    } catch (e) {
+      setOk('Storage unavailable');
+    }
+  });
   document.getElementById('fnexport').addEventListener('click', function () {
     var t =
       typeof __freenet_user_token !== 'undefined' ? __freenet_user_token : null;


### PR DESCRIPTION
## Problem

On try.freenet.org the hosted Account popover lets a user copy, restore, and
export their per-user access key, but there is no way to **start over with a
fresh identity**. To get a new ID a user has to open browser devtools and
hand-delete `localStorage['__freenet_user_token__']`.

This was reported directly by a user testing try.freenet.org (see #4645):

> I'm not seeing an Account option for generating a new ID still. I had to
> manually delete the local token to get a fresh one.

#4645 bundled two asks: (a) a clearer new-tab error page and (b) an in-UI way
to generate a new ID. PR #4652 fixed (a) and explicitly noted it did **not**
resolve (b), but the merge auto-closed #4645 anyway. This PR is (b).

## Solution

Add a **New ID** button to the Access-key section of the Account popover,
next to Copy/Restore:

- It `window.confirm()`s first — the action is destructive (the old data stays
  under the old access key), so the prompt tells the user to "Copy key" first if
  they want to get back to it.
- On confirm it clears `localStorage['__freenet_user_token__']` and reloads.
  `SHELL_USER_TOKEN_JS` already mints a fresh random token on load when the key
  is absent, so **no backend change is needed** — this mirrors the existing
  "Restore from key" handler, which writes the same key.
- The button row gets `flex-wrap` so the third button doesn't overflow the
  fixed-width (300px) popover.

## Testing

- New pin test `hosted_bar_offers_new_id_control_4645`: asserts the button
  exists, the handler confirms **before** clearing (so cancelling keeps the
  current identity), reload follows the clear, and both the clear site and the
  minting site (`SHELL_USER_TOKEN_JS`) key off the same `localStorage` key — a
  rename on either side would silently turn the reset into a no-op.
- `cargo fmt` clean, `cargo clippy -p freenet --lib -- -D warnings` clean, all
  `path_handlers` unit tests pass (82).

This is a client-only change to shell-chrome assets (JS/HTML/CSS strings) plus a
test; the per-user token mechanism and the WS/backend paths are untouched.

## Fixes

Closes the remaining half of #4645.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHNrpsMi7tz5j7PH84fvhe
