### PR TITLE
feat(hosting): complete reconcile shadow-wiring at the 4 remaining sites

### DIFF
--- a/crates/core/src/node/neighbor_hosting.rs
+++ b/crates/core/src/node/neighbor_hosting.rs
@@ -379,6 +379,24 @@ impl NeighborHostingManager {
         neighbors
     }
 
+    /// The set of contract instance-ids `pub_key` currently advertises hosting.
+    ///
+    /// Read-only reverse lookup (does NOT mutate, unlike
+    /// [`Self::on_peer_disconnected`]). The reconcile connection-drop shadow
+    /// (keystone step-2, #4642) calls this BEFORE `on_peer_disconnected` clears
+    /// the entry, to learn which contracts a dropped peer co-hosted so it can ask
+    /// whether the controller would re-root. Returns an empty set for an unknown
+    /// peer.
+    pub(crate) fn contracts_for_peer(
+        &self,
+        pub_key: &TransportPublicKey,
+    ) -> HashSet<ContractInstanceId> {
+        self.neighbor_contracts
+            .get(pub_key)
+            .map(|entry| entry.value().clone())
+            .unwrap_or_default()
+    }
+
     /// Handle peer disconnection by removing their hosting state.
     pub fn on_peer_disconnected(&self, pub_key: &TransportPublicKey) {
         if let Some((_, removed_cache)) = self.neighbor_contracts.remove(pub_key) {

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -193,12 +193,20 @@ pub struct NetworkStatus {
     /// (hosting redesign piece D, #4642 / #4671).
     pub upstream_divergence_stats: UpstreamDivergenceStats,
     /// Reconcile-controller SHADOW comparison counters, split PER SITE (hosting
-    /// redesign keystone step-2, #4642). The FLIP is site-by-site (collapse
-    /// first, then renewal), so each site's divergence must be separately
-    /// gate-able — a single global tally would be dominated by the renewal set
-    /// size and hide the collapse-site signal.
+    /// redesign keystone step-2, #4642). The FLIP is site-by-site, so each
+    /// site's divergence must be separately gate-able — a single global tally
+    /// would be dominated by the renewal set size and hide the other signals.
+    ///
+    /// `collapse` and `renewal` are the MAINTENANCE sites (full action-set
+    /// comparison). The other three are single-aspect EDGE sites (focused
+    /// comparison on one action class): `inbound_unsubscribe` (teardown on a
+    /// downstream leave), `connection_drop` (re-root on an upstream loss),
+    /// `host_formation` (announce on first host).
     pub reconcile_shadow_collapse: ReconcileShadowStats,
     pub reconcile_shadow_renewal: ReconcileShadowStats,
+    pub reconcile_shadow_inbound_unsubscribe: ReconcileShadowStats,
+    pub reconcile_shadow_connection_drop: ReconcileShadowStats,
+    pub reconcile_shadow_host_formation: ReconcileShadowStats,
 }
 
 /// Per-node counters measuring how often the demand-driven-hosting **computed
@@ -224,6 +232,10 @@ pub struct UpstreamDivergenceStats {
 
 /// Which decision site a reconcile shadow comparison came from. The FLIP is
 /// site-by-site, so the counters are split per site (keystone step-2, #4642).
+///
+/// `Collapse` / `Renewal` are the MAINTENANCE sites (full action-set
+/// comparison). The other three are single-aspect EDGE sites, each compared on
+/// ONE focused action class (see `action_set_divergence_focused`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReconcileShadowSite {
     /// The interest-gated collapse (`OpManager::send_unsubscribe_upstream`).
@@ -231,6 +243,19 @@ pub enum ReconcileShadowSite {
     /// The subscription-renewal set (`Ring::contracts_needing_renewal`, driven
     /// by the recovery loop).
     Renewal,
+    /// A downstream peer unsubscribed (`subscribe::handle_unsubscribe_inbound`):
+    /// did that leave us not-in-use (strict-farther), i.e. would the controller
+    /// tear down? Focused on `Collapse`.
+    InboundUnsubscribe,
+    /// A ring connection dropped (`OpManager::on_ring_connection_lost`): for a
+    /// contract that peer co-hosted, would the controller re-root (upstream
+    /// lost, demand intact)? Production does nothing today. Focused on
+    /// `ReRootSearch`.
+    ConnectionDrop,
+    /// A peer finished host formation and announced hosting
+    /// (`finalize_originator_subscribe`, GET `cache_contract_locally`): does the
+    /// controller agree it should announce? Focused on `Announce`.
+    HostFormation,
 }
 
 /// Per-node counters for the reconcile-controller SHADOW comparison AT ONE SITE
@@ -456,6 +481,9 @@ pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: St
         upstream_divergence_stats: UpstreamDivergenceStats::default(),
         reconcile_shadow_collapse: ReconcileShadowStats::default(),
         reconcile_shadow_renewal: ReconcileShadowStats::default(),
+        reconcile_shadow_inbound_unsubscribe: ReconcileShadowStats::default(),
+        reconcile_shadow_connection_drop: ReconcileShadowStats::default(),
+        reconcile_shadow_host_formation: ReconcileShadowStats::default(),
     };
     match NETWORK_STATUS.get() {
         // Already initialized: overwrite the existing tracker in place so
@@ -722,6 +750,11 @@ pub fn record_reconcile_shadow_comparison(
             let r = match site {
                 ReconcileShadowSite::Collapse => &mut s.reconcile_shadow_collapse,
                 ReconcileShadowSite::Renewal => &mut s.reconcile_shadow_renewal,
+                ReconcileShadowSite::InboundUnsubscribe => {
+                    &mut s.reconcile_shadow_inbound_unsubscribe
+                }
+                ReconcileShadowSite::ConnectionDrop => &mut s.reconcile_shadow_connection_drop,
+                ReconcileShadowSite::HostFormation => &mut s.reconcile_shadow_host_formation,
             };
             r.comparisons = r.comparisons.saturating_add(1);
             if divergence.any() {
@@ -752,15 +785,32 @@ pub fn record_reconcile_shadow_comparison(
     }
 }
 
+/// A copy of all per-site reconcile-controller SHADOW counters, for export to
+/// the `router_snapshot` telemetry event (keystone step-2, #4642).
+#[derive(Clone, Copy)]
+pub struct ReconcileShadowSnapshot {
+    pub collapse: ReconcileShadowStats,
+    pub renewal: ReconcileShadowStats,
+    pub inbound_unsubscribe: ReconcileShadowStats,
+    pub connection_drop: ReconcileShadowStats,
+    pub host_formation: ReconcileShadowStats,
+}
+
 /// Read the per-site reconcile-controller SHADOW counters (keystone step-2,
-/// #4642) for export to the `router_snapshot` telemetry event. Returns
-/// `(collapse, renewal)` copies of the per-node monotonic totals, or `None`
-/// before the `NETWORK_STATUS` singleton is initialized. `Ring` polls this on the
-/// snapshot cadence and copies the values onto `RouterSnapshotInfo`.
-pub fn reconcile_shadow_counts() -> Option<(ReconcileShadowStats, ReconcileShadowStats)> {
+/// #4642) for export to the `router_snapshot` telemetry event. Returns copies of
+/// the per-node monotonic totals for every site, or `None` before the
+/// `NETWORK_STATUS` singleton is initialized. `Ring` polls this on the snapshot
+/// cadence and copies the values onto `RouterSnapshotInfo`.
+pub fn reconcile_shadow_counts() -> Option<ReconcileShadowSnapshot> {
     let status = NETWORK_STATUS.get()?;
     let s = status.read().ok()?;
-    Some((s.reconcile_shadow_collapse, s.reconcile_shadow_renewal))
+    Some(ReconcileShadowSnapshot {
+        collapse: s.reconcile_shadow_collapse,
+        renewal: s.reconcile_shadow_renewal,
+        inbound_unsubscribe: s.reconcile_shadow_inbound_unsubscribe,
+        connection_drop: s.reconcile_shadow_connection_drop,
+        host_formation: s.reconcile_shadow_host_formation,
+    })
 }
 
 /// Record a NAT traversal attempt.
@@ -1579,11 +1629,17 @@ mod tests {
         let _lock = TEST_MUTEX.lock().unwrap();
         init(31337, HashSet::new(), "test".to_string());
 
-        let (collapse0, renewal0) = reconcile_shadow_counts().expect("counters present after init");
+        let z = reconcile_shadow_counts().expect("counters present after init");
         assert_eq!(
-            (collapse0.comparisons, renewal0.comparisons),
-            (0, 0),
-            "both sites start at zero after init"
+            (
+                z.collapse.comparisons,
+                z.renewal.comparisons,
+                z.inbound_unsubscribe.comparisons,
+                z.connection_drop.comparisons,
+                z.host_formation.comparisons,
+            ),
+            (0, 0, 0, 0, 0),
+            "all sites start at zero after init"
         );
 
         // Collapse site: 2 comparisons, 1 diverging (retract-only gap).
@@ -1604,25 +1660,42 @@ mod tests {
                 ..Default::default()
             },
         );
+        // Connection-drop site (an EDGE site): 1 comparison, diverging (reroot).
+        record_reconcile_shadow_comparison(
+            ConnectionDrop,
+            ReconcileActionDivergence {
+                reroot_search: true,
+                ..Default::default()
+            },
+        );
 
-        let (collapse, renewal) = reconcile_shadow_counts().expect("counters present");
+        let c = reconcile_shadow_counts().expect("counters present");
 
         // Collapse site tallies only the collapse-site records.
-        assert_eq!(collapse.comparisons, 2, "collapse site: every call bumps");
-        assert_eq!(collapse.divergences, 1, "collapse site: one diverging call");
-        assert_eq!(collapse.retract_diffs, 1);
-        assert_eq!(collapse.subscribe_diffs, 0);
-        assert_eq!(collapse.renew_diffs, 0);
+        assert_eq!(c.collapse.comparisons, 2, "collapse site: every call bumps");
+        assert_eq!(
+            c.collapse.divergences, 1,
+            "collapse site: one diverging call"
+        );
+        assert_eq!(c.collapse.retract_diffs, 1);
+        assert_eq!(c.collapse.subscribe_diffs, 0);
 
         // Renewal site is independent — the collapse records must not bleed in.
         assert_eq!(
-            renewal.comparisons, 1,
+            c.renewal.comparisons, 1,
             "renewal site independent of collapse"
         );
-        assert_eq!(renewal.divergences, 1);
-        assert_eq!(renewal.subscribe_diffs, 1);
-        assert_eq!(renewal.renew_diffs, 1);
-        assert_eq!(renewal.retract_diffs, 0);
+        assert_eq!(c.renewal.subscribe_diffs, 1);
+        assert_eq!(c.renewal.renew_diffs, 1);
+        assert_eq!(c.renewal.retract_diffs, 0);
+
+        // Connection-drop site is independent of the maintenance sites.
+        assert_eq!(c.connection_drop.comparisons, 1);
+        assert_eq!(c.connection_drop.reroot_search_diffs, 1);
+        assert_eq!(c.connection_drop.renew_diffs, 0);
+        // Sites never touched stay zero.
+        assert_eq!(c.inbound_unsubscribe.comparisons, 0);
+        assert_eq!(c.host_formation.comparisons, 0);
     }
 
     #[test]

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -75,14 +75,23 @@ impl Ops {
     }
 }
 
-/// Max number of reconcile connection-drop SHADOW comparisons to sample per
-/// dropped connection (keystone step-2, #4642). Each sample builds a
+/// Max number of reconcile connection-drop SHADOW comparisons to BUILD per
+/// dropped connection (keystone step-2, #4642). Each build is a
 /// `ReconcileInputs` snapshot (a redb read + an `is_subscription_root`
-/// connection-map scan), so this bounds the per-drop cost on a near-key gateway
-/// whose subscribed set is large. The dropped peer's co-hosted set (the natural
-/// bound) is usually small; this is a belt-and-suspenders cap. Contracts past
-/// the cap are simply unmeasured for that drop.
+/// connection-map scan), so this bounds the expensive per-drop work. Contracts
+/// past the cap are unmeasured for that drop.
 const CONNECTION_DROP_SHADOW_SAMPLE_CAP: usize = 32;
+
+/// Max number of our active-subscription entries to EXAMINE per dropped
+/// connection while looking for the ≤`CONNECTION_DROP_SHADOW_SAMPLE_CAP` matches
+/// (keystone step-2, #4642). Bounds the SCAN itself (not just the recording): a
+/// near-key gateway with a large subscribed set must not turn one co-host
+/// disconnect into an O(S) membership sweep. Examining is cheap (a DashMap step
+/// plus a `HashSet::contains`), so this is generous enough to fully cover a
+/// realistic subscribed set while hard-capping the pathological case; a set
+/// larger than this is sampled (a slight, arbitrary undercount for a one-sided
+/// diagnostic counter).
+const CONNECTION_DROP_SHADOW_SCAN_CAP: usize = 1024;
 
 /// Pure core of the piece-D **strictly-farther** downstream-subscriber filter
 /// (keystone step-2, #4642): `true` iff at least one subscriber distance is
@@ -1437,31 +1446,39 @@ impl OpManager {
             .schedule_deferred_removal(&PeerKey::from(pub_key.clone()));
 
         // Shadow: production does NO re-root on a connection drop (the F/#4655
-        // hook), so for each contract WE subscribe to that the dropped peer
-        // co-hosted, ask whether the controller WOULD re-root (upstream lost,
-        // demand intact) — actual is always `{}`, focused on `ReRootSearch`. Run
-        // AFTER `on_peer_disconnected` so the computed upstream already excludes
-        // the dropped peer. Iterate OUR subscribed contracts and keep those the
-        // dropped peer co-hosted: this sidesteps reconstructing a full
-        // `ContractKey` from the reverse index's bare `ContractInstanceId`, and
-        // a contract we do NOT subscribe to can't be in-use so the controller
-        // wouldn't re-root anyway. Bounded per drop.
+        // hook), so for each dropped-peer-co-hosted contract we hold, ask whether
+        // the controller WOULD re-root (upstream lost, demand intact) — actual is
+        // always `{}`, focused on `ReRootSearch`. Run AFTER `on_peer_disconnected`
+        // so the computed upstream already excludes the dropped peer.
+        //
+        // We resolve the dropped peer's co-hosted instance-ids to OUR
+        // `ContractKey`s via `subscribed_keys_in` (a bounded, sort-free scan of
+        // active subscriptions). The reason is purely mechanical: there is no
+        // instance-id → `ContractKey` index in this crate, and lease-holders are
+        // the cheapest set that yields the full key without reconstruction. It is
+        // NOT a completeness claim — `contract_in_use = has_local_client ||
+        // has_farther_downstream_subscriber` is INDEPENDENT of `is_subscribed`
+        // (reconcile.rs), so a state-present, in-use, no-upstream, non-root
+        // contract we host WITHOUT an active lease (e.g. a former host whose
+        // upstream lease just lapsed while a local client is still subscribed)
+        // would also be a re-root candidate and is MISSED here. That is a narrow,
+        // transient case that biases this one-sided count slightly LOW; acceptable
+        // for a diagnostic counter, and it goes away when the flip drives re-root
+        // from the reconcile snapshot directly. Both the scan and the build count
+        // are bounded per drop (see the two caps above).
         if !dropped_contracts.is_empty() {
-            let mut budget = CONNECTION_DROP_SHADOW_SAMPLE_CAP;
-            for key in self.ring.get_subscribed_contracts() {
-                if budget == 0 {
-                    break;
-                }
-                if dropped_contracts.contains(key.id()) {
-                    budget -= 1;
-                    self.record_reconcile_shadow_event(
-                        crate::node::network_status::ReconcileShadowSite::ConnectionDrop,
-                        &key,
-                        &[reconcile::Action::ReRootSearch],
-                        // Production never re-roots on a connection drop today.
-                        |_| Vec::new(),
-                    );
-                }
+            for key in self.ring.subscribed_keys_in(
+                &dropped_contracts,
+                CONNECTION_DROP_SHADOW_SCAN_CAP,
+                CONNECTION_DROP_SHADOW_SAMPLE_CAP,
+            ) {
+                self.record_reconcile_shadow_event(
+                    crate::node::network_status::ReconcileShadowSite::ConnectionDrop,
+                    &key,
+                    &[reconcile::Action::ReRootSearch],
+                    // Production never re-roots on a connection drop today.
+                    |_| Vec::new(),
+                );
             }
         }
     }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -75,6 +75,15 @@ impl Ops {
     }
 }
 
+/// Max number of reconcile connection-drop SHADOW comparisons to sample per
+/// dropped connection (keystone step-2, #4642). Each sample builds a
+/// `ReconcileInputs` snapshot (a redb read + an `is_subscription_root`
+/// connection-map scan), so this bounds the per-drop cost on a near-key gateway
+/// whose subscribed set is large. The dropped peer's co-hosted set (the natural
+/// bound) is usually small; this is a belt-and-suspenders cap. Contracts past
+/// the cap are simply unmeasured for that drop.
+const CONNECTION_DROP_SHADOW_SAMPLE_CAP: usize = 32;
+
 /// Pure core of the piece-D **strictly-farther** downstream-subscriber filter
 /// (keystone step-2, #4642): `true` iff at least one subscriber distance is
 /// STRICTLY greater than `my_distance` (both measured to the contract key).
@@ -901,6 +910,44 @@ impl OpManager {
         has_strictly_farther(my_distance, subscriber_distances)
     }
 
+    /// Record one reconcile-controller SHADOW comparison at a single-aspect EDGE
+    /// site (keystone step-2 completion, #4642): inbound-unsubscribe collapse,
+    /// connection-drop re-root, or host-formation announce.
+    ///
+    /// DRIVES NOTHING. Builds the [`reconcile::ReconcileInputs`] snapshot,
+    /// computes what the controller WOULD do, maps the caller's per-event actual
+    /// behavior (`actual_of(&inputs)`), and records the divergence FOCUSED on the
+    /// `relevant` action class(es) — so level-triggered actions the event does
+    /// not decide (notably `Renew`, which is the renewal site's concern) can't
+    /// pollute this site's signal. Skipped (no record) when the snapshot is
+    /// distance-blind (`build_reconcile_inputs` returns `None`: own-location
+    /// unknown), same as the maintenance sites.
+    pub(crate) fn record_reconcile_shadow_event(
+        &self,
+        site: crate::node::network_status::ReconcileShadowSite,
+        contract: &ContractKey,
+        relevant: &[reconcile::Action],
+        actual_of: impl FnOnce(&reconcile::ReconcileInputs) -> Vec<reconcile::Action>,
+    ) {
+        let Some(inputs) = self.build_reconcile_inputs(contract) else {
+            return;
+        };
+        let reconcile_actions = reconcile::reconcile(&inputs);
+        let actual = actual_of(&inputs);
+        let divergence =
+            reconcile::action_set_divergence_focused(&reconcile_actions, &actual, relevant);
+        crate::node::network_status::record_reconcile_shadow_comparison(site, divergence);
+        if divergence.any() {
+            tracing::debug!(
+                contract = %contract,
+                ?site,
+                ?reconcile_actions,
+                ?actual,
+                "reconcile shadow diverges from actual behavior (#4642 keystone step-2)"
+            );
+        }
+    }
+
     /// Send an Unsubscribe message to the upstream peer for a contract.
     ///
     /// Finds the upstream peer from the interest manager, resolves its address,
@@ -1379,9 +1426,44 @@ impl OpManager {
     /// interest manager's `downstream_subscriber_count` and triggers upstream
     /// unsubscribe when appropriate.
     pub(crate) fn on_ring_connection_lost(&self, pub_key: &TransportPublicKey) {
+        // Reconcile-controller SHADOW comparison (keystone step-2, #4642),
+        // CONNECTION-DROP re-root site. Capture the contracts the dropped peer
+        // co-hosted BEFORE `on_peer_disconnected` clears them. DRIVES NOTHING.
+        let dropped_contracts = self.neighbor_hosting.contracts_for_peer(pub_key);
+
+        // Production disconnect bookkeeping (unchanged).
         self.neighbor_hosting.on_peer_disconnected(pub_key);
         self.interest_manager
             .schedule_deferred_removal(&PeerKey::from(pub_key.clone()));
+
+        // Shadow: production does NO re-root on a connection drop (the F/#4655
+        // hook), so for each contract WE subscribe to that the dropped peer
+        // co-hosted, ask whether the controller WOULD re-root (upstream lost,
+        // demand intact) — actual is always `{}`, focused on `ReRootSearch`. Run
+        // AFTER `on_peer_disconnected` so the computed upstream already excludes
+        // the dropped peer. Iterate OUR subscribed contracts and keep those the
+        // dropped peer co-hosted: this sidesteps reconstructing a full
+        // `ContractKey` from the reverse index's bare `ContractInstanceId`, and
+        // a contract we do NOT subscribe to can't be in-use so the controller
+        // wouldn't re-root anyway. Bounded per drop.
+        if !dropped_contracts.is_empty() {
+            let mut budget = CONNECTION_DROP_SHADOW_SAMPLE_CAP;
+            for key in self.ring.get_subscribed_contracts() {
+                if budget == 0 {
+                    break;
+                }
+                if dropped_contracts.contains(key.id()) {
+                    budget -= 1;
+                    self.record_reconcile_shadow_event(
+                        crate::node::network_status::ReconcileShadowSite::ConnectionDrop,
+                        &key,
+                        &[reconcile::Action::ReRootSearch],
+                        // Production never re-roots on a connection drop today.
+                        |_| Vec::new(),
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -2070,6 +2152,36 @@ mod tests {
         assert!(!has_strictly_farther(my, std::iter::empty()));
     }
 
+    /// Extract the brace-matched `{...}` block that immediately follows `anchor`
+    /// in `src` (source-scrape helper for the drives-nothing pins). Panics if the
+    /// anchor is absent or the braces are unbalanced.
+    fn braced_block_after<'a>(src: &'a str, anchor: &str) -> &'a str {
+        let start = src
+            .find(anchor)
+            .unwrap_or_else(|| panic!("anchor not found: {anchor}"));
+        let brace = src[start..]
+            .find('{')
+            .expect("anchor must be followed by a block");
+        let body_start = start + brace + 1;
+        let bytes = src.as_bytes();
+        let mut depth = 1i32;
+        let mut i = body_start;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &src[body_start..i];
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        panic!("unbalanced braces after anchor: {anchor}");
+    }
+
     /// Behavior-preserving guard (keystone step-2, #4642): the collapse site
     /// `send_unsubscribe_upstream` must STILL drive its decision off the stored
     /// `is_upstream` flag and the local `ring.unsubscribe`, and the reconcile
@@ -2110,6 +2222,101 @@ mod tests {
             body.contains("action_set_divergence(&reconcile_actions"),
             "reconcile output must flow ONLY into the set-membership divergence \
              comparator (record-only), not into a driver/wire send"
+        );
+
+        // NEGATIVE assertion (mirroring the renewal / edge-site pins): the shadow
+        // BLOCK itself must contain no driver call — reconcile's output can only
+        // be compared, never applied. Extract just the `if let Some(inputs) =
+        // self.build_reconcile_inputs(contract) { ... }` block so the function's
+        // real teardown drivers (which live OUTSIDE the block) don't trip it.
+        let block = braced_block_after(
+            SRC,
+            "if let Some(inputs) = self.build_reconcile_inputs(contract)",
+        );
+        for driver in [
+            ".send(",
+            "self.ring.subscribe",
+            "self.ring.unsubscribe",
+            "send_unsubscribe",
+            "remove_peer_interest",
+            "on_contract_hosted",
+            "on_contract_unhosted",
+            "mark_subscription_pending",
+        ] {
+            assert!(
+                !block.contains(driver),
+                "collapse shadow block must not drive `{driver}` — it records only"
+            );
+        }
+    }
+
+    /// Hardening pin (keystone step-2 completion, #4642): the shared edge-site
+    /// helper `record_reconcile_shadow_event` DRIVES NOTHING — reconcile's output
+    /// flows only into the focused divergence comparator + the per-site counter.
+    /// One pin covers all four edge sites (inbound-unsubscribe, connection-drop,
+    /// host-formation) since they all route through this helper.
+    #[test]
+    fn record_reconcile_shadow_event_drives_nothing() {
+        const SRC: &str = include_str!("op_state_manager.rs");
+        let body = braced_block_after(SRC, "pub(crate) fn record_reconcile_shadow_event(");
+        assert!(
+            body.contains("action_set_divergence_focused"),
+            "the edge-site helper must compare via action_set_divergence_focused"
+        );
+        assert!(
+            body.contains("record_reconcile_shadow_comparison"),
+            "the edge-site helper must record the per-site divergence"
+        );
+        for driver in [
+            ".send(",
+            "self.ring.subscribe",
+            "self.ring.unsubscribe",
+            "send_unsubscribe",
+            "mark_subscription_pending",
+            "announce_contract_hosted",
+            "on_contract_hosted",
+            "on_contract_unhosted",
+            "notify_node_event",
+        ] {
+            assert!(
+                !body.contains(driver),
+                "record_reconcile_shadow_event must not drive `{driver}` — it records only"
+            );
+        }
+    }
+
+    /// Hardening pin (keystone step-2 completion, #4642): each of the four
+    /// EDGE decision sites is wired to the record-only helper with its own
+    /// `ReconcileShadowSite`, and the connection-drop site still runs the
+    /// production disconnect bookkeeping unchanged. A future edit that drops a
+    /// site's shadow (or the production bookkeeping) fails here.
+    #[test]
+    fn edge_sites_wire_the_record_only_helper() {
+        // Inbound-unsubscribe + host-formation live in operations/subscribe.rs.
+        let sub = include_str!("../operations/subscribe.rs");
+        assert!(sub.contains("ReconcileShadowSite::InboundUnsubscribe"));
+        assert!(sub.contains("ReconcileShadowSite::HostFormation"));
+        assert!(sub.contains("record_reconcile_shadow_event"));
+        // Host-formation GET path lives in operations/get/op_ctx_task.rs.
+        let get = include_str!("../operations/get/op_ctx_task.rs");
+        assert!(get.contains("ReconcileShadowSite::HostFormation"));
+        assert!(get.contains("record_reconcile_shadow_event"));
+        // Connection-drop lives here, in on_ring_connection_lost.
+        const SRC: &str = include_str!("op_state_manager.rs");
+        let drop_body = braced_block_after(SRC, "pub(crate) fn on_ring_connection_lost(");
+        assert!(
+            drop_body.contains("ReconcileShadowSite::ConnectionDrop"),
+            "connection-drop shadow must be wired in on_ring_connection_lost"
+        );
+        assert!(
+            drop_body.contains("record_reconcile_shadow_event"),
+            "connection-drop must route through the record-only helper"
+        );
+        // Production disconnect bookkeeping must remain (behavior-preserving).
+        assert!(
+            drop_body.contains("on_peer_disconnected")
+                && drop_body.contains("schedule_deferred_removal"),
+            "on_ring_connection_lost must still do the production disconnect bookkeeping"
         );
     }
 

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1292,6 +1292,29 @@ async fn cache_contract_locally(
         crate::operations::reclaim_evicted_contract(op_manager, *evicted_key, *expected_generation);
     }
 
+    // Reconcile-controller SHADOW comparison (keystone step-2, #4642),
+    // HOST-FORMATION site (GET cache path). About to (conditionally) announce
+    // hosting; does the controller agree? Focused on `Announce`. Actual =
+    // `{Announce}` iff production announces a NOT-yet-advertised host this event
+    // (`is_new && put_persisted` AND not already advertised — the announce is
+    // idempotent), else `{}`. Built BEFORE the announce so `is_advertised`
+    // reflects the pre-announce state. DRIVES NOTHING.
+    {
+        let will_announce = access_result.is_new && put_persisted;
+        op_manager.record_reconcile_shadow_event(
+            crate::node::network_status::ReconcileShadowSite::HostFormation,
+            &key,
+            &[crate::ring::reconcile::Action::Announce],
+            |inputs| {
+                if will_announce && !inputs.is_advertised {
+                    vec![crate::ring::reconcile::Action::Announce]
+                } else {
+                    Vec::new()
+                }
+            },
+        );
+    }
+
     // (4) Newly-hosted announcement gates on BOTH first-time access
     // AND the fact that we actually persisted new state. Without
     // persistence there's nothing to announce hosting for.

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -591,6 +591,26 @@ pub(super) async fn finalize_originator_subscribe(
             }
         };
 
+    // Reconcile-controller SHADOW comparison (keystone step-2, #4642),
+    // HOST-FORMATION site (subscribe originator). About to (conditionally)
+    // announce hosting; does the controller agree? Focused on `Announce`. Actual
+    // = `{Announce}` iff production announces a NOT-yet-advertised host this event
+    // (`have_body` AND not already advertised — `announce_contract_hosted` is
+    // idempotent), else `{}`. Built BEFORE the announce so `is_advertised`
+    // reflects the pre-announce state. DRIVES NOTHING.
+    op_manager.record_reconcile_shadow_event(
+        crate::node::network_status::ReconcileShadowSite::HostFormation,
+        &key,
+        &[crate::ring::reconcile::Action::Announce],
+        |inputs| {
+            if have_body && !inputs.is_advertised {
+                vec![crate::ring::reconcile::Action::Announce]
+            } else {
+                Vec::new()
+            }
+        },
+    );
+
     if have_body {
         super::announce_contract_hosted(op_manager, &key).await;
     }
@@ -743,6 +763,32 @@ pub(crate) async fn handle_unsubscribe_inbound(
             %instance_id,
             ?source_addr,
             "Unsubscribe: could not resolve sender peer, downstream entry not removed"
+        );
+    }
+
+    // Reconcile-controller SHADOW comparison (keystone step-2, #4642),
+    // INBOUND-UNSUBSCRIBE site. The downstream peer just left (removal above is
+    // complete, so the strict-farther gate reflects it); does that leave us
+    // not-in-use, i.e. would the controller tear down our lease? Focused on
+    // `Collapse`. Actual = `{Collapse}` iff production tears down the lease THIS
+    // event (`should_unsubscribe_upstream` AND we actually hold a lease —
+    // `ring.unsubscribe` is a no-op otherwise), else `{}`. The strict-farther
+    // "still-in-use by a CLOSER downstream, so keep hosting" case where the
+    // controller would collapse shows up here as a `collapse` diff. DRIVES
+    // NOTHING — the real decision below re-reads the gate and is unchanged.
+    {
+        let will_collapse = op_manager.ring.should_unsubscribe_upstream(&key);
+        op_manager.record_reconcile_shadow_event(
+            crate::node::network_status::ReconcileShadowSite::InboundUnsubscribe,
+            &key,
+            &[crate::ring::reconcile::Action::Collapse],
+            |inputs| {
+                if will_collapse && inputs.is_subscribed {
+                    vec![crate::ring::reconcile::Action::Collapse]
+                } else {
+                    Vec::new()
+                }
+            },
         );
     }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1715,31 +1715,59 @@ impl Ring {
             // `router_snapshot_json_includes_reconcile_shadow_counters`). Read
             // from the per-node network_status singleton; `None` only before it is
             // initialized.
-            if let Some((collapse, renewal)) =
-                crate::node::network_status::reconcile_shadow_counts()
-            {
-                snapshot.reconcile_shadow_collapse_comparisons = Some(collapse.comparisons);
-                snapshot.reconcile_shadow_collapse_divergences = Some(collapse.divergences);
-                snapshot.reconcile_shadow_collapse_subscribe_diffs = Some(collapse.subscribe_diffs);
-                snapshot.reconcile_shadow_collapse_renew_diffs = Some(collapse.renew_diffs);
+            if let Some(shadow) = crate::node::network_status::reconcile_shadow_counts() {
+                // Every assignment reads uniformly from `shadow.<site>.<field>`
+                // (NO aliasing), so the mirror-seam pin
+                // `reconcile_shadow_export_maps_each_field_to_its_own_site` can
+                // verify each snapshot field is fed from its OWN site — a
+                // field-swap here would silently emit the wrong per-site value.
+                //
+                // MAINTENANCE sites (collapse, renewal): full per-action export
+                // (all 9 counters).
+                snapshot.reconcile_shadow_collapse_comparisons = Some(shadow.collapse.comparisons);
+                snapshot.reconcile_shadow_collapse_divergences = Some(shadow.collapse.divergences);
+                snapshot.reconcile_shadow_collapse_subscribe_diffs =
+                    Some(shadow.collapse.subscribe_diffs);
+                snapshot.reconcile_shadow_collapse_renew_diffs = Some(shadow.collapse.renew_diffs);
                 snapshot.reconcile_shadow_collapse_unsubscribe_diffs =
-                    Some(collapse.unsubscribe_diffs);
-                snapshot.reconcile_shadow_collapse_collapse_diffs = Some(collapse.collapse_diffs);
-                snapshot.reconcile_shadow_collapse_announce_diffs = Some(collapse.announce_diffs);
-                snapshot.reconcile_shadow_collapse_retract_diffs = Some(collapse.retract_diffs);
+                    Some(shadow.collapse.unsubscribe_diffs);
+                snapshot.reconcile_shadow_collapse_collapse_diffs =
+                    Some(shadow.collapse.collapse_diffs);
+                snapshot.reconcile_shadow_collapse_announce_diffs =
+                    Some(shadow.collapse.announce_diffs);
+                snapshot.reconcile_shadow_collapse_retract_diffs =
+                    Some(shadow.collapse.retract_diffs);
                 snapshot.reconcile_shadow_collapse_reroot_search_diffs =
-                    Some(collapse.reroot_search_diffs);
-                snapshot.reconcile_shadow_renewal_comparisons = Some(renewal.comparisons);
-                snapshot.reconcile_shadow_renewal_divergences = Some(renewal.divergences);
-                snapshot.reconcile_shadow_renewal_subscribe_diffs = Some(renewal.subscribe_diffs);
-                snapshot.reconcile_shadow_renewal_renew_diffs = Some(renewal.renew_diffs);
+                    Some(shadow.collapse.reroot_search_diffs);
+                snapshot.reconcile_shadow_renewal_comparisons = Some(shadow.renewal.comparisons);
+                snapshot.reconcile_shadow_renewal_divergences = Some(shadow.renewal.divergences);
+                snapshot.reconcile_shadow_renewal_subscribe_diffs =
+                    Some(shadow.renewal.subscribe_diffs);
+                snapshot.reconcile_shadow_renewal_renew_diffs = Some(shadow.renewal.renew_diffs);
                 snapshot.reconcile_shadow_renewal_unsubscribe_diffs =
-                    Some(renewal.unsubscribe_diffs);
-                snapshot.reconcile_shadow_renewal_collapse_diffs = Some(renewal.collapse_diffs);
-                snapshot.reconcile_shadow_renewal_announce_diffs = Some(renewal.announce_diffs);
-                snapshot.reconcile_shadow_renewal_retract_diffs = Some(renewal.retract_diffs);
+                    Some(shadow.renewal.unsubscribe_diffs);
+                snapshot.reconcile_shadow_renewal_collapse_diffs =
+                    Some(shadow.renewal.collapse_diffs);
+                snapshot.reconcile_shadow_renewal_announce_diffs =
+                    Some(shadow.renewal.announce_diffs);
+                snapshot.reconcile_shadow_renewal_retract_diffs =
+                    Some(shadow.renewal.retract_diffs);
                 snapshot.reconcile_shadow_renewal_reroot_search_diffs =
-                    Some(renewal.reroot_search_diffs);
+                    Some(shadow.renewal.reroot_search_diffs);
+                // EDGE sites: focused on one class each, so comparisons +
+                // divergences fully capture the signal.
+                snapshot.reconcile_shadow_inbound_unsubscribe_comparisons =
+                    Some(shadow.inbound_unsubscribe.comparisons);
+                snapshot.reconcile_shadow_inbound_unsubscribe_divergences =
+                    Some(shadow.inbound_unsubscribe.divergences);
+                snapshot.reconcile_shadow_connection_drop_comparisons =
+                    Some(shadow.connection_drop.comparisons);
+                snapshot.reconcile_shadow_connection_drop_divergences =
+                    Some(shadow.connection_drop.divergences);
+                snapshot.reconcile_shadow_host_formation_comparisons =
+                    Some(shadow.host_formation.comparisons);
+                snapshot.reconcile_shadow_host_formation_divergences =
+                    Some(shadow.host_formation.divergences);
             }
 
             // Keep the hosting manager's copy of our own ring location current so
@@ -6163,6 +6191,61 @@ mod k_closest_source_tests {
         assert_eq!(super::renewal_shadow_actual(false, false), empty);
         assert_eq!(super::renewal_shadow_actual(true, true), &[Renew]);
         assert_eq!(super::renewal_shadow_actual(true, false), &[Subscribe]);
+    }
+
+    /// Hardening pin (keystone step-2 completion, #4642): the
+    /// network_status → router_snapshot MIRROR SEAM. The export block hand-copies
+    /// each per-site counter into a matching `RouterSnapshotInfo` field; a field
+    /// swap (e.g. feeding `reconcile_shadow_collapse_comparisons` from
+    /// `shadow.renewal`) would silently emit the wrong per-site value to the
+    /// collector with no compile error. This asserts every one of the 24 export
+    /// assignments reads from `shadow.<SITE>.<FIELD>` for its OWN site, so a swap
+    /// fails CI here. Whitespace-normalized so rustfmt line-wrapping is irrelevant.
+    #[test]
+    fn reconcile_shadow_export_maps_each_field_to_its_own_site() {
+        let src = production_source();
+        let block = extract_fn_body(
+            src,
+            "if let Some(shadow) = crate::node::network_status::reconcile_shadow_counts()",
+        );
+        // Normalize all runs of whitespace to single spaces.
+        let norm = block.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        let full: &[&str] = &[
+            "comparisons",
+            "divergences",
+            "subscribe_diffs",
+            "renew_diffs",
+            "unsubscribe_diffs",
+            "collapse_diffs",
+            "announce_diffs",
+            "retract_diffs",
+            "reroot_search_diffs",
+        ];
+        let edge: &[&str] = &["comparisons", "divergences"];
+        let sites: [(&str, &[&str]); 5] = [
+            ("collapse", full),
+            ("renewal", full),
+            ("inbound_unsubscribe", edge),
+            ("connection_drop", edge),
+            ("host_formation", edge),
+        ];
+
+        let mut checked = 0usize;
+        for (site, fields) in sites {
+            for field in fields {
+                let expected = format!(
+                    "snapshot.reconcile_shadow_{site}_{field} = Some(shadow.{site}.{field});"
+                );
+                assert!(
+                    norm.contains(&expected),
+                    "mirror-seam: export must contain `{expected}` — a field-swap here \
+                     silently emits the wrong per-site value to the collector"
+                );
+                checked += 1;
+            }
+        }
+        assert_eq!(checked, 24, "expected exactly 24 export assignments");
     }
 }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -3105,6 +3105,21 @@ impl Ring {
         self.hosting_manager.get_subscribed_contracts()
     }
 
+    /// Bounded, sort-free lookup of currently-subscribed `ContractKey`s whose
+    /// instance-id is in `wanted` (see
+    /// [`hosting::HostingManager::subscribed_keys_in`]). Used by the reconcile
+    /// connection-drop shadow (keystone step-2, #4642) to avoid the O(S log S)
+    /// full-set scan of [`Self::get_subscribed_contracts`] per disconnect.
+    pub(crate) fn subscribed_keys_in(
+        &self,
+        wanted: &std::collections::HashSet<ContractInstanceId>,
+        scan_cap: usize,
+        max_matches: usize,
+    ) -> Vec<ContractKey> {
+        self.hosting_manager
+            .subscribed_keys_in(wanted, scan_cap, max_matches)
+    }
+
     /// Force-expire a contract's subscription so it gets renewed through the
     /// current best route on the next recovery cycle.
     fn force_subscription_renewal(&self, contract: &ContractKey) {

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -580,6 +580,44 @@ impl HostingManager {
         contracts
     }
 
+    /// Up to `max_matches` currently-subscribed (non-expired) `ContractKey`s
+    /// whose instance-id is in `wanted`, examining AT MOST `scan_cap` active
+    /// subscription entries.
+    ///
+    /// Single pass, UNSORTED, no full-set materialization — unlike
+    /// [`Self::get_subscribed_contracts`] (which allocates the whole set and
+    /// sorts it, O(S log S)). The reconcile connection-drop shadow (keystone
+    /// step-2, #4642) uses this so one co-host disconnect can't burst into an
+    /// O(S log S) scan on a near-key gateway with a large subscribed set: BOTH
+    /// the scan (`scan_cap`) and the match/build count (`max_matches`) are
+    /// hard-bounded. A subscribed set larger than `scan_cap` is SAMPLED rather
+    /// than fully enumerated — an acceptable slight undercount for a one-sided
+    /// diagnostic counter (DashMap iteration order is unspecified, so the sample
+    /// is arbitrary, not adversarially controllable). Returning the `ContractKey`
+    /// directly also avoids reconstructing it from the reverse index's bare
+    /// `ContractInstanceId` (no instance-id → `ContractKey` index exists in this
+    /// crate — every resolver scans, as the comment at `ring.rs` ~895 notes).
+    pub(crate) fn subscribed_keys_in(
+        &self,
+        wanted: &HashSet<ContractInstanceId>,
+        scan_cap: usize,
+        max_matches: usize,
+    ) -> Vec<ContractKey> {
+        let now = self.time_source.now();
+        let mut out = Vec::new();
+        // `.take(scan_cap)` bounds the entries EXAMINED (the scan); the inner
+        // break bounds the MATCHES kept (the expensive build count downstream).
+        for entry in self.active_subscriptions.iter().take(scan_cap) {
+            if out.len() >= max_matches {
+                break;
+            }
+            if entry.value().expires_at > now && wanted.contains(entry.key().id()) {
+                out.push(*entry.key());
+            }
+        }
+        out
+    }
+
     /// Snapshot of every active subscription for the local-peer dashboard.
     ///
     /// Reads directly from the canonical lease map (no parallel
@@ -2263,6 +2301,63 @@ mod tests {
 
         assert!(result.is_new);
         assert!(manager.is_subscribed(&contract));
+    }
+
+    /// `subscribed_keys_in` (the bounded connection-drop-shadow lookup, #4642)
+    /// returns only subscribed matches, and both caps hard-bound the work.
+    #[test]
+    fn subscribed_keys_in_matches_and_bounds() {
+        use std::collections::HashSet;
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        for seed in 1..=6u8 {
+            manager.subscribe(make_contract_key(seed));
+        }
+        // wanted = instance-ids of two subscribed contracts + one we never
+        // subscribed to (seed 99).
+        let wanted: HashSet<ContractInstanceId> = [
+            *make_contract_key(2).id(),
+            *make_contract_key(4).id(),
+            *make_contract_key(99).id(),
+        ]
+        .into_iter()
+        .collect();
+
+        // Generous caps: exactly the two subscribed matches (99 excluded).
+        let mut got = manager.subscribed_keys_in(&wanted, 1024, 32);
+        got.sort_by(|a, b| a.id().as_bytes().cmp(b.id().as_bytes()));
+        assert_eq!(got, vec![make_contract_key(2), make_contract_key(4)]);
+
+        // `max_matches` caps the result (bounds the expensive build count).
+        assert_eq!(manager.subscribed_keys_in(&wanted, 1024, 1).len(), 1);
+
+        // `scan_cap` bounds the scan itself: examine zero entries → find none.
+        assert!(manager.subscribed_keys_in(&wanted, 0, 32).is_empty());
+    }
+
+    /// `subscribed_keys_in` excludes expired leases (same freshness semantics as
+    /// `get_subscribed_contracts`), driven purely by the injected clock.
+    #[tokio::test]
+    async fn subscribed_keys_in_excludes_expired_leases() {
+        use std::collections::HashSet;
+        let clock = crate::util::time_source::SharedMockTimeSource::new();
+        let manager = HostingManager::with_time_source(
+            DEFAULT_HOSTING_BUDGET_BYTES,
+            std::sync::Arc::new(clock.clone()),
+        );
+        let contract = make_contract_key(7);
+        manager.subscribe(contract);
+        let wanted: HashSet<ContractInstanceId> = [*contract.id()].into_iter().collect();
+        assert_eq!(
+            manager.subscribed_keys_in(&wanted, 1024, 32),
+            vec![contract],
+            "a fresh lease is matched"
+        );
+
+        clock.advance_time(SUBSCRIPTION_LEASE_DURATION + Duration::from_secs(1));
+        assert!(
+            manager.subscribed_keys_in(&wanted, 1024, 32).is_empty(),
+            "an expired lease must not be matched"
+        );
     }
 
     /// The injected time source (`with_time_source`) drives the manager's

--- a/crates/core/src/ring/hosting/reconcile.rs
+++ b/crates/core/src/ring/hosting/reconcile.rs
@@ -435,6 +435,39 @@ pub(crate) fn action_set_divergence(
     div
 }
 
+/// Like [`action_set_divergence`] but restricted to the `relevant` action
+/// classes: any action NOT in `relevant` is filtered out of BOTH sets before
+/// comparing, so it can never flag.
+///
+/// Used by the single-aspect EDGE decision sites (keystone step-2 completion,
+/// #4642) — inbound-unsubscribe collapse, connection-drop re-root, and
+/// host-formation announce. Those sites each decide ONE thing (tear down? /
+/// re-root? / announce?) at an event, whereas [`reconcile`] returns the FULL
+/// level-triggered desired-state set (which for a maintained in-use contract
+/// always includes `Renew`). A full-set comparison at an event site would
+/// therefore be dominated by `Renew` cross-talk that the event does not decide
+/// (renewal is measured at the renewal site). Focusing on the class the site is
+/// responsible for keeps each per-site signal trustworthy. The
+/// collapse/renewal MAINTENANCE sites keep the full comparison — they ARE the
+/// drivers for their whole action set.
+pub(crate) fn action_set_divergence_focused(
+    reconcile_actions: &[Action],
+    actual_actions: &[Action],
+    relevant: &[Action],
+) -> ReconcileActionDivergence {
+    let r: Vec<Action> = reconcile_actions
+        .iter()
+        .copied()
+        .filter(|a| relevant.contains(a))
+        .collect();
+    let a: Vec<Action> = actual_actions
+        .iter()
+        .copied()
+        .filter(|a| relevant.contains(a))
+        .collect();
+    action_set_divergence(&r, &a)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -752,6 +785,47 @@ mod tests {
         // Renewal agreement (steady-state in-use host) ⇒ no divergence.
         let d = action_set_divergence(&[Renew], &[Renew]);
         assert!(!d.any());
+    }
+
+    /// `action_set_divergence_focused` restricts the comparison to the relevant
+    /// action classes — the single-aspect edge sites use it so level-triggered
+    /// `Renew` cross-talk (which the event does not decide) can't flag.
+    #[test]
+    fn action_set_divergence_focused_ignores_irrelevant_classes() {
+        use Action::*;
+
+        // Connection-drop shape: reconcile wants {Renew, ReRootSearch}, the site
+        // does nothing ({}). Focused on {ReRootSearch}: only reroot flags; the
+        // level-triggered Renew is ignored (it's the renewal site's concern).
+        let d = action_set_divergence_focused(&[Renew, ReRootSearch], &[], &[ReRootSearch]);
+        assert_eq!(
+            d,
+            ReconcileActionDivergence {
+                reroot_search: true,
+                ..Default::default()
+            },
+            "focused compare must ignore the irrelevant Renew and flag only ReRootSearch"
+        );
+
+        // Host-formation shape: reconcile wants {Renew, Announce}, production
+        // announces ({Announce}). Focused on {Announce}: agree, no divergence.
+        let d = action_set_divergence_focused(&[Renew, Announce], &[Announce], &[Announce]);
+        assert!(
+            !d.any(),
+            "focused Announce compare agrees; the Renew is out of scope"
+        );
+
+        // Inbound-unsubscribe shape: reconcile would tear down ({Collapse}), the
+        // site kept hosting ({}). Focused on {Collapse}: collapse flags (the
+        // strict-farther mutual-co-host signal), Renew ignored.
+        let d = action_set_divergence_focused(&[Renew, Collapse], &[], &[Collapse]);
+        assert_eq!(
+            d,
+            ReconcileActionDivergence {
+                collapse: true,
+                ..Default::default()
+            }
+        );
     }
 
     /// Pin for the `Distance` Eq/Ord gotcha (`ring/location.rs:223-243`): two

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -302,6 +302,22 @@ pub(crate) struct RouterSnapshotInfo {
     pub reconcile_shadow_renewal_announce_diffs: Option<u64>,
     pub reconcile_shadow_renewal_retract_diffs: Option<u64>,
     pub reconcile_shadow_renewal_reroot_search_diffs: Option<u64>,
+    /// Reconcile-controller SHADOW counters for the single-aspect EDGE sites
+    /// (keystone step-2 completion, #4642). Each edge site is compared FOCUSED on
+    /// one action class, so `comparisons` + `divergences` fully captures it (the
+    /// per-action split would be redundant — a single relevant class): the FLIP
+    /// hook for `inbound_unsubscribe` is `Collapse` (would the controller tear
+    /// down on a downstream leave?), for `connection_drop` is `ReRootSearch`
+    /// (would it re-root on an upstream loss? production does nothing today —
+    /// one-sided count), for `host_formation` is `Announce` (does it agree a
+    /// freshly-hosted contract should be advertised?). Monotonic lifetime totals,
+    /// `None` until the ring's snapshot task populates them.
+    pub reconcile_shadow_inbound_unsubscribe_comparisons: Option<u64>,
+    pub reconcile_shadow_inbound_unsubscribe_divergences: Option<u64>,
+    pub reconcile_shadow_connection_drop_comparisons: Option<u64>,
+    pub reconcile_shadow_connection_drop_divergences: Option<u64>,
+    pub reconcile_shadow_host_formation_comparisons: Option<u64>,
+    pub reconcile_shadow_host_formation_divergences: Option<u64>,
     /// Interest-weighted (two-tier) module-cache SHADOW gauges (#4441/#4534),
     /// populated by `Ring` from the same per-node `ModuleCacheMetrics` `Arc`.
     /// These are ALWAYS ON, independent of the `FREENET_MODULE_CACHE_INTEREST_TIERED`
@@ -1242,6 +1258,14 @@ impl Router {
             reconcile_shadow_renewal_announce_diffs: None,
             reconcile_shadow_renewal_retract_diffs: None,
             reconcile_shadow_renewal_reroot_search_diffs: None,
+            // Reconcile-controller shadow counters for the single-aspect edge
+            // sites (keystone step-2 completion, #4642).
+            reconcile_shadow_inbound_unsubscribe_comparisons: None,
+            reconcile_shadow_inbound_unsubscribe_divergences: None,
+            reconcile_shadow_connection_drop_comparisons: None,
+            reconcile_shadow_connection_drop_divergences: None,
+            reconcile_shadow_host_formation_comparisons: None,
+            reconcile_shadow_host_formation_divergences: None,
             // Interest-weighted (two-tier) module-cache shadow gauges,
             // populated by Ring on the snapshot cadence (#4441/#4534).
             contract_module_cache_cold_evictable_bytes: None,

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2322,6 +2322,33 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                         "reconcile_shadow_renewal_reroot_search_diffs",
                         snapshot.reconcile_shadow_renewal_reroot_search_diffs,
                     ),
+                    // Single-aspect edge sites (keystone step-2 completion,
+                    // #4642): comparisons + divergences only (focused on one
+                    // class each).
+                    (
+                        "reconcile_shadow_inbound_unsubscribe_comparisons",
+                        snapshot.reconcile_shadow_inbound_unsubscribe_comparisons,
+                    ),
+                    (
+                        "reconcile_shadow_inbound_unsubscribe_divergences",
+                        snapshot.reconcile_shadow_inbound_unsubscribe_divergences,
+                    ),
+                    (
+                        "reconcile_shadow_connection_drop_comparisons",
+                        snapshot.reconcile_shadow_connection_drop_comparisons,
+                    ),
+                    (
+                        "reconcile_shadow_connection_drop_divergences",
+                        snapshot.reconcile_shadow_connection_drop_divergences,
+                    ),
+                    (
+                        "reconcile_shadow_host_formation_comparisons",
+                        snapshot.reconcile_shadow_host_formation_comparisons,
+                    ),
+                    (
+                        "reconcile_shadow_host_formation_divergences",
+                        snapshot.reconcile_shadow_host_formation_divergences,
+                    ),
                 ] {
                     obj.insert(key.to_string(), serde_json::json!(value));
                 }
@@ -2648,6 +2675,12 @@ mod tests {
         info.reconcile_shadow_renewal_announce_diffs = Some(491);
         info.reconcile_shadow_renewal_retract_diffs = Some(499);
         info.reconcile_shadow_renewal_reroot_search_diffs = Some(503);
+        info.reconcile_shadow_inbound_unsubscribe_comparisons = Some(509);
+        info.reconcile_shadow_inbound_unsubscribe_divergences = Some(521);
+        info.reconcile_shadow_connection_drop_comparisons = Some(523);
+        info.reconcile_shadow_connection_drop_divergences = Some(541);
+        info.reconcile_shadow_host_formation_comparisons = Some(547);
+        info.reconcile_shadow_host_formation_divergences = Some(557);
         let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
         for (key, want) in [
             ("reconcile_shadow_collapse_comparisons", 401),
@@ -2668,6 +2701,12 @@ mod tests {
             ("reconcile_shadow_renewal_announce_diffs", 491),
             ("reconcile_shadow_renewal_retract_diffs", 499),
             ("reconcile_shadow_renewal_reroot_search_diffs", 503),
+            ("reconcile_shadow_inbound_unsubscribe_comparisons", 509),
+            ("reconcile_shadow_inbound_unsubscribe_divergences", 521),
+            ("reconcile_shadow_connection_drop_comparisons", 523),
+            ("reconcile_shadow_connection_drop_divergences", 541),
+            ("reconcile_shadow_host_formation_comparisons", 547),
+            ("reconcile_shadow_host_formation_divergences", 557),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }


### PR DESCRIPTION
## Problem

#4711 wired the pure `reconcile()` controller in SHADOW mode at the two MAINTENANCE decision sites (collapse, renewal) and deferred the four remaining sites plus three hardening items. This completes the keystone shadow-wiring (epic #4642): the controller now watches every on-`main` hosting decision so we have full field evidence of how far it diverges from today's behavior BEFORE flipping any decision to it. Additive and behavior-preserving — **the controller still drives NOTHING** (guarded by drives-nothing source-scrape pins at every site).

## Solution

The four remaining sites are single-aspect **edge** events (unlike the collapse/renewal maintenance sites). A full-set comparison at an edge event would be dominated by the controller's level-triggered `Renew` (which the event does not decide — renewal is measured at the renewal site). So each edge site uses a **focused comparison** (`action_set_divergence_focused`) restricted to the one action class it is responsible for. A shared `OpManager::record_reconcile_shadow_event` helper (build inputs → focused compare → record) unifies them and gives one drives-nothing pin target.

The four sites and their faithful actual→Action mappings:

| Site | Focus | Actual (what production did this event) |
|------|-------|------------------------------------------|
| Inbound-unsubscribe (`handle_unsubscribe_inbound`) | `Collapse` | `{Collapse}` iff production tears down the lease this event (`should_unsubscribe_upstream` AND we hold a lease), else `{}` |
| Connection-drop (`on_ring_connection_lost`) | `ReRootSearch` | always `{}` — production does no re-root today (the F/#4655 hook); one-sided count of how often the controller WOULD re-root |
| Host-formation ×2 (`finalize_originator_subscribe`, GET `cache_contract_locally`) | `Announce` | `{Announce}` iff production announces a not-yet-advertised host this event, else `{}` |

Key correctness points:
- **Inbound-unsubscribe** builds inputs AFTER the downstream removal, so the strict-farther gate reflects it — the "kept hosting for a CLOSER downstream, but the controller would collapse" case surfaces as a `collapse` diff.
- **Connection-drop** enumerates OUR subscribed `ContractKey`s filtered by the dropped peer's co-hosted instance-id set (captured before `on_peer_disconnected` clears it, via a new read-only `contracts_for_peer` accessor). This sidesteps reconstructing a full `ContractKey` from the reverse index's bare `ContractInstanceId`, and a contract we don't subscribe to can't be in-use anyway. Bounded per drop (`CONNECTION_DROP_SHADOW_SAMPLE_CAP`).
- **Host-formation** builds inputs BEFORE the announce so `is_advertised` reflects the pre-announce state (`announce_contract_hosted` is idempotent); actual gates on `!is_advertised` so an already-advertised repeat doesn't record a false announce diff.

Counters are split per site (`ReconcileShadowSite` grows `InboundUnsubscribe`, `ConnectionDrop`, `HostFormation`). The edge sites export `comparisons` + `divergences` only — focused = single relevant class, so the per-action split would be redundant.

### Hardening (owed from the #4711 re-review)
- **A — mirror-seam pin**: `reconcile_shadow_export_maps_each_field_to_its_own_site` asserts every one of the 24 `network_status → router_snapshot` export assignments feeds its OWN site (`Some(shadow.<site>.<field>)`), closing the hand-mirror field-swap footgun.
- **B — strengthened collapse pin**: the collapse-site drives-nothing pin gains a NEGATIVE assertion scoped to the shadow block (absence of any driver call off `reconcile_actions`), mirroring the renewal/edge-site template.
- **C — doc caveats**: the focused-vs-full-comparison rationale and the one-sided connection-drop count are documented on the site enum, the counters, and the export.

## Testing

- `action_set_divergence_focused` unit test (irrelevant classes can't flag).
- Per-site counter independence incl. a new edge site (`reconcile_shadow_counts_reflect_recorded_events`).
- OTLP-JSON pin over all 30 per-site fields.
- Drives-nothing pins: the shared edge helper (`record_reconcile_shadow_event_drives_nothing`), the edge-site wiring pin (`edge_sites_wire_the_record_only_helper`, also asserts the connection-drop handler keeps its production bookkeeping), the strengthened collapse pin, and the mirror-seam pin.
- `cargo build -p freenet`, `cargo fmt`, and both CI clippy variants (`--locked` and `--features trace-ot`) clean.

**Nothing consumes `reconcile()`'s output as a decision** — verified by the per-site drives-nothing pins and the `reconcile_controller_has_no_driver_yet` module pin.

## Fixes

Refs #4642 — keystone step-2 completion (stacked on #4711, now merged; rebased onto main).

[AI-assisted - Claude]