### PR TITLE
feat(config): add --disable-auto-update opt-out for from-source deployments

### DIFF
--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -34,6 +34,13 @@ CHECK: env!("VERGEN_GIT_DIRTY") or equivalent build metadata
 
 WHY: Dev builds triggering auto-update replaces the dev binary with a release
 binary, destroying the development environment.
+
+The GIT_DIRTY gate only covers a DIRTY tree. A CLEAN build that is not an
+official release but intentionally runs AHEAD of the latest release (e.g. the
+try.freenet.org from-source node) has GIT_DIRTY empty, so it is NOT gated — it
+would detect the newer published release and exit 42 in a loop. For that case,
+pass `--disable-auto-update` on that deployment's `ExecStart` (default is off,
+so release nodes are unaffected). See #4690.
 ```
 
 ### WHEN tightening security (sandbox, CSP, CORS)

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -186,6 +186,23 @@ async fn run_local(config: Config) -> anyhow::Result<()> {
         .map_err(anyhow::Error::msg)
 }
 
+/// Whether the node's automatic self-update check should be skipped entirely.
+///
+/// Two independent reasons, either sufficient:
+/// - a dirty/dev build (`git_dirty` non-empty): `freenet update` would replace
+///   the binary with a prebuilt release and discard local changes (#3245);
+/// - an explicit operator opt-out (`--disable-auto-update`, #4690): for a
+///   bespoke from-source deployment that intentionally runs ahead of releases
+///   (e.g. try.freenet.org) and must not try to "update" itself to a published
+///   release.
+///
+/// A clean release build with the flag unset returns `false`, so auto-update
+/// stays ON by default. This is load-bearing: peers must keep updating
+/// automatically given Freenet's release pace — do not flip the default.
+fn auto_update_is_disabled(git_dirty: &str, disable_flag: bool) -> bool {
+    !git_dirty.is_empty() || disable_flag
+}
+
 async fn run_network(config: Config) -> anyhow::Result<()> {
     tracing::info!("Starting freenet node in network mode");
 
@@ -198,6 +215,10 @@ async fn run_network(config: Config) -> anyhow::Result<()> {
         .await
         .with_context(|| "failed to start HTTP/WebSocket client API")?;
     tracing::info!("Initializing node configuration");
+
+    // Capture before `config` is moved into NodeConfig; threaded to the
+    // update-check task so an operator opt-out (#4690) can park it.
+    let disable_auto_update = config.disable_auto_update;
 
     let node_config = NodeConfig::new(config)
         .await
@@ -212,7 +233,7 @@ async fn run_network(config: Config) -> anyhow::Result<()> {
     let shutdown_handle = node.shutdown_handle();
 
     // Run node with signal handling for graceful shutdown
-    run_network_node_with_signals(node, shutdown_handle).await
+    run_network_node_with_signals(node, shutdown_handle, disable_auto_update).await
 }
 
 /// Run the network node with signal handling for graceful shutdown.
@@ -226,6 +247,9 @@ async fn run_network(config: Config) -> anyhow::Result<()> {
 async fn run_network_node_with_signals(
     node: freenet::Node,
     shutdown_handle: freenet::ShutdownHandle,
+    // Operator opt-out of the self-update check (#4690); captured from `Config`
+    // by the caller before the node is built. Default false → auto-update ON.
+    disable_auto_update: bool,
 ) -> anyhow::Result<()> {
     use commands::auto_update::{
         UPDATE_REPOLL_INTERVAL, UPDATE_REPOLL_JITTER_FRACTION, UpdateCheckResult,
@@ -360,24 +384,38 @@ async fn run_network_node_with_signals(
     // Disabled for dirty builds — `freenet update` replaces the binary with a
     // prebuilt release, which would discard local modifications (#3245)
     let (update_tx, mut update_rx) = tokio::sync::oneshot::channel::<String>();
-    let auto_update_disabled = !build_info::GIT_DIRTY.is_empty();
+    // Two independent reasons to skip auto-update: a dirty/dev build (#3245) OR
+    // an explicit operator opt-out for a from-source deployment that runs ahead
+    // of releases (#4690). A clean release build with the flag unset keeps
+    // auto-update ON — see `auto_update_is_disabled`.
+    let auto_update_disabled = auto_update_is_disabled(build_info::GIT_DIRTY, disable_auto_update);
     let update_check_task = GlobalExecutor::spawn(async move {
         use std::time::Instant;
 
         if auto_update_disabled {
-            // Loud, operator-visible (issue #4580): a dirty/dev build never even
-            // checks for updates, so this node will stay on its current version
-            // indefinitely with no further signal. That is the intended
-            // behaviour for a local build (auto-update would clobber local
-            // changes, #3245), but it must be surfaced rather than silent.
-            tracing::warn!(
-                git_dirty = build_info::GIT_DIRTY,
-                "Auto-update is DISABLED for this dirty (locally modified) build: this node will \
-                 NOT detect or apply updates and will stay on version {} until you act. This is \
-                 expected for a local build. Run `freenet update` manually to switch to the \
-                 latest release, or install a clean release build to re-enable auto-update.",
-                build_info::VERSION,
-            );
+            // Loud, operator-visible (issue #4580): this node never even checks
+            // for updates, so it will stay on its current version indefinitely
+            // with no further signal. Surface WHY rather than staying silent.
+            if disable_auto_update {
+                tracing::warn!(
+                    "Auto-update is DISABLED by configuration (--disable-auto-update): this node \
+                     will NOT detect or apply updates and will stay on version {} until you update \
+                     it out-of-band. Intended only for a from-source deployment that manages its \
+                     own builds (e.g. try.freenet.org); a normal release node should NOT set this.",
+                    build_info::VERSION,
+                );
+            } else {
+                // Dirty/dev build: auto-update would clobber local changes (#3245).
+                tracing::warn!(
+                    git_dirty = build_info::GIT_DIRTY,
+                    "Auto-update is DISABLED for this dirty (locally modified) build: this node \
+                     will NOT detect or apply updates and will stay on version {} until you act. \
+                     This is expected for a local build. Run `freenet update` manually to switch \
+                     to the latest release, or install a clean release build to re-enable \
+                     auto-update.",
+                    build_info::VERSION,
+                );
+            }
             std::future::pending::<()>().await;
             return;
         }
@@ -1012,10 +1050,18 @@ fn freenet_main() -> anyhow::Result<()> {
         }
         Some(Command::Network { mut config }) => {
             config.mode = Some(OperationMode::Network);
+            // `--disable-auto-update` placed BEFORE the subcommand lands in the
+            // top-level `cli.config`, which this arm otherwise discards. Merge it
+            // so the safety opt-out works in either position instead of being
+            // silently ignored (#4690) — critical because a silently-ignored
+            // opt-out leaves the from-source node auto-updating (the exact loop
+            // we are preventing).
+            config.disable_auto_update |= cli.config.disable_auto_update;
             run_node(config)
         }
         Some(Command::Local { mut config }) => {
             config.mode = Some(OperationMode::Local);
+            config.disable_auto_update |= cli.config.disable_auto_update;
             run_node(config)
         }
         None => {
@@ -1195,6 +1241,52 @@ fn main() {
 mod tests {
     #[cfg(target_os = "linux")]
     use super::parse_listening_inode;
+
+    #[test]
+    fn auto_update_default_stays_enabled_flag_and_dirty_disable() {
+        use super::auto_update_is_disabled;
+        // LOAD-BEARING invariant (#4690): a clean release build with the flag
+        // UNSET must keep auto-update ON, or every peer stops updating given
+        // Freenet's release pace. This test fails if the default ever flips.
+        assert!(
+            !auto_update_is_disabled("", false),
+            "clean build + no flag must keep auto-update ON"
+        );
+        // Explicit operator opt-out disables it (the try.freenet.org from-source case).
+        assert!(
+            auto_update_is_disabled("", true),
+            "--disable-auto-update must turn auto-update OFF"
+        );
+        // A dirty/dev build still disables regardless of the flag (#3245).
+        assert!(auto_update_is_disabled("src/main.rs", false));
+        assert!(auto_update_is_disabled("src/main.rs", true));
+    }
+
+    #[test]
+    fn disable_auto_update_flag_honored_before_or_after_subcommand() {
+        use super::{Cli, Command};
+        use clap::Parser;
+        // The flag may appear BEFORE or AFTER the `network` subcommand. Before
+        // it, clap parses it into the top-level `cli.config`; after it, into the
+        // subcommand's `config`. `freenet_main` OR-merges the two so BOTH
+        // positions disable auto-update — a silently-ignored safety opt-out
+        // (#4690) would leave the from-source node auto-updating (Codex review).
+        for argv in [
+            ["freenet", "network", "--disable-auto-update"],
+            ["freenet", "--disable-auto-update", "network"],
+        ] {
+            let cli = Cli::try_parse_from(argv).expect("parse");
+            let sub = match cli.command {
+                Some(Command::Network { config }) => config.disable_auto_update,
+                _ => panic!("expected network subcommand"),
+            };
+            // Mirrors the OR-merge in freenet_main's Network/Local arms.
+            assert!(
+                sub || cli.config.disable_auto_update,
+                "flag must be honored in either position: {argv:?}"
+            );
+        }
+    }
 
     #[test]
     #[cfg(unix)]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -175,6 +175,25 @@ pub struct ConfigArgs {
     #[arg(long, env = "SHUTDOWN_DRAIN_SECS")]
     pub shutdown_drain_secs: Option<u64>,
 
+    /// Disable the node's automatic self-update check. Default: **false** — a
+    /// normal release node auto-updates and MUST NOT set this, or it stops
+    /// receiving security/protocol updates (which Freenet ships frequently).
+    ///
+    /// Intended ONLY for bespoke from-source deployments that intentionally run
+    /// *ahead* of the latest release (e.g. try.freenet.org). Such a build would
+    /// otherwise detect the newer published release, exit 42 to request an
+    /// update, and either be reinstalled as the stock release (clobbering its
+    /// unreleased build) or crash-loop under a plain restart-on-failure unit.
+    /// A dirty/dev build is already exempt via `build_info::GIT_DIRTY`; this
+    /// covers the clean-but-unofficial case that `GIT_DIRTY` misses (#4690).
+    ///
+    /// Plain boolean flag with no `env` binding: a truthy env value is easy to
+    /// leave set by accident, and silently disabling auto-update fleet-wide is
+    /// the exact failure this must avoid. The one bespoke deployment sets it
+    /// explicitly in its service `ExecStart`.
+    #[arg(long = "disable-auto-update")]
+    pub disable_auto_update: bool,
+
     #[command(flatten)]
     pub telemetry: TelemetryArgs,
 }
@@ -232,6 +251,7 @@ impl Default for ConfigArgs {
             inactive_user_sweep_interval_secs: None,
             module_cache_budget_bytes: None,
             shutdown_drain_secs: None,
+            disable_auto_update: false,
             telemetry: Default::default(),
         }
     }
@@ -983,6 +1003,7 @@ impl ConfigArgs {
             shutdown_drain_secs: self
                 .shutdown_drain_secs
                 .unwrap_or_else(default_shutdown_drain_secs),
+            disable_auto_update: self.disable_auto_update,
             telemetry: TelemetryConfig {
                 enabled: self.telemetry.enabled,
                 endpoint: self
@@ -1186,6 +1207,16 @@ pub struct Config {
         rename = "shutdown-drain-secs"
     )]
     pub shutdown_drain_secs: u64,
+
+    /// Operator opt-out of the automatic self-update check. RUNTIME-ONLY, NOT
+    /// persisted (`#[serde(skip)]`, like `secrets_dir` /
+    /// `TelemetryConfig::is_test_environment`): it is set from the
+    /// `--disable-auto-update` CLI flag in `build()`. Default `false`, so a
+    /// release node auto-updates exactly as before. See the flag's rustdoc on
+    /// `ConfigArgs::disable_auto_update` for why a from-source deployment
+    /// (try.freenet.org) needs it (#4690).
+    #[serde(skip)]
+    pub disable_auto_update: bool,
 }
 
 /// Default graceful-shutdown drain window.
@@ -4319,8 +4350,45 @@ mod tests {
             inactive_user_sweep_interval_secs: None,
             module_cache_budget_bytes: None,
             shutdown_drain_secs: None,
+            disable_auto_update: false,
             telemetry: Default::default(),
         }
+    }
+
+    #[tokio::test]
+    async fn disable_auto_update_flag_wires_through_build() {
+        // The default (no flag) MUST leave auto-update ENABLED (disable=false).
+        // This is the load-bearing default (#4690): a release node must keep
+        // updating automatically. Paired with the freenet.rs bin test on the
+        // gate helper, this covers the clap-arg -> Config plumbing end.
+        let temp = tempfile::tempdir().unwrap();
+        let default_cfg = clap_bare_args(temp.path()).build().await.unwrap();
+        assert!(
+            !default_cfg.disable_auto_update,
+            "default must keep auto-update ON"
+        );
+
+        // With the flag set on ConfigArgs, it reaches the built Config.
+        let temp2 = tempfile::tempdir().unwrap();
+        let mut args = clap_bare_args(temp2.path());
+        args.disable_auto_update = true;
+        let cfg = args.build().await.unwrap();
+        assert!(
+            cfg.disable_auto_update,
+            "--disable-auto-update must reach Config"
+        );
+    }
+
+    #[test]
+    fn disable_auto_update_flag_parses_from_cli() {
+        use clap::Parser;
+        // Absent → false (auto-update ON — the load-bearing default, #4690).
+        let none = ConfigArgs::try_parse_from(["freenet"]).expect("bare parse");
+        assert!(!none.disable_auto_update, "no flag → auto-update ON");
+        // Present → true (bespoke from-source deployment opt-out).
+        let set =
+            ConfigArgs::try_parse_from(["freenet", "--disable-auto-update"]).expect("flag parse");
+        assert!(set.disable_auto_update, "--disable-auto-update → OFF");
     }
 
     #[tokio::test]
@@ -4401,6 +4469,7 @@ mod tests {
                 iface_tx_enabled: true,
             },
             shutdown_drain_secs: 77,
+            disable_auto_update: true, // #[serde(skip)] — see destructure below
         };
 
         std::fs::write(
@@ -4431,6 +4500,10 @@ mod tests {
             module_cache_budget_bytes,
             telemetry,
             shutdown_drain_secs,
+            // #[serde(skip)] runtime CLI/env flag — set from --disable-auto-update
+            // at build() time, intentionally not persisted, so it does not
+            // round-trip through config.toml (#4690).
+            disable_auto_update: _,
         } = rebuilt;
 
         assert_eq!(mode, seed.mode, "mode");


### PR DESCRIPTION
## Problem

A node built from source that runs *ahead* of the latest GitHub release still runs the auto-update check. It detects the newer *published* release, exits code 42 to request a supervisor-applied update, and then either:

- under a supervisor that runs `freenet update`, **installs the stock release over the from-source build**, discarding unreleased features; or
- under a plain `Restart=on-failure` unit, **crash-loops** (re-detect → exit 42 → restart → repeat).

The **try.freenet.org** hosted node — a hand-built `cargo build --release` carrying unreleased features (the New ID button, #4685) — hit exactly this: its restart counter reached **138**.

The existing off-switch, `!build_info::GIT_DIRTY.is_empty()` (`freenet.rs`), only covers a **dirty** tree. A **clean** build that is merely ahead of releases sails right past it. `.claude/rules/deployment.md` already intends *"disable for dev, proceed for release"* — but only the dirty half was implemented; the clean-but-unofficial case was unaddressed.

## Solution

An **opt-in** `--disable-auto-update` CLI flag, **default `false`**, OR-ed into the existing gate:

```rust
let auto_update_disabled = auto_update_is_disabled(build_info::GIT_DIRTY, config.disable_auto_update);
```

- **The default is unchanged and load-bearing:** a release node that does not set the flag auto-updates *exactly* as before. Peers must keep updating automatically given Freenet's release pace — this PR does not change that.
- No change to update **detection / comparison / install** logic — only whether the check task runs at all (it parks, same as the dirty-build path).
- The flag maps to a **non-persisted** (`#[serde(skip)]`) runtime `Config` field set at `build()` (the systemd unit passes it every start).
- **Plain CLI flag, no `env` binding** — deliberately. A stray truthy env value silently disabling auto-update fleet-wide is the exact failure this must avoid; the one bespoke deployment (try.freenet.org) sets `--disable-auto-update` explicitly in its `ExecStart`.

## Testing

- **`auto_update_default_stays_enabled_flag_and_dirty_disable`** (bin) — pins the load-bearing invariant on the pure gate helper: clean build + flag unset → auto-update **ON**; flag set → OFF; dirty build → OFF regardless. Fails if the default ever flips.
- **`disable_auto_update_flag_parses_from_cli`** — `--disable-auto-update` parses to `true`, bare invocation to `false` (at the clap boundary).
- **`disable_auto_update_flag_wires_through_build`** — the flag reaches the built `Config`; default leaves it `false`.
- **`all_persisted_config_fields_round_trip_through_build`** — still passes; the new field is classified non-persisted (bound `_` in the exhaustive destructure).
- `cargo fmt` + `cargo clippy -p freenet --lib --bins -- -D warnings` clean.

## Review

Full-tier (deployment-critical surface). External **Codex** + an adversarial Claude pass, both focused on *"could this break auto-update for release nodes?"* Both independently confirmed the release path is unaffected (default traced end-to-end; nothing sets the flag on real nodes; threading/gate/`serde(skip)` correct). Both flagged that an `env`-bound bool would reject `FREENET_DISABLE_AUTO_UPDATE=1`; resolved by dropping `env` entirely (CLI flag only). Re-run of the review on the updated code is in the PR comments.

## Fixes

Closes #4690.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHNrpsMi7tz5j7PH84fvhe
