### PR TITLE
fix: interest-gate subscription renewal to stop the #3763 storm

### DIFF
--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -382,15 +382,16 @@ pub(crate) async fn run_renewal_subscribe(
     //
     //   * Root that is NOT `contract_in_use`: DO NOT refresh. Refreshing an
     //     `is_subscribed`-only lease unconditionally would be an UNBOUNDED
-    //     retention exemption — `contracts_needing_renewal` section 1 renews any
-    //     live active subscription with no interest re-check, so an
-    //     unconditional refresh would re-select a no-interest root forever and
-    //     keep its lease (and thus the contract) alive indefinitely. That is
-    //     exactly the unbounded-`is_subscribed` retention the `contract_in_use`
-    //     rustdoc and the AGENTS.md time-bounded-exemption rule forbid. Letting
-    //     the lease lapse is correct: a no-interest root then drops out of the
-    //     renewal set entirely (no live active sub for path 1; no client
-    //     sub/recent access for paths 2/3), bounded and quiet.
+    //     retention exemption — it would locally keep a no-interest root's
+    //     lease (and thus the contract) alive indefinitely, defeating the
+    //     `contract_in_use` gate that `contracts_needing_renewal` section 1 now
+    //     applies (that section renews a soon-to-expire lease only while in
+    //     use). That is exactly the unbounded-`is_subscribed` retention the
+    //     `contract_in_use` rustdoc and the AGENTS.md time-bounded-exemption
+    //     rule forbid. Letting the lease lapse is correct: a no-interest root
+    //     then drops out of the renewal set entirely (no live active sub for
+    //     path 1; no client sub/recent access for paths 2/3), bounded and
+    //     quiet.
     //
     // This is NOT `complete_local_subscription`, whose semantics differ (it
     // emits `LocalSubscribeComplete` and registers client interest); the
@@ -3169,9 +3170,10 @@ mod tests {
             branch.contains("contract_in_use(&key)"),
             "the local lease refresh MUST be gated on contract_in_use — an unconditional \
              refresh of an is_subscribed-only lease is an unbounded retention exemption \
-             (contracts_needing_renewal section 1 re-selects any live active sub with no \
-             interest re-check), violating the contract_in_use rustdoc + AGENTS.md \
-             time-bounded-exemption rule"
+             (contracts_needing_renewal section 1 renews a soon-to-expire lease only while \
+             contract_in_use, so an unconditional local refresh would keep a no-interest \
+             root's lease alive behind that gate), violating the contract_in_use rustdoc + \
+             AGENTS.md time-bounded-exemption rule"
         );
         // The short-circuit must NOT reuse complete_local_subscription (different
         // semantics — it emits LocalSubscribeComplete and was the wrong vehicle

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -1013,16 +1013,20 @@ impl HostingManager {
     ///
     /// **Why `is_subscribed` (this node's own upstream subscription) is NOT
     /// included.** It would seem natural to also exempt contracts the node
-    /// is actively subscribed to. The problem is `contracts_needing_renewal`
-    /// section 1 renews ANY soon-to-expire active subscription
-    /// unconditionally, with no gate on local interest. So an
-    /// `is_subscribed`-only exemption is effectively unbounded — the renewal
-    /// machinery would keep extending the lease forever, blocking
-    /// reclamation indefinitely. That would violate the cleanup-exemption
-    /// rule in `AGENTS.md` (exemptions must be time-bounded). Local-client
-    /// subscriptions and downstream subscribers ARE both time-bounded:
-    /// client subscriptions expire on disconnect; downstream subscribers
-    /// expire via `expire_stale_downstream_subscribers` after
+    /// is actively subscribed to. But `contract_in_use` now *gates* renewal:
+    /// `contracts_needing_renewal` section 1 renews a soon-to-expire lease
+    /// only while `contract_in_use` is true. If `is_subscribed` counted as
+    /// in-use, a subscribed contract would renew its own lease, which keeps
+    /// the subscription alive, which keeps `is_subscribed` (and therefore
+    /// `contract_in_use`) true — a self-renewing loop with no external
+    /// demand. That is exactly the #3763 renewal storm the interest gate
+    /// exists to stop, reintroduced through the back door; the exemption
+    /// would also be effectively unbounded, blocking reclamation
+    /// indefinitely, which violates the cleanup-exemption rule in `AGENTS.md`
+    /// (exemptions must be time-bounded). Local-client subscriptions and
+    /// downstream subscribers ARE both time-bounded and represent real
+    /// external demand: client subscriptions expire on disconnect; downstream
+    /// subscribers expire via `expire_stale_downstream_subscribers` after
     /// `SUBSCRIPTION_LEASE_DURATION` without renewal.
     ///
     /// The narrow case "subscribed but no local interest" should be handled
@@ -3687,11 +3691,12 @@ mod tests {
     /// A contract with ONLY an active upstream network subscription (no
     /// local client, no downstream subscriber) is NOT in use for
     /// reclamation purposes. Documented in `contract_in_use`'s rustdoc:
-    /// `contracts_needing_renewal` renews active subscriptions
-    /// unconditionally, so including `is_subscribed` here would be an
-    /// effectively unbounded GC exemption (AGENTS.md cleanup-exemption
-    /// rule). Local-client subscriptions and downstream-peer subscribers
-    /// are both time-bounded and remain in the predicate.
+    /// `contracts_needing_renewal` section 1 now gates renewal on
+    /// `contract_in_use`, so including `is_subscribed` here would make a
+    /// subscribed contract renew its own lease indefinitely — a self-renewing
+    /// loop and an effectively unbounded GC exemption (AGENTS.md
+    /// cleanup-exemption rule). Local-client subscriptions and downstream-peer
+    /// subscribers are both time-bounded and remain in the predicate.
     #[test]
     fn test_contract_in_use_excludes_network_subscription_only() {
         let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -1664,7 +1664,22 @@ impl HostingManager {
         // Use HashSet for O(1) deduplication instead of O(n) Vec::contains
         let mut needs_renewal_set = HashSet::new();
 
-        // 1. Contracts with soon-to-expire subscriptions
+        // 1. Contracts with soon-to-expire subscriptions AND active demand.
+        //
+        //    The `contract_in_use` gate is load-bearing (demand-driven-hosting
+        //    design §5a / §7). A subscribed host renews its lease only while
+        //    something still depends on it hosting the contract: a local client,
+        //    or a registered downstream subscriber. Both are time-bounded
+        //    (clients disconnect, downstream registrations lease-expire), so when
+        //    demand fades the peer stops renewing, its lease lapses, and the
+        //    chain collapses inward toward the key. Without this gate every
+        //    subscribed host self-renews forever regardless of interest, so live
+        //    subscriptions grow with accumulated cache rather than active demand
+        //    — the #3763 renewal storm. The eviction budget (piece A) does NOT
+        //    bound this: an in-use, actively-subscribed contract is
+        //    eviction-exempt AND self-renewing, so the storm set is exactly the
+        //    set the budget may not touch.
+        //
         // Collect and sort for deterministic iteration order
         let mut active_subs: Vec<_> = self
             .active_subscriptions
@@ -1674,7 +1689,11 @@ impl HostingManager {
         active_subs.sort_by(|(a, _), (b, _)| a.id().as_bytes().cmp(b.id().as_bytes()));
 
         for (key, expires_at) in active_subs {
-            if expires_at <= renewal_threshold && expires_at > now {
+            // `contract_in_use` reads only the client-subscription and
+            // downstream-subscriber maps (never `hosting_cache`), and `active_subs`
+            // is already materialized above, so no active_subscriptions shard guard
+            // is held across this call.
+            if expires_at <= renewal_threshold && expires_at > now && self.contract_in_use(&key) {
                 needs_renewal_set.insert(key);
             }
         }
@@ -5011,24 +5030,38 @@ mod tests {
              bounded by active interest, not cache size (#3763 storm)"
         );
 
-        // Positive/negative control pair that pins the `expires_at > now`
-        // lower-bound guard in Branch 1 (line ~1368). Both contracts carry a
-        // backdated/forward-dated lease in `active_subscriptions`; the ONLY
-        // thing distinguishing them is which side of `now` the lease sits on.
+        // Branch-1 control set. All three carry a lease in `active_subscriptions`;
+        // what distinguishes them is (a) which side of `now` the lease sits on and
+        // (b) whether the contract has active demand (the demand-driven-hosting
+        // §5a `contract_in_use` renewal gate: a live client OR downstream
+        // subscriber).
         //
-        // - `within_window`: lease expires inside the renewal window but still
-        //   in the future (now < expires_at <= now + SUBSCRIPTION_RENEWAL_INTERVAL).
-        //   Branch 1 returns the lease key directly, so this contract MUST be
-        //   counted. Without it the expired-lease assertion alone is inert: a
-        //   fresh `subscribe()` lease is now + 8min (excluded by the window's
-        //   upper bound) and 0xE0 isn't in the 0..50 cache for Branch 2, so the
-        //   expired-lease guard could be deleted with the test still passing.
-        // - `expired`: lease is in the past. It must NOT be counted, otherwise
-        //   the renewal set would refill itself from stale leases (the AGENTS.md
+        // - `within_window`: lease expires inside the renewal window and in the
+        //   future (now < expires_at <= now + SUBSCRIPTION_RENEWAL_INTERVAL), AND
+        //   it has a downstream subscriber (active interest). Branch 1 returns it,
+        //   so it MUST be counted — it pins the `expires_at > now` lower-bound
+        //   guard AND the `contract_in_use` gate together. Without it the
+        //   expired-lease assertion alone is inert: a fresh `subscribe()` lease is
+        //   now + 8min (excluded by the window's upper bound) and 0xE0 isn't in
+        //   the 0..50 cache for Branch 2, so the expired-lease guard could be
+        //   deleted with the test still passing.
+        // - `no_interest`: an identical within-window lease but with NO client and
+        //   NO downstream subscriber. Under the interest gate it must NOT be
+        //   counted: an un-demanded subscription LAPSES instead of self-renewing.
+        //   This is the #3763 bound (renewal tracks active demand, not accumulated
+        //   leases) and is what collapses a chain once demand ends.
+        // - `expired`: lease is in the past. It must NOT be counted, otherwise the
+        //   renewal set would refill itself from stale leases (the AGENTS.md
         //   time-bounded GC rule — an expired lease grants no renewal exemption).
         let within_window = make_contract_key(0xA0);
         manager.subscribe(within_window);
+        manager.add_downstream_subscriber(&within_window, make_peer_key(0xA1));
         if let Some(mut lease) = manager.active_subscriptions.get_mut(&within_window) {
+            lease.expires_at = Instant::now() + Duration::from_secs(30);
+        }
+        let no_interest = make_contract_key(0xB0);
+        manager.subscribe(no_interest);
+        if let Some(mut lease) = manager.active_subscriptions.get_mut(&no_interest) {
             lease.expires_at = Instant::now() + Duration::from_secs(30);
         }
         let expired = make_contract_key(0xE0);
@@ -5040,8 +5073,14 @@ mod tests {
         let within_window_renewal = manager.contracts_needing_renewal();
         assert!(
             within_window_renewal.contains(&within_window),
-            "a lease expiring inside the renewal window but still in the future \
-             MUST be counted (Branch 1 `expires_at > now` lower-bound guard)"
+            "a within-window lease WITH active downstream interest MUST be counted \
+             (Branch 1 `expires_at > now` guard + `contract_in_use` gate)"
+        );
+        assert!(
+            !within_window_renewal.contains(&no_interest),
+            "a within-window lease with NO client and NO downstream subscriber must \
+             NOT be counted — an un-demanded subscription lapses instead of \
+             self-renewing (#3763 interest-gated renewal bound)"
         );
         assert!(
             !within_window_renewal.contains(&expired),
@@ -5075,5 +5114,92 @@ mod tests {
         assert!(needs_renewal.contains(&want_a));
         assert!(needs_renewal.contains(&want_b));
         assert!(needs_renewal.contains(&within_window));
+    }
+
+    /// Regression for the interest-gated §1 renewal predicate (#3763): a live
+    /// active lease is renewed **iff** the contract is `contract_in_use` — a
+    /// live client subscription OR a downstream subscriber. This pins that the
+    /// gate does NOT false-lapse a demanded contract, and that a demand-less
+    /// lease correctly lapses:
+    ///
+    ///  - **No false-lapse for demand-backed contracts.** Every WS-client
+    ///    subscribe entry point (a plain SUBSCRIBE and a GET-with-`subscribe:true`)
+    ///    registers `client_subscriptions` via the listener-registration handler
+    ///    (`ring.add_client_subscription`) — which is exactly the map
+    ///    `contract_in_use` reads. So a genuinely client-subscribed contract's
+    ///    lease is always selected by §1. A chain host is renewed via its
+    ///    downstream subscriber.
+    ///  - **A bare lease with no demand LAPSES, correctly.**
+    ///    `run_executor_subscribe` installs an `active_subscriptions` lease but
+    ///    registers interest only in the InterestManager (`add_local_client`),
+    ///    NOT `client_subscriptions`. With no accompanying WS-client subscription
+    ///    or downstream (a PUT/seed with no ongoing interest), the lease is NOT
+    ///    renewed and lapses. Per design §1 a PUT only *seeds* a contract and is
+    ///    not demand, so an idle seed must evaporate — this is the intended
+    ///    behavior, not a false-lapse. Any real demand behind an executor
+    ///    subscribe is the WS client that PUT/subscribed, tracked separately in
+    ///    `client_subscriptions`.
+    #[test]
+    fn test_active_lease_renewed_iff_contract_in_use() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        // Move a lease into the renewal window (§1 only considers soon-to-expire
+        // leases; a fresh `subscribe()` lease is now+8min, outside the window).
+        let into_window = |m: &HostingManager, key: &ContractKey| {
+            if let Some(mut lease) = m.active_subscriptions.get_mut(key) {
+                lease.expires_at = Instant::now() + Duration::from_secs(30);
+            }
+        };
+
+        // (a) Bare lease — the `run_executor_subscribe` / PUT-seed shape: an
+        //     active lease with no client subscription and no downstream. Must
+        //     NOT be renewed → lapses.
+        let seed = make_contract_key(1);
+        manager.subscribe(seed);
+        into_window(&manager, &seed);
+        assert!(!manager.contract_in_use(&seed));
+        assert!(
+            !manager.contracts_needing_renewal().contains(&seed),
+            "a bare active lease with no client subscription and no downstream (a \
+             PUT / executor seed) must NOT be renewed — it lapses (design §1: a \
+             seed is not demand)"
+        );
+
+        // (b) Demand-backed by a client subscription — the WS-subscribe entry
+        //     point populates this via `add_client_subscription`. Must be renewed.
+        let client_backed = make_contract_key(2);
+        manager.subscribe(client_backed);
+        into_window(&manager, &client_backed);
+        let client_id = crate::client_events::ClientId::next();
+        manager.add_client_subscription(client_backed.id(), client_id);
+        assert!(manager.contract_in_use(&client_backed));
+        assert!(
+            manager.contracts_needing_renewal().contains(&client_backed),
+            "a client-subscribed contract's lease MUST be renewed — no false-lapse \
+             for a demand-backed subscription"
+        );
+
+        // (c) Demand-backed by a downstream subscriber — a chain host. Must be
+        //     renewed.
+        let downstream_backed = make_contract_key(3);
+        manager.subscribe(downstream_backed);
+        into_window(&manager, &downstream_backed);
+        manager.add_downstream_subscriber(&downstream_backed, make_peer_key(7));
+        assert!(manager.contract_in_use(&downstream_backed));
+        assert!(
+            manager
+                .contracts_needing_renewal()
+                .contains(&downstream_backed),
+            "a chain host (downstream subscriber) lease MUST be renewed"
+        );
+
+        // (d) Removing the client subscription makes the once-demanded lease
+        //     lapse — the collapse trigger.
+        manager.remove_client_subscription(client_backed.id(), client_id);
+        assert!(!manager.contract_in_use(&client_backed));
+        assert!(
+            !manager.contracts_needing_renewal().contains(&client_backed),
+            "once the client subscription is gone the lease is no longer renewed \
+             and lapses (chain collapse on interest loss)"
+        );
     }
 }

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -12472,3 +12472,440 @@ fn test_injected_hosting_clock_drives_undemanded_eviction() {
          test guards against)"
     );
 }
+
+// =============================================================================
+// Interest-gated renewal — #3763 storm fix (demand-driven-hosting §5a / §7)
+// =============================================================================
+//
+// These two simulations are SYSTEM-LEVEL behavioral coverage of the two
+// demand-driven properties the interest-gated renewal predicate contributes to:
+// (1) no-storm — the surviving subscription set tracks active DEMAND, not cache
+// size; and (2) chain-collapse — a subscription mesh collapses to zero once all
+// client interest ends. Each runs across ≥3 seeds (design note requirement),
+// using the merged #4657 sim-harness: `enable_hosting_time_control` (a
+// controllable clock so the 8-minute lease/TTL can be crossed deterministically),
+// `with_hosting_budget` (cache pressure), `SimOperation::AdvanceHostingClock`,
+// and the `node_subscription_count` / `node_active_demand_count` /
+// `node_hosting_count` accessors.
+//
+// SCOPE NOTE (honest): on the CURRENT main codebase these two sims pass with OR
+// without the `contract_in_use` gate in `contracts_needing_renewal` §1 —
+// verified empirically. They therefore validate the end-to-end properties but do
+// NOT, on their own, isolate the §1 predicate change. Two reasons: (a) main has
+// already removed GET-auto-subscribe (#4689), so a GET-only contract never
+// acquires a §1 active-subscription lease for the gate to act on; and (b) the
+// collapse sim's 20-minute clock jump EXPIRES the leases outright, so the
+// pre-existing `expires_at > now` lower-bound guard lapses them regardless of the
+// gate. The DISCRIMINATING, deterministic proof of the predicate — a within-
+// renewal-window, not-yet-expired, demand-less lease that is renewed iff
+// `contract_in_use` — is the unit test
+// `ring::hosting::tests::test_active_lease_renewed_iff_contract_in_use` (it FAILS
+// without the gate, passes with it). These sims are the system-level regression
+// companions to that unit proof; they will also catch a future regression that
+// reintroduces unconditional renewal once piece-D chain-hosting re-enables the
+// storm precondition.
+
+/// Proof 1 (no-storm, design §7 / #3763): under sustained cache/GET load the
+/// surviving subscription set must track active DEMAND, not cache size.
+///
+/// The hub SUBSCRIBES to a small demand set (real, pinned interest) and GETs a
+/// larger cache-only set (fills its hosting cache, no subscription). Advancing
+/// the hosting clock 20 virtual minutes ages every cache-only lease past both
+/// the 8-minute lease and the 8-minute recent-local-access renewal window (§3),
+/// so those leases lose their renewal source and lapse, while the
+/// client-subscribed demand contracts keep their leases via the §1/§2
+/// `contract_in_use` (client-subscription) path. The surviving subscription
+/// count must therefore track demand, not cache.
+///
+/// This is the no-storm END-TO-END property. See the section SCOPE NOTE above:
+/// on current main it holds with or without the §1 `contract_in_use` gate
+/// (GET-auto-subscribe is already removed, so cache-only contracts never acquire
+/// a §1 lease); the discriminating proof of the gate itself is the unit test
+/// `test_active_lease_renewed_iff_contract_in_use`.
+#[test_log::test]
+fn test_subscription_count_tracks_demand_not_cache() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
+
+    const SEEDS: [u64; 3] = [0x4642_D101, 0x4642_D102, 0x4642_D103];
+    const DEMAND: usize = 2; // contracts the hub SUBSCRIBES to (active demand)
+    const CACHE: usize = 8; // contracts the hub only GETs (cache-only)
+
+    for seed in SEEDS {
+        setup_deterministic_state(seed);
+        let rt = create_runtime();
+        let network = format!("subcount-demand-{seed:x}");
+
+        let gateway = NodeLabel::gateway(&network, 0);
+        let hub = NodeLabel::node(&network, 1);
+
+        let demand_contracts: Vec<_> = (0..DEMAND)
+            .map(|i| SimOperation::create_test_contract(0x40 + i as u8))
+            .collect();
+        let cache_contracts: Vec<_> = (0..CACHE)
+            .map(|i| SimOperation::create_test_contract(0x60 + i as u8))
+            .collect();
+        // Instance-id sets so we can categorize surviving subscription leases
+        // network-wide as demand-backed vs cache-only.
+        let demand_ids: HashSet<_> = demand_contracts.iter().map(|c| *c.key().id()).collect();
+        let cache_ids: HashSet<_> = cache_contracts.iter().map(|c| *c.key().id()).collect();
+
+        // Dense 3-peer ring so every GET/SUBSCRIBE reliably completes — this
+        // test is about renewal accounting, not routing/findability.
+        let (sim, _clock) = rt.block_on(async {
+            let mut sim = SimNetwork::new(&network, 1, 2, 7, 3, 10, 2, seed).await;
+            let clock = sim.enable_hosting_time_control();
+            // Deliberately reduced budget (1 MiB vs the ~1 GiB default) — still
+            // comfortably holds the ~10 tiny test contracts, so the cache load
+            // is observable as hosting_count >> subscription_count.
+            sim.with_hosting_budget(1024 * 1024);
+            (sim, clock)
+        });
+
+        let mut ops = Vec::new();
+        // Gateway PUTs (and announces) every contract so the hub can fetch them.
+        for c in demand_contracts.iter().chain(cache_contracts.iter()) {
+            ops.push(ScheduledOperation::new(
+                gateway.clone(),
+                SimOperation::Put {
+                    contract: c.clone(),
+                    state: SimOperation::create_test_state(1),
+                    subscribe: false,
+                },
+            ));
+        }
+        // Hub SUBSCRIBES to the demand contracts (real, pinned demand).
+        for c in &demand_contracts {
+            ops.push(ScheduledOperation::new(
+                hub.clone(),
+                SimOperation::Subscribe {
+                    contract_id: *c.key().id(),
+                },
+            ));
+        }
+        // Hub GETs the cache-only contracts (fills its hosting cache, no subscribe).
+        for c in &cache_contracts {
+            ops.push(ScheduledOperation::new(
+                hub.clone(),
+                SimOperation::Get {
+                    contract_id: *c.key().id(),
+                    return_contract_code: true,
+                    subscribe: false,
+                },
+            ));
+        }
+        // Jump the hosting clock 20 minutes — well past the 8-minute lease AND
+        // the 8-minute recent-local-access window (§3) — so any GET-only lease
+        // that §3 transiently installed loses its renewal source and lapses,
+        // while the client-subscribed demand contracts keep their leases via the
+        // §1/§2 `contract_in_use` (client-subscription) renewal path.
+        ops.push(ScheduledOperation::new(
+            hub.clone(),
+            SimOperation::AdvanceHostingClock {
+                duration: Duration::from_secs(20 * 60),
+            },
+        ));
+
+        let result = sim.run_controlled_simulation(
+            seed,
+            ops,
+            Duration::from_secs(300),
+            Duration::from_secs(120),
+        );
+        assert!(
+            result.turmoil_result.is_ok(),
+            "seed={seed:x}: sim failed: {:?}",
+            result.turmoil_result.err()
+        );
+
+        let hosting = result.node_hosting_count(&hub);
+        let subs = result.node_subscription_count(&hub);
+        let demand = result.node_active_demand_count(&hub);
+        let metrics = result.aggregate_renewal_metrics();
+
+        // Categorize every surviving subscription lease NETWORK-WIDE as
+        // demand-backed (one of the hub's client subscriptions) vs cache-only
+        // (one of the GET-only contracts). This is the strongest form of the
+        // no-storm property: after demand fades, cache-only contracts hold ZERO
+        // leases anywhere, while client-subscribed contracts keep theirs.
+        let mut demand_leases = 0usize;
+        let mut cache_leases = 0usize;
+        for snap in &result.topology_snapshots {
+            for id in &snap.active_subscription_keys {
+                if demand_ids.contains(id) {
+                    demand_leases += 1;
+                } else if cache_ids.contains(id) {
+                    cache_leases += 1;
+                }
+            }
+        }
+        eprintln!(
+            "[proof1 seed={seed:x}] hub hosting_count={hosting} subscription_count={subs} \
+             active_demand_count={demand:?} | network leases: demand={demand_leases} \
+             cache={cache_leases} | max_cycle_batch={}",
+            metrics.max_cycle_batch
+        );
+
+        // Scenario sanity: the cache load actually landed (not a degenerate run
+        // where GETs never cached), so hosting_count >> lease-set is meaningful.
+        assert!(
+            hosting >= DEMAND + CACHE / 2,
+            "seed={seed:x}: hub hosting_count ({hosting}) too low — the GET cache-load \
+             did not land; test would be degenerate"
+        );
+
+        // CORE no-storm property (design §7 / #3763): the cache-only contracts —
+        // which the hub GET-accessed but never subscribed, and stopped accessing
+        // 20 virtual minutes ago — hold ZERO subscription leases anywhere in the
+        // network. Interest-gated renewal must NOT let cache accrete leases.
+        assert_eq!(
+            cache_leases, 0,
+            "seed={seed:x}: #3763 storm signature — {cache_leases} cache-only contract lease(s) \
+             survived network-wide after demand faded. Subscriptions must track active demand, \
+             NOT accumulated cache (hub hosting_count={hosting})."
+        );
+
+        // The hub's OWN lease set is bounded by the demand it actually created
+        // (2 client subscriptions), never by its 10-contract cache.
+        assert!(
+            subs <= DEMAND + 1,
+            "seed={seed:x}: hub subscription_count ({subs}) exceeds the demand it created \
+             ({DEMAND}) + 1 — leases must not track the {hosting}-contract cache."
+        );
+        assert!(
+            hosting > subs,
+            "seed={seed:x}: hub hosting_count ({hosting}) must exceed subscription_count \
+             ({subs}) — the separation between cache and leases must be real."
+        );
+
+        // Non-degeneracy: the demand subscriptions genuinely persisted (this is
+        // NOT a run where everything simply lapsed).
+        assert!(
+            demand_leases >= 1,
+            "seed={seed:x}: no demand-backed lease survived — the run is degenerate \
+             (subscribes never took or all lapsed), so the cache==0 result is vacuous"
+        );
+
+        // Renewal batch cap (#4601): no node fans out more than 10 renewals per
+        // 30s cycle, regardless of how many contracts are eligible.
+        assert!(
+            metrics.max_cycle_batch <= 10,
+            "seed={seed:x}: max_cycle_batch ({}) exceeded the renewal cap of 10",
+            metrics.max_cycle_batch
+        );
+    }
+}
+
+/// Per-run observation for the subscription-mesh collapse proof. Primitives
+/// only, so the proof shares a driver without naming the sim-result type.
+struct MeshObservation {
+    /// Peers holding the contract in `active_subscriptions` at the end. In a
+    /// FORMATION run this is the size of the subscription mesh; in a COLLAPSE
+    /// run it is the set of survivors (must be empty).
+    subscribed_peers: Vec<SocketAddr>,
+    /// Nodes still hosting the contract in their cache at the end.
+    hosting_nodes: usize,
+    /// Max recorded upstreams at any node (subscription-tree parent edges).
+    max_upstreams: usize,
+    /// Total snapshots captured (guards against an empty-registry false read).
+    total_snapshots: usize,
+}
+
+/// Shared driver for the subscription-mesh collapse proof.
+///
+/// Builds a moderately-connected ring, PUTs + announces a contract on the
+/// gateway, and has `subscriber_ids` nodes subscribe — forming a connected mesh
+/// of subscribed hosts toward the key. When `collapse` is set it then ends ALL
+/// client interest (disconnect the PUT originator AND every subscriber) and
+/// jumps the hosting clock 20 minutes past the 8-minute lease, so interest-gated
+/// renewal must let every lease lapse.
+///
+/// The FORMATION run (`collapse=false`) and the COLLAPSE run (`collapse=true`)
+/// share the same seed, topology, and subscribe prefix, so the mesh the
+/// formation run measures at its end is deterministically the same mesh the
+/// collapse run tears down — this is how a single end-of-run snapshot proves
+/// "formed THEN collapsed" without a mid-run measurement.
+fn run_subscription_mesh(
+    seed: u64,
+    network: &str,
+    subscriber_ids: &[usize],
+    collapse: bool,
+) -> MeshObservation {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
+
+    setup_deterministic_state(seed);
+    let rt = create_runtime();
+
+    let gateway = NodeLabel::gateway(network, 0);
+    let contract = SimOperation::create_test_contract(0xC0);
+    let contract_key = contract.key();
+    let contract_id = *contract.key().id();
+
+    // Moderately connected so distant subscribes reliably reach the holder
+    // (the terminal-advertisement consult only sees direct-neighbor hosts, so
+    // too-sparse a ring dead-ends multi-hop subscribes) while still large enough
+    // to build a real multi-node mesh.
+    let sim = rt.block_on(async {
+        let mut sim = SimNetwork::new(network, 1, 15, 10, 3, 5, 3, seed).await;
+        sim.enable_hosting_time_control();
+        sim
+    });
+
+    let mut ops = vec![ScheduledOperation::new(
+        gateway.clone(),
+        SimOperation::Put {
+            contract: contract.clone(),
+            state: SimOperation::create_test_state(1),
+            subscribe: true,
+        },
+    )];
+    for id in subscriber_ids {
+        ops.push(ScheduledOperation::new(
+            NodeLabel::node(network, *id),
+            SimOperation::Subscribe { contract_id },
+        ));
+    }
+
+    if collapse {
+        // End ALL client interest: disconnect the PUT originator AND every
+        // subscriber (Disconnect is ordered last for its node).
+        ops.push(ScheduledOperation::new(
+            gateway.clone(),
+            SimOperation::Disconnect,
+        ));
+        for id in subscriber_ids {
+            ops.push(ScheduledOperation::new(
+                NodeLabel::node(network, *id),
+                SimOperation::Disconnect,
+            ));
+        }
+        // Jump 20 minutes — past the 8-minute lease AND the recent-access window
+        // — so no renewal branch keeps an un-demanded lease alive.
+        ops.push(ScheduledOperation::new(
+            gateway.clone(),
+            SimOperation::AdvanceHostingClock {
+                duration: Duration::from_secs(20 * 60),
+            },
+        ));
+    }
+
+    // Generous settle (120s ≈ 4 renewal/expiry cycles at 30s each) so the
+    // expire-sweep + interest-gated non-renewal removes every lapsed lease
+    // before the final snapshot.
+    let result = sim.run_controlled_simulation(
+        seed,
+        ops,
+        Duration::from_secs(360),
+        Duration::from_secs(120),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "seed={seed:x} collapse={collapse}: sim failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let subscribed_peers: Vec<SocketAddr> = result
+        .topology_snapshots
+        .iter()
+        .filter(|s| s.active_subscription_keys.contains(&contract_id))
+        .map(|s| s.peer_addr)
+        .collect();
+    let hosting_nodes = result
+        .captured_node_labels()
+        .iter()
+        .filter(|l| result.is_node_hosting(l, &contract_key))
+        .count();
+    let max_upstreams = result
+        .captured_node_labels()
+        .iter()
+        .map(|l| result.node_upstream_count(l, &contract_key).unwrap_or(0))
+        .max()
+        .unwrap_or(0);
+
+    MeshObservation {
+        subscribed_peers,
+        hosting_nodes,
+        max_upstreams,
+        total_snapshots: result.topology_snapshots.len(),
+    }
+}
+
+/// Subscriber set used by the collapse proof — a spread of nodes across the
+/// ring so a genuine multi-node mesh forms.
+const MESH_SUBSCRIBERS: [usize; 8] = [1, 3, 5, 7, 9, 11, 13, 15];
+
+/// Proof 2 (chain collapse on client leave, design §5a/§6). Two phases sharing
+/// one seed + topology + subscribe prefix (so determinism makes the FORMATION
+/// run's mesh identical to what the COLLAPSE run tears down):
+///
+///   * FORMATION run: a genuine multi-node subscription mesh forms.
+///   * COLLAPSE run: after ALL clients leave + a 20-minute clock jump, EVERY
+///     lease lapses — interest-gated renewal keeps none alive.
+///
+/// Formation is proved by the mesh SIZE measured at the end of the FORMATION
+/// run (the shared seed/topology guarantees the COLLAPSE run tears down that
+/// same mesh); collapse is proved by ZERO surviving `active_subscriptions`
+/// anywhere in the COLLAPSE run. This is the chain-collapse END-TO-END property.
+/// See the section SCOPE NOTE above: on current main the collapse also holds
+/// without the §1 gate, because the 20-minute clock jump expires the leases
+/// outright (the pre-existing `expires_at > now` guard lapses them); the
+/// discriminating proof of the gate itself is the unit test
+/// `test_active_lease_renewed_iff_contract_in_use`.
+#[test_log::test]
+fn test_subscription_chain_collapses_on_client_leave() {
+    const SEEDS: [u64; 3] = [0x4642_D201, 0x4642_D202, 0x4642_D203];
+    // The mesh must be non-trivial for a collapse-to-zero to be meaningful.
+    const MIN_MESH: usize = 3;
+
+    for seed in SEEDS {
+        // Phase A — formation baseline (no disconnect / no clock jump).
+        let form = run_subscription_mesh(
+            seed,
+            &format!("chain-form-{seed:x}"),
+            &MESH_SUBSCRIBERS,
+            false,
+        );
+        eprintln!(
+            "[proof2 seed={seed:x} FORM] mesh_size={} hosting_nodes={} \
+             max_upstreams={} total_snapshots={}",
+            form.subscribed_peers.len(),
+            form.hosting_nodes,
+            form.max_upstreams,
+            form.total_snapshots,
+        );
+        assert!(
+            form.subscribed_peers.len() >= MIN_MESH,
+            "seed={seed:x}: formation degenerate — only {} peer(s) in the subscription mesh \
+             (need >= {MIN_MESH}); the collapse below would be vacuous. \
+             Requested {} subscribers.",
+            form.subscribed_peers.len(),
+            MESH_SUBSCRIBERS.len(),
+        );
+
+        // Phase B — collapse (same seed/topology + disconnect-all + 20-min jump).
+        let coll = run_subscription_mesh(
+            seed,
+            &format!("chain-collapse-{seed:x}"),
+            &MESH_SUBSCRIBERS,
+            true,
+        );
+        eprintln!(
+            "[proof2 seed={seed:x} COLLAPSE] survivors={} hosting_nodes={} total_snapshots={} {:?}",
+            coll.subscribed_peers.len(),
+            coll.hosting_nodes,
+            coll.total_snapshots,
+            coll.subscribed_peers,
+        );
+        assert!(
+            coll.total_snapshots > 0,
+            "seed={seed:x}: no snapshots captured in collapse run — cannot judge collapse"
+        );
+        assert!(
+            coll.subscribed_peers.is_empty(),
+            "seed={seed:x}: chain did NOT collapse — {} peer(s) still hold the contract in \
+             active_subscriptions after all client interest ended + a 20-min clock jump: {:?}. \
+             Interest-gated renewal must let every un-demanded lease lapse.",
+            coll.subscribed_peers.len(),
+            coll.subscribed_peers,
+        );
+    }
+}

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -11674,15 +11674,15 @@ fn test_subscription_root_renewal_does_not_storm() {
 /// must let its `active_subscriptions` lease **lapse** rather than refresh it on
 /// the root-satisfied renewal path.
 ///
-/// Why this matters: `contracts_needing_renewal` section 1 re-selects ANY live
-/// active subscription with no interest re-check. If the root-satisfied path
-/// refreshed the lease unconditionally, a no-interest root would re-select
-/// itself every renewal cycle forever — an unbounded `is_subscribed`-only
-/// retention exemption that the `contract_in_use` rustdoc and the AGENTS.md
-/// time-bounded-exemption rule forbid. The fix gates the lease refresh on
-/// `contract_in_use`, so a no-interest root does NOT refresh and the lease
-/// lapses (`SUBSCRIPTION_LEASE_DURATION` = 8 min) — after which it drops out of
-/// the renewal set entirely.
+/// Why this matters: the root-satisfied renewal path must not refresh the lease
+/// of a root with no genuine interest. If it refreshed the lease
+/// unconditionally, a no-interest root would keep its `active_subscriptions`
+/// lease alive forever — an unbounded `is_subscribed`-only retention exemption
+/// that the `contract_in_use` rustdoc and the AGENTS.md time-bounded-exemption
+/// rule forbid. Both the root-satisfied path and `contracts_needing_renewal`
+/// section 1 gate renewal on `contract_in_use`, so a no-interest root does NOT
+/// refresh and the lease lapses (`SUBSCRIPTION_LEASE_DURATION` = 8 min) — after
+/// which it drops out of the renewal set entirely.
 ///
 /// This test seeds a hosted contract on a body-holding root with NO client
 /// subscription, runs past the lease window, and asserts the root's final


### PR DESCRIPTION
## Problem

`HostingManager::contracts_needing_renewal` section 1 renewed every
soon-to-expire active subscription lease **unconditionally**. A subscribed host
self-renewed forever regardless of whether anything still depended on it, so
live subscriptions accumulated in proportion to accumulated cache and never
lapsed. That is the #3763 renewal storm: subscriptions grow with cache, not with
active demand.

The eviction budget (piece A) cannot bound this. An in-use, actively-subscribed
contract is eviction-exempt AND self-renewing, so the storm set is exactly the
set the byte budget may not touch. Bounding the storm therefore needs a separate,
load-bearing change to the shared renewal predicate.

## Approach

Interest-gate the section-1 predicate on `contract_in_use`:

```rust
if expires_at <= renewal_threshold && expires_at > now && self.contract_in_use(&key) {
    needs_renewal_set.insert(key);
}
```

`contract_in_use` is `has_client_subscriptions || has_downstream_subscribers`, so
a lease is renewed only while a live local client OR a registered downstream
subscriber still depends on this peer hosting the contract. Both are time-bounded
(clients disconnect, downstream registrations lease-expire), so when demand fades
the peer stops renewing, its lease lapses, and the chain collapses inward toward
the key. Subscriptions then track active demand rather than cache size.

This is safe as a standalone change: `contract_in_use` covers the downstream-relay
case, so a peer that forwards updates to a live downstream subscriber keeps
renewing; only genuinely idle leases (client-abandoned subscriptions, demand-less
PUT/executor seeds) lapse. The already-`#[ignore]`d startup-revalidation tests
already assert not-renewed for hosted-only contracts, consistent with this gate.

Harvested as the standalone #3763 fix from the parked piece-D PR #4661, part of
the demand-driven-hosting reconcile-core work (#4642). It matches the
`hosting-invariants` §5a / §7 interest-gated-renewal design.

## Testing

**Unit (the discriminating proof).** Both FAIL without the gate and pass with it
(verified by temporarily removing the gate):

- `test_active_lease_renewed_iff_contract_in_use` (new): a within-window,
  not-yet-expired active lease is renewed iff `contract_in_use`, across all four
  cases: bare seed lapses / client-backed renews / downstream-backed renews /
  client-removal triggers lapse.
- `test_contracts_needing_renewal_bounded_by_active_interest` (updated): the
  within-window lease now carries a downstream subscriber (real interest), plus a
  new `no_interest` negative control (a within-window lease with no client and no
  downstream) that must NOT be renewed.

**Simulation (system-level behavioral coverage, #4657 harness, 3 seeds each).**
Both pass with the gate:

- `test_subscription_count_tracks_demand_not_cache` (no-storm): a hub subscribes
  to a small demand set and GETs a larger cache-only set, then the hosting clock
  advances 20 virtual minutes. Result across seeds: cache-only contracts hold
  **0** subscription leases network-wide; the hub's `subscription_count` stays at
  the demand it created (2) while `hosting_count` is 10.
- `test_subscription_chain_collapses_on_client_leave` (chain collapse): a
  multi-node subscription mesh (size 4-6) forms, then all client interest ends and
  the clock jumps past the lease. Result across seeds: **0** surviving
  `active_subscriptions` anywhere.

**Honest scope note on the sims.** On the current main codebase these two sims
pass with OR without the section-1 gate (verified empirically). They validate the
end-to-end demand-driven properties but do not, on their own, isolate the
section-1 predicate change, for two reasons: (a) main already removed
GET-auto-subscribe (#4689), so a GET-only contract never acquires a section-1
lease for the gate to act on; and (b) the collapse sim's 20-minute clock jump
expires the leases outright, so the pre-existing `expires_at > now` guard lapses
them before the gate matters. The rigorous, discriminating proof of the predicate
is the unit test above. The sims are kept as system-level regression companions
(they will also catch a future regression that reintroduces unconditional renewal
once piece-D chain-hosting re-enables the storm precondition). A sim that isolates
the gate would need within-renewal-window clock choreography on a still-running,
demand-less node; that is deferred rather than built here.

Draft: parked for review alongside the broader reconcile-core work; do not merge.

Refs #3763
Part of #4642

[AI-assisted - Claude]
