### PR TITLE
feat(hosting): shadow-wire reconcile controller at collapse + renewal

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -262,6 +262,12 @@ pub enum ReconcileShadowSite {
 ///   legitimately disagree with today's ANY-downstream, renew-everything path.
 /// - `announce`: a subscribed, state-present, not-yet-advertised host.
 ///
+/// RENEWAL-site reading: the recorded "actual" is what production did THIS TICK,
+/// so a contract the loop SKIPPED or DEFERRED (banned, spam-backoff, already
+/// pending) records `{}`. A `renew` / `subscribe` diff therefore also counts
+/// contracts the controller would keep alive but production merely deferred this
+/// tick — the intended per-tick reading, not a bug.
+///
 /// `retract_diffs` CAVEAT: it measures collapse/renewal of a contract that was
 /// EVER announced, not one with a currently-live advertisement — `is_advertised`
 /// (`NeighborHostingManager::is_hosted_locally`) is effectively MONOTONIC in

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -192,9 +192,13 @@ pub struct NetworkStatus {
     /// Computed-upstream vs. stored-`is_upstream`-flag divergence counters
     /// (hosting redesign piece D, #4642 / #4671).
     pub upstream_divergence_stats: UpstreamDivergenceStats,
-    /// Reconcile-controller SHADOW comparison counters (hosting redesign
-    /// keystone step-2, #4642).
-    pub reconcile_shadow_stats: ReconcileShadowStats,
+    /// Reconcile-controller SHADOW comparison counters, split PER SITE (hosting
+    /// redesign keystone step-2, #4642). The FLIP is site-by-site (collapse
+    /// first, then renewal), so each site's divergence must be separately
+    /// gate-able — a single global tally would be dominated by the renewal set
+    /// size and hide the collapse-site signal.
+    pub reconcile_shadow_collapse: ReconcileShadowStats,
+    pub reconcile_shadow_renewal: ReconcileShadowStats,
 }
 
 /// Per-node counters measuring how often the demand-driven-hosting **computed
@@ -218,8 +222,19 @@ pub struct UpstreamDivergenceStats {
     pub divergences: u64,
 }
 
-/// Per-node counters for the reconcile-controller SHADOW comparison (hosting
-/// redesign keystone step-2, #4642).
+/// Which decision site a reconcile shadow comparison came from. The FLIP is
+/// site-by-site, so the counters are split per site (keystone step-2, #4642).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReconcileShadowSite {
+    /// The interest-gated collapse (`OpManager::send_unsubscribe_upstream`).
+    Collapse,
+    /// The subscription-renewal set (`Ring::contracts_needing_renewal`, driven
+    /// by the recovery loop).
+    Renewal,
+}
+
+/// Per-node counters for the reconcile-controller SHADOW comparison AT ONE SITE
+/// (hosting redesign keystone step-2, #4642).
 ///
 /// At each on-`main` hosting decision site the shadow wiring builds a
 /// `ReconcileInputs` snapshot, computes what the pure `reconcile` controller
@@ -228,7 +243,8 @@ pub struct UpstreamDivergenceStats {
 /// real-world divergence from today's scattered decisions is legible in
 /// production telemetry (via `router_snapshot`) BEFORE any decision is flipped
 /// to the controller. The current code still drives every decision; these
-/// observe only.
+/// observe only. Held once PER SITE (`ReconcileShadowSite`) because the flip is
+/// site-by-site and each site must be separately gate-able.
 ///
 /// Volume-conscious: the decision sites increment these local counters
 /// in-process (NO per-event telemetry emission); only the aggregate totals are
@@ -236,15 +252,26 @@ pub struct UpstreamDivergenceStats {
 ///
 /// The per-action counters are SYMMETRIC-DIFFERENCE tallies: each counts the
 /// comparisons in which that action was present in exactly one of the
-/// {reconcile, actual} sets. Because the on-`main` sites do not yet implement
-/// several controller actions (a collapse never `Retract`s a hosting
-/// advertisement; nothing re-roots on upstream loss), a nonzero divergence on
-/// those classes is EXPECTED field evidence of the gap the keystone closes, not
-/// a health alarm — read them as the reconcile-vs-today delta.
+/// {reconcile, actual} sets. Several classes diverge BY DESIGN and are field
+/// evidence of the gap the keystone closes, NOT a health alarm — read them as
+/// the reconcile-vs-today delta:
+/// - `retract` / `reroot_search`: no on-`main` driver retracts on teardown or
+///   re-roots on upstream loss.
+/// - `renew` / `subscribe` / `unsubscribe`: the controller's strict
+///   downstream-demand gate and lease-aware `Renew`-vs-`Subscribe` split
+///   legitimately disagree with today's ANY-downstream, renew-everything path.
+/// - `announce`: a subscribed, state-present, not-yet-advertised host.
+///
+/// `retract_diffs` CAVEAT: it measures collapse/renewal of a contract that was
+/// EVER announced, not one with a currently-live advertisement — `is_advertised`
+/// (`NeighborHostingManager::is_hosted_locally`) is effectively MONOTONIC in
+/// production today, because its only clearer (`on_contract_unhosted`) is
+/// dead/test-only until the flip wires the `Retract` action. So a nonzero
+/// `retract_diffs` reflects the missing retraction driver, as intended.
 #[derive(Default, Clone, Copy)]
 pub struct ReconcileShadowStats {
-    /// Total shadow comparisons performed (the denominator — one per decision
-    /// site invocation).
+    /// Total shadow comparisons performed at this site (the denominator — one
+    /// per decision site invocation).
     pub comparisons: u64,
     /// Of those, the comparisons whose reconcile action set differed from the
     /// actual behavior's set in ANY action class.
@@ -421,7 +448,8 @@ pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: St
         nat_stats: NatStats::default(),
         terminal_consult_stats: TerminalConsultStats::default(),
         upstream_divergence_stats: UpstreamDivergenceStats::default(),
-        reconcile_shadow_stats: ReconcileShadowStats::default(),
+        reconcile_shadow_collapse: ReconcileShadowStats::default(),
+        reconcile_shadow_renewal: ReconcileShadowStats::default(),
     };
     match NETWORK_STATUS.get() {
         // Already initialized: overwrite the existing tracker in place so
@@ -670,20 +698,25 @@ pub fn upstream_divergence_counts() -> Option<(u64, u64)> {
     Some((d.comparisons, d.divergences))
 }
 
-/// Record one reconcile-controller SHADOW comparison (keystone step-2, #4642).
+/// Record one reconcile-controller SHADOW comparison AT `site` (keystone
+/// step-2, #4642).
 ///
-/// Increments the `comparisons` denominator every call, the `divergences`
-/// numerator when the reconcile action set differed from the actual behavior's
-/// set in any action class, and each per-action tally whose class was in the
-/// symmetric difference. Behavior-preserving — the current code drives the
-/// decision; this only measures how far the controller WOULD diverge, so the
-/// gap is legible in production telemetry ahead of the flip. Called from the
-/// on-`main` hosting decision sites (collapse `send_unsubscribe_upstream`,
-/// renewal `contracts_needing_renewal`).
-pub fn record_reconcile_shadow_comparison(divergence: ReconcileActionDivergence) {
+/// Increments that site's `comparisons` denominator every call, its
+/// `divergences` numerator when the reconcile action set differed from the
+/// actual behavior's set in any action class, and each per-action tally whose
+/// class was in the symmetric difference. Behavior-preserving — the current code
+/// drives the decision; this only measures how far the controller WOULD diverge,
+/// so the gap is legible in production telemetry ahead of the site-by-site flip.
+pub fn record_reconcile_shadow_comparison(
+    site: ReconcileShadowSite,
+    divergence: ReconcileActionDivergence,
+) {
     if let Some(status) = NETWORK_STATUS.get() {
         if let Ok(mut s) = status.write() {
-            let r = &mut s.reconcile_shadow_stats;
+            let r = match site {
+                ReconcileShadowSite::Collapse => &mut s.reconcile_shadow_collapse,
+                ReconcileShadowSite::Renewal => &mut s.reconcile_shadow_renewal,
+            };
             r.comparisons = r.comparisons.saturating_add(1);
             if divergence.any() {
                 r.divergences = r.divergences.saturating_add(1);
@@ -713,15 +746,15 @@ pub fn record_reconcile_shadow_comparison(divergence: ReconcileActionDivergence)
     }
 }
 
-/// Read the reconcile-controller SHADOW counters (keystone step-2, #4642) for
-/// export to the `router_snapshot` telemetry event. Returns a copy of the
-/// per-node monotonic totals, or `None` before the `NETWORK_STATUS` singleton is
-/// initialized. `Ring` polls this on the snapshot cadence and copies the values
-/// onto `RouterSnapshotInfo`.
-pub fn reconcile_shadow_counts() -> Option<ReconcileShadowStats> {
+/// Read the per-site reconcile-controller SHADOW counters (keystone step-2,
+/// #4642) for export to the `router_snapshot` telemetry event. Returns
+/// `(collapse, renewal)` copies of the per-node monotonic totals, or `None`
+/// before the `NETWORK_STATUS` singleton is initialized. `Ring` polls this on the
+/// snapshot cadence and copies the values onto `RouterSnapshotInfo`.
+pub fn reconcile_shadow_counts() -> Option<(ReconcileShadowStats, ReconcileShadowStats)> {
     let status = NETWORK_STATUS.get()?;
     let s = status.read().ok()?;
-    Some(s.reconcile_shadow_stats)
+    Some((s.reconcile_shadow_collapse, s.reconcile_shadow_renewal))
 }
 
 /// Record a NAT traversal attempt.
@@ -1525,53 +1558,65 @@ mod tests {
         );
     }
 
-    /// End-to-end for the reconcile-controller SHADOW counters (keystone step-2,
-    /// #4642): the record site must feed the `reconcile_shadow_counts()` getter
-    /// that `Ring` polls for the `router_snapshot` export. `comparisons` bumps
-    /// every call, `divergences` only when any action class diverged, and each
+    /// End-to-end for the per-site reconcile-controller SHADOW counters (keystone
+    /// step-2, #4642): the record site must feed the `reconcile_shadow_counts()`
+    /// getter that `Ring` polls for the `router_snapshot` export. `comparisons`
+    /// bumps every call, `divergences` only when any action class diverged, each
     /// per-action tally bumps only when that class is in the symmetric
-    /// difference — so a dropped increment or a mis-wired per-action field fails
+    /// difference, and — crucially — the two SITES are tallied INDEPENDENTLY (a
+    /// collapse-site record must not bleed into the renewal-site counters). So a
+    /// dropped increment, a mis-wired per-action field, or a crossed site fails
     /// here rather than silently emitting zeros in production.
     #[test]
     fn reconcile_shadow_counts_reflect_recorded_events() {
+        use ReconcileShadowSite::*;
         let _lock = TEST_MUTEX.lock().unwrap();
         init(31337, HashSet::new(), "test".to_string());
 
-        let zero = reconcile_shadow_counts().expect("counters present after init");
+        let (collapse0, renewal0) = reconcile_shadow_counts().expect("counters present after init");
         assert_eq!(
-            (zero.comparisons, zero.divergences),
+            (collapse0.comparisons, renewal0.comparisons),
             (0, 0),
-            "counters start at zero after init"
+            "both sites start at zero after init"
         );
 
-        // No divergence: bumps comparisons only.
-        record_reconcile_shadow_comparison(ReconcileActionDivergence::default());
-        // Retract-only divergence (the collapse-site gap).
-        record_reconcile_shadow_comparison(ReconcileActionDivergence {
-            retract: true,
-            ..Default::default()
-        });
-        // Subscribe + Renew divergence (the renewal-site not-subscribed case).
-        record_reconcile_shadow_comparison(ReconcileActionDivergence {
-            subscribe: true,
-            renew: true,
-            ..Default::default()
-        });
+        // Collapse site: 2 comparisons, 1 diverging (retract-only gap).
+        record_reconcile_shadow_comparison(Collapse, ReconcileActionDivergence::default());
+        record_reconcile_shadow_comparison(
+            Collapse,
+            ReconcileActionDivergence {
+                retract: true,
+                ..Default::default()
+            },
+        );
+        // Renewal site: 1 comparison, diverging (not-subscribed → Subscribe+Renew).
+        record_reconcile_shadow_comparison(
+            Renewal,
+            ReconcileActionDivergence {
+                subscribe: true,
+                renew: true,
+                ..Default::default()
+            },
+        );
 
-        let c = reconcile_shadow_counts().expect("counters present");
-        assert_eq!(c.comparisons, 3, "every call bumps comparisons");
+        let (collapse, renewal) = reconcile_shadow_counts().expect("counters present");
+
+        // Collapse site tallies only the collapse-site records.
+        assert_eq!(collapse.comparisons, 2, "collapse site: every call bumps");
+        assert_eq!(collapse.divergences, 1, "collapse site: one diverging call");
+        assert_eq!(collapse.retract_diffs, 1);
+        assert_eq!(collapse.subscribe_diffs, 0);
+        assert_eq!(collapse.renew_diffs, 0);
+
+        // Renewal site is independent — the collapse records must not bleed in.
         assert_eq!(
-            c.divergences, 2,
-            "only the two diverging calls bump divergences"
+            renewal.comparisons, 1,
+            "renewal site independent of collapse"
         );
-        assert_eq!(c.retract_diffs, 1);
-        assert_eq!(c.subscribe_diffs, 1);
-        assert_eq!(c.renew_diffs, 1);
-        // Untouched classes stay at zero.
-        assert_eq!(c.unsubscribe_diffs, 0);
-        assert_eq!(c.collapse_diffs, 0);
-        assert_eq!(c.announce_diffs, 0);
-        assert_eq!(c.reroot_search_diffs, 0);
+        assert_eq!(renewal.divergences, 1);
+        assert_eq!(renewal.subscribe_diffs, 1);
+        assert_eq!(renewal.renew_diffs, 1);
+        assert_eq!(renewal.retract_diffs, 0);
     }
 
     #[test]

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -9,6 +9,7 @@ use std::net::SocketAddr;
 use std::sync::{Arc, OnceLock, RwLock};
 use std::time::Instant;
 
+use crate::ring::reconcile::ReconcileActionDivergence;
 use crate::ring::{PeerKeyLocation, SubscribedContractSnapshot};
 use crate::router::Router;
 use crate::transport::metrics::{TRANSPORT_METRICS, TransportSnapshot};
@@ -191,6 +192,9 @@ pub struct NetworkStatus {
     /// Computed-upstream vs. stored-`is_upstream`-flag divergence counters
     /// (hosting redesign piece D, #4642 / #4671).
     pub upstream_divergence_stats: UpstreamDivergenceStats,
+    /// Reconcile-controller SHADOW comparison counters (hosting redesign
+    /// keystone step-2, #4642).
+    pub reconcile_shadow_stats: ReconcileShadowStats,
 }
 
 /// Per-node counters measuring how often the demand-driven-hosting **computed
@@ -212,6 +216,48 @@ pub struct UpstreamDivergenceStats {
     /// Of those, the times the computed upstream DISAGREED with the stored flag
     /// (different peer, or one `Some`/the other `None`).
     pub divergences: u64,
+}
+
+/// Per-node counters for the reconcile-controller SHADOW comparison (hosting
+/// redesign keystone step-2, #4642).
+///
+/// At each on-`main` hosting decision site the shadow wiring builds a
+/// `ReconcileInputs` snapshot, computes what the pure `reconcile` controller
+/// WOULD do, and compares it — BY SET MEMBERSHIP — to what the current code
+/// actually does. These counters aggregate that comparison so the controller's
+/// real-world divergence from today's scattered decisions is legible in
+/// production telemetry (via `router_snapshot`) BEFORE any decision is flipped
+/// to the controller. The current code still drives every decision; these
+/// observe only.
+///
+/// Volume-conscious: the decision sites increment these local counters
+/// in-process (NO per-event telemetry emission); only the aggregate totals are
+/// exported on the periodic snapshot cadence.
+///
+/// The per-action counters are SYMMETRIC-DIFFERENCE tallies: each counts the
+/// comparisons in which that action was present in exactly one of the
+/// {reconcile, actual} sets. Because the on-`main` sites do not yet implement
+/// several controller actions (a collapse never `Retract`s a hosting
+/// advertisement; nothing re-roots on upstream loss), a nonzero divergence on
+/// those classes is EXPECTED field evidence of the gap the keystone closes, not
+/// a health alarm — read them as the reconcile-vs-today delta.
+#[derive(Default, Clone, Copy)]
+pub struct ReconcileShadowStats {
+    /// Total shadow comparisons performed (the denominator — one per decision
+    /// site invocation).
+    pub comparisons: u64,
+    /// Of those, the comparisons whose reconcile action set differed from the
+    /// actual behavior's set in ANY action class.
+    pub divergences: u64,
+    /// Per-action symmetric-difference tallies (action present in exactly one of
+    /// the {reconcile, actual} sets).
+    pub subscribe_diffs: u64,
+    pub renew_diffs: u64,
+    pub unsubscribe_diffs: u64,
+    pub collapse_diffs: u64,
+    pub announce_diffs: u64,
+    pub retract_diffs: u64,
+    pub reroot_search_diffs: u64,
 }
 
 /// Per-node counters for the terminal advertisement consult (invariant 5:
@@ -375,6 +421,7 @@ pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: St
         nat_stats: NatStats::default(),
         terminal_consult_stats: TerminalConsultStats::default(),
         upstream_divergence_stats: UpstreamDivergenceStats::default(),
+        reconcile_shadow_stats: ReconcileShadowStats::default(),
     };
     match NETWORK_STATUS.get() {
         // Already initialized: overwrite the existing tracker in place so
@@ -621,6 +668,60 @@ pub fn upstream_divergence_counts() -> Option<(u64, u64)> {
     let s = status.read().ok()?;
     let d = &s.upstream_divergence_stats;
     Some((d.comparisons, d.divergences))
+}
+
+/// Record one reconcile-controller SHADOW comparison (keystone step-2, #4642).
+///
+/// Increments the `comparisons` denominator every call, the `divergences`
+/// numerator when the reconcile action set differed from the actual behavior's
+/// set in any action class, and each per-action tally whose class was in the
+/// symmetric difference. Behavior-preserving — the current code drives the
+/// decision; this only measures how far the controller WOULD diverge, so the
+/// gap is legible in production telemetry ahead of the flip. Called from the
+/// on-`main` hosting decision sites (collapse `send_unsubscribe_upstream`,
+/// renewal `contracts_needing_renewal`).
+pub fn record_reconcile_shadow_comparison(divergence: ReconcileActionDivergence) {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            let r = &mut s.reconcile_shadow_stats;
+            r.comparisons = r.comparisons.saturating_add(1);
+            if divergence.any() {
+                r.divergences = r.divergences.saturating_add(1);
+            }
+            if divergence.subscribe {
+                r.subscribe_diffs = r.subscribe_diffs.saturating_add(1);
+            }
+            if divergence.renew {
+                r.renew_diffs = r.renew_diffs.saturating_add(1);
+            }
+            if divergence.unsubscribe {
+                r.unsubscribe_diffs = r.unsubscribe_diffs.saturating_add(1);
+            }
+            if divergence.collapse {
+                r.collapse_diffs = r.collapse_diffs.saturating_add(1);
+            }
+            if divergence.announce {
+                r.announce_diffs = r.announce_diffs.saturating_add(1);
+            }
+            if divergence.retract {
+                r.retract_diffs = r.retract_diffs.saturating_add(1);
+            }
+            if divergence.reroot_search {
+                r.reroot_search_diffs = r.reroot_search_diffs.saturating_add(1);
+            }
+        }
+    }
+}
+
+/// Read the reconcile-controller SHADOW counters (keystone step-2, #4642) for
+/// export to the `router_snapshot` telemetry event. Returns a copy of the
+/// per-node monotonic totals, or `None` before the `NETWORK_STATUS` singleton is
+/// initialized. `Ring` polls this on the snapshot cadence and copies the values
+/// onto `RouterSnapshotInfo`.
+pub fn reconcile_shadow_counts() -> Option<ReconcileShadowStats> {
+    let status = NETWORK_STATUS.get()?;
+    let s = status.read().ok()?;
+    Some(s.reconcile_shadow_stats)
 }
 
 /// Record a NAT traversal attempt.
@@ -1422,6 +1523,55 @@ mod tests {
             "getter returns (comparisons, divergences); every call bumps comparisons, \
              only diverged calls bump divergences"
         );
+    }
+
+    /// End-to-end for the reconcile-controller SHADOW counters (keystone step-2,
+    /// #4642): the record site must feed the `reconcile_shadow_counts()` getter
+    /// that `Ring` polls for the `router_snapshot` export. `comparisons` bumps
+    /// every call, `divergences` only when any action class diverged, and each
+    /// per-action tally bumps only when that class is in the symmetric
+    /// difference — so a dropped increment or a mis-wired per-action field fails
+    /// here rather than silently emitting zeros in production.
+    #[test]
+    fn reconcile_shadow_counts_reflect_recorded_events() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        init(31337, HashSet::new(), "test".to_string());
+
+        let zero = reconcile_shadow_counts().expect("counters present after init");
+        assert_eq!(
+            (zero.comparisons, zero.divergences),
+            (0, 0),
+            "counters start at zero after init"
+        );
+
+        // No divergence: bumps comparisons only.
+        record_reconcile_shadow_comparison(ReconcileActionDivergence::default());
+        // Retract-only divergence (the collapse-site gap).
+        record_reconcile_shadow_comparison(ReconcileActionDivergence {
+            retract: true,
+            ..Default::default()
+        });
+        // Subscribe + Renew divergence (the renewal-site not-subscribed case).
+        record_reconcile_shadow_comparison(ReconcileActionDivergence {
+            subscribe: true,
+            renew: true,
+            ..Default::default()
+        });
+
+        let c = reconcile_shadow_counts().expect("counters present");
+        assert_eq!(c.comparisons, 3, "every call bumps comparisons");
+        assert_eq!(
+            c.divergences, 2,
+            "only the two diverging calls bump divergences"
+        );
+        assert_eq!(c.retract_diffs, 1);
+        assert_eq!(c.subscribe_diffs, 1);
+        assert_eq!(c.renew_diffs, 1);
+        // Untouched classes stay at zero.
+        assert_eq!(c.unsubscribe_diffs, 0);
+        assert_eq!(c.collapse_diffs, 0);
+        assert_eq!(c.announce_diffs, 0);
+        assert_eq!(c.reroot_search_diffs, 0);
     }
 
     #[test]

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -34,8 +34,8 @@ use crate::{
         stream_progress::StreamProgressRegistry,
     },
     ring::{
-        ConnectionManager, LiveTransactionTracker, PeerConnectionBackoff, PeerKey, PeerKeyLocation,
-        Ring,
+        ConnectionManager, Distance, LiveTransactionTracker, Location, PeerConnectionBackoff,
+        PeerKey, PeerKeyLocation, Ring, reconcile,
     },
     transport::TransportPublicKey,
     util::time_source::InstantTimeSrc,
@@ -73,6 +73,27 @@ impl Ops {
             under_progress: self.under_progress.len(),
         }
     }
+}
+
+/// Pure core of the piece-D **strictly-farther** downstream-subscriber filter
+/// (keystone step-2, #4642): `true` iff at least one subscriber distance is
+/// STRICTLY greater than `my_distance` (both measured to the contract key).
+///
+/// Load-bearing: the comparison uses EXACT `Distance` ordering (`Ord::cmp`),
+/// NEVER the epsilon-fuzzy `PartialEq` (`ring/location.rs:223-243`, where `==`
+/// treats one-ULP-apart distances as equal while `cmp` still orders them). A
+/// subscriber at exactly `my_distance` (bit-identical) is EXCLUDED — that
+/// exclusion of the closer/equal (upstream) peer is what stops two mutual
+/// co-hosts from perpetuating each other's leases so collapse can terminate
+/// (hosting-invariants piece-D, design §4/§6). Mixing epsilon-`==` here with the
+/// exact-`<` selection used by `most_keyward_among` is the exact bug the guard
+/// prevents, hence `cmp(..) == Greater`, not `>` or `==`.
+fn has_strictly_farther(
+    my_distance: Distance,
+    subscriber_distances: impl Iterator<Item = Distance>,
+) -> bool {
+    let mut subscriber_distances = subscriber_distances;
+    subscriber_distances.any(|d| d.cmp(&my_distance) == std::cmp::Ordering::Greater)
 }
 
 /// Thread safe and friendly data structure to maintain state of the different operations
@@ -793,6 +814,82 @@ impl OpManager {
             .collect()
     }
 
+    /// Build a [`reconcile::ReconcileInputs`] snapshot for `contract` from live
+    /// node state (keystone step-2, #4642, shadow-mode wiring).
+    ///
+    /// Reads the live maps ONCE into plain values so `reconcile` stays a pure
+    /// function. Behavior-preserving: this only reads state; it drives nothing.
+    /// Hosting is binary — `state_present` is `true` only when this peer holds
+    /// the FULL contract (code + params + state), never a partial tier.
+    pub(crate) fn build_reconcile_inputs(
+        &self,
+        contract: &ContractKey,
+    ) -> reconcile::ReconcileInputs {
+        let instance_id = *contract.id();
+        let hosting_neighbors = self
+            .neighbor_hosting
+            .neighbors_with_contract_id(&instance_id);
+        let computed_upstream = self
+            .ring
+            .most_keyward_hosting_neighbor(&instance_id, &hosting_neighbors);
+
+        reconcile::ReconcileInputs {
+            computed_upstream,
+            has_local_client: self.ring.has_client_subscriptions(contract),
+            has_farther_downstream_subscriber: self.has_farther_downstream_subscriber(contract),
+            state_present: self.ring.contract_state_present(contract),
+            is_subscribed: self.ring.is_subscribed(contract),
+            is_advertised: self.neighbor_hosting.is_hosted_locally(contract),
+            is_verified_root: self.ring.is_subscription_root(contract),
+            // STEP-3 / piece-D hook: no on-`main` source for the acquiring-
+            // transient state yet (`spawn_host_state_sync_retry` is a piece-D
+            // addition), so this is always false in shadow mode. See
+            // `ReconcileInputs::actively_acquiring`.
+            actively_acquiring: false,
+        }
+    }
+
+    /// Whether at least one lease-valid downstream subscriber is STRICTLY FARTHER
+    /// from the contract key than this peer — the piece-D H2 interest gate.
+    ///
+    /// Resolves each lease-valid downstream subscriber to its location and keeps
+    /// only those strictly farther from the key than us (the closer/upstream peer
+    /// is excluded, so mutual co-hosts cannot perpetuate each other's leases; see
+    /// [`has_strictly_farther`]). The distance filter uses EXACT `Distance`
+    /// ordering, never epsilon `==`.
+    fn has_farther_downstream_subscriber(&self, contract: &ContractKey) -> bool {
+        let subscribers = self.ring.downstream_subscriber_peers(contract);
+        if subscribers.is_empty() {
+            return false;
+        }
+        let contract_location = Location::from(contract);
+        // Own location, derived from our observed socket address — the same
+        // source `most_keyward_hosting_neighbor` / `is_subscription_root` use.
+        // When it is unknown (startup / no observed address yet) we cannot apply
+        // the strict distance filter, so fall back to "any lease-valid downstream
+        // subscriber present" (the current-code `has_downstream_subscribers`
+        // semantics) to avoid a spurious collapse divergence during that
+        // transient — the same own_location edge-noise the #4671 upstream-
+        // divergence caveat documents.
+        let Some(my_location) = self.ring.connection_manager.own_location().location() else {
+            return true;
+        };
+        let my_distance: Distance = my_location.distance(contract_location);
+        // A subscriber we can't currently resolve to a connected location (it
+        // disconnected but its lease has not expired) is skipped, not assumed
+        // farther. Known dilution edge, same noise class as own_location above:
+        // the case the strict filter targets — a CONNECTED closer co-host that is
+        // our upstream — always resolves, so skipping stragglers is safe.
+        let subscriber_distances = subscribers.iter().filter_map(|peer| {
+            self.ring
+                .connection_manager
+                .get_peer_by_pub_key(&peer.0)
+                .and_then(|pkl| pkl.location())
+                .map(|loc| loc.distance(contract_location))
+        });
+        has_strictly_farther(my_distance, subscriber_distances)
+    }
+
     /// Send an Unsubscribe message to the upstream peer for a contract.
     ///
     /// Finds the upstream peer from the interest manager, resolves its address,
@@ -844,6 +941,43 @@ impl OpManager {
                     stored_upstream = ?stored_pk,
                     computed_upstream = ?computed_pk,
                     "computed upstream diverges from stored is_upstream flag (#4642 piece D / #4671)"
+                );
+            }
+        }
+
+        // Reconcile-controller SHADOW comparison (keystone step-2, #4642),
+        // COLLAPSE site. This function is the interest-gated collapse: every
+        // path drops the local lease (`ring.unsubscribe` = `Collapse`) and, when
+        // a stored upstream exists, sends a wire `Unsubscribe`. Build the
+        // reconcile snapshot, compute what the pure controller would do, and
+        // compare BY SET MEMBERSHIP. DRIVES NOTHING — the teardown below runs
+        // unchanged.
+        //
+        // Actual→Action mapping (intent-level): `{Collapse, Unsubscribe}` when a
+        // stored upstream was located, else `{Collapse}`. The rare edge where a
+        // located upstream fails later address resolution still collapses
+        // locally (no wire send) but is folded into `{Collapse, Unsubscribe}`
+        // here — it is not worth a separate terminal-point mapping. This site
+        // NEVER retracts a hosting advertisement, so reconcile's `Retract`
+        // (emitted when `is_advertised`) is a genuine gap this shadow records,
+        // not an artifact; likewise the `Unsubscribe` diff captures the stored-
+        // vs-computed upstream disagreement (#4671) at action granularity.
+        {
+            let inputs = self.build_reconcile_inputs(contract);
+            let reconcile_actions = reconcile::reconcile(&inputs);
+            let actual_actions: &[reconcile::Action] = if upstream.is_some() {
+                &[reconcile::Action::Collapse, reconcile::Action::Unsubscribe]
+            } else {
+                &[reconcile::Action::Collapse]
+            };
+            let divergence = reconcile::action_set_divergence(&reconcile_actions, actual_actions);
+            crate::node::network_status::record_reconcile_shadow_comparison(divergence);
+            if divergence.any() {
+                tracing::debug!(
+                    contract = %contract,
+                    ?reconcile_actions,
+                    ?actual_actions,
+                    "reconcile shadow diverges from actual collapse behavior (#4642 keystone step-2)"
                 );
             }
         }
@@ -1852,6 +1986,109 @@ mod tests {
     use crate::node::network_bridge::EventLoopNotificationsReceiver;
     use either::Either;
     use tokio::time::{Duration, Instant, timeout};
+
+    /// Piece-D H2 pin (keystone step-2, #4642): the strictly-farther
+    /// downstream-subscriber filter the reconcile input-builder delegates to
+    /// (`has_farther_downstream_subscriber` → [`has_strictly_farther`]) MUST
+    /// EXCLUDE a subscriber at exactly our distance (bit-identical) and use
+    /// EXACT `Distance` ordering, never the epsilon-fuzzy `PartialEq`. A
+    /// closer/equal (upstream) peer counting as farther demand would let mutual
+    /// co-hosts perpetuate each other's leases so collapse never terminates
+    /// (hosting-invariants piece-D, design §4/§6). Feeds bit-identical distances
+    /// exactly as the H2 obligation on the builder requires.
+    #[test]
+    fn has_strictly_farther_excludes_equal_uses_exact_ordering() {
+        let my = Distance::new(0.3);
+
+        // Bit-identical (exactly our distance) ⇒ excluded.
+        assert!(
+            !has_strictly_farther(my, std::iter::once(Distance::new(0.3))),
+            "a subscriber at exactly our distance must be excluded (the closer/upstream peer)"
+        );
+        // Strictly closer ⇒ excluded.
+        assert!(
+            !has_strictly_farther(my, std::iter::once(Distance::new(0.2))),
+            "a strictly-closer subscriber must be excluded"
+        );
+        // Strictly farther ⇒ included.
+        assert!(
+            has_strictly_farther(my, std::iter::once(Distance::new(0.4))),
+            "a strictly-farther subscriber must be included"
+        );
+
+        // Epsilon boundary: one ULP FARTHER than `my` is epsilon-`==` to it (a
+        // fuzzy `==` filter would wrongly treat it as equal ⇒ excluded) but
+        // EXACT `cmp` orders it Greater ⇒ included. This is the exact-vs-epsilon
+        // bug the guard prevents (`ring/location.rs:223-243`).
+        let one_ulp_farther = Distance::new(f64::from_bits(0.3_f64.to_bits() + 1));
+        assert_eq!(
+            one_ulp_farther, my,
+            "one ULP apart is epsilon-equal under Distance PartialEq"
+        );
+        assert!(
+            has_strictly_farther(my, std::iter::once(one_ulp_farther)),
+            "exact cmp includes a one-ULP-farther subscriber that a fuzzy `==` would exclude"
+        );
+
+        // Mixed sets: any strictly-farther member triggers; equal + closer alone
+        // do not.
+        assert!(
+            has_strictly_farther(
+                my,
+                [Distance::new(0.3), Distance::new(0.2), Distance::new(0.45)].into_iter()
+            ),
+            "any strictly-farther subscriber in the set triggers"
+        );
+        assert!(
+            !has_strictly_farther(my, [Distance::new(0.3), Distance::new(0.1)].into_iter()),
+            "equal + closer only ⇒ no farther demand"
+        );
+        // Empty ⇒ false.
+        assert!(!has_strictly_farther(my, std::iter::empty()));
+    }
+
+    /// Behavior-preserving guard (keystone step-2, #4642): the collapse site
+    /// `send_unsubscribe_upstream` must STILL drive its decision off the stored
+    /// `is_upstream` flag and the local `ring.unsubscribe`, and the reconcile
+    /// controller must only RECORD a shadow comparison there — its `Vec<Action>`
+    /// flows ONLY into the set-membership divergence comparator, never into a
+    /// driver. This source-scrape pin fails if the flip lands (drive the action)
+    /// without a deliberate update, keeping the "drives nothing" invariant honest.
+    #[test]
+    fn send_unsubscribe_upstream_still_drives_and_shadow_is_record_only() {
+        const SRC: &str = include_str!("op_state_manager.rs");
+        let start = SRC
+            .find("pub async fn send_unsubscribe_upstream(")
+            .expect("send_unsubscribe_upstream must exist");
+        // Bound the scan to this function so later functions can't satisfy the
+        // markers by accident (next `\n    pub ` item after the signature).
+        let rest = &SRC[start + 1..];
+        let end = rest
+            .find("\n    pub ")
+            .map(|e| start + 1 + e)
+            .unwrap_or(SRC.len());
+        let body = &SRC[start..end];
+
+        // Production still drives the collapse:
+        assert!(
+            body.contains("interest.is_upstream"),
+            "collapse must still locate the upstream via the stored is_upstream flag"
+        );
+        assert!(
+            body.contains("self.ring.unsubscribe(contract)"),
+            "collapse must still drop the local lease via ring.unsubscribe"
+        );
+        // Reconcile is wired in SHADOW mode here and is record-only:
+        assert!(
+            body.contains("record_reconcile_shadow_comparison"),
+            "the reconcile shadow comparison must be wired at the collapse site"
+        );
+        assert!(
+            body.contains("action_set_divergence(&reconcile_actions"),
+            "reconcile output must flow ONLY into the set-membership divergence \
+             comparator (record-only), not into a driver/wire send"
+        );
+    }
 
     #[tokio::test]
     async fn notify_timeout_succeeds_when_receiver_alive() {

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -815,16 +815,30 @@ impl OpManager {
     }
 
     /// Build a [`reconcile::ReconcileInputs`] snapshot for `contract` from live
-    /// node state (keystone step-2, #4642, shadow-mode wiring).
+    /// node state (keystone step-2, #4642, shadow-mode wiring), or `None` when
+    /// the snapshot would be DISTANCE-BLIND and therefore unmeasurable.
     ///
     /// Reads the live maps ONCE into plain values so `reconcile` stays a pure
     /// function. Behavior-preserving: this only reads state; it drives nothing.
     /// Hosting is binary — `state_present` is `true` only when this peer holds
     /// the FULL contract (code + params + state), never a partial tier.
+    ///
+    /// Returns `None` when our OWN ring location is unknown (startup / no observed
+    /// address yet): without it the distance-derived fields — the computed
+    /// upstream, the verified-root check, and the strict-farther downstream gate —
+    /// are ALL unmeasurable. Defaulting the strict gate in that state would MASK
+    /// the mutual-co-host divergence the telemetry exists to reveal, so the caller
+    /// SKIPS the shadow comparison for that contract this tick rather than
+    /// recording noise. A later flip-time builder must handle unknown-location
+    /// explicitly (e.g. defer the reconcile), never count-all.
     pub(crate) fn build_reconcile_inputs(
         &self,
         contract: &ContractKey,
-    ) -> reconcile::ReconcileInputs {
+    ) -> Option<reconcile::ReconcileInputs> {
+        // Distance-blind guard: resolve our own location once up front; if it is
+        // unknown the whole snapshot is unmeasurable (see doc above).
+        let my_location = self.ring.connection_manager.own_location().location()?;
+
         let instance_id = *contract.id();
         let hosting_neighbors = self
             .neighbor_hosting
@@ -833,10 +847,11 @@ impl OpManager {
             .ring
             .most_keyward_hosting_neighbor(&instance_id, &hosting_neighbors);
 
-        reconcile::ReconcileInputs {
+        Some(reconcile::ReconcileInputs {
             computed_upstream,
             has_local_client: self.ring.has_client_subscriptions(contract),
-            has_farther_downstream_subscriber: self.has_farther_downstream_subscriber(contract),
+            has_farther_downstream_subscriber: self
+                .has_farther_downstream_subscriber(contract, my_location),
             state_present: self.ring.contract_state_present(contract),
             is_subscribed: self.ring.is_subscribed(contract),
             is_advertised: self.neighbor_hosting.is_hosted_locally(contract),
@@ -846,40 +861,36 @@ impl OpManager {
             // addition), so this is always false in shadow mode. See
             // `ReconcileInputs::actively_acquiring`.
             actively_acquiring: false,
-        }
+        })
     }
 
     /// Whether at least one lease-valid downstream subscriber is STRICTLY FARTHER
     /// from the contract key than this peer — the piece-D H2 interest gate.
     ///
-    /// Resolves each lease-valid downstream subscriber to its location and keeps
-    /// only those strictly farther from the key than us (the closer/upstream peer
-    /// is excluded, so mutual co-hosts cannot perpetuate each other's leases; see
+    /// `my_location` is this peer's ring location, resolved ONCE by the caller
+    /// ([`build_reconcile_inputs`](Self::build_reconcile_inputs), which returns
+    /// `None` and skips the whole comparison when it is unknown). Resolves each
+    /// lease-valid downstream subscriber to its location and keeps only those
+    /// strictly farther from the key than us (the closer/upstream peer is
+    /// EXCLUDED, so mutual co-hosts cannot perpetuate each other's leases; see
     /// [`has_strictly_farther`]). The distance filter uses EXACT `Distance`
     /// ordering, never epsilon `==`.
-    fn has_farther_downstream_subscriber(&self, contract: &ContractKey) -> bool {
+    fn has_farther_downstream_subscriber(
+        &self,
+        contract: &ContractKey,
+        my_location: Location,
+    ) -> bool {
         let subscribers = self.ring.downstream_subscriber_peers(contract);
         if subscribers.is_empty() {
             return false;
         }
         let contract_location = Location::from(contract);
-        // Own location, derived from our observed socket address — the same
-        // source `most_keyward_hosting_neighbor` / `is_subscription_root` use.
-        // When it is unknown (startup / no observed address yet) we cannot apply
-        // the strict distance filter, so fall back to "any lease-valid downstream
-        // subscriber present" (the current-code `has_downstream_subscribers`
-        // semantics) to avoid a spurious collapse divergence during that
-        // transient — the same own_location edge-noise the #4671 upstream-
-        // divergence caveat documents.
-        let Some(my_location) = self.ring.connection_manager.own_location().location() else {
-            return true;
-        };
         let my_distance: Distance = my_location.distance(contract_location);
         // A subscriber we can't currently resolve to a connected location (it
         // disconnected but its lease has not expired) is skipped, not assumed
-        // farther. Known dilution edge, same noise class as own_location above:
-        // the case the strict filter targets — a CONNECTED closer co-host that is
-        // our upstream — always resolves, so skipping stragglers is safe.
+        // farther. Known dilution edge: the case the strict filter targets — a
+        // CONNECTED closer co-host that is our upstream — always resolves, so
+        // skipping stragglers is safe.
         let subscriber_distances = subscribers.iter().filter_map(|peer| {
             self.ring
                 .connection_manager
@@ -946,32 +957,44 @@ impl OpManager {
         }
 
         // Reconcile-controller SHADOW comparison (keystone step-2, #4642),
-        // COLLAPSE site. This function is the interest-gated collapse: every
-        // path drops the local lease (`ring.unsubscribe` = `Collapse`) and, when
-        // a stored upstream exists, sends a wire `Unsubscribe`. Build the
+        // COLLAPSE site. This function is the interest-gated collapse. Build the
         // reconcile snapshot, compute what the pure controller would do, and
         // compare BY SET MEMBERSHIP. DRIVES NOTHING — the teardown below runs
-        // unchanged.
+        // unchanged. Skipped when the snapshot is distance-blind
+        // (`build_reconcile_inputs` returns `None`: own-location unknown), so a
+        // startup transient does not pollute the collapse-site signal.
         //
-        // Actual→Action mapping (intent-level): `{Collapse, Unsubscribe}` when a
-        // stored upstream was located, else `{Collapse}`. The rare edge where a
-        // located upstream fails later address resolution still collapses
-        // locally (no wire send) but is folded into `{Collapse, Unsubscribe}`
-        // here — it is not worth a separate terminal-point mapping. This site
-        // NEVER retracts a hosting advertisement, so reconcile's `Retract`
-        // (emitted when `is_advertised`) is a genuine gap this shadow records,
-        // not an artifact; likewise the `Unsubscribe` diff captures the stored-
-        // vs-computed upstream disagreement (#4671) at action granularity.
-        {
-            let inputs = self.build_reconcile_inputs(contract);
+        // Actual→Action mapping (mirrors what this function actually EFFECTS):
+        //   - `Collapse` iff we hold a lease at snapshot (`is_subscribed`):
+        //     `ring.unsubscribe` is a NO-OP when not subscribed (hosting.rs), and
+        //     reconcile likewise emits `Collapse` only for a held lease — so a
+        //     verified-root / hosted-only (not-subscribed) contract collapsing on
+        //     last-client-leave must NOT record a false `collapse` diff, keeping
+        //     `collapse_diffs` the clean "controller would collapse a real lease"
+        //     signal.
+        //   - `Unsubscribe` iff a stored upstream was located (`upstream.is_some()`):
+        //     the wire `Unsubscribe` is sent whenever the stored flag resolves an
+        //     upstream, regardless of `is_subscribed`. The rare edge where a
+        //     located upstream fails later address resolution still counts as the
+        //     intent to unsubscribe. The `unsubscribe` diff thus captures the
+        //     stored-vs-computed upstream disagreement (#4671) at action
+        //     granularity.
+        // This site NEVER retracts a hosting advertisement, so reconcile's
+        // `Retract` (emitted when `is_advertised`) is a genuine recorded gap.
+        if let Some(inputs) = self.build_reconcile_inputs(contract) {
             let reconcile_actions = reconcile::reconcile(&inputs);
-            let actual_actions: &[reconcile::Action] = if upstream.is_some() {
-                &[reconcile::Action::Collapse, reconcile::Action::Unsubscribe]
-            } else {
-                &[reconcile::Action::Collapse]
-            };
-            let divergence = reconcile::action_set_divergence(&reconcile_actions, actual_actions);
-            crate::node::network_status::record_reconcile_shadow_comparison(divergence);
+            let mut actual_actions: Vec<reconcile::Action> = Vec::new();
+            if inputs.is_subscribed {
+                actual_actions.push(reconcile::Action::Collapse);
+            }
+            if upstream.is_some() {
+                actual_actions.push(reconcile::Action::Unsubscribe);
+            }
+            let divergence = reconcile::action_set_divergence(&reconcile_actions, &actual_actions);
+            crate::node::network_status::record_reconcile_shadow_comparison(
+                crate::node::network_status::ReconcileShadowSite::Collapse,
+                divergence,
+            );
             if divergence.any() {
                 tracing::debug!(
                     contract = %contract,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -97,6 +97,10 @@ pub(crate) use hosting::LEGACY_FLAT_HOSTING_BUDGET_BYTES;
 /// operator-facing default and the in-code fallback can never drift. The
 /// default is RAM-scaled (capability-relative, A2) rather than a flat constant.
 pub(crate) use hosting::default_hosting_budget_bytes;
+/// Re-export the reconcile controller (pure decision core, its input/action
+/// types, and the shadow-mode set-membership comparator) so the node layer can
+/// build inputs and run the shadow compare (keystone step-2, #4642).
+pub(crate) use hosting::reconcile;
 pub use hosting::{AccessType, RecordAccessResult};
 /// Clamp bounds re-exported only for the config-default round-trip test.
 #[cfg(test)]
@@ -846,7 +850,12 @@ impl Ring {
 
     /// Returns true if this peer is the closest to the contract among its connected neighbors
     /// (i.e., it's a subscription root for this contract).
-    fn is_subscription_root(&self, contract_key: &ContractKey) -> bool {
+    ///
+    /// `pub(crate)` so the reconcile input-builder (keystone step-2, #4642) can
+    /// populate `ReconcileInputs::is_verified_root`. Note the `is_hosting_contract`
+    /// precondition below: a peer that does not yet hold the body is not reported
+    /// as root (the builder inherits that binary hosting semantics).
+    pub(crate) fn is_subscription_root(&self, contract_key: &ContractKey) -> bool {
         if !self.is_hosting_contract(contract_key) {
             return false;
         }
@@ -1630,6 +1639,31 @@ impl Ring {
                 snapshot.upstream_computed_vs_stored_divergences = Some(divergences);
             }
 
+            // Reconcile-controller SHADOW comparison counters (keystone step-2,
+            // #4642). Recorded at the on-`main` hosting decision sites (collapse
+            // via `send_unsubscribe_upstream`, renewal via
+            // `contracts_needing_renewal`) where the pure `reconcile` controller
+            // is run in parallel and compared BY SET MEMBERSHIP to the current
+            // behavior; exported here so the controller's real-world divergence
+            // from today's scattered decisions is legible in central telemetry
+            // BEFORE any decision is flipped to it. Same hand-mirror footgun as
+            // the counters above — a new `RouterSnapshotInfo` field is invisible
+            // to the collector unless added here AND in `event_kind_to_json`
+            // (pinned by `router_snapshot_json_includes_reconcile_shadow_counters`).
+            // Read from the per-node network_status singleton; `None` only before
+            // it is initialized.
+            if let Some(r) = crate::node::network_status::reconcile_shadow_counts() {
+                snapshot.reconcile_shadow_comparisons = Some(r.comparisons);
+                snapshot.reconcile_shadow_divergences = Some(r.divergences);
+                snapshot.reconcile_shadow_subscribe_diffs = Some(r.subscribe_diffs);
+                snapshot.reconcile_shadow_renew_diffs = Some(r.renew_diffs);
+                snapshot.reconcile_shadow_unsubscribe_diffs = Some(r.unsubscribe_diffs);
+                snapshot.reconcile_shadow_collapse_diffs = Some(r.collapse_diffs);
+                snapshot.reconcile_shadow_announce_diffs = Some(r.announce_diffs);
+                snapshot.reconcile_shadow_retract_diffs = Some(r.retract_diffs);
+                snapshot.reconcile_shadow_reroot_search_diffs = Some(r.reroot_search_diffs);
+            }
+
             // Keep the hosting manager's copy of our own ring location current so
             // the proximity-prior demand estimate (#4642 A3) can turn a contract
             // key into a distance. Best-effort: only push a known location.
@@ -2063,6 +2097,37 @@ impl Ring {
                 tracing::debug!("OpManager not available for subscription renewal");
                 continue;
             };
+
+            // Reconcile-controller SHADOW comparison (keystone step-2, #4642),
+            // RENEWAL site — the highest-signal one: it exercises the #3763
+            // interest gate. For every contract the current renewal set wants
+            // renewed, the actual behavior maps to the Action set `{Renew}`; we
+            // build the reconcile snapshot, compute what the pure controller
+            // would do, and record the set-membership divergence. DRIVES
+            // NOTHING — the batch renewal loop below is unchanged. A renewal the
+            // controller would NOT keep alive (e.g. a section-2/3 not-subscribed
+            // contract the controller would `Subscribe`/`ReRootSearch` instead,
+            // or one in use only via a strictly-CLOSER downstream subscriber) is
+            // exactly the drift the computed-upstream / strict-farther model
+            // corrects — expected, recorded, not a bug. Bounded per tick (30s
+            // cadence × renewal-set size); local counter increments only, no
+            // per-event telemetry emission.
+            for contract in &contracts_needing_renewal {
+                let inputs = op_manager.build_reconcile_inputs(contract);
+                let reconcile_actions = reconcile::reconcile(&inputs);
+                let divergence = reconcile::action_set_divergence(
+                    &reconcile_actions,
+                    &[reconcile::Action::Renew],
+                );
+                crate::node::network_status::record_reconcile_shadow_comparison(divergence);
+                if divergence.any() {
+                    tracing::debug!(
+                        %contract,
+                        ?reconcile_actions,
+                        "reconcile shadow diverges from actual renewal ({{Renew}}) (#4642 keystone step-2)"
+                    );
+                }
+            }
 
             // Backpressure: reduce batch size when the notification channel is
             // congested, but never skip entirely. Renewals are critical-path —
@@ -2893,6 +2958,31 @@ impl Ring {
     /// Check if we have an active (non-expired) subscription to a contract.
     pub fn is_subscribed(&self, contract: &ContractKey) -> bool {
         self.hosting_manager.is_subscribed(contract)
+    }
+
+    /// Whether the FULL contract state (code + params + state) is present on
+    /// disk for `contract` — the cheap on-disk state-store existence check, NOT
+    /// the in-memory hosting cache. Hosting is binary: this is `true` only when
+    /// this peer holds the whole contract. Used by the reconcile input-builder
+    /// (keystone step-2, #4642) for `ReconcileInputs::state_present`.
+    pub(crate) fn contract_state_present(&self, contract: &ContractKey) -> bool {
+        self.hosting_manager.contract_state_present(contract)
+    }
+
+    /// Whether at least one LOCAL WebSocket client is currently subscribed to
+    /// `contract` (real local demand, distinct from downstream peer
+    /// subscribers). Used by the reconcile input-builder (keystone step-2,
+    /// #4642) for `ReconcileInputs::has_local_client`.
+    pub(crate) fn has_client_subscriptions(&self, contract: &ContractKey) -> bool {
+        self.hosting_manager.has_client_subscriptions(contract.id())
+    }
+
+    /// Lease-valid downstream subscriber peer keys for `contract` (see
+    /// [`hosting::HostingManager::downstream_subscriber_peers`]). Used by the
+    /// reconcile input-builder (keystone step-2, #4642) to apply the piece-D
+    /// strictly-farther filter.
+    pub(crate) fn downstream_subscriber_peers(&self, contract: &ContractKey) -> Vec<PeerKey> {
+        self.hosting_manager.downstream_subscriber_peers(contract)
     }
 
     /// Get all contracts with active subscriptions.

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -402,6 +402,67 @@ fn most_keyward_among(
         .map(|(pkl, _)| pkl)
 }
 
+/// Map a renewal-loop per-tick outcome to the Action set the reconcile
+/// controller is compared against in shadow mode (keystone step-2, #4642).
+///
+/// `acted` = the loop spawned a fresh SUBSCRIBE for this contract THIS TICK (vs
+/// skipped/deferred → nothing). `run_renewal_subscribe` issues a real SUBSCRIBE,
+/// which per [`reconcile::Action`]'s docs is `Renew` when we already hold the
+/// lease and `Subscribe` when we do not — so a section-2/3 not-subscribed entry
+/// maps to `Subscribe`, never a phantom `Renew`.
+fn renewal_shadow_actual(acted: bool, is_subscribed: bool) -> &'static [reconcile::Action] {
+    match (acted, is_subscribed) {
+        (false, _) => &[],
+        (true, true) => &[reconcile::Action::Renew],
+        (true, false) => &[reconcile::Action::Subscribe],
+    }
+}
+
+/// Record one reconcile-controller SHADOW comparison for the RENEWAL site
+/// (keystone step-2, #4642), respecting the per-tick sample `budget`. DRIVES
+/// NOTHING: it builds a [`reconcile::ReconcileInputs`] snapshot, computes what
+/// the controller WOULD do, maps the loop's per-tick outcome to an Action set
+/// via [`renewal_shadow_actual`], and records only the set-membership
+/// divergence.
+///
+/// Skips (without consuming budget) when the snapshot is distance-blind — an
+/// unknown own-location makes the computed upstream / verified-root / strict
+/// downstream-demand fields unmeasurable, so recording then would be noise
+/// (`build_reconcile_inputs` returns `None`). Otherwise consumes one unit of
+/// `budget`; when the budget is exhausted the remaining contracts this tick are
+/// left unmeasured (they rotate in on later ticks via the renewal-set shuffle).
+fn record_renewal_shadow(
+    op_manager: &crate::node::OpManager,
+    budget: &mut usize,
+    contract: &ContractKey,
+    acted: bool,
+) {
+    if *budget == 0 {
+        return;
+    }
+    let Some(inputs) = op_manager.build_reconcile_inputs(contract) else {
+        // Distance-blind snapshot (own-location unknown): unmeasurable this tick,
+        // don't pollute the signal. Not counted against the budget.
+        return;
+    };
+    *budget -= 1;
+    let reconcile_actions = reconcile::reconcile(&inputs);
+    let actual = renewal_shadow_actual(acted, inputs.is_subscribed);
+    let divergence = reconcile::action_set_divergence(&reconcile_actions, actual);
+    crate::node::network_status::record_reconcile_shadow_comparison(
+        crate::node::network_status::ReconcileShadowSite::Renewal,
+        divergence,
+    );
+    if divergence.any() {
+        tracing::debug!(
+            %contract,
+            ?reconcile_actions,
+            ?actual,
+            "reconcile shadow diverges from actual renewal outcome (#4642 keystone step-2)"
+        );
+    }
+}
+
 /// Race an `.await` point in a background loop against the Ring shutdown
 /// token. Returns `true` if shutdown fired (the caller should stop its loop)
 /// and `false` if the wrapped future completed first (carry on).
@@ -1639,29 +1700,46 @@ impl Ring {
                 snapshot.upstream_computed_vs_stored_divergences = Some(divergences);
             }
 
-            // Reconcile-controller SHADOW comparison counters (keystone step-2,
-            // #4642). Recorded at the on-`main` hosting decision sites (collapse
-            // via `send_unsubscribe_upstream`, renewal via
+            // Reconcile-controller SHADOW comparison counters, split PER SITE
+            // (keystone step-2, #4642). Recorded at the on-`main` hosting decision
+            // sites (collapse via `send_unsubscribe_upstream`, renewal via
             // `contracts_needing_renewal`) where the pure `reconcile` controller
             // is run in parallel and compared BY SET MEMBERSHIP to the current
             // behavior; exported here so the controller's real-world divergence
             // from today's scattered decisions is legible in central telemetry
-            // BEFORE any decision is flipped to it. Same hand-mirror footgun as
-            // the counters above — a new `RouterSnapshotInfo` field is invisible
-            // to the collector unless added here AND in `event_kind_to_json`
-            // (pinned by `router_snapshot_json_includes_reconcile_shadow_counters`).
-            // Read from the per-node network_status singleton; `None` only before
-            // it is initialized.
-            if let Some(r) = crate::node::network_status::reconcile_shadow_counts() {
-                snapshot.reconcile_shadow_comparisons = Some(r.comparisons);
-                snapshot.reconcile_shadow_divergences = Some(r.divergences);
-                snapshot.reconcile_shadow_subscribe_diffs = Some(r.subscribe_diffs);
-                snapshot.reconcile_shadow_renew_diffs = Some(r.renew_diffs);
-                snapshot.reconcile_shadow_unsubscribe_diffs = Some(r.unsubscribe_diffs);
-                snapshot.reconcile_shadow_collapse_diffs = Some(r.collapse_diffs);
-                snapshot.reconcile_shadow_announce_diffs = Some(r.announce_diffs);
-                snapshot.reconcile_shadow_retract_diffs = Some(r.retract_diffs);
-                snapshot.reconcile_shadow_reroot_search_diffs = Some(r.reroot_search_diffs);
+            // BEFORE any decision is flipped to it. Split per site because the
+            // flip is site-by-site and each must be separately gate-able. Same
+            // hand-mirror footgun as the counters above — a new
+            // `RouterSnapshotInfo` field is invisible to the collector unless
+            // added here AND in `event_kind_to_json` (pinned by
+            // `router_snapshot_json_includes_reconcile_shadow_counters`). Read
+            // from the per-node network_status singleton; `None` only before it is
+            // initialized.
+            if let Some((collapse, renewal)) =
+                crate::node::network_status::reconcile_shadow_counts()
+            {
+                snapshot.reconcile_shadow_collapse_comparisons = Some(collapse.comparisons);
+                snapshot.reconcile_shadow_collapse_divergences = Some(collapse.divergences);
+                snapshot.reconcile_shadow_collapse_subscribe_diffs = Some(collapse.subscribe_diffs);
+                snapshot.reconcile_shadow_collapse_renew_diffs = Some(collapse.renew_diffs);
+                snapshot.reconcile_shadow_collapse_unsubscribe_diffs =
+                    Some(collapse.unsubscribe_diffs);
+                snapshot.reconcile_shadow_collapse_collapse_diffs = Some(collapse.collapse_diffs);
+                snapshot.reconcile_shadow_collapse_announce_diffs = Some(collapse.announce_diffs);
+                snapshot.reconcile_shadow_collapse_retract_diffs = Some(collapse.retract_diffs);
+                snapshot.reconcile_shadow_collapse_reroot_search_diffs =
+                    Some(collapse.reroot_search_diffs);
+                snapshot.reconcile_shadow_renewal_comparisons = Some(renewal.comparisons);
+                snapshot.reconcile_shadow_renewal_divergences = Some(renewal.divergences);
+                snapshot.reconcile_shadow_renewal_subscribe_diffs = Some(renewal.subscribe_diffs);
+                snapshot.reconcile_shadow_renewal_renew_diffs = Some(renewal.renew_diffs);
+                snapshot.reconcile_shadow_renewal_unsubscribe_diffs =
+                    Some(renewal.unsubscribe_diffs);
+                snapshot.reconcile_shadow_renewal_collapse_diffs = Some(renewal.collapse_diffs);
+                snapshot.reconcile_shadow_renewal_announce_diffs = Some(renewal.announce_diffs);
+                snapshot.reconcile_shadow_renewal_retract_diffs = Some(renewal.retract_diffs);
+                snapshot.reconcile_shadow_renewal_reroot_search_diffs =
+                    Some(renewal.reroot_search_diffs);
             }
 
             // Keep the hosting manager's copy of our own ring location current so
@@ -2098,37 +2176,6 @@ impl Ring {
                 continue;
             };
 
-            // Reconcile-controller SHADOW comparison (keystone step-2, #4642),
-            // RENEWAL site — the highest-signal one: it exercises the #3763
-            // interest gate. For every contract the current renewal set wants
-            // renewed, the actual behavior maps to the Action set `{Renew}`; we
-            // build the reconcile snapshot, compute what the pure controller
-            // would do, and record the set-membership divergence. DRIVES
-            // NOTHING — the batch renewal loop below is unchanged. A renewal the
-            // controller would NOT keep alive (e.g. a section-2/3 not-subscribed
-            // contract the controller would `Subscribe`/`ReRootSearch` instead,
-            // or one in use only via a strictly-CLOSER downstream subscriber) is
-            // exactly the drift the computed-upstream / strict-farther model
-            // corrects — expected, recorded, not a bug. Bounded per tick (30s
-            // cadence × renewal-set size); local counter increments only, no
-            // per-event telemetry emission.
-            for contract in &contracts_needing_renewal {
-                let inputs = op_manager.build_reconcile_inputs(contract);
-                let reconcile_actions = reconcile::reconcile(&inputs);
-                let divergence = reconcile::action_set_divergence(
-                    &reconcile_actions,
-                    &[reconcile::Action::Renew],
-                );
-                crate::node::network_status::record_reconcile_shadow_comparison(divergence);
-                if divergence.any() {
-                    tracing::debug!(
-                        %contract,
-                        ?reconcile_actions,
-                        "reconcile shadow diverges from actual renewal ({{Renew}}) (#4642 keystone step-2)"
-                    );
-                }
-            }
-
             // Backpressure: reduce batch size when the notification channel is
             // congested, but never skip entirely. Renewals are critical-path —
             // skipping a full cycle when the channel is busy lets subscriptions
@@ -2157,6 +2204,22 @@ impl Ring {
 
             let mut attempted = 0;
             let mut skipped = 0;
+
+            // Reconcile-controller SHADOW comparison budget (keystone step-2,
+            // #4642), RENEWAL site. The shadow compare is INLINED into this loop
+            // (below) so the recorded "actual" equals what production actually did
+            // THIS TICK — `{}` for a skipped/deferred contract, else the fresh
+            // SUBSCRIBE the loop spawns (mapped to `Renew` vs `Subscribe` by
+            // whether we hold a lease; see `renewal_shadow_actual`). It DRIVES
+            // NOTHING. Gated by the same `batch_limit` as the real renewal work:
+            // each sample builds a `ReconcileInputs` snapshot (a synchronous redb
+            // state-store read + an `is_subscription_root` scan that clones the
+            // connections map, i.e. redb read + O(neighbors) per sample), so
+            // bounding the sample count keeps the per-tick cost from scaling with
+            // the whole renewal set on near-key gateways. The shuffle above
+            // rotates which contracts get sampled across ticks; contracts past the
+            // budget or past a `break` gate are simply unmeasured this tick.
+            let mut shadow_budget = batch_limit;
 
             for contract in contracts_needing_renewal {
                 // Limit concurrent renewal attempts to avoid overwhelming the network
@@ -2196,12 +2259,18 @@ impl Ring {
                         phase = "subscription_renewal_banned_skip",
                         "skipping subscription renewal for banned contract"
                     );
+                    // Shadow: production does NOTHING for a banned contract this
+                    // tick → actual is `{}`.
+                    record_renewal_shadow(&op_manager, &mut shadow_budget, &contract, false);
                     skipped += 1;
                     continue;
                 }
 
                 // Check spam prevention (respects exponential backoff and pending checks)
                 if !ring.can_request_subscription(&contract) {
+                    // Shadow: backoff/pending gate → production does NOTHING this
+                    // tick → actual is `{}`.
+                    record_renewal_shadow(&op_manager, &mut shadow_budget, &contract, false);
                     skipped += 1;
                     continue;
                 }
@@ -2209,6 +2278,10 @@ impl Ring {
                 // Mark as pending and spawn subscription request
                 if ring.mark_subscription_pending(contract) {
                     attempted += 1;
+                    // Shadow: production spawns a fresh SUBSCRIBE
+                    // (`run_renewal_subscribe`) for this contract this tick →
+                    // actual is `{Renew}` if we hold a lease, else `{Subscribe}`.
+                    record_renewal_shadow(&op_manager, &mut shadow_budget, &contract, true);
 
                     // Spread tasks across the interval to avoid thundering-herd bursts.
                     let jitter_ms = GlobalRng::random_range(0u64..=15_000);
@@ -2327,6 +2400,11 @@ impl Ring {
                             }),
                         );
                     });
+                } else {
+                    // `mark_subscription_pending` returned false: a renewal for
+                    // this contract is already in flight, so production does
+                    // NOTHING more this tick → shadow actual is `{}`.
+                    record_renewal_shadow(&op_manager, &mut shadow_budget, &contract, false);
                 }
             }
 
@@ -2962,9 +3040,18 @@ impl Ring {
 
     /// Whether the FULL contract state (code + params + state) is present on
     /// disk for `contract` — the cheap on-disk state-store existence check, NOT
-    /// the in-memory hosting cache. Hosting is binary: this is `true` only when
-    /// this peer holds the whole contract. Used by the reconcile input-builder
-    /// (keystone step-2, #4642) for `ReconcileInputs::state_present`.
+    /// the in-memory hosting cache. Hosting is binary: a `true` from a healthy
+    /// store means this peer holds the whole contract.
+    ///
+    /// CAVEAT — conservative assume-present fallback: this returns `true` (not
+    /// `false`) when the state store is transiently unavailable — a redb read
+    /// error, an unset storage handle before startup, or a non-redb build. So a
+    /// `true` is "present, OR presence currently unknowable", never a hard
+    /// guarantee. In the reconcile shadow (keystone step-2, #4642) that can
+    /// slightly INFLATE the renewal-site `announce` divergence during a transient
+    /// store outage (the controller would `Announce` a host we can't confirm has
+    /// the body); it is a startup/outage transient, documented so the counter is
+    /// read correctly rather than mistaken for a real anomaly.
     pub(crate) fn contract_state_present(&self, contract: &ContractKey) -> bool {
         self.hosting_manager.contract_state_present(contract)
     }
@@ -6016,6 +6103,66 @@ mod k_closest_source_tests {
              not-ready peers, so a not-ready closer neighbor is still a valid route \
              target and must keep this node from short-circuiting its renewal (#4440)."
         );
+    }
+
+    /// Source-scrape pin (keystone step-2, #4642): the RENEWAL-site reconcile
+    /// shadow (`record_renewal_shadow`) must feed the controller's output ONLY
+    /// into the set-membership divergence comparator + the per-site counter — it
+    /// must DRIVE NOTHING. Symmetric to the collapse-site pin
+    /// (`send_unsubscribe_upstream_still_drives_and_shadow_is_record_only`). A
+    /// future edit that consumes the renewal-site controller output as a control
+    /// signal must trip this guard.
+    #[test]
+    fn renewal_shadow_is_record_only_not_drive() {
+        let src = production_source();
+        let body = extract_fn_body(src, "fn record_renewal_shadow(");
+        assert!(
+            body.contains("action_set_divergence"),
+            "record_renewal_shadow must compare via action_set_divergence"
+        );
+        assert!(
+            body.contains("record_reconcile_shadow_comparison"),
+            "record_renewal_shadow must record the per-site divergence"
+        );
+        // Record-only: the shadow helper must NOT drive any renewal/subscription
+        // action off the controller's output.
+        for driver in [
+            "mark_subscription_pending",
+            "run_renewal_subscribe",
+            "ring.subscribe",
+            ".unsubscribe(",
+        ] {
+            assert!(
+                !body.contains(driver),
+                "record_renewal_shadow must not drive `{driver}` — the renewal shadow is record-only"
+            );
+        }
+        // The real renewal loop still drives the actual renewal (unchanged) and
+        // wires the record-only shadow helper.
+        let loop_body = extract_fn_body(src, "async fn recover_orphaned_subscriptions(");
+        assert!(
+            loop_body.contains("mark_subscription_pending"),
+            "the renewal loop still drives the real renewal via mark_subscription_pending"
+        );
+        assert!(
+            loop_body.contains("record_renewal_shadow"),
+            "the renewal loop wires the record-only shadow helper"
+        );
+    }
+
+    /// Unit (keystone step-2, #4642): `renewal_shadow_actual` maps the renewal
+    /// loop's per-tick outcome to the Action set the controller is compared
+    /// against. A not-acted (skipped/deferred) contract maps to `{}`; an acted
+    /// contract maps to `Renew` iff we already hold the lease, else `Subscribe` —
+    /// so a section-2/3 not-subscribed entry never records a phantom `Renew`.
+    #[test]
+    fn renewal_shadow_actual_maps_by_lease() {
+        use super::reconcile::Action::{Renew, Subscribe};
+        let empty: &[super::reconcile::Action] = &[];
+        assert_eq!(super::renewal_shadow_actual(false, true), empty);
+        assert_eq!(super::renewal_shadow_actual(false, false), empty);
+        assert_eq!(super::renewal_shadow_actual(true, true), &[Renew]);
+        assert_eq!(super::renewal_shadow_actual(true, false), &[Subscribe]);
     }
 }
 

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -31,7 +31,9 @@
 
 mod cache;
 mod demand;
-mod reconcile;
+// `pub(crate)` so `ring.rs` can re-export the reconcile controller to the node
+// layer for the shadow-mode wiring (keystone step-2, #4642).
+pub(crate) mod reconcile;
 
 use crate::util::backoff::{ExponentialBackoff, TrackedBackoff};
 use crate::util::time_source::{DynTimeSource, InstantTimeSrc, TimeSource};
@@ -884,6 +886,37 @@ impl HostingManager {
         self.downstream_subscribers
             .get(contract)
             .is_some_and(|peers| !peers.is_empty())
+    }
+
+    /// Lease-valid downstream subscriber peer keys for `contract`.
+    ///
+    /// Returns the `PeerKey`s of downstream peers whose subscription lease is
+    /// still active (renewed within `SUBSCRIPTION_LEASE_DURATION`), WITHOUT
+    /// mutating the map — mirrors the read-only lease check in
+    /// [`downstream_subscriber_count`](Self::downstream_subscriber_count) /
+    /// `expire_stale_downstream_subscribers`, so a contract whose leases have all
+    /// gone stale (but not yet been swept) reports none.
+    ///
+    /// Used by the reconcile input-builder (keystone step-2, #4642) to apply the
+    /// piece-D **strictly-farther** filter: a downstream subscriber counts as
+    /// live demand only if it is farther from the contract key than this peer
+    /// (the closer/upstream one is excluded, so mutual co-hosts cannot perpetuate
+    /// each other's leases). This accessor returns the raw lease-valid set; the
+    /// caller resolves each peer's location and applies the distance filter.
+    pub(crate) fn downstream_subscriber_peers(&self, contract: &ContractKey) -> Vec<PeerKey> {
+        let now = self.time_source.now();
+        self.downstream_subscribers
+            .get(contract)
+            .map(|peers| {
+                peers
+                    .iter()
+                    .filter(|(_, last_renewed)| {
+                        now.duration_since(**last_renewed) < SUBSCRIPTION_LEASE_DURATION
+                    })
+                    .map(|(peer, _)| peer.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     /// Number of local (WebSocket) clients currently subscribed to this

--- a/crates/core/src/ring/hosting/reconcile.rs
+++ b/crates/core/src/ring/hosting/reconcile.rs
@@ -18,15 +18,27 @@
 //! the desired action set from current inputs, so a missed event is caught by the
 //! next tick and the whole stale-flag bug class disappears.
 //!
-//! # Not yet wired
+//! # Wired in SHADOW mode (drives nothing)
 //!
-//! This is **sub-task 1** of the keystone: the pure core + its types + unit tests,
-//! additive and behavior-preserving. Nothing in production calls [`reconcile`]
-//! yet. The next sub-task wires it in **shadow mode** at the ~6 on-`main` decision
-//! sites (compute what it WOULD do, compare to what the current code does, record
-//! divergence — current code still drives). The FLIP (controller actually drives)
-//! is a later step. Because it is unwired, the items here are `#[allow(dead_code)]`
-//! until that shadow wiring lands.
+//! Sub-task 1 landed the pure core + types + unit tests. Sub-task 2 (this
+//! change) wires it in **shadow mode** at the highest-signal on-`main` hosting
+//! decision sites: the interest-gated COLLAPSE (`OpManager::send_unsubscribe_
+//! upstream`) and the RENEWAL set (`Ring::contracts_needing_renewal`, driven by
+//! the recovery loop). At each site the wiring builds a [`ReconcileInputs`]
+//! snapshot from live node state, computes what [`reconcile`] WOULD do, and
+//! compares it — BY SET MEMBERSHIP — to what the current code actually does,
+//! recording the divergence in aggregate telemetry
+//! ([`action_set_divergence`] → `node::network_status::ReconcileShadowStats`).
+//! **The current scattered code still drives every decision**; nothing consumes
+//! [`reconcile`]'s output as a control signal. The FLIP (controller actually
+//! drives) is a later step, as are the remaining sites (inbound-unsubscribe
+//! collapse, connection-drop re-root, host-formation announce). Because the
+//! driver and those hooks are still unwired, some surface here is exercised only
+//! by the shadow compare and tests, so `#[allow(dead_code)]` stays until the
+//! flip.
+//!
+//! Hosting is BINARY throughout: [`ReconcileInputs::state_present`] means this
+//! peer holds the FULL contract (code + params + state), never a partial tier.
 //!
 //! # Notes for the shadow-compare wiring (next sub-task)
 //!
@@ -68,9 +80,11 @@
 //! selection. See the pin test `distance_partialeq_is_fuzzy_but_cmp_is_exact` and
 //! `ring/location.rs:223-243`.
 
-// Wired to production (in shadow mode) by the next keystone sub-task; the pure
-// core + types + tests land here first, unused by any production path, so
-// dead_code is expected and allowed until that wiring exists.
+// Wired to production in SHADOW mode by keystone sub-task 2 (compare-only, drives
+// nothing). The driver that would apply a `Vec<Action>`, and the forward-looking
+// hooks (Retract's `on_contract_unhosted`, `actively_acquiring`, the not-yet-wired
+// decision sites) remain unexercised by any control path, so dead_code stays
+// allowed until the flip.
 #![allow(dead_code)]
 
 use crate::ring::PeerKeyLocation;
@@ -323,6 +337,62 @@ pub(crate) fn reconcile(inputs: &ReconcileInputs) -> Vec<Action> {
     }
 
     actions
+}
+
+/// Per-[`Action`]-class flags marking which actions were in the SYMMETRIC
+/// DIFFERENCE of one shadow comparison — present in the reconcile controller's
+/// desired set XOR in the actual behavior's set. Plain flags so the telemetry
+/// layer (`node::network_status`) can accumulate per-action divergence counters
+/// without depending on the comparison internals or the `Action` enum shape.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ReconcileActionDivergence {
+    pub subscribe: bool,
+    pub renew: bool,
+    pub unsubscribe: bool,
+    pub collapse: bool,
+    pub announce: bool,
+    pub retract: bool,
+    pub reroot_search: bool,
+}
+
+impl ReconcileActionDivergence {
+    /// True iff any action class diverged (the two sets were not equal).
+    pub fn any(&self) -> bool {
+        self.subscribe
+            || self.renew
+            || self.unsubscribe
+            || self.collapse
+            || self.announce
+            || self.retract
+            || self.reroot_search
+    }
+}
+
+/// Compare the reconcile controller's desired action set against the actual
+/// behavior's action set BY SET MEMBERSHIP (order- and duplicate-insensitive),
+/// returning which action classes diverge. Pure; the shadow-mode wiring
+/// (keystone step-2, #4642) records the result but drives nothing.
+///
+/// An action "diverges" when it is present in exactly one of the two sets — the
+/// controller wanted it but the site did not do it, or the site did it but the
+/// controller would not. Set membership (not exact-`Vec` equality) is the right
+/// comparison: a single production site maps to a fixed Action SET (e.g.
+/// `send_unsubscribe_upstream` = `{Collapse, Unsubscribe}`), and the
+/// controller's internal emission ORDER is irrelevant to whether the two agree.
+pub(crate) fn action_set_divergence(
+    reconcile_actions: &[Action],
+    actual_actions: &[Action],
+) -> ReconcileActionDivergence {
+    let differs = |a: Action| reconcile_actions.contains(&a) != actual_actions.contains(&a);
+    ReconcileActionDivergence {
+        subscribe: differs(Action::Subscribe),
+        renew: differs(Action::Renew),
+        unsubscribe: differs(Action::Unsubscribe),
+        collapse: differs(Action::Collapse),
+        announce: differs(Action::Announce),
+        retract: differs(Action::Retract),
+        reroot_search: differs(Action::ReRootSearch),
+    }
 }
 
 #[cfg(test)]
@@ -589,6 +659,61 @@ mod tests {
         }
     }
 
+    /// `action_set_divergence` is the set-membership comparator the shadow
+    /// wiring feeds the divergence telemetry. Pin its semantics: order- and
+    /// duplicate-insensitive, per-action symmetric difference, `any()` iff the
+    /// sets differ.
+    #[test]
+    fn action_set_divergence_by_membership() {
+        use Action::*;
+
+        // Identical sets ⇒ no divergence.
+        let d = action_set_divergence(&[Collapse, Unsubscribe], &[Collapse, Unsubscribe]);
+        assert!(!d.any(), "identical sets must not diverge");
+
+        // Order- and duplicate-insensitive: same members, different order/dups.
+        let d = action_set_divergence(&[Unsubscribe, Collapse, Collapse], &[Collapse, Unsubscribe]);
+        assert!(!d.any(), "set membership ignores order and duplicates");
+
+        // The collapse Retract gap: reconcile wants Retract, the actual site
+        // does not ⇒ retract diverges, nothing else.
+        let d = action_set_divergence(&[Collapse, Unsubscribe, Retract], &[Collapse, Unsubscribe]);
+        assert_eq!(
+            d,
+            ReconcileActionDivergence {
+                retract: true,
+                ..Default::default()
+            },
+            "only Retract should diverge (present in reconcile, absent in actual)"
+        );
+
+        // Renewal disagreement: reconcile would Subscribe (not-yet-subscribed),
+        // actual renews ⇒ both Subscribe and Renew are in the symmetric diff.
+        let d = action_set_divergence(&[Subscribe], &[Renew]);
+        assert_eq!(
+            d,
+            ReconcileActionDivergence {
+                subscribe: true,
+                renew: true,
+                ..Default::default()
+            }
+        );
+
+        // Empty reconcile vs a single actual action ⇒ that action diverges.
+        let d = action_set_divergence(&[], &[Collapse]);
+        assert_eq!(
+            d,
+            ReconcileActionDivergence {
+                collapse: true,
+                ..Default::default()
+            }
+        );
+
+        // Renewal agreement (steady-state in-use host) ⇒ no divergence.
+        let d = action_set_divergence(&[Renew], &[Renew]);
+        assert!(!d.any());
+    }
+
     /// Pin for the `Distance` Eq/Ord gotcha (`ring/location.rs:223-243`): two
     /// distances one ULP apart are epsilon-`==` yet cmp-unequal. `reconcile`
     /// consumes a pre-resolved `Option<PeerKeyLocation>` precisely so no epsilon
@@ -617,5 +742,26 @@ mod tests {
             Ordering::Equal,
             "exact cmp does NOT — reconcile must never mix epsilon `==` with this ordering"
         );
+    }
+
+    /// Behavior-preserving guard (keystone step-2, #4642): reconcile is a PURE
+    /// decision core wired only in SHADOW mode. No code in this module may apply
+    /// its `Vec<Action>` to the wire/state — the controller drives NOTHING until
+    /// the deliberate FLIP (a later step). This source-scrape pin fails if a
+    /// driver/apply entry point is added here without updating the shadow-vs-drive
+    /// story, keeping the "drives nothing" invariant of this sub-task honest.
+    #[test]
+    fn reconcile_controller_has_no_driver_yet() {
+        const SRC: &str = include_str!("reconcile.rs");
+        // Scan only the PRODUCTION portion (before the test module) so this
+        // test's own forbidden-string literals don't self-match.
+        let prod = &SRC[..SRC.find("#[cfg(test)]").unwrap_or(SRC.len())];
+        for forbidden in ["fn drive", "fn apply_action", "fn apply_actions"] {
+            assert!(
+                !prod.contains(forbidden),
+                "reconcile.rs must not define `{forbidden}` in shadow mode — the \
+                 controller records divergence only and drives nothing until the flip"
+            );
+        }
     }
 }

--- a/crates/core/src/ring/hosting/reconcile.rs
+++ b/crates/core/src/ring/hosting/reconcile.rs
@@ -40,6 +40,24 @@
 //! Hosting is BINARY throughout: [`ReconcileInputs::state_present`] means this
 //! peer holds the FULL contract (code + params + state), never a partial tier.
 //!
+//! ## Expected-by-design divergences (do NOT read as anomalies)
+//!
+//! Several divergence classes are EXPECTED because the on-`main` sites do not yet
+//! implement the controller's model — they are the delta the keystone closes, not
+//! bugs:
+//! - **`retract` / `reroot_search`**: no on-`main` driver retracts a hosting
+//!   advertisement on teardown or re-roots on upstream loss, so the controller
+//!   emits these where production does nothing.
+//! - **`renew` / `subscribe` / `unsubscribe`**: the controller's STRICT
+//!   downstream-demand gate (a downstream subscriber counts only when strictly
+//!   FARTHER from the key) and its lease-aware split (`Renew` iff we hold a
+//!   lease, else `Subscribe`) legitimately disagree with today's ANY-downstream,
+//!   renew-everything renewal path — that disagreement is the signal.
+//! - **`announce`**: a subscribed, state-present host that has not yet advertised
+//!   is a controller `Announce` with no per-tick production counterpart.
+//!
+//! Read the counters as the reconcile-vs-today delta, never as a health alarm.
+//!
 //! # Notes for the shadow-compare wiring (next sub-task)
 //!
 //! - **`Collapse` is the LOCAL teardown** (drop our lease, `ring.unsubscribe`);
@@ -383,16 +401,38 @@ pub(crate) fn action_set_divergence(
     reconcile_actions: &[Action],
     actual_actions: &[Action],
 ) -> ReconcileActionDivergence {
-    let differs = |a: Action| reconcile_actions.contains(&a) != actual_actions.contains(&a);
-    ReconcileActionDivergence {
-        subscribe: differs(Action::Subscribe),
-        renew: differs(Action::Renew),
-        unsubscribe: differs(Action::Unsubscribe),
-        collapse: differs(Action::Collapse),
-        announce: differs(Action::Announce),
-        retract: differs(Action::Retract),
-        reroot_search: differs(Action::ReRootSearch),
+    // Set the divergence flag for one Action class. The exhaustive `match` (NO
+    // wildcard) is load-bearing: adding a new `Action` variant fails to COMPILE
+    // here until it is wired into the flags, so a future action can never be
+    // silently left unmeasured by the shadow telemetry.
+    fn flag(div: &mut ReconcileActionDivergence, action: Action) {
+        match action {
+            Action::Subscribe => div.subscribe = true,
+            Action::Renew => div.renew = true,
+            Action::Unsubscribe => div.unsubscribe = true,
+            Action::Collapse => div.collapse = true,
+            Action::Announce => div.announce = true,
+            Action::Retract => div.retract = true,
+            Action::ReRootSearch => div.reroot_search = true,
+        }
     }
+
+    let mut div = ReconcileActionDivergence::default();
+    // Symmetric difference: an action in exactly one of the two sets. The two
+    // passes together cover both directions; an action in BOTH sets is flagged
+    // by neither, and duplicates within a slice are idempotent (`flag` just
+    // re-sets the same bool).
+    for &a in reconcile_actions {
+        if !actual_actions.contains(&a) {
+            flag(&mut div, a);
+        }
+    }
+    for &a in actual_actions {
+        if !reconcile_actions.contains(&a) {
+            flag(&mut div, a);
+        }
+    }
+    div
 }
 
 #[cfg(test)]

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -263,6 +263,26 @@ pub(crate) struct RouterSnapshotInfo {
     /// lifetime totals, `None` until the ring's snapshot task populates them.
     pub upstream_computed_vs_stored_comparisons: Option<u64>,
     pub upstream_computed_vs_stored_divergences: Option<u64>,
+    /// Reconcile-controller SHADOW comparison counters (hosting redesign
+    /// keystone step-2, #4642). Populated by `Ring` from the per-node
+    /// `network_status` singleton on the snapshot cadence. `comparisons` is the
+    /// denominator (one per shadow comparison at a hosting decision site),
+    /// `divergences` the count whose reconcile action set differed from the
+    /// actual behavior's set; the `*_diffs` are per-action symmetric-difference
+    /// tallies. Field evidence for how far the pure `reconcile` controller
+    /// diverges from today's scattered decisions BEFORE the flip — monotonic
+    /// lifetime totals, `None` until the ring's snapshot task populates them. A
+    /// nonzero `retract` / `reroot_search` divergence is EXPECTED (those
+    /// controller actions have no on-`main` driver yet), not an alarm.
+    pub reconcile_shadow_comparisons: Option<u64>,
+    pub reconcile_shadow_divergences: Option<u64>,
+    pub reconcile_shadow_subscribe_diffs: Option<u64>,
+    pub reconcile_shadow_renew_diffs: Option<u64>,
+    pub reconcile_shadow_unsubscribe_diffs: Option<u64>,
+    pub reconcile_shadow_collapse_diffs: Option<u64>,
+    pub reconcile_shadow_announce_diffs: Option<u64>,
+    pub reconcile_shadow_retract_diffs: Option<u64>,
+    pub reconcile_shadow_reroot_search_diffs: Option<u64>,
     /// Interest-weighted (two-tier) module-cache SHADOW gauges (#4441/#4534),
     /// populated by `Ring` from the same per-node `ModuleCacheMetrics` `Arc`.
     /// These are ALWAYS ON, independent of the `FREENET_MODULE_CACHE_INTEREST_TIERED`
@@ -1182,6 +1202,18 @@ impl Router {
             // singleton on the snapshot cadence.
             upstream_computed_vs_stored_comparisons: None,
             upstream_computed_vs_stored_divergences: None,
+            // Reconcile-controller shadow comparison counters (keystone step-2,
+            // #4642), populated by Ring from the network_status singleton on the
+            // snapshot cadence.
+            reconcile_shadow_comparisons: None,
+            reconcile_shadow_divergences: None,
+            reconcile_shadow_subscribe_diffs: None,
+            reconcile_shadow_renew_diffs: None,
+            reconcile_shadow_unsubscribe_diffs: None,
+            reconcile_shadow_collapse_diffs: None,
+            reconcile_shadow_announce_diffs: None,
+            reconcile_shadow_retract_diffs: None,
+            reconcile_shadow_reroot_search_diffs: None,
             // Interest-weighted (two-tier) module-cache shadow gauges,
             // populated by Ring on the snapshot cadence (#4441/#4534).
             contract_module_cache_cold_evictable_bytes: None,

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -263,26 +263,45 @@ pub(crate) struct RouterSnapshotInfo {
     /// lifetime totals, `None` until the ring's snapshot task populates them.
     pub upstream_computed_vs_stored_comparisons: Option<u64>,
     pub upstream_computed_vs_stored_divergences: Option<u64>,
-    /// Reconcile-controller SHADOW comparison counters (hosting redesign
-    /// keystone step-2, #4642). Populated by `Ring` from the per-node
-    /// `network_status` singleton on the snapshot cadence. `comparisons` is the
-    /// denominator (one per shadow comparison at a hosting decision site),
-    /// `divergences` the count whose reconcile action set differed from the
-    /// actual behavior's set; the `*_diffs` are per-action symmetric-difference
-    /// tallies. Field evidence for how far the pure `reconcile` controller
-    /// diverges from today's scattered decisions BEFORE the flip — monotonic
-    /// lifetime totals, `None` until the ring's snapshot task populates them. A
-    /// nonzero `retract` / `reroot_search` divergence is EXPECTED (those
-    /// controller actions have no on-`main` driver yet), not an alarm.
-    pub reconcile_shadow_comparisons: Option<u64>,
-    pub reconcile_shadow_divergences: Option<u64>,
-    pub reconcile_shadow_subscribe_diffs: Option<u64>,
-    pub reconcile_shadow_renew_diffs: Option<u64>,
-    pub reconcile_shadow_unsubscribe_diffs: Option<u64>,
-    pub reconcile_shadow_collapse_diffs: Option<u64>,
-    pub reconcile_shadow_announce_diffs: Option<u64>,
-    pub reconcile_shadow_retract_diffs: Option<u64>,
-    pub reconcile_shadow_reroot_search_diffs: Option<u64>,
+    /// Reconcile-controller SHADOW comparison counters, split PER SITE (hosting
+    /// redesign keystone step-2, #4642). Populated by `Ring` from the per-node
+    /// `network_status` singleton on the snapshot cadence. Per site,
+    /// `comparisons` is the denominator (one per shadow comparison at that
+    /// hosting decision site), `divergences` the count whose reconcile action set
+    /// differed from the actual behavior's set; the `*_diffs` are per-action
+    /// symmetric-difference tallies. The FLIP is site-by-site (collapse first,
+    /// then renewal), so the counters are split so each site is separately
+    /// gate-able. Monotonic lifetime totals, `None` until the ring's snapshot task
+    /// populates them.
+    ///
+    /// Several divergence classes are EXPECTED BY DESIGN, not anomalies: the
+    /// `retract` / `reroot_search` classes (no on-`main` driver retracts on
+    /// teardown or re-roots on upstream loss), the strict-demand-gated `renew` /
+    /// `subscribe` / `unsubscribe` classes (the controller's strict-farther
+    /// downstream gate and lease-aware `Renew`-vs-`Subscribe` split legitimately
+    /// disagree with today's ANY-downstream renewal path), and `announce` (a
+    /// subscribed, state-present, not-yet-advertised host). Read them as the
+    /// reconcile-vs-today delta. `retract_diffs` in particular reflects the
+    /// missing retraction driver (`is_hosted_locally` is monotonic in production
+    /// today), not a live-advertisement leak.
+    pub reconcile_shadow_collapse_comparisons: Option<u64>,
+    pub reconcile_shadow_collapse_divergences: Option<u64>,
+    pub reconcile_shadow_collapse_subscribe_diffs: Option<u64>,
+    pub reconcile_shadow_collapse_renew_diffs: Option<u64>,
+    pub reconcile_shadow_collapse_unsubscribe_diffs: Option<u64>,
+    pub reconcile_shadow_collapse_collapse_diffs: Option<u64>,
+    pub reconcile_shadow_collapse_announce_diffs: Option<u64>,
+    pub reconcile_shadow_collapse_retract_diffs: Option<u64>,
+    pub reconcile_shadow_collapse_reroot_search_diffs: Option<u64>,
+    pub reconcile_shadow_renewal_comparisons: Option<u64>,
+    pub reconcile_shadow_renewal_divergences: Option<u64>,
+    pub reconcile_shadow_renewal_subscribe_diffs: Option<u64>,
+    pub reconcile_shadow_renewal_renew_diffs: Option<u64>,
+    pub reconcile_shadow_renewal_unsubscribe_diffs: Option<u64>,
+    pub reconcile_shadow_renewal_collapse_diffs: Option<u64>,
+    pub reconcile_shadow_renewal_announce_diffs: Option<u64>,
+    pub reconcile_shadow_renewal_retract_diffs: Option<u64>,
+    pub reconcile_shadow_renewal_reroot_search_diffs: Option<u64>,
     /// Interest-weighted (two-tier) module-cache SHADOW gauges (#4441/#4534),
     /// populated by `Ring` from the same per-node `ModuleCacheMetrics` `Arc`.
     /// These are ALWAYS ON, independent of the `FREENET_MODULE_CACHE_INTEREST_TIERED`
@@ -1202,18 +1221,27 @@ impl Router {
             // singleton on the snapshot cadence.
             upstream_computed_vs_stored_comparisons: None,
             upstream_computed_vs_stored_divergences: None,
-            // Reconcile-controller shadow comparison counters (keystone step-2,
-            // #4642), populated by Ring from the network_status singleton on the
-            // snapshot cadence.
-            reconcile_shadow_comparisons: None,
-            reconcile_shadow_divergences: None,
-            reconcile_shadow_subscribe_diffs: None,
-            reconcile_shadow_renew_diffs: None,
-            reconcile_shadow_unsubscribe_diffs: None,
-            reconcile_shadow_collapse_diffs: None,
-            reconcile_shadow_announce_diffs: None,
-            reconcile_shadow_retract_diffs: None,
-            reconcile_shadow_reroot_search_diffs: None,
+            // Reconcile-controller shadow comparison counters, split per site
+            // (keystone step-2, #4642), populated by Ring from the network_status
+            // singleton on the snapshot cadence.
+            reconcile_shadow_collapse_comparisons: None,
+            reconcile_shadow_collapse_divergences: None,
+            reconcile_shadow_collapse_subscribe_diffs: None,
+            reconcile_shadow_collapse_renew_diffs: None,
+            reconcile_shadow_collapse_unsubscribe_diffs: None,
+            reconcile_shadow_collapse_collapse_diffs: None,
+            reconcile_shadow_collapse_announce_diffs: None,
+            reconcile_shadow_collapse_retract_diffs: None,
+            reconcile_shadow_collapse_reroot_search_diffs: None,
+            reconcile_shadow_renewal_comparisons: None,
+            reconcile_shadow_renewal_divergences: None,
+            reconcile_shadow_renewal_subscribe_diffs: None,
+            reconcile_shadow_renewal_renew_diffs: None,
+            reconcile_shadow_renewal_unsubscribe_diffs: None,
+            reconcile_shadow_renewal_collapse_diffs: None,
+            reconcile_shadow_renewal_announce_diffs: None,
+            reconcile_shadow_renewal_retract_diffs: None,
+            reconcile_shadow_renewal_reroot_search_diffs: None,
             // Interest-weighted (two-tier) module-cache shadow gauges,
             // populated by Ring on the snapshot cadence (#4441/#4534).
             contract_module_cache_cold_evictable_bytes: None,

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2249,42 +2249,82 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                 // the pure `reconcile` controller diverges from today's scattered
                 // decisions ahead of the flip. Pinned by
                 // `router_snapshot_json_includes_reconcile_shadow_counters`.
-                obj.insert(
-                    "reconcile_shadow_comparisons".to_string(),
-                    serde_json::json!(snapshot.reconcile_shadow_comparisons),
-                );
-                obj.insert(
-                    "reconcile_shadow_divergences".to_string(),
-                    serde_json::json!(snapshot.reconcile_shadow_divergences),
-                );
-                obj.insert(
-                    "reconcile_shadow_subscribe_diffs".to_string(),
-                    serde_json::json!(snapshot.reconcile_shadow_subscribe_diffs),
-                );
-                obj.insert(
-                    "reconcile_shadow_renew_diffs".to_string(),
-                    serde_json::json!(snapshot.reconcile_shadow_renew_diffs),
-                );
-                obj.insert(
-                    "reconcile_shadow_unsubscribe_diffs".to_string(),
-                    serde_json::json!(snapshot.reconcile_shadow_unsubscribe_diffs),
-                );
-                obj.insert(
-                    "reconcile_shadow_collapse_diffs".to_string(),
-                    serde_json::json!(snapshot.reconcile_shadow_collapse_diffs),
-                );
-                obj.insert(
-                    "reconcile_shadow_announce_diffs".to_string(),
-                    serde_json::json!(snapshot.reconcile_shadow_announce_diffs),
-                );
-                obj.insert(
-                    "reconcile_shadow_retract_diffs".to_string(),
-                    serde_json::json!(snapshot.reconcile_shadow_retract_diffs),
-                );
-                obj.insert(
-                    "reconcile_shadow_reroot_search_diffs".to_string(),
-                    serde_json::json!(snapshot.reconcile_shadow_reroot_search_diffs),
-                );
+                for (key, value) in [
+                    (
+                        "reconcile_shadow_collapse_comparisons",
+                        snapshot.reconcile_shadow_collapse_comparisons,
+                    ),
+                    (
+                        "reconcile_shadow_collapse_divergences",
+                        snapshot.reconcile_shadow_collapse_divergences,
+                    ),
+                    (
+                        "reconcile_shadow_collapse_subscribe_diffs",
+                        snapshot.reconcile_shadow_collapse_subscribe_diffs,
+                    ),
+                    (
+                        "reconcile_shadow_collapse_renew_diffs",
+                        snapshot.reconcile_shadow_collapse_renew_diffs,
+                    ),
+                    (
+                        "reconcile_shadow_collapse_unsubscribe_diffs",
+                        snapshot.reconcile_shadow_collapse_unsubscribe_diffs,
+                    ),
+                    (
+                        "reconcile_shadow_collapse_collapse_diffs",
+                        snapshot.reconcile_shadow_collapse_collapse_diffs,
+                    ),
+                    (
+                        "reconcile_shadow_collapse_announce_diffs",
+                        snapshot.reconcile_shadow_collapse_announce_diffs,
+                    ),
+                    (
+                        "reconcile_shadow_collapse_retract_diffs",
+                        snapshot.reconcile_shadow_collapse_retract_diffs,
+                    ),
+                    (
+                        "reconcile_shadow_collapse_reroot_search_diffs",
+                        snapshot.reconcile_shadow_collapse_reroot_search_diffs,
+                    ),
+                    (
+                        "reconcile_shadow_renewal_comparisons",
+                        snapshot.reconcile_shadow_renewal_comparisons,
+                    ),
+                    (
+                        "reconcile_shadow_renewal_divergences",
+                        snapshot.reconcile_shadow_renewal_divergences,
+                    ),
+                    (
+                        "reconcile_shadow_renewal_subscribe_diffs",
+                        snapshot.reconcile_shadow_renewal_subscribe_diffs,
+                    ),
+                    (
+                        "reconcile_shadow_renewal_renew_diffs",
+                        snapshot.reconcile_shadow_renewal_renew_diffs,
+                    ),
+                    (
+                        "reconcile_shadow_renewal_unsubscribe_diffs",
+                        snapshot.reconcile_shadow_renewal_unsubscribe_diffs,
+                    ),
+                    (
+                        "reconcile_shadow_renewal_collapse_diffs",
+                        snapshot.reconcile_shadow_renewal_collapse_diffs,
+                    ),
+                    (
+                        "reconcile_shadow_renewal_announce_diffs",
+                        snapshot.reconcile_shadow_renewal_announce_diffs,
+                    ),
+                    (
+                        "reconcile_shadow_renewal_retract_diffs",
+                        snapshot.reconcile_shadow_renewal_retract_diffs,
+                    ),
+                    (
+                        "reconcile_shadow_renewal_reroot_search_diffs",
+                        snapshot.reconcile_shadow_renewal_reroot_search_diffs,
+                    ),
+                ] {
+                    obj.insert(key.to_string(), serde_json::json!(value));
+                }
             }
             body
         }
@@ -2590,26 +2630,44 @@ mod tests {
         let mut u = Unstructured::new(&[0u8; 4096]);
         let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
             .expect("construct RouterSnapshotInfo for test");
-        info.reconcile_shadow_comparisons = Some(401);
-        info.reconcile_shadow_divergences = Some(409);
-        info.reconcile_shadow_subscribe_diffs = Some(419);
-        info.reconcile_shadow_renew_diffs = Some(421);
-        info.reconcile_shadow_unsubscribe_diffs = Some(431);
-        info.reconcile_shadow_collapse_diffs = Some(433);
-        info.reconcile_shadow_announce_diffs = Some(439);
-        info.reconcile_shadow_retract_diffs = Some(443);
-        info.reconcile_shadow_reroot_search_diffs = Some(449);
+        info.reconcile_shadow_collapse_comparisons = Some(401);
+        info.reconcile_shadow_collapse_divergences = Some(409);
+        info.reconcile_shadow_collapse_subscribe_diffs = Some(419);
+        info.reconcile_shadow_collapse_renew_diffs = Some(421);
+        info.reconcile_shadow_collapse_unsubscribe_diffs = Some(431);
+        info.reconcile_shadow_collapse_collapse_diffs = Some(433);
+        info.reconcile_shadow_collapse_announce_diffs = Some(439);
+        info.reconcile_shadow_collapse_retract_diffs = Some(443);
+        info.reconcile_shadow_collapse_reroot_search_diffs = Some(449);
+        info.reconcile_shadow_renewal_comparisons = Some(457);
+        info.reconcile_shadow_renewal_divergences = Some(461);
+        info.reconcile_shadow_renewal_subscribe_diffs = Some(463);
+        info.reconcile_shadow_renewal_renew_diffs = Some(467);
+        info.reconcile_shadow_renewal_unsubscribe_diffs = Some(479);
+        info.reconcile_shadow_renewal_collapse_diffs = Some(487);
+        info.reconcile_shadow_renewal_announce_diffs = Some(491);
+        info.reconcile_shadow_renewal_retract_diffs = Some(499);
+        info.reconcile_shadow_renewal_reroot_search_diffs = Some(503);
         let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
         for (key, want) in [
-            ("reconcile_shadow_comparisons", 401),
-            ("reconcile_shadow_divergences", 409),
-            ("reconcile_shadow_subscribe_diffs", 419),
-            ("reconcile_shadow_renew_diffs", 421),
-            ("reconcile_shadow_unsubscribe_diffs", 431),
-            ("reconcile_shadow_collapse_diffs", 433),
-            ("reconcile_shadow_announce_diffs", 439),
-            ("reconcile_shadow_retract_diffs", 443),
-            ("reconcile_shadow_reroot_search_diffs", 449),
+            ("reconcile_shadow_collapse_comparisons", 401),
+            ("reconcile_shadow_collapse_divergences", 409),
+            ("reconcile_shadow_collapse_subscribe_diffs", 419),
+            ("reconcile_shadow_collapse_renew_diffs", 421),
+            ("reconcile_shadow_collapse_unsubscribe_diffs", 431),
+            ("reconcile_shadow_collapse_collapse_diffs", 433),
+            ("reconcile_shadow_collapse_announce_diffs", 439),
+            ("reconcile_shadow_collapse_retract_diffs", 443),
+            ("reconcile_shadow_collapse_reroot_search_diffs", 449),
+            ("reconcile_shadow_renewal_comparisons", 457),
+            ("reconcile_shadow_renewal_divergences", 461),
+            ("reconcile_shadow_renewal_subscribe_diffs", 463),
+            ("reconcile_shadow_renewal_renew_diffs", 467),
+            ("reconcile_shadow_renewal_unsubscribe_diffs", 479),
+            ("reconcile_shadow_renewal_collapse_diffs", 487),
+            ("reconcile_shadow_renewal_announce_diffs", 491),
+            ("reconcile_shadow_renewal_retract_diffs", 499),
+            ("reconcile_shadow_renewal_reroot_search_diffs", 503),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2242,6 +2242,49 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "upstream_computed_vs_stored_divergences".to_string(),
                     serde_json::json!(snapshot.upstream_computed_vs_stored_divergences),
                 );
+                // Reconcile-controller SHADOW comparison counters (keystone
+                // step-2, #4642) — same hand-mirror footgun: a new
+                // `RouterSnapshotInfo` field is invisible to the collector unless
+                // added here. These give production field evidence for how far
+                // the pure `reconcile` controller diverges from today's scattered
+                // decisions ahead of the flip. Pinned by
+                // `router_snapshot_json_includes_reconcile_shadow_counters`.
+                obj.insert(
+                    "reconcile_shadow_comparisons".to_string(),
+                    serde_json::json!(snapshot.reconcile_shadow_comparisons),
+                );
+                obj.insert(
+                    "reconcile_shadow_divergences".to_string(),
+                    serde_json::json!(snapshot.reconcile_shadow_divergences),
+                );
+                obj.insert(
+                    "reconcile_shadow_subscribe_diffs".to_string(),
+                    serde_json::json!(snapshot.reconcile_shadow_subscribe_diffs),
+                );
+                obj.insert(
+                    "reconcile_shadow_renew_diffs".to_string(),
+                    serde_json::json!(snapshot.reconcile_shadow_renew_diffs),
+                );
+                obj.insert(
+                    "reconcile_shadow_unsubscribe_diffs".to_string(),
+                    serde_json::json!(snapshot.reconcile_shadow_unsubscribe_diffs),
+                );
+                obj.insert(
+                    "reconcile_shadow_collapse_diffs".to_string(),
+                    serde_json::json!(snapshot.reconcile_shadow_collapse_diffs),
+                );
+                obj.insert(
+                    "reconcile_shadow_announce_diffs".to_string(),
+                    serde_json::json!(snapshot.reconcile_shadow_announce_diffs),
+                );
+                obj.insert(
+                    "reconcile_shadow_retract_diffs".to_string(),
+                    serde_json::json!(snapshot.reconcile_shadow_retract_diffs),
+                );
+                obj.insert(
+                    "reconcile_shadow_reroot_search_diffs".to_string(),
+                    serde_json::json!(snapshot.reconcile_shadow_reroot_search_diffs),
+                );
             }
             body
         }
@@ -2530,6 +2573,43 @@ mod tests {
         for (key, want) in [
             ("upstream_computed_vs_stored_comparisons", 337),
             ("upstream_computed_vs_stored_divergences", 347),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
+    }
+
+    /// Pin: the reconcile-controller SHADOW comparison counters (keystone
+    /// step-2, #4642) must also reach the hand-mirrored OTLP body — same footgun
+    /// as the divergence counters above. These are the production field evidence
+    /// for how far the pure `reconcile` controller diverges from today's
+    /// scattered decisions before the flip; a silent drop would re-blind central
+    /// telemetry to the exact signal this change adds.
+    #[test]
+    fn router_snapshot_json_includes_reconcile_shadow_counters() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.reconcile_shadow_comparisons = Some(401);
+        info.reconcile_shadow_divergences = Some(409);
+        info.reconcile_shadow_subscribe_diffs = Some(419);
+        info.reconcile_shadow_renew_diffs = Some(421);
+        info.reconcile_shadow_unsubscribe_diffs = Some(431);
+        info.reconcile_shadow_collapse_diffs = Some(433);
+        info.reconcile_shadow_announce_diffs = Some(439);
+        info.reconcile_shadow_retract_diffs = Some(443);
+        info.reconcile_shadow_reroot_search_diffs = Some(449);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        for (key, want) in [
+            ("reconcile_shadow_comparisons", 401),
+            ("reconcile_shadow_divergences", 409),
+            ("reconcile_shadow_subscribe_diffs", 419),
+            ("reconcile_shadow_renew_diffs", 421),
+            ("reconcile_shadow_unsubscribe_diffs", 431),
+            ("reconcile_shadow_collapse_diffs", 433),
+            ("reconcile_shadow_announce_diffs", 439),
+            ("reconcile_shadow_retract_diffs", 443),
+            ("reconcile_shadow_reroot_search_diffs", 449),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }


### PR DESCRIPTION
## Problem

The reconcile controller core (pure decision logic + types) landed in #4704, but nothing runs it yet. Before the demand-driven-hosting keystone can FLIP the scattered hosting decisions over to the level-triggered `reconcile()` controller, we need **field evidence** of how far the controller's desired action set diverges from today's behavior — otherwise the flip is blind. This generalizes the #4693 stored-flag divergence counter to per-action, per-site divergence.

## Approach

Wire `reconcile()` in **SHADOW mode**: at live hosting decision sites, build a `ReconcileInputs` snapshot, compute what the controller WOULD do, and compare it — **by set membership** — to what the current code actually does, recording the divergence in aggregate per-site telemetry. **Additive and behavior-preserving: the controller drives NOTHING**; every current decision runs unchanged, and nothing consumes `reconcile()`'s output as a control signal (guarded by source-scrape pins at both sites).

Wired at the **two highest-signal sites**:

- **COLLAPSE** (`OpManager::send_unsubscribe_upstream`). Actual mapped to `Collapse` iff a lease is held at snapshot (`ring.unsubscribe` is a no-op when not subscribed, matching reconcile), plus `Unsubscribe` iff a stored upstream was located.
- **RENEWAL** (`Ring::contracts_needing_renewal`, driven by the recovery loop). The shadow is **inlined into the real batch loop** so the recorded "actual" equals what production did *this tick*: `{}` for a skipped/deferred contract, else the fresh SUBSCRIBE the loop spawns — mapped to `Renew` if a lease is held, else `Subscribe` (so §2/§3 not-subscribed entries never record a phantom `Renew`). This measures the controller's **strict-farther downstream gate** and its lease-aware `Renew`-vs-`Subscribe` split. (Note: §1 is already `contract_in_use`-gated since #4697 — this is not re-measuring the raw #3763 gap, but the *stricter* strict-farther gate plus the not-subscribed §2/§3 cases.)

Key correctness points:

- **H2 strictly-farther filter** (the reviews flagged this as owed): `has_farther_downstream_subscriber` counts only downstream subscribers **strictly farther** from the contract key than this peer, using **exact `Distance` ordering, never epsilon `==`**. This is the piece-D caller-contract that keeps mutual co-hosts from perpetuating each other's leases so collapse can terminate. A pure `has_strictly_farther` core carries the comparison.
- **Distance-blind guard**: `build_reconcile_inputs` returns `None` when our own ring location is unknown (a startup transient makes the computed-upstream / verified-root / strict-farther fields unmeasurable). Both sites **skip** the comparison rather than defaulting the strict gate to true, which would mask the mutual-co-host divergence.
- **Per-site counters** (collapse vs renewal): the flip is site-by-site, so a single global tally (dominated by renewal-set size) would hide the collapse signal.
- **Exhaustiveness**: `action_set_divergence` routes each `Action` through an exhaustive `match`, so a future variant fails to compile rather than being silently unmeasured.
- **Perf**: the renewal shadow is bounded by `batch_limit` (batch-gate), so per-tick redb reads + `is_subscription_root` connection-map clones do not scale with the whole renewal set on near-key gateways.

**Expected-by-design divergences** (documented on the counters, not anomalies): `retract` / `reroot_search` (no on-`main` driver retracts or re-roots yet), the strict-gated `renew` / `subscribe` / `unsubscribe` classes, and `announce` (a subscribed, state-present, not-yet-advertised host).

**Deferred to the next sub-task (owed):** the remaining 4 decision sites (inbound-unsubscribe collapse, connection-drop re-root, the two host-formation announce sites), the sim/parity-bound test (plan §2.5 — the assert that later de-risks the FLIP), and the FLIP itself (controller drives).

## Testing

- `action_set_divergence` set-membership semantics; the exhaustive-`match` compile guard.
- **H2 pin** `has_strictly_farther_excludes_equal_uses_exact_ordering`: bit-identical distances (equal/closer excluded) plus the one-ULP epsilon boundary.
- `renewal_shadow_actual` unit test (skip → `{}`, acted+lease → `Renew`, acted+no-lease → `Subscribe`).
- Per-site counter accumulation + `any()` gating + site-independence (`reconcile_shadow_counts_reflect_recorded_events`).
- OTLP-JSON pin over all 18 per-site fields (`router_snapshot_json_includes_reconcile_shadow_counters`).
- Source-scrape guards at BOTH sites: production still drives; the reconcile output flows only into `action_set_divergence` (drives nothing); the reconcile module defines no driver/apply entry point.
- `cargo build -p freenet`, `cargo fmt`, and both CI clippy variants (`--locked` and `--features trace-ot`) clean.

Refs #4642 — keystone step-2, sub-task 2.

[AI-assisted - Claude]