### PR TITLE
feat: computed-upstream primitive + stored-flag divergence telemetry (keystone step 1)

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -188,6 +188,30 @@ pub struct NetworkStatus {
     pub nat_stats: NatStats,
     /// Terminal advertisement-consult counters (hosting redesign piece C).
     pub terminal_consult_stats: TerminalConsultStats,
+    /// Computed-upstream vs. stored-`is_upstream`-flag divergence counters
+    /// (hosting redesign piece D, #4642 / #4671).
+    pub upstream_divergence_stats: UpstreamDivergenceStats,
+}
+
+/// Per-node counters measuring how often the demand-driven-hosting **computed
+/// upstream** (`Ring::most_keyward_hosting_neighbor`) disagrees with the stored
+/// `is_upstream` interest flag at the site that still consults the flag
+/// (`OpManager::send_unsubscribe_upstream`).
+///
+/// The reconcile-core keystone (#4642 piece D) replaces the stored flag — which
+/// drifts under interest-sync gossip (#4671) — with the computed upstream. This
+/// first, behavior-preserving step computes upstream in parallel and records
+/// whether the two agree, so the flag's real-world drift rate is legible in
+/// production telemetry (via `router_snapshot`) before the flag is deleted. The
+/// stored flag still drives the actual decision; these counters observe only.
+#[derive(Default)]
+pub struct UpstreamDivergenceStats {
+    /// Times the computed upstream was compared against the stored `is_upstream`
+    /// flag (the denominator — one per `send_unsubscribe_upstream` call).
+    pub comparisons: u64,
+    /// Of those, the times the computed upstream DISAGREED with the stored flag
+    /// (different peer, or one `Some`/the other `None`).
+    pub divergences: u64,
 }
 
 /// Per-node counters for the terminal advertisement consult (invariant 5:
@@ -350,6 +374,7 @@ pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: St
         op_stats: OperationStats::default(),
         nat_stats: NatStats::default(),
         terminal_consult_stats: TerminalConsultStats::default(),
+        upstream_divergence_stats: UpstreamDivergenceStats::default(),
     };
     match NETWORK_STATUS.get() {
         // Already initialized: overwrite the existing tracker in place so
@@ -558,6 +583,44 @@ pub fn terminal_consult_counts() -> Option<(u64, u64, u64, u64)> {
     let s = status.read().ok()?;
     let c = &s.terminal_consult_stats;
     Some((c.attempts, c.hits, c.resolved_found, c.still_not_found))
+}
+
+/// Record one computed-upstream vs. stored-`is_upstream`-flag comparison
+/// (hosting redesign piece D, #4642 / #4671). Increments the `comparisons`
+/// denominator every call and the `divergences` numerator when `diverged`.
+///
+/// Called from `OpManager::send_unsubscribe_upstream`, the site that still
+/// consults the stored flag: it computes the upstream in parallel via
+/// `Ring::most_keyward_hosting_neighbor` and reports whether the two disagree.
+/// Behavior-preserving — the stored flag still drives the decision; this only
+/// measures the flag's drift so it is legible in production telemetry before the
+/// reconcile-core keystone deletes the flag.
+pub fn record_upstream_divergence_comparison(diverged: bool) {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.upstream_divergence_stats.comparisons =
+                s.upstream_divergence_stats.comparisons.saturating_add(1);
+            if diverged {
+                s.upstream_divergence_stats.divergences =
+                    s.upstream_divergence_stats.divergences.saturating_add(1);
+            }
+        }
+    }
+}
+
+/// Read the current computed-upstream vs. stored-flag divergence counters
+/// (piece D, #4642 / #4671) for export to the `router_snapshot` telemetry event.
+///
+/// Returns `(comparisons, divergences)` — the per-node monotonic totals — or
+/// `None` before the `NETWORK_STATUS` singleton is initialized. `Ring` polls this
+/// on the snapshot cadence and copies the values onto `RouterSnapshotInfo` so the
+/// stored-flag drift rate is visible in central telemetry, not just the internal
+/// singleton, giving field evidence for the flag's removal.
+pub fn upstream_divergence_counts() -> Option<(u64, u64)> {
+    let status = NETWORK_STATUS.get()?;
+    let s = status.read().ok()?;
+    let d = &s.upstream_divergence_stats;
+    Some((d.comparisons, d.divergences))
 }
 
 /// Record a NAT traversal attempt.
@@ -1324,6 +1387,40 @@ mod tests {
             terminal_consult_counts(),
             Some((3, 2, 1, 4)),
             "getter returns (attempts, hits, resolved_found, still_not_found)"
+        );
+    }
+
+    /// End-to-end for piece D (#4642 / #4671): the divergence record site must
+    /// feed the `upstream_divergence_counts()` getter that `Ring` polls for the
+    /// `router_snapshot` export. `comparisons` bumps every call, `divergences`
+    /// only when `diverged`, and the getter returns them in
+    /// `(comparisons, divergences)` order — so a dropped increment or transposed
+    /// tuple fails here rather than silently emitting zeros in production.
+    #[test]
+    fn upstream_divergence_counts_reflect_recorded_events() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        // Fresh singleton state for a deterministic baseline (init overwrites
+        // the process-global tracker in place, zeroing the counters).
+        init(31337, HashSet::new(), "test".to_string());
+
+        assert_eq!(
+            upstream_divergence_counts(),
+            Some((0, 0)),
+            "counters start at zero after init"
+        );
+
+        // 5 comparisons, 2 of them divergent → distinct so a transposition fails.
+        record_upstream_divergence_comparison(false);
+        record_upstream_divergence_comparison(true);
+        record_upstream_divergence_comparison(false);
+        record_upstream_divergence_comparison(true);
+        record_upstream_divergence_comparison(false);
+
+        assert_eq!(
+            upstream_divergence_counts(),
+            Some((5, 2)),
+            "getter returns (comparisons, divergences); every call bumps comparisons, \
+             only diverged calls bump divergences"
         );
     }
 

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -792,6 +792,16 @@ impl OpManager {
         // before the stored-flag early-return so the "stored None but computed
         // Some" (and vice-versa) cases are also counted. Cheap: this path runs on
         // client-unsubscribe / chain-collapse, not a hot loop.
+        //
+        // CAVEAT — the recorded divergence rate is NOISY AT THE EDGES. A counted
+        // divergence means genuine stored-flag drift (#4671) OR one of two edge
+        // artifacts: (a) a transient `own_location == None` (early startup / a
+        // dropped self-location) makes `most_keyward_hosting_neighbor` return
+        // `None` while the stored flag is still `Some`, and (b) the `comparisons`
+        // denominator also counts non-divergent `None == None` calls (no upstream
+        // either way), diluting the ratio. So do NOT read
+        // `upstream_computed_vs_stored_*` as pure flag-drift: attribute startup /
+        // edge noise before concluding the flag has drifted.
         {
             let instance_id = *contract.id();
             let hosting_neighbors = self

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -782,6 +782,38 @@ impl OpManager {
             .into_iter()
             .find(|(_, interest)| interest.is_upstream);
 
+        // Behavior-preserving divergence telemetry (#4642 piece D / #4671).
+        // Compute the demand-driven-hosting upstream in PARALLEL and record how
+        // often it disagrees with the stored `is_upstream` flag this function
+        // still consults. The stored flag continues to drive the decision below;
+        // the reconcile-core keystone will later compute upstream everywhere and
+        // delete the drifting flag — this first step only measures the drift so
+        // it is legible in production telemetry (`router_snapshot`). Computed
+        // before the stored-flag early-return so the "stored None but computed
+        // Some" (and vice-versa) cases are also counted. Cheap: this path runs on
+        // client-unsubscribe / chain-collapse, not a hot loop.
+        {
+            let instance_id = *contract.id();
+            let hosting_neighbors = self
+                .neighbor_hosting
+                .neighbors_with_contract_id(&instance_id);
+            let computed = self
+                .ring
+                .most_keyward_hosting_neighbor(&instance_id, &hosting_neighbors);
+            let stored_pk = upstream.as_ref().map(|(peer_key, _)| &peer_key.0);
+            let computed_pk = computed.as_ref().map(|pkl| &pkl.pub_key);
+            let diverged = stored_pk != computed_pk;
+            crate::node::network_status::record_upstream_divergence_comparison(diverged);
+            if diverged {
+                tracing::debug!(
+                    contract = %contract,
+                    stored_upstream = ?stored_pk,
+                    computed_upstream = ?computed_pk,
+                    "computed upstream diverges from stored is_upstream flag (#4642 piece D / #4671)"
+                );
+            }
+        }
+
         let Some((peer_key, _)) = upstream else {
             tracing::debug!(
                 contract = %contract,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -893,8 +893,9 @@ impl Ring {
     /// this peer. Returns `None` when no such neighbor exists — either because
     /// this peer is the most-keyward host it can see (a terminus, design §5d-a)
     /// or because closer neighbors exist but none host the contract (a stranded
-    /// host that must re-root, §5d-b); the caller distinguishes those via
-    /// `is_subscription_root`.
+    /// host that must re-root, §5d-b). No current caller distinguishes those two
+    /// `None` cases — this step is observation-only; a later keystone step will
+    /// (via `is_subscription_root`).
     ///
     /// This is the *computed upstream* of the demand-driven-hosting design (§4,
     /// #4642 piece D): derived on demand from live neighbor-hosting
@@ -6955,11 +6956,25 @@ mod most_keyward_tests {
 
     #[test]
     fn excludes_farther_or_equal_neighbors() {
+        // This test PINS the strict `<` boundary (the acyclicity guarantee)
+        // against a regression to `<=`, so the "equal" candidate's distance must
+        // be BIT-IDENTICAL to `my_distance()`. The literal 0.10 is NOT: the ring
+        // distance `Location::new(0.60).distance(Location::new(0.50))` is
+        // `0.09999999999999998`, whereas `Distance::new(0.10)` stores
+        // `0.10000000000000001`, so a candidate built from `0.10` is actually
+        // strictly GREATER and is excluded as "farther" under BOTH `<` and `<=`
+        // — pinning nothing. Feeding `my_distance()` back in (via `as_f64`, which
+        // `Distance::new` stores verbatim for values <= 0.5) makes the candidate
+        // exactly equal, so `<` excludes it (None) while a regression to `<=`
+        // would include and pick it (Some): the two now disagree and this test
+        // fails under `<=`.
+        let equal_dist = my_distance().as_f64();
+
         // A strictly-closer neighbor (0.02) coexists with one at EXACTLY my
-        // distance (0.10) and one FARTHER (0.15). Only the strictly-closer one is
+        // distance and one FARTHER (0.15). Only the strictly-closer one is
         // eligible, so it is chosen — the equal and farther peers are excluded.
         let closer = candidate("127.0.0.1:9001", 0.02);
-        let equal = candidate("127.0.0.1:9002", 0.10);
+        let equal = candidate("127.0.0.1:9002", equal_dist);
         let farther = candidate("127.0.0.1:9003", 0.15);
         let want = closer.0.clone();
         let picked = most_keyward_among(my_distance(), [equal, farther, closer].into_iter());
@@ -6971,12 +6986,14 @@ mod most_keyward_tests {
 
         // With ONLY an equal-distance neighbor present, the strict `<` excludes
         // it → None (a peer at our exact distance never becomes our upstream, the
-        // acyclicity guarantee).
-        let equal_only = candidate("127.0.0.1:9002", 0.10);
+        // acyclicity guarantee). This is the assertion that DISTINGUISHES `<`
+        // from `<=`: under the shipped `<` the equal candidate yields None, while
+        // a regression to `<=` would yield `Some(equal)` and fail here.
+        let equal_only = candidate("127.0.0.1:9002", equal_dist);
         assert_eq!(
             most_keyward_among(my_distance(), std::iter::once(equal_only)),
             None,
-            "a neighbor at exactly our distance is farther-or-equal and must be excluded"
+            "a neighbor at exactly our distance is farther-or-equal and must be excluded (pins `<`, not `<=`)"
         );
     }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -356,6 +356,43 @@ fn no_closer_routable_neighbor(
     true
 }
 
+/// Pure core of [`Ring::most_keyward_hosting_neighbor`]: from candidate hosting
+/// neighbors already paired with their ring distance to the contract, pick the
+/// one STRICTLY closer to the contract than `my_distance` (the most-keyward
+/// host), breaking ties on equal distance by ascending socket address so the
+/// choice is deterministic (design §6 point 2 total order). The
+/// `most_keyward_hosting_neighbor` caller pre-filters candidates through
+/// `pkl.location()?`, which requires a resolvable socket address, so no
+/// addressless candidate ever reaches this helper and every item here carries a
+/// concrete distance and a concrete address for the tiebreak.
+///
+/// Returns `None` when no candidate is strictly closer than us — either the
+/// candidate set is empty or every candidate is farther-or-equal (so we are the
+/// terminus / a stranded host; the caller distinguishes those). The strict `<`
+/// is the acyclicity guarantee: a peer at exactly our distance never becomes our
+/// upstream. Factored out so the strict-closer + deterministic-tiebreak
+/// selection has direct unit coverage without a heavyweight async `Ring`
+/// fixture, mirroring [`no_closer_routable_neighbor`].
+///
+/// This is the computed-upstream primitive of the demand-driven-hosting redesign
+/// (#4642 piece D): the eventual replacement for the stored `is_upstream`
+/// interest flag, which drifts under gossip (#4671). It is introduced here
+/// behavior-preservingly — computed alongside the stored flag for divergence
+/// telemetry — ahead of the reconcile-core keystone that computes upstream
+/// everywhere.
+fn most_keyward_among(
+    my_distance: Distance,
+    candidates: impl Iterator<Item = (PeerKeyLocation, Distance)>,
+) -> Option<PeerKeyLocation> {
+    candidates
+        .filter(|(_, dist)| *dist < my_distance)
+        .min_by(|(a, ad), (b, bd)| {
+            ad.cmp(bd)
+                .then_with(|| a.socket_addr().cmp(&b.socket_addr()))
+        })
+        .map(|(pkl, _)| pkl)
+}
+
 /// Race an `.await` point in a background loop against the Ring shutdown
 /// token. Returns `true` if shutdown fired (the caller should stop its loop)
 /// and `false` if the wrapped future completed first (carry on).
@@ -847,6 +884,52 @@ impl Ring {
         });
 
         no_closer_routable_neighbor(my_distance, contract_location, neighbors)
+    }
+
+    /// Compute the CURRENT upstream for a contract this peer hosts: among
+    /// `hosting_neighbors` (connected neighbors that have advertised hosting the
+    /// contract, from `NeighborHostingManager::neighbors_with_contract_id`), the
+    /// one CLOSEST to the contract's key that is STRICTLY closer to the key than
+    /// this peer. Returns `None` when no such neighbor exists — either because
+    /// this peer is the most-keyward host it can see (a terminus, design §5d-a)
+    /// or because closer neighbors exist but none host the contract (a stranded
+    /// host that must re-root, §5d-b); the caller distinguishes those via
+    /// `is_subscription_root`.
+    ///
+    /// This is the *computed upstream* of the demand-driven-hosting design (§4,
+    /// #4642 piece D): derived on demand from live neighbor-hosting
+    /// advertisements + ring distance, never a stored formation flag. "Strictly
+    /// closer to the key" makes the upstream relation a strict descent toward the
+    /// key, so it is **acyclic by construction** (§4 point 2); the deterministic
+    /// peer-address tiebreak makes equidistant hosts a total order (§6 point 2).
+    ///
+    /// It is introduced here alongside — not in place of — the stored
+    /// `is_upstream` interest flag: the reconcile-core keystone will compute
+    /// upstream everywhere and delete the stored flag, but this first step only
+    /// computes it in parallel to measure how often the two disagree (the
+    /// `hosting_upstream_computed_vs_stored_divergence` telemetry recorded at
+    /// `OpManager::send_unsubscribe_upstream`), producing field evidence for the
+    /// flag's drift (#4671). No decision consults this method yet.
+    pub(crate) fn most_keyward_hosting_neighbor(
+        &self,
+        instance_id: &ContractInstanceId,
+        hosting_neighbors: &[TransportPublicKey],
+    ) -> Option<PeerKeyLocation> {
+        let contract_location = Location::from(instance_id);
+        let my_location = self.connection_manager.own_location().location()?;
+        let my_distance = my_location.distance(contract_location);
+
+        // Resolve each advertised pub key to a live connection with a known
+        // location, then delegate the strict-closer + deterministic-tiebreak
+        // selection to `most_keyward_among` (unit-tested in `most_keyward_tests`).
+        let candidates = hosting_neighbors
+            .iter()
+            .filter_map(|pk| self.connection_manager.get_peer_by_pub_key(pk))
+            .filter_map(|pkl| {
+                let dist = pkl.location()?.distance(contract_location);
+                Some((pkl, dist))
+            });
+        most_keyward_among(my_distance, candidates)
     }
 
     /// Check if a contract-directed CONNECT is currently in backoff.
@@ -1507,6 +1590,20 @@ impl Ring {
                 snapshot.terminal_consult_still_not_found = Some(still_not_found);
             }
 
+            // Computed-upstream vs. stored-`is_upstream`-flag divergence counters
+            // (#4642 piece D / #4671). Recorded at `send_unsubscribe_upstream`
+            // where the stored flag is still consulted; exported here so the
+            // stored flag's real-world drift rate is legible in central telemetry
+            // ahead of the reconcile-core keystone that deletes the flag. Read
+            // from the per-node network_status singleton; `None` only before the
+            // singleton is initialized (i.e. always populated in production).
+            if let Some((comparisons, divergences)) =
+                crate::node::network_status::upstream_divergence_counts()
+            {
+                snapshot.upstream_computed_vs_stored_comparisons = Some(comparisons);
+                snapshot.upstream_computed_vs_stored_divergences = Some(divergences);
+            }
+
             // Keep the hosting manager's copy of our own ring location current so
             // the proximity-prior demand estimate (#4642 A3) can turn a contract
             // key into a distance. Best-effort: only push a known location.
@@ -1632,6 +1729,10 @@ impl Ring {
                 terminal_consult_hits = ?snapshot.terminal_consult_hits,
                 terminal_consult_resolved_found = ?snapshot.terminal_consult_resolved_found,
                 terminal_consult_still_not_found = ?snapshot.terminal_consult_still_not_found,
+                upstream_computed_vs_stored_comparisons =
+                    ?snapshot.upstream_computed_vs_stored_comparisons,
+                upstream_computed_vs_stored_divergences =
+                    ?snapshot.upstream_computed_vs_stored_divergences,
                 "router_snapshot"
             );
 
@@ -6802,6 +6903,123 @@ mod subscription_root_predicate_tests {
             contract_loc(),
             neighbors.into_iter(),
         ));
+    }
+}
+
+/// Direct unit coverage for the pure core of `Ring::most_keyward_hosting_neighbor`
+/// (piece D, computed-upstream selection). Building a full `Ring` fixture is
+/// heavyweight (async `Ring::new` spawns background tasks) and a peer's ring
+/// location is derived from its (masked) socket address, so distances aren't
+/// freely settable through a real `ConnectionManager`. The strict-closer +
+/// deterministic-tiebreak selection is therefore factored into the pure
+/// `most_keyward_among` helper and tested here with distances supplied directly;
+/// the pub-key resolution / own-location glue is a thin wrapper covered
+/// end-to-end by the computed-upstream simulation proofs (later keystone steps).
+#[cfg(test)]
+mod most_keyward_tests {
+    use super::most_keyward_among;
+    use crate::ring::PeerKeyLocation;
+    use crate::ring::location::{Distance, Location};
+    use crate::transport::TransportKeypair;
+    use std::net::SocketAddr;
+
+    // Contract at 0.50; "me" hosting it at distance 0.10 (I'm at 0.60).
+    const CONTRACT: f64 = 0.50;
+    fn my_distance() -> Distance {
+        Location::new(0.60).distance(Location::new(CONTRACT))
+    }
+
+    /// A candidate peer at `addr` whose distance-to-contract is `dist`. The
+    /// distance is supplied directly (the helper takes it pre-computed), so it is
+    /// decoupled from the address — the address only drives the tiebreak.
+    fn candidate(addr: &str, dist: f64) -> (PeerKeyLocation, Distance) {
+        let addr: SocketAddr = addr.parse().unwrap();
+        let pk = TransportKeypair::new().public().clone();
+        (PeerKeyLocation::new(pk, addr), Distance::new(dist))
+    }
+
+    #[test]
+    fn picks_closest_strictly_closer_neighbor() {
+        // Two neighbors, both strictly closer than my 0.10: one at 0.05, one at
+        // 0.02. The most-keyward (smallest distance) wins.
+        let near = candidate("127.0.0.1:9001", 0.02);
+        let mid = candidate("127.0.0.1:9002", 0.05);
+        let want = near.0.clone();
+        let picked = most_keyward_among(my_distance(), [mid, near].into_iter());
+        assert_eq!(
+            picked,
+            Some(want),
+            "the neighbor closest to the key (0.02) must be chosen over the farther-but-still-closer one (0.05)"
+        );
+    }
+
+    #[test]
+    fn excludes_farther_or_equal_neighbors() {
+        // A strictly-closer neighbor (0.02) coexists with one at EXACTLY my
+        // distance (0.10) and one FARTHER (0.15). Only the strictly-closer one is
+        // eligible, so it is chosen — the equal and farther peers are excluded.
+        let closer = candidate("127.0.0.1:9001", 0.02);
+        let equal = candidate("127.0.0.1:9002", 0.10);
+        let farther = candidate("127.0.0.1:9003", 0.15);
+        let want = closer.0.clone();
+        let picked = most_keyward_among(my_distance(), [equal, farther, closer].into_iter());
+        assert_eq!(
+            picked,
+            Some(want),
+            "only the strictly-closer neighbor is eligible"
+        );
+
+        // With ONLY an equal-distance neighbor present, the strict `<` excludes
+        // it → None (a peer at our exact distance never becomes our upstream, the
+        // acyclicity guarantee).
+        let equal_only = candidate("127.0.0.1:9002", 0.10);
+        assert_eq!(
+            most_keyward_among(my_distance(), std::iter::once(equal_only)),
+            None,
+            "a neighbor at exactly our distance is farther-or-equal and must be excluded"
+        );
+    }
+
+    #[test]
+    fn none_when_no_strictly_closer_neighbor() {
+        // Empty candidate set → None.
+        assert_eq!(
+            most_keyward_among(my_distance(), std::iter::empty()),
+            None,
+            "no candidates → no computed upstream"
+        );
+        // All candidates farther than us → None (we are the terminus / stranded).
+        let far_a = candidate("127.0.0.1:9001", 0.15);
+        let far_b = candidate("127.0.0.1:9002", 0.30);
+        assert_eq!(
+            most_keyward_among(my_distance(), [far_a, far_b].into_iter()),
+            None,
+            "every candidate farther than us → no strictly-closer upstream"
+        );
+    }
+
+    #[test]
+    fn deterministic_tiebreak_on_equal_distance() {
+        // Two neighbors equidistant from the key (both 0.03, both strictly closer
+        // than 0.10) but with different socket addresses. The tiebreak picks the
+        // smaller socket address, and the result is independent of iteration
+        // order.
+        let low = candidate("127.0.0.1:9001", 0.03);
+        let high = candidate("127.0.0.1:9002", 0.03);
+        let want = low.0.clone();
+
+        let picked_fwd = most_keyward_among(my_distance(), [low.clone(), high.clone()].into_iter());
+        let picked_rev = most_keyward_among(my_distance(), [high, low].into_iter());
+
+        assert_eq!(
+            picked_fwd,
+            Some(want.clone()),
+            "equidistant tie must resolve to the smaller socket address"
+        );
+        assert_eq!(
+            picked_rev, picked_fwd,
+            "the tiebreak must be deterministic regardless of iteration order"
+        );
     }
 }
 

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -240,6 +240,16 @@ pub(crate) struct RouterSnapshotInfo {
     pub terminal_consult_hits: Option<u64>,
     pub terminal_consult_resolved_found: Option<u64>,
     pub terminal_consult_still_not_found: Option<u64>,
+    /// Computed-upstream vs. stored-`is_upstream`-flag divergence counters
+    /// (hosting redesign piece D, #4642 / #4671). `comparisons` is the
+    /// denominator (one per `send_unsubscribe_upstream`), `divergences` the times
+    /// the demand-driven-hosting computed upstream
+    /// (`Ring::most_keyward_hosting_neighbor`) disagreed with the stored flag the
+    /// site still consults. Behavior-preserving field evidence for the stored
+    /// flag's drift ahead of the reconcile-core keystone deleting it; monotonic
+    /// lifetime totals, `None` until the ring's snapshot task populates them.
+    pub upstream_computed_vs_stored_comparisons: Option<u64>,
+    pub upstream_computed_vs_stored_divergences: Option<u64>,
     /// Interest-weighted (two-tier) module-cache SHADOW gauges (#4441/#4534),
     /// populated by `Ring` from the same per-node `ModuleCacheMetrics` `Arc`.
     /// These are ALWAYS ON, independent of the `FREENET_MODULE_CACHE_INTEREST_TIERED`
@@ -1152,6 +1162,11 @@ impl Router {
             terminal_consult_hits: None,
             terminal_consult_resolved_found: None,
             terminal_consult_still_not_found: None,
+            // Computed-upstream vs. stored-flag divergence counters (piece D,
+            // #4642 / #4671), populated by Ring from the network_status
+            // singleton on the snapshot cadence.
+            upstream_computed_vs_stored_comparisons: None,
+            upstream_computed_vs_stored_divergences: None,
             // Interest-weighted (two-tier) module-cache shadow gauges,
             // populated by Ring on the snapshot cadence (#4441/#4534).
             contract_module_cache_cold_evictable_bytes: None,

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2212,6 +2212,21 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "terminal_consult_still_not_found".to_string(),
                     serde_json::json!(snapshot.terminal_consult_still_not_found),
                 );
+                // Computed-upstream vs. stored-flag divergence counters (piece D,
+                // #4642 / #4671) — same hand-mirror footgun: a new
+                // `RouterSnapshotInfo` field is invisible to the collector unless
+                // added here. These give production field evidence for the stored
+                // `is_upstream` flag's drift ahead of the reconcile-core keystone
+                // deleting it. Pinned by
+                // `router_snapshot_json_includes_upstream_divergence_counters`.
+                obj.insert(
+                    "upstream_computed_vs_stored_comparisons".to_string(),
+                    serde_json::json!(snapshot.upstream_computed_vs_stored_comparisons),
+                );
+                obj.insert(
+                    "upstream_computed_vs_stored_divergences".to_string(),
+                    serde_json::json!(snapshot.upstream_computed_vs_stored_divergences),
+                );
             }
             body
         }
@@ -2454,6 +2469,29 @@ mod tests {
             ("terminal_consult_hits", 313),
             ("terminal_consult_resolved_found", 317),
             ("terminal_consult_still_not_found", 331),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
+    }
+
+    /// Pin: the computed-upstream vs. stored-flag divergence counters (piece D,
+    /// #4642 / #4671) must also reach the hand-mirrored OTLP body — same footgun
+    /// as the terminal-consult counters above. These give production field
+    /// evidence for the stored `is_upstream` flag's drift ahead of the
+    /// reconcile-core keystone deleting it; a silent drop would re-blind central
+    /// telemetry to that drift — the exact gap this change closes.
+    #[test]
+    fn router_snapshot_json_includes_upstream_divergence_counters() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.upstream_computed_vs_stored_comparisons = Some(337);
+        info.upstream_computed_vs_stored_divergences = Some(347);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        for (key, want) in [
+            ("upstream_computed_vs_stored_comparisons", 337),
+            ("upstream_computed_vs_stored_divergences", 347),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }


### PR DESCRIPTION
Keystone step 1 of the demand-driven-hosting reconcile-core (path b, harvest plan). Foundation only. Behavior-preserving. **Draft.**

## Problem

The reconcile-core keystone (#4642 piece D) replaces the stored `is_upstream` interest flag with an upstream that is **computed** from live connection + distance state on every reconcile. The stored flag drifts under interest-sync gossip, which #4671 just fixed with a fresh guard against exactly that drift; computing upstream deletes the whole bug class.

Before the keystone computes upstream everywhere, two things need to be in place:
1. The computed-upstream primitive itself.
2. Evidence of how often the stored flag actually disagrees with the computed upstream in the field, to reinforce the #4671 motivation for dropping it.

This PR delivers both without removing the flag or changing any decision.

## Approach

Behavior-preserving: compute in parallel, compare, record telemetry; the stored flag still drives every decision.

- **Primitive (harvested from #4661).** `most_keyward_among` (pure fn) + `Ring::most_keyward_hosting_neighbor`: given a contract key and the connected neighbors advertising that they host it, return the most-keyward one **strictly closer** to the key than self. Strict `<` makes the upstream relation acyclic by construction; ties break on ascending socket address (deterministic total order); empty / no-closer returns `None` (terminus or stranded host). Re-implemented cleanly on main with its unit tests (strict-closer, exclude-equal, empty/all-farther, deterministic tiebreak).
- **Divergence telemetry.** A new production counter in `network_status` (`record_upstream_divergence_comparison` / `upstream_divergence_counts`) reporting `(comparisons, divergences)`, exported through `RouterSnapshotInfo` into the `router_snapshot` event and the OTLP body, mirroring the existing terminal-consult counters. This is the field-evidence surface (debug logs are compiled out in release).
- **One parity site.** `OpManager::send_unsubscribe_upstream` is the only production site on main that still locates the upstream via the stored `is_upstream` flag. It now **also** computes the upstream via the new primitive, compares the two, records the comparison (and a divergence when they disagree), and debug-logs on divergence. The stored flag still drives the actual unsubscribe decision, so behavior is unchanged.

### Only one site wired (by design)

On main the renewal path uses `first_hop = None` and does not read the stored flag today (computed-upstream targeting there is what #4661 introduces). So `send_unsubscribe_upstream` is the only current stored-flag decision site, and it is the one wired here. Adding computed-upstream to the renewal target belongs to the later keystone step that actually changes that decision.

## Testing

- `most_keyward_tests` (4 unit tests): picks-closest-strictly-closer, excludes-farther-or-equal (incl. equal-only -> None), empty/all-farther -> None, deterministic tiebreak independent of iteration order. All pass.
- `upstream_divergence_counts_reflect_recorded_events`: record site feeds the getter in `(comparisons, divergences)` order; every call bumps comparisons, only diverged calls bump divergences.
- `router_snapshot_json_includes_upstream_divergence_counters`: the two counters reach the hand-mirrored OTLP body (guards the silent-drop footgun the terminal-consult pin also guards).
- `cargo build -p freenet`, `cargo fmt`, `cargo clippy -p freenet` all clean. The only `--all-targets` clippy warnings are pre-existing on main in files this PR does not touch (`secrets_store/store.rs`, `user_op_rate_limit.rs`, `bin/commands/update.rs`).

Part of the demand-driven-hosting reconcile-core keystone. Tracker: #4642.

[AI-assisted - Claude]