### PR TITLE
feat: remove GET-auto-subscribe (piece E GET half, #4642)

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -4934,7 +4934,6 @@ mod tests {
         // file must FAIL this pin — see the set-equality assertion below.
         let known_wired: std::collections::BTreeSet<&str> = [
             "node.rs",
-            "operations.rs",
             "operations/subscribe.rs",
             "operations/get/op_ctx_task.rs",
         ]

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -700,7 +700,6 @@ impl OpManager {
     /// * **Source 2 — interest manager** (`register_peer_interest` is_new):
     ///   - `subscribe::register_downstream_subscriber` (downstream subscriber)
     ///   - `subscribe::finalize_originator_subscribe` (originator upstream)
-    ///   - `operations::complete_piggyback_subscription` (GET-piggyback sub)
     ///   - `get::op_ctx_task` remote GET `subscribe=false` (requester interest)
     ///   - `node.rs` Interests / Summaries interest-sync handlers
     /// * **Source 1 — proximity cache** (`neighbors_with_contract`):

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -467,78 +467,18 @@ pub(crate) fn reclaim_evicted_contract(
     );
 }
 
-/// Complete subscription at the originator node via GET piggyback.
-///
-/// The subscription tree was built by relay nodes during GET response propagation.
-/// This function performs the local registration at the originator:
-/// 1. Mark subscribed (lease in active_subscriptions)
-/// 2. Register the upstream peer as an interest source
-/// 3. Register local interest so ChangeInterests from peers are processed
-/// 4. Announce contract hosted so neighbors send UPDATEs
-pub(crate) async fn complete_piggyback_subscription(
-    op_manager: &OpManager,
-    key: &ContractKey,
-    tx: &crate::message::Transaction,
-    sender_from_addr: &Option<crate::ring::PeerKeyLocation>,
-) {
-    op_manager.ring.subscribe(*key);
-    op_manager.ring.complete_subscription_request(key, true);
-
-    // Register local interest so ChangeInterests from peers get properly processed.
-    let became_interested = op_manager.interest_manager.add_local_client(key);
-    if became_interested {
-        broadcast_change_interests(op_manager, vec![*key], vec![]).await;
-    }
-
-    // Announce that we host this contract so neighbors include us in broadcast targets.
-    announce_contract_hosted(op_manager, key).await;
-
-    if let Some(upstream_pkl) = sender_from_addr.as_ref() {
-        let peer_key = crate::ring::interest::PeerKey::from(upstream_pkl.pub_key.clone());
-        let is_new = op_manager
-            .interest_manager
-            .register_peer_interest(key, peer_key, None, true);
-        if is_new {
-            // #4359 (MUST-FIX 1): the piggyback upstream is now a viable
-            // broadcast target — flush any deferred fresh-contract broadcast so
-            // a cold-id PUT that gave up with no targets reaches the network.
-            op_manager.flush_pending_broadcast_on_interest(key).await;
-        }
-        tracing::debug!(tx = %tx, contract = %key, "Subscription completed via GET piggyback");
-    } else {
-        // sender_from_addr can be None for transient connections not yet in the ring.
-        // Subscription is still marked locally; the 2-minute renewal cycle will
-        // establish a full subscription tree via a standard SUBSCRIBE operation.
-        tracing::warn!(
-            tx = %tx,
-            contract = %key,
-            "GET piggyback: upstream peer not in ring, subscription tree incomplete -- renewal will heal"
-        );
-    }
-}
-
-/// Auto-subscribe at the originator: use piggybacked subscription if available,
-/// otherwise fall back to a separate SUBSCRIBE operation.
-///
-/// Called from GET response handling when `AUTO_SUBSCRIBE_ON_GET` is enabled and
-/// the originator is not yet subscribed. Consolidates the piggyback-or-fallback
-/// logic that appears in both streaming and non-streaming response paths.
-pub(crate) async fn auto_subscribe_on_get_response(
-    op_manager: &OpManager,
-    key: &ContractKey,
-    tx: &crate::message::Transaction,
-    sender_from_addr: &Option<crate::ring::PeerKeyLocation>,
-    subscribe_requested: bool,
-    blocking_sub: bool,
-    path_label: &str,
-) {
-    if subscribe_requested {
-        complete_piggyback_subscription(op_manager, key, tx, sender_from_addr).await;
-    } else {
-        let child_tx = start_subscription_request(op_manager, *tx, *key, blocking_sub);
-        tracing::debug!(tx = %tx, %child_tx, blocking = %blocking_sub, "started subscription ({path_label}, fallback)");
-    }
-}
+// `complete_piggyback_subscription` and `auto_subscribe_on_get_response` were
+// REMOVED in piece E of the demand-driven hosting redesign
+// (docs/design/demand-driven-hosting.md §9, hosting-invariants anti-patterns
+// table). Their only caller was the GET-auto-subscribe block in
+// `get/op_ctx_task.rs`, which auto-installed a durable subscription on every
+// successful GET (subscribe=false) — the "GET-auto-subscribe" anti-pattern that
+// manufactures demand no client requested. A GET now hosts on the return path
+// only under piece A's demand gauge (evictable, non-durable); a client that
+// wants ongoing freshness sets `subscribe=true`, which routes through the
+// explicit subscribe path (`maybe_subscribe_child` -> `run_client_subscribe`).
+// do NOT re-add an auto-subscribe-on-GET helper — see hosting-invariants
+// (invariants 1 & 2).
 
 /// Broadcast ChangeInterests message to all connected peers.
 ///

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -4103,6 +4103,19 @@ mod tests {
              explicit subscribe=true. do NOT re-add auto_subscribe_on_get_response \
              — see hosting-invariants."
         );
+        // Belt-and-braces: catch a re-subscribe reintroduced via a DIFFERENT
+        // mechanism than the removed helper. The GET driver installs durable
+        // subscriptions ONLY through `maybe_subscribe_child` (a subscribe sub-op
+        // spawned on the explicit subscribe=true path); it must never call
+        // `ring.subscribe(` directly, which would re-open the GET-auto-subscribe
+        // anti-pattern regardless of the helper name.
+        assert!(
+            !src.contains("ring.subscribe("),
+            "GET driver must NOT call ring.subscribe( directly — the only durable \
+             subscribe path is maybe_subscribe_child (explicit subscribe=true). A \
+             direct ring.subscribe( in this driver re-introduces GET-auto-subscribe \
+             under a new name — see hosting-invariants (invariants 1 & 2)."
+        );
         // The explicit subscribe path must still be wired in.
         assert!(
             src.contains("maybe_subscribe_child"),
@@ -5856,6 +5869,9 @@ mod tests {
             .split("\n}\n\n/// Cause")
             .next()
             .expect("end of drive_sub_op_get body");
+        // Future-proofing: `auto_subscribe_on_get_response` no longer exists
+        // (piece E removed GET-auto-subscribe); this stays as an absence-pin so
+        // a re-added helper of that name would trip here too.
         assert!(
             !body.contains("auto_subscribe_on_get_response"),
             "drive_sub_op_get must NOT call auto_subscribe_on_get_response — \

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -337,8 +337,7 @@ async fn drive_client_get_inner(
     // returns (and the side-effect block below has run). Do not add
     // explicit `completed()` calls in the arms here — doing so would
     // race the originator-side side effects (`cache_contract_locally`,
-    // `auto_subscribe_on_get_response`, `maybe_subscribe_child`)
-    // because once the tx is in `ops.completed`, any
+    // `maybe_subscribe_child`) because once the tx is in `ops.completed`, any
     // `op_manager.push(...)` for that tx is silently dropped (see
     // `op_state_manager.rs::push` short-circuit on
     // `ops.completed.contains`).
@@ -447,35 +446,18 @@ async fn drive_client_get_inner(
             )
             .await;
 
-            // Auto-subscribe on successful GET at the originator —
-            // mirrors the legacy branches at get.rs:2313/2408/3136/3185.
-            // AUTO_SUBSCRIBE_ON_GET (ring.rs:60) is a const; we still
-            // guard on `is_subscribed` to avoid duplicate registration
-            // if the request-router already wired up a subscribe.
-            //
-            // When the client explicitly set `subscribe=true`, the
-            // dedicated `maybe_subscribe_child` path below runs — skip
-            // auto-subscribe here so we never double-subscribe.
-            if host_result.is_ok()
-                && !subscribe
-                && crate::ring::AUTO_SUBSCRIBE_ON_GET
-                && !op_manager.ring.is_subscribed(&reply_key)
-            {
-                let path_label = match &terminal {
-                    Terminal::Streaming { .. } => "streaming",
-                    Terminal::InlineFound { .. } | Terminal::LocalCompletion => "non-streaming",
-                };
-                crate::operations::auto_subscribe_on_get_response(
-                    op_manager,
-                    &reply_key,
-                    &client_tx,
-                    &Some(driver.current_target.clone()),
-                    /* subscribe_requested */ false,
-                    /* blocking_sub */ blocking_subscribe,
-                    path_label,
-                )
-                .await;
-            }
+            // GET-auto-subscribe REMOVED (piece E, demand-driven hosting).
+            // A successful GET with subscribe=false previously installed a
+            // durable subscription here (AUTO_SUBSCRIBE_ON_GET). That is the
+            // "GET-auto-subscribe" anti-pattern: it manufactures ongoing demand
+            // no client requested and pins an advertised, self-renewing copy
+            // regardless of real interest. Under the demand-driven model the GET
+            // still hosts on the return path via `cache_contract_locally` above
+            // (bounded + evicted by piece A's demand gauge — the whole
+            // distinction from relay-caching), and a client that wants ongoing
+            // freshness sets `subscribe=true`, handled by `maybe_subscribe_child`
+            // below. do NOT re-add auto-subscribe here — see hosting-invariants
+            // (invariants 1 & 2, anti-patterns table).
 
             // Emit routing event + telemetry — `report_result` (which
             // normally does both) doesn't run because the bypass
@@ -558,8 +540,10 @@ async fn drive_client_get_inner(
             // `maybe_subscribe_child` — subscribe is never handled in
             // the terminal-result construction to avoid double-subscribe
             // (commit 494a3c69). This only runs when the client set
-            // `subscribe=true`; the auto-subscribe path above handles
-            // the AUTO_SUBSCRIBE_ON_GET fallback.
+            // `subscribe=true`; it is now the ONLY subscribe path on GET
+            // (piece E removed the AUTO_SUBSCRIBE_ON_GET fallback above —
+            // a subscribe=false GET hosts under the demand gauge but does
+            // not subscribe).
             maybe_subscribe_child(
                 op_manager,
                 client_tx,
@@ -4100,23 +4084,29 @@ mod tests {
         );
     }
 
-    /// Bug #2 reproduction (source-level): the legacy branch calls
-    /// `auto_subscribe_on_get_response` for any client-initiated GET
-    /// when `AUTO_SUBSCRIBE_ON_GET` is true (see `get.rs:2313, 2408`).
-    /// The driver currently never calls it; `maybe_subscribe_child`
-    /// only handles the explicit `subscribe=true` flag. This test
-    /// pairs with `test_driver_inline_get_triggers_auto_subscribe`
-    /// (integration) to lock down both the absence and the symptom.
+    /// Piece E (demand-driven hosting): GET-auto-subscribe was REMOVED.
+    /// A successful GET with `subscribe=false` must NOT install a durable
+    /// subscription — that is the "GET-auto-subscribe" anti-pattern
+    /// (hosting-invariants, invariants 1 & 2). The driver must therefore
+    /// never call `auto_subscribe_on_get_response`; the only subscribe path
+    /// left is the explicit-`subscribe=true` `maybe_subscribe_child`. This
+    /// pairs with `test_driver_inline_get_does_not_auto_subscribe`
+    /// (integration), which asserts the requesting node does NOT subscribe.
     #[test]
-    fn driver_calls_auto_subscribe_on_get_response() {
+    fn driver_does_not_auto_subscribe_on_get_response() {
         let src = production_source();
         assert!(
-            src.contains("auto_subscribe_on_get_response"),
-            "The driver must invoke `auto_subscribe_on_get_response` on \
-             successful GET terminal paths (AUTO_SUBSCRIBE_ON_GET = true in \
-             ring.rs:60). The legacy branch does this at get.rs:2313/2408/3136/3185; \
-             the driver must mirror it so client GETs with subscribe=false \
-             still register the fallback subscription."
+            !src.contains("auto_subscribe_on_get_response"),
+            "GET must NOT auto-subscribe (piece E removed AUTO_SUBSCRIBE_ON_GET). \
+             A GET with subscribe=false hosts on the return path only under the \
+             demand gauge (cache_contract_locally); ongoing freshness requires an \
+             explicit subscribe=true. do NOT re-add auto_subscribe_on_get_response \
+             — see hosting-invariants."
+        );
+        // The explicit subscribe path must still be wired in.
+        assert!(
+            src.contains("maybe_subscribe_child"),
+            "the explicit subscribe=true path (maybe_subscribe_child) must remain"
         );
     }
 

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -499,12 +499,11 @@ pub(super) async fn fetch_contract_if_missing(
 /// completes"); the latency is the cost of the client knowing the
 /// subscriber can actually serve a follow-up GET.
 ///
-/// See also: `crate::operations::complete_piggyback_subscription` —
-/// the GET-piggyback originator finalization path, which performs the
-/// same conceptual steps in a different order (it does NOT need the
-/// fetch step because the contract just arrived inside the GET
-/// response that carried the piggyback). Keep the two helpers in sync
-/// when adding new originator-side side effects.
+/// (The former `crate::operations::complete_piggyback_subscription`
+/// GET-piggyback originator finalization path was removed with
+/// GET-auto-subscribe in piece E of the demand-driven hosting redesign;
+/// explicit `subscribe=true` GETs now route through the ordinary subscribe
+/// driver, which reaches this helper.)
 pub(super) async fn finalize_originator_subscribe(
     op_manager: &OpManager,
     key: ContractKey,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -111,10 +111,15 @@ mod placement_migration_metrics;
 pub mod topology_registry;
 pub(crate) mod update_rate_limit;
 
-/// Whether to auto-subscribe to contracts on GET.
-/// When true, GET operations will automatically subscribe to the contract
-/// to receive updates. This is controlled by hosting cache eviction.
-pub const AUTO_SUBSCRIBE_ON_GET: bool = true;
+// GET auto-subscribe (`AUTO_SUBSCRIBE_ON_GET`) was REMOVED in piece E of the
+// demand-driven hosting redesign (docs/design/demand-driven-hosting.md §9,
+// .claude/rules/hosting-invariants.md anti-patterns table). Auto-installing a
+// durable subscription on every GET manufactures demand that no client asked
+// for — the "GET-auto-subscribe" half of the relay-caching anti-pattern. A GET
+// may still host on the return path under the demand gauge (evictable,
+// non-durable; see `cache_contract_locally`), and a client that wants ongoing
+// freshness sets `subscribe=true` explicitly. do NOT re-add auto-subscribe on
+// GET — see hosting-invariants (invariants 1 & 2).
 
 /// Per-beneficiary weight for a local-client subscription when
 /// computing the LIVE benefit snapshot each governance reaper tick.

--- a/crates/core/tests/nat_subscription.rs
+++ b/crates/core/tests/nat_subscription.rs
@@ -79,8 +79,9 @@
 //! The deterministic fix is to use the supported non-host path: `nat-peer`
 //! issues `GET` with `subscribe=true`. The GET routes *toward* the contract
 //! (so it reliably resolves on `gateway`/`host-peer`), fetches and caches the
-//! body on `nat-peer`, and the GET driver's `auto_subscribe_on_get_response`
-//! then registers the subscription through the SAME relay path a bare SUBSCRIBE
+//! body on `nat-peer`, and the explicit `subscribe=true` flag then registers
+//! the subscription (`maybe_subscribe_child` -> `run_client_subscribe`) through
+//! the SAME relay path a bare SUBSCRIBE
 //! would use — the wire `SubscribeMsg::Request` still carries no address, so
 //! each hop still fills `upstream_addr` from the observed transport
 //! `source_addr` and registers the previous hop as a downstream subscriber.

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -3617,9 +3617,11 @@ fn run_fanout_liveness_scenario_inner(
         // or GET the contract before subscribing (so it can validate/apply
         // incoming updates). `GET+subscribe=true` is the documented exempt path:
         // the GET inherently fetches the WASM+state from the host over the
-        // preseeded connection, and the same op then auto-subscribes
-        // (`auto_subscribe_on_get_response`), registering downstream interest at
-        // the host and joining the broadcast set. The topology preseed only
+        // preseeded connection, and the explicit `subscribe=true` flag then
+        // subscribes (`maybe_subscribe_child` -> `run_client_subscribe`),
+        // registering downstream interest at the host and joining the broadcast
+        // set. (Piece E removed the implicit AUTO_SUBSCRIBE_ON_GET fallback; this
+        // path is unaffected because it always set subscribe=true.) The topology preseed only
         // injects ring connections, not contract state, so without the GET each
         // subscriber's bare subscribe is rejected at t=0 and only the subset
         // that happened to receive the contract first (via an early broadcast /

--- a/crates/core/tests/streaming_e2e.rs
+++ b/crates/core/tests/streaming_e2e.rs
@@ -827,7 +827,7 @@ fn test_streaming_get_1mb_with_packet_loss() {
 #[test]
 fn test_streaming_get_hosts_on_return_path() {
     const SEED: u64 = 0xDE1A_0009_CAFE_F00D;
-    const NETWORK_NAME: &str = "streaming-get-auto-subscribe";
+    const NETWORK_NAME: &str = "streaming-get-hosts-return-path";
     const THRESHOLD: usize = 1024;
     const LARGE_STATE_SIZE: usize = 100 * 1024; // 100KB, above streaming threshold
 

--- a/crates/core/tests/streaming_e2e.rs
+++ b/crates/core/tests/streaming_e2e.rs
@@ -814,14 +814,18 @@ fn test_streaming_get_1mb_with_packet_loss() {
     );
 }
 
-/// Regression test for #3704: streaming GET path must trigger auto-subscribe
-/// and hosting announcement so that subsequent GETs are served from local cache.
+/// Regression test for #3704: streaming GET path must HOST the fetched
+/// contract on the return path (call `announce_contract_hosted()`, not just
+/// `record_get_access()`) so subsequent GETs can be served from local cache.
 ///
-/// Before the fix, the streaming GET completion path only called `record_get_access()`
-/// but skipped `announce_contract_hosted()` and `start_subscription_request()`, so
-/// `is_receiving_updates()` returned false and every subsequent GET hit the network.
+/// NOTE: piece E of the demand-driven hosting redesign REMOVED GET-auto-subscribe.
+/// The GETting node hosts under piece A's demand gauge (evictable, non-durable),
+/// but it does NOT auto-install a durable subscription. This test therefore
+/// asserts only the hosting side effect (`is_hosting`), not subscription — a GET
+/// with subscribe=false must not subscribe (see hosting-invariants, invariants
+/// 1 & 2, and `test_driver_inline_get_does_not_auto_subscribe`).
 #[test]
-fn test_streaming_get_triggers_auto_subscribe() {
+fn test_streaming_get_hosts_on_return_path() {
     const SEED: u64 = 0xDE1A_0009_CAFE_F00D;
     const NETWORK_NAME: &str = "streaming-get-auto-subscribe";
     const THRESHOLD: usize = 1024;
@@ -850,7 +854,8 @@ fn test_streaming_get_triggers_auto_subscribe() {
             },
         ),
         // Node 2 GETs the contract (will be streamed since >1KB threshold).
-        // subscribe=false here — we're relying on AUTO_SUBSCRIBE_ON_GET to kick in.
+        // subscribe=false: the node hosts the fetched state on the return path
+        // (under the demand gauge) but must NOT auto-subscribe (piece E).
         ScheduledOperation::new(
             NodeLabel::node(NETWORK_NAME, 2),
             SimOperation::Get {
@@ -912,6 +917,17 @@ fn test_streaming_get_triggers_auto_subscribe() {
             ))
             .collect::<Vec<_>>()
     );
+
+    // NOTE on subscription: this test asserts ONLY host-on-GET (`is_hosting`),
+    // not the absence of a subscription. In this topology the gateway's
+    // `subscribe=true` PUT propagates the contract to its neighbors and builds a
+    // subscription tree, so the GETting node ends up subscribed via that path
+    // regardless of GET-auto-subscribe. The piece-E guarantee — that the GET
+    // *driver* itself no longer auto-subscribes on a `subscribe=false` GET — is
+    // pinned at the source level by `driver_does_not_auto_subscribe_on_get_response`
+    // (runs) and behaviorally isolated (HTL=1, no PUT propagation) by
+    // `test_driver_inline_get_does_not_auto_subscribe` (currently `#[ignore]`'d
+    // for the pre-existing #3883 topology-routing gap).
 }
 
 // =============================================================================
@@ -1136,25 +1152,28 @@ fn test_driver_streaming_get_cold_cache() {
     );
 }
 
-/// Cold-cache non-streaming GET must auto-subscribe at originator.
+/// Cold-cache non-streaming GET must NOT auto-subscribe at the originator
+/// (piece E, demand-driven hosting).
 ///
-/// Scope: bug #2 from the #3884 skeptical review — the driver never calls
-/// `auto_subscribe_on_get_response`, so a client GET with `subscribe=false`
-/// against a cold cache silently skips the AUTO_SUBSCRIBE_ON_GET fallback
-/// that the legacy `process_message` branch would have invoked.
+/// Scope: piece E removed GET-auto-subscribe. A client GET with
+/// `subscribe=false` against a cold cache HOSTS the fetched state on the
+/// return path (under piece A's demand gauge — the node stores the state) but
+/// must NOT install a durable subscription. Auto-subscribing on GET is the
+/// anti-pattern (hosting-invariants, invariants 1 & 2). A client that wants
+/// ongoing freshness sets `subscribe=true` explicitly.
 ///
 /// ## Driver isolation strategy
 ///
 /// Same HTL=1 approach as `test_driver_streaming_get_cold_cache`.
 /// Phase 1 discovers a cold node; phase 2 GETs from it with a small
 /// (inline, not streamed) payload; asserts that the driver fired
-/// (via `GET_DRIVER_CALL_COUNT`) AND that the cold node ended up
-/// with an active subscription (AUTO_SUBSCRIBE_ON_GET fallback).
+/// (via `GET_DRIVER_CALL_COUNT`), that the cold node STORED the state
+/// (host-on-GET), and that NO node ended up with an active subscription.
 ///
 /// Same infrastructure gap as above — currently `#[ignore]`'d.
 #[ignore = "Infrastructure gap — HTL=1 topology isn't routable; see docstring and #3883"]
 #[test]
-fn test_driver_inline_get_triggers_auto_subscribe() {
+fn test_driver_inline_get_does_not_auto_subscribe() {
     use freenet::dev_tool::GET_DRIVER_CALL_COUNT;
     use std::sync::atomic::Ordering;
 
@@ -1275,21 +1294,26 @@ fn test_driver_inline_get_triggers_auto_subscribe() {
         "Cold-cache node should have stored the contract state after the GET"
     );
 
-    // Bug #2 regression: after the driver-routed GET with
-    // subscribe=false, the cold node should have auto-subscribed.
-    // AUTO_SUBSCRIBE_ON_GET = true in ring.rs:60.
-    let auto_subscribed = phase2
+    // Piece E (demand-driven hosting): GET-auto-subscribe was REMOVED. A
+    // driver-routed GET with subscribe=false must NOT install a durable
+    // subscription anywhere — the node still HOSTS the fetched state on the
+    // return path (asserted above: it stored the state, under piece A's demand
+    // gauge), but no client requested ongoing freshness, so no subscription is
+    // created. This inverts the former "Bug #2" assertion: auto-subscribe on
+    // GET is the anti-pattern (hosting-invariants, invariants 1 & 2). Neither
+    // the PUTting gateway nor the cold getter set subscribe=true, so NO node
+    // should carry an active subscription for this contract.
+    let any_subscribed = phase2
         .topology_snapshots
         .iter()
         .any(|s| s.active_subscription_keys.contains(&contract_id));
 
     assert!(
-        auto_subscribed,
-        "Bug #2 regression: cold-cache GET through the driver did not \
-         auto-subscribe the requesting node {cold_node_label:?}. The \
-         driver's Done arm must invoke `auto_subscribe_on_get_response` \
-         for successful GETs when the client did not explicitly set \
-         `subscribe=true`. Active subscriptions: {:#?}",
+        !any_subscribed,
+        "GET-auto-subscribe regression: a GET with subscribe=false installed a \
+         durable subscription. Piece E removed AUTO_SUBSCRIBE_ON_GET — a GET \
+         hosts under the demand gauge but must NOT auto-subscribe. Active \
+         subscriptions: {:#?}",
         phase2
             .topology_snapshots
             .iter()


### PR DESCRIPTION
## Problem

A successful GET with `subscribe=false` used to auto-install a durable
subscription at the originator (`AUTO_SUBSCRIBE_ON_GET`). A one-shot read
should not manufacture ongoing demand no client asked for: it pins an
advertised, self-renewing copy regardless of real interest — the
"GET-auto-subscribe" half of the relay-caching anti-pattern
(`.claude/rules/hosting-invariants.md` invariants 1 & 2;
`docs/design/demand-driven-hosting.md` §9). The fetched copy still hosts on
the return path under piece A's demand gauge (shipped 0.2.90) and stays
findable via routing/anti-entropy, so the durable auto-subscription is
redundant; a client that actually wants ongoing freshness sets
`subscribe=true` explicitly.

## Approach

Remove the auto-subscribe path, keep the demand-driven replacements:

**Removed**
- `AUTO_SUBSCRIBE_ON_GET` const (`ring.rs`) + the auto-subscribe block in the
  GET client driver's `Done` arm (`get/op_ctx_task.rs`).
- The now-dead `auto_subscribe_on_get_response` + `complete_piggyback_subscription`
  helpers (`operations.rs`); `do NOT re-add` guard comments at each site.
- Stale references to the removed helpers in comments
  (`subscribe.rs`, `get/op_ctx_task.rs`, `nat_subscription`, `simulation_integration`,
  `op_state_manager`).

**Kept (demand-driven, NOT the anti-pattern)**
- **Host-on-GET** via `cache_contract_locally` — the GET still hosts the fetched
  state on the return path under piece A's demand gauge (evictable, non-durable).
  The gauge is the whole distinction from relay-caching.
- **Explicit `subscribe=true`** GETs via `maybe_subscribe_child` →
  `run_client_subscribe`.

This is the spec-aligned **GET half** extracted standalone from #4664. #4664
bundled it with a PUT relay-caching removal that is **superseded** (it folds into
the later every-hop-LRU placement work and was blocked on a piece-D fetch gap), so
**#4664 should be closed once this lands.** No PUT-relay / `should_host` /
`relay_put_*` / store-at-every-hop code is touched here.

## Testing

- `driver_does_not_auto_subscribe_on_get_response` (source-scrape pin, **runs**):
  the GET driver must not call the removed helper, and the explicit
  `maybe_subscribe_child` path must remain. Inverted from the old
  `driver_calls_auto_subscribe_on_get_response`.
- `test_driver_inline_get_does_not_auto_subscribe` (integration, driver-isolated
  HTL=1): asserts a `subscribe=false` GET hosts but does NOT subscribe. Stays
  `#[ignore]`'d for the **pre-existing** #3883 topology-routing gap (not this
  change) — inverted from the old `..._triggers_auto_subscribe`.
- `test_streaming_get_hosts_on_return_path` (**runs, passes**): asserts host-on-GET
  (`is_hosting`) is retained after a `subscribe=false` streaming GET. Renamed from
  `test_streaming_get_triggers_auto_subscribe`. NOTE added: in this topology the
  gateway's `subscribe=true` PUT builds a subscription tree that subscribes the
  GETter regardless of GET-auto-subscribe, so the driver-level non-subscription
  guarantee is pinned by the source-scrape + the isolated HTL=1 test, not here.
- `cargo build -p freenet`, `cargo fmt`, and production-code `cargo clippy`
  (matching CI: `cargo clippy -- -D warnings`) are clean. All 457 `operations::`
  lib tests pass.

Part of the demand-driven hosting epic freenet/freenet-core#4642. Extracted from
#4664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnRCbtbjepaB5GWrb5U8SR

[AI-assisted - Claude]
