### PR TITLE
fix: gate relay GET serve on freshness, not cache presence

### DIFF
--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -2223,6 +2223,11 @@ fn interest_gate_disposition(
 ///
 /// Mirrors `GetMsg::Request` match arm at `get.rs:1369-1433`.
 ///
+/// Note: the `_interest_gate` / `interest_gate_disposition` names are retained
+/// to bound this interim-guard diff, but the gate is now FRESHNESS
+/// (`is_receiving_updates`), not interest/cache-presence. A rename is deferred
+/// to piece E, which removes the unsubscribed copies these names describe.
+///
 /// Returns `(local_value, local_fallback)`:
 /// - `local_value`: Some if we should serve immediately (fresh copy — actively
 ///   receiving updates).  None if we should forward.
@@ -2273,14 +2278,51 @@ async fn check_local_with_interest_gate(
             // (`has_local_interest`), which served unsubscribed stale copies
             // first (bug activated by 0.2.92's E-GET #4689 + interest-gated
             // renewal #4697).
+            //
+            // STRICTER than the local-client path on purpose: the local-client
+            // gate (client_events.rs:933) also serves when `connection_count == 0`
+            // (isolated node) or `is_locally_hosted` (a local client requested
+            // this contract, so a subscription is likely in flight). The relay
+            // path deliberately drops both OR-terms and gates on freshness ALONE:
+            // an isolated relay has no client to answer, and "a local client
+            // wants it" is not evidence THIS relayed copy is fresh. Do NOT
+            // "reconcile" the two gates by copying those OR-terms here — that
+            // re-opens the stale-serve hole this guard closes.
+            //
+            // Deferral intentionally does NOT register the requester's interest
+            // at this hop: registering a downstream subscriber at a peer that is
+            // NOT itself in the update mesh would create a HOLLOW relay link
+            // (invariant 1 / piece D remove exactly this). The `subscribe` flag
+            // is still forwarded downstream (see the GetMsg::Request build in the
+            // retry loop), so a real fresh host registers the subscriber. The R4
+            // requester-registration below runs ONLY on the fresh-serve branch,
+            // where registering is backed by a real hosting/subscription. In the
+            // R10-exhaustion case, serving the stale copy without registration is
+            // correct too: no fresh host was found, so there is nowhere valid to
+            // register the requester anyway.
+            //
+            // Originator-loopback verdict (no NotFound-where-stale regression):
+            // a local client's own GET is gated first by client_events.rs:933; a
+            // loopback request only reaches here after that gate already declined
+            // to serve locally. Even the inconsistent-state case (store has state,
+            // `is_hosting_contract == false`, not receiving updates, stale
+            // `InterestManager.hosting == true`) is safe: this deferral keeps the
+            // copy in `local_fallback`, which R10 serves if the network search
+            // exhausts. So the client still receives the local copy as last resort
+            // (today's behavior) when nothing fresher exists, and a fresher copy
+            // when one does — the change only reorders WHEN the stale copy is
+            // served (last-resort vs first), never turns a stale-serve into a
+            // NotFound.
             let is_fresh = op_manager.ring.is_receiving_updates(&key);
-            if !is_fresh {
+            let (local_value, local_fallback) =
+                interest_gate_disposition(is_fresh, (key, state, contract));
+            if local_fallback.is_some() {
                 tracing::debug!(
                     %instance_id,
                     "GET relay: unsubscribed cache (not receiving updates), will forward"
                 );
             }
-            interest_gate_disposition(is_fresh, (key, state, contract))
+            (local_value, local_fallback)
         }
     }
 }
@@ -2648,10 +2690,15 @@ where
             %instance_id,
             contract = %key,
             phase = "complete",
-            "GET relay: contract found locally (active interest) — sending Found upstream"
+            "GET relay: contract found locally (fresh / receiving updates) — sending Found upstream"
         );
 
         // Register interest for the requester (mirrors get.rs:1447-1476).
+        // Reached ONLY on the fresh-serve branch (`local_value` is Some), so
+        // this registration is backed by a real hosting/subscription — not a
+        // hollow relay. The deferred/fallback path intentionally does NOT
+        // register here; see the freshness-gate comment in
+        // `check_local_with_interest_gate` for why.
         if subscribe {
             crate::operations::subscribe::register_downstream_subscriber(
                 op_manager,
@@ -4587,15 +4634,44 @@ mod tests {
     /// served only as the last-resort fallback (hosting-invariants.md invariant
     /// 1; #2388/#3340). Guards against re-introducing the old cache-presence
     /// gate the interim stale-read guard replaced.
+    ///
+    /// This pin is deliberately TIGHT on the composition (the behavioral test
+    /// only exercises the pure `interest_gate_disposition` helper with hardcoded
+    /// `true`/`false`, so it can't catch a wiring INVERSION here). It requires
+    /// the exact un-negated binding and call literals and forbids both inversion
+    /// forms — either `let is_fresh = !op_manager.ring.is_receiving_updates(...)`
+    /// or `interest_gate_disposition(!is_fresh, ...)` would flip the gate to
+    /// serve stale first / defer fresh (the exact bug this PR fixes) while the
+    /// helper-only behavioral test still passed.
     #[test]
     fn check_local_with_interest_gate_uses_freshness_gate() {
         let src = production_source();
         let body = extract_fn_body(src, "async fn check_local_with_interest_gate(");
+        // Un-negated freshness binding: `is_fresh` must be the value of
+        // `is_receiving_updates`, not its negation.
         assert!(
-            body.contains("is_receiving_updates"),
-            "check_local_with_interest_gate must gate on `is_receiving_updates` \
-             (freshness) — an active network/client subscription — to decide \
-             whether the local copy is served immediately or deferred to network"
+            body.contains("let is_fresh = op_manager.ring.is_receiving_updates("),
+            "check_local_with_interest_gate must bind `is_fresh` directly to \
+             `op_manager.ring.is_receiving_updates(...)` (freshness — an active \
+             network/client subscription)"
+        );
+        assert!(
+            !body.contains("!op_manager.ring.is_receiving_updates"),
+            "check_local_with_interest_gate must NOT negate the freshness signal \
+             — `let is_fresh = !op_manager.ring.is_receiving_updates(...)` inverts \
+             the gate (serve stale first, defer fresh)"
+        );
+        // Un-negated disposition call: the freshness value flows into the helper
+        // un-inverted.
+        assert!(
+            body.contains("interest_gate_disposition(is_fresh,"),
+            "check_local_with_interest_gate must delegate the serve-vs-fallback \
+             decision to `interest_gate_disposition(is_fresh, ...)`"
+        );
+        assert!(
+            !body.contains("interest_gate_disposition(!is_fresh"),
+            "check_local_with_interest_gate must pass `is_fresh` (not `!is_fresh`) \
+             to the disposition helper — negating it inverts the gate"
         );
         // Assert on the CALL syntax (`has_local_interest(`), not the bare token,
         // so the explanatory comment in the gate body may still reference the
@@ -4605,13 +4681,6 @@ mod tests {
             "check_local_with_interest_gate must NOT gate on `has_local_interest` \
              (cache presence) — that served unsubscribed stale copies first, the \
              bug the freshness gate fixes"
-        );
-        // The disposition (fresh → serve, stale → fallback) is delegated to the
-        // pure `interest_gate_disposition` helper (unit-tested behaviorally).
-        assert!(
-            body.contains("interest_gate_disposition"),
-            "check_local_with_interest_gate must delegate the serve-vs-fallback \
-             decision to `interest_gate_disposition`"
         );
     }
 

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -2182,15 +2182,52 @@ where
 /// Local fallback tuple: key, state, optional contract code.
 type LocalFallback = (ContractKey, WrappedState, Option<ContractContainer>);
 
-/// Relay-side local cache lookup with interest gate.
+/// Decide how a relay disposes of a locally-held copy, given whether that copy
+/// is genuinely fresh (`Ring::is_receiving_updates` — an active network
+/// subscription or a local client subscription).
+///
+/// Returns `(local_value, local_fallback)`:
+/// - fresh → `(Some(local), None)`: serve immediately, the copy is kept current
+///   by the update mesh.
+/// - not fresh → `(None, Some(local))`: an unsubscribed / possibly-stale cached
+///   copy. Defer to the network so a fresh copy is preferred, but keep this
+///   copy as the R10 last-resort fallback served if the network search exhausts
+///   (worst case degrades to the pre-guard behavior, never a new dead-end).
+///
+/// Freshness — NOT mere cache presence — is the correct gate: a hosting-LRU copy
+/// can outlive its subscription and go stale (hosting-invariants.md invariant 1;
+/// #3340). The old gate keyed on `InterestManager::has_local_interest`, which is
+/// true whenever the cache-presence `hosting` flag is set, so it served
+/// unsubscribed stale copies first. 0.2.92 activated that bug by stopping GET
+/// auto-subscribe (E-GET, #4689) and lapsing idle subscriptions (interest-gated
+/// renewal, #4697), turning formerly-fresh cached copies unsubscribed.
+///
+/// Pure helper so the freshness gate is unit-testable without a real
+/// `OpManager` / contract handler. Mirrors the local-client GET path, which
+/// already gates on `is_receiving_updates` (client_events.rs, #2388/#3340).
+fn interest_gate_disposition(
+    is_fresh: bool,
+    local: LocalFallback,
+) -> (Option<LocalFallback>, Option<LocalFallback>) {
+    if is_fresh {
+        // Receiving updates — the copy is fresh, serve it immediately.
+        (Some(local), None)
+    } else {
+        // Unsubscribed / possibly-stale cache — defer to network, keep as
+        // fallback.
+        (None, Some(local))
+    }
+}
+
+/// Relay-side local cache lookup with freshness gate.
 ///
 /// Mirrors `GetMsg::Request` match arm at `get.rs:1369-1433`.
 ///
 /// Returns `(local_value, local_fallback)`:
-/// - `local_value`: Some if we should serve immediately (active interest or
-///   originator).  None if we should forward.
-/// - `local_fallback`: Some if we have stale local state with no active
-///   interest — used as a fallback if all downstream peers return NotFound.
+/// - `local_value`: Some if we should serve immediately (fresh copy — actively
+///   receiving updates).  None if we should forward.
+/// - `local_fallback`: Some if we have an unsubscribed / possibly-stale local
+///   copy — used as a fallback if all downstream peers return NotFound.
 async fn check_local_with_interest_gate(
     op_manager: &OpManager,
     instance_id: &ContractInstanceId,
@@ -2226,21 +2263,24 @@ async fn check_local_with_interest_gate(
     match raw_local {
         None => (None, None),
         Some((key, state, contract)) => {
-            // Interest gate (mirrors get.rs:1408-1433):
-            // Relay peers actively hosting serve immediately.
-            // Peers with only stale LRU cache (no active interest) defer to
-            // the network but keep the local value as fallback.
-            if !op_manager.interest_manager.has_local_interest(&key) {
-                // Stale cache only — defer to network, keep as fallback.
+            // Freshness gate (hosting-invariants.md invariant 1): only a copy we
+            // are actively receiving updates for (an active network subscription
+            // or a local client subscription) is guaranteed fresh and served
+            // immediately. A hosting-LRU copy without a live subscription can be
+            // stale — it forwards and is served only as the R10 last-resort
+            // fallback. This mirrors the local-client GET path (client_events.rs,
+            // #2388/#3340) and replaces the old cache-presence gate
+            // (`has_local_interest`), which served unsubscribed stale copies
+            // first (bug activated by 0.2.92's E-GET #4689 + interest-gated
+            // renewal #4697).
+            let is_fresh = op_manager.ring.is_receiving_updates(&key);
+            if !is_fresh {
                 tracing::debug!(
                     %instance_id,
-                    "GET relay: stale cache (no local interest), will forward"
+                    "GET relay: unsubscribed cache (not receiving updates), will forward"
                 );
-                (None, Some((key, state, contract)))
-            } else {
-                // Actively hosting with interest — serve immediately.
-                (Some((key, state, contract)), None)
             }
+            interest_gate_disposition(is_fresh, (key, state, contract))
         }
     }
 }
@@ -4541,23 +4581,37 @@ mod tests {
         );
     }
 
-    /// T3: Interest gate in `check_local_with_interest_gate` — stale cache
-    /// (no local interest) must NOT return a local_value (must go to fallback).
+    /// T3: `check_local_with_interest_gate` must gate on FRESHNESS
+    /// (`is_receiving_updates`), NOT mere cache presence (`has_local_interest`).
+    /// An unsubscribed cached copy can be stale, so it must forward and be
+    /// served only as the last-resort fallback (hosting-invariants.md invariant
+    /// 1; #2388/#3340). Guards against re-introducing the old cache-presence
+    /// gate the interim stale-read guard replaced.
     #[test]
-    fn check_local_with_interest_gate_has_interest_check() {
+    fn check_local_with_interest_gate_uses_freshness_gate() {
         let src = production_source();
         let body = extract_fn_body(src, "async fn check_local_with_interest_gate(");
         assert!(
-            body.contains("has_local_interest"),
-            "check_local_with_interest_gate must call `has_local_interest` to gate \
-             whether stale cache is served immediately or deferred to network"
+            body.contains("is_receiving_updates"),
+            "check_local_with_interest_gate must gate on `is_receiving_updates` \
+             (freshness) — an active network/client subscription — to decide \
+             whether the local copy is served immediately or deferred to network"
         );
-        // The stale-cache branch must put the value into the fallback slot,
-        // not into local_value.
+        // Assert on the CALL syntax (`has_local_interest(`), not the bare token,
+        // so the explanatory comment in the gate body may still reference the
+        // old gate by name.
         assert!(
-            body.contains("None, Some("),
-            "check_local_with_interest_gate must return (None, Some(fallback)) \
-             when there is local state but no active interest"
+            !body.contains("has_local_interest("),
+            "check_local_with_interest_gate must NOT gate on `has_local_interest` \
+             (cache presence) — that served unsubscribed stale copies first, the \
+             bug the freshness gate fixes"
+        );
+        // The disposition (fresh → serve, stale → fallback) is delegated to the
+        // pure `interest_gate_disposition` helper (unit-tested behaviorally).
+        assert!(
+            body.contains("interest_gate_disposition"),
+            "check_local_with_interest_gate must delegate the serve-vs-fallback \
+             decision to `interest_gate_disposition`"
         );
     }
 
@@ -4978,33 +5032,68 @@ mod tests {
         );
     }
 
-    /// `check_local_with_interest_gate` must return the local state in
-    /// the fallback slot (not `local_value`) when the relay holds state
-    /// but `has_local_interest` is false. This locks down the interest
-    /// gate: hosting relays serve immediately, stale-cache relays defer
-    /// to the network and hold local state as a fallback.
+    /// `interest_gate_disposition` must map freshness to the right slot: a fresh
+    /// copy (`is_fresh`) → `local_value` (serve immediately); an unsubscribed /
+    /// possibly-stale copy → the `local_fallback` slot (defer to network, serve
+    /// only as last resort). Locks down the disposition source structure; the
+    /// behavioral mapping is exercised in
+    /// `interest_gate_disposition_serves_fresh_defers_stale`.
     #[test]
-    fn interest_gate_returns_fallback_when_not_actively_hosting() {
+    fn interest_gate_disposition_gates_serve_on_freshness() {
         let src = production_source();
-        let body = extract_fn_body(src, "async fn check_local_with_interest_gate(");
-        // The interest-gated branch structure must be:
-        //   if !has_local_interest(&key) {
-        //     (None, Some((key, state, contract)))
+        let body = extract_fn_body(src, "fn interest_gate_disposition(");
+        // The disposition branch structure must be:
+        //   if is_fresh {
+        //     (Some(local), None)       // fresh → serve immediately
         //   } else {
-        //     (Some((key, state, contract)), None)
+        //     (None, Some(local))       // stale → fallback slot
         //   }
-        let neg_gate = body
-            .find("if !op_manager.interest_manager.has_local_interest(&key)")
-            .expect("interest gate must check `!has_local_interest` branch explicitly");
-        let tail = &body[neg_gate..];
-        let stale_pos = tail.find("(None, Some(").expect("stale branch must exist");
-        let active_pos = tail.find("(Some(").expect("active branch must exist");
-        // active branch (Some(...), None) must come AFTER the stale branch in
-        // the `else` arm.
+        let fresh_gate = body
+            .find("if is_fresh")
+            .expect("disposition must gate the serve-vs-fallback decision on `is_fresh`");
+        let tail = &body[fresh_gate..];
+        let serve_pos = tail
+            .find("(Some(local), None)")
+            .expect("fresh branch (serve immediately) must exist");
+        let fallback_pos = tail
+            .find("(None, Some(local))")
+            .expect("stale branch (fallback slot) must exist");
         assert!(
-            stale_pos < active_pos,
-            "`if !has_local_interest` arm (stale → fallback slot) must appear \
-             before the `else` arm (active → local_value slot) in source order."
+            serve_pos < fallback_pos,
+            "`if is_fresh` arm (fresh → local_value slot) must appear before the \
+             `else` arm (stale → fallback slot) in source order."
+        );
+    }
+
+    /// Behavioral test for the interim stale-read guard: the freshness gate must
+    /// serve a genuinely fresh copy immediately, but defer an unsubscribed /
+    /// possibly-stale copy to the network (keeping it only as the R10 last-resort
+    /// fallback). A relay holding a cached copy it is NOT receiving updates for
+    /// must NOT serve it as its first choice (hosting-invariants.md invariant 1;
+    /// #2388/#3340). This is the disposition that `check_local_with_interest_gate`
+    /// computes from `Ring::is_receiving_updates`; the freshness truth-table
+    /// itself is covered in `ring/hosting.rs`.
+    #[test]
+    fn interest_gate_disposition_serves_fresh_defers_stale() {
+        let local: LocalFallback = (dummy_key(), WrappedState::new(vec![1u8, 2, 3]), None);
+
+        // Fresh (actively receiving updates) → serve immediately: local_value
+        // is populated, no fallback.
+        let (serve, fallback) = interest_gate_disposition(true, local.clone());
+        assert!(
+            serve.is_some() && fallback.is_none(),
+            "a fresh (receiving-updates) copy must be served immediately \
+             (local_value = Some, fallback = None)"
+        );
+
+        // Unsubscribed / possibly-stale → defer to network: no immediate serve,
+        // copy retained in the fallback slot for the exhaustion last resort.
+        let (serve, fallback) = interest_gate_disposition(false, local);
+        assert!(
+            serve.is_none() && fallback.is_some(),
+            "an unsubscribed (not-receiving-updates) copy must NOT be served \
+             immediately; it defers to the network and is kept as the \
+             last-resort fallback (local_value = None, fallback = Some)"
         );
     }
 


### PR DESCRIPTION
## Problem

On the relay/network GET serve path, `check_local_with_interest_gate`
(`crates/core/src/operations/get/op_ctx_task.rs`) decided serve-from-cache
vs forward using `InterestManager::has_local_interest`. That predicate is
true whenever the cache-presence `hosting` flag is set — independent of
whether the peer is subscribed. So a relay served an **unsubscribed,
possibly-stale** cached copy as its FIRST choice, violating
[hosting-invariants.md](.claude/rules/hosting-invariants.md) invariant 1
("a served copy is fresh").

The correct freshness signal is `Ring::is_receiving_updates`
(`is_subscribed() || has_client_subscriptions()`). The **local-client**
GET path already gates on it (the #2388 / #3340 fix in `client_events.rs`);
the relay path never got that protection — and it even *contradicted* the
local path, serving a stale copy the client path had just refused.

**0.2.92 activated this latent bug.** E-GET (#4689) stopped GET
auto-subscribe and interest-gated renewal (#4697) lapses idle
subscriptions, turning formerly-subscribed-fresh cached copies into
unsubscribed-stale ones the relay path still served first.

## Approach

Gate the relay serve on `op_manager.ring.is_receiving_updates(&key)`
instead of cache presence, via a small pure `interest_gate_disposition`
helper:

- **fresh** (actively receiving updates) → serve immediately;
- **unsubscribed / possibly-stale** → defer to the network so a fresh copy
  is preferred, keeping the local copy as the **existing R10 last-resort
  fallback** served only if the network search exhausts.

This reuses the existing exhaustion machinery, so worst case degrades to
**today's** behavior (the stale copy is still served as last resort) —
never a new dead-end. It also makes the relay path consistent with the
local-client path.

Minimal interim guard. Relay-caching creation and the subscribe path are
untouched.

## Testing

- Updated the two source-scrape pin tests that locked the OLD
  cache-presence gate:
  - `check_local_with_interest_gate_uses_freshness_gate` (was
    `check_local_with_interest_gate_has_interest_check`) — now pins that
    the gate calls `is_receiving_updates`, does NOT call
    `has_local_interest(`, and delegates to the disposition helper.
  - `interest_gate_disposition_gates_serve_on_freshness` (was
    `interest_gate_returns_fallback_when_not_actively_hosting`) — pins the
    fresh→serve / stale→fallback source ordering in the helper.
- New behavioral test `interest_gate_disposition_serves_fresh_defers_stale`:
  a fresh copy is served immediately (`local_value = Some`, no fallback);
  an unsubscribed copy is NOT served immediately (defers, retained only as
  the fallback). The `is_receiving_updates` freshness truth-table itself is
  already covered in `ring/hosting.rs`.
- `cargo build -p freenet`, full `operations::get::` unit suite (84
  passed), `cargo fmt`, `cargo clippy --locked -p freenet -- -D warnings`
  — all clean.

## Tradeoff

Because most cached copies are currently unsubscribed (post-0.2.92), this
guard shifts more of those GETs onto a network forward instead of an
immediate local serve — a transitional increase in GET traffic in exchange
for not serving stale state. Hosting-redesign **piece E** removes the
unsubscribed copies at the source, which removes this increase too. Filed
against the demand-driven hosting epic freenet/freenet-core#4642.

## Review follow-up (three reviews: skeptical + code-first Claude, plus Codex)

No High-severity findings; the central "worst case = today, no new
dead-end" claim was verified. Addressed:

- **Deferral intentionally does NOT register the requester at this hop.**
  Codex flagged the skipped R4 requester-registration on the deferred path
  as a P1, but the skeptical review traced it deeper: registering a
  downstream subscriber at a relay that is NOT itself in the update mesh is
  a **hollow** relay link — exactly what invariant 1 / piece D remove. The
  `subscribe` flag is still forwarded downstream (the `GetMsg::Request`
  build in the retry loop) so a **real fresh host** registers the
  subscriber. The R4 registration runs only on the fresh-serve branch,
  where it is backed by a real hosting/subscription. In the R10-exhaustion
  case, serving the stale copy without registration is also correct — no
  fresh host was found, so there is nowhere valid to register. Re-adding
  registration here would re-introduce the hollow link. Documented at the
  gate and the R4 site; **not** changed in code.

- **Composition-inversion pin (the important one).** The behavioral test
  only exercises the pure helper with hardcoded `true`/`false`, so a
  regression to `interest_gate_disposition(!is_fresh, ...)` or
  `let is_fresh = !op_manager.ring.is_receiving_updates(...)` would invert
  the gate (serve stale first, defer fresh) while all three tests still
  passed. The source-scrape pin now requires the exact un-negated literals
  and forbids both inversion forms.

- **Stricter than the local-client gate, on purpose.** The relay gate
  drops the local-client path's `connection_count == 0` / `is_locally_
  hosted` OR-terms and gates on freshness alone; documented so a future
  maintainer doesn't "reconcile" the two and re-open the stale-serve hole.

- **Originator-loopback verdict:** no NotFound-where-stale-was-served
  regression. A loopback GET only reaches the relay gate after
  `client_events.rs:933` already declined to serve locally; the deferred
  copy is retained as the R10 fallback, so if the network finds nothing the
  client still gets the local copy (today's behavior), and a fresher copy
  when one exists. Even the inconsistent-state case (store has state,
  `is_hosting_contract == false`, not receiving updates, stale
  `InterestManager.hosting == true`) only reorders WHEN the stale copy is
  served — never turns a stale-serve into a NotFound.

- Nits: fixed the now-stale success log (`active interest` → `fresh /
  receiving updates`, that branch is fresh-only now); noted the retained
  `interest_gate` names (rename deferred to piece E).

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnRCbtbjepaB5GWrb5U8SR
