### PR TITLE
feat(hosting): distance-based cold-start prior for demand estimator

### DIFF
--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -1498,15 +1498,20 @@ impl HostingManager {
     /// to model. The cache write lock is dropped before the estimator write lock
     /// (no nested lock order), matching `record_contract_access`.
     pub fn touch_hosting(&self, key: &ContractKey) {
-        let observed_read_rate = self.hosting_cache.write().touch(key);
-        if let Some(rate) = observed_read_rate {
-            let distance = {
-                let own = *self.own_location.read();
-                own.map(|loc| loc.distance(Location::from(key)).as_f64())
-            };
-            if let Some(d) = distance {
-                self.demand_estimator.write().observe(d, rate);
-            }
+        // Predict this contract's read-demand from its ring distance BEFORE
+        // touching, so a restart-loaded entry (seeded at neutral because our
+        // location was unknown at load) picks up the distance prior on this
+        // local-serve read — the same distance-prior path `record_contract_access`
+        // takes for network refetches. Read guards are dropped before the cache
+        // write lock (no nested lock order), matching `record_contract_access`.
+        let (distance, predicted_demand) = self.distance_and_demand(key);
+        let observed_read_rate = self
+            .hosting_cache
+            .write()
+            .touch_with_demand(key, predicted_demand);
+        // Cache lock dropped; train the prior from the observed local-serve rate.
+        if let (Some(d), Some(rate)) = (distance, observed_read_rate) {
+            self.demand_estimator.write().observe(d, rate);
         }
     }
 
@@ -1865,12 +1870,18 @@ impl HostingManager {
                 let age_ms = now_ms.saturating_sub(metadata.last_access_ms);
                 let age = std::time::Duration::from_millis(age_ms);
 
-                cache.load_persisted_entry(
+                // Seed the cold demand from the distance prior when our own
+                // location is already known at load; `distance_and_demand`
+                // returns NEUTRAL_DEMAND otherwise (the usual cold-restart case),
+                // and the first live read applies the prior lazily.
+                let predicted_demand = self.distance_and_demand(&key).1;
+                cache.load_persisted_entry_with_demand(
                     key,
                     metadata.size_bytes,
                     access_type,
                     age,
                     metadata.local_client_access,
+                    predicted_demand,
                 );
                 loaded += 1;
             }
@@ -1906,12 +1917,16 @@ impl HostingManager {
                 let size_bytes = storage.get_state_size(&key).unwrap_or(Some(0)).unwrap_or(0);
 
                 // Legacy contracts don't have local_client_access info
-                cache.load_persisted_entry(
+                // Distance prior when our location is known at load, else neutral
+                // (applied lazily on first read). See the metadata-load branch.
+                let predicted_demand = self.distance_and_demand(&key).1;
+                cache.load_persisted_entry_with_demand(
                     key,
                     size_bytes,
                     cache::AccessType::Get,
                     std::time::Duration::ZERO,
                     false,
+                    predicted_demand,
                 );
 
                 // Persist hosting metadata so future restarts don't need migration
@@ -2017,12 +2032,18 @@ impl HostingManager {
                 let age_ms = now_ms.saturating_sub(metadata.last_access_ms);
                 let age = std::time::Duration::from_millis(age_ms);
 
-                cache.load_persisted_entry(
+                // Seed the cold demand from the distance prior when our own
+                // location is already known at load; `distance_and_demand`
+                // returns NEUTRAL_DEMAND otherwise (the usual cold-restart case),
+                // and the first live read applies the prior lazily.
+                let predicted_demand = self.distance_and_demand(&key).1;
+                cache.load_persisted_entry_with_demand(
                     key,
                     metadata.size_bytes,
                     access_type,
                     age,
                     metadata.local_client_access,
+                    predicted_demand,
                 );
                 loaded += 1;
             }
@@ -2060,12 +2081,16 @@ impl HostingManager {
                     .unwrap_or(Some(0))
                     .unwrap_or(0);
 
-                cache.load_persisted_entry(
+                // Distance prior when our location is known at load, else neutral
+                // (applied lazily on first read). See the metadata-load branch.
+                let predicted_demand = self.distance_and_demand(&key).1;
+                cache.load_persisted_entry_with_demand(
                     key,
                     size_bytes,
                     cache::AccessType::Get,
                     std::time::Duration::ZERO,
                     false,
+                    predicted_demand,
                 );
 
                 // Persist hosting metadata so future restarts don't need migration

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -302,11 +302,10 @@ pub struct HostedContract {
     /// The abandonment hook drops the entry's `keep_score` to the current
     /// `eviction_floor` (stripping its demand credit) so that under budget
     /// pressure it is evicted before still-active entries, whose `keep_score` is
-    /// `floor + demand >= floor`. With strictly positive demand it sorts strictly
-    /// below them; when demand is zero (a far contract under a trained prior) it
-    /// ties an active entry at the floor, and the least-recently-accessed
-    /// tiebreak (`last_access_seq`) still tends to evict the abandoned entry
-    /// first (it has not been read since it lost its subscribers). Once past TTL,
+    /// `floor + demand`. The proximity prior (`predict`) is strictly positive, so
+    /// an active entry sorts strictly above an abandoned one at the floor; a
+    /// zero-demand tie is unreachable through the estimator (it could only arise
+    /// from an explicit zero handed in by a caller). Once past TTL,
     /// `evict_over_budget` picks the lowest `keep_score` first. Refreshing the
     /// entry via a read (`record_access` / `touch`) clears this field and
     /// restores its `keep_score` to `floor + predicted_demand`.
@@ -697,14 +696,25 @@ impl<T: TimeSource> HostingCache<T> {
             .unwrap_or(false)
     }
 
-    /// Touch/refresh a contract's demand without adding it if missing.
+    /// Touch/refresh a contract's demand without adding it if missing, using an
+    /// explicit freshly-derived `predicted_demand` (the proximity-prior estimate
+    /// for this contract's ring distance).
     ///
     /// Called when a user GET serves a hosted contract from local cache — the
     /// dominant read path for hot contracts. This is read-demand: it refreshes
-    /// the TTL clock and floats the contract's `keep_score` back to the frontier
-    /// (`eviction_floor + predicted_demand`, using the demand estimate stored at
-    /// the last `record_access`), counts the read, and clears any abandonment —
-    /// so actively requested contracts stay in the cache.
+    /// the TTL clock, updates the stored demand estimate to `predicted_demand`,
+    /// floats the contract's `keep_score` back to the frontier
+    /// (`eviction_floor + predicted_demand`), counts the read, and clears any
+    /// abandonment — so actively requested contracts stay in the cache.
+    ///
+    /// Refreshing the stored estimate (rather than reusing the old one) is what
+    /// lets a **restart-loaded entry** — inserted at `NEUTRAL_DEMAND` by
+    /// `load_persisted_entry` because this peer's location was unknown at load —
+    /// pick up the distance prior on its first local-serve read, exactly as
+    /// `record_access_with_demand` already does for the network-refetch path.
+    /// Without this, a persisted entry served only from local cache would sit at
+    /// neutral demand indefinitely and the cold-start distance prior would never
+    /// reach it (the restart-drift this fix closes).
     ///
     /// Returns the observed read-rate training sample (`read_count / residency`)
     /// the same way `record_access_with_demand` does, so the caller
@@ -712,7 +722,7 @@ impl<T: TimeSource> HostingCache<T> {
     /// local-serve path too — otherwise the prior would train only on network
     /// refetches and stay blind to the reads A3 is meant to model. `None` when
     /// the contract is absent or residency is zero.
-    pub fn touch(&mut self, key: &ContractKey) -> Option<f64> {
+    pub fn touch_with_demand(&mut self, key: &ContractKey, predicted_demand: f64) -> Option<f64> {
         let floor = self.eviction_floor;
         let seq = self.next_seq();
         let now = self.time_source.now();
@@ -720,14 +730,28 @@ impl<T: TimeSource> HostingCache<T> {
             existing.last_accessed = now;
             existing.last_access_seq = seq;
             existing.read_count = existing.read_count.saturating_add(1);
-            // A fresh touch is evidence of demand — clear any abandoned marker
-            // and refresh keep_score to the current frontier.
+            // A fresh touch is evidence of demand — clear any abandoned marker,
+            // refresh the stored demand estimate to the caller's freshly-derived
+            // prior, and float keep_score to the current frontier.
             existing.abandoned_at = None;
-            existing.keep_score = floor + existing.predicted_demand;
+            existing.predicted_demand = predicted_demand;
+            existing.keep_score = floor + predicted_demand;
             Self::rate_sample(existing.read_count, now, existing.inserted_at)
         } else {
             None
         }
+    }
+
+    /// Neutral-path convenience wrapper over
+    /// [`touch_with_demand`](Self::touch_with_demand) that reuses the entry's
+    /// STORED demand estimate (no fresh prior). Production goes through
+    /// `touch_with_demand` (the `HostingManager` supplies the proximity-prior
+    /// estimate); this wrapper serves the cache's own unit tests and any caller
+    /// that has no estimator handy.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn touch(&mut self, key: &ContractKey) -> Option<f64> {
+        let stored = self.contracts.get(key)?.predicted_demand;
+        self.touch_with_demand(key, stored)
     }
 
     /// Mark `key` as recently abandoned and strip its demand credit so it is the
@@ -738,11 +762,10 @@ impl<T: TimeSource> HostingCache<T> {
     /// in use" — the moment its `contract_in_use` predicate flips from
     /// `true` to `false`. The entry's `keep_score` is dropped to the current
     /// `eviction_floor` (zero demand credit), so among the credited band it
-    /// sorts first: a still-active entry keeps `floor + demand >= floor`, strictly
-    /// above when demand is positive, tying at the floor only when demand is zero
-    /// (there the least-recently-accessed tiebreak still favors evicting the
-    /// abandoned entry). The TTL gate in `evict_over_budget` still applies: an
-    /// abandoned entry within
+    /// sorts first: a still-active entry keeps `floor + demand`, and since the
+    /// proximity prior (`predict`) is strictly positive it sorts strictly above
+    /// the abandoned entry at the floor. The TTL gate in `evict_over_budget`
+    /// still applies: an abandoned entry within
     /// `min_ttl` of its last access is not yet eligible.
     ///
     /// No-op when `key` is absent (already evicted). Idempotent: calling
@@ -922,23 +945,38 @@ impl<T: TimeSource> HostingCache<T> {
         self.evict_over_budget(&should_retain)
     }
 
-    /// Load a contract entry from persisted data during startup.
+    /// Load a contract entry from persisted data during startup, using an
+    /// explicit cold `predicted_demand`.
     ///
     /// Unlike `record_access`, this uses a pre-computed last_accessed time
     /// and doesn't evict other contracts (we may be over budget after loading).
+    ///
+    /// A restart-loaded entry has no per-contract read evidence for this run, so
+    /// the **distance prior is its correct cold estimate** — the same estimate a
+    /// fresh contract at that ring distance would receive. The caller
+    /// (`HostingManager`) passes `predict(distance)` when this peer's own location
+    /// is already known at load, and `NEUTRAL_DEMAND` otherwise. At a cold
+    /// restart the location is typically not yet known, so this resolves to
+    /// neutral and the prior is applied lazily on the entry's first read
+    /// (`touch_with_demand` / `record_access_with_demand`); once the location is
+    /// known it seeds the prior at load directly.
     ///
     /// # Arguments
     /// * `key` - The contract key
     /// * `size_bytes` - Size of the contract state
     /// * `access_type` - How the contract was last accessed (GET/PUT/SUBSCRIBE)
     /// * `last_access_age` - How long ago the contract was last accessed
-    pub fn load_persisted_entry(
+    /// * `local_client_access` - Whether a local client accessed it pre-restart
+    /// * `predicted_demand` - Cold demand estimate (the distance prior, or
+    ///   `NEUTRAL_DEMAND` when this peer's location is unknown at load)
+    pub fn load_persisted_entry_with_demand(
         &mut self,
         key: ContractKey,
         size_bytes: u64,
         access_type: AccessType,
         last_access_age: Duration,
         local_client_access: bool,
+        predicted_demand: f64,
     ) {
         // Skip if already loaded (shouldn't happen, but defensive)
         if self.contracts.contains_key(&key) {
@@ -960,13 +998,14 @@ impl<T: TimeSource> HostingCache<T> {
             // Assigned a proper order by `finalize_loading` once all entries are
             // loaded (sorted by persisted recency). Temporary 0 until then.
             last_access_seq: 0,
-            // Loaded entries start with the neutral demand estimate at the
-            // current floor; the first live access re-scores them against the
-            // proximity prior. `last_accessed` (from the persisted age) is the
-            // tiebreak, so among equal (neutral) scores the oldest evicts first —
-            // the same recency ordering the old LRU load path produced.
-            keep_score: self.eviction_floor + NEUTRAL_DEMAND,
-            predicted_demand: NEUTRAL_DEMAND,
+            // Loaded entries start at the caller-supplied cold demand (the
+            // distance prior when this peer's location is known at load, else
+            // neutral). The first live read re-scores against the current prior.
+            // `last_accessed` (from the persisted age) is the tiebreak, so among
+            // equal scores the oldest evicts first — the same recency ordering
+            // the old LRU load path produced.
+            keep_score: self.eviction_floor + predicted_demand,
+            predicted_demand,
             // Reads observed this run start at zero; the persisted access_type
             // reflects the last pre-restart access, not this run's read count.
             read_count: 0,
@@ -987,6 +1026,30 @@ impl<T: TimeSource> HostingCache<T> {
 
         self.contracts.insert(key, contract);
         self.current_bytes = self.current_bytes.saturating_add(size_bytes);
+    }
+
+    /// Neutral-demand convenience wrapper over
+    /// [`load_persisted_entry_with_demand`](Self::load_persisted_entry_with_demand).
+    /// Production goes through the `_with_demand` form (the `HostingManager`
+    /// supplies the distance prior when its own location is known at load); this
+    /// wrapper serves callers/tests that have no demand estimate.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn load_persisted_entry(
+        &mut self,
+        key: ContractKey,
+        size_bytes: u64,
+        access_type: AccessType,
+        last_access_age: Duration,
+        local_client_access: bool,
+    ) {
+        self.load_persisted_entry_with_demand(
+            key,
+            size_bytes,
+            access_type,
+            last_access_age,
+            local_client_access,
+            NEUTRAL_DEMAND,
+        )
     }
 
     /// Finalize bulk loading: assign each loaded entry an access sequence in
@@ -1915,6 +1978,68 @@ mod tests {
         );
         assert!(cache.contains(&high), "high-demand contract must survive");
         assert!(!cache.contains(&low));
+    }
+
+    /// Cold-start ordering: with ZERO observed samples, two contracts at
+    /// different ring distances are separated purely by the analytic distance
+    /// prior, so under budget pressure the NEAR-key contract out-survives the
+    /// FAR-key one. This pins the intended cold-start eviction ordering that the
+    /// distance prior exists to produce (the restart-drift / under-retention fix)
+    /// AND documents the accepted demand-blind tradeoff behaviorally: because
+    /// neither contract has any per-contract read evidence yet (A4 is deferred),
+    /// a FAR-but-GET-hot contract could likewise be out-scored by an unread NEAR
+    /// one once past `min_ttl` — bounded by `min_ttl`, resolved when A4 lands.
+    #[test]
+    fn fuel_gauge_cold_start_keeps_near_key_over_far_key() {
+        // The demand values come straight from the cold estimator (no samples),
+        // so this exercises the real distance prior rather than hand-picked
+        // magic numbers.
+        let prior = super::super::demand::ProximityPrior::new();
+        assert_eq!(prior.len(), 0, "cold estimator has no samples");
+        let near_demand = prior.predict(0.02); // near this peer's key
+        let far_demand = prior.predict(0.45); // far from the key
+        assert!(
+            near_demand > far_demand,
+            "cold distance prior must slope down: near={near_demand}, far={far_demand}"
+        );
+
+        // Budget for exactly two 100-byte contracts.
+        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let near = make_key(1);
+        let far = make_key(2);
+        let trigger = make_key(3);
+
+        // Insert both cold (zero samples), scored only by the distance prior.
+        cache.record_access_with_demand(near, 100, AccessType::Get, 0, near_demand, |_| false);
+        cache.record_access_with_demand(far, 100, AccessType::Get, 0, far_demand, |_| false);
+        assert_eq!(cache.current_bytes(), 200);
+        assert!(
+            cache.get(&near).unwrap().keep_score > cache.get(&far).unwrap().keep_score,
+            "near-key contract must carry more cold demand credit than far-key"
+        );
+
+        // Age both past min_ttl so they are eviction-eligible; the trigger is
+        // age-0 and cannot be evicted by its own insert.
+        time.advance_time(Duration::from_secs(61));
+
+        let result = cache.record_access_with_demand(
+            trigger,
+            100,
+            AccessType::Get,
+            0,
+            NEUTRAL_DEMAND,
+            |_| false,
+        );
+        assert_eq!(
+            result.evicted,
+            vec![(far, 0)],
+            "cold start must evict the FAR-key contract (lower distance prior) first"
+        );
+        assert!(
+            cache.contains(&near),
+            "the NEAR-key contract out-survives the FAR-key one at cold start"
+        );
+        assert!(!cache.contains(&far));
     }
 
     /// The #4338 check at the cache level, written to actually DISCRIMINATE

--- a/crates/core/src/ring/hosting/demand.rs
+++ b/crates/core/src/ring/hosting/demand.rs
@@ -6,34 +6,48 @@
 //! `predicted_demand(X)`: a per-contract estimate of X's read-request rate at
 //! this peer.
 //!
-//! For A3 the estimate is the **proximity prior only** — `g(distance-to-key)`,
-//! a monotone non-increasing function of the ring distance between this peer
-//! and the contract's key. Contracts near this peer's location are, on average,
-//! requested more often (routing gravity), so demand falls off with distance.
-//! The blend toward each contract's OWN observed read rate is deferred to A4
-//! (see `docs/design/hosting-eviction.md`); this estimator only tracks the
-//! aggregate distance -> rate relationship.
+//! The estimate blends two terms, **outside** the regression:
 //!
-//! The prior is fit with the same isotonic-regression (PAVA) machinery the
-//! router uses for its distance -> outcome curves ([`crate::router`] /
-//! `pav_regression`), deliberately reused rather than re-implemented. Points are
-//! `(distance, observed_read_rate)` samples this peer collects from its own
-//! reads; the fit is **descending** (rate non-increasing in distance). A rolling
-//! window bounds the retained points, so the curve tracks the peer's recent
-//! demand geometry rather than its whole history.
+//! ```text
+//! predicted_demand(d) = w(n) * g0(d) + (1 - w(n)) * fit(d)
+//! ```
+//!
+//! - `g0(d)` — an **analytic cold-start prior**: a smooth, strictly-decreasing
+//!   function of the ring distance `d` between this peer and the contract's key
+//!   ([`distance_prior`]). Contracts near this peer's location are, on average,
+//!   requested more often (routing gravity), so demand falls off with distance.
+//!   This makes near-key contracts score higher **from the very first read**,
+//!   before any samples exist — the cold-start behavior that fixes the
+//!   under-retention of near-key contracts.
+//! - `fit(d)` — the **learned aggregate estimate**: a descending isotonic
+//!   (PAVA) regression over `(distance, observed_read_rate)` samples this peer
+//!   collects from its own reads, reusing the same machinery the router uses for
+//!   its distance -> outcome curves ([`crate::router`] / `pav_regression`). A
+//!   rolling window bounds the retained points so the curve tracks the peer's
+//!   recent demand geometry rather than its whole history.
+//! - `w(n)` — a blend weight that **decays in the retained sample count `n`**
+//!   ([`blend_weight`]): `1.0` at `n = 0` (pure analytic prior) and `-> 0` as
+//!   `n` grows (the learned fit takes over). So the prior dominates cold and
+//!   real observations dominate warm, with a smooth hand-off and no threshold
+//!   discontinuity.
+//!
+//! The blend is deliberately computed **outside** the PAVA fit — the prior is
+//! NOT seeded as synthetic points into the regression. Seeding would make the
+//! prior's absolute scale load-bearing (it would have to be calibrated against
+//! real rates) and the FIFO rolling window would evict the synthetic seeds in a
+//! step, reintroducing exactly the cold-start cliff this design removes. Keeping
+//! it a separate blended term means only the *ratio* g0(near)/g0(far) matters,
+//! never its absolute scale.
 //!
 //! Only RATIOS matter to eviction ordering (`keep_score` is compared, never
 //! interpreted as an absolute rate), so no absolute calibration is required.
+//!
+//! The per-contract blend toward each contract's OWN observed read rate (as
+//! opposed to this aggregate distance -> rate relationship) remains deferred to
+//! A4.
 
 use pav_regression::{IsotonicRegression, Point};
 use std::collections::VecDeque;
-
-/// Minimum retained sample count before the fitted prior is trusted. Below this
-/// the estimator returns [`NEUTRAL_DEMAND`] for every distance, which makes
-/// `keep_score` degenerate to `eviction_floor + NEUTRAL_DEMAND` for all
-/// contracts — i.e. pure Greedy-Dual aging with a recency tiebreak, the sane
-/// cold-start behavior before any demand geometry is known.
-const MIN_POINTS_FOR_PRIOR: usize = 5;
 
 /// Maximum raw `(distance, rate)` points retained. Once reached, each new
 /// observation evicts the oldest (FIFO rolling window), mirroring the router's
@@ -41,12 +55,52 @@ const MIN_POINTS_FOR_PRIOR: usize = 5;
 /// memory + refit cost.
 const MAX_PRIOR_POINTS: usize = 500;
 
-/// Demand returned when the prior has insufficient data (or cannot interpolate).
-/// Positive and uniform: with equal demand for every contract, eviction reduces
-/// to Greedy-Dual floor-ordering with a last-read tiebreak. Must be `> 0` so
-/// that an abandoned contract (whose `keep_score` is dropped to the current
+/// Demand returned only when no ring distance is available (this peer's own
+/// location is unknown) or the requested distance is non-finite. Positive and
+/// uniform: with equal demand for every contract, eviction reduces to
+/// Greedy-Dual floor-ordering with a last-read tiebreak. Must be `> 0` so that
+/// an abandoned contract (whose `keep_score` is dropped to the current
 /// `eviction_floor`, i.e. zero demand credit) sorts below a still-credited one.
+/// Also the anchor for the cold-start prior at zero distance
+/// (`g0(0) == NEUTRAL_DEMAND`), so a near-key contract keeps the old neutral
+/// credit and only farther contracts are discounted.
 pub(crate) const NEUTRAL_DEMAND: f64 = 1.0;
+
+/// Falloff rate of the analytic cold-start prior
+/// `g0(d) = NEUTRAL_DEMAND * exp(-DISTANCE_PRIOR_DECAY * d)` over ring distance
+/// `d in [0, 0.5]`. Only the RATIO `g0(near)/g0(far)` feeds eviction ordering,
+/// so the exact rate is a soft choice: `4.0` gives a ~7x near-to-far demand
+/// ratio across the half-ring (`g0(0) = 1.0` down to `g0(0.5) = e^-2 ≈ 0.135`),
+/// a mild monotone gravity toward the key that a handful of real samples
+/// quickly overrides.
+const DISTANCE_PRIOR_DECAY: f64 = 4.0;
+
+/// Pseudo-observation weight of the analytic prior. With `n` retained real
+/// samples the prior's blend weight is `PRIOR_PSEUDO_COUNT / (PRIOR_PSEUDO_COUNT
+/// plus n)` (see [`blend_weight`]): the analytic prior counts as this many real
+/// observations. At `n = PRIOR_PSEUDO_COUNT` prior and fit weigh equally; past
+/// that the learned fit dominates. Set to the sample count the old hard gate
+/// required before it trusted the fit at all, so "enough data to trust the fit"
+/// and "prior no longer dominates" coincide.
+const PRIOR_PSEUDO_COUNT: f64 = 5.0;
+
+/// Analytic cold-start demand prior: expected read demand as a smooth,
+/// strictly-decreasing function of ring distance to the contract key. Closer to
+/// the key -> more routing gravity -> higher expected read demand. Anchored so
+/// `g0(0) == NEUTRAL_DEMAND`; distance is clamped to the valid `[0, 0.5]`
+/// ring-distance range defensively. Always strictly positive.
+fn distance_prior(distance: f64) -> f64 {
+    let d = distance.clamp(0.0, 0.5);
+    NEUTRAL_DEMAND * (-DISTANCE_PRIOR_DECAY * d).exp()
+}
+
+/// Blend weight on the analytic prior given `n` retained real samples:
+/// `PRIOR_PSEUDO_COUNT / (PRIOR_PSEUDO_COUNT + n)`. `1.0` at `n = 0`, strictly
+/// decreasing in `n`, and `-> 0` as `n` grows, so the estimate slides smoothly
+/// from the pure distance prior (cold) to the pure learned fit (warm).
+fn blend_weight(n: usize) -> f64 {
+    PRIOR_PSEUDO_COUNT / (PRIOR_PSEUDO_COUNT + n as f64)
+}
 
 /// Per-peer proximity-prior demand estimator.
 ///
@@ -64,8 +118,10 @@ pub(crate) struct ProximityPrior {
 }
 
 impl ProximityPrior {
-    /// Create an empty estimator. Until [`MIN_POINTS_FOR_PRIOR`] observations
-    /// accrue, [`predict`](Self::predict) returns [`NEUTRAL_DEMAND`].
+    /// Create an empty estimator. With no observations,
+    /// [`predict`](Self::predict) returns the pure analytic distance prior
+    /// [`distance_prior`] (monotone-decreasing in distance), and slides toward
+    /// the learned fit as observations accrue.
     pub(crate) fn new() -> Self {
         // `new_descending` on an empty slice yields an empty regression; the
         // router relies on the same empty-construction path.
@@ -107,17 +163,43 @@ impl ProximityPrior {
 
     /// Predict the read-demand for a contract at ring `distance` from this peer.
     ///
-    /// Returns [`NEUTRAL_DEMAND`] until [`MIN_POINTS_FOR_PRIOR`] samples have
-    /// accrued, or if the regression cannot interpolate. Otherwise returns the
-    /// fitted rate, floored at `0.0` (the descending fit can extrapolate
-    /// slightly negative near the data-range edges).
+    /// Blends the analytic cold-start prior [`distance_prior`] with the learned
+    /// isotonic fit by a sample-count-decayed [`blend_weight`]:
+    /// `w(n) * g0(d) + (1 - w(n)) * fit(d)`. Cold (`n = 0`) this is the pure
+    /// distance prior; warm it is the pure fit. When there is no usable fit yet
+    /// (no retained points, or the regression cannot interpolate) it is the pure
+    /// prior. `NEUTRAL_DEMAND` is returned only for a non-finite `distance`.
+    /// Always finite and non-negative.
     pub(crate) fn predict(&self, distance: f64) -> f64 {
-        if self.raw_points.len() < MIN_POINTS_FOR_PRIOR || !distance.is_finite() {
+        if !distance.is_finite() {
             return NEUTRAL_DEMAND;
         }
+        let g0 = distance_prior(distance);
+        // Blend OUTSIDE the regression: never seed the analytic prior as
+        // synthetic points into the PAVA fit (that would make its absolute scale
+        // load-bearing and the FIFO window would evict the seeds in a step). The
+        // prior and the fit are combined by a weight that decays in the retained
+        // sample count, so the estimate slides smoothly from prior to fit.
+        let w = blend_weight(self.raw_points.len());
+        match self.fit(distance) {
+            Some(fit) => w * g0 + (1.0 - w) * fit,
+            None => g0,
+        }
+    }
+
+    /// The learned aggregate estimate at `distance`: the descending isotonic fit
+    /// over retained `(distance, rate)` samples, floored at `0.0` (the fit can
+    /// extrapolate slightly negative near the data-range edges). `None` when
+    /// there is no usable fit yet — no retained points, or the regression cannot
+    /// interpolate — in which case [`predict`](Self::predict) uses the pure
+    /// analytic prior.
+    fn fit(&self, distance: f64) -> Option<f64> {
+        if self.raw_points.is_empty() {
+            return None;
+        }
         match self.regression.interpolate(distance) {
-            Some(rate) if rate.is_finite() => rate.max(0.0),
-            _ => NEUTRAL_DEMAND,
+            Some(rate) if rate.is_finite() => Some(rate.max(0.0)),
+            _ => None,
         }
     }
 
@@ -138,26 +220,138 @@ impl Default for ProximityPrior {
 mod tests {
     use super::*;
 
-    /// With no data the estimator is neutral for every distance, so eviction
-    /// degenerates to floor-ordering + recency (the cold-start contract).
+    /// COLD START (no samples): the estimate is the analytic distance prior,
+    /// which is strictly decreasing in ring distance — a near-key contract
+    /// predicts MORE read-demand than a far-key one from the very first moment.
+    /// This is the cold-start drift fix: before, every distance returned a flat
+    /// `NEUTRAL_DEMAND`, so near-key contracts were under-retained.
     #[test]
-    fn empty_prior_is_neutral_everywhere() {
+    fn cold_prior_is_monotone_decreasing_in_distance() {
         let prior = ProximityPrior::new();
         assert_eq!(prior.len(), 0);
-        assert_eq!(prior.predict(0.0), NEUTRAL_DEMAND);
-        assert_eq!(prior.predict(0.25), NEUTRAL_DEMAND);
-        assert_eq!(prior.predict(0.5), NEUTRAL_DEMAND);
+
+        // Sweep the valid ring-distance range and assert non-increasing +
+        // strictly positive.
+        let mut prev = f64::INFINITY;
+        let mut x = 0.0;
+        while x <= 0.5 + 1e-9 {
+            let y = prior.predict(x);
+            assert!(y > 0.0, "cold prior must stay positive: g0({x}) = {y}");
+            assert!(
+                y <= prev + 1e-12,
+                "cold prior must be non-increasing in distance: g0({x}) = {y} > previous {prev}"
+            );
+            prev = y;
+            x += 0.05;
+        }
+
+        // A near contract must predict STRICTLY more demand than a far one at
+        // cold start — the property the flat-neutral behavior lacked.
+        assert!(
+            prior.predict(0.02) > prior.predict(0.45),
+            "near-key cold demand must exceed far-key: near={}, far={}",
+            prior.predict(0.02),
+            prior.predict(0.45),
+        );
     }
 
-    /// Below the minimum sample count the fit is not trusted yet.
+    /// As real samples accumulate the learned fit dominates and the analytic
+    /// prior's slope washes out (blend weight → 0). A FLAT observed rate across
+    /// all distances drives the near-vs-far spread from the prior's large cold
+    /// slope down toward ~0 (the flat fit) — which can only happen if the
+    /// prior's weight decays as `n` grows.
     #[test]
-    fn prior_stays_neutral_below_min_points() {
-        let mut prior = ProximityPrior::new();
-        for i in 0..(MIN_POINTS_FOR_PRIOR - 1) {
-            prior.observe(0.1 * i as f64, 10.0 - i as f64);
+    fn warm_observations_wash_out_the_sloped_cold_prior() {
+        const FLAT_RATE: f64 = 5.0;
+
+        // Cold: a fresh prior carries a real near>far slope from the distance
+        // prior.
+        let cold = ProximityPrior::new();
+        let cold_spread = cold.predict(0.02) - cold.predict(0.45);
+        assert!(
+            cold_spread > 0.3,
+            "cold prior must carry a near>far slope, got spread {cold_spread}"
+        );
+
+        // Warm: many flat-rate samples spanning the ring → ~flat fit → near and
+        // far predictions converge.
+        let mut warm = ProximityPrior::new();
+        for i in 0..200 {
+            let d = 0.01 + (i % 49) as f64 / 100.0; // 0.01..=0.49
+            warm.observe(d, FLAT_RATE);
         }
-        assert!(prior.len() < MIN_POINTS_FOR_PRIOR);
-        assert_eq!(prior.predict(0.0), NEUTRAL_DEMAND);
+        let near = warm.predict(0.02);
+        let far = warm.predict(0.45);
+        let warm_spread = (near - far).abs();
+        assert!(
+            warm_spread < 0.25,
+            "warm flat-rate fit must wash out the prior slope: near={near}, far={far}, spread={warm_spread}"
+        );
+        assert!(
+            near > 3.0 && far > 3.0,
+            "warm predictions must track the observed rate {FLAT_RATE}: near={near}, far={far}"
+        );
+    }
+
+    /// The prediction slides SMOOTHLY from the analytic prior toward the fit as
+    /// samples accrue — no flat "neutral" plateau, no discontinuous jump. With a
+    /// flat observed rate above the far-distance prior value, the far-distance
+    /// prediction strictly INCREASES with each of the first few samples, because
+    /// the prior's blend weight strictly shrinks each step.
+    #[test]
+    fn prediction_transitions_smoothly_from_prior_to_fit() {
+        const FLAT_RATE: f64 = 5.0;
+        let mut prior = ProximityPrior::new();
+
+        let p0 = prior.predict(0.45); // cold: pure prior at far distance (small)
+        prior.observe(0.20, FLAT_RATE);
+        let p1 = prior.predict(0.45);
+        prior.observe(0.25, FLAT_RATE);
+        let p2 = prior.predict(0.45);
+        prior.observe(0.30, FLAT_RATE);
+        let p3 = prior.predict(0.45);
+
+        assert!(
+            p0 < p1 && p1 < p2 && p2 < p3,
+            "far-distance prediction must climb monotonically toward the fit as \
+             samples accrue: p0={p0}, p1={p1}, p2={p2}, p3={p3}"
+        );
+        assert!(
+            p3 < FLAT_RATE,
+            "still short of the full fit after only 3 samples (prior still weighted): p3={p3}"
+        );
+    }
+
+    /// The blend weight is `1.0` cold, strictly decreasing in the retained
+    /// sample count, and decays toward `0` as samples accumulate — the property
+    /// that hands control from the analytic prior to the learned fit.
+    #[test]
+    fn blend_weight_decays_with_sample_count() {
+        assert_eq!(blend_weight(0), 1.0, "prior owns the estimate at n = 0");
+
+        // Strictly decreasing across a growing sample count.
+        let mut prev = f64::INFINITY;
+        for n in [0usize, 1, 2, 5, 10, 25, 50, 100, 250, 500] {
+            let w = blend_weight(n);
+            assert!(w > 0.0 && w <= 1.0, "weight out of (0, 1]: w({n}) = {w}");
+            assert!(
+                w < prev,
+                "weight must strictly decrease: w({n}) = {w} >= {prev}"
+            );
+            prev = w;
+        }
+
+        // Equal weighting exactly at the pseudo-count, and negligible far past
+        // the sample window.
+        assert!(
+            (blend_weight(PRIOR_PSEUDO_COUNT as usize) - 0.5).abs() < 1e-9,
+            "prior and fit weigh equally at n = PRIOR_PSEUDO_COUNT"
+        );
+        assert!(
+            blend_weight(MAX_PRIOR_POINTS) < 0.02,
+            "prior weight must be negligible once the sample window is full: {}",
+            blend_weight(MAX_PRIOR_POINTS)
+        );
     }
 
     /// The fitted prior is monotone NON-INCREASING in distance: closer contracts
@@ -183,12 +377,14 @@ mod tests {
         for (d, r) in samples {
             prior.observe(d, r);
         }
-        assert!(prior.len() >= MIN_POINTS_FOR_PRIOR);
+        assert_eq!(prior.len(), samples.len());
 
         // Sample the curve WITHIN the observed data range [0.05, 0.45] (where
         // interpolation between the non-increasing fitted points is guaranteed
-        // monotone) and assert non-increasing. Extrapolation beyond the data
-        // edges is exercised separately by `prediction_is_non_negative_out_of_range`.
+        // monotone) and assert non-increasing. Both blended terms — the analytic
+        // prior and the descending fit — are non-increasing in distance, so
+        // their blend is too. Extrapolation beyond the data edges is exercised
+        // separately by `prediction_is_non_negative_out_of_range`.
         let mut prev = f64::INFINITY;
         let mut x = 0.05;
         while x <= 0.45 + 1e-9 {
@@ -238,7 +434,13 @@ mod tests {
         prior.observe(-0.1, 5.0);
         prior.observe(0.1, -5.0);
         assert_eq!(prior.len(), 0, "no invalid point should be retained");
-        assert_eq!(prior.predict(0.1), NEUTRAL_DEMAND);
+        // With no retained points the estimate is the pure cold prior; it must
+        // stay finite and positive.
+        let cold = prior.predict(0.1);
+        assert!(
+            cold.is_finite() && cold > 0.0,
+            "empty prior must return a finite positive estimate, got {cold}"
+        );
     }
 
     /// Predicted demand is always non-negative, even at distances beyond the

--- a/crates/core/src/ring/hosting/demand.rs
+++ b/crates/core/src/ring/hosting/demand.rs
@@ -27,9 +27,16 @@
 //!   recent demand geometry rather than its whole history.
 //! - `w(n)` — a blend weight that **decays in the retained sample count `n`**
 //!   ([`blend_weight`]): `1.0` at `n = 0` (pure analytic prior) and `-> 0` as
-//!   `n` grows (the learned fit takes over). So the prior dominates cold and
-//!   real observations dominate warm, with a smooth hand-off and no threshold
-//!   discontinuity.
+//!   `n` grows (the learned fit takes over), with a smooth hand-off and no
+//!   threshold discontinuity. Note the *value* hand-off is governed by the
+//!   magnitude ratio of the two terms, not `n` alone: `g0` is anchored at
+//!   `NEUTRAL_DEMAND = 1.0` while `fit` is in reads/sec, which for a low-traffic
+//!   peer is often `<< 1`. When the observed rate is that small, the prior's
+//!   distance slope can persist in the eviction *ordering* even at large `n`
+//!   (the neutral-scale prior term keeps dominating the tiny fit term). The
+//!   ordering DIRECTION stays sane throughout — both `g0` and `fit` are
+//!   non-increasing in distance, so their blend is too — and the per-contract
+//!   own-rate blend that fully retires the aggregate distance slope is A4.
 //!
 //! The blend is deliberately computed **outside** the PAVA fit — the prior is
 //! NOT seeded as synthetic points into the regression. Seeding would make the
@@ -168,8 +175,33 @@ impl ProximityPrior {
     /// `w(n) * g0(d) + (1 - w(n)) * fit(d)`. Cold (`n = 0`) this is the pure
     /// distance prior; warm it is the pure fit. When there is no usable fit yet
     /// (no retained points, or the regression cannot interpolate) it is the pure
-    /// prior. `NEUTRAL_DEMAND` is returned only for a non-finite `distance`.
-    /// Always finite and non-negative.
+    /// prior. `NEUTRAL_DEMAND` is returned only for a non-finite `distance` (the
+    /// guard that keeps a NaN out of the eviction sort). Always finite and
+    /// strictly positive: `g0 > 0` and `fit >= 0`, and `w(n) > 0`, so the blend
+    /// `w*g0 + (1-w)*fit >= w*g0 > 0`.
+    ///
+    /// # Accepted tradeoff (A3 intermediate)
+    ///
+    /// At cold start (and for a low-traffic peer whose observed rates stay
+    /// `<< NEUTRAL_DEMAND`; see the module docs) eviction ordering is effectively
+    /// **distance-only** — demand-blind, because the per-contract observed-read-
+    /// rate signal (A4) is deferred. Concretely: a FAR contract that is actually
+    /// GET-hot can be out-scored, and once past `min_ttl` evicted, in favor of an
+    /// unread NEAR contract that merely sits closer to this peer's key. This is
+    /// the spec-accepted intermediate state, not a bug:
+    ///
+    /// - It is **bounded by `min_ttl`** — the anti-thrash retention floor kept
+    ///   deliberately per the hosting design (`hosting-invariants.md`, invariant
+    ///   3 / #4441): nothing evicts a contract within `min_ttl` of its last read,
+    ///   so a genuinely hot far contract keeps being refreshed and survives.
+    /// - It is **fully resolved when A4 lands** (per-contract own-observed-rate
+    ///   blend) together with in-flight op-pinning, at which point real read
+    ///   demand overrides the distance prior for any contract with evidence.
+    ///
+    /// The design contract for this piece is exactly "distance prior + `min_ttl`
+    /// until A4" (`.claude/rules/hosting-invariants.md`, piece A / #4642). Do NOT
+    /// try to close the gap here by reaching for a per-contract counter — that is
+    /// A4's job and belongs with its telemetry and op-pinning.
     pub(crate) fn predict(&self, distance: f64) -> f64 {
         if !distance.is_finite() {
             return NEUTRAL_DEMAND;
@@ -441,6 +473,30 @@ mod tests {
             cold.is_finite() && cold > 0.0,
             "empty prior must return a finite positive estimate, got {cold}"
         );
+    }
+
+    /// A non-finite `distance` (NaN or ±∞) short-circuits to `NEUTRAL_DEMAND`
+    /// rather than propagating through `distance_prior`/the fit. This is the
+    /// guard that keeps a NaN out of `keep_score` — a NaN there would poison the
+    /// `total_cmp` eviction sort (every comparison against NaN is `Greater` under
+    /// `total_cmp`, silently corrupting the victim order). Holds cold (no
+    /// samples, pure prior) and the check lives in `predict` itself, so it holds
+    /// warm too.
+    #[test]
+    fn predict_guards_non_finite_distance() {
+        let cold = ProximityPrior::new();
+        assert_eq!(cold.predict(f64::NAN), NEUTRAL_DEMAND);
+        assert_eq!(cold.predict(f64::INFINITY), NEUTRAL_DEMAND);
+        assert_eq!(cold.predict(f64::NEG_INFINITY), NEUTRAL_DEMAND);
+
+        // Same guard once the estimator is warm (has a usable fit).
+        let mut warm = ProximityPrior::new();
+        for i in 0..20 {
+            warm.observe(0.01 * i as f64, 5.0);
+        }
+        assert_eq!(warm.predict(f64::NAN), NEUTRAL_DEMAND);
+        assert_eq!(warm.predict(f64::INFINITY), NEUTRAL_DEMAND);
+        assert_eq!(warm.predict(f64::NEG_INFINITY), NEUTRAL_DEMAND);
     }
 
     /// Predicted demand is always non-negative, even at distances beyond the


### PR DESCRIPTION
## Problem

The demand-ordered (Greedy-Dual) eviction policy in the hosting cache scores contracts by `keep_score = eviction_floor + predicted_demand(distance)`. The demand estimator (`ring/hosting/demand.rs`) previously returned a flat `NEUTRAL_DEMAND` for **every** distance until `MIN_POINTS_FOR_PRIOR = 5` real read samples accrued.

Those samples are in-memory and reset on every restart, so a low-traffic peer sits at `NEUTRAL` indefinitely. At cold start near-key and far-key contracts get **identical** demand credit, so near-key contracts — the ones this peer is best positioned to host — are under-retained. That cold-start drift is what this change fixes.

## Approach

Replace the flat cold-start with a **distance-based prior blended OUTSIDE the regression**:

```
predicted_demand(d) = w(n) * g0(d) + (1 - w(n)) * fit(d)
```

- `g0(d) = NEUTRAL_DEMAND * exp(-4*d)` — a smooth, strictly-decreasing analytic prior (closer to the key -> higher predicted demand), anchored so `g0(0) == NEUTRAL_DEMAND` (a near-key contract keeps the old neutral credit; only farther contracts are discounted). Only the near/far **ratio** feeds eviction ordering, so the exact shape is a documented soft choice.
- `w(n) = PRIOR_PSEUDO_COUNT / (PRIOR_PSEUDO_COUNT + n)` — a blend weight that decays from `1.0` at `n = 0` toward `0` as retained samples grow. The prior dominates cold, the learned fit dominates warm, with a smooth hand-off and no threshold discontinuity.
- `fit(d)` — the existing descending isotonic (PAVA) fit, unchanged.

**Why blend outside the regression** (not seed synthetic points into the PAVA fit): seeding would make the prior's absolute scale load-bearing (it would need calibrating against real rates) and the FIFO rolling window would evict the synthetic seeds in a step, reintroducing exactly the cold-start cliff this removes. As a separate blended term, only the ratio `g0(near)/g0(far)` matters.

The old `MIN_POINTS_FOR_PRIOR` hard gate is removed — the decaying blend weight subsumes it (few samples -> high `w` -> noisy early fit is down-weighted). `PRIOR_PSEUDO_COUNT` is set to that old threshold (5), so "enough data to trust the fit" and "prior no longer dominates" coincide.

Change is confined to `demand.rs` + its unit tests. The call sites in `hosting.rs` / `cache.rs` are unchanged (the no-location branch still yields `NEUTRAL_DEMAND`).

## Testing

Unit tests written **first**, verified to FAIL against the current NEUTRAL behavior, then made to pass:

- `cold_prior_is_monotone_decreasing_in_distance` — at `n = 0` the curve is strictly decreasing in distance (near > far). Failed before: `near=1, far=1`.
- `warm_observations_wash_out_the_sloped_cold_prior` — a flat observed rate drives the near-vs-far spread from the prior's large cold slope down toward ~0 (fit dominates as `n` grows). Failed before: `cold prior slope spread 0`.
- `prediction_transitions_smoothly_from_prior_to_fit` — the far-distance prediction strictly increases with each of the first few samples (smooth hand-off, no flat plateau / discontinuous jump). Failed before: `p0=p1=p2=p3=1`.
- `blend_weight_decays_with_sample_count` — direct test of `blend_weight`: `1.0` at `n=0`, strictly decreasing, `0.5` at `n=PRIOR_PSEUDO_COUNT`, negligible once the window is full.

Retained/updated existing tests (`fitted_prior_is_monotone_non_increasing`, `rolling_window_is_bounded`, `prediction_is_non_negative_out_of_range`, `invalid_observations_are_ignored`) still pass. Full `ring::hosting` suite (127 tests) green. `cargo build -p freenet`, `cargo fmt`, `cargo clippy -p freenet` clean.

## Notes

This is the **distance-prior** piece of the demand-driven-hosting R2 (eviction) work and **gates the later `min_ttl` drop** and the placement/admission pieces. Part of the hosting redesign epic freenet/freenet-core#4642.

Draft: opening for review, not requesting merge.

## Known tradeoff (A3 intermediate)

Cold-start eviction ordering is **distance-only (demand-blind)**: with no per-contract read evidence yet (A4 deferred), a contract far from this peer's key can be out-scored — and once past `min_ttl`, evicted — in favor of an unread near-key contract, even if the far one is actually GET-hot. This is the spec-accepted intermediate, not a regression:

- **Bounded by `min_ttl`** — the anti-thrash retention floor kept deliberately per the hosting design (`.claude/rules/hosting-invariants.md`, invariant 3 / #4441): nothing evicts a contract within `min_ttl` of its last read, so a genuinely hot far contract keeps being refreshed and survives.
- **Fully resolved when A4 lands** (per-contract own-observed-rate blend) together with in-flight op-pinning: real read demand then overrides the distance prior for any contract with evidence.

The design contract for this piece is exactly "distance prior + `min_ttl` until A4" (hosting-invariants, piece A / #4642). `fuel_gauge_cold_start_keeps_near_key_over_far_key` pins this ordering behaviorally.

This PR **touches eviction ordering (a hosting invariant)**, so it awaits **Ian's sign-off** before merge.

## Review follow-ups (this revision)

- **Fix 1** — completed the restart-drift fix: persisted entries now flow through the same distance-prior path as fresh contracts (`load_persisted_entry_with_demand` seeds from `distance_and_demand` at load; `touch_with_demand` refreshes the stored estimate on first local-serve read). Previously they stayed pinned at `NEUTRAL_DEMAND` after restart.
- **Fix 2** — added `predict_guards_non_finite_distance` (NaN/±∞ → `NEUTRAL_DEMAND`) and the cold-start near-vs-far eviction test above.
- **Fix 3** — corrected the `w(n)` module docstring (magnitude-ratio hand-off, not `n` alone) and the two now-unreachable "demand is zero" tiebreak comments in cache.rs (`predict` is strictly positive).
- **Fix 4** — documented the accepted tradeoff above and on `predict`.

Full `ring::hosting` suite green (129 passing). `cargo build -p freenet`, `cargo fmt`, `cargo clippy -p freenet -- -D warnings` clean.

[AI-assisted - Claude]
