### PR TITLE
fix: guard summary-mismatch heal against broadcast fan-out regression

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -408,9 +408,64 @@ Pins (source-scrape, fail the build on regression):
   `recv_waiter_reply_*` (op_ctx.rs) and
   `orphaned_transaction_wakes_parked_waiter_with_peer_disconnected` (op_state_manager.rs)
 
+## Event emission review (targeted vs fan-out)
+
+**When reviewing (or writing) ANY code that emits a `NodeEvent`, you MUST
+explicitly verify two things and note them in the review:**
+
+```
+1. WHICH peers receive this event?
+   → Targeted   → SyncStateToPeer { target }  (exactly one peer)
+   → Fan-out    → BroadcastStateChange        (ALL subscribers of the key)
+   Name the actual recipient set out loud. "It syncs the peer" is not a
+   review — "it fans out to every subscriber of the contract" is.
+
+2. Does the code COMMENT match the actual dispatch path?
+   → A comment that describes the INTENDED effect ("sends state only to
+     peers with stale summaries") while the code takes the fan-out path is
+     a review failure, not a nit. Comments on event-emission sites MUST
+     name the concrete dispatch behavior (targeted address / all
+     subscribers), NOT the wished-for outcome.
+```
+
+**Why this is a mandatory checklist item.** #3791 was a six-week-old
+regression where the summary-mismatch handler emitted
+`BroadcastStateChange` (all-subscriber fan-out) instead of the intended
+targeted `SyncStateToPeer`. A misleading comment made the wrong event look
+correct on a quick read; it turned one mismatch into O(N × fan-out)
+transmissions and produced 19:1–163:1 upload/download ratios in
+production. The full targeted-vs-broadcast cost model is in
+`docs/architecture/event-dispatch.md`.
+
+**The trap that hid it, and how we guard against it now.** The original
+regression test only covered `InterestManager` stale-peer *data* logic —
+reverting the `node.rs` dispatch would have left that test green. A test
+for an event-emission fix MUST exercise the actual dispatch DECISION
+(which variant, which target), not just the data layer that feeds it.
+
+```
+WHEN adding or reviewing a test for an event-emission fix:
+  → Does the test assert on the emitted NodeEvent variant and its
+    recipient (target address vs all-subscriber fan-out)?
+    → NO: it does not guard the dispatch. A data-layer-only test would
+          stay green if someone reverted the emit site to a broadcast.
+  → Prefer a pure builder function for the emit decision (see
+    `node.rs::stale_peer_sync_event`) so the variant+target choice is
+    unit-testable without a full OpManager, PLUS a source-scrape pin that
+    the production loop still routes through it.
+```
+
+Pins (source-scrape / builder, fail the build on regression):
+- `stale_peer_sync_event_is_targeted_not_broadcast` (node.rs) — the heal
+  event is a targeted `SyncStateToPeer`, never a `BroadcastStateChange`.
+- `emit_site_uses_targeted_builder` (node.rs) — the `Summaries`-arm emit
+  site routes through `stale_peer_sync_event` and never names
+  `BroadcastStateChange`.
+
 ## Documentation
 
 - Architecture: `docs/architecture/operations/README.md`
+- Event dispatch (targeted vs fan-out): `docs/architecture/event-dispatch.md`
 - OpManager: `crates/core/src/node/op_state_manager.rs`
 - Round-trip primitive: `crates/core/src/operations/op_ctx.rs`
 - Orphan-wake signal: `crate::node::WaiterReply::PeerDisconnected` + `NodeEvent::TransactionOrphaned` (#4313)

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1724,11 +1724,18 @@ where
                     // the same notification channel that the executor's
                     // try_notify path is trying to keep responsive
                     // (#4145 / #4234).
-                    if let Err(e) = op_manager.try_notify_node_event(NodeEvent::SyncStateToPeer {
-                        key,
-                        new_state: state,
-                        target: source,
-                    }) {
+                    //
+                    // Targeted heal: `stale_peer_sync_event` builds a
+                    // `SyncStateToPeer` aimed at exactly `source` (the one
+                    // neighbor whose proximity announcement overlaps our
+                    // hosting), NEVER a `BroadcastStateChange` that would fan
+                    // the state out to ALL subscribers. Routing through the
+                    // shared builder keeps this second emit site pinned by
+                    // `proximity_overlap_emit_site_uses_targeted_builder`
+                    // (#3791/#3796) — the exact fan-out regression class.
+                    if let Err(e) =
+                        op_manager.try_notify_node_event(stale_peer_sync_event(key, state, source))
+                    {
                         // Best-effort by design (see comment above);
                         // log at debug to keep the caller layer in
                         // step with the helper-internal downgrade
@@ -2372,6 +2379,53 @@ fn emitted_indices_for_rotation(total: usize, start: usize) -> Vec<usize> {
     (0..budget).map(|p| (start + p) % total).collect()
 }
 
+/// Build the `NodeEvent` that heals a single peer by sending it our local
+/// state for one contract.
+///
+/// Two production emit sites route through this builder:
+///
+/// 1. The summary-mismatch heal in `handle_interest_sync_message`'s
+///    `Summaries` arm — `target` is the peer that reported the stale summary.
+/// 2. The proximity-cache overlap path in `handle_connect_msg` — `target` is
+///    the neighbor whose interest announcement just overlapped a contract we
+///    also host.
+///
+/// This MUST be a `SyncStateToPeer` — a **targeted** send to exactly the one
+/// peer (`target`) — and MUST NOT be a `BroadcastStateChange`, which fans the
+/// state out to *all* subscribers of the contract. Both sites are the same
+/// fan-out regression class (#3791/#3796): a single overlap/mismatch must cost
+/// O(1) peer transmissions, not O(subscribers).
+///
+/// # Why this is its own function (regression guard for #3791 / #3796)
+///
+/// A six-week-old regression (#3791) had the summary-mismatch handler emit
+/// `BroadcastStateChange` here. A misleading comment claimed it "sends state
+/// only to peers with stale summaries", but the production dispatch
+/// (`handle_broadcast_state_change` → `get_broadcast_targets_update`) fanned out
+/// to every subscriber (~28 peers), turning one mismatch into O(N × fan-out)
+/// transmissions and producing 19:1–163:1 upload/download ratios in production.
+///
+/// The original regression test only covered `InterestManager` data logic and
+/// would have stayed green if the `node.rs` dispatch were reverted. Isolating
+/// the dispatch *decision* (which `NodeEvent` variant, aimed at which peer) in
+/// this pure function lets `stale_peer_sync_event_is_targeted_not_broadcast`
+/// pin it directly: reverting to a `BroadcastStateChange` here fails that test.
+///
+/// See `.claude/rules/operations.md` (Event emission review) and
+/// `docs/architecture/event-dispatch.md` for the targeted-vs-fan-out
+/// distinction.
+fn stale_peer_sync_event(
+    key: freenet_stdlib::prelude::ContractKey,
+    new_state: freenet_stdlib::prelude::WrappedState,
+    target: std::net::SocketAddr,
+) -> crate::message::NodeEvent {
+    crate::message::NodeEvent::SyncStateToPeer {
+        key,
+        new_state,
+        target,
+    }
+}
+
 /// Handle incoming InterestSync messages for delta-based state synchronization.
 ///
 /// This function processes the interest exchange protocol:
@@ -2384,7 +2438,7 @@ async fn handle_interest_sync_message(
     source: std::net::SocketAddr,
     message: crate::message::InterestMessage,
 ) -> Option<crate::message::InterestMessage> {
-    use crate::message::{InterestMessage, NodeEvent, SummaryEntry};
+    use crate::message::{InterestMessage, SummaryEntry};
     use crate::ring::interest::contract_hash;
 
     match message {
@@ -2641,11 +2695,13 @@ async fn handle_interest_sync_message(
                 // will retry. Blocking here would stack the heal
                 // path on the same notification channel the executor
                 // is trying to keep responsive (#4145 / #4234).
-                if let Err(e) = op_manager.try_notify_node_event(NodeEvent::SyncStateToPeer {
-                    key: contract,
-                    new_state: state,
-                    target: source,
-                }) {
+                // Targeted heal: `stale_peer_sync_event` builds a
+                // `SyncStateToPeer` aimed at exactly `source`, NEVER an
+                // all-subscriber fan-out. Pinned by
+                // `stale_peer_sync_event_is_targeted_not_broadcast` (#3791/#3796).
+                if let Err(e) =
+                    op_manager.try_notify_node_event(stale_peer_sync_event(contract, state, source))
+                {
                     // Best-effort by design (see comment above); log
                     // at debug to keep the caller layer in step with
                     // the helper-internal downgrade (#4238).
@@ -5795,6 +5851,182 @@ mod tests {
                 "stale-sync rotation offset is no longer drawn from GlobalRng — \
                  a fixed/non-random rotation does not avoid starvation and \
                  breaks simulation determinism"
+            );
+        }
+    }
+
+    // ───────────────────────────────────────────────────────────
+    // Regression guard for #3791 (fixed by #3793) / #3796.
+    //
+    // The summary-mismatch handler in `handle_interest_sync_message`'s
+    // `Summaries` arm must heal a stale peer with a TARGETED
+    // `SyncStateToPeer` aimed at exactly that peer — never a
+    // `BroadcastStateChange`, which fans the state out to ALL subscribers
+    // (~28 peers in production) and caused the 19:1–163:1 upload/download
+    // ratios reported in #3791.
+    //
+    // The ORIGINAL regression test only exercised `InterestManager`
+    // stale-peer *data* logic and would have stayed green if the `node.rs`
+    // dispatch were reverted to `BroadcastStateChange`. These tests instead
+    // exercise the actual `node.rs` dispatch DECISION — which `NodeEvent`
+    // variant is built, and which peer it targets — via the pure
+    // `stale_peer_sync_event` builder the production loop calls. Reverting
+    // that builder to a broadcast fails `is_targeted_not_broadcast`; a
+    // source-scrape pin (`emit_site_uses_targeted_builder`) additionally
+    // fails if the loop stops routing through the builder.
+    // ───────────────────────────────────────────────────────────
+    mod fanout_regression_guard {
+        use super::super::stale_peer_sync_event;
+        use crate::message::NodeEvent;
+        use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey, WrappedState};
+
+        fn test_key() -> ContractKey {
+            ContractKey::from_id_and_code(
+                ContractInstanceId::new([7u8; 32]),
+                CodeHash::new([9u8; 32]),
+            )
+        }
+
+        /// The load-bearing assertion: the summary-mismatch heal event is a
+        /// TARGETED `SyncStateToPeer` at the reporting peer, NOT an
+        /// all-subscriber `BroadcastStateChange`. This is exactly the bug
+        /// #3791 reintroduced — the event that reverting the fix would flip
+        /// back to a broadcast fan-out.
+        #[test]
+        fn stale_peer_sync_event_is_targeted_not_broadcast() {
+            let key = test_key();
+            let state = WrappedState::new(vec![1, 2, 3, 4]);
+            let target: std::net::SocketAddr = "203.0.113.7:31337".parse().unwrap();
+
+            let event = stale_peer_sync_event(key, state.clone(), target);
+
+            // The whole point of #3791/#3796: this MUST be a targeted
+            // SyncStateToPeer, NOT a BroadcastStateChange (all-subscriber
+            // fan-out) or any other variant.
+            let NodeEvent::SyncStateToPeer {
+                key: ev_key,
+                new_state,
+                target: ev_target,
+            } = event
+            else {
+                panic!(
+                    "summary-mismatch heal must emit a targeted SyncStateToPeer, \
+                     got fan-out/other variant: {event:?}"
+                );
+            };
+            assert_eq!(
+                ev_target, target,
+                "SyncStateToPeer must target EXACTLY the peer that reported the \
+                 stale summary, not any other peer"
+            );
+            assert_eq!(ev_key, key, "event must carry the mismatched contract key");
+            assert_eq!(
+                new_state.as_ref(),
+                state.as_ref(),
+                "event must carry the local state to heal the peer with"
+            );
+        }
+
+        /// A different reporting peer must be the sole target — proves the
+        /// event is genuinely per-peer targeted and not accidentally fixed to
+        /// one address.
+        #[test]
+        fn stale_peer_sync_event_targets_the_reporting_peer() {
+            let key = test_key();
+            let state = WrappedState::new(vec![0xAB]);
+            let a: std::net::SocketAddr = "198.51.100.1:1000".parse().unwrap();
+            let b: std::net::SocketAddr = "198.51.100.2:2000".parse().unwrap();
+
+            for target in [a, b] {
+                let event = stale_peer_sync_event(key, state.clone(), target);
+                let NodeEvent::SyncStateToPeer {
+                    target: ev_target, ..
+                } = event
+                else {
+                    panic!("expected targeted SyncStateToPeer, got {event:?}");
+                };
+                assert_eq!(ev_target, target);
+            }
+        }
+
+        /// Source-scrape pin: the production emit site in the `Summaries` arm
+        /// must route through `stale_peer_sync_event` rather than constructing
+        /// a `NodeEvent` inline. Without this, someone could reintroduce an
+        /// inline `NodeEvent::BroadcastStateChange { .. }` at the emit site and
+        /// leave the (still-passing) builder tests above untouched — the exact
+        /// test-gap #3796 calls out.
+        #[test]
+        fn emit_site_uses_targeted_builder() {
+            const SOURCE: &str = include_str!("node.rs");
+
+            let anchor = "for contract in stale_contracts {";
+            let start = SOURCE
+                .find(anchor)
+                .expect("stale-contract emission loop not found — update this pin");
+            let window_end = SOURCE[start..]
+                .find("for (key, state_hash) in confirmed_states {")
+                .map(|off| start + off)
+                .unwrap_or(SOURCE.len());
+            let window = &SOURCE[start..window_end];
+
+            assert!(
+                window.contains("stale_peer_sync_event(contract, state, source)"),
+                "the stale-peer heal emit site no longer routes through \
+                 `stale_peer_sync_event(contract, state, source)` — the \
+                 targeted-vs-broadcast dispatch decision is no longer pinned \
+                 by the builder tests (#3791/#3796)"
+            );
+            assert!(
+                !window.contains("NodeEvent::BroadcastStateChange"),
+                "the stale-peer heal emit site now constructs a \
+                 NodeEvent::BroadcastStateChange — this is the #3791 \
+                 regression (all-subscriber fan-out instead of a targeted \
+                 SyncStateToPeer)"
+            );
+        }
+
+        /// Source-scrape pin for the SECOND emit site (#3796 B2 gap): the
+        /// proximity-cache overlap path in the connect handler must also route
+        /// through `stale_peer_sync_event` and MUST NOT construct an inline
+        /// `NodeEvent::SyncStateToPeer` (which a future edit could silently
+        /// flip to `BroadcastStateChange`, uncaught by any test). This site
+        /// was left unguarded by the first #3796 pass; this test closes it so
+        /// BOTH targeted-send sites are pinned to the same guarded builder.
+        #[test]
+        fn proximity_overlap_emit_site_uses_targeted_builder() {
+            const SOURCE: &str = include_str!("node.rs");
+
+            let anchor = "Proximity cache overlap — syncing state to neighbor";
+            let start = SOURCE
+                .find(anchor)
+                .expect("proximity-overlap emit site not found — update this pin");
+            // Bound the window to the emit block: from the log line to the end
+            // of the best-effort error handler that follows the try_notify call.
+            let window_end = SOURCE[start..]
+                .find("for proximity sync (best-effort)")
+                .map(|off| start + off)
+                .expect("proximity-overlap emit block end marker not found");
+            let window = &SOURCE[start..window_end];
+
+            assert!(
+                window.contains("stale_peer_sync_event(key, state, source)"),
+                "the proximity-overlap emit site no longer routes through \
+                 `stale_peer_sync_event(key, state, source)` — its \
+                 targeted-vs-broadcast dispatch decision is no longer pinned \
+                 by the builder tests (#3791/#3796 B2 gap)"
+            );
+            assert!(
+                !window.contains("NodeEvent::SyncStateToPeer"),
+                "the proximity-overlap emit site constructs an inline \
+                 NodeEvent::SyncStateToPeer instead of using the guarded \
+                 builder — an inline construction is one edit away from an \
+                 unguarded BroadcastStateChange fan-out (#3796 B2 gap)"
+            );
+            assert!(
+                !window.contains("NodeEvent::BroadcastStateChange"),
+                "the proximity-overlap emit site now constructs a \
+                 NodeEvent::BroadcastStateChange — all-subscriber fan-out \
+                 instead of a targeted SyncStateToPeer (#3791/#3796)"
             );
         }
     }

--- a/crates/core/src/ring/contract_ban_list.rs
+++ b/crates/core/src/ring/contract_ban_list.rs
@@ -1151,13 +1151,17 @@ mod tests {
             "NeighborHosting overlap-sync block is missing the ban-list egress gate — \
              banned contracts would continue to be pushed to sibling peers",
         );
+        // The targeted-sync emit is routed through the `stale_peer_sync_event`
+        // builder (the single guarded construction site introduced by #3796);
+        // the raw `NodeEvent::SyncStateToPeer` literal no longer appears inline
+        // here. Match the builder call as the emit token.
         let emit_pos = block
-            .find("NodeEvent::SyncStateToPeer")
-            .expect("NeighborHosting block is missing SyncStateToPeer emit");
+            .find("stale_peer_sync_event(")
+            .expect("NeighborHosting block is missing the stale_peer_sync_event emit");
         assert!(
             gate_pos < emit_pos,
             "NeighborHosting ban-list gate (offset {gate_pos}) must \
-             precede SyncStateToPeer emit (offset {emit_pos})"
+             precede the stale_peer_sync_event emit (offset {emit_pos})"
         );
     }
 
@@ -1202,13 +1206,17 @@ mod tests {
              banned contracts would continue to be pushed to peers that report \
              stale summaries (defeats the Phase 7 wire-boundary drop)",
         );
+        // The targeted-sync emit is routed through the `stale_peer_sync_event`
+        // builder (the single guarded construction site introduced by #3796);
+        // the raw `NodeEvent::SyncStateToPeer` literal no longer appears inline
+        // in this loop. Match the builder call as the emit token.
         let emit_pos = scan
-            .find("NodeEvent::SyncStateToPeer")
-            .expect("stale-summary loop is missing SyncStateToPeer emit");
+            .find("stale_peer_sync_event(")
+            .expect("stale-summary loop is missing the stale_peer_sync_event emit");
         assert!(
             gate_pos < emit_pos,
             "InterestSync ban-list gate (offset {gate_pos}) must \
-             precede SyncStateToPeer emit (offset {emit_pos})"
+             precede the stale_peer_sync_event emit (offset {emit_pos})"
         );
     }
 

--- a/docs/architecture/event-dispatch.md
+++ b/docs/architecture/event-dispatch.md
@@ -1,0 +1,92 @@
+# Event dispatch: targeted vs broadcast fan-out
+
+Several node paths react to a contract's state changing by pushing that
+state to other peers. There are two fundamentally different dispatch
+shapes, and choosing the wrong one is both a **correctness** and a
+**performance** bug. This document is the reference for that distinction;
+the review checklist that enforces it lives in
+[`.claude/rules/operations.md`](../../.claude/rules/operations.md) under
+"Event emission review".
+
+## The two `NodeEvent` shapes
+
+| Event | Recipients | Cost | Used for |
+|-------|-----------|------|----------|
+| `BroadcastStateChange { key, new_state, .. }` | **All** subscribers/hosts of `key` | O(fan-out) per emit | Propagating a real PUT/UPDATE outward so every subscriber converges |
+| `SyncStateToPeer { key, new_state, target }` | **Exactly one** peer (`target`) | O(1) per emit | Healing a single peer that is known to be behind (summary mismatch, proximity-cache overlap) |
+
+- `BroadcastStateChange` is handled in
+  `node/network_bridge/p2p_protoc/broadcast.rs` via
+  `get_broadcast_targets_update`, which resolves **every** subscriber of
+  the contract and sends to each. On a popular contract that is ~28–80
+  peers per emit.
+- `SyncStateToPeer` is handled in the same module but sends to the single
+  `target` socket address only.
+
+## When each is correct
+
+Use `BroadcastStateChange` when the state change is **new information the
+whole subscriber set must learn** — the normal PUT/UPDATE propagation
+path. One update, fanned out once, is the intended O(fan-out).
+
+Use `SyncStateToPeer` when you have **already identified the specific
+peer(s) that are behind** and only they need catching up:
+
+- **Summary-mismatch correction** (interest sync). A peer reports a stale
+  summary; only that peer is behind, so only that peer is healed. See
+  `node.rs::handle_interest_sync_message` (`Summaries` arm) and the
+  `stale_peer_sync_event` builder.
+- **Proximity-cache overlap.** When a neighbor is discovered to be
+  missing a contract we host, the heal is targeted at that neighbor.
+
+## Why mixing them is a bug
+
+The failure mode is emitting `BroadcastStateChange` from a path that has
+**already narrowed the problem to a single peer**. Instead of one targeted
+send you get a full fan-out, and if N peers each independently detect a
+mismatch within the same heartbeat cycle you get **O(N × fan-out)**
+transmissions where O(N) would suffice.
+
+### Concrete incident: #3791
+
+For six weeks the summary-mismatch handler emitted
+`BroadcastStateChange` instead of `SyncStateToPeer`. Production impact
+(gateway, 2026-04-07, one hour):
+
+- 4,820 `UPDATE_PROPAGATION` events; **88% triggered by summary
+  mismatches**.
+- Average fan-out **28.7 peers** per broadcast; peak 144 broadcasts/minute
+  for a single contract.
+- ~138,000 peer-transmissions/hour from one gateway.
+- Observed **19:1** and user-reported **163:1** upload/download ratios
+  (1.1 GB uploaded in 45 minutes).
+
+A misleading comment — *"Emitting BroadcastStateChange triggers the
+existing broadcast path which computes deltas and sends state only to
+peers with stale summaries"* — described the *intended* effect, not the
+*actual* all-subscriber fan-out, so the wrong event survived review.
+
+## Guardrails in the tree
+
+- **Builder isolates the decision.** `node.rs::stale_peer_sync_event`
+  builds the targeted `SyncStateToPeer`. The `Summaries`-arm emit site
+  routes through it rather than constructing a `NodeEvent` inline, so the
+  variant-and-target choice is unit-testable without a full `OpManager`.
+- **Regression tests** (`node.rs`, module `fanout_regression_guard`):
+  - `stale_peer_sync_event_is_targeted_not_broadcast` — the heal event is
+    a targeted `SyncStateToPeer`, never a `BroadcastStateChange`.
+  - `stale_peer_sync_event_targets_the_reporting_peer` — the sole target
+    is the reporting peer.
+  - `emit_site_uses_targeted_builder` — source-scrape pin: the production
+    emit site still routes through the builder and never names
+    `BroadcastStateChange`. This closes the #3791 test-gap where a
+    data-layer-only test stayed green after the dispatch was reverted.
+- **Review checklist.** Every `NodeEvent`-emitting site must be reviewed
+  for (1) which peers receive the event and (2) whether the comment names
+  the actual dispatch path. See `.claude/rules/operations.md`.
+
+## References
+
+- Bug: #3791 · Fix PR: #3793 · Process/test tracking: #3796
+- Emit budget cap on stale-sync fan-out: #3798 (see
+  `MAX_STALE_SYNCS_PER_SUMMARIES` in `node.rs`)

--- a/docs/architecture/operations/README.md
+++ b/docs/architecture/operations/README.md
@@ -466,3 +466,6 @@ sequenceDiagram
 - [Ring/DHT Architecture](../ring/README.md) - Routing decisions
 - [Transport Layer](../transport/README.md) - Network communication
 - [Testing](../testing/README.md) - DST with operation validation
+- [Event dispatch: targeted vs broadcast fan-out](../event-dispatch.md) -
+  `SyncStateToPeer` (one peer) vs `BroadcastStateChange` (all subscribers),
+  and why mixing them is a correctness + performance bug (#3791)


### PR DESCRIPTION
## Problem

PR #3793 fixed a 6-week-old regression (#3791) where summary-mismatch handlers emitted `BroadcastStateChange` (all-subscriber fan-out) instead of a targeted `SyncStateToPeer`, causing O(N × fan-out) redundant transmissions per heartbeat — 19:1–163:1 upload/download ratios in production. Two things made it recur-prone:

1. A misleading comment described *intended* behavior, not actual dispatch, so the wrong event looked correct on a quick read.
2. The original regression test only covered `InterestManager` data logic — reverting the `node.rs` dispatch fix entirely would have left it **green**.

There were also **two** inline `NodeEvent::SyncStateToPeer` construction sites in `node.rs` (the summary-mismatch heal and the proximity-cache overlap path), either of which could silently regress to a fan-out.

## Solution

**Funnel both emit sites through one guarded builder.** `stale_peer_sync_event(key, state, target)` is now the *only* production construction of `NodeEvent::SyncStateToPeer` in `node.rs`; the summary-mismatch heal and the proximity-cache overlap path both route through it. Grep confirms no remaining inline `SyncStateToPeer` and no production `BroadcastStateChange` construction in `node.rs`.

**Process + architecture docs (issue's A1/A2 deliverables):**
- New "Event emission review" section in `.claude/rules/operations.md`: reviewers must verify, at every `NodeEvent`-emitting site, *which peers receive it* (targeted vs fan-out) and *whether the comment matches the actual dispatch path*.
- New `docs/architecture/event-dispatch.md` documenting the `BroadcastStateChange` (all subscribers) vs `SyncStateToPeer` (targeted) distinction and when each is correct; pointer added from `operations/README.md`.

## Testing

Four `node::tests::fanout_regression_guard` tests, all exercising the **real `node.rs` dispatch decision** (source-scrape via `include_str!`, not a data-layer proxy — the trap the original #3791 test fell into):

- `emit_site_uses_targeted_builder` — summary-mismatch heal routes through the builder, no inline `SyncStateToPeer`, no `BroadcastStateChange`.
- `proximity_overlap_emit_site_uses_targeted_builder` — same guarantee for the proximity-cache overlap site.
- `stale_peer_sync_event_is_targeted_not_broadcast` / `stale_peer_sync_event_targets_the_reporting_peer` — builder emits a targeted sync to the specific reporting peer.

Verified load-bearing: reverting either site to an inline `SyncStateToPeer` **or** to a `BroadcastStateChange` makes the corresponding test FAIL. `cargo clippy --locked -- -D warnings` (CI-exact, default features) clean.

## Fixes

Fixes #3796