### PR TITLE
feat: disk-usage accounting + wasmtime cache relocation + telemetry

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -2386,6 +2386,11 @@ impl ConfigPathsArgs {
         let delegates_dir = app_data_dir.join("delegates");
         let secrets_dir = app_data_dir.join("secrets");
         let db_dir = app_data_dir.join("db");
+        // Wasmtime's compile cache is relocated onto the data-dir mount (#4683)
+        // so it (a) shares the mount whose free space sizes the disk budget and
+        // (b) is measurable as freenet's own on-disk usage. Its default OS-cache
+        // location is neither. A sibling of the data dirs, created below.
+        let wasmtime_cache_dir = app_data_dir.join("wasmtime-cache");
 
         if !contracts_dir.exists() {
             fs::create_dir_all(&contracts_dir)?;
@@ -2405,6 +2410,10 @@ impl ConfigPathsArgs {
         if !db_dir.exists() {
             fs::create_dir_all(&db_dir)?;
             fs::create_dir_all(db_dir.join("local"))?;
+        }
+
+        if !wasmtime_cache_dir.exists() {
+            fs::create_dir_all(&wasmtime_cache_dir)?;
         }
 
         let event_log = app_data_dir.join("_EVENT_LOG");
@@ -2435,6 +2444,7 @@ impl ConfigPathsArgs {
             delegates_dir,
             secrets_dir,
             db_dir,
+            wasmtime_cache_dir,
             event_log,
             log_dir,
         })
@@ -2452,6 +2462,12 @@ pub struct ConfigPaths {
     config_dir: PathBuf,
     #[serde(default = "get_log_dir")]
     log_dir: Option<PathBuf>,
+    /// Relocated wasmtime compile-cache directory (#4683). `#[serde(default)]`
+    /// so a `config.toml` persisted before this field existed deserializes with
+    /// an empty path; `build()` always re-derives the real one from the data
+    /// dir, so the persisted value is never load-bearing.
+    #[serde(default)]
+    wasmtime_cache_dir: PathBuf,
 }
 
 impl ConfigPaths {
@@ -2497,6 +2513,13 @@ impl ConfigPaths {
 
     pub fn data_dir(&self) -> PathBuf {
         self.data_dir.clone()
+    }
+
+    /// Relocated wasmtime compile-cache directory (#4683). Not mode-split: the
+    /// compile cache is keyed by (engine config + WASM bytes) and shared across
+    /// local/network runtimes on the same node.
+    pub fn wasmtime_cache_dir(&self) -> PathBuf {
+        self.wasmtime_cache_dir.clone()
     }
 
     pub fn secrets_dir(&self, mode: OperationMode) -> PathBuf {
@@ -2547,11 +2570,12 @@ impl ConfigPaths {
             4 => (true, &self.data_dir),
             5 => (false, &self.event_log),
             6 => (true, &self.config_dir),
+            7 => (true, &self.wasmtime_cache_dir),
             _ => panic!("invalid path index"),
         }
     }
 
-    const MAX_PATH_INDEX: usize = 6;
+    const MAX_PATH_INDEX: usize = 7;
 }
 
 pub struct ConfigPathsIter<'a> {
@@ -2587,6 +2611,11 @@ impl Config {
 
     pub fn contracts_dir(&self) -> PathBuf {
         self.config_paths.contracts_dir(self.mode)
+    }
+
+    /// Relocated wasmtime compile-cache directory (#4683). Not mode-split.
+    pub fn wasmtime_cache_dir(&self) -> PathBuf {
+        self.config_paths.wasmtime_cache_dir()
     }
 
     pub fn delegates_dir(&self) -> PathBuf {

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -20,6 +20,14 @@ const MAX_RELATED_CONTRACTS_PER_REQUEST: usize = 10;
 /// Timeout for fetching all related contracts during validation.
 const RELATED_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Soft size limit for the relocated wasmtime compile cache (#4683), pinned to
+/// wasmtime's own historical default (512 MiB). Pinned explicitly rather than
+/// left implicit so the cache's on-disk ceiling is a legible, single-sourced
+/// value the disk-budget accounting can reason about. Wasmtime self-prunes the
+/// cache to this soft limit on its 1h cleanup, so for accounting the cache is a
+/// near-fixed ceiling (re-walked on the telemetry cadence).
+const WASMTIME_CACHE_SIZE_SOFT_LIMIT_BYTES: u64 = 512 * 1024 * 1024;
+
 /// Probability that a given state-changing merge is checked for
 /// `update_state` idempotency. One re-invocation of WASM per sample, so
 /// the per-merge cost is ~`p * average_update_state_us`. At 1/32 ≈ 3%
@@ -417,6 +425,13 @@ impl Executor<Runtime> {
         let runtime_config = RuntimeConfig {
             offload_compilation: production_offload_compilation(),
             module_cache_budget_bytes: config.module_cache_budget_bytes,
+            // Relocate the wasmtime compile cache onto the data-dir mount and
+            // pin its soft-size limit (#4683) so it lives on the mount whose
+            // free space sizes the disk budget and is measurable as freenet's
+            // own on-disk usage. `with_directory` requires an absolute path;
+            // the data dir is absolute.
+            wasmtime_cache_dir: Some(config.wasmtime_cache_dir()),
+            wasmtime_cache_size_bytes: Some(WASMTIME_CACHE_SIZE_SOFT_LIMIT_BYTES),
             ..RuntimeConfig::default()
         };
         let mut rt = Runtime::build_with_shared_module_caches(

--- a/crates/core/src/contract/executor/runtime/contract_ops.rs
+++ b/crates/core/src/contract/executor/runtime/contract_ops.rs
@@ -430,7 +430,15 @@ impl Executor<Runtime> {
         key: &ContractKey,
     ) -> Result<ReclaimOutcome, ExecutorError> {
         let state_result = match self.state_store.delete(key).await {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                // Disk-usage accounting (#4683): drop this contract's state
+                // contribution from the aggregate on-disk total. Observational
+                // only in this PR. No-op until the tracker is seeded.
+                if let Some(op_manager) = &self.op_manager {
+                    op_manager.ring.record_state_removed(key);
+                }
+                Ok(())
+            }
             Err(e) => {
                 tracing::warn!(
                     contract = %key,

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -124,6 +124,12 @@ impl ContractHandler for NetworkContractHandler {
         // This must be done before loading the cache so evictions work correctly
         let storage = executor.state_store().inner().clone();
         op_manager.ring.set_hosting_storage(storage.clone());
+        // Aggregate disk-usage tracker paths (#4683): the mode-resolved
+        // contracts dir (WASM blobs) and the relocated wasmtime compile-cache
+        // dir. Seeded lazily on the first sweep tick.
+        op_manager
+            .ring
+            .set_hosting_disk_paths(config.contracts_dir(), config.wasmtime_cache_dir());
         // Hydrate broken-invariants flags from the same backing store so a
         // node that previously detected a non-idempotent contract doesn't
         // re-engage its broadcast storm after restart.

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1667,6 +1667,17 @@ impl Ring {
             snapshot.hosting_local_hits_total = Some(ring.hosting_manager.local_get_serves());
             snapshot.hosting_local_misses_total = Some(ring.hosting_manager.local_get_forwards());
 
+            // Aggregate on-disk usage gauges (#4683): state (delta-tracked) +
+            // WASM blobs + wasmtime compile cache (both du-measured) + their sum.
+            // `None` until the tracker is configured and seeded (early startup),
+            // in which case the fields stay unset. Observational only in this PR.
+            if let Some(disk) = ring.hosting_manager.disk_usage_stats() {
+                snapshot.hosting_disk_state_bytes = Some(disk.state_bytes);
+                snapshot.hosting_disk_wasm_bytes = Some(disk.wasm_bytes);
+                snapshot.hosting_disk_compile_cache_bytes = Some(disk.compile_cache_bytes);
+                snapshot.hosting_disk_total_bytes = Some(disk.total_bytes);
+            }
+
             // Terminal advertisement-consult counters (hosting redesign piece C,
             // #4646). Exported here per #4658 so the production findability
             // baseline — the dead-end decomposition (off-path-advertised-host
@@ -2570,6 +2581,34 @@ impl Ring {
                     }
                 }
             }
+
+            // Disk-usage accounting maintenance (#4683). Runs OUTSIDE any
+            // hosting-cache write lock (the du-walks would stall cache readers).
+            // First tick lazily seeds the tracker from the true on-disk state
+            // total; every tick re-walks the `du`-measured WASM-blob and
+            // compile-cache totals so telemetry stays fresh. Observational only
+            // in this PR — no admission/eviction decision reads these yet.
+            //
+            // Both operations are synchronous, blocking disk I/O: a recursive
+            // `std::fs` walk of `contracts_dir` + the wasmtime cache dir on every
+            // tick, plus a one-time sync redb `load_all_hosting_metadata` on the
+            // seeding tick. `contracts_dir` is unbounded and non-self-pruning, so
+            // on a node hosting many contracts the walk can run for a while with
+            // no `.await` point. Push it onto a blocking thread so it can never
+            // stall other tasks on the async reactor — the same discipline
+            // `secrets_store/sweep.rs` uses for its "disk walk + ReDb reads".
+            let ring_for_disk = ring.clone();
+            if let Err(err) = tokio::task::spawn_blocking(move || {
+                #[cfg(feature = "redb")]
+                ring_for_disk.hosting_manager.seed_disk_tracker_if_absent();
+                ring_for_disk.hosting_manager.refresh_disk_usage();
+            })
+            .await
+            {
+                // The walk is observational only; a panic here must not wedge the
+                // sweep loop, but it must not be swallowed silently either.
+                tracing::warn!(%err, "disk-usage accounting maintenance task failed");
+            }
         }
     }
 
@@ -2697,6 +2736,19 @@ impl Ring {
     /// cleanup of persisted metadata when contracts are evicted.
     pub fn set_hosting_storage(&self, storage: crate::contract::storages::Storage) {
         self.hosting_manager.set_storage(storage);
+    }
+
+    /// Install the aggregate disk-usage tracker's paths (#4683). Called once at
+    /// startup with the node's mode-resolved contracts dir and the relocated
+    /// wasmtime compile-cache dir. The tracker is seeded lazily on the first
+    /// sweep tick.
+    pub fn set_hosting_disk_paths(
+        &self,
+        contracts_dir: std::path::PathBuf,
+        wasmtime_cache_dir: std::path::PathBuf,
+    ) {
+        self.hosting_manager
+            .configure_disk_tracker(contracts_dir, wasmtime_cache_dir);
     }
 
     /// Drop the ring's clones of the redb `Storage` handle (hosting metadata +
@@ -3213,11 +3265,25 @@ impl Ring {
         let new_gen = self.hosting_manager.bump_state_generation(contract);
         self.hosting_manager
             .refresh_cache_generation(contract, new_gen);
+        // Disk-usage accounting (#4683): maintain the aggregate on-disk state
+        // total by signed delta (`new − previous_for_key`). Observational only
+        // in this PR — no admission/eviction decision reads it yet. No-op until
+        // the tracker is seeded.
+        self.hosting_manager
+            .record_state_write(contract, state_size as u64);
         self.report_contract_resource_usage(
             *contract.id(),
             crate::topology::meter::ResourceType::StateBytesWritten,
             state_size as f64,
         );
+    }
+
+    /// Subtract a reclaimed contract's state bytes from the aggregate disk-usage
+    /// tracker (#4683). Called from the executor's reclaim path on successful
+    /// state deletion. Observational only in this PR; no-op until the tracker is
+    /// seeded.
+    pub(crate) fn record_state_removed(&self, contract: &ContractKey) {
+        self.hosting_manager.record_state_removed(contract);
     }
 
     /// Read the current state-write generation for `contract` (0 if never written).

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -31,6 +31,7 @@
 
 mod cache;
 mod demand;
+mod disk_usage;
 // `pub(crate)` so `ring.rs` can re-export the reconcile controller to the node
 // layer for the shadow-mode wiring (keystone step-2, #4642).
 pub(crate) mod reconcile;
@@ -56,6 +57,8 @@ use cache::{DEFAULT_MIN_TTL, HostingCache, HostingCacheStats};
 pub(crate) use cache::{MAX_DEFAULT_HOSTING_BUDGET_BYTES, MIN_DEFAULT_HOSTING_BUDGET_BYTES};
 use dashmap::{DashMap, DashSet};
 use demand::ProximityPrior;
+pub(crate) use disk_usage::DiskUsageStats;
+use disk_usage::DiskUsageTracker;
 use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
 use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
@@ -339,6 +342,15 @@ pub(crate) struct HostingManager {
     /// Behind an `Arc` so the periodic sweep snapshot can iterate
     /// without re-entering the `HostingManager` borrow.
     pending_reclamation: std::sync::Arc<DashMap<ContractKey, u64>>,
+
+    /// Aggregate on-disk usage accounting (#4683): hosted state + WASM blobs +
+    /// wasmtime compile cache. `None` until [`Self::configure_disk_tracker`]
+    /// installs it with the node's real paths (done once at startup alongside
+    /// `set_storage`, since `with_time_source` has no path access). Populated
+    /// and observable in this PR but does not yet drive admission or eviction —
+    /// that is PR 2 (eviction floor) and PR 3 (admission gate). Behind an
+    /// `RwLock` for the same late-binding reason as `storage`.
+    disk_tracker: RwLock<Option<DiskUsageTracker>>,
 }
 
 impl HostingManager {
@@ -381,6 +393,7 @@ impl HostingManager {
             storage: RwLock::new(None),
             state_generation: DashMap::new(),
             pending_reclamation: std::sync::Arc::new(DashMap::new()),
+            disk_tracker: RwLock::new(None),
         }
     }
 
@@ -446,6 +459,127 @@ impl HostingManager {
     /// Called on node shutdown to help free the on-disk file lock (issue #4401).
     pub(crate) fn clear_storage(&self) {
         *self.storage.write() = None;
+    }
+
+    // =========================================================================
+    // Disk-usage accounting (#4683)
+    // =========================================================================
+
+    /// Install the aggregate disk-usage tracker with the node's real paths.
+    /// Called once at startup (alongside `set_storage`), since `with_time_source`
+    /// has no path access. The tracker starts unseeded; the first sweep tick
+    /// seeds it lazily off the hot path.
+    pub(crate) fn configure_disk_tracker(
+        &self,
+        contracts_dir: std::path::PathBuf,
+        wasmtime_cache_dir: std::path::PathBuf,
+    ) {
+        *self.disk_tracker.write() = Some(DiskUsageTracker::new(contracts_dir, wasmtime_cache_dir));
+    }
+
+    /// Lazily seed the disk tracker on first use (like the hosting-cache
+    /// `seed_if_absent`), summing the true on-disk state total from redb rows.
+    /// No-op if the tracker is absent or already seeded. Runs OUTSIDE any cache
+    /// write lock (the caller — the 60s sweep — invokes it off the hot path).
+    ///
+    /// The state seed is intentionally fail-loud on I/O error (a too-low seed
+    /// would defeat the future admission gate): a read failure leaves the
+    /// tracker UNSEEDED so the next tick retries, rather than committing an
+    /// under-count.
+    #[cfg(feature = "redb")]
+    pub(crate) fn seed_disk_tracker_if_absent(&self) {
+        use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+
+        {
+            let guard = self.disk_tracker.read();
+            match guard.as_ref() {
+                Some(t) if t.is_seeded() => return,
+                Some(_) => {}
+                None => return,
+            }
+        }
+
+        // Read the exact per-contract state sizes from redb before taking the
+        // tracker lock, so no storage I/O happens under it.
+        let rows = {
+            let storage = self.storage.read();
+            let Some(storage) = storage.as_ref() else {
+                return;
+            };
+            match storage.load_all_hosting_metadata() {
+                Ok(entries) => entries,
+                Err(e) => {
+                    // Fail-loud: leave the tracker unseeded so the next sweep
+                    // retries rather than seeding from an under-count.
+                    tracing::warn!(error = %e, "disk tracker seed deferred: failed to read hosting metadata");
+                    return;
+                }
+            }
+        };
+
+        let state_rows = rows.into_iter().filter_map(|(key_bytes, metadata)| {
+            if key_bytes.len() != 32 {
+                return None;
+            }
+            let mut id = [0u8; 32];
+            id.copy_from_slice(&key_bytes);
+            let key = ContractKey::from_id_and_code(
+                ContractInstanceId::new(id),
+                CodeHash::new(metadata.code_hash),
+            );
+            Some((key, metadata.size_bytes))
+        });
+
+        if let Some(tracker) = self.disk_tracker.read().as_ref() {
+            tracker.seed(state_rows);
+        }
+    }
+
+    /// Apply a state-write delta to the disk tracker at a state-write chokepoint.
+    /// Wired from `Ring::commit_state_write` (the single infallible post-write
+    /// funnel for all four executor chokepoints + the V2 delegate callback), so
+    /// the counter only moves after the bytes actually landed.
+    ///
+    /// Calls through even when the tracker is not yet seeded (only skipping when
+    /// absent). An unseeded write buffers its post-write size into the tracker's
+    /// per-key map so the lazy seed picks it up instead of dropping it — this is
+    /// what closes the seed/write TOCTOU (a write racing the first sweep tick's
+    /// redb snapshot would otherwise permanently under-count that key). See
+    /// [`DiskUsageTracker::record_state_write`].
+    pub(crate) fn record_state_write(&self, key: &ContractKey, new_size: u64) {
+        if let Some(tracker) = self.disk_tracker.read().as_ref() {
+            tracker.record_state_write(key, new_size);
+        }
+    }
+
+    /// Subtract a contract's state contribution from the disk tracker on
+    /// eviction/reclamation. Wired from the reclaim path. No-op when the tracker
+    /// is absent. Like [`Self::record_state_write`], calls through even while
+    /// unseeded so the per-key buffer stays consistent with the seed.
+    pub(crate) fn record_state_removed(&self, key: &ContractKey) {
+        if let Some(tracker) = self.disk_tracker.read().as_ref() {
+            tracker.record_state_removed(key);
+        }
+    }
+
+    /// Re-walk the WASM-blob and compile-cache totals. Called on the telemetry
+    /// cadence (the 60s sweep) since both are `du`-measured, not delta-tracked.
+    pub(crate) fn refresh_disk_usage(&self) {
+        if let Some(tracker) = self.disk_tracker.read().as_ref() {
+            tracker.refresh_wasm();
+            tracker.refresh_compile_cache();
+        }
+    }
+
+    /// Snapshot the disk-usage gauges for per-node telemetry, or `None` before
+    /// the tracker is configured/seeded (early startup). Aggregate scalars only.
+    pub(crate) fn disk_usage_stats(&self) -> Option<DiskUsageStats> {
+        let guard = self.disk_tracker.read();
+        let tracker = guard.as_ref()?;
+        if !tracker.is_seeded() {
+            return None;
+        }
+        Some(tracker.stats())
     }
 
     // =========================================================================

--- a/crates/core/src/ring/hosting/disk_usage.rs
+++ b/crates/core/src/ring/hosting/disk_usage.rs
@@ -1,0 +1,574 @@
+//! Aggregate on-disk usage accounting for demand-driven hosting (#4683).
+//!
+//! The demand-driven hosting budget (#4642) sizes itself from **memory** only.
+//! For a disk-constrained host, disk — not RAM — is the scarcest resource, yet
+//! nothing bounds disk in aggregate today. [`DiskUsageTracker`] is the shared
+//! source of truth that the future disk budget (eviction floor `min(ram, disk)`
+//! in PR 2, admission gate in PR 3) reads. This PR wires only the accounting +
+//! telemetry: the tracker is populated and observable but does not yet change
+//! any admission or eviction decision (zero behavior change).
+//!
+//! # What is counted
+//!
+//! Three independently-measured consumers, summed by [`DiskUsageTracker::total_bytes`]:
+//!
+//! - **Hosted contract state** — the exact byte total of persisted contract
+//!   state. Seeded once by summing every row's
+//!   [`HostingMetadata::size_bytes`](crate::contract::storages::HostingMetadata)
+//!   and thereafter maintained by signed deltas at the executor's state-write
+//!   chokepoints (via [`super::HostingManager::record_state_write`]) and at
+//!   reclamation (via [`super::HostingManager::record_state_removed`]). A small
+//!   per-key size index makes the delta exact without re-reading the DB.
+//! - **WASM code blobs** — the `*.wasm` files under `contracts_dir`. Re-walked
+//!   (`du`) on seed and on each telemetry refresh; blobs dedupe by `code_hash`
+//!   so a re-PUT of already-stored code adds nothing.
+//! - **Wasmtime compile cache** — wasmtime writes it opaquely, so it is not
+//!   delta-tracked; it is re-walked on each telemetry refresh. Cheap: bounded by
+//!   the number of distinct compiled modules and self-pruned by wasmtime at its
+//!   soft-size limit.
+//!
+//! # Seeding discipline (fail-loud)
+//!
+//! [`DiskUsageTracker::seed`] mirrors the #4561 secrets `seeded_user_total`
+//! discipline: it walks the real on-disk state ONCE and is **fail-loud** on I/O
+//! error. A silently-too-low seed would defeat the future admission gate (it
+//! would admit writes that actually overflow disk), so a seed that cannot read
+//! the truth must surface the error rather than start from an under-count.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use freenet_stdlib::prelude::ContractKey;
+use parking_lot::Mutex;
+
+/// Point-in-time on-disk usage gauges, one snapshot for telemetry.
+///
+/// Aggregate scalars only, emitted on the existing `RouterSnapshot` cadence
+/// alongside the RAM-budget gauges so the disk-budget feature is observable in
+/// production before any enforcement ships.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct DiskUsageStats {
+    /// Persisted contract-state bytes (delta-tracked, seeded from redb rows).
+    pub state_bytes: u64,
+    /// On-disk WASM code blob bytes (`du` of `contracts_dir/*.wasm`).
+    pub wasm_bytes: u64,
+    /// Wasmtime compile-cache bytes (`du` of the relocated cache dir).
+    pub compile_cache_bytes: u64,
+    /// Sum of the three above — the aggregate the disk budget will bound.
+    pub total_bytes: u64,
+}
+
+/// Signed-delta + seed-once tracker for aggregate hosting disk usage.
+///
+/// Cheap to read (three `AtomicU64` loads for [`Self::total_bytes`]); the only
+/// expensive operations are [`Self::seed`] and the two `refresh_*` `du`-walks,
+/// which run off the hot path (lazy seed on the first sweep tick, refresh on the
+/// 60s telemetry cadence).
+pub(crate) struct DiskUsageTracker {
+    /// Persisted contract-state bytes. Maintained by signed deltas.
+    state_bytes: AtomicU64,
+    /// On-disk WASM blob bytes. Refreshed by `du`-walk.
+    wasm_bytes: AtomicU64,
+    /// Wasmtime compile-cache bytes. Refreshed by `du`-walk.
+    compile_cache_bytes: AtomicU64,
+    /// One-time seed guard (like the secrets `seeded_user_total` flag).
+    seeded: AtomicBool,
+    /// Per-contract last-known state size, so a state-write delta is exact
+    /// (`new − previous_for_key`) without re-reading the DB at the chokepoint.
+    /// Seeded from the same redb rows that seed `state_bytes`.
+    ///
+    /// A whole-map `Mutex`, NOT a `DashMap`: this is the documented
+    /// cross-key-atomicity exception in `.claude/rules/code-style.md` ("WHEN
+    /// writing async code" — DashMap exception). DashMap's per-shard locks
+    /// cannot serialize the whole map against the single `seeded` flag flip,
+    /// which is exactly what closes the seed/write TOCTOU documented on
+    /// [`Self::seed`] and [`Self::record_state_write`]. Per-shard locking would
+    /// reopen that race and turn the counter into a load-bearing under-count
+    /// once the admission gate (PR 3) reads it.
+    state_sizes: Mutex<HashMap<ContractKey, u64>>,
+    /// Directory holding `*.wasm` code blobs (mode-resolved `contracts_dir`).
+    contracts_dir: PathBuf,
+    /// Relocated wasmtime compile-cache directory (on the data-dir mount).
+    compile_cache_dir: PathBuf,
+}
+
+impl DiskUsageTracker {
+    /// Create an unseeded tracker. All counters start at zero; call
+    /// [`Self::seed`] once before the counts are meaningful.
+    pub(crate) fn new(contracts_dir: PathBuf, compile_cache_dir: PathBuf) -> Self {
+        Self {
+            state_bytes: AtomicU64::new(0),
+            wasm_bytes: AtomicU64::new(0),
+            compile_cache_bytes: AtomicU64::new(0),
+            seeded: AtomicBool::new(false),
+            state_sizes: Mutex::new(HashMap::new()),
+            contracts_dir,
+            compile_cache_dir,
+        }
+    }
+
+    /// Whether [`Self::seed`] has already run successfully.
+    pub(crate) fn is_seeded(&self) -> bool {
+        self.seeded.load(Ordering::Acquire)
+    }
+
+    /// Aggregate on-disk bytes = state + wasm + compile-cache. The value the
+    /// disk budget bounds. Cheap (three atomic loads).
+    ///
+    /// The eviction floor (PR 2) and admission gate (PR 3) are the first
+    /// runtime readers; in this accounting-only PR it is exercised by tests and
+    /// the telemetry snapshot path.
+    #[allow(dead_code)]
+    pub(crate) fn total_bytes(&self) -> u64 {
+        self.state_bytes
+            .load(Ordering::Relaxed)
+            .saturating_add(self.wasm_bytes.load(Ordering::Relaxed))
+            .saturating_add(self.compile_cache_bytes.load(Ordering::Relaxed))
+    }
+
+    /// Snapshot all gauges for telemetry.
+    pub(crate) fn stats(&self) -> DiskUsageStats {
+        let state_bytes = self.state_bytes.load(Ordering::Relaxed);
+        let wasm_bytes = self.wasm_bytes.load(Ordering::Relaxed);
+        let compile_cache_bytes = self.compile_cache_bytes.load(Ordering::Relaxed);
+        DiskUsageStats {
+            state_bytes,
+            wasm_bytes,
+            compile_cache_bytes,
+            total_bytes: state_bytes
+                .saturating_add(wasm_bytes)
+                .saturating_add(compile_cache_bytes),
+        }
+    }
+
+    /// Seed the state-bytes counter and per-key size index from an exact list of
+    /// `(contract, state_size)` pairs (the caller reads these from redb rows so
+    /// this module stays storage-backend-agnostic and unit-testable). Also runs
+    /// the initial WASM + compile-cache `du`-walks.
+    ///
+    /// Idempotent-guarded: only the FIRST call takes effect; later calls are a
+    /// no-op so a racing second sweep tick cannot double-count.
+    ///
+    /// Fail-loud contract: the caller MUST pass the true on-disk state total. A
+    /// silently-too-low seed would let the future admission gate admit
+    /// overflowing writes — the exact failure the #4561 secrets seed discipline
+    /// guards against.
+    ///
+    /// # Seed/write race (TOCTOU) closure
+    ///
+    /// The caller snapshots redb rows at some time `T0` while `seeded` is still
+    /// false, then calls this. A concurrent [`Self::record_state_write`] whose
+    /// bytes land AFTER `T0` is NOT in `state_rows`, but it is NOT dropped
+    /// either: `record_state_write` always records its post-write size into
+    /// `state_sizes` (even while unseeded), and this seed treats an
+    /// already-present key as authoritative — the concurrent write's true size
+    /// wins over the (older, possibly absent) redb-snapshot value. The final
+    /// `state_bytes` is recomputed from the merged map under the same lock that
+    /// serializes writes, so every write is counted exactly once regardless of
+    /// whether its redb row made it into the snapshot. This is the lock-based
+    /// close of the window flagged in the PR-1 review (would otherwise become a
+    /// load-bearing under-count once PR 3 turns the counter into a gate input).
+    pub(crate) fn seed<I>(&self, state_rows: I)
+    where
+        I: IntoIterator<Item = (ContractKey, u64)>,
+    {
+        // Take the write-serializing lock FIRST, then flip `seeded` under it, so
+        // a concurrent `record_state_write` either (a) ran before us and its
+        // size is already in `state_sizes` (we preserve it), or (b) blocks on
+        // this lock and runs as a delta after we store the aggregate. It can
+        // never fall in a gap where it is neither seeded-in nor deltaed-in.
+        let mut sizes = self.state_sizes.lock();
+
+        // Only the first seed wins. `compare_exchange` so a concurrent caller
+        // that lost the race returns without touching any counter.
+        if self
+            .seeded
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        for (key, size) in state_rows {
+            // A concurrent post-`T0` write may already have recorded this key's
+            // true post-write size while we were unseeded. That value is newer
+            // and authoritative — do NOT overwrite it with the stale snapshot.
+            // Only rows not already buffered by such a write are inserted.
+            match sizes.entry(key) {
+                std::collections::hash_map::Entry::Occupied(_) => {}
+                std::collections::hash_map::Entry::Vacant(v) => {
+                    v.insert(size);
+                }
+            }
+        }
+        // Recompute the aggregate from the merged map so buffered concurrent
+        // writes are reflected exactly.
+        let total = sizes
+            .values()
+            .copied()
+            .fold(0u64, |acc, v| acc.saturating_add(v));
+        self.state_bytes.store(total, Ordering::Relaxed);
+        drop(sizes);
+
+        self.wasm_bytes
+            .store(du_walk_wasm(&self.contracts_dir), Ordering::Relaxed);
+        self.compile_cache_bytes
+            .store(du_walk(&self.compile_cache_dir), Ordering::Relaxed);
+    }
+
+    /// Apply a state-write at a chokepoint: set `key`'s tracked size to
+    /// `new_size` and adjust `state_bytes` by the signed delta against the
+    /// previous size for that key (0 if unseen).
+    ///
+    /// PUT of a new contract → `+new`. UPDATE of an existing one →
+    /// `+(new − old)` (shrinking updates subtract). Called from
+    /// [`super::HostingManager::record_state_write`] on the infallible
+    /// post-write path (`Ring::commit_state_write`), so the counter only moves
+    /// after the bytes actually landed.
+    ///
+    /// # Unseeded writes
+    ///
+    /// Even before [`Self::seed`] runs, this records `new_size` into
+    /// `state_sizes` (but does NOT touch `state_bytes` — the aggregate is
+    /// meaningless until seeded). This is what closes the seed/write TOCTOU: a
+    /// write that races the seed leaves its true size in the map for the seed to
+    /// pick up, instead of being silently dropped and permanently under-counted.
+    /// Once seeded, it additionally applies the signed delta to `state_bytes`.
+    /// The `state_sizes` lock serializes this against [`Self::seed`], so the
+    /// seeded/unseeded branch is decided atomically with respect to the seed.
+    pub(crate) fn record_state_write(&self, key: &ContractKey, new_size: u64) {
+        let mut sizes = self.state_sizes.lock();
+        let old = sizes.insert(*key, new_size).unwrap_or(0);
+        // While unseeded, only buffer the size; `state_bytes` is recomputed from
+        // the map at seed time, so applying a delta now would be wrong (and the
+        // aggregate is not yet meaningful). The map insert above is the record
+        // that the seed will honor.
+        if !self.seeded.load(Ordering::Acquire) {
+            return;
+        }
+        drop(sizes);
+        if new_size >= old {
+            self.state_bytes
+                .fetch_add(new_size - old, Ordering::Relaxed);
+        } else {
+            // saturating_sub floors at 0: a delta can never drive the aggregate
+            // negative even if the seed under-counted this key.
+            let dec = old - new_size;
+            let mut cur = self.state_bytes.load(Ordering::Relaxed);
+            loop {
+                let next = cur.saturating_sub(dec);
+                match self.state_bytes.compare_exchange_weak(
+                    cur,
+                    next,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => break,
+                    Err(observed) => cur = observed,
+                }
+            }
+        }
+    }
+
+    /// Remove `key`'s state contribution on eviction/reclamation: subtract its
+    /// last-known size (floored at 0) and forget the key. Idempotent — a second
+    /// removal of an already-forgotten key subtracts nothing (floor-at-0).
+    ///
+    /// While unseeded, only forgets the buffered size (mirrors the unseeded
+    /// branch of [`Self::record_state_write`]): `state_bytes` is recomputed from
+    /// the map at seed time, so removing the key from the map is sufficient and
+    /// applying a delta now would be wrong.
+    pub(crate) fn record_state_removed(&self, key: &ContractKey) {
+        let mut sizes = self.state_sizes.lock();
+        let removed = sizes.remove(key).unwrap_or(0);
+        if !self.seeded.load(Ordering::Acquire) {
+            return;
+        }
+        drop(sizes);
+        if removed == 0 {
+            return;
+        }
+        let mut cur = self.state_bytes.load(Ordering::Relaxed);
+        loop {
+            let next = cur.saturating_sub(removed);
+            match self.state_bytes.compare_exchange_weak(
+                cur,
+                next,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(observed) => cur = observed,
+            }
+        }
+    }
+
+    /// Re-measure the on-disk WASM blob total by `du`-walking `contracts_dir`.
+    /// Cheap and re-run on the telemetry cadence; deduping is inherent (each
+    /// distinct `code_hash` is one file).
+    pub(crate) fn refresh_wasm(&self) {
+        self.wasm_bytes
+            .store(du_walk_wasm(&self.contracts_dir), Ordering::Relaxed);
+    }
+
+    /// Re-measure the wasmtime compile-cache total by `du`-walking its dir.
+    /// Wasmtime writes the cache opaquely, so this re-walk (not a delta) is the
+    /// only way to account for it.
+    pub(crate) fn refresh_compile_cache(&self) {
+        self.compile_cache_bytes
+            .store(du_walk(&self.compile_cache_dir), Ordering::Relaxed);
+    }
+}
+
+/// Recursively sum the byte size of every regular file under `dir`. A missing
+/// directory (not yet created) or an unreadable entry contributes 0 rather than
+/// erroring — the refresh path is best-effort telemetry, unlike the fail-loud
+/// state seed.
+fn du_walk(dir: &Path) -> u64 {
+    let mut total: u64 = 0;
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&path) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                stack.push(entry.path());
+            } else if file_type.is_file() {
+                if let Ok(meta) = entry.metadata() {
+                    total = total.saturating_add(meta.len());
+                }
+            }
+        }
+    }
+    total
+}
+
+/// Like [`du_walk`] but only counts `*.wasm` files — the code-blob subset of
+/// `contracts_dir` (which also holds the `local/` mode split). Directory
+/// traversal is recursive so both the network and `local/` blobs are counted.
+fn du_walk_wasm(dir: &Path) -> u64 {
+    let mut total: u64 = 0;
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&path) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                stack.push(entry.path());
+            } else if file_type.is_file() {
+                let p = entry.path();
+                if p.extension().and_then(|e| e.to_str()) == Some("wasm") {
+                    if let Ok(meta) = entry.metadata() {
+                        total = total.saturating_add(meta.len());
+                    }
+                }
+            }
+        }
+    }
+    total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+    use std::io::Write;
+
+    fn test_key(seed: u8) -> ContractKey {
+        let instance = ContractInstanceId::new([seed; 32]);
+        let code = CodeHash::new([seed; 32]);
+        ContractKey::from_id_and_code(instance, code)
+    }
+
+    fn tracker() -> DiskUsageTracker {
+        // Nonexistent dirs → du-walks contribute 0, isolating state-delta math.
+        DiskUsageTracker::new(
+            PathBuf::from("/nonexistent/contracts"),
+            PathBuf::from("/nonexistent/cache"),
+        )
+    }
+
+    #[test]
+    fn seed_sums_state_rows_and_is_idempotent() {
+        let t = tracker();
+        assert!(!t.is_seeded());
+        t.seed([(test_key(1), 100), (test_key(2), 50)]);
+        assert!(t.is_seeded());
+        assert_eq!(t.stats().state_bytes, 150);
+        // A second seed must be a no-op (no double-count).
+        t.seed([(test_key(3), 999)]);
+        assert_eq!(t.stats().state_bytes, 150);
+    }
+
+    #[test]
+    fn put_new_contract_adds_full_size() {
+        let t = tracker();
+        t.seed(std::iter::empty());
+        t.record_state_write(&test_key(1), 200);
+        assert_eq!(t.stats().state_bytes, 200);
+        assert_eq!(t.total_bytes(), 200);
+    }
+
+    #[test]
+    fn update_grow_adds_delta() {
+        let t = tracker();
+        t.seed([(test_key(1), 100)]);
+        t.record_state_write(&test_key(1), 250);
+        assert_eq!(t.stats().state_bytes, 250); // +150 delta, not +250
+    }
+
+    #[test]
+    fn update_shrink_subtracts_delta() {
+        let t = tracker();
+        t.seed([(test_key(1), 300)]);
+        t.record_state_write(&test_key(1), 100);
+        assert_eq!(t.stats().state_bytes, 100); // -200 delta
+    }
+
+    #[test]
+    fn evict_removes_full_size() {
+        let t = tracker();
+        t.seed([(test_key(1), 100), (test_key(2), 40)]);
+        t.record_state_removed(&test_key(1));
+        assert_eq!(t.stats().state_bytes, 40);
+    }
+
+    #[test]
+    fn double_evict_floors_at_zero() {
+        let t = tracker();
+        t.seed([(test_key(1), 100)]);
+        t.record_state_removed(&test_key(1));
+        // Second removal of the same key subtracts nothing (key forgotten).
+        t.record_state_removed(&test_key(1));
+        assert_eq!(t.stats().state_bytes, 0);
+    }
+
+    #[test]
+    fn removal_never_drives_aggregate_negative() {
+        let t = tracker();
+        // Seed under-counts key(1) (size 10) but the true write was larger.
+        t.seed([(test_key(1), 10)]);
+        // A shrink whose "old" (10) exceeds current would floor at 0, not wrap.
+        t.record_state_write(&test_key(2), 5); // total now 15
+        t.record_state_removed(&test_key(2)); // -5 -> 10
+        t.record_state_removed(&test_key(1)); // -10 -> 0
+        assert_eq!(t.stats().state_bytes, 0);
+    }
+
+    #[test]
+    fn wasm_dedup_rewalk_counts_each_blob_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let contracts = dir.path().join("contracts");
+        std::fs::create_dir_all(contracts.join("local")).unwrap();
+        // Two distinct blobs + a non-wasm file that must NOT be counted.
+        let mut a = std::fs::File::create(contracts.join("aaaa.wasm")).unwrap();
+        a.write_all(&[0u8; 100]).unwrap();
+        let mut b = std::fs::File::create(contracts.join("local").join("bbbb.wasm")).unwrap();
+        b.write_all(&[0u8; 40]).unwrap();
+        let mut junk = std::fs::File::create(contracts.join("index.db")).unwrap();
+        junk.write_all(&[0u8; 1000]).unwrap();
+
+        let t = DiskUsageTracker::new(contracts.clone(), dir.path().join("cache"));
+        t.seed(std::iter::empty());
+        assert_eq!(t.stats().wasm_bytes, 140);
+        // Re-walking is deduped by construction (same files) — idempotent.
+        t.refresh_wasm();
+        assert_eq!(t.stats().wasm_bytes, 140);
+    }
+
+    #[test]
+    fn unseeded_write_is_buffered_and_survives_seed() {
+        // A write that lands while the tracker is unseeded (its redb row not yet
+        // in the snapshot the caller will pass to `seed`) must NOT be dropped:
+        // its true size is buffered and the seed reconciles to it, rather than
+        // permanently under-counting the key. Regression for the PR-1 seed/write
+        // TOCTOU review finding.
+        let t = tracker();
+        // Write arrives before seed; aggregate not yet meaningful.
+        t.record_state_write(&test_key(1), 200);
+        assert!(!t.is_seeded());
+        // Seed with a DIFFERENT key only (the racing write's redb row was not in
+        // the snapshot). The buffered write must still be counted.
+        t.seed([(test_key(2), 50)]);
+        assert_eq!(t.stats().state_bytes, 250);
+        assert_eq!(t.total_bytes(), 250);
+    }
+
+    #[test]
+    fn seed_prefers_concurrent_write_size_over_stale_snapshot() {
+        // If the same key appears both as a buffered post-seed write AND in the
+        // redb snapshot, the newer write size (not the stale snapshot) wins, and
+        // it is counted exactly once (no double-add).
+        let t = tracker();
+        t.record_state_write(&test_key(1), 300); // newer, post-snapshot size
+        t.seed([(test_key(1), 100)]); // stale snapshot value for same key
+        assert_eq!(t.stats().state_bytes, 300);
+    }
+
+    #[test]
+    fn racing_write_against_seed_yields_exact_total() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering as O};
+        // Stress the seed/write race across threads: a writer thread hammers
+        // `record_state_write` for a key NOT in the seed snapshot while the main
+        // thread seeds. Regardless of interleaving, the final aggregate must
+        // equal the true on-disk total (seed rows + the racing key's final size),
+        // never under-count. Run many iterations to shake out orderings.
+        for _ in 0..200 {
+            let t = Arc::new(tracker());
+            let go = Arc::new(AtomicBool::new(false));
+            let writer = {
+                let t = Arc::clone(&t);
+                let go = Arc::clone(&go);
+                std::thread::spawn(move || {
+                    while !go.load(O::Acquire) {
+                        std::hint::spin_loop();
+                    }
+                    // Final size for the racing key is 500.
+                    t.record_state_write(&test_key(9), 100);
+                    t.record_state_write(&test_key(9), 500);
+                })
+            };
+            go.store(true, O::Release);
+            // Seed with two unrelated keys totalling 150.
+            t.seed([(test_key(1), 100), (test_key(2), 50)]);
+            writer.join().unwrap();
+            // True total = 150 (seeded) + 500 (racing key's final size). The
+            // racing key must be present exactly once at its final size.
+            assert_eq!(
+                t.stats().state_bytes,
+                650,
+                "seed/write race under-counted or double-counted"
+            );
+        }
+    }
+
+    #[test]
+    fn compile_cache_du_walk_seeds_and_refreshes() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = dir.path().join("cache");
+        std::fs::create_dir_all(cache.join("sub")).unwrap();
+        let mut f = std::fs::File::create(cache.join("sub").join("mod.cache")).unwrap();
+        f.write_all(&[0u8; 512]).unwrap();
+
+        let t = DiskUsageTracker::new(dir.path().join("contracts"), cache.clone());
+        t.seed(std::iter::empty());
+        assert_eq!(t.stats().compile_cache_bytes, 512);
+
+        // Grow the cache; a refresh must observe the new total.
+        let mut g = std::fs::File::create(cache.join("mod2.cache")).unwrap();
+        g.write_all(&[0u8; 88]).unwrap();
+        t.refresh_compile_cache();
+        assert_eq!(t.stats().compile_cache_bytes, 600);
+        assert_eq!(t.total_bytes(), 600);
+    }
+}

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -231,6 +231,18 @@ pub(crate) struct RouterSnapshotInfo {
     /// until the ring is built. Per-node aggregate scalars.
     pub hosting_evicted_unread_total: Option<u64>,
     pub hosting_evicted_unread_age_secs_sum: Option<u64>,
+    /// Aggregate on-disk usage gauges (#4683), populated by `Ring` from the
+    /// `HostingManager`'s `DiskUsageTracker` on the snapshot cadence.
+    /// `hosting_disk_state_bytes` is the delta-tracked persisted-state total;
+    /// `hosting_disk_wasm_bytes` is the `du`-measured WASM-blob total;
+    /// `hosting_disk_compile_cache_bytes` is the relocated wasmtime compile-cache
+    /// total; `hosting_disk_total_bytes` is their sum — the aggregate the future
+    /// disk budget will bound. `None` until the tracker is configured and seeded
+    /// (early startup). Per-node aggregate scalars.
+    pub hosting_disk_state_bytes: Option<u64>,
+    pub hosting_disk_wasm_bytes: Option<u64>,
+    pub hosting_disk_compile_cache_bytes: Option<u64>,
+    pub hosting_disk_total_bytes: Option<u64>,
     /// Terminal advertisement-consult counters (hosting redesign piece C,
     /// #4646; exported to central telemetry per #4658), populated by `Ring`
     /// from the per-node `network_status` singleton on the snapshot cadence.
@@ -1225,6 +1237,12 @@ impl Router {
             hosting_local_misses_total: None,
             hosting_evicted_unread_total: None,
             hosting_evicted_unread_age_secs_sum: None,
+            // Aggregate on-disk usage gauges, populated by Ring from the
+            // DiskUsageTracker on the snapshot cadence (#4683).
+            hosting_disk_state_bytes: None,
+            hosting_disk_wasm_bytes: None,
+            hosting_disk_compile_cache_bytes: None,
+            hosting_disk_total_bytes: None,
             // Terminal advertisement-consult counters (piece C, #4646),
             // populated by Ring from the network_status singleton on the
             // snapshot cadence (#4658).

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2203,6 +2203,26 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "hosting_evicted_unread_age_secs_sum".to_string(),
                     serde_json::json!(snapshot.hosting_evicted_unread_age_secs_sum),
                 );
+                // Aggregate on-disk usage gauges (#4683). Same hand-mirrored
+                // footgun as the gauges above: a new `RouterSnapshotInfo` field
+                // is invisible to the collector unless added here. Pinned by
+                // `router_snapshot_json_includes_hosting_disk_gauges`.
+                obj.insert(
+                    "hosting_disk_state_bytes".to_string(),
+                    serde_json::json!(snapshot.hosting_disk_state_bytes),
+                );
+                obj.insert(
+                    "hosting_disk_wasm_bytes".to_string(),
+                    serde_json::json!(snapshot.hosting_disk_wasm_bytes),
+                );
+                obj.insert(
+                    "hosting_disk_compile_cache_bytes".to_string(),
+                    serde_json::json!(snapshot.hosting_disk_compile_cache_bytes),
+                );
+                obj.insert(
+                    "hosting_disk_total_bytes".to_string(),
+                    serde_json::json!(snapshot.hosting_disk_total_bytes),
+                );
                 // Terminal advertisement-consult counters (hosting redesign
                 // piece C, #4646; exported per #4658). Same hand-mirrored
                 // footgun as the gauges above: a new `RouterSnapshotInfo` field
@@ -2588,6 +2608,31 @@ mod tests {
         for (key, want) in [
             ("hosting_evicted_unread_total", 349),
             ("hosting_evicted_unread_age_secs_sum", 353),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
+    }
+
+    /// Pin: the aggregate on-disk usage gauges (#4683) must also reach the
+    /// hand-mirrored OTLP body — same footgun as the gauges above. A silent drop
+    /// would blind central telemetry to the disk-budget accounting this PR
+    /// introduces (the measurement the eviction floor + admission gate build on).
+    #[test]
+    fn router_snapshot_json_includes_hosting_disk_gauges() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.hosting_disk_state_bytes = Some(401);
+        info.hosting_disk_wasm_bytes = Some(409);
+        info.hosting_disk_compile_cache_bytes = Some(419);
+        info.hosting_disk_total_bytes = Some(1229);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        for (key, want) in [
+            ("hosting_disk_state_bytes", 401),
+            ("hosting_disk_wasm_bytes", 409),
+            ("hosting_disk_compile_cache_bytes", 419),
+            ("hosting_disk_total_bytes", 1229),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -1028,7 +1028,21 @@ impl WasmtimeEngine {
         // Module::new() skips compilation entirely and deserializes — ~100x faster.
         // This eliminates WASM compilation as a contributor to OPERATION_TTL timeouts
         // on slow CI runners and during cold starts in production.
-        match Cache::new(CacheConfig::new()) {
+        // Build the cache config, optionally relocating it onto the data-dir
+        // mount and pinning its soft-size limit (#4683). `with_directory`
+        // requires an ABSOLUTE path (wasmtime `create_dir_all`s + canonicalizes
+        // it); `RuntimeConfig::wasmtime_cache_dir` is `Some` only on the
+        // production path, which passes the absolute data-dir sibling. When
+        // `None` (tests/sim), the cache keeps wasmtime's default OS-cache
+        // location + 512 MiB soft limit — unchanged behavior.
+        let mut cache_config = CacheConfig::new();
+        if let Some(dir) = &config.wasmtime_cache_dir {
+            cache_config.with_directory(dir);
+        }
+        if let Some(limit) = config.wasmtime_cache_size_bytes {
+            cache_config.with_files_total_size_soft_limit(limit);
+        }
+        match Cache::new(cache_config) {
             Ok(cache) => {
                 wasmtime_config.cache(Some(cache));
                 tracing::info!("Wasmtime compilation cache enabled");
@@ -1905,7 +1919,7 @@ mod tests {
         // The build path that constructs the wasmtime Config must install a
         // disk cache via `wasmtime_config.cache(Some(...))`.
         assert!(
-            body.contains("Cache::new(CacheConfig::new())"),
+            body.contains("CacheConfig::new()") && body.contains("Cache::new(cache_config)"),
             "create_backend_engine must construct the wasmtime disk compilation cache"
         );
         assert!(

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -177,6 +177,17 @@ pub struct RuntimeConfig {
     /// deterministic in the `current_thread` + `start_paused` sim runner even
     /// if set. Production sets it `true`; tests/sim leave it `false`.
     pub offload_compilation: bool,
+    /// Directory for the wasmtime compile cache (#4683). `Some` relocates the
+    /// cache onto the data-dir mount (so it shares the mount that sizes the disk
+    /// budget and is measurable as freenet's own usage). `None` keeps wasmtime's
+    /// default OS-cache location — every test / `default()` site leaves it
+    /// unset, so their behavior is unchanged. An absolute path is required by
+    /// wasmtime's `CacheConfig::with_directory`.
+    pub wasmtime_cache_dir: Option<std::path::PathBuf>,
+    /// Soft size limit (bytes) for the wasmtime compile cache (#4683). `Some`
+    /// overrides wasmtime's 512 MiB default via
+    /// `CacheConfig::with_files_total_size_soft_limit`; `None` keeps the default.
+    pub wasmtime_cache_size_bytes: Option<u64>,
 }
 
 impl Default for RuntimeConfig {
@@ -192,6 +203,11 @@ impl Default for RuntimeConfig {
             // inline compile. Production opts in explicitly — see
             // `RuntimePool::new` / `from_config_with_shared_modules`.
             offload_compilation: false,
+            // Default: keep wasmtime's own OS-cache location + 512 MiB soft
+            // limit. Only the production `from_config*` path relocates + sizes
+            // it, so tests and sims see unchanged wasmtime cache behavior.
+            wasmtime_cache_dir: None,
+            wasmtime_cache_size_bytes: None,
         }
     }
 }


### PR DESCRIPTION
## Problem

The demand-driven hosting redesign (#4642) sizes its hosting budget from **memory only**. There is no analogous **disk** budget, yet for a disk-constrained host (small VPS, SD-card device) disk — not RAM — is the scarcest resource. Today nothing bounds a peer's aggregate on-disk usage (hosted state + WASM code blobs + wasmtime compile cache); a node that fills its disk hits an OS-level write failure first, with no proactive refuse/evict.

This is **PR 1 of 4** for the aggregate disk-space budget (#4683). It lays the measurement foundation the eviction floor (PR 2, `min(ram, disk)`) and admission gate (PR 3) build on. **Zero behavior change**: the tracker is populated and observable, but no admission or eviction decision reads it yet.

## Solution

- **`ring/hosting/disk_usage.rs` — `DiskUsageTracker`**: a seed-once + signed-delta accumulator following the #4561 secrets `seeded_user_total` discipline.
  - **State bytes**: seeded from the exact per-row `HostingMetadata.size_bytes` sum, maintained by signed deltas at the executor's state-write chokepoints (via `Ring::commit_state_write`, the single infallible post-write funnel for all four chokepoints + the V2 delegate callback) and at reclamation. A small per-key size index makes each delta exact (`new − old`) without re-reading the DB.
  - **WASM blobs** and **compile cache**: `du`-measured (re-walked on the telemetry cadence), so they need no delta wiring; dedup is inherent (one file per `code_hash`).
  - The state seed is **fail-loud** on I/O error: a too-low seed would defeat the future admission gate, so a read failure leaves the tracker unseeded to retry rather than committing an under-count.

- **Wasmtime compile-cache relocation**: threaded `wasmtime_cache_dir` / `wasmtime_cache_size_bytes` `Option`s through `RuntimeConfig` (populated only on the production `from_config` path — every test / `default()` site keeps wasmtime's defaults), consumed in `wasmtime_engine` via `CacheConfig::with_directory` + `with_files_total_size_soft_limit`. A `wasmtime_cache_dir` sibling in `ConfigPaths` puts the cache on the data-dir mount (statvfs is per-mount, so the free-space basis the disk budget will use must be that mount) and makes it measurable as freenet's own on-disk usage. The literal-string guard test in `wasmtime_engine` is updated to match the new builder.

- **Telemetry**: four `hosting_disk_*` gauges (state / wasm / compile_cache / total) on `RouterSnapshotInfo`, emitted on the existing `RouterSnapshot` cadence and mirrored into the OTLP body, so the whole feature is observable in production before any enforcement ships.

Seeding is lazy on the first 60s sweep tick, and the `du`-walks run **outside** any hosting-cache write lock (off the hot path).

### Interaction with #4651

#4651 questions whether disk persistence earns its keep. This PR's accounting + telemetry is the exact measurement that decision needs, and does not block it.

## Testing

- Unit (delta accounting, no filesystem): PUT-new adds full size; UPDATE grow/shrink adds/subtracts the delta; evict removes full size; double-evict floors at 0; a removal never drives the aggregate negative.
- Tempdir `du`-walk: WASM seed + refresh (each blob counted once, non-`.wasm` files excluded, `local/` split traversed); compile-cache seed + refresh observes growth.
- OTLP-body pin (`router_snapshot_json_includes_hosting_disk_gauges`) so a new gauge can't silently drop from central telemetry.
- Existing guard tests updated/passing: wasmtime disk-cache construction, config round-trip, `every_runtime_state_write_chokepoint_goes_through_commit_state_write`.

Gate: `cargo fmt` + `cargo clippy -p freenet -- -D warnings` clean on this diff; `cargo test -p freenet --lib` green except two pre-existing `wasm_runtime::migration_tests` failures unrelated to this change (present on `main`).

## Fixes

Part of #4683.