### PR TITLE
fix: classify Put-variant missing-params so cross-node full-state UPDATE recovers

### DIFF
--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -363,17 +363,32 @@ impl ExecutorError {
     /// originator UPDATE call sites so a malformed delta or a disk
     /// error never triggers auto-fetch storms.
     ///
-    /// Discriminator: stdlib's `ContractError::Update` with a cause
-    /// containing the literal "missing contract parameters" string
-    /// (produced by `runtime.rs`'s `get_params` failure path,
-    /// approx. lines 920–953). Any other `Update` variant cause
-    /// returns false.
+    /// Discriminator: stdlib's `ContractError::Update` OR `ContractError::Put`
+    /// with a cause containing the literal "missing contract parameters"
+    /// string. BOTH variants must be matched (issue #3279):
+    ///
+    /// - The delta / update-only path
+    ///   (`executor/runtime/contract_ops.rs`) raises the `Update` variant.
+    /// - The full-state upsert path
+    ///   (`executor/runtime/executor_impl.rs::upsert_contract_state`) raises
+    ///   the `Put` variant when `state_store.get_params` returns `None`.
+    ///
+    /// A cross-node **full-state (non-delta)** UPDATE takes the upsert path,
+    /// so it surfaces as `Put`. Matching only `Update` (the pre-#3279
+    /// behavior) silently misclassified that case: the auto-fetch recovery
+    /// gated on this predicate (the originator self-heal and the no-remote
+    /// hosting-divergence branch in `update/op_ctx_task.rs`) never fired, so
+    /// a subscriber that received a full-state broadcast without local params
+    /// stayed permanently stuck on "missing contract parameters" — exactly
+    /// the #3279 regression. Any other cause string on either variant returns
+    /// false.
     pub fn is_missing_contract_parameters(&self) -> bool {
         match &self.inner {
             Either::Left(req_err) => matches!(
                 req_err.as_ref(),
-                RequestError::ContractError(StdContractError::Update { cause, .. })
-                    if cause.contains("missing contract parameters")
+                RequestError::ContractError(
+                    StdContractError::Update { cause, .. } | StdContractError::Put { cause, .. },
+                ) if cause.contains("missing contract parameters")
             ),
             Either::Right(_) => false,
         }
@@ -1404,6 +1419,64 @@ mod tests {
             assert!(
                 !err.is_contract_queue_full(),
                 "Missing contract parameters is not queue-full"
+            );
+        }
+
+        // ── is_missing_contract_parameters over BOTH variants (issue #3279) ──
+        //
+        // The predicate MUST match "missing contract parameters" whether it
+        // arrives as a `ContractError::Update` (delta / update-only path) or a
+        // `ContractError::Put` (full-state upsert path in executor_impl.rs). A
+        // cross-node non-delta UPDATE surfaces as `Put`; matching only `Update`
+        // silently suppressed the auto-fetch recovery for that case — the exact
+        // #3279 regression.
+
+        #[test]
+        fn test_missing_contract_parameters_true_for_update_variant() {
+            let key = test_fixtures::make_contract_key();
+            let err = ExecutorError::request(StdContractError::Update {
+                key,
+                cause: "missing contract parameters".into(),
+            });
+            assert!(
+                err.is_missing_contract_parameters(),
+                "Update-variant missing-params MUST be recognized"
+            );
+        }
+
+        #[test]
+        fn test_missing_contract_parameters_true_for_put_variant() {
+            // Regression guard for issue #3279: the full-state upsert path
+            // (executor_impl.rs) raises the `Put` variant. Before the fix the
+            // predicate only matched `Update`, so this returned false and the
+            // full-state cross-node UPDATE stayed permanently stuck.
+            let key = test_fixtures::make_contract_key();
+            let err = ExecutorError::request(StdContractError::Put {
+                key,
+                cause: "missing contract parameters".into(),
+            });
+            assert!(
+                err.is_missing_contract_parameters(),
+                "Put-variant missing-params MUST be recognized (issue #3279); \
+                 the full-state cross-node UPDATE path raises this variant and \
+                 the auto-fetch recovery gates on this predicate"
+            );
+        }
+
+        #[test]
+        fn test_missing_contract_parameters_false_for_other_put_cause() {
+            // A Put failure with a DIFFERENT cause must NOT trip the predicate:
+            // broadening to the Put variant must stay scoped to the exact
+            // missing-params cause, or unrelated PUT failures would spuriously
+            // trigger auto-fetch storms.
+            let key = test_fixtures::make_contract_key();
+            let err = ExecutorError::request(StdContractError::Put {
+                key,
+                cause: "state size 999 bytes exceeds maximum allowed".into(),
+            });
+            assert!(
+                !err.is_missing_contract_parameters(),
+                "Only the missing-params cause may match, not every Put error"
             );
         }
 

--- a/crates/core/src/contract/executor/pool_tests/merge_rejected_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/merge_rejected_tests.rs
@@ -196,3 +196,105 @@ fn test_is_invalid_update_rejection_matches_website_contract_format() {
         "predicate must match website-contract's same-version error format"
     );
 }
+
+// =========================================================================
+// Test: cross-node non-delta update with missing params is classified as
+//       is_missing_contract_parameters (issue #3279)
+// =========================================================================
+
+/// Regression test for issue #3279 (Part 2).
+///
+/// Reproduces the "missing contract parameters" failure that a node hits
+/// when it applies a cross-node full-state (non-delta) UPDATE for a contract
+/// whose parameters are absent from its `state_store`. This is the exact
+/// on-disk shape the issue describes: the node has the contract *state* (and,
+/// in production, the contract *code*) but never persisted the *params* —
+/// e.g. because an earlier code-less GET response could not cache them, or
+/// because of the documented `StateStore::store` partial-failure window where
+/// the state write succeeds but the params write fails, orphaning state
+/// without params.
+///
+/// The upsert MUST fail with an error that satisfies
+/// `is_missing_contract_parameters()`. That predicate is the load-bearing
+/// discriminator the whole recovery chain depends on:
+///   - the inbound broadcast/relay path
+///     (`update/op_ctx_task.rs::drive_relay_broadcast_to`) triggers
+///     `try_auto_fetch_contract` only when the full-state merge failed
+///     because code/params are missing (NOT on a contract-side WASM
+///     rejection);
+///   - the originator UPDATE self-heal
+///     (`update/op_ctx_task.rs`) auto-fetches on exactly this predicate.
+///
+/// If this classification silently broke (e.g. the cause string drifted, or
+/// the error were mapped to a different `ContractError` variant), every
+/// missing-params recovery path would misclassify and issue #3279 would
+/// regress into a hard, unrecoverable "missing contract parameters" on every
+/// cross-node update — with no auto-fetch to heal it.
+#[tokio::test(flavor = "current_thread")]
+async fn test_missing_params_non_delta_update_is_classified_as_missing_parameters() {
+    let storage = MockStateStorage::new();
+    let mut executor = Executor::new_mock_wasm("missing_params_test", storage.clone(), None, None)
+        .await
+        .expect("create MockWasmRuntime executor");
+
+    let contract = make_contract(b"missing_params_3279");
+    let key = contract.key();
+    let initial_state = WrappedState::new(vec![1, 2, 3, 4]);
+
+    // A clean initial PUT: contract code lands in the runtime store, state and
+    // params land on disk.
+    executor
+        .upsert_contract_state(
+            key,
+            Either::Left(initial_state.clone()),
+            RelatedContracts::default(),
+            Some(contract),
+        )
+        .await
+        .expect("initial PUT should succeed");
+
+    // Now model the cross-node inconsistency issue #3279 reports: the node
+    // still has the contract state (and code) but has LOST its params (an
+    // earlier code-less GET could not cache them, or the documented
+    // `StateStore::store` partial-failure window orphaned state-without-params).
+    storage.remove_params_for_test(&key);
+    assert!(
+        storage.get_stored_state(&key).is_some(),
+        "state must remain on disk after dropping params"
+    );
+    assert!(
+        storage.get_stored_params(&key).is_none(),
+        "params must be absent — this is the #3279 orphaned-state shape"
+    );
+
+    // Now apply a cross-node full-state (non-delta) UPDATE with code == None
+    // (the wire delivery of a broadcast UPDATE carries no contract code). The
+    // executor must take the `else` branch that reads params from the
+    // state_store, find them missing, and return the typed error.
+    let incoming_state = WrappedState::new(vec![5, 6, 7, 8]);
+    let err = executor
+        .upsert_contract_state(
+            key,
+            Either::Left(incoming_state),
+            RelatedContracts::default(),
+            None,
+        )
+        .await
+        .expect_err("non-delta update with missing params must fail");
+
+    assert!(
+        err.is_missing_contract_parameters(),
+        "missing-params full-state update MUST satisfy \
+         is_missing_contract_parameters() — the recovery-chain discriminator \
+         for issue #3279; got: {err:?}"
+    );
+
+    // It must NOT be misclassified as a contract-side WASM rejection: that
+    // would suppress auto-fetch (the merge is assumed to have run against
+    // present code/params), permanently wedging the cross-node update.
+    assert!(
+        !err.is_contract_exec_rejection(),
+        "missing-params error must NOT be classified as a contract exec \
+         rejection, or auto-fetch recovery would be suppressed"
+    );
+}

--- a/crates/core/src/wasm_runtime/mock_state_storage.rs
+++ b/crates/core/src/wasm_runtime/mock_state_storage.rs
@@ -174,6 +174,18 @@ impl MockStateStorage {
         inner.params.insert(key, params);
     }
 
+    /// Drop ONLY the params for a key, leaving its state intact.
+    ///
+    /// Models the "orphaned state without params" on-disk shape that issue
+    /// #3279 reports: a node that has a contract's state (and code) but is
+    /// missing its parameters, so a cross-node non-delta update cannot run.
+    /// There is no production `remove_params` — this is a test-only helper for
+    /// constructing that inconsistency deterministically.
+    pub fn remove_params_for_test(&self, key: &ContractKey) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.params.remove(key);
+    }
+
     /// Check if a specific key should fail.
     fn should_fail_for_key(inner: &MockStateStorageInner, key: &ContractKey) -> bool {
         inner.failure_config.fail_for_keys.contains(key)


### PR DESCRIPTION
## Problem

A cross-node **full-state (non-delta) UPDATE** for a contract whose parameters are absent from the local `state_store` fails in `Executor::upsert_contract_state` (`executor_impl.rs`) with `ContractError::Put { cause: "missing contract parameters" }`. The auto-fetch self-heal that recovers this gates on `ExecutorError::is_missing_contract_parameters()` — but that predicate matched **only** the `ContractError::Update` variant (raised by the delta/update-only path). The full-state upsert path raises the `Put` variant, so the predicate returned `false`, the self-heal never fired, and a subscriber that received a full-state broadcast without local params stayed **permanently stuck** on "missing contract parameters" with no recovery.

This is **Part 2** of #3279 (the v0.1.151 regression). The surrounding recovery machinery (`try_auto_fetch_contract`, `ensure_params`, `ResyncRequest`, and the `test_auto_fetch_from_update_sender` integration test) already landed on 0.2.x since the issue was filed against 0.1.x — this fix closes the remaining **variant-mismatch hole** that silently defeated it for the full-state case.

## Solution

Broaden `is_missing_contract_parameters()` to match **both** the `Update` and `Put` `ContractError` variants, scoped to the exact missing-params cause string so unrelated PUT failures do not spuriously trigger auto-fetch storms.

## Testing

- Executor pool test `test_missing_params_non_delta_update_is_classified_as_missing_parameters`: PUTs a contract, drops **only** its params (new test-only `MockStateStorage::remove_params_for_test` reproduces the orphaned-state shape deterministically), applies a full-state `code=None` update, and asserts the resulting error satisfies `is_missing_contract_parameters()`. **Fails without the fix** — the error is a `Put` variant the old predicate ignored.
- Unit tests pinning the predicate over both `Update` and `Put` variants, and confirming a **non**-missing-params `Put` cause does NOT match (guards the scoping).
- `cargo clippy --locked -- -D warnings` (CI-exact, default features) clean; 190 executor + 67 update tests green.

## Scope

**Part 1** of #3279 (intermittent ~50% PUT/UpdateNotification timeouts on a 3-node net) is a flaky multi-node networking symptom with no deterministic unit repro; its subscription-propagation surface was largely reworked since 0.1.x. Deferred as follow-up — one logical change per PR. This PR uses `Refs` (not `Fixes`) so #3279 stays open for Part 1.

## Refs

Refs #3279 (Part 2 of 2)