### PR TITLE
feat(put): inert summary-first PUT wire scaffolding (#4642)

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -897,6 +897,52 @@ pub(crate) fn version_supports_subscribe_hint(
     remote.is_some_and(|v| v >= floor)
 }
 
+/// Minimum negotiated protocol version a peer must report before this node
+/// may emit the summary-first PUT probe/dispatch variants
+/// ([`PutMsg::ProbeRequest`](crate::operations::put::PutMsg) /
+/// `PutMsg::ProbeResponse`).
+///
+/// # INERT (#4642, step 3-bis)
+///
+/// No code emits those variants yet — the probe→dispatch driver and its
+/// send path are a LATER piece paired with every-hop placement. This floor
+/// and [`version_supports_summary_first_put`] are the emission gate that
+/// later piece will consult, so a pre-floor peer — which cannot
+/// bincode-deserialize the appended tags and would drop the connection —
+/// never receives them. The value is the release that first carries the
+/// variants in the enum (this scaffolding PR); the emitting piece MUST
+/// confirm/raise it to the release that first EMITS if that is later. Only
+/// peer pairs both on `>= this floor` will exchange probes, so activation
+/// ramps with fleet upgrade rather than switching on everywhere at once
+/// (the SubscribeHint model). Frozen once emission ships, per the
+/// wire-gated-floor rule in `docs/RELEASING.md`.
+///
+/// INERT: read only by the gate's own unit tests today; the emitting piece
+/// (later) is its first production consumer.
+#[allow(dead_code)]
+pub(crate) const SUMMARY_FIRST_PUT_MIN_VERSION: (u8, u8, u16) = (0, 2, 93);
+
+/// Pure version-gate for the summary-first PUT probe/dispatch variants,
+/// mirroring [`version_supports_subscribe_hint`]: returns `true` iff
+/// `remote` is known (`Some`) AND at least `floor`.
+///
+/// An unknown remote version is treated as unsupported (fail-closed): an
+/// older peer that cannot deserialize the appended `ProbeRequest` /
+/// `ProbeResponse` wire tag would drop the connection, so when in doubt we
+/// do NOT emit. Factored out (with an explicit `floor` param) so the gate
+/// is unit-testable independent of the production
+/// [`SUMMARY_FIRST_PUT_MIN_VERSION`].
+///
+/// INERT: no caller emits yet (see [`SUMMARY_FIRST_PUT_MIN_VERSION`]); this
+/// is the predicate the emitting piece will guard its send path with.
+#[allow(dead_code)]
+pub(crate) fn version_supports_summary_first_put(
+    remote: Option<(u8, u8, u16)>,
+    floor: (u8, u8, u16),
+) -> bool {
+    remote.is_some_and(|v| v >= floor)
+}
+
 /// Upper bound on the number of hosted contracts examined per new-peer
 /// migration trigger. Each examined contract may emit a best-effort
 /// non-blocking `try_send` (the SubscribeHint nudge), so an unbounded scan
@@ -3458,7 +3504,10 @@ mod tests {
     }
 
     mod version_gate {
-        use super::super::{SUBSCRIBE_HINT_MIN_VERSION, version_supports_subscribe_hint};
+        use super::super::{
+            SUBSCRIBE_HINT_MIN_VERSION, SUMMARY_FIRST_PUT_MIN_VERSION,
+            version_supports_subscribe_hint, version_supports_summary_first_put,
+        };
 
         const FLOOR: (u8, u8, u16) = (0, 2, 73);
 
@@ -3503,6 +3552,78 @@ mod tests {
             // (this is the simulation/test floor behavior).
             assert!(version_supports_subscribe_hint(Some((0, 0, 0)), (0, 0, 0)));
             assert!(!version_supports_subscribe_hint(None, (0, 0, 0)));
+        }
+
+        // ---- Summary-first PUT probe/dispatch gate (INERT, #4642) ----
+        // Same fail-closed semantics as the SubscribeHint gate. These are
+        // the emission gate a LATER piece consults before sending the
+        // `PutMsg::ProbeRequest` / `ProbeResponse` variants; nothing emits
+        // them yet, so this asserts the gate is correct in isolation.
+
+        const SF_FLOOR: (u8, u8, u16) = (0, 2, 93);
+
+        /// The mixed-version interop guarantee, expressed at the gate: an
+        /// UNKNOWN remote version fails closed, so a summary-first-capable
+        /// node NEVER emits the probe to a peer whose version it hasn't
+        /// captured (it would fail to deserialize the appended tag and drop
+        /// the connection). This is the "old peer never receives the probe"
+        /// property that keeps the appended wire variants additive-safe.
+        #[test]
+        fn summary_first_unknown_remote_version_fails_closed() {
+            assert!(!version_supports_summary_first_put(None, SF_FLOOR));
+        }
+
+        /// A pre-floor peer (older than the release that first carries the
+        /// probe variants) is never sent the probe — it could not decode it.
+        #[test]
+        fn summary_first_older_remote_version_is_rejected() {
+            assert!(!version_supports_summary_first_put(
+                Some((0, 2, 92)),
+                SF_FLOOR
+            ));
+            assert!(!version_supports_summary_first_put(
+                Some((0, 1, 40)),
+                SF_FLOOR
+            ));
+        }
+
+        /// A peer at or above the floor understands the appended variants
+        /// and may receive the probe. Both-sides-capable is the activation
+        /// condition (ramps with fleet upgrade, SubscribeHint model).
+        #[test]
+        fn summary_first_equal_or_newer_remote_version_is_accepted() {
+            assert!(version_supports_summary_first_put(
+                Some((0, 2, 93)),
+                SF_FLOOR
+            ));
+            assert!(version_supports_summary_first_put(
+                Some((0, 2, 94)),
+                SF_FLOOR
+            ));
+            assert!(version_supports_summary_first_put(
+                Some((0, 3, 0)),
+                SF_FLOOR
+            ));
+            assert!(version_supports_summary_first_put(
+                Some((1, 0, 0)),
+                SF_FLOOR
+            ));
+        }
+
+        /// The production floor const is wired to the same fail-closed
+        /// predicate (guards against a future refactor that swaps the
+        /// predicate for one that admits `None`).
+        #[test]
+        fn summary_first_production_floor_fails_closed_on_unknown() {
+            assert!(!version_supports_summary_first_put(
+                None,
+                SUMMARY_FIRST_PUT_MIN_VERSION
+            ));
+            // A peer exactly at the production floor qualifies.
+            assert!(version_supports_summary_first_put(
+                Some(SUMMARY_FIRST_PUT_MIN_VERSION),
+                SUMMARY_FIRST_PUT_MIN_VERSION
+            ));
         }
 
         // Superseded: the placement migration was RE-ENABLED at `(0, 2, 80)` by

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -400,6 +400,85 @@ mod messages {
             /// classification.
             cause: String,
         },
+
+        /// **Summary-first PUT — Phase-1 probe. INERT wire scaffolding
+        /// (#4642, step 3-bis; NOT yet emitted — see below).**
+        ///
+        /// Instead of shipping the full [`WrappedState`] up front (as
+        /// [`Request`](Self::Request) does), a summary-first PUT routes a
+        /// probe hop-by-hop toward the contract key carrying only a
+        /// contract-defined [`StateSummary`] — opaque bytes that Freenet
+        /// moves but the contract's `summarize_state` defines, reused
+        /// verbatim from the InterestSync anti-entropy path. Each hop can
+        /// reveal whether an existing holder is present, so the initiator
+        /// need not know in advance whether the contract is genuinely new
+        /// (ship full state) or already held (reconcile a delta).
+        ///
+        /// # NOT YET EMITTED (inert scaffolding)
+        ///
+        /// No producer constructs this variant and no send path emits it.
+        /// It is merged inert: the probe→dispatch driver, the body-fetch
+        /// flow, and the emission gate are a LATER piece paired with
+        /// every-hop placement (#4642). When emission is added it MUST be
+        /// version-gated via `version_supports_summary_first_put` (in
+        /// `node::network_bridge::p2p_protoc`) — a pre-floor peer cannot
+        /// bincode-deserialize this appended tag and would drop the
+        /// connection, so it must never receive the probe. Because nothing
+        /// emits it yet, nothing is committed on the wire and the field
+        /// layout stays refinable until first emission ships in a release.
+        #[allow(dead_code)]
+        ProbeRequest {
+            id: Transaction,
+            /// Key of the contract being probed.
+            contract_key: ContractKey,
+            /// Contract-defined opaque state summary (`summarize_state`).
+            /// Deserialized owned (`'static`) via `deser_state_summary`,
+            /// matching the `RelatedContracts` wire pattern: a borrowed
+            /// `StateSummary<'de>` is not `DeserializeOwned` and cannot
+            /// cross the bincode boundary as a plain field.
+            #[serde(deserialize_with = "StateSummary::deser_state_summary")]
+            summary: StateSummary<'static>,
+            /// Hops to live — decremented at each hop (mirrors `Request.htl`).
+            htl: usize,
+            /// Addresses to skip when selecting next hop (loop prevention).
+            skip_list: HashSet<std::net::SocketAddr>,
+        },
+
+        /// **Summary-first PUT — Phase-2 dispatch reply. INERT wire
+        /// scaffolding (#4642, step 3-bis; NOT yet emitted — see
+        /// [`ProbeRequest`](Self::ProbeRequest)).**
+        ///
+        /// Routed hop-by-hop back to the initiator, signalling whether the
+        /// probe found an existing holder:
+        ///
+        /// - `holder_found == false` → no holder → the contract is treated
+        ///   as genuinely new and full state ships hop-by-hop along the
+        ///   route (the [`Request`](Self::Request) path) — exactly where
+        ///   every-hop placement acquires its bytes.
+        /// - `holder_found == true` → a holder exists → the two copies
+        ///   reconcile bidirectionally via the contract's summary/delta
+        ///   primitives (a later piece); full state does NOT re-travel a
+        ///   mesh that already holds it. Not "ahead/behind": divergent
+        ///   copies merge via the commutative monoid.
+        ///
+        /// The reconcile message exchange is deliberately NOT modelled
+        /// here — this variant is only the new-vs-existing dispatch signal.
+        /// INERT: see [`ProbeRequest`](Self::ProbeRequest).
+        #[allow(dead_code)]
+        ProbeResponse {
+            id: Transaction,
+            /// Key of the probed contract.
+            key: ContractKey,
+            /// Whether the probe found an existing holder along the route.
+            holder_found: bool,
+            /// Forward-path hop count — same semantics as
+            /// [`Response`](Self::Response)'s `hop_count`.
+            /// `#[serde(default)]` is for source-level clarity; bincode is
+            /// positional, so cross-version compat rides the handshake
+            /// `MIN_COMPATIBLE_VERSION` gate, not the serde default.
+            #[serde(default)]
+            hop_count: usize,
+        },
     }
 
     impl InnerMessage for PutMsg {
@@ -410,7 +489,9 @@ mod messages {
                 | Self::RequestStreaming { id, .. }
                 | Self::ResponseStreaming { id, .. }
                 | Self::ForwardingAck { id, .. }
-                | Self::Error { id, .. } => id,
+                | Self::Error { id, .. }
+                | Self::ProbeRequest { id, .. }
+                | Self::ProbeResponse { id, .. } => id,
             }
         }
 
@@ -427,6 +508,8 @@ mod messages {
                 // already knows the key it requested; the failure is keyed
                 // by tx only.
                 Self::Error { .. } => None,
+                Self::ProbeRequest { contract_key, .. } => Some(Location::from(contract_key.id())),
+                Self::ProbeResponse { key, .. } => Some(Location::from(key.id())),
             }
         }
     }
@@ -479,6 +562,34 @@ mod messages {
                 }
                 Self::Error { id, cause } => {
                     write!(f, "PutError(id: {}, cause: {})", id, cause)
+                }
+                Self::ProbeRequest {
+                    id,
+                    contract_key,
+                    summary,
+                    htl,
+                    ..
+                } => {
+                    write!(
+                        f,
+                        "PutProbeRequest(id: {}, key: {}, summary_len: {}, htl: {})",
+                        id,
+                        contract_key,
+                        summary.size(),
+                        htl
+                    )
+                }
+                Self::ProbeResponse {
+                    id,
+                    key,
+                    holder_found,
+                    ..
+                } => {
+                    write!(
+                        f,
+                        "PutProbeResponse(id: {}, key: {}, holder_found: {})",
+                        id, key, holder_found
+                    )
                 }
             }
         }
@@ -594,7 +705,7 @@ mod tests {
         let tx = Transaction::new::<PutMsg>();
         let key = make_contract_key(0);
         // One minimal instance per variant, in declaration order.
-        let samples: [(u32, PutMsg); 6] = [
+        let samples: [(u32, PutMsg); 8] = [
             (
                 0,
                 PutMsg::Request {
@@ -649,6 +760,31 @@ mod tests {
                     cause: String::new(),
                 },
             ),
+            // Tags 6/7: summary-first PUT scaffolding (INERT, #4642).
+            // Appended AFTER every existing variant so tags 0-5 stay
+            // byte-identical — old peers keep deserializing them
+            // unchanged. Emission is version-gated (never sent to a
+            // pre-floor peer), so these tags never reach a node that
+            // can't decode them.
+            (
+                6,
+                PutMsg::ProbeRequest {
+                    id: tx,
+                    contract_key: key,
+                    summary: StateSummary::from(Vec::new()),
+                    htl: 0,
+                    skip_list: Default::default(),
+                },
+            ),
+            (
+                7,
+                PutMsg::ProbeResponse {
+                    id: tx,
+                    key,
+                    holder_found: false,
+                    hop_count: 0,
+                },
+            ),
         ];
         for (expected_tag, msg) in samples {
             let bytes = bincode::serialize(&msg).expect("serialize");
@@ -664,6 +800,111 @@ mod tests {
                  coordinate the upgrade."
             );
         }
+    }
+
+    /// Summary-first PUT probe (INERT scaffolding, #4642): the
+    /// `StateSummary` payload survives a bincode round-trip through the
+    /// `deser_state_summary` owned-deserialize path. A borrowed
+    /// `StateSummary<'de>` is not `DeserializeOwned`; this asserts the
+    /// `#[serde(deserialize_with = ...)]` attribute makes the variant
+    /// cross the wire intact (the wire is what a future emitting piece
+    /// will send once version-gated on).
+    #[test]
+    fn put_msg_probe_request_serde_roundtrip() {
+        let tx = Transaction::new::<PutMsg>();
+        let key = make_contract_key(3);
+        let summary_bytes = vec![0xAB, 0xCD, 0xEF, 0x01, 0x02];
+        let mut skip_list = std::collections::HashSet::new();
+        skip_list.insert(std::net::SocketAddr::from(([127, 0, 0, 1], 8080)));
+        let msg = PutMsg::ProbeRequest {
+            id: tx,
+            contract_key: key,
+            summary: StateSummary::from(summary_bytes.clone()),
+            htl: 7,
+            skip_list: skip_list.clone(),
+        };
+
+        let bytes = bincode::serialize(&msg).expect("serialize");
+        let decoded: PutMsg = bincode::deserialize(&bytes).expect("deserialize");
+        match decoded {
+            PutMsg::ProbeRequest {
+                id,
+                contract_key,
+                summary,
+                htl,
+                skip_list: decoded_skip,
+            } => {
+                assert_eq!(id, tx);
+                assert_eq!(contract_key, key);
+                assert_eq!(
+                    summary.as_ref(),
+                    summary_bytes.as_slice(),
+                    "opaque summary bytes must survive the bincode round-trip"
+                );
+                assert_eq!(htl, 7);
+                assert_eq!(decoded_skip, skip_list);
+            }
+            other => panic!("expected ProbeRequest, got {other}"),
+        }
+    }
+
+    /// Summary-first PUT dispatch reply (INERT scaffolding, #4642): the
+    /// new-vs-existing signal (`holder_found`) and `hop_count` round-trip
+    /// through bincode for both boolean cases.
+    #[test]
+    fn put_msg_probe_response_serde_roundtrip() {
+        let key = make_contract_key(4);
+        for (holder_found, hop_count) in [(false, 0usize), (true, 5usize)] {
+            let tx = Transaction::new::<PutMsg>();
+            let msg = PutMsg::ProbeResponse {
+                id: tx,
+                key,
+                holder_found,
+                hop_count,
+            };
+            let bytes = bincode::serialize(&msg).expect("serialize");
+            let decoded: PutMsg = bincode::deserialize(&bytes).expect("deserialize");
+            match decoded {
+                PutMsg::ProbeResponse {
+                    id,
+                    key: decoded_key,
+                    holder_found: decoded_holder,
+                    hop_count: decoded_hops,
+                } => {
+                    assert_eq!(id, tx);
+                    assert_eq!(decoded_key, key);
+                    assert_eq!(decoded_holder, holder_found);
+                    assert_eq!(decoded_hops, hop_count);
+                }
+                other => panic!("expected ProbeResponse, got {other}"),
+            }
+        }
+    }
+
+    /// `id()` and `requested_location()` cover the summary-first
+    /// scaffolding variants: the probe/dispatch reply carry the tx and a
+    /// key-derived location like every other addressed PUT variant.
+    #[test]
+    fn put_msg_probe_variants_id_and_location() {
+        let tx = Transaction::new::<PutMsg>();
+        let key = make_contract_key(9);
+        let req = PutMsg::ProbeRequest {
+            id: tx,
+            contract_key: key,
+            summary: StateSummary::from(Vec::new()),
+            htl: 1,
+            skip_list: Default::default(),
+        };
+        let resp = PutMsg::ProbeResponse {
+            id: tx,
+            key,
+            holder_found: true,
+            hop_count: 0,
+        };
+        assert_eq!(*req.id(), tx);
+        assert_eq!(*resp.id(), tx);
+        assert!(req.requested_location().is_some());
+        assert!(resp.requested_location().is_some());
     }
 
     /// `bound_cause` keeps short strings byte-identical and truncates


### PR DESCRIPTION
## Problem

The demand-driven hosting redesign (epic #4642) replaces the full-state
PUT with a **summary-first PUT** (spec step 3-bis): a PUT should route a
probe carrying a contract-defined `StateSummary` toward the key instead
of shipping full state up front, then dispatch on whether a holder was
found (ship full state only for a genuinely-new contract; reconcile a
delta for one already held). That behavioral change is large, Full-tier,
and depends on redesign pieces not yet on `main` (reconcile core,
every-hop placement).

This PR lands **only the wire scaffolding, inert** — the additive message
shape + the version-gate infrastructure — so the shape gets normal
multi-model review ahead of the behavioral work, without committing
anything on the wire. Same pattern as the reconcile controller (#4711,
merged inert) and SubscribeHint (added version-gated-off).

## Solution

**Option A — additive new variants** (the standard, clearly-correct
choice). All changes are in the `freenet` crate; `PutMsg` is `pub(crate)`
and node↔node only.

- **Two `PutMsg` variants appended at tags 6/7** (the enum is already
  `#[non_exhaustive]`):
  - `ProbeRequest` — carries `StateSummary<'static>` via the stdlib
    `deser_state_summary` owned-deserialize helper (the `RelatedContracts`
    wire pattern; a borrowed `StateSummary<'de>` is not `DeserializeOwned`),
    plus `htl` / `skip_list` mirroring `Request`.
  - `ProbeResponse` — the new-vs-existing dispatch signal (`holder_found`)
    + `hop_count`. The bidirectional reconcile message exchange is
    deliberately **not** modelled here (a later piece).
  - Tags 0–5 stay byte-identical, so old peers deserialize every existing
    variant unchanged.
- **Version-gate infrastructure** mirroring the SubscribeHint gate:
  `SUMMARY_FIRST_PUT_MIN_VERSION` + `version_supports_summary_first_put`
  (fail-closed on unknown remote version). **No emission yet** — the
  emitting piece will guard its send path with this predicate.

### Inert

No producer constructs either variant and nothing emits them. The
probe→dispatch driver, body-fetch flow, and emission gating are a **later
piece paired with every-hop placement**. Because nothing emits it, the
field layout stays refinable until first emission ships in a release —
merging this commits nothing on the wire.

### Compatibility

- **Additive.** Appended tags only; existing tags unchanged.
- **Not a stdlib change.** `StateSummary`/`StateDelta` already exist in
  freenet-stdlib as opaque bytes. The stdlib-first release policy does
  **not** apply.
- **Node↔node only.** `PutMsg` is `pub(crate)`. River CLI/UI, fdev, and
  riverctl speak the stdlib *client* API (`ContractRequest::Put` /
  `HostResponse`), which is untouched — they never see `PutMsg`, so their
  deserialization cannot break.
- The only compat surface is a new peer emitting to an old peer, closed by
  the version gate (an old peer would fail to bincode-deserialize an
  appended tag and drop the connection, so it must never receive the probe).

## Testing

- Extended `put_msg_wire_format_variant_tags_are_stable` to pin all **8**
  tags (locks 6/7 and guards against reordering).
- Per-variant bincode round-trip tests (`put_msg_probe_request_serde_roundtrip`
  asserts the opaque summary survives the `deser_state_summary` boundary;
  `put_msg_probe_response_serde_roundtrip` covers both `holder_found` cases).
- `id()` / `requested_location()` coverage for the new variants.
- Gate unit tests incl. the mixed-version **"old peer never receives the
  probe"** (fail-closed on unknown/pre-floor version) property.
- `cargo fmt`, `cargo clippy --locked -- -D warnings` (default + `trace-ot`)
  clean; new tests green.

## Review

Wire-format / protocol change → **Full-tier**: multi-model review + Ian
sign-off before merge. Note this is inert scaffolding; the behavioral
probe→dispatch + emission is a separate later PR.

Part of #4642.

[AI-assisted - Claude]