### PR TITLE
feat: disk budget sizing + periodic recompute + eviction floor

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -120,6 +120,19 @@ pub struct ConfigArgs {
     #[arg(long, env = "MAX_HOSTING_STORAGE")]
     pub max_hosting_storage: Option<u64>,
 
+    /// Fraction (0.0–1.0) of the disk capacity *available to Freenet*
+    /// (`used + free` on the data-dir mount) used to size the aggregate disk
+    /// budget (#4683). The disk budget is the second floor on hosting eviction:
+    /// `effective_budget = min(ram_budget, disk_budget)`. Default: 0.5.
+    #[arg(long, env = "HOSTING_DISK_PCT")]
+    pub hosting_disk_pct: Option<f64>,
+
+    /// Hard upper clamp in bytes for the aggregate disk budget (#4683). Mirrors
+    /// `--max-hosting-storage` for disk: the disk budget never exceeds this even
+    /// on a host with a very large data disk. Default: 32 GiB.
+    #[arg(long, env = "MAX_HOSTING_DISK")]
+    pub max_hosting_disk: Option<u64>,
+
     /// Per-user secret-storage quota in bytes for HOSTED mode (#4561, P5 of
     /// #4381). Bounds a single hosted user's (one `userToken`) TOTAL on-disk
     /// footprint under their `users/<user_id>/` tree, summed across every
@@ -246,6 +259,8 @@ impl Default for ConfigArgs {
             version: false,
             max_blocking_threads: None,
             max_hosting_storage: None,
+            hosting_disk_pct: None,
+            max_hosting_disk: None,
             per_user_secret_quota_bytes: None,
             per_user_inactive_ttl_secs: None,
             inactive_user_sweep_interval_secs: None,
@@ -517,6 +532,11 @@ impl ConfigArgs {
                 self.max_hosting_storage
                     .get_or_insert(cfg.max_hosting_storage);
             }
+            // #4683 disk-budget sizing knobs — persisted, so merge them back from
+            // the file (the #3890/#4275 silent-revert class). No legacy sentinel:
+            // these are new fields, so a plain get_or_insert is correct.
+            self.hosting_disk_pct.get_or_insert(cfg.hosting_disk_pct);
+            self.max_hosting_disk.get_or_insert(cfg.max_hosting_disk);
             self.per_user_secret_quota_bytes
                 .get_or_insert(cfg.per_user_secret_quota_bytes);
             self.per_user_inactive_ttl_secs
@@ -977,6 +997,12 @@ impl ConfigArgs {
             max_hosting_storage: self
                 .max_hosting_storage
                 .unwrap_or_else(crate::ring::default_hosting_budget_bytes),
+            hosting_disk_pct: self
+                .hosting_disk_pct
+                .unwrap_or(crate::ring::DEFAULT_HOSTING_DISK_PCT),
+            max_hosting_disk: self
+                .max_hosting_disk
+                .unwrap_or(crate::ring::DEFAULT_MAX_HOSTING_DISK_BYTES),
             per_user_secret_quota_bytes: self
                 .per_user_secret_quota_bytes
                 .unwrap_or(crate::wasm_runtime::DEFAULT_PER_USER_SECRET_QUOTA_BYTES as u64),
@@ -1140,6 +1166,19 @@ pub struct Config {
         skip_serializing_if = "is_default_hosting_budget"
     )]
     pub max_hosting_storage: u64,
+    /// Fraction (0.0–1.0) of the data-dir mount's Freenet-reachable capacity
+    /// (`used + free`) used to size the aggregate disk budget (#4683). The disk
+    /// budget is the second floor on hosting eviction
+    /// (`effective = min(ram_budget, disk_budget)`). Default 0.5. Persisted so an
+    /// operator override survives a flag-less restart.
+    #[serde(default = "default_hosting_disk_pct", rename = "hosting-disk-pct")]
+    pub hosting_disk_pct: f64,
+    /// Hard upper clamp in bytes for the aggregate disk budget (#4683), the disk
+    /// analogue of `max-hosting-storage`. The disk budget never exceeds this even
+    /// on a host with a very large data disk. Default 32 GiB. Persisted so an
+    /// operator override survives a flag-less restart.
+    #[serde(default = "default_max_hosting_disk", rename = "max-hosting-disk")]
+    pub max_hosting_disk: u64,
     /// Per-user secret-storage quota in bytes for hosted mode (#4561, P5 of
     /// #4381). Bounds a single hosted user's TOTAL on-disk footprint (active
     /// secret-value blobs + the `.keys` enumeration registry) under their
@@ -1242,6 +1281,19 @@ fn default_max_blocking_threads() -> usize {
 /// budget (addresses #4565); an explicit value always overrides it.
 fn default_max_hosting_storage() -> u64 {
     crate::ring::default_hosting_budget_bytes()
+}
+
+/// Default fraction of Freenet-reachable disk capacity for the aggregate disk
+/// budget (#4683): resolves to [`crate::ring::DEFAULT_HOSTING_DISK_PCT`] (0.5),
+/// the single source of truth shared with the sizing math.
+fn default_hosting_disk_pct() -> f64 {
+    crate::ring::DEFAULT_HOSTING_DISK_PCT
+}
+
+/// Default hard cap for the aggregate disk budget (#4683): resolves to
+/// [`crate::ring::DEFAULT_MAX_HOSTING_DISK_BYTES`] (32 GiB).
+fn default_max_hosting_disk() -> u64 {
+    crate::ring::DEFAULT_MAX_HOSTING_DISK_BYTES
 }
 
 /// `skip_serializing_if` predicate for [`Config::max_hosting_storage`]: true
@@ -4374,6 +4426,8 @@ mod tests {
             version: false,
             max_blocking_threads: None,
             max_hosting_storage: None,
+            hosting_disk_pct: None,
+            max_hosting_disk: None,
             per_user_secret_quota_bytes: None,
             per_user_inactive_ttl_secs: None,
             inactive_user_sweep_interval_secs: None,
@@ -4485,6 +4539,8 @@ mod tests {
             location: Some(0.5),
             max_blocking_threads: 7,
             max_hosting_storage: 123_456_789,
+            hosting_disk_pct: 0.37,
+            max_hosting_disk: 9_876_543_210,
             per_user_secret_quota_bytes: 7_654_321,
             per_user_inactive_ttl_secs: 1_234_567,
             inactive_user_sweep_interval_secs: 7_200,
@@ -4523,6 +4579,8 @@ mod tests {
             location,
             max_blocking_threads,
             max_hosting_storage,
+            hosting_disk_pct,
+            max_hosting_disk,
             per_user_secret_quota_bytes,
             per_user_inactive_ttl_secs,
             inactive_user_sweep_interval_secs,
@@ -4547,6 +4605,8 @@ mod tests {
             max_hosting_storage, seed.max_hosting_storage,
             "max_hosting_storage"
         );
+        assert_eq!(hosting_disk_pct, seed.hosting_disk_pct, "hosting_disk_pct");
+        assert_eq!(max_hosting_disk, seed.max_hosting_disk, "max_hosting_disk");
         assert_eq!(
             per_user_secret_quota_bytes, seed.per_user_secret_quota_bytes,
             "per_user_secret_quota_bytes"

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -2386,6 +2386,11 @@ impl ConfigPathsArgs {
         let delegates_dir = app_data_dir.join("delegates");
         let secrets_dir = app_data_dir.join("secrets");
         let db_dir = app_data_dir.join("db");
+        // Wasmtime's compile cache is relocated onto the data-dir mount (#4683)
+        // so it (a) shares the mount whose free space sizes the disk budget and
+        // (b) is measurable as freenet's own on-disk usage. Its default OS-cache
+        // location is neither. A sibling of the data dirs, created below.
+        let wasmtime_cache_dir = app_data_dir.join("wasmtime-cache");
 
         if !contracts_dir.exists() {
             fs::create_dir_all(&contracts_dir)?;
@@ -2405,6 +2410,10 @@ impl ConfigPathsArgs {
         if !db_dir.exists() {
             fs::create_dir_all(&db_dir)?;
             fs::create_dir_all(db_dir.join("local"))?;
+        }
+
+        if !wasmtime_cache_dir.exists() {
+            fs::create_dir_all(&wasmtime_cache_dir)?;
         }
 
         let event_log = app_data_dir.join("_EVENT_LOG");
@@ -2435,6 +2444,7 @@ impl ConfigPathsArgs {
             delegates_dir,
             secrets_dir,
             db_dir,
+            wasmtime_cache_dir,
             event_log,
             log_dir,
         })
@@ -2452,6 +2462,12 @@ pub struct ConfigPaths {
     config_dir: PathBuf,
     #[serde(default = "get_log_dir")]
     log_dir: Option<PathBuf>,
+    /// Relocated wasmtime compile-cache directory (#4683). `#[serde(default)]`
+    /// so a `config.toml` persisted before this field existed deserializes with
+    /// an empty path; `build()` always re-derives the real one from the data
+    /// dir, so the persisted value is never load-bearing.
+    #[serde(default)]
+    wasmtime_cache_dir: PathBuf,
 }
 
 impl ConfigPaths {
@@ -2497,6 +2513,13 @@ impl ConfigPaths {
 
     pub fn data_dir(&self) -> PathBuf {
         self.data_dir.clone()
+    }
+
+    /// Relocated wasmtime compile-cache directory (#4683). Not mode-split: the
+    /// compile cache is keyed by (engine config + WASM bytes) and shared across
+    /// local/network runtimes on the same node.
+    pub fn wasmtime_cache_dir(&self) -> PathBuf {
+        self.wasmtime_cache_dir.clone()
     }
 
     pub fn secrets_dir(&self, mode: OperationMode) -> PathBuf {
@@ -2547,11 +2570,12 @@ impl ConfigPaths {
             4 => (true, &self.data_dir),
             5 => (false, &self.event_log),
             6 => (true, &self.config_dir),
+            7 => (true, &self.wasmtime_cache_dir),
             _ => panic!("invalid path index"),
         }
     }
 
-    const MAX_PATH_INDEX: usize = 6;
+    const MAX_PATH_INDEX: usize = 7;
 }
 
 pub struct ConfigPathsIter<'a> {
@@ -2587,6 +2611,11 @@ impl Config {
 
     pub fn contracts_dir(&self) -> PathBuf {
         self.config_paths.contracts_dir(self.mode)
+    }
+
+    /// Relocated wasmtime compile-cache directory (#4683). Not mode-split.
+    pub fn wasmtime_cache_dir(&self) -> PathBuf {
+        self.config_paths.wasmtime_cache_dir()
     }
 
     pub fn delegates_dir(&self) -> PathBuf {

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -20,6 +20,14 @@ const MAX_RELATED_CONTRACTS_PER_REQUEST: usize = 10;
 /// Timeout for fetching all related contracts during validation.
 const RELATED_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Soft size limit for the relocated wasmtime compile cache (#4683), pinned to
+/// wasmtime's own historical default (512 MiB). Pinned explicitly rather than
+/// left implicit so the cache's on-disk ceiling is a legible, single-sourced
+/// value the disk-budget accounting can reason about. Wasmtime self-prunes the
+/// cache to this soft limit on its 1h cleanup, so for accounting the cache is a
+/// near-fixed ceiling (re-walked on the telemetry cadence).
+const WASMTIME_CACHE_SIZE_SOFT_LIMIT_BYTES: u64 = 512 * 1024 * 1024;
+
 /// Probability that a given state-changing merge is checked for
 /// `update_state` idempotency. One re-invocation of WASM per sample, so
 /// the per-merge cost is ~`p * average_update_state_us`. At 1/32 ≈ 3%
@@ -417,6 +425,13 @@ impl Executor<Runtime> {
         let runtime_config = RuntimeConfig {
             offload_compilation: production_offload_compilation(),
             module_cache_budget_bytes: config.module_cache_budget_bytes,
+            // Relocate the wasmtime compile cache onto the data-dir mount and
+            // pin its soft-size limit (#4683) so it lives on the mount whose
+            // free space sizes the disk budget and is measurable as freenet's
+            // own on-disk usage. `with_directory` requires an absolute path;
+            // the data dir is absolute.
+            wasmtime_cache_dir: Some(config.wasmtime_cache_dir()),
+            wasmtime_cache_size_bytes: Some(WASMTIME_CACHE_SIZE_SOFT_LIMIT_BYTES),
             ..RuntimeConfig::default()
         };
         let mut rt = Runtime::build_with_shared_module_caches(

--- a/crates/core/src/contract/executor/runtime/contract_ops.rs
+++ b/crates/core/src/contract/executor/runtime/contract_ops.rs
@@ -430,7 +430,15 @@ impl Executor<Runtime> {
         key: &ContractKey,
     ) -> Result<ReclaimOutcome, ExecutorError> {
         let state_result = match self.state_store.delete(key).await {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                // Disk-usage accounting (#4683): drop this contract's state
+                // contribution from the aggregate on-disk total. Observational
+                // only in this PR. No-op until the tracker is seeded.
+                if let Some(op_manager) = &self.op_manager {
+                    op_manager.ring.record_state_removed(key);
+                }
+                Ok(())
+            }
             Err(e) => {
                 tracing::warn!(
                     contract = %key,

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -127,9 +127,12 @@ impl ContractHandler for NetworkContractHandler {
         // Aggregate disk-usage tracker paths (#4683): the mode-resolved
         // contracts dir (WASM blobs) and the relocated wasmtime compile-cache
         // dir. Seeded lazily on the first sweep tick.
-        op_manager
-            .ring
-            .set_hosting_disk_paths(config.contracts_dir(), config.wasmtime_cache_dir());
+        op_manager.ring.set_hosting_disk_paths(
+            config.contracts_dir(),
+            config.wasmtime_cache_dir(),
+            config.hosting_disk_pct,
+            config.max_hosting_disk,
+        );
         // Hydrate broken-invariants flags from the same backing store so a
         // node that previously detected a non-idempotent contract doesn't
         // re-engage its broadcast storm after restart.

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -124,6 +124,12 @@ impl ContractHandler for NetworkContractHandler {
         // This must be done before loading the cache so evictions work correctly
         let storage = executor.state_store().inner().clone();
         op_manager.ring.set_hosting_storage(storage.clone());
+        // Aggregate disk-usage tracker paths (#4683): the mode-resolved
+        // contracts dir (WASM blobs) and the relocated wasmtime compile-cache
+        // dir. Seeded lazily on the first sweep tick.
+        op_manager
+            .ring
+            .set_hosting_disk_paths(config.contracts_dir(), config.wasmtime_cache_dir());
         // Hydrate broken-invariants flags from the same backing store so a
         // node that previously detected a non-idempotent contract doesn't
         // re-engage its broadcast storm after restart.

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1588,6 +1588,17 @@ impl Ring {
             snapshot.hosting_local_hits_total = Some(ring.hosting_manager.local_get_serves());
             snapshot.hosting_local_misses_total = Some(ring.hosting_manager.local_get_forwards());
 
+            // Aggregate on-disk usage gauges (#4683): state (delta-tracked) +
+            // WASM blobs + wasmtime compile cache (both du-measured) + their sum.
+            // `None` until the tracker is configured and seeded (early startup),
+            // in which case the fields stay unset. Observational only in this PR.
+            if let Some(disk) = ring.hosting_manager.disk_usage_stats() {
+                snapshot.hosting_disk_state_bytes = Some(disk.state_bytes);
+                snapshot.hosting_disk_wasm_bytes = Some(disk.wasm_bytes);
+                snapshot.hosting_disk_compile_cache_bytes = Some(disk.compile_cache_bytes);
+                snapshot.hosting_disk_total_bytes = Some(disk.total_bytes);
+            }
+
             // Terminal advertisement-consult counters (hosting redesign piece C,
             // #4646). Exported here per #4658 so the production findability
             // baseline — the dead-end decomposition (off-path-advertised-host
@@ -2390,6 +2401,16 @@ impl Ring {
                     }
                 }
             }
+
+            // Disk-usage accounting maintenance (#4683). Runs OUTSIDE any
+            // hosting-cache write lock (the du-walks would stall cache readers).
+            // First tick lazily seeds the tracker from the true on-disk state
+            // total; every tick re-walks the `du`-measured WASM-blob and
+            // compile-cache totals so telemetry stays fresh. Observational only
+            // in this PR — no admission/eviction decision reads these yet.
+            #[cfg(feature = "redb")]
+            ring.hosting_manager.seed_disk_tracker_if_absent();
+            ring.hosting_manager.refresh_disk_usage();
         }
     }
 
@@ -2517,6 +2538,19 @@ impl Ring {
     /// cleanup of persisted metadata when contracts are evicted.
     pub fn set_hosting_storage(&self, storage: crate::contract::storages::Storage) {
         self.hosting_manager.set_storage(storage);
+    }
+
+    /// Install the aggregate disk-usage tracker's paths (#4683). Called once at
+    /// startup with the node's mode-resolved contracts dir and the relocated
+    /// wasmtime compile-cache dir. The tracker is seeded lazily on the first
+    /// sweep tick.
+    pub fn set_hosting_disk_paths(
+        &self,
+        contracts_dir: std::path::PathBuf,
+        wasmtime_cache_dir: std::path::PathBuf,
+    ) {
+        self.hosting_manager
+            .configure_disk_tracker(contracts_dir, wasmtime_cache_dir);
     }
 
     /// Drop the ring's clones of the redb `Storage` handle (hosting metadata +
@@ -2984,11 +3018,25 @@ impl Ring {
         let new_gen = self.hosting_manager.bump_state_generation(contract);
         self.hosting_manager
             .refresh_cache_generation(contract, new_gen);
+        // Disk-usage accounting (#4683): maintain the aggregate on-disk state
+        // total by signed delta (`new − previous_for_key`). Observational only
+        // in this PR — no admission/eviction decision reads it yet. No-op until
+        // the tracker is seeded.
+        self.hosting_manager
+            .record_state_write(contract, state_size as u64);
         self.report_contract_resource_usage(
             *contract.id(),
             crate::topology::meter::ResourceType::StateBytesWritten,
             state_size as f64,
         );
+    }
+
+    /// Subtract a reclaimed contract's state bytes from the aggregate disk-usage
+    /// tracker (#4683). Called from the executor's reclaim path on successful
+    /// state deletion. Observational only in this PR; no-op until the tracker is
+    /// seeded.
+    pub(crate) fn record_state_removed(&self, contract: &ContractKey) {
+        self.hosting_manager.record_state_removed(contract);
     }
 
     /// Read the current state-write generation for `contract` (0 if never written).

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -98,6 +98,10 @@ pub(crate) use hosting::LEGACY_FLAT_HOSTING_BUDGET_BYTES;
 /// default is RAM-scaled (capability-relative, A2) rather than a flat constant.
 pub(crate) use hosting::default_hosting_budget_bytes;
 pub use hosting::{AccessType, RecordAccessResult};
+/// Aggregate disk-budget defaults (#4683). `config` resolves the persisted
+/// `hosting-disk-pct` / `max-hosting-disk` defaults from these so the operator-
+/// facing defaults and the in-code sizing math share one source of truth.
+pub(crate) use hosting::{DEFAULT_HOSTING_DISK_PCT, DEFAULT_MAX_HOSTING_DISK_BYTES};
 /// Clamp bounds re-exported only for the config-default round-trip test.
 #[cfg(test)]
 pub(crate) use hosting::{MAX_DEFAULT_HOSTING_BUDGET_BYTES, MIN_DEFAULT_HOSTING_BUDGET_BYTES};
@@ -2411,6 +2415,22 @@ impl Ring {
             #[cfg(feature = "redb")]
             ring.hosting_manager.seed_disk_tracker_if_absent();
             ring.hosting_manager.refresh_disk_usage();
+
+            // Eviction floor (#4683, PR 2): recompute
+            // `effective = min(ram_budget, disk_budget)` and install it as the
+            // hosting-cache budget so the next `evict_over_budget` sheds state
+            // down to the tighter of the two resource floors. The free-space read
+            // is the determinism seam — production reads the data-dir mount; a
+            // failed read falls back to `u64::MAX`, which makes the disk budget
+            // clamp to its cap (degrade to "cap only", never to zero). The
+            // du-walks above already ran OUTSIDE any cache lock; only the O(1)
+            // `set_budget_bytes` inside `recompute_effective_budget` takes the
+            // cache write lock.
+            let available = ring
+                .hosting_manager
+                .disk_available_bytes()
+                .unwrap_or(u64::MAX);
+            ring.hosting_manager.recompute_effective_budget(available);
         }
     }
 
@@ -2548,9 +2568,15 @@ impl Ring {
         &self,
         contracts_dir: std::path::PathBuf,
         wasmtime_cache_dir: std::path::PathBuf,
+        hosting_disk_pct: f64,
+        max_hosting_disk: u64,
     ) {
         self.hosting_manager
             .configure_disk_tracker(contracts_dir, wasmtime_cache_dir);
+        // #4683 eviction-floor sizing knobs (mirrors the disk paths install; the
+        // config is only reachable here). The 60s sweep's recompute reads them.
+        self.hosting_manager
+            .configure_disk_budget(hosting_disk_pct, max_hosting_disk);
     }
 
     /// Drop the ring's clones of the redb `Storage` handle (hosting metadata +

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -31,6 +31,7 @@
 
 mod cache;
 mod demand;
+mod disk_usage;
 
 use crate::util::backoff::{ExponentialBackoff, TrackedBackoff};
 use crate::util::time_source::{DynTimeSource, InstantTimeSrc, TimeSource};
@@ -53,6 +54,8 @@ use cache::{DEFAULT_MIN_TTL, HostingCache, HostingCacheStats};
 pub(crate) use cache::{MAX_DEFAULT_HOSTING_BUDGET_BYTES, MIN_DEFAULT_HOSTING_BUDGET_BYTES};
 use dashmap::{DashMap, DashSet};
 use demand::ProximityPrior;
+pub(crate) use disk_usage::DiskUsageStats;
+use disk_usage::DiskUsageTracker;
 use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
 use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
@@ -336,6 +339,15 @@ pub(crate) struct HostingManager {
     /// Behind an `Arc` so the periodic sweep snapshot can iterate
     /// without re-entering the `HostingManager` borrow.
     pending_reclamation: std::sync::Arc<DashMap<ContractKey, u64>>,
+
+    /// Aggregate on-disk usage accounting (#4683): hosted state + WASM blobs +
+    /// wasmtime compile cache. `None` until [`Self::configure_disk_tracker`]
+    /// installs it with the node's real paths (done once at startup alongside
+    /// `set_storage`, since `with_time_source` has no path access). Populated
+    /// and observable in this PR but does not yet drive admission or eviction —
+    /// that is PR 2 (eviction floor) and PR 3 (admission gate). Behind an
+    /// `RwLock` for the same late-binding reason as `storage`.
+    disk_tracker: RwLock<Option<DiskUsageTracker>>,
 }
 
 impl HostingManager {
@@ -378,6 +390,7 @@ impl HostingManager {
             storage: RwLock::new(None),
             state_generation: DashMap::new(),
             pending_reclamation: std::sync::Arc::new(DashMap::new()),
+            disk_tracker: RwLock::new(None),
         }
     }
 
@@ -443,6 +456,127 @@ impl HostingManager {
     /// Called on node shutdown to help free the on-disk file lock (issue #4401).
     pub(crate) fn clear_storage(&self) {
         *self.storage.write() = None;
+    }
+
+    // =========================================================================
+    // Disk-usage accounting (#4683)
+    // =========================================================================
+
+    /// Install the aggregate disk-usage tracker with the node's real paths.
+    /// Called once at startup (alongside `set_storage`), since `with_time_source`
+    /// has no path access. The tracker starts unseeded; the first sweep tick
+    /// seeds it lazily off the hot path.
+    pub(crate) fn configure_disk_tracker(
+        &self,
+        contracts_dir: std::path::PathBuf,
+        wasmtime_cache_dir: std::path::PathBuf,
+    ) {
+        *self.disk_tracker.write() = Some(DiskUsageTracker::new(contracts_dir, wasmtime_cache_dir));
+    }
+
+    /// Lazily seed the disk tracker on first use (like the hosting-cache
+    /// `seed_if_absent`), summing the true on-disk state total from redb rows.
+    /// No-op if the tracker is absent or already seeded. Runs OUTSIDE any cache
+    /// write lock (the caller — the 60s sweep — invokes it off the hot path).
+    ///
+    /// The state seed is intentionally fail-loud on I/O error (a too-low seed
+    /// would defeat the future admission gate): a read failure leaves the
+    /// tracker UNSEEDED so the next tick retries, rather than committing an
+    /// under-count.
+    #[cfg(feature = "redb")]
+    pub(crate) fn seed_disk_tracker_if_absent(&self) {
+        use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+
+        {
+            let guard = self.disk_tracker.read();
+            match guard.as_ref() {
+                Some(t) if t.is_seeded() => return,
+                Some(_) => {}
+                None => return,
+            }
+        }
+
+        // Read the exact per-contract state sizes from redb before taking the
+        // tracker lock, so no storage I/O happens under it.
+        let rows = {
+            let storage = self.storage.read();
+            let Some(storage) = storage.as_ref() else {
+                return;
+            };
+            match storage.load_all_hosting_metadata() {
+                Ok(entries) => entries,
+                Err(e) => {
+                    // Fail-loud: leave the tracker unseeded so the next sweep
+                    // retries rather than seeding from an under-count.
+                    tracing::warn!(error = %e, "disk tracker seed deferred: failed to read hosting metadata");
+                    return;
+                }
+            }
+        };
+
+        let state_rows = rows.into_iter().filter_map(|(key_bytes, metadata)| {
+            if key_bytes.len() != 32 {
+                return None;
+            }
+            let mut id = [0u8; 32];
+            id.copy_from_slice(&key_bytes);
+            let key = ContractKey::from_id_and_code(
+                ContractInstanceId::new(id),
+                CodeHash::new(metadata.code_hash),
+            );
+            Some((key, metadata.size_bytes))
+        });
+
+        if let Some(tracker) = self.disk_tracker.read().as_ref() {
+            tracker.seed(state_rows);
+        }
+    }
+
+    /// Apply a state-write delta to the disk tracker at a state-write chokepoint.
+    /// Wired from `Ring::commit_state_write` (the single infallible post-write
+    /// funnel for all four executor chokepoints + the V2 delegate callback), so
+    /// the counter only moves after the bytes actually landed.
+    ///
+    /// Calls through even when the tracker is not yet seeded (only skipping when
+    /// absent). An unseeded write buffers its post-write size into the tracker's
+    /// per-key map so the lazy seed picks it up instead of dropping it — this is
+    /// what closes the seed/write TOCTOU (a write racing the first sweep tick's
+    /// redb snapshot would otherwise permanently under-count that key). See
+    /// [`DiskUsageTracker::record_state_write`].
+    pub(crate) fn record_state_write(&self, key: &ContractKey, new_size: u64) {
+        if let Some(tracker) = self.disk_tracker.read().as_ref() {
+            tracker.record_state_write(key, new_size);
+        }
+    }
+
+    /// Subtract a contract's state contribution from the disk tracker on
+    /// eviction/reclamation. Wired from the reclaim path. No-op when the tracker
+    /// is absent. Like [`Self::record_state_write`], calls through even while
+    /// unseeded so the per-key buffer stays consistent with the seed.
+    pub(crate) fn record_state_removed(&self, key: &ContractKey) {
+        if let Some(tracker) = self.disk_tracker.read().as_ref() {
+            tracker.record_state_removed(key);
+        }
+    }
+
+    /// Re-walk the WASM-blob and compile-cache totals. Called on the telemetry
+    /// cadence (the 60s sweep) since both are `du`-measured, not delta-tracked.
+    pub(crate) fn refresh_disk_usage(&self) {
+        if let Some(tracker) = self.disk_tracker.read().as_ref() {
+            tracker.refresh_wasm();
+            tracker.refresh_compile_cache();
+        }
+    }
+
+    /// Snapshot the disk-usage gauges for per-node telemetry, or `None` before
+    /// the tracker is configured/seeded (early startup). Aggregate scalars only.
+    pub(crate) fn disk_usage_stats(&self) -> Option<DiskUsageStats> {
+        let guard = self.disk_tracker.read();
+        let tracker = guard.as_ref()?;
+        if !tracker.is_seeded() {
+            return None;
+        }
+        Some(tracker.stats())
     }
 
     // =========================================================================

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -39,19 +39,27 @@ pub(crate) use cache::HostingContractScore;
 /// The pre-A2 flat 1 GiB budget, used as the upgrade-migration sentinel in
 /// `config::ConfigArgs::build` (see the constant's docs).
 pub(crate) use cache::LEGACY_FLAT_HOSTING_BUDGET_BYTES;
+/// Upper clamp re-exported only for the config-default round-trip test, which
+/// asserts the resolved default lands within [MIN, MAX] without hardcoding the
+/// byte values. Gated to test builds so the re-export isn't an unused import
+/// under `-D warnings` in release.
+#[cfg(test)]
+pub(crate) use cache::MAX_DEFAULT_HOSTING_BUDGET_BYTES;
+/// The shared MIN budget floor (#4683 eviction floor uses it as the disk-budget
+/// clamp lower bound; the config round-trip test asserts the RAM default lands
+/// within [MIN, MAX]). `pub(crate)` so `ring` can re-export it for that test.
+pub(crate) use cache::MIN_DEFAULT_HOSTING_BUDGET_BYTES;
 /// Re-exported as the single source of truth for the default hosting storage
 /// budget. `config::default_max_hosting_storage()` resolves to this function so
 /// the operator-facing default and the in-code fallback can never drift. The
 /// default is RAM-scaled (capability-relative, A2) rather than a flat constant.
 pub(crate) use cache::default_hosting_budget_bytes;
 pub use cache::{AccessType, RecordAccessResult};
-use cache::{DEFAULT_MIN_TTL, HostingCache, HostingCacheStats};
-/// Clamp bounds re-exported only for the config-default round-trip test, which
-/// asserts the resolved default lands within [MIN, MAX] without hardcoding the
-/// byte values. Gated to test builds so the re-export isn't an unused import
-/// under `-D warnings` in release.
-#[cfg(test)]
-pub(crate) use cache::{MAX_DEFAULT_HOSTING_BUDGET_BYTES, MIN_DEFAULT_HOSTING_BUDGET_BYTES};
+/// Aggregate disk-budget sizing defaults + pure clamp math (#4683). Re-exported
+/// so `config` can resolve the persisted `hosting-disk-pct` / `max-hosting-disk`
+/// defaults and `ring`/`HostingManager` can size the eviction floor.
+pub(crate) use cache::{DEFAULT_HOSTING_DISK_PCT, DEFAULT_MAX_HOSTING_DISK_BYTES};
+use cache::{DEFAULT_MIN_TTL, HostingCache, HostingCacheStats, disk_budget_for_clamped};
 use dashmap::{DashMap, DashSet};
 use demand::ProximityPrior;
 pub(crate) use disk_usage::DiskUsageStats;
@@ -348,6 +356,25 @@ pub(crate) struct HostingManager {
     /// that is PR 2 (eviction floor) and PR 3 (admission gate). Behind an
     /// `RwLock` for the same late-binding reason as `storage`.
     disk_tracker: RwLock<Option<DiskUsageTracker>>,
+
+    /// The RAM-derived hosting budget the manager was constructed with (#4683).
+    /// Preserved separately from the live `hosting_cache.budget_bytes` because
+    /// the 60s recompute OVERWRITES the cache budget with the effective floor
+    /// `min(ram_budget, disk_budget)`; keeping the original RAM budget here means
+    /// a later recompute (after the disk budget grows) can restore the RAM floor
+    /// instead of ratcheting only downward.
+    ram_budget_bytes: AtomicU64,
+
+    /// Fraction of Freenet-reachable disk capacity (`used + free`) the disk
+    /// budget is sized at (#4683). Defaults to
+    /// [`cache::DEFAULT_HOSTING_DISK_PCT`]; overridden from config at startup via
+    /// [`Self::configure_disk_budget`]. Stored as bits so it lives in an
+    /// `AtomicU64` (the recompute reads it off the sweep task without a lock).
+    disk_pct_bits: AtomicU64,
+
+    /// Hard upper clamp (bytes) for the disk budget (#4683), the `--max-hosting-disk`
+    /// override. Defaults to [`cache::DEFAULT_MAX_HOSTING_DISK_BYTES`].
+    max_hosting_disk_bytes: AtomicU64,
 }
 
 impl HostingManager {
@@ -391,6 +418,9 @@ impl HostingManager {
             state_generation: DashMap::new(),
             pending_reclamation: std::sync::Arc::new(DashMap::new()),
             disk_tracker: RwLock::new(None),
+            ram_budget_bytes: AtomicU64::new(budget_bytes),
+            disk_pct_bits: AtomicU64::new(DEFAULT_HOSTING_DISK_PCT.to_bits()),
+            max_hosting_disk_bytes: AtomicU64::new(DEFAULT_MAX_HOSTING_DISK_BYTES),
         }
     }
 
@@ -472,6 +502,52 @@ impl HostingManager {
         wasmtime_cache_dir: std::path::PathBuf,
     ) {
         *self.disk_tracker.write() = Some(DiskUsageTracker::new(contracts_dir, wasmtime_cache_dir));
+    }
+
+    /// Install the operator-configured disk-budget sizing knobs (#4683): the
+    /// fraction of Freenet-reachable disk capacity and the hard cap. Called once
+    /// at startup alongside [`Self::configure_disk_tracker`] (the config is only
+    /// reachable there). If never called, the defaults set in the ctor apply.
+    pub(crate) fn configure_disk_budget(&self, disk_pct: f64, max_hosting_disk: u64) {
+        self.disk_pct_bits
+            .store(disk_pct.to_bits(), Ordering::Relaxed);
+        self.max_hosting_disk_bytes
+            .store(max_hosting_disk, Ordering::Relaxed);
+    }
+
+    /// Recompute the effective hosting-cache budget as `min(ram_budget,
+    /// disk_budget)` and install it via [`HostingCache::set_budget_bytes`] (#4683,
+    /// eviction floor). Run on the 60s sweep AFTER the du-walks refresh, and
+    /// crucially OUTSIDE any prior cache write lock: only the O(1)
+    /// `set_budget_bytes` touches the cache lock here.
+    ///
+    /// `available` is the free bytes on the data-dir mount, injected as a
+    /// parameter (prod passes `available_bytes(dir).unwrap_or(u64::MAX)`; tests
+    /// pass a fixed value) — the determinism seam. When the tracker is absent or
+    /// unseeded the aggregate `used` is not yet meaningful, so this is a no-op and
+    /// the cache keeps its RAM budget until the first seed.
+    ///
+    /// Returns the effective budget it installed (for telemetry/tests), or `None`
+    /// when it was a no-op.
+    pub(crate) fn recompute_effective_budget(&self, available: u64) -> Option<u64> {
+        let used = {
+            let guard = self.disk_tracker.read();
+            let tracker = guard.as_ref()?;
+            if !tracker.is_seeded() {
+                return None;
+            }
+            tracker.total_bytes()
+        };
+        let pct = f64::from_bits(self.disk_pct_bits.load(Ordering::Relaxed));
+        let cap = self.max_hosting_disk_bytes.load(Ordering::Relaxed);
+        let ram = self.ram_budget_bytes.load(Ordering::Relaxed);
+        let disk_budget =
+            disk_budget_for_clamped(used, available, pct, MIN_DEFAULT_HOSTING_BUDGET_BYTES, cap);
+        let effective = ram.min(disk_budget);
+        // O(1) under the cache write lock; the expensive du-walk already ran
+        // OUTSIDE any lock before this call.
+        self.hosting_cache.write().set_budget_bytes(effective);
+        Some(effective)
     }
 
     /// Lazily seed the disk tracker on first use (like the hosting-cache
@@ -559,6 +635,13 @@ impl HostingManager {
         }
     }
 
+    /// Free bytes on the data-dir mount (the `available` term the disk budget
+    /// sizes against, #4683). `None` when the tracker is absent or the platform
+    /// query fails; the sweep caller falls back to `u64::MAX`.
+    pub(crate) fn disk_available_bytes(&self) -> Option<u64> {
+        self.disk_tracker.read().as_ref()?.available_bytes()
+    }
+
     /// Re-walk the WASM-blob and compile-cache totals. Called on the telemetry
     /// cadence (the 60s sweep) since both are `du`-measured, not delta-tracked.
     pub(crate) fn refresh_disk_usage(&self) {
@@ -577,6 +660,24 @@ impl HostingManager {
             return None;
         }
         Some(tracker.stats())
+    }
+
+    /// Test-only: install a disk tracker on nonexistent paths (so the du-walks
+    /// contribute 0 and the free-space read returns `None`) and seed its state
+    /// counter from `rows`. Lets `recompute_effective_budget` be driven with a
+    /// known `used` and an injected `available`, no filesystem required.
+    #[cfg(test)]
+    pub(crate) fn seed_disk_tracker_for_test<I>(&self, rows: I)
+    where
+        I: IntoIterator<Item = (ContractKey, u64)>,
+    {
+        self.configure_disk_tracker(
+            std::path::PathBuf::from("/nonexistent/contracts"),
+            std::path::PathBuf::from("/nonexistent/cache"),
+        );
+        if let Some(tracker) = self.disk_tracker.read().as_ref() {
+            tracker.seed(rows);
+        }
     }
 
     // =========================================================================
@@ -5340,5 +5441,119 @@ mod tests {
             "once the client subscription is gone the lease is no longer renewed \
              and lapses (chain collapse on interest loss)"
         );
+    }
+
+    // --- Eviction floor: effective = min(ram_budget, disk_budget) (#4683) ---
+
+    /// When disk is the tighter resource, the recompute lowers the cache budget
+    /// to the disk budget; when RAM is tighter, the RAM budget wins; when equal,
+    /// either (the shared value) is installed. Drives `recompute_effective_budget`
+    /// with a known `used` and an injected `available`, no filesystem.
+    #[test]
+    fn recompute_installs_min_of_ram_and_disk() {
+        const MIB: u64 = 1024 * 1024;
+        const GIB: u64 = 1024 * 1024 * 1024;
+
+        // RAM budget = 4 GiB (ctor). pct = 0.5.
+        let manager = HostingManager::new(4 * GIB);
+        manager.configure_disk_budget(0.5, DEFAULT_MAX_HOSTING_DISK_BYTES);
+        // Seed disk `used` = 2 GiB.
+        manager.seed_disk_tracker_for_test([(make_contract_key(1), 2 * GIB)]);
+
+        // Case DISK WINS: available small → disk_budget = 0.5*(2+2)=2 GiB < 4 GiB RAM.
+        let eff = manager
+            .recompute_effective_budget(2 * GIB)
+            .expect("seeded → recompute runs");
+        assert_eq!(eff, 2 * GIB, "disk is tighter → disk budget wins");
+        assert_eq!(manager.hosting_budget_bytes(), 2 * GIB);
+
+        // Case RAM WINS: available huge → disk_budget clamps to cap (32 GiB) > 4
+        // GiB RAM, so RAM floor wins.
+        let eff = manager
+            .recompute_effective_budget(u64::MAX)
+            .expect("seeded → recompute runs");
+        assert_eq!(eff, 4 * GIB, "RAM is tighter → RAM budget wins");
+        assert_eq!(manager.hosting_budget_bytes(), 4 * GIB);
+
+        // Case EQUAL: choose available so disk_budget == RAM budget exactly.
+        // 0.5*(used=2 GiB + available) = 4 GiB → available = 6 GiB.
+        let eff = manager
+            .recompute_effective_budget(6 * GIB)
+            .expect("seeded → recompute runs");
+        assert_eq!(eff, 4 * GIB, "equal budgets install the shared value");
+        assert_eq!(manager.hosting_budget_bytes(), 4 * GIB);
+
+        // Below the MIN floor: a tiny disk budget can never drop below the 128
+        // MiB floor even when RAM is also small.
+        let small = HostingManager::new(64 * MIB);
+        small.configure_disk_budget(0.5, DEFAULT_MAX_HOSTING_DISK_BYTES);
+        small.seed_disk_tracker_for_test(std::iter::empty());
+        let eff = small.recompute_effective_budget(0).expect("seeded");
+        assert_eq!(
+            eff,
+            64 * MIB,
+            "RAM budget (64 MiB) is below the disk MIN floor and wins as the min"
+        );
+    }
+
+    /// An unseeded (or absent) tracker makes the recompute a no-op: the cache
+    /// keeps its RAM budget until the first seed, so early startup never installs
+    /// a bogus zero/under-counted floor.
+    #[test]
+    fn recompute_is_noop_until_seeded() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        let manager = HostingManager::new(GIB);
+
+        // No tracker configured at all → None, budget untouched.
+        assert_eq!(manager.recompute_effective_budget(0), None);
+        assert_eq!(manager.hosting_budget_bytes(), GIB);
+
+        // Tracker configured but NOT seeded → still None.
+        manager.configure_disk_tracker(
+            std::path::PathBuf::from("/nonexistent/contracts"),
+            std::path::PathBuf::from("/nonexistent/cache"),
+        );
+        assert_eq!(manager.recompute_effective_budget(0), None);
+        assert_eq!(manager.hosting_budget_bytes(), GIB);
+    }
+
+    /// The recompute takes only the O(1) `set_budget_bytes` cache write lock, so
+    /// it cannot deadlock against a concurrent `record_access_with_demand` (which
+    /// also takes the cache write lock). Interleave many recomputes with many
+    /// cache accesses from another thread and require completion.
+    #[test]
+    fn recompute_does_not_deadlock_against_cache_writes() {
+        use std::sync::Arc;
+        const GIB: u64 = 1024 * 1024 * 1024;
+
+        let manager = Arc::new(HostingManager::new(4 * GIB));
+        manager.configure_disk_budget(0.5, DEFAULT_MAX_HOSTING_DISK_BYTES);
+        manager.seed_disk_tracker_for_test([(make_contract_key(1), GIB)]);
+
+        let m2 = manager.clone();
+        let writer = std::thread::spawn(move || {
+            for i in 0..500u64 {
+                // record_contract_access takes the hosting_cache write lock.
+                m2.record_contract_access(
+                    make_contract_key((i % 250) as u8),
+                    i % 4096,
+                    AccessType::Get,
+                );
+            }
+        });
+
+        for i in 0..500u64 {
+            // Alternate the injected available so the installed floor varies,
+            // exercising the set_budget_bytes path each iteration.
+            let available = (i % 8) * GIB;
+            manager.recompute_effective_budget(available);
+        }
+        writer
+            .join()
+            .expect("writer thread must not deadlock/panic");
+
+        // Sanity: after the storm the cache budget is a valid min(ram, disk).
+        let b = manager.hosting_budget_bytes();
+        assert!(b <= 4 * GIB, "effective budget never exceeds the RAM floor");
     }
 }

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -119,6 +119,87 @@ fn budget_for_ram(total_ram: u64) -> u64 {
     )
 }
 
+/// Default fraction of the disk capacity *available to Freenet* used to size the
+/// aggregate disk budget (#4683): 50%. Sized against `used + free` (capacity the
+/// node can actually reach), NOT a naive live free-space read that shrinks as it
+/// fills. Operator-overridable via `--hosting-disk-pct`.
+pub const DEFAULT_HOSTING_DISK_PCT: f64 = 0.5;
+
+/// Default hard upper clamp for the aggregate disk budget (#4683): 32 GiB.
+///
+/// Distinct from [`MAX_DEFAULT_HOSTING_BUDGET_BYTES`] (the 1 GiB RAM-scaled
+/// ceiling) on purpose: a disk budget legitimately dwarfs the RAM budget on a
+/// host with a large data disk, so this cap is far higher. Operator-overridable
+/// via `--max-hosting-disk`; the shared MIN floor is
+/// [`MIN_DEFAULT_HOSTING_BUDGET_BYTES`] so even a tiny disk still gets a usable
+/// allowance.
+pub const DEFAULT_MAX_HOSTING_DISK_BYTES: u64 = 32 * 1024 * 1024 * 1024;
+
+/// Pure clamp math for the aggregate disk budget (#4683), the disk analogue of
+/// [`budget_for_ram`]. Split out with no filesystem dependency so the
+/// zero/huge/overflow boundary behavior is unit-testable without a real disk.
+///
+/// Returns `clamp(pct * (freenet_used + available), MIN, max_hosting_disk)`,
+/// where the basis is the disk capacity *reachable by Freenet* (bytes it already
+/// occupies plus bytes still free on the same mount), NOT a bare free-space read.
+/// Anchoring on `used + available` keeps the budget stable as the disk fills
+/// (a naive free-space basis would shrink the budget toward zero exactly when
+/// the node needs the eviction floor most).
+///
+/// `pct` is clamped to `[0.0, 1.0]` and non-finite / negative values collapse to
+/// `0.0`, so a mis-set config can only ever produce a valid budget. All fixed-
+/// point conversion saturates rather than wrapping, so a huge `used + available`
+/// cannot overflow into a small budget.
+///
+// Default-bound convenience entry: the recompute path uses
+// `disk_budget_for_clamped` with the operator cap, so this constant-bound form
+// is exercised by tests and reserved for the PR 3 admission gate.
+#[allow(dead_code)]
+pub fn disk_budget_for(freenet_used: u64, available: u64, pct: f64) -> u64 {
+    disk_budget_for_clamped(
+        freenet_used,
+        available,
+        pct,
+        MIN_DEFAULT_HOSTING_BUDGET_BYTES,
+        DEFAULT_MAX_HOSTING_DISK_BYTES,
+    )
+}
+
+/// [`disk_budget_for`] with explicit MIN/MAX clamp bounds, so the operator
+/// override (`--max-hosting-disk`) can supply the ceiling. Kept separate from
+/// the constant-bound wrapper so the pure math has one implementation.
+pub fn disk_budget_for_clamped(
+    freenet_used: u64,
+    available: u64,
+    pct: f64,
+    min_bytes: u64,
+    max_bytes: u64,
+) -> u64 {
+    // A non-finite or negative pct is meaningless — collapse to 0 (which the
+    // clamp then lifts to the MIN floor), never NaN-propagate into the budget.
+    let pct = if pct.is_finite() {
+        pct.clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let basis = freenet_used.saturating_add(available);
+    // f64 has 52 bits of mantissa; a basis above 2^52 loses precision but the
+    // result is clamped to `max_bytes` anyway, so the loss is immaterial.
+    let raw = (basis as f64) * pct;
+    // Saturating fixed-point conversion: a raw value beyond u64::MAX (only
+    // reachable via precision noise near the top of the range) clamps down
+    // rather than wrapping. `as u64` on a non-finite/negative f64 is 0 in Rust,
+    // but `raw` is already non-negative and finite here.
+    let budget = if raw >= u64::MAX as f64 {
+        u64::MAX
+    } else {
+        raw as u64
+    };
+    // If the operator set max below min, MIN wins (a usable floor beats an
+    // inconsistent zero cap): clamp lower bound last.
+    budget.min(max_bytes).max(min_bytes)
+}
+
 /// Point-in-time hosting-cache resource gauges for per-node telemetry.
 ///
 /// Aggregate scalars only (never per-contract), emitted on the existing
@@ -847,6 +928,16 @@ impl<T: TimeSource> HostingCache<T> {
     #[allow(dead_code)] // Public API for introspection
     pub fn budget_bytes(&self) -> u64 {
         self.budget_bytes
+    }
+
+    /// Overwrite the byte budget (#4683 eviction floor). The ONLY writer after
+    /// the constructor: the 60s recompute sets this to
+    /// `min(ram_budget, disk_budget)` so the existing Greedy-Dual over-budget
+    /// walk sheds the least-valuable contracts down to the tighter of the two
+    /// resource floors. O(1) and does NOT itself evict — the next
+    /// `evict_over_budget` (on sweep or cache insert) enforces the new value.
+    pub(crate) fn set_budget_bytes(&mut self, budget_bytes: u64) {
+        self.budget_bytes = budget_bytes;
     }
 
     /// Snapshot the cache's aggregate resource gauges under a single read for
@@ -1865,6 +1956,112 @@ mod tests {
         // give distinct budgets.
         assert_ne!(budget_for_ram(2 * GIB), budget_for_ram(3 * GIB));
         assert_ne!(budget_for_ram(3 * GIB), budget_for_ram(4 * GIB));
+    }
+
+    // --- Aggregate disk budget sizing (#4683) ---
+
+    /// `disk_budget_for` clamps at both ends and scales linearly in between.
+    #[test]
+    fn disk_budget_for_scales_and_clamps() {
+        // pct * (used + avail) below the MIN floor clamps up.
+        assert_eq!(
+            disk_budget_for(0, 100 * MIB, 0.5),
+            MIN_DEFAULT_HOSTING_BUDGET_BYTES,
+            "50 MiB budget is below the 128 MiB floor"
+        );
+        // Mid-range scales linearly: 0.5 * (used=4 GiB + avail=4 GiB) = 4 GiB.
+        assert_eq!(disk_budget_for(4 * GIB, 4 * GIB, 0.5), 4 * GIB);
+        // used counts toward the basis, not just free space.
+        assert_eq!(disk_budget_for(2 * GIB, 0, 0.5), GIB);
+        // Above the MAX cap clamps down.
+        assert_eq!(
+            disk_budget_for(200 * GIB, 200 * GIB, 0.5),
+            DEFAULT_MAX_HOSTING_DISK_BYTES,
+            "200 GiB budget is above the 32 GiB cap"
+        );
+    }
+
+    /// pct=0 and pct=1 are the degenerate endpoints; both stay within the clamp.
+    #[test]
+    fn disk_budget_for_pct_endpoints() {
+        // pct=0 → 0, clamped up to MIN.
+        assert_eq!(
+            disk_budget_for(10 * GIB, 10 * GIB, 0.0),
+            MIN_DEFAULT_HOSTING_BUDGET_BYTES
+        );
+        // pct=1 → full basis, clamped down to MAX when the basis is large.
+        assert_eq!(
+            disk_budget_for(100 * GIB, 0, 1.0),
+            DEFAULT_MAX_HOSTING_DISK_BYTES
+        );
+        // pct=1 with a small in-band basis passes through unclamped.
+        assert_eq!(disk_budget_for(GIB, GIB, 1.0), 2 * GIB);
+    }
+
+    /// Zero free / zero used degenerate inputs never panic and honor the floor.
+    #[test]
+    fn disk_budget_for_zero_and_huge_free() {
+        // Everything zero → MIN floor.
+        assert_eq!(disk_budget_for(0, 0, 0.5), MIN_DEFAULT_HOSTING_BUDGET_BYTES);
+        // Huge free (the `available_bytes` MAX-fallback case) does NOT overflow;
+        // it clamps to the MAX cap.
+        assert_eq!(
+            disk_budget_for(0, u64::MAX, 0.5),
+            DEFAULT_MAX_HOSTING_DISK_BYTES
+        );
+    }
+
+    /// A non-finite / out-of-range pct collapses to a valid budget rather than
+    /// propagating NaN or a nonsense value into the eviction floor.
+    #[test]
+    fn disk_budget_for_rejects_bad_pct() {
+        // NaN / infinity → 0 → clamped up to MIN.
+        assert_eq!(
+            disk_budget_for(10 * GIB, 10 * GIB, f64::NAN),
+            MIN_DEFAULT_HOSTING_BUDGET_BYTES
+        );
+        assert_eq!(
+            disk_budget_for(10 * GIB, 10 * GIB, f64::INFINITY),
+            MIN_DEFAULT_HOSTING_BUDGET_BYTES
+        );
+        // Negative pct clamps to 0 → MIN.
+        assert_eq!(
+            disk_budget_for(10 * GIB, 10 * GIB, -1.0),
+            MIN_DEFAULT_HOSTING_BUDGET_BYTES
+        );
+        // pct > 1 clamps to 1.0 (full basis), then to MAX.
+        assert_eq!(
+            disk_budget_for(100 * GIB, 0, 5.0),
+            DEFAULT_MAX_HOSTING_DISK_BYTES
+        );
+    }
+
+    /// Saturating fixed-point: `used + available` overflow saturates the basis
+    /// at `u64::MAX` (never wraps to a tiny basis), then the pct+clamp bound it.
+    #[test]
+    fn disk_budget_for_saturating_overflow() {
+        // used + avail overflows u64 → basis saturates at u64::MAX, budget
+        // clamps to the MAX cap rather than wrapping to something small.
+        assert_eq!(
+            disk_budget_for(u64::MAX, u64::MAX, 0.5),
+            DEFAULT_MAX_HOSTING_DISK_BYTES
+        );
+    }
+
+    /// Explicit clamp bounds (the operator `--max-hosting-disk` override) win,
+    /// and an inconsistent max<min still yields the usable MIN floor (never 0).
+    #[test]
+    fn disk_budget_for_clamped_honors_explicit_bounds() {
+        // Custom max below the computed value clamps down to it.
+        assert_eq!(
+            disk_budget_for_clamped(4 * GIB, 4 * GIB, 0.5, MIN_DEFAULT_HOSTING_BUDGET_BYTES, GIB),
+            GIB
+        );
+        // max < min → MIN floor wins (no panic, no zero cap).
+        assert_eq!(
+            disk_budget_for_clamped(100 * GIB, 0, 0.5, 512 * MIB, 128 * MIB),
+            512 * MIB
+        );
     }
 
     /// The real resolved default always lands within the documented clamp,

--- a/crates/core/src/ring/hosting/disk_usage.rs
+++ b/crates/core/src/ring/hosting/disk_usage.rs
@@ -1,0 +1,570 @@
+//! Aggregate on-disk usage accounting for demand-driven hosting (#4683).
+//!
+//! The demand-driven hosting budget (#4642) sizes itself from **memory** only.
+//! For a disk-constrained host, disk — not RAM — is the scarcest resource, yet
+//! nothing bounds disk in aggregate today. [`DiskUsageTracker`] is the shared
+//! source of truth that the future disk budget (eviction floor `min(ram, disk)`
+//! in PR 2, admission gate in PR 3) reads. This PR wires only the accounting +
+//! telemetry: the tracker is populated and observable but does not yet change
+//! any admission or eviction decision (zero behavior change).
+//!
+//! # What is counted
+//!
+//! Three independently-measured consumers, summed by [`DiskUsageTracker::total_bytes`]:
+//!
+//! - **Hosted contract state** — the exact byte total of persisted contract
+//!   state. Seeded once by summing every row's
+//!   [`HostingMetadata::size_bytes`](crate::contract::storages::HostingMetadata)
+//!   and thereafter maintained by signed deltas at the executor's state-write
+//!   chokepoints (via [`super::HostingManager::record_state_write`]) and at
+//!   reclamation (via [`super::HostingManager::record_state_removed`]). A small
+//!   per-key size index makes the delta exact without re-reading the DB.
+//! - **WASM code blobs** — the `*.wasm` files under `contracts_dir`. Re-walked
+//!   (`du`) on seed and on each telemetry refresh; blobs dedupe by `code_hash`
+//!   so a re-PUT of already-stored code adds nothing.
+//! - **Wasmtime compile cache** — wasmtime writes it opaquely, so it is not
+//!   delta-tracked; it is re-walked on each telemetry refresh. Cheap: bounded by
+//!   the number of distinct compiled modules and self-pruned by wasmtime at its
+//!   soft-size limit.
+//!
+//! # Seeding discipline (fail-loud)
+//!
+//! [`DiskUsageTracker::seed`] mirrors the #4561 secrets `seeded_user_total`
+//! discipline: it walks the real on-disk state ONCE and is **fail-loud** on I/O
+//! error. A silently-too-low seed would defeat the future admission gate (it
+//! would admit writes that actually overflow disk), so a seed that cannot read
+//! the truth must surface the error rather than start from an under-count.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use freenet_stdlib::prelude::ContractKey;
+use parking_lot::Mutex;
+
+/// Point-in-time on-disk usage gauges, one snapshot for telemetry.
+///
+/// Aggregate scalars only, emitted on the existing `RouterSnapshot` cadence
+/// alongside the RAM-budget gauges so the disk-budget feature is observable in
+/// production before any enforcement ships.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct DiskUsageStats {
+    /// Persisted contract-state bytes (delta-tracked, seeded from redb rows).
+    pub state_bytes: u64,
+    /// On-disk WASM code blob bytes (`du` of `contracts_dir/*.wasm`).
+    pub wasm_bytes: u64,
+    /// Wasmtime compile-cache bytes (`du` of the relocated cache dir).
+    pub compile_cache_bytes: u64,
+    /// Sum of the three above — the aggregate the disk budget will bound.
+    pub total_bytes: u64,
+}
+
+/// Signed-delta + seed-once tracker for aggregate hosting disk usage.
+///
+/// Cheap to read (three `AtomicU64` loads for [`Self::total_bytes`]); the only
+/// expensive operations are [`Self::seed`] and the two `refresh_*` `du`-walks,
+/// which run off the hot path (lazy seed on the first sweep tick, refresh on the
+/// 60s telemetry cadence).
+pub(crate) struct DiskUsageTracker {
+    /// Persisted contract-state bytes. Maintained by signed deltas.
+    state_bytes: AtomicU64,
+    /// On-disk WASM blob bytes. Refreshed by `du`-walk.
+    wasm_bytes: AtomicU64,
+    /// Wasmtime compile-cache bytes. Refreshed by `du`-walk.
+    compile_cache_bytes: AtomicU64,
+    /// One-time seed guard (like the secrets `seeded_user_total` flag).
+    seeded: AtomicBool,
+    /// Per-contract last-known state size, so a state-write delta is exact
+    /// (`new − previous_for_key`) without re-reading the DB at the chokepoint.
+    /// Seeded from the same redb rows that seed `state_bytes`.
+    state_sizes: Mutex<HashMap<ContractKey, u64>>,
+    /// Directory holding `*.wasm` code blobs (mode-resolved `contracts_dir`).
+    contracts_dir: PathBuf,
+    /// Relocated wasmtime compile-cache directory (on the data-dir mount).
+    compile_cache_dir: PathBuf,
+}
+
+impl DiskUsageTracker {
+    /// Create an unseeded tracker. All counters start at zero; call
+    /// [`Self::seed`] once before the counts are meaningful.
+    pub(crate) fn new(contracts_dir: PathBuf, compile_cache_dir: PathBuf) -> Self {
+        Self {
+            state_bytes: AtomicU64::new(0),
+            wasm_bytes: AtomicU64::new(0),
+            compile_cache_bytes: AtomicU64::new(0),
+            seeded: AtomicBool::new(false),
+            state_sizes: Mutex::new(HashMap::new()),
+            contracts_dir,
+            compile_cache_dir,
+        }
+    }
+
+    /// Whether [`Self::seed`] has already run successfully.
+    pub(crate) fn is_seeded(&self) -> bool {
+        self.seeded.load(Ordering::Acquire)
+    }
+
+    /// Aggregate on-disk bytes = state + wasm + compile-cache. The value the
+    /// disk budget bounds. Cheap (three atomic loads).
+    ///
+    /// The eviction floor (PR 2) and admission gate (PR 3) are the first
+    /// runtime readers; in this accounting-only PR it is exercised by tests and
+    /// the telemetry snapshot path.
+    #[allow(dead_code)]
+    pub(crate) fn total_bytes(&self) -> u64 {
+        self.state_bytes
+            .load(Ordering::Relaxed)
+            .saturating_add(self.wasm_bytes.load(Ordering::Relaxed))
+            .saturating_add(self.compile_cache_bytes.load(Ordering::Relaxed))
+    }
+
+    /// Snapshot all gauges for telemetry.
+    pub(crate) fn stats(&self) -> DiskUsageStats {
+        let state_bytes = self.state_bytes.load(Ordering::Relaxed);
+        let wasm_bytes = self.wasm_bytes.load(Ordering::Relaxed);
+        let compile_cache_bytes = self.compile_cache_bytes.load(Ordering::Relaxed);
+        DiskUsageStats {
+            state_bytes,
+            wasm_bytes,
+            compile_cache_bytes,
+            total_bytes: state_bytes
+                .saturating_add(wasm_bytes)
+                .saturating_add(compile_cache_bytes),
+        }
+    }
+
+    /// Seed the state-bytes counter and per-key size index from an exact list of
+    /// `(contract, state_size)` pairs (the caller reads these from redb rows so
+    /// this module stays storage-backend-agnostic and unit-testable). Also runs
+    /// the initial WASM + compile-cache `du`-walks.
+    ///
+    /// Idempotent-guarded: only the FIRST call takes effect; later calls are a
+    /// no-op so a racing second sweep tick cannot double-count.
+    ///
+    /// Fail-loud contract: the caller MUST pass the true on-disk state total. A
+    /// silently-too-low seed would let the future admission gate admit
+    /// overflowing writes — the exact failure the #4561 secrets seed discipline
+    /// guards against.
+    ///
+    /// # Seed/write race (TOCTOU) closure
+    ///
+    /// The caller snapshots redb rows at some time `T0` while `seeded` is still
+    /// false, then calls this. A concurrent [`Self::record_state_write`] whose
+    /// bytes land AFTER `T0` is NOT in `state_rows`, but it is NOT dropped
+    /// either: `record_state_write` always records its post-write size into
+    /// `state_sizes` (even while unseeded), and this seed treats an
+    /// already-present key as authoritative — the concurrent write's true size
+    /// wins over the (older, possibly absent) redb-snapshot value. The final
+    /// `state_bytes` is recomputed from the merged map under the same lock that
+    /// serializes writes, so every write is counted exactly once regardless of
+    /// whether its redb row made it into the snapshot. This is the lock-based
+    /// close of the window flagged in the PR-1 review (would otherwise become a
+    /// load-bearing under-count once PR 3 turns the counter into a gate input).
+    pub(crate) fn seed<I>(&self, state_rows: I)
+    where
+        I: IntoIterator<Item = (ContractKey, u64)>,
+    {
+        // Take the write-serializing lock FIRST, then flip `seeded` under it, so
+        // a concurrent `record_state_write` either (a) ran before us and its
+        // size is already in `state_sizes` (we preserve it), or (b) blocks on
+        // this lock and runs as a delta after we store the aggregate. It can
+        // never fall in a gap where it is neither seeded-in nor deltaed-in.
+        let mut sizes = self.state_sizes.lock();
+
+        // Only the first seed wins. `compare_exchange` so a concurrent caller
+        // that lost the race returns without touching any counter.
+        if self
+            .seeded
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        for (key, size) in state_rows {
+            // A concurrent post-`T0` write may already have recorded this key's
+            // true post-write size while we were unseeded. That value is newer
+            // and authoritative — do NOT overwrite it with the stale snapshot.
+            // Only rows not already buffered by such a write are inserted.
+            //
+            // A contract can have multiple instance rows in the snapshot; when
+            // this is a fresh insert, sum the rows rather than overwrite.
+            match sizes.entry(key) {
+                std::collections::hash_map::Entry::Occupied(_) => {}
+                std::collections::hash_map::Entry::Vacant(v) => {
+                    v.insert(0);
+                    let entry = sizes.get_mut(&key).expect("just inserted");
+                    *entry = entry.saturating_add(size);
+                }
+            }
+        }
+        // Recompute the aggregate from the merged map so buffered concurrent
+        // writes are reflected exactly.
+        let total = sizes
+            .values()
+            .copied()
+            .fold(0u64, |acc, v| acc.saturating_add(v));
+        self.state_bytes.store(total, Ordering::Relaxed);
+        drop(sizes);
+
+        self.wasm_bytes
+            .store(du_walk_wasm(&self.contracts_dir), Ordering::Relaxed);
+        self.compile_cache_bytes
+            .store(du_walk(&self.compile_cache_dir), Ordering::Relaxed);
+    }
+
+    /// Apply a state-write at a chokepoint: set `key`'s tracked size to
+    /// `new_size` and adjust `state_bytes` by the signed delta against the
+    /// previous size for that key (0 if unseen).
+    ///
+    /// PUT of a new contract → `+new`. UPDATE of an existing one →
+    /// `+(new − old)` (shrinking updates subtract). Called from
+    /// [`super::HostingManager::record_state_write`] on the infallible
+    /// post-write path (`Ring::commit_state_write`), so the counter only moves
+    /// after the bytes actually landed.
+    ///
+    /// # Unseeded writes
+    ///
+    /// Even before [`Self::seed`] runs, this records `new_size` into
+    /// `state_sizes` (but does NOT touch `state_bytes` — the aggregate is
+    /// meaningless until seeded). This is what closes the seed/write TOCTOU: a
+    /// write that races the seed leaves its true size in the map for the seed to
+    /// pick up, instead of being silently dropped and permanently under-counted.
+    /// Once seeded, it additionally applies the signed delta to `state_bytes`.
+    /// The `state_sizes` lock serializes this against [`Self::seed`], so the
+    /// seeded/unseeded branch is decided atomically with respect to the seed.
+    pub(crate) fn record_state_write(&self, key: &ContractKey, new_size: u64) {
+        let mut sizes = self.state_sizes.lock();
+        let old = sizes.insert(*key, new_size).unwrap_or(0);
+        // While unseeded, only buffer the size; `state_bytes` is recomputed from
+        // the map at seed time, so applying a delta now would be wrong (and the
+        // aggregate is not yet meaningful). The map insert above is the record
+        // that the seed will honor.
+        if !self.seeded.load(Ordering::Acquire) {
+            return;
+        }
+        drop(sizes);
+        if new_size >= old {
+            self.state_bytes
+                .fetch_add(new_size - old, Ordering::Relaxed);
+        } else {
+            // saturating_sub floors at 0: a delta can never drive the aggregate
+            // negative even if the seed under-counted this key.
+            let dec = old - new_size;
+            let mut cur = self.state_bytes.load(Ordering::Relaxed);
+            loop {
+                let next = cur.saturating_sub(dec);
+                match self.state_bytes.compare_exchange_weak(
+                    cur,
+                    next,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => break,
+                    Err(observed) => cur = observed,
+                }
+            }
+        }
+    }
+
+    /// Remove `key`'s state contribution on eviction/reclamation: subtract its
+    /// last-known size (floored at 0) and forget the key. Idempotent — a second
+    /// removal of an already-forgotten key subtracts nothing (floor-at-0).
+    ///
+    /// While unseeded, only forgets the buffered size (mirrors the unseeded
+    /// branch of [`Self::record_state_write`]): `state_bytes` is recomputed from
+    /// the map at seed time, so removing the key from the map is sufficient and
+    /// applying a delta now would be wrong.
+    pub(crate) fn record_state_removed(&self, key: &ContractKey) {
+        let mut sizes = self.state_sizes.lock();
+        let removed = sizes.remove(key).unwrap_or(0);
+        if !self.seeded.load(Ordering::Acquire) {
+            return;
+        }
+        drop(sizes);
+        if removed == 0 {
+            return;
+        }
+        let mut cur = self.state_bytes.load(Ordering::Relaxed);
+        loop {
+            let next = cur.saturating_sub(removed);
+            match self.state_bytes.compare_exchange_weak(
+                cur,
+                next,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(observed) => cur = observed,
+            }
+        }
+    }
+
+    /// Re-measure the on-disk WASM blob total by `du`-walking `contracts_dir`.
+    /// Cheap and re-run on the telemetry cadence; deduping is inherent (each
+    /// distinct `code_hash` is one file).
+    pub(crate) fn refresh_wasm(&self) {
+        self.wasm_bytes
+            .store(du_walk_wasm(&self.contracts_dir), Ordering::Relaxed);
+    }
+
+    /// Re-measure the wasmtime compile-cache total by `du`-walking its dir.
+    /// Wasmtime writes the cache opaquely, so this re-walk (not a delta) is the
+    /// only way to account for it.
+    pub(crate) fn refresh_compile_cache(&self) {
+        self.compile_cache_bytes
+            .store(du_walk(&self.compile_cache_dir), Ordering::Relaxed);
+    }
+}
+
+/// Recursively sum the byte size of every regular file under `dir`. A missing
+/// directory (not yet created) or an unreadable entry contributes 0 rather than
+/// erroring — the refresh path is best-effort telemetry, unlike the fail-loud
+/// state seed.
+fn du_walk(dir: &Path) -> u64 {
+    let mut total: u64 = 0;
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&path) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                stack.push(entry.path());
+            } else if file_type.is_file() {
+                if let Ok(meta) = entry.metadata() {
+                    total = total.saturating_add(meta.len());
+                }
+            }
+        }
+    }
+    total
+}
+
+/// Like [`du_walk`] but only counts `*.wasm` files — the code-blob subset of
+/// `contracts_dir` (which also holds the `local/` mode split). Directory
+/// traversal is recursive so both the network and `local/` blobs are counted.
+fn du_walk_wasm(dir: &Path) -> u64 {
+    let mut total: u64 = 0;
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&path) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                stack.push(entry.path());
+            } else if file_type.is_file() {
+                let p = entry.path();
+                if p.extension().and_then(|e| e.to_str()) == Some("wasm") {
+                    if let Ok(meta) = entry.metadata() {
+                        total = total.saturating_add(meta.len());
+                    }
+                }
+            }
+        }
+    }
+    total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+    use std::io::Write;
+
+    fn test_key(seed: u8) -> ContractKey {
+        let instance = ContractInstanceId::new([seed; 32]);
+        let code = CodeHash::new([seed; 32]);
+        ContractKey::from_id_and_code(instance, code)
+    }
+
+    fn tracker() -> DiskUsageTracker {
+        // Nonexistent dirs → du-walks contribute 0, isolating state-delta math.
+        DiskUsageTracker::new(
+            PathBuf::from("/nonexistent/contracts"),
+            PathBuf::from("/nonexistent/cache"),
+        )
+    }
+
+    #[test]
+    fn seed_sums_state_rows_and_is_idempotent() {
+        let t = tracker();
+        assert!(!t.is_seeded());
+        t.seed([(test_key(1), 100), (test_key(2), 50)]);
+        assert!(t.is_seeded());
+        assert_eq!(t.stats().state_bytes, 150);
+        // A second seed must be a no-op (no double-count).
+        t.seed([(test_key(3), 999)]);
+        assert_eq!(t.stats().state_bytes, 150);
+    }
+
+    #[test]
+    fn put_new_contract_adds_full_size() {
+        let t = tracker();
+        t.seed(std::iter::empty());
+        t.record_state_write(&test_key(1), 200);
+        assert_eq!(t.stats().state_bytes, 200);
+        assert_eq!(t.total_bytes(), 200);
+    }
+
+    #[test]
+    fn update_grow_adds_delta() {
+        let t = tracker();
+        t.seed([(test_key(1), 100)]);
+        t.record_state_write(&test_key(1), 250);
+        assert_eq!(t.stats().state_bytes, 250); // +150 delta, not +250
+    }
+
+    #[test]
+    fn update_shrink_subtracts_delta() {
+        let t = tracker();
+        t.seed([(test_key(1), 300)]);
+        t.record_state_write(&test_key(1), 100);
+        assert_eq!(t.stats().state_bytes, 100); // -200 delta
+    }
+
+    #[test]
+    fn evict_removes_full_size() {
+        let t = tracker();
+        t.seed([(test_key(1), 100), (test_key(2), 40)]);
+        t.record_state_removed(&test_key(1));
+        assert_eq!(t.stats().state_bytes, 40);
+    }
+
+    #[test]
+    fn double_evict_floors_at_zero() {
+        let t = tracker();
+        t.seed([(test_key(1), 100)]);
+        t.record_state_removed(&test_key(1));
+        // Second removal of the same key subtracts nothing (key forgotten).
+        t.record_state_removed(&test_key(1));
+        assert_eq!(t.stats().state_bytes, 0);
+    }
+
+    #[test]
+    fn removal_never_drives_aggregate_negative() {
+        let t = tracker();
+        // Seed under-counts key(1) (size 10) but the true write was larger.
+        t.seed([(test_key(1), 10)]);
+        // A shrink whose "old" (10) exceeds current would floor at 0, not wrap.
+        t.record_state_write(&test_key(2), 5); // total now 15
+        t.record_state_removed(&test_key(2)); // -5 -> 10
+        t.record_state_removed(&test_key(1)); // -10 -> 0
+        assert_eq!(t.stats().state_bytes, 0);
+    }
+
+    #[test]
+    fn wasm_dedup_rewalk_counts_each_blob_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let contracts = dir.path().join("contracts");
+        std::fs::create_dir_all(contracts.join("local")).unwrap();
+        // Two distinct blobs + a non-wasm file that must NOT be counted.
+        let mut a = std::fs::File::create(contracts.join("aaaa.wasm")).unwrap();
+        a.write_all(&[0u8; 100]).unwrap();
+        let mut b = std::fs::File::create(contracts.join("local").join("bbbb.wasm")).unwrap();
+        b.write_all(&[0u8; 40]).unwrap();
+        let mut junk = std::fs::File::create(contracts.join("index.db")).unwrap();
+        junk.write_all(&[0u8; 1000]).unwrap();
+
+        let t = DiskUsageTracker::new(contracts.clone(), dir.path().join("cache"));
+        t.seed(std::iter::empty());
+        assert_eq!(t.stats().wasm_bytes, 140);
+        // Re-walking is deduped by construction (same files) — idempotent.
+        t.refresh_wasm();
+        assert_eq!(t.stats().wasm_bytes, 140);
+    }
+
+    #[test]
+    fn unseeded_write_is_buffered_and_survives_seed() {
+        // A write that lands while the tracker is unseeded (its redb row not yet
+        // in the snapshot the caller will pass to `seed`) must NOT be dropped:
+        // its true size is buffered and the seed reconciles to it, rather than
+        // permanently under-counting the key. Regression for the PR-1 seed/write
+        // TOCTOU review finding.
+        let t = tracker();
+        // Write arrives before seed; aggregate not yet meaningful.
+        t.record_state_write(&test_key(1), 200);
+        assert!(!t.is_seeded());
+        // Seed with a DIFFERENT key only (the racing write's redb row was not in
+        // the snapshot). The buffered write must still be counted.
+        t.seed([(test_key(2), 50)]);
+        assert_eq!(t.stats().state_bytes, 250);
+        assert_eq!(t.total_bytes(), 250);
+    }
+
+    #[test]
+    fn seed_prefers_concurrent_write_size_over_stale_snapshot() {
+        // If the same key appears both as a buffered post-seed write AND in the
+        // redb snapshot, the newer write size (not the stale snapshot) wins, and
+        // it is counted exactly once (no double-add).
+        let t = tracker();
+        t.record_state_write(&test_key(1), 300); // newer, post-snapshot size
+        t.seed([(test_key(1), 100)]); // stale snapshot value for same key
+        assert_eq!(t.stats().state_bytes, 300);
+    }
+
+    #[test]
+    fn racing_write_against_seed_yields_exact_total() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering as O};
+        // Stress the seed/write race across threads: a writer thread hammers
+        // `record_state_write` for a key NOT in the seed snapshot while the main
+        // thread seeds. Regardless of interleaving, the final aggregate must
+        // equal the true on-disk total (seed rows + the racing key's final size),
+        // never under-count. Run many iterations to shake out orderings.
+        for _ in 0..200 {
+            let t = Arc::new(tracker());
+            let go = Arc::new(AtomicBool::new(false));
+            let writer = {
+                let t = Arc::clone(&t);
+                let go = Arc::clone(&go);
+                std::thread::spawn(move || {
+                    while !go.load(O::Acquire) {
+                        std::hint::spin_loop();
+                    }
+                    // Final size for the racing key is 500.
+                    t.record_state_write(&test_key(9), 100);
+                    t.record_state_write(&test_key(9), 500);
+                })
+            };
+            go.store(true, O::Release);
+            // Seed with two unrelated keys totalling 150.
+            t.seed([(test_key(1), 100), (test_key(2), 50)]);
+            writer.join().unwrap();
+            // True total = 150 (seeded) + 500 (racing key's final size). The
+            // racing key must be present exactly once at its final size.
+            assert_eq!(
+                t.stats().state_bytes,
+                650,
+                "seed/write race under-counted or double-counted"
+            );
+        }
+    }
+
+    #[test]
+    fn compile_cache_du_walk_seeds_and_refreshes() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = dir.path().join("cache");
+        std::fs::create_dir_all(cache.join("sub")).unwrap();
+        let mut f = std::fs::File::create(cache.join("sub").join("mod.cache")).unwrap();
+        f.write_all(&[0u8; 512]).unwrap();
+
+        let t = DiskUsageTracker::new(dir.path().join("contracts"), cache.clone());
+        t.seed(std::iter::empty());
+        assert_eq!(t.stats().compile_cache_bytes, 512);
+
+        // Grow the cache; a refresh must observe the new total.
+        let mut g = std::fs::File::create(cache.join("mod2.cache")).unwrap();
+        g.write_all(&[0u8; 88]).unwrap();
+        t.refresh_compile_cache();
+        assert_eq!(t.stats().compile_cache_bytes, 600);
+        assert_eq!(t.total_bytes(), 600);
+    }
+}

--- a/crates/core/src/ring/hosting/disk_usage.rs
+++ b/crates/core/src/ring/hosting/disk_usage.rs
@@ -315,6 +315,15 @@ impl DiskUsageTracker {
         self.compile_cache_bytes
             .store(du_walk(&self.compile_cache_dir), Ordering::Relaxed);
     }
+
+    /// Free bytes on the mount holding the tracked `contracts_dir` — the
+    /// `available` term the disk budget sizes against (#4683). `None` when the
+    /// platform query fails; the caller falls back to `u64::MAX`. The contracts
+    /// dir shares the data-dir mount, which is where all tracked bytes (state,
+    /// wasm, relocated compile cache) land, so it is the correct mount to probe.
+    pub(crate) fn available_bytes(&self) -> Option<u64> {
+        available_bytes(&self.contracts_dir)
+    }
 }
 
 /// Recursively sum the byte size of every regular file under `dir`. A missing
@@ -371,6 +380,80 @@ fn du_walk_wasm(dir: &Path) -> u64 {
         }
     }
     total
+}
+
+/// Free bytes on the filesystem mount that holds `path`, as seen by an
+/// unprivileged process (#4683). This is the `available` term the disk budget
+/// adds to `freenet_used` to size itself against total reachable capacity.
+///
+/// Returns `None` when the platform query fails or the platform is unsupported;
+/// the caller then falls back to `u64::MAX`, which makes `disk_budget_for` clamp
+/// to its MAX cap (a free-space read that cannot be trusted must not silently
+/// shrink the budget — the eviction floor degrades to "cap only" rather than to
+/// zero). The value is `f_bavail * f_frsize` (blocks available to non-root ×
+/// fragment size) — NOT `f_bfree`, so root-reserved blocks are excluded, matching
+/// what the node can actually write.
+///
+/// The `path` must live on the SAME mount as the data dir the budget accounts
+/// for: `statvfs` is per-mount, so the free-space basis has to be measured on
+/// the mount the tracked bytes land on (this is why PR 1 relocated the wasmtime
+/// cache onto the data-dir mount).
+pub fn available_bytes(path: &Path) -> Option<u64> {
+    #[cfg(unix)]
+    {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let c_path = CString::new(path.as_os_str().as_bytes()).ok()?;
+        // SAFETY: `statvfs` is an FFI call that reads the filesystem stats for a
+        // NUL-terminated path into a caller-owned `libc::statvfs` buffer. We pass
+        // a valid `CString` pointer (owned by `c_path`, alive for the call) and a
+        // zeroed, correctly-sized, stack-owned out-buffer. It writes only into
+        // that buffer and returns 0 on success / -1 on error (checked below); it
+        // borrows no memory past the call. No aliasing or lifetime hazards.
+        let stat = unsafe {
+            let mut stat: libc::statvfs = std::mem::zeroed();
+            if libc::statvfs(c_path.as_ptr(), &mut stat) != 0 {
+                return None;
+            }
+            stat
+        };
+        // `f_bavail`/`f_frsize` are `c_ulong`/`fsblkcnt_t`; widen to u64 and
+        // saturate the multiply so a pathological fs report can't overflow.
+        let avail = stat.f_bavail as u64;
+        let frsize = stat.f_frsize as u64;
+        Some(avail.saturating_mul(frsize))
+    }
+    #[cfg(all(windows, not(unix)))]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        // GetDiskFreeSpaceExW wants a wide, NUL-terminated path.
+        let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+        wide.push(0);
+        let mut free_bytes_available: u64 = 0;
+        // SAFETY: FFI call into the Win32 API. `wide` is a valid NUL-terminated
+        // UTF-16 buffer alive for the call; the three out-pointers are to
+        // stack-owned u64s. We read only `free_bytes_available` and only on a
+        // nonzero (success) return.
+        let ok = unsafe {
+            winapi::um::fileapi::GetDiskFreeSpaceExW(
+                wide.as_ptr(),
+                &mut free_bytes_available as *mut u64 as *mut _,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            None
+        } else {
+            Some(free_bytes_available)
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = path;
+        None
+    }
 }
 
 #[cfg(test)]
@@ -566,5 +649,30 @@ mod tests {
         t.refresh_compile_cache();
         assert_eq!(t.stats().compile_cache_bytes, 600);
         assert_eq!(t.total_bytes(), 600);
+    }
+
+    /// `available_bytes` on a real, existing mount returns a plausible positive
+    /// value; a nonexistent path returns `None` (the MAX-fallback case). We can't
+    /// assert an exact figure (it's the live disk), only the shape.
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn available_bytes_reports_free_space_or_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let avail = available_bytes(dir.path());
+        assert!(
+            avail.map(|v| v > 0).unwrap_or(true),
+            "existing mount should report positive free space (or None if the \
+             query is unsupported), got {avail:?}"
+        );
+        // A path that does not exist has no mount stats → None on unix (statvfs
+        // fails); the caller treats None as u64::MAX.
+        let missing = available_bytes(Path::new("/nonexistent/does/not/exist/xyz"));
+        #[cfg(unix)]
+        assert!(
+            missing.is_none(),
+            "statvfs on a nonexistent path should fail → None, got {missing:?}"
+        );
+        #[cfg(not(unix))]
+        let _ = missing;
     }
 }

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -218,6 +218,18 @@ pub(crate) struct RouterSnapshotInfo {
     pub hosting_evictions_of_recently_read_total: Option<u64>,
     pub hosting_local_hits_total: Option<u64>,
     pub hosting_local_misses_total: Option<u64>,
+    /// Aggregate on-disk usage gauges (#4683), populated by `Ring` from the
+    /// `HostingManager`'s `DiskUsageTracker` on the snapshot cadence.
+    /// `hosting_disk_state_bytes` is the delta-tracked persisted-state total;
+    /// `hosting_disk_wasm_bytes` is the `du`-measured WASM-blob total;
+    /// `hosting_disk_compile_cache_bytes` is the relocated wasmtime compile-cache
+    /// total; `hosting_disk_total_bytes` is their sum — the aggregate the future
+    /// disk budget will bound. `None` until the tracker is configured and seeded
+    /// (early startup). Per-node aggregate scalars.
+    pub hosting_disk_state_bytes: Option<u64>,
+    pub hosting_disk_wasm_bytes: Option<u64>,
+    pub hosting_disk_compile_cache_bytes: Option<u64>,
+    pub hosting_disk_total_bytes: Option<u64>,
     /// Terminal advertisement-consult counters (hosting redesign piece C,
     /// #4646; exported to central telemetry per #4658), populated by `Ring`
     /// from the per-node `network_status` singleton on the snapshot cadence.
@@ -1155,6 +1167,12 @@ impl Router {
             hosting_evictions_of_recently_read_total: None,
             hosting_local_hits_total: None,
             hosting_local_misses_total: None,
+            // Aggregate on-disk usage gauges, populated by Ring from the
+            // DiskUsageTracker on the snapshot cadence (#4683).
+            hosting_disk_state_bytes: None,
+            hosting_disk_wasm_bytes: None,
+            hosting_disk_compile_cache_bytes: None,
+            hosting_disk_total_bytes: None,
             // Terminal advertisement-consult counters (piece C, #4646),
             // populated by Ring from the network_status singleton on the
             // snapshot cadence (#4658).

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2188,6 +2188,26 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "hosting_local_misses_total".to_string(),
                     serde_json::json!(snapshot.hosting_local_misses_total),
                 );
+                // Aggregate on-disk usage gauges (#4683). Same hand-mirrored
+                // footgun as the gauges above: a new `RouterSnapshotInfo` field
+                // is invisible to the collector unless added here. Pinned by
+                // `router_snapshot_json_includes_hosting_disk_gauges`.
+                obj.insert(
+                    "hosting_disk_state_bytes".to_string(),
+                    serde_json::json!(snapshot.hosting_disk_state_bytes),
+                );
+                obj.insert(
+                    "hosting_disk_wasm_bytes".to_string(),
+                    serde_json::json!(snapshot.hosting_disk_wasm_bytes),
+                );
+                obj.insert(
+                    "hosting_disk_compile_cache_bytes".to_string(),
+                    serde_json::json!(snapshot.hosting_disk_compile_cache_bytes),
+                );
+                obj.insert(
+                    "hosting_disk_total_bytes".to_string(),
+                    serde_json::json!(snapshot.hosting_disk_total_bytes),
+                );
                 // Terminal advertisement-consult counters (hosting redesign
                 // piece C, #4646; exported per #4658). Same hand-mirrored
                 // footgun as the gauges above: a new `RouterSnapshotInfo` field
@@ -2440,6 +2460,31 @@ mod tests {
             ("hosting_evictions_of_recently_read_total", 277),
             ("hosting_local_hits_total", 281),
             ("hosting_local_misses_total", 283),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
+    }
+
+    /// Pin: the aggregate on-disk usage gauges (#4683) must also reach the
+    /// hand-mirrored OTLP body — same footgun as the gauges above. A silent drop
+    /// would blind central telemetry to the disk-budget accounting this PR
+    /// introduces (the measurement the eviction floor + admission gate build on).
+    #[test]
+    fn router_snapshot_json_includes_hosting_disk_gauges() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.hosting_disk_state_bytes = Some(401);
+        info.hosting_disk_wasm_bytes = Some(409);
+        info.hosting_disk_compile_cache_bytes = Some(419);
+        info.hosting_disk_total_bytes = Some(1229);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        for (key, want) in [
+            ("hosting_disk_state_bytes", 401),
+            ("hosting_disk_wasm_bytes", 409),
+            ("hosting_disk_compile_cache_bytes", 419),
+            ("hosting_disk_total_bytes", 1229),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -1028,7 +1028,21 @@ impl WasmtimeEngine {
         // Module::new() skips compilation entirely and deserializes — ~100x faster.
         // This eliminates WASM compilation as a contributor to OPERATION_TTL timeouts
         // on slow CI runners and during cold starts in production.
-        match Cache::new(CacheConfig::new()) {
+        // Build the cache config, optionally relocating it onto the data-dir
+        // mount and pinning its soft-size limit (#4683). `with_directory`
+        // requires an ABSOLUTE path (wasmtime `create_dir_all`s + canonicalizes
+        // it); `RuntimeConfig::wasmtime_cache_dir` is `Some` only on the
+        // production path, which passes the absolute data-dir sibling. When
+        // `None` (tests/sim), the cache keeps wasmtime's default OS-cache
+        // location + 512 MiB soft limit — unchanged behavior.
+        let mut cache_config = CacheConfig::new();
+        if let Some(dir) = &config.wasmtime_cache_dir {
+            cache_config.with_directory(dir);
+        }
+        if let Some(limit) = config.wasmtime_cache_size_bytes {
+            cache_config.with_files_total_size_soft_limit(limit);
+        }
+        match Cache::new(cache_config) {
             Ok(cache) => {
                 wasmtime_config.cache(Some(cache));
                 tracing::info!("Wasmtime compilation cache enabled");
@@ -1905,7 +1919,7 @@ mod tests {
         // The build path that constructs the wasmtime Config must install a
         // disk cache via `wasmtime_config.cache(Some(...))`.
         assert!(
-            body.contains("Cache::new(CacheConfig::new())"),
+            body.contains("CacheConfig::new()") && body.contains("Cache::new(cache_config)"),
             "create_backend_engine must construct the wasmtime disk compilation cache"
         );
         assert!(

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -177,6 +177,17 @@ pub struct RuntimeConfig {
     /// deterministic in the `current_thread` + `start_paused` sim runner even
     /// if set. Production sets it `true`; tests/sim leave it `false`.
     pub offload_compilation: bool,
+    /// Directory for the wasmtime compile cache (#4683). `Some` relocates the
+    /// cache onto the data-dir mount (so it shares the mount that sizes the disk
+    /// budget and is measurable as freenet's own usage). `None` keeps wasmtime's
+    /// default OS-cache location — every test / `default()` site leaves it
+    /// unset, so their behavior is unchanged. An absolute path is required by
+    /// wasmtime's `CacheConfig::with_directory`.
+    pub wasmtime_cache_dir: Option<std::path::PathBuf>,
+    /// Soft size limit (bytes) for the wasmtime compile cache (#4683). `Some`
+    /// overrides wasmtime's 512 MiB default via
+    /// `CacheConfig::with_files_total_size_soft_limit`; `None` keeps the default.
+    pub wasmtime_cache_size_bytes: Option<u64>,
 }
 
 impl Default for RuntimeConfig {
@@ -192,6 +203,11 @@ impl Default for RuntimeConfig {
             // inline compile. Production opts in explicitly — see
             // `RuntimePool::new` / `from_config_with_shared_modules`.
             offload_compilation: false,
+            // Default: keep wasmtime's own OS-cache location + 512 MiB soft
+            // limit. Only the production `from_config*` path relocates + sizes
+            // it, so tests and sims see unchanged wasmtime cache behavior.
+            wasmtime_cache_dir: None,
+            wasmtime_cache_size_bytes: None,
         }
     }
 }


### PR DESCRIPTION
> **Stacked on #4700 (PR 1).** Cross-repo PRs from a fork can only target
> `main`, so this diff includes PR 1's commit. Review after #4700; the
> PR-2-only change is the second commit (`feat: disk budget sizing …`).
> Part of #4683.

## Problem

The demand-driven hosting budget (#4642) sizes itself from **RAM only**
(`clamp(total_ram/8, 128 MiB, 1 GiB)`). For a disk-constrained host (small VPS,
SD-card device) disk — not RAM — is the scarcest resource, yet **nothing bounds
disk in aggregate**. If the disk fills, the node hits an OS-level write failure
before anything proactively evicts.

PR 1 (#4700, `feat/disk-budget-accounting`, the base of this stacked PR) landed the
`DiskUsageTracker` accounting + telemetry with zero behavior change. This PR turns
that measurement into the first enforcement mechanism.

## Solution

Add a disk budget as a **second floor** on the *same* Greedy-Dual eviction walk:
`effective_budget = min(ram_budget, disk_budget)`, so the tighter of the two
scarce resources governs retention. Recomputed on the existing 60s sweep.

- **`available_bytes(path)`** — free bytes on the data-dir mount via
  `libc::statvfs` (unix) / `GetDiskFreeSpaceExW` (windows) / `None`-fallback,
  same libc-FFI + `SAFETY` discipline as `read_total_ram_bytes`. A failed/unsupported
  read → caller falls back to `u64::MAX`, which makes the disk budget clamp to its
  cap (degrade to "cap only", never to zero).
- **`disk_budget_for(used, avail, pct)`** = `clamp(pct*(used+avail), MIN, cap)`,
  a pure, filesystem-free clamp beside `budget_for_ram`. Basis is capacity
  *reachable by Freenet* (`used + free`), NOT a naive free-space read that shrinks
  as the disk fills. Non-finite/negative `pct` and `used+avail` overflow saturate
  to a valid budget.
- **New disk defaults** `DEFAULT_HOSTING_DISK_PCT` (0.5) and
  `DEFAULT_MAX_HOSTING_DISK_BYTES` (32 GiB) — a disk budget legitimately exceeds
  the 1 GiB RAM ceiling.
- **Persisted config** `hosting_disk_pct` + `max_hosting_disk` mirroring
  `max_hosting_storage`, incl. `build()` `get_or_insert` merge **and** non-default
  seeds in the round-trip guard test (silent-revert class #3890/#4275).
- **`HostingCache::set_budget_bytes`** setter (the only writer after the ctor).
- **`HostingManager::recompute_effective_budget(available)`** — refresh `du` →
  `used = tracker.total_bytes()` → `disk_budget` → `effective = min(ram, disk)` →
  `set_budget_bytes`. The `du`-walk stays OUTSIDE the cache lock; only the O(1)
  `set_budget_bytes` takes it. Wired into the 60s sweep after the disk-usage
  refresh; lazy seed keeps it a no-op until the first tick.

The admission gate (hard pre-write bound on aggregate disk) is the next PR in the
stack; this PR ships the soft, self-correcting eviction floor only.

## Testing

- `disk_budget_for` boundaries: zero/huge free, `pct` 0/1, clamp both ends,
  saturating overflow, non-finite/negative `pct`, explicit clamp bounds.
- `min(ram, disk)`: each side wins, equal, and the MIN-floor case.
- `recompute_effective_budget` is a no-op until the tracker is seeded.
- `recompute` does **not** deadlock against concurrent `record_contract_access`.
- `available_bytes` shape on a real mount vs a nonexistent path.
- Config round-trip guard exercises the two new persisted fields.

Gate: `cargo fmt` + `cargo clippy -p freenet -- -D warnings` clean; full `-p freenet`
lib suite green except two **pre-existing** macOS case-insensitive-FS failures in
`wasm_runtime::migration_tests` (fail identically on the base branch, pass on Linux CI).

## Fixes

Part of #4683.
